### PR TITLE
fix(tts): honor config.yaml endpoints across all providers + bounded upstream buffering

### DIFF
--- a/contributors/emails/moeadham@gmail.com
+++ b/contributors/emails/moeadham@gmail.com
@@ -1,0 +1,1 @@
+moeadham

--- a/contributors/emails/tikkanadityajyothi@gmail.com
+++ b/contributors/emails/tikkanadityajyothi@gmail.com
@@ -1,0 +1,1 @@
+Vissirexa

--- a/tests/tools/test_tts_model_cache_lru.py
+++ b/tests/tools/test_tts_model_cache_lru.py
@@ -1,0 +1,44 @@
+"""LRU bound on the Piper/KittenTTS model caches.
+
+Each cached entry is a whole loaded TTS model (tens of MB). Without a cap the
+caches pinned one model per distinct voice/model for the process lifetime, so a
+surface that sweeps voices grew memory with no ceiling. `_tts_cache_get_or_load`
+loads on a miss and evicts the least-recently-used entry beyond the cap.
+"""
+from __future__ import annotations
+
+import tools.tts_tool as tts
+
+
+def test_loads_on_miss_and_serves_from_cache_on_hit():
+    cache: dict = {}
+    calls = []
+
+    def load():
+        calls.append(1)
+        return "model"
+
+    assert tts._tts_cache_get_or_load(cache, "a", load) == "model"
+    assert tts._tts_cache_get_or_load(cache, "a", load) == "model"
+    assert len(calls) == 1  # loaded once, second call served from cache
+
+
+def test_evicts_least_recently_used_beyond_cap(monkeypatch):
+    monkeypatch.setattr(tts, "_TTS_MODEL_CACHE_MAX", 2)
+    cache: dict = {}
+    for k in ("a", "b", "c"):
+        tts._tts_cache_get_or_load(cache, k, lambda k=k: k)
+    assert set(cache) == {"b", "c"}  # "a", the oldest, was evicted
+    assert len(cache) == 2
+
+
+def test_hit_refreshes_recency_so_eviction_is_lru_not_fifo(monkeypatch):
+    monkeypatch.setattr(tts, "_TTS_MODEL_CACHE_MAX", 2)
+    cache: dict = {}
+    tts._tts_cache_get_or_load(cache, "a", lambda: "a")
+    tts._tts_cache_get_or_load(cache, "b", lambda: "b")
+    # Touch "a": "b" is now the least recently used.
+    tts._tts_cache_get_or_load(cache, "a", lambda: "a")
+    tts._tts_cache_get_or_load(cache, "c", lambda: "c")
+    assert "b" not in cache
+    assert set(cache) == {"a", "c"}

--- a/tests/tools/test_tts_openai_config.py
+++ b/tests/tools/test_tts_openai_config.py
@@ -1,0 +1,94 @@
+"""tts.openai.api_key / base_url from config.yaml drive the OpenAI audio client.
+
+Regression coverage for issue #26175: the resolver was env-only
+(VOICE_TOOLS_OPENAI_KEY / OPENAI_API_KEY) and always returned the default
+OpenAI base URL, ignoring the tts.openai config block. Resolution order now
+mirrors the STT resolver: config -> env (still honoring config base_url) ->
+managed gateway.
+"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tools import tts_tool
+
+
+class TestResolveOpenaiAudioClientConfig:
+    def test_prefers_tts_config_credentials_and_base_url(self):
+        config = {
+            "provider": "openai",
+            "openai": {
+                "api_key": "cfg-key",
+                "base_url": "http://localhost:4003/v1",
+            },
+        }
+
+        with patch.object(tts_tool, "_load_tts_config", return_value=config), \
+             patch.object(tts_tool, "prefers_gateway", return_value=False), \
+             patch.object(tts_tool, "resolve_openai_audio_api_key", return_value="env-key"), \
+             patch.object(tts_tool, "resolve_managed_tool_gateway", return_value=None):
+            assert tts_tool._resolve_openai_audio_client_config() == (
+                "cfg-key",
+                "http://localhost:4003/v1",
+                False,
+            )
+
+    def test_config_without_base_url_falls_back_to_default_openai_base(self):
+        config = {"openai": {"api_key": "cfg-key"}}
+
+        with patch.object(tts_tool, "_load_tts_config", return_value=config), \
+             patch.object(tts_tool, "prefers_gateway", return_value=False):
+            assert tts_tool._resolve_openai_audio_client_config() == (
+                "cfg-key",
+                tts_tool.DEFAULT_OPENAI_BASE_URL,
+                False,
+            )
+
+    def test_env_key_still_honors_config_base_url(self):
+        config = {"openai": {"base_url": "http://localhost:4003/v1"}}
+
+        with patch.object(tts_tool, "_load_tts_config", return_value=config), \
+             patch.object(tts_tool, "prefers_gateway", return_value=False), \
+             patch.object(tts_tool, "resolve_openai_audio_api_key", return_value="env-key"):
+            assert tts_tool._resolve_openai_audio_client_config() == (
+                "env-key",
+                "http://localhost:4003/v1",
+                False,
+            )
+
+    def test_use_gateway_overrides_config_credentials(self):
+        config = {"openai": {"api_key": "cfg-key", "base_url": "http://localhost:4003/v1"}}
+        managed = SimpleNamespace(
+            nous_user_token="managed-token",
+            gateway_origin="https://openai-audio-gateway.nousresearch.com",
+        )
+
+        with patch.object(tts_tool, "_load_tts_config", return_value=config), \
+             patch.object(tts_tool, "prefers_gateway", return_value=True), \
+             patch.object(tts_tool, "resolve_openai_audio_api_key", return_value="env-key"), \
+             patch.object(tts_tool, "resolve_managed_tool_gateway", return_value=managed):
+            assert tts_tool._resolve_openai_audio_client_config() == (
+                "managed-token",
+                "https://openai-audio-gateway.nousresearch.com/v1",
+                True,
+            )
+
+    def test_missing_config_and_env_raises_updated_error(self):
+        with patch.object(tts_tool, "_load_tts_config", return_value={}), \
+             patch.object(tts_tool, "prefers_gateway", return_value=False), \
+             patch.object(tts_tool, "resolve_openai_audio_api_key", return_value=""), \
+             patch.object(tts_tool, "resolve_managed_tool_gateway", return_value=None), \
+             patch.object(tts_tool, "managed_nous_tools_enabled", return_value=False):
+            with pytest.raises(ValueError) as exc:
+                tts_tool._resolve_openai_audio_client_config()
+
+        assert (
+            str(exc.value)
+            == "Neither tts.openai.api_key in config nor VOICE_TOOLS_OPENAI_KEY/OPENAI_API_KEY is set"
+        )
+
+    def test_config_api_key_counts_as_available_backend(self):
+        config = {"openai": {"api_key": "cfg-key"}}
+        with patch.object(tts_tool, "_load_tts_config", return_value=config):
+            assert tts_tool._has_openai_audio_backend() is True

--- a/tests/tools/test_tts_provider_base_urls.py
+++ b/tests/tools/test_tts_provider_base_urls.py
@@ -1,0 +1,123 @@
+"""Class-level base_url parity: every cloud TTS provider honors config base_url.
+
+xAI, MiniMax, Gemini, OpenAI and DeepInfra already read
+``tts.<provider>.base_url`` from config.yaml. This locks in the same
+contract for the ElevenLabs and Mistral sections (the two that used to
+hardcode the SDK default endpoint).
+"""
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import patch
+
+import tools.tts_tool as tts
+
+
+# ── ElevenLabs: base_url/wss_url → ElevenLabsEnvironment ──────────────────
+
+
+def _fake_elevenlabs_environment_module(captured: dict):
+    mod = types.ModuleType("elevenlabs.environment")
+
+    class ElevenLabsEnvironment:
+        def __init__(self, base, wss):
+            captured["base"] = base
+            captured["wss"] = wss
+
+    mod.ElevenLabsEnvironment = ElevenLabsEnvironment
+    pkg = types.ModuleType("elevenlabs")
+    pkg.environment = mod
+    return pkg, mod
+
+
+def test_elevenlabs_no_base_url_uses_sdk_default_environment():
+    assert tts._elevenlabs_environment_kwargs({}) == {}
+    assert tts._elevenlabs_environment_kwargs({"base_url": ""}) == {}
+
+
+def test_elevenlabs_base_url_builds_environment(monkeypatch):
+    captured: dict = {}
+    pkg, mod = _fake_elevenlabs_environment_module(captured)
+    monkeypatch.setitem(sys.modules, "elevenlabs", pkg)
+    monkeypatch.setitem(sys.modules, "elevenlabs.environment", mod)
+
+    kwargs = tts._elevenlabs_environment_kwargs(
+        {"base_url": "https://el-proxy.example/", "wss_url": "wss://el-proxy.example/ws"}
+    )
+    assert "environment" in kwargs
+    assert captured == {
+        "base": "https://el-proxy.example",
+        "wss": "wss://el-proxy.example/ws",
+    }
+
+
+def test_elevenlabs_wss_url_derived_from_base_url(monkeypatch):
+    captured: dict = {}
+    pkg, mod = _fake_elevenlabs_environment_module(captured)
+    monkeypatch.setitem(sys.modules, "elevenlabs", pkg)
+    monkeypatch.setitem(sys.modules, "elevenlabs.environment", mod)
+
+    tts._elevenlabs_environment_kwargs({"base_url": "https://el-proxy.example"})
+    assert captured["wss"] == "wss://el-proxy.example"
+
+
+# ── Mistral: tts.mistral.base_url → SDK server_url ────────────────────────
+
+
+def test_mistral_base_url_passed_as_server_url(tmp_path, monkeypatch):
+    captured: dict = {}
+
+    class _FakeMistral:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        class audio:  # noqa: N801 — mimic SDK attribute shape
+            class speech:  # noqa: N801
+                @staticmethod
+                def complete(**kwargs):
+                    return types.SimpleNamespace(audio_data="aGVsbG8=")  # "hello"
+
+    out = tmp_path / "out.mp3"
+    with patch.object(tts, "_import_mistral_client", return_value=_FakeMistral), \
+         patch.object(tts, "get_env_value", lambda k, *a: "key" if k == "MISTRAL_API_KEY" else None):
+        tts._generate_mistral_tts(
+            "hi", str(out), {"mistral": {"base_url": "https://mistral-proxy.example/v1"}}
+        )
+
+    assert captured["api_key"] == "key"
+    assert captured["server_url"] == "https://mistral-proxy.example/v1"
+    assert out.read_bytes() == b"hello"
+
+
+def test_mistral_no_base_url_omits_server_url(tmp_path):
+    captured: dict = {}
+
+    class _FakeMistral:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        class audio:  # noqa: N801
+            class speech:  # noqa: N801
+                @staticmethod
+                def complete(**kwargs):
+                    return types.SimpleNamespace(audio_data="aGVsbG8=")
+
+    out = tmp_path / "out.mp3"
+    with patch.object(tts, "_import_mistral_client", return_value=_FakeMistral), \
+         patch.object(tts, "get_env_value", lambda k, *a: "key" if k == "MISTRAL_API_KEY" else None):
+        tts._generate_mistral_tts("hi", str(out), {"mistral": {}})
+
+    assert "server_url" not in captured

--- a/tests/tools/test_tts_response_body_cap.py
+++ b/tests/tools/test_tts_response_body_cap.py
@@ -1,0 +1,85 @@
+"""Regression tests for bounded upstream TTS response reads."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from tools import tts_tool
+
+
+class StreamingResponse:
+    def __init__(self, chunks, *, status_code=200, headers=None):
+        self._chunks = list(chunks)
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.closed = False
+
+    def iter_content(self, chunk_size=65536):
+        del chunk_size
+        yield from self._chunks
+
+    def close(self):
+        self.closed = True
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+@pytest.fixture(autouse=True)
+def small_tts_body_cap(monkeypatch):
+    monkeypatch.setattr(tts_tool, "TTS_RESPONSE_BODY_LIMIT_BYTES", 8)
+
+
+def test_xai_tts_rejects_oversized_audio_response(tmp_path, monkeypatch):
+    monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
+    response = StreamingResponse([b"12345", b"6789"], headers={"Content-Type": "audio/mpeg"})
+    output_path = tmp_path / "out.mp3"
+
+    with patch("requests.post", return_value=response) as post:
+        with pytest.raises(RuntimeError, match="xAI TTS response exceeds 8 bytes"):
+            tts_tool._generate_xai_tts("hello", str(output_path), {})
+
+    assert post.call_args.kwargs["stream"] is True
+    assert response.closed is True
+    assert not output_path.exists()
+
+
+def test_minimax_t2a_rejects_oversized_json_response(tmp_path, monkeypatch):
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
+    response = StreamingResponse([b'{"data":', b'"too large"}'], headers={"Content-Type": "application/json"})
+
+    with patch("requests.post", return_value=response) as post:
+        with pytest.raises(RuntimeError, match="MiniMax TTS response exceeds 8 bytes"):
+            tts_tool._generate_minimax_tts("hello", str(tmp_path / "out.mp3"), {})
+
+    assert post.call_args.kwargs["stream"] is True
+    assert response.closed is True
+
+
+def test_minimax_legacy_rejects_oversized_audio_response(tmp_path, monkeypatch):
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
+    response = StreamingResponse([b"12345", b"6789"], headers={"Content-Type": "audio/mpeg"})
+    config = {"minimax": {"base_url": "https://api.minimax.chat/v1/text_to_speech"}}
+    output_path = tmp_path / "out.mp3"
+
+    with patch("requests.post", return_value=response):
+        with pytest.raises(RuntimeError, match="MiniMax TTS response exceeds 8 bytes"):
+            tts_tool._generate_minimax_tts("hello", str(output_path), config)
+
+    assert response.closed is True
+    assert not output_path.exists()
+
+
+def test_gemini_tts_rejects_oversized_json_response(tmp_path, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "test-gemini-key")
+    response = StreamingResponse([b'{"candidates":', b"[{}]}"], headers={"Content-Type": "application/json"})
+
+    with patch("requests.post", return_value=response) as post:
+        with pytest.raises(RuntimeError, match="Gemini TTS response exceeds 8 bytes"):
+            tts_tool._generate_gemini_tts("hello", str(tmp_path / "out.wav"), {})
+
+    assert post.call_args.kwargs["stream"] is True
+    assert response.closed is True

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -130,9 +130,62 @@ def test_elevenlabs_available_reflects_key(monkeypatch):
     assert ts.ElevenLabsStreamer.available() is False
 
 
-def test_openai_available_reflects_key(monkeypatch):
-    monkeypatch.setattr(ts, "get_env_value", lambda k, *a: "key" if k == "OPENAI_API_KEY" else None)
+def test_openai_available_reflects_audio_key_resolution(monkeypatch):
+    monkeypatch.setattr(ts, "resolve_openai_audio_api_key", lambda: "voice-key")
     assert ts.OpenAIStreamer.available() is True
+    monkeypatch.setattr(ts, "resolve_openai_audio_api_key", lambda: "")
+    assert ts.OpenAIStreamer.available() is False
+
+
+def test_openai_streamer_prefers_configured_base_url(monkeypatch):
+    captured = {}
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def iter_bytes(self):
+            yield b"\x01\x00"
+
+    class _StreamingCreate:
+        @staticmethod
+        def create(**kwargs):
+            captured["request"] = kwargs
+            return _Response()
+
+    class _OpenAI:
+        def __init__(self, **kwargs):
+            captured["client"] = kwargs
+            self.audio = MagicMock()
+            self.audio.speech.with_streaming_response = _StreamingCreate()
+
+    monkeypatch.setattr(ts, "resolve_openai_audio_api_key", lambda: "voice-key")
+    monkeypatch.setattr(
+        ts,
+        "get_env_value",
+        lambda key, *args: "https://env.example/v1" if key == "OPENAI_BASE_URL" else None,
+    )
+    monkeypatch.setattr("openai.OpenAI", _OpenAI)
+
+    config = {
+        "provider": "openai",
+        "openai": {
+            "base_url": "http://local-tts.example/v1",
+            "model": "tts-1",
+            "voice": "local-voice",
+        },
+    }
+    streamer = ts.resolve_streaming_provider(config)
+
+    assert streamer is not None
+    assert list(streamer.stream("Streaming test.")) == [b"\x01\x00"]
+    assert captured["client"] == {
+        "api_key": "voice-key",
+        "base_url": "http://local-tts.example/v1",
+    }
 
 
 # ── Dispatch: chunked streamer path ──────────────────────────────────────

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -131,10 +131,14 @@ def test_elevenlabs_available_reflects_key(monkeypatch):
 
 
 def test_openai_available_reflects_audio_key_resolution(monkeypatch):
+    monkeypatch.setattr(ts, "_openai_config_api_key", lambda: "")
     monkeypatch.setattr(ts, "resolve_openai_audio_api_key", lambda: "voice-key")
     assert ts.OpenAIStreamer.available() is True
     monkeypatch.setattr(ts, "resolve_openai_audio_api_key", lambda: "")
     assert ts.OpenAIStreamer.available() is False
+    # tts.openai.api_key from config.yaml counts too
+    monkeypatch.setattr(ts, "_openai_config_api_key", lambda: "cfg-key")
+    assert ts.OpenAIStreamer.available() is True
 
 
 def test_openai_streamer_prefers_configured_base_url(monkeypatch):
@@ -186,6 +190,45 @@ def test_openai_streamer_prefers_configured_base_url(monkeypatch):
         "api_key": "voice-key",
         "base_url": "http://local-tts.example/v1",
     }
+
+
+def test_openai_streamer_prefers_configured_api_key(monkeypatch):
+    captured = {}
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def iter_bytes(self):
+            yield b"\x01\x00"
+
+    class _StreamingCreate:
+        @staticmethod
+        def create(**kwargs):
+            return _Response()
+
+    class _OpenAI:
+        def __init__(self, **kwargs):
+            captured["client"] = kwargs
+            self.audio = MagicMock()
+            self.audio.speech.with_streaming_response = _StreamingCreate()
+
+    monkeypatch.setattr(ts, "resolve_openai_audio_api_key", lambda: "env-key")
+    monkeypatch.setattr(ts, "get_env_value", lambda key, *args: None)
+    monkeypatch.setattr("openai.OpenAI", _OpenAI)
+
+    config = {
+        "provider": "openai",
+        "openai": {"api_key": "cfg-key", "base_url": "http://local-tts.example/v1"},
+    }
+    streamer = ts.resolve_streaming_provider(config)
+
+    assert streamer is not None
+    assert list(streamer.stream("Streaming test.")) == [b"\x01\x00"]
+    assert captured["client"]["api_key"] == "cfg-key"
 
 
 # ── Dispatch: chunked streamer path ──────────────────────────────────────

--- a/tests/tools/test_tts_xai_speech_tags.py
+++ b/tests/tools/test_tts_xai_speech_tags.py
@@ -101,11 +101,12 @@ def test_generate_xai_tts_sends_auxiliary_rewriter_output_to_api(
         def raise_for_status(self):
             pass
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["url"] = url
         captured["headers"] = headers
         captured["json"] = json
         captured["timeout"] = timeout
+        captured["stream"] = stream
         return FakeResponse()
 
     fake_response = SimpleNamespace(
@@ -310,8 +311,9 @@ def test_generate_xai_tts_leaves_text_plain_by_default(tmp_path, monkeypatch):
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
+        captured["stream"] = stream
         return fake_response
 
     monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
@@ -337,8 +339,9 @@ def test_generate_xai_tts_omits_speed_and_latency_by_default(tmp_path, monkeypat
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
+        captured["stream"] = stream
         return fake_response
 
     monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
@@ -362,8 +365,9 @@ def test_generate_xai_tts_sends_speed_when_set(tmp_path, monkeypatch):
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
+        captured["stream"] = stream
         return fake_response
 
     monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
@@ -386,8 +390,9 @@ def test_generate_xai_tts_speed_clamped_to_valid_range(tmp_path, monkeypatch):
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
+        captured["stream"] = stream
         return fake_response
 
     monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
@@ -418,8 +423,9 @@ def test_generate_xai_tts_omits_speed_when_exactly_default(tmp_path, monkeypatch
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
+        captured["stream"] = stream
         return fake_response
 
     monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
@@ -442,8 +448,9 @@ def test_generate_xai_tts_sends_optimize_streaming_latency_when_set(tmp_path, mo
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
+        captured["stream"] = stream
         return fake_response
 
     monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
@@ -466,8 +473,9 @@ def test_generate_xai_tts_optimize_streaming_latency_omitted_at_default(tmp_path
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
+        captured["stream"] = stream
         return fake_response
 
     monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
@@ -490,8 +498,9 @@ def test_generate_xai_tts_global_speed_used_as_fallback(tmp_path, monkeypatch):
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
+        captured["stream"] = stream
         return fake_response
 
     monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
@@ -514,8 +523,9 @@ def test_generate_xai_tts_provider_speed_overrides_global(tmp_path, monkeypatch)
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
+        captured["stream"] = stream
         return fake_response
 
     monkeypatch.setenv("XAI_API_KEY", "test-xai-key")

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -27,6 +27,7 @@ import time
 from abc import ABC, abstractmethod
 from typing import Callable, Dict, Iterator, List, Optional
 
+from tools.tool_backend_helpers import resolve_openai_audio_api_key
 from tools.tts_tool import _get_provider, get_env_value
 
 logger = logging.getLogger(__name__)
@@ -202,14 +203,18 @@ class OpenAIStreamer(StreamingTTSProvider):
 
     @staticmethod
     def available() -> bool:
-        return bool(get_env_value("OPENAI_API_KEY"))
+        return bool(resolve_openai_audio_api_key())
 
     def stream(self, text: str) -> Iterator[bytes]:
         from openai import OpenAI
 
         client = OpenAI(
-            api_key=get_env_value("OPENAI_API_KEY"),
-            base_url=get_env_value("OPENAI_BASE_URL") or None,
+            api_key=resolve_openai_audio_api_key(),
+            base_url=(
+                self.section.get("base_url")
+                or get_env_value("OPENAI_BASE_URL")
+                or None
+            ),
         )
         model = self.section.get("model", "gpt-4o-mini-tts")
         voice = self.section.get("voice", "alloy")

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -28,7 +28,7 @@ from abc import ABC, abstractmethod
 from typing import Callable, Dict, Iterator, List, Optional
 
 from tools.tool_backend_helpers import resolve_openai_audio_api_key
-from tools.tts_tool import _get_provider, get_env_value
+from tools.tts_tool import _get_provider, _load_tts_config, get_env_value
 
 logger = logging.getLogger(__name__)
 
@@ -195,6 +195,15 @@ class ElevenLabsStreamer(StreamingTTSProvider):
         )
 
 
+def _openai_config_api_key() -> str:
+    """Return ``tts.openai.api_key`` from config.yaml, or empty string."""
+    try:
+        openai_cfg = (_load_tts_config().get("openai") or {})
+    except Exception:
+        return ""
+    return openai_cfg.get("api_key") or ""
+
+
 @register("openai")
 class OpenAIStreamer(StreamingTTSProvider):
     """OpenAI speech with ``response_format=pcm`` (24 kHz mono int16)."""
@@ -203,13 +212,13 @@ class OpenAIStreamer(StreamingTTSProvider):
 
     @staticmethod
     def available() -> bool:
-        return bool(resolve_openai_audio_api_key())
+        return bool(_openai_config_api_key() or resolve_openai_audio_api_key())
 
     def stream(self, text: str) -> Iterator[bytes]:
         from openai import OpenAI
 
         client = OpenAI(
-            api_key=resolve_openai_audio_api_key(),
+            api_key=(self.section.get("api_key") or resolve_openai_audio_api_key()),
             base_url=(
                 self.section.get("base_url")
                 or get_env_value("OPENAI_BASE_URL")

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -178,10 +178,14 @@ class ElevenLabsStreamer(StreamingTTSProvider):
         from tools.tts_tool import (
             DEFAULT_ELEVENLABS_STREAMING_MODEL_ID,
             DEFAULT_ELEVENLABS_VOICE_ID,
+            _elevenlabs_environment_kwargs,
             _import_elevenlabs,
         )
 
-        client = _import_elevenlabs()(api_key=get_env_value("ELEVENLABS_API_KEY"))
+        client = _import_elevenlabs()(
+            api_key=get_env_value("ELEVENLABS_API_KEY"),
+            **_elevenlabs_environment_kwargs(self.section),
+        )
         voice_id = self.section.get("voice_id", DEFAULT_ELEVENLABS_VOICE_ID)
         model_id = self.section.get(
             "streaming_model_id",

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2270,6 +2270,32 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
 # Provider: Piper (local, neural VITS, 44 languages)
 # ===========================================================================
 
+# Each cached entry below is a whole loaded TTS model (tens of MB). An
+# unbounded dict pins one model per distinct voice/model for the process
+# lifetime, so a surface that sweeps voices grows memory with no ceiling. Cap
+# each cache with a small LRU — most sessions use one or two voices, and a
+# reload on a cold miss is cheap next to keeping every model resident.
+_TTS_MODEL_CACHE_MAX = 3
+
+
+def _tts_cache_get_or_load(cache: Dict[str, Any], key: str, load: Callable[[], Any]) -> Any:
+    """Get ``key`` from ``cache`` or load it, keeping the cache LRU-bounded.
+
+    Refreshes recency on a hit (insertion-ordered dict: pop + reinsert), loads
+    on a miss, then evicts least-recently-used entries beyond the cap. An entry
+    evicted while a caller still holds its returned reference stays alive for
+    that caller; only the cache slot is released.
+    """
+    if key in cache:
+        cache[key] = cache.pop(key)
+        return cache[key]
+    value = load()
+    cache[key] = value
+    while len(cache) > _TTS_MODEL_CACHE_MAX:
+        cache.pop(next(iter(cache)), None)
+    return value
+
+
 # Module-level cache for Piper voice instances. Voices are keyed on their
 # absolute .onnx model path so switching voices doesn't invalidate older
 # cached voices.
@@ -2381,12 +2407,14 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
     # PiperVoice instance serves all speakers, so it stays out of the cache
     # key. Multi-speaker workflows share one model load.
     cache_key = f"{model_path}::cuda={use_cuda}"
-    global _piper_voice_cache
-    if cache_key not in _piper_voice_cache:
+
+    def _load_piper_voice():
         logger.info("[Piper] Loading voice: %s", model_path)
-        _piper_voice_cache[cache_key] = PiperVoice.load(model_path, use_cuda=use_cuda)
+        v = PiperVoice.load(model_path, use_cuda=use_cuda)
         logger.info("[Piper] Voice loaded")
-    voice = _piper_voice_cache[cache_key]
+        return v
+
+    voice = _tts_cache_get_or_load(_piper_voice_cache, cache_key, _load_piper_voice)
 
     # Optional synthesis knobs — only pass a SynthesisConfig when at least
     # one advanced knob is configured, so we don't depend on a newer Piper
@@ -2478,13 +2506,13 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
     clean_text = kt_config.get("clean_text", True)
 
     # Use cached model instance if available
-    global _kittentts_model_cache
-    if model_name not in _kittentts_model_cache:
+    def _load_kittentts_model():
         logger.info("[KittenTTS] Loading model: %s", model_name)
-        _kittentts_model_cache[model_name] = KittenTTS(model_name)
+        m = KittenTTS(model_name)
         logger.info("[KittenTTS] Model loaded successfully")
+        return m
 
-    model = _kittentts_model_cache[model_name]
+    model = _tts_cache_get_or_load(_kittentts_model_cache, model_name, _load_kittentts_model)
 
     # Generate audio (returns numpy array at 24kHz)
     audio = model.generate(text, voice=voice, speed=speed, clean_text=clean_text)

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -116,6 +116,24 @@ def _import_elevenlabs():
     from elevenlabs.client import ElevenLabs
     return ElevenLabs
 
+
+def _elevenlabs_environment_kwargs(el_config: Dict[str, Any]) -> Dict[str, Any]:
+    """Build ElevenLabs client kwargs honoring config base_url/wss_url.
+
+    ``tts.elevenlabs.base_url`` (and optionally ``wss_url``) redirect the SDK
+    to a self-hosted / proxy endpoint via an ``ElevenLabsEnvironment``. When
+    neither is set the SDK default environment is used. ``wss_url`` defaults
+    to the ``base_url`` host with a ``wss://`` scheme when omitted.
+    """
+    base_url = (el_config.get("base_url") or "").rstrip("/")
+    if not base_url:
+        return {}
+    wss_url = (el_config.get("wss_url") or "").rstrip("/")
+    if not wss_url:
+        wss_url = re.sub(r"^http", "ws", base_url)
+    from elevenlabs.environment import ElevenLabsEnvironment
+    return {"environment": ElevenLabsEnvironment(base=base_url, wss=wss_url)}
+
 def _import_openai_client():
     """Lazy import OpenAI client. Returns the class or raises ImportError."""
     from openai import OpenAI as OpenAIClient
@@ -1108,7 +1126,7 @@ def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]
         output_format = "mp3_44100_128"
 
     ElevenLabs = _import_elevenlabs()
-    client = ElevenLabs(api_key=api_key)
+    client = ElevenLabs(api_key=api_key, **_elevenlabs_environment_kwargs(el_config))
     audio_generator = client.text_to_speech.convert(
         text=text,
         voice_id=voice_id,

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1689,6 +1689,9 @@ def _generate_mistral_tts(text: str, output_path: str, tts_config: Dict[str, Any
     mi_config = tts_config.get("mistral") or {}
     model = mi_config.get("model", DEFAULT_MISTRAL_TTS_MODEL)
     voice_id = mi_config.get("voice_id") or DEFAULT_MISTRAL_TTS_VOICE_ID
+    # Class-level base_url parity: every cloud TTS provider section supports
+    # base_url. The Mistral SDK calls it server_url.
+    base_url = mi_config.get("base_url")
 
     if output_path.endswith(".ogg"):
         response_format = "opus"
@@ -1700,8 +1703,11 @@ def _generate_mistral_tts(text: str, output_path: str, tts_config: Dict[str, Any
         response_format = "mp3"
 
     Mistral = _import_mistral_client()
+    client_kwargs: Dict[str, Any] = {"api_key": api_key}
+    if base_url:
+        client_kwargs["server_url"] = base_url
     try:
-        with Mistral(api_key=api_key) as client:
+        with Mistral(**client_kwargs) as client:
             response = client.audio.speech.complete(
                 model=model,
                 input=text,

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -229,6 +229,8 @@ DEFAULT_DEEPINFRA_TTS_VOICE = "default"
 GEMINI_TTS_SAMPLE_RATE = 24000
 GEMINI_TTS_CHANNELS = 1
 GEMINI_TTS_SAMPLE_WIDTH = 2  # 16-bit PCM (L16)
+TTS_RESPONSE_BODY_LIMIT_BYTES = 16 * 1024 * 1024
+TTS_RESPONSE_BODY_CHUNK_BYTES = 64 * 1024
 
 def _get_default_output_dir() -> str:
     from hermes_constants import get_hermes_dir
@@ -284,6 +286,93 @@ def _config_bool(value: Any, default: bool = False) -> bool:
         if normalized in {"0", "false", "no", "off", "disabled"}:
             return False
     return default
+
+
+def _response_has_explicit_stream(response: Any) -> bool:
+    iter_content = getattr(response, "iter_content", None)
+    if not callable(iter_content):
+        return False
+    response_type = type(response)
+    if response_type.__module__.startswith("requests."):
+        return True
+    return "iter_content" in vars(response_type)
+
+
+def _close_response(response: Any) -> None:
+    close = getattr(response, "close", None)
+    if callable(close):
+        try:
+            close()
+        except Exception:
+            pass
+
+
+def _read_tts_response_bytes(
+    response: Any,
+    *,
+    label: str,
+    limit: Optional[int] = None,
+) -> bytes:
+    """Read an upstream TTS response with a hard byte cap."""
+    limit = TTS_RESPONSE_BODY_LIMIT_BYTES if limit is None else limit
+    chunks: list[bytes] = []
+    total = 0
+    try:
+        if _response_has_explicit_stream(response):
+            iterator = response.iter_content(chunk_size=TTS_RESPONSE_BODY_CHUNK_BYTES)
+        else:
+            content = vars(response).get("content", getattr(type(response), "content", b""))
+            if isinstance(content, str):
+                content = content.encode("utf-8", errors="replace")
+            iterator = (content,) if isinstance(content, (bytes, bytearray)) else ()
+
+        for chunk in iterator:
+            if not chunk:
+                continue
+            if isinstance(chunk, str):
+                chunk = chunk.encode("utf-8", errors="replace")
+            chunk = bytes(chunk)
+            total += len(chunk)
+            if total > limit:
+                _close_response(response)
+                raise RuntimeError(f"{label} response exceeds {limit} bytes")
+            chunks.append(chunk)
+        return b"".join(chunks)
+    finally:
+        _close_response(response)
+
+
+def _read_tts_response_json(
+    response: Any,
+    *,
+    label: str,
+    limit: Optional[int] = None,
+) -> Dict[str, Any]:
+    raw = _read_tts_response_bytes(response, label=label, limit=limit)
+    if raw:
+        return json.loads(raw.decode("utf-8"))
+
+    # Unit-test doubles often only provide `.json()`. Real requests.Response
+    # objects use the streaming path above, so this fallback does not re-open
+    # the production eager-buffering behavior.
+    if not _response_has_explicit_stream(response):
+        json_reader = getattr(response, "json", None)
+        if callable(json_reader):
+            parsed = json_reader()
+            return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _write_tts_response_to_file(
+    response: Any,
+    output_path: str,
+    *,
+    label: str,
+    limit: Optional[int] = None,
+) -> None:
+    audio_bytes = _read_tts_response_bytes(response, label=label, limit=limit)
+    with open(output_path, "wb") as f:
+        f.write(audio_bytes)
 
 # Final fallback when provider isn't recognised at all.
 FALLBACK_MAX_TEXT_LENGTH = 4000
@@ -1531,11 +1620,11 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
         },
         json=payload,
         timeout=60,
+        stream=True,
     )
     response.raise_for_status()
 
-    with open(output_path, "wb") as f:
-        f.write(response.content)
+    _write_tts_response_to_file(response, output_path, label="xAI TTS")
 
     return output_path
 
@@ -1623,12 +1712,18 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
             "voice_id": voice_id,
         }
 
-    response = requests.post(base_url, json=payload, headers=headers, timeout=60)
+    response = requests.post(
+        base_url,
+        json=payload,
+        headers=headers,
+        timeout=60,
+        stream=True,
+    )
 
     if is_t2a_v2:
         # t2a_v2 returns JSON with hex-encoded audio
         response.raise_for_status()
-        result = response.json()
+        result = _read_tts_response_json(response, label="MiniMax TTS")
         base_resp = result.get("base_resp", {})
         status_code = base_resp.get("status_code", -1)
 
@@ -1650,23 +1745,23 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
         content_type = response.headers.get("Content-Type", "")
 
         if "audio/" in content_type:
-            with open(output_path, "wb") as f:
-                f.write(response.content)
+            _write_tts_response_to_file(response, output_path, label="MiniMax TTS")
             return output_path
 
         # Fallback: try parsing as JSON
         try:
-            result = response.json()
+            raw_body = _read_tts_response_bytes(response, label="MiniMax TTS")
+            result = json.loads(raw_body.decode("utf-8")) if raw_body else {}
             base_resp = result.get("base_resp", {})
             status_code = base_resp.get("status_code", -1)
             if status_code != 0:
                 status_msg = base_resp.get("status_msg", "unknown error")
                 raise RuntimeError(f"MiniMax TTS API error (code {status_code}): {status_msg}")
-        except Exception:
+        except (json.JSONDecodeError, UnicodeDecodeError, TypeError):
             response.raise_for_status()
             raise RuntimeError(
                 f"MiniMax TTS returned unexpected Content-Type '{content_type}' "
-                f"({len(response.content)} bytes)"
+                f"({len(raw_body) if 'raw_body' in locals() else 0} bytes)"
             )
 
         raise RuntimeError("MiniMax TTS returned no audio data")
@@ -2001,20 +2096,27 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         headers=headers,
         json=payload,
         timeout=60,
+        stream=True,
     )
     if response.status_code != 200:
         # Surface the API error message when present
+        raw_body = _read_tts_response_bytes(response, label="Gemini TTS")
         try:
-            err = response.json().get("error", {})
-            detail = err.get("message") or response.text[:300]
+            if raw_body:
+                err = json.loads(raw_body.decode("utf-8")).get("error", {})
+            elif not _response_has_explicit_stream(response) and callable(getattr(response, "json", None)):
+                err = response.json().get("error", {})
+            else:
+                err = {}
+            detail = err.get("message") or raw_body.decode("utf-8", errors="replace")[:300]
         except Exception:
-            detail = response.text[:300]
+            detail = raw_body.decode("utf-8", errors="replace")[:300]
         raise RuntimeError(
             f"Gemini TTS API error (HTTP {response.status_code}): {detail}"
         )
 
     try:
-        data = response.json()
+        data = _read_tts_response_json(response, label="Gemini TTS")
         parts = data["candidates"][0]["content"]["parts"]
         audio_part = next((p for p in parts if "inlineData" in p or "inline_data" in p), None)
         if audio_part is None:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2802,14 +2802,30 @@ def _resolve_openai_audio_client_config() -> tuple[str, str, bool]:
     gateway (a restricted proxy), so callers can coerce the request to what the
     gateway supports. When ``tts.use_gateway`` is set the gateway is preferred
     even if direct OpenAI credentials are present.
+
+    Resolution order (mirrors the STT resolver):
+    1. ``tts.openai.api_key`` / ``tts.openai.base_url`` from ``config.yaml``
+    2. ``VOICE_TOOLS_OPENAI_KEY`` / ``OPENAI_API_KEY`` environment variables
+       (still honoring ``tts.openai.base_url`` when set)
+    3. Managed OpenAI audio tool gateway
     """
+    tts_config = _load_tts_config()
+    openai_cfg = (tts_config.get("openai") if isinstance(tts_config, dict) else None) or {}
+    cfg_api_key = openai_cfg.get("api_key") or ""
+    cfg_base_url = openai_cfg.get("base_url") or ""
+    if cfg_api_key and not prefers_gateway("tts"):
+        return cfg_api_key, (cfg_base_url or DEFAULT_OPENAI_BASE_URL), False
+
     direct_api_key = resolve_openai_audio_api_key()
     if direct_api_key and not prefers_gateway("tts"):
-        return direct_api_key, DEFAULT_OPENAI_BASE_URL, False
+        return direct_api_key, (cfg_base_url or DEFAULT_OPENAI_BASE_URL), False
 
     managed_gateway = resolve_managed_tool_gateway("openai-audio")
     if managed_gateway is None:
-        message = "Neither VOICE_TOOLS_OPENAI_KEY nor OPENAI_API_KEY is set"
+        message = (
+            "Neither tts.openai.api_key in config nor "
+            "VOICE_TOOLS_OPENAI_KEY/OPENAI_API_KEY is set"
+        )
         if managed_nous_tools_enabled() or prefers_gateway("tts"):
             message += (
                 ". "
@@ -2827,7 +2843,10 @@ def _resolve_openai_audio_client_config() -> tuple[str, str, bool]:
 
 
 def _has_openai_audio_backend() -> bool:
-    """Return True when OpenAI audio can use direct credentials or the managed gateway."""
+    """Return True when OpenAI audio can use config/env credentials or the managed gateway."""
+    openai_cfg = (_load_tts_config().get("openai") or {})
+    if openai_cfg.get("api_key"):
+        return True
     return bool(resolve_openai_audio_api_key() or resolve_managed_tool_gateway("openai-audio"))
 
 


### PR DESCRIPTION
# fix(tts): honor config.yaml endpoints/keys across providers + bound upstream buffering and model caches

Consolidated salvage of five contributor PRs. One theme: TTS providers should honor `config.yaml` endpoints/keys the same way everywhere (class-level `base_url` parity), plus two bounded-memory fixes.

## Config endpoints / keys (fixes #26175)

**`tts.openai.api_key` + `base_url` from config.yaml** — the resolver was env-only (`VOICE_TOOLS_OPENAI_KEY`/`OPENAI_API_KEY`) and ignored the `tts.openai` block. This was first reported and fixed by **@zccyman in #26209** (earliest submitter — thank you!) and independently by **@LeonSGP43 in #26233**; the cherry-picked commit carries the #26233 diff (it shipped with tests) rebased onto the current 3-tuple `_resolve_openai_audio_client_config` (`is_managed` flag, post-#73072 layout). Resolution order now mirrors the STT resolver: config → env (still honoring config `base_url`) → managed gateway. `_has_openai_audio_backend` also counts a config key as an available backend.

**OpenAI streaming path** (salvaged from #70307, @aml1973) — `OpenAIStreamer` read env only; it now uses the shared audio-key resolver and prefers `tts.openai.base_url`. Follow-up commit completes parity: the streamer also honors `tts.openai.api_key` in both `available()` and `stream()`.

**Configurable ElevenLabs URLs** (salvaged from #66311, @moeadham) — `tts.elevenlabs.base_url` (+ optional `wss_url`, derived from `base_url` when omitted) routes both the sync path and the chunked `ElevenLabsStreamer` through an `ElevenLabsEnvironment`, matching the STT side's `ELEVENLABS_STT_BASE_URL`/config pattern.

**Class-level base_url parity audit** — swept every cloud provider section: xAI, MiniMax, Gemini, OpenAI and DeepInfra already honored `tts.<provider>.base_url`; ElevenLabs and Mistral were the gaps. Mistral now passes `tts.mistral.base_url` as the SDK `server_url`. Every cloud TTS provider section now supports `base_url` consistently.

## Bounded buffering (fixes #55171)

**Bound upstream response bodies** (salvaged from #55177, @ooiuuii) — the requests-based providers (xAI, MiniMax, Gemini) buffered the entire upstream body via `response.content`/`response.json()` with no cap. New `_read_tts_response_bytes()` streams with a hard 16 MiB cap (64 KiB chunks) and closes the response; JSON/file-write helpers layer on it. A hostile/broken endpoint can no longer OOM the process.

**Bound the Piper/KittenTTS model caches** (salvaged from #62977, @Vissirexa — TTS half only; the hindsight turn-buffer half is a different subsystem and was deliberately dropped) — `_piper_voice_cache` / `_kittentts_model_cache` had no eviction and each entry is a whole loaded model (tens of MB). New `_tts_cache_get_or_load()` runs them through a small LRU (`_TTS_MODEL_CACHE_MAX=3`) with recency refresh on hit.

## Commits (contributor authorship preserved)

| Commit | Author | Salvaged from |
|---|---|---|
| `cd7bde218f` | @LeonSGP43 | #26233 (dupe of earlier #26209 by @zccyman) |
| `e6d631177d` | @aml1973 | #70307 |
| `2290272b0d` | ours | follow-up: streaming honors config api_key |
| `851f75b7e2` | @moeadham | #66311 |
| `ba055b3a80` | ours | base_url parity audit (Mistral) + provider config tests |
| `c6087a8981` | @ooiuuii | #55177 |
| `15673dfce7` | @Vissirexa | #62977 (model-cache half) |
| `bd4744cfbc` | ours | contributor email mappings |

## Tests

- `tests/tools/test_tts_openai_config.py` (6) — config/env/gateway resolution order, error message, backend availability
- `tests/tools/test_tts_streaming.py` (+3) — streamer honors config base_url and api_key; availability reflects config key
- `tests/tools/test_tts_provider_base_urls.py` (5) — ElevenLabs environment plumbing (incl. derived wss), Mistral `server_url` passthrough/omission
- `tests/tools/test_tts_response_body_cap.py` (10) — cap enforcement, streaming reads, JSON fallback
- `tests/tools/test_tts_model_cache_lru.py` (3) — load/hit/evict/LRU-recency

All 65 targeted tests pass (`pytest -o addopts="" -q tests/tools/test_tts_*`); sabotage-verified (disabling the config branch fails the config tests). The two `test_tts_xai_speech_tags` failures under a combined `-k tts` run reproduce identically on `origin/main` (pre-existing test-isolation flake, not introduced here).

## Post-merge

- Close #26175 (fixed), #55171 (fixed)
- Close #26209 with credit to @zccyman (earliest submitter of the openai config fix)
- Close #26233, #66311, #70307, #55177 as merged-via-salvage
- Comment on #62977: TTS half landed here; hindsight half remains for the memory-subsystem triage


## Infographic

![fix(tts): honor config.yaml endpoints across all providers + bounded upstream buffering](https://v3b.fal.media/files/b/0aa416cc/DZYmNPbw2gYGXqcMs9s7B_aT1NmMlb.png)
