### PR TITLE
fix(desktop): track gateway identity for model picker

### DIFF
--- a/apps/desktop/src/app/contrib/surfaces.gateway-profile.test.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.gateway-profile.test.tsx
@@ -1,0 +1,88 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesGateway } from '@/hermes'
+import { $gateway } from '@/store/gateway'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $gatewayState } from '@/store/session'
+
+import type * as RoutesModule from '../routes'
+
+import { ChatRoutesSurface } from './surfaces'
+
+const { modelMenuProps } = vi.hoisted(() => ({
+  modelMenuProps: [] as Array<{ gateway?: unknown; profile?: string }>
+}))
+
+vi.mock('@/contrib/react/use-contributions', () => ({ useContributions: vi.fn() }))
+vi.mock('../chat', () => ({
+  ChatView: ({ modelMenuContent }: { modelMenuContent?: React.ReactNode }) => <>{modelMenuContent}</>
+}))
+vi.mock('../routes', async importOriginal => {
+  const actual = await importOriginal<typeof RoutesModule>()
+
+  return {
+    ...actual,
+    contributedRoutes: () => [],
+    NEW_CHAT_ROUTE: '/',
+    ROUTES_AREA: 'routes',
+    sessionRoute: (id: string) => `/${id}`
+  }
+})
+vi.mock('../shell/model-menu-panel', () => ({
+  ModelMenuPanel: (props: { gateway?: unknown; profile?: string }) => {
+    modelMenuProps.push(props)
+
+    return <div data-testid="model-menu" />
+  }
+}))
+vi.mock('./latest-actions', () => ({
+  latestChatActions: () => ({}),
+  latestSidebarActions: () => ({})
+}))
+
+beforeEach(() => {
+  modelMenuProps.length = 0
+  $activeGatewayProfile.set('alpha')
+  $gatewayState.set('open')
+})
+
+afterEach(() => {
+  cleanup()
+  $gateway.set(null)
+  $activeGatewayProfile.set('default')
+  $gatewayState.set('closed')
+})
+
+describe('ChatRoutesSurface active-profile gateway', () => {
+  it('replaces the picker transport when the active profile changes open gateway -> open gateway', () => {
+    const alphaGateway = { id: 'alpha' } as unknown as HermesGateway
+    const betaGateway = { id: 'beta' } as unknown as HermesGateway
+
+    $gateway.set(alphaGateway)
+
+    const actions = {
+      getGateway: () => $gateway.get(),
+      requestGateway: vi.fn(),
+      selectModel: vi.fn()
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <ChatRoutesSurface actions={actions as never} />
+      </MemoryRouter>
+    )
+
+    expect(modelMenuProps.at(-1)).toMatchObject({ gateway: alphaGateway, profile: 'alpha' })
+
+    act(() => {
+      // A prewarmed profile is already open, so $gatewayState remains exactly
+      // 'open'. Only the active gateway object/profile change.
+      $gateway.set(betaGateway)
+      $activeGatewayProfile.set('beta')
+    })
+
+    expect(modelMenuProps.at(-1)).toMatchObject({ gateway: betaGateway, profile: 'beta' })
+  })
+})

--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -13,6 +13,8 @@ import { Navigate, Route, Routes, useParams } from 'react-router-dom'
 
 import { ContribBoundary } from '@/contrib/react/boundary'
 import { useContributions } from '@/contrib/react/use-contributions'
+import type { HermesGateway } from '@/hermes'
+import { $gateway } from '@/store/gateway'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $freshDraftReady, $gatewayState } from '@/store/session'
 
@@ -102,10 +104,10 @@ export const StatusbarSurface = memo(function StatusbarSurface({
 })
 
 /** The workspace pane: the real route table (chat + full-page views + plugin
- *  routes). Subscribes to `$gatewayState` and ROUTES_AREA itself; the gateway
- *  instance + voice cap arrive as props so a reconnect/config load re-renders
- *  only this surface. ChatView subscribes to its own session atoms, so
- *  streaming never round-trips through the controller. */
+ *  routes). Subscribes to `$gateway`, `$gatewayState`, and ROUTES_AREA itself;
+ *  the voice cap arrives as a prop so a config load re-renders only this
+ *  surface. ChatView subscribes to its own session atoms, so streaming never
+ *  round-trips through the controller. */
 export const ChatRoutesSurface = memo(function ChatRoutesSurface({
   actions,
   maxVoiceRecordingSeconds
@@ -114,18 +116,12 @@ export const ChatRoutesSurface = memo(function ChatRoutesSurface({
   maxVoiceRecordingSeconds?: number
 }) {
   const activeGatewayProfile = useStore($activeGatewayProfile)
+  // Gateway identity is not implied by connection state: a prewarmed profile
+  // swap can replace one open gateway with another while state remains "open".
+  const gateway = useStore($gateway) as HermesGateway | null
   const gatewayState = useStore($gatewayState)
   useContributions(ROUTES_AREA)
   const routeContributions = contributedRoutes()
-
-  // Recapture the live gateway instance whenever the connection state flips.
-  // getGateway reads a controller ref, so gatewayState is the intentional
-  // re-eval trigger (not a value the computation itself reads).
-  const gateway = useMemo(
-    () => actions.getGateway(),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [actions, gatewayState]
-  )
 
   const modelMenuContent = useMemo(
     () =>


### PR DESCRIPTION
## Bug Description

After relaunching Hermes Desktop, the model picker could intermittently show only the current model instead of all previously selected models.

## Root Cause

`ChatRoutesSurface` captured the gateway with `actions.getGateway()` inside a memo keyed by the coarse `gatewayState` value. During profile restoration or a prewarmed profile swap, the app can replace one already-open gateway with another while `gatewayState` remains `"open"`. The memo therefore kept rendering the picker with the previous gateway object while the active profile had already moved on, causing the picker to intersect persisted model selections with the wrong/stale catalog.

## Fix

- Subscribe `ChatRoutesSurface` directly to the reactive `$gateway` atom so gateway identity changes always re-render the route surface.
- Remove the stale `actions.getGateway()` memo keyed by connection state.
- Add a regression test covering an `open gateway A/profile A -> open gateway B/profile B` transition.

## How to Verify

1. Mount the route surface with gateway/profile `alpha` in state `open`.
2. Replace the active gateway/profile with `beta` while keeping state `open`.
3. Confirm the model menu receives gateway/profile `beta`, not stale gateway `alpha`.

## Test Plan

- [x] Added regression test for this bug
- [x] Existing tests still pass
- [ ] Manual verification of the fix

Validated with:

```bash
npx vitest run src/app/contrib/surfaces.gateway-profile.test.tsx src/app/shell/model-menu-panel.test.tsx src/store/model-visibility.test.ts
npx tsc -p . --noEmit
npx tsc -p tsconfig.electron.json --noEmit
npx tsc -p tsconfig.e2e.json --noEmit
npx eslint src/app/contrib/surfaces.tsx src/app/contrib/surfaces.gateway-profile.test.tsx
git diff --check
```

## Risk Assessment

Low — renderer-only change limited to the workspace route surface. It replaces an indirect gateway capture with the already-reactive gateway atom used elsewhere; no backend API, persistence format, or model visibility state changes.
