### PR TITLE
gateway: add terminal webhook delivery metadata

### DIFF
--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -308,6 +308,7 @@ def record_accepted_route(
     chat_id: str,
     thread_id: Optional[str],
     delivery_context: Mapping[str, Any],
+    legacy_session_key: Optional[str] = None,
 ) -> str:
     """Durably admit one privacy-bounded callback route before HTTP 202.
 
@@ -354,6 +355,40 @@ def record_accepted_route(
             ).fetchone()
             if row is None:
                 raise RuntimeError("Accepted callback row disappeared")
+            legacy_route_match = (
+                row[5] == "accepted"
+                and legacy_session_key is not None
+                and row[0] == legacy_session_key
+                and row[1] == platform
+                and row[2] == str(chat_id)
+                and row[3] == _normalized_thread_id(thread_id)
+                and row[4] == context_json
+            )
+            if legacy_route_match:
+                # Heads predating durable work admission stored the synthetic
+                # webhook chat id here.  Upgrade only a still-empty accepted
+                # row whose remaining route identity matches exactly; terminal
+                # and conflict states retain their immutable identity.
+                conn.execute(
+                    """UPDATE delivery_obligations
+                       SET session_key=?, updated_at=?
+                       WHERE obligation_id=? AND state='accepted'
+                             AND session_key=? AND content=''""",
+                    (
+                        session_key,
+                        time.time(),
+                        obligation_id,
+                        legacy_session_key,
+                    ),
+                )
+                row = (
+                    session_key,
+                    row[1],
+                    row[2],
+                    row[3],
+                    row[4],
+                    row[5],
+                )
             if not _row_matches_route(
                 row,
                 session_key=session_key,
@@ -373,6 +408,23 @@ def record_accepted_route(
             decision = ADMISSION_DUPLICATE
     _prune()
     return decision
+
+
+def get_obligation_state(obligation_id: str) -> Optional[str]:
+    """Return the durable state for one obligation, if it exists.
+
+    This intentionally exposes only the state machine value.  Callers deciding
+    whether a duplicate accepted webhook still needs session admission must
+    not load terminal content or widen the privacy-bounded route projection.
+    """
+    if not obligation_id:
+        return None
+    with _DB_LOCK, _transaction() as conn:
+        row = conn.execute(
+            "SELECT state FROM delivery_obligations WHERE obligation_id=?",
+            (obligation_id,),
+        ).fetchone()
+    return str(row[0]) if row is not None else None
 
 
 def begin_terminal_attempt(

--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -9,12 +9,12 @@ ACK drops it silently (#58818, #41696, #63695).
 This module records a small durable row per outbound final response in the
 shared ``state.db`` (same file and conventions as
 ``tools.async_delegation`` — WAL, owner pid + process-start-time liveness,
-bounded retention). The gateway writes three checkpoints around the send:
+bounded retention). The gateway writes checkpoints around admission and send:
 
-    record_obligation()   state='pending'     before any send attempt
-    mark_attempting()     state='attempting'  immediately before the await
-    mark_delivered() /    state='delivered'   only on SendResult.success
-    mark_failed()         state='failed'      on a definitive rejection
+    record_accepted_route() state='accepted'    before HTTP 202
+    begin_terminal_attempt() state='attempting' atomically with final content
+    mark_delivered() /      state='delivered'   only on SendResult.success
+    mark_failed()           state='failed'      on a definitive rejection
 
 On startup, ``sweep_recoverable()`` claims rows whose owning process is
 dead and hands them to the gateway for redelivery. Crash semantics are
@@ -22,6 +22,8 @@ explicit about ambiguity (the contract review of the earlier
 delivery-outbox attempt, #61790, closed it for silently resending
 ambiguous sends):
 
+- ``accepted``    — restore the bounded route only; the resumed turn still
+  owes its first terminal envelope, so nothing is sent by the sweep.
 - ``pending``     — the send never started: redeliver plainly, no dup risk.
 - ``attempting``  — crashed mid-await: the platform MAY already have the
   message. Redelivered WITH a visible recovered-reply marker so the
@@ -29,6 +31,8 @@ ambiguous sends):
 - ``failed``      — definitively rejected once; the restart is a natural
   retry boundary. Also carries the marker.
 - ``delivered``   — nothing to do; retention prunes.
+- ``conflict``    — the same provider identity produced a different durable
+  route or terminal envelope. Fail closed; never replay either body.
 
 Poison rows cannot spin: attempts are capped, stale rows expire, and both
 transition to ``abandoned`` (kept briefly for inspection, then pruned).
@@ -75,6 +79,16 @@ RECOVERED_MARKER = (
     "♻️ Recovered reply — the gateway restarted during delivery, "
     "so this may be a duplicate:\n\n"
 )
+
+ADMISSION_RECORDED = "recorded"
+ADMISSION_DUPLICATE = "duplicate"
+TERMINAL_ATTEMPT_STARTED = "started"
+TERMINAL_ATTEMPT_IN_PROGRESS = "in_progress"
+TERMINAL_ATTEMPT_ALREADY_DELIVERED = "already_delivered"
+
+
+class DeliveryConflictError(RuntimeError):
+    """A provider identity was reused with different durable semantics."""
 
 
 def _db_path():
@@ -242,6 +256,254 @@ def _deserialize_json_object(value: Any) -> Optional[Dict[str, Any]]:
     return decoded if isinstance(decoded, dict) else None
 
 
+def _normalized_thread_id(thread_id: Optional[str]) -> Optional[str]:
+    return str(thread_id) if thread_id else None
+
+
+def _row_matches_route(
+    row: tuple,
+    *,
+    session_key: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str],
+    context_json: str,
+) -> bool:
+    return (
+        row[0] == session_key
+        and row[1] == platform
+        and row[2] == str(chat_id)
+        and row[3] == _normalized_thread_id(thread_id)
+        and row[4] == context_json
+    )
+
+
+def _mark_conflict(
+    conn: sqlite3.Connection,
+    obligation_id: str,
+    state: str,
+) -> None:
+    # A delivered obligation is immutable: report the conflicting replay but
+    # never reopen it. Unresolved rows become non-recoverable so a later boot
+    # cannot silently replay the first stale envelope.
+    if state == "delivered":
+        return
+    conn.execute(
+        """UPDATE delivery_obligations
+           SET state='conflict', updated_at=?, last_error=?
+           WHERE obligation_id=? AND state=?""",
+        (time.time(), "provider identity conflict", obligation_id, state),
+    )
+    # Conflict is itself the fail-closed durable decision. Commit it before
+    # the caller raises DeliveryConflictError; otherwise the transaction
+    # context would roll this safety transition back with the exception.
+    conn.commit()
+
+
+def record_accepted_route(
+    *,
+    obligation_id: str,
+    session_key: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str],
+    delivery_context: Mapping[str, Any],
+) -> str:
+    """Durably admit one privacy-bounded callback route before HTTP 202.
+
+    The accepted row intentionally contains no prompt, request payload,
+    terminal output, terminal metadata, secret, or tool data. Reusing the
+    provider identity with a different rendered route fails closed.
+    """
+    now = time.time()
+    pid, started = _owner_stamp()
+    context_json = _serialize_delivery_context(delivery_context)
+    if context_json is None:
+        raise ValueError("Accepted callback route is not replay-safe")
+
+    with _DB_LOCK, _transaction() as conn:
+        cursor = conn.execute(
+            """INSERT INTO delivery_obligations
+               (obligation_id, session_key, platform, chat_id, thread_id,
+                content, state, attempts, created_at, updated_at,
+                owner_pid, owner_started_at, delivery_context_json,
+                delivery_metadata_json)
+               VALUES (?, ?, ?, ?, ?, '', 'accepted', 0, ?, ?, ?, ?, ?, NULL)
+               ON CONFLICT(obligation_id) DO NOTHING""",
+            (
+                obligation_id,
+                session_key,
+                platform,
+                str(chat_id),
+                _normalized_thread_id(thread_id),
+                now,
+                now,
+                pid,
+                started,
+                context_json,
+            ),
+        )
+        if cursor.rowcount:
+            decision = ADMISSION_RECORDED
+        else:
+            row = conn.execute(
+                """SELECT session_key, platform, chat_id, thread_id,
+                          delivery_context_json, state
+                   FROM delivery_obligations WHERE obligation_id=?""",
+                (obligation_id,),
+            ).fetchone()
+            if row is None:
+                raise RuntimeError("Accepted callback row disappeared")
+            if not _row_matches_route(
+                row,
+                session_key=session_key,
+                platform=platform,
+                chat_id=chat_id,
+                thread_id=thread_id,
+                context_json=context_json,
+            ):
+                _mark_conflict(conn, obligation_id, row[5])
+                raise DeliveryConflictError(
+                    "Provider identity conflicts with the accepted callback route"
+                )
+            if row[5] == "conflict":
+                raise DeliveryConflictError(
+                    "Provider identity already has a durable conflict"
+                )
+            decision = ADMISSION_DUPLICATE
+    _prune()
+    return decision
+
+
+def begin_terminal_attempt(
+    *,
+    obligation_id: str,
+    session_key: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str],
+    content: str,
+    delivery_context: Mapping[str, Any],
+    delivery_metadata: Mapping[str, Any],
+) -> str:
+    """Atomically bind final content to an accepted provider identity.
+
+    Same-envelope retries may resume only from ``pending``/``failed``.
+    ``attempting`` fails closed as already in flight, and ``delivered`` is an
+    idempotent no-op. A different route, body, or strict terminal marker is a
+    conflict; unresolved rows become non-recoverable so stale content cannot
+    be replayed after a crash.
+    """
+    now = time.time()
+    pid, started = _owner_stamp()
+    context_json = _serialize_delivery_context(delivery_context)
+    metadata_json = _serialize_delivery_metadata(delivery_metadata)
+    if context_json is None or metadata_json is None:
+        raise ValueError("Terminal callback envelope is not replay-safe")
+
+    with _DB_LOCK, _transaction() as conn:
+        cursor = conn.execute(
+            """INSERT INTO delivery_obligations
+               (obligation_id, session_key, platform, chat_id, thread_id,
+                content, state, attempts, created_at, updated_at,
+                owner_pid, owner_started_at, delivery_context_json,
+                delivery_metadata_json)
+               VALUES (?, ?, ?, ?, ?, ?, 'attempting', 0, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(obligation_id) DO NOTHING""",
+            (
+                obligation_id,
+                session_key,
+                platform,
+                str(chat_id),
+                _normalized_thread_id(thread_id),
+                content,
+                now,
+                now,
+                pid,
+                started,
+                context_json,
+                metadata_json,
+            ),
+        )
+        if cursor.rowcount:
+            return TERMINAL_ATTEMPT_STARTED
+
+        row = conn.execute(
+            """SELECT session_key, platform, chat_id, thread_id,
+                      delivery_context_json, state, content,
+                      delivery_metadata_json
+               FROM delivery_obligations WHERE obligation_id=?""",
+            (obligation_id,),
+        ).fetchone()
+        if row is None:
+            raise RuntimeError("Terminal callback row disappeared")
+        state = row[5]
+        if not _row_matches_route(
+            row,
+            session_key=session_key,
+            platform=platform,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            context_json=context_json,
+        ):
+            _mark_conflict(conn, obligation_id, state)
+            raise DeliveryConflictError(
+                "Provider identity conflicts with the durable callback route"
+            )
+
+        if state == "accepted":
+            if row[6] != "" or row[7] is not None:
+                _mark_conflict(conn, obligation_id, state)
+                raise DeliveryConflictError(
+                    "Accepted callback contains an unexpected terminal envelope"
+                )
+            updated = conn.execute(
+                """UPDATE delivery_obligations
+                   SET content=?, state='attempting', updated_at=?,
+                       owner_pid=?, owner_started_at=?,
+                       delivery_metadata_json=?, last_error=NULL
+                   WHERE obligation_id=? AND state='accepted'
+                         AND content='' AND delivery_metadata_json IS NULL""",
+                (
+                    content,
+                    now,
+                    pid,
+                    started,
+                    metadata_json,
+                    obligation_id,
+                ),
+            )
+            if updated.rowcount:
+                return TERMINAL_ATTEMPT_STARTED
+            raise RuntimeError("Accepted callback state changed concurrently")
+
+        envelope_matches = row[6] == content and row[7] == metadata_json
+        if not envelope_matches:
+            _mark_conflict(conn, obligation_id, state)
+            raise DeliveryConflictError(
+                "Provider identity conflicts with the durable terminal envelope"
+            )
+
+        if state in {"pending", "failed"}:
+            updated = conn.execute(
+                """UPDATE delivery_obligations
+                   SET state='attempting', updated_at=?, owner_pid=?,
+                       owner_started_at=?, last_error=NULL
+                   WHERE obligation_id=? AND state=?""",
+                (now, pid, started, obligation_id, state),
+            )
+            if updated.rowcount:
+                return TERMINAL_ATTEMPT_STARTED
+            raise RuntimeError("Terminal callback state changed concurrently")
+        if state == "attempting":
+            return TERMINAL_ATTEMPT_IN_PROGRESS
+        if state == "delivered":
+            return TERMINAL_ATTEMPT_ALREADY_DELIVERED
+        raise DeliveryConflictError(
+            f"Terminal callback cannot proceed from durable state {state!r}"
+        )
+
+
 def record_obligation(
     *,
     obligation_id: str,
@@ -270,41 +532,96 @@ def record_obligation(
                ON CONFLICT(obligation_id) DO NOTHING"""
             if preserve_existing
             else
-            """INSERT OR REPLACE INTO delivery_obligations
+            """INSERT INTO delivery_obligations
                (obligation_id, session_key, platform, chat_id, thread_id,
                 content, state, attempts, created_at, updated_at,
                 owner_pid, owner_started_at, delivery_context_json,
                 delivery_metadata_json)
-               VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?, ?, ?, ?)"""
+               VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(obligation_id) DO UPDATE SET
+                   session_key=excluded.session_key,
+                   platform=excluded.platform,
+                   chat_id=excluded.chat_id,
+                   thread_id=excluded.thread_id,
+                   content=excluded.content,
+                   state='pending',
+                   attempts=0,
+                   created_at=excluded.created_at,
+                   updated_at=excluded.updated_at,
+                   owner_pid=excluded.owner_pid,
+                   owner_started_at=excluded.owner_started_at,
+                   last_error=NULL,
+                   delivery_context_json=excluded.delivery_context_json,
+                   delivery_metadata_json=excluded.delivery_metadata_json
+               WHERE delivery_obligations.state != 'delivered'"""
         )
         conn.execute(
             insert,
             (obligation_id, session_key, platform, str(chat_id),
-             str(thread_id) if thread_id else None, content, now, now,
+             _normalized_thread_id(thread_id), content, now, now,
              pid, started, context_json, metadata_json),
         )
     _prune()
 
 
 def mark_attempting(obligation_id: str) -> None:
-    _update_state(obligation_id, "attempting")
+    _update_state(
+        obligation_id,
+        "attempting",
+        from_states={"pending", "failed"},
+    )
 
 
 def mark_delivered(obligation_id: str) -> None:
-    _update_state(obligation_id, "delivered")
+    _update_state(
+        obligation_id,
+        "delivered",
+        from_states={"pending", "attempting", "failed"},
+    )
 
 
 def mark_failed(obligation_id: str, error: str = "") -> None:
-    _update_state(obligation_id, "failed", error=error)
+    _update_state(
+        obligation_id,
+        "failed",
+        error=error,
+        from_states={"pending", "attempting", "failed"},
+    )
 
 
-def _update_state(obligation_id: str, state: str, error: str = "") -> None:
+def mark_abandoned(obligation_id: str, error: str = "") -> None:
+    _update_state(
+        obligation_id,
+        "abandoned",
+        error=error,
+        from_states={"accepted", "pending", "attempting", "failed", "conflict"},
+    )
+
+
+def _update_state(
+    obligation_id: str,
+    state: str,
+    error: str = "",
+    *,
+    from_states: Optional[set[str]] = None,
+) -> None:
     with _DB_LOCK, _transaction() as conn:
+        params: list[Any] = [
+            state,
+            time.time(),
+            error[:500] if error else None,
+            obligation_id,
+        ]
+        where = "obligation_id=?"
+        if from_states:
+            placeholders = ",".join("?" for _ in from_states)
+            where += f" AND state IN ({placeholders})"
+            params.extend(sorted(from_states))
         conn.execute(
-            """UPDATE delivery_obligations
-               SET state=?, updated_at=?, last_error=?
-               WHERE obligation_id=?""",
-            (state, time.time(), error[:500] if error else None, obligation_id),
+            f"""UPDATE delivery_obligations
+                SET state=?, updated_at=?, last_error=?
+                WHERE {where}""",
+            params,
         )
 
 
@@ -339,14 +656,17 @@ def sweep_recoverable(
                       owner_pid, owner_started_at, delivery_context_json,
                       delivery_metadata_json
                FROM delivery_obligations
-               WHERE state IN ('pending', 'attempting', 'failed')"""
+               WHERE state IN ('accepted', 'pending', 'attempting', 'failed')"""
         ).fetchall()
         for (oid, session_key, platform, chat_id, thread_id, content, state,
              attempts, created_at, owner_pid, owner_started_at, context_json,
              metadata_json) in rows:
             if _owner_alive(owner_pid, owner_started_at):
                 continue  # a live gateway still owns this row
-            if attempts >= MAX_ATTEMPTS or (now - created_at) > STALE_AFTER_SECONDS:
+            if (
+                (state != "accepted" and attempts >= MAX_ATTEMPTS)
+                or (now - created_at) > STALE_AFTER_SECONDS
+            ):
                 conn.execute(
                     """UPDATE delivery_obligations
                        SET state='abandoned', updated_at=? WHERE obligation_id=?""",
@@ -360,13 +680,25 @@ def sweep_recoverable(
                 # No adapter for this platform this boot — the caller cannot
                 # send, so claiming would spend an attempt on a no-op.
                 continue
-            cursor = conn.execute(
-                """UPDATE delivery_obligations
-                   SET owner_pid=?, owner_started_at=?, attempts=attempts+1,
-                       updated_at=?
-                   WHERE obligation_id=? AND (owner_pid IS ? OR owner_pid=?)""",
-                (pid, started, now, oid, owner_pid, owner_pid),
-            )
+            if state == "accepted":
+                cursor = conn.execute(
+                    """UPDATE delivery_obligations
+                       SET owner_pid=?, owner_started_at=?, updated_at=?
+                       WHERE obligation_id=? AND state='accepted'
+                             AND (owner_pid IS ? OR owner_pid=?)""",
+                    (pid, started, now, oid, owner_pid, owner_pid),
+                )
+                claimed_attempts = attempts
+            else:
+                cursor = conn.execute(
+                    """UPDATE delivery_obligations
+                       SET owner_pid=?, owner_started_at=?, attempts=attempts+1,
+                           updated_at=?
+                       WHERE obligation_id=? AND state=?
+                             AND (owner_pid IS ? OR owner_pid=?)""",
+                    (pid, started, now, oid, state, owner_pid, owner_pid),
+                )
+                claimed_attempts = attempts + 1
             if cursor.rowcount:
                 claimed.append({
                     "obligation_id": oid,
@@ -377,8 +709,10 @@ def sweep_recoverable(
                     "content": content,
                     # pending = send never started, redeliver plainly;
                     # attempting/failed = ambiguous or rejected, carry marker.
-                    "needs_marker": state != "pending",
-                    "attempts": attempts + 1,
+                    "state": state,
+                    "ready_for_delivery": state != "accepted",
+                    "needs_marker": state not in {"accepted", "pending"},
+                    "attempts": claimed_attempts,
                     "delivery_context": project_delivery_ledger_context(
                         _deserialize_json_object(context_json)
                     ),
@@ -405,7 +739,8 @@ def _prune(now: Optional[float] = None) -> None:
         with _transaction() as conn:
             conn.execute(
                 """DELETE FROM delivery_obligations
-                   WHERE state IN ('delivered', 'abandoned') AND updated_at < ?""",
+                   WHERE state IN ('delivered', 'abandoned', 'conflict')
+                         AND updated_at < ?""",
                 (cutoff,),
             )
             total = conn.execute(
@@ -416,6 +751,7 @@ def _prune(now: Optional[float] = None) -> None:
                 conn.execute(
                     """DELETE FROM delivery_obligations WHERE obligation_id IN (
                          SELECT obligation_id FROM delivery_obligations
+                         WHERE state IN ('delivered', 'abandoned', 'conflict')
                          ORDER BY CASE state
                                     WHEN 'delivered' THEN 0
                                     WHEN 'abandoned' THEN 1

--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -33,8 +33,9 @@ ambiguous sends):
 Poison rows cannot spin: attempts are capped, stale rows expire, and both
 transition to ``abandoned`` (kept briefly for inspection, then pruned).
 
-Everything here is best-effort by design: ledger failures must never block
-or delay an actual send. Callers wrap every call in try/except.
+General messaging callers use the ledger best-effort. Terminal webhook
+callbacks that depend on persisted rendered routing fail closed if their
+pre-egress journal write cannot complete.
 """
 
 from __future__ import annotations
@@ -47,8 +48,13 @@ import sqlite3
 import threading
 import time
 from contextlib import contextmanager
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Mapping, Optional
 
+from gateway.delivery_metadata import (
+    TERMINAL_DELIVERY_METADATA_KEY,
+    project_delivery_ledger_context,
+    project_terminal_delivery,
+)
 from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
@@ -107,9 +113,32 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
             updated_at REAL NOT NULL,
             owner_pid INTEGER,
             owner_started_at INTEGER,
-            last_error TEXT
+            last_error TEXT,
+            delivery_context_json TEXT,
+            delivery_metadata_json TEXT
         )"""
     )
+    columns = {
+        row[1] for row in conn.execute("PRAGMA table_info(delivery_obligations)")
+    }
+    for column in ("delivery_context_json", "delivery_metadata_json"):
+        if column in columns:
+            continue
+        try:
+            conn.execute(
+                f"ALTER TABLE delivery_obligations ADD COLUMN {column} TEXT"
+            )
+        except sqlite3.OperationalError:
+            # Another gateway process may have completed the additive migration
+            # after our PRAGMA snapshot. Ignore only that confirmed race.
+            current = {
+                row[1]
+                for row in conn.execute(
+                    "PRAGMA table_info(delivery_obligations)"
+                )
+            }
+            if column not in current:
+                raise
 
 
 @contextmanager
@@ -185,6 +214,34 @@ def compute_obligation_id(session_key: str, message_ref: str, content: str) -> s
     return hashlib.sha256(payload.encode("utf-8", "replace")).hexdigest()[:24]
 
 
+def _serialize_delivery_context(context: Mapping[str, Any] | None) -> Optional[str]:
+    projected = project_delivery_ledger_context(context)
+    if projected is None:
+        return None
+    return json.dumps(projected, sort_keys=True, separators=(",", ":"))
+
+
+def _serialize_delivery_metadata(metadata: Mapping[str, Any] | None) -> Optional[str]:
+    terminal = project_terminal_delivery(metadata)
+    if terminal is None:
+        return None
+    return json.dumps(
+        {TERMINAL_DELIVERY_METADATA_KEY: terminal},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _deserialize_json_object(value: Any) -> Optional[Dict[str, Any]]:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        decoded = json.loads(value)
+    except (TypeError, ValueError):
+        return None
+    return decoded if isinstance(decoded, dict) else None
+
+
 def record_obligation(
     *,
     obligation_id: str,
@@ -193,20 +250,38 @@ def record_obligation(
     chat_id: str,
     thread_id: Optional[str],
     content: str,
+    delivery_context: Mapping[str, Any] | None = None,
+    delivery_metadata: Mapping[str, Any] | None = None,
+    preserve_existing: bool = False,
 ) -> None:
     """Record a final response as owed to the platform (state='pending')."""
     now = time.time()
     pid, started = _owner_stamp()
+    context_json = _serialize_delivery_context(delivery_context)
+    metadata_json = _serialize_delivery_metadata(delivery_metadata)
     with _DB_LOCK, _transaction() as conn:
-        conn.execute(
+        insert = (
+            """INSERT INTO delivery_obligations
+               (obligation_id, session_key, platform, chat_id, thread_id,
+                content, state, attempts, created_at, updated_at,
+                owner_pid, owner_started_at, delivery_context_json,
+                delivery_metadata_json)
+               VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(obligation_id) DO NOTHING"""
+            if preserve_existing
+            else
             """INSERT OR REPLACE INTO delivery_obligations
                (obligation_id, session_key, platform, chat_id, thread_id,
                 content, state, attempts, created_at, updated_at,
-                owner_pid, owner_started_at)
-               VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?, ?)""",
+                owner_pid, owner_started_at, delivery_context_json,
+                delivery_metadata_json)
+               VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?, ?, ?, ?)"""
+        )
+        conn.execute(
+            insert,
             (obligation_id, session_key, platform, str(chat_id),
              str(thread_id) if thread_id else None, content, now, now,
-             pid, started),
+             pid, started, context_json, metadata_json),
         )
     _prune()
 
@@ -261,12 +336,14 @@ def sweep_recoverable(
         rows = conn.execute(
             """SELECT obligation_id, session_key, platform, chat_id, thread_id,
                       content, state, attempts, created_at,
-                      owner_pid, owner_started_at
+                      owner_pid, owner_started_at, delivery_context_json,
+                      delivery_metadata_json
                FROM delivery_obligations
                WHERE state IN ('pending', 'attempting', 'failed')"""
         ).fetchall()
         for (oid, session_key, platform, chat_id, thread_id, content, state,
-             attempts, created_at, owner_pid, owner_started_at) in rows:
+             attempts, created_at, owner_pid, owner_started_at, context_json,
+             metadata_json) in rows:
             if _owner_alive(owner_pid, owner_started_at):
                 continue  # a live gateway still owns this row
             if attempts >= MAX_ATTEMPTS or (now - created_at) > STALE_AFTER_SECONDS:
@@ -302,6 +379,21 @@ def sweep_recoverable(
                     # attempting/failed = ambiguous or rejected, carry marker.
                     "needs_marker": state != "pending",
                     "attempts": attempts + 1,
+                    "delivery_context": project_delivery_ledger_context(
+                        _deserialize_json_object(context_json)
+                    ),
+                    "delivery_metadata": (
+                        {
+                            TERMINAL_DELIVERY_METADATA_KEY: terminal
+                        }
+                        if (
+                            terminal := project_terminal_delivery(
+                                _deserialize_json_object(metadata_json)
+                            )
+                        )
+                        is not None
+                        else None
+                    ),
                 })
     return claimed
 

--- a/gateway/delivery_metadata.py
+++ b/gateway/delivery_metadata.py
@@ -8,18 +8,33 @@ marker, never on message text, timing, or the broader ``notify`` flag.
 from __future__ import annotations
 
 import hashlib
+import re
 from typing import Any, Mapping
 
 
 TERMINAL_DELIVERY_METADATA_KEY = "hermes_terminal_delivery"
 TERMINAL_DELIVERY_VERSION = 1
 TERMINAL_DELIVERY_OUTCOMES = frozenset({"success", "error"})
+DELIVERY_LEDGER_CONTEXT_VERSION = 1
 _MAX_CORRELATION_ID_BYTES = 256
 _MAX_DELIVERY_ID_BYTES = 256
+_MAX_DELIVER_TYPE_BYTES = 64
+_DELIVERY_LEDGER_ROUTE_FIELDS = frozenset(
+    {"chat_id", "thread_id", "message_thread_id", "repo", "pr_number"}
+)
+
+
+def normalize_delivery_identity(value: Any) -> str:
+    """Normalize an opaque routing identity without stringifying containers."""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, int) and not isinstance(value, bool):
+        return str(value)
+    return ""
 
 
 def _bounded_identity(value: Any, *, prefix: str, max_bytes: int) -> str:
-    raw = str(value or "").strip()
+    raw = normalize_delivery_identity(value)
     if not raw:
         return ""
     encoded = raw.encode("utf-8")
@@ -87,11 +102,9 @@ def project_terminal_delivery(
     if marker.get("outcome") not in TERMINAL_DELIVERY_OUTCOMES:
         return None
 
-    correlation = marker.get("correlation_id")
-    delivery = marker.get("delivery_id")
-    if not isinstance(correlation, str) or not correlation.strip():
-        return None
-    if not isinstance(delivery, str) or not delivery.strip():
+    correlation = normalize_delivery_identity(marker.get("correlation_id"))
+    delivery = normalize_delivery_identity(marker.get("delivery_id"))
+    if not correlation or not delivery:
         return None
     if len(correlation.encode("utf-8")) > _MAX_CORRELATION_ID_BYTES:
         return None
@@ -103,4 +116,60 @@ def project_terminal_delivery(
         "outcome": marker["outcome"],
         "correlation_id": correlation,
         "delivery_id": delivery,
+    }
+
+
+def project_delivery_ledger_context(
+    context: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Validate the privacy-bounded webhook route persisted for replay.
+
+    Only the rendered destination, optional target thread/repository address,
+    and accepted-turn identity survive. Route secrets, prompts, payloads, tool
+    data, and arbitrary plugin metadata are rejected rather than serialized.
+    """
+    if not isinstance(context, Mapping):
+        return None
+    if set(context) != {"version", "deliver", "deliver_extra", "delivery_id"}:
+        return None
+    if context.get("version") != DELIVERY_LEDGER_CONTEXT_VERSION:
+        return None
+
+    deliver = normalize_delivery_identity(context.get("deliver")).lower()
+    if (
+        not deliver
+        or len(deliver.encode("utf-8")) > _MAX_DELIVER_TYPE_BYTES
+        or re.fullmatch(r"[a-z0-9_-]+", deliver) is None
+    ):
+        return None
+
+    delivery_id = _bounded_identity(
+        context.get("delivery_id"),
+        prefix="sha256",
+        max_bytes=_MAX_DELIVERY_ID_BYTES,
+    )
+    if not delivery_id:
+        return None
+
+    raw_extra = context.get("deliver_extra")
+    if not isinstance(raw_extra, Mapping):
+        return None
+    if not set(raw_extra).issubset(_DELIVERY_LEDGER_ROUTE_FIELDS):
+        return None
+
+    deliver_extra: dict[str, str] = {}
+    for key, value in raw_extra.items():
+        normalized = _bounded_identity(
+            value,
+            prefix="sha256",
+            max_bytes=_MAX_CORRELATION_ID_BYTES,
+        )
+        if normalized:
+            deliver_extra[key] = normalized
+
+    return {
+        "version": DELIVERY_LEDGER_CONTEXT_VERSION,
+        "deliver": deliver,
+        "deliver_extra": deliver_extra,
+        "delivery_id": delivery_id,
     }

--- a/gateway/delivery_metadata.py
+++ b/gateway/delivery_metadata.py
@@ -1,0 +1,106 @@
+"""Validated metadata for terminal cross-platform response delivery.
+
+Platform ``send()`` is also used for typing/status/interim content.  Callers
+that need the completed turn must therefore rely on an explicit gateway-owned
+marker, never on message text, timing, or the broader ``notify`` flag.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Mapping
+
+
+TERMINAL_DELIVERY_METADATA_KEY = "hermes_terminal_delivery"
+TERMINAL_DELIVERY_VERSION = 1
+TERMINAL_DELIVERY_OUTCOMES = frozenset({"success", "error"})
+_MAX_CORRELATION_ID_BYTES = 256
+_MAX_DELIVERY_ID_BYTES = 256
+
+
+def _bounded_identity(value: Any, *, prefix: str, max_bytes: int) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    encoded = raw.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return raw
+    return f"{prefix}:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def mark_terminal_delivery(
+    metadata: Mapping[str, Any] | None,
+    *,
+    outcome: str,
+    correlation_id: Any,
+    delivery_id: Any,
+) -> dict[str, Any]:
+    """Return cloned metadata with a gateway-owned terminal marker.
+
+    Oversized opaque identities are replaced with stable SHA-256 identifiers
+    instead of being truncated, which avoids collisions while keeping the
+    cross-platform envelope bounded.
+    """
+    if outcome not in TERMINAL_DELIVERY_OUTCOMES:
+        raise ValueError(f"Unsupported terminal delivery outcome: {outcome}")
+
+    correlation = _bounded_identity(
+        correlation_id,
+        prefix="sha256",
+        max_bytes=_MAX_CORRELATION_ID_BYTES,
+    )
+    delivery = _bounded_identity(
+        delivery_id,
+        prefix="sha256",
+        max_bytes=_MAX_DELIVERY_ID_BYTES,
+    )
+    if not correlation or not delivery:
+        raise ValueError("Terminal delivery identities must be non-empty")
+
+    result = dict(metadata) if metadata else {}
+    result[TERMINAL_DELIVERY_METADATA_KEY] = {
+        "version": TERMINAL_DELIVERY_VERSION,
+        "outcome": outcome,
+        "correlation_id": correlation,
+        "delivery_id": delivery,
+    }
+    return result
+
+
+def project_terminal_delivery(
+    metadata: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Return an exact validated terminal marker, otherwise ``None``.
+
+    The strict field set prevents arbitrary source metadata from crossing a
+    platform boundary under the reserved key.
+    """
+    if not isinstance(metadata, Mapping):
+        return None
+    marker = metadata.get(TERMINAL_DELIVERY_METADATA_KEY)
+    if not isinstance(marker, Mapping):
+        return None
+    if set(marker) != {"version", "outcome", "correlation_id", "delivery_id"}:
+        return None
+    if marker.get("version") != TERMINAL_DELIVERY_VERSION:
+        return None
+    if marker.get("outcome") not in TERMINAL_DELIVERY_OUTCOMES:
+        return None
+
+    correlation = marker.get("correlation_id")
+    delivery = marker.get("delivery_id")
+    if not isinstance(correlation, str) or not correlation.strip():
+        return None
+    if not isinstance(delivery, str) or not delivery.strip():
+        return None
+    if len(correlation.encode("utf-8")) > _MAX_CORRELATION_ID_BYTES:
+        return None
+    if len(delivery.encode("utf-8")) > _MAX_DELIVERY_ID_BYTES:
+        return None
+
+    return {
+        "version": TERMINAL_DELIVERY_VERSION,
+        "outcome": marker["outcome"],
+        "correlation_id": correlation,
+        "delivery_id": delivery,
+    }

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5609,9 +5609,32 @@ class BasePlatformAdapter(ABC):
                     # Slash-command and ephemeral replies are cheap to
                     # regenerate and are not recorded.
                     _obligation_id = None
-                    if not is_ephemeral_response and not str(
-                        event.text or ""
-                    ).lstrip().startswith(("/", self.typed_command_prefix or "!")):
+                    _adapter_manages_terminal_ledger = False
+                    _ledger_owner = getattr(
+                        delivery_adapter,
+                        "manages_terminal_delivery_ledger",
+                        None,
+                    )
+                    if callable(_ledger_owner):
+                        try:
+                            _adapter_manages_terminal_ledger = bool(
+                                _ledger_owner(
+                                    event.source.chat_id,
+                                    _final_text_metadata,
+                                )
+                            )
+                        except Exception:
+                            logger.debug(
+                                "adapter delivery-ledger ownership check failed",
+                                exc_info=True,
+                            )
+                    if (
+                        not _adapter_manages_terminal_ledger
+                        and not is_ephemeral_response
+                        and not str(event.text or "").lstrip().startswith(
+                            ("/", self.typed_command_prefix or "!")
+                        )
+                    ):
                         try:
                             from gateway.delivery_ledger import (
                                 compute_obligation_id,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -21,6 +21,7 @@ import weakref
 from abc import ABC, abstractmethod
 from urllib.parse import urlsplit
 
+from gateway.delivery_metadata import mark_terminal_delivery
 from utils import normalize_proxy_url
 
 logger = logging.getLogger(__name__)
@@ -91,6 +92,25 @@ def _mark_notify_metadata(metadata: dict | None) -> dict:
     notify_metadata = dict(metadata) if metadata else {}
     notify_metadata["notify"] = True
     return notify_metadata
+
+
+def _mark_webhook_terminal_metadata(
+    metadata: dict | None,
+    *,
+    platform,
+    outcome: str,
+    correlation_id,
+    delivery_id,
+) -> dict:
+    """Mark terminal webhook text without changing other platform metadata."""
+    if _platform_name(platform) != "webhook":
+        return dict(metadata) if metadata else {}
+    return mark_terminal_delivery(
+        metadata,
+        outcome=outcome,
+        correlation_id=correlation_id,
+        delivery_id=delivery_id,
+    )
 
 
 def _reply_anchor_for_event(event) -> str | None:
@@ -5509,6 +5529,13 @@ class BasePlatformAdapter(ABC):
                 # metadata stays unmarked and progress bubbles remain
                 # thread-strict.
                 _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
+                _final_text_metadata = _mark_webhook_terminal_metadata(
+                    _final_thread_metadata,
+                    platform=self.platform,
+                    outcome="success",
+                    correlation_id=getattr(event, "message_id", None) or session_key,
+                    delivery_id=getattr(event, "message_id", None) or session_key,
+                )
 
                 # Auto-TTS: if voice message, generate audio FIRST (before sending text)
                 # Gated via ``_should_auto_tts_for_chat``: fires when the chat has
@@ -5618,7 +5645,7 @@ class BasePlatformAdapter(ABC):
                         chat_id=event.source.chat_id,
                         content=text_content,
                         reply_to=_reply_anchor,
-                        metadata=_final_thread_metadata,
+                        metadata=_final_text_metadata,
                     )
                     _record_delivery(result)
                     if _obligation_id is not None:
@@ -5873,6 +5900,13 @@ class BasePlatformAdapter(ABC):
                 error_type = type(e).__name__
                 error_detail = str(e)[:300] if str(e) else "no details available"
                 _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+                _error_metadata = _mark_webhook_terminal_metadata(
+                    _thread_metadata,
+                    platform=self.platform,
+                    outcome="error",
+                    correlation_id=getattr(event, "message_id", None) or session_key,
+                    delivery_id=getattr(event, "message_id", None) or session_key,
+                )
                 await self.send(
                     chat_id=event.source.chat_id,
                     content=(
@@ -5880,7 +5914,7 @@ class BasePlatformAdapter(ABC):
                         f"{error_detail}\n"
                         "Try again or use /reset to start a fresh session."
                     ),
-                    metadata=_thread_metadata,
+                    metadata=_error_metadata,
                 )
             except Exception as notify_err:
                 logger.error(

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -483,6 +483,8 @@ class WebhookAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         context: Mapping[str, Any],
+        *,
+        session_key: Optional[str] = None,
     ) -> bool:
         """Restore only a validated, privacy-bounded rendered callback route."""
         projected = project_delivery_ledger_context(context)
@@ -493,6 +495,10 @@ class WebhookAdapter(BasePlatformAdapter):
             "deliver_extra": dict(projected["deliver_extra"]),
             "_hermes_delivery_id": projected["delivery_id"],
         }
+        if session_key:
+            self._delivery_info[str(chat_id)]["_hermes_session_key"] = str(
+                session_key
+            )
         now = time.time()
         self._delivery_info_created[str(chat_id)] = now
         self._delivery_info_order.append((now, str(chat_id)))
@@ -573,7 +579,9 @@ class WebhookAdapter(BasePlatformAdapter):
             )
             decision = begin_terminal_attempt(
                 obligation_id=obligation_id,
-                session_key=str(chat_id),
+                session_key=str(
+                    delivery.get("_hermes_session_key") or chat_id
+                ),
                 platform=Platform.WEBHOOK.value,
                 chat_id=str(chat_id),
                 thread_id=None,
@@ -630,6 +638,20 @@ class WebhookAdapter(BasePlatformAdapter):
                 from gateway.delivery_ledger import mark_delivered, mark_failed
 
                 if result.success:
+                    # The session admission marker owns the accepted-turn
+                    # recovery obligation until the terminal callback crosses
+                    # its target boundary.  Clear it before settling the
+                    # delivery row: if the process dies between these two
+                    # durable writes, the row still contains the exact
+                    # terminal body and startup redelivery owns recovery.
+                    session_key = normalize_delivery_identity(
+                        delivery.get("_hermes_session_key")
+                    )
+                    runner = self.gateway_runner
+                    if session_key and runner is not None:
+                        await runner.async_session_store.clear_resume_pending(
+                            session_key
+                        )
                     mark_delivered(obligation_id)
                 else:
                     mark_failed(obligation_id, "terminal target rejected")
@@ -1147,6 +1169,52 @@ class WebhookAdapter(BasePlatformAdapter):
         # same route get independent agent runs (not queued/interrupted).
         session_chat_id = f"webhook:{route_name}:{delivery_id}"
 
+        # Build source and event before journaling so the callback obligation
+        # and Hermes session admission use the exact same deterministic
+        # session key.  This is construction only; no prompt or payload is
+        # persisted until the existing SessionStore admission below.
+        source = self.build_source(
+            chat_id=session_chat_id,
+            chat_name=f"webhook/{route_name}",
+            chat_type="webhook",
+            user_id=f"webhook:{route_name}",
+            user_name=route_name,
+        )
+        if profile and isinstance(profile, str):
+            source.profile = profile
+        event = MessageEvent(
+            text=prompt,
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=payload,
+            message_id=delivery_id,
+        )
+
+        runner = self.gateway_runner
+        session_key_fn = getattr(runner, "_session_key_for_source", None)
+        admit_turn = getattr(runner, "admit_webhook_turn", None)
+        if not callable(session_key_fn) or not callable(admit_turn):
+            self._seen_deliveries.pop(delivery_id, None)
+            return web.json_response(
+                {
+                    "status": "error",
+                    "error": "Callback admission unavailable",
+                    "delivery_id": delivery_id,
+                },
+                status=503,
+            )
+        admission_session_key = session_key_fn(source)
+        if not isinstance(admission_session_key, str) or not admission_session_key:
+            self._seen_deliveries.pop(delivery_id, None)
+            return web.json_response(
+                {
+                    "status": "error",
+                    "error": "Callback admission unavailable",
+                    "delivery_id": delivery_id,
+                },
+                status=503,
+            )
+
         # Store delivery info for send().  Read by every send() invocation
         # for this chat_id (interim status messages and the final response),
         # so we do NOT pop on send.  TTL-based cleanup keeps the dict bounded.
@@ -1163,6 +1231,10 @@ class WebhookAdapter(BasePlatformAdapter):
                 delivery_id,
                 profile,
             ),
+            # Internal session linkage only.  The delivery-context projection
+            # rejects this field, so it never widens the privacy-bounded route
+            # JSON stored in the ledger.
+            "_hermes_session_key": admission_session_key,
         }
 
         # The 202 contract begins only after the rendered callback route and
@@ -1188,6 +1260,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 DeliveryConflictError,
                 compute_obligation_id,
                 record_accepted_route,
+                get_obligation_state,
             )
 
             admission_id = compute_obligation_id(
@@ -1198,11 +1271,12 @@ class WebhookAdapter(BasePlatformAdapter):
             admission = await asyncio.to_thread(
                 record_accepted_route,
                 obligation_id=admission_id,
-                session_key=session_chat_id,
+                session_key=admission_session_key,
                 platform=Platform.WEBHOOK.value,
                 chat_id=session_chat_id,
                 thread_id=None,
                 delivery_context=admission_context,
+                legacy_session_key=session_chat_id,
             )
         except DeliveryConflictError:
             logger.warning(
@@ -1235,7 +1309,13 @@ class WebhookAdapter(BasePlatformAdapter):
                 },
                 status=503,
             )
+        duplicate_complete = False
         if admission == ADMISSION_DUPLICATE:
+            duplicate_complete = (
+                await asyncio.to_thread(get_obligation_state, admission_id)
+                != "accepted"
+            )
+        if duplicate_complete:
             logger.info(
                 "[webhook] Durable duplicate route=%s delivery=%s",
                 route_name,
@@ -1251,23 +1331,31 @@ class WebhookAdapter(BasePlatformAdapter):
         self._delivery_info_order.append((now, session_chat_id))
         self._prune_delivery_info(now)
 
-        # Build source and event
-        source = self.build_source(
-            chat_id=session_chat_id,
-            chat_name=f"webhook/{route_name}",
-            chat_type="webhook",
-            user_id=f"webhook:{route_name}",
-            user_name=route_name,
-        )
-        if profile and isinstance(profile, str):
-            source.profile = profile
-        event = MessageEvent(
-            text=prompt,
-            message_type=MessageType.TEXT,
-            source=source,
-            raw_message=payload,
-            message_id=delivery_id,
-        )
+        # Admit the actual turn through Hermes' canonical session/transcript
+        # persistence before HTTP 202.  The route ledger remains
+        # privacy-bounded; prompt text lives only where Hermes already stores
+        # conversation turns.  The operation is idempotent by the provider
+        # message id and verifies the SQLite row before returning.
+        try:
+            should_schedule = await admit_turn(
+                event,
+                expected_session_key=admission_session_key,
+            )
+        except Exception:
+            self._seen_deliveries.pop(delivery_id, None)
+            logger.exception(
+                "[webhook] Durable turn admission failed route=%s delivery=%s",
+                route_name,
+                delivery_id,
+            )
+            return web.json_response(
+                {
+                    "status": "error",
+                    "error": "Callback admission unavailable",
+                    "delivery_id": delivery_id,
+                },
+                status=503,
+            )
 
         logger.info(
             "[webhook] %s event=%s route=%s prompt_len=%d delivery=%s",
@@ -1278,21 +1366,31 @@ class WebhookAdapter(BasePlatformAdapter):
             delivery_id,
         )
 
-        # Non-blocking — return 202 Accepted immediately.  The per-delivery
-        # session is closed by the ``on_processing_complete`` override below
-        # once the agent run actually finishes (``handle_message`` itself is
-        # fire-and-forget: it spawns ``_process_message_background`` and
-        # returns before the run starts, so nothing can be closed here).
-        await self.handle_message(event)
+        # Dispatch the already-durable turn through the existing restart
+        # resume path.  The synthetic event carries no prompt: the accepted
+        # prompt is loaded from the persisted transcript and the
+        # non-interactive resume note tells the agent to complete it.
+        if should_schedule:
+            resume_event = MessageEvent(
+                text="",
+                message_type=MessageType.TEXT,
+                source=source,
+                internal=True,
+            )
+            await self.handle_message(resume_event)
 
         return web.json_response(
             {
-                "status": "accepted",
+                "status": (
+                    "duplicate"
+                    if admission == ADMISSION_DUPLICATE
+                    else "accepted"
+                ),
                 "route": route_name,
                 "event": event_type,
                 "delivery_id": delivery_id,
             },
-            status=202,
+            status=200 if admission == ADMISSION_DUPLICATE else 202,
         )
 
     async def on_processing_complete(

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -444,7 +444,6 @@ class WebhookAdapter(BasePlatformAdapter):
     @staticmethod
     def _delivery_ledger_context_for_route(
         delivery: Mapping[str, Any],
-        terminal_delivery: Mapping[str, Any],
     ) -> Optional[Dict[str, Any]]:
         raw_extra = delivery.get("deliver_extra")
         if not isinstance(raw_extra, Mapping):
@@ -456,12 +455,13 @@ class WebhookAdapter(BasePlatformAdapter):
             in {"chat_id", "thread_id", "message_thread_id", "repo", "pr_number"}
         }
         route_chat_id = _rendered_route_identity(safe_extra.get("chat_id"))
-        safe_extra["chat_id"] = (
-            route_chat_id
-            or normalize_delivery_identity(
-                terminal_delivery.get("correlation_id")
-            )
-        )
+        if route_chat_id:
+            safe_extra["chat_id"] = route_chat_id
+        else:
+            # The strict terminal marker carries the deterministic fallback.
+            # Do not guess it at admission: a restored route with no chat_id
+            # will use that marker exactly as the live path does.
+            safe_extra.pop("chat_id", None)
         return project_delivery_ledger_context(
             {
                 "version": DELIVERY_LEDGER_CONTEXT_VERSION,
@@ -549,7 +549,6 @@ class WebhookAdapter(BasePlatformAdapter):
         obligation_id = None
         context = self._delivery_ledger_context_for_route(
             delivery,
-            terminal_delivery,
         )
         metadata = {TERMINAL_DELIVERY_METADATA_KEY: terminal_delivery}
         if context is None:
@@ -559,39 +558,53 @@ class WebhookAdapter(BasePlatformAdapter):
             )
 
         from gateway.delivery_ledger import (
+            DeliveryConflictError,
+            TERMINAL_ATTEMPT_ALREADY_DELIVERED,
+            TERMINAL_ATTEMPT_IN_PROGRESS,
+            begin_terminal_attempt,
             compute_obligation_id,
-            ledger_enabled,
-            mark_attempting,
-            record_obligation,
         )
 
-        if ledger_enabled():
-            try:
-                obligation_id = compute_obligation_id(
-                    str(chat_id),
-                    terminal_delivery["delivery_id"],
-                    "",
-                )
-                record_obligation(
-                    obligation_id=obligation_id,
-                    session_key=str(chat_id),
-                    platform=Platform.WEBHOOK.value,
-                    chat_id=str(chat_id),
-                    thread_id=None,
-                    content=content,
-                    delivery_context=context,
-                    delivery_metadata=metadata,
-                    preserve_existing=True,
-                )
-                mark_attempting(obligation_id)
-            except Exception:
-                logger.exception(
-                    "terminal webhook delivery ledger record failed"
-                )
-                return SendResult(
-                    success=False,
-                    error="Terminal webhook delivery could not be journaled",
-                )
+        try:
+            obligation_id = compute_obligation_id(
+                str(chat_id),
+                terminal_delivery["delivery_id"],
+                "",
+            )
+            decision = begin_terminal_attempt(
+                obligation_id=obligation_id,
+                session_key=str(chat_id),
+                platform=Platform.WEBHOOK.value,
+                chat_id=str(chat_id),
+                thread_id=None,
+                content=content,
+                delivery_context=context,
+                delivery_metadata=metadata,
+            )
+        except DeliveryConflictError as exc:
+            logger.warning(
+                "terminal webhook provider identity conflict for %s: %s",
+                chat_id,
+                exc,
+            )
+            return SendResult(
+                success=False,
+                error="Terminal webhook delivery conflicts with durable identity",
+            )
+        except Exception:
+            logger.exception("terminal webhook delivery ledger record failed")
+            return SendResult(
+                success=False,
+                error="Terminal webhook delivery could not be journaled",
+            )
+
+        if decision == TERMINAL_ATTEMPT_ALREADY_DELIVERED:
+            return SendResult(success=True)
+        if decision == TERMINAL_ATTEMPT_IN_PROGRESS:
+            return SendResult(
+                success=False,
+                error="Terminal webhook delivery is already attempting",
+            )
 
         try:
             result = await self._dispatch_delivery(
@@ -599,12 +612,12 @@ class WebhookAdapter(BasePlatformAdapter):
                 delivery,
                 terminal_delivery=terminal_delivery,
             )
-        except Exception as exc:
+        except Exception:
             if obligation_id is not None:
                 try:
                     from gateway.delivery_ledger import mark_failed
 
-                    mark_failed(obligation_id, str(exc))
+                    mark_failed(obligation_id, "terminal dispatch raised")
                 except Exception:
                     logger.debug(
                         "terminal webhook delivery ledger update failed",
@@ -619,13 +632,38 @@ class WebhookAdapter(BasePlatformAdapter):
                 if result.success:
                     mark_delivered(obligation_id)
                 else:
-                    mark_failed(obligation_id, str(result.error or ""))
+                    mark_failed(obligation_id, "terminal target rejected")
             except Exception:
                 logger.debug(
                     "terminal webhook delivery ledger update failed",
                     exc_info=True,
                 )
         return result
+
+    async def redeliver_claimed_obligation(
+        self,
+        chat_id: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]],
+    ) -> SendResult:
+        """Send a startup-claimed terminal envelope without reopening its row."""
+        delivery = self._delivery_info.get(str(chat_id))
+        if delivery is None:
+            return SendResult(
+                success=False,
+                error="Webhook delivery route is unavailable",
+            )
+        terminal_delivery = self._terminal_delivery_for_route(delivery, metadata)
+        if terminal_delivery is None:
+            return SendResult(
+                success=False,
+                error="Recovered terminal webhook envelope is invalid",
+            )
+        return await self._dispatch_delivery(
+            content,
+            delivery,
+            terminal_delivery=terminal_delivery,
+        )
 
     async def send(
         self,
@@ -1126,6 +1164,88 @@ class WebhookAdapter(BasePlatformAdapter):
                 profile,
             ),
         }
+
+        # The 202 contract begins only after the rendered callback route and
+        # accepted-turn identity are durable. This row is deliberately
+        # privacy-bounded: no prompt, payload, secret, tool data, or output is
+        # stored until a terminal envelope is atomically attached later.
+        admission_context = self._delivery_ledger_context_for_route(
+            deliver_config,
+        )
+        if admission_context is None:
+            self._seen_deliveries.pop(delivery_id, None)
+            return web.json_response(
+                {
+                    "status": "error",
+                    "error": "Callback route is not replay-safe",
+                    "delivery_id": delivery_id,
+                },
+                status=503,
+            )
+        try:
+            from gateway.delivery_ledger import (
+                ADMISSION_DUPLICATE,
+                DeliveryConflictError,
+                compute_obligation_id,
+                record_accepted_route,
+            )
+
+            admission_id = compute_obligation_id(
+                session_chat_id,
+                deliver_config["_hermes_delivery_id"],
+                "",
+            )
+            admission = await asyncio.to_thread(
+                record_accepted_route,
+                obligation_id=admission_id,
+                session_key=session_chat_id,
+                platform=Platform.WEBHOOK.value,
+                chat_id=session_chat_id,
+                thread_id=None,
+                delivery_context=admission_context,
+            )
+        except DeliveryConflictError:
+            logger.warning(
+                "[webhook] Conflicting durable identity route=%s delivery=%s",
+                route_name,
+                delivery_id,
+            )
+            return web.json_response(
+                {
+                    "status": "conflict",
+                    "error": "Provider delivery identity conflict",
+                    "delivery_id": delivery_id,
+                },
+                status=409,
+            )
+        except Exception:
+            # Let a provider retry after transient storage failure. A 202 is
+            # never returned unless the accepted callback route is durable.
+            self._seen_deliveries.pop(delivery_id, None)
+            logger.exception(
+                "[webhook] Durable callback admission failed route=%s delivery=%s",
+                route_name,
+                delivery_id,
+            )
+            return web.json_response(
+                {
+                    "status": "error",
+                    "error": "Callback admission unavailable",
+                    "delivery_id": delivery_id,
+                },
+                status=503,
+            )
+        if admission == ADMISSION_DUPLICATE:
+            logger.info(
+                "[webhook] Durable duplicate route=%s delivery=%s",
+                route_name,
+                delivery_id,
+            )
+            return web.json_response(
+                {"status": "duplicate", "delivery_id": delivery_id},
+                status=200,
+            )
+
         self._delivery_info[session_chat_id] = deliver_config
         self._delivery_info_created[session_chat_id] = now
         self._delivery_info_order.append((now, session_chat_id))
@@ -1163,9 +1283,7 @@ class WebhookAdapter(BasePlatformAdapter):
         # once the agent run actually finishes (``handle_message`` itself is
         # fire-and-forget: it spawns ``_process_message_background`` and
         # returns before the run starts, so nothing can be closed here).
-        task = asyncio.create_task(self.handle_message(event))
-        self._background_tasks.add(task)
-        task.add_done_callback(self._background_tasks.discard)
+        await self.handle_message(event)
 
         return web.json_response(
             {

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -1398,7 +1398,7 @@ class WebhookAdapter(BasePlatformAdapter):
             correlation_id = extra.get(
                 "correlation_id",
                 terminal_delivery["correlation_id"],
-            )
+            ) or terminal_delivery["correlation_id"]
             terminal_delivery = project_terminal_delivery(
                 mark_terminal_delivery(
                     None,

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -41,9 +41,8 @@ import re
 import subprocess
 import sys
 import time
-import uuid
 from collections import deque
-from typing import Any, Deque, Dict, List, Optional
+from typing import Any, Deque, Dict, List, Mapping, Optional
 
 try:
     from aiohttp import web
@@ -55,8 +54,11 @@ except ImportError:
 
 from gateway.config import Platform, PlatformConfig
 from gateway.delivery_metadata import (
+    DELIVERY_LEDGER_CONTEXT_VERSION,
     TERMINAL_DELIVERY_METADATA_KEY,
     mark_terminal_delivery,
+    normalize_delivery_identity,
+    project_delivery_ledger_context,
     project_terminal_delivery,
 )
 from gateway.platforms.base import (
@@ -137,6 +139,7 @@ DEFAULT_PORT = 8644
 _INSECURE_NO_AUTH = "INSECURE_NO_AUTH"
 _DYNAMIC_ROUTES_FILENAME = "webhook_subscriptions.json"
 _RATE_WINDOW_SECONDS = 60.0
+_ACCEPTED_TURN_ID_DOMAIN = b"hermes-webhook-accepted-turn-v1\0"
 # Hostnames/IP literals that only serve connections originating on the same
 # machine. Anything else is treated as a public bind for safety-rail purposes.
 _LOOPBACK_HOSTS = frozenset({
@@ -146,6 +149,47 @@ _LOOPBACK_HOSTS = frozenset({
     "ip6-localhost",
     "ip6-loopback",
 })
+
+
+def _accepted_turn_delivery_id(
+    route_name: Any,
+    provider_delivery_id: Any,
+    profile: Any = None,
+) -> str:
+    """Return a server-namespaced stable id for one admitted provider event."""
+    route = normalize_delivery_identity(route_name)
+    provider = normalize_delivery_identity(provider_delivery_id)
+    profile_name = normalize_delivery_identity(profile) or "default"
+    material = (
+        _ACCEPTED_TURN_ID_DOMAIN
+        + profile_name.encode("utf-8", "replace")
+        + b"\0"
+        + route.encode("utf-8", "replace")
+        + b"\0"
+        + provider.encode("utf-8", "replace")
+    )
+    return hashlib.sha256(material).hexdigest()
+
+
+def _provider_delivery_key(
+    value: Any,
+) -> str:
+    """Normalize and bound a provider-supplied delivery identifier."""
+    normalized = normalize_delivery_identity(value)
+    if not normalized:
+        normalized = str(int(time.time() * 1000))
+    encoded = normalized.encode("utf-8")
+    if len(encoded) > 256:
+        return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+    return normalized
+
+
+def _rendered_route_identity(value: Any) -> str:
+    """Normalize a rendered route scalar and reject unresolved templates."""
+    normalized = normalize_delivery_identity(value)
+    if re.fullmatch(r"\{[a-zA-Z0-9_.]+\}", normalized):
+        return ""
+    return normalized
 
 
 def _is_loopback_host(host: Optional[str]) -> bool:
@@ -356,6 +400,233 @@ class WebhookAdapter(BasePlatformAdapter):
         self._mark_disconnected()
         logger.info("[webhook] Disconnected")
 
+    @staticmethod
+    def _terminal_delivery_for_route(
+        delivery: Mapping[str, Any],
+        source_metadata: Optional[Dict[str, Any]],
+    ) -> Optional[Dict[str, Any]]:
+        terminal = project_terminal_delivery(source_metadata)
+        internal_delivery_id = normalize_delivery_identity(
+            delivery.get("_hermes_delivery_id")
+        )
+        if terminal is None or not internal_delivery_id:
+            return None
+
+        extra = delivery.get("deliver_extra")
+        if not isinstance(extra, Mapping):
+            extra = {}
+        correlation_id = (
+            _rendered_route_identity(extra.get("chat_id"))
+            or terminal["correlation_id"]
+        )
+        projected = project_terminal_delivery(
+            mark_terminal_delivery(
+                None,
+                outcome=terminal["outcome"],
+                correlation_id=correlation_id,
+                delivery_id=internal_delivery_id,
+            )
+        )
+        if projected is not None:
+            return projected
+        # A malformed or oversized rendered route must not downgrade a true
+        # final send into an unjournaled interim callback. Fall back to the
+        # already-validated source correlation deterministically.
+        return project_terminal_delivery(
+            mark_terminal_delivery(
+                None,
+                outcome=terminal["outcome"],
+                correlation_id=terminal["correlation_id"],
+                delivery_id=internal_delivery_id,
+            )
+        )
+
+    @staticmethod
+    def _delivery_ledger_context_for_route(
+        delivery: Mapping[str, Any],
+        terminal_delivery: Mapping[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        raw_extra = delivery.get("deliver_extra")
+        if not isinstance(raw_extra, Mapping):
+            raw_extra = {}
+        safe_extra = {
+            key: value
+            for key, value in raw_extra.items()
+            if key
+            in {"chat_id", "thread_id", "message_thread_id", "repo", "pr_number"}
+        }
+        route_chat_id = _rendered_route_identity(safe_extra.get("chat_id"))
+        safe_extra["chat_id"] = (
+            route_chat_id
+            or normalize_delivery_identity(
+                terminal_delivery.get("correlation_id")
+            )
+        )
+        return project_delivery_ledger_context(
+            {
+                "version": DELIVERY_LEDGER_CONTEXT_VERSION,
+                "deliver": delivery.get("deliver", "log"),
+                "deliver_extra": safe_extra,
+                "delivery_id": delivery.get("_hermes_delivery_id"),
+            }
+        )
+
+    def manages_terminal_delivery_ledger(
+        self,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]],
+    ) -> bool:
+        """True when send() owns the terminal obligation before callback egress."""
+        return project_terminal_delivery(metadata) is not None
+
+    def restore_delivery_ledger_context(
+        self,
+        chat_id: str,
+        context: Mapping[str, Any],
+    ) -> bool:
+        """Restore only a validated, privacy-bounded rendered callback route."""
+        projected = project_delivery_ledger_context(context)
+        if projected is None:
+            return False
+        self._delivery_info[str(chat_id)] = {
+            "deliver": projected["deliver"],
+            "deliver_extra": dict(projected["deliver_extra"]),
+            "_hermes_delivery_id": projected["delivery_id"],
+        }
+        now = time.time()
+        self._delivery_info_created[str(chat_id)] = now
+        self._delivery_info_order.append((now, str(chat_id)))
+        return True
+
+    async def _dispatch_delivery(
+        self,
+        content: str,
+        delivery: Mapping[str, Any],
+        *,
+        terminal_delivery: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        deliver_type = normalize_delivery_identity(
+            delivery.get("deliver", "log")
+        ).lower() or "log"
+
+        if deliver_type == "log":
+            logger.info("[webhook] Response: %s", content[:200])
+            return SendResult(success=True)
+
+        if deliver_type == "github_comment":
+            return await self._deliver_github_comment(content, dict(delivery))
+
+        _is_known_platform = deliver_type in _BUILTIN_DELIVER_PLATFORMS
+        if not _is_known_platform:
+            try:
+                from gateway.platform_registry import platform_registry
+
+                _is_known_platform = platform_registry.is_registered(deliver_type)
+            except Exception:
+                pass
+        if self.gateway_runner and _is_known_platform:
+            return await self._deliver_cross_platform(
+                deliver_type,
+                content,
+                dict(delivery),
+                terminal_delivery=terminal_delivery,
+            )
+
+        logger.warning("[webhook] Unknown deliver type: %s", deliver_type)
+        return SendResult(
+            success=False,
+            error=f"Unknown deliver type: {deliver_type}",
+        )
+
+    async def _dispatch_terminal_with_ledger(
+        self,
+        chat_id: str,
+        content: str,
+        delivery: Mapping[str, Any],
+        terminal_delivery: Dict[str, Any],
+    ) -> SendResult:
+        """Journal a terminal callback before crossing the target boundary."""
+        obligation_id = None
+        context = self._delivery_ledger_context_for_route(
+            delivery,
+            terminal_delivery,
+        )
+        metadata = {TERMINAL_DELIVERY_METADATA_KEY: terminal_delivery}
+        if context is None:
+            return SendResult(
+                success=False,
+                error="Terminal webhook delivery route is not replay-safe",
+            )
+
+        from gateway.delivery_ledger import (
+            compute_obligation_id,
+            ledger_enabled,
+            mark_attempting,
+            record_obligation,
+        )
+
+        if ledger_enabled():
+            try:
+                obligation_id = compute_obligation_id(
+                    str(chat_id),
+                    terminal_delivery["delivery_id"],
+                    "",
+                )
+                record_obligation(
+                    obligation_id=obligation_id,
+                    session_key=str(chat_id),
+                    platform=Platform.WEBHOOK.value,
+                    chat_id=str(chat_id),
+                    thread_id=None,
+                    content=content,
+                    delivery_context=context,
+                    delivery_metadata=metadata,
+                    preserve_existing=True,
+                )
+                mark_attempting(obligation_id)
+            except Exception:
+                logger.exception(
+                    "terminal webhook delivery ledger record failed"
+                )
+                return SendResult(
+                    success=False,
+                    error="Terminal webhook delivery could not be journaled",
+                )
+
+        try:
+            result = await self._dispatch_delivery(
+                content,
+                delivery,
+                terminal_delivery=terminal_delivery,
+            )
+        except Exception as exc:
+            if obligation_id is not None:
+                try:
+                    from gateway.delivery_ledger import mark_failed
+
+                    mark_failed(obligation_id, str(exc))
+                except Exception:
+                    logger.debug(
+                        "terminal webhook delivery ledger update failed",
+                        exc_info=True,
+                    )
+            raise
+
+        if obligation_id is not None:
+            try:
+                from gateway.delivery_ledger import mark_delivered, mark_failed
+
+                if result.success:
+                    mark_delivered(obligation_id)
+                else:
+                    mark_failed(obligation_id, str(result.error or ""))
+            except Exception:
+                logger.debug(
+                    "terminal webhook delivery ledger update failed",
+                    exc_info=True,
+                )
+        return result
+
     async def send(
         self,
         chat_id: str,
@@ -378,37 +649,26 @@ class WebhookAdapter(BasePlatformAdapter):
             )
             return SendResult(success=True)
 
-        delivery = self._delivery_info.get(chat_id, {})
-        deliver_type = delivery.get("deliver", "log")
-
-        if deliver_type == "log":
-            logger.info("[webhook] Response for %s: %s", chat_id, content[:200])
-            return SendResult(success=True)
-
-        if deliver_type == "github_comment":
-            return await self._deliver_github_comment(content, delivery)
-
-        # Cross-platform delivery — any platform with a gateway adapter.
-        # Check both built-in names and plugin-registered platforms.
-        _is_known_platform = deliver_type in _BUILTIN_DELIVER_PLATFORMS
-        if not _is_known_platform:
-            try:
-                from gateway.platform_registry import platform_registry
-                _is_known_platform = platform_registry.is_registered(deliver_type)
-            except Exception:
-                pass
-        if self.gateway_runner and _is_known_platform:
-            return await self._deliver_cross_platform(
-                deliver_type,
-                content,
-                delivery,
-                source_metadata=metadata,
+        delivery = self._delivery_info.get(chat_id)
+        if delivery is None:
+            logger.error(
+                "[webhook] Missing delivery route for %s; refusing log fallback",
+                chat_id,
+            )
+            return SendResult(
+                success=False,
+                error="Webhook delivery route is unavailable",
             )
 
-        logger.warning("[webhook] Unknown deliver type: %s", deliver_type)
-        return SendResult(
-            success=False, error=f"Unknown deliver type: {deliver_type}"
-        )
+        terminal_delivery = self._terminal_delivery_for_route(delivery, metadata)
+        if terminal_delivery is not None:
+            return await self._dispatch_terminal_with_ledger(
+                chat_id,
+                content,
+                delivery,
+                terminal_delivery,
+            )
+        return await self._dispatch_delivery(content, delivery)
 
     def _prune_delivery_info(self, now: float) -> None:
         """Drop delivery_info entries older than the idempotency TTL.
@@ -765,11 +1025,13 @@ class WebhookAdapter(BasePlatformAdapter):
                 logger.warning("[webhook] Skill loading failed: %s", e)
 
         # Build a unique delivery ID
-        delivery_id = request.headers.get(
-            "X-GitHub-Delivery",
+        delivery_id = _provider_delivery_key(
             request.headers.get(
-                "svix-id",
-                request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
+                "X-GitHub-Delivery",
+                request.headers.get(
+                    "svix-id",
+                    request.headers.get("X-Request-ID"),
+                ),
             ),
         )
 
@@ -855,10 +1117,14 @@ class WebhookAdapter(BasePlatformAdapter):
             "deliver_extra": self._render_delivery_extra(
                 route_config.get("deliver_extra", {}), payload
             ),
-            # Internal turn identity is generated after inbound idempotency
-            # admission. It is never selected by request content and remains
-            # stable for every send/retry belonging to this accepted turn.
-            "_hermes_delivery_id": uuid.uuid4().hex,
+            # Server-namespaced identity is minted after inbound idempotency
+            # admission. It is stable across process restart for the same
+            # provider delivery, without persisting any request payload.
+            "_hermes_delivery_id": _accepted_turn_delivery_id(
+                route_name,
+                delivery_id,
+                profile,
+            ),
         }
         self._delivery_info[session_chat_id] = deliver_config
         self._delivery_info_created[session_chat_id] = now
@@ -1221,7 +1487,17 @@ class WebhookAdapter(BasePlatformAdapter):
         rendered: Dict[str, Any] = {}
         for key, value in extra.items():
             if isinstance(value, str):
-                rendered[key] = self._render_prompt(value, payload, "", "")
+                exact = re.fullmatch(r"\{([a-zA-Z0-9_.]+)\}", value)
+                if exact and exact.group(1) not in {"__raw__", "event_type"}:
+                    resolved: Any = payload
+                    for part in exact.group(1).split("."):
+                        if not isinstance(resolved, dict) or part not in resolved:
+                            resolved = None
+                            break
+                        resolved = resolved[part]
+                    rendered[key] = normalize_delivery_identity(resolved)
+                else:
+                    rendered[key] = self._render_prompt(value, payload, "", "")
             else:
                 rendered[key] = value
         return rendered
@@ -1340,6 +1616,7 @@ class WebhookAdapter(BasePlatformAdapter):
         delivery: dict,
         *,
         source_metadata: Optional[Dict[str, Any]] = None,
+        terminal_delivery: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Route response to another platform (telegram, discord, etc.)."""
         if not self.gateway_runner:
@@ -1375,11 +1652,18 @@ class WebhookAdapter(BasePlatformAdapter):
 
         # Use home channel if no specific chat_id in deliver_extra
         extra = delivery.get("deliver_extra", {})
-        chat_id = extra.get("chat_id", "")
+        if not isinstance(extra, Mapping):
+            extra = {}
+        if terminal_delivery is not None:
+            chat_id = normalize_delivery_identity(
+                terminal_delivery.get("correlation_id")
+            )
+        else:
+            chat_id = _rendered_route_identity(extra.get("chat_id"))
         if not chat_id:
             home = self.gateway_runner.config.get_home_channel(target_platform)
             if home:
-                chat_id = home.chat_id
+                chat_id = normalize_delivery_identity(home.chat_id)
             else:
                 return SendResult(
                     success=False,
@@ -1388,26 +1672,23 @@ class WebhookAdapter(BasePlatformAdapter):
 
         # Pass thread_id from deliver_extra so Telegram forum topics work
         metadata = None
-        thread_id = extra.get("message_thread_id") or extra.get("thread_id")
+        thread_id = (
+            _rendered_route_identity(extra.get("message_thread_id"))
+            or _rendered_route_identity(extra.get("thread_id"))
+        )
         if thread_id:
             metadata = {"thread_id": thread_id}
 
-        terminal_delivery = project_terminal_delivery(source_metadata)
-        internal_delivery_id = delivery.get("_hermes_delivery_id")
-        if terminal_delivery is not None and isinstance(internal_delivery_id, str):
-            correlation_id = extra.get(
-                "correlation_id",
-                terminal_delivery["correlation_id"],
-            ) or terminal_delivery["correlation_id"]
-            terminal_delivery = project_terminal_delivery(
-                mark_terminal_delivery(
-                    None,
-                    outcome=terminal_delivery["outcome"],
-                    correlation_id=correlation_id,
-                    delivery_id=internal_delivery_id,
-                )
+        if terminal_delivery is None:
+            terminal_delivery = self._terminal_delivery_for_route(
+                delivery,
+                source_metadata,
             )
         else:
+            terminal_delivery = project_terminal_delivery(
+                {TERMINAL_DELIVERY_METADATA_KEY: terminal_delivery}
+            )
+        if terminal_delivery is None:
             # A terminal callback without the server-owned accepted-turn
             # identity is not safe to deduplicate. Drop the marker so a
             # final-only target fails closed instead of posting ambiguously.

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -41,6 +41,7 @@ import re
 import subprocess
 import sys
 import time
+import uuid
 from collections import deque
 from typing import Any, Deque, Dict, List, Optional
 
@@ -53,6 +54,11 @@ except ImportError:
     web = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
+from gateway.delivery_metadata import (
+    TERMINAL_DELIVERY_METADATA_KEY,
+    mark_terminal_delivery,
+    project_terminal_delivery,
+)
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -393,7 +399,10 @@ class WebhookAdapter(BasePlatformAdapter):
                 pass
         if self.gateway_runner and _is_known_platform:
             return await self._deliver_cross_platform(
-                deliver_type, content, delivery
+                deliver_type,
+                content,
+                delivery,
+                source_metadata=metadata,
             )
 
         logger.warning("[webhook] Unknown deliver type: %s", deliver_type)
@@ -846,6 +855,10 @@ class WebhookAdapter(BasePlatformAdapter):
             "deliver_extra": self._render_delivery_extra(
                 route_config.get("deliver_extra", {}), payload
             ),
+            # Internal turn identity is generated after inbound idempotency
+            # admission. It is never selected by request content and remains
+            # stable for every send/retry belonging to this accepted turn.
+            "_hermes_delivery_id": uuid.uuid4().hex,
         }
         self._delivery_info[session_chat_id] = deliver_config
         self._delivery_info_created[session_chat_id] = now
@@ -1321,7 +1334,12 @@ class WebhookAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(e))
 
     async def _deliver_cross_platform(
-        self, platform_name: str, content: str, delivery: dict
+        self,
+        platform_name: str,
+        content: str,
+        delivery: dict,
+        *,
+        source_metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Route response to another platform (telegram, discord, etc.)."""
         if not self.gateway_runner:
@@ -1373,5 +1391,29 @@ class WebhookAdapter(BasePlatformAdapter):
         thread_id = extra.get("message_thread_id") or extra.get("thread_id")
         if thread_id:
             metadata = {"thread_id": thread_id}
+
+        terminal_delivery = project_terminal_delivery(source_metadata)
+        internal_delivery_id = delivery.get("_hermes_delivery_id")
+        if terminal_delivery is not None and isinstance(internal_delivery_id, str):
+            correlation_id = extra.get(
+                "correlation_id",
+                terminal_delivery["correlation_id"],
+            )
+            terminal_delivery = project_terminal_delivery(
+                mark_terminal_delivery(
+                    None,
+                    outcome=terminal_delivery["outcome"],
+                    correlation_id=correlation_id,
+                    delivery_id=internal_delivery_id,
+                )
+            )
+        else:
+            # A terminal callback without the server-owned accepted-turn
+            # identity is not safe to deduplicate. Drop the marker so a
+            # final-only target fails closed instead of posting ambiguously.
+            terminal_delivery = None
+        if terminal_delivery is not None:
+            metadata = dict(metadata) if metadata else {}
+            metadata[TERMINAL_DELIVERY_METADATA_KEY] = terminal_delivery
 
         return await adapter.send(chat_id, content, metadata=metadata)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7679,12 +7679,48 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Platform not connected this boot — leave the row claimed;
                 # attempts cap + stale cutoff bound the retries on later boots.
                 continue
+            delivery_context = row.get("delivery_context")
+            if delivery_context is not None:
+                restore_context = getattr(
+                    adapter,
+                    "restore_delivery_ledger_context",
+                    None,
+                )
+                try:
+                    restored = bool(
+                        callable(restore_context)
+                        and restore_context(row["chat_id"], delivery_context)
+                    )
+                except Exception:
+                    restored = False
+                    logger.debug(
+                        "obligation %s: delivery context restore failed",
+                        row["obligation_id"],
+                        exc_info=True,
+                    )
+                if not restored:
+                    try:
+                        mark_failed(
+                            row["obligation_id"],
+                            "delivery context restore failed",
+                        )
+                    except Exception:
+                        logger.debug(
+                            "obligation %s: failed to record context error",
+                            row["obligation_id"],
+                            exc_info=True,
+                        )
+                    continue
             content = row["content"]
             if row.get("needs_marker"):
                 content = RECOVERED_MARKER + content
-            metadata = (
-                {"thread_id": row["thread_id"]} if row.get("thread_id") else None
-            )
+            metadata = {}
+            if row.get("thread_id"):
+                metadata["thread_id"] = row["thread_id"]
+            delivery_metadata = row.get("delivery_metadata")
+            if isinstance(delivery_metadata, dict):
+                metadata.update(delivery_metadata)
+            metadata = metadata or None
             try:
                 result = await adapter.send(
                     chat_id=row["chat_id"],

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7475,8 +7475,86 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # .clean_shutdown marker).  All three mean "the agent was mid-turn and
     # we killed it" — eligible for startup auto-resume.
     _AUTO_RESUME_REASONS = frozenset(
-        {"restart_timeout", "shutdown_timeout", "restart_interrupted"}
+        {
+            "restart_timeout",
+            "shutdown_timeout",
+            "restart_interrupted",
+            "webhook_admitted",
+        }
     )
+
+    async def admit_webhook_turn(
+        self,
+        event: MessageEvent,
+        *,
+        expected_session_key: str,
+    ) -> bool:
+        """Durably admit a managed webhook turn before its HTTP 202.
+
+        The delivery ledger intentionally cannot contain the prompt.  Hermes'
+        canonical transcript is therefore the durable work record: append the
+        rendered user turn under the provider message id, verify that SQLite
+        can read it back, then mark the existing session ``resume_pending``.
+        A fresh process can now synthesize the normal non-interactive resume
+        turn without an in-memory adapter event or task.
+
+        Returns True when this process should schedule the resume event.  A
+        duplicate arriving while either adapter or runner state is active is
+        already owned and must not enqueue a second turn.
+        """
+        source = getattr(event, "source", None)
+        if source is None or source.platform != Platform.WEBHOOK:
+            raise ValueError("Durable webhook admission requires a webhook source")
+        message_id = str(getattr(event, "message_id", "") or "").strip()
+        if not message_id:
+            raise ValueError("Durable webhook admission requires a message id")
+
+        session_entry = await self.async_session_store.get_or_create_session(
+            source
+        )
+        session_key = session_entry.session_key
+        if session_key != expected_session_key:
+            raise RuntimeError("Webhook session identity changed during admission")
+
+        already_persisted = await self.async_session_store.has_platform_message_id(
+            session_entry.session_id,
+            message_id,
+        )
+        if not already_persisted:
+            timestamp = _coerce_gateway_timestamp(
+                getattr(event, "timestamp", None)
+            )
+            await self.async_session_store.append_to_transcript(
+                session_entry.session_id,
+                {
+                    "role": "user",
+                    "content": event.text or "",
+                    "message_id": message_id,
+                    "timestamp": timestamp if timestamp is not None else time.time(),
+                },
+            )
+            persisted = await self.async_session_store.has_platform_message_id(
+                session_entry.session_id,
+                message_id,
+            )
+            if not persisted:
+                raise RuntimeError("Webhook turn transcript write was not durable")
+
+        if not session_entry.resume_pending:
+            marked = await self.async_session_store.mark_resume_pending(
+                session_key,
+                reason="webhook_admitted",
+            )
+            if not marked:
+                raise RuntimeError("Webhook turn resume marker was not durable")
+
+        adapter = self._adapter_for_source(source)
+        adapter_active = bool(
+            adapter is not None
+            and session_key in getattr(adapter, "_active_sessions", {})
+        )
+        runner_active = session_key in self._running_agents
+        return not (adapter_active or runner_active)
 
     async def _run_startup_resume_event(
         self,
@@ -7694,7 +7772,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 try:
                     restored = bool(
                         callable(restore_context)
-                        and restore_context(row["chat_id"], delivery_context)
+                        and restore_context(
+                            row["chat_id"],
+                            delivery_context,
+                            session_key=row.get("session_key"),
+                        )
                     )
                 except Exception:
                     restored = False
@@ -14417,13 +14499,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # the restart-interruption system note.
             if session_key and _should_clear_resume_pending_after_turn(agent_result):
                 self._clear_restart_failure_count(session_key)
-                try:
-                    await self.async_session_store.clear_resume_pending(session_key)
-                except Exception as _e:
-                    logger.debug(
-                        "clear_resume_pending failed for %s: %s",
-                        session_key, _e,
-                    )
+                # A durably admitted webhook owns a terminal callback
+                # obligation, not merely an agent-run obligation.  Its marker
+                # is cleared by WebhookAdapter only after the terminal target
+                # accepts the callback (or by startup terminal redelivery).
+                defer_webhook_clear = (
+                    source.platform == Platform.WEBHOOK
+                    and getattr(session_entry, "resume_reason", None)
+                    == "webhook_admitted"
+                )
+                if not defer_webhook_clear:
+                    try:
+                        await self.async_session_store.clear_resume_pending(
+                            session_key
+                        )
+                    except Exception as _e:
+                        logger.debug(
+                            "clear_resume_pending failed for %s: %s",
+                            session_key, _e,
+                        )
 
             # Normalize empty responses: surface errors, partial failures, and
             # the case where agent did work but returned no text. Fix for #18765.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7642,19 +7642,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from gateway.delivery_ledger import (
                 RECOVERED_MARKER,
                 ledger_enabled,
+                mark_abandoned,
                 mark_delivered,
                 mark_failed,
                 sweep_recoverable,
             )
 
-            if not ledger_enabled():
-                return 0
             # Only claim rows we can actually send this boot: self.adapters
             # holds a platform only after its connect() succeeded, and each
             # claim spends one of the row's three redelivery attempts.
             _deliverable = {
                 getattr(p, "value", str(p)) for p in self.adapters
             }
+            if not ledger_enabled():
+                # The config gate still disables the best-effort general
+                # messaging ledger. Managed webhook callbacks are different:
+                # their HTTP 202 contract requires durable admission/recovery.
+                _deliverable.intersection_update({Platform.WEBHOOK.value})
             claimed = await asyncio.to_thread(
                 sweep_recoverable, None, deliverable_platforms=_deliverable
             )
@@ -7680,6 +7684,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # attempts cap + stale cutoff bound the retries on later boots.
                 continue
             delivery_context = row.get("delivery_context")
+            restored = False
             if delivery_context is not None:
                 restore_context = getattr(
                     adapter,
@@ -7700,10 +7705,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                 if not restored:
                     try:
-                        mark_failed(
-                            row["obligation_id"],
-                            "delivery context restore failed",
-                        )
+                        if row.get("state") == "accepted":
+                            mark_abandoned(
+                                row["obligation_id"],
+                                "accepted delivery context restore failed",
+                            )
+                        else:
+                            mark_failed(
+                                row["obligation_id"],
+                                "delivery context restore failed",
+                            )
                     except Exception:
                         logger.debug(
                             "obligation %s: failed to record context error",
@@ -7711,6 +7722,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             exc_info=True,
                         )
                     continue
+            if row.get("state") == "accepted":
+                if delivery_context is None:
+                    try:
+                        mark_abandoned(
+                            row["obligation_id"],
+                            "accepted delivery context is unavailable",
+                        )
+                    except Exception:
+                        logger.debug(
+                            "obligation %s: failed to abandon invalid admission",
+                            row["obligation_id"],
+                            exc_info=True,
+                        )
+                # Admission rows restore only the route needed by the upcoming
+                # startup-resumed turn. They have no terminal content to send,
+                # consume no retry attempt, and must leave resume_pending set.
+                continue
             content = row["content"]
             if row.get("needs_marker"):
                 content = RECOVERED_MARKER + content
@@ -7722,11 +7750,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 metadata.update(delivery_metadata)
             metadata = metadata or None
             try:
-                result = await adapter.send(
-                    chat_id=row["chat_id"],
-                    content=content,
-                    metadata=metadata,
+                redeliver_claimed = getattr(
+                    type(adapter),
+                    "redeliver_claimed_obligation",
+                    None,
                 )
+                if callable(redeliver_claimed):
+                    result = await redeliver_claimed(
+                        adapter,
+                        chat_id=row["chat_id"],
+                        content=content,
+                        metadata=metadata,
+                    )
+                else:
+                    result = await adapter.send(
+                        chat_id=row["chat_id"],
+                        content=content,
+                        metadata=metadata,
+                    )
             except Exception as send_err:
                 logger.warning(
                     "obligation %s: redelivery send raised: %s",
@@ -7744,9 +7785,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         row["obligation_id"], row["attempts"],
                     )
                 else:
+                    durable_error = (
+                        "recovered terminal callback failed"
+                        if delivery_context is not None
+                        else str(getattr(result, "error", "") or "send failed")
+                    )
                     mark_failed(
                         row["obligation_id"],
-                        str(getattr(result, "error", "") or "send failed"),
+                        durable_error,
                     )
             except Exception:
                 logger.debug("delivery ledger update failed", exc_info=True)

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -308,6 +308,7 @@ class GatewayStreamConsumer:
         self,
         *,
         final: bool = False,
+        is_turn_final: bool = True,
         expect_edits: bool = False,
     ) -> dict | None:
         """Return per-send metadata for stream-created messages.
@@ -330,7 +331,7 @@ class GatewayStreamConsumer:
             meta["notify"] = True
             platform = getattr(self.adapter, "platform", None)
             platform_name = str(getattr(platform, "value", platform) or "").lower()
-            if platform_name == "webhook":
+            if platform_name == "webhook" and is_turn_final:
                 delivery_identity = self._initial_reply_to_id or self.chat_id
                 meta = mark_terminal_delivery(
                     meta,
@@ -1866,7 +1867,10 @@ class GatewayStreamConsumer:
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
-                metadata=self._metadata_for_send(final=True),
+                metadata=self._metadata_for_send(
+                    final=True,
+                    is_turn_final=is_turn_final,
+                ),
             )
         except Exception as e:
             logger.debug("Fresh-final send failed, falling back to edit: %s", e)
@@ -2256,6 +2260,7 @@ class GatewayStreamConsumer:
                     reply_to=self._initial_reply_to_id,
                     metadata=self._metadata_for_send(
                         final=finalize,
+                        is_turn_final=is_turn_final,
                         expect_edits=True,
                     ),
                 )

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -25,6 +25,7 @@ import time
 from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
+from gateway.delivery_metadata import mark_terminal_delivery
 from gateway.platforms.base import BasePlatformAdapter as _BasePlatformAdapter
 from gateway.platforms.base import _custom_unit_to_cp
 from gateway.platforms.base import MEDIA_TAG_CLEANUP_RE
@@ -327,6 +328,16 @@ class GatewayStreamConsumer:
             meta["expect_edits"] = True
         if final:
             meta["notify"] = True
+            platform = getattr(self.adapter, "platform", None)
+            platform_name = str(getattr(platform, "value", platform) or "").lower()
+            if platform_name == "webhook":
+                delivery_identity = self._initial_reply_to_id or self.chat_id
+                meta = mark_terminal_delivery(
+                    meta,
+                    outcome="success",
+                    correlation_id=delivery_identity,
+                    delivery_id=delivery_identity,
+                )
         return meta or None
 
     @property

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13638,12 +13638,22 @@ class WebhookCreate(BaseModel):
 
 
 def _webhook_route_summary(name: str, route: Dict[str, Any], base_url: str) -> Dict[str, Any]:
+    # Project only the non-secret chat_id binding. Never surface the raw
+    # deliver_extra bag (future keys may be sensitive) or the HMAC secret.
+    deliver_extra = route.get("deliver_extra")
+    deliver_chat_id = None
+    if isinstance(deliver_extra, dict):
+        raw_chat_id = deliver_extra.get("chat_id")
+        if isinstance(raw_chat_id, str):
+            deliver_chat_id = raw_chat_id
+
     return {
         "name": name,
         "description": route.get("description", ""),
         "events": list(route.get("events") or []),
         "deliver": route.get("deliver", "log"),
         "deliver_only": bool(route.get("deliver_only")),
+        "deliver_chat_id": deliver_chat_id,
         "prompt": route.get("prompt", ""),
         "script": route.get("script", ""),
         "skills": list(route.get("skills") or []),

--- a/tests/gateway/test_terminal_delivery_metadata.py
+++ b/tests/gateway/test_terminal_delivery_metadata.py
@@ -1,23 +1,32 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import hmac
+import json
+import sqlite3
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway import delivery_ledger as dl
 from gateway.delivery_metadata import (
     TERMINAL_DELIVERY_METADATA_KEY,
     mark_terminal_delivery,
     project_terminal_delivery,
 )
+from gateway.platform_registry import PlatformEntry, platform_registry
 from gateway.platforms.base import MessageEvent, MessageType, SendResult
 from gateway.platforms.webhook import WebhookAdapter
-from gateway.stream_consumer import GatewayStreamConsumer
+from gateway.run import GatewayRunner
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
 
 
-def _webhook_adapter() -> tuple[WebhookAdapter, AsyncMock]:
+def _webhook_adapter(
+    target_platform: Platform = Platform.TELEGRAM,
+) -> tuple[WebhookAdapter, AsyncMock]:
     adapter = WebhookAdapter(
         PlatformConfig(
             enabled=True,
@@ -28,10 +37,10 @@ def _webhook_adapter() -> tuple[WebhookAdapter, AsyncMock]:
     target = AsyncMock()
     target.send = AsyncMock(return_value=SendResult(success=True))
     runner = MagicMock()
-    runner.adapters = {Platform.TELEGRAM: target}
+    runner.adapters = {target_platform: target}
     runner.config = GatewayConfig(
         platforms={
-            Platform.TELEGRAM: PlatformConfig(enabled=True, token="test"),
+            target_platform: PlatformConfig(enabled=True, token="test"),
         }
     )
     adapter.gateway_runner = runner
@@ -43,13 +52,13 @@ def _seed_delivery(
     *,
     chat_id: str = "webhook:synthetic:external-1",
     internal_id: str = "server-turn-1",
-    correlation_id: str = "correlation-1",
+    correlation_id: object = "correlation-1",
+    deliver: str = "telegram",
 ) -> str:
     adapter._delivery_info[chat_id] = {
-        "deliver": "telegram",
+        "deliver": deliver,
         "deliver_extra": {
-            "chat_id": "callback-target",
-            "correlation_id": correlation_id,
+            "chat_id": correlation_id,
         },
         "_hermes_delivery_id": internal_id,
     }
@@ -70,6 +79,63 @@ def _terminal_metadata(
     )
 
 
+@pytest.fixture
+def ella_callback_platform():
+    name = "ella_callback"
+    previous = platform_registry._entries.get(name)
+    platform_registry.register(
+        PlatformEntry(
+            name=name,
+            label="Synthetic Ella callback",
+            adapter_factory=lambda config: None,
+            check_fn=lambda: True,
+        )
+    )
+    platform = Platform(name)
+    try:
+        yield platform
+    finally:
+        platform_registry.unregister(name)
+        if previous is not None:
+            platform_registry.register(previous)
+
+
+def _request(
+    *,
+    route_name: str,
+    delivery_id: str,
+    payload: dict,
+    secret: str | None = None,
+):
+    body = json.dumps(payload, separators=(",", ":")).encode()
+    headers = {"X-Request-ID": delivery_id}
+    if secret is not None:
+        headers["X-Webhook-Signature"] = hmac.new(
+            secret.encode(),
+            body,
+            hashlib.sha256,
+        ).hexdigest()
+    request = MagicMock()
+    request.headers = headers
+    request.content_length = len(body)
+    request.match_info = {"route_name": route_name}
+    request.method = "POST"
+    request.read = AsyncMock(return_value=body)
+    return request
+
+
+def _fake_web(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "gateway.platforms.webhook.web",
+        SimpleNamespace(
+            json_response=lambda payload, status=200: SimpleNamespace(
+                status=status,
+                payload=payload,
+            )
+        ),
+    )
+
+
 def test_terminal_metadata_projection_is_exact_and_bounded() -> None:
     metadata = mark_terminal_delivery(
         {"notify": True},
@@ -85,6 +151,49 @@ def test_terminal_metadata_projection_is_exact_and_bounded() -> None:
     assert marker["correlation_id"].startswith("sha256:")
     assert marker["delivery_id"].startswith("sha256:")
     assert "notify" not in marker
+
+
+def test_delivery_ledger_additive_schema_migration_preserves_existing_row() -> None:
+    path = dl._db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """CREATE TABLE delivery_obligations (
+                obligation_id TEXT PRIMARY KEY,
+                session_key TEXT NOT NULL,
+                platform TEXT NOT NULL,
+                chat_id TEXT NOT NULL,
+                thread_id TEXT,
+                content TEXT NOT NULL,
+                state TEXT NOT NULL,
+                attempts INTEGER NOT NULL DEFAULT 0,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                owner_pid INTEGER,
+                owner_started_at INTEGER,
+                last_error TEXT
+            )"""
+        )
+        conn.execute(
+            """INSERT INTO delivery_obligations
+               (obligation_id, session_key, platform, chat_id, content, state,
+                created_at, updated_at)
+               VALUES ('legacy-1', 'session-1', 'webhook', 'chat-1',
+                       'existing final', 'pending', 1, 1)"""
+        )
+
+    with dl._connect() as conn:
+        columns = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(delivery_obligations)")
+        }
+        preserved = conn.execute(
+            """SELECT obligation_id, content, state
+               FROM delivery_obligations WHERE obligation_id='legacy-1'"""
+        ).fetchone()
+
+    assert {"delivery_context_json", "delivery_metadata_json"} <= columns
+    assert preserved == ("legacy-1", "existing final", "pending")
 
 
 @pytest.mark.parametrize(
@@ -123,6 +232,10 @@ def test_stream_metadata_marks_only_final_webhook_text() -> None:
 
     preview = consumer._metadata_for_send(expect_edits=True)
     progress = consumer._metadata_for_send()
+    segment_final = consumer._metadata_for_send(
+        final=True,
+        is_turn_final=False,
+    )
     final = consumer._metadata_for_send(final=True)
 
     assert preview == {
@@ -136,6 +249,9 @@ def test_stream_metadata_marks_only_final_webhook_text() -> None:
     }
     assert TERMINAL_DELIVERY_METADATA_KEY not in preview
     assert TERMINAL_DELIVERY_METADATA_KEY not in progress
+    assert segment_final is not None
+    assert segment_final["notify"] is True
+    assert TERMINAL_DELIVERY_METADATA_KEY not in segment_final
     assert final is not None
     marker = final[TERMINAL_DELIVERY_METADATA_KEY]
     assert marker == {
@@ -188,6 +304,56 @@ async def test_multiple_interim_sends_then_final_project_one_terminal_marker() -
         "version": 1,
         "outcome": "success",
         "correlation_id": "correlation-1",
+        "delivery_id": "server-turn-1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_segment_break_interim_then_final_marks_only_true_turn_final(
+    ella_callback_platform,
+) -> None:
+    adapter, target = _webhook_adapter(ella_callback_platform)
+    target.send.side_effect = [
+        SendResult(success=True, message_id="interim-callback"),
+        SendResult(success=True, message_id="final-callback"),
+    ]
+    chat_id = _seed_delivery(
+        adapter,
+        correlation_id="opaque-correlation-42",
+        deliver="ella_callback",
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        chat_id,
+        StreamConsumerConfig(
+            edit_interval=0.01,
+            buffer_threshold=1,
+            cursor="",
+        ),
+        initial_reply_to_id="provider-delivery-1",
+    )
+    consumer.on_delta("interim pre-tool segment")
+    consumer.on_segment_break()
+    consumer.on_delta("completed final answer")
+    consumer.finish()
+
+    await consumer.run()
+
+    assert target.send.await_count == 2
+    interim, final = target.send.await_args_list
+    assert interim.args[:2] == (
+        "opaque-correlation-42",
+        "interim pre-tool segment",
+    )
+    assert interim.kwargs["metadata"] is None
+    assert final.args[:2] == (
+        "opaque-correlation-42",
+        "completed final answer",
+    )
+    assert final.kwargs["metadata"][TERMINAL_DELIVERY_METADATA_KEY] == {
+        "version": 1,
+        "outcome": "success",
+        "correlation_id": "opaque-correlation-42",
         "delivery_id": "server-turn-1",
     }
 
@@ -248,6 +414,141 @@ async def test_blank_external_correlation_falls_back_to_terminal_source() -> Non
     marker = target.send.await_args.kwargs["metadata"][TERMINAL_DELIVERY_METADATA_KEY]
     assert marker["correlation_id"] == "source-correlation"
     assert marker["delivery_id"] == "server-turn-1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("rendered_correlation", "expected_correlation"),
+    [
+        ("  opaque-correlation-42  ", "opaque-correlation-42"),
+        (4242, "4242"),
+    ],
+)
+async def test_exact_managed_route_uses_rendered_chat_id_as_correlation(
+    monkeypatch,
+    ella_callback_platform,
+    rendered_correlation,
+    expected_correlation,
+) -> None:
+    _fake_web(monkeypatch)
+    adapter, target = _webhook_adapter(ella_callback_platform)
+    adapter._routes["managed"] = {
+        "secret": "INSECURE_NO_AUTH",
+        "prompt": "{text}",
+        "deliver": "ella_callback",
+        "deliver_extra": {"chat_id": "{correlation_id}"},
+    }
+    adapter.handle_message = AsyncMock()
+
+    response = await adapter._handle_webhook(
+        _request(
+            route_name="managed",
+            delivery_id="provider-delivery-1",
+            payload={
+                "text": "synthetic request",
+                "correlation_id": rendered_correlation,
+            },
+        )
+    )
+    chat_id = "webhook:managed:provider-delivery-1"
+    await adapter.send(
+        chat_id,
+        "complete response",
+        metadata=_terminal_metadata(correlation_id="provider-delivery-1"),
+    )
+
+    assert response.status == 202
+    accepted_turn_id = adapter._delivery_info[chat_id]["_hermes_delivery_id"]
+    target.send.assert_awaited_once()
+    call = target.send.await_args
+    assert call.args[:2] == (expected_correlation, "complete response")
+    assert call.kwargs["metadata"][TERMINAL_DELIVERY_METADATA_KEY] == {
+        "version": 1,
+        "outcome": "success",
+        "correlation_id": expected_correlation,
+        "delivery_id": accepted_turn_id,
+    }
+    assert accepted_turn_id != "provider-delivery-1"
+    assert len(accepted_turn_id) == 64
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "malformed",
+    [None, "", "   ", {}, [], True, 1.5, "{correlation_id}"],
+)
+async def test_malformed_rendered_chat_id_falls_back_deterministically(
+    monkeypatch,
+    malformed,
+    ella_callback_platform,
+) -> None:
+    _fake_web(monkeypatch)
+    adapter, target = _webhook_adapter(ella_callback_platform)
+    adapter._routes["managed"] = {
+        "secret": "INSECURE_NO_AUTH",
+        "prompt": "{text}",
+        "deliver": "ella_callback",
+        "deliver_extra": {"chat_id": "{correlation_id}"},
+    }
+    adapter.handle_message = AsyncMock()
+
+    response = await adapter._handle_webhook(
+        _request(
+            route_name="managed",
+            delivery_id="provider-delivery-1",
+            payload={
+                "text": "synthetic request",
+                "correlation_id": malformed,
+            },
+        )
+    )
+    chat_id = "webhook:managed:provider-delivery-1"
+
+    await adapter.send(
+        chat_id,
+        "complete response",
+        metadata=_terminal_metadata(correlation_id="source-correlation"),
+    )
+
+    assert response.status == 202
+    call = target.send.await_args
+    assert call.args[0] == "source-correlation"
+    marker = call.kwargs["metadata"][TERMINAL_DELIVERY_METADATA_KEY]
+    assert marker["correlation_id"] == "source-correlation"
+    assert marker["delivery_id"] == adapter._delivery_info[chat_id][
+        "_hermes_delivery_id"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_terminal_callback_fails_closed_when_ledger_write_fails(
+    monkeypatch,
+    ella_callback_platform,
+) -> None:
+    adapter, target = _webhook_adapter(ella_callback_platform)
+    chat_id = _seed_delivery(
+        adapter,
+        correlation_id="opaque-correlation-42",
+        deliver="ella_callback",
+    )
+
+    def _fail_record(**_kwargs) -> None:
+        raise OSError("synthetic ledger failure")
+
+    monkeypatch.setattr(
+        "gateway.delivery_ledger.record_obligation",
+        _fail_record,
+    )
+
+    result = await adapter.send(
+        chat_id,
+        "complete response",
+        metadata=_terminal_metadata(correlation_id="source-correlation"),
+    )
+
+    assert result.success is False
+    assert result.error == "Terminal webhook delivery could not be journaled"
+    target.send.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -320,7 +621,7 @@ async def test_successful_handler_marks_only_final_text() -> None:
 
     target.send.assert_awaited_once()
     call = target.send.await_args
-    assert call.args[:2] == ("callback-target", "complete response")
+    assert call.args[:2] == ("correlation-1", "complete response")
     marker = call.kwargs["metadata"][TERMINAL_DELIVERY_METADATA_KEY]
     assert marker["outcome"] == "success"
     assert marker["delivery_id"] == "server-turn-1"
@@ -362,58 +663,219 @@ async def test_terminal_handler_error_is_marked_once() -> None:
 
 
 @pytest.mark.asyncio
+async def test_crash_before_callback_acceptance_replays_on_fresh_adapter(
+    monkeypatch,
+    ella_callback_platform,
+) -> None:
+    class SimulatedProcessCrash(BaseException):
+        pass
+
+    adapter, target = _webhook_adapter(ella_callback_platform)
+    chat_id = _seed_delivery(
+        adapter,
+        internal_id="server-turn-durable",
+        correlation_id="opaque-correlation-42",
+        deliver="ella_callback",
+    )
+    adapter._delivery_info[chat_id]["prompt"] = "must-not-persist"
+    adapter._delivery_info[chat_id]["secret"] = "must-not-persist"
+    adapter._delivery_info[chat_id]["deliver_extra"].update(
+        {
+            "api_key": "must-not-persist",
+            "tool_calls": [{"name": "must-not-persist"}],
+        }
+    )
+    target.send.side_effect = SimulatedProcessCrash()
+
+    with pytest.raises(SimulatedProcessCrash):
+        await adapter.send(
+            chat_id,
+            "complete response",
+            metadata=_terminal_metadata(correlation_id="provider-delivery-1"),
+        )
+
+    with dl._connect() as conn:
+        row = conn.execute(
+            """SELECT obligation_id, state, delivery_context_json,
+                      delivery_metadata_json
+               FROM delivery_obligations"""
+        ).fetchone()
+    assert row is not None
+    obligation_id, state, context_json, metadata_json = row
+    assert state == "attempting"
+    context = json.loads(context_json)
+    terminal_metadata = json.loads(metadata_json)
+    assert context == {
+        "version": 1,
+        "deliver": "ella_callback",
+        "deliver_extra": {"chat_id": "opaque-correlation-42"},
+        "delivery_id": "server-turn-durable",
+    }
+    assert terminal_metadata == {
+        TERMINAL_DELIVERY_METADATA_KEY: {
+            "version": 1,
+            "outcome": "success",
+            "correlation_id": "opaque-correlation-42",
+            "delivery_id": "server-turn-durable",
+        }
+    }
+    assert all(
+        forbidden not in context_json + metadata_json
+        for forbidden in ("must-not-persist", "secret", "tool_calls", "prompt")
+    )
+
+    fresh_adapter, fresh_target = _webhook_adapter(ella_callback_platform)
+    assert fresh_adapter._delivery_info == {}
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {
+        Platform.WEBHOOK: fresh_adapter,
+        ella_callback_platform: fresh_target,
+    }
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.WEBHOOK: PlatformConfig(enabled=True),
+            ella_callback_platform: PlatformConfig(enabled=True),
+        }
+    )
+    fresh_adapter.gateway_runner = runner
+    runner.session_store = None
+    store = MagicMock()
+    store._store = None
+    store.clear_resume_pending = AsyncMock()
+    runner._async_session_store = store
+    monkeypatch.setattr(dl, "_owner_alive", lambda *_args: False)
+
+    redelivered = await runner._redeliver_pending_obligations()
+
+    assert redelivered == 1
+    fresh_target.send.assert_awaited_once()
+    replay_call = fresh_target.send.await_args
+    assert replay_call.args[0] == "opaque-correlation-42"
+    assert replay_call.args[1].endswith("complete response")
+    assert replay_call.kwargs["metadata"] == terminal_metadata
+    with dl._connect() as conn:
+        replay_state = conn.execute(
+            "SELECT state FROM delivery_obligations WHERE obligation_id=?",
+            (obligation_id,),
+        ).fetchone()[0]
+    assert replay_state == "delivered"
+
+
+@pytest.mark.asyncio
+async def test_fresh_adapter_without_durable_route_fails_instead_of_logging() -> None:
+    adapter, target = _webhook_adapter()
+
+    result = await adapter.send(
+        "webhook:managed:provider-delivery-1",
+        "complete response",
+        metadata=_terminal_metadata(),
+    )
+
+    assert result.success is False
+    assert "route" in (result.error or "").lower()
+    target.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_distinct_accepted_turns_get_distinct_internal_delivery_ids(
     monkeypatch,
 ) -> None:
-    monkeypatch.setattr(
-        "gateway.platforms.webhook.web",
-        SimpleNamespace(
-            json_response=lambda payload, status=200: SimpleNamespace(
-                status=status,
-                payload=payload,
-            )
-        ),
-    )
-    generated = iter([
-        SimpleNamespace(hex="server-turn-1"),
-        SimpleNamespace(hex="server-turn-2"),
-    ])
-    monkeypatch.setattr(
-        "gateway.platforms.webhook.uuid.uuid4",
-        lambda: next(generated),
-    )
+    _fake_web(monkeypatch)
     adapter, _target = _webhook_adapter()
     adapter._routes["synthetic"] = {
         "secret": "INSECURE_NO_AUTH",
         "prompt": "{text}",
         "deliver": "telegram",
         "deliver_extra": {
-            "chat_id": "callback-target",
-            "correlation_id": "{correlation_id}",
+            "chat_id": "{correlation_id}",
         },
     }
     adapter.handle_message = AsyncMock()
 
-    def _request(delivery_id: str):
-        body = '{"text":"same","correlation_id":"same-correlation"}'.encode("utf-8")
-        request = MagicMock()
-        request.headers = {"X-Request-ID": delivery_id}
-        request.content_length = len(body)
-        request.match_info = {"route_name": "synthetic"}
-        request.method = "POST"
-        request.read = AsyncMock(return_value=body)
-        return request
-
-    first = await adapter._handle_webhook(_request("external-1"))
-    second = await adapter._handle_webhook(_request("external-2"))
+    payload = {"text": "same", "correlation_id": "same-correlation"}
+    first = await adapter._handle_webhook(
+        _request(
+            route_name="synthetic",
+            delivery_id="external-1",
+            payload=payload,
+        )
+    )
+    second = await adapter._handle_webhook(
+        _request(
+            route_name="synthetic",
+            delivery_id="external-2",
+            payload=payload,
+        )
+    )
 
     assert first.status == 202
     assert second.status == 202
     assert (
         adapter._delivery_info["webhook:synthetic:external-1"]["_hermes_delivery_id"]
-        == "server-turn-1"
+        != "external-1"
     )
     assert (
         adapter._delivery_info["webhook:synthetic:external-2"]["_hermes_delivery_id"]
-        == "server-turn-2"
+        != "external-2"
     )
+    assert (
+        adapter._delivery_info["webhook:synthetic:external-1"][
+            "_hermes_delivery_id"
+        ]
+        != adapter._delivery_info["webhook:synthetic:external-2"][
+            "_hermes_delivery_id"
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_same_signed_provider_delivery_keeps_identity_across_restart(
+    monkeypatch,
+) -> None:
+    _fake_web(monkeypatch)
+    secret = "synthetic-signing-secret"
+    route = {
+        "secret": secret,
+        "prompt": "{text}",
+        "deliver": "telegram",
+        "deliver_extra": {"chat_id": "{correlation_id}"},
+    }
+    payload = {
+        "text": "same synthetic request",
+        "correlation_id": "opaque-correlation-42",
+    }
+
+    first_adapter, _ = _webhook_adapter()
+    first_adapter._routes["managed"] = route
+    first_adapter.handle_message = AsyncMock()
+    first = await first_adapter._handle_webhook(
+        _request(
+            route_name="managed",
+            delivery_id="provider-delivery-1",
+            payload=payload,
+            secret=secret,
+        )
+    )
+    first_identity = first_adapter._delivery_info[
+        "webhook:managed:provider-delivery-1"
+    ]["_hermes_delivery_id"]
+
+    restarted_adapter, _ = _webhook_adapter()
+    restarted_adapter._routes["managed"] = route
+    restarted_adapter.handle_message = AsyncMock()
+    replay = await restarted_adapter._handle_webhook(
+        _request(
+            route_name="managed",
+            delivery_id="provider-delivery-1",
+            payload=payload,
+            secret=secret,
+        )
+    )
+    replay_identity = restarted_adapter._delivery_info[
+        "webhook:managed:provider-delivery-1"
+    ]["_hermes_delivery_id"]
+
+    assert first.status == replay.status == 202
+    assert first_identity == replay_identity
+    assert first_identity != "provider-delivery-1"
+    assert len(first_identity) == 64

--- a/tests/gateway/test_terminal_delivery_metadata.py
+++ b/tests/gateway/test_terminal_delivery_metadata.py
@@ -14,6 +14,7 @@ from gateway.delivery_metadata import (
 )
 from gateway.platforms.base import MessageEvent, MessageType, SendResult
 from gateway.platforms.webhook import WebhookAdapter
+from gateway.stream_consumer import GatewayStreamConsumer
 
 
 def _webhook_adapter() -> tuple[WebhookAdapter, AsyncMock]:
@@ -111,6 +112,60 @@ def test_malformed_terminal_metadata_fails_closed(marker) -> None:
     assert project_terminal_delivery({TERMINAL_DELIVERY_METADATA_KEY: marker}) is None
 
 
+def test_stream_metadata_marks_only_final_webhook_text() -> None:
+    adapter = SimpleNamespace(platform=Platform.WEBHOOK)
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "webhook:synthetic:external-1",
+        metadata={"thread_id": "thread-1"},
+        initial_reply_to_id="reply-1",
+    )
+
+    preview = consumer._metadata_for_send(expect_edits=True)
+    progress = consumer._metadata_for_send()
+    final = consumer._metadata_for_send(final=True)
+
+    assert preview == {
+        "thread_id": "thread-1",
+        "reply_to_message_id": "reply-1",
+        "expect_edits": True,
+    }
+    assert progress == {
+        "thread_id": "thread-1",
+        "reply_to_message_id": "reply-1",
+    }
+    assert TERMINAL_DELIVERY_METADATA_KEY not in preview
+    assert TERMINAL_DELIVERY_METADATA_KEY not in progress
+    assert final is not None
+    marker = final[TERMINAL_DELIVERY_METADATA_KEY]
+    assert marker == {
+        "version": 1,
+        "outcome": "success",
+        "correlation_id": "reply-1",
+        "delivery_id": "reply-1",
+    }
+    assert final["notify"] is True
+
+
+def test_non_webhook_final_metadata_remains_backward_compatible() -> None:
+    adapter = SimpleNamespace(platform=Platform.TELEGRAM)
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat-1",
+        metadata={"thread_id": "thread-1"},
+        initial_reply_to_id="reply-1",
+    )
+
+    final = consumer._metadata_for_send(final=True)
+
+    assert final == {
+        "thread_id": "thread-1",
+        "reply_to_message_id": "reply-1",
+        "notify": True,
+    }
+    assert TERMINAL_DELIVERY_METADATA_KEY not in final
+
+
 @pytest.mark.asyncio
 async def test_multiple_interim_sends_then_final_project_one_terminal_marker() -> None:
     adapter, target = _webhook_adapter()
@@ -138,6 +193,33 @@ async def test_multiple_interim_sends_then_final_project_one_terminal_marker() -
 
 
 @pytest.mark.asyncio
+async def test_retry_reprojects_same_accepted_turn_identity() -> None:
+    adapter, target = _webhook_adapter()
+    chat_id = _seed_delivery(adapter)
+
+    await adapter.send(
+        chat_id,
+        "complete response",
+        metadata=_terminal_metadata(delivery_id="external-first"),
+    )
+    await adapter.send(
+        chat_id,
+        "complete response retry",
+        metadata=_terminal_metadata(delivery_id="external-retry"),
+    )
+
+    first, retry = target.send.await_args_list
+    first_marker = first.kwargs["metadata"][TERMINAL_DELIVERY_METADATA_KEY]
+    retry_marker = retry.kwargs["metadata"][TERMINAL_DELIVERY_METADATA_KEY]
+    assert first_marker == retry_marker == {
+        "version": 1,
+        "outcome": "success",
+        "correlation_id": "correlation-1",
+        "delivery_id": "server-turn-1",
+    }
+
+
+@pytest.mark.asyncio
 async def test_missing_server_delivery_identity_drops_terminal_marker() -> None:
     adapter, target = _webhook_adapter()
     chat_id = _seed_delivery(adapter)
@@ -147,6 +229,66 @@ async def test_missing_server_delivery_identity_drops_terminal_marker() -> None:
         chat_id,
         "complete response",
         metadata=_terminal_metadata(),
+    )
+
+    assert target.send.await_args.kwargs["metadata"] is None
+
+
+@pytest.mark.asyncio
+async def test_blank_external_correlation_falls_back_to_terminal_source() -> None:
+    adapter, target = _webhook_adapter()
+    chat_id = _seed_delivery(adapter, correlation_id="")
+
+    await adapter.send(
+        chat_id,
+        "complete response",
+        metadata=_terminal_metadata(correlation_id="source-correlation"),
+    )
+
+    marker = target.send.await_args.kwargs["metadata"][TERMINAL_DELIVERY_METADATA_KEY]
+    assert marker["correlation_id"] == "source-correlation"
+    assert marker["delivery_id"] == "server-turn-1"
+
+
+@pytest.mark.asyncio
+async def test_cross_platform_delivery_strips_untrusted_source_metadata() -> None:
+    adapter, target = _webhook_adapter()
+    chat_id = _seed_delivery(adapter)
+
+    source_metadata = _terminal_metadata()
+    source_metadata["api_key"] = "sk-should-not-cross-platform"
+    source_metadata["tool_calls"] = [{"name": "read_secret"}]
+
+    await adapter.send(
+        chat_id,
+        "complete response",
+        metadata=source_metadata,
+    )
+
+    delivered_metadata = target.send.await_args.kwargs["metadata"]
+    assert set(delivered_metadata) == {TERMINAL_DELIVERY_METADATA_KEY}
+    marker = delivered_metadata[TERMINAL_DELIVERY_METADATA_KEY]
+    assert marker["correlation_id"] == "correlation-1"
+    assert marker["delivery_id"] == "server-turn-1"
+
+
+@pytest.mark.asyncio
+async def test_untrusted_terminal_marker_with_extra_fields_fails_closed() -> None:
+    adapter, target = _webhook_adapter()
+    chat_id = _seed_delivery(adapter)
+
+    await adapter.send(
+        chat_id,
+        "complete response",
+        metadata={
+            TERMINAL_DELIVERY_METADATA_KEY: {
+                "version": 1,
+                "outcome": "success",
+                "correlation_id": "source-correlation",
+                "delivery_id": "source-delivery",
+                "tool_calls": [{"name": "read_secret"}],
+            }
+        },
     )
 
     assert target.send.await_args.kwargs["metadata"] is None
@@ -223,6 +365,15 @@ async def test_terminal_handler_error_is_marked_once() -> None:
 async def test_distinct_accepted_turns_get_distinct_internal_delivery_ids(
     monkeypatch,
 ) -> None:
+    monkeypatch.setattr(
+        "gateway.platforms.webhook.web",
+        SimpleNamespace(
+            json_response=lambda payload, status=200: SimpleNamespace(
+                status=status,
+                payload=payload,
+            )
+        ),
+    )
     generated = iter([
         SimpleNamespace(hex="server-turn-1"),
         SimpleNamespace(hex="server-turn-2"),

--- a/tests/gateway/test_terminal_delivery_metadata.py
+++ b/tests/gateway/test_terminal_delivery_metadata.py
@@ -5,6 +5,7 @@ import hashlib
 import hmac
 import json
 import sqlite3
+from collections import OrderedDict
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -21,6 +22,7 @@ from gateway.platform_registry import PlatformEntry, platform_registry
 from gateway.platforms.base import MessageEvent, MessageType, SendResult
 from gateway.platforms.webhook import WebhookAdapter
 from gateway.run import GatewayRunner
+from gateway.session import AsyncSessionStore, SessionStore, build_session_key
 from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
 
 
@@ -43,6 +45,11 @@ def _webhook_adapter(
             target_platform: PlatformConfig(enabled=True, token="test"),
         }
     )
+    runner._session_key_for_source = lambda source: build_session_key(source)
+    runner.admit_webhook_turn = AsyncMock(return_value=True)
+    session_store = MagicMock()
+    session_store.clear_resume_pending = AsyncMock(return_value=True)
+    runner.async_session_store = session_store
     adapter.gateway_runner = runner
     return adapter, target
 
@@ -588,6 +595,43 @@ async def test_http_202_fails_closed_when_durable_admission_fails(
 
 
 @pytest.mark.asyncio
+async def test_http_202_fails_closed_when_turn_admission_fails(
+    monkeypatch,
+) -> None:
+    _fake_web(monkeypatch)
+    adapter, _target = _webhook_adapter()
+    adapter._routes["managed"] = {
+        "secret": "INSECURE_NO_AUTH",
+        "prompt": "{text}",
+        "deliver": "telegram",
+        "deliver_extra": {"chat_id": "{correlation_id}"},
+    }
+    adapter.handle_message = AsyncMock()
+    adapter.gateway_runner.admit_webhook_turn = AsyncMock(
+        side_effect=OSError("synthetic session persistence failure")
+    )
+
+    response = await adapter._handle_webhook(
+        _request(
+            route_name="managed",
+            delivery_id="provider-delivery-1",
+            payload={"text": "private prompt", "correlation_id": "correlation-1"},
+        )
+    )
+
+    assert response.status == 503
+    assert response.payload["status"] == "error"
+    adapter.handle_message.assert_not_awaited()
+    with dl._connect() as conn:
+        row = conn.execute(
+            """SELECT state, content, delivery_context_json
+               FROM delivery_obligations"""
+        ).fetchone()
+    assert row[0:2] == ("accepted", "")
+    assert "private prompt" not in row[2]
+
+
+@pytest.mark.asyncio
 async def test_cross_platform_delivery_strips_untrusted_source_metadata() -> None:
     adapter, target = _webhook_adapter()
     chat_id = _seed_delivery(adapter)
@@ -804,7 +848,23 @@ async def test_admission_restart_restores_route_then_delivers_final(
 ) -> None:
     _fake_web(monkeypatch)
     secret = "admission-signing-secret"
+    config = GatewayConfig(
+        platforms={
+            Platform.WEBHOOK: PlatformConfig(enabled=True),
+            ella_callback_platform: PlatformConfig(enabled=True),
+        }
+    )
     adapter, _ = _webhook_adapter(ella_callback_platform)
+    first_runner = object.__new__(GatewayRunner)
+    first_runner.config = config
+    first_runner.adapters = {Platform.WEBHOOK: adapter}
+    first_runner._profile_adapters = {}
+    first_runner._running_agents = {}
+    first_runner.session_store = SessionStore(config.sessions_dir, config)
+    first_runner._async_session_store = AsyncSessionStore(
+        first_runner.session_store
+    )
+    adapter.gateway_runner = first_runner
     adapter._routes["managed"] = {
         "secret": secret,
         "prompt": "private-prompt-{private_input}",
@@ -817,6 +877,8 @@ async def test_admission_restart_restores_route_then_delivers_final(
             "model_output": "{private_output}",
         },
     }
+    # Model a process that can durably admit and schedule, but is destroyed
+    # before the scheduled adapter task starts.
     adapter.handle_message = AsyncMock()
 
     response = await adapter._handle_webhook(
@@ -836,6 +898,27 @@ async def test_admission_restart_restores_route_then_delivers_final(
     )
 
     assert response.status == 202
+    adapter.handle_message.assert_awaited_once()
+    first_runner.session_store._ensure_loaded()
+    admitted_entries = list(first_runner.session_store._entries.values())
+    assert len(admitted_entries) == 1
+    admitted_entry = admitted_entries[0]
+    admitted_history = first_runner.session_store.load_transcript(
+        admitted_entry.session_id
+    )
+    assert admitted_entry.resume_pending is True
+    assert admitted_entry.resume_reason == "webhook_admitted"
+    admitted_session_key = admitted_entry.session_key
+    assert [
+        (item.get("role"), item.get("content"), item.get("message_id"))
+        for item in admitted_history
+    ] == [
+        (
+            "user",
+            "private-prompt-prompt-private-value",
+            "provider-delivery-admitted",
+        )
+    ]
     with dl._connect() as conn:
         row = conn.execute("SELECT * FROM delivery_obligations").fetchone()
         columns = [
@@ -884,31 +967,61 @@ async def test_admission_restart_restores_route_then_delivers_final(
         )
     )
 
+    # Destroy every process-local route, event and task reference, then boot
+    # a fresh adapter/runner against only the persisted session + ledger.
+    first_runner.session_store._db.close()
+    del first_runner
+    del adapter
+    del admitted_entries
+    del admitted_entry
+    del admitted_history
+
     fresh_adapter, fresh_target = _webhook_adapter(ella_callback_platform)
     runner = object.__new__(GatewayRunner)
     runner.adapters = {
         Platform.WEBHOOK: fresh_adapter,
         ella_callback_platform: fresh_target,
     }
-    runner.config = GatewayConfig(
-        platforms={
-            Platform.WEBHOOK: PlatformConfig(enabled=True),
-            ella_callback_platform: PlatformConfig(enabled=True),
-        }
-    )
+    runner.config = config
+    runner._profile_adapters = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._background_tasks = set()
+    runner._startup_restore_in_progress = False
+    runner._startup_restore_tasks = []
+    runner._session_sources = OrderedDict()
+    runner._session_sources_max = 512
+    runner._persist_active_agents = lambda: None
+    runner._restart_loop_guard_config = lambda: (3, 300)
+    runner._is_user_authorized = lambda _source: True
     fresh_adapter.gateway_runner = runner
-    runner.session_store = None
-    store = MagicMock()
-    store._store = None
-    store.clear_resume_pending = AsyncMock()
-    runner._async_session_store = store
+    runner.session_store = SessionStore(config.sessions_dir, config)
+    runner._async_session_store = AsyncSessionStore(runner.session_store)
+    runner._session_db = None
+
+    async def _recovered_agent(event):
+        assert event.internal is True
+        assert event.text == ""
+        entry = await runner.async_session_store.get_or_create_session(
+            event.source
+        )
+        history = await runner.async_session_store.load_transcript(
+            entry.session_id
+        )
+        assert history[-1]["content"] == "private-prompt-prompt-private-value"
+        return "terminal output generated by recovered turn"
+
+    fresh_adapter.set_message_handler(_recovered_agent)
     monkeypatch.setattr(dl, "_owner_alive", lambda *_args: False)
+    monkeypatch.setattr(
+        "gateway.restart_loop_guard.check_and_record",
+        lambda *_args, **_kwargs: False,
+    )
 
     redelivered = await runner._redeliver_pending_obligations()
 
     assert redelivered == 0
     fresh_target.send.assert_not_awaited()
-    store.clear_resume_pending.assert_not_awaited()
     assert (
         fresh_adapter._delivery_info[
             "webhook:managed:provider-delivery-admitted"
@@ -916,23 +1029,23 @@ async def test_admission_restart_restores_route_then_delivers_final(
         == "opaque-correlation-42"
     )
 
-    result = await fresh_adapter.send(
-        "webhook:managed:provider-delivery-admitted",
-        "terminal output required for callback recovery",
-        metadata=_terminal_metadata(
-            correlation_id="provider-delivery-admitted",
-            delivery_id="provider-delivery-admitted",
-        ),
-    )
+    assert runner._schedule_resume_pending_sessions() == 1
+    recovery_tasks = list(runner._background_tasks)
+    assert len(recovery_tasks) == 1
+    await asyncio.gather(*recovery_tasks)
 
-    assert result.success is True
     fresh_target.send.assert_awaited_once()
     callback = fresh_target.send.await_args
     assert callback.args[:2] == (
         "opaque-correlation-42",
-        "terminal output required for callback recovery",
+        "terminal output generated by recovered turn",
     )
     assert set(callback.kwargs["metadata"]) == {TERMINAL_DELIVERY_METADATA_KEY}
+    runner.session_store._ensure_loaded()
+    recovered_entry = runner.session_store._entries[
+        admitted_session_key
+    ]
+    assert recovered_entry.resume_pending is False
     with dl._connect() as conn:
         terminal_row = conn.execute(
             """SELECT state, content, delivery_metadata_json
@@ -940,7 +1053,7 @@ async def test_admission_restart_restores_route_then_delivers_final(
             (obligation_id,),
         ).fetchone()
     assert terminal_row[0] == "delivered"
-    assert terminal_row[1] == "terminal output required for callback recovery"
+    assert terminal_row[1] == "terminal output generated by recovered turn"
     assert json.loads(terminal_row[2]) == callback.kwargs["metadata"]
 
 
@@ -1217,7 +1330,13 @@ async def test_same_signed_provider_delivery_keeps_identity_across_restart(
     assert first.status == 202
     assert replay.status == 200
     assert replay.payload["status"] == "duplicate"
-    assert restarted_adapter._delivery_info == {}
+    assert (
+        restarted_adapter._delivery_info[
+            "webhook:managed:provider-delivery-1"
+        ]["_hermes_delivery_id"]
+        == first_identity
+    )
+    restarted_adapter.handle_message.assert_awaited_once()
     assert first_identity == durable_context["delivery_id"]
     assert first_identity != "provider-delivery-1"
     assert len(first_identity) == 64

--- a/tests/gateway/test_terminal_delivery_metadata.py
+++ b/tests/gateway/test_terminal_delivery_metadata.py
@@ -359,25 +359,25 @@ async def test_segment_break_interim_then_final_marks_only_true_turn_final(
 
 
 @pytest.mark.asyncio
-async def test_retry_reprojects_same_accepted_turn_identity() -> None:
+async def test_delivered_replay_is_idempotent_without_second_egress() -> None:
     adapter, target = _webhook_adapter()
     chat_id = _seed_delivery(adapter)
 
-    await adapter.send(
+    first = await adapter.send(
         chat_id,
         "complete response",
         metadata=_terminal_metadata(delivery_id="external-first"),
     )
-    await adapter.send(
+    replay = await adapter.send(
         chat_id,
-        "complete response retry",
+        "complete response",
         metadata=_terminal_metadata(delivery_id="external-retry"),
     )
 
-    first, retry = target.send.await_args_list
-    first_marker = first.kwargs["metadata"][TERMINAL_DELIVERY_METADATA_KEY]
-    retry_marker = retry.kwargs["metadata"][TERMINAL_DELIVERY_METADATA_KEY]
-    assert first_marker == retry_marker == {
+    assert first.success is replay.success is True
+    target.send.assert_awaited_once()
+    marker = target.send.await_args.kwargs["metadata"][TERMINAL_DELIVERY_METADATA_KEY]
+    assert marker == {
         "version": 1,
         "outcome": "success",
         "correlation_id": "correlation-1",
@@ -536,7 +536,7 @@ async def test_terminal_callback_fails_closed_when_ledger_write_fails(
         raise OSError("synthetic ledger failure")
 
     monkeypatch.setattr(
-        "gateway.delivery_ledger.record_obligation",
+        "gateway.delivery_ledger.begin_terminal_attempt",
         _fail_record,
     )
 
@@ -549,6 +549,42 @@ async def test_terminal_callback_fails_closed_when_ledger_write_fails(
     assert result.success is False
     assert result.error == "Terminal webhook delivery could not be journaled"
     target.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_http_202_fails_closed_when_durable_admission_fails(
+    monkeypatch,
+) -> None:
+    _fake_web(monkeypatch)
+    adapter, _target = _webhook_adapter()
+    adapter._routes["managed"] = {
+        "secret": "INSECURE_NO_AUTH",
+        "prompt": "{text}",
+        "deliver": "telegram",
+        "deliver_extra": {"chat_id": "{correlation_id}"},
+    }
+    adapter.handle_message = AsyncMock()
+
+    def _fail_admission(**_kwargs) -> None:
+        raise OSError("synthetic admission failure")
+
+    monkeypatch.setattr(
+        "gateway.delivery_ledger.record_accepted_route",
+        _fail_admission,
+    )
+    response = await adapter._handle_webhook(
+        _request(
+            route_name="managed",
+            delivery_id="provider-delivery-1",
+            payload={"text": "private prompt", "correlation_id": "correlation-1"},
+        )
+    )
+
+    assert response.status == 503
+    assert response.payload["status"] == "error"
+    adapter.handle_message.assert_not_awaited()
+    assert "provider-delivery-1" not in adapter._seen_deliveries
+    assert adapter._delivery_info == {}
 
 
 @pytest.mark.asyncio
@@ -762,6 +798,304 @@ async def test_crash_before_callback_acceptance_replays_on_fresh_adapter(
 
 
 @pytest.mark.asyncio
+async def test_admission_restart_restores_route_then_delivers_final(
+    monkeypatch,
+    ella_callback_platform,
+) -> None:
+    _fake_web(monkeypatch)
+    secret = "admission-signing-secret"
+    adapter, _ = _webhook_adapter(ella_callback_platform)
+    adapter._routes["managed"] = {
+        "secret": secret,
+        "prompt": "private-prompt-{private_input}",
+        "deliver": "ella_callback",
+        "deliver_extra": {
+            "chat_id": "{correlation_id}",
+            "api_key": "{private_secret}",
+            "tool_calls": "{private_tool}",
+            "oauth_state": "{private_oauth}",
+            "model_output": "{private_output}",
+        },
+    }
+    adapter.handle_message = AsyncMock()
+
+    response = await adapter._handle_webhook(
+        _request(
+            route_name="managed",
+            delivery_id="provider-delivery-admitted",
+            payload={
+                "private_input": "prompt-private-value",
+                "private_secret": "secret-private-value",
+                "private_tool": "tool-private-value",
+                "private_oauth": "oauth-private-value",
+                "private_output": "output-private-value",
+                "correlation_id": "opaque-correlation-42",
+            },
+            secret=secret,
+        )
+    )
+
+    assert response.status == 202
+    with dl._connect() as conn:
+        row = conn.execute("SELECT * FROM delivery_obligations").fetchone()
+        columns = [
+            item[1]
+            for item in conn.execute(
+                "PRAGMA table_info(delivery_obligations)"
+            ).fetchall()
+        ]
+    assert row is not None
+    durable_row = dict(zip(columns, row))
+    obligation_id = durable_row["obligation_id"]
+    state = durable_row["state"]
+    content = durable_row["content"]
+    context_json = durable_row["delivery_context_json"]
+    metadata_json = durable_row["delivery_metadata_json"]
+    last_error = durable_row["last_error"]
+    assert state == "accepted"
+    assert content == ""
+    assert metadata_json is None
+    assert last_error is None
+    assert json.loads(context_json) == {
+        "version": 1,
+        "deliver": "ella_callback",
+        "deliver_extra": {"chat_id": "opaque-correlation-42"},
+        "delivery_id": adapter._delivery_info[
+            "webhook:managed:provider-delivery-admitted"
+        ]["_hermes_delivery_id"],
+    }
+    durable_admission = "|".join(
+        str(value) for value in durable_row.values() if value is not None
+    )
+    assert all(
+        forbidden not in durable_admission
+        for forbidden in (
+            "prompt-private-value",
+            "secret-private-value",
+            "tool-private-value",
+            "oauth-private-value",
+            "output-private-value",
+            "admission-signing-secret",
+            "private-prompt",
+            "api_key",
+            "tool_calls",
+            "oauth_state",
+            "model_output",
+        )
+    )
+
+    fresh_adapter, fresh_target = _webhook_adapter(ella_callback_platform)
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {
+        Platform.WEBHOOK: fresh_adapter,
+        ella_callback_platform: fresh_target,
+    }
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.WEBHOOK: PlatformConfig(enabled=True),
+            ella_callback_platform: PlatformConfig(enabled=True),
+        }
+    )
+    fresh_adapter.gateway_runner = runner
+    runner.session_store = None
+    store = MagicMock()
+    store._store = None
+    store.clear_resume_pending = AsyncMock()
+    runner._async_session_store = store
+    monkeypatch.setattr(dl, "_owner_alive", lambda *_args: False)
+
+    redelivered = await runner._redeliver_pending_obligations()
+
+    assert redelivered == 0
+    fresh_target.send.assert_not_awaited()
+    store.clear_resume_pending.assert_not_awaited()
+    assert (
+        fresh_adapter._delivery_info[
+            "webhook:managed:provider-delivery-admitted"
+        ]["deliver_extra"]["chat_id"]
+        == "opaque-correlation-42"
+    )
+
+    result = await fresh_adapter.send(
+        "webhook:managed:provider-delivery-admitted",
+        "terminal output required for callback recovery",
+        metadata=_terminal_metadata(
+            correlation_id="provider-delivery-admitted",
+            delivery_id="provider-delivery-admitted",
+        ),
+    )
+
+    assert result.success is True
+    fresh_target.send.assert_awaited_once()
+    callback = fresh_target.send.await_args
+    assert callback.args[:2] == (
+        "opaque-correlation-42",
+        "terminal output required for callback recovery",
+    )
+    assert set(callback.kwargs["metadata"]) == {TERMINAL_DELIVERY_METADATA_KEY}
+    with dl._connect() as conn:
+        terminal_row = conn.execute(
+            """SELECT state, content, delivery_metadata_json
+               FROM delivery_obligations WHERE obligation_id=?""",
+            (obligation_id,),
+        ).fetchone()
+    assert terminal_row[0] == "delivered"
+    assert terminal_row[1] == "terminal output required for callback recovery"
+    assert json.loads(terminal_row[2]) == callback.kwargs["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_differing_terminal_body_after_rejection_conflicts_without_replay(
+    monkeypatch,
+) -> None:
+    adapter, target = _webhook_adapter()
+    chat_id = _seed_delivery(adapter)
+    target.send.side_effect = [
+        SendResult(
+            success=False,
+            error="private-provider-error-must-not-persist",
+        ),
+        SendResult(success=True),
+    ]
+
+    first = await adapter.send(
+        chat_id,
+        "first terminal body",
+        metadata=_terminal_metadata(),
+    )
+    with dl._connect() as conn:
+        failed_state, failed_error = conn.execute(
+            "SELECT state, last_error FROM delivery_obligations"
+        ).fetchone()
+    assert (failed_state, failed_error) == (
+        "failed",
+        "terminal target rejected",
+    )
+    replacement = await adapter.send(
+        chat_id,
+        "different replacement body",
+        metadata=_terminal_metadata(),
+    )
+
+    assert first.success is False
+    assert replacement.success is False
+    assert "conflicts" in (replacement.error or "")
+    assert target.send.await_count == 1
+    with dl._connect() as conn:
+        state, stored_content = conn.execute(
+            "SELECT state, content FROM delivery_obligations"
+        ).fetchone()
+    assert (state, stored_content) == ("conflict", "first terminal body")
+    with dl._connect() as conn:
+        durable_values = "|".join(
+            str(value)
+            for value in conn.execute(
+                "SELECT * FROM delivery_obligations"
+            ).fetchone()
+            if value is not None
+        )
+    assert "private-provider-error-must-not-persist" not in durable_values
+    monkeypatch.setattr(dl, "_owner_alive", lambda *_args: False)
+    assert dl.sweep_recoverable(deliverable_platforms={"webhook"}) == []
+
+
+@pytest.mark.asyncio
+async def test_differing_terminal_body_during_attempt_conflicts_fail_closed(
+    monkeypatch,
+) -> None:
+    class SimulatedProcessCrash(BaseException):
+        pass
+
+    adapter, target = _webhook_adapter()
+    chat_id = _seed_delivery(adapter)
+    target.send.side_effect = SimulatedProcessCrash()
+    with pytest.raises(SimulatedProcessCrash):
+        await adapter.send(
+            chat_id,
+            "body journaled before crash",
+            metadata=_terminal_metadata(),
+        )
+
+    conflicting = await adapter.send(
+        chat_id,
+        "different body after crash",
+        metadata=_terminal_metadata(),
+    )
+
+    assert conflicting.success is False
+    assert "conflicts" in (conflicting.error or "")
+    assert target.send.await_count == 1
+    with dl._connect() as conn:
+        state, stored_content = conn.execute(
+            "SELECT state, content FROM delivery_obligations"
+        ).fetchone()
+    assert (state, stored_content) == ("conflict", "body journaled before crash")
+    monkeypatch.setattr(dl, "_owner_alive", lambda *_args: False)
+    assert dl.sweep_recoverable(deliverable_platforms={"webhook"}) == []
+
+
+@pytest.mark.asyncio
+async def test_differing_terminal_body_after_delivery_never_reopens() -> None:
+    adapter, target = _webhook_adapter()
+    chat_id = _seed_delivery(adapter)
+
+    delivered = await adapter.send(
+        chat_id,
+        "delivered body",
+        metadata=_terminal_metadata(),
+    )
+    conflicting = await adapter.send(
+        chat_id,
+        "different body after delivery",
+        metadata=_terminal_metadata(),
+    )
+
+    assert delivered.success is True
+    assert conflicting.success is False
+    assert target.send.await_count == 1
+    with dl._connect() as conn:
+        state, stored_content = conn.execute(
+            "SELECT state, content FROM delivery_obligations"
+        ).fetchone()
+    assert (state, stored_content) == ("delivered", "delivered body")
+
+
+@pytest.mark.asyncio
+async def test_same_terminal_body_retries_from_failed_then_stays_delivered() -> None:
+    adapter, target = _webhook_adapter()
+    chat_id = _seed_delivery(adapter)
+    target.send.side_effect = [
+        SendResult(success=False, error="definitive rejection"),
+        SendResult(success=True),
+    ]
+
+    first = await adapter.send(
+        chat_id,
+        "stable terminal body",
+        metadata=_terminal_metadata(),
+    )
+    retry = await adapter.send(
+        chat_id,
+        "stable terminal body",
+        metadata=_terminal_metadata(),
+    )
+    replay = await adapter.send(
+        chat_id,
+        "stable terminal body",
+        metadata=_terminal_metadata(),
+    )
+
+    assert first.success is False
+    assert retry.success is replay.success is True
+    assert target.send.await_count == 2
+    with dl._connect() as conn:
+        state = conn.execute(
+            "SELECT state FROM delivery_obligations"
+        ).fetchone()[0]
+    assert state == "delivered"
+
+
+@pytest.mark.asyncio
 async def test_fresh_adapter_without_durable_route_fails_instead_of_logging() -> None:
     adapter, target = _webhook_adapter()
 
@@ -871,11 +1205,19 @@ async def test_same_signed_provider_delivery_keeps_identity_across_restart(
             secret=secret,
         )
     )
-    replay_identity = restarted_adapter._delivery_info[
-        "webhook:managed:provider-delivery-1"
-    ]["_hermes_delivery_id"]
+    with dl._connect() as conn:
+        durable_context = json.loads(
+            conn.execute(
+                """SELECT delivery_context_json FROM delivery_obligations
+                   WHERE chat_id=?""",
+                ("webhook:managed:provider-delivery-1",),
+            ).fetchone()[0]
+        )
 
-    assert first.status == replay.status == 202
-    assert first_identity == replay_identity
+    assert first.status == 202
+    assert replay.status == 200
+    assert replay.payload["status"] == "duplicate"
+    assert restarted_adapter._delivery_info == {}
+    assert first_identity == durable_context["delivery_id"]
     assert first_identity != "provider-delivery-1"
     assert len(first_identity) == 64

--- a/tests/gateway/test_terminal_delivery_metadata.py
+++ b/tests/gateway/test_terminal_delivery_metadata.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.delivery_metadata import (
+    TERMINAL_DELIVERY_METADATA_KEY,
+    mark_terminal_delivery,
+    project_terminal_delivery,
+)
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
+from gateway.platforms.webhook import WebhookAdapter
+
+
+def _webhook_adapter() -> tuple[WebhookAdapter, AsyncMock]:
+    adapter = WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            typing_indicator=False,
+            extra={"routes": {}, "host": "127.0.0.1", "port": 0},
+        )
+    )
+    target = AsyncMock()
+    target.send = AsyncMock(return_value=SendResult(success=True))
+    runner = MagicMock()
+    runner.adapters = {Platform.TELEGRAM: target}
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="test"),
+        }
+    )
+    adapter.gateway_runner = runner
+    return adapter, target
+
+
+def _seed_delivery(
+    adapter: WebhookAdapter,
+    *,
+    chat_id: str = "webhook:synthetic:external-1",
+    internal_id: str = "server-turn-1",
+    correlation_id: str = "correlation-1",
+) -> str:
+    adapter._delivery_info[chat_id] = {
+        "deliver": "telegram",
+        "deliver_extra": {
+            "chat_id": "callback-target",
+            "correlation_id": correlation_id,
+        },
+        "_hermes_delivery_id": internal_id,
+    }
+    return chat_id
+
+
+def _terminal_metadata(
+    *,
+    outcome: str = "success",
+    correlation_id: str = "external-1",
+    delivery_id: str = "external-1",
+) -> dict:
+    return mark_terminal_delivery(
+        None,
+        outcome=outcome,
+        correlation_id=correlation_id,
+        delivery_id=delivery_id,
+    )
+
+
+def test_terminal_metadata_projection_is_exact_and_bounded() -> None:
+    metadata = mark_terminal_delivery(
+        {"notify": True},
+        outcome="success",
+        correlation_id="c" * 300,
+        delivery_id="d" * 300,
+    )
+
+    marker = project_terminal_delivery(metadata)
+
+    assert marker is not None
+    assert marker["outcome"] == "success"
+    assert marker["correlation_id"].startswith("sha256:")
+    assert marker["delivery_id"].startswith("sha256:")
+    assert "notify" not in marker
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        None,
+        "final",
+        {},
+        {
+            "version": 1,
+            "outcome": "success",
+            "correlation_id": "c",
+            "delivery_id": "d",
+            "extra": "not allowed",
+        },
+        {
+            "version": 1,
+            "outcome": "interim",
+            "correlation_id": "c",
+            "delivery_id": "d",
+        },
+    ],
+)
+def test_malformed_terminal_metadata_fails_closed(marker) -> None:
+    assert project_terminal_delivery({TERMINAL_DELIVERY_METADATA_KEY: marker}) is None
+
+
+@pytest.mark.asyncio
+async def test_multiple_interim_sends_then_final_project_one_terminal_marker() -> None:
+    adapter, target = _webhook_adapter()
+    chat_id = _seed_delivery(adapter)
+
+    await adapter.send(chat_id, "interim one")
+    await adapter.send(chat_id, "interim two", metadata={"notify": True})
+    await adapter.send(
+        chat_id,
+        "complete response",
+        metadata=_terminal_metadata(),
+    )
+
+    assert target.send.await_count == 3
+    first, second, final = target.send.await_args_list
+    assert first.kwargs["metadata"] is None
+    assert second.kwargs["metadata"] is None
+    marker = final.kwargs["metadata"][TERMINAL_DELIVERY_METADATA_KEY]
+    assert marker == {
+        "version": 1,
+        "outcome": "success",
+        "correlation_id": "correlation-1",
+        "delivery_id": "server-turn-1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_missing_server_delivery_identity_drops_terminal_marker() -> None:
+    adapter, target = _webhook_adapter()
+    chat_id = _seed_delivery(adapter)
+    adapter._delivery_info[chat_id].pop("_hermes_delivery_id")
+
+    await adapter.send(
+        chat_id,
+        "complete response",
+        metadata=_terminal_metadata(),
+    )
+
+    assert target.send.await_args.kwargs["metadata"] is None
+
+
+@pytest.mark.asyncio
+async def test_successful_handler_marks_only_final_text() -> None:
+    adapter, target = _webhook_adapter()
+    chat_id = _seed_delivery(adapter)
+    source = adapter.build_source(
+        chat_id=chat_id,
+        chat_name="webhook/synthetic",
+        chat_type="webhook",
+        user_id="webhook:synthetic",
+        user_name="synthetic",
+    )
+    event = MessageEvent(
+        text="synthetic request",
+        message_type=MessageType.TEXT,
+        source=source,
+        raw_message={"synthetic": True},
+        message_id="external-1",
+    )
+    adapter.set_message_handler(AsyncMock(return_value="complete response"))
+    session_key = "webhook:synthetic:external-1"
+    adapter._active_sessions[session_key] = asyncio.Event()
+
+    await adapter._process_message_background(event, session_key)
+
+    target.send.assert_awaited_once()
+    call = target.send.await_args
+    assert call.args[:2] == ("callback-target", "complete response")
+    marker = call.kwargs["metadata"][TERMINAL_DELIVERY_METADATA_KEY]
+    assert marker["outcome"] == "success"
+    assert marker["delivery_id"] == "server-turn-1"
+
+
+@pytest.mark.asyncio
+async def test_terminal_handler_error_is_marked_once() -> None:
+    adapter, target = _webhook_adapter()
+    chat_id = _seed_delivery(adapter)
+    source = adapter.build_source(
+        chat_id=chat_id,
+        chat_name="webhook/synthetic",
+        chat_type="webhook",
+        user_id="webhook:synthetic",
+        user_name="synthetic",
+    )
+    event = MessageEvent(
+        text="synthetic request",
+        message_type=MessageType.TEXT,
+        source=source,
+        raw_message={"synthetic": True},
+        message_id="external-1",
+    )
+    adapter.set_message_handler(
+        AsyncMock(side_effect=RuntimeError("synthetic failure"))
+    )
+    session_key = "webhook:synthetic:external-1"
+    adapter._active_sessions[session_key] = asyncio.Event()
+
+    await adapter._process_message_background(event, session_key)
+
+    target.send.assert_awaited_once()
+    call = target.send.await_args
+    marker = call.kwargs["metadata"][TERMINAL_DELIVERY_METADATA_KEY]
+    assert marker["outcome"] == "error"
+    assert marker["correlation_id"] == "correlation-1"
+    assert marker["delivery_id"] == "server-turn-1"
+    assert "synthetic failure" in call.args[1]
+
+
+@pytest.mark.asyncio
+async def test_distinct_accepted_turns_get_distinct_internal_delivery_ids(
+    monkeypatch,
+) -> None:
+    generated = iter([
+        SimpleNamespace(hex="server-turn-1"),
+        SimpleNamespace(hex="server-turn-2"),
+    ])
+    monkeypatch.setattr(
+        "gateway.platforms.webhook.uuid.uuid4",
+        lambda: next(generated),
+    )
+    adapter, _target = _webhook_adapter()
+    adapter._routes["synthetic"] = {
+        "secret": "INSECURE_NO_AUTH",
+        "prompt": "{text}",
+        "deliver": "telegram",
+        "deliver_extra": {
+            "chat_id": "callback-target",
+            "correlation_id": "{correlation_id}",
+        },
+    }
+    adapter.handle_message = AsyncMock()
+
+    def _request(delivery_id: str):
+        body = '{"text":"same","correlation_id":"same-correlation"}'.encode("utf-8")
+        request = MagicMock()
+        request.headers = {"X-Request-ID": delivery_id}
+        request.content_length = len(body)
+        request.match_info = {"route_name": "synthetic"}
+        request.method = "POST"
+        request.read = AsyncMock(return_value=body)
+        return request
+
+    first = await adapter._handle_webhook(_request("external-1"))
+    second = await adapter._handle_webhook(_request("external-2"))
+
+    assert first.status == 202
+    assert second.status == 202
+    assert (
+        adapter._delivery_info["webhook:synthetic:external-1"]["_hermes_delivery_id"]
+        == "server-turn-1"
+    )
+    assert (
+        adapter._delivery_info["webhook:synthetic:external-2"]["_hermes_delivery_id"]
+        == "server-turn-2"
+    )

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -1057,8 +1057,8 @@ class TestIdempotency:
             assert data["status"] == "duplicate"
 
     @pytest.mark.asyncio
-    async def test_expired_delivery_id_allows_reprocess(self):
-        """After TTL expires, the same delivery ID is accepted again."""
+    async def test_expired_memory_id_does_not_bypass_durable_admission(self):
+        """The durable provider identity remains idempotent beyond memory TTL."""
         routes = {"idem": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
         adapter = _make_adapter(routes=routes)
         adapter._idempotency_ttl = 1  # 1 second TTL for test speed
@@ -1075,7 +1075,9 @@ class TestIdempotency:
             adapter._seen_deliveries["delivery-456"] = time.time() - 3700
 
             resp2 = await cli.post("/webhooks/idem", json={"x": 1}, headers=headers)
-            assert resp2.status == 202  # re-accepted
+            assert resp2.status == 200
+            assert (await resp2.json())["status"] == "duplicate"
+            adapter.handle_message.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_svix_id_used_as_delivery_id_for_deduplication(self):

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -28,13 +28,14 @@ import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
-from gateway.config import Platform, PlatformConfig
+from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import SendResult
 from gateway.platforms.webhook import (
     WebhookAdapter,
     _INSECURE_NO_AUTH,
     check_webhook_requirements,
 )
+from gateway.session import build_session_key
 
 
 # ---------------------------------------------------------------------------
@@ -65,7 +66,15 @@ def _make_config(
 def _make_adapter(routes=None, **kwargs):
     """Create a WebhookAdapter with sensible defaults for testing."""
     config = _make_config(routes=routes, **kwargs)
-    return WebhookAdapter(config)
+    adapter = WebhookAdapter(config)
+    runner = MagicMock()
+    runner.adapters = {}
+    runner.config = GatewayConfig()
+    runner._session_key_for_source = lambda source: build_session_key(source)
+    runner.admit_webhook_turn = AsyncMock(return_value=True)
+    runner.async_session_store.clear_resume_pending = AsyncMock(return_value=True)
+    adapter.gateway_runner = runner
+    return adapter
 
 
 def _create_app(adapter: WebhookAdapter) -> web.Application:
@@ -747,7 +756,10 @@ class TestPayloadFilters:
 
         await asyncio.sleep(0.05)
         assert len(captured) == 1
-        assert captured[0].text == "Message from chat-2: hello"
+        admitted_event = (
+            adapter.gateway_runner.admit_webhook_turn.await_args.args[0]
+        )
+        assert admitted_event.text == "Message from chat-2: hello"
 
     @pytest.mark.asyncio
     async def test_filter_applies_to_deliver_only_before_delivery(self):
@@ -820,8 +832,11 @@ class TestPayloadFilters:
             assert resp.status == 202
 
         await asyncio.sleep(0.05)
-        assert captured[0].text == "Task: PAY BILLS"
-        assert captured[0].raw_message["body"] == "PAY BILLS"
+        admitted_event = (
+            adapter.gateway_runner.admit_webhook_turn.await_args.args[0]
+        )
+        assert admitted_event.text == "Task: PAY BILLS"
+        assert admitted_event.raw_message["body"] == "PAY BILLS"
 
     @pytest.mark.asyncio
     async def test_script_tilde_hermes_path_resolves_to_active_profile_home(self, tmp_path, monkeypatch):
@@ -861,7 +876,10 @@ class TestPayloadFilters:
             assert resp.status == 202
 
         await asyncio.sleep(0.05)
-        assert captured[0].text == "Task: profile-safe"
+        admitted_event = (
+            adapter.gateway_runner.admit_webhook_turn.await_args.args[0]
+        )
+        assert admitted_event.text == "Task: profile-safe"
 
     @pytest.mark.asyncio
     async def test_script_silent_stdout_ignores_without_idempotency_hit(self, tmp_path, monkeypatch):
@@ -1063,6 +1081,7 @@ class TestIdempotency:
         adapter = _make_adapter(routes=routes)
         adapter._idempotency_ttl = 1  # 1 second TTL for test speed
         adapter.handle_message = AsyncMock()
+        adapter.gateway_runner.admit_webhook_turn.side_effect = [True, False]
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:

--- a/tests/gateway/test_webhook_integration.py
+++ b/tests/gateway/test_webhook_integration.py
@@ -24,6 +24,7 @@ from gateway.config import (
 )
 from gateway.platforms.base import MessageEvent, SendResult
 from gateway.platforms.webhook import WebhookAdapter, _INSECURE_NO_AUTH
+from gateway.session import build_session_key
 
 
 # ---------------------------------------------------------------------------
@@ -35,7 +36,15 @@ def _make_adapter(routes, **extra_kw) -> WebhookAdapter:
     extra = {"host": "0.0.0.0", "port": 0, "routes": routes}
     extra.update(extra_kw)
     config = PlatformConfig(enabled=True, extra=extra)
-    return WebhookAdapter(config)
+    adapter = WebhookAdapter(config)
+    runner = MagicMock()
+    runner.adapters = {}
+    runner.config = GatewayConfig()
+    runner._session_key_for_source = lambda source: build_session_key(source)
+    runner.admit_webhook_turn = AsyncMock(return_value=True)
+    runner.async_session_store.clear_resume_pending = AsyncMock(return_value=True)
+    adapter.gateway_runner = runner
+    return adapter
 
 
 def _create_app(adapter: WebhookAdapter) -> web.Application:
@@ -134,13 +143,18 @@ class TestGitHubPRWebhook:
         await asyncio.sleep(0.05)
 
         assert len(captured_events) == 1
-        event = captured_events[0]
-        assert "Review PR #42 by contributor" in event.text
-        assert "Add webhook adapter" in event.text
-        assert event.source.chat_type == "webhook"
-        assert event.source.platform == Platform.WEBHOOK
-        assert "github-pr" in event.source.chat_id
-        assert event.message_id == "gh-delivery-001"
+        resume_event = captured_events[0]
+        admitted_event = (
+            adapter.gateway_runner.admit_webhook_turn.await_args.args[0]
+        )
+        assert resume_event.text == ""
+        assert resume_event.internal is True
+        assert "Review PR #42 by contributor" in admitted_event.text
+        assert "Add webhook adapter" in admitted_event.text
+        assert admitted_event.source.chat_type == "webhook"
+        assert admitted_event.source.platform == Platform.WEBHOOK
+        assert "github-pr" in admitted_event.source.chat_id
+        assert admitted_event.message_id == "gh-delivery-001"
 
 
 # ===================================================================
@@ -199,9 +213,11 @@ class TestSkillsInjection:
             await asyncio.sleep(0.05)
 
             assert len(captured_events) == 1
-            event = captured_events[0]
+            admitted_event = (
+                adapter.gateway_runner.admit_webhook_turn.await_args.args[0]
+            )
             # The prompt should be the skill content, not the raw template
-            assert "You are a code reviewer" in event.text
+            assert "You are a code reviewer" in admitted_event.text
             mock_build.assert_called_once()
 
 
@@ -234,6 +250,11 @@ class TestCrossPlatformDelivery:
         mock_runner.adapters = {Platform.TELEGRAM: mock_tg_adapter}
         mock_runner.config = GatewayConfig(
             platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")}
+        )
+        mock_runner._session_key_for_source = lambda source: build_session_key(source)
+        mock_runner.admit_webhook_turn = AsyncMock(return_value=True)
+        mock_runner.async_session_store.clear_resume_pending = AsyncMock(
+            return_value=True
         )
         adapter.gateway_runner = mock_runner
 

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -407,13 +407,7 @@ class TestWebhookEndpoints:
     def _setup(self, _isolate_hermes_home):
         self.client, _ = _client()
 
-    def test_list_disabled_and_create_blocked(self):
-        data = self.client.get("/api/webhooks").json()
-        assert data["enabled"] is False
-        r = self.client.post("/api/webhooks", json={"name": "gh", "deliver": "log"})
-        assert r.status_code == 400
-
-    def test_create_webhook_persists_script(self):
+    def _enable_webhook_platform(self):
         from hermes_cli.config import load_config, save_config
 
         cfg = load_config()
@@ -422,6 +416,15 @@ class TestWebhookEndpoints:
             "extra": {"host": "0.0.0.0", "port": 8644},
         }
         save_config(cfg)
+
+    def test_list_disabled_and_create_blocked(self):
+        data = self.client.get("/api/webhooks").json()
+        assert data["enabled"] is False
+        r = self.client.post("/api/webhooks", json={"name": "gh", "deliver": "log"})
+        assert r.status_code == 400
+
+    def test_create_webhook_persists_script(self):
+        self._enable_webhook_platform()
 
         r = self.client.post(
             "/api/webhooks",
@@ -436,6 +439,150 @@ class TestWebhookEndpoints:
 
         subs = self.client.get("/api/webhooks").json()["subscriptions"]
         assert subs[0]["script"] == "todoist_filter.py"
+
+    def test_create_and_list_project_exact_deliver_chat_id_without_list_secret(self):
+        """Authoritative secret-safe correlation binding for dashboard bootstrap.
+
+        Create stores deliver_extra.chat_id and must project the exact non-secret
+        deliver_chat_id on both create and list. The HMAC secret is one-time on
+        create only; list must never return secret or the raw deliver_extra bag.
+        """
+        import json as _json
+
+        self._enable_webhook_platform()
+
+        create = self.client.post(
+            "/api/webhooks",
+            json={
+                "name": "ella-synthetic",
+                "description": "Synthetic callback route",
+                "events": ["ella.synthetic"],
+                "prompt": "Return only the reviewed synthetic marker.",
+                "deliver": "ella_callback",
+                "deliver_only": False,
+                "deliver_chat_id": "{correlation_id}",
+                "skills": [],
+            },
+        )
+        assert create.status_code == 200
+        created = create.json()
+        assert created["deliver_chat_id"] == "{correlation_id}"
+        assert created["deliver"] == "ella_callback"
+        assert created["deliver_only"] is False
+        assert created["secret_set"] is True
+        assert isinstance(created.get("secret"), str) and len(created["secret"]) >= 32
+        assert "deliver_extra" not in created
+        one_time_secret = created["secret"]
+
+        listed = self.client.get("/api/webhooks").json()
+        assert listed["enabled"] is True
+        assert len(listed["subscriptions"]) == 1
+        route = listed["subscriptions"][0]
+        assert route["name"] == "ella-synthetic"
+        assert route["deliver_chat_id"] == "{correlation_id}"
+        assert route["deliver"] == "ella_callback"
+        assert route["deliver_only"] is False
+        assert route["secret_set"] is True
+        assert "secret" not in route
+        assert "deliver_extra" not in route
+        assert one_time_secret not in _json.dumps(listed)
+
+    def test_omitted_deliver_chat_id_does_not_invent_binding(self):
+        self._enable_webhook_platform()
+
+        create = self.client.post(
+            "/api/webhooks",
+            json={"name": "no-bind", "deliver": "log"},
+        )
+        assert create.status_code == 200
+        created = create.json()
+        assert created.get("deliver_chat_id") is None
+        assert "deliver_extra" not in created
+        assert isinstance(created.get("secret"), str) and len(created["secret"]) >= 32
+
+        route = self.client.get("/api/webhooks").json()["subscriptions"][0]
+        assert route.get("deliver_chat_id") is None
+        assert "secret" not in route
+        assert "deliver_extra" not in route
+
+    def test_malformed_deliver_extra_does_not_invent_binding(self):
+        """Summary must fail closed when stored deliver_extra is not a string chat_id."""
+        from hermes_cli.web_server import _webhook_route_summary
+
+        base = "http://localhost:8644"
+        cases = [
+            {},  # missing deliver_extra
+            {"deliver_extra": None},
+            {"deliver_extra": "not-a-dict"},
+            {"deliver_extra": ["{correlation_id}"]},
+            {"deliver_extra": {"chat_id": 12345}},
+            {"deliver_extra": {"chat_id": True}},
+            {"deliver_extra": {"chat_id": {"nested": "{correlation_id}"}}},
+            {"deliver_extra": {"other": "{correlation_id}"}},
+        ]
+        for route in cases:
+            summary = _webhook_route_summary("probe", route, base)
+            assert summary["deliver_chat_id"] is None, route
+            assert "secret" not in summary
+            assert "deliver_extra" not in summary
+
+        # Exact string binding is projected without rewrite.
+        exact = _webhook_route_summary(
+            "probe",
+            {"deliver_extra": {"chat_id": "{correlation_id}"}},
+            base,
+        )
+        assert exact["deliver_chat_id"] == "{correlation_id}"
+        assert "deliver_extra" not in exact
+
+    def test_webhook_subscriptions_file_remains_denylisted_from_managed_files(
+        self, monkeypatch
+    ):
+        """HMAC store stays inaccessible via managed-files; summaries must not leak it."""
+        import json as _json
+
+        from hermes_constants import get_hermes_home
+
+        self._enable_webhook_platform()
+        create = self.client.post(
+            "/api/webhooks",
+            json={
+                "name": "secret-route",
+                "deliver": "log",
+                "deliver_chat_id": "{correlation_id}",
+            },
+        )
+        assert create.status_code == 200
+        secret = create.json()["secret"]
+
+        home = get_hermes_home()
+        subs_path = home / "webhook_subscriptions.json"
+        assert subs_path.is_file()
+        on_disk = subs_path.read_text(encoding="utf-8")
+        assert secret in on_disk
+        assert "{correlation_id}" in on_disk
+
+        # Operator can point the managed root at HERMES_HOME; secret basenames
+        # must still be denylisted from list/read/download.
+        monkeypatch.setenv("HERMES_DASHBOARD_FILES_ROOT", str(home))
+
+        listing = self.client.get("/api/files", params={"path": str(home)})
+        assert listing.status_code == 200
+        names = [e["name"] for e in listing.json()["entries"]]
+        assert "webhook_subscriptions.json" not in names
+
+        read = self.client.get("/api/files/read", params={"path": str(subs_path)})
+        assert read.status_code == 403
+        download = self.client.get(
+            "/api/files/download", params={"path": str(subs_path)}
+        )
+        assert download.status_code == 403
+
+        listed = self.client.get("/api/webhooks").json()
+        dump = _json.dumps(listed)
+        assert secret not in dump
+        assert listed["subscriptions"][0]["deliver_chat_id"] == "{correlation_id}"
+        assert "secret" not in listed["subscriptions"][0]
 
     def test_enable_platform_starts_gateway_restart(self, monkeypatch):
         import hermes_cli.web_server as ws


### PR DESCRIPTION
## Summary

- add a strict, versioned terminal-delivery metadata envelope for webhook-origin turns
- mark only the completed response or terminal handler error, including streaming-final paths
- generate a server-owned immutable delivery ID after inbound webhook idempotency admission
- project only the validated terminal envelope across platform boundaries; interim/status sends remain unmarked

## Why

Webhook cross-platform delivery currently routes interim/status and final messages through the same target adapter without a deterministic finality signal. Downstream platform plugins therefore cannot consume exactly one completed turn without relying on text or timing heuristics.

## Validation

`uv run --extra dev --extra messaging python -m pytest -q tests/gateway/test_terminal_delivery_metadata.py tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_integration.py tests/gateway/test_stream_consumer_thread_routing.py`

125 passed.

The new tests cover multiple interim sends followed by one final marker, terminal errors, malformed metadata, missing server identity, and distinct accepted turns with identical content/correlation receiving distinct delivery IDs.