### PR TITLE
feat(sessions): sessions.index_exclude_sources — keep chosen session sources out of the search index

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -782,6 +782,11 @@ def load_cli_config() -> Dict[str, Any]:
             os.environ["HERMES_SEARCH_SLOW_MS"] = str(
                 sessions_config["search_slow_ms"]
             )
+        if "index_exclude_sources" in sessions_config:
+            from hermes_cli.config import join_index_exclude_sources
+            os.environ["HERMES_FTS_EXCLUDE_SOURCES"] = join_index_exclude_sources(
+                sessions_config["index_exclude_sources"]
+            )
 
     return defaults
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1735,6 +1735,11 @@ def _bridge_max_turns_from_config(home: "Path") -> None:
             os.environ["HERMES_CJK_FTS"] = str(sessions_cfg["cjk_fts"])
         if "search_slow_ms" in sessions_cfg:
             os.environ["HERMES_SEARCH_SLOW_MS"] = str(sessions_cfg["search_slow_ms"])
+        if "index_exclude_sources" in sessions_cfg:
+            from hermes_cli.config import join_index_exclude_sources
+            os.environ["HERMES_FTS_EXCLUDE_SOURCES"] = join_index_exclude_sources(
+                sessions_cfg["index_exclude_sources"]
+            )
 
 
 def _current_max_iterations() -> int:
@@ -2030,6 +2035,13 @@ if _config_path.exists():
             if "search_slow_ms" in _sessions_cfg:
                 os.environ["HERMES_SEARCH_SLOW_MS"] = str(
                     _sessions_cfg["search_slow_ms"]
+                )
+            if "index_exclude_sources" in _sessions_cfg:
+                from hermes_cli.config import join_index_exclude_sources
+                os.environ["HERMES_FTS_EXCLUDE_SOURCES"] = (
+                    join_index_exclude_sources(
+                        _sessions_cfg["index_exclude_sources"]
+                    )
                 )
         _display_cfg = _cfg.get("display", {})
         if _display_cfg and isinstance(_display_cfg, dict):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3409,6 +3409,25 @@ DEFAULT_CONFIG = {
         # setting is inert when it isn't. False: never load the extension or
         # serve the cjk index. Bridged to HERMES_CJK_FTS (internal carrier).
         "cjk_fts": True,
+        # Session sources whose messages are NOT written to the full-text
+        # search indexes. Empty list (default) = index everything, which is
+        # the historical behavior.
+        #
+        # The FTS indexes cost ~4-5x the bytes of the text they cover, and on
+        # an install driven by automation (webhook routes, cron jobs,
+        # delegated subagents) those machine transcripts are the large
+        # majority of stored text while being the least likely to be
+        # keyword-searched. Listing them here — e.g.
+        # ["webhook", "cron", "subagent"] — keeps them fully STORED and
+        # readable (session_search by id, browsing, transcript reads, resume
+        # all unaffected) but leaves them out of the index, which is where
+        # the disk goes.
+        #
+        # Changing this only affects messages written from then on. To drop
+        # already-indexed rows for the newly excluded sources and return the
+        # space, run `hermes sessions prune-index`. Bridged to
+        # HERMES_FTS_EXCLUDE_SOURCES (internal carrier).
+        "index_exclude_sources": [],
         # Slow session-search log threshold in milliseconds: searches at or
         # above it log one INFO line with the routing path taken (fts_cjk /
         # fts5 / trigram / like_scan) so latency regressions stay
@@ -7517,6 +7536,29 @@ def load_config() -> Dict[str, Any]:
     ``get_provider_request_timeout`` which is called once per API turn.
     """
     return _load_config_impl(want_deepcopy=True)
+
+
+def join_index_exclude_sources(value: Any) -> str:
+    """Render ``sessions.index_exclude_sources`` for its env carrier.
+
+    Accepts the configured list (or a comma string, which users hand-editing
+    the YAML do write) and returns the comma-separated form
+    ``HERMES_FTS_EXCLUDE_SOURCES`` carries. Entries containing a comma are
+    dropped — the carrier is comma-delimited, so one would silently split into
+    two bogus source names.
+    """
+    if isinstance(value, str):
+        parts = value.split(",")
+    elif isinstance(value, (list, tuple, set)):
+        parts = list(value)
+    else:
+        return ""
+    out: list = []
+    for part in parts:
+        src = str(part).strip()
+        if src and "," not in src and src not in out:
+            out.append(src)
+    return ",".join(out)
 
 
 def load_config_readonly() -> Dict[str, Any]:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -16662,6 +16662,22 @@ def main():
         help="Skip the disk-space confirmation prompt",
     )
 
+    sessions_subparsers.add_parser(
+        "prune-index",
+        help="Drop already-indexed messages for sources excluded from search",
+        description=(
+            "Remove messages belonging to sessions.index_exclude_sources from "
+            "the full-text search index. Changing that setting only affects "
+            "messages written afterwards; rows indexed under the previous "
+            "setting stay in the index and keep occupying disk until this "
+            "runs. Only the INDEX is touched — transcripts stay fully stored, "
+            "readable, resumable, and exportable. Runs in bounded chunks so a "
+            "live gateway keeps working, and is safe to interrupt and re-run. "
+            "Freed pages are returned to the filesystem by a later "
+            "`hermes sessions optimize` (VACUUM)."
+        ),
+    )
+
     sessions_repair = sessions_subparsers.add_parser(
         "repair",
         help="Repair a malformed state.db schema so hidden sessions reappear",
@@ -17867,6 +17883,60 @@ def main():
             if result.get("vacuumed") is False:
                 print("  (VACUUM was skipped or failed — run "
                       "`hermes sessions optimize` later to reclaim freed space.)")
+
+        elif action == "prune-index":
+            excluded = db.fts_excluded_sources()
+            if not excluded:
+                print(
+                    "No session sources are excluded from the search index.\n"
+                    "Set sessions.index_exclude_sources in config.yaml first, "
+                    "e.g.:\n"
+                    "  hermes config set sessions.index_exclude_sources "
+                    "webhook,cron,subagent"
+                )
+                db.close()
+                return
+            before_mb = (db.logical_size_bytes() or 0) / (1024 * 1024)
+            print(
+                "Removing already-indexed messages for excluded source(s): "
+                + ", ".join(excluded)
+            )
+            print(
+                "  Transcripts are NOT touched — only the search index. "
+                "Safe to Ctrl-C and re-run."
+            )
+
+            _seen = {"table": None}
+
+            def _prune_progress(info):
+                table = info.get("table")
+                if table != _seen["table"] and _seen["table"] is not None:
+                    print()
+                _seen["table"] = table
+                print(
+                    f"\r  {table}: un-indexed {info.get('removed', 0):,} row(s)",
+                    end="", flush=True,
+                )
+
+            result = db.prune_fts_for_excluded_sources(
+                progress_cb=_prune_progress
+            )
+            print()
+            if not result.get("ok"):
+                print(f"Could not prune: {result.get('reason', 'unknown')}")
+                db.close()
+                return
+            total = sum(result.get("removed", {}).values())
+            after_mb = (db.logical_size_bytes() or 0) / (1024 * 1024)
+            print(f"✓ Un-indexed {total:,} message row(s).")
+            print(
+                f"  Database size: {before_mb:.1f} MB -> {after_mb:.1f} MB "
+                f"({_size_delta_label(before_mb - after_mb)})"
+            )
+            print(
+                "  Freed pages are reused by new writes. To return them to "
+                "the filesystem, run: hermes sessions optimize"
+            )
 
         elif action == "stats":
             total = db.session_count()

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -40,7 +40,7 @@ from hermes_constants import get_hermes_home
 from hermes_cli.sqlite_runtime import (
     is_sqlite_wal_reset_vulnerable as _is_sqlite_wal_reset_vulnerable,
 )
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, TypeVar
 
 try:  # Hard dependency, but tolerate scaffold-phase imports before pip install.
     import psutil
@@ -1426,6 +1426,28 @@ CREATE INDEX IF NOT EXISTS idx_sessions_handoff_state
 # predicate into a tautology (id > -1 OR id <= -1), i.e. normal operation.
 # The two state_meta PK probes per write are negligible next to the FTS
 # insert itself.
+# ── Per-source FTS exclusion (config.yaml sessions.index_exclude_sources) ──
+#
+# state_meta key holding the excluded session sources, stored comma-delimited
+# AND comma-wrapped (",webhook,cron,") so a trigger can test membership with a
+# single ``instr`` and never match a prefix ("cron" must not match "cronish").
+# The key is ABSENT when nothing is excluded, which makes the added trigger
+# predicates tautologies — byte-identical behavior to before this existed.
+# Living in state_meta rather than baked into the trigger DDL is what lets the
+# setting change without schema surgery, and keeps every process (gateway,
+# cron, CLI) agreeing on one value.
+FTS_EXCLUDE_SOURCES_KEY = "fts_exclude_sources"
+
+# Membership test shared by the index triggers. Correlates on the row's own
+# session_id, so it costs one PK probe on ``sessions`` plus one on
+# ``state_meta`` — negligible next to the FTS insert it guards.
+_FTS_SOURCE_NOT_EXCLUDED_SQL = (
+    "NOT EXISTS (SELECT 1 FROM state_meta sm JOIN sessions s "
+    "ON s.id = {alias}.session_id "
+    f"WHERE sm.key = '{FTS_EXCLUDE_SOURCES_KEY}' "
+    "AND instr(sm.value, ',' || s.source || ',') > 0)"
+)
+
 FTS_SQL = """
 CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
     content,
@@ -1442,7 +1464,8 @@ WHEN (new.id > COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
                           WHERE key = 'fts_rebuild_progress'), -1))
 BEGIN
     INSERT INTO messages_fts(rowid, content, tool_name, tool_calls)
-    VALUES (new.id, new.content, new.tool_name, new.tool_calls);
+    SELECT new.id, new.content, new.tool_name, new.tool_calls
+    WHERE __SRC_OK_NEW__;
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_delete AFTER DELETE ON messages
@@ -1452,7 +1475,8 @@ WHEN (old.id > COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
                           WHERE key = 'fts_rebuild_progress'), -1))
 BEGIN
     INSERT INTO messages_fts(messages_fts, rowid, content, tool_name, tool_calls)
-    VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
+    SELECT 'delete', old.id, old.content, old.tool_name, old.tool_calls
+    WHERE EXISTS (SELECT 1 FROM messages_fts_docsize d WHERE d.id = old.id);
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_update AFTER UPDATE ON messages
@@ -1465,9 +1489,11 @@ WHEN (old.content IS NOT new.content
                             WHERE key = 'fts_rebuild_progress'), -1))
 BEGIN
     INSERT INTO messages_fts(messages_fts, rowid, content, tool_name, tool_calls)
-    VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
+    SELECT 'delete', old.id, old.content, old.tool_name, old.tool_calls
+    WHERE EXISTS (SELECT 1 FROM messages_fts_docsize d WHERE d.id = old.id);
     INSERT INTO messages_fts(rowid, content, tool_name, tool_calls)
-    VALUES (new.id, new.content, new.tool_name, new.tool_calls);
+    SELECT new.id, new.content, new.tool_name, new.tool_calls
+    WHERE __SRC_OK_NEW__;
 END;
 """
 
@@ -1508,7 +1534,8 @@ WHEN new.role <> 'tool'
                             WHERE key = 'fts_rebuild_progress'), -1))
 BEGIN
     INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls)
-    VALUES (new.id, new.content, new.tool_name, new.tool_calls);
+    SELECT new.id, new.content, new.tool_name, new.tool_calls
+    WHERE __SRC_OK_NEW__;
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_delete AFTER DELETE ON messages
@@ -1519,7 +1546,8 @@ WHEN old.role <> 'tool'
                             WHERE key = 'fts_rebuild_progress'), -1))
 BEGIN
     INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_name, tool_calls)
-    VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
+    SELECT 'delete', old.id, old.content, old.tool_name, old.tool_calls
+    WHERE EXISTS (SELECT 1 FROM messages_fts_trigram_docsize d WHERE d.id = old.id);
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_update AFTER UPDATE ON messages
@@ -1534,10 +1562,11 @@ WHEN (old.content IS NOT new.content
 BEGIN
     INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_name, tool_calls)
     SELECT 'delete', old.id, old.content, old.tool_name, old.tool_calls
-    WHERE old.role <> 'tool';
+    WHERE old.role <> 'tool'
+      AND EXISTS (SELECT 1 FROM messages_fts_trigram_docsize d WHERE d.id = old.id);
     INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls)
     SELECT new.id, new.content, new.tool_name, new.tool_calls
-    WHERE new.role <> 'tool';
+    WHERE new.role <> 'tool' AND __SRC_OK_NEW__;
 END;
 """
 
@@ -1600,7 +1629,8 @@ WHEN new.role <> 'tool'
                             WHERE key = 'fts_cjk_rebuild_progress'), -1))
 BEGIN
     INSERT INTO messages_fts_cjk(rowid, content, tool_name, tool_calls)
-    VALUES (new.id, new.content, new.tool_name, new.tool_calls);
+    SELECT new.id, new.content, new.tool_name, new.tool_calls
+    WHERE __SRC_OK_NEW__;
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_cjk_delete AFTER DELETE ON messages
@@ -1611,7 +1641,8 @@ WHEN old.role <> 'tool'
                             WHERE key = 'fts_cjk_rebuild_progress'), -1))
 BEGIN
     INSERT INTO messages_fts_cjk(messages_fts_cjk, rowid, content, tool_name, tool_calls)
-    VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
+    SELECT 'delete', old.id, old.content, old.tool_name, old.tool_calls
+    WHERE EXISTS (SELECT 1 FROM messages_fts_cjk_docsize d WHERE d.id = old.id);
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_cjk_update AFTER UPDATE ON messages
@@ -1626,10 +1657,11 @@ WHEN (old.content IS NOT new.content
 BEGIN
     INSERT INTO messages_fts_cjk(messages_fts_cjk, rowid, content, tool_name, tool_calls)
     SELECT 'delete', old.id, old.content, old.tool_name, old.tool_calls
-    WHERE old.role <> 'tool';
+    WHERE old.role <> 'tool'
+      AND EXISTS (SELECT 1 FROM messages_fts_cjk_docsize d WHERE d.id = old.id);
     INSERT INTO messages_fts_cjk(rowid, content, tool_name, tool_calls)
     SELECT new.id, new.content, new.tool_name, new.tool_calls
-    WHERE new.role <> 'tool';
+    WHERE new.role <> 'tool' AND __SRC_OK_NEW__;
 END;
 """
 
@@ -1659,6 +1691,73 @@ def _cjk_fts_config_enabled() -> bool:
     return os.getenv("HERMES_CJK_FTS", "1").strip().lower() not in (
         "0", "false", "off", "no",
     )
+
+
+# ── Per-source FTS exclusion helpers (see FTS_EXCLUDE_SOURCES_KEY above) ──
+
+def fts_exclude_sources_from_env() -> List[str]:
+    """Excluded session sources from the ``sessions.index_exclude_sources``
+    env bridge (HERMES_FTS_EXCLUDE_SOURCES, comma-separated).
+
+    Returns a de-duplicated, order-preserving list; empty when unset.
+    """
+    raw = os.getenv("HERMES_FTS_EXCLUDE_SOURCES", "") or ""
+    out: List[str] = []
+    for part in raw.split(","):
+        src = part.strip()
+        if src and src not in out:
+            out.append(src)
+    return out
+
+
+def encode_fts_exclude_sources(sources: Iterable[str]) -> Optional[str]:
+    """Encode sources into the comma-wrapped state_meta value.
+
+    Returns None when the collection is empty, which callers translate into
+    DELETING the key (absent ⇒ index everything).
+    """
+    cleaned = []
+    for src in sources or ():
+        s = str(src).strip()
+        if s and "," not in s and s not in cleaned:
+            cleaned.append(s)
+    if not cleaned:
+        return None
+    return "," + ",".join(cleaned) + ","
+
+
+def decode_fts_exclude_sources(value: Optional[str]) -> List[str]:
+    """Inverse of :func:`encode_fts_exclude_sources`."""
+    if not value:
+        return []
+    return [p for p in value.split(",") if p]
+
+
+# Placeholder the FTS trigger DDL uses where the "this row's source is not
+# excluded" test belongs. Expanded by :func:`expand_fts_ddl` at CREATE time —
+# the DDL strings themselves stay readable and every trigger gets the exact
+# same predicate.
+_FTS_SRC_OK_NEW_TOKEN = "__SRC_OK_NEW__"
+
+
+def expand_fts_ddl(ddl: str) -> str:
+    """Substitute the source-exclusion predicate into FTS trigger DDL."""
+    return ddl.replace(
+        _FTS_SRC_OK_NEW_TOKEN,
+        _FTS_SOURCE_NOT_EXCLUDED_SQL.format(alias="new"),
+    )
+
+
+# Same predicate for backfill/sweep statements, which select FROM messages
+# under the alias ``m`` rather than acting on a trigger's NEW row. Keeping one
+# source of truth here is what stops a backfill from re-adding rows the
+# triggers deliberately skip.
+FTS_SOURCE_NOT_EXCLUDED_FOR_BACKFILL = _FTS_SOURCE_NOT_EXCLUDED_SQL.format(
+    alias="m"
+)
+
+
+
 
 
 def load_fts5_cjk_extension(conn: sqlite3.Connection) -> bool:
@@ -2352,7 +2451,7 @@ class SessionDB:
                 # `optimize-storage` run rebuilds from scratch.
                 self._fts_cjk_available = False
                 return
-            cursor.executescript(FTS_CJK_TRIGGER_SQL)
+            cursor.executescript(expand_fts_ddl(FTS_CJK_TRIGGER_SQL))
             backfill_pending = cursor.execute(
                 "SELECT 1 FROM state_meta "
                 "WHERE key = 'fts_cjk_rebuild_high_water' LIMIT 1"
@@ -2386,6 +2485,234 @@ class SessionDB:
         return int(row[0] if not isinstance(row, sqlite3.Row) else row[0])
 
     @staticmethod
+    def _drop_fts_triggers_missing_source_guard(cursor: sqlite3.Cursor) -> int:
+        """Drop FTS triggers whose stored body predates the source guard.
+
+        ``CREATE TRIGGER IF NOT EXISTS`` silently keeps an existing trigger,
+        so a DB created before ``sessions.index_exclude_sources`` existed
+        would keep indexing every source forever. Detect the old bodies by
+        the absence of the guard's marker key and drop them; the caller's
+        ensure step recreates them from current DDL. Triggers hold no index
+        data, so this loses nothing.
+
+        Returns the number of triggers dropped.
+        """
+        names = tuple(_FTS_TRIGGERS) + _FTS_CJK_TRIGGERS
+        placeholders = ",".join("?" for _ in names)
+        dropped = 0
+        try:
+            rows = cursor.execute(
+                f"SELECT name, sql FROM sqlite_master WHERE type = 'trigger' "
+                f"AND name IN ({placeholders})",
+                names,
+            ).fetchall()
+        except sqlite3.OperationalError:
+            return 0
+        for row in rows:
+            name = row[0]
+            sql = row[1] or ""
+            # Delete-side triggers gained a docsize existence check in the
+            # same change; insert/update sides gained the source guard. Both
+            # markers are absent from every pre-change body.
+            if FTS_EXCLUDE_SOURCES_KEY in sql or "_docsize d WHERE d.id" in sql:
+                continue
+            try:
+                cursor.execute(f"DROP TRIGGER IF EXISTS {name}")
+                dropped += 1
+            except sqlite3.OperationalError:
+                pass
+        if dropped:
+            logger.info(
+                "Recreating %d FTS trigger(s) to honor "
+                "sessions.index_exclude_sources.", dropped,
+            )
+        return dropped
+
+    def _sync_fts_exclude_sources(self, cursor: sqlite3.Cursor) -> List[str]:
+        """Make the state_meta marker match ``sessions.index_exclude_sources``.
+
+        config.yaml is authoritative (same discipline as ``cjk_fts`` and
+        ``search_slow_ms``): whatever the env bridge carries wins over a stale
+        marker left by an earlier configuration. Called during schema init,
+        before the trigger DDL, so a process never writes a single message
+        under the previous setting.
+
+        Returns the effective excluded-source list.
+        """
+        desired = fts_exclude_sources_from_env()
+        encoded = encode_fts_exclude_sources(desired)
+        try:
+            row = cursor.execute(
+                "SELECT value FROM state_meta WHERE key = ?",
+                (FTS_EXCLUDE_SOURCES_KEY,),
+            ).fetchone()
+        except sqlite3.OperationalError:
+            return desired
+        current = row[0] if row is not None else None
+        if current == encoded:
+            return desired
+        try:
+            if encoded is None:
+                cursor.execute(
+                    "DELETE FROM state_meta WHERE key = ?",
+                    (FTS_EXCLUDE_SOURCES_KEY,),
+                )
+            else:
+                cursor.execute(
+                    "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+                    "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    (FTS_EXCLUDE_SOURCES_KEY, encoded),
+                )
+        except sqlite3.OperationalError as exc:
+            logger.debug("Could not sync FTS exclude-sources marker: %s", exc)
+            return decode_fts_exclude_sources(current)
+        logger.info(
+            "Search index now excludes session sources: %s",
+            ", ".join(desired) if desired else "(none)",
+        )
+        return desired
+
+    def fts_excluded_sources(self) -> List[str]:
+        """Session sources currently kept OUT of the search indexes."""
+        return decode_fts_exclude_sources(
+            self.get_meta(FTS_EXCLUDE_SOURCES_KEY)
+        )
+
+    def prune_fts_for_excluded_sources(
+        self,
+        *,
+        chunk_rows: int = 2000,
+        progress_cb: Optional[Callable[[Dict[str, Any]], None]] = None,
+    ) -> Dict[str, Any]:
+        """Delete already-indexed rows belonging to now-excluded sources.
+
+        Changing ``sessions.index_exclude_sources`` only affects future
+        writes — rows indexed under the old setting stay in the index and keep
+        occupying disk. This removes them in bounded chunks so a live gateway
+        is never blocked for long, using the same external-content 'delete'
+        op the triggers use (the canonical way to un-index a row).
+
+        Rows are only touched when they are actually IN the index (docsize
+        anti-join), so re-running is a no-op and a partial run resumes
+        naturally. Message rows themselves are never modified — this is
+        index-only, the transcripts stay readable and exportable.
+
+        The freed pages are returned to the filesystem by a subsequent
+        VACUUM (``hermes sessions optimize``); this call only frees them
+        inside the file.
+
+        Returns {"ok", "sources", "removed": {<table>: <rows>}}.
+        """
+        excluded = self.fts_excluded_sources()
+        if not self._fts_enabled or self.read_only or not excluded:
+            return {
+                "ok": False,
+                "reason": (
+                    "read_only" if self.read_only
+                    else "fts5_unavailable" if not self._fts_enabled
+                    else "no_excluded_sources"
+                ),
+                "sources": excluded,
+                "removed": {},
+            }
+
+        tables = ["messages_fts"]
+        if self._fts_table_exists("messages_fts_trigram"):
+            tables.append("messages_fts_trigram")
+        if self._fts_cjk_available and self._fts_table_exists("messages_fts_cjk"):
+            tables.append("messages_fts_cjk")
+
+        placeholders = ",".join("?" for _ in excluded)
+        removed: Dict[str, int] = {}
+        for table in tables:
+            total = 0
+            while True:
+                def _do(conn, table=table):
+                    rows = conn.execute(
+                        f"SELECT m.id, m.content, m.tool_name, m.tool_calls "
+                        f"FROM messages m JOIN sessions s ON s.id = m.session_id "
+                        f"JOIN {table}_docsize d ON d.id = m.id "
+                        f"WHERE s.source IN ({placeholders}) "
+                        f"LIMIT {int(chunk_rows)}",
+                        excluded,
+                    ).fetchall()
+                    for r in rows:
+                        conn.execute(
+                            f"INSERT INTO {table}"
+                            f"({table}, rowid, content, tool_name, tool_calls) "
+                            f"VALUES ('delete', ?, ?, ?, ?)",
+                            (r[0], r[1], r[2], r[3]),
+                        )
+                    return len(rows)
+
+                try:
+                    n = int(self._execute_write(_do))
+                except sqlite3.DatabaseError as exc:
+                    logger.warning(
+                        "Index prune failed on %s: %s", table, exc
+                    )
+                    break
+                total += n
+                if progress_cb is not None:
+                    try:
+                        progress_cb({"table": table, "removed": total})
+                    except Exception:
+                        pass
+                if n < chunk_rows:
+                    break
+            removed[table] = total
+            logger.info("Un-indexed %d row(s) from %s.", total, table)
+
+        try:
+            self.optimize_fts()
+        except Exception as exc:
+            logger.debug("FTS optimize after index prune failed: %s", exc)
+
+        return {"ok": True, "sources": excluded, "removed": removed}
+
+    @staticmethod
+    def _unindex_excluded_sources(
+        cursor: sqlite3.Cursor,
+        tables: Iterable[str],
+    ) -> None:
+        """Remove excluded-source rows from freshly rebuilt FTS indexes.
+
+        FTS5's external-content ``'rebuild'`` repopulates from the whole
+        content source and has no way to filter, so a rebuild re-adds exactly
+        the rows ``sessions.index_exclude_sources`` says to leave out. Undo it
+        in the same pass, otherwise every corruption recovery or trigger
+        repair would silently re-inflate the index.
+
+        No-op when nothing is excluded. Runs on the caller's cursor (already
+        inside the schema-init transaction) — the row set is bounded by what
+        the rebuild just wrote, and a rebuild is the expensive part.
+        """
+        row = cursor.execute(
+            "SELECT value FROM state_meta WHERE key = ?",
+            (FTS_EXCLUDE_SOURCES_KEY,),
+        ).fetchone()
+        excluded = decode_fts_exclude_sources(row[0] if row else None)
+        if not excluded:
+            return
+        placeholders = ",".join("?" for _ in excluded)
+        for table in tables:
+            try:
+                cursor.execute(
+                    f"INSERT INTO {table}"
+                    f"({table}, rowid, content, tool_name, tool_calls) "
+                    f"SELECT 'delete', m.id, m.content, m.tool_name, m.tool_calls "
+                    f"FROM messages m JOIN sessions s ON s.id = m.session_id "
+                    f"JOIN {table}_docsize d ON d.id = m.id "
+                    f"WHERE s.source IN ({placeholders})",
+                    excluded,
+                )
+            except sqlite3.OperationalError as exc:
+                logger.debug(
+                    "Could not un-index excluded sources from %s: %s",
+                    table, exc,
+                )
+
+    @staticmethod
     def _rebuild_fts_indexes(
         cursor: sqlite3.Cursor,
         *,
@@ -2396,10 +2723,15 @@ class SessionDB:
         # content source (messages for the standard index, the tool-row-
         # excluding messages_fts_trigram_src view for the trigram index).
         cursor.execute("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')")
+        rebuilt = ["messages_fts"]
         if include_trigram:
             cursor.execute(
                 "INSERT INTO messages_fts_trigram(messages_fts_trigram) VALUES('rebuild')"
             )
+            rebuilt.append("messages_fts_trigram")
+        # 'rebuild' cannot filter, so it re-adds the excluded sources the
+        # triggers skip — strip them back out before returning.
+        SessionDB._unindex_excluded_sources(cursor, rebuilt)
         # 'rebuild' indexes EVERY row, so any deferred-backfill markers are
         # now satisfied — clear them, otherwise the background worker would
         # re-insert rows the rebuild already covered (duplicate entries).
@@ -2472,7 +2804,7 @@ class SessionDB:
             # Run even when the virtual table exists so any dropped or missing
             # triggers are recreated after a previous no-FTS5 runtime disabled
             # them to keep message writes working.
-            cursor.executescript(ddl)
+            cursor.executescript(expand_fts_ddl(ddl))
             return True
         except sqlite3.OperationalError as exc:
             if not self._is_fts5_unavailable_error(exc):
@@ -2764,6 +3096,7 @@ class SessionDB:
                     "SELECT m.id, m.content, m.tool_name, m.tool_calls "
                     "FROM messages m "
                     "WHERE m.id > ? AND m.id <= ? "
+                    f"AND {FTS_SOURCE_NOT_EXCLUDED_FOR_BACKFILL} "
                     "AND NOT EXISTS (SELECT 1 FROM messages_fts_docsize d WHERE d.id = m.id)",
                     (lo, hi),
                 )
@@ -2772,6 +3105,7 @@ class SessionDB:
                     "SELECT m.id, m.content, m.tool_name, m.tool_calls "
                     "FROM messages m "
                     "WHERE m.id > ? AND m.id <= ? AND m.role <> 'tool' "
+                    f"AND {FTS_SOURCE_NOT_EXCLUDED_FOR_BACKFILL} "
                     "AND NOT EXISTS (SELECT 1 FROM messages_fts_trigram_docsize d WHERE d.id = m.id)",
                     (lo, hi),
                 )
@@ -2866,16 +3200,19 @@ class SessionDB:
             upper = min(progress + chunk, high_water)
             conn.execute(
                 "INSERT INTO messages_fts(rowid, content, tool_name, tool_calls) "
-                "SELECT id, content, tool_name, tool_calls FROM messages "
-                "WHERE id > ? AND id <= ?",
+                "SELECT m.id, m.content, m.tool_name, m.tool_calls "
+                "FROM messages m WHERE m.id > ? AND m.id <= ? "
+                f"AND {FTS_SOURCE_NOT_EXCLUDED_FOR_BACKFILL}",
                 (progress, upper),
             )
             if include_trigram:
                 conn.execute(
                     "INSERT INTO messages_fts_trigram"
                     "(rowid, content, tool_name, tool_calls) "
-                    "SELECT id, content, tool_name, tool_calls FROM messages "
-                    "WHERE id > ? AND id <= ? AND role <> 'tool'",
+                    "SELECT m.id, m.content, m.tool_name, m.tool_calls "
+                    "FROM messages m WHERE m.id > ? AND m.id <= ? "
+                    "AND m.role <> 'tool' "
+                    f"AND {FTS_SOURCE_NOT_EXCLUDED_FOR_BACKFILL}",
                     (progress, upper),
                 )
             # Publish progress in the same transaction as the rows it
@@ -2941,8 +3278,10 @@ class SessionDB:
             upper = min(progress + chunk, high_water)
             conn.execute(
                 "INSERT INTO messages_fts_cjk(rowid, content, tool_name, tool_calls) "
-                "SELECT id, content, tool_name, tool_calls FROM messages "
-                "WHERE id > ? AND id <= ? AND role <> 'tool'",
+                "SELECT m.id, m.content, m.tool_name, m.tool_calls "
+                "FROM messages m WHERE m.id > ? AND m.id <= ? "
+                "AND m.role <> 'tool' "
+                f"AND {FTS_SOURCE_NOT_EXCLUDED_FOR_BACKFILL}",
                 (progress, upper),
             )
             conn.execute(
@@ -2979,6 +3318,7 @@ class SessionDB:
                     "SELECT m.id, m.content, m.tool_name, m.tool_calls "
                     "FROM messages m "
                     "WHERE m.id > ? AND m.id <= ? AND m.role <> 'tool' "
+                    f"AND {FTS_SOURCE_NOT_EXCLUDED_FOR_BACKFILL} "
                     "AND NOT EXISTS (SELECT 1 FROM messages_fts_cjk_docsize d WHERE d.id = m.id)",
                     (lo, hi),
                 )
@@ -3747,6 +4087,10 @@ class SessionDB:
             pass  # Index already exists
 
         if fts5_available:
+            # Config-authoritative: reconcile the excluded-source marker from
+            # sessions.index_exclude_sources BEFORE the trigger DDL runs, so
+            # the very first write of this process already honors it.
+            self._sync_fts_exclude_sources(cursor)
             # FTS5 setup. Run the DDL even when the virtual table exists so
             # CREATE TRIGGER IF NOT EXISTS repairs trigger-only degradation from
             # an earlier no-FTS5 runtime.
@@ -3776,6 +4120,13 @@ class SessionDB:
                             cursor, include_trigram=trigram_enabled
                         )
             else:
+                # The trigger BODIES gained the source-exclusion predicate
+                # (sessions.index_exclude_sources). CREATE TRIGGER IF NOT
+                # EXISTS will not replace an older body, so drop the FTS
+                # triggers whose SQL predates it and let the ensure calls
+                # below recreate them. Triggers carry no index data, so this
+                # is pure schema surgery — nothing to rebuild.
+                self._drop_fts_triggers_missing_source_guard(cursor)
                 triggers_need_repair = (
                     self._fts_trigger_count(cursor) < len(_FTS_TRIGGERS)
                 )
@@ -11056,6 +11407,9 @@ class SessionDB:
                     self._conn.execute(
                         f"INSERT INTO {tbl}({tbl}) VALUES('rebuild')"
                     )
+                    # 'rebuild' repopulates from the full content source and
+                    # cannot filter, so re-apply sessions.index_exclude_sources.
+                    self._unindex_excluded_sources(self._conn, (tbl,))
                     self._conn.commit()
                     rebuilt += 1
                 except sqlite3.OperationalError as exc:

--- a/tests/gateway/test_cjk_fts_config_bridge.py
+++ b/tests/gateway/test_cjk_fts_config_bridge.py
@@ -58,6 +58,40 @@ def test_search_knobs_have_documented_defaults():
     assert DEFAULT_CONFIG["sessions"]["search_slow_ms"] == 1000
 
 
+def test_index_exclude_sources_bridged_from_config(tmp_path, monkeypatch):
+    home = _write_home(tmp_path, {"index_exclude_sources": ["webhook", "cron"]})
+    monkeypatch.setattr(gateway_run, "_hermes_home", home)
+    monkeypatch.delenv("HERMES_FTS_EXCLUDE_SOURCES", raising=False)
+    gateway_run._reload_runtime_env_preserving_config_authority()
+    assert os.environ["HERMES_FTS_EXCLUDE_SOURCES"] == "webhook,cron"
+
+
+def test_config_empty_list_clears_a_stale_exclusion_env(tmp_path, monkeypatch):
+    """config.yaml is authoritative: emptying the list must turn indexing back
+    on, not leave a previous process's carrier in place."""
+    home = _write_home(tmp_path, {"index_exclude_sources": []})
+    monkeypatch.setattr(gateway_run, "_hermes_home", home)
+    monkeypatch.setenv("HERMES_FTS_EXCLUDE_SOURCES", "webhook")
+    gateway_run._reload_runtime_env_preserving_config_authority()
+    assert os.environ["HERMES_FTS_EXCLUDE_SOURCES"] == ""
+
+
+def test_env_survives_when_config_omits_index_exclude_sources(
+    tmp_path, monkeypatch
+):
+    home = _write_home(tmp_path, {"auto_prune": False})
+    monkeypatch.setattr(gateway_run, "_hermes_home", home)
+    monkeypatch.setenv("HERMES_FTS_EXCLUDE_SOURCES", "cron")
+    gateway_run._reload_runtime_env_preserving_config_authority()
+    assert os.environ["HERMES_FTS_EXCLUDE_SOURCES"] == "cron"
+
+
+def test_index_exclude_sources_default_is_index_everything():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["sessions"]["index_exclude_sources"] == []
+
+
 def test_config_false_disables_cjk_semantics(tmp_path, monkeypatch):
     """The bridged 'False' string must parse as OFF in hermes_state."""
     from hermes_state import _cjk_fts_config_enabled

--- a/tests/state/test_fts_index_exclude_sources.py
+++ b/tests/state/test_fts_index_exclude_sources.py
@@ -1,0 +1,379 @@
+"""``sessions.index_exclude_sources``: keep machine transcripts out of FTS.
+
+The two full-text indexes cost several times the bytes of the text they
+cover. On an automation-driven install the machine transcripts (webhook
+routes, cron jobs, delegated subagents) are the large majority of stored
+text and the least likely to be keyword-searched, so this setting lets an
+operator keep them fully STORED while leaving them OUT of the index.
+
+Every test here drives the real ``SessionDB`` against a temp database — the
+guard lives in trigger DDL, so a mock would prove nothing about whether a
+row actually lands in the index.
+"""
+
+import os
+import sqlite3
+from unittest import mock
+
+import pytest
+
+from hermes_state import (
+    SessionDB,
+    decode_fts_exclude_sources,
+    encode_fts_exclude_sources,
+    fts_exclude_sources_from_env,
+)
+from hermes_cli.config import join_index_exclude_sources
+
+
+def _open(tmp_path, excluded=None, name="state.db"):
+    """Open a SessionDB with ``excluded`` carried on the env bridge."""
+    env = {}
+    if excluded is not None:
+        env["HERMES_FTS_EXCLUDE_SOURCES"] = ",".join(excluded)
+    with mock.patch.dict(os.environ, env, clear=False):
+        if excluded is None:
+            os.environ.pop("HERMES_FTS_EXCLUDE_SOURCES", None)
+        return SessionDB(db_path=tmp_path / name)
+
+
+def _write(db, session_id, source, text):
+    db.create_session(session_id, source)
+    return db.append_message(session_id, "user", text)
+
+
+def _indexed(db, table, message_id):
+    """Is ``message_id`` present in ``table``'s index?"""
+    row = db._conn.execute(
+        f"SELECT 1 FROM {table}_docsize WHERE id = ?", (message_id,)
+    ).fetchone()
+    return row is not None
+
+
+# ── encoding helpers ─────────────────────────────────────────────────────────
+
+class TestEncoding:
+    def test_empty_encodes_to_none_so_the_marker_key_is_absent(self):
+        assert encode_fts_exclude_sources([]) is None
+        # Callers translate None into DELETING the marker key.
+        assert encode_fts_exclude_sources(()) is None
+
+    def test_value_is_comma_wrapped_for_prefix_safe_membership(self):
+        # The trigger tests membership with instr(value, ',' || source || ',').
+        # Without the wrapping commas "cron" would match "cronish".
+        assert encode_fts_exclude_sources(["webhook", "cron"]) == ",webhook,cron,"
+
+    def test_prefix_of_an_excluded_source_is_not_itself_excluded(self):
+        value = encode_fts_exclude_sources(["cronish"])
+        assert value is not None and ",cron," not in value
+
+    def test_round_trip(self):
+        sources = ["webhook", "cron", "subagent"]
+        assert decode_fts_exclude_sources(
+            encode_fts_exclude_sources(sources)
+        ) == sources
+
+    def test_duplicates_collapse_and_blanks_drop(self):
+        assert decode_fts_exclude_sources(
+            encode_fts_exclude_sources(["cron", "cron", " ", "webhook"])
+        ) == ["cron", "webhook"]
+
+    def test_source_containing_a_comma_is_dropped_not_split(self):
+        # The carrier is comma-delimited; splitting one name into two bogus
+        # ones would silently exclude sources nobody configured.
+        assert encode_fts_exclude_sources(["we,bhook"]) is None
+
+    def test_config_list_renders_for_the_env_carrier(self):
+        assert join_index_exclude_sources(["webhook", "cron"]) == "webhook,cron"
+
+    def test_config_accepts_a_hand_edited_comma_string(self):
+        assert join_index_exclude_sources("webhook, cron") == "webhook,cron"
+
+    def test_config_non_sequence_renders_empty(self):
+        assert join_index_exclude_sources(None) == ""
+        assert join_index_exclude_sources(7) == ""
+
+    def test_env_bridge_reads_comma_separated(self):
+        with mock.patch.dict(
+            os.environ, {"HERMES_FTS_EXCLUDE_SOURCES": "webhook, cron,"}
+        ):
+            assert fts_exclude_sources_from_env() == ["webhook", "cron"]
+
+    def test_env_bridge_unset_is_empty(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_FTS_EXCLUDE_SOURCES", None)
+            assert fts_exclude_sources_from_env() == []
+
+
+# ── indexing behavior ────────────────────────────────────────────────────────
+
+class TestIndexingHonorsExclusion:
+    def test_default_indexes_every_source(self, tmp_path):
+        db = _open(tmp_path)
+        try:
+            assert db.fts_excluded_sources() == []
+            mid = _write(db, "s-hook", "webhook", "needle alpha")
+            assert _indexed(db, "messages_fts", mid)
+        finally:
+            db.close()
+
+    def test_excluded_source_is_not_indexed(self, tmp_path):
+        db = _open(tmp_path, ["webhook", "cron"])
+        try:
+            assert db.fts_excluded_sources() == ["webhook", "cron"]
+            hook = _write(db, "s-hook", "webhook", "needle alpha")
+            cron = _write(db, "s-cron", "cron", "needle alpha")
+            kept = _write(db, "s-cli", "cli", "needle alpha")
+            assert not _indexed(db, "messages_fts", hook)
+            assert not _indexed(db, "messages_fts", cron)
+            assert _indexed(db, "messages_fts", kept)
+        finally:
+            db.close()
+
+    def test_excluded_source_is_left_out_of_the_trigram_index_too(
+        self, tmp_path
+    ):
+        db = _open(tmp_path, ["webhook"])
+        try:
+            if not db._fts_table_exists("messages_fts_trigram"):
+                pytest.skip("trigram tokenizer unavailable in this sqlite")
+            hook = _write(db, "s-hook", "webhook", "needle alpha")
+            kept = _write(db, "s-cli", "cli", "needle alpha")
+            assert not _indexed(db, "messages_fts_trigram", hook)
+            assert _indexed(db, "messages_fts_trigram", kept)
+        finally:
+            db.close()
+
+    def test_a_source_whose_name_starts_with_an_excluded_one_is_indexed(
+        self, tmp_path
+    ):
+        db = _open(tmp_path, ["cron"])
+        try:
+            mid = _write(db, "s-x", "cronish", "needle alpha")
+            assert _indexed(db, "messages_fts", mid)
+        finally:
+            db.close()
+
+    def test_transcript_stays_stored_and_readable_when_unindexed(
+        self, tmp_path
+    ):
+        db = _open(tmp_path, ["webhook"])
+        try:
+            _write(db, "s-hook", "webhook", "needle alpha")
+            msgs = db.get_messages("s-hook")
+            assert [m["content"] for m in msgs] == ["needle alpha"]
+        finally:
+            db.close()
+
+    def test_unindexed_row_is_absent_from_keyword_search_results(
+        self, tmp_path
+    ):
+        db = _open(tmp_path, ["webhook"])
+        try:
+            _write(db, "s-hook", "webhook", "zzquux")
+            _write(db, "s-cli", "cli", "zzquux")
+            found = {r["session_id"] for r in db.search_messages("zzquux")}
+            assert "s-cli" in found
+            assert "s-hook" not in found
+        finally:
+            db.close()
+
+    def test_updating_an_excluded_row_does_not_index_it(self, tmp_path):
+        db = _open(tmp_path, ["webhook"])
+        try:
+            mid = _write(db, "s-hook", "webhook", "needle alpha")
+            db._conn.execute(
+                "UPDATE messages SET content = ? WHERE id = ?",
+                ("needle beta", mid),
+            )
+            db._conn.commit()
+            assert not _indexed(db, "messages_fts", mid)
+        finally:
+            db.close()
+
+    def test_deleting_an_unindexed_row_does_not_raise(self, tmp_path):
+        # The delete trigger fires for every row, indexed or not. Issuing a
+        # 'delete' op for a row FTS5 never saw corrupts the index, which is
+        # why the trigger carries a docsize existence check.
+        db = _open(tmp_path, ["webhook"])
+        try:
+            mid = _write(db, "s-hook", "webhook", "needle alpha")
+            db._conn.execute("DELETE FROM messages WHERE id = ?", (mid,))
+            db._conn.commit()
+            assert db._conn.execute(
+                "INSERT INTO messages_fts(messages_fts) VALUES('integrity-check')"
+            ) is not None
+        finally:
+            db.close()
+
+
+class TestConfigIsAuthoritative:
+    def test_reopening_with_a_new_setting_applies_to_new_writes(
+        self, tmp_path
+    ):
+        db = _open(tmp_path)
+        try:
+            before = _write(db, "s-a", "webhook", "needle alpha")
+            assert _indexed(db, "messages_fts", before)
+        finally:
+            db.close()
+
+        db = _open(tmp_path, ["webhook"])
+        try:
+            assert db.fts_excluded_sources() == ["webhook"]
+            after = _write(db, "s-b", "webhook", "needle alpha")
+            assert not _indexed(db, "messages_fts", after)
+            # Rows indexed under the old setting are untouched until an
+            # explicit prune — that is what `hermes sessions prune-index` is
+            # for, and asserting it here documents the boundary.
+            assert _indexed(db, "messages_fts", before)
+        finally:
+            db.close()
+
+    def test_clearing_the_setting_resumes_indexing(self, tmp_path):
+        db = _open(tmp_path, ["webhook"])
+        try:
+            assert not _indexed(
+                db, "messages_fts", _write(db, "s-a", "webhook", "alpha")
+            )
+        finally:
+            db.close()
+
+        db = _open(tmp_path, [])
+        try:
+            assert db.fts_excluded_sources() == []
+            assert _indexed(
+                db, "messages_fts", _write(db, "s-b", "webhook", "alpha")
+            )
+        finally:
+            db.close()
+
+    def test_old_trigger_bodies_are_replaced_not_kept(self, tmp_path):
+        # CREATE TRIGGER IF NOT EXISTS keeps whatever body is already stored,
+        # so a database carrying a pre-change trigger would keep indexing
+        # every source forever unless the stale trigger is dropped first.
+        db = _open(tmp_path)
+        try:
+            pass
+        finally:
+            db.close()
+
+        raw = sqlite3.connect(str(tmp_path / "state.db"))
+        raw.execute("DROP TRIGGER messages_fts_insert")
+        raw.execute(
+            """
+            CREATE TRIGGER messages_fts_insert AFTER INSERT ON messages
+            BEGIN
+                INSERT INTO messages_fts(rowid, content, tool_name, tool_calls)
+                VALUES (new.id, new.content, new.tool_name, new.tool_calls);
+            END;
+            """
+        )
+        raw.commit()
+        raw.close()
+
+        db = _open(tmp_path, ["webhook"])
+        try:
+            body = db._conn.execute(
+                "SELECT sql FROM sqlite_master "
+                "WHERE name = 'messages_fts_insert'"
+            ).fetchone()[0]
+            assert "fts_exclude_sources" in body
+            assert not _indexed(
+                db, "messages_fts", _write(db, "s-b", "webhook", "alpha")
+            )
+        finally:
+            db.close()
+
+
+class TestPruneIndex:
+    def test_prune_unindexes_existing_rows_and_keeps_transcripts(
+        self, tmp_path
+    ):
+        db = _open(tmp_path)
+        try:
+            hook = _write(db, "s-hook", "webhook", "needle alpha")
+            kept = _write(db, "s-cli", "cli", "needle alpha")
+        finally:
+            db.close()
+
+        db = _open(tmp_path, ["webhook"])
+        try:
+            result = db.prune_fts_for_excluded_sources(chunk_rows=1)
+            assert result["ok"] is True
+            assert result["removed"]["messages_fts"] >= 1
+            assert not _indexed(db, "messages_fts", hook)
+            assert _indexed(db, "messages_fts", kept)
+            # Index-only: the message rows themselves survive.
+            assert [m["content"] for m in db.get_messages("s-hook")] == [
+                "needle alpha"
+            ]
+        finally:
+            db.close()
+
+    def test_prune_is_idempotent(self, tmp_path):
+        db = _open(tmp_path)
+        try:
+            _write(db, "s-hook", "webhook", "needle alpha")
+        finally:
+            db.close()
+
+        db = _open(tmp_path, ["webhook"])
+        try:
+            first = db.prune_fts_for_excluded_sources()
+            second = db.prune_fts_for_excluded_sources()
+            assert first["removed"]["messages_fts"] >= 1
+            assert second["removed"]["messages_fts"] == 0
+        finally:
+            db.close()
+
+    def test_prune_declines_when_nothing_is_excluded(self, tmp_path):
+        db = _open(tmp_path)
+        try:
+            result = db.prune_fts_for_excluded_sources()
+            assert result["ok"] is False
+            assert result["reason"] == "no_excluded_sources"
+        finally:
+            db.close()
+
+    def test_pruned_index_still_passes_its_own_integrity_check(
+        self, tmp_path
+    ):
+        db = _open(tmp_path)
+        try:
+            _write(db, "s-hook", "webhook", "needle alpha")
+            _write(db, "s-cli", "cli", "needle alpha")
+        finally:
+            db.close()
+
+        db = _open(tmp_path, ["webhook"])
+        try:
+            db.prune_fts_for_excluded_sources()
+            db._conn.execute(
+                "INSERT INTO messages_fts(messages_fts) "
+                "VALUES('integrity-check')"
+            )
+            found = {r["session_id"] for r in db.search_messages("needle")}
+            assert found == {"s-cli"}
+        finally:
+            db.close()
+
+
+class TestRebuildReappliesExclusion:
+    def test_a_full_rebuild_does_not_re_add_excluded_rows(self, tmp_path):
+        # FTS5's 'rebuild' repopulates from the whole content source and
+        # cannot filter, so every corruption recovery would silently
+        # re-inflate the index unless the exclusion is re-applied.
+        db = _open(tmp_path, ["webhook"])
+        try:
+            hook = _write(db, "s-hook", "webhook", "needle alpha")
+            kept = _write(db, "s-cli", "cli", "needle alpha")
+            SessionDB._rebuild_fts_indexes(
+                db._conn.cursor(),
+                include_trigram=db._fts_table_exists("messages_fts_trigram"),
+            )
+            db._conn.commit()
+            assert not _indexed(db, "messages_fts", hook)
+            assert _indexed(db, "messages_fts", kept)
+        finally:
+            db.close()


### PR DESCRIPTION
## What does this PR do?

Adds `sessions.index_exclude_sources` — a list of session sources whose messages are kept out of the full-text search indexes while remaining fully stored.

The two FTS5 indexes cost roughly 4-5x the bytes of the text they cover. On an install driven by automation (webhook routes, cron jobs, delegated subagents) those machine transcripts are the large majority of stored text while being the least likely to ever be keyword-searched, so the index is being paid for content nobody searches. Measured on one 11 GB `state.db`:

| Component | Size |
|---|---|
| message text | 2.0 GB |
| trigram index + its content shadow | 5.7 GB |
| standard index + its content shadow | 2.2 GB |

and 94.7% of the indexable text (1,301 MB vs 73 MB) belonged to machine sessions. That database was compacted from 28 GB to 5 GB three weeks earlier and was back to 11 GB, with concurrent writes starting to time out against it.

Default is `[]` — index everything, exactly today's behavior. Setting it to e.g. `["webhook", "cron", "subagent"]` keeps those transcripts **stored and readable** (read by id, browse, resume, export all untouched); what goes away is keyword search over them.

### Why this shape

The excluded set lives in `state_meta`, comma-wrapped, and the index triggers test membership against it. Storing it in the database rather than baking it into the trigger DDL is what lets the setting change without schema surgery, and it keeps gateway, cron and CLI processes agreeing on one value. The key is **absent** when nothing is excluded, which makes the added predicates tautologies — byte-identical behavior for anyone who doesn't set it.

Three places needed the same predicate or they would quietly undo it:

- the chunked backfill paths, which would re-add rows the triggers skipped;
- FTS5's `'rebuild'`, which repopulates from the whole content source and cannot filter, so every corruption recovery would re-inflate the index;
- `CREATE TRIGGER IF NOT EXISTS`, which keeps an existing body — so triggers written before this change are dropped and recreated on open. Triggers hold no index data, so that is pure schema surgery with nothing to rebuild.

The delete-side triggers gained a docsize existence check in the same change: with rows deliberately absent from the index, an unconditional `'delete'` op for a row FTS5 never saw corrupts the index.

Changing the setting only affects messages written afterwards, which is why the CLI half exists: `hermes sessions prune-index` un-indexes the rows already written for the excluded sources. Bounded chunks so a live gateway keeps working, safe to interrupt and re-run, index-only. It uses the same external-content `'delete'` op the triggers use and only touches rows actually present in the index (docsize anti-join), so a second run is a no-op.

## Related Issue

No upstream issue — filed straight as a PR from the operational case above. Happy to open one if you'd prefer it tracked.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/config.py` — `sessions.index_exclude_sources` in `DEFAULT_CONFIG` (default `[]`) with `join_index_exclude_sources()` rendering it for the internal env carrier. A source containing a comma is dropped rather than split, since the carrier is comma-delimited and splitting would silently exclude names nobody configured.
- `cli.py`, `gateway/run.py` — bridge the setting to `HERMES_FTS_EXCLUDE_SOURCES`, config-authoritative, same discipline as the neighbouring `cjk_fts` / `search_slow_ms` bridges.
- `hermes_state.py` — `state_meta` marker + encode/decode helpers; source-exclusion predicate injected into the standard, trigram and CJK trigger DDL; the same predicate applied to every backfill path; `_unindex_excluded_sources()` re-applied after any `'rebuild'`; `_drop_fts_triggers_missing_source_guard()` so stale trigger bodies are replaced; `prune_fts_for_excluded_sources()`; `fts_excluded_sources()`.
- `hermes_cli/main.py` — `hermes sessions prune-index` subcommand with progress and before/after size.
- `tests/state/test_fts_index_exclude_sources.py` (new, 27 tests) — real `SessionDB` against a temp database, no mocks: the guard lives in trigger DDL, so a mock would prove nothing about whether a row lands in the index.
- `tests/gateway/test_cjk_fts_config_bridge.py` — 4 tests for the new bridge alongside the existing ones.

## How to Test

1. `pytest tests/state/test_fts_index_exclude_sources.py tests/gateway/test_cjk_fts_config_bridge.py -q`
2. Regression across everything that touches the index: `pytest tests/test_hermes_state.py tests/state tests/test_fts_cjk_bigram.py tests/test_state_db_malformed_repair.py tests/run_agent/test_in_place_compaction.py tests/hermes_cli/test_session_recovery.py -q`
3. End to end by hand: with the setting unset, run a cron/webhook session and confirm its text is searchable via `session_search`. Set `sessions.index_exclude_sources: ["webhook", "cron"]`, restart, run another — the new transcript is readable by session id but no longer returned by keyword search, while a CLI session still is. Then `hermes sessions prune-index` and confirm the earlier machine rows leave the index too, `hermes sessions optimize` returns the pages, and `INSERT INTO messages_fts(messages_fts) VALUES('integrity-check')` still passes.

What the tests specifically pin, beyond the happy path: a source whose name merely starts with an excluded one (`cronish` vs `cron`) is still indexed; deleting an unindexed row keeps the index consistent; a full `'rebuild'` does not re-add excluded rows; a stale pre-change trigger body is replaced rather than kept; prune is idempotent and leaves transcripts intact; clearing the setting resumes indexing.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] Test suites above pass (576 passing in the index-related suites, 36 in the two new/extended files); I did not run the entire `tests/` tree
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.1, SQLite 3.50.x, Python 3.12

### Documentation & Housekeeping

- [x] Docstrings and inline comments cover the setting, the marker encoding, and why each backfill/rebuild path re-applies the predicate — no README/docs section describes the FTS knobs today, so nothing there to amend
- [x] `cli-config.yaml.example` — N/A: it has no `sessions:` section (neither `cjk_fts` nor `search_slow_ms` appear in it either), so adding one key alone would be inconsistent with the file as it stands. Glad to add the whole section in a follow-up if you want it documented there.
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change
- [x] Cross-platform: pure SQLite/Python, no platform-specific paths or shell-outs
- [x] Tool descriptions/schemas — N/A, no tool behavior change. `session_search` keeps working identically; excluded transcripts remain reachable by session id and by browsing, only keyword matching over them goes away.

## Screenshots / Logs

New tests:

```
$ pytest tests/state/test_fts_index_exclude_sources.py -q
...........................                                              [100%]
27 passed in 4.69s

$ pytest tests/gateway/test_cjk_fts_config_bridge.py -q
.........                                                                [100%]
9 passed in 7.15s
```

Regression across the index-touching suites:

```
$ pytest tests/test_hermes_state.py tests/state tests/test_fts_cjk_bigram.py \
    tests/test_state_db_malformed_repair.py tests/run_agent/test_in_place_compaction.py \
    tests/hermes_cli/test_session_recovery.py -q
........................................................................ [100%]
576 passed in 204.83s (0:03:24)
```

---

Written with `claude-opus-5` driving the Hermes agent, from the operational case above: measure where the bytes actually are in a bloated `state.db`, then add a config-gated way to stop indexing the transcripts that account for them, with the follow-through paths (backfill, rebuild, stale triggers, retroactive prune) covered so the exclusion cannot be silently undone. The patch, tests, and this description were authored in that session and reviewed against the real database before opening.
