### PR TITLE
fix(desktop): keep the recovery overlay up after a failed cold boot

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -309,6 +309,44 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect($desktopBoot.get().running).toBe(false)
   })
 
+  it('FIX: a stale boot snapshot cannot hide the recovery surface after boot fails', async () => {
+    const desktop = fakeDesktop()
+    type BootSnapshot = Awaited<ReturnType<typeof desktop.getBootProgress>>
+    let resolveSnapshot: (snapshot: BootSnapshot) => void = () => undefined
+
+    desktop.getBootProgress = vi.fn(
+      () =>
+        new Promise<BootSnapshot>(resolve => {
+          resolveSnapshot = resolve
+        })
+    )
+    desktop.getConnection = vi.fn(async () => {
+      throw new Error('Hermes backend did not become ready: connect ECONNREFUSED 127.0.0.1:9119')
+    })
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+
+    expect($desktopBoot.get().error).toBeTruthy()
+
+    await act(async () => {
+      resolveSnapshot({
+        error: null,
+        fakeMode: false,
+        message: 'Resolving Hermes backend',
+        phase: 'backend.resolve',
+        progress: 8,
+        running: true,
+        timestamp: Date.now()
+      })
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect($desktopBoot.get().error).toBeTruthy()
+    expect($desktopBoot.get().running).toBe(false)
+  })
+
   it('FIX: the same holds when the boot fails at the gateway socket instead of getConnection', async () => {
     // The other way a cold boot ends badly, and the one a stale token produces:
     // the backend answers and reports ready, so boot() gets past getConnection,

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -1,6 +1,7 @@
 import { act, cleanup, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { BackendExit, DesktopBootProgress } from '@/global'
 import { $desktopBoot } from '@/store/boot'
 import { $gatewayState } from '@/store/session'
 
@@ -19,7 +20,9 @@ import { useGatewayBoot } from './use-gateway-boot'
 // post-boot reconnect loop.
 
 type Listener = (ev: unknown) => void
+let backendExit: null | ((payload: BackendExit) => void) = null
 let connectionApplied: null | (() => void) = null
+let bootProgress: null | ((payload: DesktopBootProgress) => void) = null
 
 // Minimal WebSocket stand-in implementing only what json-rpc-gateway.connect()
 // touches: readyState, add/removeEventListener('open'|'error'|'close'), close().
@@ -97,8 +100,20 @@ function fakeDesktop() {
       running: true,
       timestamp: Date.now()
     })),
-    onBootProgress: vi.fn(() => () => undefined),
-    onBackendExit: vi.fn(() => () => undefined),
+    onBootProgress: vi.fn(callback => {
+      bootProgress = callback
+
+      return () => {
+        bootProgress = null
+      }
+    }),
+    onBackendExit: vi.fn(callback => {
+      backendExit = callback
+
+      return () => {
+        backendExit = null
+      }
+    }),
     onConnectionApplied: vi.fn(callback => {
       connectionApplied = callback
 
@@ -146,7 +161,9 @@ beforeEach(() => {
   vi.useFakeTimers()
   FakeWebSocket.mode = 'open'
   FakeWebSocket.instances = []
+  backendExit = null
   connectionApplied = null
+  bootProgress = null
   ;(globalThis as { WebSocket: unknown }).WebSocket = FakeWebSocket
   ;(window as { hermesDesktop?: unknown }).hermesDesktop = fakeDesktop()
   $gatewayState.set('idle')
@@ -198,6 +215,33 @@ async function advanceBackoff() {
   })
 }
 
+// One replay of the two steps startHermes() emits whenever it re-enters its
+// remote branch (electron/main.ts: advanceBootProgress 'backend.resolve' then
+// 'backend.remote', both running:true / error:null). The main process re-enters
+// it for any caller that asks for a connection, boot or no boot.
+function emitRemoteBootRetry() {
+  act(() => {
+    bootProgress?.({
+      error: null,
+      fakeMode: false,
+      message: 'Resolving Hermes backend',
+      phase: 'backend.resolve',
+      progress: 8,
+      running: true,
+      timestamp: Date.now()
+    })
+    bootProgress?.({
+      error: null,
+      fakeMode: false,
+      message: 'Connecting to remote Hermes backend at https://vps.example.com',
+      phase: 'backend.remote',
+      progress: 24,
+      running: true,
+      timestamp: Date.now()
+    })
+  })
+}
+
 describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => {
   it('INITIAL boot against a dead VPS: getConnection hangs (waitForHermes) → app sits in the connecting combo, then fails', async () => {
     // The report's actual path: a fresh launch pointed at an unreachable VPS.
@@ -234,6 +278,111 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     })
 
     expect($desktopBoot.get().error).toBeTruthy()
+  })
+
+  it('FIX: the failed boot keeps its recovery surface while the main process retries behind it', async () => {
+    // Where the test above stops, one event too early. boot() runs once, but
+    // the main process keeps startHermes() available, and every later caller
+    // that wants a connection re-enters it and replays the cold-boot progress
+    // steps. They land on a renderer whose boot is already over: the first
+    // running:true hides the recovery overlay, the second wipes boot.error, and
+    // the fullscreen CONNECTING screen covers the app for the rest of that
+    // attempt. Nothing concludes this boot a second time, so only the main
+    // process's own failure payload could bring the recovery surface back.
+    const desktop = fakeDesktop()
+    desktop.getConnection = vi.fn(async () => {
+      throw new Error('Hermes backend did not become ready: connect ECONNREFUSED 127.0.0.1:9119')
+    })
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+
+    expect($desktopBoot.get().error).toBeTruthy()
+
+    emitRemoteBootRetry()
+    emitRemoteBootRetry()
+
+    // The pair BootFailureOverlay renders on (error set, nothing running), and
+    // the same boot.error that keeps GatewayConnectingOverlay off the screen.
+    expect($desktopBoot.get().error).toBeTruthy()
+    expect($desktopBoot.get().running).toBe(false)
+  })
+
+  it('FIX: the same holds when the boot fails at the gateway socket instead of getConnection', async () => {
+    // The other way a cold boot ends badly, and the one a stale token produces:
+    // the backend answers and reports ready, so boot() gets past getConnection,
+    // and the gateway socket is what refuses. It concludes in the same catch, so
+    // the recovery surface has to survive the same replayed progress.
+    FakeWebSocket.mode = 'fail'
+
+    render(<Harness />)
+    await flushAsync()
+
+    expect($desktopBoot.get().error).toBeTruthy()
+
+    emitRemoteBootRetry()
+
+    expect($desktopBoot.get().error).toBeTruthy()
+    expect($desktopBoot.get().running).toBe(false)
+  })
+
+  it('FIX: the same holds when the backend exits during startup and onBackendExit raises the failure', async () => {
+    // The third way a boot ends in failure, and the only one that does not run
+    // inside boot()'s own catch: a local backend that dies while boot() is
+    // still awaiting a connection. onBackendExit concludes the boot on its
+    // behalf, and the main process restarting that backend is exactly what
+    // replays the progress steps, so this conclusion has to latch as well.
+    const desktop = fakeDesktop()
+    // boot() is still awaiting getConnection when the process goes away.
+    desktop.getConnection = vi.fn(() => new Promise(() => undefined))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+
+    expect($desktopBoot.get().running).toBe(true)
+
+    act(() => backendExit?.({ code: 1, signal: null }))
+
+    expect($desktopBoot.get().error).toBeTruthy()
+
+    emitRemoteBootRetry()
+
+    expect($desktopBoot.get().error).toBeTruthy()
+    expect($desktopBoot.get().running).toBe(false)
+  })
+
+  it('FIX: the failed boot is not a dead end — applying a gateway config still boots the app', async () => {
+    // The latch must not outlive the failure it describes. "Use local gateway"
+    // and the embedded gateway settings both apply a config, which drives
+    // softSwitch(): a fresh boot lifecycle that has to clear the failure and
+    // open the app.
+    let connectionFails = true
+    const desktop = fakeDesktop()
+    const healthyConnection = desktop.getConnection
+
+    desktop.getConnection = vi.fn(async () => {
+      if (connectionFails) {
+        throw new Error('Hermes backend did not become ready: connect ECONNREFUSED 127.0.0.1:9119')
+      }
+
+      return healthyConnection()
+    })
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+
+    emitRemoteBootRetry()
+    expect($desktopBoot.get().error).toBeTruthy()
+
+    connectionFails = false
+    act(() => connectionApplied?.())
+    await flushAsync()
+
+    expect($gatewayState.get()).toBe('open')
+    expect($desktopBoot.get().error).toBeNull()
   })
 
   it('resets the old machine context before connecting an applied gateway', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -1,7 +1,7 @@
 import { isGatewayReauthRequired, resolveGatewayWsUrl } from '@hermes/shared'
 import { useEffect, useRef } from 'react'
 
-import type { HermesConnection } from '@/global'
+import type { DesktopBootProgress, HermesConnection } from '@/global'
 import { HermesGateway } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { desktopDefaultCwd } from '@/lib/desktop-fs'
@@ -324,7 +324,7 @@ export function useGatewayBoot({
       }
     }
 
-    const offBootProgress = desktop.onBootProgress(payload => {
+    const handleBootProgress = (payload: DesktopBootProgress) => {
       // Soft switch / post-boot startHermes re-emits progress — ignore so the
       // cold-boot CONNECTING overlay stays down. Errors still surface. A boot
       // that ended in failure counts as ended too: its retries re-emit the same
@@ -338,11 +338,13 @@ export function useGatewayBoot({
       }
 
       applyDesktopBootProgress(payload)
-    })
+    }
+
+    const offBootProgress = desktop.onBootProgress(handleBootProgress)
 
     void desktop
       .getBootProgress()
-      .then(snapshot => applyDesktopBootProgress(snapshot))
+      .then(handleBootProgress)
       .catch(() => undefined)
 
     setDesktopBootStep({

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -111,6 +111,14 @@ export function useGatewayBoot({
     // signals that fire around wake (power resume, network online, the window
     // becoming visible).
     let bootCompleted = false
+    // The other way a cold boot ends. The main process keeps startHermes()
+    // available for retries, and every retry re-emits the progress steps a cold
+    // boot emits — but this boot is over, because boot() runs once and nothing
+    // calls it again. Without this latch that progress put the fullscreen
+    // CONNECTING overlay back over the recovery surface for the whole of every
+    // retry, leaving it reachable only between attempts. A soft switch starts a
+    // fresh boot lifecycle and clears it.
+    let bootFailed = false
     let reconnecting = false
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null
     let reconnectAttempt = 0
@@ -271,6 +279,7 @@ export function useGatewayBoot({
       reconnectAttempt = 0
       escalated = false
       reauthNotified = false
+      bootFailed = false
       callbacksRef.current.beforeConnectionSwitch()
       wipeSessionListsForGatewaySwitch()
 
@@ -305,6 +314,7 @@ export function useGatewayBoot({
       } catch (err) {
         if (!cancelled) {
           const message = err instanceof Error ? err.message : String(err)
+          bootFailed = true
           failDesktopBoot(message)
           notifyError(err, translateNow('boot.errors.desktopBootFailed'))
           setSessionsLoading(false)
@@ -316,8 +326,10 @@ export function useGatewayBoot({
 
     const offBootProgress = desktop.onBootProgress(payload => {
       // Soft switch / post-boot startHermes re-emits progress — ignore so the
-      // cold-boot CONNECTING overlay stays down. Errors still surface.
-      if ($gatewaySwitching.get() || bootCompleted) {
+      // cold-boot CONNECTING overlay stays down. Errors still surface. A boot
+      // that ended in failure counts as ended too: its retries re-emit the same
+      // steps, and replaying them would take the recovery overlay back down.
+      if ($gatewaySwitching.get() || bootCompleted || bootFailed) {
         if (payload.error) {
           applyDesktopBootProgress(payload)
         }
@@ -454,6 +466,9 @@ export function useGatewayBoot({
       }
 
       if ($desktopBoot.get().running || $desktopBoot.get().visible) {
+        // Ends a boot that is still in flight, so it latches like the catch
+        // blocks that conclude one.
+        bootFailed = true
         failDesktopBoot(translateNow('boot.errors.backgroundExitedDuringStartup'))
       }
 
@@ -527,6 +542,7 @@ export function useGatewayBoot({
       } catch (err) {
         if (!cancelled) {
           const message = err instanceof Error ? err.message : String(err)
+          bootFailed = true
           failDesktopBoot(message)
           notifyError(err, translateNow('boot.errors.desktopBootFailed'))
           setSessionsLoading(false)


### PR DESCRIPTION
## What does this PR do?

Starting the desktop while its remote gateway is unreachable leaves the window on the fullscreen CONNECTING overlay for almost all of every retry cycle. Retry, Gateway settings and Use local gateway are not reliably reachable, even though the boot already failed and `BootFailureOverlay` exists for exactly this case.

The renderer does raise the failure. `boot()` catches the rejected `getConnection()` and calls `failDesktopBoot()`, and `BootFailureOverlay` renders on `boot.error && !boot.running`.

What takes it back down is the retry. `boot()` runs once, on mount, but the main process keeps `startHermes()` available and any later caller that asks for a connection re-enters it. Each entry replays the steps a cold boot emits, and they land on a renderer whose boot has already concluded:

- `backend.resolve` carries `running: true`, which fails `BootFailureOverlay`'s `!boot.running` and hides the recovery surface.
- `backend.remote` clears `boot.error`. The store's guard against late progress, `progress.error ?? (current.running ? null : current.error)`, only holds while `current.running` is false, and the previous step just set it true.
- The window then sits on CONNECTING for the whole readiness wait, which is 45s (`DEFAULT_BACKEND_READY_TIMEOUT_MS`).
- `backend.error` restores the failure at the end of the attempt, and the recovery surface comes back until the next caller re-enters `startHermes()`.

Nothing concludes the renderer's boot a second time, so the recovery surface is only reachable in the gap between one failed attempt and the next, and CONNECTING covers it for the 45s of each attempt.

Boot progress already has a concluded-boot guard whose comment says: "Soft switch / post-boot startHermes re-emits progress — ignore so the cold-boot CONNECTING overlay stays down. Errors still surface." It covered the two conclusions it knew about, `$gatewaySwitching` and `bootCompleted`. A boot that ended in failure is the third, and it had no guard. Both the live `onBootProgress` stream and the asynchronous initial `getBootProgress()` snapshot now flow through the same guard, so a stale snapshot resolving after failure cannot set `running: true` either.

This adds it. `bootFailed` is set wherever a live boot concludes through `failDesktopBoot()`, and cleared when `softSwitch()` starts a fresh boot lifecycle, so applying a different gateway still recovers the app. Error payloads keep applying, so the message on the overlay stays current while the main process retries behind it.

Three call sites conclude a live boot: the `boot()` and `softSwitch()` catch blocks, and `onBackendExit` when the backend process dies while a boot is still in flight. All three latch. The other two `failDesktopBoot()` calls in the hook are outside this class. The IPC-bridge check runs before `onBootProgress` is ever subscribed, and the reconnect escalation is only reachable once `bootCompleted` is true, which the existing guard already covers.

Two notes on where the fix belongs:

Not the store. Preserving `boot.error` unconditionally in `applyDesktopBootProgress` is not enough, because `backend.resolve` still sets `running: true` and `BootFailureOverlay` requires `!boot.running`. That leaves a window showing neither overlay.

Not the main process. #65756 deliberately stopped latching remote boot failures so a remote backend stays retryable and self-heals without an app restart. Those retries are what replay the progress, so the renderer has to tolerate them rather than have the main process suppress them.

The post-boot half of this dead end is already handled: `RECONNECT_ESCALATE_AFTER` raises a recoverable error when a healthy connection drops and the backoff runs long. This is the cold-boot half, where the connection never came up in the first place.

## Related Issue

No issue filed.

#72751 fixes the SSH auth-failed variant of the same lockout by latching that specific failure in the main process so `startHermes()` stops re-running. This change is in the renderer and does not depend on the cause of the failure. The two touch different files.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts`: add a `bootFailed` latch next to `bootCompleted`, route both `onBootProgress` events and the `getBootProgress()` snapshot through one concluded-boot guard, set the latch at the three sites that conclude a live boot through `failDesktopBoot()` (the `boot()` and `softSwitch()` catch blocks, and `onBackendExit` during startup), and clear it when `softSwitch()` begins.
- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx`: five cases against the real hook, including a deferred stale snapshot that resolves after failure, plus fakes for `onBootProgress` and `onBackendExit` that can deliver payloads (the existing ones accepted the subscription and dropped it).

## How to Test

Reproduction, with the desktop pointed at a remote gateway under Settings > Gateway:

1. Leave the gateway unreachable, for example a host that is not up yet or a tunnel that is not open.
2. Start the desktop.
3. The boot fails once the readiness wait times out, and the window then spends each 45s retry on CONNECTING with no way into settings, dropping to the recovery overlay only between attempts.

From `~/.hermes/logs/desktop.log` while the app sits on that screen:

```
[hermes] [boot] Resolving Hermes backend
[hermes] [boot] Connecting to remote Hermes backend at http://127.0.0.1:9119
[hermes] [boot] Desktop boot failed: Hermes backend did not become ready: connect ECONNREFUSED 127.0.0.1:9119
```

That cycle repeats for as long as the window is open. The session I took this from logged 54 consecutive attempts before I corrected the gateway URL.

Automated, from `apps/desktop`:

```
vitest run --project ui src/app/gateway/hooks/use-gateway-boot.test.tsx
```

11 pass. With the `use-gateway-boot.ts` change reverted, all five new cases fail: the four replay cases lose the recovery state, and the deferred-snapshot case sets `running` back to `true`. The six existing cases still pass, so the regressions are not pinned to unrelated behavior.

The overlays that consume this state are covered by `gateway-connecting-overlay.test.tsx`, `boot-failure-overlay.test.tsx` and `boot-failure-reauth.test.ts`; those 30 cases pass unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass. This change is desktop renderer TypeScript and touches no Python, so the suite that covers it is `vitest run --project ui` in `apps/desktop`, reported above.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 (Darwin 25.5.0), Node 22.23.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A