### PR TITLE
fix(tts): fall back to mp3 when an OpenAI-compatible backend rejects response_format (#73470)

### DIFF
--- a/tests/tools/test_tts_openai_format_fallback.py
+++ b/tests/tools/test_tts_openai_format_fallback.py
@@ -169,6 +169,28 @@ class TestSpeechCreateFallback:
             )
         assert len(calls) == 1
 
+    @pytest.mark.parametrize("requested", ["wav", "flac", "pcm"])
+    def test_non_opus_rejection_is_not_retried_as_mp3(self, requested):
+        """Only opus has a post-synthesis container repair. Retrying a rejected
+        wav/flac/pcm request as mp3 would write mp3 bytes under a .wav/.flac/.pcm
+        path, so those rejections must propagate untouched (#73470 review)."""
+        calls: list = []
+
+        class _RejectSpeech:
+            def create(self, **kwargs):
+                calls.append(kwargs)
+                raise _RejectResponseFormat()
+
+        client = _FakeClient(calls)
+        client.audio.speech = _RejectSpeech()
+
+        with pytest.raises(_RejectResponseFormat):
+            tts_tool._openai_speech_create_with_format_fallback(
+                client, {"response_format": requested}
+            )
+        # No mp3 retry — the single failed call is the only one.
+        assert [c["response_format"] for c in calls] == [requested]
+
 
 # --------------------------------------------------------------------------
 # End-to-end through _generate_openai_tts (opus .ogg target recovers to mp3)

--- a/tests/tools/test_tts_openai_format_fallback.py
+++ b/tests/tools/test_tts_openai_format_fallback.py
@@ -1,0 +1,196 @@
+"""OpenAI-compatible TTS: fall back to mp3 when a backend rejects the format.
+
+`_generate_openai_tts` derives ``response_format`` from the output extension,
+so a ``.ogg`` target requests ``opus``. Self-hosted OpenAI-compatible speech
+servers (Speaches/Kokoro, …) that implement only mp3/wav/flac/pcm reject that
+request with an HTTP 400/422 *before any bytes exist*, so the post-synthesis
+``_repair_ogg_container`` hook (which only rescues backends that silently
+*ignore* the parameter) never runs and every voice reply fails. The fallback
+retries once as mp3 and lets the existing repair step rebuild the Ogg/Opus
+container. See issue #73470 (follow-up to #57184).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tools import tts_tool
+
+
+class _RejectResponseFormat(Exception):
+    """Mimics the OpenAI SDK's UnprocessableEntityError shape."""
+
+    def __init__(self, status_code: int = 422):
+        self.status_code = status_code
+        super().__init__(
+            "Error code: 422 - {'detail': [{'type': 'literal_error', "
+            "'loc': ['body', 'response_format'], "
+            "'msg': \"Input should be 'mp3', 'flac', 'wav' or 'pcm'\", "
+            "'input': 'opus'}]}"
+        )
+
+
+class _FakeResponse:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    def stream_to_file(self, output_path: str) -> None:
+        Path(output_path).write_bytes(self._payload)
+
+
+class _FakeSpeech:
+    """Rejects any non-mp3 response_format once, then succeeds on mp3."""
+
+    def __init__(self, calls: list):
+        self._calls = calls
+
+    def create(self, **kwargs):
+        self._calls.append(kwargs)
+        if kwargs.get("response_format") != "mp3":
+            raise _RejectResponseFormat()
+        return _FakeResponse(b"ID3mp3-bytes")
+
+
+class _FakeAudio:
+    def __init__(self, calls: list):
+        self.speech = _FakeSpeech(calls)
+
+
+class _FakeClient:
+    def __init__(self, calls: list):
+        self.audio = _FakeAudio(calls)
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+# --------------------------------------------------------------------------
+# _is_response_format_rejection
+# --------------------------------------------------------------------------
+class TestIsResponseFormatRejection:
+    def test_422_naming_response_format_is_a_rejection(self):
+        assert tts_tool._is_response_format_rejection(_RejectResponseFormat(422))
+
+    def test_400_naming_response_format_is_a_rejection(self):
+        assert tts_tool._is_response_format_rejection(_RejectResponseFormat(400))
+
+    def test_other_4xx_is_not_a_rejection(self):
+        err = _RejectResponseFormat(404)
+        assert not tts_tool._is_response_format_rejection(err)
+
+    def test_422_not_naming_response_format_is_not_a_rejection(self):
+        class _Other(Exception):
+            status_code = 422
+
+        assert not tts_tool._is_response_format_rejection(_Other("bad voice id"))
+
+    def test_error_without_status_code_is_not_a_rejection(self):
+        assert not tts_tool._is_response_format_rejection(
+            RuntimeError("response_format is wrong but no status")
+        )
+
+
+# --------------------------------------------------------------------------
+# _openai_speech_create_with_format_fallback
+# --------------------------------------------------------------------------
+class TestSpeechCreateFallback:
+    def test_opus_rejection_retries_as_mp3(self):
+        calls: list = []
+        client = _FakeClient(calls)
+        create_kwargs = {
+            "model": "kokoro",
+            "voice": "af_heart",
+            "input": "hi",
+            "response_format": "opus",
+            "extra_headers": {"x-idempotency-key": "original"},
+        }
+
+        resp = tts_tool._openai_speech_create_with_format_fallback(client, create_kwargs)
+
+        assert isinstance(resp, _FakeResponse)
+        assert [c["response_format"] for c in calls] == ["opus", "mp3"]
+        # Retry is a distinct request → a fresh idempotency key.
+        assert calls[1]["extra_headers"]["x-idempotency-key"] != "original"
+        # Non-format kwargs are carried through unchanged.
+        assert calls[1]["voice"] == "af_heart"
+        assert calls[1]["input"] == "hi"
+
+    def test_native_opus_support_makes_no_extra_call(self):
+        calls: list = []
+
+        class _OkSpeech:
+            def create(self, **kwargs):
+                calls.append(kwargs)
+                return _FakeResponse(b"OggS-opus")
+
+        client = _FakeClient(calls)
+        client.audio.speech = _OkSpeech()
+
+        resp = tts_tool._openai_speech_create_with_format_fallback(
+            client, {"response_format": "opus"}
+        )
+
+        assert isinstance(resp, _FakeResponse)
+        assert len(calls) == 1
+
+    def test_unrelated_error_propagates_without_retry(self):
+        calls: list = []
+
+        class _BoomSpeech:
+            def create(self, **kwargs):
+                calls.append(kwargs)
+                raise RuntimeError("connection reset")
+
+        client = _FakeClient(calls)
+        client.audio.speech = _BoomSpeech()
+
+        with pytest.raises(RuntimeError, match="connection reset"):
+            tts_tool._openai_speech_create_with_format_fallback(
+                client, {"response_format": "opus"}
+            )
+        assert len(calls) == 1
+
+    def test_mp3_rejection_is_not_retried(self):
+        calls: list = []
+
+        class _RejectSpeech:
+            def create(self, **kwargs):
+                calls.append(kwargs)
+                raise _RejectResponseFormat()
+
+        client = _FakeClient(calls)
+        client.audio.speech = _RejectSpeech()
+
+        # Already mp3 → nothing safer to fall back to; propagate.
+        with pytest.raises(_RejectResponseFormat):
+            tts_tool._openai_speech_create_with_format_fallback(
+                client, {"response_format": "mp3"}
+            )
+        assert len(calls) == 1
+
+
+# --------------------------------------------------------------------------
+# End-to-end through _generate_openai_tts (opus .ogg target recovers to mp3)
+# --------------------------------------------------------------------------
+def test_generate_openai_tts_recovers_from_opus_rejection(tmp_path, monkeypatch):
+    calls: list = []
+    client = _FakeClient(calls)
+    monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: (lambda **kw: client))
+
+    out = tmp_path / "reply.ogg"
+    result = tts_tool._generate_openai_tts(
+        "testing",
+        str(out),
+        {},
+        api_key="sk-test",
+        base_url="http://speaches:8100/v1",
+        model="speaches-ai/Kokoro-82M-v1.0-ONNX",
+        voice="af_heart",
+    )
+
+    assert result == str(out)
+    # opus requested first (from the .ogg extension), then mp3 after rejection.
+    assert [c["response_format"] for c in calls] == ["opus", "mp3"]
+    assert out.read_bytes() == b"ID3mp3-bytes"
+    assert client.closed is True

--- a/tests/tools/test_tts_openai_format_fallback.py
+++ b/tests/tools/test_tts_openai_format_fallback.py
@@ -1,0 +1,220 @@
+"""OpenAI-compatible TTS: fall back to mp3 when a backend rejects the format.
+
+`_generate_openai_tts` derives ``response_format`` from the output extension,
+so a ``.ogg`` target requests ``opus``. Self-hosted OpenAI-compatible speech
+servers (Speaches/Kokoro, …) that implement only mp3/wav/flac/pcm reject that
+request with an HTTP 400/422 *before any bytes exist*, so the post-synthesis
+``_repair_ogg_container`` hook (which only rescues backends that silently
+*ignore* the parameter) never runs and every voice reply fails. The fallback
+retries once as mp3 and lets the existing repair step rebuild the Ogg/Opus
+container. See issue #73470 (follow-up to #57184).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tools import tts_tool, tts_tool_openai
+
+
+class _RejectResponseFormat(Exception):
+    """Mimics the OpenAI SDK's UnprocessableEntityError shape."""
+
+    def __init__(self, status_code: int = 422):
+        self.status_code = status_code
+        super().__init__(
+            "Error code: 422 - {'detail': [{'type': 'literal_error', "
+            "'loc': ['body', 'response_format'], "
+            "'msg': \"Input should be 'mp3', 'flac', 'wav' or 'pcm'\", "
+            "'input': 'opus'}]}"
+        )
+
+
+class _FakeResponse:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    def stream_to_file(self, output_path: str) -> None:
+        Path(output_path).write_bytes(self._payload)
+
+
+class _FakeSpeech:
+    """Rejects any non-mp3 response_format once, then succeeds on mp3."""
+
+    def __init__(self, calls: list):
+        self._calls = calls
+
+    def create(self, **kwargs):
+        self._calls.append(kwargs)
+        if kwargs.get("response_format") != "mp3":
+            raise _RejectResponseFormat()
+        return _FakeResponse(b"ID3mp3-bytes")
+
+
+class _FakeAudio:
+    def __init__(self, calls: list):
+        self.speech = _FakeSpeech(calls)
+
+
+class _FakeClient:
+    def __init__(self, calls: list):
+        self.audio = _FakeAudio(calls)
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+# --------------------------------------------------------------------------
+# _is_response_format_rejection
+# --------------------------------------------------------------------------
+class TestIsResponseFormatRejection:
+    def test_422_naming_response_format_is_a_rejection(self):
+        assert tts_tool_openai._is_response_format_rejection(_RejectResponseFormat(422))
+
+    def test_400_naming_response_format_is_a_rejection(self):
+        assert tts_tool_openai._is_response_format_rejection(_RejectResponseFormat(400))
+
+    def test_other_4xx_is_not_a_rejection(self):
+        err = _RejectResponseFormat(404)
+        assert not tts_tool_openai._is_response_format_rejection(err)
+
+    def test_422_not_naming_response_format_is_not_a_rejection(self):
+        class _Other(Exception):
+            status_code = 422
+
+        assert not tts_tool_openai._is_response_format_rejection(_Other("bad voice id"))
+
+    def test_error_without_status_code_is_not_a_rejection(self):
+        assert not tts_tool_openai._is_response_format_rejection(
+            RuntimeError("response_format is wrong but no status")
+        )
+
+
+# --------------------------------------------------------------------------
+# _openai_speech_create_with_format_fallback
+# --------------------------------------------------------------------------
+class TestSpeechCreateFallback:
+    def test_opus_rejection_retries_as_mp3(self):
+        calls: list = []
+        client = _FakeClient(calls)
+        create_kwargs = {
+            "model": "kokoro",
+            "voice": "af_heart",
+            "input": "hi",
+            "response_format": "opus",
+            "extra_headers": {"x-idempotency-key": "original"},
+        }
+
+        resp = tts_tool_openai._openai_speech_create_with_format_fallback(client, create_kwargs)
+
+        assert isinstance(resp, _FakeResponse)
+        assert [c["response_format"] for c in calls] == ["opus", "mp3"]
+        # Retry is a distinct request → a fresh idempotency key.
+        assert calls[1]["extra_headers"]["x-idempotency-key"] != "original"
+        # Non-format kwargs are carried through unchanged.
+        assert calls[1]["voice"] == "af_heart"
+        assert calls[1]["input"] == "hi"
+
+    def test_native_opus_support_makes_no_extra_call(self):
+        calls: list = []
+
+        class _OkSpeech:
+            def create(self, **kwargs):
+                calls.append(kwargs)
+                return _FakeResponse(b"OggS-opus")
+
+        client = _FakeClient(calls)
+        client.audio.speech = _OkSpeech()
+
+        resp = tts_tool_openai._openai_speech_create_with_format_fallback(
+            client, {"response_format": "opus"}
+        )
+
+        assert isinstance(resp, _FakeResponse)
+        assert len(calls) == 1
+
+    def test_unrelated_error_propagates_without_retry(self):
+        calls: list = []
+
+        class _BoomSpeech:
+            def create(self, **kwargs):
+                calls.append(kwargs)
+                raise RuntimeError("connection reset")
+
+        client = _FakeClient(calls)
+        client.audio.speech = _BoomSpeech()
+
+        with pytest.raises(RuntimeError, match="connection reset"):
+            tts_tool_openai._openai_speech_create_with_format_fallback(
+                client, {"response_format": "opus"}
+            )
+        assert len(calls) == 1
+
+    def test_mp3_rejection_is_not_retried(self):
+        calls: list = []
+
+        class _RejectSpeech:
+            def create(self, **kwargs):
+                calls.append(kwargs)
+                raise _RejectResponseFormat()
+
+        client = _FakeClient(calls)
+        client.audio.speech = _RejectSpeech()
+
+        # Already mp3 → nothing safer to fall back to; propagate.
+        with pytest.raises(_RejectResponseFormat):
+            tts_tool_openai._openai_speech_create_with_format_fallback(
+                client, {"response_format": "mp3"}
+            )
+        assert len(calls) == 1
+
+    @pytest.mark.parametrize("requested", ["wav", "flac", "pcm"])
+    def test_non_opus_rejection_is_not_retried_as_mp3(self, requested):
+        """Only opus has a post-synthesis container repair. Retrying a rejected
+        wav/flac/pcm request as mp3 would write mp3 bytes under a .wav/.flac/.pcm
+        path, so those rejections must propagate untouched (#73470 review)."""
+        calls: list = []
+
+        class _RejectSpeech:
+            def create(self, **kwargs):
+                calls.append(kwargs)
+                raise _RejectResponseFormat()
+
+        client = _FakeClient(calls)
+        client.audio.speech = _RejectSpeech()
+
+        with pytest.raises(_RejectResponseFormat):
+            tts_tool_openai._openai_speech_create_with_format_fallback(
+                client, {"response_format": requested}
+            )
+        # No mp3 retry — the single failed call is the only one.
+        assert [c["response_format"] for c in calls] == [requested]
+
+
+# --------------------------------------------------------------------------
+# End-to-end through _generate_openai_tts (opus .ogg target recovers to mp3)
+# --------------------------------------------------------------------------
+def test_generate_openai_tts_recovers_from_opus_rejection(tmp_path, monkeypatch):
+    calls: list = []
+    client = _FakeClient(calls)
+    # ``_generate_openai_tts`` builds its client via ``_origin()._import_openai_client()``,
+    # and ``_origin()`` resolves to ``tools.tts_tool`` — patch the seam there.
+    monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: (lambda **kw: client))
+
+    out = tmp_path / "reply.ogg"
+    result = tts_tool_openai._generate_openai_tts(
+        "testing",
+        str(out),
+        {},
+        api_key="sk-test",
+        base_url="http://speaches:8100/v1",
+        model="speaches-ai/Kokoro-82M-v1.0-ONNX",
+        voice="af_heart",
+    )
+
+    assert result == str(out)
+    # opus requested first (from the .ogg extension), then mp3 after rejection.
+    assert [c["response_format"] for c in calls] == ["opus", "mp3"]
+    assert out.read_bytes() == b"ID3mp3-bytes"
+    assert client.closed is True

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1470,20 +1470,25 @@ def _is_response_format_rejection(exc: Exception) -> bool:
 
 
 def _openai_speech_create_with_format_fallback(client, create_kwargs: Dict[str, Any]):
-    """Call ``audio.speech.create``; on a response_format rejection, retry mp3.
+    """Call ``audio.speech.create``; on an *opus* rejection, retry mp3.
 
-    Native opus (or whatever the extension implies) is always requested first,
-    so backends that support it are unaffected. When the backend rejects the
-    format, we retry exactly once as ``mp3`` — a format the OpenAI speech API
-    contract guarantees — and let the downstream ``_repair_ogg_container`` step
-    transcode those mp3 bytes into a real Ogg/Opus container. The retry carries
-    a fresh idempotency key because it is a distinct request.
+    Native opus is always requested first (from a ``.ogg`` target), so backends
+    that support it are unaffected. When the backend rejects opus, we retry
+    exactly once as ``mp3`` — a format the OpenAI speech API contract
+    guarantees — and let the downstream ``_repair_ogg_container`` step transcode
+    those mp3 bytes into a real Ogg/Opus container. The retry carries a fresh
+    idempotency key because it is a distinct request.
+
+    The fallback is deliberately limited to ``opus``: ``_repair_ogg_container``
+    only rewrites ``.ogg`` outputs, so retrying a rejected ``wav``/``flac``/
+    ``pcm`` request as mp3 would leave mp3 bytes mislabeled under the requested
+    extension. Those rejections propagate unchanged (#73470 review).
     """
     try:
         return client.audio.speech.create(**create_kwargs)
     except Exception as exc:
         requested = create_kwargs.get("response_format")
-        if requested in (None, "mp3") or not _is_response_format_rejection(exc):
+        if requested != "opus" or not _is_response_format_rejection(exc):
             raise
         logger.warning(
             "TTS backend rejected response_format=%r — retrying as 'mp3' "

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1451,6 +1451,50 @@ def _tts_response_format_from_path(output_path: str) -> str:
     return "mp3"
 
 
+def _is_response_format_rejection(exc: Exception) -> bool:
+    """True when a speech.create() error is a backend rejecting response_format.
+
+    Several self-hosted OpenAI-compatible speech servers (Speaches/Kokoro,
+    etc.) implement only ``mp3``/``wav``/``flac``/``pcm`` and 4xx a request for
+    ``response_format="opus"`` outright — ``{"type": "literal_error", "loc":
+    ["body", "response_format"], ...}`` with HTTP 400/422 — before any audio
+    bytes exist. The class-level ``_repair_ogg_container`` hook only helps
+    backends that *ignore* the parameter and write playable bytes; a rejection
+    never reaches it. This predicate is intentionally narrow so unrelated
+    4xx errors still propagate.
+    """
+    status = getattr(exc, "status_code", None)
+    if status not in (400, 422):
+        return False
+    return "response_format" in str(exc)
+
+
+def _openai_speech_create_with_format_fallback(client, create_kwargs: Dict[str, Any]):
+    """Call ``audio.speech.create``; on a response_format rejection, retry mp3.
+
+    Native opus (or whatever the extension implies) is always requested first,
+    so backends that support it are unaffected. When the backend rejects the
+    format, we retry exactly once as ``mp3`` — a format the OpenAI speech API
+    contract guarantees — and let the downstream ``_repair_ogg_container`` step
+    transcode those mp3 bytes into a real Ogg/Opus container. The retry carries
+    a fresh idempotency key because it is a distinct request.
+    """
+    try:
+        return client.audio.speech.create(**create_kwargs)
+    except Exception as exc:
+        requested = create_kwargs.get("response_format")
+        if requested in (None, "mp3") or not _is_response_format_rejection(exc):
+            raise
+        logger.warning(
+            "TTS backend rejected response_format=%r — retrying as 'mp3' "
+            "(the .ogg container is rebuilt post-synthesis).",
+            requested,
+        )
+        retry_kwargs = dict(create_kwargs, response_format="mp3")
+        retry_kwargs["extra_headers"] = {"x-idempotency-key": str(uuid.uuid4())}
+        return client.audio.speech.create(**retry_kwargs)
+
+
 # ===========================================================================
 # Provider: OpenAI TTS (also used by every OpenAI-compatible TTS endpoint —
 # DeepInfra delegates here via _generate_deepinfra_tts).
@@ -1559,7 +1603,7 @@ def _generate_openai_tts(
             create_kwargs["instructions"] = instructions
         if language:
             create_kwargs["extra_body"] = {"lang_code": language}
-        response = client.audio.speech.create(**create_kwargs)
+        response = _openai_speech_create_with_format_fallback(client, create_kwargs)
 
         response.stream_to_file(output_path)
         return output_path

--- a/tools/tts_tool_openai.py
+++ b/tools/tts_tool_openai.py
@@ -79,6 +79,55 @@ def _has_openai_audio_backend() -> bool:
         return False
 
 
+def _is_response_format_rejection(exc: Exception) -> bool:
+    """True when a speech.create() error is a backend rejecting response_format.
+
+    Several self-hosted OpenAI-compatible speech servers (Speaches/Kokoro,
+    etc.) implement only ``mp3``/``wav``/``flac``/``pcm`` and 4xx a request for
+    ``response_format="opus"`` outright — ``{"type": "literal_error", "loc":
+    ["body", "response_format"], ...}`` with HTTP 400/422 — before any audio
+    bytes exist. The post-synthesis ``_repair_ogg_container`` hook only helps
+    backends that *ignore* the parameter and write playable bytes; a rejection
+    never reaches it. This predicate is intentionally narrow so unrelated
+    4xx errors still propagate.
+    """
+    status = getattr(exc, "status_code", None)
+    if status not in (400, 422):
+        return False
+    return "response_format" in str(exc)
+
+
+def _openai_speech_create_with_format_fallback(client, create_kwargs: Dict[str, Any]):
+    """Call ``audio.speech.create``; on an *opus* rejection, retry mp3.
+
+    Native opus is always requested first (from a ``.ogg`` target), so backends
+    that support it are unaffected. When the backend rejects opus, we retry
+    exactly once as ``mp3`` — a format the OpenAI speech API contract
+    guarantees — and let the downstream ``_repair_ogg_container`` step transcode
+    those mp3 bytes into a real Ogg/Opus container. The retry carries a fresh
+    idempotency key because it is a distinct request.
+
+    The fallback is deliberately limited to ``opus``: ``_repair_ogg_container``
+    only rewrites ``.ogg`` outputs, so retrying a rejected ``wav``/``flac``/
+    ``pcm`` request as mp3 would leave mp3 bytes mislabeled under the requested
+    extension. Those rejections propagate unchanged (#73470 review).
+    """
+    try:
+        return client.audio.speech.create(**create_kwargs)
+    except Exception as exc:
+        requested = create_kwargs.get("response_format")
+        if requested != "opus" or not _is_response_format_rejection(exc):
+            raise
+        logger.warning(
+            "TTS backend rejected response_format=%r — retrying as 'mp3' "
+            "(the .ogg container is rebuilt post-synthesis).",
+            requested,
+        )
+        retry_kwargs = dict(create_kwargs, response_format="mp3")
+        retry_kwargs["extra_headers"] = {"x-idempotency-key": str(uuid.uuid4())}
+        return client.audio.speech.create(**retry_kwargs)
+
+
 def _generate_openai_tts(
     text: str, output_path: str, tts_config: Dict[str, Any], *, api_key: Optional[str] = None,
     base_url: Optional[str] = None, model: Optional[str] = None, voice: Optional[str] = None,
@@ -126,7 +175,7 @@ def _generate_openai_tts(
         create_kwargs["extra_body"] = {"lang_code": oai_config["language"]}
     client = _origin()._import_openai_client()(api_key=api_key, base_url=base_url)
     try:
-        client.audio.speech.create(**create_kwargs).stream_to_file(output_path)
+        _openai_speech_create_with_format_fallback(client, create_kwargs).stream_to_file(output_path)
         return output_path
     finally:
         close = getattr(client, "close", None)


### PR DESCRIPTION
## What & why

Fixes #73470.

`_generate_openai_tts()` derives `response_format` from the output extension, so a `.ogg` target requests `opus`. Self-hosted OpenAI-compatible speech servers that implement only `mp3`/`wav`/`flac`/`pcm` — Speaches serving `speaches-ai/Kokoro-82M-v1.0-ONNX`, etc. — **reject** that request with an HTTP 400/422 *before any bytes exist*:

```
{"detail":[{"type":"literal_error","loc":["body","response_format"],
  "msg":"Input should be 'mp3', 'flac', 'wav' or 'pcm'","input":"opus"}]}
```

So `client.audio.speech.create()` raises `UnprocessableEntityError` and the whole tool fails — every Telegram voice reply errors out.

#57184 (fae29c841) added `_sniff_audio_container()` / `_repair_ogg_container()`, which rescues backends that silently **ignore** `response_format=opus` and write MP3/WAV bytes into the `.ogg` path. But that hook runs *after* synthesis, so it can't help a backend that **rejects** the parameter — the request 4xxs before any bytes exist, and execution never reaches the repair step. The comment block above `_sniff_audio_container()` names both cases ("reject/ignore"); only the ignore half was handled.

## The fix

Wrap the single `speech.create()` call so a response_format rejection retries **exactly once** as `mp3` — a format the OpenAI speech contract guarantees — then let the existing `_repair_ogg_container()` step transcode those mp3 bytes into a real Ogg/Opus container (the same end state #57184 produces for the ignore case):

- `_is_response_format_rejection(exc)` — narrow predicate: HTTP `400`/`422` **and** `"response_format"` in the error text, so unrelated 4xx errors still propagate untouched.
- `_openai_speech_create_with_format_fallback(client, create_kwargs)` — native opus is still requested first (backends that support it are unaffected); only a genuine rejection triggers the single mp3 retry, which carries a fresh idempotency key because it is a distinct request.

Scope is limited to `_generate_openai_tts` (and everything that delegates to it, e.g. DeepInfra). The Mistral path requests opus through a different SDK that supports it natively, so it's untouched.

## Tests

`tests/tools/test_tts_openai_format_fallback.py` (10 cases):

- `_is_response_format_rejection`: 400/422-naming-`response_format` → retry; other 4xx, a 422 not naming the field, and an error without `status_code` → no retry.
- fallback wrapper: opus rejection → one mp3 retry with a fresh idempotency key and carried-through kwargs; native opus → single call; an unrelated error and an already-`mp3` rejection → propagate without retry.
- end-to-end through `_generate_openai_tts`: a `.ogg` target that gets its `opus` request rejected recovers to `mp3`, writes the file, and closes the client.

`scripts/run_tests.sh <affected>` passes; also reran `test_tts_opus_routing`, `test_tts_container_repair`, `test_tts_deepinfra`, `test_tts_speed` (39 passed) since the affected-test mapping only picks up the new file.
