### PR TITLE
feat(gemini): salvage cluster — 3.6-flash aux default, vertex catalog, direct cost tracking (fixes #32400)

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -513,13 +513,51 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
     # Google Gemini
     (
         "google",
+        "gemini-3.5-flash",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.50"),
+        output_cost_per_million=Decimal("9.00"),
+        cache_read_cost_per_million=Decimal("0.15"),
+        cache_write_cost_per_million=Decimal("1.50"),
+        source="official_docs_snapshot",
+        source_url="https://ai.google.dev/pricing",
+        pricing_version="google-pricing-2026-07-07",
+    ),
+    (
+        "google",
+        "gemini-3.1-pro",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("2.00"),
+        output_cost_per_million=Decimal("12.00"),
+        cache_read_cost_per_million=Decimal("0.20"),
+        cache_write_cost_per_million=Decimal("2.00"),
+        source="official_docs_snapshot",
+        source_url="https://ai.google.dev/pricing",
+        pricing_version="google-pricing-2026-07-07",
+    ),
+    (
+        "google",
+        "gemini-3.1-flash-lite",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.25"),
+        output_cost_per_million=Decimal("1.50"),
+        cache_read_cost_per_million=Decimal("0.025"),
+        cache_write_cost_per_million=Decimal("0.25"),
+        source="official_docs_snapshot",
+        source_url="https://ai.google.dev/pricing",
+        pricing_version="google-pricing-2026-07-07",
+    ),
+    (
+        "google",
         "gemini-2.5-pro",
     ): PricingEntry(
         input_cost_per_million=Decimal("1.25"),
         output_cost_per_million=Decimal("10.00"),
+        cache_read_cost_per_million=Decimal("0.125"),
+        cache_write_cost_per_million=Decimal("1.25"),
         source="official_docs_snapshot",
         source_url="https://ai.google.dev/pricing",
-        pricing_version="google-pricing-2026-03-16",
+        pricing_version="google-pricing-2026-07-07",
     ),
     (
         "google",
@@ -527,9 +565,11 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
     ): PricingEntry(
         input_cost_per_million=Decimal("0.15"),
         output_cost_per_million=Decimal("0.60"),
+        cache_read_cost_per_million=Decimal("0.015"),
+        cache_write_cost_per_million=Decimal("0.15"),
         source="official_docs_snapshot",
         source_url="https://ai.google.dev/pricing",
-        pricing_version="google-pricing-2026-03-16",
+        pricing_version="google-pricing-2026-07-07",
     ),
     (
         "google",
@@ -537,9 +577,11 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
     ): PricingEntry(
         input_cost_per_million=Decimal("0.10"),
         output_cost_per_million=Decimal("0.40"),
+        cache_read_cost_per_million=Decimal("0.01"),
+        cache_write_cost_per_million=Decimal("0.10"),
         source="official_docs_snapshot",
         source_url="https://ai.google.dev/pricing",
-        pricing_version="google-pricing-2026-03-16",
+        pricing_version="google-pricing-2026-07-07",
     ),
     # AWS Bedrock — pricing per the Bedrock pricing page.
     # Bedrock charges the same per-token rates as the model provider but
@@ -925,11 +967,17 @@ def resolve_billing_route(
         return BillingRoute(provider="openai", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name in {"minimax", "minimax-cn"}:
         return BillingRoute(provider=provider_name, model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
-    # Vertex AI hosts the same Gemini models as Google AI Studio; price them
-    # off the gemini official-docs snapshot. Strip the "google/" vendor prefix
-    # the OpenAI-compat endpoint requires so the pricing key matches.
-    if provider_name == "vertex" or base_url_host_matches(base_url or "", "aiplatform.googleapis.com"):
-        return BillingRoute(provider="gemini", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
+    # Google AI Studio (Gemini) and Vertex AI host the same Gemini models.
+    # Price them off the official docs snapshot — the pricing keys are
+    # keyed on provider='google', so normalize every Google-flavored
+    # provider name/host onto it. Strip the "google/" vendor prefix the
+    # Vertex OpenAI-compat endpoint requires so the pricing key matches.
+    if (
+        provider_name in {"google", "gemini", "vertex", "google-gemini", "google-ai-studio", "google-vertex", "vertex-ai"}
+        or base_url_host_matches(base_url or "", "aiplatform.googleapis.com")
+        or base_url_host_matches(base_url or "", "generativelanguage.googleapis.com")
+    ):
+        return BillingRoute(provider="google", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name == "fireworks" or base_url_host_matches(base_url or "", "api.fireworks.ai"):
         # Fireworks model ids look like accounts/fireworks/models/<name>;
         # rsplit("/", 1)[-1] yields just <name> which is what the dict keys on.

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -518,7 +518,6 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         input_cost_per_million=Decimal("1.50"),
         output_cost_per_million=Decimal("9.00"),
         cache_read_cost_per_million=Decimal("0.15"),
-        cache_write_cost_per_million=Decimal("1.50"),
         source="official_docs_snapshot",
         source_url="https://ai.google.dev/pricing",
         pricing_version="google-pricing-2026-07-07",
@@ -530,7 +529,6 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         input_cost_per_million=Decimal("2.00"),
         output_cost_per_million=Decimal("12.00"),
         cache_read_cost_per_million=Decimal("0.20"),
-        cache_write_cost_per_million=Decimal("2.00"),
         source="official_docs_snapshot",
         source_url="https://ai.google.dev/pricing",
         pricing_version="google-pricing-2026-07-07",
@@ -542,7 +540,28 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         input_cost_per_million=Decimal("0.25"),
         output_cost_per_million=Decimal("1.50"),
         cache_read_cost_per_million=Decimal("0.025"),
-        cache_write_cost_per_million=Decimal("0.25"),
+        source="official_docs_snapshot",
+        source_url="https://ai.google.dev/pricing",
+        pricing_version="google-pricing-2026-07-07",
+    ),
+    (
+        "google",
+        "gemini-3-pro-preview",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("2.00"),
+        output_cost_per_million=Decimal("12.00"),
+        cache_read_cost_per_million=Decimal("0.20"),
+        source="official_docs_snapshot",
+        source_url="https://ai.google.dev/pricing",
+        pricing_version="google-pricing-2026-07-07",
+    ),
+    (
+        "google",
+        "gemini-3-flash-preview",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.50"),
+        output_cost_per_million=Decimal("3.00"),
+        cache_read_cost_per_million=Decimal("0.05"),
         source="official_docs_snapshot",
         source_url="https://ai.google.dev/pricing",
         pricing_version="google-pricing-2026-07-07",
@@ -554,7 +573,6 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         input_cost_per_million=Decimal("1.25"),
         output_cost_per_million=Decimal("10.00"),
         cache_read_cost_per_million=Decimal("0.125"),
-        cache_write_cost_per_million=Decimal("1.25"),
         source="official_docs_snapshot",
         source_url="https://ai.google.dev/pricing",
         pricing_version="google-pricing-2026-07-07",
@@ -566,7 +584,6 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         input_cost_per_million=Decimal("0.15"),
         output_cost_per_million=Decimal("0.60"),
         cache_read_cost_per_million=Decimal("0.015"),
-        cache_write_cost_per_million=Decimal("0.15"),
         source="official_docs_snapshot",
         source_url="https://ai.google.dev/pricing",
         pricing_version="google-pricing-2026-07-07",
@@ -578,7 +595,6 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         input_cost_per_million=Decimal("0.10"),
         output_cost_per_million=Decimal("0.40"),
         cache_read_cost_per_million=Decimal("0.01"),
-        cache_write_cost_per_million=Decimal("0.10"),
         source="official_docs_snapshot",
         source_url="https://ai.google.dev/pricing",
         pricing_version="google-pricing-2026-07-07",
@@ -919,6 +935,18 @@ for _base_56 in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"):
         ("openai", _base_56)
     ]
 del _base_56
+
+# The direct Gemini provider currently exposes preview IDs for these two
+# models. Keep the official snapshot keyed by both their documented stable
+# names and the provider's emitted IDs so a catalog selection is billable.
+for _alias, _canonical in {
+    "gemini-3.1-pro-preview": "gemini-3.1-pro",
+    "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite",
+}.items():
+    _OFFICIAL_DOCS_PRICING[("google", _alias)] = _OFFICIAL_DOCS_PRICING[
+        ("google", _canonical)
+    ]
+del _alias, _canonical
 
 
 def _to_decimal(value: Any) -> Optional[Decimal]:

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -513,6 +513,17 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
     # Google Gemini
     (
         "google",
+        "gemini-3.6-flash",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.50"),
+        output_cost_per_million=Decimal("7.50"),
+        cache_read_cost_per_million=Decimal("0.15"),
+        source="official_docs_snapshot",
+        source_url="https://ai.google.dev/gemini-api/docs/pricing",
+        pricing_version="google-pricing-2026-07-28",
+    ),
+    (
+        "google",
         "gemini-3.5-flash",
     ): PricingEntry(
         input_cost_per_million=Decimal("1.50"),
@@ -521,6 +532,17 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source="official_docs_snapshot",
         source_url="https://ai.google.dev/pricing",
         pricing_version="google-pricing-2026-07-07",
+    ),
+    (
+        "google",
+        "gemini-3.5-flash-lite",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.30"),
+        output_cost_per_million=Decimal("2.50"),
+        cache_read_cost_per_million=Decimal("0.03"),
+        source="official_docs_snapshot",
+        source_url="https://ai.google.dev/gemini-api/docs/pricing",
+        pricing_version="google-pricing-2026-07-28",
     ),
     (
         "google",

--- a/contributors/emails/reneisaipa@gmail.com
+++ b/contributors/emails/reneisaipa@gmail.com
@@ -1,0 +1,1 @@
+IvanMiao

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -290,7 +290,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "gemini": [
         "gemini-3.1-pro-preview",
         "gemini-3-pro-preview",
-        "gemini-3.5-flash",
+        "gemini-3.6-flash",
         "gemini-3.1-flash-lite-preview",
     ],
     "zai": [

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -575,6 +575,19 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "deepseek/deepseek-r1-0528",
         "qwen/qwen3-235b-a22b-fp8",
     ],
+    # Google Vertex AI — OpenAI-compatible endpoint
+    # (aiplatform.googleapis.com/v1beta1/projects/<proj>/locations/global/endpoints/openapi)
+    # IDs must use the "google/" prefix exactly as returned by the API.
+    # All entries below have been validated live against the antse-tooling GCP
+    # project (global region) and returned HTTP 200 as of 2026-07-21.
+    "vertex": [
+        "google/gemini-3.5-flash",           # frontier Flash; strong agentic + coding
+        "google/gemini-3.6-flash",           # incremental over 3.5-flash (newer)
+        "google/gemini-3.5-flash-lite",      # lighter/cheaper 3.5 Flash variant
+        "google/gemini-3.1-pro-preview",     # 3.1 Pro preview
+        "google/gemini-3-flash-preview",     # 3.0 Flash preview
+        "google/gemini-3.1-flash-lite",      # most cost-efficient Gemini 3.x
+    ],
 }
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -560,12 +560,17 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # /model picker only ever shows the currently-configured model.
     # Model IDs use the "google/" publisher prefix Vertex's openapi
     # endpoint expects (see hermes_cli/model_setup_flows.py).
+    # Entries validated live against a GCP project (global region,
+    # HTTP 200) as of 2026-07-21 (PR #68767).
     "vertex": [
         "google/gemini-3.1-pro-preview",
         "google/gemini-3-pro-preview",
+        "google/gemini-3.6-flash",
         "google/gemini-3.5-flash",
+        "google/gemini-3.5-flash-lite",
         "google/gemini-3-flash-preview",
         "google/gemini-3.1-flash-lite-preview",
+        "google/gemini-3.1-flash-lite",
     ],
     "novita": [
         "moonshotai/kimi-k2.5",
@@ -574,19 +579,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "deepseek/deepseek-v3-0324",
         "deepseek/deepseek-r1-0528",
         "qwen/qwen3-235b-a22b-fp8",
-    ],
-    # Google Vertex AI — OpenAI-compatible endpoint
-    # (aiplatform.googleapis.com/v1beta1/projects/<proj>/locations/global/endpoints/openapi)
-    # IDs must use the "google/" prefix exactly as returned by the API.
-    # All entries below have been validated live against the antse-tooling GCP
-    # project (global region) and returned HTTP 200 as of 2026-07-21.
-    "vertex": [
-        "google/gemini-3.5-flash",           # frontier Flash; strong agentic + coding
-        "google/gemini-3.6-flash",           # incremental over 3.5-flash (newer)
-        "google/gemini-3.5-flash-lite",      # lighter/cheaper 3.5 Flash variant
-        "google/gemini-3.1-pro-preview",     # 3.1 Pro preview
-        "google/gemini-3-flash-preview",     # 3.0 Flash preview
-        "google/gemini-3.1-flash-lite",      # most cost-efficient Gemini 3.x
     ],
 }
 

--- a/plugins/model-providers/gemini/__init__.py
+++ b/plugins/model-providers/gemini/__init__.py
@@ -55,7 +55,7 @@ gemini = GeminiProfile(
     env_vars=("GOOGLE_API_KEY", "GEMINI_API_KEY"),
     base_url="https://generativelanguage.googleapis.com/v1beta",
     auth_type="api_key",
-    default_aux_model="gemini-3.5-flash",
+    default_aux_model="gemini-3.6-flash",
 )
 
 register_provider(gemini)

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -636,3 +636,29 @@ def test_deepseek_v4_flash_estimate_usage_cost():
     assert result.amount_usd is not None
     # 1M input × $0.14/M + 500K output × $0.28/M = $0.14 + $0.14 = $0.28
     assert float(result.amount_usd) == 0.28
+
+
+def test_gemini_3_5_flash_pricing_resolved():
+    """Ensure gemini-3.5-flash pricing exists and resolves correctly."""
+    entry = get_pricing_entry("gemini-3.5-flash", provider="google")
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 1.50
+    assert float(entry.output_cost_per_million) == 9.00
+    assert float(entry.cache_read_cost_per_million) == 0.15
+    assert float(entry.cache_write_cost_per_million) == 1.50
+
+
+def test_gemini_provider_maps_to_google():
+    """Ensure using 'gemini' as provider resolves to 'google' pricing."""
+    entry = get_pricing_entry("gemini-3.5-flash", provider="gemini")
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 1.50
+
+    # Also check base URL matching
+    entry_base = get_pricing_entry(
+        "gemini-3.5-flash",
+        provider="custom",
+        base_url="https://generativelanguage.googleapis.com/v1beta",
+    )
+    assert entry_base is not None
+    assert float(entry_base.input_cost_per_million) == 1.50

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -5,6 +5,7 @@ from agent.usage_pricing import (
     estimate_usage_cost,
     get_pricing_entry,
     normalize_usage,
+    resolve_billing_route,
 )
 
 
@@ -638,27 +639,59 @@ def test_deepseek_v4_flash_estimate_usage_cost():
     assert float(result.amount_usd) == 0.28
 
 
-def test_gemini_3_5_flash_pricing_resolved():
-    """Ensure gemini-3.5-flash pricing exists and resolves correctly."""
-    entry = get_pricing_entry("gemini-3.5-flash", provider="google")
-    assert entry is not None
-    assert float(entry.input_cost_per_million) == 1.50
-    assert float(entry.output_cost_per_million) == 9.00
-    assert float(entry.cache_read_cost_per_million) == 0.15
-    assert float(entry.cache_write_cost_per_million) == 1.50
+def test_gemini_catalog_models_estimate_cached_usage():
+    """Every direct-Gemini catalog model with official pricing can estimate a
+    session that includes a cache hit, rather than reporting ``unknown``.
+    """
+    from hermes_cli.models import _PROVIDER_MODELS
+
+    usage = CanonicalUsage(input_tokens=100, output_tokens=100, cache_read_tokens=100)
+    results = [
+        estimate_usage_cost(model, usage, provider="gemini")
+        for model in _PROVIDER_MODELS["gemini"]
+    ]
+
+    assert results
+    assert all(result.status == "estimated" for result in results)
+    assert all(result.amount_usd is not None and result.amount_usd > 0 for result in results)
 
 
-def test_gemini_provider_maps_to_google():
-    """Ensure using 'gemini' as provider resolves to 'google' pricing."""
-    entry = get_pricing_entry("gemini-3.5-flash", provider="gemini")
-    assert entry is not None
-    assert float(entry.input_cost_per_million) == 1.50
-
-    # Also check base URL matching
-    entry_base = get_pricing_entry(
-        "gemini-3.5-flash",
-        provider="custom",
-        base_url="https://generativelanguage.googleapis.com/v1beta",
+def test_google_and_vertex_routes_share_official_pricing_snapshot():
+    """Direct Gemini, Vertex, and Vertex's OpenAI-compatible hostname must
+    all normalize to the Google official-pricing route.
+    """
+    routes = (
+        resolve_billing_route("model", provider="gemini"),
+        resolve_billing_route("google/model", provider="vertex"),
+        resolve_billing_route(
+            "google/model",
+            provider="custom",
+            base_url="https://aiplatform.googleapis.com/v1/projects/example",
+        ),
     )
-    assert entry_base is not None
-    assert float(entry_base.input_cost_per_million) == 1.50
+
+    assert all(route.provider == "google" for route in routes)
+    assert all(route.billing_mode == "official_docs_snapshot" for route in routes)
+
+
+def test_vertex_default_model_estimates_cached_usage(monkeypatch):
+    """The bundled Vertex profile's default auxiliary model must fall back to
+    Google snapshot pricing when the OpenAI-compatible endpoint has no model
+    metadata, including for cache-read accounting.
+    """
+    from providers import get_provider_profile
+
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_endpoint_model_metadata",
+        lambda *_args, **_kwargs: {},
+    )
+    vertex = get_provider_profile("vertex")
+    result = estimate_usage_cost(
+        vertex.default_aux_model,
+        CanonicalUsage(input_tokens=100, output_tokens=100, cache_read_tokens=100),
+        provider=vertex.name,
+        base_url=vertex.base_url,
+    )
+
+    assert result.status == "estimated"
+    assert result.amount_usd is not None and result.amount_usd > 0

--- a/tests/plugins/model_providers/test_gemini_profile.py
+++ b/tests/plugins/model_providers/test_gemini_profile.py
@@ -1,0 +1,27 @@
+"""Contract tests for the native Google Gemini provider profile."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def gemini_profile():
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("gemini")
+    assert profile is not None, "gemini provider profile must be registered"
+    return profile
+
+
+def test_native_gemini_auxiliary_default_is_in_curated_catalog(gemini_profile):
+    """The profile's default_aux_model must stay in lockstep with the curated
+    model picker catalog — whatever model the default points at has to be
+    one the picker can actually offer. Deliberately durable against future
+    model-generation bumps: it does not pin either side to a frozen
+    model-name string, only to the invariant that they never drift apart.
+    """
+    from hermes_cli.models import _PROVIDER_MODELS
+
+    assert gemini_profile.default_aux_model in _PROVIDER_MODELS["gemini"]


### PR DESCRIPTION
## Summary
Salvage wave for the three Gemini follow-ups from the catalog-swap sweep: the native Gemini provider's aux default moves to `gemini-3.6-flash`, the Vertex picker's curated list gains the live-validated Gemini 3.x models, and direct Gemini/Vertex cost tracking stops reporting $0.00 (fixes #32400).

Contributor authorship preserved via cherry-pick: @ildunari (#70416), @ceverson70 (#68767), @IvanMiao (#60063). hbentel's earlier #32404 (closed by its author in favor of #31382) and @Gautam-J's #31382 identified the same root cause first.

## Changes
- `plugins/model-providers/gemini/__init__.py` + `hermes_cli/models.py` gemini list: aux default → `gemini-3.6-flash`, plus a durable contract test (`default_aux_model` must stay in the curated catalog) — #70416
- `hermes_cli/models.py` vertex list: + `gemini-3.6-flash`, `gemini-3.5-flash-lite`, `gemini-3.1-flash-lite` (live-validated HTTP 200 on Vertex global); follow-up commit merges the duplicate `"vertex"` dict key the cherry-pick produced against main's newer list (df051c17cc)
- `agent/usage_pricing.py`: `resolve_billing_route()` now routes `gemini` / `google` / `vertex` provider names (+ `google-gemini`, `google-ai-studio`, `google-vertex`, `vertex-ai` aliases from the models.py alias table) and both Google API hosts onto `provider="google"` snapshot pricing; Gemini 3.x pricing entries added (3.5-flash, 3.1-pro(+preview alias), 3.1-flash-lite(+preview alias), 3-pro-preview, 3-flash-preview); 2.x entries gain cache-read rates — #60063
- Follow-up commit: pricing entries for `gemini-3.6-flash` ($1.50/$7.50, cache $0.15) and `gemini-3.5-flash-lite` ($0.30/$2.50, cache $0.03), verified against ai.google.dev 2026-07-28 — needed because the aux default and vertex list now carry those models

## Validation
| Check | Result |
|---|---|
| Full catalog gate (10 files) | 267 passed, 0 failed |
| E2E cost chain (temp HERMES_HOME, keys stripped) | `gemini:gemini-3.6-flash` → route google/official_docs_snapshot, $9.00 per 1M+1M; vertex + google-gemini aliases identical; 3.5-flash-lite $2.80 |
| Before | `provider: gemini` sessions → billing_mode empty, cost_status unknown, $0.00 |
| AST dupe sweep | no dup list entries / dict keys introduced (one pre-existing sonnet-5 pair on main, untouched) |
| Pricing rates | verified against https://ai.google.dev/gemini-api/docs/pricing (2026-07-28) |

Closes #32400.

## Infographic

![Gemini cluster salvage infographic](https://v3b.fal.media/files/b/0aa416f6/U_JhMLw0IgPufwqEhVd1O_DsZ20lxK.png)
