### PR TITLE
fix(telegram): retry restart notice after polling recovers

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17567,6 +17567,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "♻ Gateway restarted successfully. Your session continues.",
                 metadata=_non_conversational_metadata(metadata, platform=platform),
             )
+            if (
+                result is not None
+                and getattr(result, "success", True) is False
+                and getattr(result, "error", None) == "send_path_degraded"
+                and getattr(result, "retryable", False)
+            ):
+                wait_until_send_ready = getattr(
+                    transport.adapter,
+                    "wait_until_send_ready",
+                    None,
+                )
+                if callable(wait_until_send_ready):
+                    if await wait_until_send_ready(timeout=10.0):
+                        result = await transport.send(
+                            platform,
+                            str(chat_id),
+                            "♻ Gateway restarted successfully. Your session continues.",
+                            metadata=_non_conversational_metadata(
+                                metadata,
+                                platform=platform,
+                            ),
+                        )
             # adapter.send() catches provider errors (e.g. "Chat not found")
             # and returns SendResult(success=False) rather than raising, so
             # we must inspect the result before claiming success — otherwise

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2092,6 +2092,29 @@ class TelegramAdapter(BasePlatformAdapter):
         self._polling_conflict_count = 0
         self._send_path_degraded = False
 
+    async def wait_until_send_ready(self, timeout: float) -> bool:
+        """Wait for verified getUpdates progress before a guarded send retry."""
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + max(0.0, timeout)
+
+        while self._send_path_degraded:
+            progress = self._polling_progress_event
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return False
+            try:
+                await asyncio.wait_for(progress.wait(), timeout=min(remaining, 0.1))
+            except asyncio.TimeoutError:
+                continue
+
+            # A reconnect can replace the generation event while this task is
+            # waiting. Re-read state rather than treating stale progress as
+            # proof that the current send path is healthy.
+            if progress is not self._polling_progress_event:
+                continue
+
+        return True
+
     def _observe_polling_request_result(self, request, generation, result):
         """Record getUpdates progress from an observed do_request result.
 

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -705,6 +705,33 @@ async def test_send_restart_notification_logs_warning_on_sendresult_failure(
 
 
 @pytest.mark.asyncio
+async def test_send_restart_notification_retries_after_send_path_recovers(
+    tmp_path, monkeypatch
+):
+    """A startup send racing Telegram polling progress is retried once."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "42",
+    }))
+
+    runner, adapter = make_restart_runner()
+    adapter.wait_until_send_ready = AsyncMock(return_value=True)
+    adapter.send = AsyncMock(side_effect=[
+        SendResult(success=False, error="send_path_degraded", retryable=True),
+        SendResult(success=True, message_id="restart"),
+    ])
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target == ("telegram", "42", None)
+    adapter.wait_until_send_ready.assert_awaited_once()
+    assert adapter.send.await_count == 2
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
 async def test_send_home_channel_startup_notification_skipped_when_flag_disabled(
     tmp_path, monkeypatch
 ):

--- a/tests/gateway/test_telegram_polling_progress.py
+++ b/tests/gateway/test_telegram_polling_progress.py
@@ -44,6 +44,41 @@ def _make_adapter() -> TelegramAdapter:
     return TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
 
 
+@pytest.mark.asyncio
+async def test_wait_until_send_ready_tracks_verified_polling_progress():
+    adapter = _make_adapter()
+    generation, _progress = adapter._begin_polling_generation()
+
+    waiter = asyncio.create_task(adapter.wait_until_send_ready(timeout=1.0))
+    await asyncio.sleep(0)
+    assert not waiter.done()
+
+    adapter._record_polling_progress(generation)
+
+    assert await waiter is True
+
+
+@pytest.mark.asyncio
+async def test_wait_until_send_ready_times_out_without_progress():
+    adapter = _make_adapter()
+    adapter._begin_polling_generation()
+
+    assert await adapter.wait_until_send_ready(timeout=0.01) is False
+
+
+@pytest.mark.asyncio
+async def test_wait_until_send_ready_follows_replacement_generation():
+    adapter = _make_adapter()
+    adapter._begin_polling_generation()
+    waiter = asyncio.create_task(adapter.wait_until_send_ready(timeout=1.0))
+    await asyncio.sleep(0)
+
+    replacement_generation, _progress = adapter._begin_polling_generation()
+    adapter._record_polling_progress(replacement_generation)
+
+    assert await waiter is True
+
+
 def _mock_polling_app(*, get_me=None):
     app = MagicMock()
     app.updater = MagicMock()


### PR DESCRIPTION
## Summary

Fixes #73473.

Telegram intentionally marks its send path degraded at the start of every polling generation and clears that guard only after verified `getUpdates` I/O. The startup restart notification can race that verification: its one-shot send returns `send_path_degraded`, then the marker is deleted without a retry.

This change keeps the health gate intact and makes the restart path generation-aware:

- when—and only when—the first send returns the retryable `send_path_degraded` result, wait up to 10 seconds for verified polling progress;
- follow a replacement polling generation if a reconnect occurs while waiting;
- retry the same notification once after the current generation becomes healthy;
- preserve existing one-shot behavior for unrelated failures and bounded-timeout cases.

## Reproduction

The regression test models the startup race with a first `send_path_degraded` result followed by a healthy send. On current `main`, `_send_restart_notification()` returns `None`, logs the degraded result, removes the marker, and never calls the readiness waiter or second send.

## Validation

- Restart notification, polling progress, send-path health, startup race, and platform reconnect suites: **122 passed**
- Ruff lint on all four changed files: **passed**
- `git diff --check`: **passed**

The tests cover successful verified progress, bounded timeout, and a reconnect replacing the polling generation during the wait. The canonical Bash wrapper is unavailable in this Windows environment, so I invoked its underlying per-file isolation runner directly with the repository's Python 3.11 test environment.