### PR TITLE
fix(gateway): drain full message queue on /stop instead of only queue head

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19519,6 +19519,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if adapter and hasattr(adapter, "get_pending_message"):
             adapter.get_pending_message(session_key)  # consume and discard
         self._pending_messages.pop(session_key, None)
+        self._queued_events.pop(session_key, None)  # drain the full overflow queue too (#73060)
         if release_running_state:
             self._release_running_agent_state(session_key)
             # Evict the cached agent: ``_interrupt_requested`` is only


### PR DESCRIPTION
Closes #73060

**Problem:** `/stop` discards only the head of the message queue (`_pending_messages` single slot) while leaving the overflow list (`_queued_events`) intact. Each subsequent drain promotes the next item to the runner, so the session keeps producing replies after the user told it to stop.

**Fix:** Added `self._queued_events.pop(session_key, None)` in `_interrupt_and_clear_session`, the common clearing path shared by both the early `/stop` intercept and the `_handle_stop_command` dispatch. This drains the entire overflow queue when a stop happens.

**Verification with the repro script from the issue:**
```
after 3x /queue  slot: A overflow: ['B', 'C']
stop reply: ⚡ Stopped. You can continue this session.
after /stop      slot: None overflow: [] depth: 0
next drain runs: None remaining: []
```

The overflow list is now fully drained, `_queue_depth` reports `0`, and no further messages run autonomously.