### PR TITLE
fix(cli): catch PermissionError in _apply_managed_env() to honor fail-open contract

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -370,11 +370,14 @@ def _apply_managed_env() -> None:
         return
     if managed_dir is None:
         return
-    managed_env = managed_dir / ".env"
-    if not managed_env.exists():
+    try:
+        managed_env = managed_dir / ".env"
+        if not managed_env.exists():
+            return
+        _sanitize_env_file_if_needed(managed_env)
+        _load_dotenv_with_fallback(managed_env, override=True)
+    except Exception:  # noqa: BLE001 — managed scope must never block startup
         return
-    _sanitize_env_file_if_needed(managed_env)
-    _load_dotenv_with_fallback(managed_env, override=True)
 
 
 def _apply_external_secret_sources(home_path: Path) -> None:


### PR DESCRIPTION
In `hermes_cli/env_loader.py`, the `_apply_managed_env()` function has a fail-open contract documented in its docstring ("any error here is swallowed so managed scope can never block startup"). However, the call to `Path.exists()` on line 374 was outside any `try/except` block. `Path.exists()` can raise `PermissionError` (e.g., when the parent directory lacks search permission), which would crash startup instead of being swallowed.

**The fix:** wrap the post-import logic (the `managed_dir` check, `managed_env.exists()`, `_sanitize_env_file_if_needed()`, and `_load_dotenv_with_fallback()` calls) in a second `try/except Exception` block, so that any filesystem-level error is gracefully caught, honoring the fail-open contract.

Closes #73401