### PR TITLE
fix(runtime): keep turns alive through network/TTFB outages

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -39,6 +39,7 @@ from agent.model_metadata import (
     is_local_endpoint,
     query_ollama_num_ctx,
 )
+from agent.network_outage_retry import NetworkOutageRetryPolicy
 from agent.process_bootstrap import _install_safe_stdio
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.think_scrubber import StreamingThinkScrubber
@@ -1779,6 +1780,15 @@ def init_agent(
     except (TypeError, ValueError):
         _api_retries = 3
     agent._api_max_retries = _api_retries
+
+    # Optional second-tier recovery for provider transport outages and explicit
+    # no-byte/no-event provider response watchdog timeouts.
+    # The ordinary API retry budget remains bounded; when this policy is
+    # enabled, status-less connection/stall failures enter a slow fixed-cadence
+    # retry loop instead of terminating the active turn.
+    agent._network_outage_retry_policy = NetworkOutageRetryPolicy.from_config(
+        _agent_section.get("network_outage_retry", {})
+    )
 
     # Initialize context compressor for automatic context management
     # Compresses conversation when approaching model's context limit

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -82,6 +82,12 @@ from agent.retry_utils import (
     jittered_backoff,
     zai_coding_overload_retry_ceiling,
 )
+from agent.network_outage_retry import (
+    NetworkOutageRetryPolicy,
+    is_provider_network_outage,
+    outage_retry_wait_seconds,
+    wait_for_outage_retry,
+)
 from agent.trajectory import has_incomplete_scratchpad
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from hermes_constants import PARTIAL_STREAM_STUB_ID
@@ -1978,6 +1984,13 @@ def run_conversation(
         api_start_time = time.time()
         retry_count = 0
         max_retries = agent._api_max_retries
+        _network_outage_policy = getattr(
+            agent,
+            "_network_outage_retry_policy",
+            NetworkOutageRetryPolicy(),
+        )
+        _network_outage_started_at = None
+        _network_outage_cycle = 0
         _retry = TurnRetryState()
 
         finish_reason = "stop"
@@ -5092,6 +5105,82 @@ def run_conversation(
                         compression_attempts = 0
                         _retry.primary_recovery_attempted = False
                         continue
+
+                    # Slow outage/stall mode: the bounded quick retries, one client
+                    # rebuild, and configured fallback chain have all failed.
+                    # For a genuine status-less provider transport failure or
+                    # an explicitly classified no-byte/no-event provider stall,
+                    # keep this turn active and retry at a fixed cadence rather
+                    # than returning a terminal error.  This is opt-in because
+                    # unattended deployments may prefer a finite task budget.
+                    if (
+                        _network_outage_policy.enabled
+                        and is_provider_network_outage(api_error, classified)
+                    ):
+                        _outage_now = time.monotonic()
+                        if _network_outage_started_at is None:
+                            _network_outage_started_at = _outage_now
+                        _outage_elapsed = max(
+                            0.0, _outage_now - _network_outage_started_at
+                        )
+                        _outage_wait = outage_retry_wait_seconds(
+                            _network_outage_policy,
+                            elapsed_seconds=_outage_elapsed,
+                        )
+                        if _outage_wait is not None:
+                            _network_outage_cycle += 1
+                            _wait_display = int(round(_outage_wait))
+                            agent._emit_status(
+                                "🌐 Provider network/response outage detected — task remains "
+                                f"active; retrying in {_wait_display}s "
+                                f"(outage cycle {_network_outage_cycle})."
+                            )
+                            logger.warning(
+                                "%sProvider transport/response outage; keeping turn active "
+                                "and retrying in %.1fs (cycle=%s elapsed=%.1fs "
+                                "provider=%s model=%s)",
+                                agent.log_prefix,
+                                _outage_wait,
+                                _network_outage_cycle,
+                                _outage_elapsed,
+                                _provider,
+                                _model,
+                            )
+                            agent._touch_activity(
+                                f"provider network outage retry scheduled "
+                                f"(cycle {_network_outage_cycle})"
+                            )
+                            if not wait_for_outage_retry(
+                                agent,
+                                _outage_wait,
+                                cycle=_network_outage_cycle,
+                            ):
+                                _interrupt_text = (
+                                    "Operation interrupted during provider network "
+                                    "outage retry wait."
+                                )
+                                close_interrupted_tool_sequence(
+                                    messages, _interrupt_text
+                                )
+                                agent._persist_session(
+                                    messages, conversation_history
+                                )
+                                agent.clear_interrupt()
+                                return {
+                                    "final_response": _interrupt_text,
+                                    "messages": messages,
+                                    "api_calls": api_call_count,
+                                    "completed": False,
+                                    "interrupted": True,
+                                }
+                            # Start a fresh quick-retry/rebuild cycle.  The
+                            # original user message and tool sequence remain in
+                            # this same active turn.
+                            retry_count = 0
+                            _retry.primary_recovery_attempted = False
+                            _retry.has_retried_429 = False
+                            continue
+
                     # Terminal — flush buffered retry/fallback trace.
                     agent._flush_status_buffer()
                     _final_summary = agent._summarize_api_error(api_error)

--- a/agent/network_outage_retry.py
+++ b/agent/network_outage_retry.py
@@ -1,0 +1,147 @@
+"""Persistent retry policy for provider transport outages and stalls.
+
+The ordinary API retry loop is intentionally bounded.  This module adds an
+opt-in second tier for genuine status-less transport failures and explicit
+provider-response watchdog timeouts: after the quick retries and client
+rebuild/fallback paths are exhausted, keep the active turn alive and retry at
+a slow fixed cadence.
+
+The predicate is deliberately narrow.  HTTP responses, provider overload/rate
+limits, auth/billing errors, deterministic TLS certificate failures, context
+errors must never enter an unbounded outage loop.  Explicit no-byte/no-event
+provider watchdog timeouts are included because they are indistinguishable to
+the caller from a transient provider-path stall and the operator has opted in
+to keeping the task alive.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+from agent.error_classifier import ClassifiedError, FailoverReason
+
+
+_PROVIDER_STALL_WATCHDOG_PATTERNS = (
+    "codex stream produced no bytes within",
+    "codex stream produced no sse events for",
+    "non-streaming api call timed out after",
+)
+
+
+@dataclass(frozen=True)
+class NetworkOutageRetryPolicy:
+    """Configuration for slow provider-network outage retries.
+
+    ``max_wait_seconds == 0`` means no wall-clock limit.  Interrupts still
+    abort immediately, so an infinite outage policy never traps an operator.
+    """
+
+    enabled: bool = False
+    interval_seconds: float = 300.0
+    max_wait_seconds: float = 0.0
+
+    @classmethod
+    def from_config(cls, raw: Any) -> "NetworkOutageRetryPolicy":
+        if not isinstance(raw, Mapping):
+            raw = {}
+
+        enabled_raw = raw.get("enabled", False)
+        if isinstance(enabled_raw, str):
+            enabled = enabled_raw.strip().lower() in {"1", "true", "yes", "on"}
+        else:
+            enabled = bool(enabled_raw)
+
+        # ``sleep_seconds`` was used by an earlier local config shape.  Keep it
+        # as a compatibility alias so an enabled policy cannot silently fall
+        # back to a different cadence after an update.
+        interval_raw = raw.get("interval_seconds", raw.get("sleep_seconds", 300.0))
+        try:
+            interval = float(interval_raw)
+        except (TypeError, ValueError):
+            interval = 300.0
+        # Avoid a malformed config creating a hot retry loop.
+        interval = max(interval, 1.0)
+
+        try:
+            max_wait = float(raw.get("max_wait_seconds", 0.0))
+        except (TypeError, ValueError):
+            max_wait = 0.0
+        max_wait = max(max_wait, 0.0)
+
+        return cls(
+            enabled=enabled,
+            interval_seconds=interval,
+            max_wait_seconds=max_wait,
+        )
+
+
+def is_provider_network_outage(
+    error: Exception,
+    classified: ClassifiedError,
+) -> bool:
+    """Return True for an opted-in status-less transport/stall failure."""
+
+    # Any HTTP response means the network path reached a server. Server 5xx,
+    # overload, rate limit, auth, and billing keep their existing bounded paths.
+    if classified.status_code is not None:
+        return False
+    if getattr(error, "status_code", None) is not None:
+        return False
+    response = getattr(error, "response", None)
+    if getattr(response, "status_code", None) is not None:
+        return False
+
+    # Explicit provider response watchdogs are part of the opted-in policy.
+    # Keep them active even if a future classifier refinement stops labelling
+    # one of these exact no-byte/no-event failures as a generic timeout.
+    message = str(error).lower()
+    if any(pattern in message for pattern in _PROVIDER_STALL_WATCHDOG_PATTERNS):
+        return True
+
+    return classified.reason == FailoverReason.timeout and classified.retryable
+
+
+def outage_retry_wait_seconds(
+    policy: NetworkOutageRetryPolicy,
+    *,
+    elapsed_seconds: float,
+) -> Optional[float]:
+    """Return the next wait duration, or None when outage retry is exhausted."""
+
+    if not policy.enabled:
+        return None
+    if policy.max_wait_seconds <= 0:
+        return policy.interval_seconds
+
+    remaining = policy.max_wait_seconds - max(elapsed_seconds, 0.0)
+    if remaining <= 0:
+        return None
+    return min(policy.interval_seconds, remaining)
+
+
+def wait_for_outage_retry(agent: Any, seconds: float, *, cycle: int) -> bool:
+    """Sleep interruptibly while keeping gateway activity heartbeats alive.
+
+    Returns False when the operator interrupts the turn, otherwise True.
+    """
+
+    deadline = time.monotonic() + max(float(seconds), 0.0)
+    next_touch = time.monotonic() + 30.0
+    while True:
+        now = time.monotonic()
+        if now >= deadline:
+            return True
+        if getattr(agent, "_interrupt_requested", False):
+            return False
+        if now >= next_touch:
+            try:
+                agent._touch_activity(
+                    f"provider network outage retry wait (cycle {cycle}), "
+                    f"{max(0, int(deadline - now))}s remaining"
+                )
+            except Exception:
+                pass
+            next_touch = now + 30.0
+        time.sleep(min(0.2, max(0.0, deadline - now)))

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1258,6 +1258,7 @@ def load_gateway_config() -> GatewayConfig:
     """
     _home = get_hermes_home()
     gw_data: dict = {}
+    delivery_outage_retry: dict = {}
 
     # Legacy fallback: gateway.json provides the base layer.
     # config.yaml keys always win when both specify the same setting.
@@ -1288,6 +1289,15 @@ def load_gateway_config() -> GatewayConfig:
             # the messaging gateway. Fail-open via the shared helper.
             from hermes_cli import managed_scope
             yaml_cfg = managed_scope.apply_managed_overlay(yaml_cfg)
+
+            # The same user-facing policy protects both model-provider calls
+            # and safe pre-send platform delivery failures. Platform-local
+            # ``extra.network_outage_retry`` remains an explicit override.
+            agent_section = yaml_cfg.get("agent")
+            if isinstance(agent_section, dict):
+                outage_section = agent_section.get("network_outage_retry")
+                if isinstance(outage_section, dict):
+                    delivery_outage_retry = dict(outage_section)
 
             # Shared nested-fallback source: settings meant to be top-level
             # keys are also accepted when a user nests them under `gateway:`
@@ -1743,6 +1753,12 @@ def load_gateway_config() -> GatewayConfig:
 
     # Override with environment variables
     _apply_env_overrides(config)
+
+    if delivery_outage_retry:
+        for platform_config in config.platforms.values():
+            platform_config.extra.setdefault(
+                "network_outage_retry", dict(delivery_outage_retry)
+            )
     
     # --- Validate loaded values ---
     _validate_gateway_config(config)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4616,6 +4616,162 @@ class BasePlatformAdapter(ABC):
             return self
         return live_adapter
 
+    def _delivery_outage_retry_policy(self) -> dict[str, float | bool]:
+        """Return the opt-in long-retry policy for safe delivery outages."""
+        extra = getattr(self.config, "extra", None)
+        raw = extra.get("network_outage_retry", {}) if isinstance(extra, dict) else {}
+        if not isinstance(raw, dict):
+            raw = {}
+
+        enabled_raw = raw.get("enabled", False)
+        if isinstance(enabled_raw, str):
+            enabled = enabled_raw.strip().lower() in {"1", "true", "yes", "on"}
+        else:
+            enabled = bool(enabled_raw)
+
+        def _number(key: str, default: float) -> float:
+            try:
+                return float(raw.get(key, default))
+            except (TypeError, ValueError):
+                return default
+
+        sleep_raw = raw.get("sleep_seconds", raw.get("interval_seconds", 300.0))
+        try:
+            sleep_seconds = max(0.0, float(sleep_raw))
+        except (TypeError, ValueError):
+            sleep_seconds = 300.0
+
+        return {
+            "enabled": enabled,
+            "active_window_seconds": max(
+                1.0, _number("active_window_seconds", 180.0)
+            ),
+            "sleep_seconds": sleep_seconds,
+            "max_wait_seconds": max(0.0, _number("max_wait_seconds", 0.0)),
+        }
+
+    def _is_safe_delivery_outage(self, result: "SendResult") -> bool:
+        """Return True only when retrying cannot duplicate an accepted send."""
+        error = (result.error or "").lower()
+        if not result.retryable or self._is_timeout_error(error):
+            return False
+        if result.retry_after is not None:
+            return False
+        if (result.error_kind or "").lower() in {
+            "auth",
+            "bad_request",
+            "blocked",
+            "forbidden",
+            "not_found",
+            "permission",
+            "rate_limited",
+        }:
+            return False
+
+        # These failures happen before a platform can acknowledge/accept the
+        # outbound send. Deliberately exclude read/write timeouts and generic
+        # remote-protocol disconnects: the platform may already have received
+        # those requests, so replaying them could duplicate user-visible text.
+        return any(
+            marker in error
+            for marker in (
+                "send_path_degraded",
+                "connectionerror",
+                "connecterror",
+                "proxyerror",
+                "connection refused",
+                "network is unreachable",
+                "no route to host",
+                "name or service not known",
+                "temporary failure in name resolution",
+                "nodename nor servname provided",
+            )
+        )
+
+    async def _retry_safe_delivery_outage(
+        self,
+        *,
+        result: "SendResult",
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str],
+        metadata: Any,
+        base_delay: float,
+        started_at: float,
+        policy: dict[str, float | bool],
+    ) -> "SendResult":
+        """Keep a final/status delivery alive through a safe network outage."""
+        active_window = float(policy["active_window_seconds"])
+        sleep_seconds = float(policy["sleep_seconds"])
+        max_wait = float(policy["max_wait_seconds"])
+        window_started_at = started_at
+        attempt_in_window = 0
+        cycle = 1
+
+        while self._is_safe_delivery_outage(result):
+            now = time.monotonic()
+            elapsed = max(0.0, now - started_at)
+            if max_wait > 0 and elapsed >= max_wait:
+                logger.error(
+                    "[%s] Delivery outage retry budget exhausted after %.1fs: %s",
+                    self.name,
+                    elapsed,
+                    result.error or "unknown error",
+                )
+                return result
+
+            remaining_window = (window_started_at + active_window) - now
+            if remaining_window <= 0:
+                wait = sleep_seconds
+                if max_wait > 0:
+                    wait = min(wait, max(0.0, max_wait - elapsed))
+                    if wait <= 0:
+                        return result
+                logger.warning(
+                    "[%s] Delivery network outage persists; task response remains "
+                    "pending, sleeping %.1fs before retry cycle %d",
+                    self.name,
+                    wait,
+                    cycle + 1,
+                )
+                await asyncio.sleep(wait)
+                window_started_at = time.monotonic()
+                attempt_in_window = 0
+                cycle += 1
+                continue
+
+            delay = max(0.0, base_delay) * (2 ** min(attempt_in_window, 5))
+            delay += random.uniform(0, 1)
+            delay = min(delay, max(0.0, remaining_window))
+            if max_wait > 0:
+                delay = min(delay, max(0.0, max_wait - elapsed))
+            logger.warning(
+                "[%s] Delivery network outage detected — response remains pending; "
+                "retrying in %.1fs (cycle=%d attempt=%d)",
+                self.name,
+                delay,
+                cycle,
+                attempt_in_window + 1,
+            )
+            await asyncio.sleep(delay)
+            result = await self.send(
+                chat_id=chat_id,
+                content=content,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+            attempt_in_window += 1
+            if result.success:
+                logger.info(
+                    "[%s] Delivery succeeded after network outage (cycle=%d attempt=%d)",
+                    self.name,
+                    cycle,
+                    attempt_in_window,
+                )
+                return result
+
+        return result
+
     async def _send_with_retry(
         self,
         chat_id: str,
@@ -4634,6 +4790,7 @@ class BasePlatformAdapter(ABC):
         know to retry rather than waiting indefinitely.
         """
 
+        delivery_started_at = time.monotonic()
         result = await self.send(
             chat_id=chat_id,
             content=content,
@@ -4683,7 +4840,32 @@ class BasePlatformAdapter(ABC):
                 if not (result.retryable or self._is_retryable_error(error_str)):
                     break  # error switched to non-transient — fall through to plain-text fallback
             else:
-                # All retries exhausted (loop completed without break) — notify user
+                # All bounded retries were exhausted. For failures proven safe
+                # to replay (pre-send connectivity/path failures only), keep the
+                # response pending across active-window/cooldown cycles instead
+                # of dropping it. Ambiguous timeouts never enter this tier.
+                outage_policy = self._delivery_outage_retry_policy()
+                if outage_policy["enabled"] and self._is_safe_delivery_outage(result):
+                    result = await self._retry_safe_delivery_outage(
+                        result=result,
+                        chat_id=chat_id,
+                        content=content,
+                        reply_to=reply_to,
+                        metadata=metadata,
+                        base_delay=base_delay,
+                        started_at=delivery_started_at,
+                        policy=outage_policy,
+                    )
+                    if result.success:
+                        return result
+                    error_str = result.error or ""
+                    if self._is_safe_delivery_outage(result):
+                        # Finite max_wait_seconds exhausted. Do not attempt a
+                        # different payload: the path itself is still down.
+                        return result
+
+                # Policy disabled or error not safe for long retry — preserve
+                # the existing bounded failure-notice behavior.
                 logger.error("[%s] Failed to deliver response after %d retries: %s", self.name, max_retries, error_str)
                 notice = (
                     "\u26a0\ufe0f Message delivery failed after multiple attempts. "

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -983,6 +983,16 @@ DEFAULT_CONFIG = {
         # on flaky primaries; raise it if you prefer to tolerate longer
         # provider hiccups on a single provider.
         "api_max_retries": 3,
+        # Optional slow retry tier for genuine status-less provider transport
+        # outages and explicit no-byte/no-event provider watchdog timeouts,
+        # after normal quick retries/client rebuild/fallback paths are exhausted.
+        # Disabled by default for backwards compatibility.
+        # max_wait_seconds=0 means retry until success or operator interrupt.
+        "network_outage_retry": {
+            "enabled": False,
+            "interval_seconds": 300,
+            "max_wait_seconds": 0,
+        },
         "service_tier": "",
         # Tool-use enforcement: injects system prompt guidance that tells the
         # model to actually call tools instead of describing intended actions.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7808,7 +7808,17 @@ class SessionDB:
             content = self._decode_content(row["content"])
             if row["role"] in {"user", "assistant"} and isinstance(content, str):
                 content = sanitize_context(content).strip()
-            msg = {"role": row["role"], "content": content}
+            # Every row in this projection came from the durable store. Carry the
+            # same intrinsic marker used by AIAgent's append-only flush so a
+            # freshly loaded/adopted snapshot cannot be appended again if list
+            # identity or the separate conversation_history baseline is lost
+            # during an aborted compression attempt. The private underscore key
+            # is stripped by provider transports before the request leaves Hermes.
+            msg = {
+                "role": row["role"],
+                "content": content,
+                "_db_persisted": True,
+            }
             # api_content is the byte-fidelity sidecar: the exact string sent
             # to the API when it differed from the clean content. Returned
             # VERBATIM — no sanitize_context, no strip — because the replay

--- a/tests/gateway/test_platform_delivery_outage_retry.py
+++ b/tests/gateway/test_platform_delivery_outage_retry.py
@@ -1,0 +1,264 @@
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms import base as base_mod
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+
+class _RetryAdapter(BasePlatformAdapter):
+    def __init__(self, outcomes, *, outage_cfg=None):
+        super().__init__(
+            PlatformConfig(extra={"network_outage_retry": outage_cfg or {}}),
+            Platform.TELEGRAM,
+        )
+        self.outcomes = list(outcomes)
+        self.calls = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.calls.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        if self.outcomes:
+            return self.outcomes.pop(0)
+        return SendResult(success=True, message_id="ok")
+
+    async def get_chat_info(self, chat_id: str):
+        return {"name": str(chat_id), "type": "dm"}
+
+
+@pytest.mark.asyncio
+async def test_delivery_network_outage_retries_past_bounded_retry_budget(monkeypatch):
+    monkeypatch.setattr(base_mod.random, "uniform", lambda _a, _b: 0.0)
+
+    sleeps = []
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(base_mod.asyncio, "sleep", fake_sleep)
+
+    adapter = _RetryAdapter(
+        [
+            SendResult(success=False, error="ConnectionError: network down", retryable=True),
+            SendResult(success=False, error="ConnectionError: network down", retryable=True),
+            SendResult(success=False, error="ConnectionError: network down", retryable=True),
+            SendResult(success=True, message_id="delivered"),
+        ],
+        outage_cfg={
+            "enabled": True,
+            "active_window_seconds": 60,
+            "sleep_seconds": 300,
+        },
+    )
+
+    result = await adapter._send_with_retry("chat", "answer", max_retries=1, base_delay=0)
+
+    assert result.success is True
+    assert result.message_id == "delivered"
+    assert len(adapter.calls) == 4
+    assert sleeps == [0.0, 0.0, 0.0]
+
+
+@pytest.mark.asyncio
+async def test_delivery_network_outage_uses_active_window_then_sleep_cycle(monkeypatch):
+    monkeypatch.setattr(base_mod.random, "uniform", lambda _a, _b: 0.0)
+    clock = {"now": 0.0}
+    sleeps = []
+
+    def fake_monotonic():
+        return clock["now"]
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+        clock["now"] += seconds
+
+    monkeypatch.setattr(base_mod.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(base_mod.asyncio, "sleep", fake_sleep)
+
+    adapter = _RetryAdapter(
+        [
+            SendResult(success=False, error="ConnectionError: network down", retryable=True),
+            SendResult(success=False, error="ConnectionError: network down", retryable=True),
+            SendResult(success=False, error="ConnectionError: network down", retryable=True),
+            SendResult(success=True, message_id="delivered-after-sleep"),
+        ],
+        outage_cfg={
+            "enabled": True,
+            "active_window_seconds": 3,
+            "sleep_seconds": 5,
+        },
+    )
+
+    result = await adapter._send_with_retry("chat", "answer", max_retries=1, base_delay=2)
+
+    assert result.success is True
+    assert result.message_id == "delivered-after-sleep"
+    assert len(adapter.calls) == 4
+    assert sleeps == [2.0, 1.0, 5.0, 2.0]
+
+
+@pytest.mark.asyncio
+async def test_delivery_network_outage_honors_finite_max_wait(monkeypatch):
+    monkeypatch.setattr(base_mod.random, "uniform", lambda _a, _b: 0.0)
+    clock = {"now": 0.0}
+    sleeps = []
+
+    monkeypatch.setattr(base_mod.time, "monotonic", lambda: clock["now"])
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+        clock["now"] += seconds
+
+    monkeypatch.setattr(base_mod.asyncio, "sleep", fake_sleep)
+    adapter = _RetryAdapter(
+        [
+            SendResult(success=False, error="ConnectError: network down", retryable=True),
+            SendResult(success=False, error="ConnectError: network down", retryable=True),
+            SendResult(success=False, error="ConnectError: network down", retryable=True),
+        ],
+        outage_cfg={
+            "enabled": True,
+            "active_window_seconds": 10,
+            "sleep_seconds": 5,
+            "max_wait_seconds": 3,
+        },
+    )
+
+    result = await adapter._send_with_retry(
+        "chat", "answer", max_retries=0, base_delay=2
+    )
+
+    assert result.success is False
+    assert len(adapter.calls) == 3
+    assert sleeps == [2.0, 1.0]
+
+
+@pytest.mark.asyncio
+async def test_delivery_generic_timeout_does_not_retry_or_fallback(monkeypatch):
+    monkeypatch.setattr(base_mod.random, "uniform", lambda _a, _b: 0.0)
+
+    async def fail_if_sleep(_seconds):  # pragma: no cover - test fails if called
+        raise AssertionError("timeout path should not sleep/retry")
+
+    monkeypatch.setattr(base_mod.asyncio, "sleep", fail_if_sleep)
+    adapter = _RetryAdapter(
+        [SendResult(success=False, error="Timed out while sending", retryable=False)],
+        outage_cfg={"enabled": True, "active_window_seconds": 3, "sleep_seconds": 5},
+    )
+
+    result = await adapter._send_with_retry("chat", "answer", max_retries=5, base_delay=0)
+
+    assert result.success is False
+    assert result.error == "Timed out while sending"
+    assert len(adapter.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_delivery_ambiguous_disconnect_never_enters_long_retry(monkeypatch):
+    monkeypatch.setattr(base_mod.random, "uniform", lambda _a, _b: 0.0)
+    sleeps = []
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(base_mod.asyncio, "sleep", fake_sleep)
+    adapter = _RetryAdapter(
+        [
+            SendResult(
+                success=False,
+                error="RemoteProtocolError: server disconnected without response",
+                retryable=True,
+            ),
+            SendResult(
+                success=False,
+                error="RemoteProtocolError: server disconnected without response",
+                retryable=True,
+            ),
+            SendResult(success=False, error="notice path unavailable"),
+        ],
+        outage_cfg={"enabled": True, "active_window_seconds": 3, "sleep_seconds": 5},
+    )
+
+    result = await adapter._send_with_retry(
+        "chat", "answer", max_retries=1, base_delay=0
+    )
+
+    assert result.success is False
+    assert len(adapter.calls) == 3  # initial + bounded retry + one failure notice
+    assert sleeps == [0.0]
+
+
+@pytest.mark.asyncio
+async def test_delivery_rate_limit_does_not_enter_outage_retry(monkeypatch):
+    monkeypatch.setattr(base_mod.random, "uniform", lambda _a, _b: 0.0)
+
+    async def fail_if_sleep(_seconds):  # pragma: no cover - test fails if called
+        raise AssertionError("rate-limit path should not sleep/retry")
+
+    monkeypatch.setattr(base_mod.asyncio, "sleep", fail_if_sleep)
+    adapter = _RetryAdapter(
+        [
+            SendResult(
+                success=False,
+                error="Too Many Requests: retry after 30",
+                retryable=False,
+                error_kind="rate_limited",
+            ),
+            SendResult(
+                success=False,
+                error="Too Many Requests: retry after 30",
+                retryable=False,
+                error_kind="rate_limited",
+            ),
+        ],
+        outage_cfg={"enabled": True, "active_window_seconds": 3, "sleep_seconds": 5},
+    )
+
+    result = await adapter._send_with_retry("chat", "answer", max_retries=5, base_delay=0)
+
+    assert result.success is False
+    assert len(adapter.calls) == 2  # original + existing plain-text fallback only
+    assert adapter.calls[1]["content"].startswith("(Response formatting failed")
+
+
+def test_gateway_config_bridges_agent_outage_policy_to_platforms(
+    tmp_path, monkeypatch
+):
+    from gateway import config as config_mod
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(config_mod, "get_hermes_home", lambda: home)
+    (home / "config.yaml").write_text(
+        """
+agent:
+  network_outage_retry:
+    enabled: true
+    interval_seconds: 17
+    max_wait_seconds: 0
+platforms:
+  telegram:
+    enabled: true
+    token: 123456:test-token
+""".strip(),
+        encoding="utf-8",
+    )
+
+    config = config_mod.load_gateway_config()
+    policy = config.platforms[Platform.TELEGRAM].extra["network_outage_retry"]
+    assert policy == {
+        "enabled": True,
+        "interval_seconds": 17,
+        "max_wait_seconds": 0,
+    }

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -129,6 +129,39 @@ class TestFlushAfterCompression:
             assert len(rows) == 2
             assert [row["content"] for row in rows] == ["summary", "continuing..."]
 
+    def test_reloaded_durable_snapshot_is_intrinsically_persisted(self):
+        """A fresh DB snapshot must not be appended again if its baseline is lost.
+
+        Compression may replace the in-memory list with a newly loaded durable
+        snapshot before an auxiliary summary call fails. In that shape object
+        identity no longer matches ``conversation_history``; without an
+        intrinsic marker, the crash-resilience flush appends every durable row
+        again and doubles the session.
+        """
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            first_agent = self._make_agent(db)
+            first_agent._ensure_db_session()
+            original = [
+                {"role": "user", "content": "old question"},
+                {"role": "assistant", "content": "old answer"},
+            ]
+            first_agent._flush_messages_to_session_db(original, [])
+
+            reloaded = db.get_messages_as_conversation("original-session")
+            assert all(msg.get("_db_persisted") is True for msg in reloaded)
+
+            resumed_agent = self._make_agent(db)
+            resumed_agent._flush_messages_to_session_db(reloaded, None)
+
+            rows = db.get_messages("original-session")
+            assert [row["content"] for row in rows] == [
+                "old question",
+                "old answer",
+            ]
+
     def test_in_place_compression_rebaseline_prevents_duplicate_compacted_rows(self):
         """In-place compaction already persisted the compacted transcript.
 

--- a/tests/run_agent/test_network_outage_retry.py
+++ b/tests/run_agent/test_network_outage_retry.py
@@ -1,0 +1,110 @@
+"""Focused tests for persistent provider-network outage retries."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent.error_classifier import classify_api_error
+from agent.network_outage_retry import (
+    NetworkOutageRetryPolicy,
+    is_provider_network_outage,
+    outage_retry_wait_seconds,
+)
+
+
+class APIConnectionError(Exception):
+    """OpenAI-SDK-shaped status-less transport failure for tests."""
+
+
+class HTTPError(Exception):
+    def __init__(self, message: str, status_code: int):
+        super().__init__(message)
+        self.status_code = status_code
+        self.response = SimpleNamespace(status_code=status_code)
+
+
+def _classified(error: Exception):
+    return classify_api_error(
+        error,
+        provider="openai-codex",
+        model="gpt-5.6",
+        approx_tokens=10_000,
+        context_length=272_000,
+        num_messages=10,
+    )
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        APIConnectionError("Connection error."),
+        TimeoutError(
+            "Codex stream produced no bytes within 600s (TTFB threshold: 600s)"
+        ),
+        TimeoutError(
+            "Codex stream produced no SSE events for 300s after first byte"
+        ),
+        TimeoutError(
+            "Non-streaming API call timed out after 900s with no response"
+        ),
+    ],
+)
+def test_statusless_network_and_provider_stall_errors_enter_outage_mode(error):
+    assert is_provider_network_outage(error, _classified(error)) is True
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        HTTPError("Service temporarily unavailable", 503),
+        HTTPError("rate limited", 429),
+        HTTPError("unauthorized", 401),
+        RuntimeError("certificate verify failed"),
+        RuntimeError(
+            "Provider has been unresponsive (no response received) for 5 "
+            "consecutive stale attempts; aborting this call"
+        ),
+    ],
+)
+def test_non_network_failures_do_not_enter_outage_mode(error):
+    assert is_provider_network_outage(error, _classified(error)) is False
+
+
+def test_policy_defaults_disabled_and_clamps_bad_values():
+    policy = NetworkOutageRetryPolicy.from_config(
+        {
+            "enabled": "yes",
+            "interval_seconds": 0,
+            "max_wait_seconds": -10,
+        }
+    )
+    assert policy.enabled is True
+    assert policy.interval_seconds == 1.0
+    assert policy.max_wait_seconds == 0.0
+
+
+def test_policy_accepts_legacy_sleep_seconds_alias():
+    policy = NetworkOutageRetryPolicy.from_config(
+        {"enabled": True, "sleep_seconds": 17}
+    )
+    assert policy.interval_seconds == 17.0
+
+
+def test_unlimited_policy_retries_at_fixed_interval():
+    policy = NetworkOutageRetryPolicy(
+        enabled=True,
+        interval_seconds=300,
+        max_wait_seconds=0,
+    )
+    assert outage_retry_wait_seconds(policy, elapsed_seconds=86_400) == 300
+
+
+def test_finite_policy_stops_after_budget_and_truncates_last_wait():
+    policy = NetworkOutageRetryPolicy(
+        enabled=True,
+        interval_seconds=300,
+        max_wait_seconds=650,
+    )
+    assert outage_retry_wait_seconds(policy, elapsed_seconds=0) == 300
+    assert outage_retry_wait_seconds(policy, elapsed_seconds=600) == 50
+    assert outage_retry_wait_seconds(policy, elapsed_seconds=650) is None

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6856,6 +6856,76 @@ class TestRetryExhaustion:
         assert "error" in result
         assert "rate limited" in result["error"]
 
+    def test_network_or_ttfb_outage_keeps_turn_active_until_provider_recovers(
+        self, agent
+    ):
+        """A provider no-byte timeout must not terminate the user turn."""
+        from agent import conversation_loop as _conv_loop
+        from agent.network_outage_retry import NetworkOutageRetryPolicy
+
+        self._setup_agent(agent)
+        agent._api_max_retries = 1
+        agent._network_outage_retry_policy = NetworkOutageRetryPolicy(
+            enabled=True,
+            interval_seconds=300,
+            max_wait_seconds=0,
+        )
+        agent.client.chat.completions.create.side_effect = [
+            TimeoutError(
+                "Codex stream produced no bytes within 120s "
+                "(TTFB threshold: 120s)"
+            ),
+            _mock_response(content="recovered"),
+        ]
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_try_recover_primary_transport", return_value=False),
+            patch.object(_conv_loop, "wait_for_outage_retry", return_value=True) as wait,
+            patch.object(_conv_loop, "jittered_backoff", lambda *a, **k: 0.0),
+        ):
+            result = agent.run_conversation("continue the task")
+
+        assert result.get("completed") is True
+        assert result.get("final_response") == "recovered"
+        assert agent.client.chat.completions.create.call_count == 2
+        wait.assert_called_once_with(agent, 300, cycle=1)
+
+    def test_network_outage_mode_respects_operator_interrupt(self, agent):
+        """Unlimited outage retry remains immediately interruptible."""
+        from agent import conversation_loop as _conv_loop
+        from agent.network_outage_retry import NetworkOutageRetryPolicy
+
+        class APIConnectionError(Exception):
+            pass
+
+        self._setup_agent(agent)
+        agent._api_max_retries = 1
+        agent._network_outage_retry_policy = NetworkOutageRetryPolicy(
+            enabled=True,
+            interval_seconds=300,
+            max_wait_seconds=0,
+        )
+        agent.client.chat.completions.create.side_effect = APIConnectionError(
+            "Connection error."
+        )
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_try_recover_primary_transport", return_value=False),
+            patch.object(_conv_loop, "wait_for_outage_retry", return_value=False),
+            patch.object(_conv_loop, "jittered_backoff", lambda *a, **k: 0.0),
+        ):
+            result = agent.run_conversation("continue the task")
+
+        assert result.get("completed") is False
+        assert result.get("interrupted") is True
+        assert "interrupted" in result.get("final_response", "").lower()
+
     def test_build_api_kwargs_error_no_unbound_local(self, agent):
         """When _build_api_kwargs raises, except handler must not crash with UnboundLocalError.
 


### PR DESCRIPTION
## Summary

- keep provider/model turns active after bounded retries when the failure is a status-less transport outage or an explicit Codex no-byte/TTFB stall
- keep outbound platform responses pending through safe pre-send connectivity outages, while excluding ambiguous timeouts and semantic/auth/rate-limit failures from long replay
- mark messages reloaded from `SessionDB` as intrinsically persisted so a failed compression attempt that adopts a fresh durable snapshot cannot append the same transcript again
- expose one opt-in `agent.network_outage_retry` policy through normal `config.yaml`; gateway platforms inherit it unless they define an explicit local override

## Failure mode

A provider connection/no-byte failure could exhaust the normal retry/fallback path and end the user turn. Separately, preflight compression can adopt a freshly loaded durable snapshot. If compression then aborts without making progress, identity-based flush bookkeeping no longer recognizes those rows as persisted and can append the entire snapshot a second time.

This patch adds a long-retry tier only after existing bounded recovery is exhausted and makes durable message identity explicit. Provider HTTP/auth/rate-limit/billing/context errors remain bounded. Platform replay is limited to failures known to happen before the platform can accept a send (`ConnectError`, `ProxyError`, DNS/routing failure, or `send_path_degraded`); read/write timeout and remote-protocol ambiguity remain non-replayed.

## Verification

Applied cleanly to upstream `main` at `fbc878ee2ee56c76b2d9de49e7ffa3802d0e8ed8`.

```text
HERMES_PYTHON=<project-venv>/bin/python scripts/run_tests.sh \
  tests/run_agent/test_network_outage_retry.py \
  tests/run_agent/test_run_agent.py \
  tests/run_agent/test_32646_fallback_429_after_timeout.py \
  tests/run_agent/test_compression_persistence.py \
  tests/test_hermes_state.py \
  tests/gateway/test_platform_delivery_outage_retry.py \
  tests/gateway/test_send_retry.py \
  tests/gateway/test_slack_send_retry.py \
  tests/gateway/test_telegram_final_delivery.py \
  tests/gateway/test_delivery_ledger_producer.py -q
```

Result: **1,038 passed, 0 failed** across 10 files.

`py_compile`, `ruff check`, and patch whitespace checks also pass for every changed Python file.
