### PR TITLE
fix(desktop): remove 9px override from pane tab label, inherit parent size

### DIFF
--- a/apps/desktop/src/components/ui/pane-tab.tsx
+++ b/apps/desktop/src/components/ui/pane-tab.tsx
@@ -170,7 +170,7 @@ export const PaneTabLabel = React.forwardRef<HTMLElement, PaneTabLabelProps>(fun
       ref={ref}
       {...props}
     >
-      <span className={cn('block min-w-0 truncate text-[9px] font-medium tracking-wide uppercase', className)}>
+      <span className={cn('block min-w-0 truncate font-medium tracking-wide uppercase', className)}>
         {children}
       </span>
     </Comp>


### PR DESCRIPTION
## Description

The layout-tree renderer (63a9bde77) introduced `PaneTabLabel` with a `text-[9px]` override that shrinks the session tab label below the parent `PaneTab`'s baseline of `text-[0.6875rem]` (11px). The old `ChatHeader`/`TitleMenuTrigger` used `0.75rem` (12px), making 9px a clear regression — 25% smaller.

This drops the explicit `text-[9px]` from the label span so it inherits `0.6875rem` from the parent, restoring readable sizing and consistent typographic hierarchy.

**Before:** `text-[9px]` (9px — 25% smaller than pre-migration)  
**After:** Inherits `text-[0.6875rem]` (11px) from parent `PaneTab`

Closes #73462

## Test plan

- `pane-tab.test.tsx`: 6/6 passing
- Desktop build: clean
