### PR TITLE
fix(tts): honor tts.openai.base_url/api_key in the streaming path (#73530)

### DIFF
--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -135,6 +135,67 @@ def test_openai_available_reflects_key(monkeypatch):
     assert ts.OpenAIStreamer.available() is True
 
 
+def _capture_openai_client(monkeypatch):
+    """Inject a fake ``openai`` module and return the kwargs OpenAI() gets."""
+    captured = {}
+
+    class _FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def iter_bytes(self):
+            yield b"\x00\x00"
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.audio = MagicMock()
+            self.audio.speech.with_streaming_response.create.return_value = _FakeResponse()
+
+    fake_openai = MagicMock()
+    fake_openai.OpenAI = _FakeClient
+    monkeypatch.setitem(__import__("sys").modules, "openai", fake_openai)
+    return captured
+
+
+def test_openai_stream_honors_config_base_url_over_env(monkeypatch):
+    """tts.openai.base_url must win over the environment so a self-hosted
+    endpoint isn't bypassed for api.openai.com on the streaming path (#73530)."""
+    captured = _capture_openai_client(monkeypatch)
+    monkeypatch.setattr(
+        ts, "get_env_value",
+        lambda k, *a: {"OPENAI_API_KEY": "cloud-key"}.get(k),
+    )
+
+    section = {"base_url": "http://localhost:4003/v1", "api_key": "dummy-no-auth",
+               "model": "qwen3-tts", "voice": "mira"}
+    streamer = ts.OpenAIStreamer({"openai": section}, section)
+    list(streamer.stream("hello"))
+
+    assert captured["base_url"] == "http://localhost:4003/v1"
+    assert captured["api_key"] == "dummy-no-auth"
+
+
+def test_openai_stream_falls_back_to_env_without_config(monkeypatch):
+    """With no config override the streamer keeps the default cloud behavior:
+    api_key from the environment and base_url unset (SDK default)."""
+    captured = _capture_openai_client(monkeypatch)
+    monkeypatch.setattr(
+        ts, "get_env_value",
+        lambda k, *a: {"OPENAI_API_KEY": "cloud-key"}.get(k),
+    )
+
+    section = {"model": "gpt-4o-mini-tts", "voice": "alloy"}
+    streamer = ts.OpenAIStreamer({"openai": section}, section)
+    list(streamer.stream("hello"))
+
+    assert captured["api_key"] == "cloud-key"
+    assert captured["base_url"] is None
+
+
 # ── Dispatch: chunked streamer path ──────────────────────────────────────
 
 

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -207,10 +207,16 @@ class OpenAIStreamer(StreamingTTSProvider):
     def stream(self, text: str) -> Iterator[bytes]:
         from openai import OpenAI
 
-        client = OpenAI(
-            api_key=get_env_value("OPENAI_API_KEY"),
-            base_url=get_env_value("OPENAI_BASE_URL") or None,
-        )
+        # Mirror the synchronous synthesize() precedence: tts.openai.base_url /
+        # api_key win over the environment, so a self-hosted OpenAI-compatible
+        # endpoint configured for ordinary replies is also honored on the
+        # streaming path instead of silently escaping to api.openai.com
+        # (#73530). Falling through to the environment preserves the default
+        # cloud behavior when no config override is set. (available() still
+        # gates on OPENAI_API_KEY — the separate no-cloud-key gap.)
+        base_url = self.section.get("base_url") or get_env_value("OPENAI_BASE_URL") or None
+        api_key = self.section.get("api_key") or get_env_value("OPENAI_API_KEY")
+        client = OpenAI(api_key=api_key, base_url=base_url)
         model = self.section.get("model", "gpt-4o-mini-tts")
         voice = self.section.get("voice", "alloy")
         with client.audio.speech.with_streaming_response.create(


### PR DESCRIPTION
## Problem

Fixes #73530.

`OpenAIStreamer.stream()` in `tools/tts_streaming.py` read `model` and `voice` from the `tts.openai` config section but took `base_url` and `api_key` from the environment:

```python
client = OpenAI(
    api_key=get_env_value("OPENAI_API_KEY"),
    base_url=get_env_value("OPENAI_BASE_URL") or None,
)
```

The synchronous `synthesize()` path deliberately does the opposite — config first, environment as the last-resort default. So a self-hosted OpenAI-compatible TTS server configured under `tts.openai.base_url` worked for ordinary replies and then **silently talked to `api.openai.com`** the moment streaming was used: asking the cloud for the local model in the local voice, against the wrong endpoint, and billed.

## Fix

Mirror the synchronous path's precedence in `stream()`: config `base_url`/`api_key` win over the environment, with the environment (and the SDK's `api.openai.com` default when `base_url` is `None`) as the fallback when no override is set.

```python
base_url = self.section.get("base_url") or get_env_value("OPENAI_BASE_URL") or None
api_key = self.section.get("api_key") or get_env_value("OPENAI_API_KEY")
client = OpenAI(api_key=api_key, base_url=base_url)
```

Scope, per the issue: this is only about which endpoint the streamer opens. `available()` still gates on `OPENAI_API_KEY` — the separate "local server with no cloud key at all" gap the issue calls out is intentionally left for a follow-up so this stays a minimal, behavior-preserving change for the default cloud path.

## Tests

`tests/tools/test_tts_streaming.py`:
- `test_openai_stream_honors_config_base_url_over_env` — the reproduction config (local `base_url`, `api_key: dummy-no-auth`, `OPENAI_API_KEY` set for the LLM) now opens the local endpoint with the config key, not `api.openai.com`.
- `test_openai_stream_falls_back_to_env_without_config` — with no override, the default cloud behavior is preserved (env key, `base_url=None`).

Full `test_tts_streaming.py` suite passes (21) and `ruff` is clean.