### PR TITLE
fix(kanban): require falsification evidence for non-dependency blocks

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -17430,9 +17430,25 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
                 pass
 
     def _block(reason: str) -> None:
+        # System-observed block: the goal-loop fallback's "block" decision
+        # is the runtime observing that the worker (a) refused to
+        # finalize after a nudge, or (b) exhausted its turn budget. The
+        # reason string already encodes the falsification ("judge said
+        # done, worker still won't call kanban_complete" / "turns_used
+        # == max_turns"), so we plumb it through as the evidence field
+        # AND pass _system_observed=True so the verified-blocker gate
+        # (when enabled) recognises this as a system-observed transition
+        # rather than an agent claim. The block can land in 'blocked'
+        # either way; _system_observed is the structural marker, and
+        # reason-as-evidence is the auditable record.
         c = _kb.connect()
         try:
-            _kb.block_task(c, task_id, reason=reason)
+            _kb.block_task(
+                c, task_id,
+                reason=reason,
+                evidence=reason,
+                _system_observed=True,
+            )
         finally:
             try:
                 c.close()

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2200,6 +2200,19 @@ DEFAULT_CONFIG = {
         # worker process (if still running host-locally) is terminated
         # before the reclaim.  0 disables stale detection entirely.
         "dispatch_stale_timeout_seconds": 14400,
+        # Verified-blocker rule (Article XII P5 + XIV P2): when true,
+        # ``block_task()`` requires an ``evidence`` field on non-dependency
+        # blocks that would land in ``blocked`` (not ``todo``, not ``triage``).
+        # An agent / CLI / dashboard cannot transition a task to ``blocked``
+        # on a hypothetical or unverified condition — the falsification
+        # record (the command/observation that established the blocker is
+        # real) is structurally required. Prevents the 2026-07-19 incident
+        # class (``Blocked on SSH key`` while the key was loadable).
+        # Off by default so existing code and tests are not broken;
+        # production deployments enable it explicitly. Dependency blocks,
+        # loop-detected routing-to-triage, and the circuit-breaker
+        # auto-blocker carry their own structural evidence and are exempt.
+        "require_block_evidence": False,
     },
 
     # execute_code settings — controls the tool used for programmatic tool calls.

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -637,6 +637,21 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
             "triage to break unblock loops. Omit for a generic block."
         ),
     )
+    p_block.add_argument(
+        "--evidence", default=None,
+        help=(
+            "Falsification record — required when kanban.require_block_evidence "
+            "is enabled in config.yaml AND the block would land in 'blocked' "
+            "(not 'todo', not 'triage'). Record the command/observation that "
+            "established the blocker is real and the result you observed. "
+            "Example: 'ssh-add ~/.ssh/id_ed25519 succeeded; ssh -o BatchMode=yes "
+            "macbook-pro echo OK returned OK and exit 0; SSH key is available, "
+            "so the blocker is the account, not the key.' Without --evidence "
+            "and the gate on, the command exits non-zero with an actionable "
+            "error. Dependency blocks (--kind dependency) and loop-detected "
+            "routing to triage are exempt at the routing layer."
+        ),
+    )
 
     p_schedule = sub.add_parser("schedule", help="Park one or more tasks in Scheduled (waiting on time, not human input)")
     p_schedule.add_argument("task_id")
@@ -2258,20 +2273,45 @@ def _cmd_edit(args: argparse.Namespace) -> int:
 def _cmd_block(args: argparse.Namespace) -> int:
     reason = " ".join(args.reason).strip() if args.reason else None
     kind = getattr(args, "kind", None)
+    evidence = getattr(args, "evidence", None)
     author = _profile_author()
     ids = [args.task_id] + list(getattr(args, "ids", None) or [])
     failed: list[str] = []
+    # Pre-flight check: if the gate is on and this kind would land in
+    # 'blocked' (not 'todo', not 'triage'), refuse without --evidence
+    # BEFORE opening the connection. Loop-detected routing-to-triage
+    # depends on per-task recurrence state we don't know yet, so we can't
+    # gate that branch here — kanban_db enforces it inside the txn.
+    if reason is None and kind != "dependency":
+        print(
+            "kanban: a non-empty reason is required to block a task.",
+            file=sys.stderr,
+        )
+        return 2
     with kb.connect_closing() as conn:
         for tid in ids:
             if reason:
                 kb.add_comment(conn, tid, author, f"BLOCKED: {reason}")
-            if not kb.block_task(
-                conn,
-                tid,
-                reason=reason,
-                kind=kind,
-                expected_run_id=_worker_run_id_for(tid),
-            ):
+            try:
+                ok = kb.block_task(
+                    conn,
+                    tid,
+                    reason=reason,
+                    kind=kind,
+                    evidence=evidence,
+                    expected_run_id=_worker_run_id_for(tid),
+                )
+            except ValueError as exc:
+                # Verified-blocker gate failure (or invalid kind). Surface
+                # an actionable stderr message and treat as failure for this
+                # task; the user can re-run with --evidence.
+                print(
+                    f"kanban: cannot block {tid}: {exc}",
+                    file=sys.stderr,
+                )
+                failed.append(tid)
+                continue
+            if not ok:
                 failed.append(tid)
                 print(f"cannot block {tid}", file=sys.stderr)
             else:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5474,7 +5474,9 @@ def block_task(
     *,
     reason: Optional[str] = None,
     kind: Optional[str] = None,
+    evidence: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    _system_observed: bool = False,
 ) -> bool:
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
 
@@ -5500,6 +5502,39 @@ def block_task(
       can use it to signal "this might clear on its own"; it still participates
       in the loop breaker so a forever-flaky task eventually escalates.
 
+    ``evidence`` is the falsification record the caller supplies for the
+    blocker: the command/observation they ran to verify the blocking
+    condition, the result they observed, and the conclusion they drew.
+    When ``kanban.require_block_evidence`` is enabled in ``config.yaml``,
+    a block that would land in ``blocked`` (the human queue) MUST be
+    accompanied by a non-empty ``evidence`` — this is the runtime gate
+    against declaring a blocker without first falsifying it (Article XII
+    P5 falsify-before-concluding + Article XIV P2 blockers-create-work).
+    When supplied, the string is recorded in the ``blocked`` event
+    payload and appended to the synthesized run summary so the
+    falsification is auditable post-hoc via SQL or the dashboard.
+
+    The gate fires only when the block would land in ``blocked`` —
+    ``dependency`` blocks (route to ``todo``) and ``recurrences >=
+    BLOCK_RECURRENCE_LIMIT`` (route to ``triage``) are exempt at the
+    routing layer; their destinations are not the human queue.
+
+    ``_system_observed`` is an internal escape hatch for system-observed
+    blocks (the circuit breaker and the goal-loop budget fallback) whose
+    evidence is the system's own observation rather than a caller claim.
+    The leading underscore signals "do not pass this from caller code" —
+    it exists so the same gate can be enforced uniformly on every code
+    path that would land in ``blocked``. A caller MUST NOT use
+    ``_system_observed=True`` to bypass the gate on a claim they could
+    have falsified; the exemption is for paths where the falsification
+    is performed by the runtime itself.
+
+    When the gate is disabled (default, for backward compatibility with
+    existing code and tests), ``evidence`` is recorded when supplied but
+    is not required. Operators enable the gate in their ``config.yaml``
+    under ``kanban.require_block_evidence: true`` to opt into the
+    verified-blocker rule.
+
     Returns True on any successful transition (to ``blocked``, ``todo``, or
     ``triage``), False when the task wasn't in a blockable state.
     """
@@ -5507,6 +5542,21 @@ def block_task(
         raise ValueError(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
         )
+    # Evidence gate (verified-blocker rule). Load config defensively — the
+    # config module is itself optional at import time in some test setups, and
+    # a missing/malformed config must default the gate to OFF (existing
+    # call-site behavior) rather than break unrelated callers.
+    try:
+        from hermes_cli.config import load_config
+
+        _kanban_cfg = (load_config().get("kanban") or {})
+    except Exception:
+        _kanban_cfg = {}
+    _require_evidence = bool(_kanban_cfg.get("require_block_evidence", False))
+
+    def _evidence_valid() -> bool:
+        return isinstance(evidence, str) and bool(evidence.strip())
+
     recurrences = 0
     with write_txn(conn):
         cur_row = conn.execute(
@@ -5555,7 +5605,8 @@ def block_task(
                 )
             _append_event(
                 conn, task_id, "dependency_wait",
-                {"reason": reason, "kind": kind}, run_id=run_id,
+                {"reason": reason, "kind": kind, "evidence": evidence},
+                run_id=run_id,
             )
             _blocked_task = get_task(conn, task_id)
             _fire_kanban_lifecycle_hook(
@@ -5580,6 +5631,8 @@ def block_task(
         if recurrences >= BLOCK_RECURRENCE_LIMIT:
             # Loop detected — stop letting the unblocker spin this task. Route
             # to triage for a human-in-the-loop decision instead of blocked.
+            # The destination is ``triage``, not the human queue, so the
+            # evidence gate does not fire here regardless of caller.
             cur = conn.execute(
                 """
                 UPDATE tasks
@@ -5613,10 +5666,35 @@ def block_task(
                     "kind": kind,
                     "recurrences": recurrences,
                     "limit": BLOCK_RECURRENCE_LIMIT,
+                    "evidence": evidence,
                 },
                 run_id=run_id,
             )
         else:
+            # This branch lands in the human ``blocked`` queue. Enforce the
+            # verified-blocker gate here — after routing determination so we
+            # know the destination is ``blocked``, and exempt only
+            # system-observed blocks (circuit breaker, goal-loop fallback)
+            # whose evidence is the runtime's own observation.
+            if _require_evidence and not _system_observed and not _evidence_valid():
+                raise ValueError(
+                    "block_task: evidence is required for non-dependency blocks "
+                    "when kanban.require_block_evidence is enabled in "
+                    "config.yaml. The caller MUST record the falsification "
+                    "attempt (e.g. the command run, the result observed, the "
+                    "conclusion drawn) before transitioning a task to "
+                    "'blocked'. See Article XII P5 (falsify before concluding) "
+                    "and Article XIV P2 (blockers create work, not waiting). "
+                    "For dependency blocks use kind='dependency'."
+                )
+            # Compose the run summary so the falsification lives in attempt
+            # history (not just in the event log). When evidence is absent
+            # because the gate is off, the summary stays unchanged.
+            _summary = (
+                f"{reason}\n\n[evidence]\n{evidence}"
+                if (reason and _evidence_valid())
+                else reason
+            )
             if expected_run_id is None:
                 cur = conn.execute(
                     """
@@ -5653,19 +5731,27 @@ def block_task(
             run_id = _end_run(
                 conn, task_id,
                 outcome="blocked", status="blocked",
-                summary=reason,
+                summary=_summary,
             )
             # Synthesize a run when blocking a never-claimed task so the
-            # reason is preserved in attempt history.
+            # reason is preserved in attempt history. When evidence was
+            # supplied, the run summary includes it so the falsification
+            # attempt is auditable in task_runs (not just in the event log).
             if run_id is None and reason:
                 run_id = _synthesize_ended_run(
                     conn, task_id,
                     outcome="blocked",
-                    summary=reason,
+                    summary=_summary,
                 )
             _append_event(
                 conn, task_id, "blocked",
-                {"reason": reason, "kind": kind, "recurrences": recurrences},
+                {
+                    "reason": reason,
+                    "kind": kind,
+                    "recurrences": recurrences,
+                    "evidence": evidence,
+                    "system_observed": _system_observed,
+                },
                 run_id=run_id,
             )
         _blocked_task = get_task(conn, task_id)

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -822,6 +822,13 @@ class UpdateTaskBody(BaseModel):
     body: Optional[str] = None
     result: Optional[str] = None
     block_reason: Optional[str] = None
+    # Verified-blocker evidence: when status='blocked' and
+    # kanban.require_block_evidence is enabled in config.yaml, this is
+    # the falsification record forwarded to ``block_task``. When the
+    # gate is off the field is ignored. Dependency blocks
+    # (block_kind='dependency') and loop-detected routing to triage are
+    # exempt at the routing layer.
+    block_evidence: Optional[str] = None
     # Structured handoff fields — forwarded to complete_task when status
     # transitions to 'done'. Dashboard parity with ``hermes kanban
     # complete --summary ... --metadata ...``.
@@ -868,7 +875,23 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     metadata=payload.metadata,
                 )
             elif s == "blocked":
-                ok = kanban_db.block_task(conn, task_id, reason=payload.block_reason)
+                try:
+                    ok = kanban_db.block_task(
+                        conn, task_id,
+                        reason=payload.block_reason,
+                        evidence=payload.block_evidence,
+                    )
+                except ValueError as e:
+                    # Verified-blocker gate failure (or invalid kind).
+                    # 422: the request was well-formed but cannot be
+                    # processed as-is — the operator must supply
+                    # block_evidence. The detail message cites the
+                    # constitutional anchors so any future code that
+                    # surfaces this 422 understands the rule.
+                    raise HTTPException(
+                        status_code=422,
+                        detail=str(e),
+                    )
             elif s == "scheduled":
                 ok = kanban_db.schedule_task(conn, task_id, reason=payload.block_reason)
             elif s == "ready":
@@ -1190,6 +1213,18 @@ class BulkTaskBody(BaseModel):
     summary: Optional[str] = None
     metadata: Optional[dict] = None
     reclaim_first: bool = False
+    # Block reason forwarded to ``block_task`` when status='blocked' in
+    # this bulk request. Same role as UpdateTaskBody.block_reason.
+    block_reason: Optional[str] = None
+    # Verified-blocker evidence (same semantics as UpdateTaskBody.
+    # block_evidence): applied to every task that transitions to
+    # 'blocked' in this bulk request. When
+    # kanban.require_block_evidence is enabled, every task that lands in
+    # 'blocked' must satisfy the gate using this same evidence string —
+    # useful when the operator has already verified the condition once
+    # (e.g. "ran ssh-add; key loaded") and is bulk-blocking 10 tasks
+    # against the same root cause.
+    block_evidence: Optional[str] = None
     # Bulk model/provider override — same semantics as UpdateTaskBody.
     model_override: Optional[str] = None
     provider_override: Optional[str] = None
@@ -1231,7 +1266,20 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                             metadata=payload.metadata,
                         )
                     elif s == "blocked":
-                        ok = kanban_db.block_task(conn, tid)
+                        try:
+                            ok = kanban_db.block_task(
+                                conn, tid,
+                                reason=payload.block_reason,
+                                evidence=payload.block_evidence,
+                            )
+                        except ValueError as e:
+                            # Verified-blocker gate failure — surface as
+                            # a per-task error so siblings in the bulk
+                            # request can still process. The operator
+                            # can re-issue with block_evidence set.
+                            entry.update(ok=False, error=str(e))
+                            results.append(entry)
+                            continue
                     elif s == "ready":
                         cur = kanban_db.get_task(conn, tid)
                         if cur and cur.status in ("blocked", "scheduled"):

--- a/tests/hermes_cli/test_kanban_verified_blocker.py
+++ b/tests/hermes_cli/test_kanban_verified_blocker.py
@@ -1,0 +1,536 @@
+"""Regression tests for the verified-blocker rule (Article XII P5 + XIV P2).
+
+The 2026-07-19 incident: an audit declared a task ``Blocked on SSH key`` —
+the SSH key was available throughout (``~/.ssh/id_ed25519_macbook_pro`` was
+loadable via ``ssh-agent``); the agent did not attempt to load it. The
+false blocker went undetected for 8 days, leaving a misclaim in production
+that surfaced only after independent verification.
+
+The structural fix: ``block_task()`` now requires a falsification record
+(``evidence``) on a block that would land in ``blocked`` (the human queue)
+when ``kanban.require_block_evidence`` is enabled in ``config.yaml``.
+Dependency blocks (route to ``todo``) and loop-detected routing to
+``triage`` are exempt at the routing layer; their destinations are not
+the human queue. The circuit breaker (system-observed) and the goal-loop
+budget fallback pass ``_system_observed=True`` so the gate recognises them
+as runtime observations rather than caller claims.
+
+These tests pin the gate end-to-end:
+
+* Non-dependency block without evidence → ``ValueError`` (gate on).
+* Non-dependency block with evidence → succeeds; evidence recorded in the
+  ``blocked`` event payload and synthesized run summary.
+* Dependency block without evidence → succeeds (exempt at routing).
+* Loop-detected routing-to-triage → succeeds WITHOUT evidence on the
+  loop-triggering block (exempt at routing). The re-block that trips the
+  counter must not require evidence just because the next call would
+  route to triage.
+* Circuit-breaker (system-observed) blocker works without evidence.
+* ``_system_observed=True`` lets a system path bypass the gate cleanly.
+* Whitespace-only evidence is treated as missing.
+* Default off (legacy call sites without evidence still work).
+* Unset config (no ``kanban`` key) keeps legacy behavior.
+* 2026-07-19 failure scenario is structurally impossible.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def gate_enabled(monkeypatch):
+    """Enable the verified-blocker gate by patching load_config().
+
+    ``load_config`` is patched at the import location used by kanban_db
+    (the import happens inside the function body), so the patch is
+    applied at the hermes_cli.config module level.
+    """
+    import hermes_cli.config as cfg_module
+
+    def _patched_load():
+        return {"kanban": {"require_block_evidence": True}}
+
+    monkeypatch.setattr(cfg_module, "load_config", _patched_load)
+    return _patched_load
+
+
+@pytest.fixture
+def gate_disabled(monkeypatch):
+    """Explicitly disable the gate (the default)."""
+    import hermes_cli.config as cfg_module
+
+    def _patched_load():
+        return {"kanban": {"require_block_evidence": False}}
+
+    monkeypatch.setattr(cfg_module, "load_config", _patched_load)
+
+
+def _create_running_task(conn, title: str = "test") -> str:
+    """Create + claim a task so it's in ``running`` status (blockable)."""
+    tid = kb.create_task(conn, title=title, assignee="worker")
+    kb.claim_task(conn, tid)
+    return tid
+
+
+# ---------------------------------------------------------------------------
+# Core gate: non-dependency block requires evidence (gate ON)
+# ---------------------------------------------------------------------------
+
+def test_non_dependency_block_without_evidence_raises(kanban_home, gate_enabled):
+    """The 2026-07-19 failure mode: declare a blocker without falsification.
+    After the fix, ``block_task()`` must raise ``ValueError`` — the
+    transition is structurally impossible.
+    """
+    conn = kb.connect()
+    try:
+        tid = _create_running_task(conn, "verify live state")
+        with pytest.raises(ValueError) as exc_info:
+            kb.block_task(
+                conn, tid,
+                reason="SSH key appears unavailable",
+                kind="capability",
+            )
+        msg = str(exc_info.value)
+        assert "evidence is required" in msg
+        assert "Article XII P5" in msg
+        assert "Article XIV P2" in msg
+    finally:
+        conn.close()
+
+
+def test_non_dependency_block_with_evidence_succeeds(kanban_home, gate_enabled):
+    """A real blocker with a real falsification record is allowed."""
+    conn = kb.connect()
+    try:
+        tid = _create_running_task(conn, "test real blocker")
+        evidence = (
+            "ran `ssh-add ~/.ssh/id_ed25519_macbook_pro`; result: "
+            "Agent admitted the key, fingerprint sha256:abc123; "
+            "subsequent `ssh -o BatchMode=yes macbook-pro echo OK` "
+            "returned 'OK' and exit 0. Blocker is real because of the "
+            "user account issue, not the key."
+        )
+        ok = kb.block_task(
+            conn, tid,
+            reason="Remote account locked",
+            kind="capability",
+            evidence=evidence,
+        )
+        assert ok is True
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        # Evidence is recorded in the task_events log.
+        ev_rows = conn.execute(
+            "SELECT kind, payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'blocked'",
+            (tid,),
+        ).fetchall()
+        assert ev_rows, "blocked event was not appended"
+        payload = json.loads(ev_rows[-1]["payload"])
+        assert payload.get("evidence") == evidence
+        # Evidence is also appended to the synthesized run summary.
+        runs = conn.execute(
+            "SELECT summary FROM task_runs WHERE task_id = ? ORDER BY id DESC",
+            (tid,),
+        ).fetchall()
+        assert runs, "expected at least one task_runs row"
+        assert "[evidence]" in (runs[0]["summary"] or "")
+        assert evidence in (runs[0]["summary"] or "")
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Routing-layer exemptions: dependency → todo, loop → triage
+# ---------------------------------------------------------------------------
+
+def test_dependency_block_without_evidence_succeeds(kanban_home, gate_enabled):
+    """Dependency blocks route to ``todo`` (not ``blocked``) — no
+    external state claim, so falsification evidence is not required.
+    """
+    conn = kb.connect()
+    try:
+        tid = _create_running_task(conn, "wait on parent")
+        ok = kb.block_task(
+            conn, tid,
+            reason="waiting on parent task",
+            kind="dependency",
+            # No evidence — must not raise.
+        )
+        assert ok is True
+        task = kb.get_task(conn, tid)
+        assert task.status == "todo"
+    finally:
+        conn.close()
+
+
+def test_loop_detected_routing_to_triage_succeeds_without_evidence(kanban_home, gate_enabled):
+    """Loop detection routes to ``triage`` (not ``blocked``), so the
+    evidence gate does NOT fire on the loop-triggering block.
+
+    This is the test the v1 PR got wrong: it supplied evidence on both
+    calls, which masked the fact that the gate was firing before
+    routing determination. The fix here moves the gate after
+    routing — the loop-triggering block is the second block of the
+    same kind, and it must land in ``triage`` without any evidence
+    from the caller.
+    """
+    conn = kb.connect()
+    try:
+        tid = _create_running_task(conn, "test loop")
+        # First block with evidence — no loop yet, lands in 'blocked'.
+        kb.block_task(
+            conn, tid,
+            reason="first block",
+            kind="needs_input",
+            evidence="first-block evidence: tried X; got Y",
+        )
+        # Unblock to set up the re-block for the same kind.
+        kb.unblock_task(conn, tid)
+        # Re-claim so the task is blockable again.
+        kb.claim_task(conn, tid)
+        # Second block with same kind — recurrences becomes 2, which is
+        # >= BLOCK_RECURRENCE_LIMIT (2), so this routes to ``triage``.
+        # The gate must NOT fire here — destination is ``triage``, not
+        # the human queue. The call must succeed without evidence.
+        ok = kb.block_task(
+            conn, tid,
+            reason="second block same kind",
+            kind="needs_input",
+            # No evidence — destination is triage, exempt at routing.
+        )
+        assert ok is True
+        task = kb.get_task(conn, tid)
+        assert task.status == "triage", (
+            f"expected loop-triggered re-block to land in 'triage', "
+            f"got {task.status!r}"
+        )
+        # The loop event is recorded with the evidence field (None when
+        # not supplied) — the audit trail still has the falsification
+        # null-marker, signalling "no caller-supplied evidence".
+        ev_rows = conn.execute(
+            "SELECT kind, payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'block_loop_detected'",
+            (tid,),
+        ).fetchall()
+        assert ev_rows, "expected a block_loop_detected event"
+        payload = json.loads(ev_rows[-1]["payload"])
+        assert payload.get("recurrences") >= 2
+        assert payload.get("kind") == "needs_input"
+    finally:
+        conn.close()
+
+
+def test_empty_string_evidence_treated_as_missing(kanban_home, gate_enabled):
+    """Whitespace-only or empty evidence is treated as missing. The
+    falsification record must contain actual content.
+    """
+    conn = kb.connect()
+    try:
+        tid = _create_running_task(conn, "test empty evidence")
+        for bad_evidence in ["", "   ", "\n\t"]:
+            with pytest.raises(ValueError) as exc_info:
+                kb.block_task(
+                    conn, tid,
+                    reason="attempted block",
+                    kind="capability",
+                    evidence=bad_evidence,
+                )
+            assert "evidence is required" in str(exc_info.value)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# System-observed exemption: circuit breaker + goal-loop fallback
+# ---------------------------------------------------------------------------
+
+def test_system_observed_bypasses_gate(kanban_home, gate_enabled):
+    """``_system_observed=True`` lets a system path bypass the gate.
+
+    The circuit breaker (``_record_task_failure``) and the goal-loop
+    budget fallback are the two callers that set this flag. The
+    verification of the breaker path itself is in
+    ``test_circuit_breaker_still_works_without_evidence`` below; here
+    we pin the public contract: any caller can pass
+    ``_system_observed=True`` and the gate won't fire.
+    """
+    conn = kb.connect()
+    try:
+        tid = _create_running_task(conn, "system observed")
+        ok = kb.block_task(
+            conn, tid,
+            reason="system-observed fallback",
+            kind="capability",
+            # No evidence, but _system_observed=True → gate is bypassed.
+            _system_observed=True,
+        )
+        assert ok is True
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        # The audit trail records system_observed=True so any future
+        # investigator can see this was a system-observed transition.
+        ev_rows = conn.execute(
+            "SELECT kind, payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'blocked'",
+            (tid,),
+        ).fetchall()
+        assert ev_rows
+        payload = json.loads(ev_rows[-1]["payload"])
+        assert payload.get("system_observed") is True
+    finally:
+        conn.close()
+
+
+def test_system_observed_false_with_evidence_records_flag_correctly(kanban_home, gate_enabled):
+    """When a caller passes both ``_system_observed=False`` and a real
+    evidence, the gate is satisfied by the evidence, and the audit
+    trail records ``system_observed=False`` so it's clear this was a
+    caller claim rather than a runtime observation.
+    """
+    conn = kb.connect()
+    try:
+        tid = _create_running_task(conn, "explicit claim")
+        ok = kb.block_task(
+            conn, tid,
+            reason="explicit",
+            kind="capability",
+            evidence="verified by running X",
+            _system_observed=False,
+        )
+        assert ok is True
+        ev_rows = conn.execute(
+            "SELECT kind, payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'blocked'",
+            (tid,),
+        ).fetchall()
+        assert ev_rows
+        payload = json.loads(ev_rows[-1]["payload"])
+        assert payload.get("system_observed") is False
+        assert payload.get("evidence") == "verified by running X"
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Default-off behavior (gate OFF — legacy call sites)
+# ---------------------------------------------------------------------------
+
+def test_default_off_allows_existing_call_sites(kanban_home, gate_disabled):
+    """When the verified-blocker gate is OFF (default — set in
+    config.yaml ``kanban.require_block_evidence: false`` or unset),
+    existing call sites that don't supply evidence continue to work.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="legacy caller", assignee="worker")
+        kb.claim_task(conn, tid)
+        ok = kb.block_task(conn, tid, reason="legacy reason", kind="capability")
+        assert ok is True
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+    finally:
+        conn.close()
+
+
+def test_unset_config_allows_legacy_call_sites(kanban_home, monkeypatch):
+    """When config.yaml is absent or doesn't have the key, the gate is
+    off (no behavior change from current default). Operators who want
+    the gate MUST opt in via ``kanban.require_block_evidence: true``.
+    """
+    import hermes_cli.config as cfg_module
+
+    def _patched_load():
+        return {}
+
+    monkeypatch.setattr(cfg_module, "load_config", _patched_load)
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="no-config caller", assignee="worker")
+        kb.claim_task(conn, tid)
+        ok = kb.block_task(conn, tid, reason="no config", kind="capability")
+        assert ok is True
+        assert kb.get_task(conn, tid).status == "blocked"
+    finally:
+        conn.close()
+
+
+def test_malformed_config_does_not_break_block_task(kanban_home, monkeypatch):
+    """If load_config() raises (e.g. malformed YAML), ``block_task``
+    defaults the gate to OFF rather than blowing up. The block still
+    succeeds with whatever evidence the caller passed (or none).
+    """
+    import hermes_cli.config as cfg_module
+
+    def _patched_load():
+        raise RuntimeError("simulated malformed config")
+
+    monkeypatch.setattr(cfg_module, "load_config", _patched_load)
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="malformed config", assignee="worker")
+        kb.claim_task(conn, tid)
+        # No evidence, gate defaulted off → block succeeds.
+        ok = kb.block_task(conn, tid, reason="legacy", kind="capability")
+        assert ok is True
+        assert kb.get_task(conn, tid).status == "blocked"
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker is system-observed, not agent-claimed
+# ---------------------------------------------------------------------------
+
+def test_circuit_breaker_still_works_without_evidence(
+    kanban_home, all_assignees_spawnable, gate_enabled,
+):
+    """System-generated circuit-breaker blockers are NOT subject to the
+    evidence gate — the failure is system-observed (worker died, timeout,
+    spawn failure), not an agent claim. ``_record_task_failure`` sets
+    ``_system_observed=True`` (and the dispatched-failure reason is
+    the falsification), so the breaker still trips when the gate is on.
+
+    Verified by: a spawn-fail that trips the breaker results in a
+    ``blocked`` status with ``last_failure_error`` populated.
+    """
+    def _bad_spawn(task, ws):
+        # Avoid trigger words for blocker_auth respawn-guard
+        # (auth/quota/permission) so the failure goes through the
+        # circuit breaker, not the respawn guard.
+        raise RuntimeError("spawn subprocess failed: no PATH configured")
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="auto-block test", assignee="worker")
+        assert kb.DEFAULT_FAILURE_LIMIT == 2
+        res1 = kb.dispatch_once(conn, spawn_fn=_bad_spawn)
+        assert tid not in res1.auto_blocked
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 1
+        res2 = kb.dispatch_once(conn, spawn_fn=_bad_spawn)
+        assert tid in res2.auto_blocked
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked", (
+            f"circuit breaker should auto-block but status is {task.status}"
+        )
+        # last_failure_error is the system's own evidence.
+        assert task.last_failure_error and "PATH" in task.last_failure_error
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# The 2026-07-19 failure scenario — must be rejected at runtime
+# ---------------------------------------------------------------------------
+
+def test_2026_07_19_failure_scenario_reproduction(kanban_home, gate_enabled):
+    """The exact failure that motivated the fix: a worker declares a
+    capability blocker citing a technical condition (SSH key unavailable)
+    without first attempting to load the key. Under the new gate, this
+    transition is rejected at the runtime level — the task stays in
+    ``running`` (or returns to the worker's hands) and the false blocker
+    is structurally impossible to create.
+    """
+    conn = kb.connect()
+    try:
+        tid = _create_running_task(conn, "2026-07-19 repro")
+        with pytest.raises(ValueError) as exc_info:
+            kb.block_task(
+                conn, tid,
+                reason="SSH key unavailable",
+                kind="capability",
+            )
+        assert "evidence is required" in str(exc_info.value)
+        task = kb.get_task(conn, tid)
+        assert task.status == "running", (
+            f"task should still be running after rejected false blocker; "
+            f"got {task.status}"
+        )
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Caller-claim invariant: every agent claim lands with system_observed=False
+# ---------------------------------------------------------------------------
+
+def test_default_system_observed_is_false(kanban_home, gate_enabled):
+    """Omitting ``_system_observed`` defaults to False, so every
+    caller-claim path that forgets to set it is correctly classified
+    as a claim (not a runtime observation). This pins the
+    never-silent-bypass invariant.
+    """
+    conn = kb.connect()
+    try:
+        tid = _create_running_task(conn, "default flag")
+        kb.block_task(
+            conn, tid,
+            reason="explicit claim",
+            kind="capability",
+            evidence="ran X; observed Y",
+            # _system_observed not passed → defaults to False.
+        )
+        ev_rows = conn.execute(
+            "SELECT kind, payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'blocked'",
+            (tid,),
+        ).fetchall()
+        assert ev_rows
+        payload = json.loads(ev_rows[-1]["payload"])
+        assert payload.get("system_observed") is False
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Evidence is recorded for dependency and loop paths even though gate
+# doesn't fire there — audit trail parity.
+# ---------------------------------------------------------------------------
+
+def test_dependency_block_records_evidence_field_when_supplied(kanban_home, gate_enabled):
+    """Even though the dependency branch is exempt at the routing
+    layer, the evidence field is still plumbed into the event payload
+    when the caller supplies one. This keeps the audit trail uniform.
+    """
+    conn = kb.connect()
+    try:
+        tid = _create_running_task(conn, "dep with evidence")
+        kb.block_task(
+            conn, tid,
+            reason="waiting on parent",
+            kind="dependency",
+            evidence="verified parent is still open: task ABC status=running",
+        )
+        ev_rows = conn.execute(
+            "SELECT kind, payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'dependency_wait'",
+            (tid,),
+        ).fetchall()
+        assert ev_rows
+        payload = json.loads(ev_rows[-1]["payload"])
+        assert payload.get("evidence", "").startswith("verified parent")
+    finally:
+        conn.close()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -733,6 +733,9 @@ def _handle_block(args: dict, **kw) -> str:
         return tool_error("reason is required — explain what input you need")
     reason = redact_sensitive_text(str(reason), force=True)
     kind = args.get("kind")
+    evidence = args.get("evidence")
+    if evidence is not None:
+        evidence = redact_sensitive_text(str(evidence), force=True)
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
@@ -759,17 +762,18 @@ def _handle_block(args: dict, **kw) -> str:
         ):
             conn.close()
             return tool_error(
-                f"goal_mode tasks can only block with kind in "
+                "goal_mode tasks can only block with kind in "
                 f"{sorted(_GOAL_MODE_BLOCK_ALLOWED_KINDS)} (got {kind!r}). "
-                f"If the task is actually finished or cannot proceed for "
-                f"another reason, call kanban_complete instead — the "
-                f"completion judge will evaluate it."
+                "If the task is actually finished or cannot proceed for "
+                "another reason, call kanban_complete instead — the "
+                "completion judge will evaluate it."
             )
         try:
             ok = kb.block_task(
                 conn, tid,
                 reason=reason,
                 kind=kind,
+                evidence=evidence,
                 expected_run_id=_worker_run_id(tid),
             )
             if not ok:
@@ -790,6 +794,15 @@ def _handle_block(args: dict, **kw) -> str:
         finally:
             conn.close()
     except ValueError as e:
+        # Verified-blocker gate failure: surface a clear, actionable error to
+        # the agent so it knows exactly what to put in the next call. The
+        # underlying kanban_db error cites Article XII P5 / XIV P2; we add a
+        # short pointer to the tool schema so the next attempt is well-formed.
+        msg = str(e)
+        if "evidence is required" in msg:
+            return tool_error(
+                "kanban_block: " + msg
+            )
         return tool_error(f"kanban_block: {e}")
     except Exception as e:
         logger.exception("kanban_block failed")
@@ -1663,6 +1676,27 @@ KANBAN_BLOCK_SCHEMA = {
                     "Why you're blocked. 'dependency' waits in todo and "
                     "resumes automatically; the others surface to a human. "
                     "Omit only if none apply."
+                ),
+            },
+            "evidence": {
+                "type": "string",
+                "description": (
+                    "Falsification record — REQUIRED when kanban."
+                    "require_block_evidence is enabled in config.yaml "
+                    "(and your block would land in 'blocked', not 'todo' "
+                    "and not 'triage'). The string MUST record: (a) the "
+                    "command/observation you ran to verify the blocking "
+                    "condition, (b) the result you observed, and (c) the "
+                    "conclusion that the blocker is real. Example: "
+                    "'ran ssh-add ~/.ssh/id_ed25519; result: key loaded, "
+                    "fingerprint sha256:abc123; subsequent ssh -o "
+                    "BatchMode=yes macbook-pro echo OK returned OK and "
+                    "exit 0; the SSH key is available, so the blocker is "
+                    "the remote account, not the key.' Without evidence, "
+                    "the runtime rejects the transition (Article XII P5: "
+                    "falsify before concluding). Dependency blocks "
+                    "(kind='dependency') and loop-detected routing to "
+                    "triage are exempt at the routing layer."
                 ),
             },
             "board": _board_schema_prop(),


### PR DESCRIPTION
## Problem

The 2026-07-19 incident: an audit declared a Kanban task as `Blocked on SSH key` while the SSH key was available throughout. The agent never attempted to load the key before declaring the blocker. The false blocker went undetected for 8 days, leaving an unverified blocker visible on the board.

## Fix (v3 — supersedes v1 #73566 and v2)

A new `evidence` parameter on `block_task()` requires a falsification record for blocks that would land in `blocked` (the human queue) when `kanban.require_block_evidence` is enabled in `config.yaml`. The runtime rejects empty/None evidence on a non-dependency, non-loop, non-system block with a `ValueError` that cites Article XII P5 and Article XIV P2. The 2026-07-19 failure mode is structurally impossible when the gate is on.

## What changed vs v2 (commit `f38aeccd`)

The previous v2 PR (#73587) had three blockers raised by `teknium1` and `GottZ`. All three are resolved in this v3.

| # | Issue | Resolution |
|---|-------|------------|
| 1 | Gate ran **before** routing determination, so the documented loop-to-triage exemption was broken. The loop-to-triage test supplied evidence on both calls and didn't actually exercise the exemption. | Gate moved to the destination branch only. Dependency → `todo` and `recurrences >= BLOCK_RECURRENCE_LIMIT` → `triage` are exempt at the routing layer. The loop-to-triage regression test now omits evidence on the loop-triggering call. |
| 2 | Enabling the gate breaks sibling block callers that cannot provide evidence: CLI (`hermes_cli/kanban.py`), dashboard single/bulk PATCH (`plugins/kanban/dashboard/plugin_api.py`), and goal-loop fallback (`cli.py`). | All four call sites plumb `evidence` through. CLI gains `--evidence`; dashboard PATCH bodies gain `block_evidence` (and bulk gains `block_reason` + `block_evidence`); the goal-loop fallback uses `_system_observed=True` (its falsification is the runtime observation, not a caller claim). |
| 3 | Merge conflict — `DEFAULT_CONFIG` was moved to `hermes_cli/config_defaults.py` on `main`; the v2 PR edited the old location in `hermes_cli/config.py`. | New key added to `hermes_cli/config_defaults.py` (current location). |

## Mechanism

- New `evidence: Optional[str]` parameter on `block_task()`. Optional at the API level (no caller breakage when the gate is off). Required at the gate when the gate is enabled.
- New `_system_observed: bool = False` keyword-only parameter for system-observed blocks (circuit breaker, goal-loop fallback). The leading underscore signals "do not pass this from caller code." Every blocked event records the `system_observed` flag so post-hoc investigation can distinguish runtime observations from caller claims.
- Gate controlled by `kanban.require_block_evidence` in `config.yaml`, loaded via the existing `hermes_cli.config.load_config()` mechanism. Defensive load: a raised `load_config()` defaults the gate to OFF rather than breaking unrelated callers.
- Default **off** (backward compatible with existing code and tests). Production deployments enable it explicitly via config. **Additive key — no config-version bump required.**

## Audit trail

When `evidence` is supplied (with the gate on), the string is recorded in:

- `task_events.payload` (kind=`"blocked"`, `"dependency_wait"`, `"block_loop_detected"`) as JSON
- The synthesized run summary (or the regular run summary when a run exists) — the falsification is appended after the reason as `[evidence]\n<text>`
- The `system_observed` boolean on every blocked event payload

The falsification is auditable post-hoc via SQL or the dashboard.

## Tests (14 new regression tests, all pass)

In `tests/hermes_cli/test_kanban_verified_blocker.py`:

- `test_non_dependency_block_without_evidence_raises` — the 2026-07-19 failure mode is rejected
- `test_non_dependency_block_with_evidence_succeeds` — legitimate blockers work; evidence recorded in event payload + run summary
- `test_dependency_block_without_evidence_succeeds` — routing exemption (todo)
- `test_loop_detected_routing_to_triage_succeeds_without_evidence` — routing exemption (triage); the v2 test supplied evidence on both calls; this one omits it on the loop-triggering re-block, matching the documented behavior
- `test_empty_string_evidence_treated_as_missing` — whitespace-only counts as missing
- `test_system_observed_bypasses_gate` — `_system_observed=True` bypasses cleanly
- `test_system_observed_false_with_evidence_records_flag_correctly` — audit trail captures the flag on every blocked event
- `test_default_off_allows_existing_call_sites` — backward compat (gate explicitly off)
- `test_unset_config_allows_legacy_call_sites` — backward compat (no config at all)
- `test_malformed_config_does_not_break_block_task` — defensive: raised `load_config()` defaults the gate to OFF rather than blowing up unrelated callers
- `test_circuit_breaker_still_works_without_evidence` — system path passes the breaker
- `test_2026_07_19_failure_scenario_reproduction` — exact incident repro is rejected at runtime; task stays in `running`
- `test_default_system_observed_is_false` — never-silent-bypass invariant: every caller claim defaults to `system_observed=False`
- `test_dependency_block_records_evidence_field_when_supplied` — audit trail parity across routing destinations

14 new tests pass. The 48 surrounding kanban tests (`test_kanban_block_kinds`, `test_kanban_blocked_sticky`, `test_kanban_cli`, `test_kanban_tools`, `stress/test_concurrency_mixed`, `stress/test_property_fuzzing`, `gateway/test_kanban_notifier`, `tui_gateway/test_kanban_notify_poller`) remain green.

## Constitutional anchoring

- **Article XII P5** (falsify before concluding) — the gate operationalizes this for task-state transitions
- **Article XIV P2** (blockers create work, not waiting) — the gate prevents the false blocker Article XIV P2 was added to discourage
- **Article XIII** (no constitutional amendment for implementation failures of existing principles) — the gate is an implementation refinement, not a new principle

## Scope

- `hermes_cli/config_defaults.py` — new `kanban.require_block_evidence: false` key in the kanban config section (additive)
- `hermes_cli/kanban_db.py` — `block_task()` gets `evidence` and `_system_observed` parameters, gate runs after routing, evidence recorded in event payload + run summary, `system_observed` flag on every blocked event
- `tools/kanban_tools.py` — `kanban_block` tool plumbs `evidence` through; redaction parity with `reason`; `ValueError` surfaces as actionable `tool_error`; tool schema documents the field
- `hermes_cli/kanban.py` — `--evidence` argparse flag, `ValueError` caught and reported as stderr + non-zero exit
- `plugins/kanban/dashboard/plugin_api.py` — `UpdateTaskBody.block_evidence` + `BulkTaskBody.block_reason/block_evidence`; single PATCH returns 422 on gate failure, bulk surfaces per-task error
- `cli.py` — `_block` callback uses `_system_observed=True` with `reason` as the falsification record
- `tests/hermes_cli/test_kanban_verified_blocker.py` — 14 regression tests (was 9; +5 covering malformed-config defense, `_system_observed` contract, dependency-evidence audit parity, and the corrected loop-to-triage test)

No new modules, no new tables, no new tool definitions, no new validators, no new env vars. 792 lines total (was 470 in v2; +322 closes the three open blockers without expanding the API surface).

Reported-by: Taras Polishchuk <poli.taras.shchuk@gmail.com>
