### PR TITLE
fix(cli): exclude display_kind timeline rows from partial-compress boundary

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4022,7 +4022,11 @@ class GatewaySlashCommandsMixin:
             # Report what WOULD be compressed — no agent, no writes.
             from agent.model_metadata import estimate_request_tokens_rough
             _pv_msgs = [
-                {"role": m.get("role"), "content": m.get("content")}
+                {
+                    "role": m.get("role"),
+                    "content": m.get("content"),
+                    "display_kind": m.get("display_kind"),
+                }
                 for m in history
                 if m.get("role") in {"user", "assistant"} and m.get("content")
             ]

--- a/hermes_cli/partial_compress.py
+++ b/hermes_cli/partial_compress.py
@@ -226,6 +226,15 @@ def split_history_for_partial_compress(
     user↔assistant alternation stays valid (the compressed head's
     trailing content is followed by a fresh user turn).
 
+    Timeline bookkeeping rows (``display_kind`` set — e.g. model_switch,
+    async_delegation_complete, auto_continue, hidden) are durable
+    ``role="user"`` rows but are not real user turns; no client counts
+    them as one. Match ``list_recent_user_messages``, CLI ``/retry``,
+    ``session.undo``, and the ``prompt.submit`` ordinal path — otherwise
+    a marker landing among the last ``keep_last`` rows consumes a kept
+    slot, silently preserving one fewer real exchange than the user asked
+    for.
+
     Returns ``(head, tail)``. If the split would leave the head empty
     (not enough history to compress meaningfully), returns
     ``(history, [])`` — signaling the caller to fall back to full
@@ -239,10 +248,12 @@ def split_history_for_partial_compress(
         return [], []
 
     # Walk backwards collecting the indices of the most recent `keep_last`
-    # user-message starts. The tail begins at the earliest such index.
+    # *real* user-message starts (exclude display_kind timeline rows). The
+    # tail begins at the earliest such index.
     user_starts: List[int] = []
     for idx in range(n - 1, -1, -1):
-        if history[idx].get("role") == "user":
+        msg = history[idx]
+        if msg.get("role") == "user" and not msg.get("display_kind"):
             user_starts.append(idx)
             if len(user_starts) >= keep_last:
                 break

--- a/tests/cli/test_partial_compress.py
+++ b/tests/cli/test_partial_compress.py
@@ -92,6 +92,36 @@ def test_split_rejoin_preserves_all_messages():
     assert head + tail == h
 
 
+def test_split_skips_display_kind_timeline_rows():
+    """A display_kind marker must not count as a kept "exchange".
+
+    Timeline bookkeeping rows (model_switch, async_delegation_complete,
+    auto_continue, hidden) are durable role="user" rows but are not real
+    user turns — same predicate as list_recent_user_messages, CLI /retry,
+    and session.undo. Without it, a marker landing among the last
+    keep_last rows consumes a kept slot, silently preserving one fewer
+    real exchange than the user asked for.
+    """
+    h = [
+        {"role": "user", "content": "u0"},
+        {"role": "assistant", "content": "a0"},
+        {"role": "user", "content": "u1"},
+        {"role": "assistant", "content": "a1"},
+        {
+            "role": "user",
+            "content": "background agent work finished",
+            "display_kind": "async_delegation_complete",
+        },
+        {"role": "user", "content": "u2"},
+        {"role": "assistant", "content": "a2"},
+    ]
+    head, tail = split_history_for_partial_compress(h, keep_last=2)
+    # keep_last=2 real exchanges → u1 and u2, not the marker in between.
+    assert tail[0]["role"] == "user"
+    assert tail[0]["content"] == "u1"
+    assert head + tail == h
+
+
 # ── rejoin_compressed_head_and_tail (seam-alternation guard) ─────────
 
 

--- a/tests/gateway/test_compress_preview.py
+++ b/tests/gateway/test_compress_preview.py
@@ -85,3 +85,34 @@ async def test_aggressive_dry_run_shows_preview_plus_note():
     runner.session_store.rewrite_transcript.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_preview_with_here_boundary_skips_display_kind_marker():
+    """A display_kind timeline row (model_switch, async_delegation_complete,
+    etc.) landing among the last keep_last real exchanges must not consume
+    one of the kept slots in the /compress here --preview report — the
+    preview's own history projection must carry display_kind through to
+    split_history_for_partial_compress, same as the real (non-preview) run.
+    """
+    history = [
+        {"role": "user", "content": "u0"},
+        {"role": "assistant", "content": "a0"},
+        {"role": "user", "content": "u1"},
+        {"role": "assistant", "content": "a1"},
+        {
+            "role": "user",
+            "content": "[System: model switched]",
+            "display_kind": "model_switch",
+        },
+        {"role": "user", "content": "u2"},
+        {"role": "assistant", "content": "a2"},
+    ]
+    runner = _make_runner(history)
+    result = await runner._handle_compress_command(
+        _make_event("/compress --preview here 2")
+    )
+    # Correct boundary (marker skipped): the last 2 REAL exchanges are
+    # u1/a1/marker/u2/a2 (5 messages), leaving u0/a0 (2 messages) as head.
+    # Without the fix, the marker itself consumes one of the 2 kept "user"
+    # slots and the boundary lands one exchange later: head=4, tail=3.
+    assert "2 of 7" in result, result
+    assert "(5 message(s))" in result, result


### PR DESCRIPTION
## Summary

- `split_history_for_partial_compress` (the split behind `/compress here [N]`, shared by `cli.py`, `tui_gateway/server.py`, and `gateway/slash_commands.py`) counted every `role="user"` row as a real exchange when walking backward to find the `keep_last` boundary.
- Timeline bookkeeping rows (`display_kind` set — `model_switch`, `async_delegation_complete`, `auto_continue`, `hidden`) are durable `role="user"` rows for the API transcript, but no client counts them as real user turns. Same-day sibling fixes already excluded them from `list_recent_user_messages`, CLI `/retry`, `session.undo`, and the `prompt.submit` ordinal path — this split used the same unfiltered backward walk and was never updated to match.
- Concretely: with the default `keep_last=2`, a background-delegation-completion marker landing among the last 2 `"user"` rows consumes one of the kept slots, so `/compress here` silently preserves one fewer real exchange verbatim than the user asked for — no crash, no error, just a quiet fidelity shortfall.
- Fix mirrors the exact predicate already used elsewhere in this fix family: `msg.get("role") == "user" and not msg.get("display_kind")`.

## Test plan

- [x] Added `test_split_skips_display_kind_timeline_rows` to `tests/cli/test_partial_compress.py`.
- [x] Mutation-verified: reverted the production change and confirmed the new test fails (`tail[0]["content"]` is the bookkeeping marker instead of the real prior user turn), then restored the fix and confirmed it passes.
- [x] `uv run --frozen --extra dev python -m pytest tests/cli/test_partial_compress.py tests/cli/test_compress_here.py tests/cli/test_manual_compress.py tests/test_cli_manual_compress.py tests/gateway/test_compress_command.py tests/gateway/test_compress_preview.py -q` — all pass, no regressions.
- [x] `ruff check hermes_cli/partial_compress.py tests/cli/test_partial_compress.py` — clean.