### PR TITLE
feat(desktop): support reload-mcp slash command

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
@@ -128,6 +128,29 @@ describe('visible user ordinals', () => {
 })
 
 describe('renderRpcResult', () => {
+  describe('reload.mcp', () => {
+    it('renders the confirmation warning', () => {
+      expect(
+        renderRpcResult(
+          { status: 'confirm_required', message: 'Reply `/reload-mcp now` to proceed.' },
+          'reload-mcp'
+        )
+      ).toBe('Reply `/reload-mcp now` to proceed.')
+    })
+
+    it('renders a successful reload confirmation', () => {
+      expect(renderRpcResult({ status: 'reloaded', loaded_rev: 'abc123' }, 'reload-mcp')).toBe(
+        '✓ MCP servers reloaded.'
+      )
+    })
+
+    it('reports a coalesced reload without exposing the revision hash', () => {
+      expect(renderRpcResult({ status: 'reloaded', coalesced: true, loaded_rev: 'abc123' }, 'reload-mcp')).toBe(
+        '✓ MCP servers reloaded (coalesced with another reload).'
+      )
+    })
+  })
+
   describe('session.compress (summary shape)', () => {
     it('renders the summary headline with token line and note', () => {
       expect(

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -245,6 +245,19 @@ export function renderRpcResult(response: unknown, name: string): string {
 
   const r = response as Record<string, unknown>
 
+  // reload.mcp — the first invocation is confirmation-gated; an approved
+  // invocation returns a structured success payload. Keep both outcomes
+  // human-readable in the chat instead of exposing the raw RPC envelope.
+  if (name === 'reload-mcp') {
+    if (r.status === 'confirm_required' && typeof r.message === 'string') {
+      return r.message
+    }
+
+    if (r.status === 'reloaded') {
+      return r.coalesced ? '✓ MCP servers reloaded (coalesced with another reload).' : '✓ MCP servers reloaded.'
+    }
+  }
+
   const summary = r.summary as { headline?: string; token_line?: string; note?: string; noop?: boolean } | undefined
 
   if (summary && typeof summary === 'object' && typeof summary.headline === 'string' && summary.headline) {

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -102,7 +102,8 @@ describe('desktop slash command curation', () => {
   it('routes only stateless session commands through dedicated gateway RPCs', () => {
     const expected = {
       '/save': 'session.save',
-      '/status': 'session.status'
+      '/status': 'session.status',
+      '/reload-mcp': 'reload.mcp'
     } as const
 
     for (const [name, rpcName] of Object.entries(expected)) {
@@ -114,10 +115,34 @@ describe('desktop slash command curation', () => {
       }
 
       expect(surface.rpc).toBe(rpcName)
-      expect(surface.buildParams({ arg: 'topic A', command: name, name: name.slice(1), sessionId: 's-1' })).toEqual({
-        session_id: 's-1'
-      })
+      const params = surface.buildParams({ arg: name === '/reload-mcp' ? 'now' : 'topic A', command: name, name: name.slice(1), sessionId: 's-1' })
+
+      expect(params).toEqual(
+        name === '/reload-mcp' ? { session_id: 's-1', confirm: true } : { session_id: 's-1' }
+      )
     }
+  })
+
+  it('supports reload-mcp confirmation choices and its alias', () => {
+    const surface = resolveDesktopCommand('/reload_mcp')?.surface
+
+    expect(surface?.kind).toBe('rpc')
+
+    if (surface?.kind !== 'rpc') {
+      return
+    }
+
+    expect(surface.rpc).toBe('reload.mcp')
+    expect(surface.buildParams({ arg: '', command: '/reload-mcp', name: 'reload-mcp', sessionId: 's-1' })).toEqual({
+      session_id: 's-1'
+    })
+    expect(surface.buildParams({ arg: 'always', command: '/reload-mcp', name: 'reload-mcp', sessionId: 's-1' })).toEqual({
+      session_id: 's-1',
+      confirm: true,
+      always: true
+    })
+    expect(isDesktopSlashSuggestion('/reload-mcp')).toBe(true)
+    expect(isDesktopSlashSuggestion('/reload_mcp')).toBe(false)
   })
 
   it('keeps commands with richer CLI semantics on the slash worker', () => {

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -298,8 +298,27 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
   { name: '/usage', description: 'Show token usage for this session', surface: exec() },
   { name: '/version', description: 'Show Hermes Agent version', surface: exec() },
 
-  // No desktop surface, but carry an alias (underscore spelling variants).
-  { name: '/reload-mcp', aliases: ['/reload_mcp'], surface: unavailable('advanced') },
+  {
+    name: '/reload-mcp',
+    aliases: ['/reload_mcp'],
+    description: 'Reload MCP servers in the live session',
+    surface: rpc(
+      'reload.mcp',
+      ({ arg, sessionId }) => {
+        const choice = arg.trim().toLowerCase()
+
+        return {
+          session_id: sessionId,
+          ...(choice === 'now' || choice === 'approve' || choice === 'once' || choice === 'yes'
+            ? { confirm: true }
+            : {}),
+          ...(choice === 'always' ? { confirm: true, always: true } : {})
+        }
+      },
+      120_000
+    ),
+    argumentMode: 'text'
+  },
   { name: '/reload-skills', aliases: ['/reload_skills'], surface: unavailable('advanced') }
 ]
 


### PR DESCRIPTION
## Summary

- Add native Desktop routing for `/reload-mcp` through the `reload.mcp` gateway RPC.
- Support the existing `/reload_mcp` alias.
- Preserve confirmation semantics for one-time and always-approved reloads.
- Render confirmation and reload results as concise user-facing messages without exposing the internal MCP revision.

## Test plan

- [x] Targeted Desktop tests: 57 passed
- [x] Desktop TypeScript typecheck
- [x] ESLint on changed files
- [x] `git diff --check`
- [x] Re-ran all checks after rebasing onto current `origin/main`

## Notes

The change does not modify MCP configuration, credentials, dependencies or security settings.
