### PR TITLE
feat(providers): add Hetzner AI inference

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -29,6 +29,7 @@ model:
   #   "arcee"        - Arcee AI Trinity models (requires: ARCEEAI_API_KEY)
   #   "ollama-cloud" - Ollama Cloud (requires: OLLAMA_API_KEY — https://ollama.com/settings)
   #   "deepinfra"    - DeepInfra (requires: DEEPINFRA_API_KEY)
+  #   "hetzner"      - Hetzner AI Inference (requires: HETZNER_API_KEY)
   #   "kilocode"     - KiloCode gateway (requires: KILOCODE_API_KEY)
   #   "azure-foundry" - Microsoft Foundry / Azure OpenAI (API key or Entra ID)
   #   "lmstudio"     - LM Studio local server (optional: LM_API_KEY, defaults to http://127.0.0.1:1234/v1)

--- a/plugins/model-providers/hetzner/__init__.py
+++ b/plugins/model-providers/hetzner/__init__.py
@@ -1,10 +1,31 @@
 """Hetzner AI Inference provider profile."""
 
+from typing import Any
+
 from providers import register_provider
 from providers.base import ProviderProfile
 
 
-hetzner = ProviderProfile(
+class HetznerProfile(ProviderProfile):
+    """Hetzner Qwen thinking control through Hermes reasoning settings."""
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        if not isinstance(reasoning_config, dict):
+            return {}, {}
+
+        return {
+            "chat_template_kwargs": {
+                "enable_thinking": reasoning_config.get("enabled") is not False,
+            }
+        }, {}
+
+
+hetzner = HetznerProfile(
     name="hetzner",
     aliases=("hetzner-ai", "hetzner-inference"),
     display_name="Hetzner AI Inference",

--- a/plugins/model-providers/hetzner/__init__.py
+++ b/plugins/model-providers/hetzner/__init__.py
@@ -1,0 +1,21 @@
+"""Hetzner AI Inference provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+hetzner = ProviderProfile(
+    name="hetzner",
+    aliases=("hetzner-ai", "hetzner-inference"),
+    display_name="Hetzner AI Inference",
+    description="Hetzner AI Inference — OpenAI-compatible hosted open models",
+    signup_url="https://console.hetzner.com/",
+    env_vars=("HETZNER_API_KEY", "HETZNER_BASE_URL"),
+    base_url="https://inference.hetzner.com/api/v1",
+    auth_type="api_key",
+    supports_vision=True,
+    default_aux_model="Qwen/Qwen3.6-35B-A3B-FP8",
+    fallback_models=("Qwen/Qwen3.6-35B-A3B-FP8",),
+)
+
+register_provider(hetzner)

--- a/plugins/model-providers/hetzner/plugin.yaml
+++ b/plugins/model-providers/hetzner/plugin.yaml
@@ -1,0 +1,5 @@
+name: hetzner-provider
+kind: model-provider
+version: 1.0.0
+description: Hetzner AI Inference — OpenAI-compatible experimental inference
+author: Hermes Agent

--- a/tests/plugins/model_providers/test_hetzner_profile.py
+++ b/tests/plugins/model_providers/test_hetzner_profile.py
@@ -1,0 +1,95 @@
+"""Contract tests for the Hetzner AI Inference provider profile."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def hetzner_profile():
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("hetzner")
+    assert profile is not None, "hetzner provider profile must be registered"
+    return profile
+
+
+def test_hetzner_profile_contract(hetzner_profile):
+    profile = hetzner_profile
+    assert profile.name == "hetzner"
+    assert profile.auth_type == "api_key"
+    assert profile.api_mode == "chat_completions"
+    assert profile.base_url == "https://inference.hetzner.com/api/v1"
+    assert profile.env_vars == ("HETZNER_API_KEY", "HETZNER_BASE_URL")
+    assert profile.supports_vision is True
+    assert profile.default_aux_model == "Qwen/Qwen3.6-35B-A3B-FP8"
+    assert profile.fallback_models == ("Qwen/Qwen3.6-35B-A3B-FP8",)
+
+
+@pytest.mark.parametrize("alias", ["hetzner-ai", "hetzner-inference"])
+def test_hetzner_aliases_resolve(hetzner_profile, alias):
+    import providers
+
+    assert providers.get_provider_profile(alias) is hetzner_profile
+
+
+def test_hetzner_is_auto_registered_for_auth(hetzner_profile):
+    from hermes_cli.auth import PROVIDER_REGISTRY
+
+    config = PROVIDER_REGISTRY["hetzner"]
+    assert config.name == "Hetzner AI Inference"
+    assert config.inference_base_url == "https://inference.hetzner.com/api/v1"
+    assert config.api_key_env_vars == ("HETZNER_API_KEY",)
+    assert config.base_url_env_var == "HETZNER_BASE_URL"
+
+
+def test_hetzner_credentials_and_alias_resolve(monkeypatch, hetzner_profile):
+    from hermes_cli.auth import (
+        resolve_api_key_provider_credentials,
+        resolve_provider,
+    )
+
+    monkeypatch.setenv("HETZNER_API_KEY", "test-key")
+    monkeypatch.delenv("HETZNER_BASE_URL", raising=False)
+
+    assert resolve_provider("hetzner-ai") == "hetzner"
+    assert resolve_api_key_provider_credentials("hetzner") == {
+        "provider": "hetzner",
+        "api_key": "test-key",
+        "base_url": "https://inference.hetzner.com/api/v1",
+        "source": "HETZNER_API_KEY",
+    }
+
+
+def test_hetzner_model_picker_has_offline_fallback(monkeypatch, hetzner_profile):
+    from hermes_cli import models
+
+    monkeypatch.delenv("HETZNER_API_KEY", raising=False)
+    monkeypatch.delenv("HETZNER_BASE_URL", raising=False)
+
+    assert models.provider_model_ids("hetzner") == [
+        "Qwen/Qwen3.6-35B-A3B-FP8"
+    ]
+
+
+def test_hetzner_fetch_models_uses_bearer_and_standard_endpoint(hetzner_profile):
+    response = MagicMock()
+    response.__enter__.return_value = response
+    response.read.return_value = json.dumps(
+        {"data": [{"id": "Qwen/Qwen3.6-35B-A3B-FP8"}]}
+    ).encode()
+
+    with patch(
+        "hermes_cli.urllib_security.open_credentialed_url",
+        return_value=response,
+    ) as opener:
+        models = hetzner_profile.fetch_models(api_key="secret-token")
+
+    assert models == ["Qwen/Qwen3.6-35B-A3B-FP8"]
+    request = opener.call_args.args[0]
+    assert request.full_url == "https://inference.hetzner.com/api/v1/models"
+    assert request.get_header("Authorization") == "Bearer secret-token"

--- a/tests/plugins/model_providers/test_hetzner_profile.py
+++ b/tests/plugins/model_providers/test_hetzner_profile.py
@@ -93,3 +93,45 @@ def test_hetzner_fetch_models_uses_bearer_and_standard_endpoint(hetzner_profile)
     request = opener.call_args.args[0]
     assert request.full_url == "https://inference.hetzner.com/api/v1/models"
     assert request.get_header("Authorization") == "Bearer secret-token"
+
+
+@pytest.mark.parametrize(
+    ("reasoning_config", "expected"),
+    [
+        ({"enabled": True, "effort": "medium"}, True),
+        ({"enabled": False, "effort": "none"}, False),
+    ],
+)
+def test_hetzner_maps_reasoning_to_chat_template_kwargs(
+    hetzner_profile, reasoning_config, expected
+):
+    extra_body, top_level = hetzner_profile.build_api_kwargs_extras(
+        reasoning_config=reasoning_config,
+        model="Qwen/Qwen3.6-35B-A3B-FP8",
+    )
+
+    assert extra_body == {
+        "chat_template_kwargs": {"enable_thinking": expected}
+    }
+    assert top_level == {}
+
+
+def test_hetzner_omits_thinking_when_unconfigured(hetzner_profile):
+    assert hetzner_profile.build_api_kwargs_extras(reasoning_config=None) == ({}, {})
+
+
+def test_hetzner_thinking_reaches_chat_completion_request(hetzner_profile):
+    from agent.transports.chat_completions import ChatCompletionsTransport
+
+    kwargs = ChatCompletionsTransport().build_kwargs(
+        model="Qwen/Qwen3.6-35B-A3B-FP8",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        provider_profile=hetzner_profile,
+        reasoning_config={"enabled": False, "effort": "none"},
+        request_overrides=None,
+    )
+
+    assert kwargs["extra_body"] == {
+        "chat_template_kwargs": {"enable_thinking": False}
+    }

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -263,6 +263,10 @@ hermes chat --provider arcee --model trinity-large-thinking
 # Use the exact model ID returned by GMI's /v1/models endpoint.
 hermes chat --provider gmi --model zai-org/GLM-5.1-FP8
 # Requires: GMI_API_KEY in ~/.hermes/.env
+
+# Hetzner AI Inference
+hermes chat --provider hetzner --model Qwen/Qwen3.6-35B-A3B-FP8
+# Requires: HETZNER_API_KEY in ~/.hermes/.env
 ```
 
 Fireworks uses its native slash-form catalog IDs, such as `accounts/fireworks/models/kimi-k2p6`. Run `hermes model`, choose **Fireworks AI**, and select from the live catalog or enter another Fireworks model ID. The default endpoint is `https://api.fireworks.ai/inference/v1`; configure a different endpoint through `model.base_url` in `config.yaml`, not `.env`.
@@ -275,6 +279,23 @@ model:
 ```
 
 Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
+
+Hetzner's current Qwen model accepts `chat_template_kwargs.enable_thinking`.
+Hermes maps its normal reasoning setting to that field, so no provider-specific
+request configuration is needed:
+
+```yaml
+model:
+  provider: "hetzner"
+  default: "Qwen/Qwen3.6-35B-A3B-FP8"
+
+agent:
+  reasoning_effort: "none"  # sends enable_thinking: false
+```
+
+Use any enabled reasoning level (`minimal` through `ultra`) to send
+`enable_thinking: true`. If no reasoning preference reaches the provider, the
+field is omitted and Hetzner's server default applies.
 
 :::note Z.AI Endpoint Auto-Detection
 When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoints (global, China, coding variants) to find one that accepts your API key. You don't need to set `GLM_BASE_URL` manually — the working endpoint is detected and cached automatically.


### PR DESCRIPTION
## What does this PR do?

Adds Hetzner AI Inference as a first-class OpenAI-compatible model-provider plugin.

- Provider ID: `hetzner` (aliases: `hetzner-ai`, `hetzner-inference`)
- Default base URL: `https://inference.hetzner.com/api/v1`
- Credentials: `HETZNER_API_KEY`, optional `HETZNER_BASE_URL`
- Uses the shared chat-completions transport and authenticated `/models` discovery
- Declares vision support for Hetzner's current multimodal Qwen model
- Provides `Qwen/Qwen3.6-35B-A3B-FP8` as the offline picker and auxiliary fallback
- Is automatically exposed through the provider registry, model picker, generic setup flow, and doctor health check

Fixes #73423.

## Why a plugin-only transport integration?

Hetzner documents an OpenAI-compatible API, including standard Bearer auth, `/models`, `/chat/completions`, and image URL content. The declarative provider profile reuses those existing Hermes paths and avoids provider-specific request code.

## Tests

- `pytest tests/plugins/model_providers/test_hetzner_profile.py tests/providers/test_plugin_discovery.py tests/providers/test_provider_profiles.py tests/hermes_cli/test_api_key_providers.py -q` — 256 passed
- Runtime credential/alias smoke check — passed
- Ruff — passed
- `py_compile` — passed
- `git diff --check` — passed

No live Hetzner token is required by the tests; the endpoint, Bearer header, and response parsing are contract-tested with a mocked response.
