### PR TITLE
feat(models): Gemini 3.1 Pro + 3.6 Flash in OpenRouter/Nous catalogs; drop retired Qwen entries

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -58,9 +58,8 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("openai/gpt-5.5-pro",                     ""),
     ("openai/gpt-5.4-mini",                    ""),
     # Google
-    ("google/gemini-3-pro-preview",            ""),
     ("google/gemini-3.1-pro-preview",          ""),
-    ("google/gemini-3.5-flash",                ""),
+    ("google/gemini-3.6-flash",                ""),
     # xAI
     ("x-ai/grok-4.5",                          ""),
     # DeepSeek
@@ -68,8 +67,6 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("deepseek/deepseek-v4-flash",             ""),
     # Qwen
     ("qwen/qwen3.7-max",                       ""),
-    ("qwen/qwen3.7-plus",                      ""),
-    ("qwen/qwen3.6-35b-a3b",                   ""),
     # MoonshotAI
     ("moonshotai/kimi-k3",                     "recommended"),
     # MiniMax
@@ -209,9 +206,8 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "openai/gpt-5.5-pro",
         "openai/gpt-5.4-mini",
         # Google
-        "google/gemini-3-pro-preview",
         "google/gemini-3.1-pro-preview",
-        "google/gemini-3.5-flash",
+        "google/gemini-3.6-flash",
         # xAI
         "x-ai/grok-4.5",
         # DeepSeek
@@ -219,8 +215,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "deepseek/deepseek-v4-flash",
         # Qwen
         "qwen/qwen3.7-max",
-        "qwen/qwen3.7-plus",
-        "qwen/qwen3.6-35b-a3b",
         # MoonshotAI
         "moonshotai/kimi-k3",
         # MiniMax

--- a/tests/test_empty_model_fallback.py
+++ b/tests/test_empty_model_fallback.py
@@ -74,16 +74,16 @@ class TestGetDefaultModelForProvider:
 
         with patch(
             "hermes_cli.model_catalog.get_default_model_from_cache",
-            return_value="qwen/qwen3.7-plus",
+            return_value="qwen/qwen3.7-max",
         ):
             assert (
                 models_mod.get_preferred_silent_default_model("nous")
-                == "qwen/qwen3.7-plus"
+                == "qwen/qwen3.7-max"
             )
-            # nous catalog carries qwen3.7-plus, so the full resolver follows.
+            # nous catalog carries qwen3.7-max, so the full resolver follows.
             assert (
                 models_mod.get_default_model_for_provider("nous")
-                == "qwen/qwen3.7-plus"
+                == "qwen/qwen3.7-max"
             )
 
     def test_no_catalog_cache_falls_back_to_constant(self):

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-07-24T19:06:06Z",
+  "updated_at": "2026-07-28T16:38:40Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -77,15 +77,11 @@
           "description": ""
         },
         {
-          "id": "google/gemini-3-pro-preview",
-          "description": ""
-        },
-        {
           "id": "google/gemini-3.1-pro-preview",
           "description": ""
         },
         {
-          "id": "google/gemini-3.5-flash",
+          "id": "google/gemini-3.6-flash",
           "description": ""
         },
         {
@@ -102,14 +98,6 @@
         },
         {
           "id": "qwen/qwen3.7-max",
-          "description": ""
-        },
-        {
-          "id": "qwen/qwen3.7-plus",
-          "description": ""
-        },
-        {
-          "id": "qwen/qwen3.6-35b-a3b",
           "description": ""
         },
         {
@@ -228,13 +216,10 @@
           "id": "openai/gpt-5.4-mini"
         },
         {
-          "id": "google/gemini-3-pro-preview"
-        },
-        {
           "id": "google/gemini-3.1-pro-preview"
         },
         {
-          "id": "google/gemini-3.5-flash"
+          "id": "google/gemini-3.6-flash"
         },
         {
           "id": "x-ai/grok-4.5"
@@ -247,12 +232,6 @@
         },
         {
           "id": "qwen/qwen3.7-max"
-        },
-        {
-          "id": "qwen/qwen3.7-plus"
-        },
-        {
-          "id": "qwen/qwen3.6-35b-a3b"
         },
         {
           "id": "moonshotai/kimi-k3"


### PR DESCRIPTION
## Summary
OpenRouter and Nous Portal curated model catalogs now carry `google/gemini-3.1-pro-preview` (replacing `gemini-3-pro-preview`) and `google/gemini-3.6-flash` (replacing `gemini-3.5-flash`), and no longer list `qwen/qwen3.7-plus` or `qwen/qwen3.6-35b-a3b`.

Scoped rollout — only the two named provider lists are touched. `_PROVIDER_MODELS["gemini"]`, vertex, setup defaults, and other provider surfaces are deliberately left alone.

## Changes
- `hermes_cli/models.py`: `OPENROUTER_MODELS` + `_PROVIDER_MODELS["nous"]` — Gemini swaps, Qwen removals
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py` (openrouter 38, nous 29)
- `tests/test_empty_model_fallback.py`: catalog-label fixture swapped from removed `qwen3.7-plus` to `qwen3.7-max` (fixture requires a model present in the nous list)

## Validation
| Check | Result |
|---|---|
| OpenRouter live `/api/v1/models` | `gemini-3.1-pro-preview` ✓, `gemini-3.6-flash` ✓ (1,048,576 ctx / 65,536 max out) |
| Nous Portal live `/v1/models` | both new ids ✓; `gemini-3-pro-preview` absent |
| Context length | covered by existing `"gemini": 1048576` prefix in `DEFAULT_CONTEXT_LENGTHS` — no change needed |
| Pricing snapshot | skipped — both routes bill via live `official_models_api` |
| Targeted suites | 283 passed, 0 failed (`test_models`, `test_gmi_provider`, `test_model_catalog`, `test_usage_pricing`, `test_empty_model_fallback`, `test_model_validation`) |
| E2E curated fallback | temp `HERMES_HOME`, keys stripped: both lists contain new ids, old ids absent, no dupes |

## Infographic

![Model catalog update infographic](https://v3b.fal.media/files/b/0aa415f6/dfuMFbSpxo4q2HmLf7PCv_gp1N6wAO.png)
