### PR TITLE
fix(desktop): use camelCase-aware parser for persisted native OAuth tokens (#73271)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -138,6 +138,7 @@ import {
   nativeRefreshUrl,
   type NativeTokenSet,
   parseTokenResponse,
+  rehydratePersistedTokens,
   resolveLoginStrategy,
   tokenNeedsRefresh
 } from './native-oauth'
@@ -6100,7 +6101,7 @@ function _loadNativeTokens(baseUrl: string): NativeTokenSet | null {
       return null
     }
 
-    const tokens = parseTokenResponse(JSON.parse(plaintext))
+    const tokens = rehydratePersistedTokens(JSON.parse(plaintext))
     _nativeTokens.set(baseUrl, tokens)
 
     return tokens

--- a/apps/desktop/electron/native-oauth.test.ts
+++ b/apps/desktop/electron/native-oauth.test.ts
@@ -21,6 +21,7 @@ import {
   nativeTokenUrl,
   parseLoopbackCallback,
   parseTokenResponse,
+  rehydratePersistedTokens,
   resolveLoginStrategy,
   statusSupportsNativeFlow,
   tokenNeedsRefresh
@@ -188,4 +189,60 @@ test('tokenNeedsRefresh respects the skew window', () => {
   assert.equal(tokenNeedsRefresh({ expiresAt: now - 10 }, now), true)
   // Unknown expiry ⇒ refresh (validate before use).
   assert.equal(tokenNeedsRefresh({ expiresAt: 0 }, now), true)
+})
+
+// --- persisted token rehydration (camelCase NativeTokenSet round-trip) ---
+
+test('rehydratePersistedTokens accepts a camelCase persisted token set', () => {
+  // This is the exact shape that _persistNativeTokens writes to disk:
+  // JSON.stringify(NativeTokenSet) produces camelCase keys.
+  const persisted = {
+    accessToken: 'AT-persisted',
+    refreshToken: 'RT-persisted',
+    expiresAt: 1893456000,
+    provider: 'nous',
+    userId: 'u-1'
+  }
+
+  const t = rehydratePersistedTokens(persisted)
+
+  assert.equal(t.accessToken, 'AT-persisted')
+  assert.equal(t.refreshToken, 'RT-persisted')
+  assert.equal(t.expiresAt, 1893456000)
+  assert.equal(t.provider, 'nous')
+  assert.equal(t.userId, 'u-1')
+})
+
+test('rehydratePersistedTokens throws on missing accessToken', () => {
+  assert.throws(
+    () => rehydratePersistedTokens({ refreshToken: 'RT' }),
+    /missing accessToken/i
+  )
+})
+
+test('rehydratePersistedTokens falls back to snake_case keys', () => {
+  // Tolerates a raw OAuth response format (belt-and-suspenders).
+  const raw = {
+    access_token: 'AT-raw',
+    refresh_token: 'RT-raw',
+    expires_at: 1893456000,
+    provider: 'nous',
+    user_id: 'u-2'
+  }
+
+  const t = rehydratePersistedTokens(raw)
+
+  assert.equal(t.accessToken, 'AT-raw')
+  assert.equal(t.refreshToken, 'RT-raw')
+  assert.equal(t.expiresAt, 1893456000)
+  assert.equal(t.userId, 'u-2')
+})
+
+test('rehydratePersistedTokens tolerates absent optional fields', () => {
+  const t = rehydratePersistedTokens({ accessToken: 'AT' })
+
+  assert.equal(t.refreshToken, '')
+  assert.equal(t.expiresAt, 0)
+  assert.equal(t.provider, '')
+  assert.equal(t.userId, '')
 })

--- a/apps/desktop/electron/native-oauth.ts
+++ b/apps/desktop/electron/native-oauth.ts
@@ -194,6 +194,39 @@ export function parseTokenResponse(body: any): NativeTokenSet {
 }
 
 /**
+ * Validate and normalise a previously-persisted ``NativeTokenSet``.
+ *
+ * ``parseTokenResponse`` is designed for raw gateway OAuth responses
+ * (snake_case: ``access_token``, ``refresh_token``, …).  Persisted token
+ * sets are serialised from the internal ``NativeTokenSet`` interface
+ * (camelCase: ``accessToken``, ``refreshToken``, …).  Passing a persisted
+ * blob through ``parseTokenResponse`` always fails because the camelCase
+ * keys don't match, producing "Gateway token response missing access_token".
+ *
+ * This function accepts the camelCase persisted shape and returns a
+ * validated ``NativeTokenSet``, falling back to snake_case so that both
+ * formats are tolerated.
+ */
+export function rehydratePersistedTokens(raw: any): NativeTokenSet {
+  // Already camelCase (the normal persisted path).
+  const accessToken = String(raw?.accessToken || raw?.access_token || '')
+
+  if (!accessToken) {
+    throw new Error('Persisted token set missing accessToken')
+  }
+
+  const expiresAt = Number(raw?.expiresAt ?? raw?.expires_at)
+
+  return {
+    accessToken,
+    refreshToken: String(raw?.refreshToken || raw?.refresh_token || ''),
+    expiresAt: Number.isFinite(expiresAt) ? expiresAt : 0,
+    provider: String(raw?.provider || ''),
+    userId: String(raw?.userId || raw?.user_id || '')
+  }
+}
+
+/**
  * True when a stored token set is at/near expiry and should be refreshed
  * before use. `skewSeconds` refreshes slightly early to avoid a race where
  * the token expires in flight (mirrors the server's 60s cookie floor).


### PR DESCRIPTION
## Summary

Desktop native OAuth sign-in works during the initial process lifetime, but after a cold restart the persisted token set cannot be rehydrated — the user is forced to re-authenticate.

**Root cause:** `_loadNativeTokens()` passes the decrypted persisted `NativeTokenSet` (camelCase: `accessToken`, `refreshToken`, `expiresAt`) through `parseTokenResponse()`, which expects raw gateway OAuth response format (snake_case: `access_token`, `refresh_token`, `expires_at`). The camelCase keys don't match, so the parser throws "Gateway token response missing access_token" and returns `null` — the stored tokens are silently discarded.

## Changes

**`apps/desktop/electron/native-oauth.ts`** — Add `rehydratePersistedTokens()`:
- Accepts camelCase persisted shape (`accessToken`), falls back to snake_case (`access_token`) for belt-and-suspenders compatibility
- Same validation as `parseTokenResponse()` (throws on missing access token)
- Documented with docstring explaining why this is separate from `parseTokenResponse()`

**`apps/desktop/electron/main.ts`** — Use `rehydratePersistedTokens()` in `_loadNativeTokens()`:
- Line 6104: `parseTokenResponse()` → `rehydratePersistedTokens()`
- `parseTokenResponse()` is still used at line 6169 for raw gateway token exchange responses (correct usage)

**`apps/desktop/electron/native-oauth.test.ts`** — 4 new tests:
- camelCase persisted token set round-trips correctly
- Throws on missing `accessToken`
- Falls back to snake_case keys (belt-and-suspenders)
- Tolerates absent optional fields

## Test Plan

- [ ] Existing native-oauth tests pass
- [ ] New `rehydratePersistedTokens` tests pass
- [ ] Manual: sign in via native OAuth → close Desktop → reopen → should stay signed in without re-authentication prompt

Fixes #73271