### PR TITLE
fix(desktop): stop stale session restore and false skew warning

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
@@ -1,0 +1,95 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $activeGatewayProfile } from '@/store/profile'
+import {
+  $sessions,
+  $sessionsLoading,
+  getRememberedRoute,
+  getRememberedSessionId,
+  setRememberedRoute,
+  setRememberedSessionId
+} from '@/store/session'
+
+import { sessionRoute } from '../../routes'
+
+import { useDesktopIntegrations } from './use-desktop-integrations'
+
+vi.mock('@/store/session-sync', () => ({ onSessionsChanged: vi.fn(() => () => undefined) }))
+vi.mock('@/store/updates', () => ({
+  openUpdatesWindow: vi.fn(),
+  startUpdatePoller: vi.fn(),
+  stopUpdatePoller: vi.fn()
+}))
+vi.mock('@/store/windows', () => ({ isSecondaryWindow: vi.fn(() => false) }))
+
+const BUSINESS_ID = '20260726_161147_719ad3'
+type Navigate = (to: string, options?: { replace?: boolean }) => void
+
+function installDesktopBridge(): void {
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: {
+      onClosePreviewRequested: vi.fn(() => () => undefined),
+      onDeepLink: vi.fn(() => () => undefined),
+      onFocusSession: vi.fn(() => () => undefined),
+      onNotificationAction: vi.fn(() => () => undefined),
+      onOpenUpdatesRequested: vi.fn(() => () => undefined),
+      setPreviewShortcutActive: vi.fn(),
+      signalDeepLinkReady: vi.fn()
+    }
+  })
+}
+
+function renderIntegrations(navigate: Navigate) {
+  return renderHook(() =>
+    useDesktopIntegrations({
+      chatOpen: false,
+      hasPreview: false,
+      locationPathname: '/',
+      navigate,
+      refreshSessions: vi.fn(),
+      resumeExhaustedSessionId: null,
+      routedSessionId: null,
+      runtimeIdByStoredSessionId: { current: new Map() }
+    })
+  )
+}
+
+describe('remembered startup route', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    installDesktopBridge()
+    $activeGatewayProfile.set('theo')
+    $sessions.set([])
+    $sessionsLoading.set(false)
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('reads the remembered route before persisting the initial new-chat route', async () => {
+    setRememberedRoute('/skills')
+    setRememberedSessionId(BUSINESS_ID, 'theo')
+    const navigate = vi.fn<Navigate>()
+
+    renderIntegrations(navigate)
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/skills', { replace: true }))
+    expect(navigate).not.toHaveBeenCalledWith(sessionRoute(BUSINESS_ID), { replace: true })
+    expect(getRememberedRoute()).toBe('/skills')
+  })
+
+  it('drops an archived remembered session that is absent from the loaded session list', async () => {
+    setRememberedRoute('/')
+    setRememberedSessionId(BUSINESS_ID, 'theo')
+    const navigate = vi.fn<Navigate>()
+
+    renderIntegrations(navigate)
+
+    await waitFor(() => expect(getRememberedSessionId('theo')).toBeNull())
+    expect(navigate).not.toHaveBeenCalledWith(sessionRoute(BUSINESS_ID), { replace: true })
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -1,3 +1,4 @@
+import { useStore } from '@nanostores/react'
 import { useEffect, useRef } from 'react'
 
 import { closeActiveTab } from '@/app/chat/close-tab'
@@ -7,9 +8,11 @@ import { respondToApprovalAction } from '@/store/native-notifications'
 import { $activeGatewayProfile } from '@/store/profile'
 import {
   $sessions,
+  $sessionsLoading,
   getRememberedRoute,
   getRememberedSessionId,
   rememberedSessionProfile,
+  sessionMatchesStoredId,
   setRememberedRoute,
   setRememberedSessionId
 } from '@/store/session'
@@ -18,7 +21,7 @@ import { openUpdatesWindow, startUpdatePoller, stopUpdatePoller } from '@/store/
 import { isSecondaryWindow } from '@/store/windows'
 
 import { requestComposerFocus, requestComposerInsert } from '../../chat/composer/focus'
-import { appViewForPath, isOverlayView, NEW_CHAT_ROUTE, sessionRoute } from '../../routes'
+import { appViewForPath, isOverlayView, NEW_CHAT_ROUTE, routeSessionId, sessionRoute } from '../../routes'
 
 interface DesktopIntegrationsParams {
   chatOpen: boolean
@@ -46,6 +49,8 @@ export function useDesktopIntegrations({
   routedSessionId,
   runtimeIdByStoredSessionId
 }: DesktopIntegrationsParams): void {
+  const sessionsLoading = useStore($sessionsLoading)
+
   // Update polling — populates $desktopVersion/$updateStatus, which feed the
   // statusbar version pill and the update toasts. Also honors the main
   // process's "open updates" menu request.
@@ -66,11 +71,19 @@ export function useDesktopIntegrations({
     window.hermesDesktop?.setPreviewShortcutActive?.(true)
   }, [])
 
+  const restoredRef = useRef(false)
+
   // Remember the open chat (session id for notifications/resume) AND the last
   // non-overlay route (a page like /skills, or a session route) so a relaunch
   // lands where you were. Overlays (settings/command-center/…) aren't stored —
   // you don't want to boot into a modal.
   useEffect(() => {
+    // The first render always starts at `/`. Do not overwrite the durable route
+    // before the cold-start restore effect below has had a chance to read it.
+    if (!restoredRef.current) {
+      return
+    }
+
     if (routedSessionId) {
       setRememberedSessionId(
         routedSessionId,
@@ -83,34 +96,60 @@ export function useDesktopIntegrations({
     }
   }, [locationPathname, routedSessionId])
 
-  const restoredRef = useRef(false)
-
   // Restore once on cold start — only when the renderer booted at the default
   // route (a hidden-then-shown window keeps its own route). Prefer the full
   // remembered route (covers pages); fall back to the last session id.
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
-    if (restoredRef.current || locationPathname !== NEW_CHAT_ROUTE) {
+    if (restoredRef.current) {
+      return
+    }
+
+    if (locationPathname !== NEW_CHAT_ROUTE) {
       restoredRef.current = true
 
       return
     }
 
-    restoredRef.current = true
+    // Archived/deleted sessions are absent from the loaded session list. Wait
+    // for that list before trusting a remembered chat id so stale durable state
+    // cannot resurrect a hidden conversation on every launch.
+    if (sessionsLoading) {
+      return
+    }
+
     const route = getRememberedRoute()
 
     if (route && route !== NEW_CHAT_ROUTE && !isOverlayView(appViewForPath(route))) {
-      navigate(route, { replace: true })
+      const rememberedRouteSessionId = routeSessionId(route)
+
+      if (!rememberedRouteSessionId || $sessions.get().some(session => sessionMatchesStoredId(session, rememberedRouteSessionId))) {
+        restoredRef.current = true
+        navigate(route, { replace: true })
+
+        return
+      }
+
+      setRememberedRoute(NEW_CHAT_ROUTE)
+    }
+
+    const activeProfile = $activeGatewayProfile.get()
+    const last = getRememberedSessionId(activeProfile)
+
+    if (last && $sessions.get().some(session => sessionMatchesStoredId(session, last))) {
+      restoredRef.current = true
+      navigate(sessionRoute(last), { replace: true })
 
       return
     }
 
-    const last = getRememberedSessionId($activeGatewayProfile.get())
-
     if (last) {
-      navigate(sessionRoute(last), { replace: true })
+      setRememberedSessionId(null, activeProfile)
     }
-  }, [locationPathname, navigate])
+
+    restoredRef.current = true
+    setRememberedRoute(NEW_CHAT_ROUTE)
+  }, [locationPathname, navigate, sessionsLoading])
 
   useEffect(() => {
     if (!resumeExhaustedSessionId) {

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -125,11 +125,14 @@ describe('reportBackendContract', () => {
     expect(notifySpy).not.toHaveBeenCalled()
   })
 
-  it('warns when the backend is behind (or reports no contract)', () => {
+  it('does not infer an old backend from a partial payload with no contract', () => {
     reportBackendContract(undefined)
-    expect(notifySpy).toHaveBeenCalledTimes(1)
+    expect(notifySpy).not.toHaveBeenCalled()
+  })
+
+  it('warns when the backend explicitly reports an older contract', () => {
     reportBackendContract(1)
-    expect(notifySpy).toHaveBeenCalledTimes(2)
+    expect(notifySpy).toHaveBeenCalledTimes(1)
   })
 
   it('stays quiet on later session opens once the user closed it', () => {

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -141,7 +141,15 @@ function isInstallMethodToastSnoozed(): boolean {
  * doesn't nag on every thread switch.
  */
 export function reportBackendContract(contract: number | undefined): void {
-  if ((contract ?? 0) >= REQUIRED_BACKEND_CONTRACT) {
+  // Runtime-info updates may be partial. Absence of this optional field is not
+  // evidence that a current backend is old; only an explicit numeric contract
+  // can establish skew. Treating `undefined` as version zero created a false
+  // persistent warning after otherwise-valid session payloads.
+  if (contract === undefined) {
+    return
+  }
+
+  if (contract >= REQUIRED_BACKEND_CONTRACT) {
     dismissNotification(SKEW_TOAST_ID)
     // Backend caught up — forget any prior snooze so a future regression warns
     // immediately rather than staying silent for the rest of the window.


### PR DESCRIPTION
## Summary

Fix two Desktop startup regressions:

- wait for the authoritative session list before restoring remembered navigation, and reject/clear a remembered session that is no longer active (for example, an archived session);
- do not infer an obsolete backend from a partial runtime-info payload that omits the optional `desktop_contract` field.

## Root causes

1. The cold-start route persistence effect could save the initial `/` route before remembered navigation was restored. Startup then fell back to a stale profile-scoped session ID, including IDs for archived sessions.
2. `reportBackendContract(undefined)` treated an omitted field in partial runtime info as contract `0`, even if the live backend had already established a compatible contract.

## Verification

- `npx vitest run --project ui src/app/contrib/hooks/use-desktop-integrations.test.tsx src/store/updates.test.ts`
- `npm run typecheck`
- targeted ESLint on the four changed Desktop files
- full UI suite before rebasing: 323 files / 2,790 tests passed
- packaged macOS app cold-start test with a deliberately seeded archived session ID: stayed on `#/`, cleared the stale remembered ID, and showed no backend-skew warning
