### PR TITLE
fix(tts): restore Telegram voice bubbles on auto-TTS

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -15,6 +15,7 @@ import re
 import socket as _socket
 import subprocess
 import sys
+import tempfile
 import time
 import uuid
 import weakref
@@ -3815,6 +3816,23 @@ class BasePlatformAdapter(ABC):
         """
         return re.sub(r'[*_`#\[\]()]', '', text)[:4000].strip()
 
+    def _auto_tts_output_path(self) -> Optional[str]:
+        """Return a platform-specific temporary output path for auto-TTS.
+
+        Telegram decides between ``sendVoice`` and ``sendAudio`` from the
+        generated file extension. Auto-TTS runs after the agent's session
+        context has been cleared, so the TTS tool can no longer infer that the
+        destination is Telegram. Give it an explicit unique ``.ogg`` path so
+        every Telegram auto-TTS reply is repaired/encoded as Ogg Opus and sent
+        as a native voice bubble. Other platforms keep the provider default.
+        """
+        if self.platform == Platform.TELEGRAM:
+            return str(
+                Path(tempfile.gettempdir())
+                / f"hermes_auto_tts_{uuid.uuid4().hex}.ogg"
+            )
+        return None
+
     async def play_tts(
         self,
         chat_id: str,
@@ -5526,8 +5544,12 @@ class BasePlatformAdapter(ABC):
                             speech_text = self.prepare_tts_text(text_content)
                             if not speech_text:
                                 raise ValueError("Empty text after markdown cleanup")
+                            tts_kwargs = {"text": speech_text}
+                            tts_output_path = self._auto_tts_output_path()
+                            if tts_output_path:
+                                tts_kwargs["output_path"] = tts_output_path
                             tts_result_str = await asyncio.to_thread(
-                                text_to_speech_tool, text=speech_text
+                                text_to_speech_tool, **tts_kwargs
                             )
                             tts_data = _json.loads(tts_result_str)
                             _tts_path = tts_data.get("file_path")

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -260,6 +260,18 @@ class TestBasePlatformTopicSessions:
 
 
 class TestTelegramAutoTtsCaptionDelivery:
+    def test_telegram_auto_tts_output_paths_are_unique_ogg(self):
+        adapter = DummyTelegramAdapter()
+
+        first = adapter._auto_tts_output_path()
+        second = adapter._auto_tts_output_path()
+
+        assert first is not None
+        assert second is not None
+        assert first.endswith(".ogg")
+        assert second.endswith(".ogg")
+        assert first != second
+
     @staticmethod
     def _make_voice_event(chat_id: str = "-1001", thread_id: str = "17585") -> MessageEvent:
         return MessageEvent(
@@ -296,9 +308,10 @@ class TestTelegramAutoTtsCaptionDelivery:
         with patch("tools.tts_tool.check_tts_requirements", return_value=True), patch(
             "tools.tts_tool.text_to_speech_tool",
             return_value=json.dumps({"file_path": str(tts_path)}),
-        ):
+        ) as tts_tool:
             await adapter._process_message_background(event, build_session_key(event.source))
 
+        assert tts_tool.call_args.kwargs["output_path"].endswith(".ogg")
         adapter.play_tts.assert_awaited_once()
         assert adapter.play_tts.await_args.kwargs["caption"] == "Short reply"
         assert adapter.sent == []

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -84,7 +84,12 @@ from tools.xai_http import hermes_xai_user_agent
 # ---------------------------------------------------------------------------
 
 def _import_edge_tts():
-    """Lazy import edge_tts. Returns the module or raises ImportError."""
+    """Lazy import edge_tts. Returns the module or raises ImportError.
+
+    On Windows, inject the native certificate store before importing edge_tts.
+    This lets corporate TLS-inspection CAs trusted by Windows work with
+    edge_tts, which otherwise forces certifi's Mozilla-only CA bundle.
+    """
     try:
         from tools.lazy_deps import ensure as _lazy_ensure
         _lazy_ensure("tts.edge", prompt=False)
@@ -92,6 +97,16 @@ def _import_edge_tts():
         pass
     except Exception as e:
         raise ImportError(str(e))
+
+    if os.name == "nt":
+        try:
+            import truststore
+            truststore.inject_into_ssl()
+        except ImportError:
+            logger.debug("truststore is unavailable; Edge TTS will use certifi")
+        except Exception as e:
+            logger.warning("Could not inject Windows certificate store for Edge TTS: %s", e)
+
     import edge_tts
     return edge_tts
 


### PR DESCRIPTION
## Summary
- generate a unique `.ogg` output path for Telegram auto-TTS instead of relying on cleared session context
- keep other platforms on their existing provider-default output format
- inject the Windows certificate store before importing Edge TTS when `truststore` is available

## Root cause
Auto-TTS runs after the agent session context is cleared. The TTS tool therefore cannot infer `HERMES_SESSION_PLATFORM=telegram` and defaults to MP3. Telegram routes MP3 through `sendAudio` rather than `sendVoice`, so replies appear as audio attachments instead of native voice bubbles.

## Tests
- `tests/gateway/test_base_topic_sessions.py`: 11 passed
- `tests/tools/test_tts_opus_routing.py`: 2 passed
- Ruff check on changed files passed
- verified generated audio is Ogg/Opus and delivered through Telegram `sendVoice` on Windows