### PR TITLE
fix(gateway): pass finalize=True in got_done fallback for draft streaming

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1003,7 +1003,9 @@ class GatewayStreamConsumer:
                                 # not duplicate the visible prefix.
                                 await self._send_fallback_final(self._accumulated)
                         elif not self._already_sent:
-                            self._final_response_sent = await self._send_or_edit(self._accumulated)
+                            self._final_response_sent = await self._send_or_edit(
+                                self._accumulated, finalize=True,
+                            )
                             if self._final_response_sent:
                                 self._final_content_delivered = True
                     return

--- a/tests/gateway/test_stream_consumer_draft.py
+++ b/tests/gateway/test_stream_consumer_draft.py
@@ -208,6 +208,59 @@ class TestDraftFallbackOnFailure:
         # Final message delivered via the regular send path.
         adapter.send.assert_awaited()
 
+    @pytest.mark.asyncio
+    async def test_got_done_fallback_sends_real_message_not_draft_after_primary_send_fails(self):
+        """When the primary finalize send fails (network blip / proxy drop)
+        and the got_done handler falls through to the _already_sent guard,
+        the fallback must send a real message via adapter.send, never another
+        ephemeral draft.  Regression test for #68313 (PR #48438)."""
+        adapter = _make_draft_capable_adapter()
+        # First adapter.send call (primary finalize at line 941) fails.
+        # Second call (fallback at line 1005) succeeds after fix adds finalize=True.
+        adapter.send = AsyncMock(side_effect=[
+            SimpleNamespace(success=False, error="timeout"),
+            SimpleNamespace(success=True, message_id="msg_fallback"),
+        ])
+        cfg = StreamConsumerConfig(
+            transport="auto", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=5, cursor="",
+        )
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+
+        consumer.on_delta("Streaming ")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.on_delta("response")
+        await asyncio.sleep(0.05)
+        # Capture mid-stream draft count before finish() so we can assert
+        # the got_done fallback did NOT send additional drafts.
+        draft_count_before_finish = len(adapter.draft_calls)
+        consumer.finish()
+        await task
+
+        # Drafts animated mid-stream.
+        assert draft_count_before_finish >= 1, (
+            "expected at least one send_draft frame mid-stream"
+        )
+        # adapter.send was called twice: primary failure + fallback success.
+        assert adapter.send.await_count == 2
+        # The second send (fallback) delivered the full accumulated text as a
+        # real message, not an ephemeral draft.
+        final_call = adapter.send.call_args_list[1]
+        sent_content = (
+            final_call.kwargs.get("content")
+            if "content" in final_call.kwargs
+            else final_call.args[1] if len(final_call.args) > 1 else None
+        )
+        assert sent_content == "Streaming response"
+        # Delivery flags are set correctly after fallback succeeds.
+        assert consumer._final_response_sent is True
+        assert consumer._final_content_delivered is True
+        # No extra draft frames were sent during the fallback.
+        assert len(adapter.draft_calls) == draft_count_before_finish, (
+            "fallback must not send additional drafts after the primary send fails"
+        )
+
 
 class TestDraftIdLifecycle:
     """Each response gets its own draft_id (no animation collision across


### PR DESCRIPTION
## Summary

When draft streaming is active on Telegram and the primary finalize send fails (network blip, proxy drop, API timeout), the got_done fallback at line 1005 calls `_send_or_edit()` **without** `finalize=True`. This re-enters the draft path (`_send_draft_frame`) instead of sending a real `sendMessage` — the draft clears, the message flickers away.

## Root cause

The flood-recovery commits that landed between v0.18.2 and v0.19.0 restructured the got_done handler into a complex if/elif chain. The final `elif not self._already_sent` branch was not given `finalize=True`.

## Fix

Pass `finalize=True` so the fallback always sends a real message via `adapter.send`.

## Test

New async test in `TestDraftFallbackOnFailure`: primary finalize send fails with timeout, got_done fallback triggers. Asserts:
- Fallback sends a real message (not another draft)
- No extra draft frames during fallback
- Full accumulated text delivered
- Correct delivery flags set

## Verification

```
166 passed in 9.88s
  - tests/gateway/test_stream_consumer.py (137)
  - tests/gateway/test_stream_consumer_draft.py (19, including new test)
  - tests/gateway/test_telegram_final_delivery.py (10)
```

Cross-vendor review: Gemini 3.6 Flash + Gemini 3.1 Pro both ACCEPTABLE.

## Notes

- **Closes #68313** — reported draft-mode streaming regression between v0.18.2 and v0.19.0
- PR #48438 contains the same fix but has been stalled since June 18 (missing regression test the maintainer requested)
- PR #37638 addresses a related overflow-split edge case (bulk already addressed on main, `_already_sent` leak fix still needed as follow-up)