### PR TITLE
test(tts): accept stream kwarg in remaining xAI fake_post fixtures (unblocks all PR CI)

### DIFF
--- a/tests/tools/test_tts_xai_speech_tags.py
+++ b/tests/tools/test_tts_xai_speech_tags.py
@@ -143,7 +143,7 @@ def test_generate_xai_tts_uses_oauth_pinned_base_url(tmp_path, monkeypatch):
         def raise_for_status(self):
             pass
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["url"] = url
         captured["headers"] = headers
         return FakeResponse()
@@ -590,7 +590,7 @@ def test_generate_xai_tts_omits_text_normalization_by_default(tmp_path, monkeypa
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
         return fake_response
 
@@ -614,7 +614,7 @@ def test_generate_xai_tts_sends_text_normalization_when_enabled(tmp_path, monkey
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
         return fake_response
 
@@ -640,7 +640,7 @@ def test_generate_xai_tts_omits_text_normalization_when_explicit_false(
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
         return fake_response
 


### PR DESCRIPTION
## Summary
Fixes the main-side test break failing CI slice 2/8 on every open PR: commit a1bc12f191 added `stream=True` to the xAI TTS `requests.post` call, but 4 of the 14 `fake_post` fixtures in `test_tts_xai_speech_tags.py` still had rigid signatures → `TypeError: unexpected keyword argument 'stream'`.

## Changes
- `tests/tools/test_tts_xai_speech_tags.py`: the 4 remaining fixtures accept `stream=False`, matching the 10 that already did.

## Validation
| | Before | After |
|---|---|---|
| test_tts_xai_speech_tags.py | 26 passed, 4 failed (on main) | 30 passed, 0 failed |

## Infographic

![ci unblock](https://v3b.fal.media/files/b/0aa419b9/VDQvbIHZaxSXRsZ-OwJ1W_D49N0Omo.png)
