### PR TITLE
fix(relay): preserve provider errors and scope cleanup

### DIFF
--- a/agent/relay_llm.py
+++ b/agent/relay_llm.py
@@ -438,6 +438,11 @@ class ManagedLlmStream(Iterator[Any]):
                 run_callback(self._on_chunk, _jsonable(chunk))
 
         def relay_finalizer() -> Any:
+            # Relay can invoke the finalizer while unwinding a provider-stream
+            # failure. Preserve that original callback error instead of
+            # replacing it with a secondary "missing terminal response" error.
+            if self._callback_error is not None:
+                return None
             try:
                 if self.final_response is not None:
                     return _jsonable(self.final_response)

--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -722,7 +722,8 @@ class RelaySessionCoordinator:
         with turn.logical_llm_lock:
             logical_calls = list(turn.logical_llm_calls.items())
             turn.logical_llm_calls.clear()
-        for request_id, logical_handle in logical_calls:
+        for index in range(len(logical_calls) - 1, -1, -1):
+            request_id, logical_handle = logical_calls[index]
             try:
                 lease.host.run_in_session(
                     lease.session,
@@ -736,11 +737,21 @@ class RelaySessionCoordinator:
                 )
             except Exception:
                 with turn.logical_llm_lock:
-                    turn.logical_llm_calls.setdefault(request_id, logical_handle)
+                    # Relay scopes are stack-owned. If the newest remaining
+                    # handle cannot close, older handles cannot close safely
+                    # either, so retain the unclosed prefix for diagnostics.
+                    for pending_request_id, pending_handle in logical_calls[
+                        : index + 1
+                    ]:
+                        turn.logical_llm_calls.setdefault(
+                            pending_request_id,
+                            pending_handle,
+                        )
                 logger.warning(
                     "Hermes Relay logical LLM finalization failed",
                     exc_info=True,
                 )
+                break
 
     @staticmethod
     def _reset_turn_context(turn: RelayTurnContext) -> None:

--- a/tests/agent/test_relay_llm.py
+++ b/tests/agent/test_relay_llm.py
@@ -181,6 +181,49 @@ def test_deferred_stream_preserves_provider_error_and_logical_scope_for_retry(
     assert "request-2" in turn.logical_llm_calls
 
 
+def test_stream_provider_error_is_not_replaced_by_finalizer_error(relay_turn):
+    _relay, turn = relay_turn
+
+    class ProviderError(Exception):
+        pass
+
+    provider_error = ProviderError("provider failed before first chunk")
+    finalizer_called = False
+
+    def failing_stream(_request):
+        def generate():
+            raise provider_error
+            yield  # pragma: no cover
+
+        return generate()
+
+    def failing_finalizer():
+        nonlocal finalizer_called
+        finalizer_called = True
+        raise RuntimeError("missing terminal response")
+
+    stream = relay_llm.stream(
+        {"model": "test-model", "input": "hi"},
+        failing_stream,
+        session_id="session-1",
+        name="test-provider",
+        model_name="test-model",
+        finalizer=failing_finalizer,
+        metadata={
+            "api_mode": "codex_responses",
+            "api_request_id": "request-provider-before-finalizer",
+        },
+        defer_logical_completion=True,
+    )
+
+    with pytest.raises(ProviderError) as caught:
+        list(stream)
+
+    assert caught.value is provider_error
+    assert finalizer_called is False
+    assert "request-provider-before-finalizer" in turn.logical_llm_calls
+
+
 def test_non_deferred_partial_stream_close_cancels_logical_call(
     relay_turn,
     monkeypatch,

--- a/tests/hermes_cli/test_relay_shared_metrics_runtime.py
+++ b/tests/hermes_cli/test_relay_shared_metrics_runtime.py
@@ -1525,6 +1525,91 @@ def test_turn_cleanup_drains_logical_calls_after_turn_scope_start_failure(
     assert turn.logical_llm_calls == {}
 
 
+def test_turn_cleanup_drains_logical_calls_in_lifo_order(direct_runtime):
+    coordinator = relay_runtime.SESSION_COORDINATOR
+    profile_key = relay_runtime.current_profile_key()
+    lease = coordinator.acquire_conversation(
+        profile_key=profile_key,
+        session_id="session-lifo",
+        platform="cli",
+    )
+    assert lease.session is not None
+    turn = coordinator.begin_turn(
+        lease,
+        turn_id="turn-lifo",
+        task_id="task-lifo",
+    )
+    assert turn.handle is not None
+    runtime = lease.host
+
+    handles = []
+    for request_id in ("request-1", "request-2"):
+        handle = runtime.run_in_session(
+            lease.session,
+            runtime.relay.scope.push,
+            relay_runtime.LOGICAL_LLM_SCOPE,
+            runtime.relay.ScopeType.Function,
+            handle=turn.handle,
+            input={},
+        )
+        turn.logical_llm_calls[request_id] = handle
+        handles.append(handle)
+
+    coordinator.end_turn(turn, outcome="failed")
+    coordinator.release_conversation(lease)
+
+    logical_closes = [
+        event[1]
+        for event in direct_runtime.events
+        if event[0] == "scope.pop" and event[1] in handles
+    ]
+    assert logical_closes == list(reversed(handles))
+    assert turn.logical_llm_calls == {}
+
+
+def test_real_binding_drains_multiple_logical_calls_before_turn_close(
+    real_binding_runtime,
+    caplog,
+):
+    coordinator = relay_runtime.SESSION_COORDINATOR
+    profile_key = relay_runtime.current_profile_key()
+    lease = coordinator.acquire_conversation(
+        profile_key=profile_key,
+        session_id="session-native-lifo",
+        platform="cli",
+    )
+    assert lease.session is not None
+    turn = coordinator.begin_turn(
+        lease,
+        turn_id="turn-native-lifo",
+        task_id="task-native-lifo",
+    )
+    assert turn.handle is not None
+    runtime = lease.host
+
+    for request_id in ("request-1", "request-2"):
+        handle = runtime.run_in_session(
+            lease.session,
+            runtime.relay.scope.push,
+            relay_runtime.LOGICAL_LLM_SCOPE,
+            runtime.relay.ScopeType.Function,
+            handle=turn.handle,
+            input={},
+        )
+        turn.logical_llm_calls[request_id] = handle
+
+    coordinator.end_turn(turn, outcome="failed")
+    coordinator.release_conversation(lease)
+    coordinator.finalize_conversation(
+        profile_key=profile_key,
+        session_id=lease.session_id,
+    )
+
+    assert turn.logical_llm_calls == {}
+    assert "finalization failed" not in caplog.text
+    assert "closed with errors" not in caplog.text
+
+
 def test_shared_metrics_creates_one_task_under_concurrent_access(direct_runtime):
     runtime = relay_shared_metrics._get_runtime()
     assert runtime is not None


### PR DESCRIPTION
## What does this PR do?

Fixes two Relay finalization defects found while validating the merged repair in #73120.

First, when a provider stream failed before producing a response, Relay could still invoke the response finalizer while unwinding. For OpenAI Responses, that finalizer raised `Codex Responses stream did not emit a terminal response` and replaced the authoritative provider exception.

Second, when concurrent or overlapping deferred logical LLM calls remained at turn cleanup, Hermes closed their Relay scopes in creation order. Relay scopes are stack-owned, so the first close failed with `scope handle is not at the top of the stack`, leaving logical and turn scopes unclosed. This was reported on Windows after #73120 merged and reproduced locally against the released native NeMo Relay binding.

## Related Issue

Follow-up to #73120.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Skip the response finalizer when the provider callback has already failed, preserving the original provider exception.
- Drain outstanding logical LLM scopes in reverse creation order before closing their turn.
- Stop after the first failed logical-scope close and retain the unclosed prefix instead of cascading invalid pops.
- Add focused provider-error, close-order, and released-native-binding regressions.

## How to Test

1. Run `.venv/bin/pytest -q tests/hermes_cli/test_relay_shared_metrics_runtime.py tests/agent/test_relay_llm.py tests/agent/test_auxiliary_relay.py tests/e2e/test_relay_native_anthropic_stream.py tests/agent/test_request_client_reuse.py tests/run_agent/test_request_client_reuse_abort_races.py tests/run_agent/test_28161_anthropic_stream_pool_cleanup.py tests/agent/test_codex_runtime_live_events.py tests/scripts/test_smoke_nemo_relay_shared_metrics.py`.
2. Run `.venv/bin/ruff check agent/relay_runtime.py agent/relay_llm.py tests/agent/test_relay_llm.py tests/hermes_cli/test_relay_shared_metrics_runtime.py` and `git diff --check`.
3. Against the released native binding, open two deferred logical LLM scopes, finish the turn, and verify that both logical scopes, the turn, and the session close without a top-of-stack warning.
4. Against live Anthropic Messages, OpenAI Chat Completions, and OpenAI Responses endpoints, send an invalid-model request followed by a valid request through the same agent. The provider error must be preserved, recovery must succeed, and no Relay session or turn may remain active.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I have run `pytest tests/ -q` and all tests pass (targeted affected suites passed: 142/142)
- [x] I have added tests for my changes
- [x] I have tested on my platform: macOS arm64

### Documentation & Housekeeping

- [x] I have updated relevant documentation, or N/A: no public behavior/configuration change
- [x] I have updated `cli-config.yaml.example`, or N/A: no configuration change
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md`, or N/A: no architecture/workflow change
- [x] I have considered cross-platform impact: the failure was reported on Windows and reproduced with the same native stack semantics on macOS
- [x] I have updated tool descriptions/schemas, or N/A: no tool behavior change

## Screenshots / Logs

Targeted deterministic and native-binding suites: `142 passed in 9.84s`.

The logical-scope regression reproduces the reported `scope handle is not at the top of the stack` error before the fix. After the fix, two outstanding logical scopes close newest-first, followed by the turn and session, with no finalization warning.

The earlier local-only live matrix covered Anthropic `/v1/messages`, OpenAI `/v1/chat/completions`, and OpenAI `/v1/responses` with:

- four-call same-agent reuse and four-way isolated concurrency;
- explicit three-turn history and mixed streaming-mode reuse;
- Unicode and bounded 4 KiB input payloads;
- cancellation after at least three streamed deltas followed by same-agent recovery;
- invalid-model failure followed by same-agent recovery;
- repeated agent activation/finalization.

Extended run: 45 task lifecycles, 39 successful calls, 3 intentional cancellations, 3 intentional provider failures, and 27 schema-valid shared-metrics exports. No credentials or prompt/response canaries were present in telemetry artifacts. The local harness is not included in this PR.
