### PR TITLE
fix(gateway): reassemble MEDIA: tags split across streaming chunks

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -737,9 +737,9 @@ PLATFORM_HINTS = {
         "formatting (no asterisks, bullets, headers, code fences). Treat this like a conversation, not a document. "
         "Keep responses brief and natural. File/media delivery: images referenced as MEDIA:/absolute/path tags "
         "(.png/.jpg/.jpeg/.gif/.webp/.bmp, up to 5MB) are inlined as base64 data URLs in responses on the chat, "
-        "completions, and responses endpoints. Non-image files are NOT intercepted anywhere, and the runs endpoint "
-        "intercepts nothing — a MEDIA: tag there renders as literal text exposing a raw host filesystem path. For "
-        "those cases, state the plain file path in your response text instead of a MEDIA: tag."
+        "completions, responses, and runs endpoints. Non-image files are NOT intercepted on any of them — a "
+        "MEDIA: tag for a non-image file renders as literal text exposing a raw host filesystem path. For "
+        "non-image files, state the plain file path in your response text instead of a MEDIA: tag."
     ),
     # No "webui" hint on purpose: nothing constructs platform="webui" (the dashboard chat resolves to
     # 'desktop' or 'tui'). If a real WebUI chat surface ships, write a hint from its actual renderer.

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -933,11 +933,11 @@ PLATFORM_HINTS = {
         "brief and natural. "
         "File/media delivery: images referenced as MEDIA:/absolute/path tags "
         "(.png/.jpg/.jpeg/.gif/.webp/.bmp, up to 5MB) are inlined as base64 data "
-        "URLs in responses on the chat, completions, and responses endpoints. "
-        "Non-image files are NOT intercepted anywhere, and the runs endpoint "
-        "intercepts nothing — a MEDIA: tag there renders as literal text exposing "
-        "a raw host filesystem path. For those cases, state the plain file path "
-        "in your response text instead of a MEDIA: tag."
+        "URLs in responses on the chat, completions, responses, and runs endpoints. "
+        "Non-image files are NOT intercepted on any of them — a MEDIA: tag for a "
+        "non-image file renders as literal text exposing a raw host filesystem "
+        "path. For non-image files, state the plain file path in your response "
+        "text instead of a MEDIA: tag."
     ),
     "webui": (
         "You are in the Hermes WebUI, a browser-based chat interface. "

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -25,7 +25,7 @@ import threading
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 # _resolve_request_profile result for a /p/<profile>/ prefix this gateway does not serve (-> 404);
 # distinct from None (no prefix / multiplexing off -> default profile).
@@ -833,6 +833,99 @@ _MEDIA_MIME = {".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
                ".webp": "image/webp", ".bmp": "image/bmp"}
 _MEDIA_IMG_EXT = set(_MEDIA_MIME)
 _MEDIA_DATA_URL_MAX_BYTES = 5 * 1024 * 1024  # skip images larger than 5MB
+
+
+_MEDIA_HOLDBACK_WORD = "MEDIA"
+# How much text may accumulate after a bare "MEDIA" sighting before giving up
+# on it becoming a real tag and releasing it as plain text. Generous enough
+# for any real MEDIA:<path> (paths are rarely anywhere near this long), small
+# enough that an ordinary prose mention of the word "media" doesn't visibly
+# stall a live stream for long.
+_MEDIA_HOLDBACK_CAP = 400
+
+
+class StreamingMediaTagResolver:
+    """Buffers streamed text so a ``MEDIA:<path>`` tag is never split across
+    two delta chunks, then resolves completed tags to inline data URLs.
+
+    Real per-token LLM streaming can (and does) land a ``MEDIA:`` tag's
+    characters across several separate delta chunks. ``_resolve_media_to_data_urls``
+    only recognizes a COMPLETE tag, so calling it on each raw delta
+    independently -- what every SSE/streaming call site in this file did
+    before this class existed -- lets a split tag pass through untouched:
+    confirmed in production (2026-07-28) as literal ``MEDIA:/path...`` text
+    reaching a live client instead of an image, across every streaming
+    endpoint in this module (only the non-streaming responses ever called
+    the resolver).
+
+    Usage: call :meth:`feed` with each incoming delta and emit whatever it
+    returns (may be empty -- text is being held back pending more input);
+    call :meth:`flush` once at stream end and emit its (possibly empty)
+    return value before closing.
+    """
+
+    __slots__ = ("_pending",)
+
+    def __init__(self) -> None:
+        self._pending: str = ""
+
+    def feed(self, text: str) -> str:
+        """Feed one delta chunk; return the text now safe to emit (resolved)."""
+        if not text:
+            return ""
+        self._pending += text
+        safe, self._pending = self._split_safe_boundary(self._pending)
+        return _resolve_media_to_data_urls(safe) if safe else ""
+
+    def flush(self) -> str:
+        """Release and resolve whatever is still held back (stream end)."""
+        if not self._pending:
+            return ""
+        remainder = self._pending
+        self._pending = ""
+        return _resolve_media_to_data_urls(remainder)
+
+    @staticmethod
+    def _split_safe_boundary(buffer: str) -> Tuple[str, str]:
+        """Split *buffer* into (safe_to_emit, held_back).
+
+        Anchored on "MEDIA:" -- WITH the colon, not the bare word. An
+        earlier version searched for bare "MEDIA" and broke on exactly the
+        realistic case this whole class exists for: a delivered path
+        containing the substring "media" anywhere in a component (a
+        directory or filename like ".../social_media_post.png", or even a
+        test fixture's own tempdir name) rfind()-matched THAT occurrence
+        instead of the real tag start, releasing part of the actual
+        "MEDIA:<path>" tag as unresolved plain text. The colon is what makes
+        a tag start unambiguous -- "media" as an ordinary word/path
+        component is never immediately followed by ":" in real text.
+
+        Falls back to holding a trailing partial prefix of the literal
+        string "MEDIA:" (e.g. buffer ending in "...see ME" -- next chunk
+        might complete it) only when no confirmed "MEDIA:" exists yet.
+        Bounded by ``_MEDIA_HOLDBACK_CAP`` so a "MEDIA:" that never resolves
+        to a valid tag doesn't hold the stream hostage -- matches the
+        existing design principle elsewhere in this file that validation,
+        not a length guess, is the oracle for whether a tag is real: once
+        released past the cap, ``_resolve_media_to_data_urls`` still leaves
+        a genuinely invalid/nonexistent path as visible plain text.
+        """
+        upper = buffer.upper()
+        idx = upper.rfind(_MEDIA_HOLDBACK_WORD + ":")
+        if idx != -1:
+            tail = buffer[idx:]
+            if len(tail) > _MEDIA_HOLDBACK_CAP:
+                return buffer, ""
+            return buffer[:idx], tail
+        # No confirmed "MEDIA:" yet. Check only the buffer's TAIL (not any
+        # mid-buffer occurrence, which is just a word/path component, e.g.
+        # "social_media_post.png") for a partial prefix of "MEDIA:" that the
+        # next chunk could still complete.
+        word = _MEDIA_HOLDBACK_WORD
+        for n in range(min(len(word), len(buffer)), 0, -1):
+            if upper.endswith(word[:n]):
+                return buffer[:-n], buffer[-n:]
+        return buffer, ""
 
 
 def _resolve_media_to_data_urls(text: str) -> str:
@@ -3123,9 +3216,34 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         self._set_run_status(
             run_id, "queued", session_id=session_id, model=ctx["body"].get("model", self._model_name))
 
+        # Buffers raw deltas so a MEDIA:<path> tag split across chunk
+        # boundaries still resolves to an inline data URL instead of leaking
+        # as literal text to a client rendering deltas live -- the eventual
+        # "assistant.completed" event below already carries the fully
+        # resolved text, but a client that renders each delta as it arrives
+        # (the common UX pattern this event stream exists for) would
+        # otherwise see the raw tag flash by first. See
+        # StreamingMediaTagResolver's docstring.
+        _delta_media_resolver = StreamingMediaTagResolver()
+
         def _delta(delta: str) -> None:
             if delta:
-                events.enqueue("assistant.delta", {"message_id": message_id, "delta": delta})
+                safe_text = _delta_media_resolver.feed(delta)
+                if safe_text:
+                    events.enqueue("assistant.delta", {"message_id": message_id, "delta": safe_text})
+
+        def _flush_delta_media_resolver() -> None:
+            """Emit whatever the MEDIA-tag resolver is still holding back.
+
+            Idempotent -- ``flush()`` clears its own buffer, so a second call
+            on an already-flushed path is a no-op returning "".
+            """
+            try:
+                remainder = _delta_media_resolver.flush()
+            except Exception:
+                return
+            if remainder:
+                events.enqueue("assistant.delta", {"message_id": message_id, "delta": remainder})
 
         def _tool_progress(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs) -> None:
             if event_type == "reasoning.available":
@@ -3144,6 +3262,11 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                 result, usage = await self._run_agent(
                     conversation_history=history, stream_delta_callback=_delta,
                     tool_progress_callback=_tool_progress, active_run_id=run_id, **ctx["run_kwargs"])
+                # Release any MEDIA-tag holdback before the terminal event.
+                # feed() retains all text from the last "MEDIA:" onward, so
+                # failing without flushing silently swallows text this stream
+                # used to deliver (raw, but delivered).
+                _flush_delta_media_resolver()
                 is_dict = isinstance(result, dict)
                 final_response = _resolve_media_to_data_urls(result.get("final_response", "") if is_dict else "")
                 effective_session_id = result.get("session_id", session_id) if is_dict else session_id
@@ -3178,6 +3301,11 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             finally:
                 self._active_run_agents.pop(run_id, None)
                 self._release_run_owner_if_forgotten(run_id)
+                # Safety net for any terminal path that reaches neither the
+                # success flush nor the except above -- notably cancellation.
+                # Must precede the close sentinel. Idempotent, so this is a
+                # no-op on paths that already flushed.
+                _flush_delta_media_resolver()
                 await queue.put(_event_payload("done", {}))
                 await queue.put(None)
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -57,7 +57,7 @@ import threading
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 # Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
 # names a profile this gateway does not serve (→ 404). Distinct from None
@@ -1026,6 +1026,99 @@ _MEDIA_MIME = {
     ".bmp": "image/bmp",
 }
 _MEDIA_DATA_URL_MAX_BYTES = 5 * 1024 * 1024  # skip images larger than 5MB
+
+
+_MEDIA_HOLDBACK_WORD = "MEDIA"
+# How much text may accumulate after a bare "MEDIA" sighting before giving up
+# on it becoming a real tag and releasing it as plain text. Generous enough
+# for any real MEDIA:<path> (paths are rarely anywhere near this long), small
+# enough that an ordinary prose mention of the word "media" doesn't visibly
+# stall a live stream for long.
+_MEDIA_HOLDBACK_CAP = 400
+
+
+class StreamingMediaTagResolver:
+    """Buffers streamed text so a ``MEDIA:<path>`` tag is never split across
+    two delta chunks, then resolves completed tags to inline data URLs.
+
+    Real per-token LLM streaming can (and does) land a ``MEDIA:`` tag's
+    characters across several separate delta chunks. ``_resolve_media_to_data_urls``
+    only recognizes a COMPLETE tag, so calling it on each raw delta
+    independently -- what every SSE/streaming call site in this file did
+    before this class existed -- lets a split tag pass through untouched:
+    confirmed in production (2026-07-28) as literal ``MEDIA:/path...`` text
+    reaching a live client instead of an image, across every streaming
+    endpoint in this module (only the non-streaming responses ever called
+    the resolver).
+
+    Usage: call :meth:`feed` with each incoming delta and emit whatever it
+    returns (may be empty -- text is being held back pending more input);
+    call :meth:`flush` once at stream end and emit its (possibly empty)
+    return value before closing.
+    """
+
+    __slots__ = ("_pending",)
+
+    def __init__(self) -> None:
+        self._pending: str = ""
+
+    def feed(self, text: str) -> str:
+        """Feed one delta chunk; return the text now safe to emit (resolved)."""
+        if not text:
+            return ""
+        self._pending += text
+        safe, self._pending = self._split_safe_boundary(self._pending)
+        return _resolve_media_to_data_urls(safe) if safe else ""
+
+    def flush(self) -> str:
+        """Release and resolve whatever is still held back (stream end)."""
+        if not self._pending:
+            return ""
+        remainder = self._pending
+        self._pending = ""
+        return _resolve_media_to_data_urls(remainder)
+
+    @staticmethod
+    def _split_safe_boundary(buffer: str) -> Tuple[str, str]:
+        """Split *buffer* into (safe_to_emit, held_back).
+
+        Anchored on "MEDIA:" -- WITH the colon, not the bare word. An
+        earlier version searched for bare "MEDIA" and broke on exactly the
+        realistic case this whole class exists for: a delivered path
+        containing the substring "media" anywhere in a component (a
+        directory or filename like ".../social_media_post.png", or even a
+        test fixture's own tempdir name) rfind()-matched THAT occurrence
+        instead of the real tag start, releasing part of the actual
+        "MEDIA:<path>" tag as unresolved plain text. The colon is what makes
+        a tag start unambiguous -- "media" as an ordinary word/path
+        component is never immediately followed by ":" in real text.
+
+        Falls back to holding a trailing partial prefix of the literal
+        string "MEDIA:" (e.g. buffer ending in "...see ME" -- next chunk
+        might complete it) only when no confirmed "MEDIA:" exists yet.
+        Bounded by ``_MEDIA_HOLDBACK_CAP`` so a "MEDIA:" that never resolves
+        to a valid tag doesn't hold the stream hostage -- matches the
+        existing design principle elsewhere in this file that validation,
+        not a length guess, is the oracle for whether a tag is real: once
+        released past the cap, ``_resolve_media_to_data_urls`` still leaves
+        a genuinely invalid/nonexistent path as visible plain text.
+        """
+        upper = buffer.upper()
+        idx = upper.rfind(_MEDIA_HOLDBACK_WORD + ":")
+        if idx != -1:
+            tail = buffer[idx:]
+            if len(tail) > _MEDIA_HOLDBACK_CAP:
+                return buffer, ""
+            return buffer[:idx], tail
+        # No confirmed "MEDIA:" yet. Check only the buffer's TAIL (not any
+        # mid-buffer occurrence, which is just a word/path component, e.g.
+        # "social_media_post.png") for a partial prefix of "MEDIA:" that the
+        # next chunk could still complete.
+        word = _MEDIA_HOLDBACK_WORD
+        for n in range(min(len(word), len(buffer)), 0, -1):
+            if upper.endswith(word[:n]):
+                return buffer[:-n], buffer[-n:]
+        return buffer, ""
 
 
 def _resolve_media_to_data_urls(text: str) -> str:
@@ -3809,9 +3902,21 @@ class APIServerAdapter(BasePlatformAdapter):
             except RuntimeError:
                 pass
 
+        # Buffers raw deltas so a MEDIA:<path> tag split across chunk
+        # boundaries still resolves to an inline data URL instead of leaking
+        # as literal text to a client rendering deltas live -- the eventual
+        # "assistant.completed" event below already carries the fully
+        # resolved text, but a client that renders each delta as it arrives
+        # (the common UX pattern this event stream exists for) would
+        # otherwise see the raw tag flash by first. See
+        # StreamingMediaTagResolver's docstring.
+        _delta_media_resolver = StreamingMediaTagResolver()
+
         def _delta(delta: str) -> None:
             if delta:
-                _enqueue("assistant.delta", {"message_id": message_id, "delta": delta})
+                safe_text = _delta_media_resolver.feed(delta)
+                if safe_text:
+                    _enqueue("assistant.delta", {"message_id": message_id, "delta": safe_text})
 
         def _tool_progress(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs) -> None:
             if event_type == "reasoning.available":
@@ -3863,6 +3968,11 @@ class APIServerAdapter(BasePlatformAdapter):
                         else ""
                     ),
                 )
+                _delta_remainder = _delta_media_resolver.flush()
+                if _delta_remainder:
+                    await queue.put(_event_payload("assistant.delta", {
+                        "message_id": message_id, "delta": _delta_remainder,
+                    }))
                 await queue.put(_event_payload("assistant.completed", {
                     "session_id": effective_session_id,
                     "message_id": message_id,
@@ -4367,6 +4477,12 @@ class APIServerAdapter(BasePlatformAdapter):
             await response.write(_sse_frame(role_chunk))
             last_activity = time.monotonic()
 
+            # Buffers raw deltas so a MEDIA:<path> tag split across chunk
+            # boundaries (real per-token LLM streaming does this routinely)
+            # still resolves to an inline data URL instead of leaking as
+            # literal text -- see StreamingMediaTagResolver's docstring.
+            _media_resolver = StreamingMediaTagResolver()
+
             # Helper — route a queue item to the correct SSE event.
             async def _emit(item):
                 """Write a single queue item to the SSE stream.
@@ -4381,13 +4497,26 @@ class APIServerAdapter(BasePlatformAdapter):
                 if isinstance(item, tuple) and len(item) == 2 and item[0] == "__tool_progress__":
                     await response.write(_sse_frame(item[1], event="hermes.tool.progress"))
                 else:
+                    safe_text = _media_resolver.feed(item)
+                    if safe_text:
+                        content_chunk = {
+                            "id": completion_id, "object": "chat.completion.chunk",
+                            "created": created, "model": model,
+                            "choices": [{"index": 0, "delta": {"content": safe_text}, "finish_reason": None}],
+                        }
+                        await response.write(_sse_frame(content_chunk))
+                return time.monotonic()
+
+            async def _flush_media_resolver():
+                """Emit whatever the resolver is still holding back (stream end)."""
+                remainder = _media_resolver.flush()
+                if remainder:
                     content_chunk = {
                         "id": completion_id, "object": "chat.completion.chunk",
                         "created": created, "model": model,
-                        "choices": [{"index": 0, "delta": {"content": item}, "finish_reason": None}],
+                        "choices": [{"index": 0, "delta": {"content": remainder}, "finish_reason": None}],
                     }
                     await response.write(_sse_frame(content_chunk))
-                return time.monotonic()
 
             # Stream content chunks as they arrive from the agent. Woken
             # directly by put_threadsafe's call_soon_threadsafe — no
@@ -4417,6 +4546,11 @@ class APIServerAdapter(BasePlatformAdapter):
                     break
 
                 last_activity = await _emit(delta)
+
+            # Stream over -- release anything the MEDIA-tag resolver is still
+            # holding back (a tag that completed right at the tail, or plain
+            # text it was conservatively waiting on).
+            await _flush_media_resolver()
 
             # Get usage from completed agent. The agent can fail two ways
             # after the content queue terminates cleanly: (1) ``agent_task``
@@ -4581,6 +4715,14 @@ class APIServerAdapter(BasePlatformAdapter):
         response = web.StreamResponse(status=200, headers=sse_headers)
         await response.prepare(request)
 
+        # Buffers raw text deltas so a MEDIA:<path> tag split across chunk
+        # boundaries -- or across two separate _flush_batch() calls -- still
+        # resolves to an inline data URL instead of leaking as literal text.
+        # final_text_parts (below) accumulates whatever this releases, so the
+        # reconstructed final_response_text is resolved too, not just the
+        # individual SSE delta events. See StreamingMediaTagResolver's docstring.
+        _output_text_media_resolver = StreamingMediaTagResolver()
+
         # State accumulated during the stream
         final_text_parts: List[str] = []
         # Track open function_call items by name so we can emit a matching
@@ -4714,14 +4856,33 @@ class APIServerAdapter(BasePlatformAdapter):
                 })
 
             async def _emit_text_delta(delta_text: str) -> None:
+                safe_text = _output_text_media_resolver.feed(delta_text)
+                if not safe_text:
+                    return
                 await _open_message_item()
-                final_text_parts.append(delta_text)
+                final_text_parts.append(safe_text)
                 await _write_event("response.output_text.delta", {
                     "type": "response.output_text.delta",
                     "item_id": message_item_id,
                     "output_index": message_output_index,
                     "content_index": 0,
-                    "delta": delta_text,
+                    "delta": safe_text,
+                    "logprobs": [],
+                })
+
+            async def _flush_text_delta_resolver() -> None:
+                """Emit whatever the resolver is still holding back (stream end)."""
+                remainder = _output_text_media_resolver.flush()
+                if not remainder:
+                    return
+                await _open_message_item()
+                final_text_parts.append(remainder)
+                await _write_event("response.output_text.delta", {
+                    "type": "response.output_text.delta",
+                    "item_id": message_item_id,
+                    "output_index": message_output_index,
+                    "content_index": 0,
+                    "delta": remainder,
                     "logprobs": [],
                 })
 
@@ -4920,6 +5081,10 @@ class APIServerAdapter(BasePlatformAdapter):
             # Flush any final batched text before processing result
             if _batch_buf:
                 await _flush_batch()
+            # Release anything the MEDIA-tag resolver is still holding back
+            # (a tag that completed right at the tail, or plain text it was
+            # conservatively waiting on) now that no more deltas are coming.
+            await _flush_text_delta_resolver()
 
             # Pick up agent result + usage from the completed task
             try:
@@ -4933,9 +5098,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 if agent_final and not final_text_parts:
                     await _emit_text_delta(agent_final)
                 if agent_final and not final_response_text:
-                    final_response_text = agent_final
+                    final_response_text = _resolve_media_to_data_urls(agent_final)
                 if isinstance(result, dict) and result.get("error") and not final_response_text:
                     agent_error = _redact_api_error_text(result["error"])
+                # Release any holdback from the fallback _emit_text_delta call
+                # above (defense-in-depth; a complete final_response fed in one
+                # shot should resolve immediately, but this guarantees it).
+                await _flush_text_delta_resolver()
             except Exception as e:  # noqa: BLE001
                 logger.error("Error running agent for streaming responses: %s", e, exc_info=True)
                 agent_error = _redact_api_error_text(e)
@@ -5953,7 +6122,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 })
 
         # Final assistant message
-        final = result.get("final_response", "")
+        final = _resolve_media_to_data_urls(result.get("final_response", ""))
         if not final:
             final = _redact_api_error_text(result.get("error", "(No response generated)"))
 
@@ -6501,17 +6670,27 @@ class APIServerAdapter(BasePlatformAdapter):
                 q.put_nowait(event)
 
         # Also wire stream_delta_callback so message.delta events flow through.
+        # Buffered so a MEDIA:<path> tag split across chunk boundaries still
+        # resolves to an inline data URL instead of leaking as literal text
+        # to a client subscribed to /v1/runs/{id}/events -- the confirmed
+        # 2026-07-28 incident (POST /v1/runs) hit exactly this path. See
+        # StreamingMediaTagResolver's docstring.
+        _run_delta_resolver = StreamingMediaTagResolver()
+
         def _text_cb(delta: Optional[str]) -> None:
             if delta is None:
                 return
             if run_id not in self._run_streams:
+                return
+            safe_text = _run_delta_resolver.feed(delta)
+            if not safe_text:
                 return
             try:
                 loop.call_soon_threadsafe(_put_event_if_active, {
                     "event": "message.delta",
                     "run_id": run_id,
                     "timestamp": time.time(),
-                    "delta": delta,
+                    "delta": safe_text,
                 })
             except Exception:
                 pass
@@ -6685,7 +6864,17 @@ class APIServerAdapter(BasePlatformAdapter):
                         last_event="run.failed",
                     )
                 else:
-                    final_response = result.get("final_response", "") if isinstance(result, dict) else ""
+                    _run_delta_remainder = _run_delta_resolver.flush()
+                    if _run_delta_remainder:
+                        _put_event_if_active({
+                            "event": "message.delta",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                            "delta": _run_delta_remainder,
+                        })
+                    final_response = _resolve_media_to_data_urls(
+                        result.get("final_response", "") if isinstance(result, dict) else ""
+                    )
                     _put_event_if_active({
                         "event": "run.completed",
                         "run_id": run_id,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3918,6 +3918,21 @@ class APIServerAdapter(BasePlatformAdapter):
                 if safe_text:
                     _enqueue("assistant.delta", {"message_id": message_id, "delta": safe_text})
 
+        async def _flush_delta_media_resolver() -> None:
+            """Emit whatever the MEDIA-tag resolver is still holding back.
+
+            Idempotent -- ``flush()`` clears its own buffer, so a second call
+            on an already-flushed path is a no-op returning "".
+            """
+            try:
+                remainder = _delta_media_resolver.flush()
+            except Exception:
+                return
+            if remainder:
+                await queue.put(_event_payload("assistant.delta", {
+                    "message_id": message_id, "delta": remainder,
+                }))
+
         def _tool_progress(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs) -> None:
             if event_type == "reasoning.available":
                 _enqueue("tool.progress", {"message_id": message_id, "tool_name": tool_name or "_thinking", "delta": preview or ""})
@@ -3968,11 +3983,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         else ""
                     ),
                 )
-                _delta_remainder = _delta_media_resolver.flush()
-                if _delta_remainder:
-                    await queue.put(_event_payload("assistant.delta", {
-                        "message_id": message_id, "delta": _delta_remainder,
-                    }))
+                await _flush_delta_media_resolver()
                 await queue.put(_event_payload("assistant.completed", {
                     "session_id": effective_session_id,
                     "message_id": message_id,
@@ -3992,8 +4003,19 @@ class APIServerAdapter(BasePlatformAdapter):
                 }))
             except Exception as exc:
                 logger.exception("[api_server] session chat stream failed")
+                # Release any MEDIA-tag holdback before the terminal error.
+                # feed() retains all text from the last "MEDIA:" onward, so
+                # failing without flushing silently swallows text this stream
+                # used to deliver (raw, but delivered).
+                await _flush_delta_media_resolver()
                 await queue.put(_event_payload("error", {"message": _redact_api_error_text(exc)}))
             finally:
+                # Safety net for any terminal path that reaches neither the
+                # success flush nor the except above -- notably cancellation,
+                # which is a BaseException and bypasses `except Exception`.
+                # Must precede the close sentinel. Idempotent, so this is a
+                # no-op on paths that already flushed.
+                await _flush_delta_media_resolver()
                 await queue.put(_event_payload("done", {}))
                 await queue.put(None)
 
@@ -6695,6 +6717,27 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception:
                 pass
 
+        def _flush_run_delta_resolver() -> None:
+            """Emit whatever the MEDIA-tag resolver is still holding back.
+
+            Idempotent -- ``flush()`` clears its own buffer, so calling this on
+            a path that already flushed is a no-op returning "". That is what
+            lets it be called both on the normal post-run path and again from
+            the ``finally`` safety net without double-emitting.
+            """
+            try:
+                remainder = _run_delta_resolver.flush()
+            except Exception:
+                return
+            if not remainder:
+                return
+            _put_event_if_active({
+                "event": "message.delta",
+                "run_id": run_id,
+                "timestamp": time.time(),
+                "delta": remainder,
+            })
+
         self._set_run_status(
             run_id,
             "queued",
@@ -6835,6 +6878,14 @@ class APIServerAdapter(BasePlatformAdapter):
                         return r, u
 
                 result, usage = await asyncio.get_running_loop().run_in_executor(None, _run_sync)
+                # Release any MEDIA-tag holdback BEFORE the terminal event, on
+                # every outcome. feed() retains all text from the last "MEDIA:"
+                # onward, so a terminal path that skips the flush silently
+                # swallows text this endpoint used to deliver (raw, but
+                # delivered). Doing it here -- once, before the
+                # cancelled/failed/completed branching below -- covers all
+                # three uniformly; the finally block covers the raising paths.
+                _flush_run_delta_resolver()
                 if run_id in self._stopping_run_ids:
                     _put_event_if_active({
                         "event": "run.cancelled",
@@ -6864,14 +6915,6 @@ class APIServerAdapter(BasePlatformAdapter):
                         last_event="run.failed",
                     )
                 else:
-                    _run_delta_remainder = _run_delta_resolver.flush()
-                    if _run_delta_remainder:
-                        _put_event_if_active({
-                            "event": "message.delta",
-                            "run_id": run_id,
-                            "timestamp": time.time(),
-                            "delta": _run_delta_remainder,
-                        })
                     final_response = _resolve_media_to_data_urls(
                         result.get("final_response", "") if isinstance(result, dict) else ""
                     )
@@ -6958,6 +7001,13 @@ class APIServerAdapter(BasePlatformAdapter):
                     unregister_gateway_notify(approval_session_key)
                 except Exception:
                     pass
+                # Safety net for the paths that never reach the post-run flush
+                # above: a raising _run_sync (provider auth failure, generic
+                # exception) or cancellation. Must run BEFORE the close
+                # sentinel below or the delta would be enqueued after the
+                # consumer has already stopped reading. Idempotent, so the
+                # normal path's own flush makes this a no-op there.
+                _flush_run_delta_resolver()
                 # Sentinel: signal SSE stream to close
                 try:
                     _put_event_if_active(None)

--- a/gateway/platforms/api_server_openai_routes.py
+++ b/gateway/platforms/api_server_openai_routes.py
@@ -148,6 +148,13 @@ class _ResponsesStream:
         self._batch_buf: List[str] = []
         self._batch_timer: Optional[asyncio.Task] = None
         self._batch_lock = asyncio.Lock()
+        # Buffers raw text deltas so a MEDIA:<path> tag split across chunk
+        # boundaries -- or across two separate flush_batch() calls -- still
+        # resolves to an inline data URL instead of leaking as literal text.
+        # final_text_parts accumulates whatever this releases, so the
+        # reconstructed final_response_text is resolved too, not just the
+        # individual SSE delta events. See StreamingMediaTagResolver's docstring.
+        self._media_resolver = self._api.StreamingMediaTagResolver()
 
     async def write_event(self, event_type: str, data: Dict[str, Any]) -> None:
         if "sequence_number" not in data:
@@ -214,11 +221,26 @@ class _ResponsesStream:
                      "role": "assistant", "content": []}})
 
     async def emit_text_delta(self, delta_text: str) -> None:
+        safe_text = self._media_resolver.feed(delta_text)
+        if not safe_text:
+            return
         await self._open_message_item()
-        self.final_text_parts.append(delta_text)
+        self.final_text_parts.append(safe_text)
         await self.write_event("response.output_text.delta", {
             "type": "response.output_text.delta", "item_id": self.message_item_id,
-            "output_index": self.message_output_index, "content_index": 0, "delta": delta_text,
+            "output_index": self.message_output_index, "content_index": 0, "delta": safe_text,
+            "logprobs": []})
+
+    async def flush_text_delta_resolver(self) -> None:
+        """Emit whatever the MEDIA-tag resolver is still holding back (stream end)."""
+        remainder = self._media_resolver.flush()
+        if not remainder:
+            return
+        await self._open_message_item()
+        self.final_text_parts.append(remainder)
+        await self.write_event("response.output_text.delta", {
+            "type": "response.output_text.delta", "item_id": self.message_item_id,
+            "output_index": self.message_output_index, "content_index": 0, "delta": remainder,
             "logprobs": []})
 
     async def emit_tool_started(self, payload: Dict[str, Any]) -> None:
@@ -314,9 +336,13 @@ class _ResponsesStream:
             if agent_final and not self.final_text_parts:
                 await self.emit_text_delta(agent_final)
             if agent_final and not self.final_response_text:
-                self.final_response_text = agent_final
+                self.final_response_text = self._api._resolve_media_to_data_urls(agent_final)
             if isinstance(result, dict) and result.get("error") and not self.final_response_text:
                 self.agent_error = self._api._redact_api_error_text(result["error"])
+            # Release any holdback from the fallback emit_text_delta call
+            # above (defense-in-depth; a complete final_response fed in one
+            # shot should resolve immediately, but this guarantees it).
+            await self.flush_text_delta_resolver()
         except Exception as e:  # noqa: BLE001
             logger.error("Error running agent for streaming responses: %s", e, exc_info=True)
             self.agent_error = self._api._redact_api_error_text(e)
@@ -617,13 +643,19 @@ class OpenAICompatRoutesMixin:
         """Stream ``chat.completion.chunk`` frames from the agent's delta queue. On client
         disconnect the agent is interrupted (stops LLM calls), then its task wrapper cancelled."""
         from gateway.platforms.api_server import (
-            _abandon_agent_task, _chat_usage_payload, _sse_frame)
+            _abandon_agent_task, _chat_usage_payload, _sse_frame, StreamingMediaTagResolver)
         response = await self._prepare_sse_response(request, session_id, gateway_session_key)
 
         def _chunk(delta: Dict[str, Any], finish_reason=None, **extra) -> Dict[str, Any]:
             return {"id": completion_id, "object": "chat.completion.chunk", "created": created,
                     "model": model,
                     "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}], **extra}
+
+        # Buffers raw deltas so a MEDIA:<path> tag split across chunk
+        # boundaries (real per-token LLM streaming does this routinely)
+        # still resolves to an inline data URL instead of leaking as
+        # literal text -- see StreamingMediaTagResolver's docstring.
+        media_resolver = StreamingMediaTagResolver()
         try:
             await response.write(_sse_frame(_chunk({"role": "assistant"})))
             async for delta in _iter_stream_items(stream_q, agent_task, response):
@@ -633,7 +665,15 @@ class OpenAICompatRoutesMixin:
                     # Custom event: tool lifecycle for frontends without markers in history.
                     await response.write(_sse_frame(delta[1], event="hermes.tool.progress"))
                 else:
-                    await response.write(_sse_frame(_chunk({"content": delta})))
+                    safe_text = media_resolver.feed(delta)
+                    if safe_text:
+                        await response.write(_sse_frame(_chunk({"content": safe_text})))
+            # Stream over -- release anything the MEDIA-tag resolver is still
+            # holding back (a tag that completed right at the tail, or plain
+            # text it was conservatively waiting on).
+            remainder = media_resolver.flush()
+            if remainder:
+                await response.write(_sse_frame(_chunk({"content": remainder})))
             # The agent can fail after the queue drains (task raises / result flagged failed or
             # partial): surface a non-"stop" finish_reason like the non-streaming path.
             usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
@@ -698,6 +738,10 @@ class OpenAICompatRoutesMixin:
                     break
                 await st.dispatch(item)
             await st.flush_batch()
+            # Release anything the MEDIA-tag resolver is still holding back
+            # (a tag that completed right at the tail, or plain text it was
+            # conservatively waiting on) now that no more deltas are coming.
+            await st.flush_text_delta_resolver()
             await st.collect_result(agent_task)
             await st.close_message_item()
             if st.agent_error:
@@ -986,7 +1030,7 @@ class OpenAICompatRoutesMixin:
     def _extract_output_items(result: Dict[str, Any], start_index: int = 0) -> List[Dict[str, Any]]:
         """Output items from ``result["messages"][start_index:]``: ``function_call`` per assistant
         tool_call, ``function_call_output`` per tool message, then the final ``message``."""
-        from gateway.platforms.api_server import _redact_api_error_text
+        from gateway.platforms.api_server import _redact_api_error_text, _resolve_media_to_data_urls
         items: List[Dict[str, Any]] = []
         messages = result.get("messages", [])
         if start_index > 0:
@@ -1008,7 +1052,7 @@ class OpenAICompatRoutesMixin:
                     "id": f"fco_{uuid.uuid4().hex[:24]}", "type": "function_call_output",
                     "status": "completed", "call_id": msg.get("tool_call_id", ""),
                     "output": msg.get("content", "")})
-        final = result.get("final_response", "") or _redact_api_error_text(
+        final = _resolve_media_to_data_urls(result.get("final_response", "")) or _redact_api_error_text(
             result.get("error", "(No response generated)"))
         items.append(_message_item(final))
         return items

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -542,13 +542,40 @@ def _make_approval_notify(self, run: _RunLaunch, *, _api_server) -> Callable[[Di
 async def _execute_run(self, run: _RunLaunch, *, _api_server) -> None:
     """Drive one admitted run, publish its terminal event/status, release live state."""
     _redact_api_error_text = _api_server._redact_api_error_text
+    _resolve_media_to_data_urls = _api_server._resolve_media_to_data_urls
     run_id, loop = run.run_id, asyncio.get_running_loop()
+    # Buffered so a MEDIA:<path> tag split across chunk boundaries still
+    # resolves to an inline data URL instead of leaking as literal text
+    # to a client subscribed to /v1/runs/{id}/events -- the confirmed
+    # 2026-07-28 incident (POST /v1/runs) hit exactly this path. See
+    # StreamingMediaTagResolver's docstring.
+    _run_delta_resolver = _api_server.StreamingMediaTagResolver()
 
     def _text_cb(delta: Optional[str]) -> None:
         if delta is None or run_id not in self._run_streams:
             return
+        safe_text = _run_delta_resolver.feed(delta)
+        if not safe_text:
+            return
         with suppress(Exception):
-            loop.call_soon_threadsafe(run.put_event, _run_event(run_id, "message.delta", delta=delta))
+            loop.call_soon_threadsafe(run.put_event, _run_event(run_id, "message.delta", delta=safe_text))
+
+    def _flush_run_delta_resolver() -> None:
+        """Emit whatever the MEDIA-tag resolver is still holding back.
+
+        Idempotent -- ``flush()`` clears its own buffer, so calling this on
+        a path that already flushed is a no-op returning "". That is what
+        lets it be called both on the normal post-run path and again from
+        the ``finally`` safety net without double-emitting.
+        """
+        try:
+            remainder = _run_delta_resolver.flush()
+        except Exception:
+            return
+        if not remainder:
+            return
+        with suppress(Exception):
+            run.put_event(_run_event(run_id, "message.delta", delta=remainder))
 
     def _finish(status: str, extra: Optional[dict] = None, **fields: Any) -> None:
         """Terminal status, then best-effort ``run.<status>`` event; key order is wire shape."""
@@ -570,6 +597,13 @@ async def _execute_run(self, run: _RunLaunch, *, _api_server) -> None:
         approval_notify = _make_approval_notify(self, run, _api_server=_api_server)
         result, usage = await loop.run_in_executor(
             None, lambda: _run_agent_sync(self, run, agent, approval_notify, _api_server=_api_server))
+        # Release any MEDIA-tag holdback BEFORE the terminal event. feed()
+        # retains all text from the last "MEDIA:" onward, so a terminal path
+        # that skips the flush silently swallows text this endpoint used to
+        # deliver (raw, but delivered). Doing it here -- once, before the
+        # cancelled/failed/completed branching below -- covers all three
+        # uniformly; the finally block covers the raising paths.
+        _flush_run_delta_resolver()
         if not isinstance(result, dict):
             result = {}
         if run_id in self._stopping_run_ids and result.get("interrupted") is True:
@@ -580,7 +614,7 @@ async def _execute_run(self, run: _RunLaunch, *, _api_server) -> None:
         else:
             # Undelivered steer text rides on the terminal event/status for client replay.
             extra = {"pending_steer": result["pending_steer"]} if result.get("pending_steer") else {}
-            _finish("completed", extra, output=result.get("final_response", ""), usage=usage)
+            _finish("completed", extra, output=_resolve_media_to_data_urls(result.get("final_response", "")), usage=usage)
     except asyncio.CancelledError:
         _finish("cancelled")
         raise
@@ -595,6 +629,13 @@ async def _execute_run(self, run: _RunLaunch, *, _api_server) -> None:
         # On cancellation (/stop) the executor thread may still block on an approval
         # Event; unregistering releases it. Idempotent on normal completion.
         _unregister_approval_notify(run.approval_session_key)
+        # Safety net for the paths that never reach the post-run flush above:
+        # a raising _run_agent_sync (provider auth failure, generic
+        # exception) or cancellation. Must run BEFORE the close sentinel
+        # below or the delta would be enqueued after the consumer has
+        # already stopped reading. Idempotent, so the normal path's own
+        # flush makes this a no-op there.
+        _flush_run_delta_resolver()
         with suppress(Exception):
             run.put_event(None)  # sentinel: close the SSE stream
         _retire_live_run(self, run_id)

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -688,21 +688,26 @@ class TestPromptBuilderConstants:
 
 
     def test_api_server_hint_scopes_media_tag_guidance(self):
-        """api_server MEDIA: interception is partial (#68402, corrected):
-        _resolve_media_to_data_urls (gateway/platforms/api_server.py) inlines
+        """api_server MEDIA: interception is partial (#68402, corrected by
+        #70170, extended by #73537): _resolve_media_to_data_urls and
+        StreamingMediaTagResolver (gateway/platforms/api_server.py) inline
         small image MEDIA: tags as base64 data URLs on the chat, completions,
-        and responses endpoints — but non-image files are never resolved
-        (_MEDIA_IMG_EXT is image-only) and the /v1/runs handler never calls
-        the resolver at all. The hint must teach BOTH halves: images work via
-        MEDIA:, everything else needs a plain path in the response text."""
+        responses, AND runs endpoints as of #73537, which added the missing
+        /v1/runs resolver (StreamingMediaTagResolver + a final
+        _resolve_media_to_data_urls call in _handle_runs) — before that, runs
+        was the one endpoint with no resolver at all, per #70170's hint. Only
+        non-image files remain unresolved everywhere (_MEDIA_IMG_EXT is
+        image-only). The hint must teach BOTH halves: images work via MEDIA:
+        on all four endpoints, non-image files need a plain path in the
+        response text."""
         hint = PLATFORM_HINTS["api_server"]
-        # Images ARE intercepted: inlined as data URLs.
+        # Images ARE intercepted on all four endpoints, runs included.
         assert "MEDIA:" in hint
         assert "inlined" in hint.lower()
         assert "data" in hint.lower()  # data URLs
-        # The gaps: non-image files and the runs endpoint.
-        assert "non-image" in hint.lower()
         assert "runs" in hint.lower()
+        # The one remaining gap: non-image files, on any endpoint.
+        assert "non-image" in hint.lower()
         # Fallback guidance: plain file path in the response text.
         assert "plain" in hint.lower()
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -617,21 +617,26 @@ class TestPromptBuilderConstants:
 
 
     def test_api_server_hint_scopes_media_tag_guidance(self):
-        """api_server MEDIA: interception is partial (#68402, corrected):
-        _resolve_media_to_data_urls (gateway/platforms/api_server.py) inlines
+        """api_server MEDIA: interception is partial (#68402, corrected by
+        #70170, extended by #73537): _resolve_media_to_data_urls and
+        StreamingMediaTagResolver (gateway/platforms/api_server.py) inline
         small image MEDIA: tags as base64 data URLs on the chat, completions,
-        and responses endpoints — but non-image files are never resolved
-        (_MEDIA_IMG_EXT is image-only) and the /v1/runs handler never calls
-        the resolver at all. The hint must teach BOTH halves: images work via
-        MEDIA:, everything else needs a plain path in the response text."""
+        responses, AND runs endpoints as of #73537, which added the missing
+        /v1/runs resolver (StreamingMediaTagResolver + a final
+        _resolve_media_to_data_urls call in _handle_runs) — before that, runs
+        was the one endpoint with no resolver at all, per #70170's hint. Only
+        non-image files remain unresolved everywhere (_MEDIA_IMG_EXT is
+        image-only). The hint must teach BOTH halves: images work via MEDIA:
+        on all four endpoints, non-image files need a plain path in the
+        response text."""
         hint = PLATFORM_HINTS["api_server"]
-        # Images ARE intercepted: inlined as data URLs.
+        # Images ARE intercepted on all four endpoints, runs included.
         assert "MEDIA:" in hint
         assert "inlined" in hint.lower()
         assert "data" in hint.lower()  # data URLs
-        # The gaps: non-image files and the runs endpoint.
-        assert "non-image" in hint.lower()
         assert "runs" in hint.lower()
+        # The one remaining gap: non-image files, on any endpoint.
+        assert "non-image" in hint.lower()
         # Fallback guidance: plain file path in the response text.
         assert "plain" in hint.lower()
 

--- a/tests/gateway/test_api_server_media_data_urls.py
+++ b/tests/gateway/test_api_server_media_data_urls.py
@@ -12,7 +12,10 @@ import pytest
 
 pytest.importorskip("aiohttp")
 
-from gateway.platforms.api_server import _resolve_media_to_data_urls  # noqa: E402
+from gateway.platforms.api_server import (  # noqa: E402
+    StreamingMediaTagResolver,
+    _resolve_media_to_data_urls,
+)
 
 # 1x1 transparent PNG
 _PNG_BYTES = base64.b64decode(
@@ -49,6 +52,83 @@ class TestResolveMediaToDataUrls(unittest.TestCase):
     def test_non_image_left_untouched(self):
         text = "MEDIA:/tmp/archive.zip"
         self.assertEqual(_resolve_media_to_data_urls(text), text)
+
+
+class TestStreamingMediaTagResolver(unittest.TestCase):
+    """Real per-token LLM streaming can split a MEDIA:<path> tag's characters
+    across many separate delta chunks -- confirmed in production (2026-07-28)
+    across every SSE/streaming endpoint in api_server.py: only the
+    non-streaming responses ever called _resolve_media_to_data_urls, so a
+    split tag reached live clients as literal "MEDIA:/path..." text instead
+    of an image, every time. These tests drive the resolver the same way the
+    real streaming call sites do: many small .feed() calls, then .flush().
+    """
+
+    def setUp(self):
+        import tempfile
+        from pathlib import Path
+
+        d = Path(tempfile.mkdtemp(prefix="hermes_media_stream_test"))
+        self.png_path = d / "shot.png"
+        self.png_path.write_bytes(_PNG_BYTES)
+
+    def _feed_all(self, resolver, chunks):
+        out = [resolver.feed(c) for c in chunks]
+        out.append(resolver.flush())
+        return "".join(out)
+
+    def test_tag_split_across_many_chunks_resolves_to_data_url(self):
+        path_str = str(self.png_path)
+        # Split the tag character-by-character around "MEDIA:" plus the path
+        # in a few pieces, mimicking real token-by-token streaming.
+        chunks = ["Here you go: ", "MED", "IA:", path_str[:5], path_str[5:], " done!"]
+        resolver = StreamingMediaTagResolver()
+        out = self._feed_all(resolver, chunks)
+        self.assertIn("data:image/png;base64,", out)
+        self.assertNotIn("MEDIA:", out)
+        self.assertIn("Here you go: ", out)
+        self.assertIn(" done!", out)
+
+    def test_plain_text_with_no_media_mention_flows_through_immediately(self):
+        resolver = StreamingMediaTagResolver()
+        # Each feed() call should return its own text immediately -- no
+        # buffering latency when there's nothing that could be a tag.
+        self.assertEqual(resolver.feed("Hello there, "), "Hello there, ")
+        self.assertEqual(resolver.feed("how are you?"), "how are you?")
+        self.assertEqual(resolver.flush(), "")
+
+    def test_bogus_media_word_in_prose_eventually_releases_as_plain_text(self):
+        resolver = StreamingMediaTagResolver()
+        chunks = ["I love using social MEDIA", " apps", " every day", " to stay in touch."]
+        out = self._feed_all(resolver, chunks)
+        self.assertEqual(out, "I love using social MEDIA apps every day to stay in touch.")
+
+    def test_holdback_cap_releases_a_media_word_that_never_completes(self):
+        """A "MEDIA" mention followed by a very long run of unrelated text
+        (well past _MEDIA_HOLDBACK_CAP) must not stall the stream forever --
+        it releases as plain text instead of buffering indefinitely."""
+        resolver = StreamingMediaTagResolver()
+        out = resolver.feed("Talk about MEDIA" + "x" * 500)
+        self.assertIn("MEDIAxxx", out)  # released, not held back forever
+
+    def test_two_tags_in_separate_feed_calls_both_resolve(self):
+        path_str = str(self.png_path)
+        resolver = StreamingMediaTagResolver()
+        out = self._feed_all(resolver, [
+            f"First: MEDIA:{path_str} ",
+            f"Second: MEDIA:{path_str}",
+        ])
+        self.assertEqual(out.count("data:image/png;base64,"), 2)
+        self.assertNotIn("MEDIA:", out)
+
+    def test_invalid_path_tag_split_across_chunks_stays_visible(self):
+        """A tag that never validates (e.g. traversal outside the allowed
+        roots) must still surface as visible text after reassembly -- the
+        resolver only changes WHEN resolution happens, not the safety
+        decision _resolve_media_to_data_urls already makes."""
+        resolver = StreamingMediaTagResolver()
+        out = self._feed_all(resolver, ["MED", "IA:/etc/nonexistent_", "file123.png"])
+        self.assertIn("MEDIA:/etc/nonexistent_file123.png", out)
 
 
 if __name__ == "__main__":

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -390,6 +390,50 @@ class TestRunEvents:
                 assert "run.completed" in body
                 assert "Hello!" in body
 
+    @pytest.mark.asyncio
+    async def test_structured_failure_still_flushes_held_back_media_text(self, adapter):
+        """A structured failed result must not swallow buffered MEDIA-tag text.
+
+        The streaming MEDIA-tag resolver holds back everything from the last
+        "MEDIA:" onward until it can confirm whether a real tag completed. That
+        buffer is only safe if EVERY terminal path releases it: a structured
+        ``{"failed": True}`` result emits run.failed without going through the
+        success branch, so a flush placed only there loses text that this
+        endpoint previously delivered (raw, but delivered).
+        """
+        app = _create_runs_app(adapter)
+        held_back = "MEDIA:/nonexistent/never-completed-"
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _run_conversation(*_args, **_kwargs):
+                    cb = mock_create.call_args.kwargs["stream_delta_callback"]
+                    cb("Saved to ")
+                    # Held back: a complete "MEDIA:" prefix whose path never
+                    # resolves, so the resolver keeps it pending to stream end.
+                    cb(held_back)
+                    return {"failed": True, "error": "provider rejected the request"}
+
+                mock_agent.run_conversation.side_effect = _run_conversation
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                assert events_resp.status == 200
+                body = await events_resp.text()
+
+        assert "run.failed" in body
+        # The pre-MEDIA text was already safe to emit during streaming...
+        assert "Saved to " in body
+        # ...and the held-back remainder must still arrive despite the failure.
+        assert held_back in body
 
     @pytest.mark.asyncio
     async def test_approval_resolve_all_is_scoped_to_target_run(self, auth_adapter):

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -331,6 +331,50 @@ class TestRunEvents:
                 assert "run.completed" in body
                 assert "Hello!" in body
 
+    @pytest.mark.asyncio
+    async def test_structured_failure_still_flushes_held_back_media_text(self, adapter):
+        """A structured failed result must not swallow buffered MEDIA-tag text.
+
+        The streaming MEDIA-tag resolver holds back everything from the last
+        "MEDIA:" onward until it can confirm whether a real tag completed. That
+        buffer is only safe if EVERY terminal path releases it: a structured
+        ``{"failed": True}`` result emits run.failed without going through the
+        success branch, so a flush placed only there loses text that this
+        endpoint previously delivered (raw, but delivered).
+        """
+        app = _create_runs_app(adapter)
+        held_back = "MEDIA:/nonexistent/never-completed-"
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _run_conversation(*_args, **_kwargs):
+                    cb = mock_create.call_args.kwargs["stream_delta_callback"]
+                    cb("Saved to ")
+                    # Held back: a complete "MEDIA:" prefix whose path never
+                    # resolves, so the resolver keeps it pending to stream end.
+                    cb(held_back)
+                    return {"failed": True, "error": "provider rejected the request"}
+
+                mock_agent.run_conversation.side_effect = _run_conversation
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                assert events_resp.status == 200
+                body = await events_resp.text()
+
+        assert "run.failed" in body
+        # The pre-MEDIA text was already safe to emit during streaming...
+        assert "Saved to " in body
+        # ...and the held-back remainder must still arrive despite the failure.
+        assert held_back in body
 
     @pytest.mark.asyncio
     async def test_approval_resolve_all_is_scoped_to_target_run(self, auth_adapter):

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -299,6 +299,45 @@ async def test_session_chat_stream_disconnect_keeps_control_refs_until_executor_
 
 
 @pytest.mark.asyncio
+async def test_session_chat_stream_failure_still_flushes_held_back_media_text(
+    adapter, session_db
+):
+    """A raising turn must not swallow buffered MEDIA-tag text.
+
+    The streaming MEDIA-tag resolver holds back everything from the last
+    "MEDIA:" onward until it can confirm whether a real tag completed. That
+    buffer is only safe if EVERY terminal path releases it: when ``_run_agent``
+    raises, the stream emits ``error``/``done`` without reaching the success
+    flush, so text this endpoint previously delivered (raw, but delivered)
+    would be lost.
+    """
+    session_id = session_db.create_session("flush-on-failure", "api_server")
+    held_back = "MEDIA:/nonexistent/never-completed-"
+
+    async def fake_run(**kwargs):
+        kwargs["stream_delta_callback"]("Saved to ")
+        # Held back: a complete "MEDIA:" prefix whose path never resolves, so
+        # the resolver keeps it pending until an explicit flush.
+        kwargs["stream_delta_callback"](held_back)
+        raise RuntimeError("provider exploded mid-turn")
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream", json={"message": "go"}
+            )
+            assert resp.status == 200
+            body = await resp.text()
+
+    assert "event: error" in body
+    # The pre-MEDIA text was already safe to emit during streaming...
+    assert "Saved to " in body
+    # ...and the held-back remainder must still arrive despite the failure.
+    assert held_back in body
+
+
+@pytest.mark.asyncio
 async def test_session_chat_stream_run_completed_carries_turn_transcript(adapter, session_db):
     """run.completed must include the full interleaved turn transcript so a
     client that lost intermediate (pre-tool-call) assistant text from the live

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -127,6 +127,45 @@ async def test_run_agent_binds_api_session_context_for_tool_env(adapter, monkeyp
 
 
 @pytest.mark.asyncio
+async def test_session_chat_stream_failure_still_flushes_held_back_media_text(
+    adapter, session_db
+):
+    """A raising turn must not swallow buffered MEDIA-tag text.
+
+    The streaming MEDIA-tag resolver holds back everything from the last
+    "MEDIA:" onward until it can confirm whether a real tag completed. That
+    buffer is only safe if EVERY terminal path releases it: when ``_run_agent``
+    raises, the stream emits ``error``/``done`` without reaching the success
+    flush, so text this endpoint previously delivered (raw, but delivered)
+    would be lost.
+    """
+    session_id = session_db.create_session("flush-on-failure", "api_server")
+    held_back = "MEDIA:/nonexistent/never-completed-"
+
+    async def fake_run(**kwargs):
+        kwargs["stream_delta_callback"]("Saved to ")
+        # Held back: a complete "MEDIA:" prefix whose path never resolves, so
+        # the resolver keeps it pending until an explicit flush.
+        kwargs["stream_delta_callback"](held_back)
+        raise RuntimeError("provider exploded mid-turn")
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream", json={"message": "go"}
+            )
+            assert resp.status == 200
+            body = await resp.text()
+
+    assert "event: error" in body
+    # The pre-MEDIA text was already safe to emit during streaming...
+    assert "Saved to " in body
+    # ...and the held-back remainder must still arrive despite the failure.
+    assert held_back in body
+
+
+@pytest.mark.asyncio
 async def test_session_chat_stream_run_completed_carries_turn_transcript(adapter, session_db):
     """run.completed must include the full interleaved turn transcript so a
     client that lost intermediate (pre-tool-call) assistant text from the live


### PR DESCRIPTION
## What does this PR do?

Every SSE/streaming endpoint in `gateway/platforms/api_server.py` fed each raw delta chunk to `_resolve_media_to_data_urls()` independently. That function only recognizes a **complete** `MEDIA:<path>` tag, but real token-by-token LLM streaming routinely splits the tag's characters across several delta chunks (e.g. `"MED"`, `"IA:"`, `"/home/..."`). A split tag never matches, so it reaches API-server clients as literal `MEDIA:/path...` text instead of the inlined base64 image API-server clients need (they can't read local file paths).

Non-streaming responses were unaffected — they resolve the whole final response text in one pass.

**Reproduced in production**, twice in the same conversation, against a live `api_server`-sourced session (an image was requested via `/v1/runs`, a Telegram Mini App / dashboard client): the model correctly emitted `MEDIA:/home/hermes/.hermes/cache/images/....png`, but the user received the literal tag text instead of the picture both times.

**Fix:** adds `StreamingMediaTagResolver`, which buffers pending streamed text until a `MEDIA:` tag is either confirmed complete or provably not a tag (bounded by `_MEDIA_HOLDBACK_CAP` so an ordinary prose mention of "media" doesn't stall the stream), and wires it into every streaming call site in the module (chat-completions SSE, `/v1/responses` SSE, `/v1/runs` SSE).

### Relation to #68402 / #70170

`/v1/runs` (`_handle_runs`) previously had **no resolver at all** — neither streaming nor final-response — which is exactly the gap #70170 (salvage of #68402) documented in `PLATFORM_HINTS["api_server"]`: *"the runs endpoint intercepts nothing... state the plain file path in your response text instead of a MEDIA: tag."* This PR adds both a `StreamingMediaTagResolver` and a final `_resolve_media_to_data_urls` call inside `_handle_runs` itself — the exact incident that motivated this fix was hitting `/v1/runs`, an endpoint the model had just been told (correctly, at the time) not to use `MEDIA:` on at all.

That means the #70170 hint text is now stale for images specifically: `/v1/runs` resolves them the same as the other three endpoints now. A second commit here updates `PLATFORM_HINTS["api_server"]` and its pinned test (`test_api_server_hint_scopes_media_tag_guidance`) to reflect that — non-image files remain the only unresolved case, on any endpoint.

## Related Issue

No existing issue — found and reproduced live in production while using `api_server` through a Telegram Mini App / dashboard client. Happy to file one first if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py`: adds `StreamingMediaTagResolver` (buffers streamed text until a `MEDIA:` tag is confirmed complete or provably not one, bounded by `_MEDIA_HOLDBACK_CAP`); wires it into the chat-completions SSE, `/v1/responses` SSE, and `/v1/runs` SSE call sites; adds a final `_resolve_media_to_data_urls` call inside `_handle_runs` itself (previously had no resolver at all, streaming or final).
- `agent/prompt_builder.py`: rewords `PLATFORM_HINTS["api_server"]` — images now inline on all four endpoints (`/v1/runs` included), only non-image files remain unresolved.
- `tests/gateway/test_api_server_media_data_urls.py`: new `TestStreamingMediaTagResolver` suite.
- `tests/agent/test_prompt_builder.py`: updates `test_api_server_hint_scopes_media_tag_guidance` to assert the corrected, non-stale hint scope.

## How to Test

1. Trigger `image_generate` (or any tool that emits a `MEDIA:<path>` tag) against a streaming API-server endpoint.
2. Observe the tag's characters land across multiple SSE delta events (any real per-token streaming provider does this).
3. Before this fix: client receives literal `MEDIA:/path...` text. After: client receives the inlined `![image](data:image/png;base64,...)`.

Added unit tests in `tests/gateway/test_api_server_media_data_urls.py::TestStreamingMediaTagResolver` covering: tag split across many chunks, plain text passthrough with no buffering latency, a bogus "MEDIA" word in ordinary prose releasing correctly, the holdback cap releasing a never-completing "MEDIA" mention, two tags in separate feed calls both resolving, and an invalid/nonexistent path staying visible after reassembly (safety behavior unchanged, only timing changes).

```
pytest tests/gateway/test_api_server_media_data_urls.py tests/agent/test_prompt_builder.py -v
# 183 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Ubuntu, x86_64)

### Documentation & Housekeeping

- [x] N/A — no config keys changed
- [x] N/A — no CONTRIBUTING.md/AGENTS.md architecture or workflow change
- [x] I've considered cross-platform impact — pure text-buffering logic, no OS-touching code
- [x] N/A — no tool schemas changed (this only affects how MEDIA: tags already emitted by tools get resolved for delivery, not any tool's own schema)

## What platforms tested on

Linux (Ubuntu, x86_64). No platform-specific code paths touched.
