### PR TITLE
chore: map contributor email for AtakanGs

### DIFF
--- a/contributors/emails/atakan1705@hotmail.com
+++ b/contributors/emails/atakan1705@hotmail.com
@@ -1,0 +1,1 @@
+AtakanGs


### PR DESCRIPTION
## Summary
Maps `atakan1705@hotmail.com` → `@AtakanGs` in `contributors/emails/` so the check-attribution gate passes on the 15 open PRs from this contributor currently going through CI.

## Changes
- `contributors/emails/atakan1705@hotmail.com`: new mapping file (via `scripts/add_contributor.py`)

## Validation
Check contributors / check-attribution failed on PR #72285 with "Unmapped contributor email(s): atakan1705@hotmail.com (Atakan)". This mapping is the documented fix.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa41973/ArHBxeK9ysgvIlzFl5cky_wiBpNQwH.png)
