### PR TITLE
fix(tools): honour tts.openai.base_url in the streaming path

### DIFF
--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -135,6 +135,81 @@ def test_openai_available_reflects_key(monkeypatch):
     assert ts.OpenAIStreamer.available() is True
 
 
+def _openai_client_kwargs(monkeypatch, section, env):
+    """Return the kwargs OpenAIStreamer builds its client with for *section*/*env*."""
+    seen = {}
+
+    class _FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def iter_bytes(self, *_a, **_kw):
+            return iter([b""])
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            seen.update(kwargs)
+            speech = MagicMock()
+            speech.with_streaming_response.create = lambda **_kw: _FakeResponse()
+            self.audio = MagicMock(speech=speech)
+
+    monkeypatch.setattr(ts, "get_env_value", lambda k, *a: env.get(k))
+    with patch.dict("sys.modules", {"openai": MagicMock(OpenAI=_FakeClient)}):
+        list(ts.OpenAIStreamer({"openai": section}, section).stream("hi"))
+    return seen
+
+
+def test_openai_stream_prefers_configured_endpoint(monkeypatch):
+    """tts.openai.base_url beats the environment, as in the synchronous path.
+
+    Otherwise a self-hosted OpenAI-compatible server works for ordinary replies
+    and then streams from api.openai.com, asking it for a local model.
+    """
+    seen = _openai_client_kwargs(
+        monkeypatch,
+        {"base_url": "http://localhost:4003/v1", "api_key": "local"},
+        {"OPENAI_API_KEY": "env-key", "OPENAI_BASE_URL": "https://env.example/v1"},
+    )
+    assert seen["base_url"] == "http://localhost:4003/v1"
+    assert seen["api_key"] == "local"
+
+
+def test_openai_stream_falls_back_to_env(monkeypatch):
+    """Nothing configured — unchanged behaviour for real-OpenAI users."""
+    seen = _openai_client_kwargs(
+        monkeypatch,
+        {},
+        {"OPENAI_API_KEY": "env-key", "OPENAI_BASE_URL": "https://env.example/v1"},
+    )
+    assert seen["base_url"] == "https://env.example/v1"
+    assert seen["api_key"] == "env-key"
+
+
+def test_openai_stream_resolves_base_url_and_key_independently(monkeypatch):
+    """A configured endpoint with no configured key still uses the env key."""
+    seen = _openai_client_kwargs(
+        monkeypatch,
+        {"base_url": "http://localhost:4003/v1"},
+        {"OPENAI_API_KEY": "env-key"},
+    )
+    assert seen["base_url"] == "http://localhost:4003/v1"
+    assert seen["api_key"] == "env-key"
+
+
+def test_openai_stream_ignores_blank_config_values(monkeypatch):
+    """Empty/whitespace YAML values must not shadow the environment."""
+    seen = _openai_client_kwargs(
+        monkeypatch,
+        {"base_url": "   ", "api_key": ""},
+        {"OPENAI_API_KEY": "env-key", "OPENAI_BASE_URL": "https://env.example/v1"},
+    )
+    assert seen["base_url"] == "https://env.example/v1"
+    assert seen["api_key"] == "env-key"
+
+
 # ── Dispatch: chunked streamer path ──────────────────────────────────────
 
 

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -194,6 +194,12 @@ class ElevenLabsStreamer(StreamingTTSProvider):
         )
 
 
+def _section_value(section: Dict, key: str) -> Optional[str]:
+    """Return a non-blank string from a provider's config section, else None."""
+    value = (section or {}).get(key)
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
 @register("openai")
 class OpenAIStreamer(StreamingTTSProvider):
     """OpenAI speech with ``response_format=pcm`` (24 kHz mono int16)."""
@@ -207,10 +213,15 @@ class OpenAIStreamer(StreamingTTSProvider):
     def stream(self, text: str) -> Iterator[bytes]:
         from openai import OpenAI
 
-        client = OpenAI(
-            api_key=get_env_value("OPENAI_API_KEY"),
-            base_url=get_env_value("OPENAI_BASE_URL") or None,
-        )
+        # Mirror the synchronous path's precedence (tools/tts_tool.py): the
+        # configured endpoint wins over the environment, which is the
+        # last-resort default. Without this, a self-hosted OpenAI-compatible
+        # server works for ordinary replies and then streams from
+        # api.openai.com — asking it for a local model in a local voice.
+        base_url = _section_value(self.section, "base_url") or get_env_value("OPENAI_BASE_URL")
+        api_key = _section_value(self.section, "api_key") or get_env_value("OPENAI_API_KEY")
+
+        client = OpenAI(api_key=api_key, base_url=base_url or None)
         model = self.section.get("model", "gpt-4o-mini-tts")
         voice = self.section.get("voice", "alloy")
         with client.audio.speech.with_streaming_response.create(


### PR DESCRIPTION
## What does this PR do?

`OpenAIStreamer` reads `model` and `voice` from the `tts.openai` config section but takes `base_url` and `api_key` from the environment. The synchronous path resolves the opposite way, and says so:

```python
config_base_url = oai_config.get("base_url")
if base_url is None:
    # Config override wins over the auth-chain fallback (restores the
    # pre-refactor precedence, where tts.openai.base_url beat the resolved
    # default); the auth-chain value is the last-resort default.
    base_url = config_base_url or fallback_base or DEFAULT_OPENAI_BASE_URL
```

So `tts.openai.base_url` is honoured for `synthesize` and ignored for `stream`. A self-hosted OpenAI-compatible TTS server works for ordinary replies and then streams from `api.openai.com` — asking it for a local model name in a local voice. That request fails; with a model name that happens to exist it would instead succeed against the wrong provider, in the wrong voice, and be billed.

This applies the synchronous path's precedence in `stream()`: configured value first, environment as fallback.

## Related Issue

Fixes #73530

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`tools/tts_streaming.py`** (+15/-4): `OpenAIStreamer.stream()` resolves `base_url` and `api_key` from the provider's config section first, falling back to the environment. Adds `_section_value()`, which returns a config value only when it is a non-blank string, so an empty YAML value cannot shadow the environment. Resolution is independent per field.
- **`tests/tools/test_tts_streaming.py`** (+75): four behaviours — configured endpoint wins; nothing configured falls back to env unchanged; `base_url` and `api_key` resolve independently; blank values are ignored.

Deliberately *not* changed: `available()` still gates on `OPENAI_API_KEY`. A local server that ignores auth arguably shouldn't need an unrelated cloud key present, but that is a separate behavioural question and is not required to fix the wrong-endpoint bug. Noted in #73530.

## How to Test

Config with a self-hosted OpenAI-compatible TTS endpoint, and no `OPENAI_BASE_URL` in the environment (`OPENAI_API_KEY` set for the LLM, as is typical):

```yaml
tts:
  provider: openai
  openai:
    model: qwen3-tts-customvoice-1.7b
    voice: mira
    base_url: http://<host>:4003/v1
    api_key: dummy-no-auth
```

```python
from tools.tts_streaming import resolve_streaming_provider
s = resolve_streaming_provider(tts_config)
next(s.stream("hello"))
```

Before: connects to `https://api.openai.com/v1`. After: connects to the configured endpoint.

```bash
pytest tests/tools/test_tts_streaming.py -v
```

The two behaviour tests fail without the change and pass with it.

## Platforms tested

macOS 26.5 (Python 3.11), against a self-hosted Qwen3-TTS server on Linux/CUDA. The change is pure config resolution with no platform-specific behaviour.

Full run of the TTS/voice suites: 478 passed. Three failures in `tests/tools/test_voice_mode.py::TestPulseSocketReachable` are pre-existing on macOS (PulseAudio sockets) and reproduce identically with this change stashed.

## Notes

Found while wiring streaming TTS into the `hermes-livekit` gateway plugin against a local Qwen3-TTS server. Anything resolving a streamer inherits this, including the gateway consumer in #73358 — that PR calls `resolve_streaming_provider(tts_config)` and does not touch `base_url` itself, so it is correct as written and simply picks up whichever endpoint this function returns.
