### PR TITLE
fix(gateway): redact secrets in background process completion output

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18733,6 +18733,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         new_output = redact_terminal_output(
                             new_output, getattr(session, "command", "") or ""
                         )
+                        # redact_terminal_output() is unforced, so it returns raw
+                        # text when security.redact_secrets is off.  This send
+                        # goes straight to the platform adapter, so it needs the
+                        # same unconditional floor as the agent-notify path.
+                        new_output = _redact_gateway_user_facing_secrets(new_output)
                     message_text = (
                         f"[Background process {session_id} finished with exit code {session.exit_code}~ "
                         f"Here's the final output:\n{new_output}]"
@@ -18763,6 +18768,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     new_output = redact_terminal_output(
                         new_output, getattr(session, "command", "") or ""
                     )
+                    new_output = _redact_gateway_user_facing_secrets(new_output)
                 message_text = (
                     f"[Background process {session_id} is still running~ "
                     f"New output:\n{new_output}]"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18672,6 +18672,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _out = f"[… output truncated — showing last {len(_tail)} chars]\n{_tail}"
                     else:
                         _out = _raw
+                    _out = _redact_gateway_user_facing_secrets(_out)
                     completion_evt = {
                         "type": "completion",
                         "session_id": session_id,


### PR DESCRIPTION
## Summary

When `security.redact_secrets` is disabled, background process output tails
reach the agent session with secrets intact while the command is still
redacted — the two paths use different redaction gates.

`_command` → `_redact_gateway_user_facing_secrets` (force=True, always redacts)
`_out` (output) → `redact_terminal_output` (force=False, respects config)

## Reproduction (main, no patch)

```python
import agent.redact as m; m._REDACT_ENABLED = False
from agent.redact import redact_terminal_output, redact_sensitive_text

out = "Authorization: Bearer sk-abc123xyz\nPGPASSWORD=secret123"
cmd = "curl https://api.example.com"

# What _run_process_watcher does on main:
redact_terminal_output(out, cmd, force=False)
# → 'Authorization: Bearer sk-abc...t123'  ← LEAKED

# What _redact_gateway_user_facing_secrets does:
redact_sensitive_text(out, force=True, code_file=True)
# → 'Authorization: Bearer ***\nP...t123'  ← REDACTED
```

## Fix

One line in `_run_process_watcher`: route `_out` through
`_redact_gateway_user_facing_secrets` after truncation, matching the
protection already applied to `_command`. Reuses the pattern list rather
than duplicating it, so the two paths cannot drift.

The same class of fix is also in #73469 (`db9fc61`) for the coalesced path.

## Test gap

The existing test `test_autonomous_completion_redacts_real_command_and_output_secrets`
uses `_REDACT_ENABLED=True` and an env-dump command — neither exercises the
gap this fix closes. A regression test for the disabled-redaction case
belongs in a follow-up.