### PR TITLE
fix(photon): sidecar lifecycle cluster — crash recovery, event-loop, structured errors (salvage x7)

### DIFF
--- a/contributors/emails/spark@channel.inc
+++ b/contributors/emails/spark@channel.inc
@@ -1,0 +1,2 @@
+tom-channel
+# PR #72475 salvage

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10220,14 +10220,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         active = get_active_profile_name() or "default"
         connected = 0
-        # (platform, token-fingerprint) -> profile that claimed it. Detects two
-        # profiles trying to poll the same bot credential (impossible to do
-        # concurrently). Seed with the active profile's adapters.
+        # Resource claim -> profile that owns it. Credential claims prevent two
+        # profiles polling the same account; listener claims prevent sidecars
+        # with distinct credentials from binding the same endpoint.
         claimed: Dict[tuple, str] = {}
         for _plat, _ad in self.adapters.items():
             fp = self._adapter_credential_fingerprint(_ad)
             if fp is not None:
                 claimed[(_plat, fp)] = active
+            listener_claim = self._adapter_listener_claim(_plat, _ad)
+            if listener_claim is not None:
+                claimed[listener_claim] = active
 
         for profile_name, profile_home in profiles_to_serve(multiplex=True):
             if profile_name == active:
@@ -10353,6 +10356,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # adapter, shut down the primary profile's live sidecar.
                     continue
                 claimed[(platform, fp)] = profile_name
+
+            listener_claim = self._adapter_listener_claim(platform, adapter)
+            if listener_claim is not None:
+                owner = claimed.get(listener_claim)
+                if owner is not None:
+                    bind, port = listener_claim[-2:]
+                    logger.error(
+                        "Profile '%s' and '%s' both configure %s sidecars on "
+                        "%s:%s — refusing to start the duplicate listener. "
+                        "Set platforms.%s.extra.sidecar_port to a distinct port "
+                        "for profile '%s'.",
+                        owner,
+                        profile_name,
+                        platform.value,
+                        bind,
+                        port,
+                        platform.value,
+                        profile_name,
+                    )
+                    # Like credential conflicts, this adapter never connected
+                    # and owns no resources that should be disconnected.
+                    continue
+                claimed[listener_claim] = profile_name
 
             self._configure_profile_adapter(adapter, profile_name, platform)
 
@@ -10589,6 +10615,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return await self._handle_message(event)
 
         return _handler
+
+    @staticmethod
+    def _adapter_listener_claim(platform: Platform, adapter: Any) -> Optional[tuple]:
+        """Return the exclusive listener resource claimed by an adapter.
+
+        Photon sidecars are per-profile processes. Even when two profiles use
+        different project credentials, their sidecars cannot share a bind and
+        port. Represent that endpoint as a claim so multiplex startup rejects
+        the later adapter before either ``connect()`` or ``disconnect()`` can
+        disturb the first profile.
+        """
+        if getattr(platform, "value", None) != "photon":
+            return None
+        bind = getattr(adapter, "_sidecar_bind", None)
+        port = getattr(adapter, "_sidecar_port", None)
+        if not isinstance(bind, str) or not bind.strip():
+            return None
+        try:
+            port = int(port)
+        except (TypeError, ValueError):
+            return None
+        return ("listener", "photon", bind.strip().lower(), port)
 
     @staticmethod
     def _adapter_credential_fingerprint(adapter: Any) -> Optional[str]:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10342,12 +10342,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if owner is not None:
                     logger.error(
                         "Profile '%s' and '%s' both configure %s with the same "
-                        "credential — refusing to start the duplicate (a single "
-                        "bot token cannot be polled twice). Give each profile its "
-                        "own %s credential.",
+                        "credential — refusing to start the duplicate (one "
+                        "credential cannot be consumed twice). Give each profile "
+                        "its own %s credential.",
                         owner, profile_name, platform.value, platform.value,
                     )
-                    await self._safe_adapter_disconnect(adapter, platform)
+                    # This adapter has not connected and therefore owns no
+                    # resources to clean up. Calling disconnect here can mutate
+                    # the shared platform state and, for a same-credential Photon
+                    # adapter, shut down the primary profile's live sidecar.
                     continue
                 claimed[(platform, fp)] = profile_name
 
@@ -10591,13 +10594,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _adapter_credential_fingerprint(adapter: Any) -> Optional[str]:
         """Return a stable, log-safe fingerprint of an adapter's credential.
 
-        Used only to detect two profiles claiming the same bot token. Returns a
-        salted hash (never the token itself) of the adapter's primary
-        credential, or None when no credential is discoverable (in which case
-        we don't attempt conflict detection for it).
+        Used only to detect two profiles claiming the same platform credential.
+        Returns a salted hash (never the credential itself) of the adapter's
+        primary credential, or None when no credential is discoverable (in
+        which case we don't attempt conflict detection for it).
         """
         token = None
-        for attr in ("token", "bot_token", "_token", "api_token", "_bot_token"):
+        for attr in (
+            "token",
+            "bot_token",
+            "_token",
+            "api_token",
+            "_bot_token",
+            # Photon/Spectrum authenticates with project credentials instead
+            # of a bot token. Including its secret keeps multiplexed profiles
+            # from spawning competing sidecars for the same account and port.
+            "_project_secret",
+        ):
             val = getattr(adapter, attr, None)
             if isinstance(val, str) and val.strip():
                 token = val.strip()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10340,8 +10340,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             # Same-token conflict detection — refuse a duplicate poll.
             fp = self._adapter_credential_fingerprint(adapter)
-            if fp is not None:
-                owner = claimed.get((platform, fp))
+            credential_claim = (platform, fp) if fp is not None else None
+            if credential_claim is not None:
+                owner = claimed.get(credential_claim)
                 if owner is not None:
                     logger.error(
                         "Profile '%s' and '%s' both configure %s with the same "
@@ -10355,7 +10356,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # the shared platform state and, for a same-credential Photon
                     # adapter, shut down the primary profile's live sidecar.
                     continue
-                claimed[(platform, fp)] = profile_name
 
             listener_claim = self._adapter_listener_claim(platform, adapter)
             if listener_claim is not None:
@@ -10378,7 +10378,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # Like credential conflicts, this adapter never connected
                     # and owns no resources that should be disconnected.
                     continue
-                claimed[listener_claim] = profile_name
 
             self._configure_profile_adapter(adapter, profile_name, platform)
 
@@ -10389,6 +10388,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                 if success:
                     profile_map[platform] = adapter
+                    if credential_claim is not None:
+                        claimed[credential_claim] = profile_name
+                    if listener_claim is not None:
+                        claimed[listener_claim] = profile_name
                     connected += 1
                     logger.info("✓ %s connected (profile: %s)", platform.value, profile_name)
                 else:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8475,6 +8475,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 "config": platform_config,
                                 "attempts": 1,
                                 "next_retry": time.monotonic() + 30,
+                                "credential_claim": self._adapter_credential_claim(
+                                    platform, adapter
+                                ),
+                                "listener_claim": self._adapter_listener_claim(
+                                    platform, adapter
+                                ),
                             }
                     else:
                         self._update_platform_runtime_status(
@@ -8491,6 +8497,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "config": platform_config,
                             "attempts": 1,
                             "next_retry": time.monotonic() + 30,
+                            "credential_claim": self._adapter_credential_claim(
+                                platform, adapter
+                            ),
+                            "listener_claim": self._adapter_listener_claim(
+                                platform, adapter
+                            ),
                         }
             except Exception as e:
                 logger.error("✗ %s error: %s", platform.value, e)
@@ -8510,6 +8522,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "config": platform_config,
                     "attempts": 1,
                     "next_retry": time.monotonic() + 30,
+                    "credential_claim": self._adapter_credential_claim(
+                        platform, adapter
+                    ),
+                    "listener_claim": self._adapter_listener_claim(
+                        platform, adapter
+                    ),
                 }
             if await self._abort_startup_if_shutdown_requested():
                 return True
@@ -10231,6 +10249,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             listener_claim = self._adapter_listener_claim(_plat, _ad)
             if listener_claim is not None:
                 claimed[listener_claim] = active
+        # A retryable primary still owns its configured credential and listener.
+        # Reserve both while it is queued so a secondary cannot take the endpoint
+        # before the reconnect watcher retries the primary adapter.
+        for retry_info in getattr(self, "_failed_platforms", {}).values():
+            for claim_name in ("credential_claim", "listener_claim"):
+                retry_claim = retry_info.get(claim_name)
+                if isinstance(retry_claim, tuple):
+                    claimed[retry_claim] = active
 
         for profile_name, profile_home in profiles_to_serve(multiplex=True):
             if profile_name == active:
@@ -10339,8 +10365,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 continue
 
             # Same-token conflict detection — refuse a duplicate poll.
-            fp = self._adapter_credential_fingerprint(adapter)
-            credential_claim = (platform, fp) if fp is not None else None
+            credential_claim = self._adapter_credential_claim(platform, adapter)
             if credential_claim is not None:
                 owner = claimed.get(credential_claim)
                 if owner is not None:
@@ -10618,6 +10643,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return await self._handle_message(event)
 
         return _handler
+
+    @staticmethod
+    def _adapter_credential_claim(
+        platform: Platform, adapter: Any
+    ) -> Optional[tuple]:
+        """Return the exclusive credential resource claimed by an adapter."""
+        fingerprint = GatewayRunner._adapter_credential_fingerprint(adapter)
+        if fingerprint is None:
+            return None
+        return (platform, fingerprint)
 
     @staticmethod
     def _adapter_listener_claim(platform: Platform, adapter: Any) -> Optional[tuple]:

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -659,6 +659,47 @@ class PhotonAdapter(BasePlatformAdapter):
             self._http_client = None
         self._mark_disconnected()
 
+    def _dispatch_fatal_notification(self) -> None:
+        """Notify the gateway of a fatal error from a detached task.
+
+        ``_monitor_sidecar_health`` and ``_supervise_sidecar`` run as
+        ``self._sidecar_health_task`` / ``self._sidecar_supervisor_task`` and
+        used to call ``await self._notify_fatal_error()`` directly, on their
+        own call stack. That routes straight into
+        ``GatewayRunner._handle_adapter_fatal_error_impl``, which tears the
+        adapter down via ``_safe_adapter_disconnect`` -> ``disconnect()``.
+        ``disconnect()`` cancels ``self._sidecar_health_task`` and awaits it
+        to make sure it's really gone -- but when the *health task itself* is
+        what's driving this whole notification (the common case: the health
+        poll is what detected the fatal condition), that task IS the one
+        awaiting several frames up the stack, so ``disconnect()`` cancels and
+        awaits its own caller. ``disconnect()``'s
+        ``task is not asyncio.current_task()`` guard doesn't catch this,
+        because the wrapper task ``_await_adapter_cleanup_with_timeout``
+        creates around ``disconnect()`` (via ``asyncio.ensure_future``) is
+        the current task there, not the health/supervisor task further up
+        the plain-await chain. The self-cancellation throws an unhandled
+        ``CancelledError`` through the health/supervisor task with nothing
+        to catch it -- ``CancelledError`` stopped subclassing ``Exception``
+        in Python 3.8, so the ``except Exception`` around the notify call
+        never saw it -- and the task dies silently mid-handoff: no log line,
+        no retry, the platform stranded with no automated way back.
+
+        Dispatching the notification onto a brand-new task instead -- the
+        same pattern ``DiscordAdapter._handle_bot_task_done`` already uses --
+        means ``disconnect()`` can cancel the health/supervisor task freely
+        without that cancellation ever reaching back into the code that's
+        still running the handoff, so the handoff always reaches the
+        reconnect queue.
+        """
+        asyncio.create_task(self._notify_fatal_error_logged())
+
+    async def _notify_fatal_error_logged(self) -> None:
+        try:
+            await self._notify_fatal_error()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("[photon] fatal-error notification failed: %s", exc)
+
     # -- Inbound stream consumer ------------------------------------------
 
     async def _inbound_loop(self) -> None:
@@ -738,10 +779,7 @@ class PhotonAdapter(BasePlatformAdapter):
                 message,
                 retryable=True,
             )
-            try:
-                await self._notify_fatal_error()
-            except Exception as exc:  # pragma: no cover - defensive
-                logger.warning("[photon] fatal-error notification failed: %s", exc)
+            self._dispatch_fatal_notification()
             break
 
     async def _on_inbound_line(self, line: str) -> None:
@@ -1250,10 +1288,7 @@ class PhotonAdapter(BasePlatformAdapter):
                 f"Photon sidecar exited unexpectedly (code {exit_code})",
                 retryable=True,
             )
-            try:
-                await self._notify_fatal_error()
-            except Exception as exc:  # pragma: no cover - defensive
-                logger.warning("[photon] fatal-error notification failed: %s", exc)
+            self._dispatch_fatal_notification()
 
     async def _stop_sidecar(self) -> None:
         proc = self._sidecar_proc

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1199,7 +1199,14 @@ class PhotonAdapter(BasePlatformAdapter):
         from hermes_cli._subprocess_compat import windows_hide_flags
 
         try:
-            patch = subprocess.run(  # noqa: S603
+            # Off the event loop, for the same reason the dep reinstall above
+            # hops to a thread: this spawns node and *waits* for it (up to 10s).
+            # Run inline it holds the shared gateway loop for that whole window,
+            # so every other platform's traffic stalls — and _start_sidecar runs
+            # on every reconnect (connect(is_reconnect=True)), not just startup,
+            # so the stall recurs on a live gateway.
+            patch = await asyncio.to_thread(
+                subprocess.run,  # noqa: S603
                 [
                     self._node_bin,
                     str(_SIDECAR_DIR / "patch-spectrum-mixed-attachments.mjs"),

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1336,7 +1336,31 @@ class PhotonAdapter(BasePlatformAdapter):
             # standalone senders don't chase a dead port/token.
             _delete_runtime_record()
             if self._sidecar_supervisor_task is not None:
-                self._sidecar_supervisor_task.cancel()
+                # _stop_sidecar() is called both from external cleanup
+                # (Gateway shutdown, explicit disconnect) AND, indirectly,
+                # from WITHIN the supervisor task's own crash-handling
+                # chain: _supervise_sidecar() detects the sidecar exit,
+                # calls _set_fatal_error() + self._notify_fatal_error(),
+                # which the Gateway's fatal-error handler answers by
+                # calling adapter.disconnect() -> this same _stop_sidecar().
+                # In that second case, self._sidecar_supervisor_task IS the
+                # currently-running task. Cancelling it raises
+                # CancelledError into its own call stack (at the next
+                # await point in _notify_fatal_error() or here), which
+                # aborts the fatal-error handler before the Gateway ever
+                # reaches the "queue for background reconnection" step --
+                # Photon then stays permanently dead until a manual
+                # restart, since asyncio.CancelledError inherits from
+                # BaseException (not Exception) and isn't caught by the
+                # handler's `except Exception` guards (issue #73159).
+                # A task cannot legally cancel itself anyway (the
+                # cancellation would only take effect at its own next
+                # await, which is exactly the corruption described above),
+                # so skip it here and let the task finish exiting on its
+                # own instead.
+                current_task = asyncio.current_task()
+                if self._sidecar_supervisor_task is not current_task:
+                    self._sidecar_supervisor_task.cancel()
                 self._sidecar_supervisor_task = None
 
     # -- Outbound ----------------------------------------------------------

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -262,6 +262,11 @@ def _sidecar_error_from_response(
     error = str(data.get("error") or text[:200] or "sidecar error")
     error_class = str(data.get("error_class") or "sidecar_error")
     retryable = bool(data.get("retryable"))
+    if error_class == "target_not_allowed":
+        # Structured code path: replace whatever the sidecar echoed with the
+        # canonical user-facing explanation — never raw upstream error text.
+        error = _TARGET_NOT_ALLOWED_MESSAGE
+        retryable = False
     return PhotonSidecarError(
         path=path,
         status_code=status_code,
@@ -269,6 +274,14 @@ def _sidecar_error_from_response(
         error_class=error_class,
         retryable=retryable,
     )
+
+# User-facing explanation for the Spectrum "Target not allowed for this
+# project" AuthenticationError. Shared/free-tier lines can only reply to
+# conversations the target initiated; they cannot open new outbound threads.
+_TARGET_NOT_ALLOWED_MESSAGE = (
+    "shared/free-tier Photon lines cannot initiate outbound sends to new "
+    "targets — upgrade to a dedicated line or use another delivery channel"
+)
 
 def _coerce_port(value: Any, default: int) -> int:
     try:
@@ -1752,6 +1765,21 @@ class PhotonAdapter(BasePlatformAdapter):
             return False
         return any(pat in lowered for pat in _PHOTON_RETRYABLE_PATTERNS)
 
+    @staticmethod
+    def _is_permanent_sidecar_failure(result: SendResult) -> bool:
+        """True when the sidecar classified the failure as permanent.
+
+        ``auth_or_config`` and ``target_not_allowed`` cannot be fixed by
+        retrying or by the plain-text fallback resend — attempting either
+        just double-sends a doomed request (issue #50971).
+        """
+        raw = result.raw_response
+        return (
+            isinstance(raw, dict)
+            and raw.get("retryable") is False
+            and raw.get("error_class") in ("auth_or_config", "target_not_allowed")
+        )
+
     async def _send_with_retry(
         self,
         chat_id: str,
@@ -1777,12 +1805,12 @@ class PhotonAdapter(BasePlatformAdapter):
         if result.success:
             return result
 
-        sidecar_failure = result.raw_response
-        if (
-            isinstance(sidecar_failure, dict)
-            and sidecar_failure.get("error_class") == "auth_or_config"
-            and sidecar_failure.get("retryable") is False
-        ):
+        if self._is_permanent_sidecar_failure(result):
+            # Permanent failure classes: retrying cannot succeed and the
+            # unconditional plain-text fallback below would double-send the
+            # same doomed request. Return the structured failure as-is
+            # (with the user-facing explanation already attached for
+            # target_not_allowed in _sidecar_send).
             return result
 
         error_str = result.error or ""
@@ -1807,6 +1835,10 @@ class PhotonAdapter(BasePlatformAdapter):
                 if result.success:
                     return result
                 error_str = result.error or ""
+                if self._is_permanent_sidecar_failure(result):
+                    # A retry surfaced a permanent class — don't fall through
+                    # to the plain-text resend either.
+                    return result
                 if not (result.retryable or self._is_retryable_error(error_str)):
                     break
             else:
@@ -2037,6 +2069,32 @@ def _cache_inbound_attachment(
 # is not co-resident.  Reuses a live sidecar already listening on the
 # configured port (cron processes cannot spawn the sidecar themselves).
 
+def _standalone_error(resp: Any) -> Dict[str, Any]:
+    """Build the structured error dict for a failed standalone sidecar call.
+
+    Mirrors ``_sidecar_error_from_response``: parse the sidecar body
+    independently, carry the error class + retryability, and swap in the
+    canonical user-facing message for ``target_not_allowed`` (never the raw
+    upstream text).
+    """
+    try:
+        data = resp.json() or {}
+    except Exception:
+        data = {}
+    if not isinstance(data, dict):
+        data = {}
+    error_class = str(data.get("error_class") or "sidecar_error")
+    retryable = bool(data.get("retryable"))
+    if error_class == "target_not_allowed":
+        error = _TARGET_NOT_ALLOWED_MESSAGE
+        retryable = False
+    elif resp.status_code != 200:
+        error = f"sidecar returned {resp.status_code}: {resp.text[:200]}"
+    else:
+        error = str(data.get("error") or "sidecar reported failure")
+    return {"error": error, "error_class": error_class, "retryable": retryable}
+
+
 async def _standalone_send(
     pconfig: PlatformConfig,
     chat_id: str,
@@ -2097,10 +2155,10 @@ async def _standalone_send(
                     f"{base}/send", json=send_body, headers=headers,
                 )
                 if resp.status_code != 200:
-                    return {"error": f"sidecar returned {resp.status_code}: {resp.text[:200]}"}
+                    return _standalone_error(resp)
                 data = resp.json() or {}
                 if not data.get("ok"):
-                    return {"error": data.get("error") or "sidecar reported failure"}
+                    return _standalone_error(resp)
                 last_message_id = data.get("messageId")
 
             # 2. Each attachment as a separate /send-attachment call.
@@ -2125,10 +2183,10 @@ async def _standalone_send(
                     f"{base}/send-attachment", json=att_body, headers=headers,
                 )
                 if resp.status_code != 200:
-                    return {"error": f"sidecar returned {resp.status_code}: {resp.text[:200]}"}
+                    return _standalone_error(resp)
                 data = resp.json() or {}
                 if not data.get("ok"):
-                    return {"error": data.get("error") or "sidecar reported failure"}
+                    return _standalone_error(resp)
                 last_message_id = data.get("messageId") or last_message_id
 
         return {"success": True, "message_id": last_message_id}

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -637,14 +637,16 @@ class PhotonAdapter(BasePlatformAdapter):
                 except Exception:
                     pass
         if self._inbound_task is not None:
-            self._inbound_task.cancel()
-            try:
-                await self._inbound_task
-            except asyncio.CancelledError:
-                pass
-            except Exception:
-                pass
+            task = self._inbound_task
             self._inbound_task = None
+            task.cancel()
+            if task is not asyncio.current_task():
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                except Exception:
+                    pass
         # Cancel any pending U+FFFC placeholder tasks.
         for chat_key, (_, fffc_task) in list(self._pending_fffc.items()):
             if fffc_task and not fffc_task.done():

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1115,9 +1115,20 @@ class PhotonAdapter(BasePlatformAdapter):
                 )
         except httpx.RequestError:
             return  # nothing listening — the normal case
-        pids = self._find_listener_pids(self._sidecar_port)
-        stale = [pid for pid in pids if self._pid_is_sidecar(pid)]
-        foreign = [pid for pid in pids if pid not in stale]
+        # Off the event loop: _find_listener_pids shells out to `lsof`
+        # (timeout=5s) and _pid_is_sidecar runs a `ps` per candidate pid
+        # (timeout=5s each), so this inspection can hold the loop for
+        # 5 + 5·N seconds. _reap_stale_sidecar is awaited from
+        # _start_sidecar, which runs on every reconnect — exactly when a
+        # crashed gateway left an orphan behind — so the stall lands on a
+        # live gateway that is still serving every other platform. One hop
+        # covers the whole inspection instead of N+1 round trips.
+        def _inspect():
+            found = self._find_listener_pids(self._sidecar_port)
+            mine = [pid for pid in found if self._pid_is_sidecar(pid)]
+            return mine, [pid for pid in found if pid not in mine]
+
+        stale, foreign = await asyncio.to_thread(_inspect)
         if not stale:
             raise RuntimeError(
                 f"port {self._sidecar_port} is in use by another process "

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -223,6 +223,53 @@ _DEFAULT_MENTION_PATTERNS = [
 # ---------------------------------------------------------------------------
 # Module-level helpers — also used by check_fn / standalone send
 
+class PhotonSidecarError(RuntimeError):
+    """Structured failure returned by the supervised Photon sidecar."""
+
+    def __init__(
+        self,
+        *,
+        path: str,
+        status_code: int,
+        error: str,
+        error_class: str = "sidecar_error",
+        retryable: bool = False,
+    ) -> None:
+        self.path = path
+        self.status_code = status_code
+        self.error = error
+        self.error_class = error_class
+        self.retryable = retryable
+        super().__init__(
+            f"Photon sidecar {path} returned {status_code} "
+            f"({error_class}, retryable={retryable}): {error}"
+        )
+
+
+def _sidecar_error_from_response(
+    path: str,
+    status_code: int,
+    text: str,
+    data: Optional[Dict[str, Any]] = None,
+) -> PhotonSidecarError:
+    if data is None:
+        try:
+            parsed = json.loads(text)
+        except Exception:
+            parsed = {}
+        data = parsed if isinstance(parsed, dict) else {}
+
+    error = str(data.get("error") or text[:200] or "sidecar error")
+    error_class = str(data.get("error_class") or "sidecar_error")
+    retryable = bool(data.get("retryable"))
+    return PhotonSidecarError(
+        path=path,
+        status_code=status_code,
+        error=error,
+        error_class=error_class,
+        retryable=retryable,
+    )
+
 def _coerce_port(value: Any, default: int) -> int:
     try:
         return int(value)
@@ -1701,6 +1748,8 @@ class PhotonAdapter(BasePlatformAdapter):
         if not error:
             return False
         lowered = error.lower()
+        if "retryable=false" in lowered or "auth_or_config" in lowered:
+            return False
         return any(pat in lowered for pat in _PHOTON_RETRYABLE_PATTERNS)
 
     async def _send_with_retry(
@@ -1726,6 +1775,14 @@ class PhotonAdapter(BasePlatformAdapter):
             metadata=metadata,
         )
         if result.success:
+            return result
+
+        sidecar_failure = result.raw_response
+        if (
+            isinstance(sidecar_failure, dict)
+            and sidecar_failure.get("error_class") == "auth_or_config"
+            and sidecar_failure.get("retryable") is False
+        ):
             return result
 
         error_str = result.error or ""
@@ -1787,6 +1844,16 @@ class PhotonAdapter(BasePlatformAdapter):
             body["format"] = "markdown"
         try:
             data = await self._sidecar_call("/send", body)
+        except PhotonSidecarError as e:
+            return SendResult(
+                success=False,
+                error=str(e),
+                raw_response={
+                    "error_class": e.error_class,
+                    "retryable": e.retryable,
+                },
+                retryable=e.retryable,
+            )
         except Exception as e:
             return SendResult(success=False, error=str(e))
         self._record_sent_message(data.get("messageId"))
@@ -1836,6 +1903,16 @@ class PhotonAdapter(BasePlatformAdapter):
             body["caption"] = caption
         try:
             data = await self._sidecar_call("/send-attachment", body)
+        except PhotonSidecarError as e:
+            return SendResult(
+                success=False,
+                error=str(e),
+                raw_response={
+                    "error_class": e.error_class,
+                    "retryable": e.retryable,
+                },
+                retryable=e.retryable,
+            )
         except Exception as e:
             return SendResult(success=False, error=str(e))
         self._record_sent_message(data.get("messageId"))
@@ -1855,14 +1932,10 @@ class PhotonAdapter(BasePlatformAdapter):
         async with httpx.AsyncClient(timeout=30.0, trust_env=False) as client:
             resp = await client.post(url, json=body, headers=headers)
         if resp.status_code != 200:
-            raise RuntimeError(
-                f"Photon sidecar {path} returned {resp.status_code}: {resp.text[:200]}"
-            )
+            raise _sidecar_error_from_response(path, resp.status_code, resp.text)
         data = resp.json() or {}
         if not data.get("ok"):
-            raise RuntimeError(
-                f"Photon sidecar {path} reported error: {data.get('error')}"
-            )
+            raise _sidecar_error_from_response(path, resp.status_code, resp.text, data)
         return data
 
 

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -230,7 +230,6 @@ try {
       "Original error: " +
       (e && e.stack ? e.stack : String(e))
   );
-  process.exit(3);
 }
 let Spectrum,
   imessage,

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -596,13 +596,56 @@ function badRequest(res, msg) {
   res.end(JSON.stringify({ ok: false, error: msg }));
 }
 
-function serverError(res) {
+function classifySidecarError(err) {
+  const message = String(err && err.message ? err.message : err || "");
+  const lowered = message.toLowerCase();
+
+  if (
+    lowered.includes("unauthorized") ||
+    lowered.includes("forbidden") ||
+    lowered.includes("permission") ||
+    lowered.includes("401") ||
+    lowered.includes("403") ||
+    lowered.includes("invalid token") ||
+    lowered.includes("project secret") ||
+    lowered.includes("unable to resolve space id")
+  ) {
+    return { errorClass: "auth_or_config", retryable: false };
+  }
+
+  if (
+    lowered.includes("timeout") ||
+    lowered.includes("timed out") ||
+    lowered.includes("econnreset") ||
+    lowered.includes("econnrefused") ||
+    lowered.includes("socket hang up") ||
+    lowered.includes("fetch failed") ||
+    lowered.includes("unavailable") ||
+    lowered.includes("upstream connect") ||
+    lowered.includes("reset reason") ||
+    lowered.includes("overflow") ||
+    lowered.includes("temporarily") ||
+    lowered.includes("429")
+  ) {
+    return { errorClass: "upstream_transient", retryable: true };
+  }
+
+  return { errorClass: "sidecar_internal", retryable: false };
+}
+
+function serverError(res, err) {
   res.statusCode = 500;
   res.setHeader("Content-Type", "application/json");
+  const classified = classifySidecarError(err);
   // Don't leak stack traces or raw exception text to the caller — even
-  // though we listen on loopback, the supervisor logs the real error
-  // and the client only needs a generic failure signal.
-  res.end(JSON.stringify({ ok: false, error: "internal sidecar error" }));
+  // though we listen on loopback, the supervisor logs the real error. The
+  // Python adapter only needs a safe class plus retryability.
+  res.end(JSON.stringify({
+    ok: false,
+    error: "internal sidecar error",
+    error_class: classified.errorClass,
+    retryable: classified.retryable,
+  }));
 }
 
 function ok(res, data) {
@@ -847,7 +890,7 @@ const server = http.createServer(async (req, res) => {
     );
     // serverError() intentionally returns a generic message — see its
     // body for the rationale.
-    return serverError(res);
+    return serverError(res, e);
   }
 });
 

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -600,6 +600,15 @@ function classifySidecarError(err) {
   const message = String(err && err.message ? err.message : err || "");
   const lowered = message.toLowerCase();
 
+  // Spectrum raises AuthenticationError("Target not allowed for this
+  // project") from space.send when a shared/free-tier line tries to
+  // initiate an outbound conversation with a new target. That is a plan
+  // limitation, not a transient fault — surface a dedicated class so the
+  // adapter can explain it instead of retrying (issues #50971/#51897).
+  if (lowered.includes("target not allowed")) {
+    return { errorClass: "target_not_allowed", retryable: false };
+  }
+
   if (
     lowered.includes("unauthorized") ||
     lowered.includes("forbidden") ||

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -889,6 +889,61 @@ class TestSecondaryProfileConfigHandling:
         assert secondary.disconnected is False
         assert runner._profile_adapters["reviewer"][photon] is secondary
 
+    @pytest.mark.asyncio
+    async def test_failed_photon_connect_releases_listener_for_later_profile(
+        self, monkeypatch
+    ):
+        """A failed sidecar must not reserve an endpoint it never owned."""
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        class _PhotonAdapter:
+            def __init__(self, secret, should_connect):
+                self._project_secret = secret
+                self._sidecar_bind = "127.0.0.1"
+                self._sidecar_port = 8789
+                self.platform = Platform("photon")
+                self.should_connect = should_connect
+                self.disconnected = False
+                self.config = PlatformConfig(enabled=True)
+
+            def __getattr__(self, name):
+                if name.startswith("set_"):
+                    return lambda *args, **kwargs: None
+                raise AttributeError(name)
+
+            async def disconnect(self):
+                self.disconnected = True
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+        runner.session_store = None
+        runner._busy_text_mode = "queue"
+
+        photon = Platform("photon")
+        profile_cfg = GatewayConfig(multiplex_profiles=True)
+        profile_cfg.platforms = {photon: PlatformConfig(enabled=True)}
+        failed = _PhotonAdapter("failed-secret", False)
+        later = _PhotonAdapter("later-secret", True)
+        adapters = iter((failed, later))
+        claimed = {}
+
+        async def _connect(adapter, platform):
+            return adapter.should_connect
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: profile_cfg)
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: next(adapters))
+        monkeypatch.setattr(runner, "_connect_adapter_with_timeout", _connect)
+        monkeypatch.setattr(runner, "_make_adapter_auth_check", lambda p: None)
+
+        first = await runner._start_one_profile_adapters("broken", "/tmp/x", claimed)
+        second = await runner._start_one_profile_adapters("later", "/tmp/y", claimed)
+
+        assert first == 0
+        assert failed.disconnected is True
+        assert second == 1
+        assert runner._profile_adapters["later"][photon] is later
+
     def test_port_binding_set_covers_known_listeners(self):
         from gateway.run import _PORT_BINDING_PLATFORM_VALUES
         # Every adapter that binds a TCP port must be in the guard set.

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -783,6 +783,112 @@ class TestSecondaryProfileConfigHandling:
         assert duplicate.disconnected is False
         assert runner._profile_adapters["reviewer"] == {}
 
+    @pytest.mark.asyncio
+    async def test_secondary_distinct_photon_credentials_same_port_are_refused(
+        self, monkeypatch
+    ):
+        """The sidecar listener is exclusive even when credentials differ."""
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        class _PhotonAdapter:
+            def __init__(self, secret, port=8789):
+                self._project_secret = secret
+                self._sidecar_bind = "127.0.0.1"
+                self._sidecar_port = port
+                self.platform = Platform("photon")
+                self.connected = False
+                self.disconnected = False
+
+            async def connect(self):
+                self.connected = True
+                raise AssertionError("conflicting sidecar must not connect")
+
+            async def disconnect(self):
+                self.disconnected = True
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+
+        photon = Platform("photon")
+        reviewer_cfg = GatewayConfig(multiplex_profiles=True)
+        reviewer_cfg.platforms = {photon: PlatformConfig(enabled=True)}
+        primary = _PhotonAdapter("primary-secret")
+        duplicate = _PhotonAdapter("different-secret")
+        claimed = {
+            GatewayRunner._adapter_listener_claim(photon, primary): "default"
+        }
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: reviewer_cfg)
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: duplicate)
+
+        connected = await runner._start_one_profile_adapters(
+            "reviewer", "/tmp/x", claimed
+        )
+
+        assert connected == 0
+        assert duplicate.connected is False
+        assert duplicate.disconnected is False
+        assert runner._profile_adapters["reviewer"] == {}
+
+    @pytest.mark.asyncio
+    async def test_secondary_distinct_photon_credentials_distinct_ports_connect(
+        self, monkeypatch
+    ):
+        """Multiplexing remains supported when Photon sidecars cannot collide."""
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        class _PhotonAdapter:
+            def __init__(self, secret, port):
+                self._project_secret = secret
+                self._sidecar_bind = "127.0.0.1"
+                self._sidecar_port = port
+                self.platform = Platform("photon")
+                self.connected = False
+                self.disconnected = False
+                self.config = PlatformConfig(enabled=True)
+
+            def __getattr__(self, name):
+                if name.startswith("set_"):
+                    return lambda *args, **kwargs: None
+                raise AttributeError(name)
+
+            async def disconnect(self):
+                self.disconnected = True
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+        runner.session_store = None
+        runner._busy_text_mode = "queue"
+
+        photon = Platform("photon")
+        reviewer_cfg = GatewayConfig(multiplex_profiles=True)
+        reviewer_cfg.platforms = {photon: PlatformConfig(enabled=True)}
+        primary = _PhotonAdapter("primary-secret", 8789)
+        secondary = _PhotonAdapter("different-secret", 8790)
+        claimed = {
+            GatewayRunner._adapter_listener_claim(photon, primary): "default"
+        }
+
+        async def _connect(adapter, platform):
+            adapter.connected = True
+            return True
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: reviewer_cfg)
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: secondary)
+        monkeypatch.setattr(runner, "_connect_adapter_with_timeout", _connect)
+        monkeypatch.setattr(runner, "_make_adapter_auth_check", lambda p: None)
+
+        connected = await runner._start_one_profile_adapters(
+            "reviewer", "/tmp/x", claimed
+        )
+
+        assert connected == 1
+        assert secondary.connected is True
+        assert secondary.disconnected is False
+        assert runner._profile_adapters["reviewer"][photon] is secondary
+
     def test_port_binding_set_covers_known_listeners(self):
         from gateway.run import _PORT_BINDING_PLATFORM_VALUES
         # Every adapter that binds a TCP port must be in the guard set.

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -878,7 +878,9 @@ class TestSecondaryProfileConfigHandling:
         monkeypatch.setattr("gateway.config.load_gateway_config", lambda: reviewer_cfg)
         monkeypatch.setattr(runner, "_create_adapter", lambda p, c: secondary)
         monkeypatch.setattr(runner, "_connect_adapter_with_timeout", _connect)
-        monkeypatch.setattr(runner, "_make_adapter_auth_check", lambda p: None)
+        monkeypatch.setattr(
+            runner, "_make_adapter_auth_check", lambda p, **kwargs: None
+        )
 
         connected = await runner._start_one_profile_adapters(
             "reviewer", "/tmp/x", claimed
@@ -934,7 +936,9 @@ class TestSecondaryProfileConfigHandling:
         monkeypatch.setattr("gateway.config.load_gateway_config", lambda: profile_cfg)
         monkeypatch.setattr(runner, "_create_adapter", lambda p, c: next(adapters))
         monkeypatch.setattr(runner, "_connect_adapter_with_timeout", _connect)
-        monkeypatch.setattr(runner, "_make_adapter_auth_check", lambda p: None)
+        monkeypatch.setattr(
+            runner, "_make_adapter_auth_check", lambda p, **kwargs: None
+        )
 
         first = await runner._start_one_profile_adapters("broken", "/tmp/x", claimed)
         second = await runner._start_one_profile_adapters("later", "/tmp/y", claimed)
@@ -943,6 +947,50 @@ class TestSecondaryProfileConfigHandling:
         assert failed.disconnected is True
         assert second == 1
         assert runner._profile_adapters["later"][photon] is later
+
+    @pytest.mark.asyncio
+    async def test_failed_primary_photon_listener_is_reserved_for_retry(
+        self, monkeypatch
+    ):
+        """A retrying primary keeps secondaries off its sidecar endpoint."""
+        from gateway.config import GatewayConfig, Platform
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner.adapters = {}
+        runner._profile_adapters = {}
+        runner.pairing_stores = {}
+
+        photon = Platform("photon")
+        listener_claim = ("listener", "photon", "127.0.0.1", 8789)
+        runner._failed_platforms = {
+            photon: {
+                "config": object(),
+                "attempts": 1,
+                "next_retry": 0,
+                "listener_claim": listener_claim,
+            }
+        }
+        seen = {}
+
+        async def _start(profile_name, profile_home, claimed):
+            seen.update(claimed)
+            return 0
+
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profiles_to_serve",
+            lambda multiplex=True: (("default", "/tmp/default"), ("reviewer", "/tmp/reviewer")),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+        )
+        monkeypatch.setattr("gateway.status.write_runtime_status", lambda **kwargs: None)
+        monkeypatch.setattr(runner, "_start_one_profile_adapters", _start)
+
+        connected = await runner._start_secondary_profile_adapters()
+
+        assert connected == 0
+        assert seen[listener_claim] == "default"
 
     def test_port_binding_set_covers_known_listeners(self):
         from gateway.run import _PORT_BINDING_PLATFORM_VALUES

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -41,6 +41,22 @@ class TestCredentialFingerprint:
                 self.bot_token = "alt-token"
         assert GatewayRunner._adapter_credential_fingerprint(_AltAdapter()) is not None
 
+    def test_reads_photon_project_secret(self):
+        class _PhotonAdapter:
+            def __init__(self, secret):
+                self._project_secret = secret
+
+        fp1 = GatewayRunner._adapter_credential_fingerprint(
+            _PhotonAdapter("shared-project-secret")
+        )
+        fp2 = GatewayRunner._adapter_credential_fingerprint(
+            _PhotonAdapter("shared-project-secret")
+        )
+
+        assert fp1 == fp2
+        assert fp1 is not None
+        assert "shared-project-secret" not in fp1
+
     def test_reads_platform_config_token(self):
         class _Config:
             token = "config-token"
@@ -718,8 +734,10 @@ class TestSecondaryProfileConfigHandling:
         assert connect_calls == [(relay, Platform.RELAY)]
 
     @pytest.mark.asyncio
-    async def test_secondary_same_config_token_is_refused(self, monkeypatch):
-        """Adapters that keep their token on config still trip the mux guard."""
+    async def test_secondary_same_config_token_is_refused_without_disconnect(
+        self, monkeypatch
+    ):
+        """A never-connected duplicate must not disturb shared live state."""
         from gateway.config import GatewayConfig, Platform, PlatformConfig
 
         class _ConfigTokenAdapter:
@@ -762,7 +780,7 @@ class TestSecondaryProfileConfigHandling:
         )
 
         assert connected == 0
-        assert duplicate.disconnected is True
+        assert duplicate.disconnected is False
         assert runner._profile_adapters["reviewer"] == {}
 
     def test_port_binding_set_covers_known_listeners(self):

--- a/tests/plugins/platforms/photon/test_fatal_notify_self_cancel.py
+++ b/tests/plugins/platforms/photon/test_fatal_notify_self_cancel.py
@@ -1,0 +1,150 @@
+"""Photon's fatal-error notification must not be cancelled by its own teardown.
+
+`_monitor_sidecar_health` and `_supervise_sidecar` run as long-lived tasks on
+the adapter. When one of them detects a fatal condition, the gateway's handler
+tears the adapter down, and `disconnect()` cancels `_sidecar_health_task` and
+awaits it. If the notification is awaited inline on the health task's own call
+stack, `disconnect()` ends up cancelling its own ultimate caller: the
+`task is not asyncio.current_task()` guard in `disconnect()` compares against
+the wrapper task the gateway created around `disconnect()`, not the health task
+several plain-await frames further up, so the guard passes and the cancel lands.
+
+`CancelledError` stopped subclassing `Exception` in Python 3.8, so the
+`except Exception` that used to wrap the inline notify call never saw it. The
+health task died silently mid-handoff -- no log line, no retry -- and the
+platform stayed stranded until someone restarted the gateway by hand.
+
+PR #69112 hardened the shared dispatch path in `gateway/run.py` against a
+cancelled *caller*. These tests cover the Photon-specific self-cancellation one
+layer down, which that PR's scope could not reach.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.photon.adapter import PhotonAdapter
+
+
+def _make_adapter(monkeypatch: pytest.MonkeyPatch) -> PhotonAdapter:
+    monkeypatch.setenv("PHOTON_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("PHOTON_PROJECT_SECRET", "test-project-secret")
+    return PhotonAdapter(PlatformConfig(enabled=True, token="", extra={}))
+
+
+class TestFatalNotifyIsDetached:
+    """The notification must outlive cancellation of the task that raised it."""
+
+    @pytest.mark.asyncio
+    async def test_health_task_cancellation_does_not_kill_notification(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A fatal handler that cancels the health task (exactly what
+        ``disconnect()`` does) must still see the notification delivered."""
+        adapter = _make_adapter(monkeypatch)
+        adapter._inbound_running = True
+        adapter._sidecar_health_interval = 0
+        delivered = asyncio.Event()
+
+        async def fake_notify() -> None:
+            # Mirror the real handler: tear the adapter down, cancelling the
+            # health task, then finish the handoff.
+            await adapter.disconnect()
+            delivered.set()
+
+        monkeypatch.setattr(adapter, "_notify_fatal_error", fake_notify)
+        monkeypatch.setattr(adapter, "_stop_sidecar", lambda: _noop())
+
+        async def degraded(_path: str, _payload: Dict[str, Any]) -> Dict[str, Any]:
+            return {"stream": {"ok": False, "state": "degraded", "degradedForMs": 4000,
+                               "lastIssue": "stream persistently failing"}}
+
+        monkeypatch.setattr(adapter, "_sidecar_call", degraded)
+
+        health = asyncio.create_task(adapter._monitor_sidecar_health())
+        adapter._sidecar_health_task = health
+
+        await asyncio.wait_for(delivered.wait(), timeout=5.0)
+        assert adapter.has_fatal_error
+        assert adapter.fatal_error_code == "UPSTREAM_STREAM_DEGRADED"
+        assert adapter.fatal_error_retryable
+
+        # With the dispatch detached, the health task reaches its own `break`
+        # and returns cleanly instead of being cancelled out from under the
+        # handoff. Either way it must not die with an unhandled exception --
+        # that was the silent failure that stranded the platform.
+        await asyncio.wait_for(asyncio.shield(health), timeout=2.0)
+        assert health.done()
+        if not health.cancelled():
+            assert health.exception() is None
+
+    @pytest.mark.asyncio
+    async def test_dispatch_does_not_await_on_caller_stack(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``_dispatch_fatal_notification`` must return without awaiting, so a
+        cancel aimed at the calling task cannot reach the handoff."""
+        adapter = _make_adapter(monkeypatch)
+        started = asyncio.Event()
+        finished = asyncio.Event()
+
+        async def slow_notify() -> None:
+            started.set()
+            await asyncio.sleep(0.05)
+            finished.set()
+
+        monkeypatch.setattr(adapter, "_notify_fatal_error", slow_notify)
+
+        async def caller() -> None:
+            adapter._dispatch_fatal_notification()  # must not block
+
+        task = asyncio.create_task(caller())
+        await task  # returns immediately even though notify sleeps
+        await asyncio.wait_for(started.wait(), timeout=2.0)
+
+        task.cancel()  # cancelling the caller must not touch the notification
+        await asyncio.wait_for(finished.wait(), timeout=2.0)
+
+    @pytest.mark.asyncio
+    async def test_notification_failure_is_logged_not_raised(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A failing notification must warn rather than surface as an
+        unretrieved task exception."""
+        adapter = _make_adapter(monkeypatch)
+
+        async def boom() -> None:
+            raise RuntimeError("gateway unreachable")
+
+        monkeypatch.setattr(adapter, "_notify_fatal_error", boom)
+
+        with caplog.at_level("WARNING"):
+            await adapter._notify_fatal_error_logged()
+
+        assert "fatal-error notification failed" in caplog.text
+
+
+class TestBothCallSitesDetached:
+    """Neither fatal path may await the notification inline."""
+
+    def test_no_inline_notify_awaits_remain(self) -> None:
+        """Guard against a future edit reintroducing the inline await."""
+        import inspect
+
+        from plugins.platforms.photon import adapter as photon_adapter
+
+        for name in ("_monitor_sidecar_health", "_supervise_sidecar"):
+            src = inspect.getsource(getattr(photon_adapter.PhotonAdapter, name))
+            assert "await self._notify_fatal_error()" not in src, (
+                f"{name} awaits _notify_fatal_error inline; use "
+                f"_dispatch_fatal_notification() so disconnect() cannot cancel "
+                f"its own caller"
+            )
+            assert "_dispatch_fatal_notification()" in src
+
+
+async def _noop() -> None:
+    return None

--- a/tests/plugins/platforms/photon/test_overflow_recovery.py
+++ b/tests/plugins/platforms/photon/test_overflow_recovery.py
@@ -628,7 +628,7 @@ async def test_standalone_send_classifies_target_not_allowed(
     monkeypatch.setattr(photon_adapter.httpx, "AsyncClient", _FakeClient)
 
     result = await photon_adapter._standalone_send(
-        PlatformConfig(name="photon", enabled=True), "space-1", "hello",
+        PlatformConfig(enabled=True, extra={}), "space-1", "hello",
     )
 
     assert result.get("error") == photon_adapter._TARGET_NOT_ALLOWED_MESSAGE

--- a/tests/plugins/platforms/photon/test_overflow_recovery.py
+++ b/tests/plugins/platforms/photon/test_overflow_recovery.py
@@ -520,3 +520,118 @@ async def test_external_disconnect_still_cancels_supervisor(
         "External cleanup must still cancel a running supervisor task"
     )
     assert adapter._sidecar_supervisor_task is None
+
+
+# -- target_not_allowed: shared/free-tier outbound-send restriction ----------
+#
+# Spectrum throws AuthenticationError("Target not allowed for this project")
+# from space.send when a shared/free-tier line initiates an outbound send to
+# a new target. The sidecar classifies it as the structured code
+# `target_not_allowed`; the adapter must treat it as permanent in BOTH
+# _send_with_retry and _standalone_send, surfacing the canonical user-facing
+# message instead of raw upstream error text (issues #50971 / #51897).
+
+
+def test_target_not_allowed_maps_to_canonical_message() -> None:
+    err = photon_adapter._sidecar_error_from_response(
+        "/send",
+        500,
+        '{"ok":false,"error":"internal sidecar error",'
+        '"error_class":"target_not_allowed","retryable":false}',
+    )
+
+    assert err.error_class == "target_not_allowed"
+    assert err.retryable is False
+    assert err.error == photon_adapter._TARGET_NOT_ALLOWED_MESSAGE
+    # No raw upstream text may leak through the structured code path.
+    assert "Target not allowed for this project" not in str(err)
+
+
+def test_target_not_allowed_is_not_legacy_retryable() -> None:
+    error = str(
+        photon_adapter.PhotonSidecarError(
+            path="/send",
+            status_code=500,
+            error=photon_adapter._TARGET_NOT_ALLOWED_MESSAGE,
+            error_class="target_not_allowed",
+            retryable=False,
+        )
+    )
+
+    assert PhotonAdapter._is_retryable_error(error) is False
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_returns_immediately_on_target_not_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    calls = 0
+
+    async def _fake_sidecar_call(path: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        raise photon_adapter._sidecar_error_from_response(
+            path,
+            500,
+            '{"ok":false,"error":"internal sidecar error",'
+            '"error_class":"target_not_allowed","retryable":false}',
+        )
+
+    monkeypatch.setattr(adapter, "_sidecar_call", _fake_sidecar_call)
+
+    result = await adapter._send_with_retry("space-1", "hello", max_retries=3)
+
+    assert result.success is False
+    assert result.retryable is False
+    assert calls == 1, "permanent target_not_allowed must not be retried or resent"
+    assert photon_adapter._TARGET_NOT_ALLOWED_MESSAGE in (result.error or "")
+    assert isinstance(result.raw_response, dict)
+    assert result.raw_response.get("error_class") == "target_not_allowed"
+
+
+@pytest.mark.asyncio
+async def test_standalone_send_classifies_target_not_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PHOTON_SIDECAR_TOKEN", "token")
+
+    class _Resp:
+        status_code = 500
+        text = (
+            '{"ok":false,"error":"internal sidecar error",'
+            '"error_class":"target_not_allowed","retryable":false}'
+        )
+
+        @staticmethod
+        def json() -> Dict[str, Any]:
+            return {
+                "ok": False,
+                "error": "internal sidecar error",
+                "error_class": "target_not_allowed",
+                "retryable": False,
+            }
+
+    class _FakeClient:
+        def __init__(self, *a: Any, **k: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "_FakeClient":
+            return self
+
+        async def __aexit__(self, *a: Any) -> bool:
+            return False
+
+        async def post(self, *a: Any, **k: Any) -> _Resp:
+            return _Resp()
+
+    monkeypatch.setattr(photon_adapter.httpx, "AsyncClient", _FakeClient)
+
+    result = await photon_adapter._standalone_send(
+        PlatformConfig(name="photon", enabled=True), "space-1", "hello",
+    )
+
+    assert result.get("error") == photon_adapter._TARGET_NOT_ALLOWED_MESSAGE
+    assert result.get("error_class") == "target_not_allowed"
+    assert result.get("retryable") is False
+    assert "Target not allowed for this project" not in str(result)

--- a/tests/plugins/platforms/photon/test_overflow_recovery.py
+++ b/tests/plugins/platforms/photon/test_overflow_recovery.py
@@ -25,6 +25,8 @@ from typing import Any, Dict
 import pytest
 
 from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
+from plugins.platforms.photon import adapter as photon_adapter
 from plugins.platforms.photon.adapter import PhotonAdapter
 
 
@@ -61,6 +63,136 @@ def test_base_network_patterns_still_match() -> None:
     # The override delegates to the base classifier first, so generic
     # network strings keep working.
     assert PhotonAdapter._is_retryable_error("ConnectError: connection refused") is True
+
+
+def test_structured_non_retryable_sidecar_error_not_legacy_retried() -> None:
+    error = str(
+        photon_adapter.PhotonSidecarError(
+            path="/send",
+            status_code=500,
+            error="internal sidecar error",
+            error_class="auth_or_config",
+            retryable=False,
+        )
+    )
+
+    assert PhotonAdapter._is_retryable_error(error) is False
+
+
+@pytest.mark.asyncio
+async def test_structured_sidecar_retryable_error_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    adapter._http_client = object()
+    adapter._sidecar_bind = "127.0.0.1"
+    adapter._sidecar_port = 43210
+    adapter._sidecar_token = "token"
+
+    class _Resp:
+        status_code = 500
+        text = (
+            '{"ok":false,"error":"temporary upstream failure",'
+            '"error_class":"upstream_transient","retryable":true}'
+        )
+
+        @staticmethod
+        def json() -> Dict[str, Any]:
+            return {
+                "ok": False,
+                "error": "temporary upstream failure",
+                "error_class": "upstream_transient",
+                "retryable": True,
+            }
+
+    class _FakeClient:
+        def __init__(self, *a: Any, **k: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "_FakeClient":
+            return self
+
+        async def __aexit__(self, *a: Any) -> bool:
+            return False
+
+        async def post(self, *a: Any, **k: Any) -> _Resp:
+            return _Resp()
+
+    monkeypatch.setattr(photon_adapter.httpx, "AsyncClient", _FakeClient)
+
+    result = await adapter._sidecar_send("space-1", "hello")
+
+    assert result.success is False
+    assert result.retryable is True
+    assert "upstream_transient" in (result.error or "")
+    assert "temporary upstream failure" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_uses_structured_retryable_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    calls = 0
+    sleeps: list[float] = []
+
+    async def _fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    async def _fake_sidecar_call(path: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise photon_adapter.PhotonSidecarError(
+                path=path,
+                status_code=500,
+                error="temporary upstream failure",
+                error_class="upstream_transient",
+                retryable=True,
+            )
+        return {"ok": True, "messageId": "m-2"}
+
+    monkeypatch.setattr(photon_adapter.asyncio, "sleep", _fake_sleep)
+    monkeypatch.setattr(adapter, "_sidecar_call", _fake_sidecar_call)
+
+    result = await adapter._send_with_retry(
+        "space-1", "hello", max_retries=1, base_delay=0.25
+    )
+
+    assert result.success is True
+    assert result.message_id == "m-2"
+    assert calls == 2
+    assert sleeps == [0.25]
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_does_not_fallback_after_auth_or_config_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    calls = 0
+
+    async def _permanent_failure(**kwargs: Any) -> SendResult:
+        nonlocal calls
+        calls += 1
+        return SendResult(
+            success=False,
+            error="Photon sidecar /send returned 500 (auth_or_config)",
+            raw_response={
+                "error_class": "auth_or_config",
+                "retryable": False,
+            },
+            retryable=False,
+        )
+
+    monkeypatch.setattr(adapter, "send", _permanent_failure)
+
+    result = await adapter._send_with_retry(
+        "space-1", "hello", max_retries=2, base_delay=0
+    )
+
+    assert result.success is False
+    assert calls == 1
 
 
 # -- Gap 2: typing-indicator cooldown ---------------------------------------

--- a/tests/plugins/platforms/photon/test_overflow_recovery.py
+++ b/tests/plugins/platforms/photon/test_overflow_recovery.py
@@ -19,6 +19,7 @@ No Node sidecar is spawned and no ports are bound.
 """
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Dict
 
 import pytest
@@ -174,6 +175,10 @@ async def test_unexpected_sidecar_exit_raises_retryable_fatal(
     # than crashing the whole gateway.
     assert adapter.fatal_error_retryable is True
     assert adapter._running is False
+    # The notification is dispatched onto its own task rather than awaited on
+    # the supervisor's stack, so that disconnect() cancelling the supervisor
+    # cannot kill the handoff. Let that task run before asserting delivery.
+    await _drain_pending_tasks()
     assert notified == [True]
 
 
@@ -233,4 +238,25 @@ async def test_degraded_stream_health_raises_retryable_fatal(
     assert adapter.has_fatal_error is True
     assert adapter.fatal_error_code == "UPSTREAM_STREAM_DEGRADED"
     assert adapter.fatal_error_retryable is True
+    # Dispatched detached (see _dispatch_fatal_notification) so the health
+    # task's own teardown cannot cancel the handoff; drain before asserting.
+    await _drain_pending_tasks()
     assert notified == [True]
+
+
+async def _drain_pending_tasks(limit: int = 50) -> None:
+    """Let detached fatal-notification tasks finish before asserting on them.
+
+    ``_dispatch_fatal_notification`` deliberately does not await the
+    notification (that is what kept ``disconnect()`` from cancelling its own
+    caller), so a test that drives ``_monitor_sidecar_health`` /
+    ``_supervise_sidecar`` directly returns before the notification has run.
+    """
+    for _ in range(limit):
+        pending = [
+            t for t in asyncio.all_tasks()
+            if t is not asyncio.current_task() and not t.done()
+        ]
+        if not pending:
+            return
+        await asyncio.wait(pending, timeout=1.0)

--- a/tests/plugins/platforms/photon/test_overflow_recovery.py
+++ b/tests/plugins/platforms/photon/test_overflow_recovery.py
@@ -260,3 +260,131 @@ async def _drain_pending_tasks(limit: int = 50) -> None:
         if not pending:
             return
         await asyncio.wait(pending, timeout=1.0)
+
+
+# -- Gap 5: self-cancellation race in _stop_sidecar() (issue #73159) --------
+#
+# The tests above mock out _notify_fatal_error() entirely, so the real
+# integration chain (supervisor task -> _notify_fatal_error() ->
+# disconnect() -> _stop_sidecar() -> cancel the supervisor task) is never
+# exercised end to end. That chain is exactly where the bug lives: when
+# _notify_fatal_error() is a real callback that calls adapter.disconnect(),
+# _stop_sidecar() is invoked FROM WITHIN the currently-running supervisor
+# task, and cancelling self._sidecar_supervisor_task there cancels the very
+# task executing the fatal-error handler -- aborting it (via CancelledError,
+# a BaseException the handler's `except Exception` guards don't catch)
+# before the Gateway's reconnect-queue step ever runs.
+
+class _FakeStoppedProc:
+    """Minimal proc stand-in so _stop_sidecar() reaches its finally block
+    (it early-returns entirely when self._sidecar_proc is None) without
+    spawning a real subprocess or doing any real I/O."""
+
+    def __init__(self) -> None:
+        self.stdin = None
+
+    def wait(self, timeout: float | None = None) -> int:
+        return 0
+
+
+@pytest.mark.asyncio
+async def test_supervisor_task_survives_self_triggered_disconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real chain: _supervise_sidecar() (running as the actual
+    self._sidecar_supervisor_task) detects the crash and calls a REAL
+    _notify_fatal_error() that calls adapter.disconnect() -- which reaches
+    _stop_sidecar() from inside the task it's about to try to cancel.
+
+    Before the fix: this raises CancelledError out of _supervise_sidecar(),
+    so the task ends up in the "cancelled" state and reconnect_queued below
+    is never set (mirroring how the real Gateway's fatal-error handler,
+    which runs the reconnect-queue logic AFTER disconnect() returns, never
+    gets there either).
+
+    After the fix: disconnect() completes normally, _supervise_sidecar()
+    returns normally, and the task is NOT cancelled.
+    """
+    adapter = _make_adapter(monkeypatch)
+    adapter._inbound_running = True
+    # A minimal fake proc so _stop_sidecar() reaches its finally block
+    # (the real process-management behavior is covered separately by
+    # test_sidecar_lifecycle.py) -- this test is purely about the
+    # self-cancellation race.
+    adapter._sidecar_proc = _FakeStoppedProc()
+
+    reconnect_queued: list[bool] = []
+
+    async def _real_notify_fatal_error() -> None:
+        # Stand-in for the Gateway's actual fatal-error handler: it calls
+        # adapter.disconnect() (real chain: disconnect -> _stop_sidecar,
+        # which used to self-cancel), then -- only if that completes
+        # without the CancelledError escaping -- proceeds to queue the
+        # platform for background reconnection.
+        await adapter.disconnect()
+        reconnect_queued.append(True)
+
+    monkeypatch.setattr(adapter, "_notify_fatal_error", _real_notify_fatal_error)
+
+    async def _run_supervisor():
+        await adapter._supervise_sidecar(_DeadProc(exit_code=75))
+
+    task = asyncio.ensure_future(_run_supervisor())
+    adapter._sidecar_supervisor_task = task
+
+    # Must complete cleanly -- must NOT raise CancelledError out to us.
+    await task
+
+    assert task.cancelled() is False, (
+        "The supervisor task must not end up cancelled by its own "
+        "fatal-error handling chain"
+    )
+    assert adapter.has_fatal_error is True
+    assert adapter.fatal_error_code == "SIDECAR_CRASHED"
+    assert reconnect_queued == [True], (
+        "The reconnect-queue step (everything after disconnect() returns "
+        "in the real Gateway handler) must actually run -- this is the "
+        "exact step issue #73159 reports as silently skipped"
+    )
+    # _stop_sidecar() must have cleared the task reference either way.
+    assert adapter._sidecar_supervisor_task is None
+
+
+@pytest.mark.asyncio
+async def test_external_disconnect_still_cancels_supervisor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The OTHER call path -- external cleanup (Gateway shutdown, an
+    explicit /platform disconnect) -- calls _stop_sidecar() from a
+    DIFFERENT task than the supervisor. That legitimate case must still
+    cancel a still-running supervisor task exactly as before."""
+    adapter = _make_adapter(monkeypatch)
+    adapter._sidecar_proc = _FakeStoppedProc()
+
+    supervisor_ran_forever = asyncio.Event()
+
+    async def _hangs_forever():
+        try:
+            supervisor_ran_forever.set()
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            raise
+
+    task = asyncio.ensure_future(_hangs_forever())
+    adapter._sidecar_supervisor_task = task
+    await supervisor_ran_forever.wait()
+
+    # Called from THIS (different) task -- the external-cleanup case.
+    await adapter._stop_sidecar()
+
+    # cancel() only schedules the CancelledError; await it so the task
+    # actually settles into the cancelled state before asserting.
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    assert task.cancelled() is True, (
+        "External cleanup must still cancel a running supervisor task"
+    )
+    assert adapter._sidecar_supervisor_task is None

--- a/tests/plugins/platforms/photon/test_sidecar_lifecycle.py
+++ b/tests/plugins/platforms/photon/test_sidecar_lifecycle.py
@@ -206,3 +206,50 @@ async def test_start_sidecar_rejects_empty_node_modules(
 
     with pytest.raises(RuntimeError, match="not installed"):
         await adapter._start_sidecar()
+
+
+@pytest.mark.asyncio
+async def test_reap_inspects_listeners_off_the_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Listener inspection must not block the shared gateway event loop.
+
+    ``_find_listener_pids`` shells out to ``lsof`` (timeout=5s) and
+    ``_pid_is_sidecar`` runs a ``ps`` per candidate pid (timeout=5s each), so
+    inline this holds the loop for 5 + 5·N seconds. ``_reap_stale_sidecar`` is
+    awaited from ``_start_sidecar``, which runs on every reconnect — exactly
+    when a crashed gateway left an orphan — so the stall lands on a live
+    gateway still serving every other platform.
+    """
+    import threading
+
+    adapter = _make_adapter(monkeypatch)
+    monkeypatch.setattr(photon_adapter.sys, "platform", "linux")
+    monkeypatch.setattr(photon_adapter.httpx, "AsyncClient", _ProbeClient)
+
+    main_thread = threading.current_thread()
+    seen: Dict[str, Any] = {}
+
+    def _fake_find(port: int) -> List[int]:
+        seen["find"] = threading.current_thread()
+        return [4242]
+
+    def _fake_is_sidecar(pid: int) -> bool:
+        seen["ps"] = threading.current_thread()
+        return True
+
+    monkeypatch.setattr(adapter, "_find_listener_pids", _fake_find)
+    monkeypatch.setattr(adapter, "_pid_is_sidecar", _fake_is_sidecar)
+    monkeypatch.setattr(adapter, "_pid_alive", lambda pid: False)
+    _capture_kills(monkeypatch)
+
+    await adapter._reap_stale_sidecar()
+
+    assert seen.get("find") is not None, "lsof lookup never ran"
+    assert seen.get("ps") is not None, "ps check never ran"
+    for label in ("find", "ps"):
+        assert seen[label] is not main_thread, (
+            f"{label} ran on the event-loop thread; the listener inspection "
+            "must be dispatched via asyncio.to_thread so a 5s lsof/ps spawn "
+            "can't freeze every other platform on the gateway loop"
+        )

--- a/tests/plugins/platforms/photon/test_sidecar_lifecycle.py
+++ b/tests/plugins/platforms/photon/test_sidecar_lifecycle.py
@@ -253,3 +253,70 @@ async def test_reap_inspects_listeners_off_the_event_loop(
             "must be dispatched via asyncio.to_thread so a 5s lsof/ps spawn "
             "can't freeze every other platform on the gateway loop"
         )
+
+
+@pytest.mark.asyncio
+async def test_spectrum_patch_runs_off_the_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The node patch run must not block the shared gateway event loop.
+
+    ``_start_sidecar`` spawns the Spectrum patch script and *waits* for it
+    (``timeout=10``). Run inline it holds the loop for that whole window, so
+    every other platform's traffic stalls — and ``_start_sidecar`` runs on
+    every reconnect (``connect(is_reconnect=True)``), not just startup, so the
+    stall recurs on a live gateway. The dep reinstall a few lines above already
+    hops to a thread for exactly this reason; the patch run must too.
+    """
+    import threading
+
+    adapter = _make_adapter(monkeypatch)
+    main_thread = threading.current_thread()
+    seen: Dict[str, Any] = {}
+
+    # node_modules present + deps fresh, so we reach the patch run.
+    monkeypatch.setattr(photon_adapter.Path, "exists", lambda self: True)
+    monkeypatch.setattr(photon_adapter, "_sidecar_deps_stale", lambda: False)
+
+    async def _no_reap() -> None:
+        return None
+
+    monkeypatch.setattr(adapter, "_reap_stale_sidecar", _no_reap)
+
+    def _fake_run(*a: Any, **k: Any) -> Any:
+        seen["thread"] = threading.current_thread()
+
+        class _Done:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _Done()
+
+    monkeypatch.setattr(photon_adapter.subprocess, "run", _fake_run)
+
+    class _FakeProc:
+        pid = 4242
+        stdin = None
+        stdout = None
+
+        def poll(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        photon_adapter.subprocess, "Popen", lambda *a, **k: _FakeProc()
+    )
+
+    try:
+        await adapter._start_sidecar()
+    except Exception:
+        # Readiness/handshake past the patch run may fail under the fakes —
+        # irrelevant here; we only assert where the patch run executed.
+        pass
+
+    assert seen.get("thread") is not None, "patch run never executed"
+    assert seen["thread"] is not main_thread, (
+        "Spectrum patch subprocess ran on the event-loop thread; it must be "
+        "dispatched via asyncio.to_thread so a 10s node spawn can't freeze "
+        "every other platform on the gateway loop"
+    )

--- a/tests/plugins/platforms/photon/test_spectrum_patch.py
+++ b/tests/plugins/platforms/photon/test_spectrum_patch.py
@@ -1,27 +1,151 @@
 """Regression tests for Hermes' Spectrum mixed text+attachment workaround."""
+
 from __future__ import annotations
 
+import json
+import os
+import shutil
+import socket
 import subprocess
 import textwrap
+import time
+import urllib.request
 from pathlib import Path
 
 
 _PATCHER = Path("plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs")
 
 
-def test_sidecar_applies_spectrum_patch_before_importing_sdk() -> None:
-    """Existing installs should self-heal at runtime, not only during npm postinstall."""
-    index = Path("plugins/platforms/photon/sidecar/index.mjs").read_text(encoding="utf-8")
-    assert "import { patchSpectrumTs }" in index
-    assert "patchSpectrumTs();" in index
-    assert index.index("patchSpectrumTs();") < index.index('await import("spectrum-ts")')
+def _sidecar_env(port: int) -> dict[str, str]:
+    return {
+        **os.environ,
+        "PHOTON_PROJECT_ID": "test-project",
+        "PHOTON_PROJECT_SECRET": "test-secret",
+        "PHOTON_SIDECAR_PORT": str(port),
+        "PHOTON_SIDECAR_TOKEN": "test-token",
+    }
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _write_sidecar_fixture(tmp_path: Path, *, sdk_available: bool) -> Path:
+    sidecar = tmp_path / "sidecar"
+    sidecar.mkdir()
+    shutil.copyfile("plugins/platforms/photon/sidecar/index.mjs", sidecar / "index.mjs")
+    (sidecar / "patch-spectrum-mixed-attachments.mjs").write_text(
+        "export function patchSpectrumTs() { throw new Error('forced patch failure'); }\n",
+        encoding="utf-8",
+    )
+
+    if not sdk_available:
+        return sidecar
+
+    package = sidecar / "node_modules" / "spectrum-ts"
+    (package / "providers").mkdir(parents=True)
+    (package / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "spectrum-ts",
+                "type": "module",
+                "exports": {
+                    ".": "./index.js",
+                    "./providers/imessage": "./providers/imessage.js",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (package / "index.js").write_text(
+        textwrap.dedent(
+            """
+            export async function Spectrum() {
+              return {
+                messages: { [Symbol.asyncIterator]() { return { next: () => new Promise(() => {}) }; } },
+                stop: async () => undefined,
+              };
+            }
+            export const attachment = value => value;
+            export const voice = value => value;
+            export const text = value => value;
+            export const markdown = value => value;
+            export const typing = value => value;
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    (package / "providers" / "imessage.js").write_text(
+        "export function imessage() { return {}; }\nimessage.config = () => ({});\n",
+        encoding="utf-8",
+    )
+    return sidecar
+
+
+def test_sidecar_patch_failure_still_reaches_health_endpoint(tmp_path: Path) -> None:
+    """The compatibility patch is optional when the SDK itself remains usable."""
+    sidecar = _write_sidecar_fixture(tmp_path, sdk_available=True)
+    port = _free_port()
+    proc = subprocess.Popen(
+        ["node", "index.mjs"],
+        cwd=sidecar,
+        env=_sidecar_env(port),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{port}/healthz",
+        data=b"{}",
+        headers={"X-Hermes-Sidecar-Token": "test-token"},
+        method="POST",
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while True:
+            try:
+                with urllib.request.urlopen(request, timeout=0.5) as response:
+                    payload = json.load(response)
+                break
+            except OSError:
+                if proc.poll() is not None or time.monotonic() >= deadline:
+                    raise
+                time.sleep(0.05)
+
+        assert payload["ok"] is True
+        assert proc.poll() is None
+    finally:
+        proc.terminate()
+        _, stderr = proc.communicate(timeout=5)
+
+    assert "forced patch failure" in stderr
+
+
+def test_sidecar_missing_sdk_remains_fatal_after_patch_failure(tmp_path: Path) -> None:
+    sidecar = _write_sidecar_fixture(tmp_path, sdk_available=False)
+    result = subprocess.run(
+        ["node", "index.mjs"],
+        cwd=sidecar,
+        env=_sidecar_env(_free_port()),
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+
+    assert result.returncode == 3
+    assert "spectrum-ts is not installed" in result.stderr
 
 
 def test_sidecar_healthz_reports_stream_health() -> None:
     """Local process health must include upstream stream health."""
-    index = Path("plugins/platforms/photon/sidecar/index.mjs").read_text(encoding="utf-8")
+    index = Path("plugins/platforms/photon/sidecar/index.mjs").read_text(
+        encoding="utf-8"
+    )
     assert "function streamHealthSnapshot()" in index
-    assert 'return ok(res, { stream: streamHealthSnapshot() });' in index
+    assert "return ok(res, { stream: streamHealthSnapshot() });" in index
     assert "STREAM_INTERRUPTED_DEGRADE_COUNT" in index
     assert "process.exit(75);" in index
 
@@ -35,7 +159,9 @@ def test_sidecar_intercepts_both_console_channels() -> None:
     only console.error would miss every interrupt burst (the primary silent-
     inbound symptom), so both channels must be intercepted.
     """
-    index = Path("plugins/platforms/photon/sidecar/index.mjs").read_text(encoding="utf-8")
+    index = Path("plugins/platforms/photon/sidecar/index.mjs").read_text(
+        encoding="utf-8"
+    )
     assert "function classifyStreamLog(" in index
     assert "console.error = (...args) =>" in index
     assert "console.log = (...args) =>" in index
@@ -45,7 +171,9 @@ def test_sidecar_intercepts_both_console_channels() -> None:
 
 def test_sidecar_labels_catchup_internal_errors_as_upstream_photon() -> None:
     """Photon cloud stream failures should not look like local auth problems."""
-    index = Path("plugins/platforms/photon/sidecar/index.mjs").read_text(encoding="utf-8")
+    index = Path("plugins/platforms/photon/sidecar/index.mjs").read_text(
+        encoding="utf-8"
+    )
     assert "function inboundStreamErrorMessage" in index
     assert "EventService/CatchUpEvents" in index
     assert "this is upstream of Hermes" in index


### PR DESCRIPTION
## Summary
Consolidated Photon sidecar lifecycle salvage — the crash-recovery cluster. Sidecar failures now recover instead of stranding the platform: no more self-cancelled supervisors, fatal notifications that die with their caller, patch-failure boot aborts, event-loop stalls during spawn/reap, multi-profile port storms, or permanent auth failures retried (and double-sent) as generic 500s.

Salvages seven contributor PRs onto current main with authorship preserved: #61868 (@s00rz), #58047 (@tianma-if), #72475 (@tom-channel), #73170 (@ygd58), #66956 + #66940 (@Frowtek), #51193 (@westkite1201) — plus maintainer widening commits.

## Changes
- #61868: duplicate-sidecar-storm guard in gateway/run.py (multiplexed profiles both defaulting to port 8789).
- #58047: spectrum-patch failure is non-fatal — sidecar boots; SDK imports are independently guarded. Closes the live half of #58035.
- #72475: fatal-error notification dispatched from a detached task (Discord `_handle_bot_task_done` pattern) — reconnect handoff can't be cancelled mid-flight.
- #73170: `asyncio.current_task()` guard so `_stop_sidecar` can't cancel its own supervisor. Maintainer widening: same guard on the inbound-task cancel in `disconnect()` (same class).
- #66956/#66940: lsof/ps port inspection and the spectrum-patch `subprocess.run` moved off the gateway event loop.
- #51193 + maintainer rework: sidecar emits structured error classes instead of collapsing everything to `internal sidecar error`; `auth_or_config` returns before the fallback send (no more double-send on permanent failures); classification widened to `/send-attachment`, `/react`, `/typing` and `_standalone_send`; upstream `Target not allowed` mapped to a structured non-retryable `target_not_allowed` with a clear shared-line message (no raw provider text leaked).

## Validation
| | Result |
|---|---|
| Photon suite + targeted gateway tests | all passed, 0 failed |
| ruff on adapter.py | clean |
| Stale-base gate | 0 behind; diff = photon plugin + gateway/run.py + tests + mapping |

Fixes #73159. Fixes #50971. Fixes #52794 (outbound half; Desktop-stale half tracked separately).

## Infographic

![photon sidecar lifecycle](https://v3b.fal.media/files/b/0aa41913/RNmXWERVjcNrf6YnuLTHp_VsrUESEQ.png)
