### PR TITLE
fix(desktop): normalize artifact timestamps

### DIFF
--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -27,6 +27,15 @@ export interface ArtifactLoadResult {
   failures: ArtifactLoadFailure[]
 }
 
+// Hermes wire timestamps use Unix seconds. Preserve already-normalized modern
+// millisecond values above this boundary; ambiguous smaller values (including
+// pre-1973 milliseconds) are interpreted as seconds by contract.
+const UNIX_MILLISECONDS_THRESHOLD = 100_000_000_000
+
+function normalizeArtifactTimestamp(timestamp: number): number {
+  return timestamp < UNIX_MILLISECONDS_THRESHOLD ? timestamp * 1000 : timestamp
+}
+
 const MARKDOWN_IMAGE_RE = /!\[([^\]]*)\]\(([^)\s]+)\)/g
 const MARKDOWN_LINK_RE = /\[([^\]]+)\]\(([^)\s]+)\)/g
 const URL_RE = /https?:\/\/[^\s<>"')]+/g
@@ -283,7 +292,9 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
         label: artifactLabel(value),
         sessionId: session.id,
         sessionTitle: title,
-        timestamp: message.timestamp || session.last_active || session.started_at || Date.now()
+        timestamp: normalizeArtifactTimestamp(
+          message.timestamp || session.last_active || session.started_at || Date.now()
+        )
       })
     })
   }

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -67,6 +67,64 @@ describe('collectArtifactsForSession', () => {
     })
   })
 
+  it('normalizes Unix-second timestamps before rendering artifacts', () => {
+    const seconds = 1_785_144_916.737_952
+
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: 'Reference: https://example.com/from-seconds',
+        role: 'assistant',
+        timestamp: seconds
+      }
+    ])
+
+    expect(artifacts[0]?.timestamp).toBe(seconds * 1000)
+    expect(new Date(artifacts[0]?.timestamp ?? 0).getUTCFullYear()).toBe(2026)
+  })
+
+  it('preserves timestamps that are already milliseconds', () => {
+    const milliseconds = 1_785_144_916_737
+
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: 'Reference: https://example.com/from-milliseconds',
+        role: 'assistant',
+        timestamp: milliseconds
+      }
+    ])
+
+    expect(artifacts[0]?.timestamp).toBe(milliseconds)
+  })
+
+  it('interprets ambiguous values below the millisecond threshold as Unix seconds', () => {
+    const ambiguousTimestamp = 42_000_000_000
+
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: 'Reference: https://example.com/from-ambiguous-timestamp',
+        role: 'assistant',
+        timestamp: ambiguousTimestamp
+      }
+    ])
+
+    expect(artifacts[0]?.timestamp).toBe(ambiguousTimestamp * 1000)
+  })
+
+  it('does not multiply the Date.now fallback', () => {
+    const now = 1_785_144_916_737
+
+    vi.spyOn(Date, 'now').mockReturnValue(now)
+
+    const artifacts = collectArtifactsForSession(makeSession({ last_active: 0, started_at: 0 }), [
+      {
+        content: 'Reference: https://example.com/from-now',
+        role: 'assistant'
+      }
+    ])
+
+    expect(artifacts[0]?.timestamp).toBe(now)
+  })
+
   it('resolves remote image artifact thumbnails through the desktop fs bridge', async () => {
     const api = vi.fn(async ({ path }: { path: string }) => {
       if (path.startsWith('/api/fs/read-data-url?')) {


### PR DESCRIPTION
## Summary  Fixes #73454.  Session and message timestamps returned by the backend are Unix seconds, while JavaScript `Date` expects milliseconds. The Artifacts panel stored the raw value, so entries from 2026 rendered near January 1970.  Normalize the selected timestamp at the artifact collection boundary. Unix-second values are converted to milliseconds; existing modern millisecond values and the `Date.now()` fallback remain unchanged. Keeping the invariant on `ArtifactRecord.timestamp` also preserves correct sorting and avoids making each renderer remember the backend unit.  ## Unit contract  Hermes wire timestamps use Unix seconds. Values below `100_000_000_000` are therefore interpreted as seconds; values at or above that boundary are treated as already-normalized milliseconds. Ambiguous pre-1973 millisecond values fall on the seconds side of this contract.  ## Current-main reproduction  On the current-main replay used for head `c5849c99c`, an ambiguous value below the threshold remained unchanged before the fix (RED) and was multiplied by 1000 after normalization (GREEN).  ## Behavior covered  - fractional Unix seconds normalize to milliseconds; - already-normalized modern millisecond timestamps are unchanged; - the `Date.now()` fallback is not multiplied; - the explicit below-threshold contract is covered through the production artifact collector; - existing artifact extraction and remote image resolution continue to work.  ## Validation  - Artifacts UI test module: **8 passed** - full Desktop TypeScript typecheck (renderer, Electron and E2E configs): passed - targeted ESLint: passed with zero warnings - targeted Prettier check: passed - `git diff HEAD^ --check`: passed