### PR TITLE
fix(discord): show full long clarify options

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -52,6 +52,8 @@ _DISCORD_COMMAND_SYNC_POLICIES = {"safe", "bulk", "off"}
 _DISCORD_COMMAND_SYNC_STATE_SUBDIR = "gateway"
 _DISCORD_COMMAND_SYNC_STATE_FILENAME = "discord_command_sync_state.json"
 _DISCORD_NONCONVERSATIONAL_STATE_FILENAME = "discord_nonconversational_messages.json"
+_DISCORD_FULL_OPTION_THRESHOLD_UTF16_UNITS = 40
+_DISCORD_EMBED_FIELD_UTF16_LIMIT = 1024
 
 _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS = 4.5
 _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
@@ -6803,6 +6805,44 @@ class DiscordAdapter(BasePlatformAdapter):
                     value="Pick one below, or click ✏️ Other to type a custom answer.",
                     inline=False,
                 )
+                if any(
+                    utf16_len(choice) > _DISCORD_FULL_OPTION_THRESHOLD_UTF16_UNITS
+                    for choice in clean_choices
+                ):
+                    full_options = "\n".join(
+                        f"{index}. {choice}" for index, choice in enumerate(
+                            clean_choices, start=1
+                        )
+                    )
+                    lines = full_options.split("\n")
+                    chunks = []
+                    chunk = []
+                    chunk_units = 0
+                    for line in lines:
+                        line_units = utf16_len(line)
+                        if not chunk:
+                            chunk.append(line)
+                            chunk_units = line_units
+                            continue
+                        if chunk_units + 1 + line_units <= _DISCORD_EMBED_FIELD_UTF16_LIMIT:
+                            chunk.append(line)
+                            chunk_units += 1 + line_units
+                        else:
+                            chunks.append("\n".join(chunk))
+                            chunk = [line]
+                            chunk_units = line_units
+                    if chunk:
+                        chunks.append("\n".join(chunk))
+
+                    for chunk_index, chunk_value in enumerate(chunks):
+                        embed.add_field(
+                            name=(
+                                "Full options"
+                                if chunk_index == 0 else "Full options (continued)"
+                            ),
+                            value=chunk_value,
+                            inline=False,
+                        )
                 view = ClarifyChoiceView(
                     choices=clean_choices,
                     clarify_id=clarify_id,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -53,7 +53,6 @@ _DISCORD_COMMAND_SYNC_STATE_SUBDIR = "gateway"
 _DISCORD_COMMAND_SYNC_STATE_FILENAME = "discord_command_sync_state.json"
 _DISCORD_NONCONVERSATIONAL_STATE_FILENAME = "discord_nonconversational_messages.json"
 _DISCORD_FULL_OPTION_THRESHOLD_UTF16_UNITS = 40
-_DISCORD_EMBED_FIELD_UTF16_LIMIT = 1024
 
 _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS = 4.5
 _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
@@ -6809,40 +6808,14 @@ class DiscordAdapter(BasePlatformAdapter):
                     utf16_len(choice) > _DISCORD_FULL_OPTION_THRESHOLD_UTF16_UNITS
                     for choice in clean_choices
                 ):
-                    full_options = "\n".join(
-                        f"{index}. {choice}" for index, choice in enumerate(
-                            clean_choices, start=1
-                        )
+                    embed.add_field(
+                        name="Full options",
+                        value="\n".join(
+                            f"{index}. {choice}"
+                            for index, choice in enumerate(clean_choices, start=1)
+                        ),
+                        inline=False,
                     )
-                    lines = full_options.split("\n")
-                    chunks = []
-                    chunk = []
-                    chunk_units = 0
-                    for line in lines:
-                        line_units = utf16_len(line)
-                        if not chunk:
-                            chunk.append(line)
-                            chunk_units = line_units
-                            continue
-                        if chunk_units + 1 + line_units <= _DISCORD_EMBED_FIELD_UTF16_LIMIT:
-                            chunk.append(line)
-                            chunk_units += 1 + line_units
-                        else:
-                            chunks.append("\n".join(chunk))
-                            chunk = [line]
-                            chunk_units = line_units
-                    if chunk:
-                        chunks.append("\n".join(chunk))
-
-                    for chunk_index, chunk_value in enumerate(chunks):
-                        embed.add_field(
-                            name=(
-                                "Full options"
-                                if chunk_index == 0 else "Full options (continued)"
-                            ),
-                            value=chunk_value,
-                            inline=False,
-                        )
                 view = ClarifyChoiceView(
                     choices=clean_choices,
                     clarify_id=clarify_id,

--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -361,11 +361,12 @@ class TestDiscordSendClarify:
         sent_msg.id = 123456
         channel.send = AsyncMock(return_value=sent_msg)
         adapter._client.get_channel = MagicMock(return_value=channel)
+        long_choice = "x" * 41
 
         result = await adapter.send_clarify(
             chat_id="9001",
             question="Pick a color",
-            choices=["red", "green", "blue"],
+            choices=["red", long_choice, "blue"],
             clarify_id="cidM",
             session_key="sk-M",
         )
@@ -385,7 +386,10 @@ class TestDiscordSendClarify:
             fields["Choices"]
             == "Pick one below, or click ✏️ Other to type a custom answer."
         )
-        assert "Full options" not in fields
+        assert fields["Full options"] == f"1. red\n2. {long_choice}\n3. blue"
+        assert kwargs["view"].children[0].label == "1. red"
+        assert kwargs["view"].children[1].label == f"2. {long_choice}"
+        assert kwargs["view"].children[2].label == "3. blue"
 
     @pytest.mark.asyncio
     async def test_open_ended_omits_view(self):
@@ -464,50 +468,11 @@ class TestDiscordSendClarify:
         )
         kwargs = channel.send.call_args.kwargs
         view = kwargs["view"]
+        fields = {f["name"]: f["value"] for f in kwargs["embed"].fields}
+        assert "Full options" not in fields
         # Only 1 real choice + 1 Other = 2 children
         assert len(view.children) == 2
         assert "real-choice" in view.children[0].label
-
-    @pytest.mark.asyncio
-    async def test_long_choice_renders_numbered_choices_in_embed_field(self):
-        adapter = _make_adapter()
-        channel = MagicMock()
-        sent_msg = MagicMock()
-        sent_msg.id = 901
-        channel.send = AsyncMock(return_value=sent_msg)
-        adapter._client.get_channel = MagicMock(return_value=channel)
-
-        long_choice = "x" * 41
-        short_choice = "Use cached defaults"
-        assert utf16_len(long_choice) > 40
-
-        await adapter.send_clarify(
-            chat_id="9001",
-            question="Choose one:",
-            choices=[short_choice, long_choice, "No"],
-            clarify_id="cidFull",
-            session_key="sk-Full",
-        )
-
-        kwargs = channel.send.call_args.kwargs
-        embed = kwargs["embed"]
-        fields = {f["name"]: f["value"] for f in embed.fields}
-        assert (
-            fields["Choices"]
-            == "Pick one below, or click ✏️ Other to type a custom answer."
-        )
-        expected_full = "\n".join(
-            [
-                "1. Use cached defaults",
-                f"2. {long_choice}",
-                "3. No",
-            ]
-        )
-        assert fields["Full options"] == expected_full
-        view = kwargs["view"]
-        assert view.children[0].label == "1. Use cached defaults"
-        assert view.children[1].label == f"2. {long_choice}"
-        assert view.children[2].label == "3. No"
 
     @pytest.mark.asyncio
     async def test_unwraps_dict_choices_to_description(self):
@@ -639,43 +604,3 @@ class TestDiscordSendClarify:
         for label in choice_labels:
             assert "only_name_here" not in label, f"name leaked: {label!r}"
             assert "only_value_here" not in label, f"value leaked: {label!r}"
-
-    @pytest.mark.asyncio
-    async def test_full_options_splits_when_exceeding_1024_utf16_units(self):
-        adapter = _make_adapter()
-        channel = MagicMock()
-        sent_msg = MagicMock()
-        sent_msg.id = 999
-        channel.send = AsyncMock(return_value=sent_msg)
-        adapter._client.get_channel = MagicMock(return_value=channel)
-
-        choices = ["x" * 41 for _ in range(24)]
-        assert len(choices) == 24
-        assert all(utf16_len(c) > 40 for c in choices)
-
-        await adapter.send_clarify(
-            chat_id="9001",
-            question="Choose one:",
-            choices=choices,
-            clarify_id="cidSplit",
-            session_key="sk-Split",
-        )
-
-        kwargs = channel.send.call_args.kwargs
-        embed = kwargs["embed"]
-        full_option_fields = [
-            f
-            for f in embed.fields
-            if f["name"] in {"Full options", "Full options (continued)"}
-        ]
-        assert len(full_option_fields) > 1
-        assert full_option_fields[0]["name"] == "Full options"
-        assert all(
-            f["name"] == "Full options (continued)" for f in full_option_fields[1:]
-        )
-        assert all(utf16_len(f["value"]) <= 1024 for f in full_option_fields)
-        expected = "\n".join(
-            f"{idx}. {choice}" for idx, choice in enumerate(choices, start=1)
-        )
-        reconstructed = "\n".join(f["value"] for f in full_option_fields)
-        assert reconstructed == expected

--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -380,6 +380,12 @@ class TestDiscordSendClarify:
         assert isinstance(kwargs["view"], ClarifyChoiceView)
         # 3 choice buttons + 1 Other
         assert len(kwargs["view"].children) == 4
+        fields = {f["name"]: f["value"] for f in kwargs["embed"].fields}
+        assert (
+            fields["Choices"]
+            == "Pick one below, or click ✏️ Other to type a custom answer."
+        )
+        assert "Full options" not in fields
 
     @pytest.mark.asyncio
     async def test_open_ended_omits_view(self):
@@ -461,6 +467,47 @@ class TestDiscordSendClarify:
         # Only 1 real choice + 1 Other = 2 children
         assert len(view.children) == 2
         assert "real-choice" in view.children[0].label
+
+    @pytest.mark.asyncio
+    async def test_long_choice_renders_numbered_choices_in_embed_field(self):
+        adapter = _make_adapter()
+        channel = MagicMock()
+        sent_msg = MagicMock()
+        sent_msg.id = 901
+        channel.send = AsyncMock(return_value=sent_msg)
+        adapter._client.get_channel = MagicMock(return_value=channel)
+
+        long_choice = "x" * 41
+        short_choice = "Use cached defaults"
+        assert utf16_len(long_choice) > 40
+
+        await adapter.send_clarify(
+            chat_id="9001",
+            question="Choose one:",
+            choices=[short_choice, long_choice, "No"],
+            clarify_id="cidFull",
+            session_key="sk-Full",
+        )
+
+        kwargs = channel.send.call_args.kwargs
+        embed = kwargs["embed"]
+        fields = {f["name"]: f["value"] for f in embed.fields}
+        assert (
+            fields["Choices"]
+            == "Pick one below, or click ✏️ Other to type a custom answer."
+        )
+        expected_full = "\n".join(
+            [
+                "1. Use cached defaults",
+                f"2. {long_choice}",
+                "3. No",
+            ]
+        )
+        assert fields["Full options"] == expected_full
+        view = kwargs["view"]
+        assert view.children[0].label == "1. Use cached defaults"
+        assert view.children[1].label == f"2. {long_choice}"
+        assert view.children[2].label == "3. No"
 
     @pytest.mark.asyncio
     async def test_unwraps_dict_choices_to_description(self):
@@ -592,3 +639,43 @@ class TestDiscordSendClarify:
         for label in choice_labels:
             assert "only_name_here" not in label, f"name leaked: {label!r}"
             assert "only_value_here" not in label, f"value leaked: {label!r}"
+
+    @pytest.mark.asyncio
+    async def test_full_options_splits_when_exceeding_1024_utf16_units(self):
+        adapter = _make_adapter()
+        channel = MagicMock()
+        sent_msg = MagicMock()
+        sent_msg.id = 999
+        channel.send = AsyncMock(return_value=sent_msg)
+        adapter._client.get_channel = MagicMock(return_value=channel)
+
+        choices = ["x" * 41 for _ in range(24)]
+        assert len(choices) == 24
+        assert all(utf16_len(c) > 40 for c in choices)
+
+        await adapter.send_clarify(
+            chat_id="9001",
+            question="Choose one:",
+            choices=choices,
+            clarify_id="cidSplit",
+            session_key="sk-Split",
+        )
+
+        kwargs = channel.send.call_args.kwargs
+        embed = kwargs["embed"]
+        full_option_fields = [
+            f
+            for f in embed.fields
+            if f["name"] in {"Full options", "Full options (continued)"}
+        ]
+        assert len(full_option_fields) > 1
+        assert full_option_fields[0]["name"] == "Full options"
+        assert all(
+            f["name"] == "Full options (continued)" for f in full_option_fields[1:]
+        )
+        assert all(utf16_len(f["value"]) <= 1024 for f in full_option_fields)
+        expected = "\n".join(
+            f"{idx}. {choice}" for idx, choice in enumerate(choices, start=1)
+        )
+        reconstructed = "\n".join(f["value"] for f in full_option_fields)
+        assert reconstructed == expected


### PR DESCRIPTION
## Summary

- Add a `Full options` embed field when any normalized Discord clarify option exceeds the existing 40 UTF-16-unit mobile-safe threshold.
- Keep the current button labels, truncation, styles, custom IDs, callbacks, and plain-text mirror unchanged.
- Keep short-option prompts unchanged.

## Why this matters

Discord accepts button labels up to 80 UTF-16 units, but its mobile client can visibly clip labels much earlier. Today, the embed only says to pick a button, so a mobile user may be asked to choose among options they cannot fully read.

Mirroring complete numbered choices in the embed makes the decision readable without redesigning the interaction. The field is conditional, so ordinary short prompts retain their current compact presentation.

## Before / after

**Before**

The native Discord mobile screenshot shows all three choice labels clipped with ellipses:

![Discord mobile clipping long clarification option labels](https://cdn.discordapp.com/attachments/1506701337025581340/1531707995598225611/Screenshot_20260729_024654.jpg?ex=6a6a31bb&is=6a68e03b&hm=33f3b028b47bda099bcff7762b546abf9d93894ed87126753803c971f1de5018&)

```text
Choices
Pick one below, or click ✏️ Other to type a custom answer.

[long option buttons may be clipped by Discord mobile]
```

**After, only when an option exceeds 40 UTF-16 units**

```text
Choices
Pick one below, or click ✏️ Other to type a custom answer.

Full options
1. <complete first option>
2. <complete second option>
3. <complete third option>

[existing buttons remain unchanged]
```

The screenshot above is native Discord mobile evidence of the broken state. A native after-screenshot is not attached because this headless development environment cannot render the mobile client. The exact outgoing embed fields and unchanged button labels are asserted by the regression tests and were also exercised through the adapter's rendered payload.

## Prior art / duplicate audit

Related open PR: #62291 addresses the same clipping symptom by changing every choice button to a numeric-only label and always mirroring choices. This PR is intentionally narrower: it preserves the existing buttons and adds full embed text only when a choice crosses the mobile-safe threshold.

## How to test

```bash
scripts/run_tests.sh tests/gateway/test_discord_clarify_buttons.py -q

python -m ruff check \
  plugins/platforms/discord/adapter.py \
  tests/gateway/test_discord_clarify_buttons.py

python scripts/check-windows-footguns.py
```

Results:

- Discord clarify suite: **21 passed** through the repository test wrapper
- Ruff: **all checks passed**
- Windows footgun scan: **2 changed files scanned, no findings**
- `git diff --check`: clean

## Platforms tested

- Linux 6.8
- Python 3.13
- Discord adapter rendering through the repository's Discord test double
