### PR TITLE
fix: avoid long folder path pushing other contents out of project cre…

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/project-dialog.tsx
+++ b/apps/desktop/src/app/chat/sidebar/project-dialog.tsx
@@ -176,7 +176,10 @@ export function ProjectDialog() {
         )}
 
         {mode === 'create' && (
-          <div className="flex flex-col gap-1.5">
+          // min-w-0: this is a grid item of DialogContent — without it, a long
+          // nowrap folder path propagates its min-content width up and pushes
+          // other contents out of the dialog.
+          <div className="flex min-w-0 flex-col gap-1.5">
             <span className="text-[0.6875rem] font-medium text-(--ui-text-tertiary)">{p.foldersLabel}</span>
             {folders.length === 0 ? (
               <span className="text-[0.75rem] text-(--ui-text-quaternary)">{p.noFolders}</span>


### PR DESCRIPTION
## What does this PR do?

In desktop app when creating a new project with a long folder path, the dialog content will be expanded to a degree that buttons are pushed out of the dialog. This PR fixed the issue.


## Related Issue

Fixes #73548 

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Add `min-w-0` to the dialog in `apps/desktop/src/app/chat/sidebar/project-dialog.tsx`

## How to Test

1. Navigation bar > Projects > Create
2. Add a long path folder into the project.
3. Observed the "Create" button is pushed out from the dialog 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) **Pure UI**
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or **N/A**
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or **N/A**
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or **N/A**
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or **N/A**
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or **N/A**

## Screenshots / Logs
|Before fix|After fix|
|-|-|
|<img width="461" height="433" alt="bug" src="https://github.com/user-attachments/assets/a65eb7a7-0211-4c36-a0bd-59fbfb926a5e" />|<img width="476" height="429" alt="after_fix" src="https://github.com/user-attachments/assets/3476783d-a564-426e-8bbd-0df9bddf73b3" />|
|-|-|

