### PR TITLE
fix(gateway): preserve memory prompt during manual compression

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3914,7 +3914,11 @@ class GatewaySlashCommandsMixin:
             # unbound/default "cli" host source — see #50422. _platform_config_key
             # maps LOCAL->"cli" exactly like the live turn, avoiding a new
             # "local" vs "cli" mismatch.
-            from gateway.run import _platform_config_key
+            from gateway.run import (
+                _GATEWAY_HYGIENE_PLATFORM,
+                _platform_config_key,
+                _seed_hygiene_system_prompt,
+            )
             platform_key = (
                 _platform_config_key(source.platform) if source.platform else None
             )
@@ -3963,6 +3967,25 @@ class GatewaySlashCommandsMixin:
             if platform_key is not None:
                 runtime_kwargs["platform"] = platform_key
             runtime_kwargs["gateway_session_key"] = session_key
+
+            # The manual compression helper skips memory-provider initialization,
+            # but _compress_context may persist its cached system prompt. Restore
+            # the exact live-session prompt so provider blocks are retained.
+            session_row = None
+            get_session = getattr(self._session_db, "get_session", None)
+            if callable(get_session):
+                try:
+                    session_row = await get_session(session_entry.session_id)
+                except Exception as exc:
+                    logger.warning(
+                        "Manual compression could not restore the system prompt "
+                        "for session %s: %s. Preserving an empty prompt so the "
+                        "live turn rebuilds it with its configured providers.",
+                        session_entry.session_id,
+                        exc,
+                        exc_info=True,
+                    )
+
             tmp_agent = AIAgent(
                 **runtime_kwargs,
                 model=model,
@@ -3973,6 +3996,12 @@ class GatewaySlashCommandsMixin:
                 session_id=session_entry.session_id,
                 session_db=getattr(self._session_db, "_db", self._session_db),
             )
+            _seed_hygiene_system_prompt(tmp_agent, session_row)
+            # Keep the real source platform during construction so external
+            # context engines bind correctly. If compression has to rebuild the
+            # prompt, stamp that provider-less fallback as stale for the next
+            # real gateway turn.
+            tmp_agent.platform = _GATEWAY_HYGIENE_PLATFORM
             try:
                 tmp_agent._print_fn = lambda *a, **kw: None
                 # Prevent close() from ending the newly rotated session —

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -1,7 +1,7 @@
 """Tests for gateway /compress user-facing messaging."""
 
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -509,6 +509,67 @@ async def test_compress_command_preserves_platform_and_gateway_session_key():
     # Stable gateway session key preserved, identical to a normal gateway turn.
     assert kwargs.get("gateway_session_key") == runner._session_key_for_source(_make_source())
     assert kwargs["gateway_session_key"]
+
+
+@pytest.mark.asyncio
+async def test_compress_command_preserves_persisted_provider_prompt():
+    """Manual /compress must not replace a provider-aware session prompt.
+
+    Its temporary agent intentionally skips memory-provider initialization, so
+    it must reuse the exact persisted prompt. If compression rebuilds instead,
+    the hygiene-only marker makes that fallback stale for the next live turn.
+    """
+    from gateway.run import _GATEWAY_HYGIENE_PLATFORM
+
+    history = _make_history()
+    stored_prompt = (
+        "base prompt\n\n"
+        "<hindsight_memories>\n"
+        "## Personal Memory\n"
+        "- pinned: exact provider content\n"
+        "</hindsight_memories>\n"
+    )
+    runner = _make_runner(history)
+    runner._session_db = MagicMock()
+    runner._session_db.get_session = AsyncMock(
+        return_value={"system_prompt": stored_prompt}
+    )
+
+    agent_instance = MagicMock()
+    agent_instance.shutdown_memory_provider = MagicMock()
+    agent_instance.close = MagicMock()
+    agent_instance._cached_system_prompt = "provider-less prompt"
+    agent_instance.platform = "telegram"
+    agent_instance.tools = None
+    agent_instance.context_compressor.has_content_to_compress.return_value = True
+    agent_instance.session_id = "sess-1"
+    agent_instance._compression_skipped_due_to_lock = False
+
+    def _compress(messages, *_args, **_kwargs):
+        assert messages == history
+        assert agent_instance._cached_system_prompt == stored_prompt
+        assert agent_instance.platform == _GATEWAY_HYGIENE_PLATFORM
+        return list(history), ""
+
+    agent_instance._compress_context.side_effect = _compress
+
+    def _estimate(messages, **kwargs):
+        assert messages == history
+        assert kwargs["system_prompt"] == stored_prompt
+        return 100
+
+    with (
+        patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}),
+        patch("gateway.run._resolve_gateway_model", return_value="test-model"),
+        patch("run_agent.AIAgent", return_value=agent_instance) as mock_agent,
+        patch("agent.model_metadata.estimate_request_tokens_rough", side_effect=_estimate),
+    ):
+        await runner._handle_compress_command(_make_event())
+
+    runner._session_db.get_session.assert_awaited_once_with("sess-1")
+    assert mock_agent.call_args.kwargs["platform"] == "telegram"
+    assert agent_instance._cached_system_prompt == stored_prompt
+    assert agent_instance.platform == _GATEWAY_HYGIENE_PLATFORM
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Preserves the live gateway session's provider-aware system prompt when a user runs manual `/compress`.

The manual command creates a temporary `AIAgent` with `skip_memory=True`. Its compression path can persist `_cached_system_prompt`, so the provider-less temporary prompt could replace the session's existing prompt and remove external memory content. Automatic pre-turn hygiene compression already guards this path after #72978, but manual `/compress` did not.

This change restores the exact persisted prompt onto the temporary agent before compression. The agent is still constructed with the real gateway platform so context-engine binding remains correct, then marked with the hygiene-only platform before compression. If the prompt must be rebuilt instead of retained, the provider-less result is deliberately stale for the next live gateway turn.

This preserves the current prompt-cache contract. It does not reload newly changed provider content into an existing session.

## Related Issue

Follow-up to #72978.

Discord support thread: https://discord.com/channels/1053877538025386074/1531439166871568394

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/slash_commands.py`: load and seed the persisted session prompt for manual `/compress`, then mark provider-less fallback rebuilds stale for real gateway surfaces.
- `tests/gateway/test_compress_command.py`: verify exact provider prompt retention, real platform construction, and the hygiene-only compression marker.

## How to Test

1. Start a gateway session with an external memory provider whose content is present in the persisted system prompt.
2. Run `/compress` after the transcript has enough content to compress.
3. Verify the compression agent receives the exact persisted prompt and the next live turn retains the provider content.
4. Run `tests/gateway/test_compress_command.py` and confirm `test_compress_command_preserves_persisted_provider_prompt` passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (static validation; regression execution delegated to CI)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing workflow or configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-independent gateway logic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Local validation:

- `python -m py_compile gateway/slash_commands.py tests/gateway/test_compress_command.py`
- `python scripts/check-windows-footguns.py gateway/slash_commands.py tests/gateway/test_compress_command.py`
- `git diff --check`

Pytest was not run locally due to this workstation's resource-safety constraint. The focused regression is included for GitHub CI.
