### PR TITLE
fix(cli): warn on unrecognized MoA preset and slot config keys

### DIFF
--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import base64
 import json
+import logging
 import math
 from copy import deepcopy
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 MOA_MARKER_PREFIX = "__HERMES_MOA_TURN_V1__"
 DEFAULT_MOA_PRESET_NAME = "default"
@@ -191,9 +194,87 @@ def _coerce_bool(value: Any, default: bool = True) -> bool:
     return bool(value)
 
 
-def _clean_slot(slot: Any, *, include_enabled: bool = False) -> dict[str, Any] | None:
+# ``normalize_moa_config`` runs on every ``resolve_moa_preset`` /
+# ``list_moa_presets`` / ``exact_moa_preset_name`` call — i.e. on every model
+# switch and every MoA turn — so an undeduplicated warning would fire dozens of
+# times for the same static config.yaml. Deduplicate per (scope, signature) for
+# the process lifetime, mirroring ``_warn_once_per_provider`` in
+# ``hermes_cli/config.py``.
+_MOA_NORMALIZE_WARNED: set = set()
+
+
+def _warn_once(scope: str, signature: str, msg: str, *args: Any) -> None:
+    """Emit ``logger.warning(msg, *args)`` at most once per (scope, signature)."""
+    dedup_key = (scope or "?", signature)
+    if dedup_key in _MOA_NORMALIZE_WARNED:
+        return
+    _MOA_NORMALIZE_WARNED.add(dedup_key)
+    logger.warning(msg, *args)
+
+
+# Keys ``_normalize_preset`` actually reads off a preset mapping — one entry per
+# ``raw.get(...)`` call in that function. Nothing downstream can see any other
+# key, because ``_normalize_preset`` returns a freshly built dict and every
+# consumer (agent/moa_loop.py, hermes_cli/moa_cmd.py, the dashboard) reads the
+# NORMALIZED preset. A new preset knob must therefore be added here alongside
+# the reader that consumes it, or configs setting it warn spuriously.
+_KNOWN_PRESET_KEYS = frozenset({
+    "enabled",
+    "reference_models",
+    "aggregator",
+    "reference_temperature",
+    "aggregator_temperature",
+    "reference_timeout",
+    "degraded_reference_policy",
+    "max_tokens",
+    "reference_max_tokens",
+    "fanout",
+})
+
+# Keys ``_clean_slot`` actually reads off a reference/aggregator slot.
+# ``enabled`` is listed unconditionally even though ``_clean_slot`` only honors
+# it for reference slots (``include_enabled=True``): Hermes' own writer emits it
+# into the aggregator slot too (``MoaModelSlot`` in ``hermes_cli/web_server.py``
+# declares ``enabled: bool = True``, and ``_slot_dict`` keeps every non-None
+# field), so warning about it there would fire on every GUI-saved config.
+_KNOWN_SLOT_KEYS = frozenset({
+    "provider",
+    "model",
+    "reasoning_effort",
+    "max_tokens",
+    "enabled",
+})
+
+
+def _warn_unknown_keys(scope: str, mapping: dict[str, Any], known: frozenset) -> None:
+    """Warn once about keys in ``mapping`` that no reader consumes.
+
+    ``scope`` is the dotted config path being normalized (e.g.
+    ``moa.presets.fast.reference_models[1]``); it doubles as the dedup bucket.
+    Keys are stringified before sorting because hand-edited YAML can yield
+    non-string mapping keys, which are not mutually orderable.
+    """
+    unknown = sorted(str(key) for key in mapping if key not in known)
+    if not unknown:
+        return
+    _warn_once(
+        scope, "unknown:" + ",".join(unknown),
+        "%s: unknown config keys ignored: %s",
+        scope, ", ".join(unknown),
+    )
+
+
+def _clean_slot(
+    slot: Any, *, include_enabled: bool = False, warn_scope: str | None = None
+) -> dict[str, Any] | None:
     if not isinstance(slot, dict):
         return None
+    # Warn before the validity checks below: whether the slot survives is a
+    # separate axis (validate_moa_payload owns that on the write path), and a
+    # user whose slot was dropped for an unrelated reason should still learn
+    # that they misspelled a key.
+    if warn_scope:
+        _warn_unknown_keys(warn_scope, slot, _KNOWN_SLOT_KEYS)
     provider = str(slot.get("provider") or "").strip()
     model = str(slot.get("model") or "").strip()
     if not provider or not model:
@@ -310,9 +391,22 @@ def _default_preset() -> dict[str, Any]:
     }
 
 
-def _normalize_preset(raw: Any) -> dict[str, Any]:
+def _normalize_preset(raw: Any, *, warn_scope: str | None = None) -> dict[str, Any]:
+    """Build a preset from ``raw``, dropping anything no reader consumes.
+
+    ``warn_scope`` (the dotted config path, e.g. ``moa.presets.fast``) opts this
+    call into the unknown-key diagnostic asked for in #65110. It is supplied
+    ONLY by the real per-preset loop in ``normalize_moa_config``: the legacy
+    flat-config fallback passes the whole ``moa`` block here, whose legitimate
+    top-level keys (``save_traces``, ``trace_dir``, ``default_preset``,
+    ``active_preset``, ``privacy_filter``, ``presets``) are not preset keys and
+    would every one of them be reported as unknown.
+    """
     if not isinstance(raw, dict):
         raw = {}
+
+    if warn_scope:
+        _warn_unknown_keys(warn_scope, raw, _KNOWN_PRESET_KEYS)
 
     raw_refs = raw.get("reference_models")
     # reference_models may be a JSON string (hand-edited config.yaml) or a list.
@@ -326,12 +420,24 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         # defaults instead of crashing the iteration, mirroring the tolerance
         # for the scalar fields below (reference_temperature / max_tokens).
         raw_refs = [raw_refs] if isinstance(raw_refs, dict) else []
-    refs = [_clean_slot(item, include_enabled=True) for item in raw_refs]
+    refs = [
+        _clean_slot(
+            item,
+            include_enabled=True,
+            # Index into the RAW list so the path in the warning matches what
+            # the user wrote, even when an earlier slot is dropped.
+            warn_scope=f"{warn_scope}.reference_models[{index}]" if warn_scope else None,
+        )
+        for index, item in enumerate(raw_refs)
+    ]
     refs = [item for item in refs if item is not None]
     if not refs:
         refs = _default_reference_models()
 
-    aggregator = _clean_slot(raw.get("aggregator")) or deepcopy(DEFAULT_MOA_AGGREGATOR)
+    aggregator = _clean_slot(
+        raw.get("aggregator"),
+        warn_scope=f"{warn_scope}.aggregator" if warn_scope else None,
+    ) or deepcopy(DEFAULT_MOA_AGGREGATOR)
 
     return {
         "enabled": _coerce_bool(raw.get("enabled"), True),
@@ -384,9 +490,13 @@ def normalize_moa_config(raw: Any) -> dict[str, Any]:
         for name, preset in presets_raw.items():
             clean_name = str(name or "").strip()
             if clean_name:
-                presets[clean_name] = _normalize_preset(preset)
+                presets[clean_name] = _normalize_preset(
+                    preset, warn_scope=f"moa.presets.{clean_name}"
+                )
 
-    # Legacy flat config becomes the default preset.
+    # Legacy flat config becomes the default preset. No warn_scope: ``raw`` is
+    # the whole ``moa`` block here, and its own top-level keys are not preset
+    # keys — warning would fire on every valid legacy config.
     if not presets:
         presets[DEFAULT_MOA_PRESET_NAME] = _normalize_preset(raw)
 
@@ -497,6 +607,9 @@ def decode_moa_turn(message: Any) -> tuple[str, dict[str, Any] | None]:
     except Exception:
         return message, None
     prompt = str(payload.get("prompt") or "")
+    # No warn_scope: the payload carries an ALREADY-normalized preset produced
+    # by encode_moa_turn, not user-authored YAML — there is nothing here the
+    # user could have misspelled, and the source config was already checked.
     return prompt, _normalize_preset(payload.get("config") or {})
 
 

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -8,6 +8,7 @@ from hermes_cli.moa_config import (
     build_moa_turn_prompt,
     decode_moa_turn,
     exact_moa_preset_name,
+    list_moa_presets,
     normalize_moa_config,
     resolve_moa_preset,
     set_active_moa_preset,
@@ -181,3 +182,180 @@ def test_validate_moa_payload_agrees_with_clean_slot():
 
 
 
+
+
+# ── Unknown-key diagnostic (#65110) ─────────────────────────────────────────
+
+
+@pytest.fixture
+def moa_warnings(caplog):
+    """Capture moa_config warnings with the process-lifetime dedup set cleared.
+
+    ``_MOA_NORMALIZE_WARNED`` persists for the process, so without an explicit
+    reset the first test to warn would suppress every later one.
+    """
+    import logging
+
+    from hermes_cli import moa_config
+
+    moa_config._MOA_NORMALIZE_WARNED.clear()
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.moa_config"):
+        yield caplog
+    moa_config._MOA_NORMALIZE_WARNED.clear()
+
+
+def _warning_texts(caplog):
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "hermes_cli.moa_config"
+    ]
+
+
+def test_unknown_preset_key_warns_with_preset_name_and_key(moa_warnings):
+    """#65110: `reasoning_effort` at the preset level is dropped — say so."""
+    normalize_moa_config(_preset(reasoning_effort="high"))
+
+    messages = _warning_texts(moa_warnings)
+    assert messages == [
+        "moa.presets.p: unknown config keys ignored: reasoning_effort"
+    ]
+
+
+def test_unknown_reference_slot_key_warns_with_index(moa_warnings):
+    """A slot warning must name WHICH reference model carries the bad key."""
+    cfg = {
+        "default_preset": "p",
+        "presets": {
+            "p": {
+                "reference_models": [
+                    {"provider": "openrouter", "model": "a"},
+                    {"provider": "openrouter", "model": "b"},
+                    {"provider": "openrouter", "model": "c", "temperature": 0.4},
+                ],
+                "aggregator": {"provider": "openrouter", "model": "agg"},
+            },
+        },
+    }
+
+    normalize_moa_config(cfg)
+
+    assert _warning_texts(moa_warnings) == [
+        "moa.presets.p.reference_models[2]: unknown config keys ignored: temperature"
+    ]
+
+
+def test_unknown_aggregator_slot_key_warns(moa_warnings):
+    normalize_moa_config(
+        _preset(aggregator={"provider": "openrouter", "model": "agg", "effort": "high"})
+    )
+
+    assert _warning_texts(moa_warnings) == [
+        "moa.presets.p.aggregator: unknown config keys ignored: effort"
+    ]
+
+
+def test_unknown_key_warning_is_emitted_once_per_process(moa_warnings):
+    """normalize_moa_config runs on every model switch — one warning, not N."""
+    cfg = _preset(reasoning_effort="high")
+    for _ in range(5):
+        normalize_moa_config(cfg)
+    resolve_moa_preset(cfg, "p")
+    list_moa_presets(cfg)
+
+    assert len(_warning_texts(moa_warnings)) == 1
+
+
+def test_legacy_flat_moa_block_does_not_warn(moa_warnings):
+    """Negative control — the legacy flat shape must stay silent.
+
+    In the flat shape the whole ``moa`` block IS the default preset, so its own
+    legitimate top-level keys (save_traces, trace_dir, default_preset,
+    active_preset, privacy_filter) would every one of them look "unknown" to a
+    preset allow-list. Warning here would fire on valid configs.
+    """
+    flat = {
+        "save_traces": True,
+        "trace_dir": "/custom/traces",
+        "default_preset": "default",
+        "active_preset": "",
+        "privacy_filter": "display",
+        "reference_models": [{"provider": "openrouter", "model": "a"}],
+        "aggregator": {"provider": "openrouter", "model": "agg"},
+        "max_tokens": 4096,
+        "enabled": True,
+    }
+
+    cfg = normalize_moa_config(flat)
+
+    assert list(cfg["presets"]) == [DEFAULT_MOA_PRESET_NAME]
+    assert _warning_texts(moa_warnings) == []
+
+
+def test_fully_populated_valid_preset_does_not_warn(moa_warnings):
+    """Negative control — every documented knob, plus a GUI-written config.
+
+    ``enabled`` on the AGGREGATOR slot is the load-bearing case: _clean_slot
+    only honors it for reference slots, but web_server's MoaModelSlot writes it
+    into the aggregator on every dashboard save, so it must not warn.
+    """
+    cfg = {
+        "default_preset": "p",
+        "active_preset": "p",
+        "privacy_filter": "full",
+        "presets": {
+            "p": {
+                "enabled": True,
+                "reference_models": [
+                    {
+                        "provider": "openrouter",
+                        "model": "a",
+                        "reasoning_effort": "high",
+                        "max_tokens": 600,
+                        "enabled": True,
+                    },
+                ],
+                "aggregator": {
+                    "provider": "openrouter",
+                    "model": "agg",
+                    "reasoning_effort": "high",
+                    "enabled": True,
+                },
+                "reference_temperature": 0.6,
+                "aggregator_temperature": 0.4,
+                "reference_timeout": 120,
+                "degraded_reference_policy": "silent",
+                "max_tokens": 4096,
+                "reference_max_tokens": 600,
+                "fanout": "per_iteration",
+            },
+        },
+    }
+
+    normalize_moa_config(cfg)
+
+    assert _warning_texts(moa_warnings) == []
+
+
+def test_unknown_keys_do_not_change_normalized_output(moa_warnings):
+    """The diagnostic is a warning only — normalization is byte-for-byte equal."""
+    with_unknown = normalize_moa_config(
+        _preset(
+            reasoning_effort="high",
+            reference_models=[
+                {"provider": "openrouter", "model": "a", "temperature": 0.4},
+            ],
+            aggregator={"provider": "openrouter", "model": "agg", "effort": "high"},
+        )
+    )
+    expected = normalize_moa_config(
+        _preset(
+            reference_models=[{"provider": "openrouter", "model": "a"}],
+            aggregator={"provider": "openrouter", "model": "agg"},
+        )
+    )
+
+    assert with_unknown == expected
+    # ...and it did warn (preset + reference slot + aggregator), so the
+    # equality above is not vacuously comparing two silent runs.
+    assert len(_warning_texts(moa_warnings)) == 3


### PR DESCRIPTION
## What does this PR do?

`hermes_cli/moa_config.py` builds every normalized MoA preset and slot from a **closed set** of reads — `_normalize_preset` from ten `raw.get(...)` calls, `_clean_slot` from five `slot.get(...)` calls. Anything else the user writes under `moa.presets.<name>`, or inside a `reference_models` / `aggregator` slot, is dropped with **no diagnostic at all**.

That is the failure mode in #65110: a hand-edited preset-level `reasoning_effort` was silently ignored, MoA appeared to run at the wrong depth, and the only way to find out was to open an issue. This PR makes normalization say so:

```
WARNING  moa.presets.代码编程-非高峰: unknown config keys ignored: reasoning_effort
WARNING  moa.presets.fast.reference_models[2]: unknown config keys ignored: temperature
WARNING  moa.presets.fast.aggregator: unknown config keys ignored: effort
```

**Scope: gap 1 of #65110 only.** The status-bar effort badge (gap 2) needs a gateway event change and belongs in its own PR. Whether a preset-level `reasoning_effort` should cascade into slots is the design question the maintainer explicitly left open on the issue — this PR does **not** implement it, and deliberately warns about the key rather than quietly making it work.

### Mirrors the existing in-repo diagnostic

This is not a new pattern — `hermes_cli/config.py` already ships exactly this shape for provider entries, and the new code mirrors it one-for-one:

| `hermes_cli/config.py` | `hermes_cli/moa_config.py` (this PR) |
|---|---|
| `logger = logging.getLogger(__name__)` | same |
| `_PROVIDER_NORMALIZE_WARNED: set` | `_MOA_NORMALIZE_WARNED: set` |
| `_warn_once_per_provider(provider_key, signature, msg, *args)` | `_warn_once(scope, signature, msg, *args)` |
| `_KNOWN_KEYS` allow-list | `_KNOWN_PRESET_KEYS` / `_KNOWN_SLOT_KEYS` |
| `"providers.%s: unknown config keys ignored: %s"` | `"%s: unknown config keys ignored: %s"` |

Deduplication is load-bearing, for the same reason it is in `config.py`: `normalize_moa_config` runs inside `resolve_moa_preset`, `list_moa_presets` and `exact_moa_preset_name`, i.e. on **every model switch and every MoA turn**. Without the dedup set, one static `config.yaml` would emit the same warning dozens of times per session.

### The allow-lists are derived from the readers, not from a schema

`_KNOWN_PRESET_KEYS` is one entry per `raw.get(...)` in `_normalize_preset` (`enabled`, `reference_models`, `aggregator`, `reference_temperature`, `aggregator_temperature`, `reference_timeout`, `degraded_reference_policy`, `max_tokens`, `reference_max_tokens`, `fanout`). `_KNOWN_SLOT_KEYS` is one entry per `slot.get(...)` in `_clean_slot` (`provider`, `model`, `reasoning_effort`, `max_tokens`, `enabled`).

Nothing downstream can observe any other key: both functions return **freshly built** dicts, and every consumer (`agent/moa_loop.py`, `hermes_cli/moa_cmd.py`, `hermes_cli/inventory.py`, `hermes_cli/auth.py`, the dashboard) reads the *normalized* preset. I checked each `preset.get(...)` / `slot.get(...)` read in `agent/moa_loop.py` against the lists — no reader consumes a key the lists omit.

**Forward-compat, stated plainly:** #66359 (per-slot `extra_body`), #56133 and #58500 are open and add keys to these same structures. Because the lists are derived from the readers, a new key must be added to the matching list **alongside the reader that consumes it**, or configs setting it will warn spuriously. That is the honest maintenance cost of this diagnostic, and it is better named up front than discovered by a spurious warning after a merge. Whichever of those PRs lands second only needs a one-line addition here.

### The correctness crux: which call sites may warn

The warning is opt-in per call site via a keyword-only `warn_scope`, and **only the real per-preset loop in `normalize_moa_config` supplies one**:

- **Legacy flat config** — `presets[DEFAULT_MOA_PRESET_NAME] = _normalize_preset(raw)` passes the *whole* `moa` block, whose legitimate top-level keys (`save_traces`, `trace_dir`, `default_preset`, `active_preset`, `privacy_filter`, `presets`) are not preset keys. Warning here would fire on every valid legacy config. **Stays silent**, with a negative-control test.
- **`decode_moa_turn`** — normalizes an already-normalized payload produced by `encode_moa_turn`, not user-authored YAML. Nothing here can be misspelled. **Stays silent.**

Related: `enabled` is a known **slot** key unconditionally, even though `_clean_slot` only honors it for reference slots (`include_enabled=True`). `MoaModelSlot` in `hermes_cli/web_server.py` declares `enabled: bool = True` and `_slot_dict` keeps every non-`None` field, so Hermes' own dashboard writes `enabled` into the **aggregator** slot on every save — warning about it there would fire on virtually every GUI-managed config. Covered by a negative-control test.

### Sibling-site sweep

`grep -rn "def _normalize_preset\|def _clean_slot\|def normalize_moa_config\|def _default_preset\|def validate_moa_payload\|def coerce_privacy_filter" --include="*.py" . | grep -v "/tests/\|test_"`

| Site | Decision |
|---|---|
| `hermes_cli/moa_config.py:_normalize_preset` | **Covered** — the site the issue names. |
| `hermes_cli/moa_config.py:_clean_slot` | **Covered** — same root cause, slot level; this is where `reasoning_effort` legitimately lives, so a typo here is the most likely follow-on report. |
| `hermes_cli/moa_config.py:normalize_moa_config` | Excluded — the `moa` top level legitimately carries `save_traces` / `trace_dir` (see `tests/hermes_cli/test_moa_set_models_preserves_extra_keys.py`, issue #58819) and, in the legacy-flat shape, an entire preset body. There is no safe allow-list; a warning here fires on valid configs. |
| `hermes_cli/moa_config.py:validate_moa_payload` | Excluded — write-path rejector. Unknown keys there would **reject saves**, not warn, and it never sees a hand-edited `config.yaml`. The issue asks for a warning *during normalization*. |
| `hermes_cli/moa_config.py:_default_preset` | Excluded — constructs defaults from nothing; there is no user input to drop. |
| `hermes_cli/moa_config.py:coerce_privacy_filter` | Excluded — coerces a scalar, not a mapping; invalid values already degrade to the documented default. |
| `hermes_cli/web_server.py:set_moa_models._preset_dict` | Excluded — Pydantic API boundary; unknown keys are already handled upstream by `MoaConfigPayload`, and this path builds the mapping itself. |

Documentation cross-check: every MoA key in `website/docs/user-guide/features/mixture-of-agents.md` and `website/docs/user-guide/configuration.md` is in one of the two allow-lists (the only leftovers are preset *names* under `presets:`). No config key is added or renamed, so `cli-config.yaml.example` needs no change.

## Related Issue

Fixes #65110

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/moa_config.py`
  - module `logger`, `_MOA_NORMALIZE_WARNED` dedup set, `_warn_once(scope, signature, msg, *args)`, and `_warn_unknown_keys(scope, mapping, known)` (keys are stringified before sorting — hand-edited YAML can produce non-string mapping keys, which are not mutually orderable).
  - `_KNOWN_PRESET_KEYS` / `_KNOWN_SLOT_KEYS`, each documented as derived from its reader.
  - `_normalize_preset(raw, *, warn_scope=None)` and `_clean_slot(slot, *, include_enabled=False, warn_scope=None)`; slot scopes carry the raw list index (`…​.reference_models[2]`) so the path in the message matches what the user wrote even when an earlier slot was dropped.
  - `normalize_moa_config` passes `warn_scope=f"moa.presets.{clean_name}"` in the per-preset loop only. The legacy-flat fallback and `decode_moa_turn` pass nothing.
- `tests/hermes_cli/test_moa_config.py` — 7 tests, including 2 negative controls.

No behavior change beyond the log line: normalization output is unchanged, and one of the tests asserts that a config with unknown keys normalizes to a dict **equal** to the same config with those keys removed.

## How to Test

1. Reproduce the report from #65110 — put a preset-level `reasoning_effort` in `config.yaml`:
   ```yaml
   moa:
     presets:
       fast:
         reasoning_effort: high          # not a preset key — silently dropped on main
         reference_models:
           - provider: openrouter
             model: anthropic/claude-opus-4.8
             temperature: 0.4            # not a slot key either
         aggregator:
           provider: openrouter
           model: anthropic/claude-opus-4.8
   ```
   Run `hermes moa list`. On `main` there is no output about either key. With this PR:
   ```
   WARNING  moa.presets.fast: unknown config keys ignored: reasoning_effort
   WARNING  moa.presets.fast.reference_models[0]: unknown config keys ignored: temperature
   ```
2. Confirm no false positives on a legacy flat `moa:` block (`save_traces` / `trace_dir` / `default_preset` at the top level) and on a dashboard-saved config (`enabled` present on the aggregator slot) — neither warns.
3. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_moa_config.py -q` → **69 passed**.

### Fails-before / passes-after

Proven by neutering only the emission inside `_warn_unknown_keys` (early-return before `_warn_once`) and leaving everything else in place:

| | before | after |
|---|---|---|
| `test_unknown_preset_key_warns_with_preset_name_and_key` | FAIL | PASS |
| `test_unknown_reference_slot_key_warns_with_index` | FAIL | PASS |
| `test_unknown_aggregator_slot_key_warns` | FAIL | PASS |
| `test_unknown_key_warning_is_emitted_once_per_process` | FAIL | PASS |
| `test_unknown_keys_do_not_change_normalized_output` | FAIL | PASS |
| `test_legacy_flat_moa_block_does_not_warn` (negative control) | PASS | PASS |
| `test_fully_populated_valid_preset_does_not_warn` (negative control) | PASS | PASS |

`5 failed, 64 passed` before → `69 passed` after. The two negative controls pass in both directions by design — they exist to catch a *future* over-eager allow-list, and they are the tests that fail if `warn_scope` ever leaks into the legacy-flat call site.

### Wider runs

- All MoA suites (`tests/hermes_cli/test_moa_config.py`, `test_moa_set_models_preserves_extra_keys.py`, `tests/agent/test_moa_*.py`, `tests/run_agent/test_moa_*.py`) — **217 passed**.
- `tests/hermes_cli/test_config.py`, `test_config_validation.py`, `test_inventory.py`, `test_model_switch_*.py` — **382 passed**.
- `tests/hermes_cli/test_console_engine.py` — **73 passed**.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the MoA, config, inventory, model-switch and console-engine suites listed above (all green); the full `tests/` run is not reproducible on this machine (`tests/hermes_cli/test_web_ui_build.py` needs an npm toolchain and fails identically on unmodified `main`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.12.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new functions and both allow-lists carry docstrings/comments explaining the derivation rule; no user-facing doc changes needed since no key is added or renamed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config key added or changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure stdlib `logging`, no paths or platform-specific behavior; the dedup set exists partly because repeated-warning storms are worst on Windows (`concurrent-log-handler` rotation lock), the same rationale as `config.py`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ hermes moa list
WARNING  moa.presets.fast: unknown config keys ignored: reasoning_effort
WARNING  moa.presets.fast.reference_models[0]: unknown config keys ignored: temperature
```
