### PR TITLE
fix(honcho): enforce transcript write containment

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -29,6 +29,22 @@ from tools.registry import tool_error
 logger = logging.getLogger(__name__)
 
 
+_INTERNAL_GATEWAY_TURN_RE = re.compile(
+    r"^\s*(?:"
+    r"\[ASYNC (?:DELEGATION )?(?:BATCH )?COMPLETE[^\]]*\]|"
+    r"\[CONTEXT COMPACTION(?:\s*[—-]\s*REFERENCE ONLY)?\]|"
+    r"\[PRIOR CONTEXT(?:\s*[—-]\s*FOR REFERENCE ONLY)?\]|"
+    r"\[Your active task list was preserved across context compression\]"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _is_internal_gateway_turn(text: str) -> bool:
+    """Return whether text is a machine-generated gateway notification."""
+    return bool(_INTERNAL_GATEWAY_TURN_RE.match(text or ""))
+
+
 # ---------------------------------------------------------------------------
 # Tool schemas (moved from tools/honcho_tools.py)
 # ---------------------------------------------------------------------------
@@ -1333,6 +1349,11 @@ class HonchoMemoryProvider(MemoryProvider):
         """
         if self._cron_skipped:
             return
+        if self._config and not getattr(self._config, "save_messages", True):
+            return
+        if _is_internal_gateway_turn(user_content):
+            logger.debug("Honcho sync skipped machine-generated gateway turn")
+            return
         if self._recall_mode == "tools" and not self._session_ready():
             return
         if not self._session_ready():
@@ -1342,6 +1363,8 @@ class HonchoMemoryProvider(MemoryProvider):
         msg_limit = self._config.message_max_chars if self._config else 25000
         clean_user_content = sanitize_context(user_content or "").strip()
         clean_assistant_content = sanitize_context(assistant_content or "").strip()
+        if not clean_user_content or not clean_assistant_content:
+            return
 
         def _sync():
             try:

--- a/tests/test_honcho_startup_fail_open.py
+++ b/tests/test_honcho_startup_fail_open.py
@@ -405,6 +405,124 @@ def test_honcho_tools_eager_init_failure_does_not_leave_ready_manager(monkeypatc
     assert provider._manager is None
 
 
+def test_honcho_sync_turn_skips_write_when_save_messages_is_disabled():
+    """The resolved write-disable switch must gate an initialized provider."""
+    provider = HonchoMemoryProvider()
+    cfg = _configured_tools_config(init_on_session_start=True)
+    cfg.save_messages = False
+    manager_calls = []
+
+    class Manager:
+        def get_or_create(self, session_key):
+            manager_calls.append(session_key)
+            return SimpleNamespace()
+
+    provider._config = cfg
+    provider._manager = Manager()
+    provider._session_key = "test-session"
+    provider._session_initialized = True
+
+    provider.sync_turn("a genuine user turn", "a genuine assistant reply")
+
+    assert provider._sync_thread is None
+    assert manager_calls == []
+
+
+def test_honcho_sync_turn_skips_anchored_gateway_notifications():
+    """Known bracketed gateway wrappers must not become durable messages."""
+    wrappers = (
+        "[ASYNC DELEGATION BATCH COMPLETE]\nworker results follow",
+        "[CONTEXT COMPACTION — REFERENCE ONLY]\nsummary follows",
+        "[PRIOR CONTEXT — FOR REFERENCE ONLY]\nprior session details",
+        "[Your active task list was preserved across context compression]",
+    )
+
+    for wrapper in wrappers:
+        provider = HonchoMemoryProvider()
+        manager_calls = []
+
+        class Manager:
+            def get_or_create(self, session_key):
+                manager_calls.append(session_key)
+                return SimpleNamespace()
+
+        provider._config = _configured_tools_config(init_on_session_start=True)
+        provider._manager = Manager()
+        provider._session_key = "test-session"
+        provider._session_initialized = True
+
+        provider.sync_turn(wrapper, "Thanks for the update.")
+
+        assert provider._sync_thread is None
+        assert manager_calls == []
+
+
+def test_honcho_sync_turn_keeps_human_background_status_discussion():
+    """A human discussing a background process is not a gateway wrapper."""
+    provider = HonchoMemoryProvider()
+    manager_calls = []
+
+    class Manager:
+        def get_or_create(self, session_key):
+            manager_calls.append(session_key)
+            return SimpleNamespace()
+
+    provider._config = _configured_tools_config(init_on_session_start=True)
+    provider._manager = Manager()
+    provider._session_key = "test-session"
+    provider._session_initialized = True
+
+    provider.sync_turn(
+        "A background process has finished. I want to discuss its result.",
+        "Let's review it together.",
+    )
+    provider._sync_thread.join(timeout=1)
+
+    assert manager_calls == ["test-session"]
+
+
+def test_honcho_sync_turn_skips_empty_sanitized_turn():
+    """Context-only turns must not create a partial durable record."""
+    provider = HonchoMemoryProvider()
+    manager_calls = []
+
+    class Manager:
+        def get_or_create(self, session_key):
+            manager_calls.append(session_key)
+            return SimpleNamespace()
+
+    provider._config = _configured_tools_config(init_on_session_start=True)
+    provider._manager = Manager()
+    provider._session_key = "test-session"
+    provider._session_initialized = True
+
+    provider.sync_turn("", "A response without a user message.")
+
+    assert provider._sync_thread is None
+    assert manager_calls == []
+
+
+def test_honcho_sync_turn_skips_empty_assistant_content():
+    """A user turn without a usable reply must not be persisted alone."""
+    provider = HonchoMemoryProvider()
+    manager_calls = []
+
+    class Manager:
+        def get_or_create(self, session_key):
+            manager_calls.append(session_key)
+            return SimpleNamespace()
+
+    provider._config = _configured_tools_config(init_on_session_start=True)
+    provider._manager = Manager()
+    provider._session_key = "test-session"
+    provider._session_initialized = True
+
+    provider.sync_turn("A valid user turn.", "   ")
+
+    assert provider._sync_thread is None
+    assert manager_calls == []
+
+
 def test_honcho_tools_lazy_hooks_do_not_prestart_background_init(monkeypatch):
     """tools lazy mode lets the first tool call own session initialization."""
     provider = HonchoMemoryProvider()


### PR DESCRIPTION
## Summary
- enforce the resolved `saveMessages: false` gate at `HonchoMemoryProvider.sync_turn()` before session or network work
- exclude known bracketed gateway/control-plane wrapper turns from automatic transcript persistence
- avoid partial durable records when either sanitized turn side is empty
- preserve ordinary human discussion of background-process status

## Verification
- focused containment tests: 5 passed
- relevant Honcho suites: 261 passed
- broader Honcho selection: 517 passed, 2 skipped (pre-existing warning-only output)
- independent review: passed after a false-positive matcher finding was corrected

## Operational notes
- no direct writes to `main`
- no auto-merge
- explicit/manual Honcho conclusion writes remain intentionally unchanged; this PR gates automatic transcript persistence only
