### PR TITLE
test: fix xai TTS fake_post fixtures for stream kwarg (voice-train interaction)

### DIFF
--- a/tests/tools/test_tts_xai_speech_tags.py
+++ b/tests/tools/test_tts_xai_speech_tags.py
@@ -143,7 +143,7 @@ def test_generate_xai_tts_uses_oauth_pinned_base_url(tmp_path, monkeypatch):
         def raise_for_status(self):
             pass
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["url"] = url
         captured["headers"] = headers
         return FakeResponse()
@@ -590,7 +590,7 @@ def test_generate_xai_tts_omits_text_normalization_by_default(tmp_path, monkeypa
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
         return fake_response
 
@@ -614,7 +614,7 @@ def test_generate_xai_tts_sends_text_normalization_when_enabled(tmp_path, monkey
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
         return fake_response
 
@@ -640,7 +640,7 @@ def test_generate_xai_tts_omits_text_normalization_when_explicit_false(
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
         return fake_response
 


### PR DESCRIPTION
## Summary

Four xAI TTS tests fail on current main: #73512 added `stream=` to the xAI TTS POST while #73511/#73513's test stubs (each green against pre-train main) don't accept the kwarg. Pure test-contract fix — 4 `fake_post` signatures gain `stream=False`.

Cross-PR interaction from the voice merge train; each PR was individually green because CI ran them against pre-train main in parallel.

## Validation

| | Before | After |
|---|---|---|
| tests/tools/test_tts_xai_speech_tags.py | 4 failed, 26 passed | 30 passed |

## Infographic

![xai tts test contract fix](https://v3b.fal.media/files/b/0aa416f3/ufyTppbGu9N_KWglweqSq_hPxjHPoo.png)
