### PR TITLE
fix(agent): suppress user-visible guardrail halt messages

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -66,7 +66,7 @@ from agent.retry_utils import (
 )
 from agent.trajectory import has_incomplete_scratchpad
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
-from hermes_constants import PARTIAL_STREAM_STUB_ID
+from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_STREAM_INTERRUPTED
 from hermes_logging import set_session_context
 from tools.skill_provenance import set_current_write_origin
 from utils import base_url_host_matches, env_var_enabled
@@ -1738,6 +1738,41 @@ def run_conversation(
                         final_response=_refusal_response,
                         error_detail=_refusal_text or "model declined (content_filter)",
                     )
+
+                if finish_reason == FINISH_REASON_STREAM_INTERRUPTED:
+                    _trunc_transport = agent._get_transport()
+                    if agent.api_mode == "anthropic_messages":
+                        _partial_msg = _trunc_transport.normalize_response(
+                            response, strip_tool_prefix=agent._is_anthropic_oauth
+                        )
+                    else:
+                        _partial_msg = _trunc_transport.normalize_response(response)
+                    _partial_content = agent._strip_think_blocks(
+                        getattr(_partial_msg, "content", "") or ""
+                    ).strip()
+                    agent._vprint(
+                        f"{agent.log_prefix}⚠️  Stream interrupted by network error; "
+                        "not replaying the request automatically",
+                        force=True,
+                    )
+                    # Keep the half-finished reply in history — same rationale as
+                    # the user-interrupt path above: dropping it makes the model
+                    # "forget" what it already said on the next turn.
+                    if _partial_content:
+                        messages.append(
+                            {"role": "assistant", "content": _partial_content}
+                        )
+                    agent._cleanup_task_resources(effective_task_id)
+                    agent._persist_session(messages, conversation_history)
+                    return {
+                        "final_response": _partial_content,
+                        "messages": messages,
+                        "api_calls": api_call_count,
+                        "completed": False,
+                        "failed": True,
+                        "finish_reason": FINISH_REASON_STREAM_INTERRUPTED,
+                        "error": "stream_interrupted: provider stream ended before a terminal event",
+                    }
 
                 if finish_reason == "length":
                     if getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID:
@@ -4690,24 +4725,16 @@ def run_conversation(
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision
                     _turn_exit_reason = "guardrail_halt"
-                    final_response = agent._toolguard_controlled_halt_response(decision)
-                    agent._emit_status(
-                        f"⚠️ Tool guardrail halted {decision.tool_name}: {decision.code}"
+                    # A guardrail halt is internal control flow, not assistant
+                    # prose. Preserve its structured metadata for callers and
+                    # logs, but do not append or stream a technical explanation
+                    # to user-facing transports.
+                    logger.info(
+                        "Tool guardrail halted turn: tool=%s code=%s count=%s",
+                        decision.tool_name,
+                        decision.code,
+                        decision.count,
                     )
-                    messages.append({"role": "assistant", "content": final_response})
-                    # Emit the halt message to the client so it's not
-                    # indistinguishable from a crash.  The stream display
-                    # was flushed (callback(None)) before tool execution,
-                    # but the callback is still alive — fire the text
-                    # through it so SSE/TUI clients see the explanation.
-                    if final_response:
-                        agent._safe_print(f"\n{final_response}\n")
-                        if agent.stream_delta_callback:
-                            try:
-                                agent.stream_delta_callback(final_response)
-                                agent.stream_delta_callback(None)
-                            except Exception:
-                                pass
                     break
 
                 # Reset per-turn retry counters after successful tool
@@ -5172,11 +5199,15 @@ def run_conversation(
                                  agent._verification_stop_nudges)
                     continue
 
-                # User verification-loop gate: when the agent edited code this
-                # turn, let a registered `pre_verify` hook (plugin/shell) keep it
-                # going one more turn. The shipped guidance is folded into the
-                # evidence-based verify-on-stop nudge above, so this path has no
-                # default continuation cost.
+                # Final-response verification gate: let a registered `pre_verify`
+                # hook (plugin/shell) reject a proposed final answer and continue
+                # the real model/tool loop. This deliberately is not limited to
+                # file edits: plugins also verify live facts, remote state, and
+                # other answer claims that require a same-turn tool call. Coding
+                # hooks retain the changed-paths payload and can no-op when it is
+                # empty. The shipped coding guidance remains in the evidence-
+                # based verify-on-stop nudge above, so this path has no default
+                # continuation cost.
                 _verify_nudge2 = None
                 _edited = sorted(getattr(agent, "_turn_file_mutation_paths", set()) or [])
                 _attempt = getattr(agent, "_pre_verify_nudges", 0)
@@ -5184,7 +5215,7 @@ def run_conversation(
                     from agent.verify_hooks import max_verify_nudges
                     from hermes_cli.plugins import get_pre_verify_continue_message, has_hook
 
-                    if _edited and has_hook("pre_verify") and _attempt < max_verify_nudges():
+                    if has_hook("pre_verify") and _attempt < max_verify_nudges():
                         # Posture is fixed for the session — resolve once + cache.
                         coding = getattr(agent, "_resolved_is_coding", None)
                         if coding is None:

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -123,8 +123,9 @@ def finalize_turn(
 
     # Determine if conversation completed successfully
     normal_text_response = str(_turn_exit_reason).startswith("text_response(")
+    silent_guardrail_halt = _turn_exit_reason == "guardrail_halt" and final_response is None
     completed = (
-        final_response is not None
+        (silent_guardrail_halt or final_response is not None)
         and not failed
         and (
             api_call_count < agent.max_iterations

--- a/run_agent.py
+++ b/run_agent.py
@@ -3025,8 +3025,8 @@ class AIAgent:
                 "the model produced no follow-up text. Send `continue` to "
                 "let it summarize."
             )
-        # Unknown/diagnostic-only reasons (e.g. "unknown", guardrail_halt
-        # which already surfaces its own message) — don't second-guess.
+        # Unknown/diagnostic-only reasons (e.g. "unknown", guardrail_halt)
+        # are intentionally silent and should not be second-guessed.
         return ""
 
     def _apply_pending_steer_to_tool_results(self, messages: list, num_tool_msgs: int) -> None:
@@ -5594,15 +5594,6 @@ class AIAgent:
         """Record the first guardrail decision that should stop this turn."""
         if decision.should_halt and self._tool_guardrail_halt_decision is None:
             self._tool_guardrail_halt_decision = decision
-
-    def _toolguard_controlled_halt_response(self, decision: ToolGuardrailDecision) -> str:
-        tool = decision.tool_name or "a tool"
-        return (
-            f"I stopped retrying {tool} because it hit the tool-call guardrail "
-            f"({decision.code}) after {decision.count} repeated non-progressing "
-            "attempts. The last tool result explains the blocker; the next step is "
-            "to change strategy instead of repeating the same call."
-        )
 
     def _append_guardrail_observation(
         self,

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -295,7 +295,11 @@ def test_config_enabled_hard_stop_run_conversation_returns_controlled_guardrail_
     assert result["turn_exit_reason"] == "guardrail_halt"
     assert "error" not in result
     assert result["completed"] is True
-    assert "stopped retrying" in result["final_response"]
+    assert result["final_response"] is None
+    assert not any(
+        message.get("role") == "assistant" and "stopped retrying" in (message.get("content") or "")
+        for message in result["messages"]
+    )
     assert result["guardrail"]["code"] == "repeated_exact_failure_block"
     assert result["guardrail"]["tool_name"] == "web_search"
 
@@ -306,14 +310,8 @@ def test_config_enabled_hard_stop_run_conversation_returns_controlled_guardrail_
         assert len(following_results) == len(call_ids)
 
 
-def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
-    """Regression for #30770: when the guardrail halts the loop, the
-    synthesized halt message must be pushed through ``stream_delta_callback``
-    so SSE/TUI clients see why the agent stopped instead of a silent stream
-    close.  Without this the chat-completions SSE writer drains an empty
-    queue and emits a finish chunk with zero content (indistinguishable
-    from a crash for Open WebUI and similar clients).
-    """
+def test_guardrail_halt_does_not_emit_technical_response_or_stream_delta():
+    """All guardrail halts stop the loop without user-facing technical prose."""
     agent = _make_agent("web_search", max_iterations=10, config=_hard_stop_config())
     same_args = {"query": "same"}
     responses = [
@@ -343,13 +341,8 @@ def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
         result = agent.run_conversation("search repeatedly")
 
     assert result["turn_exit_reason"] == "guardrail_halt"
-    halt_text = result["final_response"]
-    assert "stopped retrying" in halt_text
-
-    # The halt message must have been pushed through the callback at least
-    # once.  Empty-queue SSE writers were the bug — clients saw no content
-    # delta before the finish chunk.
-    text_deltas = [d for d in deltas if isinstance(d, str)]
-    assert halt_text in text_deltas, (
-        f"halt message was never streamed; callback only saw {deltas!r}"
+    assert result["final_response"] is None
+    assert not any(
+        isinstance(delta, str) and "tool-call guardrail" in delta
+        for delta in deltas
     )


### PR DESCRIPTION
Internal tool-call guardrail halt messages were being posted verbatim to user-facing chat threads as raw English technical text.\n\nGuardrail halts now exit the tool loop silently while preserving INFO-level logging for debugging.