### PR TITLE
fix(slack): prevent thread parent edit replays

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -350,6 +350,59 @@ def _collect_slack_block_mentions(blocks: list) -> list:
     return mentions
 
 
+def _slack_block_tree_trusted(blocks: Any) -> bool:
+    """Return whether every node ``_collect_slack_block_mentions`` walks is typed.
+
+    The mention walker skips whatever it cannot parse, so "no mention found"
+    in a malformed tree is silence, not proof of absence. This validator
+    checks exactly the fields that walker reads — ``type``, the ``elements`` /
+    ``element`` children it recurses into, and a ``user`` node's ``user_id`` —
+    so callers that need absence *proof* can tell a trustworthy snapshot from
+    one that merely failed to parse.
+    """
+
+    def _verbatim_label(value: Any) -> bool:
+        """Whether *value* is a label Slack sends verbatim.
+
+        Slack emits bare identifiers and the walker compares them
+        literally, so a blank or whitespace-padded value matches none of
+        its branches and names nobody.
+        """
+        return isinstance(value, str) and bool(value.strip()) and value == value.strip()
+
+    def _trusted(node: Any) -> bool:
+        if isinstance(node, list):
+            return all(_trusted(item) for item in node)
+        if not isinstance(node, dict):
+            return False
+        # Every Block Kit node Slack sends is typed. A node whose ``type``
+        # is missing, blank, padded, or non-string silently matches none of
+        # the walker's branches, so a mention node that lost its label reads
+        # as ordinary content and cannot witness a mention's absence.
+        node_type = node.get("type")
+        if not _verbatim_label(node_type):
+            return False
+        # A blank or padded ``user_id`` identifies nobody: the walker either
+        # drops the mention outright or emits ``<@ U123 >``, which matches no
+        # bot uid. Either way the node cannot witness a mention's absence.
+        if node_type == "user" and not _verbatim_label(node.get("user_id")):
+            return False
+        for key in ("elements", "element"):
+            if key in node and not _trusted(node[key]):
+                return False
+        return True
+
+    # Slack's top-level ``blocks`` container is a list; the walker iterates
+    # it directly. Anything else (a bare block dict, a mapping, a string) is
+    # a payload it never traverses, so it proves nothing about mentions.
+    if not isinstance(blocks, list):
+        return False
+    try:
+        return _trusted(blocks)
+    except Exception:  # pragma: no cover - defensive, mirrors the walker
+        return False
+
+
 def _slack_mention_detection_text(event: dict) -> str:
     """Return the text used for @mention detection on a Slack message event.
 
@@ -5097,6 +5150,108 @@ class SlackAdapter(BasePlatformAdapter):
             fallback_event["thread_ts"] = thread_ts
         await self._handle_slack_message(fallback_event)
 
+    @classmethod
+    def _slack_message_has_thread_replies(cls, *messages: Any) -> bool:
+        """Return True when a snapshot proves the message already has replies.
+
+        Slack only decorates a thread *parent* with reply bookkeeping, so a
+        positive answer means "this is a thread root that has already been
+        answered" — the precondition for treating a later edit of it as a
+        replay of settled instructions rather than a fresh request. Every
+        field is treated as untrusted input.
+        """
+        for message in messages:
+            if not isinstance(message, dict):
+                continue
+            # ``latest_reply`` is a Slack message ts. Any other string is
+            # noise Slack never sends, and treating it as proof of a reply
+            # would suppress a genuine edit on an unanswered message.
+            if cls._is_valid_slack_timestamp(message.get("latest_reply")):
+                return True
+            # ``replies`` is a list of reply stubs; only an entry carrying a
+            # real Slack ts witnesses a reply. A non-empty list of unparsable
+            # members is the same silence as an empty one.
+            replies = message.get("replies")
+            if isinstance(replies, list) and any(
+                isinstance(entry, dict)
+                and cls._is_valid_slack_timestamp(entry.get("ts"))
+                for entry in replies
+            ):
+                return True
+            # ``reply_users`` holds Slack user IDs. Their exact shape is
+            # Slack's business, but a non-string / blank member identifies
+            # nobody, so it cannot witness that somebody replied.
+            reply_users = message.get("reply_users")
+            if isinstance(reply_users, list) and any(
+                isinstance(uid, str) and uid.strip() for uid in reply_users
+            ):
+                return True
+            for field in ("reply_count", "reply_users_count"):
+                value = message.get(field)
+                if isinstance(value, bool):
+                    continue
+                if isinstance(value, int) and value > 0:
+                    return True
+                if isinstance(value, str):
+                    digits = value.strip()
+                    # ``strip("0")`` keeps this allocation-free for absurd
+                    # digit strings that int() would refuse to parse.
+                    if digits.isascii() and digits.isdigit() and digits.strip("0"):
+                        return True
+        return False
+
+    def _slack_message_addresses_bot(self, message: Any, self_uids: set) -> bool:
+        """Return True when *message* @-mentions this bot or hits a wake word.
+
+        Best-effort on purpose: a malformed ``text``/``blocks`` field is
+        skipped rather than trusted, so a Block-Kit-only mention still counts
+        even when the flat text field carries garbage.
+        """
+        if not isinstance(message, dict):
+            return False
+        text = message.get("text")
+        blocks = message.get("blocks")
+        detection_text = _slack_mention_detection_text(
+            {
+                "text": text if isinstance(text, str) else "",
+                "blocks": blocks if isinstance(blocks, list) else None,
+            }
+        )
+        if not detection_text:
+            return False
+        return bool(
+            self._slack_message_mentions_self(detection_text, self_uids)
+            or self._slack_message_matches_mention_patterns(detection_text)
+        )
+
+    def _slack_previous_addressed_bot(
+        self, previous_message: Any, self_uids: set
+    ) -> Optional[bool]:
+        """Tri-state view of a ``previous_message`` snapshot's addressing.
+
+        ``True``/``False`` mean the pre-edit snapshot provably did / did not
+        address this bot. ``None`` means Slack sent nothing we can trust
+        (absent, wrong type, a non-string ``text``, or a ``blocks`` tree the
+        mention walker cannot fully parse), so callers must fail closed
+        instead of assuming an edit newly added the mention.
+        """
+        if not isinstance(previous_message, dict):
+            return None
+        if self._slack_message_addresses_bot(previous_message, self_uids):
+            return True
+        # Proving the ABSENCE of a mention needs a trustworthy snapshot. The
+        # mention walker reads exactly two fields, so both must carry the
+        # types Slack documents — the same typed-payload bar the visible
+        # payload comparison above applies. A malformed node anywhere in the
+        # walked block tree is silence, not proof: the walker skips what it
+        # cannot parse, so a mention may be hiding behind it.
+        if not isinstance(previous_message.get("text"), str):
+            return None
+        blocks = previous_message.get("blocks")
+        if blocks is not None and not _slack_block_tree_trusted(blocks):
+            return None
+        return False
+
     def _register_mentioned_thread(self, thread_ts: str, team_id: str = "") -> None:
         """Record a thread as bot-mentioned so future replies auto-trigger.
 
@@ -5393,6 +5548,50 @@ class SlackAdapter(BasePlatformAdapter):
                     latest_reply_ts,
                 )
                 return
+
+            # A thread parent that ALREADY addressed the bot has been answered
+            # in that thread. Re-delivering its edited text opens a brand-new
+            # turn from instructions the agent acted on hours ago — the
+            # "phantom turn" the in-memory ``_processed_message_ts`` set misses
+            # whenever the original ts is not in this process's state (that set
+            # is per-process and is not a durable record of past deliveries).
+            # Route such an edit only when the event itself proves the mention
+            # is new; a user who wants the edited wording acted on can post an
+            # ordinary reply, which we must never synthesize on their behalf.
+            #
+            # Bot identity is workspace-local: resolve exactly ONE uid for the
+            # event's team, because the primary workspace's bot uid can belong
+            # to an ordinary member of a secondary workspace. The outer event
+            # normally carries the team, but fall back to the edited message
+            # when it doesn't — never letting the inner value override an
+            # authoritative outer one.
+            team_id = self._event_team_id(event, payload) or self._event_team_id(
+                updated_message
+            )
+            bot_uid = self._team_bot_user_ids.get(team_id) or self._bot_user_id
+            self_uids = {bot_uid} if bot_uid else set()
+            if self._slack_message_has_thread_replies(
+                updated_message, previous_message
+            ):
+                previously_addressed = self._slack_previous_addressed_bot(
+                    previous_message, self_uids
+                )
+                # The pre-edit snapshot is what proves the thread was already
+                # answered, so a proven prior mention suppresses the edit even
+                # when the edited payload no longer addresses the bot (or is
+                # malformed). When the snapshot is untrustworthy, fail closed
+                # only if the edit itself still addresses the bot.
+                if previously_addressed is True or (
+                    previously_addressed is None
+                    and self._slack_message_addresses_bot(updated_message, self_uids)
+                ):
+                    logger.debug(
+                        "[Slack] Ignoring edit of already-addressed thread "
+                        "parent %s: previous mention evidence=%s",
+                        original_message_ts,
+                        "present" if previously_addressed else "unknown",
+                    )
+                    return
             changed_event_ts = str(
                 event.get("event_ts") or (edited_ts if edited_ts_valid else "") or ""
             )

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1081,6 +1081,24 @@ class SlackAdapter(BasePlatformAdapter):
             fraction_int = 0
         return seconds_int, fraction_int, str(ts)
 
+    @staticmethod
+    def _is_valid_slack_timestamp(ts: Any) -> bool:
+        """Return whether *ts* has Slack's numeric seconds[.fraction] shape."""
+        if not isinstance(ts, str):
+            return False
+        seconds, separator, fraction = ts.partition(".")
+        if (
+            not 1 <= len(seconds) <= 20
+            or not seconds.isascii()
+            or not seconds.isdigit()
+        ):
+            return False
+        return not separator or (
+            1 <= len(fraction) <= 6
+            and fraction.isascii()
+            and fraction.isdigit()
+        )
+
     @classmethod
     def _discard_oldest_slack_timestamps(
         cls, timestamps: set[str], count: int
@@ -5253,6 +5271,71 @@ class SlackAdapter(BasePlatformAdapter):
             if not isinstance(updated_message, dict):
                 return
 
+            previous_message = event.get("previous_message")
+            visible_payload_changed = None
+            if isinstance(previous_message, dict):
+                visible_fields = ("text", "blocks", "attachments", "files")
+                has_previous_typed_field = False
+                has_proven_list_change = False
+                has_unknown_field = False
+                comparable_fields = []
+                for field in visible_fields:
+                    previous_value = previous_message.get(field)
+                    current_value = updated_message.get(field)
+                    if field == "text":
+                        previous_valid = isinstance(previous_value, str)
+                        current_valid = isinstance(current_value, str)
+                    else:
+                        previous_valid = isinstance(previous_value, list) and all(
+                            isinstance(item, dict) for item in previous_value
+                        )
+                        current_valid = isinstance(current_value, list) and all(
+                            isinstance(item, dict) for item in current_value
+                        )
+                    has_previous_typed_field |= previous_valid
+                    previous_empty = previous_value is None or previous_value in ("", [])
+                    current_empty = current_value is None or current_value in ("", [])
+                    if field != "text" and (
+                        (
+                            previous_valid
+                            and not previous_empty
+                            and (current_value is None or current_value == [])
+                        )
+                        or (
+                            previous_value is None
+                            and current_valid
+                            and not current_empty
+                        )
+                    ):
+                        has_proven_list_change = True
+                        continue
+                    if previous_valid and current_valid:
+                        comparable_fields.append(field)
+                        continue
+
+                    if not (previous_empty and current_empty):
+                        has_unknown_field = True
+
+                if has_proven_list_change or any(
+                    updated_message[field] != previous_message[field]
+                    for field in comparable_fields
+                ):
+                    visible_payload_changed = True
+                elif has_previous_typed_field and not has_unknown_field:
+                    visible_payload_changed = False
+                if visible_payload_changed is not True:
+                    logger.debug(
+                        "[Slack] Ignoring message_changed with %s visible payload "
+                        "evidence for message %s",
+                        (
+                            "unchanged"
+                            if visible_payload_changed is False
+                            else "unknown"
+                        ),
+                        updated_message.get("ts", ""),
+                    )
+                    return
+
             original_message_ts = str(updated_message.get("ts") or "")
             if (
                 original_message_ts
@@ -5260,11 +5343,59 @@ class SlackAdapter(BasePlatformAdapter):
             ):
                 return
             edited = updated_message.get("edited")
-            edited_ts = ""
-            if isinstance(edited, dict):
-                edited_ts = str(edited.get("ts") or "")
+            edited_ts = edited.get("ts") if isinstance(edited, dict) else None
             outer_event_ts = str(event.get("ts") or "")
-            changed_event_ts = str(event.get("event_ts") or edited_ts or "")
+            previous_latest_reply = (
+                previous_message.get("latest_reply")
+                if isinstance(previous_message, dict)
+                else None
+            )
+            updated_latest_reply = updated_message.get("latest_reply")
+            latest_reply_ts = (
+                updated_latest_reply
+                if updated_latest_reply not in (None, "")
+                else previous_latest_reply
+            )
+            reply_metadata_fields = (
+                "latest_reply",
+                "reply_count",
+                "reply_users_count",
+                "reply_users",
+                "replies",
+            )
+            has_reply_metadata = any(
+                field in updated_message for field in reply_metadata_fields
+            ) or (
+                isinstance(previous_message, dict)
+                and any(field in previous_message for field in reply_metadata_fields)
+            )
+            latest_reply_valid = self._is_valid_slack_timestamp(latest_reply_ts)
+            edited_ts_valid = self._is_valid_slack_timestamp(edited_ts)
+            latest_reply_at_or_after_edit = bool(
+                latest_reply_valid
+                and edited_ts_valid
+                and self._slack_timestamp_sort_key(latest_reply_ts)[:2]
+                >= self._slack_timestamp_sort_key(edited_ts)[:2]
+            )
+            ambiguous_reply_order = bool(
+                has_reply_metadata
+                and not (latest_reply_valid and edited_ts_valid)
+                and visible_payload_changed is not True
+            )
+            if visible_payload_changed is not True and has_reply_metadata and (
+                latest_reply_at_or_after_edit or ambiguous_reply_order
+            ):
+                logger.debug(
+                    "[Slack] Ignoring thread parent reply metadata update "
+                    "for message %s: edited_ts=%s latest_reply=%s",
+                    original_message_ts,
+                    edited_ts,
+                    latest_reply_ts,
+                )
+                return
+            changed_event_ts = str(
+                event.get("event_ts") or (edited_ts if edited_ts_valid else "") or ""
+            )
             if (
                 not changed_event_ts
                 and outer_event_ts
@@ -5275,6 +5406,21 @@ class SlackAdapter(BasePlatformAdapter):
                 changed_event_ts = f"{original_message_ts}:changed"
 
             normalized_event = dict(updated_message)
+            if "text" in normalized_event and not isinstance(
+                normalized_event["text"], str
+            ):
+                normalized_event["text"] = ""
+            for field in ("blocks", "attachments", "files"):
+                if field not in normalized_event:
+                    continue
+                if not isinstance(normalized_event[field], list):
+                    normalized_event[field] = []
+                else:
+                    normalized_event[field] = [
+                        item
+                        for item in normalized_event[field]
+                        if isinstance(item, dict)
+                    ]
             for key in ("channel", "channel_type", "team", "team_id"):
                 if not normalized_event.get(key) and event.get(key):
                     normalized_event[key] = event.get(key)

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1830,6 +1830,111 @@ class TestIncomingAudioHandling:
 
 
 # ---------------------------------------------------------------------------
+# Helpers — edited thread-parent (``message_changed``) events
+# ---------------------------------------------------------------------------
+
+_UNSET = object()
+
+_PARENT_MENTION_TEXT = "<@U_BOT> ship the release notes"
+_EDITED_MENTION_TEXT = "<@U_BOT> ship the release notes, revised"
+_PARENT_PLAIN_TEXT = "ship the release notes"
+_EDITED_PLAIN_TEXT = "ship the release notes, revised"
+_REPLIED_PARENT_FIELDS = {"reply_count": 2, "latest_reply": "200.000001"}
+
+
+def _rich_text_blocks(*elements):
+    """Wrap *elements* in the ``rich_text``/``rich_text_section`` tree Slack sends."""
+    return [
+        {
+            "type": "rich_text",
+            "elements": [{"type": "rich_text_section", "elements": list(elements)}],
+        }
+    ]
+
+
+def _replied_parent_edit_event(
+    *,
+    text=_EDITED_MENTION_TEXT,
+    previous_text=_PARENT_MENTION_TEXT,
+    blocks=None,
+    previous_blocks=None,
+    previous_message=_UNSET,
+    reply_fields=_REPLIED_PARENT_FIELDS,
+    channel="C123",
+    channel_type="channel",
+    team="T123",
+    message_team=None,
+    parent_ts="100.000001",
+    thread_ts=_UNSET,
+    event_ts="301.000001",
+    edited_ts="300.000001",
+    message_extra=None,
+):
+    """Build a ``message_changed`` event editing an already-replied thread parent.
+
+    The defaults reproduce the live incident shape: a thread root that
+    @mentions the bot, already carries reply bookkeeping, and whose text was
+    edited later.  Each regression varies one facet through a keyword:
+
+    ``text`` / ``previous_text`` / ``blocks`` / ``previous_blocks``
+        the edited and pre-edit payloads (``blocks=None`` omits the key).
+    ``previous_message``
+        replaces the generated pre-edit snapshot wholesale; ``None`` drops
+        the key entirely.
+    ``reply_fields``
+        the reply bookkeeping copied into both snapshots.
+    ``channel`` / ``channel_type`` / ``team`` / ``message_team``
+        routing identity; ``team=None`` omits the outer team so only the
+        edited message carries one.
+    ``parent_ts`` / ``thread_ts`` / ``event_ts`` / ``edited_ts``
+        timestamps; ``thread_ts`` defaults to ``parent_ts`` (a thread root)
+        and ``None`` omits it.
+    ``message_extra``
+        extra keys merged into the edited message only.
+    """
+    resolved_thread_ts = parent_ts if thread_ts is _UNSET else thread_ts
+
+    def _snapshot(body_text, body_blocks, extra=None):
+        message = {
+            "type": "message",
+            "text": body_text,
+            "user": "U_USER",
+            "channel": channel,
+            "ts": parent_ts,
+            **dict(reply_fields or {}),
+        }
+        if resolved_thread_ts is not None:
+            message["thread_ts"] = resolved_thread_ts
+        if body_blocks is not None:
+            message["blocks"] = body_blocks
+        if message_team is not None:
+            message["team"] = message_team
+        message.update(extra or {})
+        return message
+
+    event = {
+        "type": "message",
+        "subtype": "message_changed",
+        "channel": channel,
+        "channel_type": channel_type,
+        "ts": event_ts,
+        "event_ts": event_ts,
+        "message": _snapshot(
+            text,
+            blocks,
+            {"edited": {"user": "U_USER", "ts": edited_ts}, **(message_extra or {})},
+        ),
+    }
+    if team is not None:
+        event["team"] = team
+    if previous_message is _UNSET:
+        event["previous_message"] = _snapshot(previous_text, previous_blocks)
+    elif previous_message is not None:
+        event["previous_message"] = previous_message
+    return event
+
+
+# ---------------------------------------------------------------------------
 # TestMessageRouting
 # ---------------------------------------------------------------------------
 
@@ -2662,6 +2767,303 @@ class TestMessageRouting:
         await adapter._handle_slack_message(event)
 
         adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_addressed_thread_parent_edit_not_replayed_when_cold(self, adapter):
+        """Editing an already-addressed thread parent must not start a new turn.
+
+        Live incident: a thread root that already @mentioned the bot was
+        edited hours later.  ``_processed_message_ts`` did not suppress the
+        edit — the original ts was absent from this process's set — so the
+        proven visible text change pushed the edit through as fresh inbound
+        input, replaying instructions the agent had already executed in that
+        thread.  The guard is per-process state, so a missing entry proves
+        nothing about whether the message was delivered before.
+        """
+        assert adapter._processed_message_ts == {}
+        event = _replied_parent_edit_event(
+            parent_ts="1785736676.775279",
+            event_ts="1785736692.000100",
+            edited_ts="1785736692.000000",
+            reply_fields={"reply_count": 4, "latest_reply": "1785736690.000200"},
+        )
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_repeated_addressed_thread_parent_edits_not_replayed(self, adapter):
+        """Every later edit of an addressed parent stays out of the loop."""
+        for index, revision in enumerate(("first revision", "second revision"), 1):
+            event = _replied_parent_edit_event(
+                text=f"{_PARENT_MENTION_TEXT} — {revision}",
+                event_ts=f"20{index}.000001",
+                edited_ts=f"20{index}.000000",
+                reply_fields={"reply_count": 2, "latest_reply": "150.000001"},
+            )
+
+            await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "previous_message",
+        [
+            None,
+            "malformed",
+            {"text": 123},
+            {"user": "U_USER"},
+            {"text": "ship the release notes", "blocks": ["malformed"]},
+        ],
+        ids=("absent", "not-a-dict", "untyped-text", "no-text", "untyped-blocks"),
+    )
+    async def test_addressed_thread_parent_edit_without_proof_fails_closed(
+        self, adapter, previous_message
+    ):
+        """Without a trustworthy pre-edit snapshot, never replay the parent."""
+        event = _replied_parent_edit_event(previous_message=previous_message)
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_thread_parent_edit_adding_mention_processed(self, adapter):
+        """A newly added @mention on a replied parent still routes once."""
+        event = _replied_parent_edit_event(
+            text=_PARENT_MENTION_TEXT, previous_text=_PARENT_PLAIN_TEXT
+        )
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_called_once()
+        delivered = adapter.handle_message.call_args.args[0]
+        assert delivered.text == "ship the release notes"
+
+    @pytest.mark.asyncio
+    async def test_addressed_parent_edit_without_replies_processed(self, adapter):
+        """An edit with no reply evidence keeps its existing routing."""
+        event = _replied_parent_edit_event(
+            thread_ts=None, reply_fields={"reply_count": 0}
+        )
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_block_kit_only_mention_parent_edit_not_replayed(self, adapter):
+        """A Block-Kit-authored mention counts as already addressing the bot."""
+
+        def _blocks(body: str) -> list:
+            return _rich_text_blocks(
+                {"type": "user", "user_id": "U_BOT"},
+                {"type": "text", "text": f" {body}"},
+            )
+
+        event = _replied_parent_edit_event(
+            text=_EDITED_PLAIN_TEXT,
+            previous_text=_PARENT_PLAIN_TEXT,
+            blocks=_blocks(_EDITED_PLAIN_TEXT),
+            previous_blocks=_blocks(_PARENT_PLAIN_TEXT),
+        )
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_addressed_parent_edit_removing_mention_not_replayed(self, adapter):
+        """Dropping the mention while editing an answered parent is still a replay.
+
+        The pre-edit snapshot proves the thread root already addressed the
+        bot, so the thread was answered. Whether the *edited* wording still
+        carries the mention says nothing about that — re-delivering it
+        replays instructions the agent already acted on.
+        """
+        event = _replied_parent_edit_event(
+            text=_EDITED_PLAIN_TEXT, channel="D123", channel_type="im"
+        )
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_addressed_parent_edit_with_malformed_text_not_replayed(
+        self, adapter
+    ):
+        """A malformed current payload cannot launder an answered parent's edit."""
+        event = _replied_parent_edit_event(
+            text=123,
+            message_extra={"attachments": [{"fallback": "added attachment"}]},
+            channel="D123",
+            channel_type="im",
+        )
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_wake_word_parent_edit_removing_wake_word_not_replayed(
+        self, adapter
+    ):
+        """A wake-word parent counts as addressed even after the word is edited out."""
+        adapter.config.extra["mention_patterns"] = [r"^\s*hermes\b"]
+
+        event = _replied_parent_edit_event(
+            text=_EDITED_PLAIN_TEXT,
+            previous_text="hermes ship the release notes",
+            channel="D123",
+            channel_type="im",
+        )
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "previous_blocks",
+        [
+            [{"type": "rich_text", "elements": "malformed"}],
+            _rich_text_blocks({"type": "user", "user_id": ""}),
+            _rich_text_blocks({"type": ""}),
+            # Slack sends bare identifiers: a blank or padded label names
+            # nobody and matches none of the walker's branches, so it is
+            # silence rather than proof the mention was absent.
+            pytest.param(
+                _rich_text_blocks({"type": "user", "user_id": "   "}),
+                id="blank-user-id",
+            ),
+            pytest.param(
+                _rich_text_blocks({"type": "user", "user_id": " U123 "}),
+                id="padded-user-id",
+            ),
+            pytest.param(_rich_text_blocks({"type": "   "}), id="blank-type"),
+            pytest.param(
+                _rich_text_blocks({"type": " user ", "user_id": "U123"}),
+                id="padded-type",
+            ),
+            # Every Block Kit node Slack sends is typed. A node missing
+            # ``type`` is a partial payload the walker reads as ordinary
+            # content, so it cannot witness that the mention was absent.
+            pytest.param(
+                _rich_text_blocks({"user_id": "U_BOT"}),
+                id="missing-type",
+            ),
+            # Slack's ``blocks`` container is a list. A bare dict is not the
+            # payload the walker traverses, so it proves nothing either.
+            pytest.param(
+                {"type": "rich_text", "elements": []},
+                id="top-level-not-a-list",
+            ),
+        ],
+    )
+    async def test_nested_malformed_previous_blocks_fail_closed(
+        self, adapter, previous_blocks
+    ):
+        """A malformed node inside the traversed block tree is not absence proof."""
+        event = _replied_parent_edit_event(
+            text=_PARENT_MENTION_TEXT,
+            previous_text=_PARENT_PLAIN_TEXT,
+            previous_blocks=previous_blocks,
+        )
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_valid_nested_previous_blocks_prove_mention_absence(self, adapter):
+        """A well-formed mention-free block tree still proves the mention is new."""
+        event = _replied_parent_edit_event(
+            text=_PARENT_MENTION_TEXT,
+            blocks=_rich_text_blocks(
+                {"type": "user", "user_id": "U_BOT"},
+                {"type": "text", "text": f" {_PARENT_PLAIN_TEXT}"},
+            ),
+            previous_text=_PARENT_PLAIN_TEXT,
+            previous_blocks=_rich_text_blocks(
+                {"type": "text", "text": _PARENT_PLAIN_TEXT}
+            ),
+        )
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "reply_fields",
+        [
+            {"reply_count": 0, "latest_reply": "malformed"},
+            {"reply_count": 0, "replies": ["malformed"]},
+            {"reply_count": 0, "replies": [{"ts": "malformed"}]},
+            {"reply_count": 0, "reply_users": [123]},
+        ],
+    )
+    async def test_malformed_reply_evidence_alone_is_not_reply_proof(
+        self, adapter, reply_fields
+    ):
+        """Malformed reply bookkeeping must not stand in for real replies."""
+        event = _replied_parent_edit_event(thread_ts=None, reply_fields=reply_fields)
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "reply_fields",
+        [
+            {"reply_count": 0, "replies": [{"user": "U_OTHER", "ts": "200.000001"}]},
+            {"reply_count": 0, "reply_users": ["U_OTHER"]},
+        ],
+    )
+    async def test_reply_collection_evidence_suppresses_addressed_parent_edit(
+        self, adapter, reply_fields
+    ):
+        """Well-formed ``replies``/``reply_users`` entries still prove replies."""
+        event = _replied_parent_edit_event(thread_ts=None, reply_fields=reply_fields)
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_secondary_workspace_does_not_trust_primary_bot_uid(self, adapter):
+        """Slack user IDs are workspace-local: the primary UID is not this bot here."""
+        adapter._team_bot_user_ids = {"T_SECOND": "U_BOT2"}
+
+        event = _replied_parent_edit_event(
+            channel="D123", channel_type="im", team="T_SECOND"
+        )
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_called_once()
+        delivered = adapter.handle_message.call_args.args[0]
+        assert delivered.text == "<@U_BOT> ship the release notes, revised"
+
+    @pytest.mark.asyncio
+    async def test_inner_message_team_resolves_secondary_workspace_bot(self, adapter):
+        """When only the edited message carries ``team``, resolve the bot from it."""
+        adapter._team_bot_user_ids = {"T_SECOND": "U_BOT2"}
+
+        event = _replied_parent_edit_event(
+            text="<@U_BOT2> ship the release notes, revised",
+            previous_text="<@U_BOT2> ship the release notes",
+            team=None,
+            message_team="T_SECOND",
+        )
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_not_called()
 
 # ---------------------------------------------------------------------------
 # TestSendTyping — assistant.threads.setStatus

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1936,6 +1936,733 @@ class TestMessageRouting:
         assert msg_event.message_id == "1234567890.000001"
 
 
+    @pytest.mark.asyncio
+    async def test_stale_message_changed_metadata_update_ignored(self, adapter):
+        """A parent metadata update must not replay an old user edit as new input."""
+        event = {
+            "type": "message",
+            "subtype": "message_changed",
+            "hidden": True,
+            "channel": "D123",
+            "channel_type": "im",
+            "team": "T123",
+            "ts": "201.000001",
+            "event_ts": "201.000001",
+            "message": {
+                "type": "message",
+                "text": "old thread parent",
+                "user": "U_USER",
+                "channel": "D123",
+                "ts": "100.000001",
+                "thread_ts": "100.000001",
+                "edited": {"user": "U_USER", "ts": "150.000001"},
+                "reply_count": 2,
+                "latest_reply": "200.000001",
+            },
+        }
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_thread_metadata_only_parent_update_ignored(self, adapter):
+        """Reply bookkeeping must not replay an unchanged thread parent."""
+        parent = {
+            "type": "message",
+            "text": "old thread parent",
+            "files": [],
+            "user": "U_USER",
+            "channel": "D123",
+            "ts": "100.000001",
+            "thread_ts": "100.000001",
+            "reply_count": 2,
+        }
+        previous = {
+            "type": "message",
+            "text": "old thread parent",
+            "user": "U_USER",
+            "channel": "D123",
+            "ts": "100.000001",
+        }
+        event = {
+            "type": "message",
+            "subtype": "message_changed",
+            "hidden": True,
+            "channel": "D123",
+            "channel_type": "im",
+            "team": "T123",
+            "ts": "200.000002",
+            "event_ts": "200.000002",
+            "message": parent,
+            "previous_message": previous,
+        }
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("previous_message", [None, "malformed"])
+    async def test_unedited_parent_reply_update_without_previous_ignored(
+        self, adapter, previous_message
+    ):
+        """Reply metadata ordering identifies updates without previous_message."""
+        event = {
+            "type": "message",
+            "subtype": "message_changed",
+            "hidden": True,
+            "channel": "D123",
+            "channel_type": "im",
+            "team": "T123",
+            "ts": "1726133701.028300",
+            "event_ts": "1726133701.028300",
+            "message": {
+                "type": "message",
+                "text": "old unedited thread parent",
+                "user": "U_USER",
+                "channel": "D123",
+                "ts": "1726133698.626339",
+                "thread_ts": "1726133698.626339",
+                "reply_count": 2,
+                "latest_reply": "1726133700.887259",
+            },
+        }
+        if previous_message is not None:
+            event["previous_message"] = previous_message
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "previous_message",
+        [
+            None,
+            "malformed",
+            {},
+            {"reply_count": 1},
+            {"text": None},
+            {"files": "malformed"},
+        ],
+    )
+    @pytest.mark.parametrize("latest_reply", [None, "malformed", 150])
+    async def test_ambiguous_reply_order_without_visible_snapshot_ignored(
+        self, adapter, previous_message, latest_reply
+    ):
+        """Ambiguous reply ordering must fail closed after a cold restart."""
+        event = {
+            "type": "message",
+            "subtype": "message_changed",
+            "hidden": True,
+            "channel": "D123",
+            "channel_type": "im",
+            "team": "T123",
+            "ts": "201.000001",
+            "event_ts": "201.000001",
+            "message": {
+                "type": "message",
+                "text": "old parent instruction with side effects",
+                "user": "U_USER",
+                "channel": "D123",
+                "ts": "100.000001",
+                "thread_ts": "100.000001",
+                "edited": {"user": "U_USER", "ts": "150.000001"},
+                "reply_count": 2,
+            },
+        }
+        if latest_reply is not None:
+            event["message"]["latest_reply"] = latest_reply
+        if previous_message is not None:
+            event["previous_message"] = previous_message
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "reply_fields,previous_message,edited_ts",
+        [
+            ({"reply_count": 0}, {}, None),
+            ({"reply_users_count": 0}, {}, None),
+            ({"reply_users": []}, {}, None),
+            ({"replies": []}, {}, None),
+            (
+                {
+                    "reply_count": 0,
+                    "reply_users_count": 0,
+                    "reply_users": [],
+                    "replies": [],
+                },
+                {},
+                None,
+            ),
+            (
+                {},
+                {"reply_count": 1, "latest_reply": "150.000001"},
+                "200.000001",
+            ),
+            (
+                {"reply_count": 1, "latest_reply": "150.000001"},
+                {"reply_count": 2, "latest_reply": "300.000001"},
+                "200.000001",
+            ),
+            (
+                {"reply_count": 0},
+                {
+                    "text": "old parent instruction with side effects",
+                    "files": [],
+                    "reply_count": 1,
+                },
+                None,
+            ),
+            (
+                {"files": {}, "reply_count": 0},
+                {
+                    "text": "old parent instruction with side effects",
+                    "files": [],
+                    "reply_count": 1,
+                },
+                None,
+            ),
+            (
+                {"files": "", "reply_count": 0},
+                {
+                    "text": "old parent instruction with side effects",
+                    "files": [{"id": "F_PREVIOUS"}],
+                    "reply_count": 1,
+                },
+                None,
+            ),
+        ],
+    )
+    async def test_reply_metadata_transition_ignored(
+        self, adapter, reply_fields, previous_message, edited_ts
+    ):
+        """Reply metadata transitions must not replay a thread parent."""
+        event = {
+            "type": "message",
+            "subtype": "message_changed",
+            "hidden": True,
+            "channel": "D123",
+            "channel_type": "im",
+            "team": "T123",
+            "ts": "201.000001",
+            "event_ts": "201.000001",
+            "message": {
+                "type": "message",
+                "text": "old parent instruction with side effects",
+                "user": "U_USER",
+                "channel": "D123",
+                "ts": "100.000001",
+                "thread_ts": "100.000001",
+                **reply_fields,
+            },
+            "previous_message": previous_message,
+        }
+        if edited_ts is not None:
+            event["message"]["edited"] = {"user": "U_USER", "ts": edited_ts}
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_message_changed_visible_text_update_processed(self, adapter):
+        """A genuine edit routes when event_ts follows edited.ts by milliseconds."""
+        event = {
+            "type": "message",
+            "subtype": "message_changed",
+            "channel": "D123",
+            "channel_type": "im",
+            "team": "T123",
+            "ts": "1665102362.013600",
+            "event_ts": "1665102362.013600",
+            "message": {
+                "type": "message",
+                "text": "corrected text",
+                "user": "U_USER",
+                "channel": "D123",
+                "ts": "1665102338.901939",
+                "edited": {"user": "U_USER", "ts": "1665102362.000000"},
+            },
+            "previous_message": {
+                "type": "message",
+                "text": "original text",
+                "user": "U_USER",
+                "channel": "D123",
+                "ts": "1665102338.901939",
+            },
+        }
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_called_once()
+        delivered = adapter.handle_message.call_args.args[0]
+        assert delivered.text == "corrected text"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "edited_ts,latest_reply",
+        [(None, "malformed"), ("200.000001", "300.000001")],
+    )
+    async def test_visible_edit_with_ambiguous_reply_order_processed(
+        self, adapter, edited_ts, latest_reply
+    ):
+        """A proven visible edit wins over incomplete or older edit ordering."""
+        event = {
+            "type": "message",
+            "subtype": "message_changed",
+            "channel": "D123",
+            "channel_type": "im",
+            "team": "T123",
+            "ts": "301.000002",
+            "event_ts": "301.000002",
+            "message": {
+                "type": "message",
+                "text": "corrected despite malformed metadata",
+                "user": "U_USER",
+                "channel": "D123",
+                "ts": "100.000001",
+                "thread_ts": "100.000001",
+                "reply_count": 2,
+                "latest_reply": latest_reply,
+            },
+            "previous_message": {
+                "type": "message",
+                "text": "original text",
+                "user": "U_USER",
+                "channel": "D123",
+                "ts": "100.000001",
+                "reply_count": 2,
+                "latest_reply": latest_reply,
+            },
+        }
+        if edited_ts is not None:
+            event["message"]["edited"] = {"user": "U_USER", "ts": edited_ts}
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_called_once()
+        delivered = adapter.handle_message.call_args.args[0]
+        assert delivered.text == "corrected despite malformed metadata"
+
+    @pytest.mark.asyncio
+    async def test_thread_parent_edit_after_latest_reply_processed(self, adapter):
+        """A newer parent edit must route even without previous_message."""
+        event = {
+            "type": "message",
+            "subtype": "message_changed",
+            "channel": "D123",
+            "channel_type": "im",
+            "team": "T123",
+            "ts": "301.000001",
+            "event_ts": "301.000001",
+            "message": {
+                "type": "message",
+                "text": "parent corrected after replies",
+                "user": "U_USER",
+                "channel": "D123",
+                "ts": "100.000001",
+                "thread_ts": "100.000001",
+                "edited": {"user": "U_USER", "ts": "300.000001"},
+                "reply_count": 2,
+                "latest_reply": "200.000001",
+            },
+        }
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_called_once()
+        delivered = adapter.handle_message.call_args.args[0]
+        assert delivered.text == "parent corrected after replies"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("field", "previous_value"),
+        [
+            ("attachments", [{"fallback": "removed attachment"}]),
+            ("files", [{"id": "F_REMOVED"}]),
+            ("blocks", [{"type": "section"}]),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "explicit_null", [False, True], ids=("omitted", "explicit-null")
+    )
+    async def test_visible_payload_removal_with_reply_metadata_processed(
+        self, adapter, field, previous_value, explicit_null
+    ):
+        """Removing visible payload must win over reply metadata transitions."""
+        parent = {
+            "type": "message",
+            "text": "unchanged parent text",
+            "user": "U_USER",
+            "channel": "D123",
+            "ts": "100.000001",
+            "thread_ts": "100.000001",
+            "reply_count": 2,
+            "latest_reply": "200.000001",
+        }
+        if explicit_null:
+            parent[field] = None
+        previous = {
+            "type": "message",
+            "text": "unchanged parent text",
+            "user": "U_USER",
+            "channel": "D123",
+            "ts": "100.000001",
+            "thread_ts": "100.000001",
+            "reply_count": 1,
+            "latest_reply": "150.000001",
+            field: previous_value,
+        }
+        event = {
+            "type": "message",
+            "subtype": "message_changed",
+            "channel": "D123",
+            "channel_type": "im",
+            "team": "T123",
+            "ts": "201.000001",
+            "event_ts": "201.000001",
+            "message": parent,
+            "previous_message": previous,
+        }
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_called_once()
+        delivered = adapter.handle_message.call_args.args[0]
+        assert delivered.text == "unchanged parent text"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("edited_ts", "latest_reply"),
+        [
+            ("150.000001", "²"),
+            ("150.000001", "150.²"),
+            ("150.000001", "150.000001"),
+            ("150.000001", "9" * 5_000),
+        ],
+        ids=("unicode-seconds", "unicode-fraction", "equal-order", "oversized"),
+    )
+    async def test_malformed_slack_timestamp_reply_update_ignored(
+        self, adapter, edited_ts, latest_reply
+    ):
+        """Non-protocol timestamps must fail closed instead of replaying a parent."""
+        event = {
+            "type": "message",
+            "subtype": "message_changed",
+            "channel": "D123",
+            "channel_type": "im",
+            "team": "T123",
+            "ts": "201.000001",
+            "event_ts": "201.000001",
+            "message": {
+                "type": "message",
+                "text": "stale parent text",
+                "user": "U_USER",
+                "channel": "D123",
+                "ts": "100.000001",
+                "thread_ts": "100.000001",
+                "edited": {"user": "U_USER", "ts": edited_ts},
+                "reply_count": 2,
+                "latest_reply": latest_reply,
+            },
+        }
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("edited_ts", "latest_reply"),
+        [
+            ("200.100000", "200.1"),
+            ("200.000000", "200"),
+        ],
+    )
+    async def test_equivalent_slack_timestamp_reply_update_ignored(
+        self, adapter, edited_ts, latest_reply
+    ):
+        """Different encodings of the same timestamp are numerically equal."""
+        event = {
+            "type": "message",
+            "subtype": "message_changed",
+            "channel": "D123",
+            "channel_type": "im",
+            "team": "T123",
+            "ts": "201.000001",
+            "event_ts": "201.000001",
+            "message": {
+                "type": "message",
+                "text": "stale parent text",
+                "user": "U_USER",
+                "channel": "D123",
+                "ts": "100.000001",
+                "thread_ts": "100.000001",
+                "edited": {"user": "U_USER", "ts": edited_ts},
+                "reply_count": 2,
+                "latest_reply": latest_reply,
+            },
+        }
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("current_visible", "previous_visible"),
+        [
+            (
+                {"text": "stale parent text", "files": {}},
+                {"text": "stale parent text", "files": []},
+            ),
+            (
+                {"text": "stale parent text", "files": ["malformed"]},
+                {"text": "stale parent text", "files": []},
+            ),
+            (
+                {"files": []},
+                {"text": "stale parent text", "files": []},
+            ),
+        ],
+        ids=("wrong-typed-list", "wrong-typed-list-item", "omitted-text"),
+    )
+    async def test_unknown_visible_evidence_with_newer_edit_ignored(
+        self, adapter, current_visible, previous_visible
+    ):
+        """A newer edit timestamp cannot turn unknown visible evidence into input."""
+        common = {
+            "type": "message",
+            "user": "U_USER",
+            "channel": "D123",
+            "ts": "100.000001",
+            "thread_ts": "100.000001",
+            "reply_count": 2,
+            "latest_reply": "200.000001",
+        }
+        event = {
+            "type": "message",
+            "subtype": "message_changed",
+            "channel": "D123",
+            "channel_type": "im",
+            "team": "T123",
+            "ts": "301.000001",
+            "event_ts": "301.000001",
+            "message": {
+                **common,
+                **current_visible,
+                "edited": {"user": "U_USER", "ts": "300.000001"},
+            },
+            "previous_message": {**common, **previous_visible},
+        }
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("field", ["blocks", "attachments", "files"])
+    @pytest.mark.parametrize(
+        "malformed_value",
+        [{"unexpected": "value"}, ["malformed"]],
+        ids=("wrong-container", "wrong-item"),
+    )
+    async def test_visible_text_update_with_malformed_list_field_processed(
+        self, adapter, field, malformed_value
+    ):
+        """A proven text edit routes without iterating malformed list payloads."""
+        event = {
+            "type": "message",
+            "subtype": "message_changed",
+            "channel": "D123",
+            "channel_type": "im",
+            "team": "T123",
+            "ts": "301.000001",
+            "event_ts": "301.000001",
+            "message": {
+                "type": "message",
+                "text": "corrected parent text",
+                "user": "U_USER",
+                "channel": "D123",
+                "ts": "100.000001",
+                "thread_ts": "100.000001",
+                "edited": {"user": "U_USER", "ts": "300.000001"},
+                field: malformed_value,
+            },
+            "previous_message": {
+                "type": "message",
+                "text": "original parent text",
+                "user": "U_USER",
+                "channel": "D123",
+                "ts": "100.000001",
+                "thread_ts": "100.000001",
+                field: [],
+            },
+        }
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_called_once()
+        delivered = adapter.handle_message.call_args.args[0]
+        assert delivered.text == "corrected parent text"
+        assert delivered.raw_message[field] == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("malformed_text", [None, {}, 123])
+    async def test_visible_collection_addition_with_malformed_text_processed(
+        self, adapter, malformed_text
+    ):
+        """A proven collection addition routes with type-safe normalized text."""
+        event = {
+            "type": "message",
+            "subtype": "message_changed",
+            "channel": "D123",
+            "channel_type": "im",
+            "team": "T123",
+            "ts": "201.000001",
+            "event_ts": "201.000001",
+            "message": {
+                "type": "message",
+                "text": malformed_text,
+                "attachments": [{"fallback": "added attachment"}],
+                "user": "U_USER",
+                "channel": "D123",
+                "ts": "100.000001",
+                "thread_ts": "100.000001",
+            },
+            "previous_message": {
+                "type": "message",
+                "user": "U_USER",
+                "channel": "D123",
+                "ts": "100.000001",
+                "thread_ts": "100.000001",
+            },
+        }
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_called_once()
+        delivered = adapter.handle_message.call_args.args[0]
+        assert delivered.text == "📎 added attachment"
+        assert delivered.raw_message["text"] == ""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("field", "current_value"),
+        [
+            ("attachments", [{"fallback": "added attachment"}]),
+            ("files", [{"id": "F_ADDED"}]),
+            ("blocks", [{"type": "section"}]),
+        ],
+    )
+    async def test_visible_payload_addition_with_reply_metadata_processed(
+        self, adapter, field, current_value
+    ):
+        """Adding visible payload must win over reply metadata transitions."""
+        parent = {
+            "type": "message",
+            "text": "unchanged parent text",
+            "user": "U_USER",
+            "channel": "D123",
+            "ts": "100.000001",
+            "thread_ts": "100.000001",
+            "reply_count": 2,
+            "latest_reply": "200.000001",
+            field: current_value,
+        }
+        previous = {
+            "type": "message",
+            "text": "unchanged parent text",
+            "user": "U_USER",
+            "channel": "D123",
+            "ts": "100.000001",
+            "thread_ts": "100.000001",
+            "reply_count": 1,
+            "latest_reply": "150.000001",
+        }
+        event = {
+            "type": "message",
+            "subtype": "message_changed",
+            "channel": "D123",
+            "channel_type": "im",
+            "team": "T123",
+            "ts": "201.000001",
+            "event_ts": "201.000001",
+            "message": parent,
+            "previous_message": previous,
+        }
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_called_once()
+        delivered = adapter.handle_message.call_args.args[0]
+        assert delivered.text.startswith("unchanged parent text")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("field", "current_value"),
+        [
+            ("attachments", [{"fallback": "added attachment"}]),
+            ("files", [{"id": "F_ADDED"}]),
+            (
+                "blocks",
+                [
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": "added block"},
+                    }
+                ],
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "explicit_null", [False, True], ids=("omitted", "explicit-null")
+    )
+    async def test_visible_payload_addition_without_typed_previous_processed(
+        self, adapter, field, current_value, explicit_null
+    ):
+        """A proven list addition does not require another typed prior field."""
+        previous = {
+            "type": "message",
+            "user": "U_USER",
+            "channel": "D123",
+            "ts": "100.000001",
+            "thread_ts": "100.000001",
+            "reply_count": 1,
+            "latest_reply": "150.000001",
+        }
+        if explicit_null:
+            previous[field] = None
+        event = {
+            "type": "message",
+            "subtype": "message_changed",
+            "channel": "D123",
+            "channel_type": "im",
+            "team": "T123",
+            "ts": "201.000001",
+            "event_ts": "201.000001",
+            "message": {
+                "type": "message",
+                "user": "U_USER",
+                "channel": "D123",
+                "ts": "100.000001",
+                "thread_ts": "100.000001",
+                "reply_count": 2,
+                "latest_reply": "200.000001",
+                field: current_value,
+            },
+            "previous_message": previous,
+        }
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_called_once()
+
 # ---------------------------------------------------------------------------
 # TestSendTyping — assistant.threads.setStatus
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Slack can emit `message_changed` for an existing thread parent. In the incident that motivated this follow-up, the Slack thread contained a root text edit but no new user reply; the adapter normalized that edit as fresh inbound input when the root timestamp was absent from the process-local `_processed_message_ts` set.

A missing in-memory timestamp does not prove that the root was never delivered. Replaying an already-addressed parent can therefore create a phantom user turn from instructions the agent already acted on.

This PR now handles both replay classes before message normalization:

- filters metadata-only parent updates without suppressing proven visible text, block, attachment, or file additions/removals
- detects replied parents whose pre-edit snapshot already addressed this workspace's bot by mention, Block Kit, or configured wake pattern
- suppresses later edits of those addressed parents even if the mention is removed or the current payload is malformed
- routes a newly added mention exactly once only when the previous snapshot reliably proves that the bot was not addressed
- fails closed when the current edit addresses the bot but `previous_message` is missing, partial, or malformed
- preserves existing visible-edit routing when there is no bot-address evidence, and preserves edits with no reply evidence
- validates reply evidence and traversed Block Kit shapes before using them as proof
- resolves one workspace-local bot identity, with the edited message's team used only as a fallback when the outer event has none

Users who want revised parent text acted on can send a new thread reply. The adapter does not synthesize one and does not add durable session infrastructure.

## Related Issue

N/A — reproduced from a live Slack Socket Mode event sequence and covered by regression tests.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/slack/adapter.py`
  - classifies visible parent edits before normalization
  - validates thread-reply evidence
  - derives a tri-state pre-edit bot-address result from trusted text and Block Kit data
  - blocks answered-parent replays while preserving proven absent-to-present mention transitions
  - keeps workspace bot identity scoped to the event team
- `tests/gateway/test_slack.py`
  - covers cold process state, repeated edits, mention and wake-word removal, malformed current and previous payloads, nested Block Kit corruption, valid Block Kit transitions, malformed/valid reply evidence, multi-workspace identity, and preserved visible-edit paths

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_slack.py -q
ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack.py
python -m py_compile plugins/platforms/slack/adapter.py tests/gateway/test_slack.py
git diff --check
```

The broader Slack run dynamically resolves every `tests/**/*slack*.py` file and passes all 33 files.

## Verification

- focused parent-edit/proof regressions: `26 passed`
- `tests/gateway/test_slack.py`: `260 passed`
- all dynamically resolved Slack test files: `33 files, 476 passed`
- Ruff check: passed
- `py_compile`: passed
- `git diff --check`: passed
- fresh read-only exact-diff review: no blocking findings
- current upstream `main` conflict probe: clean; no relevant overlap since the reviewed target snapshot

A local canonical full-run attempt did not pass: it reported 73 non-Slack test failures and 10 collection/import failures. No Slack test failed in that run, and the full-suite checklist remains unchecked. Upstream Actions remain the authority for the repository-wide and cross-platform result.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.3.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A; internal Slack event filtering only
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — platform-independent Python event handling
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

The regression tests model sanitized Slack envelopes directly; no workspace-specific logs or identifiers are included.
