### PR TITLE
Capture ACP/auth drift from protected main

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -31,10 +31,13 @@ else:
 
 import argparse
 import asyncio
+import contextlib
 import logging
 import os
 import sys
+from asyncio import transports as asyncio_transports
 from pathlib import Path
+from typing import BinaryIO, cast
 from hermes_constants import get_hermes_home
 
 
@@ -47,6 +50,70 @@ from hermes_constants import get_hermes_home
 # traceback is pure noise. We keep the protocol response intact and only
 # silence the stderr noise for this specific benign case.
 _BENIGN_PROBE_METHODS = frozenset({"ping", "health", "healthcheck"})
+
+
+class _ACPWriteProtocol(asyncio.BaseProtocol):
+    async def _drain_helper(self) -> None:
+        return None
+
+
+class _ACPStdoutTransport(asyncio.WriteTransport):
+    """Write ACP frames without polling the read side of a stdio socket."""
+
+    def __init__(self, stream: BinaryIO) -> None:
+        self._stream = stream
+        self._closing = False
+
+    def write(self, data: bytes) -> None:  # type: ignore[override]
+        if self._closing:
+            return
+        self._stream.write(data)
+        self._stream.flush()
+
+    def is_closing(self) -> bool:  # type: ignore[override]
+        return self._closing
+
+    def can_write_eof(self) -> bool:  # type: ignore[override]
+        return False
+
+    def close(self) -> None:  # type: ignore[override]
+        self._closing = True
+        with contextlib.suppress(Exception):
+            self._stream.flush()
+
+    def abort(self) -> None:  # type: ignore[override]
+        self.close()
+
+    def get_extra_info(self, name: str, default=None):  # type: ignore[override]
+        return default
+
+
+async def _acp_stdio_streams() -> tuple[asyncio.StreamWriter, asyncio.StreamReader]:
+    """Create ACP streams that remain open when Node launches stdout as a socket."""
+    loop = asyncio.get_running_loop()
+    reader = asyncio.StreamReader(limit=50 * 1024 * 1024)
+    reader_protocol = asyncio.StreamReaderProtocol(reader)
+    await loop.connect_read_pipe(lambda: reader_protocol, sys.stdin)
+
+    write_protocol = _ACPWriteProtocol()
+    transport = _ACPStdoutTransport(sys.stdout.buffer)
+    writer = asyncio.StreamWriter(
+        cast(asyncio_transports.WriteTransport, transport),
+        write_protocol,
+        None,
+        loop,
+    )
+    return writer, reader
+
+
+async def _run_acp_agent(acp_module, agent) -> None:
+    writer, reader = await _acp_stdio_streams()
+    await acp_module.run_agent(
+        agent,
+        input_stream=writer,
+        output_stream=reader,
+        use_unstable_protocol=True,
+    )
 
 
 class _BenignProbeMethodFilter(logging.Filter):
@@ -155,6 +222,7 @@ def _print_version() -> None:
 
 def _run_check() -> None:
     import acp  # noqa: F401
+    from acp.schema import AuthMethodAgent  # noqa: F401
     from acp_adapter.server import HermesACPAgent  # noqa: F401
 
     print("Hermes ACP check OK")
@@ -262,7 +330,7 @@ def main(argv: list[str] | None = None) -> None:
 
     agent = HermesACPAgent()
     try:
-        asyncio.run(acp.run_agent(agent, use_unstable_protocol=True))
+        asyncio.run(_run_acp_agent(acp, agent))
     except KeyboardInterrupt:
         logger.info("Shutting down (KeyboardInterrupt)")
     except Exception:

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1982,7 +1982,13 @@ class HermesACPAgent(acp.Agent):
 
         await self._send_usage_update(state)
 
-        stop_reason = "cancelled" if cancelled else "end_turn"
+        failed = bool(
+            result.get("failed")
+            or result.get("partial")
+            or result.get("error")
+            or result.get("completed") is False
+        )
+        stop_reason = "cancelled" if cancelled else "refusal" if failed else "end_turn"
         return PromptResponse(stop_reason=stop_reason, usage=usage)
 
     # ---- Slash commands (headless) -------------------------------------------
@@ -2346,7 +2352,7 @@ class HermesACPAgent(acp.Agent):
                 current_provider or "openrouter",
             )
             state.model = resolved_model
-            provider_changed = bool(current_provider and requested_provider != current_provider)
+            provider_changed = requested_provider != current_provider
             current_base_url = None if provider_changed else getattr(state.agent, "base_url", None)
             current_api_mode = None if provider_changed else getattr(state.agent, "api_mode", None)
             state.agent = self.session_manager._make_agent(

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1166,6 +1166,9 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
     # OAuth grants (#43589) — reusing this function's atomic O_EXCL + 0o600
     # write so the root auth.json gets the same TOCTOU-safe treatment.
     auth_file = target_path if target_path is not None else _auth_file_path()
+    if os.environ.get("HERMES_AUTH_STORE_READ_ONLY") == "1":
+        logger.debug("Auth store persistence suppressed for this isolated runtime")
+        return auth_file
     auth_file.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir to 0o700 so siblings can't traverse to creds.
     # No-op on Windows (POSIX mode bits not enforced); ignore failures.

--- a/tests/acp/test_entry.py
+++ b/tests/acp/test_entry.py
@@ -1,6 +1,7 @@
 """Tests for acp_adapter.entry startup wiring."""
 
 import sys
+from io import BytesIO
 
 import acp
 import pytest
@@ -11,26 +12,70 @@ from acp_adapter import entry
 def test_main_enables_unstable_protocol(monkeypatch):
     calls = {}
 
+    async def fake_stdio_streams():
+        return "writer", "reader"
+
     async def fake_run_agent(agent, **kwargs):
         calls["kwargs"] = kwargs
 
     monkeypatch.setattr(entry, "_setup_logging", lambda: None)
     monkeypatch.setattr(entry, "_load_env", lambda: None)
+    monkeypatch.setattr(entry, "_acp_stdio_streams", fake_stdio_streams)
     monkeypatch.setattr(acp, "run_agent", fake_run_agent)
 
     entry.main([])
 
     assert calls["kwargs"]["use_unstable_protocol"] is True
+    assert calls["kwargs"]["input_stream"] == "writer"
+    assert calls["kwargs"]["output_stream"] == "reader"
+
+
+def test_acp_stdout_transport_writes_and_flushes_without_closing_stream():
+    class FlushTrackingBuffer(BytesIO):
+        flush_count = 0
+
+        def flush(self):
+            self.flush_count += 1
+            super().flush()
+
+    stream = FlushTrackingBuffer()
+    transport = entry._ACPStdoutTransport(stream)
+
+    transport.write(b'{"jsonrpc":"2.0"}\n')
+    transport.close()
+
+    assert stream.getvalue() == b'{"jsonrpc":"2.0"}\n'
+    assert stream.flush_count == 2
+    assert transport.is_closing() is True
+    assert stream.closed is False
+
+
+def test_swarm_read_only_auth_flag_suppresses_auth_store_writes(tmp_path, monkeypatch):
+    from hermes_cli import auth
+
+    target = tmp_path / "auth.json"
+    payload = {"version": 1, "providers": {}}
+    monkeypatch.setenv("HERMES_AUTH_STORE_READ_ONLY", "1")
+
+    result = auth._save_auth_store(payload, target_path=target)
+
+    assert result == target
+    assert target.exists() is False
+    assert "updated_at" not in payload
 
 
 def test_main_skips_configured_mcp_discovery_when_requested(monkeypatch):
     discovery_calls = []
+
+    async def fake_stdio_streams():
+        return "writer", "reader"
 
     async def fake_run_agent(agent, **kwargs):
         pass
 
     monkeypatch.setattr(entry, "_setup_logging", lambda: None)
     monkeypatch.setattr(entry, "_load_env", lambda: None)
+    monkeypatch.setattr(entry, "_acp_stdio_streams", fake_stdio_streams)
     monkeypatch.setenv("HERMES_ACP_SKIP_CONFIGURED_MCP", "1")
     monkeypatch.setattr(
         "tools.mcp_tool.discover_mcp_tools",
@@ -47,11 +92,15 @@ def test_main_skips_configured_mcp_discovery_when_requested(monkeypatch):
 def test_main_discovers_configured_mcp_when_skip_is_not_enabled(monkeypatch, skip_value):
     discovery_calls = []
 
+    async def fake_stdio_streams():
+        return "writer", "reader"
+
     async def fake_run_agent(agent, **kwargs):
         pass
 
     monkeypatch.setattr(entry, "_setup_logging", lambda: None)
     monkeypatch.setattr(entry, "_load_env", lambda: None)
+    monkeypatch.setattr(entry, "_acp_stdio_streams", fake_stdio_streams)
     if skip_value is None:
         monkeypatch.delenv("HERMES_ACP_SKIP_CONFIGURED_MCP", raising=False)
     else:

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1257,6 +1257,8 @@ class TestSessionConfiguration:
             assert state.agent.provider == "openrouter"
             assert state.agent.base_url == "https://openrouter.example/v1"
             assert state.agent.api_mode == "chat_completions"
+            state.agent.provider = ""
+            state.agent.base_url = "https://openrouter.example/v1"
             result = await acp_agent.set_session_model(
                 model_id="anthropic:claude-sonnet-4-6",
                 session_id=state.session_id,
@@ -1370,6 +1372,28 @@ class TestPrompt:
         assert state.agent.stream_delta_callback is not None
         assert state.agent.reasoning_callback is not None
         assert state.agent.thinking_callback is None
+
+    @pytest.mark.asyncio
+    async def test_prompt_returns_refusal_when_agent_turn_failed(self, agent):
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.agent.run_conversation = MagicMock(return_value={
+            "final_response": "HTTP 401: User not found.",
+            "messages": [],
+            "failed": True,
+            "completed": False,
+        })
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        resp = await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="hello")],
+            session_id=new_resp.session_id,
+        )
+
+        assert resp.stop_reason == "refusal"
 
     @pytest.mark.asyncio
     async def test_prompt_updates_history(self, agent):


### PR DESCRIPTION
## Summary

Routes the audited ACP and auth changes that were stranded as uncommitted drift on the protected local `main` branch into a rebased draft PR.

## Included

- ACP stdio transport compatibility for Node-launched stdout sockets
- ACP refusal stop reason for failed or partial turns
- Provider reset when the previous provider is empty
- Read-only auth-store behavior for isolated runtime execution
- Regression coverage for transport wiring, failure signaling, provider reset, and auth persistence

## Validation

- `scripts/run_tests.sh tests/acp/test_entry.py tests/acp/test_server.py -q`
- Result: 110 passed
- `uv run ruff check acp_adapter/entry.py acp_adapter/server.py hermes_cli/auth.py tests/acp/test_entry.py tests/acp/test_server.py`
- Result: all checks passed

## Scope Notes

- `result.json` and `hermes-bridge.sh` were intentionally left out as untracked outliers: the former is a stale runtime artifact, and the latter has no documented caller.
- This PR is draft for human review before merge.
