### PR TITLE
fix(cron): make kanban dispatcher count blocker_auth failures toward failure_limit

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7892,11 +7892,13 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         The task's last failure error matches a quota / authentication
         pattern. Retrying immediately is unlikely to help (rate limits
         reset on a timer; auth needs human action), so we defer to the
-        next tick. The existing ``consecutive_failures`` counter still
-        trips the auto-block circuit breaker after ``failure_limit``
-        consecutive failures, so a persistent auth error eventually
-        blocks via the normal path — but a transient 429 gets a few
-        ticks of recovery first.
+        next tick. The blocker_auth guard alone would prevent any spawn
+        attempt, freezing ``consecutive_failures`` and letting the task
+        loop in ``ready`` forever (bug #73369). To break that loop, the
+        dispatcher's guard handler counts each deferred tick as a failure
+        via ``_record_task_failure``, so the circuit breaker can still
+        trip after ``failure_limit`` consecutive deferrals. A transient
+        429 gets a few ticks of recovery first before the breaker trips.
 
     ``"recent_success"``
         A completed run exists within ``_RESPAWN_GUARD_SUCCESS_WINDOW``
@@ -8358,10 +8360,12 @@ def _dispatch_once_locked(
         # in-flight/recent, or when the last failure is a deterministic
         # blocker (quota / auth). The guard defers the spawn this tick so
         # the task gets a chance to clear (rate limits often reset in
-        # seconds-to-minutes); the existing consecutive_failures counter
-        # still trips the auto-block circuit breaker after failure_limit
-        # consecutive failures, so a persistent auth error eventually
-        # blocks via the normal path rather than on first occurrence.
+        # seconds-to-minutes). For blocker_auth, the guard handler also
+        # counts the deferred tick as a failure via _record_task_failure
+        # (#73369), so the circuit breaker can trip after failure_limit
+        # consecutive deferrals — preventing the task from looping in
+        # ready forever. Other guard reasons (rate_limit_cooldown,
+        # recent_success, active_pr) do NOT increment failures.
         guard_reason = check_respawn_guard(conn, row["id"])
         if guard_reason is not None:
             result.respawn_guarded.append((row["id"], guard_reason))
@@ -8374,6 +8378,33 @@ def _dispatch_once_locked(
                         conn, row["id"], "respawn_guarded",
                         {"reason": guard_reason},
                     )
+                # When blocker_auth fires, the guard prevents the spawn
+                # attempt, so _record_spawn_failure (normally called in
+                # the spawn exception handler) never runs — the task
+                # stays frozen at its current consecutive_failures count
+                # and loops in ready forever. Count the deferred tick as
+                # a failure so the circuit breaker eventually trips and
+                # auto-blocks the task (#73369).
+                # Only do this for blocker_auth, not rate_limit_cooldown
+                # (which has its own bounded retry cadence) or
+                # recent_success / active_pr (liveness guards unrelated
+                # to spawn failures).
+                if guard_reason == "blocker_auth":
+                    err_row = conn.execute(
+                        "SELECT last_failure_error FROM tasks WHERE id = ?",
+                        (row["id"],),
+                    ).fetchone()
+                    if err_row and err_row["last_failure_error"]:
+                        auto = _record_task_failure(
+                            conn, row["id"],
+                            err_row["last_failure_error"],
+                            outcome="spawn_failed",
+                            failure_limit=failure_limit,
+                            release_claim=False,
+                            end_run=False,
+                        )
+                        if auto:
+                            result.auto_blocked.append(row["id"])
             continue
         if dry_run:
             result.spawned.append((row["id"], row_assignee, ""))

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1989,6 +1989,46 @@ def test_dispatch_respawn_guard_defers_auth_error_without_auto_block(
         assert kb.get_task(conn, t).status == "ready"
 
 
+def test_dispatch_respawn_guard_blocker_auth_counts_toward_failure_limit(
+    kanban_home, all_assignees_spawnable
+):
+    """dispatch_once counts each blocker_auth deferral as a failure toward
+    failure_limit, so a persistently blocker_auth task gets auto-blocked
+    instead of looping in ready forever (#73369)."""
+    spawned_ids = []
+
+    def fake_spawn(task, workspace):
+        spawned_ids.append(task.id)
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="stuck-auth", assignee="alice",
+                            max_retries=2)
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+            ("403 Forbidden: unauthorized", t),
+        )
+        # Tick 1: defer + record failure (consecutive_failures 0 -> 1)
+        r1 = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+        assert t not in r1.auto_blocked
+        assert (t, "blocker_auth") in r1.respawn_guarded
+        assert t not in spawned_ids
+        task1 = kb.get_task(conn, t)
+        assert task1.status == "ready"
+        assert task1.consecutive_failures == 1
+
+        # Tick 2: defer + fail again (consecutive_failures 1 -> 2 >=
+        # max_retries=2) → auto-blocked
+        r2 = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+        assert t in r2.auto_blocked, (
+            f"second blocker_auth tick should auto-block; "
+            f"got auto_blocked={r2.auto_blocked!r}"
+        )
+        assert t not in spawned_ids
+        task2 = kb.get_task(conn, t)
+        assert task2.status == "blocked"
+        assert task2.consecutive_failures == 2
+
+
 def test_dispatch_respawn_guard_skips_recent_success(
     kanban_home, all_assignees_spawnable
 ):


### PR DESCRIPTION
## Problem

When a spawn fails with an error matching `_RESPAWN_BLOCKER_RE` (e.g. "Permission denied"), `check_respawn_guard()` returns `"blocker_auth"`. In `_dispatch_once_locked()`, the guard handler only emitted a `respawn_guarded` event and `continue`d — without calling `_record_spawn_failure()`. Since `consecutive_failures` never incremented past its initial value, the task stayed `ready` forever, ignoring the `kanban.failure_limit` circuit breaker entirely.

## Root cause

`_dispatch_once_locked()` would `continue` before `_record_spawn_failure()` when the guard returned `"blocker_auth"`, freezing `consecutive_failures` at the count set by the first (and only) real spawn failure. No subsequent dispatcher tick would ever increment the counter, so the breaker could never trip.

The existing docstrings claimed that "the existing `consecutive_failures` counter still trips the auto-block circuit breaker after `failure_limit` consecutive failures" — but this was incorrect: the guard prevented any spawn attempt, so no failure was ever recorded.

## Fix

In the `_dispatch_once_locked()` guard handler, when `guard_reason == "blocker_auth"`, call `_record_task_failure()` (with `release_claim=False, end_run=False` — the task is never claimed) to increment `consecutive_failures` and stamp the error. This way:

1. Each blocker_auth deferral counts as a failure toward the circuit breaker
2. After `failure_limit` consecutive deferrals, the task auto-blocks
3. A transient 429 still gets a few ticks of recovery before the breaker trips

Only `blocker_auth` gets this treatment — `rate_limit_cooldown` (bounded retry cadence), `recent_success`, and `active_pr` (liveness guards unrelated to spawn failures) do NOT increment failures.

## Changes

- **`hermes_cli/kanban_db.py`**: Add `_record_task_failure()` call in the blocker_auth guard handler. Updated misleading docstrings in `check_respawn_guard()` and `_dispatch_once_locked()` that claimed the counter would already handle this.
- **`tests/hermes_cli/test_kanban_db.py`**: Add `test_dispatch_respawn_guard_blocker_auth_counts_toward_failure_limit` — verifies two dispatcher ticks with blocker_auth: tick 1 defers + increments (no auto-block), tick 2 auto-blocks at failure_limit.

Closes #73369