### PR TITLE
fix(desktop): contain preview fs.watch errors so a deleted watch dir can't crash main

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -152,6 +152,7 @@ import {
 import { runNativeLogin } from './native-oauth-login'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 import { createKeepAwake } from './power-save'
+import { createPreviewWatchRegistry } from './preview-watch'
 import { FirstRunSetupResetError, runPrimaryBackendStartup } from './primary-backend-startup'
 import { rehomePrimaryConnection } from './primary-connection-rehome'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
@@ -1094,7 +1095,6 @@ let bootstrapRepairRequested = false
 let connectionConfigCache = null
 let connectionConfigCacheMtime = null
 const hermesLog = []
-const previewWatchers = new Map()
 let previewShortcutActive = false
 let desktopLogBuffer = ''
 let desktopLogFlushTimer = null
@@ -4915,65 +4915,29 @@ function sendPreviewFileChanged(payload) {
   webContents.send('hermes:preview-file-changed', payload)
 }
 
+// Watcher lifecycle lives in ./preview-watch (unit-tested there): the
+// FSWatcher 'error' path is contained so a deleted/unmounted watch directory
+// can never crash the main process. This wrapper only resolves the preview
+// URL and shapes the renderer payload.
+const previewWatchRegistry = createPreviewWatchRegistry({
+  fileExists,
+  debounceMs: PREVIEW_WATCH_DEBOUNCE_MS,
+  sendChanged: ({ id, path: changedPath }) =>
+    sendPreviewFileChanged({ id, path: changedPath, url: pathToFileURL(changedPath).toString() })
+})
+
 async function watchPreviewFile(rawUrl) {
   const filePath = await filePathFromPreviewUrl(rawUrl)
-  const watchDir = path.dirname(filePath)
-  const targetName = path.basename(filePath)
-  const id = crypto.randomBytes(12).toString('base64url')
-  let timer = null
 
-  const watcher = fs.watch(watchDir, (_eventType, filename) => {
-    const changedName = filename ? path.basename(String(filename)) : ''
-
-    if (changedName && changedName !== targetName) {
-      return
-    }
-
-    if (timer) {
-      clearTimeout(timer)
-    }
-
-    timer = setTimeout(() => {
-      timer = null
-
-      if (!fileExists(filePath)) {
-        return
-      }
-
-      sendPreviewFileChanged({ id, path: filePath, url: pathToFileURL(filePath).toString() })
-    }, PREVIEW_WATCH_DEBOUNCE_MS)
-  })
-
-  previewWatchers.set(id, {
-    close: () => {
-      if (timer) {
-        clearTimeout(timer)
-      }
-
-      watcher.close()
-    }
-  })
-
-  return { id, path: filePath }
+  return previewWatchRegistry.watch(filePath)
 }
 
 function stopPreviewFileWatch(id) {
-  const watcher = previewWatchers.get(id)
-
-  if (!watcher) {
-    return false
-  }
-
-  watcher.close()
-  previewWatchers.delete(id)
-
-  return true
+  return previewWatchRegistry.stop(id)
 }
 
 function closePreviewWatchers() {
-  for (const id of previewWatchers.keys()) {
-    stopPreviewFileWatch(id)
-  }
+  previewWatchRegistry.closeAll()
 }
 
 /** Watch a DIRECTORY for entry churn (folders appearing/vanishing) — the
@@ -4988,31 +4952,9 @@ function watchDirectory(rawDir) {
     throw new Error(`Not a directory: ${watchDir}`)
   }
 
-  const id = crypto.randomBytes(12).toString('base64url')
-  let timer = null
-
-  const watcher = fs.watch(watchDir, () => {
-    if (timer) {
-      clearTimeout(timer)
-    }
-
-    timer = setTimeout(() => {
-      timer = null
-      sendPreviewFileChanged({ id, path: watchDir, url: pathToFileURL(watchDir).toString() })
-    }, PREVIEW_WATCH_DEBOUNCE_MS)
+  return previewWatchRegistry.watchDirectory(watchDir, {
+    dirExists: (p) => fs.existsSync(p) && fs.statSync(p).isDirectory()
   })
-
-  previewWatchers.set(id, {
-    close: () => {
-      if (timer) {
-        clearTimeout(timer)
-      }
-
-      watcher.close()
-    }
-  })
-
-  return { id, path: watchDir }
 }
 
 // Best-effort read of a gateway's advertised auth providers, cached per base

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -306,6 +306,7 @@ import { poolTouchKeys } from './pool-touch-scope'
 import { createKeepAwake } from './power-save'
 import { capturePreviewContents } from './preview-capture'
 import { PreviewReachRegistry } from './preview-reach'
+import { createPreviewWatchRegistry } from './preview-watch'
 import {
   createPrimaryRemoteConnection,
   FirstRunSetupResetError,
@@ -1705,7 +1706,6 @@ let connectionRegistryCache = null
 let connectionRegistryCacheMtime = null
 let remoteHeaderRulesInstalled = false
 const remoteWsHeaderStore = createRemoteWsHeaderStore()
-const previewWatchers = new Map()
 let previewShortcutActive = false
 let nativeThemeListenerInstalled = false
 
@@ -6422,65 +6422,29 @@ function sendPreviewFileChanged(payload) {
   webContents.send('hermes:preview-file-changed', payload)
 }
 
+// Watcher lifecycle lives in ./preview-watch (unit-tested there): the
+// FSWatcher 'error' path is contained so a deleted/unmounted watch directory
+// can never crash the main process. This wrapper only resolves the preview
+// URL and shapes the renderer payload.
+const previewWatchRegistry = createPreviewWatchRegistry({
+  fileExists,
+  debounceMs: PREVIEW_WATCH_DEBOUNCE_MS,
+  sendChanged: ({ id, path: changedPath }) =>
+    sendPreviewFileChanged({ id, path: changedPath, url: pathToFileURL(changedPath).toString() })
+})
+
 async function watchPreviewFile(rawUrl) {
   const filePath = await filePathFromPreviewUrl(rawUrl)
-  const watchDir = path.dirname(filePath)
-  const targetName = path.basename(filePath)
-  const id = crypto.randomBytes(12).toString('base64url')
-  let timer = null
 
-  const watcher = fs.watch(watchDir, (_eventType, filename) => {
-    const changedName = filename ? path.basename(String(filename)) : ''
-
-    if (changedName && changedName !== targetName) {
-      return
-    }
-
-    if (timer) {
-      clearTimeout(timer)
-    }
-
-    timer = setTimeout(() => {
-      timer = null
-
-      if (!fileExists(filePath)) {
-        return
-      }
-
-      sendPreviewFileChanged({ id, path: filePath, url: pathToFileURL(filePath).toString() })
-    }, PREVIEW_WATCH_DEBOUNCE_MS)
-  })
-
-  previewWatchers.set(id, {
-    close: () => {
-      if (timer) {
-        clearTimeout(timer)
-      }
-
-      watcher.close()
-    }
-  })
-
-  return { id, path: filePath }
+  return previewWatchRegistry.watch(filePath)
 }
 
 function stopPreviewFileWatch(id) {
-  const watcher = previewWatchers.get(id)
-
-  if (!watcher) {
-    return false
-  }
-
-  watcher.close()
-  previewWatchers.delete(id)
-
-  return true
+  return previewWatchRegistry.stop(id)
 }
 
 function closePreviewWatchers() {
-  for (const id of previewWatchers.keys()) {
-    stopPreviewFileWatch(id)
-  }
+  previewWatchRegistry.closeAll()
 }
 
 function requestOptionsWithHeaders(options: any = {}, headers = {}) {
@@ -6505,31 +6469,9 @@ function watchDirectory(rawDir) {
     throw new Error(`Not a directory: ${watchDir}`)
   }
 
-  const id = crypto.randomBytes(12).toString('base64url')
-  let timer = null
-
-  const watcher = fs.watch(watchDir, () => {
-    if (timer) {
-      clearTimeout(timer)
-    }
-
-    timer = setTimeout(() => {
-      timer = null
-      sendPreviewFileChanged({ id, path: watchDir, url: pathToFileURL(watchDir).toString() })
-    }, PREVIEW_WATCH_DEBOUNCE_MS)
+  return previewWatchRegistry.watchDirectory(watchDir, {
+    dirExists: (p) => fs.existsSync(p) && fs.statSync(p).isDirectory()
   })
-
-  previewWatchers.set(id, {
-    close: () => {
-      if (timer) {
-        clearTimeout(timer)
-      }
-
-      watcher.close()
-    }
-  })
-
-  return { id, path: watchDir }
 }
 
 // Best-effort read of a gateway's advertised auth providers, cached per base

--- a/apps/desktop/electron/preview-watch.test.ts
+++ b/apps/desktop/electron/preview-watch.test.ts
@@ -1,0 +1,338 @@
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+
+import { afterEach, beforeEach, test, vi } from 'vitest'
+
+import { createPreviewWatchRegistry } from './preview-watch'
+
+// Fake FSWatcher. Faithful to real Node semantics where it matters:
+// EventEmitter-based (so emitting 'error' with no listener would throw,
+// exactly like the uncaught-exception crash this fix targets) and SILENT
+// after close() (a real FSWatcher delivers no events once closed). `closed`
+// is fake bookkeeping only — real FSWatcher exposes no such property.
+function fakeWatchImpl() {
+  const created: any[] = []
+
+  const impl = (dir: string, listener: (...args: any[]) => void) => {
+    const watcher: any = new EventEmitter()
+    watcher.dir = dir
+    watcher.closed = false
+
+    watcher.close = () => {
+      watcher.closed = true
+    }
+
+    watcher.emitChange = (filename: any) => {
+      if (!watcher.closed) {
+        listener('change', filename)
+      }
+    }
+
+    watcher.emitRename = (filename: any) => {
+      if (!watcher.closed) {
+        listener('rename', filename)
+      }
+    }
+
+    created.push(watcher)
+
+    return watcher
+  }
+
+  return { impl, created }
+}
+
+function makeRegistry(overrides: any = {}) {
+  const sent: any[] = []
+  const warnings: any[] = []
+  const { impl, created } = fakeWatchImpl()
+
+  const registry = createPreviewWatchRegistry({
+    fileExists: () => true,
+    sendChanged: (payload: any) => sent.push(payload),
+    debounceMs: 120,
+    watchImpl: impl,
+    log: (...args: any[]) => warnings.push(args),
+    ...overrides
+  })
+
+  return { registry, sent, warnings, created }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+test('change to the watched file debounces into one sendChanged with the watch id', () => {
+  const { registry, sent, created } = makeRegistry()
+
+  const { id } = registry.watch('/tmp/preview/note.md')
+  const watcher = created[0]
+
+  watcher.emitChange('note.md')
+  watcher.emitChange('note.md')
+  assert.equal(sent.length, 0)
+
+  vi.advanceTimersByTime(200)
+  assert.deepEqual(sent, [{ id, path: '/tmp/preview/note.md' }])
+})
+
+test('rename events (atomic save-by-rename) trigger a reload', () => {
+  const { registry, sent, created } = makeRegistry()
+
+  registry.watch('/tmp/preview/note.md')
+  created[0].emitRename('note.md')
+
+  vi.advanceTimersByTime(200)
+  assert.equal(sent.length, 1)
+})
+
+test('changes to sibling files in the same directory are ignored', () => {
+  const { registry, sent, created } = makeRegistry()
+
+  registry.watch('/tmp/preview/note.md')
+  created[0].emitChange('other.md')
+  created[0].emitChange('note.md.tmp')
+
+  vi.advanceTimersByTime(1000)
+  assert.equal(sent.length, 0)
+})
+
+test('null filename (documented fs.watch behavior) is treated as a match — reload beats a missed save', () => {
+  const { registry, sent, created } = makeRegistry()
+
+  registry.watch('/tmp/preview/note.md')
+  created[0].emitChange(null)
+
+  vi.advanceTimersByTime(200)
+  assert.equal(sent.length, 1)
+})
+
+test('filename delivered as a Buffer still matches the target', () => {
+  const { registry, sent, created } = makeRegistry()
+
+  registry.watch('/tmp/preview/note.md')
+  created[0].emitChange(Buffer.from('note.md'))
+
+  vi.advanceTimersByTime(200)
+  assert.equal(sent.length, 1)
+})
+
+test('a deleted target file does not send', () => {
+  const { registry, sent, created } = makeRegistry({
+    fileExists: () => false
+  })
+
+  registry.watch('/tmp/preview/note.md')
+  created[0].emitChange('note.md')
+
+  vi.advanceTimersByTime(1000)
+  assert.equal(sent.length, 0)
+})
+
+test('watch attaches an error listener synchronously (crash-prevention invariant)', () => {
+  const { registry, created } = makeRegistry()
+
+  registry.watch('/tmp/preview/note.md')
+
+  // The whole point of the fix: an FSWatcher that emits 'error' with no
+  // listener raises an uncaught exception and crashes the main process.
+  assert.ok(created[0].listenerCount('error') > 0)
+})
+
+test('watcher error does not throw: watch is closed, deregistered, and stops sending', () => {
+  const { registry, sent, warnings, created } = makeRegistry()
+
+  registry.watch('/tmp/preview/note.md')
+  const watcher = created[0]
+  assert.equal(registry.size(), 1)
+
+  // A deleted/unmounted watch dir surfaces as an 'error' event on the
+  // FSWatcher. Without a listener Node would crash the process; the
+  // registry must absorb it and tear down just this watch.
+  watcher.emit('error', new Error('ENOENT: no such file or directory, watch'))
+
+  assert.equal(registry.size(), 0)
+  assert.equal(watcher.closed, true)
+  assert.equal(warnings.length, 1)
+
+  watcher.emitChange('note.md')
+  vi.advanceTimersByTime(1000)
+  assert.equal(sent.length, 0)
+})
+
+test('a second error event is a no-op (no duplicate teardown or log)', () => {
+  const { registry, warnings, created } = makeRegistry()
+
+  registry.watch('/tmp/preview/note.md')
+
+  created[0].emit('error', new Error('first'))
+  assert.doesNotThrow(() => created[0].emit('error', new Error('second')))
+
+  assert.equal(registry.size(), 0)
+  assert.equal(warnings.length, 1)
+})
+
+test('stop after an error returns false and does not double-close', () => {
+  const { registry, created } = makeRegistry()
+
+  const { id } = registry.watch('/tmp/preview/note.md')
+  created[0].emit('error', new Error('EPERM'))
+
+  assert.equal(registry.stop(id), false)
+  assert.equal(created[0].closed, true)
+})
+
+test('watcher error cancels a pending debounce timer', () => {
+  const { registry, sent, created } = makeRegistry()
+
+  registry.watch('/tmp/preview/note.md')
+  const watcher = created[0]
+
+  watcher.emitChange('note.md')
+  watcher.emit('error', new Error('EPERM'))
+
+  vi.advanceTimersByTime(1000)
+  assert.equal(sent.length, 0)
+})
+
+test('a watchImpl that throws synchronously logs and rethrows (renderer sees a rejected invoke, never a crash)', () => {
+  const { registry, warnings } = makeRegistry({
+    watchImpl: () => {
+      throw new Error('ENOENT')
+    }
+  })
+
+  assert.throws(() => registry.watch('/tmp/preview/note.md'), /ENOENT/)
+  assert.equal(warnings.length, 1)
+  assert.equal(registry.size(), 0)
+})
+
+test('two watches of the same directory are independent', () => {
+  const { registry, sent, created } = makeRegistry()
+
+  const a = registry.watch('/tmp/preview/note.md')
+  registry.watch('/tmp/preview/other.md')
+  assert.equal(created.length, 2)
+
+  created[0].emitChange('note.md')
+  vi.advanceTimersByTime(200)
+
+  assert.deepEqual(sent, [{ id: a.id, path: '/tmp/preview/note.md' }])
+})
+
+test('stop closes the watcher and reports unknown ids as not found', () => {
+  const { registry, created } = makeRegistry()
+
+  const { id } = registry.watch('/tmp/preview/note.md')
+  assert.equal(registry.stop(id), true)
+  assert.equal(created[0].closed, true)
+  assert.equal(registry.stop(id), false)
+  assert.equal(registry.stop('never-existed'), false)
+})
+
+test('stop before the debounce fires suppresses the send', () => {
+  const { registry, sent, created } = makeRegistry()
+
+  const { id } = registry.watch('/tmp/preview/note.md')
+  created[0].emitChange('note.md')
+  registry.stop(id)
+
+  vi.advanceTimersByTime(1000)
+  assert.equal(sent.length, 0)
+})
+
+test('closeAll tears down every registered watch', () => {
+  const { registry, created } = makeRegistry()
+
+  registry.watch('/tmp/preview/a.md')
+  registry.watch('/tmp/preview/b.md')
+  assert.equal(registry.size(), 2)
+
+  registry.closeAll()
+
+  assert.equal(registry.size(), 0)
+  assert.equal(created[0].closed, true)
+  assert.equal(created[1].closed, true)
+})
+
+// ---------------------------------------------------------------------------
+// Directory watching (watchDirectory) — the plugins-door path.
+// Same error containment, debounce, and lifecycle as file watches.
+// ---------------------------------------------------------------------------
+
+test('watchDirectory debounces changes and sends the directory path', () => {
+  const { registry, sent, created } = makeRegistry()
+
+  const { id } = registry.watchDirectory('/tmp/plugins', { dirExists: () => true })
+
+  // Two rapid changes should coalesce into one debounced send
+  created[0].emitChange('new-plugin')
+  created[0].emitChange('another-plugin')
+
+  vi.advanceTimersByTime(200)
+  assert.equal(sent.length, 1)
+  assert.equal(sent[0].id, id)
+  assert.equal(sent[0].path, '/tmp/plugins')
+})
+
+test('watchDirectory error tears down that watch without crashing', () => {
+  const { registry, warnings, created } = makeRegistry()
+
+  const { id } = registry.watchDirectory('/tmp/plugins', { dirExists: () => true })
+  assert.equal(registry.size(), 1)
+
+  created[0].emit('error', new Error('directory deleted'))
+
+  assert.equal(registry.size(), 0)
+  assert.equal(created[0].closed, true)
+  assert.ok(warnings.length >= 1)
+
+  // A second error must be a no-op (guard)
+  created[0].emit('error', new Error('double error'))
+  assert.equal(warnings.length, 1)
+
+  // stop() on the torn-down watch is a no-op
+  assert.equal(registry.stop(id), false)
+})
+
+test('watchDirectory stop tears down and suppresses pending debounce', () => {
+  const { registry, sent, created } = makeRegistry()
+
+  const { id } = registry.watchDirectory('/tmp/plugins', { dirExists: () => true })
+  created[0].emitChange('new-plugin')
+
+  assert.equal(registry.stop(id), true)
+  assert.equal(created[0].closed, true)
+
+  vi.advanceTimersByTime(1000)
+  assert.equal(sent.length, 0)
+})
+
+test('watchDirectory dirExists=false suppresses the send after debounce', () => {
+  const { registry, sent, created } = makeRegistry()
+
+  registry.watchDirectory('/tmp/plugins', { dirExists: () => false })
+  created[0].emitChange('plugin-added')
+
+  vi.advanceTimersByTime(200)
+  assert.equal(sent.length, 0)
+})
+
+test('watchDirectory closeAll reaps directory watches alongside file watches', () => {
+  const { registry, created } = makeRegistry()
+
+  registry.watch('/tmp/preview/note.md')
+  registry.watchDirectory('/tmp/plugins', { dirExists: () => true })
+  assert.equal(registry.size(), 2)
+
+  registry.closeAll()
+
+  assert.equal(registry.size(), 0)
+  assert.equal(created[0].closed, true)
+  assert.equal(created[1].closed, true)
+})

--- a/apps/desktop/electron/preview-watch.ts
+++ b/apps/desktop/electron/preview-watch.ts
@@ -1,0 +1,194 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+
+// Live-reload watching for previewed files.
+//
+// The watcher is registered on the file's PARENT DIRECTORY (a plain file
+// watch does not survive atomic save-by-rename, which is how most editors
+// write). A deleted/unmounted/permission-revoked watch directory makes the
+// FSWatcher emit 'error'; with no listener Node raises it as an uncaught
+// exception and takes down the whole main process. Watcher failure is
+// therefore treated as terminal for that watch only: the registry entry is
+// dropped and the preview simply stops live-reloading instead of crashing
+// the app.
+export function createPreviewWatchRegistry({
+  fileExists,
+  sendChanged,
+  debounceMs,
+  watchImpl = fs.watch,
+  log = console.warn
+}) {
+  const watchers = new Map()
+
+  function watch(filePath) {
+    const watchDir = path.dirname(filePath)
+    const targetName = path.basename(filePath)
+    const id = crypto.randomBytes(12).toString('base64url')
+    let timer = null
+    // Flipped by the error path and by close(); guards against a change
+    // event racing watcher teardown (some platforms deliver a final event
+    // during close()).
+    let active = true
+
+    const clearPending = () => {
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+    }
+
+    let watcher
+
+    try {
+      watcher = watchImpl(watchDir, (_eventType: any, filename: any) => {
+        if (!active) {
+          return
+        }
+
+        // filename is a utf8 string with the default encoding, but decode
+        // defensively: String(buffer) would yield "<Buffer …>" garbage.
+        const raw = typeof filename === 'string' ? filename : filename ? filename.toString() : ''
+        const changedName = raw ? path.basename(raw) : ''
+
+        if (changedName && changedName !== targetName) {
+          return
+        }
+
+        clearPending()
+
+        timer = setTimeout(() => {
+          timer = null
+
+          if (!fileExists(filePath)) {
+            return
+          }
+
+          sendChanged({ id, path: filePath })
+        }, debounceMs)
+      })
+    } catch (err) {
+      // fs.watch can throw SYNCHRONOUSLY (e.g. ENOENT/EPERM when the watch
+      // directory was deleted before the call). Log for diagnostics, then
+      // rethrow: inside ipcMain.handle this becomes a rejected invoke() for
+      // the renderer — terminal for this watch, never a main-process crash.
+      log(`[preview-watch] failed to watch ${watchDir}:`, err)
+      throw err
+    }
+
+    watcher.on('error', err => {
+      // Some platforms deliver a final 'error' during close(); the first one
+      // already tore this watch down.
+      if (!active) {
+        return
+      }
+
+      log(`[preview-watch] watcher failed for ${watchDir}, live reload disabled:`, err)
+      active = false
+      clearPending()
+      watchers.delete(id)
+      watcher.close()
+    })
+
+    watchers.set(id, {
+      close: () => {
+        active = false
+        clearPending()
+        watcher.close()
+      }
+    })
+
+    return { id, path: filePath }
+  }
+
+  /**
+   * Watch a DIRECTORY for entry churn (folders/files appearing or vanishing).
+   * Used by the desktop plugins door to detect new/removed plugins without
+   * polling. Unlike watch(), this does not filter by filename — any change
+   * in the directory fires the debounced callback. The same error-containment
+   * and lifecycle management applies.
+   */
+  function watchDirectory(
+    dirPath,
+    { dirExists }: { dirExists: (p: string) => boolean } = { dirExists: p => fs.existsSync(p) }
+  ) {
+    const id = crypto.randomBytes(12).toString('base64url')
+    let timer = null
+    let active = true
+
+    const clearPending = () => {
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+    }
+
+    let watcher
+
+    try {
+      watcher = watchImpl(dirPath, () => {
+        if (!active) {
+          return
+        }
+
+        clearPending()
+
+        timer = setTimeout(() => {
+          timer = null
+
+          if (!dirExists(dirPath)) {
+            return
+          }
+
+          sendChanged({ id, path: dirPath })
+        }, debounceMs)
+      })
+    } catch (err) {
+      log(`[preview-watch] failed to watch directory ${dirPath}:`, err)
+      throw err
+    }
+
+    watcher.on('error', err => {
+      if (!active) {
+        return
+      }
+
+      log(`[preview-watch] directory watcher failed for ${dirPath}, live reload disabled:`, err)
+      active = false
+      clearPending()
+      watchers.delete(id)
+      watcher.close()
+    })
+
+    watchers.set(id, {
+      close: () => {
+        active = false
+        clearPending()
+        watcher.close()
+      }
+    })
+
+    return { id, path: dirPath }
+  }
+
+  function stop(id) {
+    const entry = watchers.get(id)
+
+    if (!entry) {
+      return false
+    }
+
+    entry.close()
+    watchers.delete(id)
+
+    return true
+  }
+
+  function closeAll() {
+    for (const id of [...watchers.keys()]) {
+      stop(id)
+    }
+  }
+
+  return { watch, watchDirectory, stop, closeAll, size: () => watchers.size }
+}


### PR DESCRIPTION
## What

The desktop preview live-reload watcher (`watchPreviewFile` in `apps/desktop/electron/main.ts`) created an `fs.watch` `FSWatcher` with **no `'error'` listener**. When a previewed file's parent directory is deleted, unmounted, or loses permissions, Node raises the watcher `'error'` event as an **uncaught exception and takes down the entire Electron main process**.

## Fix

- Extract the watcher lifecycle into `electron/preview-watch.ts` as a small DI-testable registry (matching the repo's module-per-concern pattern, e.g. `fs-read-dir.ts`), with an `'error'` handler that treats watcher failure as terminal **for that watch only**: cancel the pending debounce, drop the registry entry, close the watcher, log a warning, and keep the app running with live reload disabled for that preview.
- `main.ts` keeps only the URL resolution + renderer payload shaping; the `{id, path, url}` payload contract and both IPC handlers (`hermes:watchPreviewFile`, `hermes:stopPreviewFileWatch`) are unchanged, and `closePreviewWatchers()` still runs on `before-quit`.
- Additional hardening in the same class: an `active` guard against change/error events racing teardown, second `'error'` delivery is a no-op, synchronous `fs.watch()` creation failure (ENOENT/EPERM on an already-deleted dir) is logged and rethrown so the renderer gets a rejected `invoke()` instead of an untracked failure, and `Buffer` filenames are decoded defensively.

## How to test

1. Open a file preview in the desktop app (live reload active).
2. Delete the previewed file's parent directory (or unmount its drive).
3. **Before:** main process crashes (uncaught `FSWatcher` error). **After:** app survives; console shows `[preview-watch] watcher failed …, live reload disabled`; other previews keep working.

Automated: `cd apps/desktop && npx vitest run --project electron electron/preview-watch.test.ts` — 16 tests covering debounce, rename events (atomic save-by-rename), sibling filtering, null/Buffer filenames, deleted-target suppression, the error-listener crash invariant, error containment, double-error no-op, stop-after-error, sync-throw contract, same-dir independence, stop semantics, and `closeAll`. Also green: `tsc -p tsconfig.electron.json --noEmit`, `eslint` on touched files. Full electron project suite shows no new failures (the 17 pre-existing Windows ssh/symlink env failures are byte-identical on clean `main`).

## Platforms

Implemented and tested on Windows 11 (Node 22). Watcher error semantics are identical on macOS/Linux (`FSWatcher` `'error'` with no listener is an uncaught exception on every platform).

## Notes for reviewers

- **Dedupe:** searched open/merged/closed PRs for `fs.watch`, `watchPreviewFile`, `FSWatcher`, preview watcher/crash — no prior or in-progress fix (verified 2026-07-28). #41742 (scroll position on preview reload) is complementary, different layer, no file overlap.
- **Deliberately out of scope** (pre-existing behavior, unchanged from the original inline code): case-sensitive filename compare on case-insensitive filesystems, and no dedup of multiple watchers on the same directory. Happy to follow up on either if wanted.
