### PR TITLE
fix(state): route session-resume reads through the WAL read-only connection

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7751,9 +7751,9 @@ class SessionDB:
             session_ids = self._session_lineage_root_to_tip(session_id)
 
         active_clause = "" if include_inactive else " AND active = 1"
-        with self._lock:
+        with self._read_ctx() as conn:
             placeholders = ",".join("?" for _ in session_ids)
-            rows = self._conn.execute(
+            rows = conn.execute(
                 "SELECT role, content, tool_call_id, tool_calls, tool_name, effect_disposition, "
                 "finish_reason, reasoning, reasoning_content, reasoning_details, "
                 "codex_reasoning_items, codex_message_items, platform_message_id, observed, timestamp, "
@@ -7925,9 +7925,9 @@ class SessionDB:
         output (see test_get_resume_conversations_matches_separate_reads).
         """
         session_ids = self._session_lineage_root_to_tip(session_id)
-        with self._lock:
+        with self._read_ctx() as conn:
             placeholders = ",".join("?" for _ in session_ids)
-            rows = self._conn.execute(
+            rows = conn.execute(
                 f"SELECT session_id, {self._CONVERSATION_ROW_COLUMNS} "
                 f"FROM messages WHERE session_id IN ({placeholders}) AND active = 1 "
                 # ORDER BY id (insertion order) — see get_messages_as_conversation
@@ -7977,9 +7977,9 @@ class SessionDB:
         session_ids = self._session_lineage_root_to_tip(session_id)
         if len(session_ids) <= 1:
             return []
-        with self._lock:
+        with self._read_ctx() as conn:
             placeholders = ",".join("?" for _ in session_ids)
-            rows = self._conn.execute(
+            rows = conn.execute(
                 f"SELECT session_id, {self._CONVERSATION_ROW_COLUMNS} "
                 f"FROM messages WHERE session_id IN ({placeholders}) AND active = 1 "
                 "ORDER BY id",
@@ -8016,13 +8016,13 @@ class SessionDB:
         chain = []
         current = session_id
         seen = set()
-        with self._lock:
+        with self._read_ctx() as conn:
             for _ in range(100):
                 if not current or current in seen:
                     break
                 seen.add(current)
                 chain.append(current)
-                row = self._conn.execute(
+                row = conn.execute(
                     "SELECT parent_session_id FROM sessions WHERE id = ?",
                     (current,),
                 ).fetchone()

--- a/tests/test_session_db_read_path_split.py
+++ b/tests/test_session_db_read_path_split.py
@@ -158,3 +158,41 @@ def test_anchored_view_and_around_use_read_path(db):
         assert done["view"]["window"]
     finally:
         db._lock.release()
+
+
+@pytest.mark.requires_wal
+def test_session_resume_reads_do_not_take_writer_lock(db):
+    """session.resume's three read paths must not convoy behind writer flushes.
+
+    get_messages_as_conversation / get_resume_conversations /
+    get_ancestor_display_prefix are the hottest reads in the file — every
+    resume across the gateway, CLI, and ACP adapter goes through one of
+    them — so they must use the same per-thread read-only connection as
+    get_messages, not the legacy self._lock path.
+    """
+    db.create_session(session_id="parent1", source="cli", model="m")
+    db.append_message("parent1", role="user", content="parent turn")
+    db.append_message("parent1", role="assistant", content="parent reply")
+    db.create_session(session_id="child1", source="cli", model="m", parent_session_id="parent1")
+    db.append_message("child1", role="user", content="child turn")
+    db.append_message("child1", role="assistant", content="child reply")
+
+    acquired = db._lock.acquire()
+    try:
+        done = {}
+
+        def reader():
+            done["conversation"] = db.get_messages_as_conversation("s1")
+            done["resume"] = db.get_resume_conversations("child1")
+            done["ancestor_prefix"] = db.get_ancestor_display_prefix("child1")
+
+        t = threading.Thread(target=reader)
+        t.start(); t.join(timeout=5.0)
+        assert not t.is_alive(), "session resume reads blocked on writer lock"
+        assert len(done["conversation"]) == 2
+        model_history, display_history = done["resume"]
+        assert len(model_history) == 2
+        assert len(display_history) == 4
+        assert len(done["ancestor_prefix"]) == 2
+    finally:
+        db._lock.release()


### PR DESCRIPTION
## Summary

- `get_messages_as_conversation`, `get_resume_conversations`, and `get_ancestor_display_prefix` still acquired `self._lock` before reading, even though the recent WAL read-path split (per-thread read-only connections via `_read_ctx()`) was meant to remove exactly this choke point from every recall/browse read. These three are arguably the hottest reads in the file — every session resume across the gateway, CLI, and ACP adapter goes through one of them — so a resume racing a burst of concurrent-session writer flushes still convoys behind them the same way the already-fixed paths used to (measured convoy on the original fix: a 0.23s query stretching to 112s under 6-8 concurrent turns).
- `_session_lineage_root_to_tip` — the lineage-walk helper shared by all three functions above, plus `get_conversation_root` — had its own independent `self._lock` use. Converting only the three outer functions is not enough: they all call this helper as their first step, so it needed the same conversion or the block would just move one frame down.
- Both changes mirror the exact `with self._lock: self._conn.execute(...)` → `with self._read_ctx() as conn: conn.execute(...)` pattern already applied to `get_session`, `get_messages`, `get_messages_around`, `get_anchored_view`, and `search_messages`.

## Test plan

- [x] Added `test_session_resume_reads_do_not_take_writer_lock` to `tests/test_session_db_read_path_split.py`, mirroring the existing `test_reads_do_not_take_writer_lock` pattern (holds `self._lock` in the main thread, asserts the reader thread completes without blocking).
- [x] This dev venv links SQLite 3.50.4, which is below Hermes's WAL-reset-bug threshold (3.51.3), so the runtime falls back to `journal_mode=DELETE` and every `requires_wal`-marked test — including the new one — skips here, same as its siblings. Verified the fix empirically instead: a standalone script that forces `journal_mode=WAL` + `_wal_active=True` on a temp `SessionDB`, holds `self._lock` in the main thread, and calls all three functions from a second thread.
  - Before the fix: the reader thread blocked for the writer's full lock-hold duration (first on `get_messages_as_conversation`, then again on `get_resume_conversations` via the un-converted `_session_lineage_root_to_tip`).
  - After the fix: all three complete in well under a millisecond while the lock is held.
- [x] `uv run --frozen --extra dev python -m pytest tests/test_hermes_state.py tests/test_session_db_read_path_split.py tests/cli/test_cli_resume_command.py tests/cli/test_resume_display.py tests/tui_gateway/test_protocol.py tests/test_tui_gateway_server.py tests/hermes_cli/test_context_switch_guard.py -q` — 1119 passed, 7 skipped (WAL-gated), no regressions.
- [x] `ruff check hermes_state.py tests/test_session_db_read_path_split.py` — clean.