### PR TITLE
fix(cli): resolve deferred platform plugin for its top-level CLI command (salvage #54717)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -15245,6 +15245,35 @@ def _plugin_cli_discovery_needed() -> bool:
     return True
 
 
+def _resolve_deferred_platform_cli_command(command_name: str | None) -> None:
+    """Materialize the deferred platform whose top-level CLI command matches.
+
+    Bundled platform plugins are cheap-registered as *deferred* entries to
+    avoid importing every gateway SDK during normal startup. A platform that
+    registers a top-level ``hermes <name>`` command (e.g. Photon ->
+    ``ctx.register_cli_command(name="photon", ...)``) only runs that side
+    effect when its module is imported. On the unknown-top-level-command slow
+    path, ``discover_plugins()`` records the deferred loader but does not
+    import it, so the CLI registration never happens and ``hermes photon``
+    fails with argparse ``invalid choice`` (issue #54678).
+
+    Resolving only the platform whose name matches the first positional token
+    keeps normal startup cheap while making the targeted command available.
+    """
+    if not command_name:
+        return
+    try:
+        from gateway.platform_registry import platform_registry
+
+        platform_registry.get(command_name)
+    except Exception as exc:
+        logging.getLogger(__name__).debug(
+            "Deferred platform CLI resolution failed for %s: %s",
+            command_name,
+            exc,
+        )
+
+
 _AGENT_COMMANDS = {None, "chat", "acp", "rl"}
 _AGENT_SUBCOMMANDS = {
     "cron": ("cron_command", {"run", "tick"}),
@@ -16105,6 +16134,11 @@ def main():
                 seen_plugin_commands.add(cmd_info["name"])
 
             discover_plugins()
+            # A bundled platform whose top-level CLI command is the one being
+            # invoked is still only a deferred entry at this point; import it
+            # so its register_cli_command side effect runs before we read
+            # _cli_commands (issue #54678).
+            _resolve_deferred_platform_cli_command(_first_positional_argv())
             for cmd_info in get_plugin_manager()._cli_commands.values():
                 if cmd_info["name"] in seen_plugin_commands:
                     continue

--- a/tests/hermes_cli/test_startup_plugin_gating.py
+++ b/tests/hermes_cli/test_startup_plugin_gating.py
@@ -32,6 +32,7 @@ from hermes_cli.main import (
     _BUILTIN_SUBCOMMANDS,
     _first_positional_argv,
     _plugin_cli_discovery_needed,
+    _resolve_deferred_platform_cli_command,
 )
 
 
@@ -178,3 +179,73 @@ def test_builtin_set_has_no_phantom_entries():
         f"_BUILTIN_SUBCOMMANDS has entries that are not registered as "
         f"top-level subparsers: {sorted(phantom)}"
     )
+
+
+# ── _resolve_deferred_platform_cli_command (issue #54678) ──────────────────
+
+
+def test_deferred_platform_cli_resolution_targets_matching_platform():
+    """The slow path must import the deferred platform whose name matches the
+    invoked command, so its register_cli_command side effect fires.
+
+    Photon registers ``hermes photon`` only when its adapter module is
+    imported; on the unknown-command slow path the platform is still a
+    deferred entry, so without this resolution step the CLI command stays
+    absent and argparse rejects ``photon`` (issue #54678).
+    """
+    from hermes_cli import main as _main
+
+    class _FakeRegistry:
+        def __init__(self):
+            self.resolved: list[str] = []
+
+        def get(self, name):
+            self.resolved.append(name)
+            return None
+
+    fake = _FakeRegistry()
+    fake_module = type(sys)("gateway.platform_registry")
+    fake_module.platform_registry = fake
+    with patch.dict(sys.modules, {"gateway.platform_registry": fake_module}):
+        _resolve_deferred_platform_cli_command("photon")
+
+    assert fake.resolved == ["photon"]
+
+
+def test_deferred_platform_cli_resolution_ignores_empty_command():
+    """A None/empty first token (bare ``hermes`` / flags only) must not touch
+    the registry — normal startup stays cheap."""
+    from hermes_cli import main as _main
+
+    class _FakeRegistry:
+        def __init__(self):
+            self.resolved: list[str] = []
+
+        def get(self, name):  # pragma: no cover - must not be called
+            self.resolved.append(name)
+            return None
+
+    fake = _FakeRegistry()
+    fake_module = type(sys)("gateway.platform_registry")
+    fake_module.platform_registry = fake
+    with patch.dict(sys.modules, {"gateway.platform_registry": fake_module}):
+        _resolve_deferred_platform_cli_command(None)
+        _resolve_deferred_platform_cli_command("")
+
+    assert fake.resolved == []
+
+
+def test_deferred_platform_cli_resolution_swallows_registry_errors():
+    """A registry/import failure must be logged-and-ignored, never crash the
+    CLI startup path."""
+    from hermes_cli import main as _main
+
+    class _BoomRegistry:
+        def get(self, name):
+            raise RuntimeError("boom")
+
+    fake_module = type(sys)("gateway.platform_registry")
+    fake_module.platform_registry = _BoomRegistry()
+    with patch.dict(sys.modules, {"gateway.platform_registry": fake_module}):
+        # Must not raise.
+        _resolve_deferred_platform_cli_command("photon")

--- a/tests/hermes_cli/test_startup_plugin_gating.py
+++ b/tests/hermes_cli/test_startup_plugin_gating.py
@@ -249,3 +249,79 @@ def test_deferred_platform_cli_resolution_swallows_registry_errors():
     with patch.dict(sys.modules, {"gateway.platform_registry": fake_module}):
         # Must not raise.
         _resolve_deferred_platform_cli_command("photon")
+
+
+def test_deferred_platform_loader_registers_cli_command_before_parser_table():
+    """Fake deferred loader must resolve through real registry + register CLI
+    before argparse builds plugin command subparsers (issue #54678 review).
+
+    Existing unit tests mock ``platform_registry.get`` and only assert the
+    helper calls it. This regression exercises the full chain hermes-sweeper
+    asked for:
+
+    1. a deferred platform loader is pending on a real ``PlatformRegistry``
+    2. that loader materializes a ``register_cli_command`` side effect on the
+       plugin manager (no Photon SDK import)
+    3. ``_resolve_deferred_platform_cli_command`` runs the pending loader
+    4. the registered command is present on the manager *and* visible as an
+       argparse subparser/choice after the same construction path ``main()``
+       uses for plugin CLI commands
+    """
+    import argparse
+
+    from gateway.platform_registry import PlatformRegistry
+    from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+    mgr = PluginManager()
+    manifest = PluginManifest(name="fake-photon-platform")
+    command_name = "fakephoton"
+
+    def _fake_loader():
+        # Mirrors what a real platform adapter does on import: register its
+        # top-level hermes <name> CLI command via PluginContext.
+        ctx = PluginContext(manifest, mgr)
+        ctx.register_cli_command(
+            name=command_name,
+            help="Fake deferred platform CLI (test-only)",
+            setup_fn=lambda p: None,
+            description="Hermetic stand-in for deferred platform CLI registration",
+        )
+
+    registry = PlatformRegistry()
+    registry.register_deferred(command_name, _fake_loader)
+
+    # Precondition: deferred is known, but CLI command is not yet registered.
+    assert registry.is_registered(command_name)
+    assert command_name not in mgr._cli_commands
+    assert command_name in registry._deferred
+
+    fake_module = type(sys)("gateway.platform_registry")
+    fake_module.platform_registry = registry
+    with patch.dict(sys.modules, {"gateway.platform_registry": fake_module}):
+        _resolve_deferred_platform_cli_command(command_name)
+
+    # Loader resolution must promote deferred -> concrete and fire CLI register.
+    assert command_name not in registry._deferred
+    assert command_name in mgr._cli_commands
+    cmd_info = mgr._cli_commands[command_name]
+    assert cmd_info["name"] == command_name
+    assert cmd_info["plugin"] == "fake-photon-platform"
+
+    # Same parser-table assembly main() uses after reading _cli_commands.
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    for info in mgr._cli_commands.values():
+        plugin_parser = subparsers.add_parser(
+            info["name"],
+            help=info["help"],
+            description=info.get("description", ""),
+        )
+        info["setup_fn"](plugin_parser)
+        if info.get("handler_fn") is not None:
+            plugin_parser.set_defaults(func=info["handler_fn"])
+
+    # argparse surface: choices + parse success.
+    choices = getattr(subparsers, "choices", None) or {}
+    assert command_name in choices
+    parsed = parser.parse_args([command_name])
+    assert parsed.command == command_name


### PR DESCRIPTION
## Summary
`hermes photon` (and any future platform plugin's top-level CLI command) works again — the deferred platform lazy-loader now fires for the one platform whose name matches the invoked command, so its `register_cli_command()` side effect runs before argparse builds the subparser table.

Root cause: PR #54448 made bundled `kind: platform` plugins lazy-load (deferred registry loaders) to cut startup time. Photon is the only platform that registers a top-level `hermes <name>` CLI command inside its plugin `register()`, so deferral silently unregistered `hermes photon` — argparse rejects it with `invalid choice` (issue #54678, reported again by TheSameCat on X, July 28). The docs were correct; the command had vanished.

Salvages PR #54717 by @Bartok9 (earliest fix, June 29) onto current main with authorship preserved.

## Changes
- `hermes_cli/main.py`: new `_resolve_deferred_platform_cli_command()` — on the unknown-top-level-command slow path, after `discover_plugins()`, resolve the deferred platform matching the first positional argv token via `platform_registry.get()` so its loader imports the module and registers the CLI command. Only the matched platform loads; errors are logged-and-swallowed.
- `tests/hermes_cli/test_startup_plugin_gating.py`: 4 regression tests, including a hermetic full-chain test (real `PlatformRegistry` + real `PluginManager` + fake deferred loader → CLI command visible in argparse choices) — no Photon SDK import.

## Validation
| | Before | After |
|---|---|---|
| `hermes photon --help` | `invalid choice: 'photon'` | full subcommand help |
| `hermes photon status` (temp HERMES_HOME) | unreachable | correct status table, exit 0 |
| `hermes version` fast path | ~0.2s | ~0.2s (unchanged — resolution only runs on the unknown-command slow path) |
| `test_startup_plugin_gating.py` | — | 41/41 |
| `test_plugin_cli_registration.py` + `tests/plugins/platforms/photon/` | — | 119/119 |

Fixes #54678.

## Infographic

![hermes photon command restored](https://v3b.fal.media/files/b/0aa416af/SwTTCDPhXXVF-2YEZfYH__uWNQbrkH.png)
