### PR TITLE
fix(observability): export shared metrics after task completion

### DIFF
--- a/hermes_cli/observability/relay_shared_metrics.py
+++ b/hermes_cli/observability/relay_shared_metrics.py
@@ -351,7 +351,10 @@ class _Runtime:
         with session.lock:
             if session.closing:
                 return
-            self._finish_task(session, task_id, event)
+            finished = self._finish_task(session, task_id, event)
+        if finished:
+            self._safe(self.relay.subscribers.flush)
+            self._export()
 
     def close_session(self, event: dict[str, Any]) -> None:
         session = self._session(event)
@@ -560,10 +563,10 @@ class _Runtime:
         session: _MetricsSession,
         task_id: str,
         event: dict[str, Any],
-    ) -> None:
+    ) -> bool:
         task = session.tasks.get(task_id)
         if task is None:
-            return
+            return False
         self._end_pending_model_calls(session, {**event, "task_id": task_id})
         fields = task_terminal_fields(
             {**task.start_fields, **event},
@@ -592,9 +595,10 @@ class _Runtime:
                     turn_key = (session.session_id, turn_id)
                     if self._turn_sessions.get(turn_key) is session:
                         self._turn_sessions.pop(turn_key, None)
+        return True
 
     def _export(self) -> None:
-        self._safe(self.subscriber.store.create_and_export_package)
+        self._safe(self.subscriber.store.create_and_export_package_if_due)
 
     def _event_metadata(self) -> dict[str, str]:
         return {

--- a/hermes_cli/observability/relay_shared_metrics.py
+++ b/hermes_cli/observability/relay_shared_metrics.py
@@ -353,8 +353,15 @@ class _Runtime:
                 return
             finished = self._finish_task(session, task_id, event)
         if finished:
-            self._safe(self.relay.subscribers.flush)
-            self._export()
+            try:
+                self.relay.subscribers.flush()
+            except Exception:
+                logger.warning(
+                    "Hermes shared-metrics task flush failed",
+                    exc_info=True,
+                )
+            else:
+                self._export()
 
     def close_session(self, event: dict[str, Any]) -> None:
         session = self._session(event)
@@ -383,7 +390,8 @@ class _Runtime:
             self.relay.subscribers.flush()
         except Exception as exc:
             failures.append(f"subscriber flush failed: {exc}")
-        self._export()
+        else:
+            self._export()
         with self._sessions_lock:
             if self._sessions.get(session.session_id) is session:
                 self._sessions.pop(session.session_id, None)
@@ -402,8 +410,15 @@ class _Runtime:
             self._safe(self.close_session, {"session_id": session_id})
         if not self._registered:
             return
-        self._safe(self.relay.subscribers.flush)
-        self._export()
+        try:
+            self.relay.subscribers.flush()
+        except Exception:
+            logger.warning(
+                "Hermes shared-metrics shutdown flush failed",
+                exc_info=True,
+            )
+        else:
+            self._export()
         self._safe(self.relay.subscribers.deregister, self._subscriber_name)
         self.host.release_managed_execution(self._subscriber_name)
         self._registered = False

--- a/hermes_cli/observability/shared_metrics.py
+++ b/hermes_cli/observability/shared_metrics.py
@@ -114,6 +114,14 @@ class SharedMetricsStore:
         for _ in range(pending_periods):
             if self._create_package() is None:
                 break
+        return self._export_and_prune()
+
+    def create_and_export_package_if_due(self) -> list[Path]:
+        """Create pending packages at most once per UTC day, then export them."""
+        self._create_pending_packages_if_due()
+        return self._export_and_prune()
+
+    def _export_and_prune(self) -> list[Path]:
         exported = self._export_pending_packages()
         try:
             self._prune_expired_history()
@@ -280,6 +288,26 @@ class SharedMetricsStore:
                 """
             ).fetchone()
         return int(row["period_count"]) if row is not None else 0
+
+    def _create_pending_packages_if_due(self) -> None:
+        now = _utc_now()
+        with self._connection() as connection:
+            with write_txn(connection):
+                # Gate on the committed package, not its file write, so a failed
+                # outbox export can be retried without packaging deltas twice.
+                package_created_today = connection.execute(
+                    """
+                    SELECT 1
+                    FROM package_outbox
+                    WHERE substr(created_at, 1, 10) >= ?
+                    LIMIT 1
+                    """,
+                    (now.date().isoformat(),),
+                ).fetchone()
+                if package_created_today is not None:
+                    return
+                while self._create_package_in_transaction(connection, now) is not None:
+                    pass
 
     def _create_package(self) -> dict[str, Any] | None:
         now = _utc_now()

--- a/tests/hermes_cli/test_relay_shared_metrics.py
+++ b/tests/hermes_cli/test_relay_shared_metrics.py
@@ -18,6 +18,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from hermes_cli.observability import shared_metrics as shared_metrics_module
 from hermes_cli.observability.shared_metrics import SharedMetricsStore
 from hermes_cli.observability.shared_metrics_contract import (
     COUNT_BUCKETS,
@@ -140,6 +141,43 @@ def test_model_call_counter_survives_restart_and_exports_only_new_deltas(tmp_pat
     assert second_package["metrics"][0]["value"] == 1
     assert restarted.counter_snapshot()[0]["value"] == 3
     assert restarted.counter_snapshot()[0]["packaged_value"] == 3
+
+
+def test_due_export_runs_once_per_utc_day_and_catches_up_pending_deltas(
+    tmp_path, monkeypatch
+):
+    current_time = datetime(2026, 7, 28, 9, tzinfo=timezone.utc)
+    monkeypatch.setattr(shared_metrics_module, "_utc_now", lambda: current_time)
+    store = SharedMetricsStore(tmp_path / "metrics.sqlite3", tmp_path / "outbox")
+
+    store.record_model_call(_dimensions(), "test-version")
+    assert len(store.create_and_export_package_if_due()) == 1
+
+    current_time = datetime(2026, 7, 28, 18, tzinfo=timezone.utc)
+    store = SharedMetricsStore(tmp_path / "metrics.sqlite3", tmp_path / "outbox")
+    store.record_model_call(_dimensions(), "test-version")
+    assert store.create_and_export_package_if_due() == []
+    assert len(list((tmp_path / "outbox").glob("*.json"))) == 1
+    assert store.counter_snapshot()[0] == {
+        "period_start": "2026-07-28",
+        "metric_name": "hermes.model_call.count",
+        "hermes_version": "test-version",
+        "dimensions": _dimensions(),
+        "value": 2,
+        "packaged_value": 1,
+    }
+
+    current_time = datetime(2026, 7, 29, 9, tzinfo=timezone.utc)
+    store.record_model_call(_dimensions(), "test-version")
+    assert len(store.create_and_export_package_if_due()) == 2
+    assert len(list((tmp_path / "outbox").glob("*.json"))) == 3
+    assert all(
+        row["value"] == row["packaged_value"] for row in store.counter_snapshot()
+    )
+
+    store.record_model_call(_dimensions(), "test-version")
+    assert store.create_and_export_package_if_due() == []
+    assert len(list((tmp_path / "outbox").glob("*.json"))) == 3
 
 
 def test_package_schema_matches_the_model_call_contract():
@@ -755,6 +793,32 @@ def test_concurrent_package_builders_commit_one_delta(tmp_path):
 
     assert outbox_count == 1
     assert package["metrics"][0]["value"] == 1
+    assert store.counter_snapshot()[0]["packaged_value"] == 1
+
+
+def test_concurrent_due_exports_create_one_daily_package(tmp_path):
+    database_path = tmp_path / "metrics.sqlite3"
+    outbox_directory = tmp_path / "outbox"
+    store = SharedMetricsStore(database_path, outbox_directory)
+    store.record_model_call(_dimensions(), "test-version")
+    ready = threading.Barrier(8)
+
+    def export() -> None:
+        worker_store = SharedMetricsStore(database_path, outbox_directory)
+        ready.wait(timeout=5)
+        worker_store.create_and_export_package_if_due()
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        futures = [executor.submit(export) for _ in range(8)]
+        for future in futures:
+            future.result()
+
+    with sqlite3.connect(database_path) as connection:
+        [outbox_count] = connection.execute(
+            "SELECT COUNT(*) FROM package_outbox"
+        ).fetchone()
+    assert outbox_count == 1
+    assert len(list(outbox_directory.glob("*.json"))) == 1
     assert store.counter_snapshot()[0]["packaged_value"] == 1
 
 

--- a/tests/hermes_cli/test_relay_shared_metrics_runtime.py
+++ b/tests/hermes_cli/test_relay_shared_metrics_runtime.py
@@ -6,6 +6,7 @@ import contextvars
 import asyncio
 import json
 import threading
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -321,6 +322,7 @@ def test_direct_runtime_records_without_enabling_a_plugin(direct_runtime, tmp_pa
 def test_real_binding_drives_lifecycle_aggregation_export_and_snapshot(
     real_binding_runtime,
     tmp_path,
+    monkeypatch,
 ):
     assert real_binding_runtime._native is not None
     prompt_canary = "real-relay-sensitive-prompt"
@@ -416,6 +418,12 @@ def test_real_binding_drives_lifecycle_aggregation_export_and_snapshot(
 
     root = tmp_path / "hermes-home" / "telemetry" / "shared_metrics"
     store = SharedMetricsStore(root / "metrics.sqlite3", root / "outbox")
+    tomorrow = datetime.now(timezone.utc) + timedelta(days=1)
+    monkeypatch.setattr(
+        "hermes_cli.observability.shared_metrics._utc_now",
+        lambda: tomorrow,
+    )
+    assert len(store.create_and_export_package_if_due()) == 1
     snapshot = store.counter_snapshot()
     by_metric: dict[str, list[dict[str, Any]]] = {}
     for counter in snapshot:
@@ -451,7 +459,7 @@ def test_real_binding_drives_lifecycle_aggregation_export_and_snapshot(
     }
     package_values: dict[tuple[str, tuple[tuple[str, str], ...]], int] = {}
     packages = sorted((root / "outbox").glob("*.json"))
-    assert len(packages) == 3
+    assert len(packages) == 2
     package_payloads = [
         json.loads(package.read_text(encoding="utf-8")) for package in packages
     ]
@@ -2279,32 +2287,74 @@ def test_session_finalize_closes_a_pending_task_as_system_aborted(direct_runtime
     }
 
 
-def test_sequential_tasks_in_one_session_aggregate_once_each(direct_runtime, tmp_path):
+def test_desktop_task_completion_exports_once_per_utc_day(
+    direct_runtime, tmp_path, monkeypatch
+):
+    current_time = datetime(2026, 7, 28, 9, tzinfo=timezone.utc)
+    monkeypatch.setattr(
+        "hermes_cli.observability.shared_metrics._utc_now",
+        lambda: current_time,
+    )
     for task_id in ("t1", "t2"):
         lifecycle.invoke_hook(
             "pre_llm_call",
             session_id="s1",
             task_id=task_id,
-            platform="cli",
+            platform="desktop",
         )
         lifecycle.invoke_hook(
             "on_session_end",
             session_id="s1",
             task_id=task_id,
-            platform="cli",
+            platform="desktop",
             completed=True,
             failed=False,
             interrupted=False,
             turn_exit_reason="text_response(stop)",
         )
-    lifecycle.finalize_session(session_id="s1")
 
     outbox = tmp_path / "hermes-home" / "telemetry" / "shared_metrics" / "outbox"
-    [package_path] = list(outbox.glob("*.json"))
-    package = json.loads(package_path.read_text(encoding="utf-8"))
-    metrics = {metric["name"]: metric for metric in package["metrics"]}
-    assert metrics["hermes.task_run.started"]["value"] == 2
-    assert metrics["hermes.task_run.finished"]["value"] == 2
+    [first_package_path] = list(outbox.glob("*.json"))
+    first_package = json.loads(first_package_path.read_text(encoding="utf-8"))
+    first_metrics = {metric["name"]: metric for metric in first_package["metrics"]}
+    assert first_metrics["hermes.task_run.started"]["value"] == 1
+    assert first_metrics["hermes.task_run.started"]["dimensions"] == {
+        "entrypoint": "interactive",
+        "execution_surface": "desktop",
+    }
+    assert first_metrics["hermes.task_run.finished"]["value"] == 1
+
+    lifecycle.finalize_session(session_id="s1")
+    assert list(outbox.glob("*.json")) == [first_package_path]
+
+    current_time = datetime(2026, 7, 29, 9, tzinfo=timezone.utc)
+    lifecycle.invoke_hook(
+        "pre_llm_call",
+        session_id="s1",
+        task_id="t3",
+        platform="desktop",
+    )
+    lifecycle.invoke_hook(
+        "on_session_end",
+        session_id="s1",
+        task_id="t3",
+        platform="desktop",
+        completed=True,
+        failed=False,
+        interrupted=False,
+        turn_exit_reason="text_response(stop)",
+    )
+
+    packages = [
+        json.loads(package_path.read_text(encoding="utf-8"))
+        for package_path in outbox.glob("*.json")
+    ]
+    totals: dict[str, int] = {}
+    for package in packages:
+        for metric in package["metrics"]:
+            totals[metric["name"]] = totals.get(metric["name"], 0) + metric["value"]
+    assert totals["hermes.task_run.started"] == 3
+    assert totals["hermes.task_run.finished"] == 3
 
 
 def test_task_ownership_survives_session_id_rotation(direct_runtime):

--- a/tests/hermes_cli/test_relay_shared_metrics_runtime.py
+++ b/tests/hermes_cli/test_relay_shared_metrics_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextvars
 import asyncio
 import json
+import sqlite3
 import threading
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -2355,6 +2356,65 @@ def test_desktop_task_completion_exports_once_per_utc_day(
             totals[metric["name"]] = totals.get(metric["name"], 0) + metric["value"]
     assert totals["hermes.task_run.started"] == 3
     assert totals["hermes.task_run.finished"] == 3
+
+
+def test_failed_flush_keeps_daily_export_open_for_later_task(
+    direct_runtime, tmp_path, monkeypatch, caplog
+):
+    current_time = datetime(2026, 7, 28, 9, tzinfo=timezone.utc)
+    monkeypatch.setattr(
+        "hermes_cli.observability.shared_metrics._utc_now",
+        lambda: current_time,
+    )
+    original_flush = direct_runtime.subscribers.flush
+    flush_attempts = 0
+
+    def fail_first_flush() -> None:
+        nonlocal flush_attempts
+        flush_attempts += 1
+        if flush_attempts == 1:
+            raise RuntimeError("simulated flush failure")
+        original_flush()
+
+    direct_runtime.subscribers.flush = fail_first_flush
+
+    def finish_desktop_task(task_id: str) -> None:
+        lifecycle.invoke_hook(
+            "pre_llm_call",
+            session_id="s1",
+            task_id=task_id,
+            platform="desktop",
+        )
+        lifecycle.invoke_hook(
+            "on_session_end",
+            session_id="s1",
+            task_id=task_id,
+            platform="desktop",
+            completed=True,
+            failed=False,
+            interrupted=False,
+            turn_exit_reason="text_response(stop)",
+        )
+
+    finish_desktop_task("t1")
+
+    root = tmp_path / "hermes-home" / "telemetry" / "shared_metrics"
+    assert list((root / "outbox").glob("*.json")) == []
+    with sqlite3.connect(root / "metrics.sqlite3") as connection:
+        [package_count] = connection.execute(
+            "SELECT COUNT(*) FROM package_outbox"
+        ).fetchone()
+    assert package_count == 0
+
+    finish_desktop_task("t2")
+
+    [package_path] = list((root / "outbox").glob("*.json"))
+    package = json.loads(package_path.read_text(encoding="utf-8"))
+    metrics = {metric["name"]: metric for metric in package["metrics"]}
+    assert metrics["hermes.task_run.started"]["value"] == 2
+    assert metrics["hermes.task_run.finished"]["value"] == 2
+    assert flush_attempts == 2
+    assert "Hermes shared-metrics task flush failed" in caplog.text
 
 
 def test_task_ownership_survives_session_id_rotation(direct_runtime):


### PR DESCRIPTION
## What does this PR do?

Shared-metrics packages were created when a Relay session closed. Desktop sessions are long-lived, so a normal completed desktop task could update SQLite without creating an outbox entry.

This moves the export opportunity to task completion. Package creation is gated by the durable SQLite outbox, so Hermes creates packages at most once per UTC day across tasks, threads, processes, and restarts. Session close and runtime shutdown remain fallback opportunities and use the same gate.

The gate uses the committed package timestamp rather than the file-write timestamp. If writing the outbox file fails, a later task can retry the write without packaging the same counter deltas twice.

Package creation only runs after Relay subscriber flushing succeeds. A failed flush leaves the daily gate open so a later same-day task can flush the complete queue and create that day's package.

## Related Issue

Follow-up to #67607.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Flush Relay subscriber work and attempt a gated export after a task closes.
- Add a transactional, persistent once-per-UTC-day package gate to `SharedMetricsStore`.
- Preserve session-finalization and shutdown exports as idempotent fallbacks.
- Prevent task, session-close, and shutdown paths from advancing the daily gate after a failed subscriber flush.
- Add desktop, restart, next-day catch-up, flush-retry, native binding, and concurrent-export coverage.

## How to Test

1. Enable `telemetry.shared_metrics.enabled`.
2. Complete a desktop task without closing the desktop session and verify an outbox JSON file exists under `telemetry/shared_metrics/outbox`.
3. Complete another task on the same UTC day and verify no second package is created; on the next UTC day, verify pending deltas are packaged.

Validation run:

- `662 passed` across the shared-metrics store, runtime, lifecycle, desktop gateway, lazy-session, and smoke-harness suites.
- A temporary native-binding harness verified that a failed first flush creates no package row or file, while a later same-day task creates one package containing both tasks. The harness was not added to the branch.
- Direct Hermes -> local OpenAI-compatible endpoint -> NeMo Relay -> SQLite/outbox smoke passed with all three base metric families and no privacy canaries.
- Ruff and `git diff --check` passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

A direct native smoke completed one Hermes task without requiring an explicit session close. The SQLite snapshot showed `value=1` and `packaged_value=1` for `hermes.task_run.started`, `hermes.task_run.finished`, and `hermes.model_call.count`, with one schema-valid outbox package.

The temporary native flush-failure harness then forced the first eligible flush to fail. It verified zero package rows and files after that failure, followed by one same-day package with `started=2` and `finished=2` after the next task completed.