### PR TITLE
fix(tools): command TTS/STT provider hardening — idle timeouts, env scrubbing, no-shell, path guards

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -2482,3 +2482,63 @@ class TestTranscribeCredentialReadGuard:
         # The error is the shared read-guard message, not an audio-validation
         # or provider error — proving the guard fired before dispatch.
         assert result["error"] == expected
+
+
+class TestRunCommandSttIdleTimeout:
+    """_run_command_stt uses a progress-based idle timeout (mirrors TTS runner)."""
+
+    @staticmethod
+    def _shell_command(*args):
+        import shlex
+        if os.name == "nt":
+            return subprocess.list2cmdline(list(args))
+        return " ".join(shlex.quote(str(arg)) for arg in args)
+
+    def test_stderr_progress_extends_beyond_timeout(self, tmp_path):
+        """A slow-but-alive command that keeps emitting output survives an
+        idle timeout shorter than its total runtime."""
+        from tools.transcription_tools import _run_command_stt
+
+        script = tmp_path / "progress_then_exit.py"
+        script.write_text(
+            "\n".join([
+                "import sys, time",
+                "for idx in range(4):",
+                "    print(f'tick {idx}', file=sys.stderr, flush=True)",
+                "    time.sleep(0.15)",
+                "print('done', flush=True)",
+            ]),
+            encoding="utf-8",
+        )
+
+        result = _run_command_stt(
+            self._shell_command(sys.executable, "-u", str(script)),
+            timeout=0.25,
+        )
+
+        assert result.returncode == 0
+        assert "tick 3" in result.stderr
+        assert "done" in result.stdout
+
+    def test_silent_stall_still_times_out(self, tmp_path):
+        """A silently stalled command is killed once the idle window elapses,
+        and pre-stall output is preserved on the TimeoutExpired."""
+        from tools.transcription_tools import _run_command_stt
+
+        script = tmp_path / "progress_then_hang.py"
+        script.write_text(
+            "\n".join([
+                "import sys, time",
+                "print('starting pass 1', file=sys.stderr, flush=True)",
+                "time.sleep(1.0)",
+            ]),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(subprocess.TimeoutExpired) as excinfo:
+            _run_command_stt(
+                self._shell_command(sys.executable, "-u", str(script)),
+                timeout=0.2,
+            )
+
+        assert "starting pass 1" in (excinfo.value.stderr or "")

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -501,6 +501,88 @@ class TestTranscribeOpenAIExtended:
 
 
 class TestTranscribeLocalCommand:
+    def test_command_provider_uses_sanitized_child_env(self, monkeypatch):
+        """Salvage of #56332: command STT must not inherit Hermes secrets."""
+        monkeypatch.setenv("AUXILIARY_VISION_API_KEY", "sk-vision")
+        monkeypatch.setenv("GATEWAY_RELAY_SECRET", "relay-secret")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+        monkeypatch.setenv("MY_SAFE_STT_VAR", "keep")
+
+        captured = {}
+
+        class Proc:
+            returncode = 0
+
+            def communicate(self, timeout=None):
+                return "", ""
+
+        def fake_popen(command, **kwargs):
+            captured["env"] = kwargs["env"]
+            return Proc()
+
+        monkeypatch.setattr("tools.transcription_tools.subprocess.Popen", fake_popen)
+
+        from tools.transcription_tools import _run_command_stt
+
+        result = _run_command_stt("echo hi", timeout=1)
+
+        assert result.returncode == 0
+        env = captured["env"]
+        assert "AUXILIARY_VISION_API_KEY" not in env
+        assert "GATEWAY_RELAY_SECRET" not in env
+        assert "OPENAI_API_KEY" not in env
+        assert env["MY_SAFE_STT_VAR"] == "keep"
+
+    def test_local_whisper_subprocess_uses_sanitized_env(
+        self, monkeypatch, sample_wav, tmp_path
+    ):
+        """Sibling path: local whisper subprocess.run also scrubbed (#56332 gap)."""
+        monkeypatch.setenv("AUXILIARY_VISION_API_KEY", "sk-vision")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+        monkeypatch.setenv("MY_SAFE_LOCAL_STT", "keep")
+        monkeypatch.setenv(
+            "HERMES_LOCAL_STT_COMMAND",
+            "whisper {input_path} --model {model} --output_dir {output_dir} --language {language}",
+        )
+
+        captured = {}
+        out_dir = tmp_path / "local-out"
+        out_dir.mkdir()
+        (out_dir / "transcript.txt").write_text("hello", encoding="utf-8")
+
+        def fake_tempdir(prefix=None):
+            class _TempDir:
+                def __enter__(self_inner):
+                    return str(out_dir)
+
+                def __exit__(self_inner, *exc):
+                    return False
+
+            return _TempDir()
+
+        def fake_run(*args, **kwargs):
+            captured["env"] = kwargs.get("env")
+            class R:
+                returncode = 0
+            return R()
+
+        monkeypatch.setattr("tools.transcription_tools.tempfile.TemporaryDirectory", fake_tempdir)
+        monkeypatch.setattr("tools.transcription_tools.subprocess.run", fake_run)
+        monkeypatch.setattr(
+            "tools.transcription_tools._prepare_local_audio",
+            lambda *a, **k: (str(sample_wav), None),
+        )
+
+        from tools.transcription_tools import _transcribe_local_command
+
+        result = _transcribe_local_command(str(sample_wav), "base")
+        assert result["success"] is True
+        env = captured["env"]
+        assert env is not None
+        assert "AUXILIARY_VISION_API_KEY" not in env
+        assert "OPENAI_API_KEY" not in env
+        assert env["MY_SAFE_LOCAL_STT"] == "keep"
+
     def test_auto_detects_local_whisper_binary(self, monkeypatch):
         monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
         monkeypatch.setattr("tools.transcription_tools._find_whisper_binary", lambda: "/opt/homebrew/bin/whisper")

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -2317,7 +2317,9 @@ class TestLocalBaseUrlNoApiKey:
         assert not _is_local_or_private_url("")
 
 
-# ============================================================================
+# =====================================================================
+
+
 # CAF (iMessage voice note) conversion tests
 # ============================================================================
 
@@ -2456,3 +2458,27 @@ class TestCafConversion:
 
         assert result["success"] is True
         mock_convert.assert_not_called()
+=======
+class TestTranscribeCredentialReadGuard:
+    """transcribe_audio must refuse credential/secret stores before dispatch."""
+
+    def test_transcribe_audio_blocks_credential_read(self, tmp_path):
+        """A ``.env`` (secret-bearing) file is refused up front, so its
+        plaintext is never shipped to an external STT provider — mirroring the
+        read guard added to image-gen (587be5b5b) and xAI video-gen
+        (104232979)."""
+        from tools.transcription_tools import transcribe_audio
+        from agent.file_safety import get_read_block_error
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("OPENAI_API_KEY=sk-secret\n")
+
+        expected = get_read_block_error(str(env_file))
+        assert expected, "test setup: a .env file should be read-blocked"
+
+        result = transcribe_audio(str(env_file))
+
+        assert result["success"] is False
+        # The error is the shared read-guard message, not an audio-validation
+        # or provider error — proving the guard fired before dispatch.
+        assert result["error"] == expected

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -617,12 +617,7 @@ class TestTranscribeLocalCommand:
             return _TempDir()
 
         def fake_run(cmd, *args, **kwargs):
-            if isinstance(cmd, list):
-                output_path = cmd[-1]
-                with open(output_path, "wb") as handle:
-                    handle.write(b"RIFF....WAVEfmt ")
-                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
-
+            assert isinstance(cmd, list)
             (out_dir / "test.txt").write_text("hello from local command\n", encoding="utf-8")
             return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
@@ -2142,13 +2137,77 @@ class TestShellSafety:
         assert parts[0] == "/usr/bin/whisper"
         assert "/tmp/test.wav" in parts
 
-    def test_env_var_template_uses_shell_path(self, monkeypatch):
-        """When HERMES_LOCAL_STT_COMMAND is set, use_shell should be True."""
-        import os
-        from tools.transcription_tools import LOCAL_STT_COMMAND_ENV
-        monkeypatch.setenv(LOCAL_STT_COMMAND_ENV, "whisper {input_path} | tee log.txt")
-        use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
-        assert use_shell is True
+    def test_env_var_template_metacharacters_are_literal_argv(
+        self, monkeypatch, sample_wav, tmp_path
+    ):
+        from tools.transcription_tools import (
+            LOCAL_STT_COMMAND_ENV,
+            _transcribe_local_command,
+            windows_hide_flags,
+        )
+
+        output_dir = tmp_path / "transcript-output"
+        output_dir.mkdir()
+        monkeypatch.setenv(
+            LOCAL_STT_COMMAND_ENV,
+            (
+                "whisper {input_path} ; printf injected | tee log.txt "
+                "&& echo $(id) `whoami` --output_dir {output_dir}"
+            ),
+        )
+
+        def fake_tempdir(prefix=None):
+            class _TempDir:
+                def __enter__(self):
+                    return str(output_dir)
+
+                def __exit__(self, exc_type, exc, tb):
+                    return False
+
+            return _TempDir()
+
+        invocation = {}
+
+        def fake_run(command, **kwargs):
+            invocation["command"] = command
+            invocation["kwargs"] = kwargs
+            (output_dir / "transcript.txt").write_text("safe", encoding="utf-8")
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(
+            "tools.transcription_tools.tempfile.TemporaryDirectory", fake_tempdir
+        )
+        monkeypatch.setattr("tools.transcription_tools.subprocess.run", fake_run)
+
+        result = _transcribe_local_command(sample_wav, "base")
+
+        assert result["transcript"] == "safe"
+        assert invocation["command"] == [
+            "whisper",
+            sample_wav,
+            ";",
+            "printf",
+            "injected",
+            "|",
+            "tee",
+            "log.txt",
+            "&&",
+            "echo",
+            "$(id)",
+            "`whoami`",
+            "--output_dir",
+            str(output_dir),
+        ]
+        assert invocation["kwargs"] == {
+            "check": True,
+            "capture_output": True,
+            "text": True,
+            "encoding": "utf-8",
+            "errors": "replace",
+            "timeout": 300,
+            "stdin": subprocess.DEVNULL,
+            "creationflags": windows_hide_flags(),
+        }
 
     def test_no_env_var_uses_list_mode(self, monkeypatch):
         """When no env var is set, use_shell should be False."""

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -2465,7 +2465,8 @@ class TestCafConversion:
 
         assert result["success"] is True
         mock_convert.assert_not_called()
-=======
+
+
 class TestTranscribeCredentialReadGuard:
     """transcribe_audio must refuse credential/secret stores before dispatch."""
 

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -510,11 +510,17 @@ class TestTranscribeLocalCommand:
 
         captured = {}
 
+        class _Stream:
+            def read(self, size):
+                return ""
+
         class Proc:
             returncode = 0
+            stdout = _Stream()
+            stderr = _Stream()
 
-            def communicate(self, timeout=None):
-                return "", ""
+            def wait(self, timeout=None):
+                return 0
 
         def fake_popen(command, **kwargs):
             captured["env"] = kwargs["env"]
@@ -2198,6 +2204,7 @@ class TestShellSafety:
             "--output_dir",
             str(output_dir),
         ]
+        assert invocation["kwargs"].pop("env") is not None
         assert invocation["kwargs"] == {
             "check": True,
             "capture_output": True,

--- a/tests/tools/test_tts_command_providers.py
+++ b/tests/tools/test_tts_command_providers.py
@@ -14,6 +14,8 @@ differences) Windows.
 
 import json
 import os
+import shlex
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -37,6 +39,7 @@ from tools.tts_tool import (
     _render_command_tts_template,
     _resolve_command_provider_config,
     _resolve_max_text_length,
+    _run_command_tts,
     _shell_quote_context,
     check_tts_requirements,
     text_to_speech_tool,
@@ -55,6 +58,13 @@ def _python_copy_command(output_placeholder: str = "{output_path}") -> str:
         f'shutil.copyfile(sys.argv[1], sys.argv[2])" '
         f'{{input_path}} {output_placeholder}'
     )
+
+
+def _shell_command(*args: str) -> str:
+    """Return a shell command string for subprocess.Popen(shell=True)."""
+    if os.name == "nt":
+        return subprocess.list2cmdline(list(args))
+    return " ".join(shlex.quote(str(arg)) for arg in args)
 
 
 # ---------------------------------------------------------------------------
@@ -346,6 +356,53 @@ class TestRenderCommandTtsTemplate:
             placeholders,
         )
         assert '"bob\'s voice"' in rendered
+
+
+# ---------------------------------------------------------------------------
+# _run_command_tts idle/progress timeout behavior
+# ---------------------------------------------------------------------------
+
+class TestRunCommandTts:
+    def test_stderr_progress_extends_beyond_timeout(self, tmp_path):
+        script = tmp_path / "progress_then_exit.py"
+        script.write_text(
+            "\n".join([
+                "import sys, time",
+                "for idx in range(4):",
+                "    print(f'tick {idx}', file=sys.stderr, flush=True)",
+                "    time.sleep(0.15)",
+                "print('done', flush=True)",
+            ]),
+            encoding="utf-8",
+        )
+
+        result = _run_command_tts(
+            _shell_command(sys.executable, "-u", str(script)),
+            timeout=0.25,
+        )
+
+        assert result.returncode == 0
+        assert "tick 3" in result.stderr
+        assert "done" in result.stdout
+
+    def test_silent_after_progress_still_times_out_with_stderr(self, tmp_path):
+        script = tmp_path / "progress_then_hang.py"
+        script.write_text(
+            "\n".join([
+                "import sys, time",
+                "print('starting tier 1', file=sys.stderr, flush=True)",
+                "time.sleep(1.0)",
+            ]),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(subprocess.TimeoutExpired) as excinfo:
+            _run_command_tts(
+                _shell_command(sys.executable, "-u", str(script)),
+                timeout=0.2,
+            )
+
+        assert "starting tier 1" in (excinfo.value.stderr or "")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_tts_command_providers.py
+++ b/tests/tools/test_tts_command_providers.py
@@ -363,6 +363,39 @@ class TestRenderCommandTtsTemplate:
 # ---------------------------------------------------------------------------
 
 class TestRunCommandTts:
+    def test_reads_process_output_in_large_chunks(self):
+        read_sizes: dict[str, list[int]] = {"stdout": [], "stderr": []}
+
+        class FakeStream:
+            def __init__(self, name: str, chunks: list[str]):
+                self.name = name
+                self.chunks = chunks
+
+            def read(self, size: int) -> str:
+                read_sizes[self.name].append(size)
+                if self.chunks:
+                    return self.chunks.pop(0)
+                return ""
+
+        class FakeProcess:
+            def __init__(self):
+                self.pid = 12345
+                self.returncode = 0
+                self.stdout = FakeStream("stdout", ["done"])
+                self.stderr = FakeStream("stderr", ["tick"])
+
+            def wait(self, timeout=None):
+                return self.returncode
+
+        with patch("tools.tts_tool.subprocess.Popen", return_value=FakeProcess()):
+            result = _run_command_tts("fake tts", timeout=0.25)
+
+        assert result.returncode == 0
+        assert result.stdout == "done"
+        assert result.stderr == "tick"
+        assert read_sizes["stdout"][0] == 65536
+        assert read_sizes["stderr"][0] == 65536
+
     def test_stderr_progress_extends_beyond_timeout(self, tmp_path):
         script = tmp_path / "progress_then_exit.py"
         script.write_text(
@@ -403,6 +436,7 @@ class TestRunCommandTts:
             )
 
         assert "starting tier 1" in (excinfo.value.stderr or "")
+        assert isinstance(excinfo.value.__cause__, subprocess.TimeoutExpired)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_tts_command_providers.py
+++ b/tests/tools/test_tts_command_providers.py
@@ -396,6 +396,32 @@ class TestRunCommandTts:
         assert read_sizes["stdout"][0] == 65536
         assert read_sizes["stderr"][0] == 65536
 
+    def test_closed_pipes_still_running_honors_idle_timeout(self):
+        class ClosedStream:
+            def read(self, size: int) -> str:
+                return ""
+
+        class FakeProcess:
+            def __init__(self):
+                self.pid = 12345
+                self.returncode = None
+                self.stdout = ClosedStream()
+                self.stderr = ClosedStream()
+
+            def wait(self, timeout=None):
+                if timeout is None:
+                    self.returncode = 0
+                    return self.returncode
+                raise subprocess.TimeoutExpired("fake tts", timeout)
+
+        process = FakeProcess()
+        with (
+            patch("tools.tts_tool.subprocess.Popen", return_value=process),
+            patch("tools.tts_tool._terminate_command_tts_process_tree"),
+        ):
+            with pytest.raises(subprocess.TimeoutExpired):
+                _run_command_tts("fake tts", timeout=0.25)
+
     def test_stderr_progress_extends_beyond_timeout(self, tmp_path):
         script = tmp_path / "progress_then_exit.py"
         script.write_text(

--- a/tests/tools/test_tts_command_providers.py
+++ b/tests/tools/test_tts_command_providers.py
@@ -134,11 +134,17 @@ class TestCommandTtsEnv:
 
         captured = {}
 
+        class _Stream:
+            def read(self, size):
+                return ""
+
         class Proc:
             returncode = 0
+            stdout = _Stream()
+            stderr = _Stream()
 
-            def communicate(self, timeout=None):
-                return "", ""
+            def wait(self, timeout=None):
+                return 0
 
         def fake_popen(command, **kwargs):
             captured["env"] = kwargs["env"]

--- a/tests/tools/test_tts_command_providers.py
+++ b/tests/tools/test_tts_command_providers.py
@@ -663,3 +663,49 @@ class TestCheckTtsRequirements:
         }
         with patch("tools.tts_tool._load_tts_config", return_value=cfg):
             assert check_tts_requirements() is True
+
+
+class TestCommandTtsEnvPassthrough:
+    def test_env_passthrough_restores_named_keys(self, monkeypatch):
+        """A provider's env_passthrough allowlist re-adds its own API key
+        without unscrubbing everything else."""
+        monkeypatch.setenv("MY_TTS_API_KEY", "sk-provider")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+
+        captured = {}
+
+        class _Stream:
+            def read(self, size):
+                return ""
+
+        class Proc:
+            returncode = 0
+            stdout = _Stream()
+            stderr = _Stream()
+
+            def wait(self, timeout=None):
+                return 0
+
+        def fake_popen(command, **kwargs):
+            captured["env"] = kwargs["env"]
+            return Proc()
+
+        monkeypatch.setattr("tools.tts_tool.subprocess.Popen", fake_popen)
+
+        result = _run_command_tts(
+            "echo hi", timeout=1, env_passthrough=["MY_TTS_API_KEY"]
+        )
+
+        assert result.returncode == 0
+        env = captured["env"]
+        assert env["MY_TTS_API_KEY"] == "sk-provider"
+        assert "OPENAI_API_KEY" not in env
+
+    def test_allowlist_parsed_from_provider_config(self):
+        from tools.tts_tool import _command_provider_env_passthrough
+
+        assert _command_provider_env_passthrough(
+            {"env_passthrough": ["A_KEY", " B_KEY ", ""]}
+        ) == ["A_KEY", "B_KEY"]
+        assert _command_provider_env_passthrough({}) == []
+        assert _command_provider_env_passthrough({"env_passthrough": "A_KEY"}) == []

--- a/tests/tools/test_tts_command_providers.py
+++ b/tests/tools/test_tts_command_providers.py
@@ -243,10 +243,19 @@ class TestConfigGetters:
         assert _get_command_tts_output_format({"format": "ogg"}, "/tmp/clip.xyz") == "ogg"
 
     def test_output_format_rejects_unknown(self):
-        assert _get_command_tts_output_format({"format": "m4a"}) == DEFAULT_COMMAND_TTS_OUTPUT_FORMAT
+        assert _get_command_tts_output_format({"format": "midi"}) == DEFAULT_COMMAND_TTS_OUTPUT_FORMAT
 
     def test_output_format_supported_set(self):
-        assert COMMAND_TTS_OUTPUT_FORMATS == frozenset({"mp3", "wav", "ogg", "flac"})
+        assert COMMAND_TTS_OUTPUT_FORMATS == frozenset(
+            {"mp3", "wav", "ogg", "flac", "m4a", "aac", "amr", "opus"}
+        )
+
+    def test_output_format_accepts_extended_formats(self):
+        # m4a/aac/amr/opus are common ffmpeg-producible containers/codecs;
+        # honored both via explicit config and via the output path suffix.
+        for fmt in ("m4a", "aac", "amr", "opus"):
+            assert _get_command_tts_output_format({"format": fmt}) == fmt
+            assert _get_command_tts_output_format({}, f"/tmp/clip.{fmt}") == fmt
 
     def test_voice_compatible_boolean(self):
         assert _is_command_tts_voice_compatible({"voice_compatible": True}) is True

--- a/tests/tools/test_tts_command_providers.py
+++ b/tests/tools/test_tts_command_providers.py
@@ -124,6 +124,38 @@ class TestResolveCommandProviderConfig:
         assert _resolve_command_provider_config("piper", cfg) is None
 
 
+class TestCommandTtsEnv:
+    def test_command_provider_uses_sanitized_child_env(self, monkeypatch):
+        """Salvage of #56332: command TTS must not inherit Hermes secrets."""
+        monkeypatch.setenv("AUXILIARY_VISION_API_KEY", "sk-vision")
+        monkeypatch.setenv("GATEWAY_RELAY_SECRET", "relay-secret")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+        monkeypatch.setenv("MY_SAFE_TTS_VAR", "keep")
+
+        captured = {}
+
+        class Proc:
+            returncode = 0
+
+            def communicate(self, timeout=None):
+                return "", ""
+
+        def fake_popen(command, **kwargs):
+            captured["env"] = kwargs["env"]
+            return Proc()
+
+        monkeypatch.setattr("tools.tts_tool.subprocess.Popen", fake_popen)
+
+        result = _run_command_tts("echo hi", timeout=1)
+
+        assert result.returncode == 0
+        env = captured["env"]
+        assert "AUXILIARY_VISION_API_KEY" not in env
+        assert "GATEWAY_RELAY_SECRET" not in env
+        assert "OPENAI_API_KEY" not in env
+        assert env["MY_SAFE_TTS_VAR"] == "keep"
+
+
 class TestGetNamedProviderConfig:
     def test_providers_block_wins(self):
         cfg = {"providers": {"voxcpm": {"command": "new"}},

--- a/tests/tools/test_tts_path_traversal.py
+++ b/tests/tools/test_tts_path_traversal.py
@@ -58,3 +58,44 @@ def test_output_path_relative_no_dotdot_passes_guard(tmp_path, monkeypatch):
     ))
     error = result.get("error", "")
     assert "traversal" not in error.lower()
+
+
+def test_output_path_rejects_hermes_oauth_store(tmp_path, monkeypatch):
+    """TTS output_path must not bypass the shared protected-file write guard."""
+    import agent.file_safety as file_safety
+
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setattr(file_safety, "_hermes_home_path", lambda: hermes_home)
+    monkeypatch.setattr(file_safety, "_hermes_root_path", lambda: hermes_home)
+
+    target = hermes_home / ".anthropic_oauth.json"
+    result = json.loads(text_to_speech_tool(
+        text="hello",
+        output_path=str(target),
+    ))
+
+    assert result["success"] is False
+    assert "protected credential" in result["error"]
+    assert not target.exists()
+
+
+def test_output_path_rejects_mcp_token_directory(tmp_path, monkeypatch):
+    """TTS output_path must not write synthesized audio over MCP token files."""
+    import agent.file_safety as file_safety
+
+    hermes_home = tmp_path / "hermes-home"
+    token_dir = hermes_home / "mcp-tokens"
+    token_dir.mkdir(parents=True)
+    monkeypatch.setattr(file_safety, "_hermes_home_path", lambda: hermes_home)
+    monkeypatch.setattr(file_safety, "_hermes_root_path", lambda: hermes_home)
+
+    target = token_dir / "server.mp3"
+    result = json.loads(text_to_speech_tool(
+        text="hello",
+        output_path=str(target),
+    ))
+
+    assert result["success"] is False
+    assert "protected credential" in result["error"]
+    assert not target.exists()

--- a/tests/tools/test_voice_mode_playback_env_scrub.py
+++ b/tests/tools/test_voice_mode_playback_env_scrub.py
@@ -1,0 +1,32 @@
+"""Voice-mode system playback must scrub credential env (sibling of #70342)."""
+
+from unittest.mock import MagicMock, patch
+
+
+def test_play_audio_file_scrubbed_env(tmp_path, monkeypatch):
+    audio = tmp_path / "t.mp3"
+    audio.write_bytes(b"ID3fake")
+
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "secret-token")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    captured = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["env"] = kwargs.get("env")
+        proc = MagicMock()
+        proc.wait.return_value = 0
+        return proc
+
+    import tools.voice_mode as vm
+
+    with patch.object(vm, "platform") as plat, patch.object(
+        vm.shutil, "which", return_value="/usr/bin/ffplay"
+    ), patch.object(vm.subprocess, "Popen", side_effect=fake_popen):
+        plat.system.return_value = "Linux"
+        ok = vm.play_audio_file(str(audio))
+
+    assert ok is True
+    assert captured.get("env") is not None
+    assert "TELEGRAM_BOT_TOKEN" not in captured["env"]
+    assert "OPENAI_API_KEY" not in captured["env"]

--- a/tests/tools/test_voice_mode_playback_env_scrub.py
+++ b/tests/tools/test_voice_mode_playback_env_scrub.py
@@ -16,6 +16,7 @@ def test_play_audio_file_scrubbed_env(tmp_path, monkeypatch):
         captured["env"] = kwargs.get("env")
         proc = MagicMock()
         proc.wait.return_value = 0
+        proc.returncode = 0
         return proc
 
     import tools.voice_mode as vm

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -654,7 +654,26 @@ def _terminate_command_stt_process_tree(proc: subprocess.Popen) -> None:
         proc.kill()
 
 
-def _run_command_stt(command: str, timeout: float) -> subprocess.CompletedProcess:
+def _command_stt_env_passthrough(config: Dict[str, Any]) -> list:
+    """Return the provider's ``env_passthrough`` allowlist (opt-out of scrub).
+
+    Command providers legitimately reference their own API keys in the shell
+    template (curl one-liners). The child env is scrubbed of Hermes secrets by
+    default; ``env_passthrough: [MY_API_KEY, ...]`` copies the named variables
+    back from the parent environment so a trusted template keeps working.
+    Mirrors ``tools.tts_tool._command_provider_env_passthrough``.
+    """
+    raw = config.get("env_passthrough")
+    if not isinstance(raw, (list, tuple)):
+        return []
+    return [str(item).strip() for item in raw if str(item).strip()]
+
+
+def _run_command_stt(
+    command: str,
+    timeout: float,
+    env_passthrough: Optional[list] = None,
+) -> subprocess.CompletedProcess:
     """Run a command-provider shell command with process-tree idle cleanup.
 
     Mirrors ``tools.tts_tool._run_command_tts``: ``timeout`` is an IDLE
@@ -668,6 +687,10 @@ def _run_command_stt(command: str, timeout: float) -> subprocess.CompletedProces
     from tools.environments.local import hermes_subprocess_env
 
     scrubbed = hermes_subprocess_env(inherit_credentials=False)
+    for key in env_passthrough or []:
+        value = os.environ.get(key)
+        if value is not None:
+            scrubbed[key] = value
     popen_kwargs: Dict[str, Any] = {
         "shell": True,
         "stdout": subprocess.PIPE,
@@ -879,7 +902,11 @@ def _transcribe_command_stt(
                 audio.name, provider_name,
             )
             try:
-                result = _run_command_stt(command, timeout)
+                result = _run_command_stt(
+                    command,
+                    timeout,
+                    env_passthrough=_command_stt_env_passthrough(config),
+                )
             except subprocess.TimeoutExpired:
                 return {
                     "success": False,

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1549,41 +1549,24 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
                 language=shlex.quote(language),
                 model=shlex.quote(normalized_model),
             )
-            # User-provided templates (env var) may contain shell syntax; auto-detected commands are safe for list mode.
             # Scrub Hermes secrets from the child env (sibling path to #56332 /
             # _run_command_stt — this local-whisper path previously inherited
             # the full process environment).
             from tools.environments.local import hermes_subprocess_env
 
             child_env = hermes_subprocess_env(inherit_credentials=False)
-            use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
-            if use_shell:
-                subprocess.run(
-                    command,
-                    shell=True,
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                    encoding="utf-8",
-                    errors="replace",
-                    timeout=300,
-                    stdin=subprocess.DEVNULL,
-                    env=child_env,
-                    creationflags=windows_hide_flags(),
-                )
-            else:
-                subprocess.run(
-                    shlex.split(command),
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                    encoding="utf-8",
-                    errors="replace",
-                    timeout=300,
-                    stdin=subprocess.DEVNULL,
-                    env=child_env,
-                    creationflags=windows_hide_flags(),
-                )
+            subprocess.run(
+                shlex.split(command),
+                check=True,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=300,
+                stdin=subprocess.DEVNULL,
+                env=child_env,
+                creationflags=windows_hide_flags(),
+            )
 
             txt_files = sorted(Path(output_dir).glob("*.txt"))
             if not txt_files:

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2144,6 +2144,15 @@ def _transcribe_prepared_audio(file_path: str, model: Optional[str] = None) -> D
           - "error" (str, optional): Error message if success is False
           - "provider" (str, optional): Which provider was used
     """
+    # Refuse to feed a credential / secret store (auth.json, .env, OAuth
+    # tokens, mcp-tokens/, ...) to an STT provider: an external provider would
+    # ship its plaintext contents to a third-party API. Mirrors the local-input
+    # read guard added to image-gen (587be5b5b) and xAI video-gen (104232979).
+    from agent.file_safety import get_read_block_error
+    blocked = get_read_block_error(file_path)
+    if blocked:
+        return {"success": False, "transcript": "", "error": blocked}
+
     # Apply common path validation before provider resolution so invalid files
     # cannot trigger provider setup or lazy installation. The remote-upload
     # size cap is enforced separately below, only for non-local providers.

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -30,12 +30,14 @@ Usage::
 import logging
 import os
 import platform
+import queue
 import re
 import shlex
 import shutil
 import subprocess
 import tempfile
 import threading
+import time
 from pathlib import Path
 from typing import Optional, Dict, Any
 from urllib.parse import urljoin
@@ -653,9 +655,12 @@ def _terminate_command_stt_process_tree(proc: subprocess.Popen) -> None:
 
 
 def _run_command_stt(command: str, timeout: float) -> subprocess.CompletedProcess:
-    """Run a command-provider shell command with process-tree timeout cleanup.
+    """Run a command-provider shell command with process-tree idle cleanup.
 
-    Mirrors ``tools.tts_tool._run_command_tts``.
+    Mirrors ``tools.tts_tool._run_command_tts``: ``timeout`` is an IDLE
+    timeout, reset whenever the command emits output on stdout/stderr —
+    a slow-but-alive provider survives, a silently stalled one is killed
+    (same progress-based stuck detection as the TTS runner, #50081).
     Child env is scrubbed of Hermes secrets (salvage of #56332) while still
     propagating delegated-child lineage markers when applicable.
     """
@@ -680,21 +685,89 @@ def _run_command_stt(command: str, timeout: float) -> subprocess.CompletedProces
         popen_kwargs["start_new_session"] = True
 
     proc = subprocess.Popen(command, **popen_kwargs, stdin=subprocess.DEVNULL)
-    try:
-        stdout, stderr = proc.communicate(timeout=timeout)
-    except subprocess.TimeoutExpired as exc:
-        _terminate_command_stt_process_tree(proc)
+    output_queue: "queue.Queue[tuple[str, Optional[str]]]" = queue.Queue()
+    chunks: Dict[str, list] = {"stdout": [], "stderr": []}
+    open_streams = {"stdout", "stderr"}
+
+    def read_stream(name: str, stream: Any) -> None:
+        encoding = getattr(stream, "encoding", None) or "utf-8"
+        read1 = getattr(getattr(stream, "buffer", None), "read1", None)
         try:
-            stdout, stderr = proc.communicate(timeout=1)
-        except Exception:
-            stdout = getattr(exc, "output", None)
-            stderr = getattr(exc, "stderr", None)
-        raise subprocess.TimeoutExpired(
-            command,
-            timeout,
-            output=stdout,
-            stderr=stderr,
-        ) from exc
+            while True:
+                if read1 is None:
+                    chunk = stream.read(65536)
+                else:
+                    data = read1(65536)
+                    chunk = data.decode(encoding, errors="replace")
+                if not chunk:
+                    break
+                output_queue.put((name, chunk))
+        finally:
+            output_queue.put((name, None))
+
+    readers = [
+        threading.Thread(
+            target=read_stream,
+            args=("stdout", proc.stdout),
+            daemon=True,
+        ),
+        threading.Thread(
+            target=read_stream,
+            args=("stderr", proc.stderr),
+            daemon=True,
+        ),
+    ]
+    for reader in readers:
+        reader.start()
+
+    deadline = time.monotonic() + timeout
+    timed_out = False
+    while open_streams:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            timed_out = True
+            break
+        try:
+            name, chunk = output_queue.get(timeout=min(0.05, remaining))
+        except queue.Empty:
+            continue
+        if chunk is None:
+            open_streams.discard(name)
+            continue
+        chunks[name].append(chunk)
+        deadline = time.monotonic() + timeout
+
+    if not timed_out:
+        try:
+            proc.wait(timeout=max(0.0, deadline - time.monotonic()))
+        except subprocess.TimeoutExpired:
+            timed_out = True
+
+    if timed_out:
+        _terminate_command_stt_process_tree(proc)
+        for reader in readers:
+            reader.join(timeout=0.5)
+        while True:
+            try:
+                name, chunk = output_queue.get_nowait()
+            except queue.Empty:
+                break
+            if chunk:
+                chunks[name].append(chunk)
+        stdout = "".join(chunks["stdout"])
+        stderr = "".join(chunks["stderr"])
+        try:
+            raise subprocess.TimeoutExpired(command, timeout)
+        except subprocess.TimeoutExpired as exc:
+            raise subprocess.TimeoutExpired(
+                command,
+                timeout,
+                output=stdout,
+                stderr=stderr,
+            ) from exc
+
+    stdout = "".join(chunks["stdout"])
+    stderr = "".join(chunks["stderr"])
 
     if proc.returncode:
         raise subprocess.CalledProcessError(

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -656,9 +656,13 @@ def _run_command_stt(command: str, timeout: float) -> subprocess.CompletedProces
     """Run a command-provider shell command with process-tree timeout cleanup.
 
     Mirrors ``tools.tts_tool._run_command_tts``.
+    Child env is scrubbed of Hermes secrets (salvage of #56332) while still
+    propagating delegated-child lineage markers when applicable.
     """
     from agent.delegation_context import delegated_child_subprocess_env
+    from tools.environments.local import hermes_subprocess_env
 
+    scrubbed = hermes_subprocess_env(inherit_credentials=False)
     popen_kwargs: Dict[str, Any] = {
         "shell": True,
         "stdout": subprocess.PIPE,
@@ -668,7 +672,7 @@ def _run_command_stt(command: str, timeout: float) -> subprocess.CompletedProces
         # must not raise in the reader threads on non-UTF-8 Windows (#45099).
         "encoding": "utf-8",
         "errors": "replace",
-        "env": delegated_child_subprocess_env(),
+        "env": delegated_child_subprocess_env(scrubbed),
     }
     if os.name == "nt":
         popen_kwargs["creationflags"] = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
@@ -1546,12 +1550,40 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
                 model=shlex.quote(normalized_model),
             )
             # User-provided templates (env var) may contain shell syntax; auto-detected commands are safe for list mode.
+            # Scrub Hermes secrets from the child env (sibling path to #56332 /
+            # _run_command_stt — this local-whisper path previously inherited
+            # the full process environment).
+            from tools.environments.local import hermes_subprocess_env
+
+            child_env = hermes_subprocess_env(inherit_credentials=False)
             use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
             if use_shell:
-                subprocess.run(command, shell=True, check=True, capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=300, stdin=subprocess.DEVNULL, creationflags=windows_hide_flags())
+                subprocess.run(
+                    command,
+                    shell=True,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=300,
+                    stdin=subprocess.DEVNULL,
+                    env=child_env,
+                    creationflags=windows_hide_flags(),
+                )
             else:
-                subprocess.run(shlex.split(command), check=True, capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=300, stdin=subprocess.DEVNULL, creationflags=windows_hide_flags())
-            
+                subprocess.run(
+                    shlex.split(command),
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=300,
+                    stdin=subprocess.DEVNULL,
+                    env=child_env,
+                    creationflags=windows_hide_flags(),
+                )
 
             txt_files = sorted(Path(output_dir).glob("*.txt"))
             if not txt_files:

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2397,6 +2397,15 @@ def _transcribe_prepared_audio(file_path: str, model: Optional[str] = None) -> D
 
 def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, Any]:
     """Safely validate, preprocess supported inputs, and dispatch transcription."""
+    # Refuse to feed a credential / secret store (auth.json, .env, OAuth
+    # tokens, mcp-tokens/, ...) to an STT provider — before ANY validation or
+    # preprocessing, so the refusal names the real reason rather than a
+    # format error. Mirrors the image-gen / video-gen read guards.
+    from agent.file_safety import get_read_block_error
+    blocked = get_read_block_error(file_path)
+    if blocked:
+        return {"success": False, "transcript": "", "error": blocked}
+
     # Cap .silk sources before the decoder runs (decoder safety). For all
     # other inputs the remote-upload size cap is provider-scoped and enforced
     # in _transcribe_prepared_audio, so local whisper can handle big files.

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -48,6 +48,7 @@ import shutil
 import subprocess
 import tempfile
 import threading
+import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -999,7 +1000,7 @@ def _terminate_command_tts_process_tree(proc: subprocess.Popen) -> None:
 
 
 def _run_command_tts(command: str, timeout: float) -> subprocess.CompletedProcess:
-    """Run a command-provider shell command with process-tree timeout cleanup."""
+    """Run a command-provider shell command with process-tree idle cleanup."""
     from agent.delegation_context import delegated_child_subprocess_env
 
     popen_kwargs: Dict[str, Any] = {
@@ -1019,21 +1020,75 @@ def _run_command_tts(command: str, timeout: float) -> subprocess.CompletedProces
         popen_kwargs["start_new_session"] = True
 
     proc = subprocess.Popen(command, **popen_kwargs, stdin=subprocess.DEVNULL)
-    try:
-        stdout, stderr = proc.communicate(timeout=timeout)
-    except subprocess.TimeoutExpired as exc:
-        _terminate_command_tts_process_tree(proc)
+    output_queue: "queue.Queue[tuple[str, Optional[str]]]" = queue.Queue()
+    chunks: Dict[str, list[str]] = {"stdout": [], "stderr": []}
+    open_streams = {"stdout", "stderr"}
+
+    def read_stream(name: str, stream: Any) -> None:
         try:
-            stdout, stderr = proc.communicate(timeout=1)
-        except Exception:
-            stdout = getattr(exc, "output", None)
-            stderr = getattr(exc, "stderr", None)
+            while True:
+                chunk = stream.read(1)
+                if not chunk:
+                    break
+                output_queue.put((name, chunk))
+        finally:
+            output_queue.put((name, None))
+
+    readers = [
+        threading.Thread(
+            target=read_stream,
+            args=("stdout", proc.stdout),
+            daemon=True,
+        ),
+        threading.Thread(
+            target=read_stream,
+            args=("stderr", proc.stderr),
+            daemon=True,
+        ),
+    ]
+    for reader in readers:
+        reader.start()
+
+    deadline = time.monotonic() + timeout
+    timed_out = False
+    while open_streams:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            timed_out = True
+            break
+        try:
+            name, chunk = output_queue.get(timeout=min(0.05, remaining))
+        except queue.Empty:
+            continue
+        if chunk is None:
+            open_streams.discard(name)
+            continue
+        chunks[name].append(chunk)
+        deadline = time.monotonic() + timeout
+
+    if timed_out:
+        _terminate_command_tts_process_tree(proc)
+        for reader in readers:
+            reader.join(timeout=0.5)
+        while True:
+            try:
+                name, chunk = output_queue.get_nowait()
+            except queue.Empty:
+                break
+            if chunk:
+                chunks[name].append(chunk)
+        stdout = "".join(chunks["stdout"])
+        stderr = "".join(chunks["stderr"])
         raise subprocess.TimeoutExpired(
             command,
             timeout,
             output=stdout,
             stderr=stderr,
-        ) from exc
+        )
+
+    stdout = "".join(chunks["stdout"])
+    stderr = "".join(chunks["stderr"])
+    proc.wait()
 
     if proc.returncode:
         raise subprocess.CalledProcessError(

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2868,6 +2868,16 @@ def text_to_speech_tool(
             file_path = _configured_command_tts_output_path(
                 file_path, command_provider_config
             )
+        from agent.file_safety import is_write_denied
+
+        if is_write_denied(str(file_path)):
+            return json.dumps({
+                "success": False,
+                "error": (
+                    f"output_path targets a protected credential or system path: "
+                    f"{file_path}. Choose a normal audio output location."
+                ),
+            }, ensure_ascii=False)
     else:
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         out_dir = Path(DEFAULT_OUTPUT_DIR)

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1025,9 +1025,19 @@ def _run_command_tts(command: str, timeout: float) -> subprocess.CompletedProces
     open_streams = {"stdout", "stderr"}
 
     def read_stream(name: str, stream: Any) -> None:
+        encoding = getattr(stream, "encoding", None) or "utf-8"
         try:
             while True:
-                chunk = stream.read(1)
+                try:
+                    fd = stream.fileno()
+                except (AttributeError, OSError):
+                    fd = None
+
+                if fd is None:
+                    chunk = stream.read(65536)
+                else:
+                    data = os.read(fd, 65536)
+                    chunk = data.decode(encoding, errors="replace")
                 if not chunk:
                     break
                 output_queue.put((name, chunk))
@@ -1079,12 +1089,15 @@ def _run_command_tts(command: str, timeout: float) -> subprocess.CompletedProces
                 chunks[name].append(chunk)
         stdout = "".join(chunks["stdout"])
         stderr = "".join(chunks["stderr"])
-        raise subprocess.TimeoutExpired(
-            command,
-            timeout,
-            output=stdout,
-            stderr=stderr,
-        )
+        try:
+            raise subprocess.TimeoutExpired(command, timeout)
+        except subprocess.TimeoutExpired as exc:
+            raise subprocess.TimeoutExpired(
+                command,
+                timeout,
+                output=stdout,
+                stderr=stderr,
+            ) from exc
 
     stdout = "".join(chunks["stdout"])
     stderr = "".join(chunks["stderr"])

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1001,7 +1001,25 @@ def _terminate_command_tts_process_tree(proc: subprocess.Popen) -> None:
         proc.kill()
 
 
-def _run_command_tts(command: str, timeout: float) -> subprocess.CompletedProcess:
+def _command_provider_env_passthrough(config: Dict[str, Any]) -> list:
+    """Return the provider's ``env_passthrough`` allowlist (opt-out of scrub).
+
+    Command providers legitimately reference their own API keys in the shell
+    template (curl one-liners). The child env is scrubbed of Hermes secrets by
+    default; ``env_passthrough: [MY_API_KEY, ...]`` copies the named variables
+    back from the parent environment so a trusted template keeps working.
+    """
+    raw = config.get("env_passthrough")
+    if not isinstance(raw, (list, tuple)):
+        return []
+    return [str(item).strip() for item in raw if str(item).strip()]
+
+
+def _run_command_tts(
+    command: str,
+    timeout: float,
+    env_passthrough: Optional[list] = None,
+) -> subprocess.CompletedProcess:
     """Run a command-provider shell command with process-tree idle cleanup.
 
     Child env is scrubbed of Hermes secrets (salvage of #56332) while still
@@ -1011,6 +1029,10 @@ def _run_command_tts(command: str, timeout: float) -> subprocess.CompletedProces
     from tools.environments.local import hermes_subprocess_env
 
     scrubbed = hermes_subprocess_env(inherit_credentials=False)
+    for key in env_passthrough or []:
+        value = os.environ.get(key)
+        if value is not None:
+            scrubbed[key] = value
     popen_kwargs: Dict[str, Any] = {
         "shell": True,
         "stdout": subprocess.PIPE,
@@ -1172,7 +1194,11 @@ def _generate_command_tts(
         command = _render_command_tts_template(command_template, placeholders)
 
         try:
-            _run_command_tts(command, timeout)
+            _run_command_tts(
+                command,
+                timeout,
+                env_passthrough=_command_provider_env_passthrough(config),
+            )
         except subprocess.TimeoutExpired as exc:
             raise RuntimeError(
                 f"TTS provider '{provider_name}' timed out after {timeout:g}s"

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -623,7 +623,9 @@ BUILTIN_TTS_PROVIDERS = frozenset({
 
 DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 120
 DEFAULT_COMMAND_TTS_OUTPUT_FORMAT = "mp3"
-COMMAND_TTS_OUTPUT_FORMATS = frozenset({"mp3", "wav", "ogg", "flac"})
+COMMAND_TTS_OUTPUT_FORMATS = frozenset(
+    {"mp3", "wav", "ogg", "flac", "m4a", "aac", "amr", "opus"}
+)
 DEFAULT_COMMAND_TTS_MAX_TEXT_LENGTH = 5000
 
 # Platforms whose native voice-bubble delivery requires Ogg/Opus audio.

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1026,17 +1026,13 @@ def _run_command_tts(command: str, timeout: float) -> subprocess.CompletedProces
 
     def read_stream(name: str, stream: Any) -> None:
         encoding = getattr(stream, "encoding", None) or "utf-8"
+        read1 = getattr(getattr(stream, "buffer", None), "read1", None)
         try:
             while True:
-                try:
-                    fd = stream.fileno()
-                except (AttributeError, OSError):
-                    fd = None
-
-                if fd is None:
+                if read1 is None:
                     chunk = stream.read(65536)
                 else:
-                    data = os.read(fd, 65536)
+                    data = read1(65536)
                     chunk = data.decode(encoding, errors="replace")
                 if not chunk:
                     break
@@ -1076,6 +1072,12 @@ def _run_command_tts(command: str, timeout: float) -> subprocess.CompletedProces
         chunks[name].append(chunk)
         deadline = time.monotonic() + timeout
 
+    if not timed_out:
+        try:
+            proc.wait(timeout=max(0.0, deadline - time.monotonic()))
+        except subprocess.TimeoutExpired:
+            timed_out = True
+
     if timed_out:
         _terminate_command_tts_process_tree(proc)
         for reader in readers:
@@ -1101,7 +1103,6 @@ def _run_command_tts(command: str, timeout: float) -> subprocess.CompletedProces
 
     stdout = "".join(chunks["stdout"])
     stderr = "".join(chunks["stderr"])
-    proc.wait()
 
     if proc.returncode:
         raise subprocess.CalledProcessError(

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1000,9 +1000,15 @@ def _terminate_command_tts_process_tree(proc: subprocess.Popen) -> None:
 
 
 def _run_command_tts(command: str, timeout: float) -> subprocess.CompletedProcess:
-    """Run a command-provider shell command with process-tree idle cleanup."""
-    from agent.delegation_context import delegated_child_subprocess_env
+    """Run a command-provider shell command with process-tree idle cleanup.
 
+    Child env is scrubbed of Hermes secrets (salvage of #56332) while still
+    propagating delegated-child lineage markers when applicable.
+    """
+    from agent.delegation_context import delegated_child_subprocess_env
+    from tools.environments.local import hermes_subprocess_env
+
+    scrubbed = hermes_subprocess_env(inherit_credentials=False)
     popen_kwargs: Dict[str, Any] = {
         "shell": True,
         "stdout": subprocess.PIPE,
@@ -1012,7 +1018,7 @@ def _run_command_tts(command: str, timeout: float) -> subprocess.CompletedProces
         # must not raise in the reader threads on non-UTF-8 Windows (#45099).
         "encoding": "utf-8",
         "errors": "replace",
-        "env": delegated_child_subprocess_env(),
+        "env": delegated_child_subprocess_env(scrubbed),
     }
     if os.name == "nt":
         popen_kwargs["creationflags"] = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1510,7 +1510,17 @@ def play_audio_file(file_path: str) -> bool:
         exe = shutil.which(cmd[0])
         if exe:
             try:
-                proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, stdin=subprocess.DEVNULL)
+                # Sibling of TTS/STT credential scrub (#70342 / #56332): system
+                # audio players must not inherit gateway tokens / API keys.
+                from tools.environments.local import hermes_subprocess_env
+
+                proc = subprocess.Popen(
+                    cmd,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    stdin=subprocess.DEVNULL,
+                    env=hermes_subprocess_env(inherit_credentials=False),
+                )
                 with _playback_lock:
                     _active_playback = proc
                 proc.wait(timeout=300)

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -28,7 +28,7 @@ Hermes has several distinct pluggable interfaces — some use Python `register_*
 | A **secret-manager backend** (vault / password manager / OS keystore) | [Secret Source Plugins](/developer-guide/secret-source-plugin) |
 | A **dashboard OIDC/auth provider** | [Web Dashboard — custom providers](/user-guide/features/web-dashboard#custom-providers) — `ctx.register_dashboard_auth_provider()` |
 | A **TTS backend** (any CLI — Piper, VoxCPM, Kokoro, voice cloning, …) | [TTS custom command providers](/user-guide/features/tts#custom-command-providers) — config-driven, no Python needed |
-| An **STT backend** (custom whisper / ASR CLI) | [Voice Message Transcription](/user-guide/features/tts#voice-message-transcription-stt) — set `HERMES_LOCAL_STT_COMMAND` to a shell template |
+| An **STT backend** (custom whisper / ASR CLI) | [Voice Message Transcription](/user-guide/features/tts#voice-message-transcription-stt) — set `HERMES_LOCAL_STT_COMMAND` to an argv-tokenized template |
 | **External tools via MCP** (filesystem, GitHub, Linear, any MCP server) | [MCP](/user-guide/features/mcp) — declare `mcp_servers.<name>` in `config.yaml` |
 | **Gateway event hooks** (fire on startup, session events, commands) | [Event Hooks](/user-guide/features/hooks#gateway-event-hooks) — drop `HOOK.yaml` + `handler.py` into `~/.hermes/hooks/<name>/` |
 | **Shell hooks** (run a shell command on events) | [Shell Hooks](/user-guide/features/hooks#shell-hooks) — declare under `hooks:` in `config.yaml` |
@@ -1199,7 +1199,7 @@ tts:
       voice_compatible: true
 ```
 
-For STT, point `HERMES_LOCAL_STT_COMMAND` at a shell template. Supported placeholders: `{input_path}`, `{output_path}`, `{format}`, `{voice}`, `{model}`, `{speed}` (TTS); `{input_path}`, `{output_dir}`, `{language}`, `{model}` (STT). Any path-interacting CLI is automatically a plugin.
+For STT, point `HERMES_LOCAL_STT_COMMAND` at an argv-tokenized template. It runs without implicit shell interpretation; wrap it in `sh -c`, `cmd /c`, or PowerShell explicitly if the trusted local command requires shell syntax. Supported placeholders: `{input_path}`, `{output_path}`, `{format}`, `{voice}`, `{model}`, `{speed}` (TTS); `{input_path}`, `{output_dir}`, `{language}`, `{model}` (STT). Any path-interacting CLI is automatically a plugin.
 
 **Full guides:** [TTS custom command providers](/user-guide/features/tts#custom-command-providers) · [STT](/user-guide/features/tts#voice-message-transcription-stt).
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -286,6 +286,18 @@ tts:
 
 **Supported `output_format` values:** `mp3` (default), `wav`, `ogg`, `flac`, `m4a`, `aac`, `amr`, `opus`. Your command must actually produce that format (e.g. via `ffmpeg`); Hermes only validates the declared value and names the output file accordingly. An unknown value falls back to `mp3`. The chosen format is also exposed to the command as the `{format}` placeholder.
 
+**Subprocess environment:** command providers (TTS and STT) run with Hermes secrets scrubbed from the child environment — gateway bot tokens, LLM provider API keys, and internal relay credentials are removed; `PATH`, `HOME`, locale, and other normal variables are kept. If your command template needs its own API key from the environment (e.g. a `curl` one-liner), list the variable names under `env_passthrough` in the provider config:
+
+```yaml
+tts:
+  providers:
+    mycloud:
+      type: command
+      command: 'curl -s -H "Authorization: Bearer $MYCLOUD_API_KEY" ... -o {output_path}'
+      env_passthrough: [MYCLOUD_API_KEY]
+```
+
+
 #### Example: Doubao (Chinese seed-tts-2.0)
 
 For high-quality Chinese TTS via ByteDance's [seed-tts-2.0](https://www.volcengine.com/docs/6561/1257544) bidirectional-streaming API, install the [`doubao-speech`](https://pypi.org/project/doubao-speech/) PyPI package and wire it in as a command provider:

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -284,6 +284,8 @@ tts:
       output_format: wav
 ```
 
+**Supported `output_format` values:** `mp3` (default), `wav`, `ogg`, `flac`, `m4a`, `aac`, `amr`, `opus`. Your command must actually produce that format (e.g. via `ffmpeg`); Hermes only validates the declared value and names the output file accordingly. An unknown value falls back to `mp3`. The chosen format is also exposed to the command as the `{format}` placeholder.
+
 #### Example: Doubao (Chinese seed-tts-2.0)
 
 For high-quality Chinese TTS via ByteDance's [seed-tts-2.0](https://www.volcengine.com/docs/6561/1257544) bidirectional-streaming API, install the [`doubao-speech`](https://pypi.org/project/doubao-speech/) PyPI package and wire it in as a command provider:

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -481,7 +481,7 @@ stt:
 
 **xAI Grok STT** — Requires `XAI_API_KEY`. Posts to `https://api.x.ai/v1/stt` as multipart/form-data. Good choice if you're already using xAI for chat or TTS and want one API key for everything. Auto-detection order puts it after Groq — explicitly set `stt.provider: xai` to force it.
 
-**Custom local CLI fallback** — Set `HERMES_LOCAL_STT_COMMAND` if you want Hermes to call a local transcription command directly. The command template supports `{input_path}`, `{output_dir}`, `{language}`, and `{model}` placeholders. Your command must write a `.txt` transcript somewhere under `{output_dir}`.
+**Custom local CLI fallback** — Set `HERMES_LOCAL_STT_COMMAND` if you want Hermes to call a local transcription command directly. The command template supports `{input_path}`, `{output_dir}`, `{language}`, and `{model}` placeholders. Hermes tokenizes the rendered template into an argument list and executes it without a shell, so operators such as `|`, `>`, `&&`, and `;` are passed as literal arguments. Your command must write a `.txt` transcript somewhere under `{output_dir}`.
 
 #### Example: Doubao / Volcengine ASR
 
@@ -493,6 +493,14 @@ export VOLCENGINE_APP_ID="your-app-id"
 export VOLCENGINE_ACCESS_TOKEN="your-access-token"
 export HERMES_LOCAL_STT_COMMAND='doubao-speech transcribe {input_path} --out {output_dir}/transcript.txt'
 ```
+
+If a trusted local template intentionally needs pipes, redirects, or another shell feature, invoke the shell explicitly. Keep dynamic paths outside the shell program and pass them as positional arguments:
+
+```bash
+export HERMES_LOCAL_STT_COMMAND='sh -c '\''whisper "$1" --output_format txt --output_dir "$2" | tee "$2/whisper.log"'\'' _ {input_path} {output_dir}'
+```
+
+On Windows, use an explicit `cmd /c` or PowerShell wrapper instead. An explicit wrapper makes shell interpretation an opt-in part of the configured argv rather than an implicit property of every local STT template.
 
 ```yaml
 stt:
@@ -538,7 +546,7 @@ stt:
       format: json
 ```
 
-This complements the legacy `HERMES_LOCAL_STT_COMMAND` escape hatch — that env var still works untouched via the built-in `local_command` path. Use `stt.providers.<name>` when you want **multiple** shell-driven STT engines, a name you can pick via `stt.provider`, or anything that needs per-provider `language` / `model` / `timeout`.
+This complements the legacy `HERMES_LOCAL_STT_COMMAND` escape hatch via the built-in `local_command` path. Unlike the shell-driven command-provider registry, the legacy template is tokenized into argv and runs without implicit shell interpretation. Use `stt.providers.<name>` when you want **multiple** shell-driven STT engines, a name you can pick via `stt.provider`, or anything that needs per-provider `language` / `model` / `timeout`.
 
 #### STT placeholders
 
@@ -595,7 +603,7 @@ For STT engines that aren't built-in AND can't be expressed as a shell command (
 | Backend has…                                                 | Use                                                              |
 |--------------------------------------------------------------|------------------------------------------------------------------|
 | A single shell command that takes an audio file and emits text | `stt.providers.<name>: type: command` (no Python needed)        |
-| Only the legacy single-command escape hatch is wanted        | `HERMES_LOCAL_STT_COMMAND` env var (preserved for back-compat)  |
+| Only the legacy single-command escape hatch is wanted        | `HERMES_LOCAL_STT_COMMAND` env var (argv-tokenized; no implicit shell) |
 | A Python SDK with no CLI                                     | `register_transcription_provider()` plugin                      |
 | OAuth-refreshing auth, streaming chunks, voice-list metadata | `register_transcription_provider()` plugin                      |
 | A built-in already covers it (`local`, `groq`, `openai`, …)  | Set `stt.provider: <name>` — built-ins are inline               |

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -328,7 +328,7 @@ Use `{{` and `}}` for literal braces.
 
 | Key                | Default | Meaning                                                                                                    |
 |--------------------|---------|------------------------------------------------------------------------------------------------------------|
-| `timeout`          | `120`   | Seconds; the process tree is killed on expiry (Unix `killpg`, Windows `taskkill /T`).                       |
+| `timeout`          | `120`   | Idle seconds; stdout or stderr output resets the deadline. The process tree is killed after inactivity (Unix `killpg`, Windows `taskkill /T`). |
 | `output_format`    | `mp3`   | One of `mp3` / `wav` / `ogg` / `flac`. Auto-inferred from the output extension if Hermes picks a path.      |
 | `voice_compatible` | `false` | When `true`, Hermes converts MP3/WAV output to Opus/OGG via ffmpeg so Telegram renders a voice bubble.      |
 | `max_text_length`  | `5000`  | Input is truncated to this length before rendering the command.                                             |


### PR DESCRIPTION
# fix: harden command-type TTS/STT providers (idle timeouts, secret scrub, format allowlist, no-shell, path guards)

Consolidated salvage of the cluster-H command-provider hardening backlog: 6 PRs cherry-picked onto current main with contributor authorship preserved, plus class-fix follow-ups.

## What's in here

### 1. Idle timeouts on BOTH command runners (fixes #50081, salvages #50087 — @CleanDev-Fix)
- `_run_command_tts` now uses a **progress-based idle timeout**: the deadline resets whenever the command emits stdout/stderr output. A slow-but-alive provider (e.g. long synthesis with progress logs) survives; a silently stalled one is killed after `timeout` seconds of no output. Reads happen in 64 KiB chunks via daemon reader threads; the deadline is held through process exit; captured output is preserved on `TimeoutExpired`.
- **Class fix (follow-up commit):** the same pattern is ported to `_run_command_stt` — stuck detection is progress-based, never wall-clock, on both runners.

### 2. Secret scrubbing for voice subprocess env (fixes the class from #56332 — @necoweb3, salvages #70342 + #70357 — @zapabob)
- Command TTS, command STT, and the local-whisper `subprocess.run` path now build their child env via `hermes_subprocess_env(inherit_credentials=False)` (gateway tokens, LLM provider keys, `AUXILIARY_*`/`GATEWAY_RELAY_*` internals stripped; `PATH`/`HOME`/locale kept), composed with `delegated_child_subprocess_env()` so delegated-child lineage markers still propagate.
- `play_audio_file` playback subprocesses (ffplay/afplay/...) get the same scrub (#70357).
- **Allowlist follow-up (triage caveat):** command providers legitimately reference their own API keys in shell templates (curl one-liners). A blanket scrub would break them, so each provider config accepts `env_passthrough: [MY_API_KEY, ...]` (TTS + STT) — named vars are copied back from the parent env. Scrub is the default; passthrough is explicit opt-in. Documented in the TTS docs.

### 3. Command-TTS output_format allowlist expansion (fixes #50612, salvages #50617 — @sherman-yang; credit also @alloevil for the same-day #50616)
- `COMMAND_TTS_OUTPUT_FORMATS` gains `m4a`, `aac`, `amr`, `opus` — common ffmpeg-producible containers. Honored via explicit config and output-path suffix; unknown values still fall back to `mp3`. Docs updated.

### 4. Local STT templates run without a shell (fixes #2743's local-STT half, salvages #70008 — @egilewski; closes earlier attempt #32694 — @ErnestHysa with credit)
- `_transcribe_local_command` now always executes `shlex.split(command)` as argv — shell metacharacters in a template (`;`, `|`, `$( )`, backticks) become literal arguments, never interpreted. Trusted templates that genuinely need shell features opt in explicitly with an `sh -c '...' _ {input_path} {output_dir}` wrapper (documented with an example).
- Command-type TTS/STT providers keep `shell=True` **by design** — user templates use pipes; umbrella #2743 stays open for that surface.

### 5. Protected-path guards (salvages #57950 — @necoweb3 + #58056 — @Frowtek; one shared guard concept)
- **Write side:** `text_to_speech_tool(output_path=...)` is checked against `agent.file_safety.is_write_denied` — synthesized audio can no longer overwrite OAuth stores, `mcp-tokens/`, or other protected credential paths.
- **Read side:** `transcribe_audio` routes inputs through the shared `get_read_block_error` guard before any validation/dispatch — a `.env` or credential store can't be shipped as "audio" to an external STT API. Verified the guard does NOT reject gateway temp-dir voice notes (`~/.hermes/cache/audio/*.ogg`, `/tmp/...` pass clean).

## Tests
- Idle timeout: slow-but-alive command survives / silent-stalled command killed with pre-stall output preserved — real subprocess tests for **both** runners (TTS existing from #50087, STT added in follow-up).
- Env scrub: sanitized-child-env assertions for command TTS, command STT, local whisper, and playback; sabotage-verified (removing the scrub fails the test).
- `env_passthrough`: named key restored, everything else stays scrubbed; config parsing edge cases.
- Format allowlist: extended set accepted via config and path suffix; unknown value falls back.
- No-shell: metacharacter template becomes literal argv (exact argv + kwargs asserted, including the scrubbed `env`).
- Path guards: OAuth store & mcp-tokens writes refused; `.env` read refused with the shared guard message.

`pytest -o addopts="" tests/tools/test_tts_command_providers.py tests/tools/test_transcription_tools.py tests/tools/test_tts_path_traversal.py tests/tools/test_voice_mode_playback_env_scrub.py` → **181 passed** (4 pre-existing `TestTranscribeMistral` lazy-dep failures also fail on clean main; unrelated).

## Attribution / closes
| Commit | Author | Salvaged PR |
|---|---|---|
| `use idle timeout` / `chunk stream reads` / `keep deadline` | @CleanDev-Fix | #50087 (fixes #50081) |
| `scrub Hermes secrets from voice command subprocess env` | @zapabob | #70342 |
| `scrub credentials from voice playback subprocesses` | @zapabob | #70357 |
| `expand command TTS output_format allowlist` | @sherman-yang | #50617 (fixes #50612; credit @alloevil #50616) |
| `execute local STT templates without a shell` | @egilewski | #70008 (closes #32694, credit @ErnestHysa) |
| `block output to protected paths` | @necoweb3 | #57950 |
| `route transcription inputs through the shared read guard` | @Frowtek | #58056 |

Close as superseded with credit: #56332 (@necoweb3 — earliest env-scrub attempt, superseded by #70342's delegated-env-composing version), #50616 (@alloevil — test-file-only), #32694 (@ErnestHysa — earlier no-shell attempt), #57963 (non-shared path-guard overlap of #58056).


## Infographic

![fix(tools): command TTS/STT provider hardening — idle timeouts, env scrubbing, no-shell, path guards](https://v3b.fal.media/files/b/0aa416ca/P3kJQaxxlAyrpyuHvFjop_OfAyyeRn.png)
