### PR TITLE
feat(mcp): add AgentKey catalog entry

### DIFF
--- a/optional-mcps/agentkey/manifest.yaml
+++ b/optional-mcps/agentkey/manifest.yaml
@@ -1,0 +1,38 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: agentkey
+description: Optional hosted AgentKey MCP for live-data search, extraction, and structured data tools.
+source: https://github.com/chainbase-labs/Agentkey
+
+# AgentKey ships a hosted Streamable HTTP MCP endpoint. Hermes connects
+# directly; no local subprocess, package install, or per-provider API keys are
+# configured by this catalog entry.
+transport:
+  type: http
+  url: https://api.agentkey.app/v1/mcp
+
+# AgentKey's hosted endpoint supports MCP OAuth. Hermes handles discovery,
+# browser authorization, token exchange, and refresh through the standard MCP
+# OAuth flow.
+auth:
+  type: oauth
+
+# Keep the default surface focused on AgentKey's discovery/execution control
+# plane. Users can enable any additional server-exposed tools after probing
+# with `hermes mcp configure agentkey`.
+tools:
+  default_enabled:
+    - list_tools
+    - find_tools
+    - describe_tool
+    - execute_tool
+
+post_install: |
+  On first connection Hermes will open a browser to authenticate with AgentKey.
+  After auth, restart your Hermes session so the AgentKey MCP tools are loaded.
+
+  The default tool selection keeps the dynamic discovery/execution surface
+  enabled. Re-run the checklist any time with:
+    hermes mcp configure agentkey


### PR DESCRIPTION
## What does this PR do?

Adds an optional AgentKey MCP catalog entry so users can install the hosted AgentKey remote MCP through Hermes' normal MCP catalog flow instead of manually pasting MCP config.

The entry uses Streamable HTTP plus the standard MCP OAuth flow. It does not add a local subprocess, Python dependency, bundled tool, or default enablement. The default tool surface is limited to AgentKey's documented discovery/execution control-plane tools: `list_tools`, `find_tools`, `describe_tool`, and `execute_tool`.

The main use case is opt-in access to live external data sources through a hosted MCP when a standard search-provider-only backend is not enough. The integration stays within the MCP catalog boundary rather than adding a third-party product plugin to core.

## Related Issue

Fixes #73443

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-mcps/agentkey/manifest.yaml`: adds the AgentKey catalog manifest with HTTP transport, OAuth auth, default discovery/execution tools, and post-install guidance.

## How to Test

1. `python -m pytest tests/hermes_cli/test_mcp_catalog.py -q`

   Observed result: `39 passed`.

2. Parsed the new manifest through `hermes_cli.mcp_catalog._parse_manifest`.

   Observed result: `agentkey http https://api.agentkey.app/v1/mcp oauth ['list_tools', 'find_tools', 'describe_tool', 'execute_tool']`.

3. Checked the AgentKey upstream repo config and skill docs.

   Observed result: `.codex-plugin/mcp.json` points to `https://api.agentkey.app/v1/mcp`, and `skills/agentkey/SKILL.md` documents the four discovery/execution tools enabled by default here.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (focused MCP catalog tests passed; full suite not run locally)
- [x] I've added tests for my changes (covered by existing MCP catalog manifest parsing tests)
- [x] I've tested on my platform: macOS, Python 3.11 Hermes venv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; catalog entry includes post-install guidance
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — remote HTTP MCP only, no local command path
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused test output:

```text
.......................................                                  [100%]
39 passed
```
