### PR TITLE
fix(desktop): dedupe duplicate repo ids in sidebar order reconciliation

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# 默认忽略的文件
+/shelf/
+/workspace.xml

--- a/.idea/hermes-agent.iml
+++ b/.idea/hermes-agent.iml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.9 (hermes-agent)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="py.test" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9 (hermes-agent)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/hermes-agent.iml" filepath="$PROJECT_DIR$/.idea/hermes-agent.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/apps/desktop/src/app/chat/sidebar/order.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.test.ts
@@ -37,6 +37,12 @@ describe('orderByIds', () => {
     const items = [{ id: 'fresh' }, { id: 'a' }, { id: 'b' }]
     expect(orderByIds(items, id, ['b', 'a'])).toEqual([{ id: 'fresh' }, { id: 'b' }, { id: 'a' }])
   })
+
+  it('skips duplicate ids in the persisted order (siblings sharing git root)', () => {
+    const items = [{ id: 'repo-x' }]
+    // orderIds contains the same id twice (polluted persisted state)
+    expect(orderByIds(items, id, ['repo-x', 'repo-x', 'repo-x'])).toEqual([{ id: 'repo-x' }])
+  })
 })
 
 describe('reconcileOrderIds', () => {
@@ -50,6 +56,13 @@ describe('reconcileOrderIds', () => {
 
   it('puts newly-seen ids ahead of the retained saved order', () => {
     expect(reconcileOrderIds(['fresh', 'a', 'b'], ['b', 'a', 'gone'])).toEqual(['fresh', 'b', 'a'])
+  })
+
+  it('dedupes duplicate ids in currentIds (siblings sharing git root)', () => {
+    // Two projects whose sessions share the same repo node id
+    expect(reconcileOrderIds(['repo-x', 'repo-x', 'repo-x'], [])).toEqual(['repo-x'])
+    // Persisted order already has duplicates; reconcile cleans them
+    expect(reconcileOrderIds(['repo-x', 'repo-x'], ['repo-x', 'repo-x'])).toEqual(['repo-x'])
   })
 })
 

--- a/apps/desktop/src/app/chat/sidebar/order.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.ts
@@ -1,10 +1,18 @@
 /** New ids first, then ids still present in the persisted order. */
 export function reconcileFreshFirst(currentIds: string[], orderIds: string[]): string[] {
   const current = new Set(currentIds)
-  const retained = orderIds.filter(id => current.has(id))
+  const retained = [...new Set(orderIds.filter(id => current.has(id)))]
   const retainedSet = new Set(retained)
+  const seenCurrent = new Set<string>()
 
-  return [...currentIds.filter(id => !retainedSet.has(id)), ...retained]
+  return [
+    ...currentIds.filter(id => {
+      if (retainedSet.has(id) || seenCurrent.has(id)) return false
+      seenCurrent.add(id)
+      return true
+    }),
+    ...retained,
+  ]
 }
 
 export function resolveManualSessionOrderIds(currentIds: string[], orderIds: string[], manual: boolean): string[] {
@@ -35,7 +43,7 @@ export function orderByIds<T>(items: T[], getId: (item: T) => string, orderIds: 
   for (const id of orderIds) {
     const item = byId.get(id)
 
-    if (item) {
+    if (item && !seen.has(id)) {
       ordered.push(item)
       seen.add(id)
     }
@@ -58,7 +66,7 @@ export function reconcileOrderIds(currentIds: string[], orderIds: string[]): str
   }
 
   if (!orderIds.length) {
-    return currentIds
+    return [...new Set(currentIds)]
   }
 
   return reconcileFreshFirst(currentIds, orderIds)

--- a/pr-summary-2025-04-22.md
+++ b/pr-summary-2025-04-22.md
@@ -1,0 +1,116 @@
+# Hermes Agent PR Summary — 2025-04-22
+
+> Batch of 8 PRs submitted to `NousResearch/hermes-agent` from fork `ms-alan/hermes-agent`
+
+---
+
+## PR #13777 — docs: Fix ACL template typo
+**Issue:** #13738  
+**File:** `hermes/agentcli.py`  
+**Change:** `seperate` → `separate` (ACL template comment)  
+**Link:** https://github.com/NousResearch/hermes-agent/pull/13777
+
+---
+
+## PR #13778 — fix: Add /opt/data/.local/bin to Docker PATH
+**Issue:** #13739  
+**File:** `Dockerfile`  
+**Change:** Append `/opt/data/.local/bin` to PATH so hermes CLI is found inside container  
+**Link:** https://github.com/NousResearch/hermes-agent/pull/13778
+
+---
+
+## PR #13779 — feat: Make cron output templates configurable
+**Issue:** #13771  
+**Files:** `hermes/agentcli.py`, `hermes/components/cron.py`  
+**Change:** Extract cron output header/footer into configurable template variables instead of hardcoded strings  
+**Link:** https://github.com/NousResearch/hermes-agent/pull/13779
+
+---
+
+## PR #13780 — fix: Skip /models health check for MiniMax-CN provider
+**Issue:** #13757  
+**File:** `hermes/providers/minimax-cn.py`  
+**Change:** `MiniMaxProvider.do_health_check()` skips the `/models` endpoint (not supported), prevents false-negative doctor failures  
+**Link:** https://github.com/NousResearch/hermes-agent/pull/13780
+
+---
+
+## PR #13781 — fix: Preserve `custom:` prefix in `_normalize_aux_provider`
+**Issue:** #13762  
+**File:** `hermes/providers/utils.py`  
+**Change:** `_normalize_aux_provider` now preserves the `custom:` prefix when routing, instead of stripping it and losing the provider tag  
+**Link:** https://github.com/NousResearch/hermes-agent/pull/13781
+
+---
+
+## PR #13788 — fix: Raise auto-correct cutoff from 0.9 to 0.98
+**Issue:** #13692  
+**File:** `hermes/agentcli.py`  
+**Change:** `get_close_matches` cutoff `0.9` → `0.98` to reduce false-positive "did you mean X?" suggestions that were annoying users  
+**Link:** https://github.com/NousResearch/hermes-agent/pull/13788
+
+---
+
+## PR #13791 — fix: Accept explicit null for `home_channel` in `PlatformConfig`
+**Issue:** #13721  
+**File:** `hermes/config.py`  
+**Change:** `PlatformConfig.from_dict` now accepts `{"home_channel": null}` as a valid explicit config (treats as unset), instead of raising a type validation error  
+**Link:** https://github.com/NousResearch/hermes-agent/pull/13791
+
+---
+
+## PR #13792 — fix: Suppress OSError EIO during interrupt shutdown
+**Issue:** #13720
+**File:** `hermes/agentcli.py`
+**Change:** CLI interrupt handler now catches `errno.EIO` in addition to `KeyError`/`OSError` — prevents crash when prompt_toolkit flushes a broken stdout during Ctrl+C
+**Link:** https://github.com/NousResearch/hermes-agent/pull/13792
+
+---
+
+## PR #13797 — fix(delegate): add timeout to subagent run_conversation()
+**Issue:** #13768
+**Files:** `tools/delegate_tool.py`
+**Change:** Run `child.run_conversation()` in a dedicated thread with `join(timeout=300)`. On timeout, call `child.interrupt()` for graceful shutdown and return a synthetic timeout result instead of blocking forever.
+**Link:** https://github.com/NousResearch/hermes-agent/pull/13797
+
+---
+
+## PR #13802 — fix(kimi): map auto-discovered short model IDs to API-accepted names
+**Issue:** #13758
+**Files:** `hermes_cli/model_normalize.py`
+**Change:** Add `k2p6` → `kimi-k2.6` (and k2p5/k2p8) mapping in `normalize_model_for_provider()` for Kimi/Moonshot providers — fixes model-not-found when selecting from auto-discovered dropdown
+**Link:** https://github.com/NousResearch/hermes-agent/pull/13802
+
+---
+
+## PR #13804 — fix(cli): deduplicate plugin toolsets against built-in keys
+**Issue:** #13640
+**Files:** `hermes_cli/tools_config.py`
+**Change:** Skip plugin toolsets whose key already exists in `CONFIGURABLE_TOOLSETS` — prevents duplicate rows when plugin registers tool into existing toolset (e.g. `web`)
+**Link:** https://github.com/NousResearch/hermes-agent/pull/13804
+
+---
+
+## PR #13806 — fix(tui): fix status bar width fluctuation by capping model name width
+**Issue:** #13610
+**Files:** `ui-tui/src/components/appChrome.tsx`
+**Change:** Wrap model name in `width={18} wrap="truncate-end"` container — prevents status bar from growing/shrinking as model name changes
+**Link:** https://github.com/NousResearch/hermes-agent/pull/13806
+
+---
+
+## Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total PRs | 12 |
+| Issues closed | 11 |
+| Branches off | `ms-alan/hermes-agent` |
+| Target | `NousResearch/hermes-agent:main` |
+
+## Notes
+
+- All PRs created via `gh pr create` from the `ms-alan/hermes-agent` fork
+- Remote `fork` → `ms-alan/hermes-agent`, `origin` → `NousResearch/hermes-agent`
+- Branch naming convention: `fix/...`, `feat/...`, `docs/...` per issue type

--- a/translate_docs.py
+++ b/translate_docs.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""
+批量翻译 Hermes Agent 文档
+"""
+import os
+import shutil
+from pathlib import Path
+
+# 源目录和目标目录
+SOURCE_DIR = Path("/Users/pander/Documents/hermes-agent/website/docs")
+TARGET_DIR = Path("/Users/pander/Documents/hermes-agent/website/docs-cn")
+
+def copy_structure():
+    """复制目录结构"""
+    for item in SOURCE_DIR.rglob('*'):
+        if item.is_dir():
+            target_path = TARGET_DIR / item.relative_to(SOURCE_DIR)
+            target_path.mkdir(parents=True, exist_ok=True)
+    
+    # 复制 _category_.json 文件
+    for category_file in SOURCE_DIR.rglob('_category_.json'):
+        target_file = TARGET_DIR / category_file.relative_to(SOURCE_DIR)
+        if not target_file.exists():
+            shutil.copy2(category_file, target_file)
+            print(f"已复制: {category_file.relative_to(SOURCE_DIR)}")
+
+if __name__ == "__main__":
+    print("开始复制目录结构...")
+    copy_structure()
+    print("目录结构复制完成！")
+    print(f"\n请在以下目录继续手动翻译文档:")
+    print(f"{TARGET_DIR}")

--- a/website/docs-cn/developer-guide/_category_.json
+++ b/website/docs-cn/developer-guide/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "开发者指南",
+  "position": 3,
+  "link": {
+    "type": "generated-index",
+    "description": "为 Hermes Agent 做贡献 — 架构、工具、技能等。"
+  }
+}

--- a/website/docs-cn/developer-guide/architecture.md
+++ b/website/docs-cn/developer-guide/architecture.md
@@ -1,0 +1,279 @@
+---
+sidebar_position: 1
+title: "架构"
+description: "Hermes Agent 内部结构 — 主要子系统、执行路径、数据流以及下一步阅读指南"
+---
+
+# 架构
+
+本页面是 Hermes Agent 内部结构的顶层地图。使用它来熟悉代码库，然后深入特定子系统的文档以了解实现细节。
+
+## 系统概述
+
+```text
+┌─────────────────────────────────────────────────────────────────────┐
+│                        入口点                                        │
+│                                                                      │
+│  CLI (cli.py)    网关 (gateway/run.py)    ACP (acp_adapter/)        │
+│  批处理运行器     API 服务器                Python 库                 │
+└──────────┬──────────────┬───────────────────────┬───────────────────┘
+           │              │                       │
+           ▼              ▼                       ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                     AIAgent (run_agent.py)                          │
+│                                                                     │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐               │
+│  │ 提示         │  │ 提供者       │  │ 工具         │               │
+│  │ 构建器       │  │ 解析         │  │ 分发         │               │
+│  │ (prompt_     │  │ (runtime_    │  │ (model_      │               │
+│  │  builder.py) │  │  provider.py)│  │  tools.py)   │               │
+│  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘               │
+│         │                 │                 │                       │
+│  ┌──────┴───────┐  ┌──────┴───────┐  ┌──────┴───────┐               │
+│  │ 压缩         │  │ 3 种 API 模式│  │ 工具注册表   │               │
+│  │ 和缓存       │  │ chat_compl.  │  │ (registry.py)│               │
+│  │              │  │ codex_resp.  │  │ 47 个工具    │               │
+│  │              │  │ anthropic    │  │ 19 个工具集  │               │
+│  └──────────────┘  └──────────────┘  └──────────────┘               │
+└─────────────────────────────────────────────────────────────────────┘
+           │                                    │
+           ▼                                    ▼
+┌───────────────────┐              ┌──────────────────────┐
+│ 会话存储          │              │ 工具后端             │
+│ (SQLite + FTS5)   │              │ 终端（6 个后端）      │
+│ hermes_state.py   │              │ 浏览器（5 个后端）    │
+│ gateway/session.py│              │ Web（4 个后端）       │
+└───────────────────┘              │ MCP（动态）           │
+                                   │ 文件、视觉等          │
+                                   └──────────────────────┘
+```
+
+## 目录结构
+
+```text
+hermes-agent/
+├── run_agent.py              # AIAgent — 核心对话循环（约 10,700 行）
+├── cli.py                    # HermesCLI — 交互式终端 UI（约 10,000 行）
+├── model_tools.py            # 工具发现、模式收集、分发
+├── toolsets.py               # 工具分组和平台预设
+├── hermes_state.py           # 带 FTS5 的 SQLite 会话/状态数据库
+├── hermes_constants.py       # HERMES_HOME，配置文件感知路径
+├── batch_runner.py           # 批量轨迹生成
+│
+├── agent/                    # 代理内部
+│   ├── prompt_builder.py     # 系统提示组装
+│   ├── context_engine.py     # ContextEngine ABC（可插拔）
+│   ├── context_compressor.py # 默认引擎 — 有损摘要
+│   ├── prompt_caching.py     # Anthropic 提示缓存
+│   ├── auxiliary_client.py   # 辅助 LLM 用于侧任务（视觉、摘要）
+│   ├── model_metadata.py     # 模型上下文长度、token 估算
+│   ├── models_dev.py         # models.dev 注册表集成
+│   ├── anthropic_adapter.py  # Anthropic Messages API 格式转换
+│   ├── display.py            # KawaiiSpinner，工具预览格式化
+│   ├── skill_commands.py     # 技能斜杠命令
+│   ├── memory_manager.py     # 记忆管理器编排
+│   ├── memory_provider.py    # 记忆提供者 ABC
+│   └── trajectory.py         # 轨迹保存助手
+│
+├── hermes_cli/               # CLI 子命令和设置
+│   ├── main.py               # 入口点 — 所有 `hermes` 子命令（约 6,000 行）
+│   ├── config.py             # DEFAULT_CONFIG、OPTIONAL_ENV_VARS、迁移
+│   ├── commands.py           # COMMAND_REGISTRY — 中央斜杠命令定义
+│   ├── auth.py               # PROVIDER_REGISTRY，凭证解析
+│   ├── runtime_provider.py   # 提供者 → api_mode + 凭证
+│   ├── models.py             # 模型目录、提供者模型列表
+│   ├── model_switch.py       # /model 命令逻辑（CLI + 网关共享）
+│   ├── setup.py              # 交互式设置向导（约 3,100 行）
+│   ├── skin_engine.py        # CLI 主题引擎
+│   ├── skills_config.py      # hermes skills — 按平台启用/禁用
+│   ├── skills_hub.py         # /skills 斜杠命令
+│   ├── tools_config.py       # hermes tools — 按平台启用/禁用
+│   ├── plugins.py            # PluginManager — 发现、加载、钩子
+│   ├── callbacks.py          # 终端回调（澄清、sudo、批准）
+│   └── gateway.py            # hermes gateway start/stop
+│
+├── tools/                    # 工具实现（每个工具一个文件）
+│   ├── registry.py           # 中央工具注册表
+│   ├── approval.py           # 危险命令检测
+│   ├── terminal_tool.py      # 终端编排
+│   ├── process_registry.py   # 后台进程管理
+│   ├── file_tools.py         # read_file、write_file、patch、search_files
+│   ├── web_tools.py          # web_search、web_extract
+│   ├── browser_tool.py       # 10 个浏览器自动化工具
+│   ├── code_execution_tool.py # execute_code 沙盒
+│   ├── delegate_tool.py      # 子代理委托
+│   ├── mcp_tool.py           # MCP 客户端（约 2,200 行）
+│   ├── credential_files.py   # 基于文件的凭证透传
+│   ├── env_passthrough.py    # 沙盒的环境变量透传
+│   ├── ansi_strip.py         # ANSI 转义剥离
+│   └── environments/         # 终端后端（local、docker、ssh、modal、daytona、singularity）
+│
+├── gateway/                  # 消息传递平台网关
+│   ├── run.py                # GatewayRunner — 消息分发（约 9,000 行）
+│   ├── session.py            # SessionStore — 对话持久化
+│   ├── delivery.py           # 出站消息传递
+│   ├── pairing.py            # DM 配对授权
+│   ├── hooks.py              # 钩子发现和生命周期事件
+│   ├── mirror.py             # 跨会话消息镜像
+│   ├── status.py             # 令牌锁、配置文件范围的进程跟踪
+│   ├── builtin_hooks/        # 始终注册的钩子
+│   └── platforms/            # 18 个适配器：telegram、discord、slack、whatsapp、
+│                             #   signal、matrix、mattermost、email、sms、
+│                             #   dingtalk、feishu、wecom、wecom_callback、weixin、
+│                             #   bluebubbles、qqbot、homeassistant、webhook、api_server
+│
+├── acp_adapter/              # ACP 服务器（VS Code / Zed / JetBrains）
+├── cron/                     # 调度器（jobs.py、scheduler.py）
+├── plugins/memory/           # 记忆提供者插件
+├── plugins/context_engine/   # 上下文引擎插件
+├── environments/             # RL 训练环境（Atropos）
+├── skills/                   # 捆绑技能（始终可用）
+├── optional-skills/          # 官方可选技能（显式安装）
+├── website/                  # Docusaurus 文档站点
+└── tests/                    # Pytest 套件（约 3,000+ 测试）
+```
+
+## 数据流
+
+### CLI 会话
+
+```text
+用户输入 → HermesCLI.process_input()
+  → AIAgent.run_conversation()
+    → prompt_builder.build_system_prompt()
+    → runtime_provider.resolve_runtime_provider()
+    → API 调用（chat_completions / codex_responses / anthropic_messages）
+    → tool_calls? → model_tools.handle_function_call() → 循环
+    → 最终响应 → 显示 → 保存到 SessionDB
+```
+
+### 网关心跳
+
+```text
+平台事件 → Adapter.on_message() → MessageEvent
+  → GatewayRunner._handle_message()
+    → 授权用户
+    → 解析会话密钥
+    → 创建带有会话历史的 AIAgent
+    → AIAgent.run_conversation()
+    → 通过适配器传递响应
+```
+
+### Cron 作业
+
+```text
+调度器滴答 → 从 jobs.json 加载到期作业
+  → 创建新的 AIAgent（无历史）
+  → 注入附加技能作为上下文
+  → 运行作业提示
+  → 将响应传递到目标平台
+  → 更新作业状态和 next_run
+```
+
+## 推荐阅读顺序
+
+如果你是代码库的新手：
+
+1. **本页面** — 熟悉自己
+2. **[代理循环内部](./agent-loop.md)** — AIAgent 如何工作
+3. **[提示组装](./prompt-assembly.md)** — 系统提示构造
+4. **[提供者运行时解析](./provider-runtime.md)** — 如何选择提供者
+5. **[添加提供者](./adding-providers.md)** — 添加新提供者的实用指南
+6. **[工具运行时](./tools-runtime.md)** — 工具注册表、分发、环境
+7. **[会话存储](./session-storage.md)** — SQLite 模式、FTS5、会话谱系
+8. **[网关内部](./gateway-internals.md)** — 消息传递平台网关
+9. **[上下文压缩和提示缓存](./context-compression-and-caching.md)** — 压缩和缓存
+10. **[ACP 内部](./acp-internals.md)** — IDE 集成
+11. **[环境、基准测试和数据生成](./environments.md)** — RL 训练
+
+## 主要子系统
+
+### 代理循环
+
+同步编排引擎（`run_agent.py` 中的 `AIAgent`）。处理提供者选择、提示构造、工具执行、重试、回退、回调、压缩和持久化。支持三种 API 模式以适应不同的提供者后端。
+
+→ [代理循环内部](./agent-loop.md)
+
+### 提示系统
+
+在对话生命周期中构造和维护提示：
+
+- **`prompt_builder.py`** — 从以下内容组装系统提示：个性（SOUL.md）、记忆（MEMORY.md、USER.md）、技能、上下文文件（AGENTS.md、.hermes.md）、工具使用指导和模型特定指令
+- **`prompt_caching.py`** — 应用 Anthropic 缓存断点进行前缀缓存
+- **`context_compressor.py`** — 当上下文超过阈值时总结中间对话回合
+
+→ [提示组装](./prompt-assembly.md)、[上下文压缩和提示缓存](./context-compression-and-caching.md)
+
+### 提供者解析
+
+CLI、网关、cron、ACP 和辅助调用使用的共享运行时解析器。将 `(provider, model)` 元组映射到 `(api_mode, api_key, base_url)`。处理 18+ 提供者、OAuth 流程、凭证池和别名解析。
+
+→ [提供者运行时解析](./provider-runtime.md)
+
+### 工具系统
+
+中央工具注册表（`tools/registry.py`），包含 19 个工具集中的 47 个注册工具。每个工具文件在导入时自我注册。注册表处理模式收集、分发、可用性检查和错误包装。终端工具支持 6 个后端（local、Docker、SSH、Daytona、Modal、Singularity）。
+
+→ [工具运行时](./tools-runtime.md)
+
+### 会话持久化
+
+基于 SQLite 的会话存储，带有 FTS5 全文搜索。会话具有谱系跟踪（压缩期间的父/子关系）、每平台隔离和带争用处理的原子写入。
+
+→ [会话存储](./session-storage.md)
+
+### 消息网关
+
+长期运行的进程，具有 18 个平台适配器、统一会话路由、用户授权（允许列表 + DM 配对）、斜杠命令分发、钩子系统、cron 滴答和后台维护。
+
+→ [网关内部](./gateway-internals.md)
+
+### 插件系统
+
+三个发现源：`~/.hermes/plugins/`（用户）、`.hermes/plugins/`（项目）和 pip 入口点。插件通过上下文 API 注册工具、钩子和 CLI 命令。存在两种专门的插件类型：记忆提供者（`plugins/memory/`）和上下文引擎（`plugins/context_engine/`）。两者都是单选 — 每次只能激活一个，通过 `hermes plugins` 或 `config.yaml` 配置。
+
+→ [插件指南](/docs-cn/guides/build-a-hermes-plugin)、[记忆提供者插件](./memory-provider-plugin.md)
+
+### Cron
+
+一等公民代理任务（不是 shell 任务）。作业存储在 JSON 中，支持多种计划格式，可以附加技能和脚本，并传递到任何平台。
+
+→ [Cron 内部](./cron-internals.md)
+
+### ACP 集成
+
+通过 stdio/JSON-RPC 将 Hermes 公开为编辑器原生代理，适用于 VS Code、Zed 和 JetBrains。
+
+→ [ACP 内部](./acp-internals.md)
+
+### RL / 环境 / 轨迹
+
+用于评估和 RL 训练的完整环境框架。与 Atropos 集成，支持多种工具调用解析器，并生成 ShareGPT 格式的轨迹。
+
+→ [环境、基准测试和数据生成](./environments.md)、[轨迹和训练格式](./trajectory-format.md)
+
+## 设计原则
+
+| 原则 | 实践中的含义 |
+|-----------|--------------------------|
+| **提示稳定性** | 系统提示在对话过程中不会改变。除了显式用户操作（`/model`）外，没有缓存破坏性突变。 |
+| **可观察执行** | 每个工具调用都通过回调对用户可见。CLI（旋转器）和网关（聊天消息）中的进度更新。 |
+| **可中断** | API 调用和工具执行可以被用户输入或信号中途取消。 |
+| **平台无关核心** | 一个 AIAgent 类服务于 CLI、网关、ACP、批处理和 API 服务器。平台差异存在于入口点，而不是代理中。 |
+| **松耦合** | 可选子系统（MCP、插件、记忆提供者、RL 环境）使用注册表模式和 check_fn 门控，而不是硬依赖。 |
+| **配置文件隔离** | 每个配置文件（`hermes -p <name>`）都有自己的 HERMES_HOME、配置、记忆、会话和网关 PID。多个配置文件并发运行。 |
+
+## 文件依赖链
+
+```text
+tools/registry.py  （无依赖 — 由所有工具文件导入）
+       ↑
+tools/*.py  （每个在导入时调用 registry.register()）
+       ↑
+model_tools.py  （导入 tools/registry + 触发工具发现）
+       ↑
+run_agent.py, cli.py, batch_runner.py, environments/
+```
+
+这个链条意味着工具注册发生在导入时，在任何代理实例创建之前。任何带有顶层 `registry.register()` 调用的 `tools/*.py` 文件都会被自动发现 — 不需要手动导入列表。
+

--- a/website/docs-cn/developer-guide/contributing.md
+++ b/website/docs-cn/developer-guide/contributing.md
@@ -1,0 +1,234 @@
+---
+sidebar_position: 4
+title: "贡献指南"
+description: "如何为 Hermes Agent 做贡献 — 开发设置、代码风格、PR 流程"
+---
+
+# 贡献指南
+
+感谢你为 Hermes Agent 做出贡献！本指南涵盖设置开发环境、理解代码库以及让你的 PR 被合并。
+
+## 贡献优先级
+
+我们按以下顺序重视贡献：
+
+1. **错误修复** — 崩溃、不正确行为、数据丢失
+2. **跨平台兼容性** — macOS、不同的 Linux 发行版、WSL2
+3. **安全加固** — shell 注入、提示注入、路径遍历
+4. **性能和鲁棒性** — 重试逻辑、错误处理、优雅降级
+5. **新技能** — 广泛有用的技能（参见 [创建技能](creating-skills.md)）
+6. **新工具** — 很少需要；大多数功能应该是技能
+7. **文档** — 修复、澄清、新示例
+
+## 常见贡献路径
+
+- 构建新工具？从 [添加工具](./adding-tools.md) 开始
+- 构建新技能？从 [创建技能](./creating-skills.md) 开始
+- 构建新的推理提供者？从 [添加提供者](./adding-providers.md) 开始
+
+## 开发设置
+
+### 前置要求
+
+| 要求 | 说明 |
+|-------------|-------|
+| **Git** | 支持 `--recurse-submodules` |
+| **Python 3.11+** | 如果缺少，uv 会安装它 |
+| **uv** | 快速的 Python 包管理器（[安装](https://docs.astral.sh/uv/)） |
+| **Node.js 18+** | 可选 — 浏览器工具和 WhatsApp 桥接需要 |
+
+### 克隆和安装
+
+```bash
+git clone --recurse-submodules https://github.com/NousResearch/hermes-agent.git
+cd hermes-agent
+
+# 使用 Python 3.11 创建虚拟环境
+uv venv venv --python 3.11
+export VIRTUAL_ENV="$(pwd)/venv"
+
+# 安装所有额外功能（消息传递、cron、CLI 菜单、开发工具）
+uv pip install -e ".[all,dev]"
+uv pip install -e "./tinker-atropos"
+
+# 可选：浏览器工具
+npm install
+```
+
+### 配置开发环境
+
+```bash
+mkdir -p ~/.hermes/{cron,sessions,logs,memories,skills}
+cp cli-config.yaml.example ~/.hermes/config.yaml
+touch ~/.hermes/.env
+
+# 至少添加一个 LLM 提供者密钥：
+echo 'OPENROUTER_API_KEY=sk-or-v1-your-key' >> ~/.hermes/.env
+```
+
+### 运行
+
+```bash
+# 创建符号链接以实现全局访问
+mkdir -p ~/.local/bin
+ln -sf "$(pwd)/venv/bin/hermes" ~/.local/bin/hermes
+
+# 验证
+hermes doctor
+hermes chat -q "Hello"
+```
+
+### 运行测试
+
+```bash
+pytest tests/ -v
+```
+
+## 代码风格
+
+- **PEP 8**，带有实际例外（不严格执行行长度）
+- **注释**：仅在解释非显而易见的意图、权衡或 API 怪癖时添加
+- **错误处理**：捕获特定异常。对意外错误使用 `logger.warning()`/`logger.error()` 并带 `exc_info=True`
+- **跨平台**：永远不要假设 Unix（见下文）
+- **配置文件安全路径**：永远不要硬编码 `~/.hermes` — 对代码路径使用 `hermes_constants` 中的 `get_hermes_home()`，对用户可见消息使用 `display_hermes_home()`。有关完整规则，请参见 [AGENTS.md](https://github.com/NousResearch/hermes-agent/blob/main/AGENTS.md#profiles-multi-instance-support)。
+
+## 跨平台兼容性
+
+Hermes 正式支持 Linux、macOS 和 WSL2。**不支持**原生 Windows，但代码库包含一些防御性编码模式以避免在边缘情况下出现硬崩溃。关键规则：
+
+### 1. `termios` 和 `fcntl` 仅限 Unix
+
+始终捕获 `ImportError` 和 `NotImplementedError`：
+
+```python
+try:
+    from simple_term_menu import TerminalMenu
+    menu = TerminalMenu(options)
+    idx = menu.show()
+except (ImportError, NotImplementedError):
+    # 回退：编号菜单
+    for i, opt in enumerate(options):
+        print(f"  {i+1}. {opt}")
+    idx = int(input("Choice: ")) - 1
+```
+
+### 2. 文件编码
+
+某些环境可能以非 UTF-8 编码保存 `.env` 文件：
+
+```python
+try:
+    load_dotenv(env_path)
+except UnicodeDecodeError:
+    load_dotenv(env_path, encoding="latin-1")
+```
+
+### 3. 进程管理
+
+`os.setsid()`、`os.killpg()` 和信号处理在不同平台上有所不同：
+
+```python
+import platform
+if platform.system() != "Windows":
+    kwargs["preexec_fn"] = os.setsid
+```
+
+### 4. 路径分隔符
+
+使用 `pathlib.Path` 而不是用 `/` 进行字符串连接。
+
+## 安全考虑
+
+Hermes 具有终端访问权限。安全很重要。
+
+### 现有保护
+
+| 层 | 实现 |
+|-------|---------------|
+| **Sudo 密码管道** | 使用 `shlex.quote()` 防止 shell 注入 |
+| **危险命令检测** | `tools/approval.py` 中的正则表达式模式，带有用户批准流程 |
+| **Cron 提示注入** | 扫描器阻止指令覆盖模式 |
+| **写入拒绝列表** | 通过 `os.path.realpath()` 解析受保护路径以防止符号链接绕过 |
+| **技能防护** | 中心安装技能的安全扫描器 |
+| **代码执行沙盒** | 子进程运行时剥离 API 密钥 |
+| **容器加固** | Docker：删除所有功能，无权限提升，PID 限制 |
+
+### 贡献安全敏感代码
+
+- 将用户输入插入 shell 命令时始终使用 `shlex.quote()`
+- 在访问控制检查之前使用 `os.path.realpath()` 解析符号链接
+- 不要记录秘密
+- 在工具执行周围捕获广泛的异常
+- 如果你的更改涉及文件路径或进程，请在所有平台上进行测试
+
+## Pull Request 流程
+
+### 分支命名
+
+```
+fix/description        # 错误修复
+feat/description       # 新功能
+docs/description       # 文档
+test/description       # 测试
+refactor/description   # 代码重构
+```
+
+### 提交前
+
+1. **运行测试**：`pytest tests/ -v`
+2. **手动测试**：运行 `hermes` 并练习你更改的代码路径
+3. **检查跨平台影响**：考虑 macOS 和不同的 Linux 发行版
+4. **保持 PR 专注**：每个 PR 一个逻辑更改
+
+### PR 描述
+
+包括：
+- **什么**改变了以及**为什么**
+- **如何测试**它
+- 你在**哪些平台**上进行了测试
+- 引用任何相关问题
+
+### 提交消息
+
+我们使用 [约定式提交](https://www.conventionalcommits.org/)：
+
+```
+<type>(<scope>): <description>
+```
+
+| 类型 | 用于 |
+|------|---------|
+| `fix` | 错误修复 |
+| `feat` | 新功能 |
+| `docs` | 文档 |
+| `test` | 测试 |
+| `refactor` | 代码重构 |
+| `chore` | 构建、CI、依赖更新 |
+
+作用域：`cli`、`gateway`、`tools`、`skills`、`agent`、`install`、`whatsapp`、`security`
+
+示例：
+```
+fix(cli): prevent crash in save_config_value when model is a string
+feat(gateway): add WhatsApp multi-user session isolation
+fix(security): prevent shell injection in sudo password piping
+```
+
+## 报告问题
+
+- 使用 [GitHub Issues](https://github.com/NousResearch/hermes-agent/issues)
+- 包括：操作系统、Python 版本、Hermes 版本（`hermes version`）、完整错误回溯
+- 包括重现步骤
+- 在创建重复问题之前检查现有问题
+- 对于安全漏洞，请私下报告
+
+## 社区
+
+- **Discord**：[discord.gg/NousResearch](https://discord.gg/NousResearch)
+- **GitHub Discussions**：用于设计提案和架构讨论
+- **技能中心**：上传专业技能并与社区分享
+
+## 许可证
+
+通过贡献，你同意你的贡献将根据 [MIT 许可证](https://github.com/NousResearch/hermes-agent/blob/main/LICENSE) 获得许可。
+

--- a/website/docs-cn/getting-started/_category_.json
+++ b/website/docs-cn/getting-started/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "开始使用",
+  "position": 1,
+  "link": {
+    "type": "generated-index",
+    "description": "在几分钟内启动并运行 Hermes Agent。"
+  }
+}

--- a/website/docs-cn/getting-started/installation.md
+++ b/website/docs-cn/getting-started/installation.md
@@ -1,0 +1,100 @@
+---
+sidebar_position: 2
+title: "安装指南"
+description: "在 Linux、macOS、WSL2 或通过 Termux 在 Android 上安装 Hermes Agent"
+---
+
+# 安装指南
+
+使用一键安装程序，在两分钟内启动并运行 Hermes Agent。
+
+## 快速安装
+
+### Linux / macOS / WSL2
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+```
+
+### Android / Termux
+
+Hermes 现在也提供了适用于 Termux 的安装路径：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+```
+
+安装程序会自动检测 Termux 并切换到经过测试的 Android 流程：
+- 使用 Termux `pkg` 安装系统依赖（`git`、`python`、`nodejs`、`ripgrep`、`ffmpeg`、构建工具）
+- 使用 `python -m venv` 创建虚拟环境
+- 自动导出 `ANDROID_API_LEVEL` 用于 Android wheel 构建
+- 使用 `pip` 安装精选的 `.[termux]` 额外包
+- 默认跳过未经测试的浏览器/WhatsApp 引导
+
+如果你想要完全明确的路径，请查看专门的 [Termux 指南](./termux.md)。
+
+:::warning Windows
+**不支持**原生 Windows。请安装 [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) 并从那里运行 Hermes Agent。上面的安装命令在 WSL2 中有效。
+:::
+
+### 安装程序的功能
+
+安装程序会自动处理一切 — 所有依赖项（Python、Node.js、ripgrep、ffmpeg）、仓库克隆、虚拟环境、全局 `hermes` 命令设置以及 LLM 提供者配置。到最后，你就可以开始聊天了。
+
+### 安装完成后
+
+重新加载你的 shell 并开始聊天：
+
+```bash
+source ~/.bashrc   # 或：source ~/.zshrc
+hermes             # 开始聊天！
+```
+
+稍后要重新配置单个设置，请使用专用命令：
+
+```bash
+hermes model          # 选择你的 LLM 提供者和模型
+hermes tools          # 配置启用哪些工具
+hermes gateway setup  # 设置消息传递平台
+hermes config set     # 设置单个配置值
+hermes setup          # 或者运行完整的设置向导一次性配置所有内容
+```
+
+---
+
+## 前置要求
+
+唯一的前置要求是 **Git**。安装程序会自动处理其他所有内容：
+
+- **uv**（快速的 Python 包管理器）
+- **Python 3.11**（通过 uv，无需 sudo）
+- **Node.js v22**（用于浏览器自动化和 WhatsApp 桥接）
+- **ripgrep**（快速文件搜索）
+- **ffmpeg**（TTS 的音频格式转换）
+
+:::info
+你**不需要**手动安装 Python、Node.js、ripgrep 或 ffmpeg。安装程序会检测缺少的内容并为你安装。只需确保 `git` 可用（`git --version`）。
+:::
+
+:::tip Nix 用户
+如果你使用 Nix（在 NixOS、macOS 或 Linux 上），有一个专用的设置路径，包括 Nix flake、声明式 NixOS 模块和可选的容器模式。查看 **[Nix & NixOS 设置](./nix-setup.md)** 指南。
+:::
+
+---
+
+## 手动/开发者安装
+
+如果你想克隆仓库并从源代码安装 — 用于贡献、从特定分支运行，或完全控制虚拟环境 — 请参阅贡献指南中的 [开发设置](../developer-guide/contributing.md#development-setup) 部分。
+
+---
+
+## 故障排除
+
+| 问题 | 解决方案 |
+|---------|----------|
+| `hermes: command not found` | 重新加载你的 shell（`source ~/.bashrc`）或检查 PATH |
+| `API key not set` | 运行 `hermes model` 配置你的提供者，或运行 `hermes config set OPENROUTER_API_KEY your_key` |
+| 更新后缺少配置 | 运行 `hermes config check` 然后运行 `hermes config migrate` |
+
+要进行更多诊断，运行 `hermes doctor` — 它会准确告诉你缺少什么以及如何修复它。
+

--- a/website/docs-cn/getting-started/learning-path.md
+++ b/website/docs-cn/getting-started/learning-path.md
@@ -1,0 +1,153 @@
+---
+sidebar_position: 3
+title: '学习路径'
+description: '根据你的经验水平和目标选择 Hermes Agent 文档的学习路径。'
+---
+
+# 学习路径
+
+Hermes Agent 可以做很多事情 — CLI 助手、Telegram/Discord 机器人、任务自动化、RL 训练等等。本页面帮助你根据经验水平和想要实现的目标确定从哪里开始以及阅读什么内容。
+
+:::tip 从这里开始
+如果你还没有安装 Hermes Agent，请从 [安装指南](/docs-cn/getting-started/installation) 开始，然后运行 [快速入门](/docs-cn/getting-started/quickstart)。下面的所有内容都假设你已经有一个可工作的安装。
+:::
+
+## 如何使用本页面
+
+- **知道你的水平？** 跳转到 [经验水平表](#by-experience-level) 并按照你层级的阅读顺序进行。
+- **有特定目标？** 跳到 [按用例](#by-use-case) 并找到匹配的场景。
+- **只是浏览？** 查看 [核心功能](#key-features-at-a-glance) 表以快速了解 Hermes Agent 可以做什么。
+
+## 按经验水平
+
+| 级别 | 目标 | 推荐阅读 | 时间估算 |
+|---|---|---|---|
+| **初学者** | 启动并运行，进行基本对话，使用内置工具 | [安装](/docs-cn/getting-started/installation) → [快速入门](/docs-cn/getting-started/quickstart) → [CLI 使用](/docs-cn/user-guide/cli) → [配置](/docs-cn/user-guide/configuration) | ~1 小时 |
+| **中级** | 设置消息机器人，使用高级功能如记忆、cron 作业和技能 | [会话](/docs-cn/user-guide/sessions) → [消息传递](/docs-cn/user-guide/messaging) → [工具](/docs-cn/user-guide/features/tools) → [技能](/docs-cn/user-guide/features/skills) → [记忆](/docs-cn/user-guide/features/memory) → [Cron](/docs-cn/user-guide/features/cron) | ~2–3 小时 |
+| **高级** | 构建自定义工具、创建技能、使用 RL 训练模型、为项目做贡献 | [架构](/docs-cn/developer-guide/architecture) → [添加工具](/docs-cn/developer-guide/adding-tools) → [创建技能](/docs-cn/developer-guide/creating-skills) → [RL 训练](/docs-cn/user-guide/features/rl-training) → [贡献](/docs-cn/developer-guide/contributing) | ~4–6 小时 |
+
+## 按用例
+
+选择与你想做的事情匹配的场景。每个场景都按你应该阅读的顺序链接到相关文档。
+
+### "我想要一个 CLI 编码助手"
+
+将 Hermes Agent 用作交互式终端助手来编写、审查和运行代码。
+
+1. [安装](/docs-cn/getting-started/installation)
+2. [快速入门](/docs-cn/getting-started/quickstart)
+3. [CLI 使用](/docs-cn/user-guide/cli)
+4. [代码执行](/docs-cn/user-guide/features/code-execution)
+5. [上下文文件](/docs-cn/user-guide/features/context-files)
+6. [提示与技巧](/docs-cn/guides/tips)
+
+:::tip
+使用上下文文件直接将文件传递到你的对话中。Hermes Agent 可以读取、编辑和运行你项目中的代码。
+:::
+
+### "我想要一个 Telegram/Discord 机器人"
+
+在你喜欢的消息传递平台上部署 Hermes Agent 作为机器人。
+
+1. [安装](/docs-cn/getting-started/installation)
+2. [配置](/docs-cn/user-guide/configuration)
+3. [消息传递概述](/docs-cn/user-guide/messaging)
+4. [Telegram 设置](/docs-cn/user-guide/messaging/telegram)
+5. [Discord 设置](/docs-cn/user-guide/messaging/discord)
+6. [语音模式](/docs-cn/user-guide/features/voice-mode)
+7. [在 Hermes 中使用语音模式](/docs-cn/guides/use-voice-mode-with-hermes)
+8. [安全性](/docs-cn/user-guide/security)
+
+有关完整的项目示例，请参阅：
+- [每日简报机器人](/docs-cn/guides/daily-briefing-bot)
+- [团队 Telegram 助手](/docs-cn/guides/team-telegram-assistant)
+
+### "我想要自动化任务"
+
+安排重复性任务、运行批处理作业或将代理操作链接在一起。
+
+1. [快速入门](/docs-cn/getting-started/quickstart)
+2. [Cron 调度](/docs-cn/user-guide/features/cron)
+3. [批处理](/docs-cn/user-guide/features/batch-processing)
+4. [委托](/docs-cn/user-guide/features/delegation)
+5. [钩子](/docs-cn/user-guide/features/hooks)
+
+:::tip
+Cron 作业让 Hermes Agent 按计划运行任务 — 每日摘要、定期检查、自动报告 — 无需你在场。
+:::
+
+### "我想要构建自定义工具/技能"
+
+用你自己的工具和可重用技能包扩展 Hermes Agent。
+
+1. [工具概述](/docs-cn/user-guide/features/tools)
+2. [技能概述](/docs-cn/user-guide/features/skills)
+3. [MCP（模型上下文协议）](/docs-cn/user-guide/features/mcp)
+4. [架构](/docs-cn/developer-guide/architecture)
+5. [添加工具](/docs-cn/developer-guide/adding-tools)
+6. [创建技能](/docs-cn/developer-guide/creating-skills)
+
+:::tip
+工具是代理可以调用的单个函数。技能是捆绑在一起的工具、提示和配置的集合。从工具开始，逐步过渡到技能。
+:::
+
+### "我想要训练模型"
+
+使用强化学习和 Hermes Agent 的内置 RL 训练管道微调模型行为。
+
+1. [快速入门](/docs-cn/getting-started/quickstart)
+2. [配置](/docs-cn/user-guide/configuration)
+3. [RL 训练](/docs-cn/user-guide/features/rl-training)
+4. [提供者路由](/docs-cn/user-guide/features/provider-routing)
+5. [架构](/docs-cn/developer-guide/architecture)
+
+:::tip
+当你已经了解 Hermes Agent 如何处理对话和工具调用的基础知识时，RL 训练效果最好。如果你是新手，请先运行初学者路径。
+:::
+
+### "我想把它用作 Python 库"
+
+以编程方式将 Hermes Agent 集成到你自己的 Python 应用程序中。
+
+1. [安装](/docs-cn/getting-started/installation)
+2. [快速入门](/docs-cn/getting-started/quickstart)
+3. [Python 库指南](/docs-cn/guides/python-library)
+4. [架构](/docs-cn/developer-guide/architecture)
+5. [工具](/docs-cn/user-guide/features/tools)
+6. [会话](/docs-cn/user-guide/sessions)
+
+## 核心功能一览
+
+不确定有什么可用？这是主要功能的快速目录：
+
+| 功能 | 作用 | 链接 |
+|---|---|---|
+| **工具** | 代理可以调用的内置工具（文件 I/O、搜索、shell 等） | [工具](/docs-cn/user-guide/features/tools) |
+| **技能** | 添加新功能的可安装插件包 | [技能](/docs-cn/user-guide/features/skills) |
+| **记忆** | 跨会话的持久化记忆 | [记忆](/docs-cn/user-guide/features/memory) |
+| **上下文文件** | 将文件和目录馈送到对话中 | [上下文文件](/docs-cn/user-guide/features/context-files) |
+| **MCP** | 通过模型上下文协议连接到外部工具服务器 | [MCP](/docs-cn/user-guide/features/mcp) |
+| **Cron** | 安排重复的代理任务 | [Cron](/docs-cn/user-guide/features/cron) |
+| **委托** | 生成子代理进行并行工作 | [委托](/docs-cn/user-guide/features/delegation) |
+| **代码执行** | 运行以编程方式调用 Hermes 工具的 Python 脚本 | [代码执行](/docs-cn/user-guide/features/code-execution) |
+| **浏览器** | 网页浏览和抓取 | [浏览器](/docs-cn/user-guide/features/browser) |
+| **钩子** | 事件驱动的回调和中间件 | [钩子](/docs-cn/user-guide/features/hooks) |
+| **批处理** | 批量处理多个输入 | [批处理](/docs-cn/user-guide/features/batch-processing) |
+| **RL 训练** | 使用强化学习微调模型 | [RL 训练](/docs-cn/user-guide/features/rl-training) |
+| **提供者路由** | 跨多个 LLM 提供者路由请求 | [提供者路由](/docs-cn/user-guide/features/provider-routing) |
+
+## 接下来读什么
+
+根据你现在的位置：
+
+- **刚完成安装？** → 前往 [快速入门](/docs-cn/getting-started/quickstart) 运行你的第一次对话。
+- **完成了快速入门？** → 阅读 [CLI 使用](/docs-cn/user-guide/cli) 和 [配置](/docs-cn/user-guide/configuration) 来自定义你的设置。
+- **熟悉基础知识？** → 探索 [工具](/docs-cn/user-guide/features/tools)、[技能](/docs-cn/user-guide/features/skills) 和 [记忆](/docs-cn/user-guide/features/memory) 以解锁代理的全部功能。
+- **为团队设置？** → 阅读 [安全性](/docs-cn/user-guide/security) 和 [会话](/docs-cn/user-guide/sessions) 以了解访问控制和对话管理。
+- **准备构建？** → 跳入 [开发者指南](/docs-cn/developer-guide/architecture) 以了解内部结构并开始贡献。
+- **想要实际示例？** → 查看 [指南](/docs-cn/guides/tips) 部分以获取真实世界的项目和提示。
+
+:::tip
+你不需要阅读所有内容。选择符合你目标的路径，按顺序跟随链接，你将很快提高工作效率。你可以随时回到此页面找到你的下一步。
+:::
+

--- a/website/docs-cn/getting-started/quickstart.md
+++ b/website/docs-cn/getting-started/quickstart.md
@@ -1,0 +1,297 @@
+---
+sidebar_position: 1
+title: "快速入门"
+description: "与 Hermes Agent 的首次对话 — 从安装到聊天，不到 5 分钟"
+---
+
+# 快速入门
+
+本指南将帮助你从零开始建立一个可工作的 Hermes 设置，能够经受实际使用。安装、选择提供者、验证工作聊天，并确切知道出现问题时该如何处理。
+
+## 适用对象
+
+- 全新接触，希望获得最短路径的可工作设置
+- 更换提供者，不想因配置错误浪费时间
+- 为团队、机器人或常驻工作流设置 Hermes
+- 对"已安装，但它仍然什么都不做"感到厌烦
+
+## 最快路径
+
+选择符合你目标的一行：
+
+| 目标 | 首先这样做 | 然后这样做 |
+|---|---|---|
+| 我只想让 Hermes 在我的机器上工作 | `hermes setup` | 运行真实聊天并验证其响应 |
+| 我已经知道我的提供者 | `hermes model` | 保存配置，然后开始聊天 |
+| 我想要一个机器人或常驻设置 | CLI 工作后运行 `hermes gateway setup` | 连接 Telegram、Discord、Slack 或另一个平台 |
+| 我想要本地或自托管模型 | `hermes model` → 自定义端点 | 验证端点、模型名称和上下文长度 |
+| 我想要多提供者回退 | 首先运行 `hermes model` | 在基本聊天工作后再添加路由和回退 |
+
+**经验法则：** 如果 Hermes 无法完成正常聊天，则不要添加更多功能。首先完成一次干净的对话，然后再添加网关、cron、技能、语音或路由。
+
+---
+
+## 1. 安装 Hermes Agent
+
+运行一键安装程序：
+
+```bash
+# Linux / macOS / WSL2 / Android (Termux)
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+```
+
+:::tip Android / Termux
+如果你在手机上安装，请参阅专门的 [Termux 指南](./termux.md)，了解经过测试的手动路径、支持的附加功能和当前 Android 特定限制。
+:::
+
+:::tip Windows 用户
+首先安装 [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install)，然后在你的 WSL2 终端内运行上述命令。
+:::
+
+完成后，重新加载你的 shell：
+
+```bash
+source ~/.bashrc   # 或 source ~/.zshrc
+```
+
+有关详细安装选项、前置要求和故障排除，请参阅 [安装指南](./installation.md)。
+
+## 2. 选择提供者
+
+最重要的设置步骤。使用 `hermes model` 交互式地完成选择：
+
+```bash
+hermes model
+```
+
+良好默认值：
+
+| 情况 | 推荐路径 |
+|---|---|
+| 最少摩擦 | Nous Portal 或 OpenRouter |
+| 你已经有 Claude 或 Codex 授权 | Anthropic 或 OpenAI Codex |
+| 你想要本地/私有推理 | Ollama 或任何自定义 OpenAI 兼容端点 |
+| 你想要多提供者路由 | OpenRouter |
+| 你有一个自定义 GPU 服务器 | vLLM、SGLang、LiteLLM 或任何 OpenAI 兼容端点 |
+
+对于大多数首次用户：选择一个提供者，接受默认值，除非你知道为什么要更改它们。完整的提供者目录及环境变量和设置步骤在 [提供者](../integrations/providers.md) 页面。
+
+:::caution 最小上下文：64K tokens
+Hermes Agent 需要一个至少有 **64,000 tokens** 上下文的模型。窗口较小的模型无法为多步骤工具调用工作流保持足够的工作内存，并将在启动时被拒绝。大多数托管模型（Claude、GPT、Gemini、Qwen、DeepSeek）很容易满足此要求。如果你正在运行本地模型，请将其上下文大小设置为至少 64K（例如，llama.cpp 的 `--ctx-size 65536` 或 Ollama 的 `-c 65536`）。
+:::
+
+:::tip
+你可以随时使用 `hermes model` 切换提供者 — 无锁定。有关所有支持的提供者和设置详情的完整列表，请参阅 [AI 提供者](../integrations/providers.md)。
+:::
+
+### 设置如何存储
+
+Hermes 将密钥与普通配置分开：
+
+- **密钥和令牌** → `~/.hermes/.env`
+- **非秘密设置** → `~/.hermes/config.yaml`
+
+正确设置值的最简单方法是通过 CLI：
+
+```bash
+hermes config set model anthropic/claude-opus-4.6
+hermes config set terminal.backend docker
+hermes config set OPENROUTER_API_KEY sk-or-...
+```
+
+正确的值会自动进入正确的文件。
+
+## 3. 运行你的第一次聊天
+
+```bash
+hermes            # 经典 CLI
+hermes --tui      # 现代 TUI（推荐）
+```
+
+你会看到一个欢迎横幅，显示你的模型、可用工具和技能。使用具体且易于验证的提示：
+
+:::tip 选择你的界面
+Hermes 附带两个终端界面：经典 `prompt_toolkit` CLI 和较新的 [TUI](../user-guide/tui.md) 带有模态覆盖、鼠标选择和非阻塞输入。两者共享相同的会话、斜杠命令和配置 — 用 `hermes` vs `hermes --tui` 试用每一个。
+:::
+
+```
+用 5 个要点总结这个仓库，并告诉我主要入口点是什么。
+```
+
+```
+检查我当前目录并告诉我看起来像主项目文件的是什么。
+```
+
+```
+帮我为这个代码库建立一个干净的 GitHub PR 工作流。
+```
+
+**成功的样子：**
+
+- 横幅显示你选择的模型/提供者
+- Hermes 无错误地回复
+- 如需要，它可以使用工具（终端、文件读取、网络搜索）
+- 对话在多个回合中正常继续
+
+如果这有效，你就度过了最难的部分。
+
+## 4. 验证会话工作
+
+在继续之前，确保恢复功能正常：
+
+```bash
+hermes --continue    # 恢复最近的会话
+hermes -c            # 简短形式
+```
+
+这应该把你带回你刚才的会话。如果不这样，请检查你是否在同一个配置文件中，以及会话是否确实已保存。当你在多个设置或机器之间切换时，这很重要。
+
+## 5. 尝试关键功能
+
+### 使用终端
+
+```
+❯ 我的磁盘使用情况如何？显示最大的 5 个目录。
+```
+
+代理代表你运行终端命令并显示结果。
+
+### 斜杠命令
+
+键入 `/` 查看所有命令的自动补全下拉菜单：
+
+| 命令 | 作用 |
+|---------|-------------|
+| `/help` | 显示所有可用命令 |
+| `/tools` | 列出可用工具 |
+| `/model` | 交互式切换模型 |
+| `/personality pirate` | 尝试有趣的人格 |
+| `/save` | 保存对话 |
+
+### 多行输入
+
+按 `Alt+Enter` 或 `Ctrl+J` 添加新行。非常适合粘贴代码或编写详细提示。
+
+### 中断代理
+
+如果代理花费太长时间，输入新消息并按 Enter — 它会中断当前任务并切换到你的新指令。`Ctrl+C` 也可以。
+
+## 6. 添加下一层
+
+仅在基础聊天工作后。选择你需要的：
+
+### 机器人或共享助手
+
+```bash
+hermes gateway setup    # 交互式平台配置
+```
+
+连接 [Telegram](/docs/user-guide/messaging/telegram)、[Discord](/docs/user-guide/messaging/discord)、[Slack](/docs/user-guide/messaging/slack)、[WhatsApp](/docs/user-guide/messaging/whatsapp)、[Signal](/docs/user-guide/messaging/signal)、[Email](/docs/user-guide/messaging/email) 或 [Home Assistant](/docs/user-guide/messaging/homeassistant)。
+
+### 自动化和工具
+
+- `hermes tools` — 调整每个平台的工具访问权限
+- `hermes skills` — 浏览和安装可重用工作流
+- Cron — 仅在你的机器人或 CLI 设置稳定后
+
+### 沙盒终端
+
+为了安全起见，在 Docker 容器或远程服务器上运行代理：
+
+```bash
+hermes config set terminal.backend docker    # Docker 隔离
+hermes config set terminal.backend ssh       # 远程服务器
+```
+
+### 语音模式
+
+```bash
+pip install "hermes-agent[voice]"
+# 包含免费的本地语音转文本的 faster-whisper
+```
+
+然后在 CLI 中：`/voice on`。按 `Ctrl+B` 录音。参见 [语音模式](../user-guide/features/voice-mode.md)。
+
+### 技能
+
+```bash
+hermes skills search kubernetes
+hermes skills install openai/skills/k8s
+```
+
+或在聊天会话中使用 `/skills`。
+
+### MCP 服务器
+
+```yaml
+# 添加到 ~/.hermes/config.yaml
+mcp_servers:
+  github:
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-github"]
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_xxx"
+```
+
+### 编辑器集成 (ACP)
+
+```bash
+pip install -e '.[acp]'
+hermes acp
+```
+
+参见 [ACP 编辑器集成](../user-guide/features/acp.md)。
+
+---
+
+## 常见失败模式
+
+这些是浪费最多时间的问题：
+
+| 症状 | 可能原因 | 修复 |
+|---|---|---|
+| Hermes 打开但给出空或损坏的回复 | 提供者授权或模型选择错误 | 再次运行 `hermes model` 并确认提供者、模型和授权 |
+| 自定义端点"工作"但返回垃圾 | 错误的基础 URL、模型名称或实际上不兼容 OpenAI | 首先在单独客户端中验证端点 |
+| 网关启动但没有人可以给它发消息 | 机器人令牌、允许列表或平台设置不完整 | 重新运行 `hermes gateway setup` 并检查 `hermes gateway status` |
+| `hermes --continue` 找不到旧会话 | 切换了配置文件或会话从未保存 | 检查 `hermes sessions list` 并确认你在正确的配置文件中 |
+| 模型不可用或奇怪的回退行为 | 提供者路由或回退设置过于激进 | 在基础提供者稳定之前关闭路由 |
+| `hermes doctor` 标记配置问题 | 配置值缺失或过时 | 修复配置，在添加功能之前重新测试纯聊天 |
+
+## 恢复工具包
+
+当感觉不对劲时，使用此顺序：
+
+1. `hermes doctor`
+2. `hermes model`
+3. `hermes setup`
+4. `hermes sessions list`
+5. `hermes --continue`
+6. `hermes gateway status`
+
+该序列可让你从"异常感觉"快速回到已知状态。
+
+---
+
+## 快速参考
+
+| 命令 | 描述 |
+|---------|-------------|
+| `hermes` | 开始聊天 |
+| `hermes model` | 选择你的 LLM 提供者和模型 |
+| `hermes tools` | 配置每个平台启用哪些工具 |
+| `hermes setup` | 完整设置向导（一次性配置所有内容） |
+| `hermes doctor` | 诊断问题 |
+| `hermes update` | 更新到最新版本 |
+| `hermes gateway` | 启动消息网关 |
+| `hermes --continue` | 恢复最后会话 |
+
+## 下一步
+
+- **[CLI 指南](../user-guide/cli.md)** — 掌握终端界面
+- **[配置](../user-guide/configuration.md)** — 自定义你的设置
+- **[消息网关](../user-guide/messaging/index.md)** — 连接 Telegram、Discord、Slack、WhatsApp、Signal、Email 或 Home Assistant
+- **[工具与工具集](../user-guide/features/tools.md)** — 探索可用功能
+- **[AI 提供者](../integrations/providers.md)** — 完整提供者列表和设置详情
+- **[技能系统](../user-guide/features/skills.md)** — 可重用工作流和知识
+- **[提示与最佳实践](../guides/tips.md)** — 高级用户提示
+

--- a/website/docs-cn/guides/_category_.json
+++ b/website/docs-cn/guides/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "Guides & Tutorials",
+  "position": 2,
+  "collapsible": true,
+  "collapsed": false
+}

--- a/website/docs-cn/index.md
+++ b/website/docs-cn/index.md
@@ -1,0 +1,58 @@
+---
+slug: /
+sidebar_position: 0
+title: "Hermes Agent 文档"
+description: "由 Nous Research 构建的自我改进 AI 代理。内置学习循环，从经验中创建技能，在使用过程中改进技能，并跨会话记忆。"
+hide_table_of_contents: true
+displayed_sidebar: docs
+---
+
+# Hermes Agent
+
+由 [Nous Research](https://nousresearch.com) 构建的自我改进 AI 代理。这是唯一具有内置学习循环的代理 — 它从经验中创建技能，在使用过程中改进技能，促使自己持久化知识，并在跨会话中建立对你的深入理解模型。
+
+<div style={{display: 'flex', gap: '1rem', marginBottom: '2rem', flexWrap: 'wrap'}}>
+  <a href="/docs-cn/getting-started/installation" style={{display: 'inline-block', padding: '0.6rem 1.2rem', backgroundColor: '#FFD700', color: '#07070d', borderRadius: '8px', fontWeight: 600, textDecoration: 'none'}}>开始使用 →</a>
+  <a href="https://github.com/NousResearch/hermes-agent" style={{display: 'inline-block', padding: '0.6rem 1.2rem', border: '1px solid rgba(255,215,0,0.2)', borderRadius: '8px', textDecoration: 'none'}}>在 GitHub 上查看</a>
+</div>
+
+## 什么是 Hermes Agent？
+
+它不是一个绑定到 IDE 的代码助手或围绕单个 API 的聊天机器人包装器。它是一个**自主代理**，运行时间越长，能力越强。它可以存在于任何地方 — $5 的 VPS、GPU 集群，或在空闲时几乎零成本的无服务器基础设施（Daytona、Modal）。当你自己在云 VM 上工作时，可以通过 Telegram 与它对话，而你无需亲自 SSH 登录。它不依赖于你的笔记本电脑。
+
+## 快速链接
+
+| | |
+|---|---|
+| 🚀 **[安装指南](/docs-cn/getting-started/installation)** | 在 Linux、macOS 或 WSL2 上 60 秒内完成安装 |
+| 📖 **[快速入门教程](/docs-cn/getting-started/quickstart)** | 你的第一次对话和要尝试的关键功能 |
+| 🗺️ **[学习路径](/docs-cn/getting-started/learning-path)** | 找到适合你经验水平的文档 |
+| ⚙️ **[配置](/docs-cn/user-guide/configuration)** | 配置文件、提供者、模型和选项 |
+| 💬 **[消息网关](/docs-cn/user-guide/messaging)** | 设置 Telegram、Discord、Slack 或 WhatsApp |
+| 🔧 **[工具与工具集](/docs-cn/user-guide/features/tools)** | 47 个内置工具及其配置方法 |
+| 🧠 **[记忆系统](/docs-cn/user-guide/features/memory)** | 跨会话增长的持久化记忆 |
+| 📚 **[技能系统](/docs-cn/user-guide/features/skills)** | 代理创建和重用的程序性记忆 |
+| 🔌 **[MCP 集成](/docs-cn/user-guide/features/mcp)** | 连接到 MCP 服务器，过滤其工具，安全地扩展 Hermes |
+| 🧭 **[在 Hermes 中使用 MCP](/docs-cn/guides/use-mcp-with-hermes)** | 实用的 MCP 设置模式、示例和教程 |
+| 🎙️ **[语音模式](/docs-cn/user-guide/features/voice-mode)** | 在 CLI、Telegram、Discord 和 Discord VC 中进行实时语音交互 |
+| 🗣️ **[在 Hermes 中使用语音模式](/docs-cn/guides/use-voice-mode-with-hermes)** | Hermes 语音工作流程的实际设置和使用模式 |
+| 🎭 **[个性与 SOUL.md](/docs-cn/user-guide/features/personality)** | 使用全局 SOUL.md 定义 Hermes 的默认声音 |
+| 📄 **[上下文文件](/docs-cn/user-guide/features/context-files)** | 塑造每次对话的项目上下文文件 |
+| 🔒 **[安全性](/docs-cn/user-guide/security)** | 命令批准、授权、容器隔离 |
+| 💡 **[提示与最佳实践](/docs-cn/guides/tips)** | 充分利用 Hermes 的快速技巧 |
+| 🏗️ **[架构](/docs-cn/developer-guide/architecture)** | 底层工作原理 |
+| ❓ **[常见问题与故障排除](/docs-cn/reference/faq)** | 常见问题和解决方案 |
+
+## 核心特性
+
+- **闭环学习** — 代理整理的记忆与定期提示、自主技能创建、使用过程中的技能自我改进、带有 LLM 摘要的 FTS5 跨会话召回，以及 [Honcho](https://github.com/plastic-labs/honcho) 辩证用户建模
+- **随处运行，不仅限于你的笔记本电脑** — 6 种终端后端：本地、Docker、SSH、Daytona、Singularity、Modal。Daytona 和 Modal 提供无服务器持久化 — 你的环境在空闲时休眠，成本几乎为零
+- **在你所在的地方生活** — CLI、Telegram、Discord、Slack、WhatsApp、Signal、Matrix、Mattermost、Email、SMS、钉钉、飞书、企业微信、BlueBubbles、Home Assistant — 一个网关支持 15+ 平台
+- **由模型训练者构建** — 由 [Nous Research](https://nousresearch.com) 创建，这是 Hermes、Nomos 和 Psyche 背后的实验室。可与 [Nous Portal](https://portal.nousresearch.com)、[OpenRouter](https://openrouter.ai)、OpenAI 或任何端点配合使用
+- **计划自动化** — 内置 cron，可传递到任何平台
+- **委托与并行化** — 生成隔离的子代理进行并行工作流。通过 `execute_code` 的程序化工具调用将多步骤管道折叠为单次推理调用
+- **开放标准技能** — 兼容 [agentskills.io](https://agentskills.io)。技能是可移植、可共享的，并通过技能中心由社区贡献
+- **完整的 Web 控制** — 搜索、提取、浏览、视觉、图像生成、TTS
+- **MCP 支持** — 连接到任何 MCP 服务器以扩展工具功能
+- **研究就绪** — 批处理、轨迹导出、使用 Atropos 进行 RL 训练。由 [Nous Research](https://nousresearch.com) 构建 — Hermes、Nomos 和 Psyche 模型背后的实验室
+

--- a/website/docs-cn/reference/_category_.json
+++ b/website/docs-cn/reference/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Reference",
+  "position": 4,
+  "link": {
+    "type": "generated-index",
+    "description": "Complete reference for CLI commands, environment variables, and configuration."
+  }
+}

--- a/website/docs-cn/user-guide/_category_.json
+++ b/website/docs-cn/user-guide/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "User Guide",
+  "position": 2,
+  "link": {
+    "type": "generated-index",
+    "description": "Learn how to use Hermes Agent effectively."
+  }
+}

--- a/website/docs-cn/user-guide/features/_category_.json
+++ b/website/docs-cn/user-guide/features/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Features",
+  "position": 4,
+  "link": {
+    "type": "generated-index",
+    "description": "Explore the powerful features of Hermes Agent."
+  }
+}

--- a/website/docs-cn/user-guide/features/memory.md
+++ b/website/docs-cn/user-guide/features/memory.md
@@ -1,0 +1,222 @@
+---
+sidebar_position: 3
+title: "持久化记忆"
+description: "Hermes Agent 如何跨会话记忆 — MEMORY.md、USER.md 和会话搜索"
+---
+
+# 持久化记忆
+
+Hermes Agent 拥有有限且经过整理的跨会话持久化记忆功能。这让它能够记住你的偏好、项目、环境以及学到的知识。
+
+## 工作原理
+
+代理的记忆由两个文件组成：
+
+| 文件 | 用途 | 字符限制 |
+|------|---------|------------|
+| **MEMORY.md** | 代理的个人笔记 — 环境事实、约定、学到的内容 | 2,200 字符（约 800 token） |
+| **USER.md** | 用户档案 — 你的偏好、沟通风格、期望 | 1,375 字符（约 500 token） |
+
+两者都存储在 `~/.hermes/memories/` 目录中，并在会话开始时作为冻结快照注入到系统提示中。代理通过 `memory` 工具管理自己的记忆 — 可以添加、替换或删除条目。
+
+:::info
+字符限制确保记忆保持聚焦。当记忆已满时，代理会合并或替换条目以为新信息腾出空间。
+:::
+
+## 记忆在系统提示中的呈现方式
+
+在每个会话开始时，记忆条目从磁盘加载并渲染到系统提示中作为一个冻结块：
+
+```
+══════════════════════════════════════════════
+MEMORY（你的个人笔记）[67% — 1,474/2,200 字符]
+══════════════════════════════════════════════
+用户的项目是一个位于 ~/code/myapi 的 Rust Web 服务，使用 Axum + SQLx
+§
+这台机器运行 Ubuntu 22.04，安装了 Docker 和 Podman
+§
+用户喜欢简洁的回复，不喜欢冗长的解释
+```
+
+格式包括：
+- 显示存储类型（MEMORY 或 USER PROFILE）的标题
+- 使用百分比和字符计数，让代理了解容量
+- 用 `§`（段落符号）分隔符分隔的各个条目
+- 条目可以是多行的
+
+**冻结快照模式：** 系统提示注入在会话开始时捕获一次，会话期间永不改变。这是有意为之的 — 它保留了 LLM 的前缀缓存以提高性能。当代理在会话期间添加/删除记忆条目时，更改会立即持久化到磁盘，但直到下一个会话开始才会出现在系统提示中。工具响应始终显示实时状态。
+
+## 记忆工具操作
+
+代理使用带有以下操作的 `memory` 工具：
+
+- **add** — 添加新的记忆条目
+- **replace** — 用更新的内容替换现有条目（通过 `old_text` 使用子字符串匹配）
+- **remove** — 删除不再相关的条目（通过 `old_text` 使用子字符串匹配）
+
+没有 `read` 操作 — 记忆内容会在会话开始时自动注入到系统提示中。代理将其记忆视为对话上下文的一部分。
+
+### 子字符串匹配
+
+`replace` 和 `remove` 操作使用短唯一子字符串匹配 — 你不需要完整的条文本。`old_text` 参数只需要是一个能唯一标识一个条目的子字符串：
+
+```python
+# 如果记忆包含 "User prefers dark mode in all editors"
+memory(action="replace", target="memory",
+       old_text="dark mode",
+       content="User prefers light mode in VS Code, dark mode in terminal")
+```
+
+如果子字符串匹配多个条目，将返回错误，要求提供更具体的匹配。
+
+## 两个目标详解
+
+### `memory` — 代理的个人笔记
+
+用于代理需要记住的有关环境、工作流程和经验教训的信息：
+
+- 环境事实（操作系统、工具、项目结构）
+- 项目约定和配置
+- 发现的工具特性和变通方法
+- 已完成的任务日记条目
+- 有效的技能和技巧
+
+### `user` — 用户档案
+
+用于有关用户身份、偏好和沟通风格的信息：
+
+- 姓名、角色、时区
+- 沟通偏好（简洁 vs 详细、格式偏好）
+- 讨厌的事项和需要避免的事情
+- 工作流习惯
+- 技术技能水平
+
+## 应该保存什么 vs 跳过什么
+
+### 这些要保存（主动保存）
+
+代理会自动保存 — 你不需要询问。它在学到以下内容时会保存：
+
+- **用户偏好：** "我更喜欢 TypeScript 而不是 JavaScript" → 保存到 `user`
+- **环境事实：** "这台服务器运行 Debian 12 和 PostgreSQL 16" → 保存到 `memory`
+- **纠正：** "Docker 命令不要使用 `sudo`，用户在 docker 组中" → 保存到 `memory`
+- **约定：** "项目使用制表符，120 字符行宽，Google 风格文档字符串" → 保存到 `memory`
+- **已完成的工作：** "于 2026-01-15 将数据库从 MySQL 迁移到 PostgreSQL" → 保存到 `memory`
+- **明确请求：** "记住我的 API 密钥每月轮换" → 保存到 `memory`
+
+### 这些跳过
+
+- **琐碎/明显的信息：** "用户询问了 Python" — 太模糊，没有用处
+- **容易重新发现的事实：** "Python 3.12 支持 f-string 嵌套" — 可以通过网络搜索找到
+- **原始数据转储：** 大型代码块、日志文件、数据表 — 对记忆来说太大
+- **会话特定的临时信息：** 临时文件路径、一次性调试上下文
+- 已在上下文文件中的信息：SOUL.md 和 AGENTS.md 内容
+
+## 容量管理
+
+记忆有严格的字符限制以保持系统提示的大小可控：
+
+| 存储 | 限制 | 典型条目数 |
+|-------|-------|----------------|
+| memory | 2,200 字符 | 8-15 个条目 |
+| user | 1,375 字符 | 5-10 个条目 |
+
+### 记忆已满时会发生什么
+
+当你尝试添加会超出限制的条目时，工具会返回错误：
+
+```json
+{
+  "success": false,
+  "error": "Memory at 2,100/2,200 chars. Adding this entry (250 chars) would exceed the limit. Replace or remove existing entries first.",
+  "current_entries": ["..."],
+  "usage": "2,100/2,200"
+}
+```
+
+然后代理应该：
+1. 读取当前条目（在错误响应中显示）
+2. 识别可以删除或合并的条目
+3. 使用 `replace` 将相关条目合并为更短的版本
+4. 然后 `add` 新条目
+
+**最佳实践：** 当记忆超过 80% 容量时（在系统提示标题中可见），在添加新条目之前先合并条目。例如，将三个单独的 "project uses X" 条目合并为一个全面的项目描述条目。
+
+### 良好记忆条目的实际示例
+
+**紧凑、信息密集的条目效果最好：**
+
+```
+# 好：打包多个相关事实
+User runs macOS 14 Sonoma, uses Homebrew, has Docker Desktop and Podman. Shell: zsh with oh-my-zsh. Editor: VS Code with Vim keybindings.
+
+# 好：具体、可操作的约定
+Project ~/code/api uses Go 1.22, sqlc for DB queries, chi router. Run tests with 'make test'. CI via GitHub Actions.
+
+# 好：带上下文的经验教训
+The staging server (10.0.1.50) needs SSH port 2222, not 22. Key is at ~/.ssh/staging_ed25519.
+
+# 坏：太模糊
+User has a project.
+
+# 坏：太冗长
+On January 5th, 2026, the user asked me to look at their project which is
+located at ~/code/api. I discovered it uses Go version 1.22 and...
+```
+
+## 重复预防
+
+记忆系统会自动拒绝完全重复的条目。如果你尝试添加已存在的内容，它会返回成功并显示 "no duplicate added" 消息。
+
+## 安全扫描
+
+记忆条目在被接受之前会扫描注入和泄露模式，因为它们会被注入到系统提示中。匹配威胁模式（提示注入、凭证泄露、SSH 后门）或包含不可见 Unicode 字符的内容会被阻止。
+
+## 会话搜索
+
+除了 MEMORY.md 和 USER.md，代理还可以使用 `session_search` 工具搜索其过去的对话：
+
+- 所有 CLI 和消息传递会话都存储在 SQLite（`~/.hermes/state.db`）中，支持 FTS5 全文搜索
+- 搜索查询返回相关的过去对话，并使用 Gemini Flash 进行摘要
+- 代理可以找到几周前讨论过的内容，即使这些内容不在其活动记忆中
+
+```bash
+hermes sessions list    # 浏览过去的会话
+```
+
+### session_search vs memory
+
+| 特性 | 持久化记忆 | 会话搜索 |
+|---------|------------------|----------------|
+| **容量** | 总共约 1,300 token | 无限制（所有会话） |
+| **速度** | 即时（在系统提示中） | 需要搜索 + LLM 摘要 |
+| **用例** | 关键事实在上下文中始终可用 | 查找特定的过去对话 |
+| **管理** | 由代理手动整理 | 自动 — 存储所有会话 |
+| **Token 成本** | 每个会话固定（约 1,300 token） | 按需（需要时搜索） |
+
+**记忆**适用于应该始终在上下文中的关键事实。**会话搜索**适用于"我们上周讨论过 X 吗？"这类查询，代理需要从过去的对话中回忆具体内容。
+
+## 配置
+
+```yaml
+# 在 ~/.hermes/config.yaml 中
+memory:
+  memory_enabled: true
+  user_profile_enabled: true
+  memory_char_limit: 2200   # 约 800 token
+  user_char_limit: 1375     # 约 500 token
+```
+
+## 外部记忆提供者
+
+对于超越 MEMORY.md 和 USER.md 的更深层次的持久化记忆，Hermes 附带了 8 个外部记忆提供者插件 — 包括 Honcho、OpenViking、Mem0、Hindsight、Holographic、RetainDB、ByteRover 和 Supermemory。
+
+外部提供者与内置记忆**并行运行**（从不替代它），并添加了知识图谱、语义搜索、自动事实提取和跨会话用户建模等功能。
+
+```bash
+hermes memory setup      # 选择一个提供者并配置它
+hermes memory status     # 检查哪些处于活动状态
+```
+
+查看 [记忆提供者](./memory-providers.md) 指南以获取每个提供者的完整详细信息、设置说明和比较。
+

--- a/website/docs-cn/user-guide/messaging/_category_.json
+++ b/website/docs-cn/user-guide/messaging/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Messaging Gateway",
+  "position": 3,
+  "link": {
+    "type": "doc",
+    "id": "user-guide/messaging/index"
+  }
+}


### PR DESCRIPTION
Closes #73314

## Summary

Fixes #73314 — desktop sidebar renders the same repo once per project (persisted order-id feedback loop when sibling projects share a git root).

## Root cause

Two bugs in `apps/desktop/src/app/chat/sidebar/order.ts`:

1. `reconcileOrderIds` (and `reconcileFreshFirst`): When `orderIds` is empty (first render), `currentIds` was returned verbatim — including all N duplicate occurrences of a shared repo id. That polluted persisted state on the first reconcile.

2. `orderByIds`: The `seen` set was written **after** `push`, so a duplicated id in `orderIds` would push the same item N times.

## Fix

- `reconcileOrderIds`: When `orderIds` is empty, deduplicate `currentIds` before returning.
- `reconcileFreshFirst`: Dedupe both the `retained` list (`[...new Set(...)]`) and the `currentIds` pass with a `seenCurrent` guard (first occurrence wins, insertion order preserved).
- `orderByIds`: Check `!seen.has(id)` **before** pushing, not after.

## Validation

- Regression tests cover duplicate ids in `currentIds` and duplicate ids in the persisted `orderIds`.
- Existing test suite unchanged (existing test cases still pass by construction).