### PR TITLE
fix: resolve Termux --version crash due to PROJECT_ROOT used before definition

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -388,11 +388,26 @@ def _read_openai_version_fast() -> str | None:
     return None
 
 
+_FAST_PROJECT_ROOT: str | None = None
+
+
+def _set_fast_project_root() -> None:
+    global _FAST_PROJECT_ROOT
+    if _FAST_PROJECT_ROOT is not None:
+        return
+    try:
+        _FAST_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    except Exception:
+        _FAST_PROJECT_ROOT = "<unknown>"
+
+
 def _print_fast_version_info() -> None:
     from hermes_cli import __release_date__, __version__
 
+    _set_fast_project_root()
+
     print(f"Hermes Agent v{__version__} ({__release_date__})")
-    print(f"Install directory: {PROJECT_ROOT}")
+    print(f"Install directory: {_FAST_PROJECT_ROOT}")
 
     print(f"Python: {sys.version.split()[0]}")
 


### PR DESCRIPTION
## Bug Description

`hermes --version` crashes on Termux with:
```
Traceback (most recent call last):
  File ".../hermes_cli/main.py", line 416, in <module>
    if _try_termux_ultrafast_version():
  File ".../hermes_cli/main.py", line 412, in _try_termux_ultrafast_version
    _print_fast_version_info()
  File ".../hermes_cli/main.py", line 395, in _print_fast_version_info
    print(f"Install directory: {PROJECT_ROOT}")
NameError: name 'PROJECT_ROOT' is not defined
```

## Root Cause

On Termux, the ultrafast version path runs at module level (line 416) before `PROJECT_ROOT` is defined at line 492. The function `_print_fast_version_info()` references `PROJECT_ROOT`, but it has not been assigned yet.

## Fix

Introduce a module-level sentinel `_FAST_PROJECT_ROOT` and a helper `_set_fast_project_root()` that resolves the path using `os.path.dirname` (available early, unlike `Path` which is imported later). The helper is called inside `_print_fast_version_info()` on demand, avoiding the forward-reference to `PROJECT_ROOT`.

## How to Verify

1. Run `hermes --version` on Termux — should print version info without crashing.
2. Run `hermes --version` on a non-Termux platform — no regression.
3. Run `hermes doctor` — should still pass.

## Risk Assessment

Low — the change is isolated to `_print_fast_version_info()` and only affects the Termux ultrafast version printing path.