### PR TITLE
fix(deps): repair Google transitive security floors (#72108)

### DIFF
--- a/plugins/platforms/google_chat/oauth.py
+++ b/plugins/platforms/google_chat/oauth.py
@@ -65,8 +65,11 @@ import secrets
 import stat
 import subprocess
 import sys
+from importlib.metadata import version as _distribution_version
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
+
+from packaging.requirements import Requirement
 
 # Pin the legacy logger name so operator-side log filters keep matching
 # after the in-tree → plugin migration. See adapter.py for context.
@@ -157,11 +160,15 @@ SCOPES: List[str] = [
     "https://www.googleapis.com/auth/chat.messages.create",
 ]
 
-# Pip packages required for the OAuth flow.
+# Pip packages required by the Google Chat adapter and its OAuth flow.
 _REQUIRED_PACKAGES = [
-    "google-api-python-client",
-    "google-auth-oauthlib",
-    "google-auth-httplib2",
+    "google-cloud-pubsub==2.39.0",
+    "google-api-python-client==2.194.0",
+    "google-auth==2.55.1",
+    "google-auth-oauthlib==1.3.1",
+    "google-auth-httplib2==0.3.1",
+    "httplib2==0.32.0",
+    "pyasn1==0.6.4",
 ]
 
 # Out-of-band redirect: Google deprecated the ``urn:ietf:wg:oauth:2.0:oob``
@@ -367,31 +374,44 @@ def _write_private_json(path: Path, data: Any) -> None:
 
 
 def _ensure_deps() -> None:
-    """Check deps available; install if not; exit on failure."""
-    try:
-        import googleapiclient  # noqa: F401
-        import google_auth_oauthlib  # noqa: F401
-    except ImportError:
-        if not install_deps():
-            sys.exit(1)
+    """Check exact dependency versions; install if stale; exit on failure."""
+    if _missing_required_packages() and not install_deps():
+        sys.exit(1)
+
+
+def _missing_required_packages() -> List[str]:
+    """Return exact requirements absent or stale in this interpreter."""
+    missing = []
+    for spec in _REQUIRED_PACKAGES:
+        requirement = Requirement(spec)
+        try:
+            installed = _distribution_version(requirement.name)
+            satisfied = requirement.specifier.contains(installed, prereleases=True)
+        except Exception:
+            satisfied = False
+        if not satisfied:
+            missing.append(spec)
+    return missing
 
 
 def install_deps() -> bool:
-    try:
-        import googleapiclient  # noqa: F401
-        import google_auth_oauthlib  # noqa: F401
+    missing = _missing_required_packages()
+    if not missing:
         print("Dependencies already installed.")
         return True
-    except ImportError:
-        pass
 
-    print("Installing Google Chat OAuth dependencies...")
+    print("Installing Google Chat dependencies...")
     try:
         from hermes_cli.tools_config import _pip_install
 
-        result = _pip_install(["--quiet"] + _REQUIRED_PACKAGES)
+        result = _pip_install(["--quiet"] + missing)
         if result.returncode != 0:
             raise RuntimeError((result.stderr or "install failed").strip()[:300])
+        remaining = _missing_required_packages()
+        if remaining:
+            raise RuntimeError(
+                "dependencies remain stale after install: " + " ".join(remaining)
+            )
         print("Dependencies installed.")
         return True
     except Exception as exc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,7 +255,7 @@ mistral = ["mistralai==2.4.8"]
 # NOT in [all].
 otlp = ["opentelemetry-sdk==1.39.1", "opentelemetry-exporter-otlp-proto-http==1.39.1"]
 bedrock = ["boto3==1.42.89"]
-vertex = ["google-auth==2.55.1"]
+vertex = ["google-auth==2.55.1", "pyasn1==0.6.4"]
 azure-identity = ["azure-identity==1.25.3"]
 termux = [
   # Baseline Android / Termux path for reliable fresh installs.
@@ -286,8 +286,13 @@ google = [
   # and packagers ship them without hitting runtime `pip install` paths that
   # fail in environments without pip (e.g. Nix-managed Python).
   "google-api-python-client==2.194.0",
+  "google-auth==2.55.1",
   "google-auth-oauthlib==1.3.1",
   "google-auth-httplib2==0.3.1",
+  # The Google SDKs permit older vulnerable transitives, so unlocked installs
+  # must carry the same fixed floors as uv.lock and the runtime installers.
+  "httplib2==0.32.0",
+  "pyasn1==0.6.4",
 ]
 youtube = [
   # Required by skills/media/youtube-content and

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -29,7 +29,10 @@ import os
 import shutil
 import subprocess
 import sys
+from importlib.metadata import version as _distribution_version
 from pathlib import Path
+
+from packaging.requirements import Requirement
 
 # Ensure sibling modules (_hermes_home) are importable when run standalone.
 _SCRIPTS_DIR = str(Path(__file__).resolve().parent)
@@ -54,7 +57,14 @@ SCOPES = [
     "https://www.googleapis.com/auth/documents",
 ]
 
-REQUIRED_PACKAGES = ["google-api-python-client", "google-auth-oauthlib", "google-auth-httplib2"]
+REQUIRED_PACKAGES = [
+    "google-api-python-client==2.194.0",
+    "google-auth==2.55.1",
+    "google-auth-oauthlib==1.3.1",
+    "google-auth-httplib2==0.3.1",
+    "httplib2==0.32.0",
+    "pyasn1==0.6.4",
+]
 
 # OAuth redirect for "out of band" manual code copy flow.
 # Google deprecated OOB, so we use a localhost redirect and tell the user to
@@ -93,24 +103,40 @@ def _format_missing_scopes(missing_scopes: list[str]) -> str:
     )
 
 
+def _missing_required_packages() -> list[str]:
+    """Return exact requirements absent or stale in this interpreter."""
+    missing = []
+    for spec in REQUIRED_PACKAGES:
+        requirement = Requirement(spec)
+        try:
+            installed = _distribution_version(requirement.name)
+            satisfied = requirement.specifier.contains(installed, prereleases=True)
+        except Exception:
+            satisfied = False
+        if not satisfied:
+            missing.append(spec)
+    return missing
+
+
 def install_deps():
-    """Install Google API packages if missing. Returns True on success."""
-    try:
-        import googleapiclient  # noqa: F401
-        import google_auth_oauthlib  # noqa: F401
+    """Install missing or stale Google API packages. Returns True on success."""
+    missing = _missing_required_packages()
+    if not missing:
         print("Dependencies already installed.")
         return True
-    except ImportError:
-        pass
 
     print("Installing Google API dependencies...")
 
     # First choice: pip in the current interpreter. Works for most installs.
     try:
         subprocess.check_call(
-            [sys.executable, "-m", "pip", "install", "--quiet"] + REQUIRED_PACKAGES,
+            [sys.executable, "-m", "pip", "install", "--quiet"] + missing,
             stdout=subprocess.DEVNULL,
         )
+        remaining = _missing_required_packages()
+        if remaining:
+            print(f"ERROR: Dependencies remain stale after pip install: {' '.join(remaining)}")
+            return False
         print("Dependencies installed.")
         return True
     except subprocess.CalledProcessError as e:
@@ -126,9 +152,13 @@ def install_deps():
         try:
             subprocess.check_call(
                 [uv, "pip", "install", "--python", sys.executable, "--quiet"]
-                + REQUIRED_PACKAGES,
+                + missing,
                 stdout=subprocess.DEVNULL,
             )
+            remaining = _missing_required_packages()
+            if remaining:
+                print(f"ERROR: Dependencies remain stale after uv install: {' '.join(remaining)}")
+                return False
             print("Dependencies installed.")
             return True
         except subprocess.CalledProcessError as e:
@@ -147,13 +177,9 @@ def install_deps():
 
 
 def _ensure_deps():
-    """Check deps are available, install if not, exit on failure."""
-    try:
-        import googleapiclient  # noqa: F401
-        import google_auth_oauthlib  # noqa: F401
-    except ImportError:
-        if not install_deps():
-            sys.exit(1)
+    """Check exact dependency versions, install if stale, exit on failure."""
+    if _missing_required_packages() and not install_deps():
+        sys.exit(1)
 
 
 def check_auth_live():

--- a/tests/gateway/test_google_chat_oauth_dependencies.py
+++ b/tests/gateway/test_google_chat_oauth_dependencies.py
@@ -1,0 +1,63 @@
+"""Security-floor tests for the Google Chat runtime installer."""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+from types import SimpleNamespace
+
+from plugins.platforms.google_chat import oauth
+
+
+def test_stale_google_transitives_are_reported_missing(monkeypatch):
+    installed = {
+        "google-cloud-pubsub": "2.39.0",
+        "google-api-python-client": "2.194.0",
+        "google-auth": "2.55.0",
+        "google-auth-oauthlib": "1.3.1",
+        "google-auth-httplib2": "0.3.1",
+        "httplib2": "0.31.2",
+        "pyasn1": "0.6.3",
+    }
+
+    def fake_version(name):
+        try:
+            return installed[name]
+        except KeyError:
+            raise PackageNotFoundError(name) from None
+
+    monkeypatch.setattr(oauth, "_distribution_version", fake_version)
+
+    assert oauth._missing_required_packages() == [
+        "google-auth==2.55.1",
+        "httplib2==0.32.0",
+        "pyasn1==0.6.4",
+    ]
+
+
+def test_installer_repairs_stale_transitives(monkeypatch):
+    states = iter(
+        [
+            [
+                "google-auth==2.55.1",
+                "httplib2==0.32.0",
+                "pyasn1==0.6.4",
+            ],
+            [],
+        ]
+    )
+    monkeypatch.setattr(oauth, "_missing_required_packages", lambda: next(states))
+    calls = []
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._pip_install",
+        lambda argv: calls.append(argv) or SimpleNamespace(returncode=0, stderr=""),
+    )
+
+    assert oauth.install_deps() is True
+    assert calls == [
+        [
+            "--quiet",
+            "google-auth==2.55.1",
+            "httplib2==0.32.0",
+            "pyasn1==0.6.4",
+        ]
+    ]

--- a/tests/skills/test_google_workspace_setup.py
+++ b/tests/skills/test_google_workspace_setup.py
@@ -1,0 +1,90 @@
+"""Security-floor tests for the Google Workspace runtime installer."""
+
+from __future__ import annotations
+
+import importlib.util
+from importlib.metadata import PackageNotFoundError
+from pathlib import Path
+
+import pytest
+
+
+SETUP_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills/productivity/google-workspace/scripts/setup.py"
+)
+
+
+@pytest.fixture()
+def setup_module():
+    spec = importlib.util.spec_from_file_location(
+        "test_google_workspace_setup_module",
+        SETUP_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_stale_google_transitives_are_reported_missing(setup_module, monkeypatch):
+    installed = {
+        "google-api-python-client": "2.194.0",
+        "google-auth": "2.55.0",
+        "google-auth-oauthlib": "1.3.1",
+        "google-auth-httplib2": "0.3.1",
+        "httplib2": "0.31.2",
+        "pyasn1": "0.6.3",
+    }
+
+    def fake_version(name):
+        try:
+            return installed[name]
+        except KeyError:
+            raise PackageNotFoundError(name) from None
+
+    monkeypatch.setattr(setup_module, "_distribution_version", fake_version)
+
+    assert setup_module._missing_required_packages() == [
+        "google-auth==2.55.1",
+        "httplib2==0.32.0",
+        "pyasn1==0.6.4",
+    ]
+
+
+def test_installer_repairs_stale_transitives(setup_module, monkeypatch):
+    states = iter(
+        [
+            [
+                "google-auth==2.55.1",
+                "httplib2==0.32.0",
+                "pyasn1==0.6.4",
+            ],
+            [],
+        ]
+    )
+    monkeypatch.setattr(
+        setup_module,
+        "_missing_required_packages",
+        lambda: next(states),
+    )
+    calls = []
+    monkeypatch.setattr(
+        setup_module.subprocess,
+        "check_call",
+        lambda argv, **kwargs: calls.append(argv),
+    )
+
+    assert setup_module.install_deps() is True
+    assert calls == [
+        [
+            setup_module.sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--quiet",
+            "google-auth==2.55.1",
+            "httplib2==0.32.0",
+            "pyasn1==0.6.4",
+        ]
+    ]

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -225,6 +225,59 @@ class TestIsSatisfiedVersionAware:
         assert ld._is_satisfied(spec) is True
         assert ld.feature_missing("tool.trace_upload") == ()
 
+    @pytest.mark.parametrize(
+        ("feature", "installed_versions", "expected_repairs"),
+        [
+            (
+                "skill.google_workspace",
+                {
+                    "google-api-python-client": "2.194.0",
+                    "google-auth": "2.55.0",
+                    "google-auth-oauthlib": "1.3.1",
+                    "google-auth-httplib2": "0.3.1",
+                    "httplib2": "0.31.2",
+                    "pyasn1": "0.6.3",
+                },
+                (
+                    "google-auth==2.55.1",
+                    "httplib2==0.32.0",
+                    "pyasn1==0.6.4",
+                ),
+            ),
+            (
+                "provider.vertex",
+                {
+                    "google-auth": "2.55.1",
+                    "pyasn1": "0.6.3",
+                },
+                ("pyasn1==0.6.4",),
+            ),
+        ],
+    )
+    def test_google_features_repair_stale_transitives(
+        self,
+        monkeypatch,
+        feature,
+        installed_versions,
+        expected_repairs,
+    ):
+        self._fake_version(monkeypatch, installed_versions)
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        installed = []
+
+        def fake_install(specs, **kwargs):
+            installed.extend(specs)
+            for spec in specs:
+                package, wanted = spec.split("==", 1)
+                installed_versions[package] = wanted
+            return ld._InstallResult(True, "ok", "")
+
+        monkeypatch.setattr(ld, "_venv_pip_install", fake_install)
+
+        ld.ensure(feature, prompt=False)
+
+        assert tuple(installed) == expected_repairs
+
 
 # ---------------------------------------------------------------------------
 # active_features + refresh_active_features (Piece A — hermes update wiring)

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -104,7 +104,10 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # Google Vertex AI provider — OAuth2 token minting for the Gemini
     # OpenAI-compatible endpoint. Only loaded when provider=vertex is selected;
     # google-auth is NOT in [all] so plain installs don't carry it.
-    "provider.vertex": ("google-auth==2.55.1",),
+    "provider.vertex": (
+        "google-auth==2.55.1",
+        "pyasn1==0.6.4",
+    ),
     # Microsoft Foundry — Entra ID auth (managed identity, workload identity,
     # service principal, az login, VS Code, azd, PowerShell). Only loaded
     # when model.auth_mode=entra_id is selected; key-based azure-foundry
@@ -257,8 +260,11 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # ─── Skills ────────────────────────────────────────────────────────────
     "skill.google_workspace": (
         "google-api-python-client==2.194.0",
+        "google-auth==2.55.1",
         "google-auth-oauthlib==1.3.1",
         "google-auth-httplib2==0.3.1",
+        "httplib2==0.32.0",
+        "pyasn1==0.6.4",
     ),
     "skill.youtube": ("youtube-transcript-api==1.2.4",),
 

--- a/uv.lock
+++ b/uv.lock
@@ -1593,9 +1593,12 @@ all = [
     { name = "aiohttp" },
     { name = "fastapi" },
     { name = "google-api-python-client" },
+    { name = "google-auth" },
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
+    { name = "httplib2" },
     { name = "mcp" },
+    { name = "pyasn1" },
     { name = "python-multipart" },
     { name = "simple-term-menu" },
     { name = "starlette" },
@@ -1654,8 +1657,11 @@ firecrawl = [
 ]
 google = [
     { name = "google-api-python-client" },
+    { name = "google-auth" },
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
+    { name = "httplib2" },
+    { name = "pyasn1" },
 ]
 hindsight = [
     { name = "hindsight-client" },
@@ -1730,10 +1736,13 @@ termux-all = [
     { name = "aiohttp" },
     { name = "fastapi" },
     { name = "google-api-python-client" },
+    { name = "google-auth" },
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
     { name = "honcho-ai" },
+    { name = "httplib2" },
     { name = "mcp" },
+    { name = "pyasn1" },
     { name = "python-multipart" },
     { name = "python-telegram-bot", extra = ["webhooks"] },
     { name = "simple-term-menu" },
@@ -1748,6 +1757,7 @@ vercel = [
 ]
 vertex = [
     { name = "google-auth" },
+    { name = "pyasn1" },
 ]
 voice = [
     { name = "faster-whisper" },
@@ -1814,6 +1824,7 @@ requires-dist = [
     { name = "fire", specifier = "==0.7.1" },
     { name = "firecrawl-py", marker = "extra == 'firecrawl'", specifier = "==4.17.0" },
     { name = "google-api-python-client", marker = "extra == 'google'", specifier = "==2.194.0" },
+    { name = "google-auth", marker = "extra == 'google'", specifier = "==2.55.1" },
     { name = "google-auth", marker = "extra == 'vertex'", specifier = "==2.55.1" },
     { name = "google-auth-httplib2", marker = "extra == 'google'", specifier = "==0.3.1" },
     { name = "google-auth-oauthlib", marker = "extra == 'google'", specifier = "==1.3.1" },
@@ -1840,6 +1851,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["youtube"], marker = "extra == 'all'" },
     { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.6.1" },
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.2.0" },
+    { name = "httplib2", marker = "extra == 'google'", specifier = "==0.32.0" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.6.8" },
@@ -1868,6 +1880,8 @@ requires-dist = [
     { name = "psutil", specifier = "==7.2.2" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'", specifier = ">=0.7.0,<1" },
     { name = "pvporcupine", marker = "extra == 'wake'", specifier = "==4.0.3" },
+    { name = "pyasn1", marker = "extra == 'google'", specifier = "==0.6.4" },
+    { name = "pyasn1", marker = "extra == 'vertex'", specifier = "==0.6.4" },
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.13.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.2" },
@@ -1985,14 +1999,14 @@ wheels = [
 
 [[package]]
 name = "httplib2"
-version = "0.31.2"
+version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyparsing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/f5/ccf58de92d61e3ad921119668f54ed36ca1d0cf5dcc5c1657dfb164fd78b/httplib2-0.32.0.tar.gz", hash = "sha256:48a0ef30a42db65d8f3399045e1d09ab0ba66e3b9efc360d07f80ea55d286025", size = 254283, upload-time = "2026-06-26T10:13:56.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a0/550eec327e5f5c7b732531c489f5307efec41f047b0d703bd4ca1e5ad2db/httplib2-0.32.0-py3-none-any.whl", hash = "sha256:dc6705cacdf3fb0a2aba7629fa33c90fd93e30035db0c157325826be177e4816", size = 93148, upload-time = "2026-06-26T10:13:54.985Z" },
 ]
 
 [[package]]
@@ -3278,11 +3292,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]

--- a/website/docs/user-guide/messaging/google_chat.md
+++ b/website/docs/user-guide/messaging/google_chat.md
@@ -166,10 +166,11 @@ GOOGLE_CHAT_MAX_BYTES=16777216                  # 16 MiB — cap on in-flight me
 The project ID also falls back to `GOOGLE_CLOUD_PROJECT`, and the SA path falls
 back to `GOOGLE_APPLICATION_CREDENTIALS` — use whichever convention you prefer.
 
-Install the dependencies the Google Chat adapter needs (no Hermes extra is currently published — install them directly):
+Install the Google Chat adapter dependencies through its maintained installer.
+It applies the same pinned security floors used by the runtime checks:
 
 ```bash
-pip install google-cloud-pubsub google-api-python-client google-auth google-auth-oauthlib
+python -m plugins.platforms.google_chat.oauth --install-deps
 ```
 
 Start the gateway:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/google_chat.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/google_chat.md
@@ -138,10 +138,10 @@ GOOGLE_CHAT_MAX_BYTES=16777216                  # 16 MiB — 在途消息字节�
 
 项目 ID 也可回退到 `GOOGLE_CLOUD_PROJECT`，SA 路径可回退到 `GOOGLE_APPLICATION_CREDENTIALS`——使用你偏好的约定即可。
 
-安装 Google Chat 适配器所需的依赖（目前没有发布 Hermes extra，请直接安装）：
+通过适配器维护的安装程序安装 Google Chat 依赖。该程序会应用与运行时检查相同的固定安全版本：
 
 ```bash
-pip install google-cloud-pubsub google-api-python-client google-auth google-auth-oauthlib
+python -m plugins.platforms.google_chat.oauth --install-deps
 ```
 
 启动 gateway（网关）：


### PR DESCRIPTION
Google API and authentication packages permit older httplib2 and pyasn1
transitives, while the standalone Workspace and Google Chat setup paths
previously accepted any importable version. Existing environments could
therefore remain vulnerable after the project pins were repaired.

Carry the reviewed exact floors through the Google and Vertex extras, lazy
features, and both runtime installers. Detect stale distributions before OAuth
setup, install only the missing requirements, and verify the result before
continuing.

Related #72108
Extracted from #72840

## Review boundaries

- covers Google, Vertex, Workspace, and Google Chat dependency propagation
- includes stale-runtime detection and repair regressions
- Pillow compatibility and server dependency floors are intentionally excluded

## Validation

- 83 focused tests passed
- Ruff, `uv lock --check`, and diff checks passed
- the signed tree is identical to the independently reviewed tree
- CodeRabbit completed with no findings

## AI disclosure

Prepared by GPT-5.6-sol with xhigh reasoning in Codex. The account owner loosely reviews my actions and receives usual GitHub notifications.
