### PR TITLE
fix(voice): CLI/TUI voice mode UX and environment fixes (15 items)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12140,9 +12140,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         """Return whether CLI voice mode should play record start/stop beeps."""
         try:
             from hermes_cli.config import load_config
+            from utils import is_truthy_value
             voice_cfg = load_config().get("voice", {})
             if isinstance(voice_cfg, dict):
-                return bool(voice_cfg.get("beep_enabled", True))
+                # is_truthy_value handles quoted YAML strings like "false"
+                # which bool() would misread as True (#49883).
+                return is_truthy_value(voice_cfg.get("beep_enabled", True), default=True)
         except Exception:
             pass
         return True

--- a/cli.py
+++ b/cli.py
@@ -4076,6 +4076,23 @@ def _normalize_moa_model(model: Optional[str]) -> tuple[Optional[str], Optional[
     return None, model
 
 
+class _VoiceInputMessage:
+    """Sentinel wrapper for voice-transcribed messages in ``_pending_input``.
+
+    Distinguishes STT output from manually typed text while voice mode is
+    active, so the concise-voice-response prefix is applied only to messages
+    that actually came from the microphone (#65827).
+    """
+
+    __slots__ = ("text",)
+
+    def __init__(self, text: str):
+        self.text = text
+
+    def __str__(self) -> str:
+        return self.text
+
+
 class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     """
     Interactive CLI for the Hermes Agent.
@@ -11921,7 +11938,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 self._attached_images.clear()
                 if hasattr(self, '_app') and self._app:
                     self._app.invalidate()
-                self._pending_input.put(transcript)
+                self._pending_input.put(_VoiceInputMessage(transcript))
                 submitted = True
             elif result.get("success"):
                 _cprint(f"{_DIM}No speech detected.{_RST}")
@@ -12102,7 +12119,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     _cprint(f"\n{_DIM}Stop phrase detected — ending voice chat.{_RST}")
                     self._disable_voice_mode()
                     return
-                self._pending_input.put(transcript)
+                self._pending_input.put(_VoiceInputMessage(transcript))
                 submitted = True
             elif not result.get("success"):
                 _cprint(f"\n{_DIM}Transcription failed: {result.get('error', 'Unknown error')}{_RST}")
@@ -12806,7 +12823,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             except Exception:
                 pass
 
-    def chat(self, message, images: list = None) -> Optional[str]:
+    def chat(self, message, images: list = None, voice_input: bool = False) -> Optional[str]:
         """
         Send a message to the agent and get a response.
         
@@ -12821,6 +12838,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         Args:
             message: The user's message (str or multimodal content list)
             images: Optional list of Path objects for attached images
+            voice_input: True when the message came from voice transcription
+                (gates the concise voice-response prefix, #65827)
             
         Returns:
             The agent's response, or None on error
@@ -13048,7 +13067,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # model responds concisely. The prefix is API-call-local only —
             # run_conversation persists the original clean user message.
             _voice_prefix = ""
-            if self._voice_mode and isinstance(message, str):
+            if voice_input and isinstance(message, str):
                 _voice_prefix = (
                     "[Voice input — respond concisely and conversationally, "
                     "2-3 sentences max. No code blocks or markdown.] "
@@ -16212,7 +16231,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                             except Exception:
                                 pass
                         continue
-                    
+
+                    # Voice-transcribed messages arrive wrapped in a sentinel
+                    # so only genuine STT output gets the voice prefix (#65827).
+                    is_voice_input = isinstance(user_input, _VoiceInputMessage)
+                    if is_voice_input:
+                        user_input = user_input.text
+
                     if not user_input:
                         continue
 
@@ -16308,7 +16333,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     app.invalidate()  # Refresh status line
 
                     try:
-                        self.chat(user_input, images=submit_images or None)
+                        self.chat(user_input, images=submit_images or None, voice_input=is_voice_input)
                     finally:
                         self._agent_running = False
                         self._spinner_text = ""

--- a/cli.py
+++ b/cli.py
@@ -11759,6 +11759,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._voice_recorder._silence_duration = (
             _duration if isinstance(_duration, (int, float)) and not isinstance(_duration, bool) else 3.0
         )
+        # voice.max_recording_seconds — hard cap on a single recording's length.
+        # Same numeric guard as the silence params (bool excluded: a hand-edited
+        # ``max_recording_seconds: true`` must not become ``1``). <= 0 disables
+        # the cap. Previously this documented key was never read, so the setting
+        # had no effect (dead config); wiring it here makes it take effect.
+        _max_rec = voice_cfg.get("max_recording_seconds")
+        self._voice_recorder._max_recording_seconds = (
+            _max_rec
+            if isinstance(_max_rec, (int, float)) and not isinstance(_max_rec, bool) and _max_rec > 0
+            else 0.0
+        )
 
         def _on_silence():
             """Called by AudioRecorder when silence is detected after speech."""

--- a/cli.py
+++ b/cli.py
@@ -15014,15 +15014,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     daemon=True,
                 ).start()
             else:
-                # Guard: don't START recording during agent run or interactive prompts
-                if cli_ref._agent_running:
+                # Allow disarming continuous mode even when the agent is
+                # running or transcribing — otherwise the user is stuck in
+                # an auto-restart loop until /voice off (#67545).
+                if cli_ref._agent_running or cli_ref._voice_processing:
+                    with cli_ref._voice_lock:
+                        cli_ref._voice_continuous = False
+                    event.app.invalidate()
                     return
+                # Guard: don't START recording during interactive prompts
                 if cli_ref._clarify_state or cli_ref._sudo_state or cli_ref._approval_state or cli_ref._slash_confirm_state:
-                    return
-                # Guard: don't start while a previous stop/transcribe cycle is
-                # still running — recorder.stop() holds AudioRecorder._lock and
-                # start() would block the event-loop thread waiting for it.
-                if cli_ref._voice_processing:
                     return
 
                 # Interrupt TTS if playing, so user can start talking.

--- a/cli.py
+++ b/cli.py
@@ -11991,11 +11991,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 tts_result = json.loads(raw_result) if isinstance(raw_result, str) else {}
             except Exception:
                 tts_result = {}
-            audio_path = tts_result.get("file_path") or mp3_path
 
-            # Play the actual file returned by the TTS provider. Command
-            # providers may keep native formats such as FLAC/WAV instead of
-            # writing the requested MP3 path.
+            # Prefer the requested MP3 when the provider produced it. This
+            # preserves reliable local playback while still supporting
+            # providers that write to and return a different path.
+            audio_path = mp3_path
+            if not os.path.isfile(mp3_path) or os.path.getsize(mp3_path) == 0:
+                audio_path = tts_result.get("file_path") or mp3_path
+
             if os.path.isfile(audio_path) and os.path.getsize(audio_path) > 0:
                 play_audio_file(audio_path)
                 # Clean up

--- a/cli.py
+++ b/cli.py
@@ -11761,14 +11761,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         )
         # voice.max_recording_seconds — hard cap on a single recording's length.
         # Same numeric guard as the silence params (bool excluded: a hand-edited
-        # ``max_recording_seconds: true`` must not become ``1``). <= 0 disables
-        # the cap. Previously this documented key was never read, so the setting
-        # had no effect (dead config); wiring it here makes it take effect.
+        # ``max_recording_seconds: true`` must not become ``1`` — it falls back
+        # to the documented 120 default, mirroring the silence-param handling).
+        # An explicit numeric value <= 0 disables the cap. Previously this
+        # documented key was never read (dead config); wiring it here makes it
+        # take effect.
         _max_rec = voice_cfg.get("max_recording_seconds")
         self._voice_recorder._max_recording_seconds = (
-            _max_rec
-            if isinstance(_max_rec, (int, float)) and not isinstance(_max_rec, bool) and _max_rec > 0
-            else 0.0
+            (_max_rec if _max_rec > 0 else 0.0)
+            if isinstance(_max_rec, (int, float)) and not isinstance(_max_rec, bool)
+            else 120.0
         )
 
         def _on_silence():

--- a/cli.py
+++ b/cli.py
@@ -11819,13 +11819,36 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         threading.Thread(target=_refresh_level, daemon=True).start()
 
     def _voice_stt_model(self) -> Optional[str]:
-        """STT model override from config, or None for the provider default."""
+        """STT model override from config, or None for the provider default.
+
+        For the local provider, prefer stt.local.model (default ``base``) so the
+        CLI passes a real model name into the local STT backend.
+        """
         try:
             from hermes_cli.config import load_config
             stt_config = load_config().get("stt", {})
-            return stt_config.get("model") if isinstance(stt_config, dict) else None
+            if not isinstance(stt_config, dict):
+                return None
+            provider = str(stt_config.get("provider") or "").strip().lower()
+            if provider == "local":
+                local_config = stt_config.get("local") or {}
+                if not isinstance(local_config, dict):
+                    local_config = {}
+                return local_config.get("model") or "base"
+            return stt_config.get("model")
         except Exception:
             return None
+
+    def _voice_stt_provider(self) -> str:
+        """Configured STT provider name (lowercased), or empty string."""
+        try:
+            from hermes_cli.config import load_config
+            stt_config = load_config().get("stt", {})
+            if not isinstance(stt_config, dict):
+                return ""
+            return str(stt_config.get("provider") or "").strip().lower()
+        except Exception:
+            return ""
 
     def _voice_restart_recording_async(self) -> None:
         """Restart continuous-mode recording off-thread (start() can block)."""
@@ -11873,10 +11896,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # _voice_processing is already True (set atomically above)
             if hasattr(self, '_app') and self._app:
                 self._app.invalidate()
-            _cprint(f"{_DIM}Transcribing...{_RST}")
+
+            stt_model = self._voice_stt_model()
+            if self._voice_stt_provider() == "local":
+                _cprint(
+                    f"{_DIM}Preparing local STT model '{stt_model}' "
+                    f"(first use may download it from Hugging Face)...{_RST}"
+                )
+            else:
+                _cprint(f"{_DIM}Transcribing...{_RST}")
 
             from tools.voice_mode import transcribe_recording
-            result = transcribe_recording(wav_path, model=self._voice_stt_model())
+            result = transcribe_recording(wav_path, model=stt_model)
 
             if result.get("success") and result.get("transcript", "").strip():
                 transcript = result["transcript"].strip()

--- a/cli.py
+++ b/cli.py
@@ -11986,17 +11986,27 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 f"tts_{time.strftime('%Y%m%d_%H%M%S')}.mp3",
             )
 
-            text_to_speech_tool(text=tts_text, output_path=mp3_path)
+            raw_result = text_to_speech_tool(text=tts_text, output_path=mp3_path)
+            try:
+                tts_result = json.loads(raw_result) if isinstance(raw_result, str) else {}
+            except Exception:
+                tts_result = {}
+            audio_path = tts_result.get("file_path") or mp3_path
 
-            # Play the MP3 directly (the TTS tool returns OGG path but MP3 still exists)
-            if os.path.isfile(mp3_path) and os.path.getsize(mp3_path) > 0:
-                play_audio_file(mp3_path)
+            # Play the actual file returned by the TTS provider. Command
+            # providers may keep native formats such as FLAC/WAV instead of
+            # writing the requested MP3 path.
+            if os.path.isfile(audio_path) and os.path.getsize(audio_path) > 0:
+                play_audio_file(audio_path)
                 # Clean up
                 try:
-                    os.unlink(mp3_path)
-                    ogg_path = mp3_path.rsplit(".", 1)[0] + ".ogg"
-                    if os.path.isfile(ogg_path):
-                        os.unlink(ogg_path)
+                    cleanup_paths = {audio_path, mp3_path}
+                    for path in list(cleanup_paths):
+                        ogg_path = path.rsplit(".", 1)[0] + ".ogg"
+                        cleanup_paths.add(ogg_path)
+                    for path in cleanup_paths:
+                        if os.path.isfile(path):
+                            os.unlink(path)
                 except OSError:
                     pass
         except Exception as e:

--- a/cli.py
+++ b/cli.py
@@ -11906,13 +11906,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 pass
 
             # Track consecutive no-speech cycles to avoid infinite restart loops.
+            stop_continuous_restart = False
             if not submitted:
                 self._no_speech_count = getattr(self, '_no_speech_count', 0) + 1
                 if self._no_speech_count >= 3:
                     self._voice_continuous = False
                     self._no_speech_count = 0
                     _cprint(f"{_DIM}No speech detected 3 times, continuous mode stopped.{_RST}")
-                    return
+                    stop_continuous_restart = True
             else:
                 self._no_speech_count = 0
 
@@ -11920,7 +11921,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # restart recording so the user can keep talking.
             # (When transcript IS submitted, process_loop handles restart
             # after chat() completes.)
-            if self._voice_continuous and not submitted and not self._voice_recording:
+            if (
+                self._voice_continuous
+                and not submitted
+                and not self._voice_recording
+                and not stop_continuous_restart
+            ):
                 self._voice_restart_recording_async()
 
     def _voice_speak_response_async(self, text: str) -> None:

--- a/contributors/emails/brice@brice.net
+++ b/contributors/emails/brice@brice.net
@@ -1,0 +1,1 @@
+bricelb

--- a/contributors/emails/brunopira@gmail.com
+++ b/contributors/emails/brunopira@gmail.com
@@ -1,0 +1,1 @@
+brunopirz

--- a/contributors/emails/ipkharitonov@gmail.com
+++ b/contributors/emails/ipkharitonov@gmail.com
@@ -1,0 +1,1 @@
+kharitonov-ivan

--- a/contributors/emails/normanking@me.com
+++ b/contributors/emails/normanking@me.com
@@ -1,0 +1,1 @@
+RedClaus

--- a/contributors/emails/simon@everythingmma.com.au
+++ b/contributors/emails/simon@everythingmma.com.au
@@ -1,0 +1,1 @@
+simonmmafs

--- a/contributors/emails/simonmmafs@users.noreply.github.com
+++ b/contributors/emails/simonmmafs@users.noreply.github.com
@@ -1,0 +1,1 @@
+simonmmafs

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2365,6 +2365,7 @@ DEFAULT_CONFIG = {
         "max_recording_seconds": 120,
         "auto_tts": False,
         "beep_enabled": True,         # Play record start/stop beeps in CLI voice mode
+        "beep_volume": 0.3,           # Beep amplitude multiplier (0.0-1.0, default keeps prior hardcoded value)
         "silence_threshold": 200,     # RMS below this = silence (0-32767)
         "silence_duration": 3.0,      # Seconds of silence before auto-stop
         "barge_in": True,             # Stop TTS playback when the user starts talking

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -374,6 +374,7 @@ def start_continuous(
     silence_threshold: int = 200,
     silence_duration: float = 3.0,
     auto_restart: bool = True,
+    max_recording_seconds: float = 0.0,
 ) -> bool:
     """Start a VAD-driven continuous recording loop.
 
@@ -391,6 +392,10 @@ def start_continuous(
 
     ``on_status`` is called with ``"listening"`` / ``"transcribing"`` /
     ``"idle"`` so the UI can show a live indicator.
+
+    ``max_recording_seconds`` is the hard cap on a single recording's length
+    (``voice.max_recording_seconds``); any non-positive or non-numeric value
+    disables the cap, preserving the previous unbounded behaviour.
     """
     global _continuous_active, _continuous_recorder, _continuous_auto_restart
     global _continuous_on_transcript, _continuous_on_status, _continuous_on_silent_limit
@@ -416,6 +421,15 @@ def start_continuous(
 
         _continuous_recorder._silence_threshold = silence_threshold
         _continuous_recorder._silence_duration = silence_duration
+        # Same numeric-with-bool-excluded guard as the CLI wiring in
+        # cli.py:_voice_start_recording — <= 0 (or garbage) disables the cap.
+        _continuous_recorder._max_recording_seconds = (
+            max_recording_seconds
+            if isinstance(max_recording_seconds, (int, float))
+            and not isinstance(max_recording_seconds, bool)
+            and max_recording_seconds > 0
+            else 0.0
+        )
         rec = _continuous_recorder
 
     _debug(

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -250,10 +250,13 @@ def _beeps_enabled() -> bool:
     """CLI parity: voice.beep_enabled in config.yaml (default True)."""
     try:
         from hermes_cli.config import load_config
+        from utils import is_truthy_value
 
         voice_cfg = load_config().get("voice", {})
         if isinstance(voice_cfg, dict):
-            return bool(voice_cfg.get("beep_enabled", True))
+            # is_truthy_value handles quoted YAML strings like "false"
+            # which bool() would misread as True (#49883).
+            return is_truthy_value(voice_cfg.get("beep_enabled", True), default=True)
     except Exception:
         pass
     return True

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -847,7 +847,13 @@ def speak_text(text: str) -> None:
             tts_result = json.loads(raw_result) if isinstance(raw_result, str) else {}
         except Exception:
             tts_result = {}
-        audio_path = tts_result.get("file_path") or mp3_path
+
+        # Prefer the requested MP3 when the provider produced it. This
+        # preserves reliable local playback while still supporting providers
+        # that write to and return a different path.
+        audio_path = mp3_path
+        if not os.path.isfile(mp3_path) or os.path.getsize(mp3_path) == 0:
+            audio_path = tts_result.get("file_path") or mp3_path
 
         if os.path.isfile(audio_path) and os.path.getsize(audio_path) > 0:
             _debug(f"speak_text: playing {audio_path} ({os.path.getsize(audio_path)} bytes)")

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -21,6 +21,7 @@ Two usage modes are exposed:
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import sys
@@ -841,20 +842,28 @@ def speak_text(text: str) -> None:
         )
 
         _debug(f"speak_text: synthesizing {len(tts_text)} chars -> {mp3_path}")
-        text_to_speech_tool(text=tts_text, output_path=mp3_path)
+        raw_result = text_to_speech_tool(text=tts_text, output_path=mp3_path)
+        try:
+            tts_result = json.loads(raw_result) if isinstance(raw_result, str) else {}
+        except Exception:
+            tts_result = {}
+        audio_path = tts_result.get("file_path") or mp3_path
 
-        if os.path.isfile(mp3_path) and os.path.getsize(mp3_path) > 0:
-            _debug(f"speak_text: playing {mp3_path} ({os.path.getsize(mp3_path)} bytes)")
-            play_audio_file(mp3_path)
+        if os.path.isfile(audio_path) and os.path.getsize(audio_path) > 0:
+            _debug(f"speak_text: playing {audio_path} ({os.path.getsize(audio_path)} bytes)")
+            play_audio_file(audio_path)
             try:
-                os.unlink(mp3_path)
-                ogg_path = mp3_path.rsplit(".", 1)[0] + ".ogg"
-                if os.path.isfile(ogg_path):
-                    os.unlink(ogg_path)
+                cleanup_paths = {audio_path, mp3_path}
+                for path in list(cleanup_paths):
+                    ogg_path = path.rsplit(".", 1)[0] + ".ogg"
+                    cleanup_paths.add(ogg_path)
+                for path in cleanup_paths:
+                    if os.path.isfile(path):
+                        os.unlink(path)
             except OSError:
                 pass
         else:
-            _debug(f"speak_text: TTS tool produced no audio at {mp3_path}")
+            _debug(f"speak_text: TTS tool produced no audio at {audio_path}")
     except Exception as e:
         logger.warning("Voice TTS playback failed: %s", e)
         _debug(f"speak_text raised {type(e).__name__}: {e}")

--- a/tests/hermes_cli/test_voice_wrapper.py
+++ b/tests/hermes_cli/test_voice_wrapper.py
@@ -294,12 +294,36 @@ class TestSpeakTextGuards:
         from tools import tts_tool
 
         played = []
+        returned_path = "/tmp/hermes_voice/actual.flac"
 
         monkeypatch.setattr(
             tts_tool,
             "text_to_speech_tool",
-            lambda **_kwargs: '{"success": true, "file_path": "/tmp/hermes_voice/actual.flac"}',
+            lambda **_kwargs: f'{{"success": true, "file_path": "{returned_path}"}}',
         )
+        monkeypatch.setattr(voice.os, "makedirs", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(voice.os.path, "isfile", lambda path: path == returned_path)
+        monkeypatch.setattr(voice.os.path, "getsize", lambda _path: 1000)
+        monkeypatch.setattr(voice.os, "unlink", lambda _path: None)
+        monkeypatch.setattr(voice, "play_audio_file", lambda path: played.append(path))
+
+        assert voice.speak_text("Hello world") is None
+        assert played == [returned_path]
+
+    def test_speak_text_prefers_requested_mp3_over_returned_ogg(self, monkeypatch):
+        import hermes_cli.voice as voice
+        from tools import tts_tool
+
+        played = []
+        requested_paths = []
+
+        def fake_tts(**kwargs):
+            requested_path = kwargs["output_path"]
+            requested_paths.append(requested_path)
+            ogg_path = requested_path.rsplit(".", 1)[0] + ".ogg"
+            return f'{{"success": true, "file_path": "{ogg_path}"}}'
+
+        monkeypatch.setattr(tts_tool, "text_to_speech_tool", fake_tts)
         monkeypatch.setattr(voice.os, "makedirs", lambda *_args, **_kwargs: None)
         monkeypatch.setattr(voice.os.path, "isfile", lambda _path: True)
         monkeypatch.setattr(voice.os.path, "getsize", lambda _path: 1000)
@@ -307,7 +331,7 @@ class TestSpeakTextGuards:
         monkeypatch.setattr(voice, "play_audio_file", lambda path: played.append(path))
 
         assert voice.speak_text("Hello world") is None
-        assert played == ["/tmp/hermes_voice/actual.flac"]
+        assert played == requested_paths
 
 
 class TestContinuousAPI:

--- a/tests/hermes_cli/test_voice_wrapper.py
+++ b/tests/hermes_cli/test_voice_wrapper.py
@@ -289,6 +289,26 @@ class TestSpeakTextGuards:
         # Should simply return None without raising.
         assert speak_text(text) is None
 
+    def test_speak_text_uses_returned_tts_file_path(self, monkeypatch):
+        import hermes_cli.voice as voice
+        from tools import tts_tool
+
+        played = []
+
+        monkeypatch.setattr(
+            tts_tool,
+            "text_to_speech_tool",
+            lambda **_kwargs: '{"success": true, "file_path": "/tmp/hermes_voice/actual.flac"}',
+        )
+        monkeypatch.setattr(voice.os, "makedirs", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(voice.os.path, "isfile", lambda _path: True)
+        monkeypatch.setattr(voice.os.path, "getsize", lambda _path: 1000)
+        monkeypatch.setattr(voice.os, "unlink", lambda _path: None)
+        monkeypatch.setattr(voice, "play_audio_file", lambda path: played.append(path))
+
+        assert voice.speak_text("Hello world") is None
+        assert played == ["/tmp/hermes_voice/actual.flac"]
+
 
 class TestContinuousAPI:
     """Continuous (VAD) mode API — CLI-parity loop entry points."""

--- a/tests/hermes_cli/test_voice_wrapper.py
+++ b/tests/hermes_cli/test_voice_wrapper.py
@@ -751,3 +751,36 @@ class TestContinuousLoopSimulation:
         # The in-flight transcript was suppressed because we stopped mid-flight
         assert transcripts == []
         assert voice.is_continuous_active() is False
+
+
+class TestBeepsEnabledTruthyStrings:
+    """voice.beep_enabled quoted in YAML ("false"/"off") must disable beeps —
+    bool("false") is True, so the gate must use utils.is_truthy_value (#49883)."""
+
+    def _enabled_with(self, monkeypatch, value):
+        import hermes_cli.voice as voice
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"voice": {"beep_enabled": value}},
+        )
+        return voice._beeps_enabled()
+
+    def test_quoted_false_string_disables(self, monkeypatch):
+        assert self._enabled_with(monkeypatch, "false") is False
+
+    def test_quoted_off_string_disables(self, monkeypatch):
+        assert self._enabled_with(monkeypatch, "off") is False
+
+    def test_quoted_true_string_enables(self, monkeypatch):
+        assert self._enabled_with(monkeypatch, "true") is True
+
+    def test_real_booleans_pass_through(self, monkeypatch):
+        assert self._enabled_with(monkeypatch, True) is True
+        assert self._enabled_with(monkeypatch, False) is False
+
+    def test_missing_key_defaults_true(self, monkeypatch):
+        import hermes_cli.voice as voice
+
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"voice": {}})
+        assert voice._beeps_enabled() is True

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1306,6 +1306,55 @@ def test_voice_record_start_handles_non_dict_voice_cfg(monkeypatch):
         assert captured["auto_restart"] is False
 
 
+def test_voice_record_start_forwards_max_recording_seconds(monkeypatch):
+    """voice.max_recording_seconds must reach start_continuous from the TUI.
+
+    The CLI wiring alone doesn't cover TUI recordings: the gateway forwards
+    recorder params explicitly, so a missing kwarg here silently leaves the
+    cap dead in the TUI while CLI tests stay green. Semantics mirror the
+    silence params: non-numeric / bool / missing falls back to the documented
+    120 default, an explicit numeric value <= 0 disables the cap.
+    """
+    captured: dict = {}
+
+    def fake_start_continuous(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.voice",
+        types.SimpleNamespace(
+            start_continuous=fake_start_continuous, stop_continuous=lambda: None
+        ),
+    )
+    monkeypatch.setenv("HERMES_VOICE", "1")
+
+    for cfg, expected in (
+        ({"max_recording_seconds": 45}, 45),        # explicit cap forwarded as-is
+        ({"max_recording_seconds": 0}, 0.0),        # explicit 0 = disabled
+        ({"max_recording_seconds": -5}, 0.0),       # negative = disabled
+        ({}, 120.0),                                # missing = documented default
+        ({"max_recording_seconds": True}, 120.0),   # bool must not become 1s cap
+        ({"max_recording_seconds": "long"}, 120.0), # garbage = documented default
+    ):
+        captured.clear()
+        monkeypatch.setattr(server, "_load_cfg", lambda c=cfg: {"voice": c})
+
+        resp = server.dispatch(
+            {
+                "id": "voice-record-cap",
+                "method": "voice.record",
+                "params": {"action": "start"},
+            }
+        )
+
+        assert "result" in resp, f"voice.record raised for cfg={cfg!r}: {resp.get('error')}"
+        assert resp["result"]["status"] == "recording"
+        assert (
+            captured["max_recording_seconds"] == expected
+        ), f"cfg={cfg!r} forwarded {captured.get('max_recording_seconds')!r}, expected {expected!r}"
+
+
 def test_voice_record_stop_forces_transcription(monkeypatch):
     captured: dict = {}
 

--- a/tests/test_voice_max_recording_seconds.py
+++ b/tests/test_voice_max_recording_seconds.py
@@ -1,0 +1,32 @@
+"""Regression test: voice.max_recording_seconds is actually enforced.
+
+Before this fix, ``voice.max_recording_seconds`` was defined in the default
+config (hermes_cli/config.py) and documented, but no code read it — the
+AudioRecorder had no total-length cap, so the setting was dead config. This
+test pins the enforcement contract on the recorder:
+
+* cap disabled (0 / unset) → never auto-stops on duration (previous behaviour),
+* cap set to N>0 → auto-stop condition becomes true once elapsed >= N.
+"""
+from tools.voice_mode import AudioRecorder
+
+
+def test_cap_disabled_by_default():
+    r = AudioRecorder()
+    assert r._max_recording_seconds == 0.0
+    # No cap → duration trigger never fires, even at absurd elapsed times.
+    assert r._max_duration_reached(10_000.0) is False
+
+
+def test_cap_enforced_when_set():
+    r = AudioRecorder()
+    r._max_recording_seconds = 120
+    assert r._max_duration_reached(119.9) is False
+    assert r._max_duration_reached(120.0) is True
+    assert r._max_duration_reached(300.0) is True
+
+
+def test_zero_means_unlimited():
+    r = AudioRecorder()
+    r._max_recording_seconds = 0
+    assert r._max_duration_reached(99_999.0) is False

--- a/tests/tools/test_clipboard.py
+++ b/tests/tools/test_clipboard.py
@@ -1079,7 +1079,12 @@ class TestVoiceSubmission:
                         cli._voice_stop_and_transcribe()
 
         assert cli._attached_images == []
-        assert cli._pending_input.get_nowait() == "hello"
+        queued = cli._pending_input.get_nowait()
+        # Voice transcripts are wrapped in the _VoiceInputMessage sentinel
+        # (#65827) so process_loop can distinguish STT output from typed text.
+        from cli import _VoiceInputMessage
+        assert isinstance(queued, _VoiceInputMessage)
+        assert queued.text == "hello"
 
 
 # ═════════════════════════════════════════════════════════════════════════

--- a/tests/tools/test_termux_api_detection.py
+++ b/tests/tools/test_termux_api_detection.py
@@ -1,0 +1,307 @@
+"""Regression tests for issue #31015 — Termux:API app detection.
+
+`/voice on` was reporting "Termux:API Android app is not installed"
+even on devices where the app *is* installed and the
+`termux-microphone-record` binary works fine. The cause was a single
+brittle probe (`pm list packages com.termux.api`) that returns a
+false negative on some Android versions / Termux configurations.
+
+These tests pin the new probe ladder:
+
+  1. `pm list packages` confirms the app → True (back-compat).
+  2. `pm` missing or non-zero → fall back to
+     `cmd package list packages` (modern Android API 28+).
+  3. Both probes inconclusive but `termux-microphone-record` on PATH
+     → trust the binary, return True.
+  4. At least one probe ran cleanly and definitively did not list
+     the package → return False (the genuine "CLI without app"
+     case the existing warning was written for).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _make_run_dispatcher(behaviors):
+    """Build a fake `subprocess.run` that returns / raises per-command.
+
+    `behaviors` maps the first arg of each invocation to either a
+    SimpleNamespace (returncode, stdout, stderr) or an Exception class
+    instance to raise.
+    """
+    def _fake_run(cmd, **kwargs):
+        key = cmd[0] if isinstance(cmd, (list, tuple)) and cmd else cmd
+        action = behaviors.get(key)
+        if action is None:
+            raise AssertionError(f"Unexpected probe command: {cmd!r}")
+        if isinstance(action, BaseException):
+            raise action
+        return action
+    return _fake_run
+
+
+def _force_termux(monkeypatch):
+    monkeypatch.setattr("tools.voice_mode._is_termux_environment", lambda: True)
+
+
+# ── _termux_api_app_installed: probe ladder ───────────────────────────────
+
+
+class TestTermuxApiAppInstalledProbeLadder:
+    """The probe ladder is the heart of the #31015 fix — keep its truth
+    table pinned so future "simplifications" can't silently regress it."""
+
+    def test_returns_false_outside_termux(self, monkeypatch):
+        monkeypatch.setattr("tools.voice_mode._is_termux_environment", lambda: False)
+        from tools.voice_mode import _termux_api_app_installed
+        assert _termux_api_app_installed() is False
+
+    def test_pm_confirms_package_returns_true(self, monkeypatch):
+        _force_termux(monkeypatch)
+        run = _make_run_dispatcher({
+            "pm": SimpleNamespace(
+                returncode=0,
+                stdout="package:com.termux.api\n",
+                stderr="",
+            ),
+        })
+        monkeypatch.setattr("tools.voice_mode.subprocess.run", run)
+
+        from tools.voice_mode import _termux_api_app_installed
+        assert _termux_api_app_installed() is True
+
+    def test_pm_clean_miss_then_cmd_confirms(self, monkeypatch):
+        """`pm` ran cleanly with no match → fall through to `cmd package`,
+        which finds the app. Some devices return empty `pm` output for
+        the calling user even when the package is installed."""
+        _force_termux(monkeypatch)
+        run = _make_run_dispatcher({
+            "pm": SimpleNamespace(returncode=0, stdout="", stderr=""),
+            "cmd": SimpleNamespace(
+                returncode=0,
+                stdout="package:com.termux.api\n",
+                stderr="",
+            ),
+        })
+        monkeypatch.setattr("tools.voice_mode.subprocess.run", run)
+
+        from tools.voice_mode import _termux_api_app_installed
+        assert _termux_api_app_installed() is True
+
+    def test_pm_missing_then_cmd_confirms(self, monkeypatch):
+        """`pm` not on PATH → FileNotFoundError → fall through to `cmd`."""
+        _force_termux(monkeypatch)
+        run = _make_run_dispatcher({
+            "pm": FileNotFoundError("pm: command not found"),
+            "cmd": SimpleNamespace(
+                returncode=0,
+                stdout="package:com.termux.api\n",
+                stderr="",
+            ),
+        })
+        monkeypatch.setattr("tools.voice_mode.subprocess.run", run)
+
+        from tools.voice_mode import _termux_api_app_installed
+        assert _termux_api_app_installed() is True
+
+    def test_pm_timeout_then_cmd_confirms(self, monkeypatch):
+        """A hung `pm` (5s timeout) must not block detection."""
+        _force_termux(monkeypatch)
+        run = _make_run_dispatcher({
+            "pm": subprocess.TimeoutExpired(cmd="pm", timeout=5),
+            "cmd": SimpleNamespace(
+                returncode=0,
+                stdout="package:com.termux.api\n",
+                stderr="",
+            ),
+        })
+        monkeypatch.setattr("tools.voice_mode.subprocess.run", run)
+
+        from tools.voice_mode import _termux_api_app_installed
+        assert _termux_api_app_installed() is True
+
+    def test_pm_nonzero_exit_then_cmd_confirms(self, monkeypatch):
+        """Non-zero exit (e.g. permission denied for the calling user)
+        is treated as inconclusive, not as a definitive "no"."""
+        _force_termux(monkeypatch)
+        run = _make_run_dispatcher({
+            "pm": SimpleNamespace(returncode=1, stdout="", stderr="permission denied"),
+            "cmd": SimpleNamespace(
+                returncode=0,
+                stdout="package:com.termux.api\n",
+                stderr="",
+            ),
+        })
+        monkeypatch.setattr("tools.voice_mode.subprocess.run", run)
+
+        from tools.voice_mode import _termux_api_app_installed
+        assert _termux_api_app_installed() is True
+
+    def test_both_probes_inconclusive_but_binary_present_returns_true(self, monkeypatch):
+        """Core #31015 case: both probes fail or are unavailable, but the
+        `termux-microphone-record` binary is on PATH. Trust the binary —
+        a false positive only surfaces a precise runtime error, while a
+        false negative blocks /voice on entirely (the user-reported
+        symptom)."""
+        _force_termux(monkeypatch)
+        run = _make_run_dispatcher({
+            "pm": FileNotFoundError("pm: command not found"),
+            "cmd": FileNotFoundError("cmd: command not found"),
+        })
+        monkeypatch.setattr("tools.voice_mode.subprocess.run", run)
+        monkeypatch.setattr(
+            "tools.voice_mode.shutil.which",
+            lambda name: "/data/data/com.termux/files/usr/bin/termux-microphone-record"
+            if name == "termux-microphone-record" else None,
+        )
+
+        from tools.voice_mode import _termux_api_app_installed
+        assert _termux_api_app_installed() is True
+
+    def test_both_probes_inconclusive_and_no_binary_returns_false(self, monkeypatch):
+        """Without the binary on PATH there's nothing to trust — fall
+        through to False so the user gets the install hint."""
+        _force_termux(monkeypatch)
+        run = _make_run_dispatcher({
+            "pm": FileNotFoundError("pm: command not found"),
+            "cmd": FileNotFoundError("cmd: command not found"),
+        })
+        monkeypatch.setattr("tools.voice_mode.subprocess.run", run)
+        monkeypatch.setattr("tools.voice_mode.shutil.which", lambda name: None)
+
+        from tools.voice_mode import _termux_api_app_installed
+        assert _termux_api_app_installed() is False
+
+    def test_both_probes_clean_no_match_returns_false(self, monkeypatch):
+        """Clean (returncode=0) probes that don't list the package are
+        authoritative — the app is genuinely missing.  Don't promote
+        this to True via the binary fallback."""
+        _force_termux(monkeypatch)
+        run = _make_run_dispatcher({
+            "pm": SimpleNamespace(returncode=0, stdout="", stderr=""),
+            "cmd": SimpleNamespace(returncode=0, stdout="", stderr=""),
+        })
+        monkeypatch.setattr("tools.voice_mode.subprocess.run", run)
+        monkeypatch.setattr(
+            "tools.voice_mode.shutil.which",
+            lambda name: "/data/data/com.termux/files/usr/bin/termux-microphone-record"
+            if name == "termux-microphone-record" else None,
+        )
+
+        from tools.voice_mode import _termux_api_app_installed
+        assert _termux_api_app_installed() is False
+
+    def test_match_is_case_insensitive(self, monkeypatch):
+        """Defensive against ROMs that capitalise the prefix differently."""
+        _force_termux(monkeypatch)
+        run = _make_run_dispatcher({
+            "pm": SimpleNamespace(
+                returncode=0,
+                stdout="Package:com.termux.api\n",
+                stderr="",
+            ),
+        })
+        monkeypatch.setattr("tools.voice_mode.subprocess.run", run)
+
+        from tools.voice_mode import _termux_api_app_installed
+        assert _termux_api_app_installed() is True
+
+
+# ── End-to-end through detect_audio_environment ───────────────────────────
+
+
+class TestDetectAudioEnvironmentTermuxFallback:
+    """The point of the fix is that #31015 users with the binary on PATH
+    no longer see the misleading 'Termux:API Android app is not installed'
+    warning when the package-manager probe is inconclusive."""
+
+    def test_inconclusive_probes_with_binary_does_not_emit_app_warning(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
+        monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+        monkeypatch.delenv("SSH_CLIENT", raising=False)
+        monkeypatch.delenv("SSH_TTY", raising=False)
+        monkeypatch.delenv("SSH_CONNECTION", raising=False)
+
+        # No sounddevice — we go down the Termux:API branch.
+        monkeypatch.setattr(
+            "tools.voice_mode._import_audio",
+            lambda: (_ for _ in ()).throw(ImportError("no audio libs")),
+        )
+        monkeypatch.setattr(
+            "tools.voice_mode._termux_microphone_command",
+            lambda: "/data/data/com.termux/files/usr/bin/termux-microphone-record",
+        )
+        # Both probes fail (the #31015 reproduction).
+        run = _make_run_dispatcher({
+            "pm": FileNotFoundError("pm: command not found"),
+            "cmd": FileNotFoundError("cmd: command not found"),
+        })
+        monkeypatch.setattr("tools.voice_mode.subprocess.run", run)
+        monkeypatch.setattr(
+            "tools.voice_mode.shutil.which",
+            lambda name: "/data/data/com.termux/files/usr/bin/termux-microphone-record"
+            if name == "termux-microphone-record" else None,
+        )
+
+        from tools.voice_mode import detect_audio_environment
+        result = detect_audio_environment()
+
+        assert result["available"] is True, (
+            f"Voice mode should be available when the binary is on PATH "
+            f"and probes are inconclusive (issue #31015). Got: {result}"
+        )
+        assert not any(
+            "Termux:API Android app is not installed" in w
+            for w in result["warnings"]
+        ), (
+            "The misleading 'app is not installed' warning must not fire "
+            "when probes are inconclusive but the binary works (issue "
+            f"#31015). warnings={result['warnings']!r}"
+        )
+        assert any(
+            "Termux:API microphone recording available" in n
+            for n in result.get("notices", [])
+        )
+
+    def test_clean_probes_no_match_still_blocks(self, monkeypatch):
+        """The genuine "CLI installed without the app" case still blocks
+        with the existing warning — important so users don't lose the
+        install hint when the package manager *can* tell us the truth."""
+        monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
+        monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+        monkeypatch.delenv("SSH_CLIENT", raising=False)
+        monkeypatch.delenv("SSH_TTY", raising=False)
+        monkeypatch.delenv("SSH_CONNECTION", raising=False)
+
+        monkeypatch.setattr(
+            "tools.voice_mode._import_audio",
+            lambda: (_ for _ in ()).throw(ImportError("no audio libs")),
+        )
+        monkeypatch.setattr(
+            "tools.voice_mode._termux_microphone_command",
+            lambda: "/data/data/com.termux/files/usr/bin/termux-microphone-record",
+        )
+        run = _make_run_dispatcher({
+            "pm": SimpleNamespace(returncode=0, stdout="", stderr=""),
+            "cmd": SimpleNamespace(returncode=0, stdout="", stderr=""),
+        })
+        monkeypatch.setattr("tools.voice_mode.subprocess.run", run)
+
+        from tools.voice_mode import detect_audio_environment
+        result = detect_audio_environment()
+
+        assert result["available"] is False
+        assert any(
+            "Termux:API Android app is not installed" in w
+            for w in result["warnings"]
+        )

--- a/tests/tools/test_tts_macos_output.py
+++ b/tests/tools/test_tts_macos_output.py
@@ -1,0 +1,100 @@
+"""macOS output policy for streaming TTS.
+
+On macOS, stream_tts_to_speaker must NOT open a sounddevice OutputStream
+(PortAudio/CoreAudio init triggers a kTCCServiceMediaLibrary prompt). It
+should route audio through the tempfile/afplay fallback instead.
+See PR #62601 / #13291.
+"""
+
+import queue
+import threading
+
+import pytest
+
+
+def _run_stream(monkeypatch, system_name):
+    """Drive stream_tts_to_speaker once with a mock client on *system_name*.
+
+    Returns True if _import_sounddevice was called during the run.
+    """
+    import tools.tts_tool as tts
+
+    monkeypatch.setattr("tools.tts_tool.platform.system", lambda: system_name)
+    monkeypatch.setattr("tools.tts_tool.get_env_value",
+                        lambda name, default=None: "fake-key"
+                        if name == "ELEVENLABS_API_KEY" else default)
+    monkeypatch.setattr("tools.tts_tool._load_tts_config", lambda: {})
+
+    class _FakeTTS:
+        def __init__(self, *a, **k):
+            self.text_to_speech = self
+
+        def convert(self, *a, **k):
+            return iter([])  # no audio chunks needed for setup assertion
+
+    monkeypatch.setattr("tools.tts_tool._import_elevenlabs", lambda: _FakeTTS)
+
+    sd_called = {"hit": False}
+
+    def _spy_import_sd():
+        sd_called["hit"] = True
+        raise AssertionError("sounddevice must not be imported for output on macOS")
+
+    monkeypatch.setattr("tools.tts_tool._import_sounddevice", _spy_import_sd)
+
+    text_queue: queue.Queue = queue.Queue()
+    text_queue.put(None)  # end-of-text sentinel: no sentence spoken
+    stop_event = threading.Event()
+    done_event = threading.Event()
+
+    tts.stream_tts_to_speaker(text_queue, stop_event, done_event)
+    assert done_event.is_set()
+    return sd_called["hit"]
+
+
+def test_streaming_tts_skips_sounddevice_on_macos(monkeypatch):
+    assert _run_stream(monkeypatch, "Darwin") is False
+
+
+def test_streaming_tts_uses_sounddevice_off_macos(monkeypatch):
+    # Off macOS the OutputStream setup runs; _import_sounddevice raising here
+    # is caught by the function's own guard, so the call itself is what we assert.
+    called = _run_stream_offmac(monkeypatch)
+    assert called is True
+
+
+def _run_stream_offmac(monkeypatch):
+    """Like _run_stream but tolerant of the sounddevice import being attempted."""
+    import tools.tts_tool as tts
+
+    monkeypatch.setattr("tools.tts_tool.platform.system", lambda: "Linux")
+    monkeypatch.setattr("tools.tts_tool.get_env_value",
+                        lambda name, default=None: "fake-key"
+                        if name == "ELEVENLABS_API_KEY" else default)
+    monkeypatch.setattr("tools.tts_tool._load_tts_config", lambda: {})
+
+    class _FakeTTS:
+        def __init__(self, *a, **k):
+            self.text_to_speech = self
+
+        def convert(self, *a, **k):
+            return iter([])
+
+    monkeypatch.setattr("tools.tts_tool._import_elevenlabs", lambda: _FakeTTS)
+
+    sd_called = {"hit": False}
+
+    def _spy_import_sd():
+        sd_called["hit"] = True
+        raise OSError("no audio device in test")  # handled by the function's guard
+
+    monkeypatch.setattr("tools.tts_tool._import_sounddevice", _spy_import_sd)
+
+    text_queue: queue.Queue = queue.Queue()
+    text_queue.put(None)
+    stop_event = threading.Event()
+    done_event = threading.Event()
+
+    tts.stream_tts_to_speaker(text_queue, stop_event, done_event)
+    assert done_event.is_set()
+    return sd_called["hit"]

--- a/tests/tools/test_tts_macos_output.py
+++ b/tests/tools/test_tts_macos_output.py
@@ -12,6 +12,16 @@ import threading
 import pytest
 
 
+class _FakeStreamer:
+    """Minimal chunked-streamer stand-in so the OutputStream setup path runs."""
+
+    sample_rate = 24000
+    channels = 1
+
+    def stream(self, text):
+        return iter([])
+
+
 def _run_stream(monkeypatch, system_name):
     """Drive stream_tts_to_speaker once with a mock client on *system_name*.
 
@@ -33,6 +43,10 @@ def _run_stream(monkeypatch, system_name):
             return iter([])  # no audio chunks needed for setup assertion
 
     monkeypatch.setattr("tools.tts_tool._import_elevenlabs", lambda: _FakeTTS)
+    monkeypatch.setattr(
+        "tools.tts_streaming.resolve_streaming_provider",
+        lambda cfg, preferred=None: _FakeStreamer(),
+    )
 
     sd_called = {"hit": False}
 
@@ -81,6 +95,10 @@ def _run_stream_offmac(monkeypatch):
             return iter([])
 
     monkeypatch.setattr("tools.tts_tool._import_elevenlabs", lambda: _FakeTTS)
+    monkeypatch.setattr(
+        "tools.tts_streaming.resolve_streaming_provider",
+        lambda cfg, preferred=None: _FakeStreamer(),
+    )
 
     sd_called = {"hit": False}
 

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -915,6 +915,59 @@ class TestVoiceBeepConfigReal:
         mock_beep.assert_not_called()
 
 
+class TestMaxRecordingSecondsConfigReal:
+    """voice.max_recording_seconds must reach the recorder from config.
+
+    Regression for the dead-config fix: the predicate alone can stay green
+    while the CLI wiring regresses, so pin the actual assignment made by
+    ``_voice_start_recording`` for the valid / disabled / corrupted cases.
+    """
+
+    def _start_with_voice_cfg(self, voice_cfg):
+        with patch("cli._cprint"), \
+             patch("cli.threading.Thread", return_value=MagicMock(start=MagicMock())), \
+             patch("tools.voice_mode.play_beep"), \
+             patch("tools.voice_mode.create_audio_recorder") as mock_create, \
+             patch(
+                 "tools.voice_mode.check_voice_requirements",
+                 return_value={
+                     "available": True,
+                     "audio_available": True,
+                     "stt_available": True,
+                     "details": "OK",
+                     "missing_packages": [],
+                 },
+             ), \
+             patch("hermes_cli.config.load_config", return_value={"voice": voice_cfg}):
+            recorder = MagicMock()
+            recorder.supports_silence_autostop = True
+            mock_create.return_value = recorder
+
+            cli = _make_voice_cli()
+            cli._voice_start_recording()
+
+        return recorder
+
+    def test_configured_cap_reaches_recorder(self):
+        recorder = self._start_with_voice_cfg({"max_recording_seconds": 45})
+        assert recorder._max_recording_seconds == 45
+
+    def test_non_positive_value_disables_cap(self):
+        recorder = self._start_with_voice_cfg({"max_recording_seconds": 0})
+        assert recorder._max_recording_seconds == 0.0
+
+    def test_bool_falls_back_to_documented_default(self):
+        # bool is a subclass of int — ``max_recording_seconds: true`` must not
+        # become a 1-second cap; it falls back to the documented 120 default,
+        # mirroring the silence-param corruption handling.
+        recorder = self._start_with_voice_cfg({"max_recording_seconds": True})
+        assert recorder._max_recording_seconds == 120.0
+
+    def test_garbage_falls_back_to_documented_default(self):
+        recorder = self._start_with_voice_cfg({"max_recording_seconds": "long"})
+        assert recorder._max_recording_seconds == 120.0
+
+
 class TestDisableVoiceModeReal:
     """Tests _disable_voice_mode with real CLI instance."""
 

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -1113,6 +1113,23 @@ class TestVoiceSpeakResponseReal:
         cli._voice_speak_response("Hello world")
         mock_play.assert_called_once()
 
+    @patch("cli._cprint")
+    @patch("cli.os.unlink")
+    @patch("cli.os.path.getsize", return_value=1000)
+    @patch("cli.os.path.isfile", return_value=True)
+    @patch("cli.os.makedirs")
+    @patch("tools.voice_mode.play_audio_file")
+    @patch(
+        "tools.tts_tool.text_to_speech_tool",
+        return_value='{"success": true, "file_path": "/tmp/hermes_voice/actual.flac"}',
+    )
+    def test_play_audio_uses_returned_tts_file_path(
+        self, _tts, mock_play, _mkd, _isf, _gsz, _unl, _cp
+    ):
+        cli = _make_voice_cli(_voice_tts=True)
+        cli._voice_speak_response("Hello world")
+        mock_play.assert_called_once_with("/tmp/hermes_voice/actual.flac")
+
 
 class TestVoiceStopAndTranscribeReal:
     """Tests _voice_stop_and_transcribe with real CLI instance."""

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -1297,6 +1297,56 @@ class TestVoiceStopAndTranscribeReal:
         cli._voice_stop_and_transcribe()
         cli._voice_start_recording.assert_not_called()
 
+    @pytest.mark.parametrize(
+        ("stt_config", "expected_model"),
+        [
+            ({"provider": "local", "model": "whisper-1", "local": {"model": "small"}}, "small"),
+            ({"provider": "local", "local": {"model": "tiny"}}, "tiny"),
+            ({"provider": "local", "model": "whisper-1"}, "base"),
+        ],
+    )
+    def test_local_stt_shows_model_download_status(self, stt_config, expected_model):
+        recorder = MagicMock()
+        recorder.stop.return_value = "/tmp/test.wav"
+        cli = _make_voice_cli(_voice_recording=True, _voice_recorder=recorder)
+
+        with patch("cli._cprint") as mock_print, \
+             patch("cli.os.path.isfile", return_value=False), \
+             patch("hermes_cli.config.load_config", return_value={"stt": stt_config}), \
+             patch("tools.voice_mode.transcribe_recording",
+                   return_value={"success": True, "transcript": "hello"}) as mock_transcribe, \
+             patch("tools.voice_mode.play_beep"):
+            cli._voice_stop_and_transcribe()
+
+        messages = [call.args[0] for call in mock_print.call_args_list]
+        assert any(
+            f"local STT model '{expected_model}'" in message
+            and "first use may download it from Hugging Face" in message
+            for message in messages
+        )
+        mock_transcribe.assert_called_once_with("/tmp/test.wav", model=expected_model)
+
+    def test_non_local_stt_keeps_generic_transcribing_status(self):
+        recorder = MagicMock()
+        recorder.stop.return_value = "/tmp/test.wav"
+        cli = _make_voice_cli(_voice_recording=True, _voice_recorder=recorder)
+
+        with patch("cli._cprint") as mock_print, \
+             patch("cli.os.path.isfile", return_value=False), \
+             patch(
+                 "hermes_cli.config.load_config",
+                 return_value={"stt": {"provider": "openai", "model": "whisper-1"}},
+             ), \
+             patch("tools.voice_mode.transcribe_recording",
+                   return_value={"success": True, "transcript": "hello"}) as mock_transcribe, \
+             patch("tools.voice_mode.play_beep"):
+            cli._voice_stop_and_transcribe()
+
+        messages = [call.args[0] for call in mock_print.call_args_list]
+        assert any("Transcribing..." in message for message in messages)
+        assert all("Hugging Face" not in message for message in messages)
+        mock_transcribe.assert_called_once_with("/tmp/test.wav", model="whisper-1")
+
     @patch("cli._cprint")
     @patch("cli.os.unlink")
     @patch("cli.os.path.isfile", return_value=True)

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -1206,7 +1206,12 @@ class TestVoiceStopAndTranscribeReal:
         recorder.stop.return_value = "/tmp/test.wav"
         cli = _make_voice_cli(_voice_recording=True, _voice_recorder=recorder)
         cli._voice_stop_and_transcribe()
-        assert cli._pending_input.get_nowait() == "hello world"
+        queued = cli._pending_input.get_nowait()
+        # Voice transcripts are wrapped in the _VoiceInputMessage sentinel so
+        # only genuine STT output gets the voice prefix (#65827).
+        from cli import _VoiceInputMessage
+        assert isinstance(queued, _VoiceInputMessage)
+        assert str(queued) == "hello world"
 
     @patch("cli._cprint")
     @patch("cli.os.unlink")
@@ -1422,7 +1427,10 @@ class TestVoiceBargeCaptureSubmit:
 
         cli._voice_submit_barge_utterance(str(wav))
 
-        assert cli._pending_input.get_nowait() == "stop, do it differently"
+        queued = cli._pending_input.get_nowait()
+        from cli import _VoiceInputMessage
+        assert isinstance(queued, _VoiceInputMessage)
+        assert str(queued) == "stop, do it differently"
         assert not cli._voice_barge_capture.is_set()
         assert not wav.exists()
 

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -1126,9 +1126,33 @@ class TestVoiceSpeakResponseReal:
     def test_play_audio_uses_returned_tts_file_path(
         self, _tts, mock_play, _mkd, _isf, _gsz, _unl, _cp
     ):
+        _isf.side_effect = lambda path: path == "/tmp/hermes_voice/actual.flac"
         cli = _make_voice_cli(_voice_tts=True)
         cli._voice_speak_response("Hello world")
         mock_play.assert_called_once_with("/tmp/hermes_voice/actual.flac")
+
+    @patch("cli._cprint")
+    @patch("cli.os.unlink")
+    @patch("cli.os.path.getsize", return_value=1000)
+    @patch("cli.os.path.isfile", return_value=True)
+    @patch("cli.os.makedirs")
+    @patch("tools.voice_mode.play_audio_file")
+    @patch("tools.tts_tool.text_to_speech_tool")
+    def test_play_audio_prefers_requested_mp3_over_returned_ogg(
+        self, mock_tts, mock_play, _mkd, _isf, _gsz, _unl, _cp
+    ):
+        def fake_tts(**kwargs):
+            mp3_path = kwargs["output_path"]
+            ogg_path = mp3_path.rsplit(".", 1)[0] + ".ogg"
+            return f'{{"success": true, "file_path": "{ogg_path}"}}'
+
+        mock_tts.side_effect = fake_tts
+
+        cli = _make_voice_cli(_voice_tts=True)
+        cli._voice_speak_response("Hello world")
+
+        requested_path = mock_tts.call_args.kwargs["output_path"]
+        mock_play.assert_called_once_with(requested_path)
 
 
 class TestVoiceStopAndTranscribeReal:

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -1208,6 +1208,92 @@ class TestSilenceDetection:
 
 
 # ============================================================================
+# Max recording length cap (voice.max_recording_seconds)
+# ============================================================================
+
+class TestMaxRecordingCap:
+    """The hard cap must auto-stop through the real InputStream-callback
+    path — not just the predicate — and fire the one-shot callback exactly
+    once, independent of the silence-detection branches."""
+
+    def _get_stream_callback(self, mock_sd):
+        callback = mock_sd.InputStream.call_args.kwargs.get("callback")
+        if callback is None:
+            callback = mock_sd.InputStream.call_args[1]["callback"]
+        return callback
+
+    def test_cap_fires_one_shot_callback_during_continuous_speech(self, mock_sd):
+        np = pytest.importorskip("numpy")
+        import threading
+
+        mock_sd.InputStream.return_value = MagicMock()
+
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        recorder._max_recording_seconds = 0.1
+        # Park the other auto-stop branches far away so only the cap can fire:
+        # loud frames keep the silence branch off, and max_wait covers the
+        # no-speech branch.
+        recorder._silence_duration = 60.0
+        recorder._max_wait = 60.0
+
+        fires = []
+        fired = threading.Event()
+
+        def on_stop():
+            fires.append(1)
+            fired.set()
+
+        recorder.start(on_silence_stop=on_stop)
+        callback = self._get_stream_callback(mock_sd)
+
+        loud_frame = np.full((1600, 1), 5000, dtype="int16")
+        callback(loud_frame, 1600, None, None)
+        assert not fired.is_set(), "cap must not fire before the limit elapses"
+
+        # Cross the cap while the user is STILL speaking — the silence branch
+        # can never fire here, so a hit proves the cap path.
+        time.sleep(0.12)
+        callback(loud_frame, 1600, None, None)
+        assert fired.wait(timeout=1.0) is True
+
+        # One-shot: the handler cleared _on_silence_stop, further frames past
+        # the cap must not fire again.
+        assert recorder._on_silence_stop is None
+        callback(loud_frame, 1600, None, None)
+        time.sleep(0.05)
+        assert len(fires) == 1
+
+        recorder.cancel()
+
+    def test_disabled_cap_never_fires_on_duration(self, mock_sd):
+        np = pytest.importorskip("numpy")
+        import threading
+
+        mock_sd.InputStream.return_value = MagicMock()
+
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        recorder._max_recording_seconds = 0.0  # disabled (previous behaviour)
+        recorder._silence_duration = 60.0
+        recorder._max_wait = 60.0
+
+        fired = threading.Event()
+        recorder.start(on_silence_stop=lambda: fired.set())
+        callback = self._get_stream_callback(mock_sd)
+
+        loud_frame = np.full((1600, 1), 5000, dtype="int16")
+        callback(loud_frame, 1600, None, None)
+        time.sleep(0.12)
+        callback(loud_frame, 1600, None, None)
+
+        assert fired.wait(timeout=0.2) is False
+        recorder.cancel()
+
+
+# ============================================================================
 # Playback interrupt
 # ============================================================================
 

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -916,6 +916,10 @@ class TestWhisperHallucinationFilter:
 class TestPlayAudioFile:
     def test_play_wav_via_sounddevice(self, monkeypatch, sample_wav):
         np = pytest.importorskip("numpy")
+        # Pin to a non-macOS platform: on macOS WAV output deliberately skips
+        # sounddevice (see TestMacOSAudioOutputPolicy), so this path is only
+        # exercised off Darwin.
+        monkeypatch.setattr("tools.voice_mode.platform.system", lambda: "Linux")
 
         mock_sd_obj = MagicMock()
         # Simulate stream completing immediately (get_stream().active = False)
@@ -952,6 +956,106 @@ class TestPlayAudioFile:
 
         result = play_audio_file("/nonexistent/file.wav")
         assert result is False
+
+
+# ============================================================================
+# macOS output policy (no sounddevice for OUTPUT -> avoids TCC prompt)
+# ============================================================================
+
+class TestMacOSAudioOutputPolicy:
+    def test_output_disallowed_on_macos(self, monkeypatch):
+        monkeypatch.setattr("tools.voice_mode.platform.system", lambda: "Darwin")
+        from tools.voice_mode import _sounddevice_output_allowed
+
+        assert _sounddevice_output_allowed() is False
+
+    def test_output_allowed_off_macos(self, monkeypatch):
+        monkeypatch.setattr("tools.voice_mode.platform.system", lambda: "Linux")
+        from tools.voice_mode import _sounddevice_output_allowed
+
+        assert _sounddevice_output_allowed() is True
+
+    def test_play_audio_file_skips_sounddevice_on_macos(self, monkeypatch, sample_wav):
+        """On macOS, WAV playback must not import sounddevice; it routes to afplay."""
+        monkeypatch.setattr("tools.voice_mode.platform.system", lambda: "Darwin")
+
+        def _forbidden_import():
+            raise AssertionError("sounddevice must not be imported for output on macOS")
+
+        monkeypatch.setattr("tools.voice_mode._import_audio", _forbidden_import)
+
+        popen_cmds = []
+
+        class _FakeProc:
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+        def _fake_popen(cmd, **kwargs):
+            popen_cmds.append(cmd)
+            return _FakeProc()
+
+        monkeypatch.setattr("shutil.which", lambda exe: f"/usr/bin/{exe}")
+        monkeypatch.setattr("subprocess.Popen", _fake_popen)
+
+        from tools.voice_mode import play_audio_file
+
+        result = play_audio_file(sample_wav)
+
+        assert result is True
+        assert popen_cmds, "expected a system player to be invoked"
+        assert popen_cmds[0][0] == "afplay"
+
+    def test_play_beep_routes_through_afplay_on_macos(self, monkeypatch):
+        """On macOS, beeps synthesize with numpy but play via the tempfile/afplay path."""
+        pytest.importorskip("numpy")
+        monkeypatch.setattr("tools.voice_mode.platform.system", lambda: "Darwin")
+
+        def _forbidden_import():
+            raise AssertionError("sounddevice must not be imported for beeps on macOS")
+
+        monkeypatch.setattr("tools.voice_mode._import_audio", _forbidden_import)
+
+        calls = []
+        monkeypatch.setattr(
+            "tools.voice_mode._play_int16_via_tempfile",
+            lambda audio, sample_rate: calls.append((len(audio), sample_rate)),
+        )
+
+        import tools.voice_mode as vm
+
+        vm.play_beep(frequency=880, count=1)
+
+        assert len(calls) == 1
+        n_samples, sample_rate = calls[0]
+        assert n_samples > 0
+        assert sample_rate == vm.SAMPLE_RATE
+
+    def test_play_beep_uses_sounddevice_off_macos(self, monkeypatch):
+        """Off macOS, beeps go straight through sounddevice."""
+        np = pytest.importorskip("numpy")
+        monkeypatch.setattr("tools.voice_mode.platform.system", lambda: "Linux")
+
+        mock_sd = MagicMock()
+        mock_stream = MagicMock()
+        mock_stream.active = False
+        mock_sd.get_stream.return_value = mock_stream
+        monkeypatch.setattr("tools.voice_mode._import_audio", lambda: (mock_sd, np))
+
+        tempfile_calls = []
+        monkeypatch.setattr(
+            "tools.voice_mode._play_int16_via_tempfile",
+            lambda audio, sample_rate: tempfile_calls.append(True),
+        )
+
+        import tools.voice_mode as vm
+
+        vm.play_beep(frequency=880, count=1)
+
+        mock_sd.play.assert_called_once()
+        assert not tempfile_calls, "off macOS should not use the tempfile/afplay path"
 
 
 # ============================================================================

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -1019,6 +1019,8 @@ class TestMacOSAudioOutputPolicy:
         popen_cmds = []
 
         class _FakeProc:
+            returncode = 0
+
             def wait(self, timeout=None):
                 return 0
 
@@ -2213,6 +2215,8 @@ class TestWSLAudioEnvironmentGate:
 
         monkeypatch.delenv("PULSE_SERVER", raising=False)
         monkeypatch.delenv("PIPEWIRE_REMOTE", raising=False)
+        for _ssh_var in ("SSH_CLIENT", "SSH_TTY", "SSH_CONNECTION"):
+            monkeypatch.delenv(_ssh_var, raising=False)
         monkeypatch.setattr("tools.voice_mode._import_audio",
                             lambda: (MagicMock(), MagicMock()))
         with patch("builtins.open", side_effect=self._fake_open_wsl), \
@@ -2238,6 +2242,8 @@ class TestWSLAudioEnvironmentGate:
 
         monkeypatch.delenv("PULSE_SERVER", raising=False)
         monkeypatch.delenv("PIPEWIRE_REMOTE", raising=False)
+        for _ssh_var in ("SSH_CLIENT", "SSH_TTY", "SSH_CONNECTION"):
+            monkeypatch.delenv(_ssh_var, raising=False)
         monkeypatch.setattr("tools.voice_mode._import_audio",
                             lambda: (MagicMock(), MagicMock()))
         with patch("builtins.open", side_effect=self._fake_open_wsl), \
@@ -2257,6 +2263,8 @@ class TestWSLAudioEnvironmentGate:
         from tools import voice_mode as vm
 
         monkeypatch.setenv("PULSE_SERVER", "unix:/mnt/wslg/PulseServer")
+        for _ssh_var in ("SSH_CLIENT", "SSH_TTY", "SSH_CONNECTION"):
+            monkeypatch.delenv(_ssh_var, raising=False)
         monkeypatch.setattr("tools.voice_mode._import_audio",
                             lambda: (MagicMock(), MagicMock()))
         with patch("builtins.open", side_effect=self._fake_open_wsl), \
@@ -2264,4 +2272,8 @@ class TestWSLAudioEnvironmentGate:
             result = vm.detect_audio_environment()
 
         assert result["available"] is True
-        assert any("PulseAudio bridge" in n for n in result["notices"])
+        # Merged with #37346: any forwarded sound server (PULSE_SERVER or
+        # PIPEWIRE_REMOTE) yields the shared reachable-sound-server notice.
+        assert any(
+            "PulseAudio" in n and "WSL" in n for n in result["notices"]
+        )

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -594,6 +594,38 @@ class TestAudioRecorder:
         with pytest.raises(RuntimeError, match="sounddevice and numpy"):
             recorder.start()
 
+    def test_start_oserror_points_at_portaudio_not_pip(self, monkeypatch):
+        """OSError from _import_audio means PortAudio's shared library is
+        missing — pip can't fix that. The error must point at the system
+        package, not 'pip install sounddevice numpy' (#18432)."""
+        def _fail_import():
+            raise OSError("PortAudio library not found")
+        monkeypatch.setattr("tools.voice_mode._import_audio", _fail_import)
+        monkeypatch.setattr("tools.voice_mode._is_termux_environment", lambda: False)
+
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        with pytest.raises(RuntimeError) as exc_info:
+            recorder.start()
+        msg = str(exc_info.value)
+        assert "PortAudio system library not found" in msg
+        assert "libportaudio2" in msg
+        assert "pip install" not in msg
+
+    def test_start_oserror_termux_hint(self, monkeypatch):
+        """Same OSError path on Termux points at pkg install portaudio."""
+        def _fail_import():
+            raise OSError("PortAudio library not found")
+        monkeypatch.setattr("tools.voice_mode._import_audio", _fail_import)
+        monkeypatch.setattr("tools.voice_mode._is_termux_environment", lambda: True)
+
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        with pytest.raises(RuntimeError, match="pkg install portaudio"):
+            recorder.start()
+
     def test_start_creates_and_starts_stream(self, mock_sd):
         mock_stream = MagicMock()
         mock_sd.InputStream.return_value = mock_stream

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -1814,3 +1814,66 @@ class TestPlayBeepVolumeWiring:
         )
         assert "beep_volume * 32767" in source
         assert "_get_beep_volume()" in source
+
+
+# ============================================================================
+# Device-native input sample rate — mics that reject 16 kHz capture
+# ============================================================================
+
+class TestDefaultInputSamplerate:
+    def test_uses_device_default_rate(self):
+        from tools.voice_mode import _default_input_samplerate
+
+        sd = MagicMock()
+        sd.query_devices.return_value = {"default_samplerate": 44100.0}
+        assert _default_input_samplerate(sd) == 44100
+
+    def test_falls_back_when_query_fails(self):
+        from tools.voice_mode import SAMPLE_RATE, _default_input_samplerate
+
+        sd = MagicMock()
+        sd.query_devices.side_effect = RuntimeError("no device")
+        assert _default_input_samplerate(sd) == SAMPLE_RATE
+
+    def test_falls_back_on_non_numeric_rate(self):
+        from tools.voice_mode import SAMPLE_RATE, _default_input_samplerate
+
+        sd = MagicMock()
+        sd.query_devices.return_value = {"default_samplerate": None}
+        assert _default_input_samplerate(sd) == SAMPLE_RATE
+
+    def test_recorder_opens_stream_at_device_rate(self, mock_sd):
+        mock_sd.query_devices.return_value = {"default_samplerate": 48000.0}
+        mock_stream = MagicMock()
+        mock_sd.InputStream.return_value = mock_stream
+
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        recorder.start()
+
+        assert recorder.is_recording is True
+        assert mock_sd.InputStream.call_args.kwargs["samplerate"] == 48000
+
+    def test_wav_written_at_capture_rate(self, mock_sd, temp_voice_dir):
+        np = pytest.importorskip("numpy")
+
+        mock_sd.query_devices.return_value = {"default_samplerate": 48000.0}
+        mock_stream = MagicMock()
+        mock_sd.InputStream.return_value = mock_stream
+
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        recorder.start()
+
+        # 1 second of loud audio at the device rate (above RMS threshold)
+        frame = np.full((48000, 1), 1000, dtype="int16")
+        recorder._frames = [frame]
+        recorder._peak_rms = 1000
+
+        wav_path = recorder.stop()
+
+        assert wav_path is not None
+        with wave.open(wav_path, "rb") as wf:
+            assert wf.getframerate() == 48000

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -1877,3 +1877,255 @@ class TestDefaultInputSamplerate:
         assert wav_path is not None
         with wave.open(wav_path, "rb") as wf:
             assert wf.getframerate() == 48000
+
+
+class TestWSL2PowerShellFallback:
+    """Regression tests for WSL2 PowerShell TTS fallback (issue #17608).
+
+    On WSL2 without a PulseAudio bridge, ffplay/aplay have no audio device.
+    play_audio_file() should insert a PowerShell-based player at the front
+    of the player list when powershell.exe and ffmpeg are available.
+    """
+
+    def _fake_check_output(self, responses):
+        """Build a subprocess.check_output side_effect from a list of responses."""
+        it = iter(responses)
+        def _side_effect(cmd, **kwargs):
+            return next(it)
+        return _side_effect
+
+    def test_wsl2_powershell_player_inserted_first(self, monkeypatch, sample_wav):
+        """When WSL2 is detected and powershell.exe + ffmpeg are available,
+        a sh -c pipeline must be inserted before ffplay/aplay in the player list."""
+        from unittest.mock import patch, MagicMock
+        from tools import voice_mode as vm
+
+        captured_players = []
+
+        def _capture_popen(cmd, **kw):
+            captured_players.append(list(cmd))
+            m = MagicMock()
+            m.returncode = 0
+            m.wait = MagicMock(return_value=0)
+            return m
+
+        with patch("tools.voice_mode._is_wsl2_env", return_value=True), \
+             patch("tools.voice_mode._import_audio", side_effect=ImportError), \
+             patch("tools.voice_mode.shutil.which",
+                   side_effect=lambda x: f"/bin/{x}" if x in ("powershell.exe", "ffmpeg", "ffplay", "sh") else (x if x.startswith("/") else None)), \
+             patch("tools.voice_mode.subprocess.check_output",
+                   side_effect=self._fake_check_output([
+                       b"C:/Temp\r\n",
+                       b"/mnt/c/Temp\n",
+                       b"C:/Temp/hermes.wav\n",
+                   ])), \
+             patch("tools.voice_mode.subprocess.Popen", side_effect=_capture_popen):
+            vm.play_audio_file(str(sample_wav))
+
+        assert captured_players, "No players were tried"
+        first_cmd = captured_players[0]
+        assert first_cmd[0] in ("/bin/sh", "sh") and first_cmd[1] == "-c", (
+            f"Expected sh -c as first player, got {first_cmd}"
+        )
+        assert "powershell.exe" in first_cmd[2]
+        assert "PlaySync" in first_cmd[2]
+
+    def test_powershell_pipeline_preserves_real_exit_status(self, sample_wav):
+        """Regression (review of #63768): the shell pipeline must preserve
+        the (ffmpeg && powershell) exit status past the unconditional
+        cleanup, so a real conversion/playback failure falls through to the
+        next player instead of being masked by rm -f's always-zero exit."""
+        from unittest.mock import patch, MagicMock
+        from tools import voice_mode as vm
+
+        captured_cmds = []
+
+        def _capture_popen(cmd, **kw):
+            captured_cmds.append(list(cmd))
+            m = MagicMock()
+            # Simulate the PowerShell pipeline failing (nonzero rc), and
+            # the fallback ffplay succeeding.
+            if cmd[0] in ("/bin/sh", "sh"):
+                m.returncode = 1
+            else:
+                m.returncode = 0
+            m.wait = MagicMock(return_value=m.returncode)
+            return m
+
+        with patch("tools.voice_mode._is_wsl2_env", return_value=True), \
+             patch("tools.voice_mode._import_audio", side_effect=ImportError), \
+             patch("tools.voice_mode.shutil.which",
+                   side_effect=lambda x: f"/bin/{x}" if x in ("powershell.exe", "ffmpeg", "ffplay", "sh") else (x if x.startswith("/") else None)), \
+             patch("tools.voice_mode.subprocess.check_output",
+                   side_effect=self._fake_check_output([
+                       b"C:/Temp\r\n",
+                       b"/mnt/c/Temp\n",
+                       b"C:/Temp/hermes.wav\n",
+                   ])), \
+             patch("tools.voice_mode.subprocess.Popen", side_effect=_capture_popen):
+            result = vm.play_audio_file(str(sample_wav))
+
+        assert result is True, "Must fall through to ffplay and succeed"
+        assert len(captured_cmds) == 2, (
+            f"Expected sh pipeline to be tried and fail, then ffplay to be "
+            f"tried: {captured_cmds}"
+        )
+        assert captured_cmds[0][0] in ("/bin/sh", "sh")
+        assert captured_cmds[1][0] == "ffplay"
+        # The subshell command must capture and re-exit with $rc, not rely
+        # on rm -f's exit status.
+        sh_script = captured_cmds[0][2]
+        assert "rc=$?" in sh_script and "exit $rc" in sh_script, (
+            "Shell pipeline must preserve the real exit status past cleanup: " + sh_script
+        )
+
+    def test_wsl2_unique_temp_filename(self, monkeypatch, tmp_path, sample_wav):
+        """Two concurrent calls must use different temp WAV filenames."""
+        from unittest.mock import patch, MagicMock
+        from tools import voice_mode as vm
+
+        filenames = []
+
+        def _capture_check_output(cmd, **kwargs):
+            cmd_str = " ".join(str(c) for c in cmd)
+            if "TEMP" in cmd_str:
+                return b"C:\\Temp\r\n"
+            if "wslpath" in cmd_str and "-u" in cmd_str:
+                return b"/mnt/c/Temp\n"
+            if "wslpath" in cmd_str and "-w" in cmd_str:
+                wsl_path = cmd[-1] if isinstance(cmd[-1], str) else cmd[-1].decode()
+                filenames.append(wsl_path.split("/")[-1])
+                return f"C:\\Temp\\{wsl_path.split('/')[-1]}\n".encode()
+            return b""
+
+        def _fake_open(path, *args, **kwargs):
+            if str(path) == "/proc/version":
+                import io
+                return io.StringIO("Linux Microsoft WSL2")
+            return open(path, *args, **kwargs)
+
+        with patch("builtins.open", side_effect=_fake_open), \
+             patch("shutil.which", side_effect=lambda x: f"/bin/{x}" if x in ("powershell.exe", "ffmpeg", "ffplay") else None), \
+             patch("subprocess.check_output", side_effect=_capture_check_output), \
+             patch("subprocess.Popen", return_value=MagicMock(returncode=0, wait=lambda **k: 0)), \
+             patch("tools.voice_mode._playback_lock"), \
+             patch("tools.voice_mode._active_playback", None):
+            vm.play_audio_file(str(sample_wav))
+            vm.play_audio_file(str(sample_wav))
+
+        # Regression (review of #63768): the original test made this
+        # assertion conditional on len(filenames) >= 2, so a broken
+        # (zero-captured) run passed trivially. Require exactly two.
+        assert len(filenames) == 2, (
+            f"Expected exactly 2 captured temp filenames from 2 calls, got "
+            f"{len(filenames)}: {filenames}"
+        )
+        assert filenames[0] != filenames[1], (
+            "Concurrent TTS calls must use unique temp WAV filenames"
+        )
+
+    def test_non_wsl_skips_powershell_fallback(self, monkeypatch, sample_wav):
+        """On non-WSL Linux, the PowerShell player must not be inserted."""
+        from unittest.mock import patch, MagicMock
+        from tools import voice_mode as vm
+
+        captured_players = []
+
+        def _capture_popen(cmd, **kw):
+            captured_players.append(cmd)
+            m = MagicMock()
+            m.returncode = 0
+            m.wait.return_value = 0
+            return m
+
+        def _fake_open(path, *args, **kwargs):
+            if str(path) == "/proc/version":
+                import io
+                return io.StringIO("Linux version 5.15.0-generic #72-Ubuntu")
+            return open(path, *args, **kwargs)
+
+        with patch("builtins.open", side_effect=_fake_open), \
+             patch("tools.voice_mode._import_audio", side_effect=ImportError), \
+             patch("shutil.which", side_effect=lambda x: f"/bin/{x}" if x in ("ffplay", "aplay") else None), \
+             patch("subprocess.Popen", side_effect=_capture_popen), \
+             patch("tools.voice_mode._playback_lock"), \
+             patch("tools.voice_mode._active_playback", None):
+            vm.play_audio_file(str(sample_wav))
+
+        assert captured_players, "No players were tried"
+        for cmd in captured_players:
+            assert not (cmd[0] == "sh" and "powershell" in " ".join(str(c) for c in cmd)), (
+                "PowerShell player must not appear on non-WSL Linux"
+            )
+
+
+class TestWSLAudioEnvironmentGate:
+    """Regression tests (review of #63768) for detect_audio_environment()'s
+    WSL gate: when the PowerShell TTS fallback is viable, voice mode must
+    not be hard-blocked, but the recording/STT PulseAudio-bridge guidance
+    must still be surfaced (as a non-blocking notice)."""
+
+    def _fake_open_wsl(self, path, *args, **kwargs):
+        if str(path) == "/proc/version":
+            import io
+            return io.StringIO("Linux version 5.15 Microsoft Standard WSL2")
+        return open(path, *args, **kwargs)
+
+    def test_wsl_no_pulse_but_powershell_available_not_hard_blocked(self, monkeypatch):
+        from unittest.mock import patch
+        from tools import voice_mode as vm
+
+        monkeypatch.delenv("PULSE_SERVER", raising=False)
+        monkeypatch.delenv("PIPEWIRE_REMOTE", raising=False)
+        monkeypatch.setattr("tools.voice_mode._import_audio",
+                            lambda: (MagicMock(), MagicMock()))
+        with patch("builtins.open", side_effect=self._fake_open_wsl), \
+             patch("tools.voice_mode._wsl_powershell_tts_available", return_value=True), \
+             patch("tools.voice_mode._pulse_socket_reachable", return_value=False), \
+             patch("hermes_constants.is_container", return_value=False):
+            result = vm.detect_audio_environment()
+
+        assert result["available"] is True, (
+            "PowerShell TTS fallback must keep voice mode enabled even "
+            "without a PulseAudio bridge: " + str(result["warnings"])
+        )
+        assert any("PowerShell" in n or "Media.SoundPlayer" in n for n in result["notices"]), (
+            "The PowerShell fallback path must be mentioned in notices"
+        )
+        assert any("recording" in n.lower() or "PulseAudio" in n for n in result["notices"]), (
+            "The recording/STT PulseAudio caveat must still be surfaced"
+        )
+
+    def test_wsl_no_pulse_no_powershell_still_blocked(self, monkeypatch):
+        from unittest.mock import patch
+        from tools import voice_mode as vm
+
+        monkeypatch.delenv("PULSE_SERVER", raising=False)
+        monkeypatch.delenv("PIPEWIRE_REMOTE", raising=False)
+        monkeypatch.setattr("tools.voice_mode._import_audio",
+                            lambda: (MagicMock(), MagicMock()))
+        with patch("builtins.open", side_effect=self._fake_open_wsl), \
+             patch("tools.voice_mode._wsl_powershell_tts_available", return_value=False), \
+             patch("tools.voice_mode._pulse_socket_reachable", return_value=False), \
+             patch("hermes_constants.is_container", return_value=False):
+            result = vm.detect_audio_environment()
+
+        assert result["available"] is False, (
+            "Without PulseAudio AND without the PowerShell fallback, WSL "
+            "must still be hard-blocked as before"
+        )
+
+    def test_wsl_with_pulse_server_unaffected(self, monkeypatch):
+        """PULSE_SERVER already configured: existing behavior unchanged."""
+        from unittest.mock import patch
+        from tools import voice_mode as vm
+
+        monkeypatch.setenv("PULSE_SERVER", "unix:/mnt/wslg/PulseServer")
+        monkeypatch.setattr("tools.voice_mode._import_audio",
+                            lambda: (MagicMock(), MagicMock()))
+        with patch("builtins.open", side_effect=self._fake_open_wsl), \
+             patch("hermes_constants.is_container", return_value=False):
+            result = vm.detect_audio_environment()
+
+        assert result["available"] is True
+        assert any("PulseAudio bridge" in n for n in result["notices"])

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -1718,3 +1718,99 @@ class TestListenForSpeechCapture:
         monkeypatch.setattr("tools.voice_mode._import_audio", MagicMock(side_effect=OSError("no audio")))
         from tools.voice_mode import listen_for_speech
         assert listen_for_speech(lambda: False, capture=True) is None
+
+
+class TestGetBeepVolume:
+    """Issue #55908: beep amplitude must come from config.yaml, with safe fallback."""
+
+    def _get(self):
+        from tools.voice_mode import _get_beep_volume
+        return _get_beep_volume()
+
+    def test_default_when_key_missing(self):
+        with patch("hermes_cli.config.load_config", return_value={"voice": {}}):
+            assert self._get() == 0.3
+
+    def test_default_when_voice_section_missing(self):
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert self._get() == 0.3
+
+    def test_custom_value_honored(self):
+        with patch("hermes_cli.config.load_config",
+                   return_value={"voice": {"beep_volume": 0.6}}):
+            assert self._get() == 0.6
+
+    def test_zero_is_accepted(self):
+        with patch("hermes_cli.config.load_config",
+                   return_value={"voice": {"beep_volume": 0.0}}):
+            assert self._get() == 0.0
+
+    def test_one_is_accepted(self):
+        with patch("hermes_cli.config.load_config",
+                   return_value={"voice": {"beep_volume": 1.0}}):
+            assert self._get() == 1.0
+
+    def test_out_of_range_high_clamps_to_default(self):
+        with patch("hermes_cli.config.load_config",
+                   return_value={"voice": {"beep_volume": 1.5}}):
+            assert self._get() == 0.3
+
+    def test_out_of_range_low_clamps_to_default(self):
+        with patch("hermes_cli.config.load_config",
+                   return_value={"voice": {"beep_volume": -0.5}}):
+            assert self._get() == 0.3
+
+    def test_string_numeric_is_coerced(self):
+        with patch("hermes_cli.config.load_config",
+                   return_value={"voice": {"beep_volume": "0.7"}}):
+            assert self._get() == 0.7
+
+    def test_non_numeric_falls_back(self):
+        with patch("hermes_cli.config.load_config",
+                   return_value={"voice": {"beep_volume": "loud"}}):
+            assert self._get() == 0.3
+
+    def test_bool_value_falls_back(self):
+        """Booleans must not silently pass as 0.0/1.0 (same guard as silence_threshold)."""
+        with patch("hermes_cli.config.load_config",
+                   return_value={"voice": {"beep_volume": True}}):
+            assert self._get() == 0.3
+
+    def test_nan_falls_back(self):
+        with patch("hermes_cli.config.load_config",
+                   return_value={"voice": {"beep_volume": float("nan")}}):
+            assert self._get() == 0.3
+
+    def test_load_config_exception_falls_back(self):
+        with patch("hermes_cli.config.load_config",
+                   side_effect=RuntimeError("broken config")):
+            assert self._get() == 0.3
+
+    def test_voice_section_wrong_type_falls_back(self):
+        with patch("hermes_cli.config.load_config",
+                   return_value={"voice": "not-a-dict"}):
+            assert self._get() == 0.3
+
+
+class TestPlayBeepVolumeWiring:
+    """Issue #55908: play_beep multiplies by the volume returned by _get_beep_volume.
+
+    Static wiring check — the behaviour is covered by TestGetBeepVolume above; this
+    class guards against regressions that re-introduce a hardcoded ``0.3`` literal
+    at the amplitude line in play_beep (the original bug class).
+    """
+
+    def test_play_beep_does_not_use_hardcoded_0_3_literal(self):
+        import inspect
+
+        from tools import voice_mode as vm_mod
+
+        source = inspect.getsource(vm_mod.play_beep)
+        # The fix replaces ``tone * 0.3 * 32767`` with ``tone * beep_volume * 32767``
+        # where beep_volume is the result of _get_beep_volume().
+        hardcoded = " * 0.3 * 32767"
+        assert hardcoded not in source, (
+            "play_beep still contains a hardcoded 0.3 amplitude; use _get_beep_volume()"
+        )
+        assert "beep_volume * 32767" in source
+        assert "_get_beep_volume()" in source

--- a/tests/tools/test_voice_wsl_pipewire.py
+++ b/tests/tools/test_voice_wsl_pipewire.py
@@ -1,0 +1,58 @@
+"""Regression: WSL voice detection must honor PIPEWIRE_REMOTE, not only PULSE_SERVER.
+
+detect_audio_environment() honors forwarded audio (has_forwarded_audio =
+PULSE_SERVER or PIPEWIRE_REMOTE or a reachable socket) in the SSH and container
+blocks, but the WSL block previously checked only PULSE_SERVER — so a WSL user
+with PipeWire forwarding (PIPEWIRE_REMOTE) was wrongly blocked from voice mode.
+These tests mock /proc/version so they reproduce the WSL path on any host.
+"""
+import builtins
+import io
+from unittest.mock import MagicMock
+
+WSL = "Linux version 5.15.0-microsoft-standard-WSL2 (oe-user@oe-host)"
+
+
+def _force_wsl(monkeypatch, content=WSL):
+    real_open = builtins.open
+    def fake_open(file, *a, **k):
+        if str(file) == "/proc/version":
+            return io.StringIO(content)
+        return real_open(file, *a, **k)
+    monkeypatch.setattr(builtins, "open", fake_open)
+
+
+def _base(monkeypatch):
+    for v in ("SSH_CLIENT", "SSH_TTY", "SSH_CONNECTION", "PULSE_SERVER"):
+        monkeypatch.delenv(v, raising=False)
+    monkeypatch.delenv("PIPEWIRE_REMOTE", raising=False)
+    monkeypatch.setattr("hermes_constants.is_container", lambda: False)
+    monkeypatch.setattr("tools.voice_mode._pulse_socket_reachable", lambda: False)
+    sd = MagicMock(); sd.query_devices.return_value = [{"name": "dev"}]
+    monkeypatch.setattr("tools.voice_mode._import_audio", lambda: (sd, MagicMock()))
+
+
+def test_wsl_with_pipewire_remote_allows_voice(monkeypatch):
+    _base(monkeypatch)
+    monkeypatch.setenv("PIPEWIRE_REMOTE", "/run/user/1000/pipewire-0")
+    _force_wsl(monkeypatch)
+    from tools.voice_mode import detect_audio_environment
+    result = detect_audio_environment()
+    assert result["available"] is True, result["warnings"]
+
+
+def test_wsl_with_pulse_server_still_allows_voice(monkeypatch):
+    _base(monkeypatch)
+    monkeypatch.setenv("PULSE_SERVER", "unix:/mnt/wslg/PulseServer")
+    _force_wsl(monkeypatch)
+    from tools.voice_mode import detect_audio_environment
+    assert detect_audio_environment()["available"] is True
+
+
+def test_wsl_without_forwarding_still_blocks(monkeypatch):
+    _base(monkeypatch)
+    _force_wsl(monkeypatch)  # no PULSE_SERVER, no PIPEWIRE_REMOTE
+    from tools.voice_mode import detect_audio_environment
+    res = detect_audio_environment()
+    assert res["available"] is False
+    assert any("WSL" in w for w in res["warnings"])

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -41,6 +41,7 @@ import json
 import logging
 import os
 import queue
+import platform
 import re
 import shlex
 import shutil
@@ -2910,20 +2911,28 @@ def stream_tts_to_speaker(
                 )
             except Exception:
                 stream_max_len = 0
-            try:
-                sd = _import_sounddevice()
-                output_stream = sd.OutputStream(
-                    samplerate=streamer.sample_rate,
-                    channels=streamer.channels,
-                    dtype="int16",
-                )
-                output_stream.start()
-            except (ImportError, OSError) as exc:
-                logger.debug("sounddevice not available, streamer→tempfile: %s", exc)
+            # On macOS, skip the sounddevice OutputStream entirely: PortAudio/
+            # CoreAudio init triggers a kTCCServiceMediaLibrary permission
+            # prompt even though output needs no media-library access. Leaving
+            # output_stream=None routes each sentence through the tempfile
+            # -> play_audio_file -> afplay path. See PR #62601 / #13291.
+            if platform.system() == "Darwin":
                 output_stream = None
-            except Exception as exc:
-                logger.warning("sounddevice OutputStream failed: %s", exc)
-                output_stream = None
+            else:
+                try:
+                    sd = _import_sounddevice()
+                    output_stream = sd.OutputStream(
+                        samplerate=streamer.sample_rate,
+                        channels=streamer.channels,
+                        dtype="int16",
+                    )
+                    output_stream.start()
+                except (ImportError, OSError) as exc:
+                    logger.debug("sounddevice not available, streamer→tempfile: %s", exc)
+                    output_stream = None
+                except Exception as exc:
+                    logger.warning("sounddevice OutputStream failed: %s", exc)
+                    output_stream = None
 
         chunker = SentenceChunker()
         long_flush_len = 100

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -497,10 +497,24 @@ class AudioRecorder:
         self._silence_threshold: int = SILENCE_RMS_THRESHOLD
         self._silence_duration: float = SILENCE_DURATION_SECONDS
         self._max_wait: float = 15.0  # Max seconds to wait for speech before auto-stop
+        # Hard cap on total recording length, wired from voice.max_recording_seconds
+        # by the CLI before each recording. 0 (or unset) = no cap (previous behaviour).
+        self._max_recording_seconds: float = 0.0
         # Peak RMS seen during recording (for speech presence check in stop())
         self._peak_rms: int = 0
         # Live audio level (read by UI for visual feedback)
         self._current_rms: int = 0
+
+    def _max_duration_reached(self, elapsed: float) -> bool:
+        """Whether the configured hard recording-length cap has elapsed.
+
+        ``voice.max_recording_seconds`` is applied by the CLI before each
+        recording (see ``HermesCLI._voice_start_recording``). A value <= 0
+        (or unset) disables the cap, preserving the previous unbounded
+        behaviour.
+        """
+        cap = self._max_recording_seconds
+        return bool(cap and cap > 0 and elapsed >= cap)
 
     # -- public properties ---------------------------------------------------
 
@@ -616,6 +630,14 @@ class AudioRecorder:
                 elif not self._has_spoken and elapsed >= self._max_wait:
                     logger.info("No speech within %.0fs, auto-stopping",
                                 self._max_wait)
+                    should_fire = True
+
+                # 3. Hard cap on total recording length (voice.max_recording_seconds).
+                #    Independent of speech/silence so a continuous speaker past the
+                #    configured limit still auto-stops instead of recording forever.
+                if not should_fire and self._max_duration_reached(elapsed):
+                    logger.info("Max recording length reached (%.0fs), auto-stopping",
+                                self._max_recording_seconds)
                     should_fire = True
 
                 if should_fire:

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -10,6 +10,7 @@ Dependencies (optional):
 """
 
 import logging
+import math
 import os
 import platform
 import re
@@ -288,6 +289,41 @@ _TEMP_DIR = os.path.join(tempfile.gettempdir(), "hermes_voice")
 # ============================================================================
 # Audio cues (beep tones)
 # ============================================================================
+_DEFAULT_BEEP_VOLUME = 0.3   # Backward-compatible default (matches prior hardcoded value)
+
+
+def _get_beep_volume() -> float:
+    """Read ``voice.beep_volume`` from config.yaml; clamps to 0.0-1.0.
+
+    Defaults to 0.3 when the key is missing, invalid, or when the config
+    system can't be imported (e.g. broken ~/.hermes/config.yaml during a
+    partial install). Failures fall back silently so the audio cue never
+    breaks the voice loop on a degenerate config.
+    """
+    try:
+        from hermes_cli.config import load_config
+        voice_cfg = load_config().get("voice", {})
+        if not isinstance(voice_cfg, dict):
+            return _DEFAULT_BEEP_VOLUME
+        raw = voice_cfg.get("beep_volume", _DEFAULT_BEEP_VOLUME)
+    except Exception:
+        return _DEFAULT_BEEP_VOLUME
+    try:
+        volume = float(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_BEEP_VOLUME
+    if isinstance(raw, bool) or volume < 0.0 or volume > 1.0 or _is_nan(volume):
+        return _DEFAULT_BEEP_VOLUME
+    return volume
+
+
+def _is_nan(value: float) -> bool:
+    try:
+        return math.isnan(value)
+    except Exception:
+        return False
+
+
 def play_beep(frequency: int = 880, duration: float = 0.12, count: int = 1) -> None:
     """Play a short beep tone using numpy + sounddevice.
 
@@ -305,6 +341,7 @@ def play_beep(frequency: int = 880, duration: float = 0.12, count: int = 1) -> N
         samples_per_beep = int(SAMPLE_RATE * duration)
         samples_per_gap = int(SAMPLE_RATE * gap)
 
+        beep_volume = _get_beep_volume()
         parts = []
         for i in range(count):
             t = np.linspace(0, duration, samples_per_beep, endpoint=False)
@@ -313,7 +350,7 @@ def play_beep(frequency: int = 880, duration: float = 0.12, count: int = 1) -> N
             fade_len = min(int(SAMPLE_RATE * 0.01), samples_per_beep // 4)
             tone[:fade_len] *= np.linspace(0, 1, fade_len)
             tone[-fade_len:] *= np.linspace(1, 0, fade_len)
-            parts.append((tone * 0.3 * 32767).astype(np.int16))
+            parts.append((tone * beep_volume * 32767).astype(np.int16))
             if i < count - 1:
                 parts.append(np.zeros(samples_per_gap, dtype=np.int16))
 

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -207,19 +207,21 @@ def detect_audio_environment() -> dict:
                 "    PipeWire:    -e PIPEWIRE_REMOTE=$XDG_RUNTIME_DIR/pipewire-0"
             )
 
-    # WSL detection — PulseAudio bridge makes audio work in WSL.
-    # Only block if PULSE_SERVER is not configured.
+    # WSL detection — a reachable sound server makes audio work in WSL.
+    # Honor any forwarding (PulseAudio bridge OR a forwarded PipeWire/Pulse
+    # socket), mirroring the SSH and container blocks above. Only block when
+    # no forwarding is configured.
     try:
         with open('/proc/version', 'r', encoding="utf-8") as f:
             if 'microsoft' in f.read().lower():
-                if os.environ.get('PULSE_SERVER'):
-                    notices.append("Running in WSL with PulseAudio bridge")
+                if has_forwarded_audio:
+                    notices.append("Running in WSL with a reachable PulseAudio/PipeWire sound server")
                 else:
                     warnings.append(
-                        "Running in WSL -- audio requires PulseAudio bridge.\n"
-                        "  1. Set PULSE_SERVER=unix:/mnt/wslg/PulseServer\n"
-                        "  2. Create ~/.asoundrc pointing ALSA at PulseAudio\n"
-                        "  3. Verify with: arecord -d 3 /tmp/test.wav && aplay /tmp/test.wav"
+                        "Running in WSL -- audio requires a forwarded sound server.\n"
+                        "  PulseAudio: export PULSE_SERVER=unix:/mnt/wslg/PulseServer\n"
+                        "  PipeWire:   export PIPEWIRE_REMOTE=$XDG_RUNTIME_DIR/pipewire-0\n"
+                        "  Then verify: arecord -d 3 /tmp/test.wav && aplay /tmp/test.wav"
                     )
     except (FileNotFoundError, PermissionError, OSError):
         pass

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -83,21 +83,74 @@ def _termux_microphone_command() -> Optional[str]:
 
 
 
+# Probes used to detect whether the Termux:API Android app is installed.
+# `pm list packages` is the canonical Android lookup but is unreliable on
+# some devices: on certain ROMs / Android API levels `pm` itself isn't on
+# Termux's PATH while `cmd package` is, on others `pm` returns nothing for
+# the calling user even when the app is present.  We try both before
+# concluding that the app is genuinely missing (issue #31015).
+_TERMUX_API_PACKAGE_PROBES = (
+    ("pm", "list", "packages", "com.termux.api"),
+    ("cmd", "package", "list", "packages", "com.termux.api"),
+)
+
+
 def _termux_api_app_installed() -> bool:
+    """Return True iff the Termux:API Android app is installed.
+
+    Strategy (issue #31015):
+
+    1. Try each probe in ``_TERMUX_API_PACKAGE_PROBES`` and look for
+       ``package:com.termux.api`` in stdout.  Any positive hit is
+       authoritative — return True.
+    2. If every probe is *inconclusive* (binary missing, permission
+       denied, timeout, non-zero exit) we cannot honestly say the app
+       is missing; fall back to trusting the ``termux-microphone-record``
+       binary on PATH.  The binary ships with the ``termux-api`` package
+       and is only useful when the Android app is installed; users who
+       installed the package deliberately almost always have the app
+       too.  A false negative on this gate blocks ``/voice on``
+       outright (the symptom reported in #31015), while a false
+       positive only surfaces a precise runtime error from the binary
+       itself — strictly more actionable.
+    3. If at least one probe ran cleanly and definitively did not
+       mention the package, treat the app as missing and return False
+       — that's the genuine "Termux:API CLI installed without the app"
+       case the existing warning was written for.
+    """
     if not _is_termux_environment():
         return False
-    try:
-        result = subprocess.run(
-            ["pm", "list", "packages", "com.termux.api"],
-            capture_output=True,
-            text=True, encoding='utf-8', errors='replace',
-            timeout=5,
-            check=False,
-            stdin=subprocess.DEVNULL,
+
+    inconclusive = False
+    for cmd in _TERMUX_API_PACKAGE_PROBES:
+        try:
+            result = subprocess.run(
+                list(cmd),
+                capture_output=True,
+                text=True, encoding='utf-8', errors='replace',
+                timeout=5,
+                check=False,
+                stdin=subprocess.DEVNULL,
+            )
+        except (FileNotFoundError, PermissionError, OSError):
+            inconclusive = True
+            continue
+        except subprocess.TimeoutExpired:
+            inconclusive = True
+            continue
+        if result.returncode != 0:
+            inconclusive = True
+            continue
+        if "package:com.termux.api" in (result.stdout or "").lower():
+            return True
+
+    if inconclusive and shutil.which("termux-microphone-record") is not None:
+        logger.debug(
+            "Termux package-manager probes inconclusive; trusting "
+            "termux-microphone-record binary on PATH (issue #31015)."
         )
-        return "package:com.termux.api" in (result.stdout or "")
-    except Exception:
-        return False
+        return True
+    return False
 
 
 def _termux_voice_capture_available() -> bool:

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -891,7 +891,23 @@ class AudioRecorder:
         """
         try:
             sd, _ = _import_audio()
-        except (ImportError, OSError) as e:
+        except OSError as e:
+            # sounddevice imports but PortAudio's shared library is missing —
+            # a pip install can't fix that; point at the system package
+            # instead of misreporting missing Python packages (#18432).
+            if _is_termux_environment():
+                portaudio_hint = "  Termux: pkg install portaudio"
+            else:
+                portaudio_hint = (
+                    "  Linux:  sudo apt-get install libportaudio2\n"
+                    "  macOS:  brew install portaudio"
+                )
+            raise RuntimeError(
+                "PortAudio system library not found -- install it first:\n"
+                f"{portaudio_hint}\n"
+                "Then retry /voice on."
+            ) from e
+        except ImportError as e:
             raise RuntimeError(
                 "Voice mode requires sounddevice and numpy.\n"
                 f"Install with: {sys.executable} -m pip install sounddevice numpy"

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -50,6 +50,22 @@ def _audio_available() -> bool:
         return False
 
 
+def _default_input_samplerate(sd) -> int:
+    """Return the preferred capture rate for the default input device.
+
+    Falls back to the Whisper-friendly 16 kHz constant when the backend does
+    not expose a numeric default rate.
+    """
+    try:
+        info = sd.query_devices(None, "input")
+        rate = info.get("default_samplerate") if isinstance(info, dict) else getattr(info, "default_samplerate", None)
+        if isinstance(rate, (int, float)) and rate > 0:
+            return int(round(rate))
+    except Exception:
+        pass
+    return SAMPLE_RATE
+
+
 from hermes_constants import is_termux as _is_termux_environment
 
 
@@ -521,6 +537,7 @@ class AudioRecorder:
         self._frames: List[Any] = []
         self._recording = False
         self._start_time: float = 0.0
+        self._sample_rate: int = SAMPLE_RATE
         # Silence detection state
         self._has_spoken = False
         self._speech_start: float = 0.0  # When speech attempt began
@@ -693,7 +710,7 @@ class AudioRecorder:
         stream = None
         try:
             stream = sd.InputStream(
-                samplerate=SAMPLE_RATE,
+                samplerate=self._sample_rate,
                 channels=CHANNELS,
                 dtype=DTYPE,
                 callback=_callback,
@@ -727,7 +744,7 @@ class AudioRecorder:
         or if a recording is already in progress.
         """
         try:
-            _import_audio()
+            sd, _ = _import_audio()
         except (ImportError, OSError) as e:
             raise RuntimeError(
                 "Voice mode requires sounddevice and numpy.\n"
@@ -749,13 +766,13 @@ class AudioRecorder:
             self._peak_rms = 0
             self._current_rms = 0
             self._on_silence_stop = on_silence_stop
-
         # Ensure the persistent stream is alive (no-op after first call).
+        self._sample_rate = _default_input_samplerate(sd)
         self._ensure_stream()
 
         with self._lock:
             self._recording = True
-        logger.info("Voice recording started (rate=%d, channels=%d)", SAMPLE_RATE, CHANNELS)
+        logger.info("Voice recording started (rate=%d, channels=%d)", self._sample_rate, CHANNELS)
 
     def _close_stream_with_timeout(self, timeout: float = 3.0) -> None:
         """Close the audio stream with a timeout to prevent CoreAudio hangs."""
@@ -810,7 +827,7 @@ class AudioRecorder:
             logger.info("Voice recording stopped (%.1fs, %d samples)", elapsed, len(audio_data))
 
             # Skip very short recordings (< 0.3s of audio)
-            min_samples = int(SAMPLE_RATE * 0.3)
+            min_samples = int(self._sample_rate * 0.3)
             if len(audio_data) < min_samples:
                 logger.debug("Recording too short (%d samples), discarding", len(audio_data))
                 return None
@@ -822,7 +839,7 @@ class AudioRecorder:
                             self._peak_rms, SILENCE_RMS_THRESHOLD)
                 return None
 
-            return self._write_wav(audio_data)
+            return self._write_wav(audio_data, sample_rate=self._sample_rate)
 
     def cancel(self) -> None:
         """Stop recording and discard all captured audio.
@@ -849,7 +866,7 @@ class AudioRecorder:
     # -- private helpers -----------------------------------------------------
 
     @staticmethod
-    def _write_wav(audio_data) -> str:
+    def _write_wav(audio_data, *, sample_rate: int = SAMPLE_RATE) -> str:
         """Write numpy int16 audio data to a WAV file.
 
         Returns the file path.
@@ -861,7 +878,7 @@ class AudioRecorder:
         with wave.open(wav_path, "wb") as wf:
             wf.setnchannels(CHANNELS)
             wf.setsampwidth(SAMPLE_WIDTH)
-            wf.setframerate(SAMPLE_RATE)
+            wf.setframerate(sample_rate)
             wf.writeframes(audio_data.tobytes())
 
         file_size = os.path.getsize(wav_path)

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -18,6 +18,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 import tempfile
 import threading
 import time
@@ -122,6 +123,19 @@ from hermes_constants import is_termux as _is_termux_environment
 def _voice_capture_install_hint() -> str:
     if _is_termux_environment():
         return "pkg install python-numpy portaudio && python -m pip install sounddevice"
+    # If we're running inside a venv (e.g. the bundled Hermes venv at
+    # ~/.hermes/profiles/<name>/hermes-agent/venv/), `pip install` on the
+    # user's PATH won't reach the right site-packages — the bare hint sends
+    # them off to whichever Python their shell resolves first, which on macOS
+    # is often a system Python under Rosetta with a totally separate wheel
+    # index. Point them at the actual interpreter pip is sitting next to.
+    try:
+        if sys.prefix != getattr(sys, "base_prefix", sys.prefix):
+            pip_in_venv = Path(sys.prefix) / "bin" / "pip"
+            if pip_in_venv.exists():
+                return f"{pip_in_venv} install sounddevice numpy"
+    except Exception:
+        pass
     return "pip install sounddevice numpy"
 
 

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1338,11 +1338,10 @@ def stop_playback() -> None:
 def _is_wsl() -> bool:
     """True when running inside Windows Subsystem for Linux."""
     try:
-        with open("/proc/version", "r") as f:
+        with open("/proc/version", "r", encoding="utf-8", errors="replace") as f:
             return "microsoft" in f.read().lower()
     except Exception:
         return False
-    return False
 
 
 def _is_wsl2_env() -> bool:

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -42,6 +42,55 @@ def _import_audio():
     return sd, np
 
 
+def _import_numpy():
+    """Lazy-import numpy only (no sounddevice).  Returns the module.
+
+    Used where we need to synthesize/convert audio samples but must NOT
+    import sounddevice — see _sounddevice_output_allowed.
+    """
+    import numpy as np
+    return np
+
+
+def _sounddevice_output_allowed() -> bool:
+    """Whether sounddevice may be used for audio OUTPUT.
+
+    Returns False on macOS: importing/initializing sounddevice
+    (PortAudio/CoreAudio) for output triggers a kTCCServiceMediaLibrary
+    permission prompt, even though playback needs no media-library access.
+    On macOS all output is routed through ``afplay`` instead. This does NOT
+    affect audio *input* (recording), which legitimately needs microphone
+    permission. See PR #62601 / #13291.
+    """
+    return platform.system() != "Darwin"
+
+
+def _play_int16_via_tempfile(audio, sample_rate: int) -> None:
+    """Write int16 mono PCM to a temp WAV and play it via play_audio_file.
+
+    Used on macOS so tone/beep output goes through ``afplay`` instead of
+    sounddevice (avoids the TCC media-library prompt).
+    """
+    tmp_path = None
+    try:
+        tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        tmp_path = tmp.name
+        with wave.open(tmp, "wb") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)  # 16-bit
+            wf.setframerate(sample_rate)
+            wf.writeframes(audio.tobytes())
+        play_audio_file(tmp_path)
+    except Exception as e:
+        logger.debug("Tone tempfile playback failed: %s", e)
+    finally:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+
 def _audio_available() -> bool:
     """Return True if audio libraries can be imported."""
     try:
@@ -419,9 +468,11 @@ def play_beep(frequency: int = 880, duration: float = 0.12, count: int = 1) -> N
         duration: Duration of each beep in seconds.
         count: Number of beeps to play (with short gap between).
     """
+    # Synthesize the tone with numpy only (no sounddevice import yet, so the
+    # macOS TCC prompt is not triggered on the synthesis step).
     try:
-        sd, np = _import_audio()
-    except (ImportError, OSError):
+        np = _import_numpy()
+    except ImportError:
         return
     try:
         gap = 0.06  # seconds between beeps
@@ -442,6 +493,16 @@ def play_beep(frequency: int = 880, duration: float = 0.12, count: int = 1) -> N
                 parts.append(np.zeros(samples_per_gap, dtype=np.int16))
 
         audio = np.concatenate(parts)
+
+        # On macOS, route the tone through afplay instead of sounddevice.
+        if not _sounddevice_output_allowed():
+            _play_int16_via_tempfile(audio, SAMPLE_RATE)
+            return
+
+        try:
+            sd, _ = _import_audio()
+        except (ImportError, OSError):
+            return
         sd.play(audio, samplerate=SAMPLE_RATE)
         # sd.wait() calls Event.wait() without timeout — hangs forever if the
         # audio device stalls.  Poll with a 2s ceiling and force-stop.
@@ -1303,10 +1364,11 @@ def play_audio_file(file_path: str) -> bool:
         logger.warning("Audio file not found: %s", file_path)
         return False
 
-    # On macOS, skip sounddevice entirely — PortAudio/CoreAudio init triggers
-    # a kTCCServiceMediaLibrary permission prompt even though we don't need it.
-    # afplay handles all formats natively without touching the media stack.
-    if file_path.endswith(".wav") and platform.system() != "Darwin":
+    # Skip sounddevice for output where it is not allowed (macOS): PortAudio/
+    # CoreAudio init triggers a kTCCServiceMediaLibrary permission prompt even
+    # though playback needs no media-library access. afplay (added to the
+    # system-player list below) handles all formats natively instead.
+    if file_path.endswith(".wav") and _sounddevice_output_allowed():
         try:
             sd, np = _import_audio()
             with wave.open(file_path, "rb") as wf:

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1175,6 +1175,16 @@ def stop_playback() -> None:
         pass
 
 
+def _is_wsl() -> bool:
+    """True when running inside Windows Subsystem for Linux."""
+    try:
+        with open("/proc/version", "r") as f:
+            return "microsoft" in f.read().lower()
+    except Exception:
+        return False
+    return False
+
+
 def play_audio_file(file_path: str) -> bool:
     """Play an audio file through the default output device.
 
@@ -1203,7 +1213,27 @@ def play_audio_file(file_path: str) -> bool:
                 audio_data = np.frombuffer(frames, dtype=np.int16)
                 sample_rate = wf.getframerate()
 
-            sd.play(audio_data, samplerate=sample_rate)
+            # WSLg RDP audio needs a warmup to avoid crackling at the start.
+            # The RDP virtual-channel connection takes ~100 ms to stabilise,
+            # and small default blocksize exasperates timing jitter caused by
+            # systemd-timesyncd clock adjustments (microsoft/wslg#1257).
+            if _is_wsl():
+                silence_samples = int(0.1 * sample_rate)
+                fade_samples = int(0.1 * sample_rate)
+                fade = np.linspace(0.0, 1.0, fade_samples, dtype=np.float64)
+                audio_float = audio_data.astype(np.float64)
+                audio_float[:fade_samples] *= fade
+                tail = np.zeros(int(0.05 * sample_rate), dtype=np.int16)
+                audio_data = np.concatenate([
+                    np.zeros(silence_samples, dtype=np.int16),
+                    audio_float.astype(np.int16),
+                    tail,
+                ])
+                blocksize = 4096
+            else:
+                blocksize = 0  # default (auto)
+
+            sd.play(audio_data, samplerate=sample_rate, blocksize=blocksize)
             # sd.wait() calls Event.wait() without timeout — hangs forever if
             # the audio device stalls.  Poll with a ceiling and force-stop.
             duration_secs = len(audio_data) / sample_rate

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1303,8 +1303,10 @@ def play_audio_file(file_path: str) -> bool:
         logger.warning("Audio file not found: %s", file_path)
         return False
 
-    # Try sounddevice for WAV files
-    if file_path.endswith(".wav"):
+    # On macOS, skip sounddevice entirely — PortAudio/CoreAudio init triggers
+    # a kTCCServiceMediaLibrary permission prompt even though we don't need it.
+    # afplay handles all formats natively without touching the media stack.
+    if file_path.endswith(".wav") and platform.system() != "Darwin":
         try:
             sd, np = _import_audio()
             with wave.open(file_path, "rb") as wf:

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -14,6 +14,7 @@ import math
 import os
 import platform
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -209,13 +210,28 @@ def detect_audio_environment() -> dict:
 
     # WSL detection — a reachable sound server makes audio work in WSL.
     # Honor any forwarding (PulseAudio bridge OR a forwarded PipeWire/Pulse
-    # socket), mirroring the SSH and container blocks above. Only block when
-    # no forwarding is configured.
+    # socket), mirroring the SSH and container blocks above. When no
+    # forwarding is configured, only hard-block if the WSL2 PowerShell TTS
+    # fallback (Media.SoundPlayer via powershell.exe, see play_audio_file)
+    # isn't available either. The PowerShell path only covers OUTPUT (TTS
+    # playback) -- microphone recording genuinely still needs the
+    # PulseAudio bridge -- so when it's the only thing available we
+    # downgrade to a notice (keeps the same recording guidance visible,
+    # but doesn't block /voice on for TTS-only usage).
     try:
         with open('/proc/version', 'r', encoding="utf-8") as f:
             if 'microsoft' in f.read().lower():
                 if has_forwarded_audio:
                     notices.append("Running in WSL with a reachable PulseAudio/PipeWire sound server")
+                elif _wsl_powershell_tts_available():
+                    notices.append(
+                        "Running in WSL without a PulseAudio bridge -- TTS playback "
+                        "will use the PowerShell/Media.SoundPlayer fallback. "
+                        "Voice INPUT (recording) still requires a PulseAudio bridge:\n"
+                        "  1. Set PULSE_SERVER=unix:/mnt/wslg/PulseServer\n"
+                        "  2. Create ~/.asoundrc pointing ALSA at PulseAudio\n"
+                        "  3. Verify with: arecord -d 3 /tmp/test.wav && aplay /tmp/test.wav"
+                    )
                 else:
                     warnings.append(
                         "Running in WSL -- audio requires a forwarded sound server.\n"
@@ -1185,6 +1201,36 @@ def _is_wsl() -> bool:
     return False
 
 
+def _is_wsl2_env() -> bool:
+    """Return True when running inside WSL2 (Windows Subsystem for Linux 2).
+
+    Reads /proc/version and checks for the Microsoft kernel signature.
+    Returns False on any error (non-WSL Linux, Docker, SSH, etc.).
+    Extracted as a module-level function so tests can patch it directly
+    without fighting builtins.open patching complexity.
+    """
+    try:
+        with open("/proc/version", encoding="utf-8", errors="replace") as _fv:
+            return "microsoft" in _fv.read().lower()
+    except OSError:
+        return False
+
+
+def _wsl_powershell_tts_available() -> bool:
+    """Return True when the WSL2 PowerShell TTS playback fallback can be used.
+
+    This only covers OUTPUT (TTS playback via Media.SoundPlayer on the
+    Windows host) -- it does NOT make microphone recording work. A caller
+    using this to relax the audio-environment gate must still surface the
+    existing PulseAudio-bridge guidance for recording/STT.
+    """
+    return bool(
+        _is_wsl2_env()
+        and shutil.which("powershell.exe")
+        and shutil.which("ffmpeg")
+    )
+
+
 def play_audio_file(file_path: str) -> bool:
     """Play an audio file through the default output device.
 
@@ -1253,6 +1299,60 @@ def play_audio_file(file_path: str) -> bool:
 
     if system == "Darwin":
         players.append(["afplay", file_path])
+
+    # WSL2 PowerShell fallback: when running in WSL without a PulseAudio
+    # bridge, ffplay and aplay have no audio device. If powershell.exe and
+    # ffmpeg are available, convert the audio to a uniquely-named WAV in the
+    # Windows %TEMP% directory and play it via Media.SoundPlayer -- which
+    # always has a working audio device on the Windows host (#17608).
+    # A unique suffix prevents concurrent Hermes TTS calls from colliding on
+    # the same filename. The WAV is deleted in the shell pipeline
+    # unconditionally (success or failure), and the ORIGINAL ffmpeg/
+    # powershell exit status is preserved past that cleanup so the player
+    # loop below can correctly fall through to ffplay/aplay on failure.
+    if system == "Linux" and shutil.which("powershell.exe") and shutil.which("ffmpeg"):
+        if _is_wsl2_env():
+            try:
+                import uuid
+                _win_tmp_raw = subprocess.check_output(
+                    ["cmd.exe", "/c", "echo %TEMP%"],
+                    stderr=subprocess.DEVNULL, timeout=3,
+                ).decode(errors="replace").strip()
+                _win_tmp_wsl = subprocess.check_output(
+                    ["wslpath", "-u", _win_tmp_raw],
+                    stderr=subprocess.DEVNULL, timeout=3,
+                ).decode(errors="replace").strip()
+                if _win_tmp_wsl:
+                    # Unique suffix prevents concurrent TTS playback collision.
+                    _unique = uuid.uuid4().hex[:8]
+                    _wsl_wav = os.path.join(_win_tmp_wsl, f"hermes-tts-{_unique}.wav")
+                    _win_wav = subprocess.check_output(
+                        ["wslpath", "-w", _wsl_wav],
+                        stderr=subprocess.DEVNULL, timeout=3,
+                    ).decode(errors="replace").strip()
+                    if _win_wav:
+                        _win_wav_safe = _win_wav.replace("'", "''")
+                        _ps_script = (
+                            f"(New-Object Media.SoundPlayer '{_win_wav_safe}').PlaySync()"
+                        )
+                        _ps_cmd = " && ".join([
+                            shlex.join(["ffmpeg", "-i", file_path, "-f", "wav",
+                                        _wsl_wav, "-loglevel", "quiet", "-y"]),
+                            shlex.join(["powershell.exe", "-NoProfile", "-Command",
+                                        _ps_script]),
+                        ])
+                        _cleanup = shlex.join(["rm", "-f", _wsl_wav])
+                        # Capture the (ffmpeg && powershell) exit status into
+                        # $rc BEFORE cleanup runs, then exit with that status
+                        # instead of rm -f's (rm -f always exits 0, which
+                        # would otherwise mask a conversion/playback failure
+                        # and prevent falling through to the next player).
+                        _full_cmd = f"( {_ps_cmd} ); rc=$?; {_cleanup}; exit $rc"
+                        # Use full path so the which(cmd[0]) check in the player loop passes.
+                        players.insert(0, ["/bin/sh", "-c", _full_cmd])
+            except Exception:
+                pass  # WSL path resolution failed; fall through to ffplay/aplay
+
     players.append(["ffplay", "-nodisp", "-autoexit", "-loglevel", "quiet", file_path])
     if system == "Linux":
         players.append(["aplay", "-q", file_path])
@@ -1265,9 +1365,15 @@ def play_audio_file(file_path: str) -> bool:
                 with _playback_lock:
                     _active_playback = proc
                 proc.wait(timeout=300)
+                rc = proc.returncode
                 with _playback_lock:
                     _active_playback = None
-                return True
+                if rc == 0:
+                    return True
+                # Non-zero exit: player failed (e.g. WSL ffplay/aplay with no
+                # audio device, or the PowerShell fallback's ffmpeg/playback
+                # step failing). Fall through to the next player in the list.
+                logger.debug("System player %s exited with code %d, trying next", cmd[0], rc)
             except subprocess.TimeoutExpired:
                 logger.warning("System player %s timed out, killing process", cmd[0])
                 proc.kill()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -17735,6 +17735,16 @@ def _(rid, params: dict) -> dict:
                 if isinstance(duration, (int, float)) and not isinstance(duration, bool)
                 else 3.0
             )
+            # voice.max_recording_seconds — hard cap on a single recording's
+            # length. Same guard as the silence params: non-numeric / bool /
+            # missing falls back to the documented 120 default, while an
+            # explicit numeric value <= 0 disables the cap (0.0).
+            max_rec = voice_cfg.get("max_recording_seconds")
+            safe_max_rec = (
+                (max_rec if max_rec > 0 else 0.0)
+                if isinstance(max_rec, (int, float)) and not isinstance(max_rec, bool)
+                else 120.0
+            )
             started = start_continuous(
                 on_transcript=lambda t: _voice_emit("voice.transcript", {"text": t}),
                 on_status=lambda s: _voice_emit("voice.status", {"state": s}),
@@ -17744,6 +17754,7 @@ def _(rid, params: dict) -> dict:
                 silence_threshold=safe_threshold,
                 silence_duration=safe_duration,
                 auto_restart=False,
+                max_recording_seconds=safe_max_rec,
             )
             if started is False:
                 return _ok(rid, {"status": "busy"})

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -282,7 +282,7 @@ For Docker sandboxes, you can also enable the **egress credential-injection prox
 # From the Hermes install directory (the curl installer placed it at
 # ~/.hermes/hermes-agent on Linux/macOS or %LOCALAPPDATA%\hermes\hermes-agent on Windows):
 cd ~/.hermes/hermes-agent
-uv pip install -e ".[voice]"
+uv pip install --python ./venv/bin/python -e ".[voice]"
 # Includes faster-whisper for free local speech-to-text
 ```
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1755,6 +1755,7 @@ voice:
   max_recording_seconds: 120    # Hard stop for long recordings
   auto_tts: false               # Enable spoken replies automatically when /voice on
   beep_enabled: true            # Play record start/stop beeps in CLI voice mode
+  beep_volume: 0.3              # Beep amplitude (0.0-1.0); raise it on quiet systems / headphones
   silence_threshold: 200        # RMS threshold for speech detection
   silence_duration: 3.0         # Seconds of silence before auto-stop
 ```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
@@ -258,7 +258,7 @@ hermes config set terminal.backend ssh       # 远程服务器
 # 在 Hermes 安装目录下运行（curl 安装器在 Linux/macOS 上将其放置于
 # ~/.hermes/hermes-agent，在 Windows 上为 %LOCALAPPDATA%\hermes\hermes-agent）：
 cd ~/.hermes/hermes-agent
-uv pip install -e ".[voice]"
+uv pip install --python ./venv/bin/python -e ".[voice]"
 # 包含 faster-whisper，用于免费的本地语音转文字
 ```
 


### PR DESCRIPTION
# Consolidated salvage: 15 CLI/TUI voice-mode UX & environment fixes

One consolidated salvage branch for the Cluster-D voice CLI/TUI backlog. Each fix is its own commit with original contributor authorship preserved (cherry-picked onto current main, post-#73106 `voice.stop_phrases` merge — all conflicting regions re-merged against the stop-phrase / barge-in / `_voice_restart_recording_async` code that landed since these PRs were cut).

## What's included (per-contributor commits)

| Fix | Source PR | Author | Closes |
|---|---|---|---|
| Record hotkey disarms continuous mode during STT/agent run | #67550 | @kyssta-exe | #67545; dupe #67573 (@webtecnica, 67 min later) |
| Restart race after 3 no-speech cycles (return-in-finally) | #52004 | @brunopirz (co-credit @liuhao1024, earliest via #21100) | #21088; stale #21100 #21261 #23709 |
| `[Voice input]` prefix only for actually-transcribed messages (`_VoiceInputMessage` sentinel) | #65961 (re-cut — original diff had the class inside `__init__`'s docstring) | @webtecnica (earliest route-by-origin: #11744 @KeroZelvin) | #65827; #65961 #11744 |
| `voice.max_recording_seconds` actually enforced (CLI + wrapper + TUI gateway) | #34522 (2 commits) | @Solitud1nem | — |
| Auto-play audio from agent `text_to_speech` tool results in CLI voice mode | #43131 (2 commits) | @valda (parallel work: #38833 @kharitonov-ivan, issue author) | #38831; #38833 |
| Beep volume configurable (`voice.beep_volume`) | #56116 | @Kewe63 | #55908 |
| Capture at input device's native sample rate (devices without 16 kHz support) | #61463 | @bricelb | — |
| WSL: honor `PIPEWIRE_REMOTE` forwarding in detection | #37346 | @Solitud1nem | — |
| WSL: audio warmup eliminates RDP crackling | #38896 | @kharitonov-ivan | #38893 |
| WSL2: PowerShell/Media.SoundPlayer TTS playback fallback (no Pulse bridge → TTS still works; gate downgrades to notice) | #68604 | @ygd58 | #17573 |
| Termux:API detection probe ladder (`pm` → `cmd package` → trust binary) | #31028 (2 commits) | @xxxigm | #31015; dupe #31029 |
| macOS: one no-sounddevice-for-output policy (WAV, beeps, streaming TTS) — avoids kTCCServiceMediaLibrary prompt | #62601 (2 commits) | @simonmmafs (earliest macOS crash work: #13291 @ChuanQiao1128) | #13291 |
| Voice pip hint points at the venv's pip, not system Python | #68307 | @RedClaus | — |
| Docs: voice extra install command targets the installer venv | #44367 | @liuhao1024 | #44364 |
| Surface local STT model preparation ("first use may download…") | #65841 | @locker95 | #8098 |

## In-house micro-fixes (fresh commit)

- **#49883** — `voice.beep_enabled` quoted as `"false"`/`"off"` in YAML kept beeps on (`bool("false") is True`). Both gates (cli.py, hermes_cli/voice.py) now route through `utils.is_truthy_value`.
- **#18432** — `AudioRecorder.start()` collapsed `OSError` (PortAudio shared library missing) into the `pip install sounddevice numpy` hint, which pip can't fix. Now mirrors `detect_audio_environment`'s system-package hint (libportaudio2 / brew portaudio / Termux `pkg install portaudio`).

## Rebase notes (post-#73106)

- #52004's flag pattern was re-merged onto main's `_voice_restart_recording_async()` helper (the PR predates that refactor).
- #68604's WSL gate was merged WITH #37346: `has_forwarded_audio` (Pulse **or** PipeWire) short-circuits first, then the PowerShell TTS-only fallback downgrades the hard block to a notice.
- #62601's follow-up landed with main's chunked-streamer path in `stream_tts_to_speaker` — Darwin skips the `OutputStream` so playback falls through to tempfile/afplay.
- #65961 was re-cut cleanly (author credited via `--author`): sentinel class at module level, wrap at both transcript-put sites (PTT/continuous + barge-in), unwrap in `process_loop`, `voice_input=` threaded through `chat()`.
- Salvaged tests adapted to current main (SSH-env clearing in the WSL gate tests, `returncode` on fake Popen procs, streamer stub for the macOS streaming test, sentinel unwrap in integration tests).

## Verification

- `pytest -o addopts="" -q` on the full voice surface (real venv): **792 passed** — `tests/tools/test_voice_mode.py`, `test_voice_cli_integration.py`, `test_voice_stop_phrase.py`, `test_termux_api_detection.py`, `test_voice_wsl_pipewire.py`, `test_tts_macos_output.py`, `tests/hermes_cli/test_voice_wrapper.py`, `tests/test_voice_max_recording_seconds.py`, `tests/test_tui_gateway_server.py`
- Sabotage check: reverting the `_VoiceInputMessage` wrap makes `test_successful_transcription_queues_input` fail (then restored).
- `ruff check` clean on all touched files; stale-base gate: merge-base == origin/main (0 behind), diff shows only intended files.
- Contributor mapping files added for all non-auto-resolving emails (`contributors/emails/`), committed before first push.

## Post-merge actions

- Close as merged-via-salvage: #67550 #52004 #65961 #34522 #43131 #56116 #61463 #37346 #38896 #68604 #31028 #62601 #68307 #44367 #65841
- Close fixed issues: #67545 #21088 #65827 #38831 #55908 #31015 #17573 #38893 #44364 #8098 #49883 #18432
- Close dupes/stale with credit: #67573 (dupe of #67550), #21100 #21261 #23709 (stale return-in-finally trio; #21100 co-credited), #11744 (earliest sentinel-route attempt, credited), #38833 (parallel auto-play work, credited), #31029 (dupe of #31028), #13291 (earliest macOS crash work, credited)


## Infographic

![fix(voice): CLI/TUI voice mode UX and environment fixes (15 items)](https://v3b.fal.media/files/b/0aa416e4/jNkN0t2OkvHAEXdq6VC14_XFkIJy7m.png)
