### PR TITLE
fix(agent): filter raw chat-template spec from Kimi K3 responses on third-party providers

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1399,6 +1399,15 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     if isinstance(_san_content, str) and _san_content:
         _san_content = agent._strip_think_blocks(_san_content).strip()
 
+    # Strip raw chat-template special tokens (<|open|>, <|close|>, <|sep|>,
+    # <|im_start|>, etc.) that some providers (e.g. Kimi K3 via Fireworks)
+    # intermittently leak as assistant content instead of processing them
+    # as template instructions.  These tokens are not user-facing text and
+    # must be removed before persisting to session history, delivering to
+    # messaging platforms, or replaying as API context.  (#73491)
+    if isinstance(_san_content, str) and _san_content:
+        _san_content = re.sub(r'<\|[a-z_]+\|>', '', _san_content).strip()
+
     # Defence-in-depth: redact credentials (PATs, API keys, Bearer tokens)
     # from assistant content BEFORE the message enters conversation history.
     # If the model accidentally inlines a secret in its natural-language

--- a/run_agent.py
+++ b/run_agent.py
@@ -1563,6 +1563,11 @@ class AIAgent:
 
         # Remove all reasoning tag variants (must match _strip_think_blocks)
         cleaned = self._strip_think_blocks(content)
+        # Also remove raw chat-template tokens (e.g. <|open|>, <|close|>, <|sep|>)
+        # that providers like Kimi K3 via Fireworks may leak as assistant content.
+        # These are not user-facing text and should not count as "actual content"
+        # for thinking-exhaustion detection.  (#73491)
+        cleaned = re.sub(r'<\|[a-z_]+\|>', '', cleaned)
 
         # Check if there's any non-whitespace content remaining
         return bool(cleaned.strip())


### PR DESCRIPTION
## Summary

Kimi K3 served via Fireworks (`accounts/fireworks/models/kimi-k3`) intermittently emits its raw chat-template special tokens as assistant content instead of processing them as template instructions. The leaked string is persisted to session history and delivered to the user verbatim.

Observed leaked content:
`<|open|>response<|sep|><|close|>response<|sep|><|close|>message<|sep|>`

## Changes

1. **agent/chat_completion_helpers.py** — strip `<|[a-z_]+|>` tokens at the storage boundary (after reasoning-tag stripping, before credential redaction). This is the single chokepoint where assistant content is cleaned before persisting to session history, delivering to messaging platforms, or replaying as API context.

2. **run_agent.py \_has\_content\_after\_think\_block** — also strip template tokens so a response consisting solely of leaked markup is not mistaken for actual content during thinking-exhaustion detection.

## Testing

The regex `r'<\|[a-z_]+\|>'` matches all known chat-template special tokens:
- `<|open|>`, `<|close|>`, `<|sep|>`
- `<|im_start|>`, `<|im_end|>`
- `<|endoftext|>`
- Any other `<|...|>` token with lowercase letters/underscores

Closes #73491