### PR TITLE
fix(cli): preserve Python dunder underscores in strip Markdown mode

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2803,9 +2803,7 @@ def _strip_markdown_syntax(text: str) -> str:
     plain = re.sub(r"!\[([^\]]*)\]\([^\)]*\)", r"\1", plain)
     plain = re.sub(r"\[([^\]]+)\]\([^\)]*\)", r"\1", plain)
     plain = re.sub(r"\*\*\*([^*]+)\*\*\*", r"\1", plain)
-    plain = re.sub(r"(?<!\w)___([^_]+)___(?!\w)", r"\1", plain)
     plain = re.sub(r"\*\*([^*]+)\*\*", r"\1", plain)
-    plain = re.sub(r"(?<!\w)__([^_]+)__(?!\w)", r"\1", plain)
     # Only strip `*emphasis*` markers when the inner text is non-whitespace.
     # This avoids corrupting cron expressions like "* * * * *".
     plain = re.sub(r"\*([^\s*][^*]*?[^\s*])\*", r"\1", plain)


### PR DESCRIPTION
Closes #73212