### PR TITLE
fix(cli): align prompt-size tools with focus mode

### DIFF
--- a/hermes_cli/prompt_size.py
+++ b/hermes_cli/prompt_size.py
@@ -55,6 +55,7 @@ def _build_inspection_agent(platform: str) -> Any:
     platform come from the caller so the breakdown matches a real session.
     """
     from run_agent import AIAgent
+    from agent.coding_context import coding_selection
     from hermes_cli.config import load_config
     from hermes_cli.tools_config import _get_platform_tools
 
@@ -62,8 +63,10 @@ def _build_inspection_agent(platform: str) -> Any:
     model_cfg = cfg.get("model", {}) if isinstance(cfg.get("model"), dict) else {}
     model = model_cfg.get("default") or model_cfg.get("model") or ""
 
-    # Resolve platform-specific toolsets the same way the gateway does.
-    enabled_toolsets = sorted(_get_platform_tools(cfg, platform))
+    # Resolve focus-mode toolsets before falling back to the platform defaults.
+    enabled_toolsets = coding_selection(platform=platform, config=cfg)
+    if enabled_toolsets is None:
+        enabled_toolsets = sorted(_get_platform_tools(cfg, platform))
     agent_cfg = cfg.get("agent") or {}
     disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
 

--- a/tests/hermes_cli/test_prompt_size.py
+++ b/tests/hermes_cli/test_prompt_size.py
@@ -75,6 +75,37 @@ def test_runs_offline_without_credentials(isolated_home, monkeypatch):
     assert data["system_prompt"]["bytes"] > 0
 
 
+def test_inspection_agent_prefers_coding_selection(monkeypatch):
+    """Inspection forwards the runtime focus selection unchanged."""
+    captured = {}
+
+    class FakeAIAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    cfg = {"model": {"default": "test/model"}}
+    selected = ["coding", "stripe-agent"]
+
+    monkeypatch.setitem(
+        sys.modules,
+        "run_agent",
+        SimpleNamespace(AIAgent=FakeAIAgent),
+    )
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+    monkeypatch.setattr(
+        "agent.coding_context.coding_selection",
+        lambda *, platform, config: selected,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        lambda passed_cfg, platform: pytest.fail("platform fallback was called"),
+    )
+
+    _build_inspection_agent("cli")
+
+    assert captured["enabled_toolsets"] is selected
+
+
 def test_inspection_agent_uses_resolved_platform_toolsets(monkeypatch):
     """Inspection must match real CLI tool resolution, including disables."""
     captured = {}
@@ -94,6 +125,10 @@ def test_inspection_agent_uses_resolved_platform_toolsets(monkeypatch):
         SimpleNamespace(AIAgent=FakeAIAgent),
     )
     monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+    monkeypatch.setattr(
+        "agent.coding_context.coding_selection",
+        lambda *, platform, config: None,
+    )
     monkeypatch.setattr(
         "hermes_cli.tools_config._get_platform_tools",
         lambda passed_cfg, platform: {"terminal", "file"},


### PR DESCRIPTION
## Summary

- make `hermes prompt-size` use the same focus-first toolset selection as the runtime CLI
- fall back to platform tool resolution only when `coding_selection(...)` returns `None`
- preserve `agent.disabled_toolsets` propagation
- add regression coverage for both focus selection and the platform fallback

## Root cause

The runtime CLI resolves `coding_selection(...)` before `_get_platform_tools(...)`, but `_build_inspection_agent()` always used the platform resolver. In a focus-mode coding workspace this made `prompt-size` over-report tool schemas.

Measured in the Hermes repository before the fix:

- `prompt-size`: 31 tools / 60,859 JSON bytes
- runtime focus selection: 28 tools / 49,633 JSON bytes

After the fix, the diagnostic and runtime both report 28 tools / 49,633 JSON bytes.

## Tests

```text
python3 -m pytest tests/hermes_cli/test_prompt_size.py -o 'addopts=' -q
16 passed

python3 -m pytest tests/agent/test_coding_context.py -o 'addopts=' -q
55 passed

python3 -m pytest tests/agent/test_prompt_builder.py -o 'addopts=' -q
166 passed, 1 skipped

git diff --check
PASS
```

The patch was rebased onto current `origin/main` before the final verification.
