### PR TITLE
fix(google-chat): scope multiplex profile config

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -48,6 +48,8 @@ import time
 from pathlib import Path as _Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from agent.secret_scope import get_secret
+
 # Heavy google-cloud + googleapiclient imports are deferred to first
 # adapter use. Importing them eagerly here added ~110ms wall and ~33MB
 # RSS to *every* CLI invocation (the plugin loader imports this module at
@@ -736,28 +738,48 @@ class GoogleChatAdapter(BasePlatformAdapter):
         # end-of-turn by on_processing_complete via patch-to-empty so
         # they don't sit in the chat forever as "Hermes is thinking…".
         self._orphan_typing_messages: Dict[str, List[str]] = {}
-        # FlowControl knobs (env-configurable).
+        # Snapshot profile-scoped settings while adapter construction still
+        # runs inside _profile_runtime_scope. Pub/Sub invokes callbacks from
+        # its own threads, where the ContextVar secret scope is intentionally
+        # unavailable; callbacks must use these instance values rather than
+        # consulting process-global environment state.
+        extra = self.config.extra
         try:
-            self._max_messages = int(os.getenv("GOOGLE_CHAT_MAX_MESSAGES", "1"))
+            self._max_messages = int(
+                extra.get("max_messages")
+                or get_secret("GOOGLE_CHAT_MAX_MESSAGES", "1")
+            )
         except (ValueError, TypeError):
             self._max_messages = 1
         try:
-            self._max_bytes = int(os.getenv("GOOGLE_CHAT_MAX_BYTES", str(16 * 1024 * 1024)))
+            self._max_bytes = int(
+                extra.get("max_bytes")
+                or get_secret("GOOGLE_CHAT_MAX_BYTES", str(16 * 1024 * 1024))
+            )
         except (ValueError, TypeError):
             self._max_bytes = 16 * 1024 * 1024
+        self._bootstrap_spaces = str(
+            extra.get("bootstrap_spaces")
+            or get_secret("GOOGLE_CHAT_BOOTSTRAP_SPACES", "")
+            or ""
+        ).strip()
+        self._debug_raw = bool(
+            extra.get("debug_raw")
+            or get_secret("GOOGLE_CHAT_DEBUG_RAW")
+        )
         self._http_events_url = (
-            self.config.extra.get("http_events_url")
-            or os.getenv("GOOGLE_CHAT_HTTP_EVENTS_URL", "")
+            extra.get("http_events_url")
+            or get_secret("GOOGLE_CHAT_HTTP_EVENTS_URL", "")
             or ""
         ).strip()
         self._http_events_audience = (
-            self.config.extra.get("http_events_audience")
-            or os.getenv("GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE", "")
+            extra.get("http_events_audience")
+            or get_secret("GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE", "")
             or self._http_events_url
         ).strip()
         self._http_events_service_account_email = (
-            self.config.extra.get("http_events_service_account_email")
-            or os.getenv("GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL", "")
+            extra.get("http_events_service_account_email")
+            or get_secret("GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL", "")
             or ""
         ).strip().lower()
 
@@ -779,7 +801,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         """
         sa_path = (
             self.config.extra.get("service_account_json")
-            or os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+            or get_secret("GOOGLE_APPLICATION_CREDENTIALS")
         )
         if sa_path:
             # Inline JSON (rare, but supported).
@@ -952,7 +974,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         if self.config.home_channel and self.config.home_channel.chat_id:
             candidate_spaces.append(self.config.home_channel.chat_id)
         # Env-configured allowed spaces (comma-separated). Optional.
-        extra_spaces = os.getenv("GOOGLE_CHAT_BOOTSTRAP_SPACES", "").strip()
+        extra_spaces = self._bootstrap_spaces
         if extra_spaces:
             candidate_spaces.extend(
                 s.strip() for s in extra_spaces.split(",") if s.strip()
@@ -1399,7 +1421,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
             list(envelope.keys()),
             ce_type,
         )
-        if os.getenv("GOOGLE_CHAT_DEBUG_RAW"):
+        if self._debug_raw:
             # Dangerous flag: contains message text and sender email. Route
             # through the global redaction filter and gate at DEBUG level so
             # default log configurations never surface it. Operators must
@@ -3351,14 +3373,14 @@ def _check_for_registry() -> bool:
     if not check_google_chat_requirements():
         return False
     project = (
-        os.getenv("GOOGLE_CHAT_PROJECT_ID")
-        or os.getenv("GOOGLE_CLOUD_PROJECT")
+        get_secret("GOOGLE_CHAT_PROJECT_ID")
+        or get_secret("GOOGLE_CLOUD_PROJECT")
     )
     subscription = (
-        os.getenv("GOOGLE_CHAT_SUBSCRIPTION_NAME")
-        or os.getenv("GOOGLE_CHAT_SUBSCRIPTION")
+        get_secret("GOOGLE_CHAT_SUBSCRIPTION_NAME")
+        or get_secret("GOOGLE_CHAT_SUBSCRIPTION")
     )
-    http_events_url = os.getenv("GOOGLE_CHAT_HTTP_EVENTS_URL")
+    http_events_url = get_secret("GOOGLE_CHAT_HTTP_EVENTS_URL")
     return bool(http_events_url or (project and subscription))
 
 
@@ -3382,14 +3404,14 @@ def _env_enablement() -> Optional[Dict[str, Any]]:
     ``PlatformConfig`` rather than being merged into ``extra``.
     """
     project = (
-        os.getenv("GOOGLE_CHAT_PROJECT_ID")
-        or os.getenv("GOOGLE_CLOUD_PROJECT")
+        get_secret("GOOGLE_CHAT_PROJECT_ID")
+        or get_secret("GOOGLE_CLOUD_PROJECT")
     )
     subscription = (
-        os.getenv("GOOGLE_CHAT_SUBSCRIPTION_NAME")
-        or os.getenv("GOOGLE_CHAT_SUBSCRIPTION")
+        get_secret("GOOGLE_CHAT_SUBSCRIPTION_NAME")
+        or get_secret("GOOGLE_CHAT_SUBSCRIPTION")
     )
-    http_events_url = os.getenv("GOOGLE_CHAT_HTTP_EVENTS_URL")
+    http_events_url = get_secret("GOOGLE_CHAT_HTTP_EVENTS_URL")
     if not (http_events_url or (project and subscription)):
         return None
     seed: Dict[str, Any] = {}
@@ -3399,23 +3421,32 @@ def _env_enablement() -> Optional[Dict[str, Any]]:
         seed["subscription_name"] = subscription
     if http_events_url:
         seed["http_events_url"] = http_events_url
-    http_events_audience = os.getenv("GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE")
+    http_events_audience = get_secret("GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE")
     if http_events_audience:
         seed["http_events_audience"] = http_events_audience
-    http_events_sa_email = os.getenv("GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL")
+    http_events_sa_email = get_secret("GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL")
     if http_events_sa_email:
         seed["http_events_service_account_email"] = http_events_sa_email
+    for env_name, extra_name in (
+        ("GOOGLE_CHAT_MAX_MESSAGES", "max_messages"),
+        ("GOOGLE_CHAT_MAX_BYTES", "max_bytes"),
+        ("GOOGLE_CHAT_BOOTSTRAP_SPACES", "bootstrap_spaces"),
+        ("GOOGLE_CHAT_DEBUG_RAW", "debug_raw"),
+    ):
+        value = get_secret(env_name)
+        if value:
+            seed[extra_name] = value
     sa_json = (
-        os.getenv("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON")
-        or os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+        get_secret("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON")
+        or get_secret("GOOGLE_APPLICATION_CREDENTIALS")
     )
     if sa_json:
         seed["service_account_json"] = sa_json
-    home = os.getenv("GOOGLE_CHAT_HOME_CHANNEL")
+    home = get_secret("GOOGLE_CHAT_HOME_CHANNEL")
     if home:
         seed["home_channel"] = {
             "chat_id": home,
-            "name": os.getenv("GOOGLE_CHAT_HOME_CHANNEL_NAME", "Home"),
+            "name": get_secret("GOOGLE_CHAT_HOME_CHANNEL_NAME", "Home"),
         }
     return seed
 
@@ -3565,8 +3596,8 @@ async def _standalone_send(
     extra = getattr(pconfig, "extra", {}) or {}
     sa_value = (
         extra.get("service_account_json")
-        or os.getenv("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON")
-        or os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+        or get_secret("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON")
+        or get_secret("GOOGLE_APPLICATION_CREDENTIALS")
     )
 
     if service_account is None:

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -20,6 +20,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from agent.secret_scope import set_multiplex_active
 from gateway.config import Platform, PlatformConfig, load_gateway_config
 
 # Platform uses _missing_() for dynamic members, so "google_chat" is
@@ -312,6 +313,70 @@ class TestEnvConfigLoading:
             cfg.platforms[_GC].extra["http_events_service_account_email"]
             == "chat-callback@example.iam.gserviceaccount.com"
         )
+
+    def test_multiplex_profile_uses_scoped_google_chat_config(
+        self, monkeypatch, tmp_path
+    ):
+        from gateway.run import _profile_runtime_scope
+
+        self._clean_env(monkeypatch)
+        monkeypatch.setenv("GOOGLE_CHAT_PROJECT_ID", "active-project")
+        monkeypatch.setenv(
+            "GOOGLE_CHAT_SUBSCRIPTION_NAME",
+            "projects/active-project/subscriptions/chat",
+        )
+        monkeypatch.setenv(
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            "/secrets/active-profile.json",
+        )
+        profile_home = tmp_path / "worker"
+        profile_home.mkdir()
+        (profile_home / ".env").write_text(
+            "GOOGLE_CHAT_PROJECT_ID=worker-project\n"
+            "GOOGLE_CHAT_SUBSCRIPTION_NAME="
+            "projects/worker-project/subscriptions/chat\n"
+            "GOOGLE_APPLICATION_CREDENTIALS=/secrets/worker-profile.json\n",
+            encoding="utf-8",
+        )
+        set_multiplex_active(True)
+        try:
+            with _profile_runtime_scope(profile_home):
+                cfg = load_gateway_config()
+        finally:
+            set_multiplex_active(False)
+
+        google_chat = cfg.platforms[_GC]
+        assert google_chat.extra["project_id"] == "worker-project"
+        assert (
+            google_chat.extra["subscription_name"]
+            == "projects/worker-project/subscriptions/chat"
+        )
+        assert (
+            google_chat.extra["service_account_json"]
+            == "/secrets/worker-profile.json"
+        )
+
+    def test_multiplex_bare_profile_does_not_inherit_google_chat(
+        self, monkeypatch, tmp_path
+    ):
+        from gateway.run import _profile_runtime_scope
+
+        self._clean_env(monkeypatch)
+        monkeypatch.setenv("GOOGLE_CHAT_PROJECT_ID", "active-project")
+        monkeypatch.setenv(
+            "GOOGLE_CHAT_SUBSCRIPTION_NAME",
+            "projects/active-project/subscriptions/chat",
+        )
+        profile_home = tmp_path / "bare"
+        profile_home.mkdir()
+        set_multiplex_active(True)
+        try:
+            with _profile_runtime_scope(profile_home):
+                cfg = load_gateway_config()
+        finally:
+            set_multiplex_active(False)
+
+        assert _GC not in cfg.platforms
 
 
 # ===========================================================================
@@ -646,6 +711,20 @@ class TestOnPubsubMessage:
         adapter._on_pubsub_message(msg)
         msg.nack.assert_called_once()
         msg.ack.assert_not_called()
+
+    def test_callback_uses_settings_captured_before_scope_is_gone(self, adapter):
+        """Pub/Sub callback threads do not inherit the profile ContextVar."""
+        set_multiplex_active(True)
+        try:
+            msg = _make_pubsub_message(
+                _make_chat_envelope(sender_type="BOT")
+            )
+            adapter._on_pubsub_message(msg)
+        finally:
+            set_multiplex_active(False)
+
+        msg.ack.assert_called_once()
+        msg.nack.assert_not_called()
 
     def test_malformed_json_acks_without_dispatch(self, adapter):
         msg = MagicMock()


### PR DESCRIPTION
## Summary

Fixes #73439.

Google Chat's plugin registry hooks and adapter fallbacks read `os.environ` directly. Under `gateway.multiplex_profiles`, that is the active/root profile's environment, so every secondary profile inherited the same Google Chat project, Pub/Sub subscription, callback settings, and service-account path.

This change routes Google Chat environment reads through the existing profile-aware `agent.secret_scope.get_secret()` resolver. The registry now seeds each `PlatformConfig.extra` from the current profile scope, while a profile with no Google Chat settings stays disabled instead of inheriting the root bot.

## Behavior covered

- A multiplexed worker profile resolves its own project, subscription, and service-account path even when process-global values belong to the active profile.
- A bare multiplexed profile does not auto-enable Google Chat from another profile's process environment.
- Adapter initialization, registry enablement, HTTP callback settings, bootstrap/debug settings, and standalone delivery use the same scoped resolver.
- Single-profile behavior is preserved because `get_secret()` falls back to `os.environ` when multiplexing is inactive.

## Validation

- Reproduced both failures on current `main` before the implementation.
- `tests/gateway/test_google_chat.py`, `tests/gateway/test_multiplex_phase0.py`, and `tests/gateway/test_config.py`: **358 passed**.
- The two temp-`HERMES_HOME` profile isolation regressions: **2 passed**.
- Ruff on both changed files: **passed**.
- `git diff --check`: **passed**.

The repository's shell wrapper cannot run in this native Windows environment because WSL has no `/bin/bash`; the same test targets were run with the repository's existing Python virtual environment.