### PR TITLE
fix(whatsapp): honor group ingress policy in bridge

### DIFF
--- a/scripts/whatsapp-bridge/allowlist.js
+++ b/scripts/whatsapp-bridge/allowlist.js
@@ -63,6 +63,21 @@ export function expandWhatsAppIdentifiers(identifier, sessionDir) {
   return resolved;
 }
 
+export function matchesInboundWhatsAppGroup({
+  chatId,
+  groupPolicy,
+  groupAllowedUsers,
+  sessionDir,
+}) {
+  if (groupPolicy === 'disabled' || groupPolicy === 'pairing') {
+    return false;
+  }
+  if (groupPolicy === 'allowlist') {
+    return matchesAllowedUser(chatId, groupAllowedUsers, sessionDir);
+  }
+  return groupPolicy === 'open';
+}
+
 export function matchesAllowedUser(senderId, allowedUsers, sessionDir) {
   // Empty allowlist = NO ONE allowed (secure default, #8389).  Operators
   // who want an open bot must set ``WHATSAPP_ALLOWED_USERS=*`` explicitly.

--- a/scripts/whatsapp-bridge/allowlist.test.mjs
+++ b/scripts/whatsapp-bridge/allowlist.test.mjs
@@ -6,6 +6,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 
 import {
   expandWhatsAppIdentifiers,
+  matchesInboundWhatsAppGroup,
   matchesAllowedUser,
   normalizeWhatsAppIdentifier,
   parseAllowedUsers,
@@ -53,6 +54,27 @@ test('matchesAllowedUser treats * as allow-all wildcard', () => {
     const allowedUsers = parseAllowedUsers('*');
     assert.equal(matchesAllowedUser('19175395595@s.whatsapp.net', allowedUsers, sessionDir), true);
     assert.equal(matchesAllowedUser('267383306489914@lid', allowedUsers, sessionDir), true);
+  } finally {
+    rmSync(sessionDir, { recursive: true, force: true });
+  }
+});
+
+test('group intake follows group policy and group-JID allowlist independently of DM users', () => {
+  const sessionDir = mkdtempSync(path.join(os.tmpdir(), 'hermes-wa-allowlist-'));
+
+  try {
+    const groupAllowedUsers = parseAllowedUsers('120363001234567890@g.us');
+    const base = {
+      chatId: '120363001234567890@g.us',
+      groupAllowedUsers,
+      sessionDir,
+    };
+
+    assert.equal(matchesInboundWhatsAppGroup({ ...base, groupPolicy: 'allowlist' }), true);
+    assert.equal(matchesInboundWhatsAppGroup({ ...base, chatId: 'other@g.us', groupPolicy: 'allowlist' }), false);
+    assert.equal(matchesInboundWhatsAppGroup({ ...base, chatId: 'other@g.us', groupPolicy: 'open' }), true);
+    assert.equal(matchesInboundWhatsAppGroup({ ...base, groupPolicy: 'disabled' }), false);
+    assert.equal(matchesInboundWhatsAppGroup({ ...base, groupPolicy: 'pairing' }), false);
   } finally {
     rmSync(sessionDir, { recursive: true, force: true });
   }

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -30,7 +30,7 @@ import { randomBytes, createHash } from 'crypto';
 import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
-import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { matchesInboundWhatsAppGroup, matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
 import {
@@ -110,7 +110,11 @@ const PAIR_ONLY = args.includes('--pair-only');
 const PAIR_JSON = args.includes('--pair-json');
 const WHATSAPP_MODE = getArg('mode', process.env.WHATSAPP_MODE || 'self-chat'); // "bot" or "self-chat"
 const WHATSAPP_DM_POLICY = String(process.env.WHATSAPP_DM_POLICY || 'open').trim().toLowerCase();
+const WHATSAPP_GROUP_POLICY = String(process.env.WHATSAPP_GROUP_POLICY || 'pairing').trim().toLowerCase();
 const ALLOWED_USERS = parseAllowedUsers(process.env.WHATSAPP_ALLOWED_USERS || '');
+// Group authorization is by group JID, not by every participant's JID.  The
+// Python adapter still applies group policy and mention rules after intake.
+const GROUP_ALLOWED_USERS = parseAllowedUsers(process.env.WHATSAPP_GROUP_ALLOWED_USERS || '');
 const DEFAULT_REPLY_PREFIX = '⚕ *Hermes Agent*\n────────────\n';
 const REPLY_PREFIX = process.env.WHATSAPP_REPLY_PREFIX === undefined
   ? DEFAULT_REPLY_PREFIX
@@ -641,11 +645,20 @@ async function startSocket() {
           } catch {}
           continue;
         }
-        if (WHATSAPP_DM_POLICY !== 'pairing' && !matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
+        const intakeAllowed = isGroup
+          ? matchesInboundWhatsAppGroup({
+              chatId,
+              groupPolicy: WHATSAPP_GROUP_POLICY,
+              groupAllowedUsers: GROUP_ALLOWED_USERS,
+              sessionDir: SESSION_DIR,
+            })
+          : WHATSAPP_DM_POLICY === 'pairing'
+            || matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR);
+        if (!intakeAllowed) {
           try {
             console.log(JSON.stringify({
               event: 'ignored',
-              reason: 'allowlist_mismatch',
+              reason: isGroup ? 'group_policy_rejected' : 'allowlist_mismatch',
               chatId,
               senderId,
             }));


### PR DESCRIPTION
## What does this PR do?

The Baileys Node bridge currently applies `WHATSAPP_ALLOWED_USERS`—the DM sender allowlist—to every non-self inbound message. In a group, that rejects ordinary participants before the Python adapter can evaluate the existing `group_policy`, `group_allow_from`, and `require_mention` controls.

This change makes bridge intake use the existing group-specific policy instead:

- `group_policy: allowlist` matches the chat's group JID against `WHATSAPP_GROUP_ALLOWED_USERS`;
- `group_policy: open` forwards the group message for Python-side policy and mention checks;
- `group_policy: disabled` or `pairing` rejects it at the bridge;
- DMs retain the existing pairing/sender-allowlist behavior unchanged.

The policy is isolated in a small pure helper so the bridge behavior is testable without a live WhatsApp session. This is a narrow current-main replacement for the bridge portion of conflict-dirty PR #43929; Martin Gontovnikas is credited as co-author. PR #53623 contains a broader variant that forwards every group to Python, but it is also conflict-dirty and bundles unrelated owner/reaction behavior.

## Related Issue

Fixes #7269

Related prior art: #43929, #53623, #11597, #30288.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/whatsapp-bridge/allowlist.js`
  - Add a fail-closed group-ingress policy helper using the existing group JID allowlist matcher.
- `scripts/whatsapp-bridge/bridge.js`
  - Read the already-supported `WHATSAPP_GROUP_POLICY` and `WHATSAPP_GROUP_ALLOWED_USERS` bridge environment.
  - Apply group policy to group chats while preserving the existing DM gate.
- `scripts/whatsapp-bridge/allowlist.test.mjs`
  - Cover listed/unlisted groups and `open`, `allowlist`, `disabled`, and `pairing` policies with synthetic identifiers.

## How to Test

1. Configure WhatsApp bot mode with a restricted DM allowlist and an allowlisted group:
   ```yaml
   whatsapp:
     dm_policy: disabled
     group_policy: allowlist
     group_allow_from:
       - "120363001234567890@g.us"
     require_mention: true
   ```
2. Send a mention from a group participant who is not in `allow_from`: the bridge should forward it, and the Python adapter should process it.
3. Send the same message from an unlisted group or send an unknown DM: it should remain rejected.
4. Run:
   ```bash
   node --check scripts/whatsapp-bridge/allowlist.js
   node --check scripts/whatsapp-bridge/bridge.js
   node --test scripts/whatsapp-bridge/*.test.mjs
   python -m pytest -o 'addopts=' -q tests/gateway/test_whatsapp_group_gating.py tests/gateway/test_whatsapp_connect.py tests/gateway/test_config_driven_access_policy.py tests/gateway/test_relay_upstream_authz.py
   ```

Verified locally:

- Node bridge suite: 22 passed.
- Adjacent Python gateway suites: 142 passed.
- JavaScript syntax checks and `git diff --check`: passed.
- WhatsApp bridge lockfile unchanged after deterministic `npm ci --omit=dev`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing open/closed PRs and issues, including #43929 and #53623
- [x] My PR contains **only** changes related to this fix (one commit, three bridge files)
- [ ] I've run `pytest tests/ -q` and all tests pass — the repository-wide 45,203-test wrapper was stopped at 21.7% after 10,758 passes and 37 unrelated provider/platform failures on this Catalina host; all affected/adjacent suites pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 10.15.8, Node.js 22.22.0, Python 3.11.15, Baileys bridge bot mode

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A — no config keys or documented behavior are added; this makes existing controls reach the bridge
- [x] `cli-config.yaml.example`: N/A — existing keys only
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no architecture or workflow change
- [x] Cross-platform impact considered — pure JavaScript policy logic, no platform-specific APIs
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

Not applicable. The regression is covered by deterministic bridge-policy tests; no private WhatsApp identifiers or logs are included.
