### PR TITLE
fix(tts): retry unsupported response formats

### DIFF
--- a/tests/tools/test_tts_openai_format_fallback.py
+++ b/tests/tools/test_tts_openai_format_fallback.py
@@ -1,0 +1,73 @@
+"""OpenAI-compatible TTS response-format fallback behavior."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.tts_tool import _generate_openai_tts
+
+
+class _FormatError(Exception):
+    status_code = 422
+
+
+def _client_with_responses(*responses):
+    client = MagicMock()
+    client.audio.speech.create.side_effect = responses
+    return client
+
+
+def test_retries_unsupported_opus_as_mp3(tmp_path):
+    output_path = tmp_path / "voice.ogg"
+    response = MagicMock()
+    client = _client_with_responses(
+        _FormatError("response_format must be mp3, flac, wav, or pcm"),
+        response,
+    )
+
+    with patch("tools.tts_tool._import_openai_client", return_value=lambda **_: client):
+        result = _generate_openai_tts(
+            "hello",
+            str(output_path),
+            {},
+            api_key="test-key",
+            base_url="http://tts.example/v1",
+        )
+
+    assert result == str(output_path)
+    assert [
+        call.kwargs["response_format"]
+        for call in client.audio.speech.create.call_args_list
+    ] == [
+        "opus",
+        "mp3",
+    ]
+    first_headers = client.audio.speech.create.call_args_list[0].kwargs["extra_headers"]
+    retry_headers = client.audio.speech.create.call_args_list[1].kwargs["extra_headers"]
+    assert first_headers["x-idempotency-key"] != retry_headers["x-idempotency-key"]
+    response.stream_to_file.assert_called_once_with(str(output_path))
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        _FormatError("voice is unsupported"),
+        type("_ServerError", (Exception,), {"status_code": 500})(
+            "response_format failed"
+        ),
+    ],
+)
+def test_does_not_retry_unrelated_errors(tmp_path, error):
+    client = _client_with_responses(error)
+
+    with patch("tools.tts_tool._import_openai_client", return_value=lambda **_: client):
+        with pytest.raises(type(error), match=str(error)):
+            _generate_openai_tts(
+                "hello",
+                str(tmp_path / "voice.ogg"),
+                {},
+                api_key="test-key",
+                base_url="http://tts.example/v1",
+            )
+
+    client.audio.speech.create.assert_called_once()

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1451,6 +1451,35 @@ def _tts_response_format_from_path(output_path: str) -> str:
     return "mp3"
 
 
+def _create_openai_speech_with_format_fallback(
+    client: Any,
+    create_kwargs: Dict[str, Any],
+) -> Any:
+    """Retry format-specific compatibility failures with universally supported MP3."""
+    try:
+        return client.audio.speech.create(**create_kwargs)
+    except Exception as exc:
+        requested_format = create_kwargs.get("response_format")
+        is_format_rejection = getattr(exc, "status_code", None) in (
+            400,
+            422,
+        ) and "response_format" in str(exc)
+        if requested_format in (None, "mp3") or not is_format_rejection:
+            raise
+
+        logger.info(
+            "TTS backend rejected response_format=%r (%s); retrying as mp3",
+            requested_format,
+            type(exc).__name__,
+        )
+        retry_kwargs = {
+            **create_kwargs,
+            "response_format": "mp3",
+            "extra_headers": {"x-idempotency-key": str(uuid.uuid4())},
+        }
+        return client.audio.speech.create(**retry_kwargs)
+
+
 # ===========================================================================
 # Provider: OpenAI TTS (also used by every OpenAI-compatible TTS endpoint —
 # DeepInfra delegates here via _generate_deepinfra_tts).
@@ -1559,7 +1588,7 @@ def _generate_openai_tts(
             create_kwargs["instructions"] = instructions
         if language:
             create_kwargs["extra_body"] = {"lang_code": language}
-        response = client.audio.speech.create(**create_kwargs)
+        response = _create_openai_speech_with_format_fallback(client, create_kwargs)
 
         response.stream_to_file(output_path)
         return output_path


### PR DESCRIPTION
## Summary

Fixes #73470.

OpenAI-compatible TTS backends do not all support every OpenAI response format. Hermes currently requests `opus` for an `.ogg` target and only repairs the container after synthesis, so a backend that rejects `response_format=opus` with 400/422 fails before the existing repair step can run.

This change preserves native format requests as the first choice, then retries once as MP3 only when all of these conditions hold:

- the backend returned HTTP 400 or 422;
- the error identifies `response_format` as the rejected field;
- the original request was not already MP3.

The retry uses a fresh idempotency key. Unrelated client errors, server errors, and MP3 failures continue to propagate unchanged. The existing `_repair_ogg_container()` path then converts successful MP3 fallback bytes to a real Ogg/Opus file.

## Reproduction

A regression test models a Speaches-style 422 rejection. On current `main`, the first exception propagates and the test fails at `client.audio.speech.create`. With this patch, calls are `opus` then `mp3`, and the successful response is streamed normally.

## Validation

- 5 related test files: **54 passed**
- Ruff lint on changed files: **passed**
- Ruff format check on the new test: **passed**
- `git diff --check`: **passed**

The canonical Bash wrapper is not executable in this Windows environment because no POSIX Bash is installed; I invoked its underlying per-file isolation runner directly with the repository's Python 3.11 test environment.