### PR TITLE
fix(auth): honor built-in provider api_key config

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -576,12 +576,30 @@ def has_usable_secret(value: Any, *, min_length: int = 4) -> bool:
     return True
 
 
+def _configured_api_key_provider_secret(provider_id: str) -> tuple[str, str]:
+    """Return a usable inline key from ``providers.<id>``, if configured."""
+    try:
+        from hermes_cli.config import load_config
+
+        providers = load_config().get("providers")
+        entry = providers.get(provider_id) if isinstance(providers, dict) else None
+        configured_key = entry.get("api_key") if isinstance(entry, dict) else None
+        if has_usable_secret(configured_key):
+            return configured_key.strip(), f"config:providers.{provider_id}.api_key"
+    except Exception:
+        # Preserve env/pool fallback when config is temporarily unreadable.
+        pass
+    return "", ""
+
+
 def _resolve_api_key_provider_secret(
     provider_id: str, pconfig: ProviderConfig
 ) -> tuple[str, str]:
     """Resolve an API-key provider's token and indicate where it came from."""
     if provider_id == "copilot":
-        # Use the dedicated copilot auth module for proper token validation
+        # Copilot credentials are raw GitHub tokens, not inference bearer
+        # tokens. Always exchange them through the dedicated resolver instead
+        # of treating providers.copilot.api_key as a direct API credential.
         try:
             from hermes_cli.copilot_auth import resolve_copilot_token, get_copilot_api_token
             token, source = resolve_copilot_token()
@@ -593,6 +611,14 @@ def _resolve_api_key_provider_secret(
         except Exception:
             pass
         return "", ""
+
+    # ``providers.<id>`` is also the supported configuration surface for
+    # built-in providers.  Resolve an inline key there before the provider's
+    # conventional env vars and credential pool so an explicit config choice
+    # cannot be silently replaced by an ambient shell credential.
+    configured_key, configured_source = _configured_api_key_provider_secret(provider_id)
+    if configured_key:
+        return configured_key, configured_source
 
     from hermes_cli.config import get_env_value_prefer_dotenv
     for env_var in pconfig.api_key_env_vars:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -364,6 +364,27 @@ def _model_level_key_env(provider_id: str) -> str:
     return str(model_cfg.get("key_env") or model_cfg.get("api_key_env") or "").strip()
 
 
+def _configured_api_key_provider_secret(provider_id: str) -> tuple[str, str]:
+    """Return a usable inline key from ``providers.<id>``, if configured."""
+    try:
+        from hermes_cli.config import load_config
+
+        providers = load_config().get("providers")
+        entry = providers.get(provider_id) if isinstance(providers, dict) else None
+        configured_key = entry.get("api_key") if isinstance(entry, dict) else None
+        configured_key = _usable_declared_secret(
+            provider_id,
+            configured_key,
+            f"config:providers.{provider_id}.api_key",
+        )
+        if configured_key:
+            return configured_key, f"config:providers.{provider_id}.api_key"
+    except Exception:
+        # Preserve env/pool fallback when config is temporarily unreadable.
+        pass
+    return "", ""
+
+
 def _resolve_api_key_provider_secret(provider_id: str, pconfig: ProviderConfig) -> tuple[str, str]:
     """Resolve an API-key provider's token and indicate where it came from."""
     if provider_id == "copilot":
@@ -379,6 +400,14 @@ def _resolve_api_key_provider_secret(provider_id: str, pconfig: ProviderConfig) 
         except Exception:
             pass
         return "", ""
+
+    # ``providers.<id>`` is also the supported configuration surface for
+    # built-in providers. Resolve an inline key there before the provider's
+    # conventional env vars and credential pool so an explicit config choice
+    # cannot be silently replaced by an ambient shell credential.
+    configured_key, configured_source = _configured_api_key_provider_secret(provider_id)
+    if configured_key:
+        return configured_key, configured_source
 
     # Prefer ~/.hermes/.env over os.environ so a deliberate key rotation in .env isn't shadowed by
     # a stale shell export inherited from a parent process (Codex CLI, test runners, etc.).

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -500,8 +500,23 @@ def _refresh_nous_pool_entry(pool: CredentialPool, entry: Any, pool_api_key: str
 def _resolve_from_pool(provider: str, requested_provider: str, model_cfg: Dict[str, Any], explicit_api_key, explicit_base_url,
                        target_model) -> Optional[Dict[str, Any]]:
     """Runtime from the provider's credential pool, or None to continue down the ladder."""
-    should_use_pool = provider != "openrouter" or _openrouter_should_use_pool(requested_provider, model_cfg, explicit_api_key,
-                                                                             explicit_base_url)
+    configured_api_key = ""
+    pconfig = PROVIDER_REGISTRY.get(provider)
+    if pconfig and pconfig.auth_type == "api_key" and provider != "copilot":
+        configured_api_key, _ = auth_mod._configured_api_key_provider_secret(provider)
+
+    # API-key providers can have an explicit inline key under
+    # ``providers.<id>``. It must take precedence over a credential-pool
+    # entry, which may have been seeded from an ambient environment variable.
+    should_use_pool = not configured_api_key and (
+        provider != "openrouter"
+        or _openrouter_should_use_pool(
+            requested_provider,
+            model_cfg,
+            explicit_api_key,
+            explicit_base_url,
+        )
+    )
     try:
         pool = load_pool(provider) if should_use_pool else None
     except Exception:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1805,7 +1805,15 @@ def resolve_runtime_provider(
     if explicit_runtime:
         return explicit_runtime
 
-    should_use_pool = provider != "openrouter"
+    configured_api_key = ""
+    pconfig = PROVIDER_REGISTRY.get(provider)
+    if pconfig and pconfig.auth_type == "api_key" and provider != "copilot":
+        configured_api_key, _ = auth_mod._configured_api_key_provider_secret(provider)
+
+    # API-key providers can have an explicit inline key under
+    # ``providers.<id>``.  It must take precedence over a credential-pool
+    # entry, which may have been seeded from an ambient environment variable.
+    should_use_pool = provider != "openrouter" and not configured_api_key
     if provider == "openrouter":
         cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
         cfg_base_url = str(model_cfg.get("base_url") or "").strip()

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from hermes_constants import get_hermes_home
 from hermes_cli import runtime_provider as rp
 
 
@@ -28,6 +29,51 @@ def test_configured_api_key_provider_without_key_fails_closed(monkeypatch):
 
     with pytest.raises(rp.AuthError, match="No usable credentials.*deepseek"):
         rp.resolve_runtime_provider()
+
+
+def test_builtin_provider_config_api_key_precedes_environment(monkeypatch):
+    """An explicit built-in provider key in config.yaml wins over its env key."""
+    (get_hermes_home() / "config.yaml").write_text(
+        "providers:\n"
+        "  deepseek:\n"
+        "    api_key: configured-deepseek-key\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "environment-deepseek-key")
+
+    from hermes_cli.config import load_config
+
+    assert load_config()["providers"]["deepseek"]["api_key"] == "configured-deepseek-key"
+    resolved = rp.resolve_runtime_provider(requested="deepseek")
+
+    assert resolved["provider"] == "deepseek"
+    assert resolved["base_url"] == "https://api.deepseek.com/v1"
+    assert resolved["api_key"] == "configured-deepseek-key"
+    assert resolved["source"] == "config:providers.deepseek.api_key"
+
+
+def test_copilot_config_api_key_does_not_bypass_token_exchange(monkeypatch):
+    """Copilot config values must not be used as direct inference tokens."""
+    (get_hermes_home() / "config.yaml").write_text(
+        "providers:\n"
+        "  copilot:\n"
+        "    api_key: configured-github-token\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: None)
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.resolve_copilot_token",
+        lambda: ("gho-raw-github-token", "GH_TOKEN"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.get_copilot_api_token",
+        lambda _token: ("exchanged-copilot-token", None),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="copilot")
+
+    assert resolved["api_key"] == "exchanged-copilot-token"
+    assert resolved["source"] == "GH_TOKEN"
 
 
 def test_noauth_lmstudio_still_resolves(monkeypatch):


### PR DESCRIPTION
## What changed and why

Per the follow-up discussion, this refreshes the narrow authentication behavior from closed #21743: a usable inline `providers.<id>.api_key` takes precedence over provider environment variables and credential-pool entries when resolving a canonical built-in API-key provider. This fixes the DeepSeek configuration path in #21725 without changing `key_env`, base-URL overrides, or model-catalog routing.

## Addressing maintainer feedback

- #19519 (closed) is the related duplicate identified by the maintainer; this addresses the shared built-in inline-`api_key` resolution defect.
- #19565 (merged) improved the authentication error message, but did not change credential-resolution precedence; this remains a complementary fix.

## How to test

- `pytest tests/hermes_cli/test_runtime_provider_resolution.py -q -x --timeout=60`
- `pytest tests/hermes_cli/test_api_key_providers.py -q -x --timeout=60`
- The new regression writes `providers.deepseek.api_key` to an isolated `HERMES_HOME`, also supplies `DEEPSEEK_API_KEY`, and verifies runtime resolution uses the configured key.

## What platforms tested on

- macOS (local development environment)

Fixes #21725

<!-- autocontrib:worker-id=issue-followup-0ff8925d kind=pr-open -->