### PR TITLE
fix(gateway): stop leaking Codex app-server sessions

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -925,12 +925,15 @@ class WebhookAdapter(BasePlatformAdapter):
     async def _end_webhook_session(
         self, event: "MessageEvent", session_chat_id: str
     ) -> None:
-        """Mark the per-delivery webhook session ended in state.db.
+        """End the per-delivery session and evict its cached agent.
 
         Resolves the persisted ``session_id`` from the gateway session store
         using the SAME source the run was keyed on (so profile multiplexing
         and key construction match exactly), then closes it via the existing
-        ``SessionDB.end_session`` API — never a hand-written UPDATE.
+        ``SessionDB.end_session`` API — never a hand-written UPDATE.  Webhook
+        delivery IDs make these sessions one-shot, so retaining their agents
+        cannot provide a cache hit and keeps provider runtimes alive until the
+        general cache cap or idle sweep runs.
         """
         runner = self.gateway_runner
         if runner is None:
@@ -939,6 +942,7 @@ class WebhookAdapter(BasePlatformAdapter):
         store = getattr(runner, "session_store", None)
         if session_db is None or store is None:
             return
+        session_key = None
         try:
             key_fn = getattr(runner, "_session_key_for_source", None)
             if key_fn is None:
@@ -985,6 +989,18 @@ class WebhookAdapter(BasePlatformAdapter):
                 session_chat_id,
                 e,
             )
+        finally:
+            if session_key:
+                evict = getattr(runner, "_evict_cached_agent", None)
+                if callable(evict):
+                    try:
+                        evict(session_key)
+                    except Exception as e:
+                        logger.debug(
+                            "[webhook] Failed to evict cached agent for %s: %s",
+                            session_chat_id,
+                            e,
+                        )
 
     # ------------------------------------------------------------------
     # Signature validation

--- a/run_agent.py
+++ b/run_agent.py
@@ -3828,6 +3828,17 @@ class AIAgent:
         except Exception:
             pass
 
+    def _close_codex_session(self) -> None:
+        """Detach and close the Codex app-server session, if one is active."""
+        codex_session = getattr(self, "_codex_session", None)
+        self._codex_session = None
+        if codex_session is None:
+            return
+        try:
+            codex_session.close()
+        except Exception:
+            logger.debug("Failed to close Codex app-server session", exc_info=True)
+
     def release_clients(self) -> None:
         """Release LLM client resources WITHOUT tearing down session tool state.
 
@@ -3865,6 +3876,11 @@ class AIAgent:
                         pass
         except Exception:
             pass
+
+        # A rebuilt agent cannot reuse this instance's Codex thread. Closing
+        # it here prevents cache eviction from orphaning the app-server and
+        # its MCP subprocesses.
+        self._close_codex_session()
 
         # Retire the OpenAI/httpx client to release sockets immediately.
         # #70773: eviction runs on the gateway's memory-manager thread — a
@@ -3934,7 +3950,10 @@ class AIAgent:
         except Exception:
             pass
 
-        # 5. Close the OpenAI/httpx client
+        # 5. Close the Codex app-server runtime owned by this agent.
+        self._close_codex_session()
+
+        # 6. Close the OpenAI/httpx client
         try:
             client = getattr(self, "client", None)
             if client is not None:
@@ -3943,14 +3962,14 @@ class AIAgent:
         except Exception:
             pass
 
-        # 5b. Close the cached per-request wire client (reused across
+        # 6b. Close the cached per-request wire client (reused across
         # sequential LLM calls; see _create_request_openai_client).
         try:
             self._close_cached_request_openai_client(reason="agent_close")
         except Exception:
             pass
 
-        # 6. Free conversation history.  Mirrors _release_evicted_agent_soft's
+        # 7. Free conversation history.  Mirrors _release_evicted_agent_soft's
         # soft-eviction clear — close() is the hard teardown for true session
         # boundaries (/new, /reset, session expiry), so the message list won't
         # be reused.  Drops the reference proactively rather than waiting for
@@ -3961,7 +3980,7 @@ class AIAgent:
         except Exception:
             pass
 
-        # 7. Finalize the owned SQLite session row unless this agent is only a
+        # 8. Finalize the owned SQLite session row unless this agent is only a
         # temporary helper that deliberately handed session ownership forward
         # (manual compression helpers that rotate to a continuation session_id,
         # or background-review forks that share the live parent's session_id and

--- a/tests/gateway/test_webhook_session_close.py
+++ b/tests/gateway/test_webhook_session_close.py
@@ -51,9 +51,13 @@ class _FakeRunner:
     def __init__(self, store: SessionStore):
         self.session_store = store
         self._session_db = store._db
+        self.evicted_session_keys = []
 
     def _session_key_for_source(self, source: SessionSource) -> str:
         return self.session_store._generate_session_key(source)
+
+    def _evict_cached_agent(self, session_key: str) -> None:
+        self.evicted_session_keys.append(session_key)
 
 
 def _make_store(tmp_path) -> SessionStore:
@@ -144,6 +148,9 @@ async def test_completed_webhook_delivery_closes_its_session(tmp_path):
         "prune_sessions can never reap it (the ghost-session leak)"
     )
     assert row["end_reason"] == "webhook_complete"
+    assert runner.evicted_session_keys == [
+        runner._session_key_for_source(event.source)
+    ]
 
     # And the closed row is actually prunable, unlike the pre-fix leak.
     pruned = store._db.prune_sessions(older_than_days=0, source="webhook")
@@ -184,6 +191,9 @@ async def test_webhook_session_closed_even_when_agent_run_raises(tmp_path):
         "on the error path"
     )
     assert row["end_reason"] == "webhook_complete"
+    assert runner.evicted_session_keys == [
+        runner._session_key_for_source(event.source)
+    ]
     store._db.close()
 
 
@@ -209,4 +219,7 @@ async def test_end_webhook_session_awaits_async_session_db(tmp_path):
     row = store._db.get_session(entry.session_id)
     assert row["ended_at"] is not None
     assert row["end_reason"] == "webhook_complete"
+    assert runner.evicted_session_keys == [
+        runner._session_key_for_source(event.source)
+    ]
     store._db.close()

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -72,6 +72,50 @@ class TestApiModeAccepted:
         assert agent.api_mode == "codex_app_server"
 
 
+class TestCodexSessionLifecycle:
+    def test_release_clients_closes_and_detaches_codex_session(self):
+        agent = _make_codex_agent()
+        session = MagicMock()
+        agent._codex_session = session
+
+        agent.release_clients()
+
+        session.close.assert_called_once_with()
+        assert agent._codex_session is None
+
+    def test_close_closes_and_detaches_codex_session(self):
+        agent = _make_codex_agent()
+        session = MagicMock()
+        agent._codex_session = session
+
+        agent.close()
+
+        session.close.assert_called_once_with()
+        assert agent._codex_session is None
+
+    def test_repeated_cleanup_closes_codex_session_once(self):
+        agent = _make_codex_agent()
+        session = MagicMock()
+        agent._codex_session = session
+
+        agent.release_clients()
+        agent.close()
+
+        session.close.assert_called_once_with()
+        assert agent._codex_session is None
+
+    def test_cleanup_detaches_codex_session_when_close_raises(self):
+        agent = _make_codex_agent()
+        session = MagicMock()
+        session.close.side_effect = RuntimeError("close failed")
+        agent._codex_session = session
+
+        agent.release_clients()
+
+        session.close.assert_called_once_with()
+        assert agent._codex_session is None
+
+
 class TestRunConversationCodexPath:
     def test_run_conversation_returns_codex_shape(self, fake_session):
         agent = _make_codex_agent()
@@ -786,4 +830,3 @@ class TestCodexToolProgressBridge:
 
         assert "on_event" in captured_init and captured_init["on_event"] is not None
         assert ("tool.started", "exec_command", "pytest") in events
-


### PR DESCRIPTION
## What does this PR do?

Closes and detaches an agent-owned Codex app-server session whenever `AIAgent` releases its clients or performs full cleanup, and evicts one-shot webhook agents as soon as their delivery finishes.

Long-running gateways create short-lived agents for cron and webhook work. Evicted agents already released their LLM clients, child agents, and tool resources, but `_codex_session` was omitted from both cleanup paths. Each eviction could therefore retain a Codex app-server and its MCP subprocesses until the gateway itself restarted.

Webhook deliveries have unique session keys, but their completed agents also remained in the general agent cache. That cache permits 128 entries and can defer idle eviction for finite-reset sessions, so webhook runtimes could consume memory long before normal cache pressure cleaned them up.

The lifecycle helper detaches the session before best-effort close, making cleanup idempotent and preventing a close failure from retaining the session reference. The webhook completion hook now evicts its unique one-shot cache key after ending the persisted session; interactive chat caching is unchanged.

## Related Issue

N/A — no matching issue or PR was found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add an idempotent `_close_codex_session()` lifecycle helper in `run_agent.py`.
- Invoke it from both soft client release and full agent close.
- Cover both paths, repeated cleanup, and a raising `close()` implementation.
- Evict each unique webhook delivery agent after its existing `webhook_complete` session close.
- Cover successful, failed, and async-SessionDB webhook completion paths.

## How to Test

1. Run the Codex test matrix: all `tests/**/test_*codex*.py` files.
2. Run gateway cache, shutdown, webhook, and cron lifecycle tests.
3. In a long-running gateway using `codex_app_server`, complete repeated cron and webhook runs and verify no `codex app-server` or MCP child remains in the gateway cgroup after each one-shot run.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched open and closed issues and PRs for duplicates.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass. The complete suite has three pre-existing macOS ACP failures on untouched `main`: ACP edit-approval tests classify pytest's `/private/var/...` temp directory as a sensitive system path.
- [x] I've added regression tests for the bug.
- [x] I've tested on macOS 26.5.2 and in a live NixOS gateway.

### Documentation & Housekeeping

- [x] Documentation update: N/A; this is internal lifecycle cleanup with a docstring and comments.
- [x] `cli-config.yaml.example`: N/A; no config changes.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow changes.
- [x] Cross-platform impact considered: cleanup uses the existing platform-neutral session API.
- [x] Tool descriptions/schemas: N/A; no tool behavior changes.

## Test Results

- `802 passed` — every Codex-named test file across agent, transport, CLI, cron, tools, plugins, and TUI.
- `268 passed` — gateway webhook completion/cache/shutdown and cron shutdown lifecycle tests.
- Ruff, Windows-footgun, and whitespace checks passed.
- ACP subset: `348 passed, 3 failed`; the same three failures reproduce on untouched upstream `main`.
- Live NixOS acceptance: two consecutive real scheduled runs and two distinct accepted webhook deliveries completed; the gateway cgroup returned to the gateway process only after every run, with no retained Codex or MCP child.
