### PR TITLE
feat(cron): dead-pin guard — auto-pause + alert on missing script

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2750,6 +2750,141 @@ def _guard_job_credential_exfil(job: dict) -> None:
         raise RuntimeError(f"Cron job '{job_id}' blocked for safety: {err}")
 
 
+# Channel id for the #critical-alerts Discord channel, the structural
+# complement to #critical-alerts: scheduler-level faults that must never sit
+# silent (the missing-script "dead-pin" black-hole class) are routed here.
+# Reused by the dead-pin guard below. Do not invent a new channel — this is
+# the one the dqsh_audit_watchdog cron (0ead099b5eac) and other critical
+# alerts already target.
+_CRITICAL_ALERTS_CHANNEL_ID = "1521973787363508325"  # #critical-alerts (Discord)
+
+
+def _is_missing_script_error(script_output: str) -> bool:
+    """Return True if a ``_run_job_script`` failure is the missing-file class.
+
+    The missing-file class is ``"Script not found: <path>"`` (file absent) or
+    ``"Script path is not a file: <path>"`` (path exists but is not a regular
+    file, e.g. a directory). These are *permanent* misconfigurations — the job
+    will never run until the operator fixes the path — so they warrant an
+    auto-pause. Transient failures (non-zero exit, timeout, execution error)
+    are deliberately excluded: a script that exists but crashed this tick
+    should keep firing so a fixed version resumes and so we don't mask a real
+    error behind a paused job.
+    """
+    if not script_output:
+        return False
+    lowered = script_output.lower()
+    return "script not found" in lowered or "not a file" in lowered
+
+
+def _alert_critical_alerts(message: str) -> None:
+    """Best-effort delivery of ``message`` to the #critical-alerts Discord channel.
+
+    This is the LOUD escape hatch for scheduler-level faults that must never
+    sit silent (the missing-script black-hole class). It prefers the gateway's
+    live Discord adapter when available, then falls back to ``logger.critical``
+    rather than raising — the operator still sees it in the scheduler log, and
+    the failure to alert is itself logged.
+
+    Fail-safe by design: a broken alert path must NEVER crash the scheduler
+    tick or prevent due jobs from running.
+    """
+    try:
+        from gateway.config import load_gateway_config, Platform
+        from tools.send_message_tool import _send_to_platform
+
+        config = load_gateway_config()
+        platform = Platform.DISCORD
+        pconfig = config.platforms.get(platform)
+        if pconfig and getattr(pconfig, "enabled", False):
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = None
+
+            async def _emit() -> None:
+                await _send_to_platform(
+                    "discord",
+                    pconfig,
+                    _CRITICAL_ALERTS_CHANNEL_ID,
+                    message,
+                )
+
+            if loop is not None and loop.is_running():
+                asyncio.ensure_future(_emit())
+            else:
+                try:
+                    asyncio.run(_emit())
+                except RuntimeError:
+                    def _run() -> None:
+                        try:
+                            asyncio.run(_emit())
+                        except Exception:
+                            logger.exception("critical-alerts preflight send failed")
+                    try:
+                        concurrent.futures.ThreadPoolExecutor(max_workers=1).submit(_run)
+                    except Exception:
+                        logger.exception("critical-alerts preflight send failed")
+            return
+        else:
+            logger.warning(
+                "Discord not enabled — cannot route #critical-alerts preflight; "
+                "emitting via logger.critical instead"
+            )
+    except Exception:
+        logger.exception("Failed to deliver #critical-alerts preflight; logging instead")
+
+    # Hard fallback: the alert is always visible in the scheduler log even if
+    # Discord delivery is unavailable.
+    logger.critical("%s", message)
+
+
+def _handle_cron_dead_pin(job: dict, script_path: str, script_output: str) -> None:
+    """Alert #critical-alerts and auto-pause a job whose script is missing.
+
+    Called from both the no_agent and LLM fire paths when ``_run_job_script``
+    fails with the missing-file class. Only missing-file failures auto-pause;
+    transient failures (non-zero exit, timeout) alert (via the caller's normal
+    error path) but keep firing.
+
+    The job's schedule is left untouched — only the broken job is paused,
+    pending operator fix + resume. This is the structural fix for the
+    silent-dead-pin incident class (e.g. a job failing for days with no alert).
+    """
+    job_id = job["id"]
+    job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
+    now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
+
+    alert = (
+        f"⚠ Cron dead-pin: job '{job_name}' references a script that does not exist.\n\n"
+        f"Job ID: {job_id}\n"
+        f"Script: {script_path}\n"
+        f"Script error: {script_output}\n\n"
+        f"Time: {now_iso}\n\n"
+        f"The job has been AUTO-PAUSED to stop the silent failure. Fix the script "
+        f"path (or restore the file) and resume it with "
+        f"cronjob(action='update', job_id='{job_id}', script='<correct path>') "
+        f"or cronjob(action='resume', job_id='{job_id}')."
+    )
+    _alert_critical_alerts(alert)
+
+    reason = f"dead-pin: script not found: {script_path}"
+    try:
+        from cron.jobs import pause_job
+        paused = pause_job(job_id, reason=reason)
+        if paused is None:
+            logger.warning(
+                "Dead-pin auto-pause: job '%s' not found (already removed?)", job_id
+            )
+        else:
+            logger.warning(
+                "Dead-pin auto-pause: job '%s' (%s) paused — %s", job_id, job_name, reason
+            )
+    except Exception as e:
+        # Never let a pause failure crash the tick; the alert already fired.
+        logger.error("Dead-pin auto-pause failed for job '%s': %s", job_id, e)
+
+
 def run_job(
     job: dict, *, defer_agent_teardown: Optional[list] = None
 ) -> tuple[bool, str, str, Optional[str]]:
@@ -2838,6 +2973,11 @@ def run_job(
                 f"**Status:** script failed\n\n"
                 f"{output}\n"
             )
+            # Dead-pin guard: a missing script (not a transient crash) must not
+            # fail silently forever. Alert #critical-alerts AND auto-pause the
+            # broken job so the operator sees it and fixes it.
+            if _is_missing_script_error(output):
+                _handle_cron_dead_pin(job, script_path, output)
             return False, doc, alert, output
 
         # Honour the wakeAgent gate as a silent signal — `wakeAgent: false`
@@ -2960,6 +3100,14 @@ def run_job(
     if script_path:
         prerun_script = _run_job_script_with_claim_heartbeat(job, script_path)
         _ran_ok, _script_output = prerun_script
+        if _is_missing_script_error(_script_output):
+            # Dead-pin guard (LLM path): the script is missing. The prompt
+            # builder will still inject a "## Script Error" block so the agent
+            # reports it, but a missing-file failure must ALSO escalate:
+            # alert #critical-alerts and auto-pause the job so it stops
+            # silently failing. We fire it once here (on the pre-check run)
+            # rather than inside _build_job_prompt to avoid double-handling.
+            _handle_cron_dead_pin(job, script_path, _script_output)
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info(
                 "Job '%s' (ID: %s): wakeAgent=false, skipping agent run",

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -364,6 +364,9 @@ class TestCronjobToolScript:
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob
 
+        # Dead-pin guard: the script file must exist on disk at create time.
+        (cron_env / "scripts" / "monitor.py").write_text('print("ok")\n')
+
         result = json.loads(cronjob(
             action="create",
             schedule="every 1h",
@@ -384,6 +387,9 @@ class TestCronjobToolScript:
         ))
         job_id = create_result["job_id"]
 
+        # Dead-pin guard: the new script must exist on disk at update time.
+        (cron_env / "scripts" / "new_script.py").write_text('print("ok")\n')
+
         update_result = json.loads(cronjob(
             action="update",
             job_id=job_id,
@@ -395,6 +401,9 @@ class TestCronjobToolScript:
     def test_clear_script(self, cron_env, monkeypatch):
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob
+
+        # Dead-pin guard: the initial script must exist on disk at create time.
+        (cron_env / "scripts" / "some_script.py").write_text('print("ok")\n')
 
         create_result = json.loads(cronjob(
             action="create",
@@ -415,6 +424,9 @@ class TestCronjobToolScript:
     def test_list_shows_script(self, cron_env, monkeypatch):
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob
+
+        # Dead-pin guard: the script must exist on disk at create time.
+        (cron_env / "scripts" / "data_collector.py").write_text('print("ok")\n')
 
         cronjob(
             action="create",
@@ -583,6 +595,9 @@ class TestCronjobToolScriptValidation:
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob
 
+        # Dead-pin guard: the script file must exist on disk at create time.
+        (cron_env / "scripts" / "monitor.py").write_text('print("ok")\n')
+
         result = json.loads(cronjob(
             action="create",
             schedule="every 1h",
@@ -616,6 +631,9 @@ class TestCronjobToolScriptValidation:
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob
 
+        # Dead-pin guard: the initial script must exist on disk at create time.
+        (cron_env / "scripts" / "monitor.py").write_text('print("ok")\n')
+
         create_result = json.loads(cronjob(
             action="create",
             schedule="every 1h",
@@ -643,6 +661,84 @@ class TestCronjobToolScriptValidation:
             script="C:\\Users\\evil\\script.py",
         ))
         assert result["success"] is False
+
+
+class TestDeadPinGuardEnableTime:
+    """Dead-pin guard (enable-time): a script file that does not exist on disk
+    must be rejected at create/update time with a clear error.
+
+    This closes the silent-failure class where a job is created pointing at a
+    non-existent script and then fails every tick with no operator feedback.
+    """
+
+    def test_create_rejects_nonexistent_script(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Monitor things",
+            script="does_not_exist.py",
+        ))
+        assert result["success"] is False
+        # Clear, actionable error naming the dead-pin.
+        err = result["error"].lower()
+        assert "not found" in err or "not exist" in err or "dead-pin" in err
+
+    def test_update_rejects_nonexistent_script(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        create_result = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Monitor things",
+        ))
+        job_id = create_result["job_id"]
+
+        update_result = json.loads(cronjob(
+            action="update",
+            job_id=job_id,
+            script="vanished.py",
+        ))
+        assert update_result["success"] is False
+        err = update_result["error"].lower()
+        assert "not found" in err or "not exist" in err or "dead-pin" in err
+
+    def test_update_rejects_nonexistent_subdir_script(self, cron_env, monkeypatch):
+        """A missing script nested in a subdir must also be rejected."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        create_result = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Monitor things",
+        ))
+        job_id = create_result["job_id"]
+
+        update_result = json.loads(cronjob(
+            action="update",
+            job_id=job_id,
+            script="monitors/vanished.py",
+        ))
+        assert update_result["success"] is False
+
+    def test_create_allows_existing_script(self, cron_env, monkeypatch):
+        """A script that exists on disk is accepted (no regression)."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        (cron_env / "scripts" / "exists.py").write_text('print("ok")\n')
+        result = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Monitor things",
+            script="exists.py",
+        ))
+        assert result["success"] is True
+        assert result["job"]["script"] == "exists.py"
 
 
 class TestRunJobEnvVarCleanup:

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -780,3 +780,108 @@ class TestRunJobEnvVarCleanup:
         assert os.environ.get("HERMES_SESSION_PLATFORM") is None
         assert os.environ.get("HERMES_SESSION_CHAT_ID") is None
         assert os.environ.get("HERMES_SESSION_CHAT_NAME") is None
+
+
+class TestRunJobDeadPinFireTime:
+    """Fire-time dead-pin behavior: a missing script auto-pauses the job;
+    a transient failure (non-zero exit) alerts but does NOT auto-pause.
+
+    These exercise the real ``run_job`` entry point (no_agent path) so the
+    acceptance criteria are proven end-to-end, not just the helper.
+    """
+
+    def _make_job(self, cron_env, monkeypatch, script, no_agent=True):
+        import json as _json
+        from tools.cronjob_tools import cronjob
+
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        # Create time uses the enable-time guard, so seed an existing script.
+        (cron_env / "scripts" / "seed.py").write_text('print("ok")\n')
+        created = _json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="probe",
+            script="seed.py",
+            no_agent=no_agent,
+        ))
+        job_id = created["job_id"]
+        # Now point the job at the (possibly missing) script directly in the
+        # persisted store, bypassing the enable-time guard, and read it back.
+        from cron.jobs import update_job, get_job
+        update_job(job_id, {"script": script, "no_agent": no_agent})
+        job = get_job(job_id)
+        assert job is not None
+        return job
+
+    def test_missing_script_autopauses_no_agent(self, cron_env, monkeypatch):
+        from cron.scheduler import run_job
+        from cron.jobs import get_job
+
+        job = self._make_job(cron_env, monkeypatch, "vanished.py", no_agent=True)
+        job_id = job["id"]
+
+        success, doc, response, err = run_job(job)
+        assert success is False
+        assert "Script not found" in err
+
+        paused = get_job(job_id)
+        assert paused["enabled"] is False
+        assert paused["state"] == "paused"
+        assert paused["paused_reason"].startswith("dead-pin: script not found:")
+        # Schedule is untouched — only the broken job is paused.
+        assert paused["schedule"] is not None
+
+    def test_not_a_file_autopauses(self, cron_env, monkeypatch):
+        from cron.scheduler import run_job
+        from cron.jobs import get_job
+
+        # Create a directory at the target path so it "exists but is not a file".
+        (cron_env / "scripts" / "adir").mkdir()
+        job = self._make_job(cron_env, monkeypatch, "adir", no_agent=True)
+        job_id = job["id"]
+
+        success, doc, response, err = run_job(job)
+        assert success is False
+        assert "not a file" in err
+
+        paused = get_job(job_id)
+        assert paused["enabled"] is False
+        assert paused["state"] == "paused"
+
+    def test_transient_failure_does_not_autopause(self, cron_env, monkeypatch):
+        from cron.scheduler import run_job
+        from cron.jobs import get_job
+
+        script = cron_env / "scripts" / "boom.py"
+        script.write_text("import sys\nsys.exit(3)\n")
+        job = self._make_job(cron_env, monkeypatch, "boom.py", no_agent=True)
+        job_id = job["id"]
+
+        success, doc, response, err = run_job(job)
+        assert success is False
+        assert "exited with code 3" in err
+
+        still_enabled = get_job(job_id)
+        # Transient failure must NOT auto-pause: the job keeps firing.
+        assert still_enabled["state"] != "paused"
+        assert still_enabled["enabled"] is True
+
+    def test_missing_script_autopauses_llm_path(self, cron_env, monkeypatch):
+        """LLM path (no_agent=False) also auto-pauses on a missing script."""
+        from cron.scheduler import run_job
+        from cron.jobs import get_job
+
+        job = self._make_job(cron_env, monkeypatch, "gone.py", no_agent=False)
+        job_id = job["id"]
+
+        # LLM path will fail downstream (no model), but the dead-pin guard
+        # must have already fired during the pre-check script run.
+        try:
+            run_job(job)
+        except Exception:
+            pass
+
+        paused = get_job(job_id)
+        assert paused["enabled"] is False
+        assert paused["state"] == "paused"
+        assert paused["paused_reason"].startswith("dead-pin: script not found:")

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -741,6 +741,45 @@ class TestDeadPinGuardEnableTime:
         assert result["job"]["script"] == "exists.py"
 
 
+class TestValidateCronScriptPathDeadPin:
+    """Unit-level dead-pin guard for the API-boundary validator.
+
+    Complements TestDeadPinGuardEnableTime (which drives the full ``cronjob``
+    tool end-to-end). These tests pin the exact contract of
+    ``_validate_cron_script_path`` so a regression in the guard surfaces even
+    if the tool's error plumbing changes. This is the ``_validate_cron_script_path``-
+    equivalent named in the task spec for requirement (1).
+    """
+
+    def test_rejects_nonexistent_script(self, cron_env):
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        err = _validate_cron_script_path("does_not_exist.py")
+        assert err is not None
+        low = err.lower()
+        assert "not found" in low or "dead-pin" in low
+
+    def test_rejects_nonexistent_subdir_script(self, cron_env):
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        err = _validate_cron_script_path("monitors/vanished.py")
+        assert err is not None
+
+    def test_allows_existing_script(self, cron_env):
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        (cron_env / "scripts" / "exists.py").write_text('print("ok")\n')
+        assert _validate_cron_script_path("exists.py") is None
+
+    def test_empty_script_is_none(self, cron_env):
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        # Empty / None / whitespace = clearing the field, always allowed.
+        assert _validate_cron_script_path("") is None
+        assert _validate_cron_script_path(None) is None
+        assert _validate_cron_script_path("   ") is None
+
+
 class TestRunJobEnvVarCleanup:
     """Test that run_job() env vars are cleaned up even on early failure."""
 
@@ -830,6 +869,67 @@ class TestRunJobDeadPinFireTime:
         assert paused["paused_reason"].startswith("dead-pin: script not found:")
         # Schedule is untouched — only the broken job is paused.
         assert paused["schedule"] is not None
+
+    def test_missing_script_delivers_alert_no_agent(self, cron_env, monkeypatch):
+        """Requirement (2a): a missing script must deliver a #critical-alerts ping.
+
+        Auto-pause alone is not enough — the incident class this closes is the
+        *silent* failure. We assert the alert was actually emitted, not merely
+        that the job got paused.
+        """
+        import cron.scheduler as sched_mod
+        from cron.scheduler import run_job
+        from cron.jobs import get_job
+
+        alerts = []
+        monkeypatch.setattr(sched_mod, "_alert_critical_alerts", alerts.append)
+
+        job = self._make_job(cron_env, monkeypatch, "vanished.py", no_agent=True)
+        job_id = job["id"]
+
+        success, doc, response, err = run_job(job)
+        assert success is False
+        assert "Script not found" in err
+
+        # The alert was actually delivered (the structural fix for the silent
+        # dead-pin: the operator is paged, not left guessing).
+        assert alerts, "expected a #critical-alerts ping for a missing script"
+        assert any("dead-pin" in a.lower() for a in alerts)
+        # And the job is paused, as required by (2b).
+        paused = get_job(job_id)
+        assert paused["enabled"] is False
+        assert paused["paused_reason"].startswith("dead-pin: script not found:")
+
+    def test_transient_failure_no_deadpin_alert(self, cron_env, monkeypatch):
+        """Requirement (3): a non-missing failure must NOT raise a dead-pin alert.
+
+        A script that exists but crashes this tick must keep firing — a false
+        auto-pause would mask a real error behind a paused job and hide it the
+        same way the dead-pin class does. We assert no dead-pin alert fires and
+        the job stays enabled.
+        """
+        import cron.scheduler as sched_mod
+        from cron.scheduler import run_job
+        from cron.jobs import get_job
+
+        alerts = []
+        monkeypatch.setattr(sched_mod, "_alert_critical_alerts", alerts.append)
+
+        script = cron_env / "scripts" / "boom.py"
+        script.write_text("import sys\nsys.exit(3)\n")
+        job = self._make_job(cron_env, monkeypatch, "boom.py", no_agent=True)
+        job_id = job["id"]
+
+        success, doc, response, err = run_job(job)
+        assert success is False
+        assert "exited with code 3" in err
+
+        # Transient failure must NOT trigger the dead-pin alert.
+        assert not any("dead-pin" in a.lower() for a in alerts), \
+            "transient failure must not trigger the dead-pin alert"
+        still_enabled = get_job(job_id)
+        assert still_enabled["enabled"] is True
+        assert still_enabled["state"] != "paused"
 
     def test_not_a_file_autopauses(self, cron_env, monkeypatch):
         from cron.scheduler import run_job

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -519,6 +519,23 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
             f"Script path escapes the scripts directory via traversal: {raw!r}"
         )
 
+    # Dead-pin guard: the resolved script file must actually exist on disk.
+    # A job pointing at a non-existent script silently fails to fire forever
+    # (the incident class this closes). Reject at enable/update time so the
+    # operator learns about the missing file immediately, not days later.
+    # NOTE: this deliberately checks only the job-time path; the scheduler
+    # *also* re-checks at fire time (files can be deleted after creation), so
+    # a missing script is caught whether it vanished before or after enable.
+    resolved = (scripts_dir / raw)
+    if not resolved.exists() or not resolved.is_file():
+        return (
+            f"Script file not found: {raw!r}. "
+            f"Place the script in ~/.hermes/scripts/ (resolved: {resolved}) "
+            f"before creating/updating the job. "
+            f"A dead-pin (missing script) is rejected so the job does not "
+            f"fail silently at fire time."
+        )
+
     return None
 
 


### PR DESCRIPTION
## Summary
Carries the cron **dead-pin guard** (cron script path missing → auto-pause + critical-alert) into `main`. Source was green in the unmerged `wt/t_02f2bb64_control_center` worktree but never shipped to the live editable checkout, leaving the running agent unable to detect a dead/missing cron script — exactly the silent-failure class this guard prevents.

Scope is **only the 4 guard commits**, cherry-picked cleanly onto current `origin/main` (no conflict; the 3071-file control-center branch is excluded).

## Commits
- `774463d4f` feat(cron): reject missing script at create/update time (dead-pin enable-time guard)
- `fdf4f26b1` feat(cron): fire-time dead-pin alert + auto-pause for missing scripts
- `184f86309` test(cron): add fire-time dead-pin tests for run_job auto-pause behavior
- `53ebf7bd9` test(cron): add dead-pin alert-delivery + validator unit tests

## Acceptance evidence (pre-merge, on clean checkout of branch tip)
- `python3 -m pytest tests/cron/test_cron_script.py` → **52 passed, 0 failed** (dead-pin tests ≥ 14).
- `python3 -m py_compile cron/scheduler.py` → OK; no conflict markers.
- `grep -rci "dead.pin" --include=*.py` → scheduler.py=13, test_cron_script.py=24, cronjob_tools.py=2.
- `cron/scheduler.py` contains `_handle_cron_dead_pin` (def @2640) and `'dead-pin: script not found:'` pause reason (used @2777, @2907).
- Branch base is an ancestor of current `origin/main` → clean, conflict-free merge.

## Live verification (AC5 — post-merge/landing)
After this PR lands on the live editable checkout and the gateway restarts, verify the running agent auto-pauses + critical-alerts when a cron `script` path is missing. (Tracked separately by devops once merged.)

## Notes
- No credentials/secrets, no provider/model routing, no live trading, no prod trading deploy touched.
- Mirrors task t_23fc8d82 (jarvis-os). Parent verdict context: t_b50f908a (sycode-trading, eval-runner independent verdict).