### PR TITLE
fix(state): bound routine FTS merge work — stop 'optimize' from holding the write lock 9-18s per index

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1976,13 +1976,21 @@ class SessionDB:
     _WRITE_RETRY_MAX_S = 0.150   # 150ms
     # Attempt a WAL checkpoint every N successful writes (PASSIVE mode).
     _CHECKPOINT_EVERY_N_WRITES = 50
-    # Retain the existing coarse 1000-write maintenance cadence, but give each
-    # FTS5 index only one positive-rank merge command per pass. SQLite treats
-    # that rank as an approximate output-page budget. A 500-page budget keeps
-    # routine work small while automerge handles normal background compaction;
-    # unlike ``optimize``, it cannot chase every remaining segment in one write.
+    # Retain the existing coarse 1000-write maintenance cadence, but replace
+    # the unbounded FTS5 ``'optimize'`` (measured holding the write lock for
+    # 9-18 s per index on a 10 GB production DB — longer than a competing
+    # writer's full retry patience, surfacing as "database is locked" /
+    # session_persistence_failed) with bounded ``'merge'`` commands. A
+    # positive merge rank is an approximate output-page budget, so each
+    # command holds the write lock for milliseconds; up to
+    # ``_FTS_MERGE_COMMANDS_PER_PASS`` commands run per index per cadence,
+    # stopping early on the documented no-progress signal. ``usermerge`` is
+    # lowered to 2 so positive merges act on any level with >= 2 segments —
+    # without that, levels below the default threshold of 4 are skipped and
+    # a fragmented index never converges (SQLite FTS5 §6.8-6.9).
     _FTS_MERGE_EVERY_N_WRITES = 1000
     _FTS_MERGE_MAX_PAGES_PER_INDEX = 500
+    _FTS_MERGE_COMMANDS_PER_PASS = 4
     # Session imports intentionally use a lower cap than exports: import holds
     # one BEGIN IMMEDIATE transaction, so bounded batches avoid starving live
     # gateway/CLI writers. The dashboard accepts one exported JSON/JSONL file
@@ -2020,6 +2028,9 @@ class SessionDB:
         # in place at most once per SessionDB instance so a genuinely
         # unrecoverable database can't put writers into a rebuild loop.
         self._fts_runtime_rebuild_attempted = False
+        # One-shot guard for the usermerge-floor config write on the
+        # incremental FTS merge cadence (see _merge_fts_incrementally).
+        self._fts_usermerge_floor_applied = False
         self._fts_enabled = False
         self._trigram_available = False
         # CJK-bigram index (cjk_unicode61 loadable tokenizer). _fts_cjk_loaded:
@@ -11295,41 +11306,76 @@ class SessionDB:
             logger.debug("Could not read logical DB size: %s", exc)
             return None
 
-    def _merge_fts_incrementally(self, *, max_pages: int) -> int:
-        """Issue one positive-rank FTS5 ``merge`` per present index.
+    def _merge_fts_incrementally(
+        self, *, max_pages: int, max_commands: Optional[int] = None
+    ) -> int:
+        """Run bounded FTS5 ``'merge'`` commands against each present index.
 
-        A positive rank tells SQLite to stop after approximately that many
-        output pages. This method deliberately does not loop: one invocation
-        executes at most one merge command for each table in ``_FTS_TABLES``.
-        Missing tables are valid schema variants; all other SQLite errors
-        propagate to the caller.
+        A positive merge rank tells SQLite to stop after approximately that
+        many output pages, so each command holds the write lock for
+        milliseconds regardless of index size — unlike ``'optimize'``, which
+        rewrites the whole index in one transaction (measured 9-18 s per
+        index on a 10 GB production DB, long enough to exhaust a competing
+        writer's entire lock-retry patience).
+
+        Protocol (SQLite FTS5 §6.8-6.9):
+
+        - ``usermerge`` is lowered to its minimum of 2 (persisted in the
+          ``%_config`` shadow table, applied once per instance) so a
+          positive merge acts on ANY level holding >= 2 segments. With the
+          default of 4, levels below that threshold are never merged by a
+          positive-rank command and a fragmented index cannot converge.
+        - Up to *max_commands* merge commands run per index, stopping early
+          on the documented no-progress signal: the delta in
+          ``total_changes`` is < 2 (the command's own INSERT accounts
+          for 1 change; >= 2 means real merge work happened).
+
+        Each command is its own implicit transaction (the connection runs
+        with ``isolation_level=None``), so the SQLite write lock is released
+        between commands and competing processes can interleave writes
+        mid-pass. Missing tables are valid schema variants (FTS variants are
+        optional, and ``optimize_fts_storage`` legitimately drops + backfills
+        these tables while writers keep running) and are skipped, mirroring
+        ``optimize_fts``. Other SQLite errors propagate to the caller.
+
+        Returns the number of merge commands executed.
         """
         if isinstance(max_pages, bool) or not isinstance(max_pages, int):
             raise TypeError("max_pages must be an integer")
         if max_pages <= 0:
             raise ValueError("max_pages must be greater than zero")
+        if max_commands is None:
+            max_commands = self._FTS_MERGE_COMMANDS_PER_PASS
+        if isinstance(max_commands, bool) or not isinstance(max_commands, int):
+            raise TypeError("max_commands must be an integer")
+        if max_commands <= 0:
+            raise ValueError("max_commands must be greater than zero")
 
-        merged = 0
+        executed = 0
         with self._lock:
-            rows = self._conn.execute(
-                "SELECT name FROM sqlite_master "
-                "WHERE type = 'table' AND name IN (?, ?)",
-                self._FTS_TABLES,
-            ).fetchall()
-            present = {row[0] for row in rows}
-            if "messages_fts" not in present:
-                raise sqlite3.OperationalError(
-                    "required FTS5 index is missing: messages_fts"
-                )
             for tbl in self._FTS_TABLES:
-                if tbl not in present:
+                if not self._fts_table_exists(tbl):
                     continue
-                self._conn.execute(
-                    f"INSERT INTO {tbl}({tbl}, rank) VALUES('merge', ?)",
-                    (max_pages,),
-                )
-                merged += 1
-        return merged
+                # One-time (per instance) usermerge floor; the value is
+                # persisted in the index's config shadow table so future
+                # connections inherit it. Setting config is a metadata-only
+                # write — it never touches segment data.
+                if not getattr(self, "_fts_usermerge_floor_applied", False):
+                    self._conn.execute(
+                        f"INSERT INTO {tbl}({tbl}, rank) "
+                        "VALUES('usermerge', 2)"
+                    )
+                for _ in range(max_commands):
+                    before = self._conn.total_changes
+                    self._conn.execute(
+                        f"INSERT INTO {tbl}({tbl}, rank) VALUES('merge', ?)",
+                        (max_pages,),
+                    )
+                    executed += 1
+                    if self._conn.total_changes - before < 2:
+                        break
+            self._fts_usermerge_floor_applied = True
+        return executed
 
     def vacuum(self) -> int:
         """Run VACUUM to reclaim disk space after large deletes.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1976,16 +1976,13 @@ class SessionDB:
     _WRITE_RETRY_MAX_S = 0.150   # 150ms
     # Attempt a WAL checkpoint every N successful writes (PASSIVE mode).
     _CHECKPOINT_EVERY_N_WRITES = 50
-    # Merge fragmented FTS5 segments every N successful writes. The message
-    # triggers append one segment per insert; left unmaintained these grow
-    # into tens of thousands of segments, so every MATCH must scan them all
-    # and every insert pays a growing automerge cost — which lengthens the
-    # write-lock hold time and starves competing writers (gateway + cron
-    # processes share one state.db), surfacing as "database is locked".
-    # 'optimize' is a no-op once the index is already merged, so an idle DB
-    # pays almost nothing; the cadence is deliberately coarse so the one-off
-    # merge cost is amortised far below the checkpoint cadence.
-    _OPTIMIZE_EVERY_N_WRITES = 1000
+    # Retain the existing coarse 1000-write maintenance cadence, but give each
+    # FTS5 index only one positive-rank merge command per pass. SQLite treats
+    # that rank as an approximate output-page budget. A 500-page budget keeps
+    # routine work small while automerge handles normal background compaction;
+    # unlike ``optimize``, it cannot chase every remaining segment in one write.
+    _FTS_MERGE_EVERY_N_WRITES = 1000
+    _FTS_MERGE_MAX_PAGES_PER_INDEX = 500
     # Session imports intentionally use a lower cap than exports: import holds
     # one BEGIN IMMEDIATE transaction, so bounded batches avoid starving live
     # gateway/CLI writers. The dashboard accepts one exported JSON/JSONL file
@@ -2611,8 +2608,8 @@ class SessionDB:
                 self._write_count += 1
                 if self._write_count % self._CHECKPOINT_EVERY_N_WRITES == 0:
                     self._try_wal_checkpoint()
-                if self._write_count % self._OPTIMIZE_EVERY_N_WRITES == 0:
-                    self._try_optimize_fts()
+                if self._write_count % self._FTS_MERGE_EVERY_N_WRITES == 0:
+                    self._try_incremental_merge_fts()
                 return result
             except sqlite3.OperationalError as exc:
                 err_msg = str(exc).lower()
@@ -2740,21 +2737,19 @@ class SessionDB:
         except Exception as exc:
             logger.warning("WAL checkpoint (PASSIVE) failed: %s", exc)
 
-    def _try_optimize_fts(self) -> None:
-        """Best-effort FTS5 segment merge. Never raises.
-
-        Runs on the ``_OPTIMIZE_EVERY_N_WRITES`` cadence from the write hot
-        path (off the lock — ``optimize_fts`` re-acquires ``self._lock``
-        itself, mirroring ``_try_wal_checkpoint``). ``read_only`` connections
-        never reach the write path, so this is implicitly skipped for them.
-        Once the index is merged the 'optimize' command is close to free, so
-        the steady-state cost is negligible; the expensive case is only the
-        first merge of a long-neglected index.
-        """
+    def _try_incremental_merge_fts(self) -> None:
+        """Run one bounded FTS5 merge pass without failing the completed write."""
+        if not self._fts_enabled:
+            return
         try:
-            self.optimize_fts()
-        except Exception:
-            pass  # Best effort — never fatal.
+            self._merge_fts_incrementally(
+                max_pages=self._FTS_MERGE_MAX_PAGES_PER_INDEX
+            )
+        except sqlite3.Error as exc:
+            # Routine maintenance is best effort, but unexpected SQLite errors
+            # must remain visible instead of being silently mistaken for an
+            # optional missing index.
+            logger.warning("FTS incremental merge failed: %s", exc)
 
     def close(self):
         """Close the database connection.
@@ -11299,6 +11294,42 @@ class SessionDB:
         except Exception as exc:
             logger.debug("Could not read logical DB size: %s", exc)
             return None
+
+    def _merge_fts_incrementally(self, *, max_pages: int) -> int:
+        """Issue one positive-rank FTS5 ``merge`` per present index.
+
+        A positive rank tells SQLite to stop after approximately that many
+        output pages. This method deliberately does not loop: one invocation
+        executes at most one merge command for each table in ``_FTS_TABLES``.
+        Missing tables are valid schema variants; all other SQLite errors
+        propagate to the caller.
+        """
+        if isinstance(max_pages, bool) or not isinstance(max_pages, int):
+            raise TypeError("max_pages must be an integer")
+        if max_pages <= 0:
+            raise ValueError("max_pages must be greater than zero")
+
+        merged = 0
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type = 'table' AND name IN (?, ?)",
+                self._FTS_TABLES,
+            ).fetchall()
+            present = {row[0] for row in rows}
+            if "messages_fts" not in present:
+                raise sqlite3.OperationalError(
+                    "required FTS5 index is missing: messages_fts"
+                )
+            for tbl in self._FTS_TABLES:
+                if tbl not in present:
+                    continue
+                self._conn.execute(
+                    f"INSERT INTO {tbl}({tbl}, rank) VALUES('merge', ?)",
+                    (max_pages,),
+                )
+                merged += 1
+        return merged
 
     def vacuum(self) -> int:
         """Run VACUUM to reclaim disk space after large deletes.

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -5414,7 +5414,15 @@ class TestOptimizeFts:
         """A fresh DB has both FTS indexes; optimize merges both."""
         db.create_session(session_id="s1", source="cli")
         db.append_message(session_id="s1", role="user", content="hello world")
-        assert db.optimize_fts() == 2
+        statements = []
+        db._conn.set_trace_callback(statements.append)
+        try:
+            assert db.optimize_fts() == 2
+        finally:
+            db._conn.set_trace_callback(None)
+        optimize_sql = [sql for sql in statements if "'optimize'" in sql]
+        assert len(optimize_sql) == 2
+        assert not any("'merge'" in sql for sql in optimize_sql)
 
     def test_optimize_preserves_search_and_snippet(self, db):
         """Optimize is layout-only: MATCH results + snippets are unchanged."""
@@ -5466,39 +5474,103 @@ class TestOptimizeFts:
         # Search still works after repeated optimization.
         assert len(db.search_messages("repeat")) == 1
 
-    def test_write_path_optimizes_fts_on_cadence(self, db, monkeypatch):
-        """Writes periodically merge FTS segments so they never accumulate
-        into the tens-of-thousands that lengthen the write-lock hold and
-        starve competing writers ("database is locked")."""
-        db._OPTIMIZE_EVERY_N_WRITES = 5
-        calls = {"n": 0}
-        real_optimize = db.optimize_fts
-
-        def _counting_optimize():
-            calls["n"] += 1
-            return real_optimize()
-
-        monkeypatch.setattr(db, "optimize_fts", _counting_optimize)
-        # create_session is write #1; appends are #2.. -> #5 and #10 trigger.
+    def test_incremental_merge_is_one_bounded_command_per_present_index(self, db):
         db.create_session(session_id="s1", source="cli")
-        for i in range(9):
+        db.append_message(session_id="s1", role="user", content="bounded merge")
+        statements = []
+        db._conn.set_trace_callback(statements.append)
+        try:
+            assert db._merge_fts_incrementally(max_pages=37) == 2
+        finally:
+            db._conn.set_trace_callback(None)
+
+        merge_sql = [sql for sql in statements if "VALUES('merge', 37)" in sql]
+        assert len(merge_sql) == 2
+        assert sum(
+            "messages_fts(messages_fts, rank)" in sql for sql in merge_sql
+        ) == 1
+        assert sum(
+            "messages_fts_trigram(messages_fts_trigram, rank)" in sql
+            for sql in merge_sql
+        ) == 1
+        assert not any("'optimize'" in sql for sql in statements)
+
+    def test_incremental_merge_skips_absent_optional_index(self, db):
+        with db._lock:
+            for trigger in (
+                "messages_fts_trigram_insert",
+                "messages_fts_trigram_delete",
+                "messages_fts_trigram_update",
+            ):
+                db._conn.execute(f"DROP TRIGGER {trigger}")
+            db._conn.execute("DROP TABLE messages_fts_trigram")
+
+        statements = []
+        db._conn.set_trace_callback(statements.append)
+        try:
+            assert db._merge_fts_incrementally(max_pages=19) == 1
+        finally:
+            db._conn.set_trace_callback(None)
+        merge_sql = [sql for sql in statements if "VALUES('merge', 19)" in sql]
+        assert len(merge_sql) == 1
+        assert "messages_fts(messages_fts, rank)" in merge_sql[0]
+
+    def test_incremental_merge_does_not_hide_missing_required_index(self, db):
+        with db._lock:
+            for trigger in (
+                "messages_fts_insert",
+                "messages_fts_delete",
+                "messages_fts_update",
+            ):
+                db._conn.execute(f"DROP TRIGGER {trigger}")
+            db._conn.execute("DROP TABLE messages_fts")
+
+        with pytest.raises(
+            sqlite3.OperationalError,
+            match="required FTS5 index is missing: messages_fts",
+        ):
+            db._merge_fts_incrementally(max_pages=19)
+
+    def test_write_path_merges_fts_only_at_cadence_boundary(self, db, monkeypatch):
+        """Routine writes use bounded merge and never full optimize."""
+        db._FTS_MERGE_EVERY_N_WRITES = 5
+        calls = []
+
+        def _counting_merge(*, max_pages):
+            calls.append(max_pages)
+            return 0
+
+        def _unexpected_optimize():
+            raise AssertionError("routine cadence must not call optimize")
+
+        monkeypatch.setattr(db, "_merge_fts_incrementally", _counting_merge)
+        monkeypatch.setattr(db, "optimize_fts", _unexpected_optimize)
+        db.create_session(session_id="s1", source="cli")
+        for i in range(3):
             db.append_message(session_id="s1", role="user", content=f"needle {i}")
-        assert calls["n"] == 2
-        # The auto-merge is layout-only: search is unaffected.
+        assert calls == []  # Four successful writes are below the boundary.
+        db.append_message(session_id="s1", role="user", content="needle 3")
+        assert calls == [500]  # The fifth write gets the production page budget.
+        for i in range(4, 8):
+            db.append_message(session_id="s1", role="user", content=f"needle {i}")
+        assert calls == [500]
+        db.append_message(session_id="s1", role="user", content="needle 8")
+        assert calls == [500, 500]  # The tenth write is the next boundary.
         assert len(db.search_messages("needle")) == 9
 
-    def test_write_path_optimize_failure_never_breaks_write(self, db, monkeypatch):
-        """A failing periodic optimize must not fail the surrounding write."""
-        db._OPTIMIZE_EVERY_N_WRITES = 2
+    def test_write_path_merge_failure_is_logged_without_breaking_write(
+        self, db, monkeypatch, caplog
+    ):
+        db._FTS_MERGE_EVERY_N_WRITES = 2
 
-        def _boom():
-            raise sqlite3.OperationalError("simulated optimize failure")
+        def _boom(*, max_pages):
+            raise sqlite3.OperationalError("simulated merge failure")
 
-        monkeypatch.setattr(db, "optimize_fts", _boom)
+        monkeypatch.setattr(db, "_merge_fts_incrementally", _boom)
         db.create_session(session_id="s1", source="cli")  # write #1
-        # write #2 trips the cadence; the swallowed failure must not propagate.
         db.append_message(session_id="s1", role="user", content="still persists")
         assert len(db.get_messages("s1")) == 1
+        assert "FTS incremental merge failed: simulated merge failure" in caplog.text
 
 
 class TestAutoMaintenance:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -5474,26 +5474,114 @@ class TestOptimizeFts:
         # Search still works after repeated optimization.
         assert len(db.search_messages("repeat")) == 1
 
-    def test_incremental_merge_is_one_bounded_command_per_present_index(self, db):
+    def test_incremental_merge_bounded_commands_per_present_index(self, db):
+        """Each pass issues bounded 'merge' commands, never 'optimize'."""
         db.create_session(session_id="s1", source="cli")
         db.append_message(session_id="s1", role="user", content="bounded merge")
         statements = []
         db._conn.set_trace_callback(statements.append)
         try:
-            assert db._merge_fts_incrementally(max_pages=37) == 2
+            executed = db._merge_fts_incrementally(max_pages=37)
         finally:
             db._conn.set_trace_callback(None)
 
+        # At least one merge command per present FTS index, and never more
+        # than the per-pass command cap per index.
+        present = [t for t in db._FTS_TABLES if db._fts_table_exists(t)]
+        assert len(present) >= 2  # messages_fts + trigram on a fresh DB
         merge_sql = [sql for sql in statements if "VALUES('merge', 37)" in sql]
-        assert len(merge_sql) == 2
-        assert sum(
-            "messages_fts(messages_fts, rank)" in sql for sql in merge_sql
-        ) == 1
-        assert sum(
-            "messages_fts_trigram(messages_fts_trigram, rank)" in sql
-            for sql in merge_sql
-        ) == 1
+        assert len(merge_sql) == executed
+        assert len(present) <= executed <= (
+            len(present) * db._FTS_MERGE_COMMANDS_PER_PASS
+        )
+        for tbl in present:
+            n = sum(f"{tbl}({tbl}, rank)" in sql for sql in merge_sql)
+            assert 1 <= n <= db._FTS_MERGE_COMMANDS_PER_PASS
+        # The usermerge floor is applied so positive merges can make
+        # progress on levels with >= 2 segments (SQLite FTS5 §6.8).
+        assert any("VALUES('usermerge', 2)" in sql for sql in statements)
         assert not any("'optimize'" in sql for sql in statements)
+
+    def test_incremental_merge_converges_on_fragmented_index(self, db):
+        """Bounded passes make real progress on a fragmented index and
+        reach a no-more-work steady state — the failure mode of a bare
+        positive-rank merge (usermerge default 4) is that it never merges
+        anything and the index stays fragmented forever."""
+        db.create_session(session_id="s1", source="cli")
+        # Suppress automerge so every insert leaves its own level-0 segment
+        # — a deliberately fragmented index that only explicit merge
+        # commands can compact. Config is scoped to this test's temp DB.
+        with db._lock:
+            for tbl in ("messages_fts", "messages_fts_trigram"):
+                db._conn.execute(
+                    f"INSERT INTO {tbl}({tbl}, rank) VALUES('automerge', 0)"
+                )
+        for i in range(60):
+            db.append_message(
+                session_id="s1", role="user",
+                content=f"fragment needle {i} lorem ipsum dolor",
+            )
+
+        # First pass must do real merge work (shadow-table rows change).
+        before = db._conn.total_changes
+        executed_first = db._merge_fts_incrementally(max_pages=500)
+        assert executed_first >= 2
+        assert db._conn.total_changes - before > executed_first  # real work
+
+        # Repeated passes converge: eventually a pass issues exactly one
+        # no-progress command per present index and stops early.
+        present = sum(1 for t in db._FTS_TABLES if db._fts_table_exists(t))
+        for _ in range(50):
+            if db._merge_fts_incrementally(max_pages=500) == present:
+                break
+        else:
+            pytest.fail("bounded merge passes never converged")
+
+        # Merging is layout-only: every row is still searchable.
+        assert len(db.search_messages("fragment", limit=100)) == 60
+
+    def test_incremental_merge_compacts_below_default_usermerge(self, db):
+        """A level with only 2-3 segments — below FTS5's default usermerge
+        threshold of 4 — must still get merged. A bare positive-rank
+        'merge' skips such levels entirely (SQLite FTS5 §6.8), which is
+        why the cadence lowers usermerge to 2 first; without the floor,
+        light fragmentation persists forever and every MATCH pays for it."""
+
+        def _segment_count(tbl: str) -> int:
+            # FTS5 structure record: id=10 in the %_data shadow table.
+            # Format: 4-byte cookie, then varint nlevel, varint nsegment...
+            # nsegment fits in one varint byte for small indexes; parse the
+            # second varint (single-byte values < 128 read directly).
+            blob = db._conn.execute(
+                f"SELECT block FROM {tbl}_data WHERE id=10"
+            ).fetchone()[0]
+            pos = 4
+            for _ in range(1):  # skip nlevel varint (single byte here)
+                assert blob[pos] < 0x80
+                pos += 1
+            assert blob[pos] < 0x80
+            return blob[pos]
+
+        db.create_session(session_id="s1", source="cli")
+        with db._lock:
+            db._conn.execute(
+                "INSERT INTO messages_fts(messages_fts, rank) "
+                "VALUES('automerge', 0)"
+            )
+        # Exactly 3 level-0 segments: below the default usermerge of 4.
+        for i in range(3):
+            db.append_message(
+                session_id="s1", role="user", content=f"sparse token{i}"
+            )
+        assert _segment_count("messages_fts") == 3
+
+        for _ in range(10):
+            db._merge_fts_incrementally(max_pages=500)
+
+        assert _segment_count("messages_fts") == 1, (
+            "3-segment level was not compacted — usermerge floor missing?"
+        )
+        assert len(db.search_messages("sparse")) == 3
 
     def test_incremental_merge_skips_absent_optional_index(self, db):
         with db._lock:
@@ -5508,14 +5596,18 @@ class TestOptimizeFts:
         statements = []
         db._conn.set_trace_callback(statements.append)
         try:
-            assert db._merge_fts_incrementally(max_pages=19) == 1
+            assert db._merge_fts_incrementally(max_pages=19) >= 1
         finally:
             db._conn.set_trace_callback(None)
         merge_sql = [sql for sql in statements if "VALUES('merge', 19)" in sql]
-        assert len(merge_sql) == 1
-        assert "messages_fts(messages_fts, rank)" in merge_sql[0]
+        assert merge_sql
+        assert all("messages_fts(messages_fts, rank)" in sql for sql in merge_sql)
 
-    def test_incremental_merge_does_not_hide_missing_required_index(self, db):
+    def test_incremental_merge_skips_missing_primary_index(self, db):
+        """A missing messages_fts is a valid transient state (chunked
+        optimize-storage rebuild drops + backfills it while writers keep
+        running) — the cadence must skip it, not raise a warning every
+        1000 writes for the whole backfill window."""
         with db._lock:
             for trigger in (
                 "messages_fts_insert",
@@ -5525,11 +5617,16 @@ class TestOptimizeFts:
                 db._conn.execute(f"DROP TRIGGER {trigger}")
             db._conn.execute("DROP TABLE messages_fts")
 
-        with pytest.raises(
-            sqlite3.OperationalError,
-            match="required FTS5 index is missing: messages_fts",
-        ):
-            db._merge_fts_incrementally(max_pages=19)
+        statements = []
+        db._conn.set_trace_callback(statements.append)
+        try:
+            executed = db._merge_fts_incrementally(max_pages=19)
+        finally:
+            db._conn.set_trace_callback(None)
+        assert executed >= 1  # trigram index still present and merged
+        assert not any(
+            "messages_fts(messages_fts, rank)" in sql for sql in statements
+        )
 
     def test_write_path_merges_fts_only_at_cadence_boundary(self, db, monkeypatch):
         """Routine writes use bounded merge and never full optimize."""


### PR DESCRIPTION
## Summary

Routine FTS maintenance on the state.db write hot path no longer holds the SQLite write lock long enough to starve competing writers into `database is locked` / `session_persistence_failed` turn kills.

Root cause: every 1000th successful write ran FTS5 `'optimize'` inline — a full-index rewrite in one transaction. Measured on a real 10.7 GB production state.db (1.49M messages): 9.2 s for `messages_fts` + 18.1 s for `messages_fts_trigram`, while a competing writer's entire retry patience is ~17 s (15 × 1 s busy timeout + jitter). The "'optimize' is close to free once merged" premise in the original comment was wrong — `'optimize'` merges everything into ONE segment, so the next cadence pays a near-full rewrite again, forever.

Salvaged from #65554 by @the3asic (bounded positive-rank `'merge'` replacing `'optimize'`), plus follow-up commits completing the merge protocol per SQLite FTS5 §6.8–6.9:

## Changes

- `hermes_state.py`: cadence now issues bounded `INSERT INTO t(t, rank) VALUES('merge', 500)` commands instead of `'optimize'` (@the3asic, #65554)
- `hermes_state.py`: lower `usermerge` to its minimum of 2 (one-time per instance, persisted in the FTS config shadow table) — without it a positive merge skips levels with <4 segments and a fragmented index never converges (the sweeper-review gap on #65554)
- `hermes_state.py`: up to 4 merge commands per index per pass, stopping early on the documented no-progress signal (`total_changes` delta < 2); each command is its own implicit transaction so the write lock is released between commands
- `hermes_state.py`: missing `messages_fts` is skipped, not raised — the chunked optimize-storage rebuild legitimately drops + backfills FTS tables while writers keep running
- `tests/test_hermes_state.py`: behavioral tests — real fragmented-index convergence (automerge suppressed, 60 level-0 segments) and a 3-segment below-default-usermerge compaction test, both sabotage-verified to fail against a bare positive-rank merge

## Validation

E2E on a `sqlite3.backup()` copy of a real 10.7 GB production state.db, real `SessionDB` imports, no mocks:

| | Before (`'optimize'`) | After (bounded `'merge'`) |
|---|---|---|
| Worst write-lock hold | 18.1 s (trigram) / 9.2 s (fts) | 41.8 ms per command |
| Steady-state cadence cost | ~0 only if nothing changed; full rewrite otherwise | 0.0 ms (converged, no-progress early stop) |
| Search results | — | byte-identical before/after |
| `fts5 integrity-check` | — | OK (both indexes) |
| `PRAGMA integrity_check` | — | ok |

Targeted tests: 477 passed, 1 skipped (`tests/test_hermes_state.py`, full file). Sabotage runs confirmed the new convergence + usermerge tests fail against the naive single-merge variant.

## Infographic

![bounded FTS merge infographic](https://v3b.fal.media/files/b/0aa41984/sGfLc6p8idc53ic_yA_6a_TyeNPfC7.png)
