### PR TITLE
fix(agent): detect Kimi runtime by model slug on third-party providers

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -32,6 +32,7 @@ from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import FailoverReason
 from agent.errors import EmptyStreamError
 from agent.turn_context import substitute_api_content
+from agent.anthropic_adapter import _model_name_is_kimi_family
 from agent.gemini_native_adapter import is_native_gemini_base_url
 from agent.model_metadata import is_local_endpoint
 from agent.message_content import flatten_message_text
@@ -1203,6 +1204,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         base_url_host_matches(agent.base_url, "api.kimi.com")
         or base_url_host_matches(agent.base_url, "moonshot.ai")
         or base_url_host_matches(agent.base_url, "moonshot.cn")
+        or _model_name_is_kimi_family(agent.model)
     )
     _is_tokenhub = base_url_host_matches(agent._base_url_lower, "tokenhub.tencentmaas.com")
     _is_lmstudio = (agent.provider or "").strip().lower() == "lmstudio"


### PR DESCRIPTION
The current `_is_kimi` detection in `agent/chat_completion_helpers.py` only matches by URL hostname (`api.kimi.com`, `moonshot.ai`, `moonshot.cn`). When Kimi K3 (or other Kimi-family models) runs via a third-party provider such as Fireworks AI (`api.fireworks.ai`), the detection fails — `reasoning_effort` and `thinking` parameters are never sent, breaking the Kimi runtime on those providers.

**Fix:** Import the existing `_model_name_is_kimi_family` function from `agent.anthropic_adapter` (line 480, already used elsewhere in the codebase) and add `or _model_name_is_kimi_family(agent.model)` to the `_is_kimi` check. This matches Kimi models by their model slug (e.g. `k3`, `kimi-k2.5`, `moonshotai/kimi-*`) regardless of which API endpoint serves them.

Closes #73335