### PR TITLE
feat(slack): custom Web API base_url + NO_PROXY-aware custom host

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -794,6 +794,111 @@ def _apply_slack_base_url(client: Any, base_url: Optional[str]) -> None:
         client.base_url = base_url
 
 
+def _slack_url_origin(url: Optional[str]) -> Optional[Tuple[str, str, int]]:
+    """Return the ``(scheme, host, port)`` origin of *url*, or ``None``.
+
+    ``None`` for anything unusable (blank, non-HTTP scheme, no host, invalid
+    port) so callers never treat a malformed URL as a match. The port is
+    defaulted per scheme, making ``https://host/`` and ``https://host:443/``
+    the same origin.
+    """
+    if not url:
+        return None
+    try:
+        parts = urlsplit(str(url).strip())
+    except Exception:
+        return None
+    scheme = (parts.scheme or "").strip().lower()
+    if scheme not in {"http", "https"}:
+        return None
+    host = (parts.hostname or "").strip().lower().rstrip(".")
+    if not host:
+        return None
+    try:
+        port = parts.port
+    except ValueError:
+        return None
+    if port is None:
+        port = 443 if scheme == "https" else 80
+    return (scheme, host, port)
+
+
+def _slack_trusted_origin_label(base_url: Optional[str]) -> Optional[str]:
+    """Render the trusted origin of *base_url* as ``scheme://host[:port]``.
+
+    Used in refusal messages so an operator can see *which* origin is trusted:
+    the trust is exact-origin, so a relay that serves files from a sibling host
+    (mirroring ``slack.com`` vs ``files.slack.com``) is refused, and without
+    the origin in the message that failure is indistinguishable from a genuine
+    SSRF block. ``None`` when no usable custom base URL is configured.
+    """
+    origin = _slack_url_origin(base_url)
+    if origin is None:
+        return None
+    scheme, host, port = origin
+    if port == (443 if scheme == "https" else 80):
+        return f"{scheme}://{host}"
+    return f"{scheme}://{host}:{port}"
+
+
+def _slack_trust_hint(base_url: Optional[str]) -> str:
+    """Trailing clause naming the trusted origins for a refusal message."""
+    trusted = _slack_trusted_origin_label(base_url)
+    if not trusted:
+        return ""
+    return (
+        f" (trusted: the Slack CDN, plus exactly {trusted} from slack.base_url "
+        "— scheme, host and port must all match, sibling hosts are not covered)"
+    )
+
+
+def _is_slack_base_url_origin(url: str, base_url: Optional[str]) -> bool:
+    """Return True when *url* lives on the configured custom Slack origin.
+
+    ``url_private`` / ``url_private_download`` values are minted by whatever
+    Slack endpoint the workspace actually talks to. With a custom
+    ``slack.base_url`` (self-hosted relay, Enterprise proxy, mock Slack) those
+    links point at that endpoint instead of the Slack CDN, so the inbound file
+    download guards have to trust it — the same trust ``_apply_slack_base_url``
+    already grants it for every Web API call.
+
+    Origin equality (scheme + host + port) is the whole test: it cannot be
+    steered by a forged file object, because the origin comes from local
+    config. With no ``base_url`` configured this always returns False, leaving
+    the Slack-CDN allowlist as the only trust source.
+    """
+    origin = _slack_url_origin(base_url)
+    return origin is not None and _slack_url_origin(url) == origin
+
+
+def _slack_base_url_redirect_guard(base_url: Optional[str]) -> Any:
+    """Build a redirect guard that pins every hop to the custom Slack origin.
+
+    A custom endpoint may legitimately 3xx inside its own origin (auth
+    handoff, path rewrite), so those hops pass. Anything that leaves the
+    origin is refused outright rather than deferred to the generic
+    private-IP guard: this client is a plain ``httpx.AsyncClient`` (the
+    DNS-pinned one cannot dial a relay on a private address), so an
+    off-origin hop would be validated by hostname only and reopen the
+    DNS-rebinding window between the check and the TCP connect — with the
+    bot token attached.
+    """
+    from gateway.platforms.base import safe_url_for_log
+
+    async def guard(response: Any) -> None:
+        from tools.url_safety import redirect_target_from_response
+
+        target = redirect_target_from_response(response)
+        if target and not _is_slack_base_url_origin(target, base_url):
+            raise ValueError(
+                "Blocked Slack file redirect off the configured base_url "
+                f"origin {_slack_trusted_origin_label(base_url)}: "
+                f"{safe_url_for_log(target)}"
+            )
+
+    return guard
+
+
 _SLACK_PROXY_HOSTS = (
     "slack.com",
     "files.slack.com",
@@ -8661,6 +8766,71 @@ class SlackAdapter(BasePlatformAdapter):
             cls._SLACK_CDN_HOST_SUFFIXES
         )
 
+    def _open_slack_file_client(self, url: str) -> Any:
+        """Validate an inbound file URL and open the client to download it with.
+
+        Raises ``ValueError`` when the URL must not receive the bot token. The
+        returned object is an ``httpx.AsyncClient`` async context manager.
+
+        Two trust paths:
+
+        * Slack CDN (the default): pre-flight ``is_safe_url`` + CDN allowlist +
+          a DNS-pinned client, unchanged from upstream.
+        * The configured custom ``slack.base_url`` origin: the private-IP
+          checks are skipped for that origin only, because a self-hosted relay
+          legitimately lives on localhost / an internal address. In exchange
+          the client is origin-pinned — every redirect that leaves the trusted
+          origin is refused, so the token never follows a hop we cannot vet.
+        """
+        import httpx
+        from gateway.platforms.base import _ssrf_redirect_guard, safe_url_for_log
+        from tools.url_safety import create_ssrf_safe_async_client, is_safe_url
+
+        base_url = self._resolve_slack_base_url()
+        if _is_slack_base_url_origin(url, base_url):
+            logger.debug(
+                "[Slack] Trusting file URL on the configured base_url origin: %s",
+                safe_url_for_log(url),
+            )
+            return httpx.AsyncClient(
+                timeout=30.0,
+                follow_redirects=True,
+                event_hooks={"response": [_slack_base_url_redirect_guard(base_url)]},
+            )
+
+        # SSRF guard: the download attaches the bot token, so a URL that
+        # resolves to (or 3xx-redirects into) a private/internal address would
+        # both leak the token and let the server reach internal services
+        # (CWE-918). The outbound send_image() path is already guarded; this
+        # is the inbound sibling that was missing the same protection.
+        if not is_safe_url(url):
+            raise ValueError(
+                "Blocked unsafe Slack file URL (SSRF protection): "
+                f"{safe_url_for_log(url)}{_slack_trust_hint(base_url)}"
+            )
+
+        # Tighter than the generic SSRF check: these URLs come from Slack file
+        # objects (``url_private`` / ``url_private_download``) and legitimately
+        # only ever point at the Slack CDN — or at the configured custom
+        # endpoint, handled above. Refusing everything else stops a forged file
+        # object from steering the Bearer-token download at an arbitrary public
+        # host (token exfiltration), which the private-IP check alone cannot
+        # prevent.
+        if not self._is_slack_cdn_url(url):
+            raise ValueError(
+                "Blocked non-Slack-CDN file URL (token-exfiltration protection): "
+                f"{safe_url_for_log(url)}{_slack_trust_hint(base_url)}"
+            )
+
+        # DNS-pinned client: resolve + validate once, dial the vetted IP
+        # (closes the DNS-rebinding TOCTOU window between is_safe_url and
+        # TCP connect — the redirect hook still re-validates every hop).
+        return create_ssrf_safe_async_client(
+            timeout=30.0,
+            follow_redirects=True,
+            event_hooks={"response": [_ssrf_redirect_guard]},
+        )
+
     def _resolve_download_token(self, url: str, team_id: str = "") -> str:
         """Pick the correct bot token for a Slack file download.
 
@@ -8691,41 +8861,14 @@ class SlackAdapter(BasePlatformAdapter):
     ) -> str:
         """Download a Slack file using the bot token for auth, with retry."""
         import httpx
-        from gateway.platforms.base import _ssrf_redirect_guard, safe_url_for_log
-        from tools.url_safety import create_ssrf_safe_async_client, is_safe_url
 
-        # SSRF guard: the download attaches the bot token, so a URL that
-        # resolves to (or 3xx-redirects into) a private/internal address would
-        # both leak the token and let the server reach internal services
-        # (CWE-918). The outbound send_image() path is already guarded; this
-        # is the inbound sibling that was missing the same protection.
-        if not is_safe_url(url):
-            raise ValueError(
-                f"Blocked unsafe Slack file URL (SSRF protection): {safe_url_for_log(url)}"
-            )
-
-        # Tighter than the generic SSRF check: these URLs come from Slack file
-        # objects (``url_private`` / ``url_private_download``) and legitimately
-        # only ever point at the Slack CDN. Refusing everything else stops a
-        # forged file object from steering the Bearer-token download at an
-        # arbitrary public host (token exfiltration), which the private-IP
-        # check alone cannot prevent.
-        if not self._is_slack_cdn_url(url):
-            raise ValueError(
-                "Blocked non-Slack-CDN file URL (token-exfiltration protection): "
-                f"{safe_url_for_log(url)}"
-            )
+        # URL trust policy + client construction live in one place so both
+        # download paths (this one and _download_slack_file_bytes) stay in sync.
+        client_cm = self._open_slack_file_client(url)
 
         bot_token = self._resolve_download_token(url, team_id)
 
-        # DNS-pinned client: resolve + validate once, dial the vetted IP
-        # (closes the DNS-rebinding TOCTOU window between is_safe_url and
-        # TCP connect — the redirect hook still re-validates every hop).
-        async with create_ssrf_safe_async_client(
-            timeout=30.0,
-            follow_redirects=True,
-            event_hooks={"response": [_ssrf_redirect_guard]},
-        ) as client:
+        async with client_cm as client:
             for attempt in range(3):
                 try:
                     response = await client.get(
@@ -8774,34 +8917,14 @@ class SlackAdapter(BasePlatformAdapter):
     async def _download_slack_file_bytes(self, url: str, team_id: str = "") -> bytes:
         """Download a Slack file and return raw bytes, with retry."""
         import httpx
-        from gateway.platforms.base import _ssrf_redirect_guard, safe_url_for_log
-        from tools.url_safety import create_ssrf_safe_async_client, is_safe_url
 
-        # SSRF guard (CWE-918): see _download_slack_file. This sibling path
-        # also attaches the bot token and must validate the destination plus
-        # every redirect hop.
-        if not is_safe_url(url):
-            raise ValueError(
-                f"Blocked unsafe Slack file URL (SSRF protection): {safe_url_for_log(url)}"
-            )
-
-        # Slack-CDN allowlist — see _download_slack_file for the rationale.
-        if not self._is_slack_cdn_url(url):
-            raise ValueError(
-                "Blocked non-Slack-CDN file URL (token-exfiltration protection): "
-                f"{safe_url_for_log(url)}"
-            )
+        # Same trust policy as _download_slack_file (CWE-918 pre-flight, CDN /
+        # custom-base_url allowlist, per-redirect guard).
+        client_cm = self._open_slack_file_client(url)
 
         bot_token = self._resolve_download_token(url, team_id)
 
-        # DNS-pinned client: resolve + validate once, dial the vetted IP
-        # (closes the DNS-rebinding TOCTOU window between is_safe_url and
-        # TCP connect — the redirect hook still re-validates every hop).
-        async with create_ssrf_safe_async_client(
-            timeout=30.0,
-            follow_redirects=True,
-            event_hooks={"response": [_ssrf_redirect_guard]},
-        ) as client:
+        async with client_cm as client:
             for attempt in range(3):
                 try:
                     response = await client.get(

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -871,6 +871,14 @@ def _is_slack_base_url_trusted(url: str, base_url: Optional[str]) -> bool:
     config. With no ``base_url`` configured this always returns False, leaving
     the Slack-CDN allowlist as the only trust source.
 
+    Trusting a subtree means trusting the whole DNS zone below the configured
+    host: any name someone can publish under it — ``evil.slack.internal.corp``
+    for a ``base_url`` of ``https://slack.internal.corp/api/`` — is treated as
+    the endpoint and receives the bot token. That is the same premise the
+    Slack-CDN allowlist makes about ``*.slack.com``, so point ``base_url`` at a
+    host whose zone the operator controls; if it does not, serve file content
+    from the ``base_url`` host itself, which needs no subtree trust.
+
     Callers check the CDN allowlist first: a ``base_url`` on Slack itself
     must not turn CDN links into "configured" ones, which would cost them
     ``is_safe_url`` and the DNS-pinned client.

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -18,7 +18,7 @@ import re
 import time
 import unicodedata
 from dataclasses import dataclass, field
-from typing import Callable, ClassVar, Dict, Optional, Any, Tuple, List
+from typing import Callable, ClassVar, Dict, Optional, Any, Sequence, Tuple, List
 from urllib.parse import urlsplit
 
 import aiohttp
@@ -920,11 +920,29 @@ def _slack_proxy_bypass_hosts(base_url: Optional[str] = None) -> Tuple[str, ...]
     return _SLACK_PROXY_HOSTS
 
 
-def _resolve_slack_proxy_url(base_url: Optional[str] = None) -> Optional[str]:
+def _slack_endpoint_bypass_hosts(base_url: Optional[str] = None) -> Tuple[str, ...]:
+    """Return the NO_PROXY hosts for a caller scoped to the Web API endpoint.
+
+    ``resolve_proxy_url`` bypasses the proxy as soon as *any* host it is given
+    matches NO_PROXY, so a caller whose traffic is anchored to the Web API
+    endpoint passes that host alone — otherwise ``NO_PROXY=files.slack.com``
+    would send a call to a custom endpoint direct. A default deployment is
+    unaffected: the endpoint host is ``slack.com``, and NO_PROXY entries match
+    subdomains. Clients that also open the Socket Mode connection use
+    ``_slack_proxy_bypass_hosts`` instead.
+    """
+    host = _slack_base_url_host(base_url) or _slack_base_url_host(
+        _DEFAULT_SLACK_BASE_URL
+    )
+    return (host,) if host else ()
+
+
+def _resolve_slack_proxy_url(bypass_hosts: Sequence[str]) -> Optional[str]:
     """Resolve a proxy URL that Slack SDK clients can safely use.
 
-    When ``base_url`` points at a custom Slack endpoint, its host participates
-    in the NO_PROXY bypass check alongside the built-in Slack hosts.
+    ``bypass_hosts`` are the hosts checked against NO_PROXY: a client that
+    also opens Socket Mode passes ``_slack_proxy_bypass_hosts``, one anchored
+    to the Web API endpoint passes ``_slack_endpoint_bypass_hosts``.
     """
     proxy_url = resolve_proxy_url()
     if not proxy_url:
@@ -938,10 +956,7 @@ def _resolve_slack_proxy_url(base_url: Optional[str] = None) -> Optional[str]:
         )
         return None
 
-    if any(
-        is_host_excluded_by_no_proxy(host)
-        for host in _slack_proxy_bypass_hosts(base_url)
-    ):
+    if any(is_host_excluded_by_no_proxy(host) for host in bypass_hosts):
         logger.info("[Slack] NO_PROXY bypasses Slack proxy configuration")
         return None
 
@@ -2055,7 +2070,7 @@ class SlackAdapter(BasePlatformAdapter):
                 safe_url_for_log(base_url),
             )
 
-        proxy_url = _resolve_slack_proxy_url(base_url)
+        proxy_url = _resolve_slack_proxy_url(_slack_proxy_bypass_hosts(base_url))
         if proxy_url:
             logger.info(
                 "[Slack] Using proxy for Slack transport: %s",
@@ -9216,7 +9231,8 @@ class SlackAdapter(BasePlatformAdapter):
 
 
 # Cache for Slack user ID -> DM conversation ID resolution in the standalone
-# send path.  Keyed by "{token}:{user_id}" to support multi-workspace setups.
+# send path.  Keyed by "{base_url}|{token}:{user_id}" to support multi-workspace
+# setups and Slack-compatible endpoints with their own conversation IDs.
 _slack_dm_cache: Dict[str, str] = {}
 _SLACK_DM_CACHE_MAX = 5000
 
@@ -9239,9 +9255,9 @@ async def _resolve_slack_user_dm(
     hands out its own conversation IDs.  Returns None if resolution fails
     (missing ``im:write`` scope, unknown user, etc.).
 
-    ``base_url`` must already be normalized (trailing slash) — see
-    ``_normalize_slack_base_url``. ``None`` means the real Slack endpoint.
+    ``None`` for ``base_url`` means the real Slack endpoint.
     """
+    base_url = _normalize_slack_base_url(base_url)
     cache_key = f"{base_url or _DEFAULT_SLACK_BASE_URL}|{token}:{user_id}"
     if cache_key in _slack_dm_cache:
         return _slack_dm_cache[cache_key]
@@ -9253,10 +9269,11 @@ async def _resolve_slack_user_dm(
     try:
         from gateway.platforms.base import proxy_kwargs_for_aiohttp
 
-        # NO_PROXY-aware for the built-in Slack hosts and any custom base_url
-        # host — a self-hosted endpoint is typically the reason a proxy must
-        # be bypassed in the first place.
-        _proxy = _resolve_slack_proxy_url(base_url)
+        # NO_PROXY-aware for the endpoint this call targets, same as the DM
+        # leg in tools/send_message_tool.py. Not _resolve_slack_proxy_url:
+        # that one drops non-http(s) proxies for the Slack SDK, while aiohttp
+        # supports SOCKS.
+        _proxy = resolve_proxy_url(target_hosts=_slack_endpoint_bypass_hosts(base_url))
         _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
         url = (base_url or _DEFAULT_SLACK_BASE_URL) + "conversations.open"
         headers = {
@@ -9383,8 +9400,7 @@ async def _standalone_send(
     token = tokens[0]
 
     # base_url from PlatformConfig.extra (config.yaml), matching the in-process
-    # adapter. Resolved once here so every leg of this send — DM resolution,
-    # the media client, the text post — talks to the same endpoint.
+    # adapter. Resolved once so every leg below talks to the same endpoint.
     _extra = getattr(pconfig, "extra", None) or {}
     _base_url = _normalize_slack_base_url(_extra.get("base_url"))
 
@@ -9446,7 +9462,13 @@ async def _standalone_send(
 
         client = _AsyncWebClient(token=token)
         _apply_slack_base_url(client, _base_url)
-        _apply_slack_proxy(client, _resolve_slack_proxy_url(_base_url))
+        # One proxy decision per client, taken against the endpoint host —
+        # same rule as the text-only leg below. files_upload_v2 then posts the
+        # bytes to whatever upload URL the endpoint hands out (files.slack.com
+        # unless it rewrites them), reusing that decision.
+        _apply_slack_proxy(
+            client, _resolve_slack_proxy_url(_slack_endpoint_bypass_hosts(_base_url))
+        )
         last_message_id = None
 
         # Caption mode: skip a separate text post; comment rides the upload.
@@ -9554,8 +9576,8 @@ async def _standalone_send(
     try:
         from gateway.platforms.base import proxy_kwargs_for_aiohttp
 
-        # NO_PROXY-aware for the built-in Slack hosts and any custom base_url host.
-        _proxy = resolve_proxy_url(target_hosts=_slack_proxy_bypass_hosts(_base_url))
+        # NO_PROXY-aware for the endpoint this call targets.
+        _proxy = resolve_proxy_url(target_hosts=_slack_endpoint_bypass_hosts(_base_url))
         _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
         url = (_base_url or _DEFAULT_SLACK_BASE_URL) + "chat.postMessage"
         # Errors that mean "wrong workspace token for this channel" — worth

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -824,13 +824,12 @@ def _slack_url_origin(url: Optional[str]) -> Optional[Tuple[str, str, int]]:
 
 
 def _slack_trusted_origin_label(base_url: Optional[str]) -> Optional[str]:
-    """Render the trusted origin of *base_url* as ``scheme://host[:port]``.
+    """Render the origin of *base_url* as ``scheme://host[:port]``.
 
-    Used in refusal messages so an operator can see *which* origin is trusted:
-    the trust is exact-origin, so a relay that serves files from a sibling host
-    (mirroring ``slack.com`` vs ``files.slack.com``) is refused, and without
-    the origin in the message that failure is indistinguishable from a genuine
-    SSRF block. ``None`` when no usable custom base URL is configured.
+    Used in refusal messages so an operator can see which endpoint is
+    trusted; without it, a URL that simply sits outside the configured
+    endpoint is indistinguishable from a genuine SSRF block. ``None`` when no
+    usable custom base URL is configured.
     """
     origin = _slack_url_origin(base_url)
     if origin is None:
@@ -842,18 +841,18 @@ def _slack_trusted_origin_label(base_url: Optional[str]) -> Optional[str]:
 
 
 def _slack_trust_hint(base_url: Optional[str]) -> str:
-    """Trailing clause naming the trusted origins for a refusal message."""
+    """Trailing clause naming the trusted endpoint for a refusal message."""
     trusted = _slack_trusted_origin_label(base_url)
     if not trusted:
         return ""
     return (
-        f" (trusted: the Slack CDN, plus exactly {trusted} from slack.base_url "
-        "— scheme, host and port must all match, sibling hosts are not covered)"
+        f" (trusted: the Slack CDN, plus {trusted} and hosts below it from "
+        "slack.base_url — scheme and port must match too)"
     )
 
 
-def _is_slack_base_url_origin(url: str, base_url: Optional[str]) -> bool:
-    """Return True when *url* lives on the configured custom Slack origin.
+def _is_slack_base_url_trusted(url: str, base_url: Optional[str]) -> bool:
+    """Return True when *url* lives on the configured custom Slack endpoint.
 
     ``url_private`` / ``url_private_download`` values are minted by whatever
     Slack endpoint the workspace actually talks to. With a custom
@@ -862,26 +861,40 @@ def _is_slack_base_url_origin(url: str, base_url: Optional[str]) -> bool:
     download guards have to trust it — the same trust ``_apply_slack_base_url``
     already grants it for every Web API call.
 
-    Origin equality (scheme + host + port) is the whole test: it cannot be
-    steered by a forged file object, because the origin comes from local
+    Trust covers the configured host *and hosts below it*, on the same scheme
+    and port. Slack itself splits the Web API (``slack.com``) from file
+    content (``files.slack.com``), so a Slack-compatible deployment mirrors
+    that split under its own host and hands out file links on a subdomain of
+    ``base_url``; this is the same shape as the Slack-CDN allowlist
+    (``slack.com`` plus ``*.slack.com``). It cannot be steered by a forged
+    file object, because the host everything is anchored to comes from local
     config. With no ``base_url`` configured this always returns False, leaving
     the Slack-CDN allowlist as the only trust source.
+
+    Callers check the CDN allowlist first: a ``base_url`` on Slack itself
+    must not turn CDN links into "configured" ones, which would cost them
+    ``is_safe_url`` and the DNS-pinned client.
     """
     origin = _slack_url_origin(base_url)
-    return origin is not None and _slack_url_origin(url) == origin
+    target = _slack_url_origin(url)
+    if origin is None or target is None:
+        return False
+    scheme, host, port = origin
+    if (target[0], target[2]) != (scheme, port):
+        return False
+    return target[1] == host or target[1].endswith("." + host)
 
 
 def _slack_base_url_redirect_guard(base_url: Optional[str]) -> Any:
-    """Build a redirect guard that pins every hop to the custom Slack origin.
+    """Build a redirect guard that pins every hop to the custom Slack endpoint.
 
-    A custom endpoint may legitimately 3xx inside its own origin (auth
-    handoff, path rewrite), so those hops pass. Anything that leaves the
-    origin is refused outright rather than deferred to the generic
-    private-IP guard: this client is a plain ``httpx.AsyncClient`` (the
-    DNS-pinned one cannot dial a relay on a private address), so an
-    off-origin hop would be validated by hostname only and reopen the
-    DNS-rebinding window between the check and the TCP connect — with the
-    bot token attached.
+    A custom endpoint may legitimately 3xx within itself (auth handoff, path
+    rewrite, API host to file host), so those hops pass. Anything that leaves
+    it is refused outright rather than deferred to the generic private-IP
+    guard: this client is a plain ``httpx.AsyncClient`` (the DNS-pinned one
+    cannot dial a relay on a private address), so such a hop would be
+    validated by hostname only and reopen the DNS-rebinding window between the
+    check and the TCP connect — with the bot token attached.
     """
     from gateway.platforms.base import safe_url_for_log
 
@@ -889,10 +902,10 @@ def _slack_base_url_redirect_guard(base_url: Optional[str]) -> Any:
         from tools.url_safety import redirect_target_from_response
 
         target = redirect_target_from_response(response)
-        if target and not _is_slack_base_url_origin(target, base_url):
+        if target and not _is_slack_base_url_trusted(target, base_url):
             raise ValueError(
                 "Blocked Slack file redirect off the configured base_url "
-                f"origin {_slack_trusted_origin_label(base_url)}: "
+                f"endpoint {_slack_trusted_origin_label(base_url)}: "
                 f"{safe_url_for_log(target)}"
             )
 
@@ -8789,22 +8802,30 @@ class SlackAdapter(BasePlatformAdapter):
 
         Two trust paths:
 
-        * Slack CDN (the default): pre-flight ``is_safe_url`` + CDN allowlist +
-          a DNS-pinned client, unchanged from upstream.
-        * The configured custom ``slack.base_url`` origin: the private-IP
-          checks are skipped for that origin only, because a self-hosted relay
-          legitimately lives on localhost / an internal address. In exchange
-          the client is origin-pinned — every redirect that leaves the trusted
-          origin is refused, so the token never follows a hop we cannot vet.
+        * Slack CDN — checked first, so a ``base_url`` on Slack itself never
+          weakens it: pre-flight ``is_safe_url`` + CDN allowlist + a
+          DNS-pinned client.
+        * A custom (non-Slack) ``slack.base_url`` endpoint — its host and
+          hosts below it: the private-IP checks are skipped there only,
+          because a self-hosted relay legitimately lives on localhost / an
+          internal address. In exchange the client is pinned to that endpoint
+          — every redirect that leaves it is refused, so the token never
+          follows a hop we cannot vet.
         """
         import httpx
         from gateway.platforms.base import _ssrf_redirect_guard, safe_url_for_log
         from tools.url_safety import create_ssrf_safe_async_client, is_safe_url
 
         base_url = self._resolve_slack_base_url()
-        if _is_slack_base_url_origin(url, base_url):
+        # CDN first: a base_url on Slack itself (``https://slack.com/api/``,
+        # or an Enterprise ``*.slack.com`` endpoint) would otherwise make
+        # every real CDN link "configured", dropping is_safe_url and the
+        # DNS-pinned client for downloads that never needed either.
+        if not self._is_slack_cdn_url(url) and _is_slack_base_url_trusted(
+            url, base_url
+        ):
             logger.debug(
-                "[Slack] Trusting file URL on the configured base_url origin: %s",
+                "[Slack] Trusting file URL on the configured base_url endpoint: %s",
                 safe_url_for_log(url),
             )
             return httpx.AsyncClient(

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -19,6 +19,7 @@ import time
 import unicodedata
 from dataclasses import dataclass, field
 from typing import Callable, ClassVar, Dict, Optional, Any, Tuple, List
+from urllib.parse import urlsplit
 
 import aiohttp
 
@@ -745,6 +746,54 @@ async def _cancel_socket_tasks(tasks: Any) -> None:
         )
 
 
+# Default Slack Web API base URL used by ``slack_sdk`` (AsyncWebClient.BASE_URL).
+_DEFAULT_SLACK_BASE_URL = "https://slack.com/api/"
+
+
+def _normalize_slack_base_url(raw: Optional[str]) -> Optional[str]:
+    """Normalize a custom Slack Web API base URL.
+
+    Returns ``None`` when unset/blank so callers fall back to the slack_sdk
+    default (``https://slack.com/api/``). A trailing slash is enforced because
+    ``slack_sdk`` joins ``base_url`` with the API method via ``urljoin`` — a
+    missing slash would drop the final path segment (``.../api`` +
+    ``chat.postMessage`` -> ``.../chat.postMessage``).
+    """
+    if not raw:
+        return None
+    value = str(raw).strip()
+    if not value:
+        return None
+    if not value.endswith("/"):
+        value += "/"
+    return value
+
+
+def _slack_base_url_host(base_url: Optional[str]) -> Optional[str]:
+    """Extract the lowercase hostname from a Slack base URL for NO_PROXY checks."""
+    if not base_url:
+        return None
+    try:
+        host = urlsplit(str(base_url)).hostname
+    except Exception:
+        return None
+    if not host:
+        return None
+    return host.strip().lower() or None
+
+
+def _apply_slack_base_url(client: Any, base_url: Optional[str]) -> None:
+    """Point a Slack SDK client at a custom Web API base URL when configured.
+
+    Set post-construction (like ``_apply_slack_proxy``) because ``slack_sdk``
+    reads ``client.base_url`` at call time in ``api_call()`` — so overriding it
+    after the client is built is respected on every request. A ``None``/blank
+    ``base_url`` leaves the slack_sdk default untouched.
+    """
+    if base_url and hasattr(client, "base_url"):
+        client.base_url = base_url
+
+
 _SLACK_PROXY_HOSTS = (
     "slack.com",
     "files.slack.com",
@@ -752,8 +801,26 @@ _SLACK_PROXY_HOSTS = (
 )
 
 
-def _resolve_slack_proxy_url() -> Optional[str]:
-    """Resolve a proxy URL that Slack SDK clients can safely use."""
+def _slack_proxy_bypass_hosts(base_url: Optional[str] = None) -> Tuple[str, ...]:
+    """Return the hosts checked against NO_PROXY for Slack.
+
+    Always includes the built-in Slack hosts; when a custom ``base_url`` is
+    configured its host is appended so ``NO_PROXY=<custom-host>`` disables the
+    proxy for a self-hosted / mock Slack endpoint too (the built-in list alone
+    only covers the real ``slack.com`` hosts).
+    """
+    custom_host = _slack_base_url_host(base_url)
+    if custom_host and custom_host not in _SLACK_PROXY_HOSTS:
+        return _SLACK_PROXY_HOSTS + (custom_host,)
+    return _SLACK_PROXY_HOSTS
+
+
+def _resolve_slack_proxy_url(base_url: Optional[str] = None) -> Optional[str]:
+    """Resolve a proxy URL that Slack SDK clients can safely use.
+
+    When ``base_url`` points at a custom Slack endpoint, its host participates
+    in the NO_PROXY bypass check alongside the built-in Slack hosts.
+    """
     proxy_url = resolve_proxy_url()
     if not proxy_url:
         return None
@@ -766,7 +833,10 @@ def _resolve_slack_proxy_url() -> Optional[str]:
         )
         return None
 
-    if any(is_host_excluded_by_no_proxy(host) for host in _SLACK_PROXY_HOSTS):
+    if any(
+        is_host_excluded_by_no_proxy(host)
+        for host in _slack_proxy_bypass_hosts(base_url)
+    ):
         logger.info("[Slack] NO_PROXY bypasses Slack proxy configuration")
         return None
 
@@ -1077,6 +1147,7 @@ class SlackAdapter(BasePlatformAdapter):
         # self-heal when Slack silently drops the websocket.
         self._app_token: Optional[str] = None
         self._proxy_url: Optional[str] = None
+        self._base_url: Optional[str] = None
         self._socket_watchdog_task: Optional[asyncio.Task] = None
         self._socket_reconnect_lock = asyncio.Lock()
         self._socket_watchdog_interval_s = 15.0
@@ -1807,6 +1878,18 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception:  # pragma: no cover - diagnostics must never break connect
             pass
 
+    def _resolve_slack_base_url(self) -> Optional[str]:
+        """Return the custom Slack Web API base URL, or ``None`` for the default.
+
+        Read from ``PlatformConfig.extra['base_url']`` (populated from
+        ``config.yaml``). ``None`` keeps the slack_sdk default
+        (``https://slack.com/api/``).
+        """
+        raw = None
+        if self.config.extra:
+            raw = self.config.extra.get("base_url")
+        return _normalize_slack_base_url(raw)
+
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Connect to Slack via Socket Mode."""
         if not SLACK_AVAILABLE:
@@ -1860,7 +1943,14 @@ class SlackAdapter(BasePlatformAdapter):
             )
             return False
 
-        proxy_url = _resolve_slack_proxy_url()
+        base_url = self._resolve_slack_base_url()
+        if base_url:
+            logger.info(
+                "[Slack] Using custom Slack API base URL: %s",
+                safe_url_for_log(base_url),
+            )
+
+        proxy_url = _resolve_slack_proxy_url(base_url)
         if proxy_url:
             logger.info(
                 "[Slack] Using proxy for Slack transport: %s",
@@ -1938,6 +2028,7 @@ class SlackAdapter(BasePlatformAdapter):
             self._app = None
             self._app_token = app_token
             self._proxy_url = proxy_url
+            self._base_url = base_url
 
             # Reset multi-workspace state before re-populating it so a
             # reconnect that drops a workspace (or rotates the primary bot
@@ -1957,6 +2048,7 @@ class SlackAdapter(BasePlatformAdapter):
             )
             self._app = AsyncApp(token=primary_token, client=primary_client)
             _apply_slack_proxy(self._app.client, proxy_url)
+            _apply_slack_base_url(self._app.client, base_url)
 
             # Register each bot token and map team_id → client
             for token in bot_tokens:
@@ -1965,6 +2057,7 @@ class SlackAdapter(BasePlatformAdapter):
                     user_agent_prefix=_HERMES_SLACK_USER_AGENT_PREFIX,
                 )
                 _apply_slack_proxy(client, proxy_url)
+                _apply_slack_base_url(client, base_url)
                 auth_response = await client.auth_test()
                 team_id = auth_response.get("team_id", "")
                 bot_user_id = auth_response.get("user_id", "")
@@ -9321,9 +9414,14 @@ async def _standalone_send(
     try:
         from gateway.platforms.base import proxy_kwargs_for_aiohttp
 
-        _proxy = resolve_proxy_url()
+        _extra = getattr(pconfig, "extra", None) or {}
+        # base_url from PlatformConfig.extra (config.yaml), matching the
+        # in-process adapter.
+        _base_url = _normalize_slack_base_url(_extra.get("base_url"))
+        # NO_PROXY-aware for the built-in Slack hosts and any custom base_url host.
+        _proxy = resolve_proxy_url(target_hosts=_slack_proxy_bypass_hosts(_base_url))
         _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
-        url = "https://slack.com/api/chat.postMessage"
+        url = (_base_url or _DEFAULT_SLACK_BASE_URL) + "chat.postMessage"
         # Errors that mean "wrong workspace token for this channel" — worth
         # retrying with the next token. Anything else is terminal.
         retryable_token_errors = {
@@ -9491,14 +9589,17 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
     legacy ``slack_cfg`` block that used to live in
     ``gateway/config.py::load_gateway_config()`` before this migration.
 
-    The SlackAdapter reads its runtime configuration via ``os.getenv()``
-    throughout the connect / handle code paths, so rather than rewrite those
-    call sites to read from ``PlatformConfig.extra``, this hook keeps the
-    existing env-driven model and owns the YAML→env translation here, next to
-    the adapter that consumes it. Env vars take precedence over YAML — every
-    assignment is guarded by ``not os.getenv(...)`` so explicit env vars
-    survive a config.yaml update. Returns ``None`` because no extras are
-    seeded into ``PlatformConfig.extra`` directly (everything flows through env).
+    The SlackAdapter reads most of its runtime configuration via
+    ``os.getenv()`` throughout the connect / handle code paths, so rather than
+    rewrite those call sites to read from ``PlatformConfig.extra``, this hook
+    keeps the existing env-driven model and owns the YAML→env translation here,
+    next to the adapter that consumes it. Env vars take precedence over YAML —
+    every assignment is guarded by ``not os.getenv(...)`` so explicit env vars
+    survive a config.yaml update.
+
+    ``base_url`` is the exception: instead of an env var it is returned in the
+    extras dict, which the loader merges into ``PlatformConfig.extra`` for the
+    adapter to read.
     """
     if "require_mention" in slack_cfg and not os.getenv("SLACK_REQUIRE_MENTION"):
         os.environ["SLACK_REQUIRE_MENTION"] = str(slack_cfg["require_mention"]).lower()
@@ -9550,7 +9651,16 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
         if isinstance(ic, list):
             ic = ",".join(str(v) for v in ic)
         os.environ["SLACK_IGNORED_CHANNELS"] = str(ic)
-    return None  # all settings flow through env; nothing to merge into extras
+    # base_url (custom / self-hosted Slack endpoint) is behavioral config, so it
+    # lives in config.yaml, not .env. Return it in extras (merged into
+    # PlatformConfig.extra) — the adapter reads it from there, not an env var.
+    extras: dict = {}
+    bu = slack_cfg.get("base_url")
+    if bu is not None:
+        bu = str(bu).strip()
+        if bu:
+            extras["base_url"] = bu
+    return extras or None
 
 
 def _is_connected(config) -> bool:
@@ -9589,9 +9699,10 @@ def register(ctx) -> None:
         # keys (require_mention, strict_mention, ignore_other_user_mentions,
         # thread_require_mention, allow_bots, free_response_channels,
         # reactions, disable_dms, allowed_channels, ignored_channels) into
-        # SLACK_* env vars that
-        # the adapter reads via os.getenv(). Replaces the
-        # hardcoded block in gateway/config.py. Hook contract: #24849.
+        # SLACK_* env vars that the adapter reads via os.getenv(). The one
+        # non-env key, base_url, is returned in extras and merged into
+        # PlatformConfig.extra. Replaces the hardcoded block in
+        # gateway/config.py. Hook contract: #24849.
         apply_yaml_config_fn=_apply_yaml_config,
         # Auth env vars for _is_user_authorized() integration
         allowed_users_env="SLACK_ALLOWED_USERS",

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -9104,15 +9104,22 @@ def _trim_slack_dm_cache() -> None:
         _slack_dm_cache.pop(next(iter(_slack_dm_cache)))
 
 
-async def _resolve_slack_user_dm(token: str, user_id: str) -> Optional[str]:
+async def _resolve_slack_user_dm(
+    token: str, user_id: str, base_url: Optional[str] = None
+) -> Optional[str]:
     """Resolve a Slack user ID (U.../W...) to a DM conversation ID (D...).
 
     ``chat.postMessage`` and ``files_upload_v2`` require a conversation ID; a
     DM must be opened first via ``conversations.open``.  Results are cached
-    per (token, user_id) pair to avoid redundant API calls.  Returns None if
-    resolution fails (missing ``im:write`` scope, unknown user, etc.).
+    per (base_url, token, user_id) triple to avoid redundant API calls — the
+    endpoint is part of the key because a custom Slack-compatible backend
+    hands out its own conversation IDs.  Returns None if resolution fails
+    (missing ``im:write`` scope, unknown user, etc.).
+
+    ``base_url`` must already be normalized (trailing slash) — see
+    ``_normalize_slack_base_url``. ``None`` means the real Slack endpoint.
     """
-    cache_key = f"{token}:{user_id}"
+    cache_key = f"{base_url or _DEFAULT_SLACK_BASE_URL}|{token}:{user_id}"
     if cache_key in _slack_dm_cache:
         return _slack_dm_cache[cache_key]
 
@@ -9123,9 +9130,12 @@ async def _resolve_slack_user_dm(token: str, user_id: str) -> Optional[str]:
     try:
         from gateway.platforms.base import proxy_kwargs_for_aiohttp
 
-        _proxy = resolve_proxy_url()
+        # NO_PROXY-aware for the built-in Slack hosts and any custom base_url
+        # host — a self-hosted endpoint is typically the reason a proxy must
+        # be bypassed in the first place.
+        _proxy = _resolve_slack_proxy_url(base_url)
         _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
-        url = "https://slack.com/api/conversations.open"
+        url = (base_url or _DEFAULT_SLACK_BASE_URL) + "conversations.open"
         headers = {
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
@@ -9249,6 +9259,12 @@ async def _standalone_send(
         return {"error": "Slack send failed: SLACK_BOT_TOKEN not configured"}
     token = tokens[0]
 
+    # base_url from PlatformConfig.extra (config.yaml), matching the in-process
+    # adapter. Resolved once here so every leg of this send — DM resolution,
+    # the media client, the text post — talks to the same endpoint.
+    _extra = getattr(pconfig, "extra", None) or {}
+    _base_url = _normalize_slack_base_url(_extra.get("base_url"))
+
     # User-targeted delivery: chat.postMessage / files_upload_v2 reject bare
     # user IDs (U.../W...) — resolve to a DM conversation ID (D...) first via
     # conversations.open so `deliver=slack:U…` cron jobs reach the user's DM
@@ -9257,7 +9273,7 @@ async def _standalone_send(
     if chat_id[:1] in ("U", "W"):
         resolved = None
         for _tok in tokens:
-            resolved = await _resolve_slack_user_dm(_tok, chat_id)
+            resolved = await _resolve_slack_user_dm(_tok, chat_id, _base_url)
             if resolved is not None:
                 token = _tok
                 break
@@ -9306,7 +9322,8 @@ async def _standalone_send(
             }
 
         client = _AsyncWebClient(token=token)
-        _apply_slack_proxy(client, resolve_proxy_url())
+        _apply_slack_base_url(client, _base_url)
+        _apply_slack_proxy(client, _resolve_slack_proxy_url(_base_url))
         last_message_id = None
 
         # Caption mode: skip a separate text post; comment rides the upload.
@@ -9414,10 +9431,6 @@ async def _standalone_send(
     try:
         from gateway.platforms.base import proxy_kwargs_for_aiohttp
 
-        _extra = getattr(pconfig, "extra", None) or {}
-        # base_url from PlatformConfig.extra (config.yaml), matching the
-        # in-process adapter.
-        _base_url = _normalize_slack_base_url(_extra.get("base_url"))
         # NO_PROXY-aware for the built-in Slack hosts and any custom base_url host.
         _proxy = resolve_proxy_url(target_hosts=_slack_proxy_bypass_hosts(_base_url))
         _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -371,6 +371,34 @@ class TestLoadGatewayConfig:
             config.platforms[Platform.SLACK].typing_status_text == "chasing yarn…"
         )
 
+    def test_bridges_slack_base_url_from_config_yaml(self, tmp_path, monkeypatch):
+        """config.yaml ``slack.base_url`` propagates into
+        ``PlatformConfig.extra['base_url']`` through the plugin's
+        apply_yaml_config hook (not an env var).
+
+        Exercises the real loader -> registry dispatch -> _apply_yaml_config
+        chain (no mocks), so the full config-propagation path is covered.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "slack:\n  base_url: https://slack.internal.corp/api\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        with patch.dict(os.environ, clear=False):
+            os.environ.pop("SLACK_BASE_URL", None)
+            config = load_gateway_config()
+            # Seeded into PlatformConfig.extra, NOT bridged to an env var.
+            assert Platform.SLACK in config.platforms
+            assert (
+                config.platforms[Platform.SLACK].extra.get("base_url")
+                == "https://slack.internal.corp/api"
+            )
+            assert os.environ.get("SLACK_BASE_URL") is None
+
     def test_multiplex_profiles_from_nested_gateway_section(self, tmp_path, monkeypatch):
         """``gateway.multiplex_profiles: true`` (the nested form written by
         ``hermes config set gateway.multiplex_profiles true``) must enable

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1127,6 +1127,282 @@ class TestStandaloneSendUserDmResolution:
 
 
 # ---------------------------------------------------------------------------
+# TestSlackBaseUrl
+# ---------------------------------------------------------------------------
+
+
+class TestSlackBaseUrl:
+    """Custom Slack Web API base URL + its NO_PROXY interaction."""
+
+    def test_normalize_slack_base_url(self):
+        assert _slack_mod._normalize_slack_base_url(None) is None
+        assert _slack_mod._normalize_slack_base_url("") is None
+        assert _slack_mod._normalize_slack_base_url("   ") is None
+        # Trailing slash is enforced (slack_sdk urljoin needs it).
+        assert (
+            _slack_mod._normalize_slack_base_url("https://slack.internal.corp/api")
+            == "https://slack.internal.corp/api/"
+        )
+        assert (
+            _slack_mod._normalize_slack_base_url("https://slack.internal.corp/api/")
+            == "https://slack.internal.corp/api/"
+        )
+        assert _slack_mod._normalize_slack_base_url("  https://x/api  ") == "https://x/api/"
+
+    def test_slack_base_url_host(self):
+        assert _slack_mod._slack_base_url_host(None) is None
+        assert _slack_mod._slack_base_url_host("") is None
+        assert (
+            _slack_mod._slack_base_url_host("https://slack.internal.corp/api/")
+            == "slack.internal.corp"
+        )
+        # Host is lowercased and the port is dropped.
+        assert (
+            _slack_mod._slack_base_url_host("https://SLACK.INTERNAL.CORP:8443/api/")
+            == "slack.internal.corp"
+        )
+
+    def test_slack_proxy_bypass_hosts_appends_custom_host(self):
+        assert _slack_mod._slack_proxy_bypass_hosts() == _slack_mod._SLACK_PROXY_HOSTS
+        assert _slack_mod._slack_proxy_bypass_hosts(None) == _slack_mod._SLACK_PROXY_HOSTS
+        hosts = _slack_mod._slack_proxy_bypass_hosts("https://slack.internal.corp/api/")
+        assert "slack.internal.corp" in hosts
+        assert set(_slack_mod._SLACK_PROXY_HOSTS).issubset(set(hosts))
+        # A base_url that resolves to a built-in host is not duplicated.
+        assert (
+            _slack_mod._slack_proxy_bypass_hosts("https://slack.com/api/")
+            == _slack_mod._SLACK_PROXY_HOSTS
+        )
+
+    def test_apply_slack_base_url_sets_client_base_url(self):
+        class _Client:
+            base_url = "https://slack.com/api/"
+
+        client = _Client()
+        _slack_mod._apply_slack_base_url(client, "https://slack.internal.corp/api/")
+        assert client.base_url == "https://slack.internal.corp/api/"
+        # None leaves the current base_url untouched (never clears it).
+        _slack_mod._apply_slack_base_url(client, None)
+        assert client.base_url == "https://slack.internal.corp/api/"
+
+    def test_resolve_slack_proxy_url_bypasses_custom_base_url_host(self):
+        with (
+            patch.object(
+                _slack_mod,
+                "resolve_proxy_url",
+                return_value="http://proxy.example.com:3128",
+            ),
+            patch.object(
+                _slack_mod,
+                "is_host_excluded_by_no_proxy",
+                side_effect=lambda host: host == "slack.internal.corp",
+            ) as excluded,
+        ):
+            assert (
+                _slack_mod._resolve_slack_proxy_url("https://slack.internal.corp/api/")
+                is None
+            )
+            excluded.assert_any_call("slack.internal.corp")
+
+    def test_resolve_slack_proxy_url_keeps_proxy_when_custom_host_not_bypassed(self):
+        with (
+            patch.object(
+                _slack_mod,
+                "resolve_proxy_url",
+                return_value="http://proxy.example.com:3128",
+            ),
+            patch.object(
+                _slack_mod, "is_host_excluded_by_no_proxy", return_value=False
+            ),
+        ):
+            assert (
+                _slack_mod._resolve_slack_proxy_url("https://slack.internal.corp/api/")
+                == "http://proxy.example.com:3128"
+            )
+
+    def test_resolve_slack_base_url_reads_from_extra(self):
+        # Read from PlatformConfig.extra (config.yaml -> extra), normalized.
+        cfg = PlatformConfig(
+            enabled=True,
+            token="xoxb-x",
+            extra={"base_url": "https://from-extra/api"},
+        )
+        adapter = SlackAdapter(cfg)
+        assert adapter._resolve_slack_base_url() == "https://from-extra/api/"
+
+        # No base_url in extra -> None (slack_sdk default); a stray
+        # SLACK_BASE_URL env var is ignored.
+        adapter2 = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-x", extra={}))
+        assert adapter2._resolve_slack_base_url() is None
+        with patch.dict(os.environ, {"SLACK_BASE_URL": "https://from-env/api"}, clear=False):
+            assert adapter2._resolve_slack_base_url() is None
+
+    def test_apply_yaml_config_seeds_base_url_into_extra(self):
+        # base_url is returned as an extra (merged into PlatformConfig.extra by
+        # the loader), not set as an env var.
+        with patch.dict(os.environ, clear=False):
+            os.environ.pop("SLACK_BASE_URL", None)
+            result = _slack_mod._apply_yaml_config(
+                {"slack": {"base_url": "https://slack.internal.corp/api"}},
+                {"base_url": "https://slack.internal.corp/api"},
+            )
+            assert result == {"base_url": "https://slack.internal.corp/api"}
+            # The hook sets no env var.
+            assert os.environ.get("SLACK_BASE_URL") is None
+
+    def test_apply_yaml_config_without_base_url_returns_none(self):
+        # No base_url key -> nothing seeded (None); a blank value is unset too.
+        with patch.dict(os.environ, clear=False):
+            os.environ.pop("SLACK_BASE_URL", None)
+            assert _slack_mod._apply_yaml_config({"slack": {}}, {}) is None
+            assert (
+                _slack_mod._apply_yaml_config(
+                    {"slack": {"base_url": "   "}}, {"base_url": "   "}
+                )
+                is None
+            )
+            assert os.environ.get("SLACK_BASE_URL") is None
+
+    @pytest.mark.asyncio
+    async def test_connect_applies_custom_base_url_to_clients(self):
+        created_apps = []
+        created_clients = []
+
+        class FakeWebClient:
+            def __init__(self, token, user_agent_prefix=None):
+                self.token = token
+                self.proxy = None
+                self.base_url = "https://slack.com/api/"
+                suffix = token.split("-")[-1]
+                self.auth_test = AsyncMock(
+                    return_value={
+                        "team_id": f"T_{suffix}",
+                        "user_id": f"U_{suffix}",
+                        "user": f"bot-{suffix}",
+                        "team": f"Team {suffix}",
+                    }
+                )
+                created_clients.append(self)
+
+        class FakeApp:
+            def __init__(self, token, client=None):
+                self.token = token
+                self.client = client if client is not None else FakeWebClient(token)
+                created_apps.append(self)
+
+            def event(self, event_type):
+                def decorator(fn):
+                    return fn
+
+                return decorator
+
+            def command(self, command_name):
+                def decorator(fn):
+                    return fn
+
+                return decorator
+
+            def action(self, action_id):
+                def decorator(fn):
+                    return fn
+
+                return decorator
+
+        class FakeSocketModeHandler:
+            def __init__(self, app, app_token, proxy=None):
+                self.app = app
+                self.app_token = app_token
+                self.proxy = proxy
+                self.client = MagicMock()
+
+            async def start_async(self):
+                return None
+
+            async def close_async(self):
+                return None
+
+        # base_url without a trailing slash → normalized end-to-end.
+        config = PlatformConfig(
+            enabled=True,
+            token="xoxb-primary,xoxb-secondary",
+            extra={"base_url": "https://slack.internal.corp/api"},
+        )
+        adapter = SlackAdapter(config)
+
+        with (
+            patch.object(_slack_mod, "AsyncApp", side_effect=FakeApp),
+            patch.object(_slack_mod, "AsyncWebClient", side_effect=FakeWebClient),
+            patch.object(_slack_mod, "AsyncSocketModeHandler", FakeSocketModeHandler),
+            patch.object(_slack_mod, "_resolve_slack_proxy_url", return_value=None),
+            patch.dict(os.environ, {"SLACK_APP_TOKEN": "xapp-fake"}, clear=False),
+            patch("gateway.status.acquire_scoped_lock", return_value=(True, None)),
+            patch("asyncio.create_task", side_effect=_fake_create_task),
+        ):
+            result = await adapter.connect()
+
+        assert result is True
+        assert created_apps[0].client.base_url == "https://slack.internal.corp/api/"
+        assert all(
+            client.base_url == "https://slack.internal.corp/api/"
+            for client in created_clients
+        )
+        assert adapter._base_url == "https://slack.internal.corp/api/"
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_uses_custom_base_url(self, monkeypatch):
+        from types import SimpleNamespace
+
+        class _Resp:
+            status = 200
+
+            async def json(self):
+                return {"ok": True, "ts": "1699999999.000100"}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return None
+
+        class _Session:
+            def __init__(self):
+                self.calls = []
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return None
+
+            def post(self, url, **kwargs):
+                self.calls.append((url, kwargs))
+                return _Resp()
+
+        session = _Session()
+        fake_aiohttp = SimpleNamespace(
+            ClientSession=lambda timeout=None, **kw: session,
+            ClientTimeout=lambda total=None: None,
+        )
+        monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)
+        # No proxy so the request kwargs stay empty and deterministic.
+        monkeypatch.setattr(
+            "gateway.platforms.base.resolve_proxy_url", lambda *a, **kw: None
+        )
+
+        cfg = PlatformConfig(
+            enabled=True,
+            token="xoxb-tok",
+            extra={"base_url": "https://slack.internal.corp/api"},
+        )
+        result = await _slack_mod._standalone_send(cfg, "C123", "hello cron")
+
+        assert result.get("success") is True
+        assert len(session.calls) == 1
+        url, _kwargs = session.calls[0]
+        assert url == "https://slack.internal.corp/api/chat.postMessage"
+
+
+# ---------------------------------------------------------------------------
 # TestSendDocument
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1403,6 +1403,188 @@ class TestSlackBaseUrl:
 
 
 # ---------------------------------------------------------------------------
+# TestSlackBaseUrlDeliveryLegs
+# ---------------------------------------------------------------------------
+
+
+class TestSlackBaseUrlDeliveryLegs:
+    """Every leg of a standalone send must honor the custom endpoint.
+
+    Review on #73433: the text post was routed correctly while user-DM
+    resolution still hardcoded slack.com and the media client was built
+    without a base URL — so `deliver=slack:U…` and MEDIA attachments leaked
+    to the real Slack while everything else went to the private endpoint.
+    """
+
+    BASE = "https://slack.internal.corp/api"
+    NORMALIZED = "https://slack.internal.corp/api/"
+
+    @staticmethod
+    def _mock_resp(payload):
+        resp = MagicMock()
+        resp.status = 200
+        resp.json = AsyncMock(return_value=payload)
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=None)
+        return resp
+
+    def _mock_session(self, *responses):
+        session = MagicMock()
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=None)
+        session.post = MagicMock(side_effect=list(responses))
+        return session
+
+    def _config(self):
+        return PlatformConfig(
+            enabled=True, token="xoxb-tok", extra={"base_url": self.BASE}
+        )
+
+    @pytest.mark.asyncio
+    async def test_user_dm_resolution_hits_the_custom_endpoint(self):
+        _slack_mod._slack_dm_cache.clear()
+        session = self._mock_session(
+            self._mock_resp({"ok": True, "channel": {"id": "D999"}}),
+            self._mock_resp({"ok": True, "ts": "1.1"}),
+        )
+        with (
+            patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session),
+            patch.object(_slack_mod, "resolve_proxy_url", return_value=None),
+        ):
+            result = await _slack_mod._standalone_send(
+                self._config(), "U1234567890", "hello"
+            )
+
+        assert result["success"] is True
+        assert result["chat_id"] == "D999"
+        assert (
+            session.post.call_args_list[0].args[0]
+            == self.NORMALIZED + "conversations.open"
+        )
+        assert (
+            session.post.call_args_list[1].args[0]
+            == self.NORMALIZED + "chat.postMessage"
+        )
+        _slack_mod._slack_dm_cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_dm_cache_is_scoped_to_the_endpoint(self):
+        """Two endpoints hand out their own conversation IDs for one user."""
+        _slack_mod._slack_dm_cache.clear()
+        custom = self._mock_session(self._mock_resp({"ok": True, "channel": {"id": "D_CUSTOM"}}))
+        with (
+            patch.object(_slack_mod.aiohttp, "ClientSession", return_value=custom),
+            patch.object(_slack_mod, "resolve_proxy_url", return_value=None),
+        ):
+            assert (
+                await _slack_mod._resolve_slack_user_dm("tok", "U1", self.NORMALIZED)
+                == "D_CUSTOM"
+            )
+
+        default = self._mock_session(self._mock_resp({"ok": True, "channel": {"id": "D_SLACK"}}))
+        with (
+            patch.object(_slack_mod.aiohttp, "ClientSession", return_value=default),
+            patch.object(_slack_mod, "resolve_proxy_url", return_value=None),
+        ):
+            assert await _slack_mod._resolve_slack_user_dm("tok", "U1") == "D_SLACK"
+        _slack_mod._slack_dm_cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_user_dm_resolution_honors_no_proxy_for_the_custom_host(self):
+        """NO_PROXY on the private host must keep conversations.open direct."""
+        _slack_mod._slack_dm_cache.clear()
+        session = self._mock_session(
+            self._mock_resp({"ok": True, "channel": {"id": "D999"}})
+        )
+        with (
+            patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session),
+            patch.object(
+                _slack_mod, "resolve_proxy_url", return_value="http://proxy:3128"
+            ),
+            patch.object(
+                _slack_mod,
+                "is_host_excluded_by_no_proxy",
+                side_effect=lambda host: host == "slack.internal.corp",
+            ),
+        ):
+            assert (
+                await _slack_mod._resolve_slack_user_dm("tok", "U1", self.NORMALIZED)
+                == "D999"
+            )
+        assert "proxy" not in session.post.call_args.kwargs
+        _slack_mod._slack_dm_cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_user_dm_resolution_uses_the_proxy_when_not_bypassed(self):
+        """Control for the case above: without NO_PROXY the proxy still applies."""
+        _slack_mod._slack_dm_cache.clear()
+        session = self._mock_session(
+            self._mock_resp({"ok": True, "channel": {"id": "D999"}})
+        )
+        with (
+            patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session),
+            patch.object(
+                _slack_mod, "resolve_proxy_url", return_value="http://proxy:3128"
+            ),
+            patch.object(
+                _slack_mod, "is_host_excluded_by_no_proxy", return_value=False
+            ),
+        ):
+            await _slack_mod._resolve_slack_user_dm("tok", "U1", self.NORMALIZED)
+        assert session.post.call_args.kwargs.get("proxy") == "http://proxy:3128"
+        _slack_mod._slack_dm_cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_media_client_targets_the_custom_endpoint(self, tmp_path):
+        image = tmp_path / "report.png"
+        image.write_bytes(b"\x89PNG\r\n\x1a\n")
+        client = MagicMock()
+        client.base_url = "https://slack.com/api/"
+        client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "1.0"})
+        client.files_upload_v2 = AsyncMock(return_value={"ok": True, "ts": "9.9"})
+
+        with (
+            _fake_slack_sdk_modules(client),
+            patch.object(_slack_mod, "resolve_proxy_url", return_value=None),
+        ):
+            result = await _slack_mod._standalone_send(
+                self._config(),
+                "C123",
+                "daily report",
+                media_files=[(str(image), False)],
+            )
+
+        assert result["success"] is True
+        assert client.base_url == self.NORMALIZED
+
+    @pytest.mark.asyncio
+    async def test_media_client_honors_no_proxy_for_the_custom_host(self, tmp_path):
+        image = tmp_path / "report.png"
+        image.write_bytes(b"\x89PNG\r\n\x1a\n")
+        client = MagicMock()
+        client.files_upload_v2 = AsyncMock(return_value={"ok": True, "ts": "9.9"})
+
+        with (
+            _fake_slack_sdk_modules(client),
+            patch.object(
+                _slack_mod, "resolve_proxy_url", return_value="http://proxy:3128"
+            ),
+            patch.object(
+                _slack_mod,
+                "is_host_excluded_by_no_proxy",
+                side_effect=lambda host: host == "slack.internal.corp",
+            ),
+            patch.object(_slack_mod, "_apply_slack_proxy") as apply_proxy,
+        ):
+            result = await _slack_mod._standalone_send(
+                self._config(), "C123", "", media_files=[(str(image), False)]
+            )
+
+        assert result["success"] is True
+        apply_proxy.assert_called_once_with(client, None)
+
+
+# ---------------------------------------------------------------------------
 # TestSendDocument
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -100,6 +100,49 @@ _slack_mod.SLACK_AVAILABLE = True
 from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
 
 
+def _mock_resp(payload):
+    """An aiohttp response context manager that answers with ``payload``."""
+    resp = MagicMock()
+    resp.status = 200
+    resp.json = AsyncMock(return_value=payload)
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=None)
+    return resp
+
+
+def _mock_session(*responses):
+    """An aiohttp session whose posts answer ``responses`` in order."""
+    session = MagicMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+    session.post = MagicMock(side_effect=list(responses))
+    return session
+
+
+@contextlib.contextmanager
+def _captured_proxy_urls():
+    """Collect the proxy URLs handed to ``proxy_kwargs_for_aiohttp``.
+
+    That URL is the proxy decision itself; the kwargs it returns are
+    transport detail — with aiohttp-socks installed every scheme travels as
+    a ``connector`` in the session kwargs and no ``proxy`` request kwarg.
+    """
+    seen = []
+    with patch(
+        "gateway.platforms.base.proxy_kwargs_for_aiohttp",
+        side_effect=lambda url: (seen.append(url), ({}, {}))[1],
+    ):
+        yield seen
+
+
+@pytest.fixture(autouse=True)
+def _isolate_dm_cache():
+    """The DM cache is module state shared by every test in the file."""
+    _slack_mod._slack_dm_cache.clear()
+    yield
+    _slack_mod._slack_dm_cache.clear()
+
+
 def test_slack_mock_bootstrap_preserves_installed_packages():
     """Installed Slack dependencies must remain importable as real packages."""
     for package in ("slack_sdk", "aiohttp"):
@@ -844,7 +887,12 @@ class TestSlackProxyBehavior:
                 side_effect=lambda host: host == "wss-primary.slack.com",
             ) as excluded,
         ):
-            assert _slack_mod._resolve_slack_proxy_url() is None
+            assert (
+                _slack_mod._resolve_slack_proxy_url(
+                    _slack_mod._slack_proxy_bypass_hosts()
+                )
+                is None
+            )
             excluded.assert_has_calls(
                 [
                     call("slack.com"),
@@ -1061,28 +1109,10 @@ class TestStandaloneSendUserDmResolution:
     bypasses send_message()'s tool-level resolution, so the standalone
     sender must resolve on its own."""
 
-    @staticmethod
-    def _mock_resp(payload):
-        resp = MagicMock()
-        resp.status = 200
-        resp.json = AsyncMock(return_value=payload)
-        resp.__aenter__ = AsyncMock(return_value=resp)
-        resp.__aexit__ = AsyncMock(return_value=None)
-        return resp
-
-    def _mock_session(self, *responses):
-        session = MagicMock()
-        session.__aenter__ = AsyncMock(return_value=session)
-        session.__aexit__ = AsyncMock(return_value=None)
-        session.post = MagicMock(side_effect=list(responses))
-        return session
-
-
     @pytest.mark.asyncio
     async def test_channel_id_skips_resolution(self):
-        _slack_mod._slack_dm_cache.clear()
-        post_resp = self._mock_resp({"ok": True, "ts": "123.456"})
-        session = self._mock_session(post_resp)
+        post_resp = _mock_resp({"ok": True, "ts": "123.456"})
+        session = _mock_session(post_resp)
         config = PlatformConfig(enabled=True, token="xoxb-fake-token")
 
         with patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session):
@@ -1096,11 +1126,10 @@ class TestStandaloneSendUserDmResolution:
     @pytest.mark.asyncio
     async def test_user_id_media_delivery_resolves_dm_before_upload(self, tmp_path):
         """Media path composes with DM resolution: files_upload_v2 gets D…"""
-        _slack_mod._slack_dm_cache.clear()
         image = tmp_path / "report.png"
         image.write_bytes(b"\x89PNG\r\n\x1a\n")
-        open_resp = self._mock_resp({"ok": True, "channel": {"id": "D777666555"}})
-        session = self._mock_session(open_resp)
+        open_resp = _mock_resp({"ok": True, "channel": {"id": "D777666555"}})
+        session = _mock_session(open_resp)
         client = MagicMock()
         client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "1.0"})
         client.files_upload_v2 = AsyncMock(return_value={"ok": True, "ts": "9.9"})
@@ -1123,7 +1152,6 @@ class TestStandaloneSendUserDmResolution:
         assert result["chat_id"] == "D777666555"
         client.files_upload_v2.assert_awaited_once()
         assert client.files_upload_v2.await_args.kwargs["channel"] == "D777666555"
-        _slack_mod._slack_dm_cache.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -1174,6 +1202,15 @@ class TestSlackBaseUrl:
             == _slack_mod._SLACK_PROXY_HOSTS
         )
 
+    def test_slack_endpoint_bypass_hosts_is_the_endpoint_alone(self):
+        """A caller anchored to the Web API endpoint checks that host and
+        nothing else, so an unrelated Slack host in NO_PROXY cannot bypass."""
+        assert _slack_mod._slack_endpoint_bypass_hosts() == ("slack.com",)
+        assert _slack_mod._slack_endpoint_bypass_hosts(None) == ("slack.com",)
+        assert _slack_mod._slack_endpoint_bypass_hosts(
+            "https://slack.internal.corp/api/"
+        ) == ("slack.internal.corp",)
+
     def test_apply_slack_base_url_sets_client_base_url(self):
         class _Client:
             base_url = "https://slack.com/api/"
@@ -1199,7 +1236,11 @@ class TestSlackBaseUrl:
             ) as excluded,
         ):
             assert (
-                _slack_mod._resolve_slack_proxy_url("https://slack.internal.corp/api/")
+                _slack_mod._resolve_slack_proxy_url(
+                    _slack_mod._slack_proxy_bypass_hosts(
+                        "https://slack.internal.corp/api/"
+                    )
+                )
                 is None
             )
             excluded.assert_any_call("slack.internal.corp")
@@ -1216,7 +1257,11 @@ class TestSlackBaseUrl:
             ),
         ):
             assert (
-                _slack_mod._resolve_slack_proxy_url("https://slack.internal.corp/api/")
+                _slack_mod._resolve_slack_proxy_url(
+                    _slack_mod._slack_proxy_bypass_hosts(
+                        "https://slack.internal.corp/api/"
+                    )
+                )
                 == "http://proxy.example.com:3128"
             )
 
@@ -1410,30 +1455,23 @@ class TestSlackBaseUrl:
 class TestSlackBaseUrlDeliveryLegs:
     """Every leg of a standalone send must honor the custom endpoint.
 
-    Review on #73433: the text post was routed correctly while user-DM
-    resolution still hardcoded slack.com and the media client was built
-    without a base URL — so `deliver=slack:U…` and MEDIA attachments leaked
-    to the real Slack while everything else went to the private endpoint.
+    DM resolution and the media upload are separate clients from the text
+    post, so each one can leak to the real Slack on its own.
     """
 
     BASE = "https://slack.internal.corp/api"
     NORMALIZED = "https://slack.internal.corp/api/"
 
     @staticmethod
-    def _mock_resp(payload):
-        resp = MagicMock()
-        resp.status = 200
-        resp.json = AsyncMock(return_value=payload)
-        resp.__aenter__ = AsyncMock(return_value=resp)
-        resp.__aexit__ = AsyncMock(return_value=None)
-        return resp
-
-    def _mock_session(self, *responses):
-        session = MagicMock()
-        session.__aenter__ = AsyncMock(return_value=session)
-        session.__aexit__ = AsyncMock(return_value=None)
-        session.post = MagicMock(side_effect=list(responses))
-        return session
+    def _proxy_env(monkeypatch, **env):
+        """Pin the proxy env so the host's own settings cannot leak in."""
+        for key in (
+            "HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "NO_PROXY",
+            "https_proxy", "http_proxy", "all_proxy", "no_proxy",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
 
     def _config(self):
         return PlatformConfig(
@@ -1442,10 +1480,9 @@ class TestSlackBaseUrlDeliveryLegs:
 
     @pytest.mark.asyncio
     async def test_user_dm_resolution_hits_the_custom_endpoint(self):
-        _slack_mod._slack_dm_cache.clear()
-        session = self._mock_session(
-            self._mock_resp({"ok": True, "channel": {"id": "D999"}}),
-            self._mock_resp({"ok": True, "ts": "1.1"}),
+        session = _mock_session(
+            _mock_resp({"ok": True, "channel": {"id": "D999"}}),
+            _mock_resp({"ok": True, "ts": "1.1"}),
         )
         with (
             patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session),
@@ -1465,13 +1502,11 @@ class TestSlackBaseUrlDeliveryLegs:
             session.post.call_args_list[1].args[0]
             == self.NORMALIZED + "chat.postMessage"
         )
-        _slack_mod._slack_dm_cache.clear()
 
     @pytest.mark.asyncio
     async def test_dm_cache_is_scoped_to_the_endpoint(self):
         """Two endpoints hand out their own conversation IDs for one user."""
-        _slack_mod._slack_dm_cache.clear()
-        custom = self._mock_session(self._mock_resp({"ok": True, "channel": {"id": "D_CUSTOM"}}))
+        custom = _mock_session(_mock_resp({"ok": True, "channel": {"id": "D_CUSTOM"}}))
         with (
             patch.object(_slack_mod.aiohttp, "ClientSession", return_value=custom),
             patch.object(_slack_mod, "resolve_proxy_url", return_value=None),
@@ -1481,58 +1516,108 @@ class TestSlackBaseUrlDeliveryLegs:
                 == "D_CUSTOM"
             )
 
-        default = self._mock_session(self._mock_resp({"ok": True, "channel": {"id": "D_SLACK"}}))
+        default = _mock_session(_mock_resp({"ok": True, "channel": {"id": "D_SLACK"}}))
         with (
             patch.object(_slack_mod.aiohttp, "ClientSession", return_value=default),
             patch.object(_slack_mod, "resolve_proxy_url", return_value=None),
         ):
             assert await _slack_mod._resolve_slack_user_dm("tok", "U1") == "D_SLACK"
-        _slack_mod._slack_dm_cache.clear()
 
     @pytest.mark.asyncio
-    async def test_user_dm_resolution_honors_no_proxy_for_the_custom_host(self):
+    async def test_dm_resolution_normalizes_the_endpoint(self):
+        """An endpoint without a trailing slash still builds a valid URL and
+        shares the cache entry with its normalized form."""
+        session = _mock_session(_mock_resp({"ok": True, "channel": {"id": "D999"}}))
+        with (
+            patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session),
+            patch.object(_slack_mod, "resolve_proxy_url", return_value=None),
+        ):
+            assert (
+                await _slack_mod._resolve_slack_user_dm("tok", "U1", self.BASE)
+                == "D999"
+            )
+            assert (
+                await _slack_mod._resolve_slack_user_dm("tok", "U1", self.NORMALIZED)
+                == "D999"
+            )
+
+        assert (
+            session.post.call_args_list[0].args[0]
+            == self.NORMALIZED + "conversations.open"
+        )
+        assert session.post.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_user_dm_resolution_honors_no_proxy_for_the_custom_host(
+        self, monkeypatch
+    ):
         """NO_PROXY on the private host must keep conversations.open direct."""
-        _slack_mod._slack_dm_cache.clear()
-        session = self._mock_session(
-            self._mock_resp({"ok": True, "channel": {"id": "D999"}})
+        session = _mock_session(
+            _mock_resp({"ok": True, "channel": {"id": "D999"}})
+        )
+        self._proxy_env(
+            monkeypatch,
+            HTTPS_PROXY="http://proxy:3128",
+            NO_PROXY="slack.internal.corp",
         )
         with (
             patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session),
-            patch.object(
-                _slack_mod, "resolve_proxy_url", return_value="http://proxy:3128"
-            ),
-            patch.object(
-                _slack_mod,
-                "is_host_excluded_by_no_proxy",
-                side_effect=lambda host: host == "slack.internal.corp",
-            ),
+            _captured_proxy_urls() as seen,
         ):
             assert (
                 await _slack_mod._resolve_slack_user_dm("tok", "U1", self.NORMALIZED)
                 == "D999"
             )
-        assert "proxy" not in session.post.call_args.kwargs
-        _slack_mod._slack_dm_cache.clear()
+        assert seen == [None]
 
     @pytest.mark.asyncio
-    async def test_user_dm_resolution_uses_the_proxy_when_not_bypassed(self):
+    async def test_user_dm_resolution_uses_the_proxy_when_not_bypassed(
+        self, monkeypatch
+    ):
         """Control for the case above: without NO_PROXY the proxy still applies."""
-        _slack_mod._slack_dm_cache.clear()
-        session = self._mock_session(
-            self._mock_resp({"ok": True, "channel": {"id": "D999"}})
+        session = _mock_session(
+            _mock_resp({"ok": True, "channel": {"id": "D999"}})
+        )
+        self._proxy_env(monkeypatch, HTTPS_PROXY="http://proxy:3128")
+        with (
+            patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session),
+            _captured_proxy_urls() as seen,
+        ):
+            await _slack_mod._resolve_slack_user_dm("tok", "U1", self.NORMALIZED)
+        assert seen == ["http://proxy:3128"]
+
+    @pytest.mark.asyncio
+    async def test_no_proxy_on_slack_com_does_not_bypass_a_custom_endpoint(
+        self, monkeypatch
+    ):
+        """NO_PROXY is matched against the endpoint the call targets, and
+        nothing else — the same rule the send_message_tool DM leg applies."""
+        session = _mock_session(
+            _mock_resp({"ok": True, "channel": {"id": "D999"}})
+        )
+        self._proxy_env(
+            monkeypatch, HTTPS_PROXY="http://proxy:3128", NO_PROXY="slack.com"
         )
         with (
             patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session),
-            patch.object(
-                _slack_mod, "resolve_proxy_url", return_value="http://proxy:3128"
-            ),
-            patch.object(
-                _slack_mod, "is_host_excluded_by_no_proxy", return_value=False
-            ),
+            _captured_proxy_urls() as seen,
         ):
             await _slack_mod._resolve_slack_user_dm("tok", "U1", self.NORMALIZED)
-        assert session.post.call_args.kwargs.get("proxy") == "http://proxy:3128"
-        _slack_mod._slack_dm_cache.clear()
+        assert seen == ["http://proxy:3128"]
+
+    @pytest.mark.asyncio
+    async def test_user_dm_resolution_keeps_a_socks_proxy(self, monkeypatch):
+        """aiohttp handles SOCKS; only the Slack SDK legs are http(s)-only."""
+        session = _mock_session(
+            _mock_resp({"ok": True, "channel": {"id": "D999"}})
+        )
+        self._proxy_env(monkeypatch, ALL_PROXY="socks5://127.0.0.1:1080")
+        with (
+            patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session),
+            _captured_proxy_urls() as seen,
+        ):
+            await _slack_mod._resolve_slack_user_dm("tok", "U1", self.NORMALIZED)
+        assert seen == ["socks5://127.0.0.1:1080"]
 
     @pytest.mark.asyncio
     async def test_media_client_targets_the_custom_endpoint(self, tmp_path):
@@ -1582,6 +1667,32 @@ class TestSlackBaseUrlDeliveryLegs:
 
         assert result["success"] is True
         apply_proxy.assert_called_once_with(client, None)
+
+    @pytest.mark.asyncio
+    async def test_no_proxy_on_another_slack_host_does_not_bypass_media(
+        self, monkeypatch, tmp_path
+    ):
+        """The upload client's proxy decision belongs to the Web API
+        endpoint, so an unrelated Slack host in NO_PROXY must not send it
+        direct."""
+        image = tmp_path / "report.png"
+        image.write_bytes(b"\x89PNG\r\n\x1a\n")
+        client = MagicMock()
+        client.files_upload_v2 = AsyncMock(return_value={"ok": True, "ts": "9.9"})
+
+        self._proxy_env(
+            monkeypatch, HTTPS_PROXY="http://proxy:3128", NO_PROXY="files.slack.com"
+        )
+        with (
+            _fake_slack_sdk_modules(client),
+            patch.object(_slack_mod, "_apply_slack_proxy") as apply_proxy,
+        ):
+            result = await _slack_mod._standalone_send(
+                self._config(), "C123", "", media_files=[(str(image), False)]
+            )
+
+        assert result["success"] is True
+        apply_proxy.assert_called_once_with(client, "http://proxy:3128")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slack_download_ssrf.py
+++ b/tests/gateway/test_slack_download_ssrf.py
@@ -39,9 +39,10 @@ _ensure_slack_mock()
 from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
 
 
-def _fake_adapter():
+def _fake_adapter(base_url=None):
     self = SlackAdapter.__new__(SlackAdapter)
-    self.config = SimpleNamespace(token="xoxb-test-token")
+    extra = {"base_url": base_url} if base_url else {}
+    self.config = SimpleNamespace(token="xoxb-test-token", extra=extra)
     self._team_clients = {}
     return self
 
@@ -146,5 +147,211 @@ def test_redirect_guard_is_wired(monkeypatch, method_name):
 # whose DNS answer flips from public at preflight to a metadata IP at connect
 # time must be blocked before any TCP connect is attempted.
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Custom ``slack.base_url`` origin
+#
+# Both guards above were written assuming Slack is always the real slack.com.
+# With a custom ``slack.base_url`` (self-hosted relay / Enterprise proxy /
+# mock Slack) the file links in the event payload point at THAT endpoint, so
+# an origin-matched file URL must be downloadable even when it resolves to a
+# private address. Anything off that origin keeps the upstream behaviour.
+# ---------------------------------------------------------------------------
+
+_RELAY_BASE_URL = "http://127.0.0.1:49917/api/"
+_RELAY_FILE_URL = "http://127.0.0.1:49917/files/T1-F1/chart.png"
+
+
+class _OkClient:
+    """Minimal httpx.AsyncClient stand-in that serves one successful response."""
+
+    last_kwargs = None
+    requested = None
+
+    def __init__(self, **kwargs):
+        type(self).last_kwargs = kwargs
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url, **kwargs):
+        type(self).requested = (url, kwargs)
+        return SimpleNamespace(
+            content=b"png-bytes",
+            headers={"content-type": "image/png"},
+            raise_for_status=lambda: None,
+        )
+
+
+def _redirect_response(location):
+    return SimpleNamespace(
+        is_redirect=True,
+        headers={"location": location},
+        url=_RELAY_FILE_URL,
+        next_request=None,
+        status_code=302,
+    )
+
+
+def test_url_origin_contract():
+    from plugins.platforms.slack import adapter as slack_adapter
+
+    origin = slack_adapter._slack_url_origin
+    # Scheme-default ports make the two spellings one origin.
+    assert origin("https://host/api/") == origin("https://host:443/api/")
+    assert origin("http://host/api/") == origin("http://HOST.:80/other")
+    # Unusable inputs never produce an origin (so they can never match).
+    for bad in (None, "", "   ", "ftp://host/x", "https://", "not a url"):
+        assert origin(bad) is None
+
+
+def test_base_url_origin_match_requires_same_scheme_host_port():
+    from plugins.platforms.slack import adapter as slack_adapter
+
+    same_origin = slack_adapter._is_slack_base_url_origin
+    assert same_origin(_RELAY_FILE_URL, _RELAY_BASE_URL)
+    # Different port / host / scheme are all different origins.
+    assert not same_origin("http://127.0.0.1:8080/files/x", _RELAY_BASE_URL)
+    assert not same_origin("http://127.0.0.2:49917/files/x", _RELAY_BASE_URL)
+    assert not same_origin("https://127.0.0.1:49917/files/x", _RELAY_BASE_URL)
+    # With no base_url configured nothing is trusted by origin.
+    assert not same_origin(_RELAY_FILE_URL, None)
+    assert not same_origin("https://files.slack.com/x.png", None)
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["_download_slack_file", "_download_slack_file_bytes"],
+)
+def test_configured_base_url_origin_is_downloadable(monkeypatch, method_name, tmp_path):
+    """A file URL on the configured base_url origin downloads even though it
+    resolves to a private address (that is the point of a local relay)."""
+    import tools.url_safety as url_safety
+
+    checked = []
+
+    def fake_is_safe_url(url, *a, **k):
+        checked.append(url)
+        return False  # a relay on 127.0.0.1 never passes the private-IP check
+
+    monkeypatch.setattr(url_safety, "is_safe_url", fake_is_safe_url)
+    monkeypatch.setattr("httpx.AsyncClient", _OkClient)
+    monkeypatch.setattr(
+        "gateway.platforms.base.cache_image_from_bytes",
+        lambda content, ext: str(tmp_path / f"cached{ext}"),
+    )
+
+    self = _fake_adapter(base_url=_RELAY_BASE_URL)
+    args = (_RELAY_FILE_URL, ".png") if method_name == "_download_slack_file" else (_RELAY_FILE_URL,)
+
+    result = asyncio.run(getattr(self, method_name)(*args))
+
+    if method_name == "_download_slack_file_bytes":
+        assert result == b"png-bytes"
+    else:
+        assert result == str(tmp_path / "cached.png")
+    assert _OkClient.requested[0] == _RELAY_FILE_URL
+    assert checked == [], "origin-trusted URLs must not go through is_safe_url"
+
+    # Skipping the private-IP checks is only safe because the client itself is
+    # origin-pinned, so assert the guard is actually wired — and drive it, so
+    # a hook that no longer refuses off-origin hops fails here too.
+    hooks = (_OkClient.last_kwargs or {}).get("event_hooks", {}).get("response") or []
+    assert hooks, "origin-trusted client must register a redirect guard"
+    with pytest.raises(ValueError):
+        asyncio.run(hooks[0](_redirect_response("https://evil.example.com/x.png")))
+
+
+@pytest.mark.parametrize(
+    "other_url",
+    [
+        "http://127.0.0.1:8080/files/x.png",  # same host, different port
+        "http://169.254.169.254/latest/meta-data/",  # metadata endpoint
+        "https://evil.example.com/x.png",  # public host off the CDN
+    ],
+)
+def test_configured_base_url_does_not_widen_trust(monkeypatch, other_url):
+    """Configuring base_url trusts exactly one origin — nothing else."""
+    import tools.url_safety as url_safety
+
+    # Pass the private-IP pre-flight (no live DNS in tests) so the refusal has
+    # to come from the origin/CDN trust decision itself.
+    monkeypatch.setattr(url_safety, "is_safe_url", lambda *a, **k: True)
+    monkeypatch.setattr("httpx.AsyncClient", _RecordingClient)
+
+    self = _fake_adapter(base_url=_RELAY_BASE_URL)
+    with pytest.raises(ValueError) as exc:
+        asyncio.run(self._download_slack_file_bytes(other_url))
+    # The trust is exact-origin, so the refusal must name the origin that IS
+    # trusted — otherwise a misconfigured relay is indistinguishable from a
+    # genuine SSRF block.
+    assert "http://127.0.0.1:49917" in str(exc.value)
+
+
+def test_trusted_origin_label_omits_default_ports():
+    from plugins.platforms.slack import adapter as slack_adapter
+
+    label = slack_adapter._slack_trusted_origin_label
+    assert label("https://slack.internal.corp/api/") == "https://slack.internal.corp"
+    assert label("https://slack.internal.corp:443/api/") == "https://slack.internal.corp"
+    assert label("http://127.0.0.1:49917/api/") == "http://127.0.0.1:49917"
+    # No usable custom endpoint → nothing to advertise as trusted.
+    for blank in (None, "", "ftp://host/x"):
+        assert label(blank) is None
+        assert slack_adapter._slack_trust_hint(blank) == ""
+
+
+def test_sibling_host_refusal_names_the_trusted_origin(monkeypatch):
+    """A relay serving files from a sibling host (the slack.com vs
+    files.slack.com split) is refused — the message has to say why."""
+    import tools.url_safety as url_safety
+
+    monkeypatch.setattr(url_safety, "is_safe_url", lambda *a, **k: True)
+    monkeypatch.setattr("httpx.AsyncClient", _RecordingClient)
+
+    self = _fake_adapter(base_url="https://slack.internal.corp/api/")
+    with pytest.raises(ValueError) as exc:
+        asyncio.run(
+            self._download_slack_file_bytes(
+                "https://files.slack.internal.corp/files-pri/T1-F1/doc.pdf"
+            )
+        )
+    message = str(exc.value)
+    assert "https://slack.internal.corp" in message
+    assert "slack.base_url" in message
+
+
+def test_base_url_redirect_guard_allows_same_origin():
+    """A relay may 3xx inside its own origin (auth handoff, path rewrite)."""
+    from plugins.platforms.slack import adapter as slack_adapter
+
+    guard = slack_adapter._slack_base_url_redirect_guard(_RELAY_BASE_URL)
+    asyncio.run(guard(_redirect_response("http://127.0.0.1:49917/files/next.png")))
+    # A non-redirect response carries no hop to vet.
+    asyncio.run(guard(SimpleNamespace(is_redirect=False, headers={}, url=_RELAY_FILE_URL)))
+
+
+@pytest.mark.parametrize(
+    "location",
+    [
+        "https://files.slack.com/x.png",  # public, and even a real CDN host
+        "http://127.0.0.1:8080/x.png",  # same host, different port
+        "http://169.254.169.254/latest/meta-data/",
+    ],
+)
+def test_base_url_redirect_guard_blocks_off_origin_hops(location):
+    """The origin-trusted client has no connect-time DNS pinning, so a hop off
+    the trusted origin is refused outright rather than hostname-checked."""
+    from plugins.platforms.slack import adapter as slack_adapter
+
+    guard = slack_adapter._slack_base_url_redirect_guard(_RELAY_BASE_URL)
+    with pytest.raises(ValueError) as exc:
+        asyncio.run(guard(_redirect_response(location)))
+    # Same diagnosability requirement as the up-front refusals.
+    assert "http://127.0.0.1:49917" in str(exc.value)
 
 

--- a/tests/gateway/test_slack_download_ssrf.py
+++ b/tests/gateway/test_slack_download_ssrf.py
@@ -150,13 +150,15 @@ def test_redirect_guard_is_wired(monkeypatch, method_name):
 
 
 # ---------------------------------------------------------------------------
-# Custom ``slack.base_url`` origin
+# Custom ``slack.base_url`` endpoint
 #
 # Both guards above were written assuming Slack is always the real slack.com.
 # With a custom ``slack.base_url`` (self-hosted relay / Enterprise proxy /
 # mock Slack) the file links in the event payload point at THAT endpoint, so
-# an origin-matched file URL must be downloadable even when it resolves to a
-# private address. Anything off that origin keeps the upstream behaviour.
+# they must be downloadable even when they resolve to a private address. The
+# trusted set mirrors the Slack-CDN allowlist: the configured host plus hosts
+# below it (Slack itself splits ``slack.com`` from ``files.slack.com``).
+# Anything outside keeps the upstream behaviour.
 # ---------------------------------------------------------------------------
 
 _RELAY_BASE_URL = "http://127.0.0.1:49917/api/"
@@ -209,18 +211,26 @@ def test_url_origin_contract():
         assert origin(bad) is None
 
 
-def test_base_url_origin_match_requires_same_scheme_host_port():
+def test_base_url_trust_covers_the_endpoint_host_and_hosts_below_it():
     from plugins.platforms.slack import adapter as slack_adapter
 
-    same_origin = slack_adapter._is_slack_base_url_origin
-    assert same_origin(_RELAY_FILE_URL, _RELAY_BASE_URL)
-    # Different port / host / scheme are all different origins.
-    assert not same_origin("http://127.0.0.1:8080/files/x", _RELAY_BASE_URL)
-    assert not same_origin("http://127.0.0.2:49917/files/x", _RELAY_BASE_URL)
-    assert not same_origin("https://127.0.0.1:49917/files/x", _RELAY_BASE_URL)
-    # With no base_url configured nothing is trusted by origin.
-    assert not same_origin(_RELAY_FILE_URL, None)
-    assert not same_origin("https://files.slack.com/x.png", None)
+    trusted = slack_adapter._is_slack_base_url_trusted
+    api = "https://slack.internal.corp/api/"
+    assert trusted(_RELAY_FILE_URL, _RELAY_BASE_URL)
+    assert trusted("https://files.slack.internal.corp/files-pri/T1-F1/x", api)
+    assert trusted("https://a.b.slack.internal.corp/x", api)
+    # Below the configured host only: its parent, a sibling of that parent and
+    # a host merely ending in the same letters are all outside it.
+    assert not trusted("https://internal.corp/x", api)
+    assert not trusted("https://files.internal.corp/x", api)
+    assert not trusted("https://evilslack.internal.corp/x", api)
+    # Scheme and port still have to match exactly.
+    assert not trusted("http://127.0.0.1:8080/files/x", _RELAY_BASE_URL)
+    assert not trusted("http://127.0.0.2:49917/files/x", _RELAY_BASE_URL)
+    assert not trusted("https://127.0.0.1:49917/files/x", _RELAY_BASE_URL)
+    # With no base_url configured nothing is trusted this way.
+    assert not trusted(_RELAY_FILE_URL, None)
+    assert not trusted("https://files.slack.com/x.png", None)
 
 
 @pytest.mark.parametrize(
@@ -275,7 +285,7 @@ def test_configured_base_url_origin_is_downloadable(monkeypatch, method_name, tm
     ],
 )
 def test_configured_base_url_does_not_widen_trust(monkeypatch, other_url):
-    """Configuring base_url trusts exactly one origin — nothing else."""
+    """Configuring base_url trusts that endpoint — nothing else."""
     import tools.url_safety as url_safety
 
     # Pass the private-IP pre-flight (no live DNS in tests) so the refusal has
@@ -286,9 +296,8 @@ def test_configured_base_url_does_not_widen_trust(monkeypatch, other_url):
     self = _fake_adapter(base_url=_RELAY_BASE_URL)
     with pytest.raises(ValueError) as exc:
         asyncio.run(self._download_slack_file_bytes(other_url))
-    # The trust is exact-origin, so the refusal must name the origin that IS
-    # trusted — otherwise a misconfigured relay is indistinguishable from a
-    # genuine SSRF block.
+    # The refusal must name the endpoint that IS trusted — otherwise a
+    # misconfigured relay is indistinguishable from a genuine SSRF block.
     assert "http://127.0.0.1:49917" in str(exc.value)
 
 
@@ -305,34 +314,86 @@ def test_trusted_origin_label_omits_default_ports():
         assert slack_adapter._slack_trust_hint(blank) == ""
 
 
-def test_sibling_host_refusal_names_the_trusted_origin(monkeypatch):
-    """A relay serving files from a sibling host (the slack.com vs
-    files.slack.com split) is refused — the message has to say why."""
+@pytest.mark.parametrize(
+    "file_url",
+    [
+        "https://slack.internal.corp/files-pri/T1-F1/doc.pdf",
+        "https://files.slack.internal.corp/files-pri/T1-F1/doc.pdf",
+    ],
+)
+def test_file_host_below_the_endpoint_is_downloadable(monkeypatch, file_url):
+    """A deployment that mirrors Slack's own API/file host split hands out
+    file links on a host below base_url, and those must download."""
     import tools.url_safety as url_safety
 
-    monkeypatch.setattr(url_safety, "is_safe_url", lambda *a, **k: True)
-    monkeypatch.setattr("httpx.AsyncClient", _RecordingClient)
+    # False everywhere: reaching the download proves the endpoint trust path
+    # was taken rather than the private-IP one.
+    monkeypatch.setattr(url_safety, "is_safe_url", lambda *a, **k: False)
+    monkeypatch.setattr("httpx.AsyncClient", _OkClient)
 
     self = _fake_adapter(base_url="https://slack.internal.corp/api/")
-    with pytest.raises(ValueError) as exc:
-        asyncio.run(
-            self._download_slack_file_bytes(
-                "https://files.slack.internal.corp/files-pri/T1-F1/doc.pdf"
-            )
-        )
-    message = str(exc.value)
-    assert "https://slack.internal.corp" in message
-    assert "slack.base_url" in message
+
+    assert asyncio.run(self._download_slack_file_bytes(file_url)) == b"png-bytes"
+    assert _OkClient.requested[0] == file_url
 
 
-def test_base_url_redirect_guard_allows_same_origin():
-    """A relay may 3xx inside its own origin (auth handoff, path rewrite)."""
+@pytest.mark.parametrize(
+    "slack_base_url",
+    [
+        "https://slack.com/api/",  # the documented default, spelled out
+        "https://acme.enterprise.slack.com/api/",  # Enterprise Grid
+    ],
+)
+def test_slack_owned_base_url_keeps_cdn_downloads_pinned(monkeypatch, slack_base_url):
+    """A base_url on Slack itself must not make CDN links "configured".
+
+    Host-and-below trust would otherwise cover the whole CDN, costing every
+    ordinary download the SSRF pre-flight and the DNS-pinned client.
+    """
+    import tools.url_safety as url_safety
+
+    checked = []
+
+    def fake_is_safe_url(url, *a, **k):
+        checked.append(url)
+        return True
+
+    pinned = []
+
+    def fake_pinned_client(**kwargs):
+        pinned.append(kwargs)
+        return _OkClient(**kwargs)
+
+    monkeypatch.setattr(url_safety, "is_safe_url", fake_is_safe_url)
+    monkeypatch.setattr(url_safety, "create_ssrf_safe_async_client", fake_pinned_client)
+    # Taking the endpoint-trust path would build a plain client instead, and
+    # this one refuses to perform I/O.
+    monkeypatch.setattr("httpx.AsyncClient", _RecordingClient)
+
+    self = _fake_adapter(base_url=slack_base_url)
+    cdn_url = "https://files.slack.com/files-pri/T1-F1/x.png"
+
+    assert asyncio.run(self._download_slack_file_bytes(cdn_url)) == b"png-bytes"
+    assert checked == [cdn_url], "CDN downloads must keep the SSRF pre-flight"
+    assert pinned, "CDN downloads must keep the DNS-pinned client"
+
+
+def test_base_url_redirect_guard_allows_hops_within_the_endpoint():
+    """A relay may 3xx within itself (auth handoff, path rewrite)."""
     from plugins.platforms.slack import adapter as slack_adapter
 
     guard = slack_adapter._slack_base_url_redirect_guard(_RELAY_BASE_URL)
     asyncio.run(guard(_redirect_response("http://127.0.0.1:49917/files/next.png")))
     # A non-redirect response carries no hop to vet.
     asyncio.run(guard(SimpleNamespace(is_redirect=False, headers={}, url=_RELAY_FILE_URL)))
+    # Same trusted set as the up-front check: the API host may hand off to the
+    # file host below it.
+    named = slack_adapter._slack_base_url_redirect_guard(
+        "https://slack.internal.corp/api/"
+    )
+    asyncio.run(
+        named(_redirect_response("https://files.slack.internal.corp/files-pri/T1-F1/x"))
+    )
 
 
 @pytest.mark.parametrize(
@@ -343,9 +404,9 @@ def test_base_url_redirect_guard_allows_same_origin():
         "http://169.254.169.254/latest/meta-data/",
     ],
 )
-def test_base_url_redirect_guard_blocks_off_origin_hops(location):
-    """The origin-trusted client has no connect-time DNS pinning, so a hop off
-    the trusted origin is refused outright rather than hostname-checked."""
+def test_base_url_redirect_guard_blocks_off_endpoint_hops(location):
+    """The endpoint-trusted client has no connect-time DNS pinning, so a hop
+    that leaves it is refused outright rather than hostname-checked."""
     from plugins.platforms.slack import adapter as slack_adapter
 
     guard = slack_adapter._slack_base_url_redirect_guard(_RELAY_BASE_URL)

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -33,6 +33,7 @@ from tools.send_message_tool import (
     _send_signal,
     _send_telegram,
     _send_to_platform,
+    _slack_dm_base_url,
     send_message_tool,
 )
 # Discord helpers moved to the plugin in #24325.  Import from the new path
@@ -272,6 +273,49 @@ def _ensure_slack_mock(monkeypatch):
         ("slack_sdk.web.async_client", slack_sdk.web.async_client),
     ]:
         monkeypatch.setitem(sys.modules, name, mod)
+
+
+class TestSlackDmBaseUrl:
+    """_slack_dm_base_url falls back to the slack_sdk default for unset/blank
+    values and always yields a trailing slash, so the conversations.open URL is
+    never malformed (the reviewer-flagged '/conversations.open' collapse)."""
+
+    def test_unset_falls_back_to_default(self):
+        assert _slack_dm_base_url(None) == "https://slack.com/api/"
+        assert _slack_dm_base_url({}) == "https://slack.com/api/"
+
+    def test_empty_string_falls_back_to_default(self):
+        assert _slack_dm_base_url({"base_url": ""}) == "https://slack.com/api/"
+
+    def test_whitespace_falls_back_to_default(self):
+        # Reachable verbatim via platforms.slack.extra.base_url; must not
+        # collapse to "/".
+        assert _slack_dm_base_url({"base_url": "   "}) == "https://slack.com/api/"
+
+    def test_custom_host_gets_trailing_slash(self):
+        assert (
+            _slack_dm_base_url({"base_url": "https://slack.internal.corp/api"})
+            == "https://slack.internal.corp/api/"
+        )
+
+    def test_custom_host_trailing_slash_preserved(self):
+        assert (
+            _slack_dm_base_url({"base_url": "https://slack.internal.corp/api/"})
+            == "https://slack.internal.corp/api/"
+        )
+
+    def test_surrounding_whitespace_is_stripped(self):
+        assert (
+            _slack_dm_base_url({"base_url": "  https://slack.internal.corp/api  "})
+            == "https://slack.internal.corp/api/"
+        )
+
+    def test_conversations_open_url_never_collapses_to_root(self):
+        # The exact string the DM path builds must always be well-formed.
+        for extra in (None, {}, {"base_url": ""}, {"base_url": "   "}):
+            url = _slack_dm_base_url(extra) + "conversations.open"
+            assert url == "https://slack.com/api/conversations.open"
+            assert not url.startswith("/conversations.open")
 
 
 class TestSendMessageTool:

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -319,23 +319,13 @@ class TestSlackDmBaseUrl:
 
 
 class TestSlackDmProxyBypass:
-    """DM resolution must tell resolve_proxy_url which hosts it targets.
+    """NO_PROXY applies to the endpoint DM resolution actually talks to.
 
-    ``resolve_proxy_url`` only consults NO_PROXY when ``target_hosts`` is
-    passed, so calling it bare sent conversations.open through the corporate
-    proxy even when the operator excluded the (usually private) Slack host.
+    ``resolve_proxy_url`` consults NO_PROXY only for the hosts it is told
+    about, and bypasses as soon as any of them matches.
     """
 
     BASE = "https://slack.internal.corp/api/"
-
-    def test_target_hosts_cover_slack_and_the_custom_host(self):
-        from tools.send_message_tool import _slack_proxy_target_hosts
-
-        hosts = _slack_proxy_target_hosts(self.BASE)
-        assert "slack.internal.corp" in hosts
-        assert "slack.com" in hosts
-        # The default endpoint needs no extra host beyond the built-ins.
-        assert "slack.com" in _slack_proxy_target_hosts("https://slack.com/api/")
 
     @staticmethod
     def _fake_aiohttp(monkeypatch, calls):
@@ -370,6 +360,13 @@ class TestSlackDmProxyBypass:
         )
 
     def _resolve(self, monkeypatch, env):
+        """Run the DM leg and return the proxy URL it resolved.
+
+        That URL is the proxy decision itself; the kwargs it turns into are
+        transport detail — with aiohttp-socks installed every scheme travels
+        as a ``connector`` in the session kwargs and no ``proxy`` request
+        kwarg.
+        """
         from tools.send_message_tool import _resolve_slack_user_target
 
         calls = []
@@ -379,29 +376,51 @@ class TestSlackDmProxyBypass:
             monkeypatch.delenv(key, raising=False)
         for key, value in env.items():
             monkeypatch.setenv(key, value)
-        resolved, error = asyncio.run(
-            _resolve_slack_user_target("xoxb", "user:U1", {"base_url": self.BASE})
-        )
+        seen = []
+        with patch(
+            "gateway.platforms.base.proxy_kwargs_for_aiohttp",
+            side_effect=lambda url: (seen.append(url), ({}, {}))[1],
+        ):
+            resolved, error = asyncio.run(
+                _resolve_slack_user_target("xoxb", "user:U1", {"base_url": self.BASE})
+            )
         assert error is None, error
         assert resolved == "D1"
         assert calls and calls[0][0] == self.BASE + "conversations.open"
-        return calls[0][1]
+        assert len(seen) == 1
+        return seen[0]
 
     def test_no_proxy_on_the_custom_host_keeps_the_request_direct(
         self, monkeypatch
     ):
-        kwargs = self._resolve(
-            monkeypatch,
-            {
-                "HTTPS_PROXY": "http://proxy:3128",
-                "NO_PROXY": "slack.internal.corp",
-            },
+        assert (
+            self._resolve(
+                monkeypatch,
+                {
+                    "HTTPS_PROXY": "http://proxy:3128",
+                    "NO_PROXY": "slack.internal.corp",
+                },
+            )
+            is None
         )
-        assert "proxy" not in kwargs
 
     def test_proxy_still_applies_without_a_matching_no_proxy(self, monkeypatch):
-        kwargs = self._resolve(monkeypatch, {"HTTPS_PROXY": "http://proxy:3128"})
-        assert kwargs.get("proxy") == "http://proxy:3128"
+        assert (
+            self._resolve(monkeypatch, {"HTTPS_PROXY": "http://proxy:3128"})
+            == "http://proxy:3128"
+        )
+
+    def test_no_proxy_on_slack_com_does_not_bypass_a_custom_endpoint(
+        self, monkeypatch
+    ):
+        """Only the endpoint being called counts, not Slack's own hosts."""
+        assert (
+            self._resolve(
+                monkeypatch,
+                {"HTTPS_PROXY": "http://proxy:3128", "NO_PROXY": "slack.com"},
+            )
+            == "http://proxy:3128"
+        )
 
 
 class TestSendMessageTool:

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -318,6 +318,92 @@ class TestSlackDmBaseUrl:
             assert not url.startswith("/conversations.open")
 
 
+class TestSlackDmProxyBypass:
+    """DM resolution must tell resolve_proxy_url which hosts it targets.
+
+    ``resolve_proxy_url`` only consults NO_PROXY when ``target_hosts`` is
+    passed, so calling it bare sent conversations.open through the corporate
+    proxy even when the operator excluded the (usually private) Slack host.
+    """
+
+    BASE = "https://slack.internal.corp/api/"
+
+    def test_target_hosts_cover_slack_and_the_custom_host(self):
+        from tools.send_message_tool import _slack_proxy_target_hosts
+
+        hosts = _slack_proxy_target_hosts(self.BASE)
+        assert "slack.internal.corp" in hosts
+        assert "slack.com" in hosts
+        # The default endpoint needs no extra host beyond the built-ins.
+        assert "slack.com" in _slack_proxy_target_hosts("https://slack.com/api/")
+
+    @staticmethod
+    def _fake_aiohttp(monkeypatch, calls):
+        class _Resp:
+            async def json(self):
+                return {"ok": True, "channel": {"id": "D1"}}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return None
+
+        class _Session:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return None
+
+            def post(self, url, **kwargs):
+                calls.append((url, kwargs))
+                return _Resp()
+
+        monkeypatch.setitem(
+            sys.modules,
+            "aiohttp",
+            SimpleNamespace(
+                ClientSession=lambda timeout=None, **kw: _Session(),
+                ClientTimeout=lambda total=None: None,
+            ),
+        )
+
+    def _resolve(self, monkeypatch, env):
+        from tools.send_message_tool import _resolve_slack_user_target
+
+        calls = []
+        self._fake_aiohttp(monkeypatch, calls)
+        for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "NO_PROXY",
+                    "https_proxy", "http_proxy", "all_proxy", "no_proxy"):
+            monkeypatch.delenv(key, raising=False)
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+        resolved, error = asyncio.run(
+            _resolve_slack_user_target("xoxb", "user:U1", {"base_url": self.BASE})
+        )
+        assert error is None, error
+        assert resolved == "D1"
+        assert calls and calls[0][0] == self.BASE + "conversations.open"
+        return calls[0][1]
+
+    def test_no_proxy_on_the_custom_host_keeps_the_request_direct(
+        self, monkeypatch
+    ):
+        kwargs = self._resolve(
+            monkeypatch,
+            {
+                "HTTPS_PROXY": "http://proxy:3128",
+                "NO_PROXY": "slack.internal.corp",
+            },
+        )
+        assert "proxy" not in kwargs
+
+    def test_proxy_still_applies_without_a_matching_no_proxy(self, monkeypatch):
+        kwargs = self._resolve(monkeypatch, {"HTTPS_PROXY": "http://proxy:3128"})
+        assert kwargs.get("proxy") == "http://proxy:3128"
+
+
 class TestSendMessageTool:
     def test_ntfy_topic_target_is_explicit(self):
         chat_id, thread_id, is_explicit = _parse_target_ref("ntfy", "alerts-channel")

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -474,8 +474,13 @@ def _handle_send(args):
             _slack_dm_target = f"user:{_slack_dm_target}"
         if _slack_dm_target.startswith(("user:", "user_name:")):
             from model_tools import _run_async
+            # Honor a custom Slack Web API base URL (config.yaml → PlatformConfig
+            # .extra) so DM resolution hits the same endpoint as the rest of the
+            # Slack integration.
             _resolved, _resolve_err = _run_async(
-                _resolve_slack_user_target(pconfig.token, _slack_dm_target)
+                _resolve_slack_user_target(
+                    pconfig.token, _slack_dm_target, getattr(pconfig, "extra", None)
+                )
             )
             if _resolve_err:
                 return json.dumps(_resolve_err)
@@ -1675,7 +1680,22 @@ async def _registry_standalone_send(platform_name, pconfig, chat_id, message, th
 # wired via standalone_sender_fn and reached through _registry_standalone_send. #41112.
 
 
-async def _resolve_slack_user_target(token, chat_id):
+def _slack_dm_base_url(extra: dict | None) -> str:
+    """Resolve the Slack Web API base URL for DM resolution (conversations.open).
+
+    Falls back to the slack_sdk default (``https://slack.com/api/``) when the
+    configured value is unset or blank, so a whitespace-only ``base_url``
+    (reachable verbatim via ``platforms.slack.extra.base_url``) never collapses
+    to ``"/"``. A trailing slash is enforced.
+    """
+    raw = (extra or {}).get("base_url")
+    base = (str(raw).strip() if raw else "") or "https://slack.com/api/"
+    if not base.endswith("/"):
+        base += "/"
+    return base
+
+
+async def _resolve_slack_user_target(token, chat_id, extra=None):
     """Resolve a Slack user target to a D... DM conversation ID.
 
     ``chat_id`` may be a Slack conversation ID (C/G/D...) — returned unchanged —
@@ -1696,11 +1716,11 @@ async def _resolve_slack_user_target(token, chat_id):
         from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
         _proxy = resolve_proxy_url()
         _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
-        base_url = "https://slack.com/api"
+        base_url = _slack_dm_base_url(extra)
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
         async def post_api(session, method, payload):
-            async with session.post(f"{base_url}/{method}", headers=headers, json=payload, **_req_kw) as resp:
+            async with session.post(f"{base_url}{method}", headers=headers, json=payload, **_req_kw) as resp:
                 return await resp.json()
 
         async def resolve_user_name(session, name):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1695,6 +1695,26 @@ def _slack_dm_base_url(extra: dict | None) -> str:
     return base
 
 
+def _slack_proxy_target_hosts(base_url: str) -> tuple:
+    """Hosts to check against NO_PROXY for Slack DM resolution.
+
+    ``resolve_proxy_url`` only honors NO_PROXY when it is told which hosts the
+    request targets, so calling it bare sends conversations.open through the
+    proxy even when the operator excluded the Slack host. Delegates to the
+    Slack plugin so the host list stays defined in one place; falls back to the
+    base URL's own host if the plugin is unavailable.
+    """
+    try:
+        from plugins.platforms.slack.adapter import _slack_proxy_bypass_hosts
+
+        return tuple(_slack_proxy_bypass_hosts(base_url))
+    except Exception:
+        from urllib.parse import urlsplit
+
+        host = (urlsplit(base_url).hostname or "").strip().lower()
+        return (host,) if host else ()
+
+
 async def _resolve_slack_user_target(token, chat_id, extra=None):
     """Resolve a Slack user target to a D... DM conversation ID.
 
@@ -1714,9 +1734,10 @@ async def _resolve_slack_user_target(token, chat_id, extra=None):
         return None, {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
         from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
-        _proxy = resolve_proxy_url()
-        _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
         base_url = _slack_dm_base_url(extra)
+        # NO_PROXY-aware for the built-in Slack hosts and any custom base_url host.
+        _proxy = resolve_proxy_url(target_hosts=_slack_proxy_target_hosts(base_url))
+        _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
         async def post_api(session, method, payload):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1695,26 +1695,6 @@ def _slack_dm_base_url(extra: dict | None) -> str:
     return base
 
 
-def _slack_proxy_target_hosts(base_url: str) -> tuple:
-    """Hosts to check against NO_PROXY for Slack DM resolution.
-
-    ``resolve_proxy_url`` only honors NO_PROXY when it is told which hosts the
-    request targets, so calling it bare sends conversations.open through the
-    proxy even when the operator excluded the Slack host. Delegates to the
-    Slack plugin so the host list stays defined in one place; falls back to the
-    base URL's own host if the plugin is unavailable.
-    """
-    try:
-        from plugins.platforms.slack.adapter import _slack_proxy_bypass_hosts
-
-        return tuple(_slack_proxy_bypass_hosts(base_url))
-    except Exception:
-        from urllib.parse import urlsplit
-
-        host = (urlsplit(base_url).hostname or "").strip().lower()
-        return (host,) if host else ()
-
-
 async def _resolve_slack_user_target(token, chat_id, extra=None):
     """Resolve a Slack user target to a D... DM conversation ID.
 
@@ -1734,9 +1714,13 @@ async def _resolve_slack_user_target(token, chat_id, extra=None):
         return None, {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
         from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
+        from urllib.parse import urlsplit
         base_url = _slack_dm_base_url(extra)
-        # NO_PROXY-aware for the built-in Slack hosts and any custom base_url host.
-        _proxy = resolve_proxy_url(target_hosts=_slack_proxy_target_hosts(base_url))
+        # resolve_proxy_url only consults NO_PROXY for the hosts it is told
+        # about, and every request below goes to base_url and nowhere else —
+        # the rule the Slack adapter's DM leg applies as well.
+        _api_host = (urlsplit(base_url).hostname or "").strip().lower()
+        _proxy = resolve_proxy_url(target_hosts=[_api_host] if _api_host else None)
         _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -592,6 +592,34 @@ uploads, …), including out-of-process cron delivery. Socket Mode obtains its
 WebSocket URL dynamically from the endpoint's `apps.connections.open`, so a fully
 custom endpoint must implement that method too.
 
+#### Inbound file downloads from a custom endpoint
+
+Incoming attachments — images, voice clips, PDFs, anything else — are fetched
+from the `url_private` / `url_private_download` links in the event payload, and
+those links are minted by whatever endpoint the workspace actually talks to. So
+`base_url` governs downloads too: **file URLs on that exact origin are trusted**
+for inbound downloads. Concretely, for that origin only:
+
+- the URL may resolve to a **private or loopback address**
+  (`http://127.0.0.1:49917/files/…`) — the usual SSRF block that protects the
+  bot token does not apply to an endpoint you configured yourself;
+- **redirects are pinned to the origin.** Your endpoint may `3xx` within itself
+  (auth handoff, path rewrite), but any hop that leaves the origin is refused,
+  because the bot token travels with the request.
+
+"Exact origin" means **scheme + host + port must all match** `base_url`. A
+sibling host is *not* covered: if your relay mirrors Slack's own split
+(`slack.com` for the API, `files.slack.com` for files) and hands out file links
+on a different hostname than `base_url`, those downloads are refused — the
+refusal in `~/.hermes/logs/gateway.log` names the trusted origin so the
+mismatch is obvious. Serve files from the same origin as the API (e.g. a
+`/files/…` path under it), or point `base_url` at the host that mints the file
+links.
+
+Without a custom `base_url` nothing changes: inbound file URLs are accepted only
+on Slack's own CDN hosts (`slack.com`, `slack-files.com` and their subdomains)
+over `https`.
+
 #### Routing Slack through a proxy
 
 Hermes honors the standard `HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY` environment

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -597,24 +597,37 @@ custom endpoint must implement that method too.
 Incoming attachments — images, voice clips, PDFs, anything else — are fetched
 from the `url_private` / `url_private_download` links in the event payload, and
 those links are minted by whatever endpoint the workspace actually talks to. So
-`base_url` governs downloads too: **file URLs on that exact origin are trusted**
-for inbound downloads. Concretely, for that origin only:
+`base_url` governs downloads too: **file URLs on that endpoint are trusted** for
+inbound downloads. Concretely, there only:
 
 - the URL may resolve to a **private or loopback address**
   (`http://127.0.0.1:49917/files/…`) — the usual SSRF block that protects the
   bot token does not apply to an endpoint you configured yourself;
-- **redirects are pinned to the origin.** Your endpoint may `3xx` within itself
-  (auth handoff, path rewrite), but any hop that leaves the origin is refused,
-  because the bot token travels with the request.
+- **redirects are pinned to the endpoint.** It may `3xx` within itself (auth
+  handoff, path rewrite, API host to file host), but any hop that leaves it is
+  refused, because the bot token travels with the request.
 
-"Exact origin" means **scheme + host + port must all match** `base_url`. A
-sibling host is *not* covered: if your relay mirrors Slack's own split
-(`slack.com` for the API, `files.slack.com` for files) and hands out file links
-on a different hostname than `base_url`, those downloads are refused — the
-refusal in `~/.hermes/logs/gateway.log` names the trusted origin so the
-mismatch is obvious. Serve files from the same origin as the API (e.g. a
-`/files/…` path under it), or point `base_url` at the host that mints the file
-links.
+"That endpoint" means the **host of `base_url` and any host below it**, on the
+same scheme and port — the same shape as the Slack-CDN allowlist. Slack splits
+the API (`slack.com`) from file content (`files.slack.com`), so a deployment
+mirroring that split serves files from `files.slack.internal.corp` while
+`base_url` is `https://slack.internal.corp/api/`, and those downloads are
+trusted. A host that is *not* below `base_url` is refused, including its parent
+domain (`internal.corp`) and that parent's other children
+(`files.internal.corp`); the refusal in `~/.hermes/logs/gateway.log` names the
+trusted endpoint so the mismatch is obvious. Serve file content below the host
+`base_url` names.
+
+Pointing `base_url` at Slack itself (`https://slack.com/api/`, or an Enterprise
+`*.slack.com` endpoint) changes nothing for downloads: Slack's own CDN hosts keep
+the standard path, with the SSRF pre-flight and the DNS-pinned client intact.
+
+If your endpoint fronts the real Slack rather than serving the workspace
+itself, the file links it passes through still point at `https://files.slack.com/…`
+and are fetched from Slack directly. Rewrite them to your own host in the
+endpoint's API responses (and in Socket Mode frames) if downloads have to go
+through it — for example when only the endpoint holds a usable bot token, as
+the CDN then answers with an HTML login page instead of file bytes.
 
 Without a custom `base_url` nothing changes: inbound file URLs are accepted only
 on Slack's own CDN hosts (`slack.com`, `slack-files.com` and their subdomains)

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -659,6 +659,13 @@ that endpoint's host alone — `NO_PROXY=slack.com` does not send it direct once
 then post the bytes to the upload URL the endpoint hands out (`files.slack.com`
 unless it rewrites them).
 
+That scoping also narrows **partial** `NO_PROXY` entries on a default
+deployment: `NO_PROXY=files.slack.com` alone no longer sends cron /
+`send_message` Web API calls direct, because they are matched against the API
+host (`slack.com`) only. The in-process bot is unaffected — it still matches any
+of the Slack hosts it uses. Name the API host (`NO_PROXY=slack.com`, or your
+`base_url` host) when out-of-process delivery has to bypass the proxy too.
+
 ### Session Isolation
 
 ```yaml

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -634,11 +634,17 @@ To send Slack **directly**, bypassing the proxy, add a Slack host to `NO_PROXY`:
 NO_PROXY=slack.com
 ```
 
-`NO_PROXY=slack.com` covers `slack.com`, `files.slack.com`, and
-`wss-primary.slack.com`. When you set a custom `base_url`, **its host is honored in
-`NO_PROXY` too** — so `NO_PROXY=slack.internal.corp` disables the proxy for your
-custom endpoint. As soon as a matching host appears in `NO_PROXY`, Slack traffic
-goes direct.
+`NO_PROXY` entries match subdomains, so `NO_PROXY=slack.com` covers
+`files.slack.com` and `wss-primary.slack.com` as well. When you set a custom
+`base_url`, **its host is honored in `NO_PROXY` too** — so
+`NO_PROXY=slack.internal.corp` disables the proxy for your custom endpoint.
+The in-process bot keeps a Socket Mode connection alongside the Web API, so any
+of those hosts in `NO_PROXY` sends its traffic direct. Out-of-process delivery
+(cron, `send_message`) talks to the Web API endpoint only and is matched against
+that endpoint's host alone — `NO_PROXY=slack.com` does not send it direct once
+`base_url` points somewhere else. Attachment uploads inherit that decision and
+then post the bytes to the upload URL the endpoint hands out (`files.slack.com`
+unless it rewrites them).
 
 ### Session Isolation
 

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -573,6 +573,45 @@ platforms:
 - The card stream is stopped exactly once when the turn finalizes, including
   on interrupt/disconnect, so no dangling live indicator is left behind.
 
+### Custom API endpoint (`base_url`) & network proxy
+
+By default Hermes talks to Slack's Web API at `https://slack.com/api/`. If you run
+a **self-hosted Slack-compatible server**, a **staging/mock endpoint**, or a
+dedicated Enterprise endpoint, point Hermes at it with `base_url`:
+
+```yaml
+slack:
+  # Custom Slack Web API base URL (default: https://slack.com/api/).
+  # A trailing slash is added automatically if you omit it. Set it here in
+  # config.yaml, not .env (which holds secrets like SLACK_BOT_TOKEN).
+  base_url: "https://slack.internal.corp/api/"
+```
+
+`base_url` applies to every Web API call (`chat.postMessage`, `auth.test`, file
+uploads, …), including out-of-process cron delivery. Socket Mode obtains its
+WebSocket URL dynamically from the endpoint's `apps.connections.open`, so a fully
+custom endpoint must implement that method too.
+
+#### Routing Slack through a proxy
+
+Hermes honors the standard `HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY` environment
+variables (and, on macOS, the system proxy) for Slack traffic. Only `http://` and
+`https://` proxy schemes are used for the in-process Slack bot; other schemes
+(e.g. SOCKS) are ignored for it.
+
+To send Slack **directly**, bypassing the proxy, add a Slack host to `NO_PROXY`:
+
+```bash
+# Bypass the proxy for the real Slack hosts
+NO_PROXY=slack.com
+```
+
+`NO_PROXY=slack.com` covers `slack.com`, `files.slack.com`, and
+`wss-primary.slack.com`. When you set a custom `base_url`, **its host is honored in
+`NO_PROXY` too** — so `NO_PROXY=slack.internal.corp` disables the proxy for your
+custom endpoint. As soon as a matching host appears in `NO_PROXY`, Slack traffic
+goes direct.
+
 ### Session Isolation
 
 ```yaml


### PR DESCRIPTION
## What does this PR do?

Adds support for pointing the Slack integration at a **custom Web API `base_url`** (self-hosted / Slack-compatible / mock / Enterprise endpoint) and makes the Slack proxy `NO_PROXY` bypass honor that custom host — previously the bypass only recognized the hardcoded `slack.com` family.

Until now the Slack integration always talked to the slack_sdk default (`https://slack.com/api/`): `connect()` built every `AsyncWebClient` with only `token` + `user_agent_prefix`, and the `NO_PROXY` bypass list was hardcoded to `slack.com` / `files.slack.com` / `wss-primary.slack.com`. There was no way to reach a different Slack-compatible endpoint, and even if there had been, a custom host could not be excluded from an `HTTP_PROXY` via `NO_PROXY`.

The setting is plugin-owned and cache-safe: `base_url` is a **behavioral** setting, so it lives in `config.yaml` (never `.env`, which is reserved for secrets) and flows into `PlatformConfig.extra['base_url']` — exactly the way the Telegram adapter reads its custom Bot API endpoint. There is deliberately **no** `SLACK_BASE_URL` env var. The value applies to every Web API call — `auth.test`, `chat.postMessage`, `conversations.open` (DM resolution) and cron delivery — so a self-hosted endpoint stays consistent across the whole integration.

**Inbound file downloads are covered too.** `url_private` / `url_private_download` links are minted by whatever endpoint the workspace actually talks to, not by `slack.com`, so with a custom endpoint the existing inbound guards (`is_safe_url()` + the Slack-CDN allowlist in `_download_slack_file` / `_download_slack_file_bytes`) refuse **every** attachment — image, voice clip, PDF, document, video — with `Blocked unsafe Slack file URL (SSRF protection)`. Without this the feature is half-configured: the API reaches your endpoint, but nothing a user posts can be read. Trust is anchored to the configured endpoint: **the host of `base_url` and hosts below it**, on the same scheme and port — the same shape as the Slack-CDN allowlist (`slack.com` plus `*.slack.com`), because Slack itself splits the Web API from file content and a Slack-compatible deployment mirrors that split under its own host. The host comes from local config and never from the file object, so a forged file payload cannot steer the Bearer-token download. Because the endpoint may legitimately be private/loopback (where the DNS-pinned client cannot dial), the trusted client is **pinned to that endpoint** instead: it may `3xx` within itself, but any hop that leaves it is refused rather than re-checked by hostname, which would reopen the DNS-rebinding window with the bot token attached. The CDN allowlist is checked **first**, so a `base_url` on Slack itself (`https://slack.com/api/`, or an Enterprise `*.slack.com` endpoint) never turns real CDN links into "configured" ones and never costs them `is_safe_url` or the DNS-pinned client. With no custom `base_url` configured the inbound path is byte-for-byte upstream behavior, refusal wording included.

**Trust model, stated plainly.** Trusting `base_url` is trusting the operator's own configuration, and it has two consequences worth naming rather than burying. First, trusting the configured host *and hosts below it* delegates trust to the whole DNS zone under it: any name that can be published below `slack.internal.corp` is treated as the endpoint — the same premise the Slack-CDN allowlist already makes about `*.slack.com`, so `base_url` should name a host whose zone you control (if it doesn't, serve file content from the `base_url` host itself, which needs no subtree trust). Second, the endpoint client is a plain `httpx.AsyncClient`: the DNS-pinned client refuses private addresses by design and so cannot dial a loopback/private relay at all, which is exactly the deployment this feature exists for. The initial dial is therefore validated against the configured origin and then resolved by hostname, so an endpoint that rebinds to another address would receive the bot token on the first request. That is an accepted residual risk, not an oversight: it is the same exposure `base_url` already grants every Web API call (`auth.test`, `chat.postMessage`, the token goes there by definition), and it is bounded to the one origin in local config. Everything *after* the first hop is pinned — redirects off the endpoint are refused outright instead of being re-checked by hostname, which is where a rebinding window would otherwise open. With no custom `base_url` configured none of this applies: the CDN path keeps the SSRF pre-flight and the DNS-pinned client.

**`NO_PROXY` is matched against the endpoint a call actually targets.** `resolve_proxy_url` bypasses the proxy as soon as *any* host it is handed matches `NO_PROXY`. Handing it the built-in Slack host list from a call that only ever reaches the Web API endpoint therefore let an unrelated entry — `NO_PROXY=files.slack.com`, or the documented `NO_PROXY=slack.com` — send a custom-endpoint request direct, out of the operator's proxy. Callers anchored to the endpoint now check that host alone; the in-process SDK clients keep the full list, because they also open the Socket Mode connection, so `NO_PROXY=wss-primary.slack.com` is a valid reason for *them* to go direct.

## Related Issue

No linked issue — feature request for a custom / self-hosted Slack-compatible endpoint plus proxy egress control in sandboxed deployments.

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Web API routing:

- `plugins/platforms/slack/adapter.py`: new helpers `_normalize_slack_base_url` (enforces a trailing slash), `_slack_base_url_host` (hostname for `NO_PROXY` checks), `_apply_slack_base_url` (points an SDK client at the custom base), and `_slack_proxy_bypass_hosts` (built-in Slack hosts **plus** the custom host). `_resolve_slack_base_url()` reads `PlatformConfig.extra['base_url']`; `connect()` applies it to `AsyncApp.client` and every per-team `AsyncWebClient`. `_apply_yaml_config` seeds `base_url` into `extra` (returns an extras dict) rather than an env var. The cron `_standalone_send` path is `base_url`- and `NO_PROXY`-aware: DM resolution (`conversations.open`) targets the endpoint and keys its cache by it (a Slack-compatible backend hands out its own conversation IDs), and the media client is pointed at the endpoint too, so `MEDIA:` attachments are no longer uploaded to `slack.com`.
- `tools/send_message_tool.py`: new `_slack_dm_base_url()` helper (falls back to the slack_sdk default for unset/blank values, enforces a trailing slash). The Slack DM-resolution path (`_resolve_slack_user_target` → `conversations.open`) now honors the configured `base_url` from `PlatformConfig.extra`, so DM resolution hits the same endpoint as the rest of the integration.

Inbound file downloads:

- `plugins/platforms/slack/adapter.py`: `_slack_url_origin` + `_is_slack_base_url_trusted` (the configured host and hosts below it, with scheme and port exact), `_slack_base_url_redirect_guard` (same predicate, so the API host may hand off to the file host below it) and `_slack_trusted_origin_label` / `_slack_trust_hint` so refusals name the trusted endpoint. The trust decision plus client construction are centralized in one `_open_slack_file_client()` used by **both** `_download_slack_file` and `_download_slack_file_bytes`, so the sibling paths cannot drift; the Slack-CDN allowlist is consulted before endpoint trust, and anything outside the endpoint keeps the full existing chain (`is_safe_url` → `_is_slack_cdn_url` → `create_ssrf_safe_async_client` + `_ssrf_redirect_guard`).

`NO_PROXY` scoping:

- `plugins/platforms/slack/adapter.py`: new `_slack_endpoint_bypass_hosts` (the endpoint host alone) used by DM resolution, the standalone media client and the text post; `_slack_proxy_bypass_hosts` is reserved for the SDK clients that also hold Socket Mode. `_resolve_slack_proxy_url` takes a single required `bypass_hosts` argument — the host list is the caller's decision, and a default made `base_url` and `bypass_hosts` mutually exclusive parameters. The DM leg resolves its proxy through `resolve_proxy_url` directly: `_resolve_slack_proxy_url` drops non-`http(s)` proxies because the Slack SDK cannot use them, but that leg is `aiohttp`, which supports SOCKS via `aiohttp_socks`.
- `tools/send_message_tool.py`: the DM leg passes the `api_base` host only.

Tests and docs:

- `tests/gateway/test_slack.py`: `TestSlackBaseUrl` (URL normalization, host extraction, `NO_PROXY` custom-host bypass, application to `AsyncApp`/per-team clients, YAML→`extra` seeding, cron URL) and `TestSlackBaseUrlDeliveryLegs` (DM resolution and the following `chat.postMessage` both hit the endpoint, endpoint-scoped DM cache, endpoint normalization, the media client's endpoint and proxy decision, `NO_PROXY` honored for the endpoint host and *not* for unrelated Slack hosts, SOCKS preserved).
- `tests/gateway/test_slack_download_ssrf.py`: the trust boundary (a file host below the endpoint, a deeper subdomain — and the negatives: the parent domain, that parent's other children, a look-alike host, a foreign port or scheme), relay downloads through both loaders (asserting `is_safe_url` is not consulted for the endpoint and that the redirect guard is registered), refusals for a metadata IP / public host, both directions of the redirect guard, and a regression test that a Slack-owned `base_url` keeps CDN downloads on the pre-flight + DNS-pinned path.
- `tests/gateway/test_config.py`: no-mock E2E test that exercises the real `load_gateway_config()` → registry dispatch → `_apply_yaml_config` chain (config.yaml `slack.base_url` lands in `PlatformConfig.extra['base_url']` and **no** env var is set).
- `tests/tools/test_send_message_tool.py`: `TestSlackDmBaseUrl` (unset/blank/whitespace fall back to the default; trailing slash enforced; the `conversations.open` URL never collapses to `/`) and `TestSlackDmProxyBypass` (`NO_PROXY` on the endpoint host goes direct, an unrelated Slack host does not). Proxy assertions read the URL handed to `proxy_kwargs_for_aiohttp` rather than the request kwargs — with `aiohttp-socks` installed every scheme travels as a `connector` and there is no `proxy` kwarg to inspect.
- `website/docs/user-guide/messaging/slack.md`: new "Custom API endpoint (`base_url`) & network proxy" section; an "Inbound file downloads from a custom endpoint" subsection covering host-and-below trust with its covered/refused examples, the private-address allowance, the redirect pinning, and the note that a Slack-owned `base_url` changes nothing for downloads; and a `NO_PROXY` section that separates the in-process bot (full host list, Socket Mode) from out-of-process delivery (endpoint host only), including what the narrower scope means for a *partial* entry on a default deployment (`NO_PROXY=files.slack.com` without `slack.com` no longer sends cron / `send_message` calls direct; the in-process bot is unaffected).

## How to Test

1. In `config.yaml`, set:
   ```yaml
   slack:
     base_url: "https://slack.internal.corp/api/"   # trailing slash added automatically if omitted
   ```
2. Start the Slack gateway — every Web API call (`auth.test`, `chat.postMessage`, `conversations.open`, cron delivery) now targets the custom host instead of `slack.com`.
3. Proxy bypass: with `HTTP_PROXY` set, add the custom host to `NO_PROXY` — Slack traffic now goes direct (previously only the hardcoded `slack.com` family could be excluded). With `NO_PROXY=slack.com` instead, a call to the custom endpoint must still go through the proxy.
4. Inbound files: post an image, a voice clip and a PDF. Before this PR every attachment failed with `Blocked unsafe Slack file URL (SSRF protection)` in `~/.hermes/logs/gateway.log`; now they download and reach the agent — including links served from a host below `base_url` (`https://files.slack.internal.corp/…`), which is how a deployment mirroring Slack's own API/file split hands them out.
5. Trust boundary: hand out a file link on the parent domain (`internal.corp`), on a sibling of that parent (`files.internal.corp`) or on a look-alike host — each is still refused, with the trusted endpoint named in the log.
6. Set `base_url` to `https://slack.com/api/` and post an attachment: the download must still take the CDN path (SSRF pre-flight + DNS-pinned client), i.e. a Slack-owned endpoint does not widen anything.
7. Unset `base_url` and confirm inbound files still load only from Slack's own CDN hosts.
8. Out-of-process delivery: `send_message` with `MEDIA:/tmp/x.png` to a `user:U…` target, and a `deliver=slack:U…` cron job — both must reach the custom endpoint (before, `conversations.open` and `files.getUploadURLExternal` went to the real `slack.com`).

Automated (rebased on `main`, macOS 15 arm64):

- `pytest tests/gateway/test_slack.py tests/gateway/test_slack_download_ssrf.py tests/tools/test_send_message_tool.py -q` → **257 passed**.
- Whole Slack surface: `pytest tests/gateway tests/tools tests/plugins -k slack -q` → **509 passed, 1 skipped**.
- The same three files with `aiohttp_socks` importable (the matrix extra) → **260 passed**, which is what the rewritten proxy assertions are for.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) — the PR title (`feat(slack): …`) is conventional and is intended as the squash-merge message
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits) — 5 commits (Web API `base_url` + `NO_PROXY`; DM resolution & media uploads; inbound file downloads; endpoint-scoped `NO_PROXY`; endpoint-host download trust), rebased onto current `main`
- [x] I've run the affected suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `website/docs/user-guide/messaging/slack.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (per-platform messaging keys aren't tracked there; documented in the Slack messaging docs instead, matching the existing convention)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure Python config / URL string logic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool schema changed; internal `send_message` DM path only)

## Screenshots / Logs

**Before:** the Slack integration always resolved to `https://slack.com/api/`; a custom host could not be configured, and the `NO_PROXY` bypass only recognized the hardcoded `slack.com` / `files.slack.com` / `wss-primary.slack.com` family.

**After:** `slack.base_url` in `config.yaml` routes every Web API call (including cron delivery, DM resolution and attachment uploads) to the custom endpoint, `NO_PROXY` is matched against the endpoint that call targets, and inbound attachments served by that endpoint — on its host or a host below it — are downloadable. A link that really is outside the endpoint is still refused, and the refusal names the trusted set:

```
Blocked non-Slack-CDN file URL (token-exfiltration protection): https://files.internal.corp/... (trusted: the Slack CDN, plus https://slack.internal.corp and hosts below it from slack.base_url — scheme and port must match too)
```

