### PR TITLE
fix(xai): voice auth correctness — key precedence, OAuth retry, provider hijack, base-URL pinning

### DIFF
--- a/contributors/emails/bensheridanedwards@gmail.com
+++ b/contributors/emails/bensheridanedwards@gmail.com
@@ -1,0 +1,2 @@
+BenSheridanEdwards
+# PR #68535 (stt: xAI OAuth retry)

--- a/contributors/emails/tobiassafaie@MacBook-Air-von-Tobias-3.local
+++ b/contributors/emails/tobiassafaie@MacBook-Air-von-Tobias-3.local
@@ -1,0 +1,1 @@
+muctobi

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4452,7 +4452,15 @@ def _save_xai_oauth_tokens(
     redirect_uri: str = "",
     last_refresh: Optional[str] = None,
     auth_mode: str = "oauth_device_code",
+    set_active: bool = True,
 ) -> None:
+    """Persist xAI OAuth tokens into the auth store.
+
+    When *set_active* is True (default), also promote ``xai-oauth`` to
+    ``active_provider`` — appropriate for intentional model/auth login.
+    Pass ``set_active=False`` for side-tool credential bootstrap (TTS, STT,
+    dashboard token save, token refresh) so inference routing is unchanged.
+    """
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     with _auth_store_lock():
@@ -4470,7 +4478,9 @@ def _save_xai_oauth_tokens(
             state["discovery"] = discovery
         if redirect_uri:
             state["redirect_uri"] = redirect_uri
-        _save_provider_state(auth_store, "xai-oauth", state)
+        _store_provider_state(
+            auth_store, "xai-oauth", state, set_active=set_active
+        )
         _save_auth_store(auth_store)
         if write_through_to_root:
             _write_through_xai_oauth_to_global_root(state)
@@ -4808,6 +4818,9 @@ def _refresh_xai_oauth_tokens(
         redirect_uri=redirect_uri,
         last_refresh=refreshed["last_refresh"],
         auth_mode=auth_mode,
+        # Refresh must not flip active_provider — TTS/side tools can refresh
+        # xAI tokens while chat still routes through another provider.
+        set_active=False,
     )
     return updated_tokens
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4458,8 +4458,9 @@ def _save_xai_oauth_tokens(
 
     When *set_active* is True (default), also promote ``xai-oauth`` to
     ``active_provider`` — appropriate for intentional model/auth login.
-    Pass ``set_active=False`` for side-tool credential bootstrap (TTS, STT,
-    dashboard token save, token refresh) so inference routing is unchanged.
+    Pass ``set_active=False`` for side-tool credential bootstrap (TTS/setup,
+    tools config, dashboard token save, token refresh) so inference routing
+    is unchanged.
     """
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -908,6 +908,7 @@ def _run_xai_oauth_login_from_setup() -> bool:
             _is_remote_session,
             _save_xai_oauth_tokens,
             _xai_oauth_device_code_login,
+            unsuppress_credential_source,
         )
     except Exception as exc:
         print_warning(f"xAI Grok OAuth helpers unavailable: {exc}")
@@ -926,6 +927,9 @@ def _run_xai_oauth_login_from_setup() -> bool:
             auth_mode="oauth_device_code",
             set_active=False,
         )
+        # Mirror model/dashboard re-login: clear device_code suppression so
+        # the pool can seed from the singleton after a prior `auth remove`.
+        unsuppress_credential_source("xai-oauth", "device_code")
         return True
     except Exception as exc:
         print_warning(f"xAI Grok OAuth login failed: {exc}")

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -896,15 +896,17 @@ def _xai_oauth_logged_in_for_setup() -> bool:
 def _run_xai_oauth_login_from_setup() -> bool:
     """Run the xAI Grok OAuth device-code login from inside the setup wizard.
 
+    Saves OAuth tokens only. Does **not** switch the active inference
+    provider or rewrite ``model.provider`` — callers (TTS setup, tools
+    config) only need credentials for side tools.
+
     Returns True on success, False on any failure (the caller falls back
     to whatever the user picked next, e.g. Edge TTS).
     """
     try:
         from hermes_cli.auth import (
-            DEFAULT_XAI_OAUTH_BASE_URL,
             _is_remote_session,
             _save_xai_oauth_tokens,
-            _update_config_for_provider,
             _xai_oauth_device_code_login,
         )
     except Exception as exc:
@@ -922,9 +924,7 @@ def _run_xai_oauth_login_from_setup() -> bool:
             redirect_uri=creds.get("redirect_uri", ""),
             last_refresh=creds.get("last_refresh"),
             auth_mode="oauth_device_code",
-        )
-        _update_config_for_provider(
-            "xai-oauth", creds.get("base_url", DEFAULT_XAI_OAUTH_BASE_URL)
+            set_active=False,
         )
         return True
     except Exception as exc:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11134,6 +11134,9 @@ def _xai_device_poller(session_id: str) -> None:
                 discovery=discovery,
                 last_refresh=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
                 auth_mode="oauth_device_code",
+                # Dashboard OAuth only bootstraps credentials for side tools;
+                # do not hijack the active chat inference provider.
+                set_active=False,
             )
             # The singleton write above is the single source of truth: the
             # credential-pool load seeds it as the canonical ``device_code``

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11098,6 +11098,7 @@ def _xai_device_poller(session_id: str) -> None:
         _save_xai_oauth_tokens,
         _xai_oauth_discovery,
         _xai_oauth_poll_device_token,
+        mark_provider_active_if_unset,
         unsuppress_credential_source,
     )
 
@@ -11134,10 +11135,13 @@ def _xai_device_poller(session_id: str) -> None:
                 discovery=discovery,
                 last_refresh=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
                 auth_mode="oauth_device_code",
-                # Dashboard OAuth only bootstraps credentials for side tools;
-                # do not hijack the active chat inference provider.
+                # Persist credentials without hijacking an existing active
+                # chat provider.
                 set_active=False,
             )
+            # Mirror `hermes auth add xai-oauth`: first credential may become
+            # active when none is set yet; never overwrite an existing choice.
+            mark_provider_active_if_unset("xai-oauth")
             # The singleton write above is the single source of truth: the
             # credential-pool load seeds it as the canonical ``device_code``
             # entry. Do NOT also insert a parallel ``manual:dashboard_*`` pool

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -281,6 +281,40 @@ def test_save_and_read_xai_oauth_tokens_roundtrip(tmp_path, monkeypatch):
     assert data["discovery"]["token_endpoint"] == "https://auth.x.ai/oauth2/token"
 
 
+def test_save_xai_oauth_tokens_set_active_false_preserves_active_provider(
+    tmp_path, monkeypatch
+):
+    """Side-tool credential saves must not flip auth.json active_provider."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    auth_path = hermes_home / "auth.json"
+    auth_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "active_provider": "openrouter",
+                "providers": {},
+            }
+        )
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    _save_xai_oauth_tokens(
+        {
+            "access_token": "side-tool-at",
+            "refresh_token": "side-tool-rt",
+            "id_token": "",
+            "token_type": "Bearer",
+        },
+        discovery={"token_endpoint": "https://auth.x.ai/oauth2/token"},
+        set_active=False,
+    )
+
+    raw = json.loads(auth_path.read_text())
+    assert raw["active_provider"] == "openrouter"
+    assert raw["providers"]["xai-oauth"]["tokens"]["access_token"] == "side-tool-at"
+
+
 def test_read_xai_oauth_tokens_missing(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir(parents=True, exist_ok=True)

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -14,6 +14,7 @@ from hermes_cli.auth import (
     XAI_OAUTH_CLIENT_ID,
     XAI_OAUTH_SCOPE,
     _read_xai_oauth_tokens,
+    _refresh_xai_oauth_tokens,
     _save_xai_oauth_tokens,
     _xai_access_token_is_expiring,
     _xai_oauth_poll_device_token,
@@ -313,6 +314,75 @@ def test_save_xai_oauth_tokens_set_active_false_preserves_active_provider(
     raw = json.loads(auth_path.read_text())
     assert raw["active_provider"] == "openrouter"
     assert raw["providers"]["xai-oauth"]["tokens"]["access_token"] == "side-tool-at"
+
+
+def test_save_xai_oauth_tokens_default_sets_active_provider(tmp_path, monkeypatch):
+    """Intentional login default must promote xai-oauth to active_provider."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    auth_path = hermes_home / "auth.json"
+    auth_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "active_provider": "openrouter",
+                "providers": {},
+            }
+        )
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    _save_xai_oauth_tokens(
+        {
+            "access_token": "login-at",
+            "refresh_token": "login-rt",
+            "id_token": "",
+            "token_type": "Bearer",
+        },
+        discovery={"token_endpoint": "https://auth.x.ai/oauth2/token"},
+    )
+
+    raw = json.loads(auth_path.read_text())
+    assert raw["active_provider"] == "xai-oauth"
+    assert raw["providers"]["xai-oauth"]["tokens"]["access_token"] == "login-at"
+
+
+def test_refresh_xai_oauth_tokens_preserves_active_provider(tmp_path, monkeypatch):
+    """Token refresh must not flip active_provider away from the chat provider."""
+    hermes_home = tmp_path / "hermes"
+    near = _jwt_with_exp(int(time.time()) + 30)
+    _setup_hermes_auth(hermes_home, access_token=near, refresh_token="rt-old")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    auth_path = hermes_home / "auth.json"
+    raw = json.loads(auth_path.read_text())
+    raw["active_provider"] = "openrouter"
+    auth_path.write_text(json.dumps(raw))
+
+    new_access = _jwt_with_exp(int(time.time()) + 7200)
+
+    def _fake_pure(access_token, refresh_token, **kwargs):
+        return {
+            "access_token": new_access,
+            "refresh_token": "rt-new",
+            "id_token": "",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+            "last_refresh": "2026-07-25T12:00:00Z",
+        }
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_xai_oauth_pure", _fake_pure)
+
+    tokens = _read_xai_oauth_tokens()["tokens"]
+    _refresh_xai_oauth_tokens(
+        tokens,
+        token_endpoint="https://auth.x.ai/oauth2/token",
+        timeout_seconds=5.0,
+    )
+
+    after = json.loads(auth_path.read_text())
+    assert after["active_provider"] == "openrouter"
+    assert after["providers"]["xai-oauth"]["tokens"]["access_token"] == new_access
 
 
 def test_read_xai_oauth_tokens_missing(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_setup_tts_xai_oauth.py
+++ b/tests/hermes_cli/test_setup_tts_xai_oauth.py
@@ -1,4 +1,4 @@
-﻿"""Regression: TTS/setup xAI OAuth must not hijack the active chat provider."""
+"""Regression: TTS/setup xAI OAuth must not hijack the active chat provider."""
 
 import json
 
@@ -62,9 +62,15 @@ def test_run_xai_oauth_login_from_setup_does_not_hijack_active_provider(
     )
     monkeypatch.setattr("hermes_cli.auth._is_remote_session", lambda: True)
 
+    from hermes_cli.auth import is_source_suppressed, suppress_credential_source
     from hermes_cli.setup import _run_xai_oauth_login_from_setup
 
+    suppress_credential_source("xai-oauth", "device_code")
+    assert is_source_suppressed("xai-oauth", "device_code") is True
+
     assert _run_xai_oauth_login_from_setup() is True
+
+    assert is_source_suppressed("xai-oauth", "device_code") is False
 
     auth = json.loads(auth_path.read_text(encoding="utf-8"))
     assert auth["active_provider"] == "openrouter"

--- a/tests/hermes_cli/test_setup_tts_xai_oauth.py
+++ b/tests/hermes_cli/test_setup_tts_xai_oauth.py
@@ -1,0 +1,78 @@
+﻿"""Regression: TTS/setup xAI OAuth must not hijack the active chat provider."""
+
+import json
+
+import yaml
+
+
+def test_run_xai_oauth_login_from_setup_does_not_hijack_active_provider(
+    tmp_path, monkeypatch
+):
+    """TTS/setup OAuth must save tokens without switching chat inference routing.
+
+    Regression: `_run_xai_oauth_login_from_setup` used to call
+    `_update_config_for_provider("xai-oauth")` (and token save flipped
+    `active_provider`), so `hermes setup tts` OAuth login hijacked the main
+    chat provider.
+    """
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    auth_path = hermes_home / "auth.json"
+    auth_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "active_provider": "openrouter",
+                "providers": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "provider": "openrouter",
+                    "default": "anthropic/claude-sonnet-4",
+                    "base_url": "https://openrouter.ai/api/v1",
+                },
+                "tts": {"provider": "edge"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "hermes_cli.auth._xai_oauth_device_code_login",
+        lambda **kwargs: {
+            "tokens": {
+                "access_token": "tts-xai-access",
+                "refresh_token": "tts-xai-refresh",
+                "id_token": "",
+                "token_type": "Bearer",
+            },
+            "discovery": {"token_endpoint": "https://auth.x.ai/oauth2/token"},
+            "redirect_uri": "",
+            "base_url": "https://api.x.ai/v1",
+            "last_refresh": "2026-07-25T12:00:00Z",
+        },
+    )
+    monkeypatch.setattr("hermes_cli.auth._is_remote_session", lambda: True)
+
+    from hermes_cli.setup import _run_xai_oauth_login_from_setup
+
+    assert _run_xai_oauth_login_from_setup() is True
+
+    auth = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert auth["active_provider"] == "openrouter"
+    xai_state = auth["providers"]["xai-oauth"]
+    assert xai_state["tokens"]["access_token"] == "tts-xai-access"
+    assert xai_state["tokens"]["refresh_token"] == "tts-xai-refresh"
+
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert config["model"]["provider"] == "openrouter"
+    assert config["model"]["base_url"] == "https://openrouter.ai/api/v1"
+    assert config["model"]["default"] == "anthropic/claude-sonnet-4"

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -20,6 +20,7 @@ The fix:
 These tests pin the corrected behavior.
 """
 import asyncio
+import json
 import time
 from datetime import datetime, timezone
 from unittest.mock import patch
@@ -665,6 +666,19 @@ def test_xai_dashboard_poller_seeds_single_entry_and_clears_suppression(tmp_path
     monkeypatch.delenv("HERMES_XAI_BASE_URL", raising=False)
     monkeypatch.delenv("XAI_BASE_URL", raising=False)
 
+    # Existing chat provider must not be overwritten by dashboard OAuth.
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "active_provider": "openrouter",
+                "providers": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
     # Prior `hermes auth remove xai-oauth` left the source suppressed.
     auth_mod.suppress_credential_source("xai-oauth", "device_code")
     assert auth_mod.is_source_suppressed("xai-oauth", "device_code") is True
@@ -707,6 +721,10 @@ def test_xai_dashboard_poller_seeds_single_entry_and_clears_suppression(tmp_path
     # The interactive dashboard login cleared the suppression marker.
     assert auth_mod.is_source_suppressed("xai-oauth", "device_code") is False
 
+    after = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert after["active_provider"] == "openrouter"
+    assert after["providers"]["xai-oauth"]["tokens"]["access_token"] == "xai-dashboard-access"
+
     # The credential pool has exactly one entry, seeded from the
     # singleton as ``device_code`` — no parallel ``manual:dashboard_*``
     # duplicate sharing the single-use refresh token.
@@ -717,6 +735,61 @@ def test_xai_dashboard_poller_seeds_single_entry_and_clears_suppression(tmp_path
     assert not any(
         getattr(e, "source", "").startswith("manual:dashboard") for e in entries
     )
+
+
+def test_xai_dashboard_poller_marks_active_when_unset(tmp_path, monkeypatch):
+    """First dashboard xAI login may set active_provider when none is set yet."""
+    from hermes_cli import auth as auth_mod
+    from hermes_cli import web_server as ws
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_XAI_BASE_URL", raising=False)
+    monkeypatch.delenv("XAI_BASE_URL", raising=False)
+
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text(
+        json.dumps({"version": 1, "providers": {}}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        auth_mod,
+        "_xai_oauth_discovery",
+        lambda *a, **k: {"token_endpoint": "https://auth.x.ai/token"},
+    )
+    monkeypatch.setattr(
+        auth_mod,
+        "_xai_oauth_poll_device_token",
+        lambda client, **kwargs: {
+            "access_token": "xai-dashboard-first",
+            "refresh_token": "rt-first",
+            "id_token": "",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        },
+    )
+
+    session_id = "xai-dashboard-first-active-test"
+    ws._oauth_sessions[session_id] = {
+        "session_id": session_id,
+        "provider": "xai-oauth",
+        "flow": "device_code",
+        "created_at": time.time(),
+        "status": "pending",
+        "error_message": None,
+        "device_code": "device-code",
+        "interval": 5,
+        "expires_at": time.time() + 600,
+    }
+    try:
+        ws._xai_device_poller(session_id)
+        assert ws._oauth_sessions[session_id]["status"] == "approved"
+    finally:
+        ws._oauth_sessions.pop(session_id, None)
+
+    after = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert after["active_provider"] == "xai-oauth"
+    assert after["providers"]["xai-oauth"]["tokens"]["access_token"] == "xai-dashboard-first"
 
 
 def test_unknown_pkce_provider_rejected_cleanly():

--- a/tests/tools/test_transcription_dotenv_fallback.py
+++ b/tests/tools/test_transcription_dotenv_fallback.py
@@ -205,13 +205,7 @@ class TestTranscribeCallSitesReadDotenv:
         assert seen_keys == ["mistral-dotenv-key"]
 
     def test_transcribe_xai_forwards_dotenv_key(self):
-        """xAI STT now resolves credentials through ``tools.xai_http`` so the
-        OAuth bearer wins when present and ``XAI_API_KEY`` is the fallback.
-        Patch the resolver's ``get_env_value`` to simulate a dotenv-only key
-        and confirm it reaches the HTTP call. The per-call-site
-        ``transcription_tools.get_env_value`` is still consulted for the
-        ``XAI_STT_BASE_URL`` override (covered by ``test_custom_base_url``).
-        """
+        """An explicit XAI_API_KEY must win over Grok subscription OAuth for STT."""
         from tools import transcription_tools as tt
         from tools import xai_http
 
@@ -231,7 +225,12 @@ class TestTranscribeCallSitesReadDotenv:
                 return "xai-dotenv-key"
             return None
 
-        with patch.object(xai_http, "get_env_value", side_effect=fake_get_env_value), \
+        with patch.object(tt, "get_env_value", side_effect=fake_get_env_value), \
+             patch.object(xai_http, "resolve_xai_http_credentials", return_value={
+                 "provider": "xai-oauth",
+                 "api_key": "subscription-oauth-token",
+                 "base_url": "https://api.x.ai/v1",
+             }), \
              patch("requests.post", side_effect=fake_post), \
              patch("builtins.open", MagicMock()):
             result = tt._transcribe_xai("/tmp/fake.mp3", "grok-stt")

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1434,6 +1434,38 @@ class TestTranscribeXAI:
         url = call_args[0][0] if call_args[0] else call_args.kwargs.get("url", "")
         assert "custom.x.ai" in url
 
+    def test_oauth_credentials_ignore_stt_base_url_override(
+        self,
+        monkeypatch,
+        sample_ogg,
+        mock_xai_http_module,
+    ):
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        monkeypatch.setenv("XAI_STT_BASE_URL", "https://attacker.example/v1")
+        mock_xai_http_module.resolve_xai_http_credentials.return_value = {
+            "provider": "xai-oauth",
+            "api_key": "oauth-bearer-token",
+            "base_url": "https://api.x.ai/v1",
+        }
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"text": "test", "language": "en", "duration": 1.0}
+
+        with patch(
+            "tools.transcription_tools._load_stt_config",
+            return_value={"xai": {"base_url": "https://attacker.example/config"}},
+        ), patch("requests.post", return_value=mock_response) as mock_post:
+            from tools.transcription_tools import _transcribe_xai
+
+            result = _transcribe_xai(sample_ogg, "grok-stt")
+
+        assert result["success"] is True
+        call_args = mock_post.call_args
+        url = call_args[0][0] if call_args[0] else call_args.kwargs.get("url", "")
+        assert url == "https://api.x.ai/v1/stt"
+        assert call_args.kwargs["headers"]["Authorization"] == "Bearer oauth-bearer-token"
+
     def test_diarize_sent_when_configured(self, monkeypatch, sample_ogg, mock_xai_http_module):
         monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
 

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1305,8 +1305,9 @@ class TestTranscribeXAI:
         assert "HTTP 400" in result["error"]
         assert "Invalid audio format" in result["error"]
 
-    def test_retries_403_with_refreshed_oauth_credentials(
-        self, sample_ogg, mock_xai_http_module
+    @pytest.mark.parametrize("rejected_status", [401, 403])
+    def test_retries_auth_rejection_with_refreshed_oauth_credentials(
+        self, sample_ogg, mock_xai_http_module, rejected_status
     ):
         mock_xai_http_module.resolve_xai_http_credentials.side_effect = [
             {
@@ -1322,7 +1323,7 @@ class TestTranscribeXAI:
         ]
 
         rejected = MagicMock()
-        rejected.status_code = 403
+        rejected.status_code = rejected_status
         rejected.json.return_value = {
             "error": {"message": "OAuth2 access token could not be validated"}
         }

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -11,7 +11,7 @@ import struct
 import subprocess
 import types
 import wave
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -1304,6 +1304,59 @@ class TestTranscribeXAI:
         assert result["success"] is False
         assert "HTTP 400" in result["error"]
         assert "Invalid audio format" in result["error"]
+
+    def test_retries_403_with_refreshed_oauth_credentials(
+        self, sample_ogg, mock_xai_http_module
+    ):
+        mock_xai_http_module.resolve_xai_http_credentials.side_effect = [
+            {
+                "api_key": "stale-oauth-token",
+                "base_url": "https://api.x.ai/v1",
+                "provider": "xai-oauth",
+            },
+            {
+                "api_key": "fresh-oauth-token",
+                "base_url": "https://api.x.ai/v1",
+                "provider": "xai-oauth",
+            },
+        ]
+
+        rejected = MagicMock()
+        rejected.status_code = 403
+        rejected.json.return_value = {
+            "error": {"message": "OAuth2 access token could not be validated"}
+        }
+        accepted = MagicMock()
+        accepted.status_code = 200
+        accepted.json.return_value = {
+            "text": "fleet speech transcription proof",
+            "language": "en",
+            "duration": 2.1,
+        }
+
+        stt_config = {"provider": "xai"}
+        with patch("tools.transcription_tools._load_stt_config", return_value=stt_config), \
+             patch("tools.transcription_tools._get_provider", return_value="xai"), \
+             patch("requests.post", side_effect=[rejected, accepted]) as mock_post:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_ogg)
+
+        assert result == {
+            "success": True,
+            "transcript": "fleet speech transcription proof",
+            "provider": "xai",
+        }
+        assert mock_post.call_count == 2
+        assert mock_post.call_args_list[0].kwargs["headers"]["Authorization"] == (
+            "Bearer stale-oauth-token"
+        )
+        assert mock_post.call_args_list[1].kwargs["headers"]["Authorization"] == (
+            "Bearer fresh-oauth-token"
+        )
+        assert mock_xai_http_module.resolve_xai_http_credentials.call_args_list == [
+            call(),
+            call(force_refresh=True, api_key_hint="stale-oauth-token"),
+        ]
 
     def test_empty_transcript_returns_failure(self, monkeypatch, sample_ogg, mock_xai_http_module):
         monkeypatch.setenv("XAI_API_KEY", "xai-test-key")

--- a/tests/tools/test_tts_xai_speech_tags.py
+++ b/tests/tools/test_tts_xai_speech_tags.py
@@ -132,6 +132,48 @@ def test_generate_xai_tts_sends_auxiliary_rewriter_output_to_api(
     assert captured["json"]["text"] == rewriter_output
 
 
+def test_generate_xai_tts_uses_oauth_pinned_base_url(tmp_path, monkeypatch):
+    """OAuth bearer tokens must not follow user/env base URL overrides."""
+    captured = {}
+
+    class FakeResponse:
+        content = b"mp3"
+
+        def raise_for_status(self):
+            pass
+
+    def fake_post(url, headers, json, timeout):
+        captured["url"] = url
+        captured["headers"] = headers
+        return FakeResponse()
+
+    monkeypatch.setenv("XAI_BASE_URL", "https://attacker.example/v1")
+    monkeypatch.setattr(
+        "tools.xai_http.resolve_xai_http_credentials",
+        lambda: {
+            "provider": "xai-oauth",
+            "api_key": "oauth-bearer-token",
+            "base_url": "https://api.x.ai/v1",
+        },
+    )
+    monkeypatch.setattr("requests.post", fake_post)
+
+    out = tmp_path / "out.mp3"
+    _generate_xai_tts(
+        "Bonjour.",
+        str(out),
+        {
+            "xai": {
+                "base_url": "https://attacker.example/config",
+                "auto_speech_tags": False,
+            }
+        },
+    )
+
+    assert captured["url"] == "https://api.x.ai/v1/tts"
+    assert captured["headers"]["Authorization"] == "Bearer oauth-bearer-token"
+
+
 def test_auto_speech_tags_calls_auxiliary_rewriter_with_tts_audio_tags_task():
     """When input has no explicit speech tags, the function must call the
     auxiliary rewriter with task='tts_audio_tags' and a system prompt

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1624,11 +1624,11 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
                         refreshed_key,
                         _resolve_base_url(refreshed_creds),
                     )
-            except Exception as refresh_exc:
+            except Exception as retry_exc:
                 logger.warning(
-                    "xAI STT OAuth refresh after HTTP %d failed: %s",
+                    "xAI STT OAuth refresh-and-retry after HTTP %d failed: %s",
                     response.status_code,
-                    refresh_exc,
+                    retry_exc,
                 )
 
         if response.status_code != 200:

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1562,6 +1562,12 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
     xai_config = stt_config.get("xai") or {}
 
     def _resolve_base_url(resolved_creds: Dict[str, str]) -> str:
+        # OAuth bearers are pinned to the resolver-validated xAI origin;
+        # config/env base URL overrides only apply to API-key credentials.
+        if resolved_creds.get("provider") == "xai-oauth":
+            return str(
+                resolved_creds.get("base_url") or XAI_STT_BASE_URL
+            ).strip().rstrip("/")
         return str(
             xai_config.get("base_url")
             or get_env_value("XAI_STT_BASE_URL")

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1535,7 +1535,21 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
     """
     from tools.xai_http import resolve_xai_http_credentials
 
-    creds = resolve_xai_http_credentials()
+    # STT is an API-billed endpoint. Prefer the explicit XAI_API_KEY over the
+    # general xAI OAuth/Grok-subscription credential; subscription OAuth may be
+    # valid for Grok while returning personal-team spending-limit errors for
+    # /v1/stt. Other xAI integrations keep their existing resolver precedence.
+    direct_api_key = str(get_env_value("XAI_API_KEY") or "").strip()
+    if direct_api_key:
+        creds = {
+            "provider": "xai",
+            "api_key": direct_api_key,
+            "base_url": str(
+                get_env_value("XAI_BASE_URL") or "https://api.x.ai/v1"
+            ).strip().rstrip("/"),
+        }
+    else:
+        creds = resolve_xai_http_credentials()
     api_key = str(creds.get("api_key") or "").strip()
     if not api_key:
         return {

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1560,12 +1560,16 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
 
     stt_config = _load_stt_config()
     xai_config = stt_config.get("xai") or {}
-    base_url = str(
-        xai_config.get("base_url")
-        or get_env_value("XAI_STT_BASE_URL")
-        or creds.get("base_url")
-        or XAI_STT_BASE_URL
-    ).strip().rstrip("/")
+
+    def _resolve_base_url(resolved_creds: Dict[str, str]) -> str:
+        return str(
+            xai_config.get("base_url")
+            or get_env_value("XAI_STT_BASE_URL")
+            or resolved_creds.get("base_url")
+            or XAI_STT_BASE_URL
+        ).strip().rstrip("/")
+
+    base_url = _resolve_base_url(creds)
     language = _resolve_stt_language("xai", stt_config) or ""
     # .get("format", True) already defaults to True when the key is absent;
     # is_truthy_value only normalizes truthy/falsy strings from config.
@@ -1584,19 +1588,48 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
         if use_diarize:
             data["diarize"] = "true"
 
-        with open(file_path, "rb") as audio_file:
-            response = requests.post(
-                f"{base_url}/stt",
-                headers={
-                    "Authorization": f"Bearer {api_key}",
-                    "User-Agent": hermes_xai_user_agent(),
-                },
-                files={
-                    "file": (Path(file_path).name, audio_file),
-                },
-                data=data,
-                timeout=120,
+        def _post_transcription(bearer: str, endpoint_base_url: str):
+            with open(file_path, "rb") as audio_file:
+                return requests.post(
+                    f"{endpoint_base_url}/stt",
+                    headers={
+                        "Authorization": f"Bearer {bearer}",
+                        "User-Agent": hermes_xai_user_agent(),
+                    },
+                    files={
+                        "file": (Path(file_path).name, audio_file),
+                    },
+                    data=data,
+                    timeout=120,
+                )
+
+        response = _post_transcription(api_key, base_url)
+
+        if (
+            response.status_code in {401, 403}
+            and creds.get("provider") == "xai-oauth"
+        ):
+            logger.info(
+                "xAI STT got HTTP %d; refreshing OAuth credentials and retrying once",
+                response.status_code,
             )
+            try:
+                refreshed_creds = resolve_xai_http_credentials(
+                    force_refresh=True,
+                    api_key_hint=api_key,
+                )
+                refreshed_key = str(refreshed_creds.get("api_key") or "").strip()
+                if refreshed_key and refreshed_key != api_key:
+                    response = _post_transcription(
+                        refreshed_key,
+                        _resolve_base_url(refreshed_creds),
+                    )
+            except Exception as refresh_exc:
+                logger.warning(
+                    "xAI STT OAuth refresh after HTTP %d failed: %s",
+                    response.status_code,
+                    refresh_exc,
+                )
 
         if response.status_code != 200:
             detail = ""

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1465,12 +1465,15 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
         optimize_streaming_latency = max(0, min(2, optimize_streaming_latency))
     if auto_speech_tags:
         text = _apply_xai_auto_speech_tags(text)
-    base_url = str(
-        xai_config.get("base_url")
-        or creds.get("base_url")
-        or get_env_value("XAI_BASE_URL")
-        or DEFAULT_XAI_BASE_URL
-    ).strip().rstrip("/")
+    if creds.get("provider") == "xai-oauth":
+        base_url = str(creds.get("base_url") or DEFAULT_XAI_BASE_URL).strip().rstrip("/")
+    else:
+        base_url = str(
+            xai_config.get("base_url")
+            or creds.get("base_url")
+            or get_env_value("XAI_BASE_URL")
+            or DEFAULT_XAI_BASE_URL
+        ).strip().rstrip("/")
 
     # Match the documented minimal POST /v1/tts shape by default. Only send
     # output_format when Hermes actually needs a non-default format/override.


### PR DESCRIPTION
# fix(voice): xAI STT/TTS auth correctness — explicit key precedence, OAuth retry, provider-hijack fix, OAuth base-URL pinning

Consolidated salvage of four external contributions, cherry-picked onto current `main` with original authorship preserved. All four touch the xAI auth paths for the voice side-tools (STT/TTS) and are ordered so each builds on the previous.

## Salvaged PRs (in commit order)

### 1. #64579 — prefer explicit `XAI_API_KEY` over Grok OAuth for STT (@muctobi)
`resolve_xai_http_credentials()` always prefers xAI OAuth when present, but STT (`POST /v1/stt`) is an **API-billed** endpoint: a Grok-subscription OAuth bearer can be valid for chat while returning personal-team spending-limit 403s for STT. `_transcribe_xai` now uses an explicit `XAI_API_KEY` (env or `~/.hermes/.env`) first and only falls back to the OAuth resolver when no key is set. Deliberately scoped to STT — other xAI integrations keep the existing resolver precedence.

### 2. #68535 — retry xAI STT once after OAuth auth rejection (@BenSheridanEdwards)
`xai_http.py` already grew `force_refresh`/`api_key_hint` machinery, but nothing in `transcription_tools.py` called it. On HTTP 401/403 with an OAuth credential, `_transcribe_xai` now force-refreshes the exact issuing pool entry (via `api_key_hint`) and retries the request once with the refreshed bearer. Includes parametrized 401/403 regression tests; the contributor's follow-up commit (drop proof image from diff, retry-failure log wording) is included.

### 3. #71365 — stop TTS/setup xAI OAuth from hijacking the active chat provider (@fangliquanflq)
Running the xAI OAuth device-code flow from a *side-tool* context (TTS setup wizard, tools config, dashboard token save, token refresh) rewrote `active_provider` / `model.provider`, silently switching the user's chat inference to xAI. `_save_xai_oauth_tokens` gains `set_active=` (default `True` for intentional `hermes model`/auth login); side-tool callers pass `set_active=False`, the dashboard poller uses `mark_provider_active_if_unset` (first-credential-becomes-active only), and setup's login no longer calls `_update_config_for_provider`. Token refresh never flips the provider. 3 commits, ~260 lines of new tests across auth/setup/web dispatch.

### 4. #62325 — pin OAuth TTS/STT requests to the resolver-validated base URL (@necoweb3)
The auth layer pins the xAI OAuth bearer to `api.x.ai`/`*.x.ai` (`_xai_validate_inference_base_url`) precisely because `XAI_BASE_URL=https://attacker.example/v1` would exfiltrate the SuperGrok token. But the TTS/STT side-tools let `tts.xai.base_url` / `stt.xai.base_url` / `XAI_STT_BASE_URL` config-env overrides **replace** the resolver's pinned URL after credential resolution. Triage initially marked the STT half fixed-on-main; verification showed main's precedence chain (`xai_config.get("base_url") or env or creds`) still lets overrides beat the pinned OAuth URL in **both** tools, so the full PR is salvaged. OAuth credentials now use only the resolver-provided base URL; API-key usage keeps full custom base-URL behavior. Conflict resolution folds the pin into #68535's `_resolve_base_url()` helper so the 401/403 retry path also re-pins against refreshed credentials.

## Conflict resolutions
- `_transcribe_xai` base-URL block: #68535's `_resolve_base_url(creds)` closure kept (retry needs it), main's `_resolve_stt_language` refactor preserved over the PRs' older inline language chain, #62325's OAuth pin folded into the closure.

## Verification
- `pytest -o addopts="" -q` over the six touched test files: **256 passed**.
- Sabotage check: disabling the OAuth base-URL pin makes `test_oauth_credentials_ignore_stt_base_url_override` fail; restoring it passes.
- `ruff check` clean on all touched files.
- Stale-base gate: branch base is 0 behind `origin/main`; diff shows only the 13 intended files.
- Contributor mapping: `contributors/emails/` files added for tobiassafaie@… → muctobi, bensheridanedwards@… (contributor's own commit), sswdarius@… → necoweb3, fangliquan@oppo.com (already present).

## Post-merge actions
- Close #64579, #68535, #71365, #62325 with credit (commits cherry-picked with authorship preserved; rebase-merge this PR).


## Infographic

![fix(xai): voice auth correctness — key precedence, OAuth retry, provider hijack, base-URL pinning](https://v3b.fal.media/files/b/0aa416c7/IxRiH2auBrpLKgU3puBeb_86IjwST9.png)
