### PR TITLE
fix(credits): remove the 'Grant spent · $X top-up left' notice

### DIFF
--- a/agent/credits_tracker.py
+++ b/agent/credits_tracker.py
@@ -288,20 +288,12 @@ def evaluate_credits_notices(
                 current_band = band
     # Top-up suppression: when the account holds purchased (top-up) credits,
     # the subscription-cap gauge is the wrong denominator — warning "90% used"
-    # at a user sitting on $50 of top-up is noise (and it previously stuck
-    # PERMANENTLY alongside grant_spent at >=100%). Suppress the usage band
-    # entirely; the cap-reached case is covered by the grant_spent info notice
-    # below, which already names the remaining top-up balance. A top-up landing
-    # mid-session flips current_band → None and the clear path below removes
-    # any showing band line.
+    # at a user sitting on $50 of top-up is noise. Suppress the usage band
+    # entirely; /usage still reports the full balance breakdown. A top-up
+    # landing mid-session flips current_band → None and the clear path below
+    # removes any showing band line.
     if state.purchased_micros > 0:
         current_band = None
-    grant_cond = (
-        state.denominator_kind == "subscription_cap"
-        and uf is not None
-        and uf >= 1.0
-        and state.purchased_micros > 0
-    )
     depleted_cond = not state.paid_access
 
     # ── usage gauge (escalating single notice: 50 → 75 → 90) ──────────────────
@@ -339,22 +331,6 @@ def evaluate_credits_notices(
             )
             active.add(CREDITS_USAGE_KEY)
         latch["usage_band"] = target_band
-
-    # ── grant_spent ──────────────────────────────────────────────────────────
-    if grant_cond and "credits.grant_spent" not in active:
-        to_show.append(
-            AgentNotice(
-                text=f"• Grant spent · ${state.purchased_usd} top-up left",
-                level="info",
-                kind=CREDITS_NOTICE_KIND,
-                key="credits.grant_spent",
-                id="credits.grant_spent",
-            )
-        )
-        active.add("credits.grant_spent")
-    elif "credits.grant_spent" in active and not grant_cond:
-        to_clear.append("credits.grant_spent")
-        active.discard("credits.grant_spent")
 
     # ── depleted ─────────────────────────────────────────────────────────────
     # Suppressed while the active model is free: inference still works there,
@@ -627,7 +603,7 @@ _DEV_FIXTURES: dict[str, dict] = {
         subscription_limit_micros=20_000_000, subscription_limit_usd="20.00",
         denominator_kind="subscription_cap", paid_access=True,
     ),
-    "grant_exhausted": dict(  # used_fraction == 1.0 + purchased>0 → credits.grant_spent
+    "grant_exhausted": dict(  # cap reached + purchased>0 → no notice (gauge suppressed by top-up)
         remaining_micros=12_340_000, remaining_usd="12.34",
         subscription_micros=0, subscription_usd="0.00",
         subscription_limit_micros=20_000_000, subscription_limit_usd="20.00",

--- a/apps/desktop/src/app/contrib/dev/credits-notice-demo.ts
+++ b/apps/desktop/src/app/contrib/dev/credits-notice-demo.ts
@@ -25,7 +25,7 @@ interface NoticeStep {
 }
 
 // Walks the same lifecycle the Nous credits tracker drives: usage escalates in
-// place (50→75→90, one key), then grant-spent, then the depleted/restored pair.
+// place (50→75→90, one key), then the depleted/restored pair.
 // Wraps around. These are all separate SHOW steps; the stepper auto-clears the
 // previous notice when the key changes, so the demo shows one toast at a time
 // (real usage CAN stack these, but that's noise when you're eyeballing a single
@@ -34,7 +34,6 @@ const STEPS: readonly NoticeStep[] = [
   { key: 'credits.usage', kind: 'sticky', level: 'info', text: "• You've used $110.00 of your $220.00 cap" },
   { key: 'credits.usage', kind: 'sticky', level: 'warn', text: "⚠ You've used $165.00 of your $220.00 cap" },
   { key: 'credits.usage', kind: 'sticky', level: 'warn', text: "⚠ You've used $198.00 of your $220.00 cap" },
-  { key: 'credits.grant_spent', kind: 'sticky', level: 'info', text: '• Grant spent · $12.00 top-up left' },
   { key: 'credits.depleted', kind: 'sticky', level: 'error', text: '✕ Credit access paused · run /topup to top up' },
   { key: 'credits.restored', kind: 'ttl', level: 'success', text: '✓ Credit access restored', ttl_ms: 8000 }
 ]

--- a/apps/desktop/src/store/agent-notices.test.ts
+++ b/apps/desktop/src/store/agent-notices.test.ts
@@ -83,10 +83,10 @@ test('the leading severity glyph is stripped from the toast message', () => {
 })
 
 test('the trailing "· detail" is split off as a secondary meta line, not inlined', () => {
-  // grant_spent still carries a `· detail` tail.
-  const grant = noticeToToast({ key: 'credits.grant_spent', level: 'info', text: '• Grant spent · $12.00 top-up left' })
-  expect(grant?.message).toBe('Grant spent')
-  expect(grant?.meta).toBe('$12.00 top-up left')
+  // Detail-carrying notices split on the first ` · `.
+  const paused = noticeToToast({ key: 'credits.depleted', level: 'error', text: '✕ Credit access paused · run /topup to top up' })
+  expect(paused?.message).toBe('Credit access paused')
+  expect(paused?.meta).toBe('run /topup to top up')
 
   // The usage line has no middot → whole line is the message, no meta.
   const plain = noticeToToast(usage())
@@ -95,7 +95,7 @@ test('the trailing "· detail" is split off as a secondary meta line, not inline
 })
 
 test('splitMeta splits on the first space-middot-space only', () => {
-  expect(splitMeta('Grant spent · $12.00 top-up left')).toEqual(['Grant spent', '$12.00 top-up left'])
+  expect(splitMeta('Credit access paused · run /topup to top up')).toEqual(['Credit access paused', 'run /topup to top up'])
   expect(splitMeta('Credit access restored')).toEqual(['Credit access restored', undefined])
   // Interior middots after the first split stay in the meta.
   expect(splitMeta('a · b · c')).toEqual(['a', 'b · c'])
@@ -117,7 +117,7 @@ test('usageFraction derives $used / $cap from the notice text', () => {
   expect(usageFraction("You've used $15.00 of your $20.00 cap")).toBeCloseTo(0.75)
   expect(usageFraction("You've used $198.00 of your $220.00 cap")).toBeCloseTo(0.9)
   // Fewer than two amounts, or a zero cap → no fraction.
-  expect(usageFraction('Grant spent')).toBeNull()
+  expect(usageFraction('Credit access restored')).toBeNull()
   expect(usageFraction("You've used $5.00 of your $0.00 cap")).toBeNull()
   expect(usageFraction(undefined)).toBeNull()
 })
@@ -138,7 +138,7 @@ test('usage accent stays muted below 75%, then ramps orange → red', () => {
 test('terminal credit states carry their own accent; others stay default', () => {
   expect(noticeAccent({ key: 'credits.depleted', text: '✕ paused' })).toBe('var(--ui-red)')
   expect(noticeAccent({ key: 'credits.restored', text: '✓ restored' })).toBe('var(--ui-green)')
-  expect(noticeAccent({ key: 'credits.grant_spent', text: '• Grant spent' })).toBeUndefined()
+  expect(noticeAccent({ key: 'credits.usage', text: '• Credits update' })).toBeUndefined()
   expect(noticeAccent(undefined)).toBeUndefined()
 })
 
@@ -189,7 +189,7 @@ test('clearAgentNotice dismisses only the matching key', () => {
 
 test('only credits.depleted and credits.restored map to a native notification', () => {
   expect(nativeNoticeInput(usage({ key: 'credits.usage' }), 'Credits')).toBeNull()
-  expect(nativeNoticeInput(usage({ key: 'credits.grant_spent' }), 'Credits')).toBeNull()
+  expect(nativeNoticeInput(usage({ key: 'credits.other' }), 'Credits')).toBeNull()
   expect(nativeNoticeInput({ text: 'x', key: undefined }, 'Credits')).toBeNull()
   expect(nativeNoticeInput({ text: '', key: 'credits.depleted' }, 'Credits')).toBeNull()
 })

--- a/apps/desktop/src/store/agent-notices.ts
+++ b/apps/desktop/src/store/agent-notices.ts
@@ -175,8 +175,8 @@ export function clearAgentNotice(key: string | undefined): void {
 
 // Only these two credit notices are urgent enough to break through as a native
 // OS notification (when Hermes is backgrounded). The escalating usage line
-// (`credits.usage`) and the grant-spent notice stay in-app toasts only — they
-// aren't worth interrupting the user's OS for.
+// (`credits.usage`) stays an in-app toast only — it isn't worth interrupting
+// the user's OS for.
 const NATIVE_NOTICE_KEYS = new Set(['credits.depleted', 'credits.restored'])
 
 /**

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1962,7 +1962,7 @@ DEFAULT_CONFIG = {
         # class of over-claim that otherwise forces users to run
         # `git status` to verify edits landed.  Set false to suppress.
         "file_mutation_verifier": True,
-        # Nous credits status-bar notices (usage bands, grant-spent, depleted /
+        # Nous credits status-bar notices (usage bands, depleted /
         # restored).  When false, no credits notices are emitted — balance data
         # is still captured and /usage keeps working.  Off switch for sub +
         # top-up users who find the gauge noisy.

--- a/tests/agent/test_credits_cold_start.py
+++ b/tests/agent/test_credits_cold_start.py
@@ -49,22 +49,20 @@ def test_cold_start_opens_already_at_90pct_warns():
     assert "credits.usage" in _cold_start_notices(s)
 
 
-def test_cold_start_grant_exhausted_grant_spent_only():
-    """Cap reached but top-up funds remain → grant_spent info notice ONLY.
+def test_cold_start_grant_exhausted_no_notice():
+    """Cap reached but top-up funds remain → NO notice.
 
-    The usage band is suppressed whenever purchased (top-up) credits exist:
-    the sub-cap gauge is the wrong denominator for an account that can keep
-    spending, and previously the 90/100% warn banner stuck permanently
-    alongside grant_spent."""
+    The usage band is suppressed whenever purchased (top-up) credits exist
+    (the sub-cap gauge is the wrong denominator for an account that can keep
+    spending), and the old 'Grant spent · $X top-up left' notice was removed —
+    it camped in the status bar with no action to take."""
     s = _state(
         remaining_micros=12_340_000, subscription_micros=0,
         subscription_limit_micros=20_000_000, subscription_limit_usd="20.00",
         purchased_micros=12_340_000, denominator_kind="subscription_cap", paid_access=True,
     )
     assert s.used_fraction == 1.0
-    keys = _cold_start_notices(s)
-    assert "credits.usage" not in keys
-    assert "credits.grant_spent" in keys
+    assert _cold_start_notices(s) == []
 
 
 def test_cold_start_depleted_warns():

--- a/tests/agent/test_credits_policy.py
+++ b/tests/agent/test_credits_policy.py
@@ -163,11 +163,10 @@ class TestBoundaryFractions:
         assert "credits.usage" in keys
         assert "credits.usage" not in to_clear
 
-    def test_just_below_1_0_does_not_fire_grant_spent(self):
-        """subscription_micros = limit - 1 (used_fraction just under 1.0) must NOT fire grant_spent.
-
-        Locks the boundary so a future used_fraction clamp refactor cannot fire
-        grant_spent a micro early.
+    def test_just_below_1_0_boundary_no_notices_with_topup(self):
+        """subscription_micros = 1 (used_fraction just under 1.0) with top-up
+        funds → nothing fires: gauge suppressed by purchased>0, and the old
+        grant_spent notice no longer exists at any fraction.
         """
         latch = fresh_latch()
         limit = 20_000_000
@@ -182,49 +181,42 @@ class TestBoundaryFractions:
         )
         assert s.used_fraction is not None and s.used_fraction < 1.0
         to_show, to_clear = evaluate_credits_notices(s, latch)
-        assert all(n.key != "credits.grant_spent" for n in to_show)
-        assert "credits.grant_spent" not in to_clear
+        assert to_show == []
+        assert to_clear == []
 
 
-# ── Scenario 4: grant_spent ───────────────────────────────────────────────────
+# ── Scenario 4: grant_spent removed ──────────────────────────────────────────
 
 
-class TestGrantSpent:
-    def _grant_state(self, purchased_micros: int = 12_340_000) -> CreditsState:
+class TestGrantSpentRemoved:
+    """The 'Grant spent · $X top-up left' notice was removed (July 2026) — it
+    camped in the status bar for every sub+top-up user and carried no action.
+    The policy must never emit or clear the key, even for the state that used
+    to fire it (cap reached + purchased top-up funds)."""
+
+    def _old_trigger_state(self) -> CreditsState:
         return state_with_fraction(
             1.0,
             denominator_kind="subscription_cap",
-            purchased_micros=purchased_micros,
+            purchased_micros=12_340_000,
             purchased_usd="12.34",
         )
 
-    def test_grant_spent_fires_on_first_obs(self):
-        """No crossing gate for grant_spent — fires immediately on first obs."""
+    def test_never_fires_on_old_trigger_state(self):
         latch = fresh_latch()
-        to_show, to_clear = evaluate_credits_notices(self._grant_state(), latch)
-        keys = [n.key for n in to_show]
-        assert "credits.grant_spent" in keys
-
-    def test_grant_spent_no_refire(self):
-        latch = fresh_latch()
-        evaluate_credits_notices(self._grant_state(), latch)
-        to_show, to_clear = evaluate_credits_notices(self._grant_state(), latch)
+        to_show, to_clear = evaluate_credits_notices(self._old_trigger_state(), latch)
         assert all(n.key != "credits.grant_spent" for n in to_show)
         assert "credits.grant_spent" not in to_clear
+        assert "credits.grant_spent" not in latch["active"]
 
-    def test_grant_spent_clears_when_purchased_zero(self):
+    def test_stale_active_key_is_left_alone(self):
+        """A latch persisted from an older build may still hold the key; the
+        policy neither re-fires nor clears it (frontends drop unknown keys)."""
         latch = fresh_latch()
-        evaluate_credits_notices(self._grant_state(), latch)
-        # Now purchased → 0: grant_cond becomes False
-        s_no_purchase = state_with_fraction(
-            1.0,
-            denominator_kind="subscription_cap",
-            purchased_micros=0,
-            purchased_usd="0.00",
-        )
-        to_show, to_clear = evaluate_credits_notices(s_no_purchase, latch)
-        assert "credits.grant_spent" in to_clear
+        latch["active"].add("credits.grant_spent")
+        to_show, to_clear = evaluate_credits_notices(self._old_trigger_state(), latch)
         assert all(n.key != "credits.grant_spent" for n in to_show)
+        assert "credits.grant_spent" not in to_clear
 
 
 # ── Scenario 5: depleted + recovery ──────────────────────────────────────────
@@ -451,7 +443,9 @@ class TestNoticeCopy:
         assert "$20.00" in warn_notice.text
         assert "cap" in warn_notice.text
 
-    def test_grant_spent_contains_verbatim_purchased_usd(self):
+    def test_grant_spent_never_emitted(self):
+        """Old grant_spent trigger state produces no notice at all — the gauge
+        is suppressed by top-up and the grant_spent notice is gone."""
         latch = fresh_latch()
         s = state_with_fraction(
             1.0,
@@ -460,9 +454,7 @@ class TestNoticeCopy:
             purchased_usd="12.34",
         )
         to_show, _ = evaluate_credits_notices(s, latch)
-        grant_notice = next(n for n in to_show if n.key == "credits.grant_spent")
-        assert "$12.34" in grant_notice.text
-        assert "top-up left" in grant_notice.text
+        assert to_show == []
 
     def test_depleted_mentions_credits_command(self):
         latch = fresh_latch()
@@ -476,18 +468,11 @@ class TestNoticeCopy:
 
 
 class TestSeverityOrder:
-    def test_multiple_new_notices_ordered_ascending_severity(self):
-        """grant_spent < depleted in to_show when both fire in one call.
-
-        (usage is suppressed here: purchased>0 — see TestTopUpSuppression.
-        usage + grant_spent are now mutually exclusive by design.)
-        """
+    def test_depleted_only_notice_with_topup_at_cap(self):
+        """With top-up funds and cap reached while unpaid, only depleted fires:
+        the usage gauge is suppressed by purchased>0 and grant_spent is gone."""
         latch = {"active": set(), "seen_below_90": True, "usage_band": None}
 
-        # Build state: subscription_cap, uf >= 1.0, purchased_micros > 0, NOT paid_access
-        # grant_cond: subscription_cap + uf >= 1.0 + purchased > 0 ✓
-        # depleted_cond: not paid_access ✓
-        # usage band: suppressed (purchased > 0)
         s = CreditsState(
             subscription_limit_micros=20_000_000,
             subscription_limit_usd="20.00",
@@ -499,11 +484,7 @@ class TestSeverityOrder:
         )
         to_show, _ = evaluate_credits_notices(s, latch)
         keys = [n.key for n in to_show]
-        assert "credits.usage" not in keys
-        assert "credits.grant_spent" in keys
-        assert "credits.depleted" in keys
-        # Ascending severity: grant_spent before depleted
-        assert keys.index("credits.grant_spent") < keys.index("credits.depleted")
+        assert keys == ["credits.depleted"]
 
     def test_usage_before_depleted_without_topup(self):
         """With no top-up funds, usage fires and precedes depleted."""
@@ -573,9 +554,9 @@ class TestTopUpSuppression:
         assert "$19.00" in n.text
         assert latch["usage_band"] == 90
 
-    def test_grant_spent_still_fires_with_topup(self):
-        """Suppression only affects the gauge — grant_spent (which NEEDS purchased>0)
-        is untouched."""
+    def test_no_notice_at_cap_with_topup(self):
+        """Cap reached with top-up funds → nothing fires: gauge suppressed,
+        grant_spent removed."""
         latch = fresh_latch()
         s = state_with_fraction(
             1.0,
@@ -584,9 +565,7 @@ class TestTopUpSuppression:
             purchased_usd="12.34",
         )
         to_show, _ = evaluate_credits_notices(s, latch)
-        keys = [n.key for n in to_show]
-        assert "credits.grant_spent" in keys
-        assert "credits.usage" not in keys
+        assert to_show == []
 
     def test_depleted_unaffected_by_topup_suppression(self):
         latch = fresh_latch()

--- a/tests/gateway/test_notice_rendering.py
+++ b/tests/gateway/test_notice_rendering.py
@@ -84,7 +84,7 @@ def test_real_policy_notices_render_without_doubling():
     notices = (
         _emitted(uf=0.9)                          # band 90 (warn)
         + _emitted(uf=0.5)                        # band 50 (info)
-        + _emitted(uf=1.0, purchased=5_000_000)   # band 90 + grant_spent
+        + _emitted(uf=1.0, purchased=5_000_000)   # top-up at cap → no notices (empty)
         + _emitted(uf=None, paid=False)           # depleted
     )
     assert notices, "policy produced no notices to check"

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -989,12 +989,12 @@ class TurnController {
     this.interrupted = false
     this.persistedToolLabels.clear()
     // "Flash and yield" notices clear when a new turn starts: a usage-band heads-up
-    // (credits.usage, 50/75/90%) and the one-time "grant spent" transition
-    // (credits.grant_spent) should show once, then get out of the way — not camp the
-    // bar (e.g. "Grant spent · $990 top-up left" sitting there with plenty of top-up
-    // left). Depletion (credits.depleted) and other notices stay — they're explicitly
-    // sticky until the policy clears them. The Python `active` latch retains the key,
-    // so a yielded notice won't re-fire on the next turn.
+    // (credits.usage, 50/75/90%) should show once, then get out of the way — not
+    // camp the bar. Depletion (credits.depleted) and other notices stay — they're
+    // explicitly sticky until the policy clears them. The Python `active` latch
+    // retains the key, so a yielded notice won't re-fire on the next turn.
+    // (credits.grant_spent is also cleared here for back-compat with older
+    // backends that still emit it — the notice was removed in July 2026.)
     const yieldingNoticeKey = getUiState().notice?.key
 
     if (yieldingNoticeKey === 'credits.usage' || yieldingNoticeKey === 'credits.grant_spent') {

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1542,7 +1542,7 @@ display:
     enabled: false
     fields: ["model", "context_pct", "cwd"]
   file_mutation_verifier: true    # Append an advisory footer when write_file/patch calls failed this turn
-  credits_notices: true   # Nous credits status-bar notices (usage bands, grant-spent, depleted). false = silence them; /usage still works
+  credits_notices: true   # Nous credits status-bar notices (usage bands, depleted). false = silence them; /usage still works
   language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | zh-hant | ja | de | es | fr | tr | uk | af | ko | it | ga | pt | ru | hu
 ```
 


### PR DESCRIPTION
## Summary
Removes the "Grant spent · $X top-up left" credits notice from every surface — it camped in the CLI/TUI status bar and desktop toasts for any subscription user holding top-up funds, with no action for the user to take (the account keeps working off top-up).

## Changes
- `agent/credits_tracker.py`: drop `grant_cond` + the `credits.grant_spent` emit/clear block; the `grant_exhausted` dev fixture now correctly produces no notice
- `ui-tui/src/app/turnController.ts`: keep the turn-start clear of `credits.grant_spent` as back-compat for older backends that still emit the key
- `apps/desktop`: remove the demo step and stale comment references; retest split-meta/accent/native-notification paths on surviving notices
- `hermes_cli/config.py` + `website/docs/user-guide/configuration.md`: drop grant-spent from the `display.credits_notices` descriptions
- Tests: policy + cold-start suites now assert the key never fires (including the old trigger state and a stale persisted latch key)

Usage bands (50/75/90), depleted, and restored notices are unchanged; `/usage` still reports the full balance breakdown.

## Validation
| | Before | After |
|---|---|---|
| Cap reached + top-up funds | "• Grant spent · $X top-up left" camps in status bar / toast | no notice |
| Depleted / restored | fires | unchanged |
| Tests | — | 68 Python (policy/cold-start/rendering) + desktop 20 + TUI 92 vitest all green |

## Infographic

![Removing the Grant spent notice](https://v3b.fal.media/files/b/0aa417d0/pT6INiYXfOAfoq13tzcwG_Xg0KHDjq.png)
