### PR TITLE
fix(desktop): hide inactive terminal overlay

### DIFF
--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
@@ -4,6 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { PaneVisibleContext } from '@/components/pane-shell/pane-visibility'
 
+import { $terminalTakeover } from '../store'
+
 import { PersistentTerminal, TerminalSlot } from './persistent'
 
 vi.mock('./terminals', () => ({
@@ -166,6 +168,7 @@ describe('PersistentTerminal rect tracking', () => {
 
   afterEach(() => {
     cleanup()
+    $terminalTakeover.set(false)
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
     setVisibility(false)
@@ -314,23 +317,37 @@ describe('PersistentTerminal rect tracking', () => {
     expect(raf.pending()).toBe(1)
   })
 
-  it('hides the overlay when the terminal pane is an inactive kept-alive tab', () => {
+  it('hides the inactive overlay without remounting its terminal workspace', () => {
     installRaf()
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(rect(10, 20, 200, 100))
+    $terminalTakeover.set(true)
 
     render(<Harness />)
 
     const overlay = container!.lastElementChild as HTMLElement
+    const workspace = container!.querySelector('[data-testid="terminal-workspace"]')
+
     expect(overlay.style.visibility).toBe('visible')
+    expect(overlay.style.opacity).toBe('1')
+    expect(overlay.style.pointerEvents).toBe('auto')
+    expect(workspace).not.toBeNull()
 
     act(() => {
       root!.render(<Harness paneVisible={false} />)
     })
 
-    // Inactive tree tabs deliberately retain the same non-zero layout rect.
-    // Pane visibility, rather than geometry, must remove the fixed overlay.
     expect(overlay.style.visibility).toBe('hidden')
+    expect(overlay.style.opacity).toBe('0')
     expect(overlay.style.pointerEvents).toBe('none')
-    expect(overlay.getAttribute('aria-hidden')).toBe('true')
+    expect(container!.querySelector('[data-testid="terminal-workspace"]')).toBe(workspace)
+
+    act(() => {
+      root!.render(<Harness />)
+    })
+
+    expect(overlay.style.visibility).toBe('visible')
+    expect(overlay.style.opacity).toBe('1')
+    expect(overlay.style.pointerEvents).toBe('auto')
+    expect(container!.querySelector('[data-testid="terminal-workspace"]')).toBe(workspace)
   })
 })

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
@@ -2,6 +2,8 @@ import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { PaneVisibleContext } from '@/components/pane-shell/pane-visibility'
+
 import { PersistentTerminal, TerminalSlot } from './persistent'
 
 vi.mock('./terminals', () => ({
@@ -114,10 +116,12 @@ function installRaf() {
   }
 }
 
-function Harness() {
+function Harness({ paneVisible = true }: { paneVisible?: boolean }) {
   return (
     <>
-      <TerminalSlot className="slot" />
+      <PaneVisibleContext.Provider value={paneVisible}>
+        <TerminalSlot className="slot" />
+      </PaneVisibleContext.Provider>
       <PersistentTerminal onAddSelectionToChat={() => undefined} />
     </>
   )
@@ -308,5 +312,25 @@ describe('PersistentTerminal rect tracking', () => {
     act(() => window.dispatchEvent(new Event('focus')))
 
     expect(raf.pending()).toBe(1)
+  })
+
+  it('hides the overlay when the terminal pane is an inactive kept-alive tab', () => {
+    installRaf()
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(rect(10, 20, 200, 100))
+
+    render(<Harness />)
+
+    const overlay = container!.lastElementChild as HTMLElement
+    expect(overlay.style.visibility).toBe('visible')
+
+    act(() => {
+      root!.render(<Harness paneVisible={false} />)
+    })
+
+    // Inactive tree tabs deliberately retain the same non-zero layout rect.
+    // Pane visibility, rather than geometry, must remove the fixed overlay.
+    expect(overlay.style.visibility).toBe('hidden')
+    expect(overlay.style.pointerEvents).toBe('none')
+    expect(overlay.getAttribute('aria-hidden')).toBe('true')
   })
 })

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
@@ -214,6 +214,7 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
     display: 'flex',
     flexDirection: 'column',
     visibility: visible ? 'visible' : 'hidden',
+    opacity: visible ? 1 : 0,
     pointerEvents: visible ? 'auto' : 'none',
     zIndex: 4,
     // Match the live skin surface so the header strip (transparent) and body

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { atom } from 'nanostores'
 import { type CSSProperties, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
+import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { createRendererLoopPauseController } from '@/lib/renderer-loop-pause'
 
 import { $terminalTakeover } from '../store'
@@ -17,11 +18,13 @@ import { TerminalWorkspace } from './workspace'
  */
 
 const $slot = atom<HTMLElement | null>(null)
+const $slotVisible = atom(false)
 
 const SLOT_CLASS = 'relative flex min-h-0 min-w-0 flex-1 flex-col'
 
 export function TerminalSlot({ className = SLOT_CLASS }: { className?: string }) {
   const ref = useRef<HTMLDivElement | null>(null)
+  const paneVisible = usePaneVisible()
 
   useEffect(() => {
     const el = ref.current
@@ -35,9 +38,16 @@ export function TerminalSlot({ className = SLOT_CLASS }: { className?: string })
     return () => {
       if ($slot.get() === el) {
         $slot.set(null)
+        $slotVisible.set(false)
       }
     }
   }, [])
+
+  useEffect(() => {
+    if ($slot.get() === ref.current) {
+      $slotVisible.set(paneVisible)
+    }
+  }, [paneVisible])
 
   return <div className={className} ref={ref} />
 }
@@ -58,6 +68,7 @@ const sameRect = (a: Rect | null, b: Rect) =>
 
 export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalProps) {
   const slot = useStore($slot)
+  const slotVisible = useStore($slotVisible)
   const terminalTakeover = useStore($terminalTakeover)
   const [rect, setRect] = useState<Rect | null>(null)
   const [ready, setReady] = useState(false)
@@ -192,7 +203,7 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
     }
   }, [slot])
 
-  const visible = Boolean(rect && rect.width > 0 && rect.height > 0)
+  const visible = Boolean(slotVisible && rect && rect.width > 0 && rect.height > 0)
 
   const style: CSSProperties = {
     position: 'fixed',


### PR DESCRIPTION
## Summary

Fixes #73385.

Hermes Desktop keeps inactive layout tabs mounted with their original geometry. The persistent xterm overlay previously treated any non-zero terminal slot rectangle as visible, so in the Focus layout a background Terminal tab could cover the foreground chat.

This change carries the layout tree's existing pane-visibility signal from `TerminalSlot` to the root-mounted overlay. The terminal workspace and PTYs remain mounted, but the fixed overlay becomes hidden and non-interactive whenever Terminal is not the active tab.

## Validation

- Reproduced on current `main`: a terminal slot under `PaneVisibleContext=false` retained a 200x100 rect and the overlay remained visible.
- `persistent.test.tsx` plus the pane-shell tree suite: **50 passed**.
- Full Desktop TypeScript typecheck: **passed**.
- Targeted ESLint: **0 errors** (existing test-file restricted-global warnings only).
- `git diff --check`: **passed**.