### PR TITLE
fix(gateway): transcribe voice replies before clarify resolution and busy steering

### DIFF
--- a/contributors/emails/lumina@douno.it
+++ b/contributors/emails/lumina@douno.it
@@ -1,0 +1,1 @@
+chefboyrdave21

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2267,11 +2267,16 @@ def _invalidate_pending_stt_cache(event: MessageEvent) -> None:
     ``_transcribe_pending_audio_event_once``); if the cached event gains new
     media after the cache was populated, the stale transcript must be
     discarded so the next transcription call picks up the merged attachments.
+
+    Only the *derived* transcription cache is dropped.  The echo ledger
+    (``_gateway_pending_stt_echoed``) records which transcripts were already
+    delivered to the user and must survive the merge: the re-run transcription
+    returns the earlier notes again, so clearing the ledger would echo them a
+    second time.
     """
     for attr in (
         "_gateway_pending_stt_text",
         "_gateway_pending_stt_transcripts",
-        "_gateway_pending_stt_echo_sent",
     ):
         if hasattr(event, attr):
             delattr(event, attr)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4138,6 +4138,15 @@ class BasePlatformAdapter(ABC):
         for match in media_pattern.finditer(scan_content):
             path = _normalize_media_tag_path(match.group("path"))
             if path:
+                # ``[[audio_as_voice]]`` is message-global, but it must only
+                # affect audio files. Tagging a non-audio file (image, video,
+                # document) as is_voice taints it: an image flagged is_voice is
+                # excluded from the embedded-photo batch and falls through to
+                # send_document, arriving as a file attachment instead of an
+                # inline photo. Gating on the extension lets one message carry
+                # an embedded image AND a voice bubble together.
+                ext = os.path.splitext(path)[1].lower()
+                is_voice = has_voice_tag and ext in _AUDIO_EXTS
                 try:
                     expanded = os.path.expanduser(path)
                 except (OSError, RuntimeError, ValueError):
@@ -4146,7 +4155,7 @@ class BasePlatformAdapter(ABC):
                     continue
                 if expanded not in seen_paths:
                     seen_paths.add(expanded)
-                    media.append((expanded, has_voice_tag))
+                    media.append((expanded, is_voice))
 
         for match in MEDIA_EXTENSIONLESS_TAG_RE.finditer(scan_content):
             path = _normalize_media_tag_path(match.group("path"))
@@ -4157,7 +4166,8 @@ class BasePlatformAdapter(ABC):
                 continue
             safe = resolved[0]
             if safe not in seen_paths:
-                media.append((safe, has_voice_tag))
+                _safe_ext = os.path.splitext(safe)[1].lower()
+                media.append((safe, has_voice_tag and _safe_ext in _AUDIO_EXTS))
                 seen_paths.add(safe)
 
         # Remove the delivered MEDIA tags from the user-visible text. Mask a

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6172,48 +6172,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         the automatic STT contract used by ``_prepare_inbound_message_text``.
         If transcription fails, preserve any caption and let the existing
         steer fallback handle an otherwise empty event without losing it.
+
+        Routes through ``_transcribe_and_echo_pending_voice`` — the single
+        out-of-band transcription choke point shared with the interrupt
+        monitor and the pending-drain path — so the STT call is made at most
+        once per platform message (cached on the event) and the transcript
+        echo respects the count-based ledger.  If steering later falls back
+        to queue mode, the drain path reuses the cached transcript instead of
+        paying for a second STT call or re-echoing the same line.
         """
         text = (event.text or "").strip()
-        media_urls = getattr(event, "media_urls", None) or []
-        media_types = getattr(event, "media_types", None) or []
-        voice_paths: List[str] = []
-
-        for index, path in enumerate(media_urls):
-            media_type = media_types[index] if index < len(media_types) else ""
-            is_voice = event.message_type == MessageType.VOICE or (
-                media_type.startswith("audio/")
-                and event.message_type not in {MessageType.AUDIO, MessageType.DOCUMENT}
-            )
-            if is_voice:
-                voice_paths.append(path)
-
-        if not voice_paths:
+        if not self._pending_event_audio_paths(event):
             return text
 
-        enriched_text, successful_transcripts = await self._enrich_message_with_transcription(
+        adapter = self._adapter_for_source(event.source)
+        enriched_text, successful_transcripts = await self._transcribe_and_echo_pending_voice(
+            event,
+            adapter,
+            event.source,
             text,
-            voice_paths,
+            log_context="Busy-steer",
         )
         if not successful_transcripts:
             return text
-
-        if self._should_echo_stt_transcripts():
-            adapter = self._adapter_for_source(event.source)
-            if adapter:
-                echo_meta = self._thread_metadata_for_source(
-                    event.source,
-                    self._reply_anchor_for_event(event),
-                )
-                for transcript in successful_transcripts:
-                    try:
-                        await adapter.send(
-                            event.source.chat_id,
-                            f'🎙️ "{transcript}"',
-                            metadata=echo_meta,
-                        )
-                    except Exception as exc:
-                        logger.debug("Busy-steer transcript echo failed (non-fatal): %s", exc)
-
         return (enriched_text or text).strip()
 
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
@@ -6404,11 +6385,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         redirected = False
         if effective_mode == "steer":
             steer_text = await self._prepare_busy_steer_text(event)
+            # A follow-up qualifies for steering when it is plain text, OR
+            # when every attachment is STT-eligible voice media whose
+            # transcript was just folded into steer_text — otherwise a voice
+            # note in steer mode silently degrades to queue mode (#58780).
+            _steer_media_urls = getattr(event, "media_urls", None) or []
+            _steer_all_voice = bool(_steer_media_urls) and (
+                len(self._pending_event_audio_paths(event)) == len(_steer_media_urls)
+            )
             can_steer = (
                 steer_text
-                and event.message_type == MessageType.TEXT
-                and not event.media_urls
-                and not event.media_types
+                and (
+                    (
+                        event.message_type == MessageType.TEXT
+                        and not event.media_urls
+                        and not event.media_types
+                    )
+                    or _steer_all_voice
+                )
                 and running_agent is not None
                 and running_agent is not _AGENT_PENDING_SENTINEL
                 and hasattr(running_agent, "steer")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6160,6 +6160,62 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         self._enqueue_fifo(session_key, event, adapter)
 
+    async def _prepare_busy_steer_text(self, event: MessageEvent) -> str:
+        """Return steerable text for a busy follow-up, transcribing voice first.
+
+        Fresh and queued voice messages reach the normal inbound STT pipeline,
+        but successful steer messages intentionally bypass that queue. Without
+        preprocessing here, a media-only voice follow-up has an empty text
+        payload and steer mode silently degrades to queue mode.
+
+        Audio file attachments remain files; only voice-message media follows
+        the automatic STT contract used by ``_prepare_inbound_message_text``.
+        If transcription fails, preserve any caption and let the existing
+        steer fallback handle an otherwise empty event without losing it.
+        """
+        text = (event.text or "").strip()
+        media_urls = getattr(event, "media_urls", None) or []
+        media_types = getattr(event, "media_types", None) or []
+        voice_paths: List[str] = []
+
+        for index, path in enumerate(media_urls):
+            media_type = media_types[index] if index < len(media_types) else ""
+            is_voice = event.message_type == MessageType.VOICE or (
+                media_type.startswith("audio/")
+                and event.message_type not in {MessageType.AUDIO, MessageType.DOCUMENT}
+            )
+            if is_voice:
+                voice_paths.append(path)
+
+        if not voice_paths:
+            return text
+
+        enriched_text, successful_transcripts = await self._enrich_message_with_transcription(
+            text,
+            voice_paths,
+        )
+        if not successful_transcripts:
+            return text
+
+        if self._should_echo_stt_transcripts():
+            adapter = self._adapter_for_source(event.source)
+            if adapter:
+                echo_meta = self._thread_metadata_for_source(
+                    event.source,
+                    self._reply_anchor_for_event(event),
+                )
+                for transcript in successful_transcripts:
+                    try:
+                        await adapter.send(
+                            event.source.chat_id,
+                            f'🎙️ "{transcript}"',
+                            metadata=echo_meta,
+                        )
+                    except Exception as exc:
+                        logger.debug("Busy-steer transcript echo failed (non-fatal): %s", exc)
+
+        return (enriched_text or text).strip()
+
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Authorization gate (#17775) ---
         # The cold path (_handle_message) checks _is_user_authorized before
@@ -6347,7 +6403,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         steered = False
         redirected = False
         if effective_mode == "steer":
-            steer_text = (event.text or "").strip()
+            steer_text = await self._prepare_busy_steer_text(event)
             can_steer = (
                 steer_text
                 and event.message_type == MessageType.TEXT

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11193,7 +11193,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             _pending_clarify = None
         if _pending_clarify is not None and _clarify_mod is not None:
-            _raw_clarify_reply = (event.text or "").strip()
+            _clarify_has_audio = bool(self._pending_event_audio_paths(event))
+            _raw_clarify_reply = await self._prepare_clarify_reply_text(event)
+            if _clarify_has_audio and not _raw_clarify_reply:
+                logger.info(
+                    "Gateway retained pending clarify after voice transcription "
+                    "produced no usable text (session=%s, id=%s)",
+                    _quick_key,
+                    _pending_clarify.clarify_id,
+                )
+                return ""
             # Skip slash commands — the user clearly wanted to issue a
             # command, not answer the clarify.  Leave the clarify pending
             # so the user can retry; if it times out, the agent unblocks
@@ -13020,6 +13029,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             source=source,
             history=history,
             session_key=session_key,
+        )
+
+    async def _prepare_clarify_reply_text(self, event) -> str:
+        """Return raw text or successful voice transcripts for a clarify reply."""
+        if not self._pending_event_audio_paths(event):
+            return (event.text or "").strip()
+
+        _, successful_transcripts = await self._transcribe_pending_audio_event_once(
+            event, "",
+        )
+        return "\n\n".join(
+            transcript.strip()
+            for transcript in successful_transcripts
+            if transcript.strip()
         )
 
     def _consume_pending_native_image_paths(self, session_key: str) -> List[str]:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18145,16 +18145,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         metadata=None,
         log_context: str = "Transcript",
     ) -> None:
-        """Echo pending-event STT transcripts to the chat at most once."""
+        """Echo pending-event STT transcripts to the chat at most once.
+
+        The already-echoed transcripts are tracked as a COUNT rather than a
+        single boolean.  ``merge_pending_message_event`` can append a second
+        voice note to an event whose first transcript was already echoed and
+        invalidates the transcription cache; the re-run transcription then
+        returns the earlier transcripts as a prefix of the new list, so
+        echoing only the unsent tail suppresses the repeat while still
+        surfacing the newly merged note.  A count rather than a set of seen
+        values because two separate notes that transcribe identically are two
+        distinct deliveries and both must be echoed.
+        """
         if (
             not transcripts
             or not self._should_echo_stt_transcripts()
             or adapter is None
-            or getattr(event, "_gateway_pending_stt_echo_sent", False)
         ):
             return
-        setattr(event, "_gateway_pending_stt_echo_sent", True)
-        for tx in transcripts:
+        already_echoed = int(getattr(event, "_gateway_pending_stt_echoed", 0) or 0)
+        unsent = transcripts[already_echoed:]
+        setattr(event, "_gateway_pending_stt_echoed", already_echoed + len(unsent))
+        for tx in unsent:
             try:
                 await adapter.send(
                     source.chat_id,

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -350,6 +350,44 @@ class TestBusySessionAck:
         assert "Interrupting" not in content
 
     @pytest.mark.asyncio
+    async def test_steer_mode_transcribes_voice_before_injection(self, monkeypatch):
+        """A busy voice follow-up is transcribed and steered, never queued."""
+        import gateway.run as _gr
+
+        monkeypatch.delenv("HERMES_GATEWAY_BUSY_STEER_ACK_ENABLED", raising=False)
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        runner._should_echo_stt_transcripts = MagicMock(return_value=False)
+        runner._enrich_message_with_transcription = AsyncMock(
+            return_value=('"yönü teknik mimariye çevir"', ["yönü teknik mimariye çevir"])
+        )
+        adapter = _make_adapter()
+
+        event = _make_event(text="")
+        event.message_type = MessageType.VOICE
+        event.media_urls = ["/tmp/follow-up.ogg"]
+        event.media_types = ["audio/ogg"]
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        runner._enrich_message_with_transcription.assert_awaited_once_with(
+            "", ["/tmp/follow-up.ogg"]
+        )
+        agent.steer.assert_called_once_with('"yönü teknik mimariye çevir"')
+        agent.interrupt.assert_not_called()
+        assert sk not in adapter._pending_messages
+        content = adapter._send_with_retry.call_args.kwargs["content"]
+        assert "Steered" in content
+        assert "Queued" not in content
+
+    @pytest.mark.asyncio
     async def test_steer_mode_can_suppress_visible_ack_without_disabling_steer(self, monkeypatch):
         """busy_steer_ack_enabled=false keeps steering but drops the echo bubble."""
         import gateway.run as _gr

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -349,6 +349,29 @@ class TestExtractMedia:
         assert media[0][0] == "/path/to/voice.ogg"
         assert media[0][1] is True  # voice tag present
 
+    def test_voice_directive_only_taints_audio_files(self):
+        """[[audio_as_voice]] is message-global but must only flag audio files.
+
+        A non-audio file marked is_voice is excluded from the embedded-photo
+        batch and falls through to send_document, so an image sharing a
+        message with a voice note used to arrive as a file attachment
+        (#44826).
+        """
+        content = "[[audio_as_voice]]\nMEDIA:/tmp/pic.png\nMEDIA:/tmp/voice.ogg"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        flags = dict(media)
+        assert flags["/tmp/pic.png"] is False
+        assert flags["/tmp/voice.ogg"] is True
+        assert "[[audio_as_voice]]" not in cleaned
+
+    def test_voice_directive_skips_video_and_documents(self):
+        content = "[[audio_as_voice]]\nMEDIA:/tmp/clip.mp4\nMEDIA:/tmp/report.pdf\nMEDIA:/tmp/note.opus"
+        media, _ = BasePlatformAdapter.extract_media(content)
+        flags = dict(media)
+        assert flags["/tmp/clip.mp4"] is False
+        assert flags["/tmp/report.pdf"] is False
+        assert flags["/tmp/note.opus"] is True
+
     def test_multiple_media_tags(self):
         content = "MEDIA:/a.ogg\nMEDIA:/b.ogg"
         media, _ = BasePlatformAdapter.extract_media(content)

--- a/tests/gateway/test_telegram_voice_v0_regressions.py
+++ b/tests/gateway/test_telegram_voice_v0_regressions.py
@@ -357,3 +357,135 @@ async def test_voice_tts_is_explicit_audio_reply_opt_in():
     assert runner._voice_mode["telegram:12345"] == "all"
     assert "12345" in adapter._auto_tts_enabled_chats
     assert result
+
+
+def _voice_event(source, urls):
+    return MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        media_urls=list(urls),
+        media_types=["audio/ogg"] * len(urls),
+    )
+
+
+@pytest.mark.asyncio
+async def test_pending_stt_merge_does_not_re_echo_delivered_transcript():
+    """A follow-up message must not replay an already-echoed transcript.
+
+    ``merge_pending_message_event`` invalidates the transcription cache so the
+    merged text/media is picked up, which makes the drain path transcribe
+    again.  The echo ledger has to survive that invalidation, otherwise the
+    user sees the same 🎙️ line twice.
+    """
+    from gateway.platforms.base import merge_pending_message_event
+
+    adapter = SimpleNamespace(send=AsyncMock())
+    runner = _runner(adapter)
+    source = _source()
+    event = _voice_event(source, ["/tmp/voice-1.ogg"])
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "hello", "provider": "mock"},
+    ):
+        _, transcripts = await runner._transcribe_pending_audio_event_once(event, event.text)
+        await runner._echo_pending_stt_transcripts_once(event, adapter, source, transcripts)
+
+        # A plain text follow-up merges into the still-pending voice event.
+        merge_pending_message_event(
+            {"telegram:dm:12345": event},
+            "telegram:dm:12345",
+            MessageEvent(text="and also this", message_type=MessageType.TEXT, source=source),
+        )
+
+        drain_text, drain_transcripts = await runner._transcribe_pending_audio_event_once(
+            event, event.text
+        )
+        await runner._echo_pending_stt_transcripts_once(
+            event, adapter, source, drain_transcripts
+        )
+
+    assert event.text == "and also this"
+    assert "and also this" in drain_text
+    adapter.send.assert_awaited_once_with("12345", '🎙️ "hello"', metadata=None)
+
+
+@pytest.mark.asyncio
+async def test_pending_stt_merge_echoes_only_the_newly_merged_transcript():
+    """A second voice note still gets echoed, without repeating the first."""
+    from gateway.platforms.base import merge_pending_message_event
+
+    adapter = SimpleNamespace(send=AsyncMock())
+    runner = _runner(adapter)
+    source = _source()
+    event = _voice_event(source, ["/tmp/voice-1.ogg"])
+
+    def _fake_transcribe(path):
+        name = "hello" if path.endswith("voice-1.ogg") else "world"
+        return {"success": True, "transcript": name, "provider": "mock"}
+
+    with patch("tools.transcription_tools.transcribe_audio", side_effect=_fake_transcribe):
+        _, transcripts = await runner._transcribe_pending_audio_event_once(event, event.text)
+        await runner._echo_pending_stt_transcripts_once(event, adapter, source, transcripts)
+
+        merge_pending_message_event(
+            {"telegram:dm:12345": event},
+            "telegram:dm:12345",
+            _voice_event(source, ["/tmp/voice-2.ogg"]),
+        )
+
+        _, drain_transcripts = await runner._transcribe_pending_audio_event_once(
+            event, event.text
+        )
+        await runner._echo_pending_stt_transcripts_once(
+            event, adapter, source, drain_transcripts
+        )
+
+    assert drain_transcripts == ["hello", "world"]
+    assert [c.args[1] for c in adapter.send.await_args_list] == [
+        '🎙️ "hello"',
+        '🎙️ "world"',
+    ]
+
+
+@pytest.mark.asyncio
+async def test_pending_stt_merge_echoes_two_identical_transcripts():
+    """Two separate notes that transcribe identically are two deliveries.
+
+    The ledger counts what was already echoed rather than remembering the
+    transcript strings: a value-based dedup would silently collapse a repeated
+    phrase into one echo, dropping a note the user actually sent.
+    """
+    from gateway.platforms.base import merge_pending_message_event
+
+    adapter = SimpleNamespace(send=AsyncMock())
+    runner = _runner(adapter)
+    source = _source()
+    event = _voice_event(source, ["/tmp/voice-1.ogg"])
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "on my way", "provider": "mock"},
+    ):
+        _, transcripts = await runner._transcribe_pending_audio_event_once(event, event.text)
+        await runner._echo_pending_stt_transcripts_once(event, adapter, source, transcripts)
+
+        merge_pending_message_event(
+            {"telegram:dm:12345": event},
+            "telegram:dm:12345",
+            _voice_event(source, ["/tmp/voice-2.ogg"]),
+        )
+
+        _, drain_transcripts = await runner._transcribe_pending_audio_event_once(
+            event, event.text
+        )
+        await runner._echo_pending_stt_transcripts_once(
+            event, adapter, source, drain_transcripts
+        )
+
+    assert drain_transcripts == ["on my way", "on my way"]
+    assert [c.args[1] for c in adapter.send.await_args_list] == [
+        '🎙️ "on my way"',
+        '🎙️ "on my way"',
+    ], "the second note must still be echoed even though it transcribes the same"

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
-from gateway.platforms.base import MessageEvent
+from gateway.platforms.base import MessageEvent, MessageType
 from gateway.session import SessionEntry, SessionSource, build_session_key
 
 
@@ -28,6 +28,18 @@ def _make_source() -> SessionSource:
 
 def _make_event(text: str) -> MessageEvent:
     return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_voice_event(text: str = "voice_message_1.ogg") -> MessageEvent:
+    source = _make_source()
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.VOICE,
+        source=source,
+        message_id="m1",
+        media_urls=["/tmp/voice_message_1.ogg"],
+        media_types=["audio/ogg"],
+    )
 
 
 def _make_runner():
@@ -198,6 +210,67 @@ async def test_underscored_alias_for_hyphenated_builtin_not_flagged(monkeypatch)
     # Whatever /reload_mcp returns, it must not be the unknown-command guard.
     if result is not None:
         assert "Unknown command" not in result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("event_text", ["voice_message_1.ogg", ""])
+async def test_pending_clarify_voice_reply_uses_transcript_and_choice_coercion(
+    monkeypatch,
+    event_text,
+):
+    """Filename-bearing and captionless voice replies resolve from raw STT text."""
+    import gateway.run as gateway_run
+    from tools import clarify_gateway
+
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    clarify_id = f"clarify-voice-{event_text or 'empty'}"
+    clarify_gateway.register(
+        clarify_id,
+        session_key,
+        "Pick one",
+        ["first choice", "second choice"],
+    )
+    runner.hooks.emit_collect = AsyncMock(return_value=[])
+    runner._transcribe_pending_audio_event_once = AsyncMock(
+        return_value=('"2"', ["2"]),
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_voice_event(event_text))
+
+    assert result == ""
+    runner._transcribe_pending_audio_event_once.assert_awaited_once()
+    assert clarify_gateway.wait_for_response(clarify_id, timeout=0.1) == "second choice"
+
+
+@pytest.mark.asyncio
+async def test_failed_clarify_voice_transcription_does_not_resolve_marker(monkeypatch):
+    """An STT status marker is not a user answer; the clarify stays pending."""
+    import gateway.run as gateway_run
+    from tools import clarify_gateway
+
+    runner = _make_runner()
+    event = _make_voice_event("")
+    session_key = build_session_key(event.source)
+    clarify_id = "clarify-voice-stt-failure"
+    clarify_gateway.register(clarify_id, session_key, "Say anything", None)
+    runner._transcribe_pending_audio_event_once = AsyncMock(
+        return_value=("[voice message could not be transcribed]", []),
+    )
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    try:
+        assert await runner._handle_message(event) == ""
+        runner._transcribe_pending_audio_event_once.assert_awaited_once()
+        assert clarify_gateway.has_pending(session_key) is True
+    finally:
+        clarify_gateway.clear_session(session_key)
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
# fix(gateway): voice messages during agent activity are first-class — transcribe before clarify + steer, gate audio_as_voice, keep the echo ledger

Consolidated salvage of four contributor PRs. Class-level framing: **out-of-band voice** (a voice note that arrives while the agent is busy or waiting on a clarify) now routes through **one transcription choke point** — `_transcribe_and_echo_pending_voice` / `_transcribe_pending_audio_event_once` — so each platform message pays at most one STT call, and the transcript echo respects a count-based ledger that survives pending-media merges.

## What was broken on main (all premises re-verified on f228e145ba)

1. **Clarify ignored voice replies** — the clarify intercept in `gateway/run.py` read `event.text` raw. A voice reply arrives with the *filename* as text (e.g. `voice_message_1.ogg`), so the clarify was "answered" with a filename, or dropped. Fixes #52998, #56739.
2. **Steer mode silently degraded voice to queue** — `can_steer` required `message_type == TEXT` with zero media, so with `display.busy_input_mode: steer` a voice follow-up quietly fell back to queue. Fixes the steer half of #58780.
3. **`[[audio_as_voice]]` tainted non-audio files** — the directive is message-global; an image sharing a message with a voice note got `is_voice=True`, was excluded from the embedded-photo batch, and arrived as a document attachment.
4. **STT echo ledger lost on merge** — `_invalidate_pending_stt_cache()` deleted `_gateway_pending_stt_echo_sent` when a follow-up merged into a pending event, so the re-run transcription re-echoed (and re-paid for) the earlier voice note.

## Commits (contributor authorship preserved via cherry-pick)

| Commit | Author | Salvaged from | What it does |
|---|---|---|---|
| `ebe57ca7fe` | @izumi0uu | #53020 | `_prepare_clarify_reply_text`: transcribe pending voice audio before resolving a clarify; retain the pending clarify when STT yields no usable text (a failure marker is not an answer). |
| `97f2a91f53` | @canorionen | #65023 | `_prepare_busy_steer_text`: transcribe busy voice follow-ups before the steer decision. |
| `6f8ccd5136` | @chefboyrdave21 | #44826 | Gate `[[audio_as_voice]]` on audio file extensions in `extract_media`; wrap `expanduser` in try/except so a crafted `~\x00` path is skipped, not fatal. |
| `92818ae028` | @Frowtek | #67281 | Keep the echo ledger out of `_invalidate_pending_stt_cache`; track echoed transcripts as a **count** so only the unsent tail is echoed after a merge (two identical transcripts stay two deliveries). |
| `a3f970c16c` | us (follow-up) | — | Unify: `_prepare_busy_steer_text` now routes through the shared `_transcribe_and_echo_pending_voice` choke point (event-cached STT + count-ledger echo, same as interrupt/drain); `can_steer` accepts all-voice-media events so the transcript actually steers; extension gating also applied to extensionless MEDIA-tag resolution; adds `extract_media` gating tests + contributor mapping. |

## Duplicate PRs to close with credit (earliest submitter first)

**Clarify-voice trio** — earliest was **#50925 by @Adridot (June 22)**; #53020 (@izumi0uu, June 26) won on diff quality (reuses `_pending_event_audio_paths`, retains the clarify on empty STT); #67014 (@dpowrepo, July 18) same idea later.
- Close #50925 — thank you @Adridot for being first to report-and-fix this; the merged diff is #53020's but your PR identified the same root cause four days earlier.
- Close #67014 — subsumed, credit @dpowrepo.

**Steer-voice pair** — earliest was **#49949 by @the3asic (June 21)**; #65023 (@canorionen, July 15) won on diff quality (mirrors the inbound STT contract instead of inlining media classification).
- Close #49949 — thank you @the3asic for the earlier fix of the same gap.

## Issues

- Closes #52998, #56739 (clarify ignores voice)
- Closes the steer half of #58780 (queue half already works on main — queued voice goes through normal inbound STT; `display.busy_input_mode` docs answer the rest)

## Tests

- `tests/gateway/test_unknown_command.py`: clarify-with-voice — transcript resolves the clarify (incl. numeric choice coercion), failed STT leaves the clarify pending (2 new tests, parametrized).
- `tests/gateway/test_busy_session_ack.py`: steer-with-voice — voice follow-up is transcribed and steered, never queued.
- `tests/gateway/test_platform_base.py`: `[[audio_as_voice]]` gating — image+voice message keeps the image inline; video/pdf never flagged (2 new tests; verified they FAIL when the gate is reverted).
- `tests/gateway/test_telegram_voice_v0_regressions.py`: 4 new ledger tests incl. `test_pending_stt_merge_echoes_two_identical_transcripts` and no-re-echo across text-only merges.
- Full `tests/gateway` suite: 11297 passed; the only failures (`test_voice_command.py::TestVoiceReception` DAVE decrypt pair + env-dependent errors) reproduce identically on clean `origin/main` — pre-existing, unrelated.

Merge method: **rebase** (preserves contributor authorship per-commit).


## Infographic

![fix(gateway): transcribe voice replies before clarify resolution and busy steering](https://v3b.fal.media/files/b/0aa416de/nt6ALO1j0_zybGS_lafQd_ooLeaAsb.png)
