### PR TITLE
feat(desktop): add Performance settings section with Max Speed and GP…

### DIFF
--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -29,6 +29,7 @@ import { PanelEmpty } from '../overlays/panel'
 
 import { ConfigField } from './config-field'
 import { enumOptionsFor, getNested, isExternalMemoryProvider, sectionFieldEntries, setNested } from './helpers'
+import { FIELD_DESCRIPTIONS, FIELD_LABELS } from './constants'
 import { MemoryConnect } from './memory/connect'
 import { ProviderConfigPanel } from './memory/provider-config-panel'
 import { ModelSettings, ModelSettingsSkeleton } from './model-settings'
@@ -316,11 +317,14 @@ export function ConfigSettings({
           <QuickEntrySettings />
         </>
       )}
+      {activeSectionId === 'performance' && config && (
+        <PerformanceSettings config={config} updateConfig={updateConfig} />
+      )}
       {/* Device-local attach/preview byte cap (main-process IPC guard). Chat is
           where image-attachment behavior already lives, so this sits above the
           schema fields for that section. */}
       {activeSectionId === 'chat' ? <AttachmentSizeSetting /> : null}
-      {visibleFields.length === 0 && activeSectionId !== 'chat' ? (
+      {visibleFields.length === 0 && activeSectionId !== 'chat' && activeSectionId !== 'performance' ? (
         <EmptyState description={c.emptyDesc} title={c.emptyTitle} />
       ) : visibleFields.length === 0 ? null : (
         <div className="grid gap-1">
@@ -428,5 +432,57 @@ function AttachmentSizeSetting() {
       description={c.attachmentSizeDesc}
       title={c.attachmentSizeTitle}
     />
+  )
+}
+
+// Performance panel: two bespoke toggles that don't map to a single schema
+// field each. Max Speed writes delegation.max_concurrent_children (12 on /
+// 3 off) so the orchestrator fans out up to 12 parallel subagents. GPU
+// Acceleration writes desktop.disable_gpu (false = GPU on, true = software);
+// the CLI bridges that to HERMES_DESKTOP_DISABLE_GPU before the Electron app
+// launches, so the change takes effect on the next app start.
+const MAX_SPEED_ON = 12
+const MAX_SPEED_OFF = 3
+
+function PerformanceSettings({
+  config,
+  updateConfig
+}: {
+  config: HermesConfigRecord
+  updateConfig: (next: HermesConfigRecord) => void
+}) {
+  const { t } = useI18n()
+
+  const maxConcurrent = Number(getNested(config, 'delegation.max_concurrent_children') ?? MAX_SPEED_OFF)
+  const maxSpeedOn = maxConcurrent >= MAX_SPEED_ON
+
+  const disableGpuRaw = getNested(config, 'desktop.disable_gpu')
+  // `auto` / false / "0" → GPU enabled (toggle on). true / "1" → disabled.
+  const gpuOn = !(disableGpuRaw === true || disableGpuRaw === 'true' || disableGpuRaw === '1')
+
+  const setMaxSpeed = (on: boolean) => {
+    updateConfig(setNested(config, 'delegation.max_concurrent_children', on ? MAX_SPEED_ON : MAX_SPEED_OFF))
+  }
+
+  const setGpu = (on: boolean) => {
+    // Persist as a boolean so the CLI normalizes it to "0"/"1" for the env bridge.
+    updateConfig(setNested(config, 'desktop.disable_gpu', on ? false : true))
+  }
+
+  return (
+    <div className="grid gap-1">
+      <ToggleRow
+        checked={maxSpeedOn}
+        description={FIELD_DESCRIPTIONS['maxSpeed'] ?? 'Run up to 12 parallel subagents (vs the default 3).'}
+        label={FIELD_LABELS['maxSpeed'] ?? 'Max Speed'}
+        onChange={setMaxSpeed}
+      />
+      <ToggleRow
+        checked={gpuOn}
+        description={FIELD_DESCRIPTIONS['desktop.disableGpu'] ?? 'Use the GPU for rendering. Off forces software rendering.'}
+        label={FIELD_LABELS['desktop.disableGpu'] ?? 'GPU Acceleration'}
+        onChange={setGpu}
+      />
+    </div>
   )
 }

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -9,7 +9,8 @@ import {
   Moon,
   Palette,
   Sun,
-  Wrench
+  Wrench,
+  Zap
 } from '@/lib/icons'
 import { REASONING_EFFORTS } from '@/lib/reasoning-effort'
 import type { ThemeMode } from '@/themes/context'
@@ -396,8 +397,13 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
   desktop: {
     repoScanEnabled: 'Automatic Repository Discovery',
     repoScanRoots: 'Repository Discovery Roots',
-    repoScanExcludePaths: 'Excluded Repository Paths'
+    repoScanExcludePaths: 'Excluded Repository Paths',
+    disableGpu: 'GPU Acceleration',
+    gpuAcceleration: 'GPU Acceleration'
   },
+  // Synthetic (non-config) label for the Max Speed toggle: it writes
+  // delegation.max_concurrent_children (12 on / 3 off) rather than its own key.
+  maxSpeed: 'Max Speed',
   agent: {
     maxTurns: 'Max Agent Steps',
     imageInputMode: 'Image Attachments',
@@ -562,8 +568,11 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
   desktop: {
     repoScanEnabled: 'Scan local folders for Git repositories to show in Projects.',
     repoScanRoots: 'Folders to scan. Leave empty to scan your home directory.',
-    repoScanExcludePaths: 'Folders and their descendants to skip during repository discovery.'
+    repoScanExcludePaths: 'Folders and their descendants to skip during repository discovery.',
+    disableGpu: 'Use the GPU for rendering. Off forces software rendering (helps on GPU-less VMs / remote displays).',
+    gpuAcceleration: 'Use the GPU for rendering. Off forces software rendering (helps on GPU-less VMs / remote displays).'
   },
+  maxSpeed: 'Run up to 12 parallel subagents (vs the default 3) for max-throughput fan-out.',
   timezone: 'Used when Hermes needs local time context. Blank uses the system timezone.',
   agent: {
     imageInputMode: 'Controls how image attachments are sent to the model.',
@@ -776,6 +785,16 @@ export const SECTIONS: DesktopConfigSection[] = [
       'delegation.reasoning_effort',
       'updates.non_interactive_local_changes'
     ]
+  },
+  {
+    id: 'performance',
+    label: 'Performance',
+    icon: Zap,
+    // Custom-rendered toggles (see ConfigSettings `performance` branch):
+    // Max Speed writes delegation.max_concurrent_children (12/3), and GPU
+    // Acceleration writes desktop.disable_gpu. Empty keys keeps the generic
+    // field loop from double-rendering them as raw schema fields.
+    keys: []
   }
 ]
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -409,7 +409,8 @@ export const en: Translations = {
       safety: 'Safety',
       memory: 'Memory & Context',
       voice: 'Voice',
-      advanced: 'Advanced'
+      advanced: 'Advanced',
+      performance: 'Performance'
     },
     searchPlaceholder: {
       about: 'About Hermes Desktop',


### PR DESCRIPTION
…U toggles

Add a new Settings → Performance panel exposing two app-performance knobs that were already config-backed but had no UI surface:

- Max Speed: writes delegation.max_concurrent_children (12 on / 3 off) to raise the parallel subagent fan-out cap.
- GPU Acceleration: writes desktop.disable_gpu (false = GPU on, true = software), bridged by the CLI to HERMES_DESKTOP_DISABLE_GPU at launch.

Both render as ToggleRows via a bespoke PerformanceSettings component (empty SECTIONS keys + EmptyState guard so they aren't double-rendered as raw schema fields). Typecheck: tsc --noEmit clean.


