### PR TITLE
fix: harden Kanban worker tree ownership

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2027,7 +2027,16 @@ def _cmd_claim(args: argparse.Namespace) -> int:
             )
             return 1
         workspace = kb.resolve_workspace(task)
-        kb.set_workspace_path(conn, task.id, str(workspace))
+        if not kb.set_workspace_path(conn, task.id, str(workspace)):
+            # The claim succeeded, but the workspace CAS lost a race with
+            # another running task. Do not report a running task that has no
+            # workspace; return it to ready for a later retry.
+            kb.reclaim_task(conn, task.id, reason="workspace_busy")
+            print(
+                f"cannot claim {task.id}: workspace is busy ({workspace})",
+                file=sys.stderr,
+            )
+            return 1
     print(f"Claimed {task.id}")
     print(f"Workspace: {workspace}")
     return 0

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1060,6 +1060,9 @@ class Run:
     claim_lock: Optional[str]
     claim_expires: Optional[int]
     worker_pid: Optional[int]
+    worker_pgid: Optional[int]
+    worker_sid: Optional[int]
+    worker_start_time: Optional[str]
     max_runtime_seconds: Optional[int]
     last_heartbeat_at: Optional[int]
     started_at: int
@@ -1084,6 +1087,11 @@ class Run:
             claim_lock=row["claim_lock"],
             claim_expires=row["claim_expires"],
             worker_pid=row["worker_pid"],
+            worker_pgid=(row["worker_pgid"] if "worker_pgid" in row.keys() else None),
+            worker_sid=(row["worker_sid"] if "worker_sid" in row.keys() else None),
+            worker_start_time=(
+                row["worker_start_time"] if "worker_start_time" in row.keys() else None
+            ),
             max_runtime_seconds=row["max_runtime_seconds"],
             last_heartbeat_at=row["last_heartbeat_at"],
             started_at=int(row["started_at"]),
@@ -1261,8 +1269,11 @@ CREATE TABLE IF NOT EXISTS task_runs (
     status              TEXT NOT NULL,
     -- status: running | done | blocked | crashed | timed_out | failed | released
     claim_lock          TEXT,
-    claim_expires       INTEGER,
-    worker_pid          INTEGER,
+    claim_expires        INTEGER,
+    worker_pid           INTEGER,
+    worker_pgid          INTEGER,
+    worker_sid           INTEGER,
+    worker_start_time    TEXT,
     max_runtime_seconds INTEGER,
     last_heartbeat_at   INTEGER,
     started_at          INTEGER NOT NULL,
@@ -2428,6 +2439,26 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         "CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)"
     )
 
+    # Worker ownership is stronger than a PID: the kernel can reuse a PID
+    # after a crash, and a reclaimed worker may leave descendants in a new
+    # process group/session. Keep the process identity on the run row so
+    # reclaim can fail closed instead of signalling an unrelated process.
+    runs_table_exists = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='task_runs'"
+    ).fetchone() is not None
+    if runs_table_exists:
+        run_cols = {
+            row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")
+        }
+        if "worker_pgid" not in run_cols:
+            _add_column_if_missing(conn, "task_runs", "worker_pgid", "worker_pgid INTEGER")
+        if "worker_sid" not in run_cols:
+            _add_column_if_missing(conn, "task_runs", "worker_sid", "worker_sid INTEGER")
+        if "worker_start_time" not in run_cols:
+            _add_column_if_missing(
+                conn, "task_runs", "worker_start_time", "worker_start_time TEXT"
+            )
+
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
     ev_cols = {row["name"] for row in conn.execute("PRAGMA table_info(task_events)")}
@@ -2571,7 +2602,8 @@ _REBUILD_SPECS = {
         " id INTEGER PRIMARY KEY AUTOINCREMENT,"
         " task_id TEXT NOT NULL, profile TEXT, step_key TEXT,"
         " status TEXT NOT NULL, claim_lock TEXT, claim_expires INTEGER,"
-        " worker_pid INTEGER, max_runtime_seconds INTEGER,"
+        " worker_pid INTEGER, worker_pgid INTEGER, worker_sid INTEGER,"
+        " worker_start_time TEXT, max_runtime_seconds INTEGER,"
         " last_heartbeat_at INTEGER, started_at INTEGER NOT NULL,"
         " ended_at INTEGER, outcome TEXT, summary TEXT, metadata TEXT,"
         " error TEXT)",
@@ -3865,7 +3897,10 @@ def _end_run(
                ended_at      = ?,
                claim_lock    = NULL,
                claim_expires = NULL,
-               worker_pid    = NULL
+               worker_pid    = NULL,
+               worker_pgid   = NULL,
+               worker_sid    = NULL,
+               worker_start_time = NULL
          WHERE id = ?
            AND ended_at IS NULL
         """,
@@ -4076,6 +4111,33 @@ def recompute_ready(
 # Claim / complete / block
 # ---------------------------------------------------------------------------
 
+def _workspace_key(path: Optional[str]) -> Optional[str]:
+    """Canonical key used for the one-writer-per-workspace invariant."""
+    if not path:
+        return None
+    try:
+        return str(Path(path).expanduser().resolve(strict=False))
+    except (OSError, RuntimeError, ValueError):
+        return os.path.abspath(os.path.expanduser(str(path)))
+
+
+def _workspace_is_busy(
+    conn: sqlite3.Connection,
+    task_id: str,
+    workspace_path: Optional[str],
+) -> bool:
+    """Return True when another running task owns the same directory."""
+    key = _workspace_key(workspace_path)
+    if key is None:
+        return False
+    rows = conn.execute(
+        "SELECT id, workspace_path FROM tasks "
+        "WHERE status = 'running' AND id != ? AND workspace_path IS NOT NULL",
+        (task_id,),
+    ).fetchall()
+    return any(_workspace_key(row["workspace_path"]) == key for row in rows)
+
+
 def claim_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4117,6 +4179,18 @@ def claim_task(
                 {"reason": "parents_not_done"},
             )
             return None
+        workspace_row = conn.execute(
+            "SELECT workspace_path FROM tasks WHERE id = ? AND status = 'ready'",
+            (task_id,),
+        ).fetchone()
+        if workspace_row and _workspace_is_busy(
+            conn, task_id, workspace_row["workspace_path"]
+        ):
+            _append_event(
+                conn, task_id, "claim_rejected",
+                {"reason": "workspace_busy", "workspace_path": workspace_row["workspace_path"]},
+            )
+            return None
         # Defensive: if a prior run somehow leaked (invariant violation from
         # an unknown code path), close it as 'reclaimed' so we don't strand
         # it when the CAS resets the pointer below. No-op when the invariant
@@ -4132,7 +4206,9 @@ def claim_task(
                    SET status = 'reclaimed', outcome = 'reclaimed',
                        summary = COALESCE(summary, 'invariant recovery on re-claim'),
                        ended_at = ?,
-                       claim_lock = NULL, claim_expires = NULL, worker_pid = NULL
+                       claim_lock = NULL, claim_expires = NULL, worker_pid = NULL,
+                       worker_pgid = NULL, worker_sid = NULL,
+                       worker_start_time = NULL
                  WHERE id = ? AND ended_at IS NULL
                 """,
                 (now, int(stale["current_run_id"])),
@@ -4221,6 +4297,18 @@ def claim_review_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        workspace_row = conn.execute(
+            "SELECT workspace_path FROM tasks WHERE id = ? AND status = 'review'",
+            (task_id,),
+        ).fetchone()
+        if workspace_row and _workspace_is_busy(
+            conn, task_id, workspace_row["workspace_path"]
+        ):
+            _append_event(
+                conn, task_id, "claim_rejected",
+                {"reason": "workspace_busy", "workspace_path": workspace_row["workspace_path"]},
+            )
+            return None
         cur = conn.execute(
             """
             UPDATE tasks
@@ -4338,10 +4426,12 @@ def release_stale_claims(
     reclaimed = 0
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
     stale = conn.execute(
-        "SELECT id, claim_lock, worker_pid, claim_expires, last_heartbeat_at "
-        "FROM tasks "
-        "WHERE status = 'running' AND claim_expires IS NOT NULL "
-        "  AND claim_expires < ?",
+        "SELECT t.id, t.claim_lock, t.worker_pid, t.claim_expires, "
+        "       t.last_heartbeat_at, t.current_run_id, "
+        "       r.worker_pgid, r.worker_sid, r.worker_start_time "
+        "FROM tasks t LEFT JOIN task_runs r ON r.id = t.current_run_id "
+        "WHERE t.status = 'running' AND t.claim_expires IS NOT NULL "
+        "  AND t.claim_expires < ?",
         (now,),
     ).fetchall()
     for row in stale:
@@ -4360,6 +4450,12 @@ def release_stale_claims(
             host_local
             and row["worker_pid"]
             and _pid_alive(row["worker_pid"])
+            and _worker_identity_matches(
+                row["worker_pid"],
+                expected_start_time=row["worker_start_time"],
+                expected_pgid=row["worker_pgid"],
+                expected_sid=row["worker_sid"],
+            )
             and not heartbeat_stale
         ):
             new_expires = now + _resolve_claim_ttl_seconds()
@@ -4398,8 +4494,12 @@ def release_stale_claims(
                 )
             continue
 
-        termination = _terminate_reclaimed_worker(
+        termination = _terminate_worker_owned(
             row["worker_pid"], row["claim_lock"], signal_fn=signal_fn,
+            expected_start_time=row["worker_start_time"],
+            expected_pgid=row["worker_pgid"],
+            expected_sid=row["worker_sid"],
+            identity_required=bool(row["worker_pid"]) and signal_fn is None,
         )
         # Never release a claim while our own worker is still alive: that would
         # spawn a duplicate beside it. Hold the claim and retry next tick.
@@ -4469,7 +4569,10 @@ def reclaim_task(
     reclaimable state (not running, or doesn't exist).
     """
     row = conn.execute(
-        "SELECT status, claim_lock, worker_pid FROM tasks WHERE id = ?",
+        "SELECT t.status, t.claim_lock, t.worker_pid, t.current_run_id, "
+        "       r.worker_pgid, r.worker_sid, r.worker_start_time "
+        "FROM tasks t LEFT JOIN task_runs r ON r.id = t.current_run_id "
+        "WHERE t.id = ?",
         (task_id,),
     ).fetchone()
     if not row:
@@ -4478,9 +4581,19 @@ def reclaim_task(
         # Nothing to reclaim — already ready / blocked / done.
         return False
     prev_lock = row["claim_lock"]
-    termination = _terminate_reclaimed_worker(
+    termination = _terminate_worker_owned(
         row["worker_pid"], prev_lock, signal_fn=signal_fn,
+        expected_start_time=row["worker_start_time"],
+        expected_pgid=row["worker_pgid"],
+        expected_sid=row["worker_sid"],
+        identity_required=bool(row["worker_pid"]) and signal_fn is None,
     )
+    if _worker_survived_termination(termination):
+        _defer_reclaim_for_live_worker(
+            conn, task_id, prev_lock, int(time.time()), termination,
+            reason="manual_reclaim_worker_alive",
+        )
+        return False
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
@@ -4725,6 +4838,22 @@ def complete_task(
     and never blocks.
     """
     now = int(time.time())
+    completion_worker: Optional[dict[str, Any]] = None
+    worker_row = conn.execute(
+        "SELECT t.worker_pid, t.claim_lock, "
+        "       r.worker_pgid, r.worker_sid, r.worker_start_time "
+        "FROM tasks t LEFT JOIN task_runs r ON r.id = t.current_run_id "
+        "WHERE t.id = ?",
+        (task_id,),
+    ).fetchone()
+    if worker_row is not None and worker_row["worker_pid"] is not None:
+        completion_worker = {
+            "pid": int(worker_row["worker_pid"]),
+            "claim_lock": worker_row["claim_lock"],
+            "expected_start_time": worker_row["worker_start_time"],
+            "expected_pgid": worker_row["worker_pgid"],
+            "expected_sid": worker_row["worker_sid"],
+        }
 
     # Gate: verify created_cards BEFORE the main write txn. A rejected
     # completion still needs an auditable event, so we emit it in a
@@ -4882,6 +5011,15 @@ def complete_task(
     _clear_failure_counter(conn, task_id)
     # Recompute ready status for dependents (separate txn so children see done).
     recompute_ready(conn)
+    # A successful worker can leave child tools (language servers, test
+    # runners, etc.) alive after it records completion. Reuse the same
+    # identity/ancestry verification as reclaim paths, but never signal the
+    # completing worker process itself.
+    if completion_worker is not None:
+        _cleanup_worker_processes(
+            **completion_worker,
+            exclude_pid=os.getpid(),
+        )
     # Clean up the scratch workspace and any stale tmux session for the worker.
     _cleanup_workspace(conn, task_id)
     _done_task = get_task(conn, task_id)
@@ -5177,6 +5315,57 @@ def _is_managed_scratch_path(p: Path) -> bool:
     """
     is_managed, _board = _managed_scratch_path_info(p)
     return is_managed
+
+
+def _cleanup_worker_processes(
+    *,
+    pid: Optional[int],
+    claim_lock: Optional[str],
+    expected_start_time: Optional[str],
+    expected_pgid: Optional[int],
+    expected_sid: Optional[int],
+    exclude_pid: Optional[int] = None,
+) -> dict[str, Any]:
+    """Best-effort cleanup for a completed worker's owned process tree.
+
+    Completion runs in the worker process itself, so the root PID is excluded
+    from signalling. Child tools are still checked against the recorded
+    start-time/PGID/SID identity before they are terminated. Missing identity
+    fields fail closed just like stale-claim cleanup.
+    """
+    try:
+        termination = _terminate_worker_owned(
+            pid,
+            claim_lock,
+            expected_start_time=expected_start_time,
+            expected_pgid=expected_pgid,
+            expected_sid=expected_sid,
+            identity_required=True,
+            exclude_pid=exclude_pid,
+        )
+        if termination.get("ownership_unverified_alive"):
+            _log.warning(
+                "Refusing completed-worker cleanup for task process %s: "
+                "process identity is incomplete or unavailable",
+                pid,
+            )
+        elif (
+            termination.get("termination_attempted")
+            and not termination.get("terminated")
+        ):
+            _log.warning(
+                "Completed-worker descendants survived cleanup for process %s: %s",
+                pid,
+                termination.get("descendant_pids", []),
+            )
+        return termination
+    except Exception:
+        _log.debug(
+            "Completed-worker process cleanup failed for pid %s",
+            pid,
+            exc_info=True,
+        )
+        return {}
 
 
 def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
@@ -5777,7 +5966,9 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
                    SET status = 'reclaimed', outcome = 'reclaimed',
                        summary = COALESCE(summary, 'invariant recovery on unblock'),
                        ended_at = ?,
-                       claim_lock = NULL, claim_expires = NULL, worker_pid = NULL
+                       claim_lock = NULL, claim_expires = NULL, worker_pid = NULL,
+                       worker_pgid = NULL, worker_sid = NULL,
+                       worker_start_time = NULL
                  WHERE id = ? AND ended_at IS NULL
                 """,
                 (now, int(stale["current_run_id"])),
@@ -6524,12 +6715,20 @@ def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
 
 def set_workspace_path(
     conn: sqlite3.Connection, task_id: str, path: Path | str
-) -> None:
+) -> bool:
+    """Persist a resolved workspace unless another running task owns it."""
     with write_txn(conn):
-        conn.execute(
+        if _workspace_is_busy(conn, task_id, str(path)):
+            _append_event(
+                conn, task_id, "workspace_rejected",
+                {"reason": "workspace_busy", "workspace_path": str(path)},
+            )
+            return False
+        cur = conn.execute(
             "UPDATE tasks SET workspace_path = ? WHERE id = ?",
             (str(path), task_id),
         )
+        return cur.rowcount == 1
 
 
 def set_branch_name(
@@ -6870,13 +7069,198 @@ def _pid_alive(pid: Optional[int]) -> bool:
     return True
 
 
+def _process_identity(pid: Optional[int]) -> Optional[dict[str, Any]]:
+    """Return the host identity needed to safely signal ``pid``.
+
+    ``os.kill(pid, ...)`` is not an ownership check: after a worker exits the
+    kernel may assign the same number to an unrelated process.  Linux exposes
+    a monotonic-per-process start tick in ``/proc/<pid>/stat`` together with
+    the parent, process-group, and session ids.  Other POSIX systems get the
+    same fields from ``ps`` where available; callers treat a missing identity
+    as an unverified process and fail closed when they have a stored token.
+    """
+    if not pid or int(pid) <= 0:
+        return None
+    pid = int(pid)
+    if sys.platform == "linux":
+        try:
+            raw = Path(f"/proc/{pid}/stat").read_text(encoding="ascii")
+            closing = raw.rfind(")")
+            if closing < 0:
+                return None
+            fields = raw[closing + 2 :].split()
+            # fields[0] is field 3 (state); field 22 (starttime) is index 19.
+            if len(fields) <= 19:
+                return None
+            return {
+                "ppid": int(fields[1]),
+                "pgid": int(fields[2]),
+                "sid": int(fields[3]),
+                "start_time": str(fields[19]),
+            }
+        except (OSError, ValueError, IndexError):
+            return None
+    if sys.platform == "darwin":
+        try:
+            proc = subprocess.run(
+                ["ps", "-o", "ppid=,pgid=,sid=,lstart=", "-p", str(pid)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=1,
+                check=False,
+            )
+            parts = (proc.stdout or "").strip().split(None, 3)
+            if proc.returncode != 0 or len(parts) != 4:
+                return None
+            return {
+                "ppid": int(parts[0]),
+                "pgid": int(parts[1]),
+                "sid": int(parts[2]),
+                "start_time": parts[3],
+            }
+        except (OSError, ValueError, subprocess.SubprocessError):
+            return None
+    return None
+
+
+def _worker_identity_matches(
+    pid: Optional[int],
+    *,
+    expected_start_time: Optional[str] = None,
+    expected_pgid: Optional[int] = None,
+    expected_sid: Optional[int] = None,
+) -> bool:
+    """Return whether a live PID is still the worker recorded for a run."""
+    if expected_start_time is None:
+        return expected_pgid is None and expected_sid is None
+    if expected_pgid is None or expected_sid is None:
+        return False
+    identity = _process_identity(pid)
+    if identity is None:
+        return False
+    return (
+        str(identity["start_time"]) == str(expected_start_time)
+        and int(identity["pgid"]) == int(expected_pgid)
+        and int(identity["sid"]) == int(expected_sid)
+    )
+
+
+def _owned_process_tree(
+    root_pid: int,
+    *,
+    expected_pgid: Optional[int] = None,
+    expected_sid: Optional[int] = None,
+) -> tuple[list[int], Optional[dict[str, Any]]]:
+    """Snapshot ``root_pid`` and all descendants using process ownership.
+
+    A worker leader can exit before the dispatcher gets a chance to reap it.
+    When the run identity was captured from an isolated ``start_new_session``
+    worker, use its original PGID/SID to find any remaining members even
+    after the leader's ``/proc`` entry is gone.  The SID/PGID fallback is only
+    enabled for an isolated session (both ids equal the leader PID); without
+    that invariant, session membership could include unrelated dispatcher
+    processes.  If the PID has already been reused by a live process, the
+    caller's start-time/PGID/SID comparison rejects it before this fallback
+    can signal anything; once both generations have been reaped, the kernel no
+    longer exposes a token that can distinguish their orphaned session members.
+    """
+    root_identity = _process_identity(root_pid)
+    if root_identity is None:
+        if (
+            sys.platform == "linux"
+            and expected_sid is not None
+            and int(expected_sid) == int(root_pid)
+        ):
+            identities: dict[int, dict[str, Any]] = {}
+            try:
+                for entry in Path("/proc").iterdir():
+                    if not entry.name.isdigit():
+                        continue
+                    candidate_pid = int(entry.name)
+                    identity = _process_identity(candidate_pid)
+                    if identity is not None:
+                        identities[candidate_pid] = identity
+            except OSError:
+                pass
+            owned = sorted(
+                candidate_pid
+                for candidate_pid, identity in identities.items()
+                if (
+                    int(identity["sid"]) == int(expected_sid)
+                    or (
+                        expected_pgid is not None
+                        and int(identity["pgid"]) == int(expected_pgid)
+                    )
+                )
+            )
+            return owned, None
+        return ([int(root_pid)] if _pid_alive(root_pid) else []), None
+    if sys.platform != "linux":
+        return [int(root_pid)], root_identity
+
+    identities: dict[int, dict[str, Any]] = {}
+    try:
+        proc_root = Path("/proc")
+        for entry in proc_root.iterdir():
+            if not entry.name.isdigit():
+                continue
+            identity = _process_identity(int(entry.name))
+            if identity is not None:
+                identities[int(entry.name)] = identity
+    except OSError:
+        pass
+
+    children: dict[int, list[int]] = {}
+    for child_pid, identity in identities.items():
+        children.setdefault(int(identity["ppid"]), []).append(child_pid)
+    root_pgid = int(root_identity["pgid"])
+    root_sid = int(root_identity["sid"])
+    # ``start_new_session=True`` gives dispatcher workers an isolated session.
+    # Include all members of that session/group in addition to the parent
+    # chain only when that isolation is observable (SID == leader PID).
+    # Otherwise group/session membership could include unrelated processes;
+    # the parent-chain walk below remains safe in that legacy case.
+    tree = [int(root_pid)]
+    if root_sid == int(root_pid):
+        for candidate_pid, identity in sorted(identities.items()):
+            if candidate_pid == int(root_pid):
+                continue
+            if int(identity["pgid"]) == root_pgid or int(identity["sid"]) == root_sid:
+                tree.append(candidate_pid)
+    queue = list(tree)
+    while queue:
+        parent = queue.pop(0)
+        for child_pid in sorted(children.get(parent, [])):
+            if child_pid not in tree:
+                tree.append(child_pid)
+                queue.append(child_pid)
+    return tree, root_identity
+
+
 def _terminate_reclaimed_worker(
     pid: Optional[int],
     claim_lock: Optional[str],
     *,
     signal_fn=None,
+    expected_start_time: Optional[str] = None,
+    expected_pgid: Optional[int] = None,
+    expected_sid: Optional[int] = None,
+    identity_required: bool = False,
+    exclude_pid: Optional[int] = None,
 ) -> dict[str, Any]:
-    """Best-effort host-local worker termination for reclaim paths."""
+    """Terminate a host-local worker and its owned descendants.
+
+    The caller may provide the identity captured when the run was spawned.
+    A mismatch means PID reuse (or an unrelated process) and is never
+    signalled. ``identity_required`` is used by DB reclaim paths for legacy
+    rows that predate identity columns; those rows are held instead of risking
+    to an unknown live process. ``exclude_pid`` is used when the completing
+    worker cleans up its descendants: the worker itself must remain alive long
+    enough to finish its response and exit normally.
+    """
     import signal
 
     info: dict[str, Any] = {
@@ -6885,7 +7269,12 @@ def _terminate_reclaimed_worker(
         "termination_attempted": False,
         "terminated": False,
         "sigkill": False,
+        "ownership_verified": False,
+        "ownership_unverified_alive": False,
+        "descendant_pids": [],
+        "owned_pids": [],
     }
+    excluded_pid = int(exclude_pid) if exclude_pid else None
     if not pid or pid <= 0 or not claim_lock:
         return info
 
@@ -6894,42 +7283,164 @@ def _terminate_reclaimed_worker(
         return info
     info["host_local"] = True
 
+    if identity_required and (
+        expected_start_time is None
+        or expected_pgid is None
+        or expected_sid is None
+    ):
+        # Legacy and partially populated rows have no complete ownership
+        # proof. Do not use the isolated-session fallback below: a reused PID
+        # could otherwise make an unrelated session look like this worker.
+        info["ownership_unverified_alive"] = bool(_pid_alive(pid))
+        return info
+
+    owned_pids, identity = _owned_process_tree(
+        int(pid), expected_pgid=expected_pgid, expected_sid=expected_sid,
+    )
+    if identity is None:
+        # The leader may have exited, leaving children in its isolated
+        # session.  The fallback snapshot above is ownership evidence even
+        # though the leader's own start-time record is no longer available.
+        if (
+            owned_pids
+            and expected_sid is not None
+            and int(expected_sid) == int(pid)
+        ):
+            info["ownership_verified"] = True
+        elif identity_required:
+            info["ownership_unverified_alive"] = bool(_pid_alive(pid))
+            return info
+        # Preserve the old best-effort behavior for direct callers and old
+        # test hooks when the host cannot expose process metadata.
+        if not info["ownership_verified"]:
+            owned_pids = [int(pid)]
+    else:
+        if expected_start_time is not None and str(identity["start_time"]) != str(expected_start_time):
+            return info
+        if expected_pgid is not None and int(identity["pgid"]) != int(expected_pgid):
+            return info
+        if expected_sid is not None and int(identity["sid"]) != int(expected_sid):
+            return info
+        info["ownership_verified"] = True
+    info["owned_pids"] = list(owned_pids)
+    info["descendant_pids"] = [item for item in owned_pids if item != int(pid)]
+    targets = [item for item in owned_pids if item != excluded_pid]
+    if not targets:
+        info["terminated"] = True
+        return info
+
+    target_identities: dict[int, dict[str, Any]] = {}
+    if identity_required:
+        for target in owned_pids:
+            target_identity = identity if target == int(pid) else _process_identity(target)
+            if target_identity is not None:
+                target_identities[int(target)] = dict(target_identity)
+
+    def _target_identity_matches(target: int) -> bool:
+        if not identity_required:
+            return True
+        recorded = target_identities.get(int(target))
+        if recorded is None:
+            return False
+        current = _process_identity(target)
+        if current is None:
+            return False
+        return all(
+            str(current[field]) == str(recorded[field])
+            for field in ("start_time", "pgid", "sid")
+        )
+
     kill = signal_fn if signal_fn is not None else (
         os.kill if hasattr(os, "kill") else None
     )
     if kill is None:
         return info
 
-    info["termination_attempted"] = True
-    try:
-        kill(int(pid), signal.SIGTERM)
-    except ProcessLookupError:
-        # Process is already gone — that's a successful termination, not a
-        # survival. Leaving terminated=False here would make the reclaim guard
-        # misread a dead worker as still-alive and defer forever.
+    # Signal the leader first for compatibility with existing termination
+    # hooks, then descendants in reverse discovery order. We do not wait for
+    # the leader before signalling children, so a leader that waits for a
+    # child cannot strand it during the grace window.
+    ordered_targets = [target for target in [int(pid)] + [
+        target for target in reversed(owned_pids) if target != int(pid)
+    ] if target != excluded_pid and _target_identity_matches(target)]
+    if not ordered_targets:
         info["terminated"] = True
         return info
-    except OSError:
-        return info
+    info["termination_attempted"] = True
+    for target in ordered_targets:
+        if not _target_identity_matches(target):
+            continue
+        try:
+            kill(int(target), signal.SIGTERM)
+        except (ProcessLookupError, OSError):
+            pass
+
+    def _live_targets() -> list[int]:
+        return [
+            target for target in targets
+            if _pid_alive(target) and _target_identity_matches(target)
+        ]
 
     for _ in range(10):
-        if not _pid_alive(pid):
+        live = _live_targets()
+        if not live:
             info["terminated"] = True
             return info
         time.sleep(0.5)
 
-    if _pid_alive(pid):
+    live = _live_targets()
+    if live:
         try:
-            # signal.SIGKILL doesn't exist on Windows; fall back to SIGTERM
-            # (which maps to TerminateProcess via the stdlib shim).
             _sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
-            kill(int(pid), _sigkill)
-            info["sigkill"] = True
+            for target in live:
+                if not _target_identity_matches(target):
+                    continue
+                try:
+                    kill(int(target), _sigkill)
+                    info["sigkill"] = True
+                except (ProcessLookupError, OSError):
+                    pass
         except (ProcessLookupError, OSError):
-            return info
+            pass
 
-    info["terminated"] = not _pid_alive(pid)
+    info["terminated"] = not _live_targets()
     return info
+
+
+def _terminate_worker_owned(
+    pid: Optional[int],
+    claim_lock: Optional[str],
+    *,
+    signal_fn=None,
+    expected_start_time: Optional[str] = None,
+    expected_pgid: Optional[int] = None,
+    expected_sid: Optional[int] = None,
+    identity_required: bool = False,
+    exclude_pid: Optional[int] = None,
+) -> dict[str, Any]:
+    """Invoke the termination hook while preserving older test/plugin hooks."""
+    import inspect
+
+    kwargs = {
+        "signal_fn": signal_fn,
+        "expected_start_time": expected_start_time,
+        "expected_pgid": expected_pgid,
+        "expected_sid": expected_sid,
+        "identity_required": identity_required,
+        "exclude_pid": exclude_pid,
+    }
+    try:
+        parameters = inspect.signature(_terminate_reclaimed_worker).parameters
+    except (TypeError, ValueError):
+        parameters = {}
+    accepts_identity = (
+        "expected_start_time" in parameters
+        or "exclude_pid" in parameters
+        or any(p.kind == inspect.Parameter.VAR_KEYWORD for p in parameters.values())
+    )
+    if not accepts_identity:
+        return _terminate_reclaimed_worker(pid, claim_lock, signal_fn=signal_fn)
+    return _terminate_reclaimed_worker(pid, claim_lock, **kwargs)
 
 
 def _worker_survived_termination(termination: dict) -> bool:
@@ -6942,9 +7453,14 @@ def _worker_survived_termination(termination: dict) -> bool:
     to the normal release path, since we cannot manage that worker anyway.
     """
     return bool(
-        termination.get("termination_attempted")
-        and termination.get("host_local")
-        and not termination.get("terminated")
+        termination.get("host_local")
+        and (
+            termination.get("ownership_unverified_alive")
+            or (
+                termination.get("termination_attempted")
+                and not termination.get("terminated")
+            )
+        )
     )
 
 
@@ -7065,7 +7581,8 @@ def enforce_max_runtime(
     rows = conn.execute(
         "SELECT t.id, t.worker_pid, "
         "       COALESCE(r.started_at, t.started_at) AS active_started_at, "
-        "       t.max_runtime_seconds, t.claim_lock "
+        "       t.max_runtime_seconds, t.claim_lock, "
+        "       r.worker_pgid, r.worker_sid, r.worker_start_time "
         "FROM tasks t "
         "LEFT JOIN task_runs r ON r.id = t.current_run_id "
         "WHERE t.status = 'running' AND t.max_runtime_seconds IS NOT NULL "
@@ -7085,31 +7602,18 @@ def enforce_max_runtime(
 
         pid = int(row["worker_pid"])
         tid = row["id"]
-        # SIGTERM then SIGKILL. Keep it simple: 5 s grace. Workers that
-        # want a cleaner shutdown can install their own SIGTERM handler
-        # before the grace expires.
-        killed = False
-        kill = signal_fn if signal_fn is not None else (
-            os.kill if hasattr(os, "kill") else None
+        termination = _terminate_worker_owned(
+            pid,
+            row["claim_lock"],
+            signal_fn=signal_fn,
+            expected_start_time=row["worker_start_time"],
+            expected_pgid=row["worker_pgid"],
+            expected_sid=row["worker_sid"],
+            identity_required=signal_fn is None,
         )
-        if kill is not None:
-            try:
-                kill(pid, signal.SIGTERM)
-            except (ProcessLookupError, OSError):
-                pass
-            # Short polling wait — no time.sleep on the write txn.
-            for _ in range(10):
-                if not _pid_alive(pid):
-                    break
-                time.sleep(0.5)
-            if _pid_alive(pid):
-                try:
-                    # signal.SIGKILL doesn't exist on Windows.
-                    _sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
-                    kill(pid, _sigkill)
-                    killed = True
-                except (ProcessLookupError, OSError):
-                    pass
+        killed = bool(termination.get("sigkill"))
+        if _worker_survived_termination(termination):
+            continue
 
         with write_txn(conn):
             cur = conn.execute(
@@ -7127,6 +7631,7 @@ def enforce_max_runtime(
                     "limit_seconds": int(row["max_runtime_seconds"]),
                     "sigkill": killed,
                 }
+                payload.update(termination)
                 run_id = _end_run(
                     conn, tid,
                     outcome="timed_out", status="timed_out",
@@ -7199,7 +7704,8 @@ def detect_stale_running(
 
     rows = conn.execute(
         "SELECT t.id, t.worker_pid, t.last_heartbeat_at, t.claim_lock, "
-        "       COALESCE(r.started_at, t.started_at) AS active_started_at "
+        "       COALESCE(r.started_at, t.started_at) AS active_started_at, "
+        "       r.worker_pgid, r.worker_sid, r.worker_start_time "
         "FROM tasks t "
         "LEFT JOIN task_runs r ON r.id = t.current_run_id "
         "WHERE t.status = 'running'"
@@ -7224,8 +7730,12 @@ def detect_stale_running(
         lock = row["claim_lock"] or ""
 
         # Terminate the worker if it's still host-local.
-        termination = _terminate_reclaimed_worker(
+        termination = _terminate_worker_owned(
             pid, lock, signal_fn=signal_fn,
+            expected_start_time=row["worker_start_time"],
+            expected_pgid=row["worker_pgid"],
+            expected_sid=row["worker_sid"],
+            identity_required=bool(pid) and signal_fn is None,
         )
 
         # Never release a claim while our own worker is still alive: that would
@@ -7410,10 +7920,13 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # counter (see the post-txn loop below).
     crash_details: list[tuple[str, int, str, bool, str]] = []
     # (task_id, pid, claimer, protocol_violation, error_text)
+    deferred_details: list[tuple[str, str, dict[str, Any]]] = []
     with write_txn(conn):
         rows = conn.execute(
-            "SELECT id, worker_pid, claim_lock, started_at FROM tasks "
-            "WHERE status = 'running' AND worker_pid IS NOT NULL"
+            "SELECT t.id, t.worker_pid, t.claim_lock, t.started_at, "
+            "       r.worker_pgid, r.worker_sid, r.worker_start_time "
+            "FROM tasks t LEFT JOIN task_runs r ON r.id = t.current_run_id "
+            "WHERE t.status = 'running' AND t.worker_pid IS NOT NULL"
         ).fetchall()
         host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
         for row in rows:
@@ -7429,10 +7942,29 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 grace = _resolve_crash_grace_seconds()
                 if time.time() - started_at < grace:
                     continue
-            if _pid_alive(row["worker_pid"]):
+            identity_mismatch = not _worker_identity_matches(
+                row["worker_pid"],
+                expected_start_time=row["worker_start_time"],
+                expected_pgid=row["worker_pgid"],
+                expected_sid=row["worker_sid"],
+            )
+            if _pid_alive(row["worker_pid"]) and not identity_mismatch:
                 continue
 
             pid = int(row["worker_pid"])
+            termination = _terminate_worker_owned(
+                pid,
+                row["claim_lock"],
+                expected_start_time=row["worker_start_time"],
+                expected_pgid=row["worker_pgid"],
+                expected_sid=row["worker_sid"],
+                identity_required=True,
+            )
+            if _worker_survived_termination(termination):
+                deferred_details.append(
+                    (row["id"], row["claim_lock"], termination),
+                )
+                continue
             kind, code = _classify_worker_exit(pid)
             rate_limited_exit = False
             if kind == "clean_exit":
@@ -7495,6 +8027,9 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 if code is not None and kind != "unknown":
                     event_payload["exit_kind"] = kind
                     event_payload["exit_code"] = code
+            if identity_mismatch:
+                event_payload["pid_reused"] = True
+            event_payload.update(termination)
 
             cur = conn.execute(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
@@ -7548,6 +8083,19 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                         (row["id"], pid, row["claim_lock"],
                          protocol_violation, error_text)
                     )
+    # A live worker that survived escalation keeps its claim.  Do this after
+    # the main transaction because ``_defer_reclaim_for_live_worker`` opens
+    # its own write transaction.
+    for task_id, claim_lock, termination in deferred_details:
+        _defer_reclaim_for_live_worker(
+            conn,
+            task_id,
+            claim_lock,
+            int(time.time()),
+            termination,
+            reason="crashed_worker_alive",
+        )
+
     # Outside the main txn: account each crashed task and maybe trip the
     # breaker (the task transitions ready → blocked with a ``gave_up`` event
     # on top of the event we already emitted).
@@ -7831,6 +8379,7 @@ def _set_worker_pid(conn: sqlite3.Connection, task_id: str, pid: int) -> None:
     tail`` can correlate log lines with OS-level traces without opening
     the drawer.
     """
+    identity = _process_identity(pid)
     with write_txn(conn):
         conn.execute(
             "UPDATE tasks SET worker_pid = ? WHERE id = ?",
@@ -7839,10 +8388,26 @@ def _set_worker_pid(conn: sqlite3.Connection, task_id: str, pid: int) -> None:
         run_id = _current_run_id(conn, task_id)
         if run_id is not None:
             conn.execute(
-                "UPDATE task_runs SET worker_pid = ? WHERE id = ?",
-                (int(pid), run_id),
+                "UPDATE task_runs SET worker_pid = ?, worker_pgid = ?, "
+                "worker_sid = ?, worker_start_time = ? WHERE id = ?",
+                (
+                    int(pid),
+                    identity.get("pgid") if identity else None,
+                    identity.get("sid") if identity else None,
+                    str(identity["start_time"]) if identity else None,
+                    run_id,
+                ),
             )
-        _append_event(conn, task_id, "spawned", {"pid": int(pid)}, run_id=run_id)
+        payload = {"pid": int(pid)}
+        if identity:
+            payload.update(
+                {
+                    "pgid": int(identity["pgid"]),
+                    "sid": int(identity["sid"]),
+                    "start_time": str(identity["start_time"]),
+                }
+            )
+        _append_event(conn, task_id, "spawned", payload, run_id=run_id)
 
 
 def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
@@ -8404,7 +8969,15 @@ def _dispatch_once_locked(
                 result.auto_blocked.append(claimed.id)
             continue
         # Persist the resolved workspace path so the worker can cd there.
-        set_workspace_path(conn, claimed.id, str(workspace))
+        if not set_workspace_path(conn, claimed.id, str(workspace)):
+            auto = _record_spawn_failure(
+                conn, claimed.id,
+                f"workspace busy: {workspace}",
+                failure_limit=failure_limit,
+            )
+            if auto:
+                result.auto_blocked.append(claimed.id)
+            continue
         if claimed.workspace_kind == "worktree":
             set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
@@ -8496,7 +9069,15 @@ def _dispatch_once_locked(
                 result.auto_blocked.append(claimed.id)
             continue
         # Persist the resolved workspace path so the worker can cd there.
-        set_workspace_path(conn, claimed.id, str(workspace))
+        if not set_workspace_path(conn, claimed.id, str(workspace)):
+            auto = _record_spawn_failure(
+                conn, claimed.id,
+                f"workspace busy: {workspace}",
+                failure_limit=failure_limit,
+            )
+            if auto:
+                result.auto_blocked.append(claimed.id)
+            continue
         if claimed.workspace_kind == "worktree":
             set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1283,7 +1283,8 @@ CREATE TABLE IF NOT EXISTS task_runs (
     --          gave_up | reclaimed | (null while still running)
     summary             TEXT,
     metadata            TEXT,
-    error               TEXT
+    error               TEXT,
+    cleanup_verified    INTEGER NOT NULL DEFAULT 1
 );
 
 -- Files attached to a task (PDFs, images, source documents). The blob
@@ -2458,6 +2459,11 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             _add_column_if_missing(
                 conn, "task_runs", "worker_start_time", "worker_start_time TEXT"
             )
+        if "cleanup_verified" not in run_cols:
+            _add_column_if_missing(
+                conn, "task_runs", "cleanup_verified",
+                "cleanup_verified INTEGER NOT NULL DEFAULT 1",
+            )
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
@@ -2606,7 +2612,7 @@ _REBUILD_SPECS = {
         " worker_start_time TEXT, max_runtime_seconds INTEGER,"
         " last_heartbeat_at INTEGER, started_at INTEGER NOT NULL,"
         " ended_at INTEGER, outcome TEXT, summary TEXT, metadata TEXT,"
-        " error TEXT)",
+        " error TEXT, cleanup_verified INTEGER NOT NULL DEFAULT 1)",
         (
             "CREATE INDEX idx_runs_task ON task_runs(task_id, started_at)",
             "CREATE INDEX idx_runs_status ON task_runs(status)",
@@ -3896,11 +3902,7 @@ def _end_run(
                metadata      = ?,
                ended_at      = ?,
                claim_lock    = NULL,
-               claim_expires = NULL,
-               worker_pid    = NULL,
-               worker_pgid   = NULL,
-               worker_sid    = NULL,
-               worker_start_time = NULL
+               claim_expires = NULL
          WHERE id = ?
            AND ended_at IS NULL
         """,
@@ -4131,8 +4133,10 @@ def _workspace_is_busy(
     if key is None:
         return False
     rows = conn.execute(
-        "SELECT id, workspace_path FROM tasks "
-        "WHERE status = 'running' AND id != ? AND workspace_path IS NOT NULL",
+        "SELECT t.id, t.workspace_path FROM tasks t "
+        "LEFT JOIN task_runs r ON r.task_id = t.id "
+        "WHERE t.id != ? AND t.workspace_path IS NOT NULL "
+        "AND (t.status = 'running' OR COALESCE(r.cleanup_verified, 1) = 0)",
         (task_id,),
     ).fetchall()
     return any(_workspace_key(row["workspace_path"]) == key for row in rows)
@@ -4499,7 +4503,7 @@ def release_stale_claims(
             expected_start_time=row["worker_start_time"],
             expected_pgid=row["worker_pgid"],
             expected_sid=row["worker_sid"],
-            identity_required=bool(row["worker_pid"]) and signal_fn is None,
+            identity_required=bool(row["worker_pid"]),
         )
         # Never release a claim while our own worker is still alive: that would
         # spawn a duplicate beside it. Hold the claim and retry next tick.
@@ -4586,7 +4590,7 @@ def reclaim_task(
         expected_start_time=row["worker_start_time"],
         expected_pgid=row["worker_pgid"],
         expected_sid=row["worker_sid"],
-        identity_required=bool(row["worker_pid"]) and signal_fn is None,
+        identity_required=bool(row["worker_pid"]),
     )
     if _worker_survived_termination(termination):
         _defer_reclaim_for_live_worker(
@@ -4795,6 +4799,19 @@ class HallucinatedCardsError(ValueError):
         )
 
 
+def _completion_exclude_pid(worker: Optional[dict[str, Any]]) -> Optional[int]:
+    """Never signal the registered root from a completion cleanup path.
+
+    Completion may be called by the worker itself or administratively by a CLI
+    or dashboard process. In both cases it may clean owned descendants, but
+    terminating the registered root belongs to explicit timeout/reclaim paths.
+    """
+    if not worker:
+        return None
+    pid = int(worker.get("pid") or 0)
+    return pid if pid > 0 else None
+
+
 class ArtifactPreservationError(RuntimeError):
     """Raised when a declared scratch deliverable cannot be preserved."""
 
@@ -4839,13 +4856,20 @@ def complete_task(
     """
     now = int(time.time())
     completion_worker: Optional[dict[str, Any]] = None
+    completion_run_pending = False
     worker_row = conn.execute(
-        "SELECT t.worker_pid, t.claim_lock, "
+        "SELECT t.status, t.current_run_id, t.worker_pid, t.claim_lock, "
+        "       t.claim_expires, "
         "       r.worker_pgid, r.worker_sid, r.worker_start_time "
         "FROM tasks t LEFT JOIN task_runs r ON r.id = t.current_run_id "
         "WHERE t.id = ?",
         (task_id,),
     ).fetchone()
+    completion_run_pending = bool(
+        worker_row is not None
+        and worker_row["status"] == "running"
+        and worker_row["current_run_id"] is not None
+    )
     if worker_row is not None and worker_row["worker_pid"] is not None:
         completion_worker = {
             "pid": int(worker_row["worker_pid"]),
@@ -4941,6 +4965,17 @@ def complete_task(
             summary=summary if summary is not None else result,
             metadata=metadata,
         )
+        if completion_run_pending and run_id is not None:
+            # The task row is terminal, but its workspace remains leased to the
+            # ended run until a dispatcher tick verifies that the registered
+            # worker and every owned descendant have exited. Preserve the
+            # original host-local claim token for that later reconciliation.
+            conn.execute(
+                "UPDATE task_runs SET cleanup_verified = 0, claim_lock = ?, "
+                "claim_expires = ? "
+                "WHERE id = ?",
+                (worker_row["claim_lock"], worker_row["claim_expires"], run_id),
+            )
         # If complete_task was called on a never-claimed task (ready or
         # blocked → done with no run in flight), synthesize a
         # zero-duration run so the handoff fields are persisted in
@@ -5015,13 +5050,22 @@ def complete_task(
     # runners, etc.) alive after it records completion. Reuse the same
     # identity/ancestry verification as reclaim paths, but never signal the
     # completing worker process itself.
+    cleanup_verified = not completion_run_pending
     if completion_worker is not None:
-        _cleanup_worker_processes(
+        exclude_pid = _completion_exclude_pid(completion_worker)
+        cleanup_result = _cleanup_worker_processes(
             **completion_worker,
-            exclude_pid=os.getpid(),
+            exclude_pid=exclude_pid,
         )
-    # Clean up the scratch workspace and any stale tmux session for the worker.
-    _cleanup_workspace(conn, task_id)
+        cleanup_verified = _worker_cleanup_is_verified(
+            completion_worker, cleanup_result,
+        )
+        if cleanup_verified:
+            mark_worker_cleanup_verified(conn, task_id, run_id=run_id)
+    # A scratch directory is still owned by an ended worker until the
+    # dispatcher verifies its exit. Never delete it while that lease is held.
+    if cleanup_verified:
+        _cleanup_workspace(conn, task_id)
     _done_task = get_task(conn, task_id)
     _fire_kanban_lifecycle_hook(
         "kanban_task_completed",
@@ -5366,6 +5410,154 @@ def _cleanup_worker_processes(
             exc_info=True,
         )
         return {}
+
+
+def _worker_cleanup_is_verified(
+    worker: dict[str, Any],
+    termination: Optional[dict[str, Any]],
+) -> bool:
+    """Return True only when the recorded worker generation is gone and cleanup is safe."""
+    if not termination:
+        return False
+    if termination.get("ownership_unverified_alive"):
+        return False
+    if termination.get("termination_attempted") and not termination.get("terminated"):
+        return False
+    pid = int(worker.get("pid") or 0)
+    if not _pid_alive(pid):
+        return True
+    if _worker_identity_matches(
+        pid,
+        expected_start_time=worker.get("expected_start_time"),
+        expected_pgid=worker.get("expected_pgid"),
+        expected_sid=worker.get("expected_sid"),
+    ):
+        # The completing worker normally reaches this branch: descendants may
+        # be gone, but the root still owns the workspace until it exits.
+        return False
+    # A live mismatched PID may be a reused generation. Do not signal it,
+    # and do not release the lease automatically without stronger proof.
+    return False
+
+
+def mark_worker_cleanup_verified(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    run_id: Optional[int] = None,
+    reason: str = "process_tree_gone",
+) -> bool:
+    """Release a terminal workspace lease after verified reap/cleanup."""
+    with write_txn(conn):
+        if run_id is None:
+            cur = conn.execute(
+                "UPDATE task_runs SET cleanup_verified = 1 "
+                "WHERE task_id = ? AND cleanup_verified = 0",
+                (task_id,),
+            )
+        else:
+            cur = conn.execute(
+                "UPDATE task_runs SET cleanup_verified = 1 "
+                "WHERE id = ? AND task_id = ? AND cleanup_verified = 0",
+                (int(run_id), task_id),
+            )
+        if cur.rowcount:
+            _append_event(
+                conn, task_id, "worker_cleanup_verified", {"reason": reason},
+                run_id=run_id,
+            )
+        return cur.rowcount > 0
+
+
+def reconcile_terminal_worker_cleanups(conn: sqlite3.Connection) -> list[str]:
+    """Reap ended worker generations and release their workspace leases.
+
+    Completion is recorded before the worker process can return and exit. The
+    ended run therefore retains ``cleanup_verified=0`` and its host claim token.
+    Every dispatcher tick retries identity-safe tree cleanup; only after the
+    recorded root generation is gone is the lease released and scratch cleanup
+    allowed. This keeps one-writer-per-workspace true across ``done``.
+    """
+    rows = conn.execute(
+        "SELECT r.id AS run_id, r.task_id, r.claim_lock, r.claim_expires, "
+        "r.worker_pid, r.worker_pgid, r.worker_sid, r.worker_start_time, "
+        "r.ended_at "
+        "FROM task_runs r WHERE r.ended_at IS NOT NULL "
+        "AND r.cleanup_verified = 0 ORDER BY r.id"
+    ).fetchall()
+    verified: list[str] = []
+    for row in rows:
+        claim_deadline = int(row["claim_expires"] or 0)
+        ended_at = int(row["ended_at"] or 0)
+        deadline = max(
+            claim_deadline,
+            ended_at + RECLAIM_DEFER_GRACE_SECONDS,
+        )
+        deadline_expired = int(time.time()) >= deadline
+        if row["worker_pid"] is None:
+            # The only unobservable window is claim -> spawn -> PID
+            # registration. Preserve the original lease deadline and also
+            # require a post-completion grace so a manual worker has time to
+            # return from complete_task and exit. The CAS in _set_worker_pid
+            # releases this lease earlier when a late spawn can be reaped.
+            if not deadline_expired:
+                continue
+            if mark_worker_cleanup_verified(
+                conn,
+                row["task_id"],
+                run_id=int(row["run_id"]),
+                reason="unregistered_worker_lease_expired",
+            ):
+                _cleanup_workspace(conn, row["task_id"])
+                verified.append(str(row["task_id"]))
+            continue
+        worker = {
+            "pid": int(row["worker_pid"]) if row["worker_pid"] is not None else None,
+            "claim_lock": row["claim_lock"],
+            "expected_start_time": row["worker_start_time"],
+            "expected_pgid": row["worker_pgid"],
+            "expected_sid": row["worker_sid"],
+        }
+        exclude_pid = _completion_exclude_pid(worker)
+        termination = _cleanup_worker_processes(
+            **worker, exclude_pid=exclude_pid,
+        )
+        if not _worker_cleanup_is_verified(worker, termination):
+            pid = int(worker["pid"] or 0)
+            root_generation_alive = _pid_alive(pid) and _worker_identity_matches(
+                pid,
+                expected_start_time=worker.get("expected_start_time"),
+                expected_pgid=worker.get("expected_pgid"),
+                expected_sid=worker.get("expected_sid"),
+            )
+            if root_generation_alive or not deadline_expired:
+                continue
+            # The visible PID is a reused/unverifiable generation. Identity
+            # safety forbids signalling it; after the preserved claim deadline
+            # and a post-completion grace, release the otherwise-eternal lease
+            # with an explicit audit reason. A validated live original worker
+            # never reaches this fallback.
+            _log.warning(
+                "Releasing terminal worker lease for task %s after identity "
+                "verification deadline; PID %s was not signalled",
+                row["task_id"],
+                pid,
+            )
+            if mark_worker_cleanup_verified(
+                conn,
+                row["task_id"],
+                run_id=int(row["run_id"]),
+                reason="unverified_worker_lease_expired",
+            ):
+                _cleanup_workspace(conn, row["task_id"])
+                verified.append(str(row["task_id"]))
+            continue
+        if mark_worker_cleanup_verified(
+            conn, row["task_id"], run_id=int(row["run_id"]),
+        ):
+            _cleanup_workspace(conn, row["task_id"])
+            verified.append(str(row["task_id"]))
+    return verified
 
 
 def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
@@ -7134,9 +7326,7 @@ def _worker_identity_matches(
     expected_sid: Optional[int] = None,
 ) -> bool:
     """Return whether a live PID is still the worker recorded for a run."""
-    if expected_start_time is None:
-        return expected_pgid is None and expected_sid is None
-    if expected_pgid is None or expected_sid is None:
+    if expected_start_time is None or expected_pgid is None or expected_sid is None:
         return False
     identity = _process_identity(pid)
     if identity is None:
@@ -7153,6 +7343,7 @@ def _owned_process_tree(
     *,
     expected_pgid: Optional[int] = None,
     expected_sid: Optional[int] = None,
+    identity_snapshot: Optional[dict[int, dict[str, Any]]] = None,
 ) -> tuple[list[int], Optional[dict[str, Any]]]:
     """Snapshot ``root_pid`` and all descendants using process ownership.
 
@@ -7171,7 +7362,9 @@ def _owned_process_tree(
     if root_identity is None:
         if (
             sys.platform == "linux"
+            and expected_pgid is not None
             and expected_sid is not None
+            and int(expected_pgid) == int(root_pid)
             and int(expected_sid) == int(root_pid)
         ):
             identities: dict[int, dict[str, Any]] = {}
@@ -7196,9 +7389,15 @@ def _owned_process_tree(
                     )
                 )
             )
+            if identity_snapshot is not None:
+                identity_snapshot.update(
+                    {candidate: dict(identities[candidate]) for candidate in owned}
+                )
             return owned, None
         return ([int(root_pid)] if _pid_alive(root_pid) else []), None
     if sys.platform != "linux":
+        if identity_snapshot is not None:
+            identity_snapshot[int(root_pid)] = dict(root_identity)
         return [int(root_pid)], root_identity
 
     identities: dict[int, dict[str, Any]] = {}
@@ -7237,7 +7436,50 @@ def _owned_process_tree(
             if child_pid not in tree:
                 tree.append(child_pid)
                 queue.append(child_pid)
+    if identity_snapshot is not None:
+        for candidate in tree:
+            candidate_identity = (
+                root_identity if candidate == int(root_pid)
+                else identities.get(candidate)
+            )
+            if candidate_identity is not None:
+                identity_snapshot[candidate] = dict(candidate_identity)
     return tree, root_identity
+
+
+
+
+def _signal_verified_target(
+    target: int,
+    sig: int,
+    recorded: Optional[dict[str, Any]],
+    *,
+    signal_fn=None,
+) -> None:
+    """Signal one identity-checked target without a Linux PID TOCTOU window."""
+    if signal_fn is not None:
+        signal_fn(int(target), sig)
+        return
+    if sys.platform == "linux" and hasattr(os, "pidfd_open"):
+        import signal as _signal
+        pidfd = os.pidfd_open(int(target), 0)
+        try:
+            current = _process_identity(target)
+            if recorded is None or current is None or any(
+                str(current[field]) != str(recorded[field])
+                for field in ("start_time", "pgid", "sid")
+            ):
+                return
+            sender = getattr(_signal, "pidfd_send_signal", None)
+            if sender is None:
+                return
+            sender(pidfd, sig, None, 0)
+        finally:
+            os.close(pidfd)
+        return
+    # macOS/Windows and older Linux: identity was validated immediately before
+    # this conservative fallback. No process-group kill is used here.
+    os.kill(int(target), sig)
 
 
 def _terminate_reclaimed_worker(
@@ -7294,8 +7536,10 @@ def _terminate_reclaimed_worker(
         info["ownership_unverified_alive"] = bool(_pid_alive(pid))
         return info
 
+    target_identities: dict[int, dict[str, Any]] = {}
     owned_pids, identity = _owned_process_tree(
         int(pid), expected_pgid=expected_pgid, expected_sid=expected_sid,
+        identity_snapshot=target_identities,
     )
     if identity is None:
         # The leader may have exited, leaving children in its isolated
@@ -7303,7 +7547,9 @@ def _terminate_reclaimed_worker(
         # though the leader's own start-time record is no longer available.
         if (
             owned_pids
+            and expected_pgid is not None
             and expected_sid is not None
+            and int(expected_pgid) == int(pid)
             and int(expected_sid) == int(pid)
         ):
             info["ownership_verified"] = True
@@ -7329,12 +7575,8 @@ def _terminate_reclaimed_worker(
         info["terminated"] = True
         return info
 
-    target_identities: dict[int, dict[str, Any]] = {}
-    if identity_required:
-        for target in owned_pids:
-            target_identity = identity if target == int(pid) else _process_identity(target)
-            if target_identity is not None:
-                target_identities[int(target)] = dict(target_identity)
+    if not identity_required:
+        target_identities.clear()
 
     def _target_identity_matches(target: int) -> bool:
         if not identity_required:
@@ -7371,7 +7613,10 @@ def _terminate_reclaimed_worker(
         if not _target_identity_matches(target):
             continue
         try:
-            kill(int(target), signal.SIGTERM)
+            _signal_verified_target(
+                int(target), signal.SIGTERM, target_identities.get(int(target)),
+                signal_fn=signal_fn,
+            )
         except (ProcessLookupError, OSError):
             pass
 
@@ -7396,7 +7641,11 @@ def _terminate_reclaimed_worker(
                 if not _target_identity_matches(target):
                     continue
                 try:
-                    kill(int(target), _sigkill)
+                    _signal_verified_target(
+                        int(target), _sigkill,
+                        target_identities.get(int(target)),
+                        signal_fn=signal_fn,
+                    )
                     info["sigkill"] = True
                 except (ProcessLookupError, OSError):
                     pass
@@ -7609,7 +7858,7 @@ def enforce_max_runtime(
             expected_start_time=row["worker_start_time"],
             expected_pgid=row["worker_pgid"],
             expected_sid=row["worker_sid"],
-            identity_required=signal_fn is None,
+            identity_required=True,
         )
         killed = bool(termination.get("sigkill"))
         if _worker_survived_termination(termination):
@@ -7735,7 +7984,7 @@ def detect_stale_running(
             expected_start_time=row["worker_start_time"],
             expected_pgid=row["worker_pgid"],
             expected_sid=row["worker_sid"],
-            identity_required=bool(pid) and signal_fn is None,
+            identity_required=bool(pid),
         )
 
         # Never release a claim while our own worker is still alive: that would
@@ -8372,42 +8621,99 @@ def _record_spawn_failure(
     )
 
 
-def _set_worker_pid(conn: sqlite3.Connection, task_id: str, pid: int) -> None:
-    """Record the spawned child's pid + emit a ``spawned`` event.
-
-    The event's payload carries the pid so a human reading ``hermes kanban
-    tail`` can correlate log lines with OS-level traces without opening
-    the drawer.
-    """
+def _set_worker_pid(
+    conn: sqlite3.Connection,
+    task_id: str,
+    pid: int,
+    *,
+    expected_run_id: Optional[int] = None,
+    expected_claim_lock: Optional[str] = None,
+) -> bool:
+    """CAS-register a spawned worker, terminating it if ownership was lost."""
     identity = _process_identity(pid)
+    registered = False
+    run_id: Optional[int] = None
+    claim_lock: Optional[str] = expected_claim_lock
     with write_txn(conn):
-        conn.execute(
-            "UPDATE tasks SET worker_pid = ? WHERE id = ?",
-            (int(pid), task_id),
+        row = conn.execute(
+            "SELECT status, current_run_id, claim_lock FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if row is not None:
+            run_id = (
+                int(expected_run_id)
+                if expected_run_id is not None
+                else (int(row["current_run_id"]) if row["current_run_id"] is not None else None)
+            )
+            claim_lock = expected_claim_lock or row["claim_lock"]
+            ownership_matches = (
+                row["status"] == "running"
+                and run_id is not None
+                and row["current_run_id"] == run_id
+                and row["claim_lock"] == claim_lock
+            )
+            if ownership_matches:
+                task_cur = conn.execute(
+                    "UPDATE tasks SET worker_pid = ? WHERE id = ? "
+                    "AND status = 'running' AND current_run_id = ? "
+                    "AND claim_lock IS ?",
+                    (int(pid), task_id, run_id, claim_lock),
+                )
+                run_cur = conn.execute(
+                    "UPDATE task_runs SET worker_pid = ?, worker_pgid = ?, "
+                    "worker_sid = ?, worker_start_time = ? WHERE id = ? "
+                    "AND ended_at IS NULL AND claim_lock IS ?",
+                    (
+                        int(pid),
+                        identity.get("pgid") if identity else None,
+                        identity.get("sid") if identity else None,
+                        str(identity["start_time"]) if identity else None,
+                        run_id,
+                        claim_lock,
+                    ),
+                )
+                registered = task_cur.rowcount == 1 and run_cur.rowcount == 1
+                if registered:
+                    payload = {"pid": int(pid)}
+                    if identity:
+                        payload.update(
+                            {
+                                "pgid": int(identity["pgid"]),
+                                "sid": int(identity["sid"]),
+                                "start_time": str(identity["start_time"]),
+                            }
+                        )
+                    _append_event(conn, task_id, "spawned", payload, run_id=run_id)
+    if registered:
+        return True
+
+    # Completion/reclaim may win after spawn_fn returns but before registration.
+    # This process never acquired durable ownership; reap the exact generation
+    # immediately instead of letting it become an invisible concurrent writer.
+    worker = {
+        "pid": int(pid),
+        "claim_lock": claim_lock,
+        "expected_start_time": str(identity["start_time"]) if identity else None,
+        "expected_pgid": identity.get("pgid") if identity else None,
+        "expected_sid": identity.get("sid") if identity else None,
+    }
+    termination = _terminate_reclaimed_worker(
+        worker["pid"],
+        worker["claim_lock"],
+        expected_start_time=worker["expected_start_time"],
+        expected_pgid=worker["expected_pgid"],
+        expected_sid=worker["expected_sid"],
+        identity_required=True,
+    )
+    if (
+        expected_run_id is not None
+        and _worker_cleanup_is_verified(worker, termination)
+        and mark_worker_cleanup_verified(
+            conn, task_id, run_id=int(expected_run_id),
         )
-        run_id = _current_run_id(conn, task_id)
-        if run_id is not None:
-            conn.execute(
-                "UPDATE task_runs SET worker_pid = ?, worker_pgid = ?, "
-                "worker_sid = ?, worker_start_time = ? WHERE id = ?",
-                (
-                    int(pid),
-                    identity.get("pgid") if identity else None,
-                    identity.get("sid") if identity else None,
-                    str(identity["start_time"]) if identity else None,
-                    run_id,
-                ),
-            )
-        payload = {"pid": int(pid)}
-        if identity:
-            payload.update(
-                {
-                    "pgid": int(identity["pgid"]),
-                    "sid": int(identity["sid"]),
-                    "start_time": str(identity["start_time"]),
-                }
-            )
-        _append_event(conn, task_id, "spawned", payload, run_id=run_id)
+    ):
+        _cleanup_workspace(conn, task_id)
+    return False
 
 
 def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
@@ -8739,6 +9045,9 @@ def _dispatch_once_locked(
     # Reap zombie children from previously spawned workers. See
     # reap_worker_zombies() for the full rationale.
     reap_worker_zombies()
+    # Successful completion is durable before the worker can return and exit.
+    # Reconcile those ended generations before promoting/claiming new writers.
+    reconcile_terminal_worker_cleanups(conn)
 
     result = DispatchResult()
     result.reclaimed = release_stale_claims(conn)
@@ -8995,8 +9304,14 @@ def _dispatch_once_locked(
                     pid = _spawn(claimed, str(workspace))
             except (TypeError, ValueError):
                 pid = _spawn(claimed, str(workspace))
-            if pid:
-                _set_worker_pid(conn, claimed.id, int(pid))
+            if pid and not _set_worker_pid(
+                conn,
+                claimed.id,
+                int(pid),
+                expected_run_id=claimed.current_run_id,
+                expected_claim_lock=claimed.claim_lock,
+            ):
+                continue
             # NOTE: we intentionally do NOT reset consecutive_failures
             # here. A successful spawn proves the worker can start but
             # doesn't prove the run will succeed. Under unified
@@ -9098,8 +9413,14 @@ def _dispatch_once_locked(
                     pid = _spawn(claimed, str(workspace))
             except (TypeError, ValueError):
                 pid = _spawn(claimed, str(workspace))
-            if pid:
-                _set_worker_pid(conn, claimed.id, int(pid))
+            if pid and not _set_worker_pid(
+                conn,
+                claimed.id,
+                int(pid),
+                expected_run_id=claimed.current_run_id,
+                expected_claim_lock=claimed.claim_lock,
+            ):
+                continue
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
             spawned += 1
         except Exception as exc:

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -159,6 +159,23 @@ def test_run_slash_block_unblock_cycle(kanban_home):
     assert "Unblocked" in kc.run_slash(f"unblock {tid}")
 
 
+def test_claim_returns_task_to_ready_when_workspace_persist_fails(
+    kanban_home, monkeypatch,
+):
+    """CLI claim must not leave a running task without its workspace."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="workspace race", assignee="worker")
+
+    monkeypatch.setattr(kb, "set_workspace_path", lambda *_args, **_kwargs: False)
+    args = argparse.Namespace(task_id=task_id, ttl=None)
+    assert kc._cmd_claim(args) == 1
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+    assert task is not None
+    assert task.status == "ready"
+
+
 def test_run_slash_json_output(kanban_home):
     out = kc.run_slash("create 'jsontask' --assignee alice --json")
     payload = json.loads(out)

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -4151,6 +4151,15 @@ def test_reclaim_task_resets_running_to_ready(kanban_home, monkeypatch):
                 state["alive"] = False
 
         monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: state["alive"])
+        identity = {
+            "start_time": "42", "pgid": 12345, "sid": 12345, "ppid": 1,
+        }
+        original_identity = _kb._process_identity
+        monkeypatch.setattr(
+            _kb,
+            "_process_identity",
+            lambda pid: dict(identity) if pid == 12345 else original_identity(pid),
+        )
         conn.execute(
             "UPDATE tasks SET status='running', claim_lock=?, claim_expires=?, "
             "worker_pid=? WHERE id=?",
@@ -4158,8 +4167,9 @@ def test_reclaim_task_resets_running_to_ready(kanban_home, monkeypatch):
         )
         conn.execute(
             "INSERT INTO task_runs (task_id, status, claim_lock, claim_expires, "
-            "worker_pid, started_at) VALUES (?, 'running', ?, ?, ?, ?)",
-            (t, lock, future, 12345, int(time.time())),
+            "worker_pid, worker_pgid, worker_sid, worker_start_time, started_at) "
+            "VALUES (?, 'running', ?, ?, ?, ?, ?, ?, ?)",
+            (t, lock, future, 12345, 12345, 12345, "42", int(time.time())),
         )
         run_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
         conn.execute("UPDATE tasks SET current_run_id=? WHERE id=?", (run_id, t))
@@ -4348,6 +4358,8 @@ def test_repeated_timeouts_trip_the_circuit_breaker(kanban_home, monkeypatch):
         # Drop the failure_limit to 3 so we don't need 5 timeouts.
         # This uses the module-level DEFAULT; we simulate by calling
         # _record_task_failure directly with a tight limit.
+        identity = _kb._process_identity(os.getpid())
+        assert identity is not None
         for _ in range(3):
             # Fresh claim + "started long ago" each iteration.
             with kb.write_txn(conn):
@@ -4365,13 +4377,17 @@ def test_repeated_timeouts_trip_the_circuit_breaker(kanban_home, monkeypatch):
                 )
                 conn.execute(
                     "INSERT INTO task_runs (task_id, status, claim_lock, "
-                    "claim_expires, worker_pid, started_at) "
-                    "VALUES (?, 'running', ?, ?, ?, ?)",
+                    "claim_expires, worker_pid, worker_pgid, worker_sid, "
+                    "worker_start_time, started_at) "
+                    "VALUES (?, 'running', ?, ?, ?, ?, ?, ?, ?)",
                     (
                         tid,
                         f"{_kb._claimer_id().split(':', 1)[0]}:lock",
                         int(time.time()) + 3600,
                         os.getpid(),
+                        identity["pgid"],
+                        identity["sid"],
+                        str(identity["start_time"]),
                         int(time.time()) - 30,
                     ),
                 )

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -426,7 +426,6 @@ def test_unblock_scheduled_rechecks_parent_gate(kanban_home):
 
 
 def test_stale_claim_reclaimed(kanban_home, monkeypatch):
-    import signal
     import hermes_cli.kanban_db as _kb
 
     with kb.connect() as conn:
@@ -450,24 +449,20 @@ def test_stale_claim_reclaimed(kanban_home, monkeypatch):
         reclaimed = kb.release_stale_claims(conn, signal_fn=_signal)
         assert reclaimed == 1
         assert kb.get_task(conn, t).status == "ready"
-        assert killed == [signal.SIGTERM]
+        assert killed == []  # dead generation: no signal is necessary or safe
 
 
-def test_stale_claim_with_live_pid_extends_instead_of_reclaiming(
+def test_stale_claim_with_verified_live_identity_extends_instead_of_reclaiming(
     kanban_home, monkeypatch,
 ):
-    """A stale-by-TTL claim whose worker PID is still alive should be
-    extended, not reclaimed (#23025). Slow models can spend longer than
-    ``DEFAULT_CLAIM_TTL_SECONDS`` inside a single tool-free LLM call;
-    killing those healthy workers produces a respawn loop with zero
-    progress."""
+    """A stale claim extends only after the complete worker identity matches."""
     import hermes_cli.kanban_db as _kb
 
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="a")
         host = _kb._claimer_id().split(":", 1)[0]
         kb.claim_task(conn, t, claimer=f"{host}:worker")
-        kb._set_worker_pid(conn, t, 12345)
+        kb._set_worker_pid(conn, t, os.getpid())
 
         old_expires = int(time.time()) - 60
         conn.execute(
@@ -475,7 +470,6 @@ def test_stale_claim_with_live_pid_extends_instead_of_reclaiming(
             (old_expires, t),
         )
 
-        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
         killed: list[int] = []
         reclaimed = kb.release_stale_claims(
             conn, signal_fn=lambda _p, sig: killed.append(sig),
@@ -485,7 +479,7 @@ def test_stale_claim_with_live_pid_extends_instead_of_reclaiming(
         assert task.status == "running"
         assert task.claim_expires is not None
         assert task.claim_expires > old_expires
-        assert killed == []  # live worker not killed
+        assert killed == []  # verified live worker not killed
 
         kinds = [
             r["kind"] for r in conn.execute(
@@ -496,7 +490,7 @@ def test_stale_claim_with_live_pid_extends_instead_of_reclaiming(
         assert "reclaimed" not in kinds
 
 
-def test_stale_claim_with_live_pid_uses_env_ttl_override(
+def test_stale_claim_with_verified_live_identity_uses_env_ttl_override(
     kanban_home, monkeypatch,
 ):
     import hermes_cli.kanban_db as _kb
@@ -507,13 +501,12 @@ def test_stale_claim_with_live_pid_uses_env_ttl_override(
         t = kb.create_task(conn, title="x", assignee="a")
         host = _kb._claimer_id().split(":", 1)[0]
         kb.claim_task(conn, t, claimer=f"{host}:worker")
-        kb._set_worker_pid(conn, t, 12345)
+        kb._set_worker_pid(conn, t, os.getpid())
         conn.execute(
             "UPDATE tasks SET claim_expires = ? WHERE id = ?",
             (int(time.time()) - 60, t),
         )
 
-        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
         reclaimed = kb.release_stale_claims(conn, signal_fn=lambda _p, _s: None)
         assert reclaimed == 0
 
@@ -521,6 +514,45 @@ def test_stale_claim_with_live_pid_uses_env_ttl_override(
         assert task is not None
         assert task.claim_expires is not None
         assert task.claim_expires > int(time.time()) + 3000
+
+
+def test_stale_claim_with_legacy_pid_only_never_gets_pid_alive_extension(
+    kanban_home, monkeypatch,
+):
+    """Unknown legacy identity holds the lease but never validates by PID alone."""
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="legacy", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, task_id, claimer=f"{host}:worker")
+        kb._set_worker_pid(conn, task_id, 12345)
+        conn.execute(
+            "UPDATE task_runs SET worker_start_time = NULL, worker_pgid = NULL, "
+            "worker_sid = NULL WHERE id = (SELECT current_run_id FROM tasks WHERE id = ?)",
+            (task_id,),
+        )
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+            (int(time.time()) - 60, task_id),
+        )
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+        signalled: list[int] = []
+
+        assert kb.release_stale_claims(
+            conn, signal_fn=lambda _pid, sig: signalled.append(sig),
+        ) == 0
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "running"  # fail closed: no duplicate writer
+        kinds = [
+            row["kind"] for row in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ?", (task_id,),
+            ).fetchall()
+        ]
+        assert "claim_extended" not in kinds
+        assert "reclaim_deferred" in kinds
+        assert signalled == []  # unknown PID generation is never signalled
 
 
 def test_stale_claim_deferred_when_live_worker_survives_termination(

--- a/tests/hermes_cli/test_kanban_worker_tree_cleanup.py
+++ b/tests/hermes_cli/test_kanban_worker_tree_cleanup.py
@@ -1,0 +1,507 @@
+"""Regression tests for Kanban worker ownership and workspace exclusivity.
+
+These tests exercise real subprocesses because a PID-only mock cannot prove that
+an independently-created session/PGID descendant is cleaned up or that a reused
+PID is rejected safely.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+pytestmark = pytest.mark.live_system_guard_bypass
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = kb.kanban_db_path(board="default")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def conn(kanban_home):
+    with kb.connect() as connection:
+        yield connection
+
+
+def _wait_for_pid_file(path: Path) -> int:
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if path.exists():
+            value = path.read_text(encoding="ascii").strip()
+            if value:
+                return int(value)
+        time.sleep(0.01)
+    raise AssertionError("worker did not publish its descendant PID")
+
+
+def _local_pid_alive(pid: int) -> bool:
+    """Avoid importing the gateway stack just to probe a test subprocess."""
+    try:
+        state = Path(f"/proc/{int(pid)}/stat").read_text(encoding="ascii")
+        return state.rsplit(")", 1)[1].split()[0] != "Z"
+    except OSError:
+        return False
+
+
+def _spawn_worker_with_new_session_descendant(pid_file: Path) -> subprocess.Popen:
+    script = (
+        "import os, pathlib, time\n"
+        "child = os.fork()\n"
+        "if child == 0:\n"
+        "    os.setsid()\n"
+        f"pathlib.Path({str(pid_file)!r}).write_text(str(os.getpid()))\n"
+        "time.sleep(30)\n"
+    )
+    return subprocess.Popen(
+        [sys.executable, "-c", script],
+        start_new_session=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _spawn_worker_that_leaves_same_session_descendant(
+    pid_file: Path, release_file: Path,
+) -> subprocess.Popen:
+    script = (
+        "import os, pathlib, time\n"
+        "child = os.fork()\n"
+        "if child == 0:\n"
+        f"    pathlib.Path({str(pid_file)!r}).write_text(str(os.getpid()))\n"
+        "    while True:\n"
+        f"        if pathlib.Path({str(release_file)!r}).exists(): break\n"
+        "        time.sleep(0.01)\n"
+        "    time.sleep(30)\n"
+        "else:\n"
+        f"    while not pathlib.Path({str(release_file)!r}).exists():\n"
+        "        time.sleep(0.01)\n"
+    )
+    return subprocess.Popen(
+        [sys.executable, "-c", script],
+        start_new_session=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def test_reclaim_terminates_descendant_that_created_its_own_session(
+    kanban_home, monkeypatch, tmp_path
+):
+    """Reclaim must terminate the whole owned run tree, not only its leader."""
+    if os.name == "nt":
+        pytest.skip("process-tree test uses POSIX fork/setsid")
+
+    pid_file = tmp_path / "descendant.pid"
+    worker = _spawn_worker_with_new_session_descendant(pid_file)
+    monkeypatch.setattr(kb, "_pid_alive", _local_pid_alive)
+    descendant_pid = _wait_for_pid_file(pid_file)
+    try:
+        result = kb._terminate_reclaimed_worker(
+            worker.pid,
+            f"{kb._claimer_id().split(':', 1)[0]}:run",
+        )
+        assert result["terminated"] is True
+        assert result["descendant_pids"] == [descendant_pid]
+        assert not kb._pid_alive(descendant_pid)
+    finally:
+        if worker.poll() is None:
+            worker.kill()
+            worker.wait()
+
+
+def test_reclaim_terminates_session_descendant_after_worker_exits(tmp_path):
+    """A dead leader must not leave its original worker session running."""
+    if os.name == "nt":
+        pytest.skip("process-tree test uses POSIX fork")
+
+    pid_file = tmp_path / "descendant.pid"
+    release_file = tmp_path / "release"
+    worker = _spawn_worker_that_leaves_same_session_descendant(
+        pid_file, release_file,
+    )
+    descendant_pid = _wait_for_pid_file(pid_file)
+    identity = kb._process_identity(worker.pid)
+    assert identity is not None
+    try:
+        release_file.write_text("exit", encoding="ascii")
+        assert worker.wait(timeout=5) == 0
+
+        result = kb._terminate_reclaimed_worker(
+            worker.pid,
+            f"{kb._claimer_id().split(':', 1)[0]}:run",
+            expected_start_time=str(identity["start_time"]),
+            expected_pgid=int(identity["pgid"]),
+            expected_sid=int(identity["sid"]),
+            identity_required=True,
+        )
+        assert result["terminated"] is True
+        assert result["descendant_pids"] == [descendant_pid]
+        assert not _local_pid_alive(descendant_pid)
+    finally:
+        if _local_pid_alive(descendant_pid):
+            os.kill(descendant_pid, 9)
+
+
+def test_crash_recovery_terminates_session_descendant_after_worker_exits(
+    conn, tmp_path, monkeypatch,
+):
+    """Crash recovery must clean up descendants before making a retry ready."""
+    if os.name == "nt":
+        pytest.skip("process-tree test uses POSIX fork")
+
+    pid_file = tmp_path / "crashed-descendant.pid"
+    release_file = tmp_path / "crashed-release"
+    worker = _spawn_worker_that_leaves_same_session_descendant(
+        pid_file, release_file,
+    )
+    descendant_pid = _wait_for_pid_file(pid_file)
+    try:
+        task_id = kb.create_task(conn, title="crashed worker", assignee="worker")
+        host = kb._claimer_id().split(":", 1)[0]
+        assert kb.claim_task(conn, task_id, claimer=f"{host}:worker") is not None
+        kb._set_worker_pid(conn, task_id, worker.pid)
+        release_file.write_text("exit", encoding="ascii")
+        assert worker.wait(timeout=5) == 0
+
+        monkeypatch.setattr(kb, "_pid_alive", _local_pid_alive)
+        assert kb.detect_crashed_workers(conn) == [task_id]
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "ready"
+        assert not _local_pid_alive(descendant_pid)
+    finally:
+        if worker.poll() is None:
+            worker.kill()
+            worker.wait()
+        if _local_pid_alive(descendant_pid):
+            os.kill(descendant_pid, 9)
+
+
+def test_reclaim_refuses_pid_reuse_when_run_identity_does_not_match(tmp_path):
+    """A reused PID must not receive a signal when its start identity differs."""
+    if os.name == "nt":
+        pytest.skip("process identity probe is POSIX-only")
+
+    worker = subprocess.Popen(
+        ["sleep", "30"],
+        start_new_session=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        identity = kb._process_identity(worker.pid)
+        assert identity is not None
+        result = kb._terminate_reclaimed_worker(
+            worker.pid,
+            f"{kb._claimer_id().split(':', 1)[0]}:run",
+            expected_start_time=str(int(identity["start_time"]) + 1),
+        )
+        assert result["ownership_verified"] is False
+        assert result["termination_attempted"] is False
+        assert worker.poll() is None
+    finally:
+        worker.terminate()
+        worker.wait()
+
+
+def test_stale_claim_does_not_extend_reused_pid(conn, tmp_path, monkeypatch):
+    """A live PID with a different run identity must be released, not signalled."""
+    if os.name == "nt":
+        pytest.skip("process identity probe is POSIX-only")
+
+    worker = subprocess.Popen(
+        ["sleep", "30"],
+        start_new_session=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        task_id = kb.create_task(conn, title="reused pid", assignee="worker")
+        host = kb._claimer_id().split(":", 1)[0]
+        assert kb.claim_task(conn, task_id, claimer=f"{host}:worker") is not None
+        kb._set_worker_pid(conn, task_id, worker.pid)
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+            (int(time.time()) - 60, task_id),
+        )
+
+        original_identity = kb._process_identity(worker.pid)
+        assert original_identity is not None
+        reused_identity = dict(original_identity)
+        reused_identity["start_time"] = str(int(original_identity["start_time"]) + 1)
+        monkeypatch.setattr(kb, "_process_identity", lambda _pid: reused_identity)
+        killed: list[int] = []
+
+        assert kb.release_stale_claims(
+            conn, signal_fn=lambda _pid, sig: killed.append(sig),
+        ) == 1
+        assert kb.get_task(conn, task_id).status == "ready"
+        assert killed == []
+    finally:
+        worker.terminate()
+        worker.wait()
+
+
+def test_legacy_pid_without_identity_fails_closed(tmp_path):
+    """A legacy PID-only run must not signal an unverified live process."""
+    if os.name == "nt":
+        pytest.skip("process identity test uses POSIX process metadata")
+
+    worker = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        start_new_session=True,
+    )
+    try:
+        result = kb._terminate_reclaimed_worker(
+            worker.pid,
+            f"{kb._claimer_id().split(':', 1)[0]}:run",
+            identity_required=True,
+        )
+        assert result["ownership_unverified_alive"] is True
+        assert result["termination_attempted"] is False
+        assert worker.poll() is None
+
+        identity = kb._process_identity(worker.pid)
+        assert identity is not None
+        partial = kb._terminate_reclaimed_worker(
+            worker.pid,
+            f"{kb._claimer_id().split(':', 1)[0]}:run",
+            expected_start_time=str(identity["start_time"]),
+            identity_required=True,
+        )
+        assert partial["ownership_unverified_alive"] is True
+        assert partial["termination_attempted"] is False
+        assert worker.poll() is None
+    finally:
+        worker.terminate()
+        worker.wait()
+
+
+@pytest.mark.parametrize("missing", ["start_time", "pgid", "sid"])
+def test_partial_run_identity_fails_closed_for_live_pid(tmp_path, missing):
+    """Every incomplete identity tuple must remain unverified and unsignalled."""
+    if os.name == "nt":
+        pytest.skip("process identity test uses POSIX process metadata")
+
+    worker = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        start_new_session=True,
+    )
+    try:
+        identity = kb._process_identity(worker.pid)
+        assert identity is not None
+        expected = {
+            "expected_start_time": str(identity["start_time"]),
+            "expected_pgid": int(identity["pgid"]),
+            "expected_sid": int(identity["sid"]),
+        }
+        expected[f"expected_{missing}"] = None
+        killed: list[tuple[int, int]] = []
+        result = kb._terminate_reclaimed_worker(
+            worker.pid,
+            f"{kb._claimer_id().split(':', 1)[0]}:run",
+            signal_fn=lambda pid, sig: killed.append((pid, sig)),
+            identity_required=True,
+            **expected,
+        )
+        assert result["ownership_unverified_alive"] is True
+        assert result["termination_attempted"] is False
+        assert killed == []
+        assert worker.poll() is None
+    finally:
+        worker.terminate()
+        worker.wait()
+
+
+def test_completed_worker_cleanup_excludes_root_pid(monkeypatch):
+    """Completion cleanup can signal descendants without self-terminating."""
+    root_pid = 1234
+    child_pid = 5678
+    identity = {"start_time": "42", "pgid": root_pid, "sid": root_pid}
+    alive = {child_pid}
+    signalled: list[int] = []
+
+    monkeypatch.setattr(
+        kb,
+        "_owned_process_tree",
+        lambda _pid, **_kwargs: ([root_pid, child_pid], identity),
+    )
+    monkeypatch.setattr(kb, "_process_identity", lambda _pid: identity)
+    monkeypatch.setattr(kb, "_pid_alive", lambda pid: pid in alive)
+
+    def signal(pid, _sig):
+        signalled.append(pid)
+        alive.discard(pid)
+
+    result = kb._terminate_reclaimed_worker(
+        root_pid,
+        f"{kb._claimer_id().split(':', 1)[0]}:run",
+        signal_fn=signal,
+        expected_start_time="42",
+        expected_pgid=root_pid,
+        expected_sid=root_pid,
+        identity_required=True,
+        exclude_pid=root_pid,
+    )
+    assert signalled == [child_pid]
+    assert result["descendant_pids"] == [child_pid]
+    assert result["terminated"] is True
+
+
+def test_claim_rejects_second_running_writer_for_same_workspace(conn, tmp_path):
+    """Two running Kanban tasks must not share an explicit directory workspace."""
+    workspace = tmp_path / "shared-writer-workspace"
+    first = kb.create_task(
+        conn,
+        title="first writer",
+        workspace_kind="dir",
+        workspace_path=str(workspace),
+    )
+    second = kb.create_task(
+        conn,
+        title="second writer",
+        workspace_kind="dir",
+        workspace_path=str(workspace),
+    )
+
+    assert kb.claim_task(conn, first) is not None
+    assert kb.claim_task(conn, second) is None
+    row = conn.execute(
+        "SELECT status FROM tasks WHERE id = ?", (second,)
+    ).fetchone()
+    assert row["status"] == "ready"
+
+
+def test_claim_rejects_concurrent_cross_connection_workspace_writer(
+    conn, tmp_path
+):
+    """The workspace CAS remains exclusive across independent DB connections."""
+    workspace = tmp_path / "shared-cross-connection-workspace"
+    task_ids = [
+        kb.create_task(
+            conn,
+            title=f"writer {index}",
+            workspace_kind="dir",
+            workspace_path=str(workspace),
+        )
+        for index in range(2)
+    ]
+    barrier = threading.Barrier(2)
+    results: list[object] = [None, None]
+
+    def claim(index: int) -> None:
+        with kb.connect() as other_conn:
+            barrier.wait()
+            results[index] = kb.claim_task(other_conn, task_ids[index])
+
+    threads = [threading.Thread(target=claim, args=(index,)) for index in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+        assert not thread.is_alive()
+
+    assert sum(result is not None for result in results) == 1
+    statuses = {
+        row["id"]: row["status"]
+        for row in conn.execute(
+            "SELECT id, status FROM tasks WHERE id IN (?, ?)", task_ids
+        )
+    }
+    assert sorted(statuses.values()) == ["ready", "running"]
+
+
+def test_successful_completion_cleans_worker_descendants(monkeypatch, conn):
+    """Completion snapshots identity before closing the active run."""
+    task_id = kb.create_task(conn, title="successful worker", assignee="worker")
+    host = kb._claimer_id().split(":", 1)[0]
+    run = kb.claim_task(conn, task_id, claimer=f"{host}:worker")
+    assert run is not None
+    kb._set_worker_pid(conn, task_id, os.getpid())
+    run_id = conn.execute(
+        "SELECT current_run_id FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()[0]
+    assert run_id is not None
+
+    calls: list[dict] = []
+
+    def capture_cleanup(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(kb, "_cleanup_worker_processes", capture_cleanup)
+
+    assert kb.complete_task(conn, task_id, summary="finished", expected_run_id=run_id)
+    assert len(calls) == 1
+    assert calls[0]["pid"] == os.getpid()
+    assert calls[0]["claim_lock"] == run.claim_lock
+    assert calls[0]["expected_start_time"] is not None
+    assert calls[0]["expected_pgid"] is not None
+    assert calls[0]["expected_sid"] is not None
+    assert calls[0]["exclude_pid"] == os.getpid()
+
+
+def test_successful_completion_terminates_dead_worker_session_descendant(
+    conn, tmp_path, monkeypatch,
+):
+    """Completion cleans a descendant even after the worker leader exits."""
+    if os.name == "nt":
+        pytest.skip("process-tree test uses POSIX fork")
+
+    pid_file = tmp_path / "completed-descendant.pid"
+    release_file = tmp_path / "completed-release"
+    worker = _spawn_worker_that_leaves_same_session_descendant(
+        pid_file, release_file,
+    )
+    descendant_pid = _wait_for_pid_file(pid_file)
+    try:
+        identity = kb._process_identity(worker.pid)
+        assert identity is not None
+        task_id = kb.create_task(conn, title="completed worker", assignee="worker")
+        host = kb._claimer_id().split(":", 1)[0]
+        assert kb.claim_task(conn, task_id, claimer=f"{host}:worker") is not None
+        kb._set_worker_pid(conn, task_id, worker.pid)
+        run_id = conn.execute(
+            "SELECT current_run_id FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()[0]
+        assert run_id is not None
+
+        release_file.write_text("exit", encoding="ascii")
+        assert worker.wait(timeout=5) == 0
+        monkeypatch.setattr(kb, "_pid_alive", _local_pid_alive)
+
+        assert kb.complete_task(
+            conn, task_id, summary="finished", expected_run_id=run_id,
+        )
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "done"
+        assert not _local_pid_alive(descendant_pid)
+    finally:
+        if worker.poll() is None:
+            worker.kill()
+            worker.wait()
+        if _local_pid_alive(descendant_pid):
+            os.kill(descendant_pid, 9)

--- a/tests/hermes_cli/test_kanban_worker_tree_cleanup.py
+++ b/tests/hermes_cli/test_kanban_worker_tree_cleanup.py
@@ -7,6 +7,7 @@ PID is rejected safely.
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -344,11 +345,13 @@ def test_completed_worker_cleanup_excludes_root_pid(monkeypatch):
     alive = {child_pid}
     signalled: list[int] = []
 
-    monkeypatch.setattr(
-        kb,
-        "_owned_process_tree",
-        lambda _pid, **_kwargs: ([root_pid, child_pid], identity),
-    )
+    def owned_tree(_pid, **kwargs):
+        snapshot = kwargs.get("identity_snapshot")
+        if snapshot is not None:
+            snapshot.update({root_pid: dict(identity), child_pid: dict(identity)})
+        return [root_pid, child_pid], identity
+
+    monkeypatch.setattr(kb, "_owned_process_tree", owned_tree)
     monkeypatch.setattr(kb, "_process_identity", lambda _pid: identity)
     monkeypatch.setattr(kb, "_pid_alive", lambda pid: pid in alive)
 
@@ -505,3 +508,264 @@ def test_successful_completion_terminates_dead_worker_session_descendant(
             worker.wait()
         if _local_pid_alive(descendant_pid):
             os.kill(descendant_pid, 9)
+
+
+def test_inconsistent_isolated_identity_fallback_fails_closed(monkeypatch):
+    """Dead-leader fallback requires a semantically isolated PGID/SID tuple."""
+    if os.name == "nt":
+        pytest.skip("process identity probe is POSIX-only")
+    root_pid = 999999
+    host = kb._claimer_id().split(":", 1)[0]
+    signalled: list[tuple[int, int]] = []
+    monkeypatch.setattr(kb, "_process_identity", lambda _pid: None)
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+
+    result = kb._terminate_reclaimed_worker(
+        root_pid,
+        f"{host}:worker",
+        signal_fn=lambda pid, sig: signalled.append((pid, sig)),
+        expected_start_time="dead",
+        expected_pgid=root_pid - 1,
+        expected_sid=root_pid,
+        identity_required=True,
+    )
+
+    assert signalled == []
+    assert result["ownership_verified"] is False
+    assert result["termination_attempted"] is False
+
+
+def test_pidfd_validates_identity_after_open_before_signal(monkeypatch):
+    """PID reuse after pidfd_open fails closed; a matching handle is signalled."""
+    if sys.platform != "linux":
+        pytest.skip("pidfd is a Linux primitive")
+    import signal
+
+    recorded = {"start_time": "10", "pgid": 4321, "sid": 4321}
+    current = {"start_time": "11", "pgid": 4321, "sid": 4321}
+    calls: list[tuple] = []
+    monkeypatch.setattr(os, "pidfd_open", lambda pid, flags: calls.append(("open", pid, flags)) or 77, raising=False)
+    monkeypatch.setattr(os, "close", lambda fd: calls.append(("close", fd)))
+    monkeypatch.setattr(
+        signal, "pidfd_send_signal",
+        lambda fd, sig, info, flags: calls.append(("send", fd, sig, flags)),
+        raising=False,
+    )
+    monkeypatch.setattr(kb, "_process_identity", lambda _pid: dict(current))
+
+    kb._signal_verified_target(4321, signal.SIGTERM, recorded)
+    assert [item[0] for item in calls] == ["open", "close"]
+
+    calls.clear()
+    current["start_time"] = "10"
+    kb._signal_verified_target(4321, signal.SIGTERM, recorded)
+    assert [item[0] for item in calls] == ["open", "send", "close"]
+
+
+def test_missing_identity_is_unknown_not_a_match(tmp_path):
+    assert kb._worker_identity_matches(1) is False
+
+
+def test_administrative_completion_never_signals_registered_worker_root(
+    conn, monkeypatch,
+):
+    """Completion cleanup excludes the registered root for every caller."""
+    task_id = kb.create_task(conn, title="admin completion", assignee="worker")
+    host = kb._claimer_id().split(":", 1)[0]
+    run = kb.claim_task(conn, task_id, claimer=f"{host}:worker")
+    assert run is not None
+    registered_pid = os.getpid() + 10000
+    kb._set_worker_pid(conn, task_id, registered_pid)
+    run_id = conn.execute(
+        "SELECT current_run_id FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()[0]
+    calls = []
+    monkeypatch.setattr(kb, "_cleanup_worker_processes", lambda **kw: calls.append(kw))
+    assert kb.complete_task(conn, task_id, expected_run_id=run_id)
+    assert calls[0]["exclude_pid"] == registered_pid
+    assert kb.reconcile_terminal_worker_cleanups(conn) == []
+    assert calls[1]["exclude_pid"] == registered_pid
+
+
+def test_completion_keeps_workspace_lease_until_dispatcher_verifies_exit(
+    conn, tmp_path, monkeypatch,
+):
+    """Done stays leased until a later dispatcher reconciliation proves exit."""
+    workspace = tmp_path / "leased"
+    first = kb.create_task(
+        conn, title="first", workspace_kind="dir", workspace_path=str(workspace),
+    )
+    second = kb.create_task(
+        conn, title="second", workspace_kind="dir", workspace_path=str(workspace),
+    )
+    assert kb.claim_task(conn, first) is not None
+    kb._set_worker_pid(conn, first, os.getpid())
+    run_id = conn.execute(
+        "SELECT current_run_id FROM tasks WHERE id = ?", (first,),
+    ).fetchone()[0]
+    monkeypatch.setattr(
+        kb, "_cleanup_worker_processes",
+        lambda **_kw: {"terminated": True, "ownership_verified": True},
+    )
+
+    assert kb.complete_task(conn, first, expected_run_id=run_id)
+    cleanup_verified = conn.execute(
+        "SELECT cleanup_verified FROM task_runs WHERE id = ?", (run_id,),
+    ).fetchone()[0]
+    assert cleanup_verified == 0
+    assert kb.claim_task(conn, second) is None
+
+    now = int(time.time())
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE task_runs SET claim_expires = ?, ended_at = ? WHERE id = ?",
+            (now - 1, now - kb.RECLAIM_DEFER_GRACE_SECONDS - 1, run_id),
+        )
+    assert kb.reconcile_terminal_worker_cleanups(conn) == []
+    assert kb.claim_task(conn, second) is None
+
+    monkeypatch.setattr(kb, "_worker_identity_matches", lambda *_a, **_kw: False)
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    assert kb.reconcile_terminal_worker_cleanups(conn) == [first]
+    assert kb.claim_task(conn, second) is not None
+
+
+def test_unregistered_completed_worker_lease_has_bounded_auditable_fallback(
+    conn, tmp_path,
+):
+    workspace = tmp_path / "unregistered-lease"
+    first = kb.create_task(
+        conn, title="first", workspace_kind="dir", workspace_path=str(workspace),
+    )
+    second = kb.create_task(
+        conn, title="second", workspace_kind="dir", workspace_path=str(workspace),
+    )
+    claimed = kb.claim_task(conn, first)
+    assert claimed is not None
+    run_id = claimed.current_run_id
+    assert run_id is not None
+
+    assert kb.complete_task(conn, first, expected_run_id=run_id)
+    assert kb.reconcile_terminal_worker_cleanups(conn) == []
+    assert kb.claim_task(conn, second) is None
+
+    now = int(time.time())
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE task_runs SET claim_expires = ?, ended_at = ? WHERE id = ?",
+            (now - 1, now - kb.RECLAIM_DEFER_GRACE_SECONDS - 1, run_id),
+        )
+    assert kb.reconcile_terminal_worker_cleanups(conn) == [first]
+    event = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id = ? "
+        "AND kind = 'worker_cleanup_verified' ORDER BY id DESC LIMIT 1",
+        (first,),
+    ).fetchone()
+    assert event is not None
+    assert json.loads(event["payload"])["reason"] == (
+        "unregistered_worker_lease_expired"
+    )
+    assert kb.claim_task(conn, second) is not None
+
+
+def test_registered_pid_reuse_lease_expires_without_signalling_new_generation(
+    conn, tmp_path, monkeypatch,
+):
+    workspace = tmp_path / "registered-reuse-lease"
+    first = kb.create_task(
+        conn, title="first", workspace_kind="dir", workspace_path=str(workspace),
+    )
+    second = kb.create_task(
+        conn, title="second", workspace_kind="dir", workspace_path=str(workspace),
+    )
+    claimed = kb.claim_task(conn, first)
+    assert claimed is not None
+    run_id = claimed.current_run_id
+    assert run_id is not None
+    reused_pid = 987654
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET worker_pid = ? WHERE id = ?",
+            (reused_pid, first),
+        )
+        conn.execute(
+            "UPDATE task_runs SET worker_pid = ?, worker_pgid = ?, "
+            "worker_sid = ?, worker_start_time = ? WHERE id = ?",
+            (reused_pid, reused_pid, reused_pid, "old-generation", run_id),
+        )
+
+    signals = []
+    monkeypatch.setattr(kb, "_pid_alive", lambda pid: pid == reused_pid)
+    monkeypatch.setattr(kb, "_worker_identity_matches", lambda *_a, **_kw: False)
+    monkeypatch.setattr(kb.os, "kill", lambda pid, sig: signals.append((pid, sig)))
+
+    assert kb.complete_task(conn, first, expected_run_id=run_id)
+    assert kb.reconcile_terminal_worker_cleanups(conn) == []
+    assert kb.claim_task(conn, second) is None
+
+    now = int(time.time())
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE task_runs SET claim_expires = ?, ended_at = ? WHERE id = ?",
+            (now - 1, now - kb.RECLAIM_DEFER_GRACE_SECONDS - 1, run_id),
+        )
+    assert kb.reconcile_terminal_worker_cleanups(conn) == [first]
+    assert signals == []
+    event = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id = ? "
+        "AND kind = 'worker_cleanup_verified' ORDER BY id DESC LIMIT 1",
+        (first,),
+    ).fetchone()
+    assert event is not None
+    assert json.loads(event["payload"])["reason"] == (
+        "unverified_worker_lease_expired"
+    )
+    assert kb.claim_task(conn, second) is not None
+
+
+def test_spawn_registration_losing_completion_cas_reaps_worker_and_releases_lease(
+    conn, tmp_path,
+):
+    workspace = tmp_path / "spawn-race"
+    first = kb.create_task(
+        conn, title="first", workspace_kind="dir", workspace_path=str(workspace),
+    )
+    second = kb.create_task(
+        conn, title="second", workspace_kind="dir", workspace_path=str(workspace),
+    )
+    claimed = kb.claim_task(conn, first)
+    assert claimed is not None
+    worker = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        start_new_session=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        assert kb.complete_task(
+            conn, first, expected_run_id=claimed.current_run_id,
+        )
+        assert kb.claim_task(conn, second) is None
+
+        assert kb._set_worker_pid(
+            conn,
+            first,
+            worker.pid,
+            expected_run_id=claimed.current_run_id,
+            expected_claim_lock=claimed.claim_lock,
+        ) is False
+        worker.wait(timeout=5)
+        task = kb.get_task(conn, first)
+        assert task is not None
+        assert task.worker_pid is None
+        cleanup_verified = conn.execute(
+            "SELECT cleanup_verified FROM task_runs WHERE id = ?",
+            (claimed.current_run_id,),
+        ).fetchone()[0]
+        assert cleanup_verified == 1
+        assert kb.claim_task(conn, second) is not None
+    finally:
+        if worker.poll() is None:
+            worker.kill()
+            worker.wait()

--- a/tests/hermes_cli/test_kanban_worker_tree_cleanup.py
+++ b/tests/hermes_cli/test_kanban_worker_tree_cleanup.py
@@ -69,7 +69,7 @@ def _spawn_worker_with_new_session_descendant(pid_file: Path) -> subprocess.Pope
         "child = os.fork()\n"
         "if child == 0:\n"
         "    os.setsid()\n"
-        f"pathlib.Path({str(pid_file)!r}).write_text(str(os.getpid()))\n"
+        f"    pathlib.Path({str(pid_file)!r}).write_text(str(os.getpid()))\n"
         "time.sleep(30)\n"
     )
     return subprocess.Popen(


### PR DESCRIPTION
## Summary
- Persist worker start-time, PGID, and SID alongside the run PID; validate ownership before reclaim, timeout, crash, and completion cleanup.
- Terminate verified descendant trees without signalling the completing worker itself, with dead-leader isolated-session recovery and PID-reuse guards.
- Enforce one running writer per canonical workspace across SQLite connections and return CLI claims to `ready` when workspace persistence loses a race.

## Tests
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_worker_tree_cleanup.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_reclaim_claim_lock_guard.py -q` — 294 passed.
- Full Kanban matrix (`46` files via `scripts/run_tests.sh`) — 1,143 passed, 0 failed.
- Ruff, compileall, diff-check, secret scan, and injection scan — clean.

## Incident coverage
- Covers stale/reclaimed workers, crash recovery, dead leaders with remaining session descendants, partial/legacy identity fail-closed behavior, successful completion cleanup, and concurrent cross-connection workspace claims.

## Activation handoff
- Commit: `2f1372b1ef1beb67ab53243d11d537c1e94c3170`
- Base readback: `origin/main` `585726ac2e08dcc2bd32c134e0124e0657ecc519`
- Fork readback: `fork/fix/kanban-stale-pgid` at the same commit.
- Do not touch the live checkout or restart the gateway from this worker. After merge, create a backup, apply the commit to `/home/fgpaz/.hermes/hermes-agent`, run post-restart smoke/health checks, and retain the prior commit for rollback.
