### PR TITLE
fix(agent): prevent tool_search retry loop on eager-loaded MCP tools

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -284,6 +284,16 @@ def _tool_search_scoped_names(agent) -> frozenset:
             skip_tool_search_assembly=True,
         ) or []
         names = _ts.scoped_deferrable_names(scoped_defs)
+        # Also include visible (non-deferrable) tool names so tool_call
+        # can transparently route eager-loaded tools.  See issue #73388.
+        _all_visible = {
+            (td.get("function") or {}).get("name")
+            for td in scoped_defs
+            if (td.get("function") or {}).get("name")
+            and (td.get("function") or {}).get("name") not in names
+        }
+        if _all_visible:
+            names = names | _all_visible
     except Exception:
         names = frozenset()
     try:

--- a/model_tools.py
+++ b/model_tools.py
@@ -1173,19 +1173,47 @@ def handle_function_call(
                 return json.dumps({"error": err or "tool_call could not be resolved"},
                                   ensure_ascii=False)
             # Defense in depth: the underlying tool MUST be in the session's
-            # scoped deferrable catalog. resolve_underlying_call() only checks
-            # that the name is deferrable in the global registry; this gate
-            # additionally rejects any tool the session was not granted, so a
-            # restricted session can never invoke an out-of-scope tool through
-            # the bridge even if the catalog scoping above regressed.
+            # scoped deferrable catalog, or be a visible (eager-loaded) tool
+            # the session was granted. resolve_underlying_call() no longer
+            # blocks non-deferrable names (see issue #73388), so we enforce
+            # session boundaries here instead, rejecting out-of-scope tools.
             _scoped_deferrable = _ts_mod.scoped_deferrable_names(current_defs)
             if underlying_name not in _scoped_deferrable:
-                return json.dumps({
-                    "error": (
-                        f"'{underlying_name}' is not available in this session. "
-                        "Use tool_search to find tools you can call."
-                    ),
-                }, ensure_ascii=False)
+                # Check if it's a visible (non-deferrable) tool -- the model
+                # may route eager-loaded tools through tool_call. If found,
+                # dispatch it directly without the deferred-call validate
+                # probe (the model already sees the full schema).
+                _visible_names = {
+                    (td.get("function") or {}).get("name")
+                    for td in current_defs
+                    if (td.get("function") or {}).get("name")
+                    and not _ts_mod.is_deferrable_tool_name(
+                        (td.get("function") or {}).get("name")
+                    )
+                }
+                if underlying_name not in _visible_names:
+                    return json.dumps({
+                        "error": (
+                            f"'{underlying_name}' is not available in this session. "
+                            "Use tool_search to find tools you can call."
+                        ),
+                    }, ensure_ascii=False)
+                # Visible tool -- recurse directly, no probe-validate needed.
+                return handle_function_call(
+                    function_name=underlying_name,
+                    function_args=underlying_args,
+                    task_id=task_id,
+                    tool_call_id=tool_call_id,
+                    session_id=session_id,
+                    user_task=user_task,
+                    enabled_tools=enabled_tools,
+                    skip_pre_tool_call_hook=skip_pre_tool_call_hook,
+                    skip_tool_request_middleware=skip_tool_request_middleware,
+                    skip_tool_execution_middleware=skip_tool_execution_middleware,
+                    tool_request_middleware_trace=list(_tool_middleware_trace),
+                    enabled_toolsets=enabled_toolsets,
+                    disabled_toolsets=disabled_toolsets,
+                )
             # Probe-validate against the deferred tool's schema (ironclaw#5149):
             # a blind call missing required arguments returns the parameter
             # schema instead of dispatching into an opaque downstream failure.

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -387,14 +387,16 @@ class TestBridgeDispatch:
         result = dispatch_tool_describe({}, current_tool_defs=[])
         assert "error" in json.loads(result)
 
-    def test_tool_describe_rejects_non_deferrable(self):
-        """If the model asks to describe a core tool, refuse — it's already
-        in the visible list."""
+    def test_tool_describe_returns_visible_tool_schema(self):
+        """If the model asks to describe a tool that's visible (eager-loaded),
+        return its schema directly instead of refusing. See issue #73388."""
         from tools.tool_search import dispatch_tool_describe
         result = dispatch_tool_describe(
             {"name": "terminal"}, current_tool_defs=[_td("terminal", "Run shell")],
         )
-        assert "error" in json.loads(result)
+        payload = json.loads(result)
+        assert payload.get("name") == "terminal"
+        assert payload.get("description") == "Run shell"
 
     def test_resolve_underlying_call_parses_object_args(self):
         from tools.tool_search import resolve_underlying_call
@@ -402,21 +404,23 @@ class TestBridgeDispatch:
             "name": "unknown_xxx",
             "arguments": {"foo": "bar"},
         })
-        # Will fail classification because unknown_xxx isn't deferrable.
-        assert err is not None
+        # No error — resolve_underlying_call now passes through all tools,
+        # leaving scope enforcement to the caller. See issue #73388.
+        assert err is None
+        assert name == "unknown_xxx"
+        assert args == {"foo": "bar"}
 
     def test_resolve_underlying_call_parses_json_string_args(self):
         """Some models emit ``arguments`` as a JSON string instead of object."""
         from tools.tool_search import resolve_underlying_call
-        # Use a name that won't classify (so we don't depend on registry),
-        # but exercise the JSON parse path.
-        _, _, err = resolve_underlying_call({
+        # Now passes through any tool name (no longer rejects non-deferrable).
+        name, args, err = resolve_underlying_call({
             "name": "fake",
             "arguments": '{"a": 1}',
         })
-        # err is about classification, but the parse worked (it would have
-        # failed earlier with "not valid JSON" otherwise).
-        assert "not valid JSON" not in (err or "")
+        assert err is None
+        assert name == "fake"
+        assert args == {"a": 1}
 
     def test_resolve_underlying_call_rejects_bad_json(self):
         from tools.tool_search import resolve_underlying_call
@@ -496,16 +500,18 @@ class TestRegression_OpenClawCron84141:
         # deferrable tools to put behind them.
         assert "terminal" in names
 
-    def test_unwrap_rejects_core_tool_attempt(self):
-        """Even if the model tries to invoke a core tool through tool_call,
-        we reject the call and tell the model to use it directly."""
+    def test_unwrap_passes_through_core_tool(self):
+        """tool_call now transparently passes through core tools; the
+        scope gate in model_tools / tool_executor enforces session
+        boundaries instead. See issue #73388."""
         from tools.tool_search import resolve_underlying_call
-        _, _, err = resolve_underlying_call({
+        name, args, err = resolve_underlying_call({
             "name": "terminal",
             "arguments": {"command": "echo hi"},
         })
-        assert err is not None
-        assert "not a deferrable" in err
+        assert err is None
+        assert name == "terminal"
+        assert args == {"command": "echo hi"}
 
 
 class TestRegression_ToolsetScoping:

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -894,6 +894,18 @@ def dispatch_tool_describe(args: Dict[str, Any],
     if not name:
         return json.dumps({"error": "name is required"}, ensure_ascii=False)
     if not is_deferrable_tool_name(name):
+        # Not a deferrable tool -- check if it's a visible (eager-loaded)
+        # tool and return its schema from the visible list.
+        # See issue #73388.
+        visible, _ = classify_tools(current_tool_defs)
+        for td in visible:
+            fn = td.get("function") or {}
+            if fn.get("name") == name:
+                return json.dumps({
+                    "name": name,
+                    "description": fn.get("description", ""),
+                    "parameters": fn.get("parameters", {}),
+                }, ensure_ascii=False)
         return json.dumps({
             "error": (
                 f"'{name}' is not a deferrable tool. If you see it in the tools list "
@@ -1015,10 +1027,13 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
     if not isinstance(raw_args, dict):
         return None, {}, "tool_call 'arguments' must be an object"
     if not is_deferrable_tool_name(name):
-        return None, {}, (
-            f"'{name}' is not a deferrable tool. If it appears in the model-facing tools "
-            "list already, call it directly instead of via tool_call."
-        )
+        # Not a deferrable tool -- but the model may still route it through
+        # tool_call due to training bias toward the search->describe->call
+        # pattern.  Pass it through instead of erroring: the downstream
+        # scope gate (model_tools / tool_executor) still enforces session
+        # boundaries, so this never grants access to out-of-scope tools.
+        # See issue #73388.
+        pass
     return name, raw_args, None
 
 


### PR DESCRIPTION
## Problem

When the toolset is small enough that MCP tools are eager-loaded (not deferred by the bridge), the model still routes calls through `tool_search` → `tool_describe` → `tool_call` for tools that are already visible. Each attempt returns:

```
{"error": "'mcp__monitoring__host_get' is not a deferrable tool. If you see it in the tools list already, call it directly..."}
```

The model's training bias toward the search→describe→call pattern causes it to retry, wasting turns and potentially triggering the `same_tool_failure_halt` guardrail.

## Root Cause

`resolve_underlying_call()` (used by `tool_call`) and `dispatch_tool_describe()` (used by `tool_describe`) both rejected non-deferrable tool names with an error, even when the tool was visible and available. The error message told the model to call the tool directly, but models — especially smaller/cheaper ones — don't always learn from a single tool-result error.

## Fix

Made the bridge tools transparent for **any** tool the session has access to, regardless of whether it's deferred or eager-loaded:

1. **`resolve_underlying_call`**: Pass through all non-bridge tool names instead of erroring for non-deferrable ones. The downstream scope gate (in `model_tools` / `tool_executor`) still enforces session boundaries.

2. **`dispatch_tool_describe`**: When a tool name is not deferrable, check the visible tool list and return its schema from there instead of refusing. The model gets the schema it needs in one round-trip.

3. **`model_tools.py` scope gate**: When a tool called via `tool_call` is not in the deferrable set, check if it's a visible (non-deferrable) tool in the session's scope and dispatch it directly. Skips the probe-validate step for visible tools since the model already sees the full schema.

4. **`agent/tool_executor.py` scope gate**: Extended `_tool_search_scoped_names` to include visible tool names so the executor unwrap can route them too.

## Testing

- `tests/tools/test_tool_search.py` — 57/57 passed (3 tests updated to match new pass-through behavior)
- `tests/test_model_tools.py` — 33/33 passed
- `tests/agent/test_tool_guardrails.py` — 23/23 passed

Closes #73388