### PR TITLE
fix(cli): stop shredding an existing MEMORY.md on hermes import-agent

### DIFF
--- a/hermes_cli/agent_import.py
+++ b/hermes_cli/agent_import.py
@@ -40,16 +40,14 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import re
 import shutil
 import sys
-import tempfile
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-from utils import atomic_replace
+from utils import atomic_write_text
 
 logger = logging.getLogger(__name__)
 
@@ -248,30 +246,6 @@ def backup_memory_file(path: Path) -> Optional[Path]:
     shutil.copy2(path, backup)
     return backup
 
-
-def atomic_write_text(path: Path, content: str) -> None:
-    """Write ``content`` to ``path`` via temp file + atomic rename.
-
-    Mirrors ``MemoryStore._write_file``: an interrupted or failed write can
-    never leave a truncated memory store on disk, and readers always see
-    either the old complete file or the new one.  ``atomic_replace`` also
-    keeps a symlinked destination a symlink.
-    """
-    fd, tmp_path = tempfile.mkstemp(
-        dir=str(path.parent), suffix=".tmp", prefix=".import_"
-    )
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            handle.write(content)
-            handle.flush()
-            os.fsync(handle.fileno())
-        atomic_replace(tmp_path, path)
-    except BaseException:
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
-        raise
 
 
 def merge_entries(
@@ -582,10 +556,16 @@ class AgentImporter:
                 return
             if backup is not None:
                 details["backup"] = str(backup)
-            atomic_write_text(
-                destination,
-                ENTRY_DELIMITER.join(merged) + ("\n" if merged else ""),
-            )
+            try:
+                atomic_write_text(
+                    destination,
+                    ENTRY_DELIMITER.join(merged) + ("\n" if merged else ""),
+                )
+            except OSError as exc:
+                self.record(kind, source, destination, "error",
+                            f"Could not write merged memory file: {exc}",
+                            **details)
+                return
             self.record(kind, source, destination, "imported", **details)
         else:
             self.record(kind, source, destination, "imported",

--- a/hermes_cli/agent_import.py
+++ b/hermes_cli/agent_import.py
@@ -40,11 +40,16 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import shutil
 import sys
+import tempfile
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from utils import atomic_replace
 
 logger = logging.getLogger(__name__)
 
@@ -205,14 +210,68 @@ def extract_markdown_entries(text: str) -> List[str]:
 
 
 def parse_existing_memory_entries(path: Path) -> List[str]:
+    """Parse the DESTINATION memory store into entries.
+
+    ``memories/MEMORY.md`` is the entry-delimited store written by
+    ``MemoryStore._write_file`` (tools/memory_tool.py), not a markdown
+    document, so this splits on ``ENTRY_DELIMITER`` only — exactly what
+    ``MemoryStore._parse_entries`` does.  A store with no delimiter (a single
+    entry, or one that was hand-edited / shell-appended) is therefore ONE
+    intact entry.
+
+    Do NOT fall back to :func:`extract_markdown_entries` here.  That extractor
+    is correct for CLAUDE.md / AGENTS.md *sources*, but it drops fenced code
+    blocks and table rows and splits a block into one entry per bullet — and
+    the merged result is written straight back over the user's store, so the
+    loss is permanent.
+    """
     if not path.exists():
         return []
     raw = read_text(path)
     if not raw.strip():
         return []
-    if ENTRY_DELIMITER in raw:
-        return [e.strip() for e in raw.split(ENTRY_DELIMITER) if e.strip()]
-    return extract_markdown_entries(raw)
+    return [e.strip() for e in raw.split(ENTRY_DELIMITER) if e.strip()]
+
+
+def backup_memory_file(path: Path) -> Optional[Path]:
+    """Snapshot ``path`` before a destructive rewrite; return the backup path.
+
+    Restores parity with the openclaw migration script this module was ported
+    from, which calls ``maybe_backup(destination)`` before rewriting a memory
+    store.  Uses the same ``<name>.bak.<unix_ts>`` naming as
+    ``MemoryStore._backup_drifted_file``.  Returns None when there is nothing
+    to back up.
+    """
+    if not path.exists():
+        return None
+    backup = path.with_suffix(path.suffix + f".bak.{int(time.time())}")
+    shutil.copy2(path, backup)
+    return backup
+
+
+def atomic_write_text(path: Path, content: str) -> None:
+    """Write ``content`` to ``path`` via temp file + atomic rename.
+
+    Mirrors ``MemoryStore._write_file``: an interrupted or failed write can
+    never leave a truncated memory store on disk, and readers always see
+    either the old complete file or the new one.  ``atomic_replace`` also
+    keeps a symlinked destination a symlink.
+    """
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent), suffix=".tmp", prefix=".import_"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        atomic_replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def merge_entries(
@@ -513,9 +572,19 @@ class AgentImporter:
             return
         if self.execute:
             destination.parent.mkdir(parents=True, exist_ok=True)
-            destination.write_text(
+            try:
+                backup = backup_memory_file(destination)
+            except OSError as exc:
+                # Never rewrite the store when the safety net failed.
+                self.record(kind, source, destination, "error",
+                            f"Could not back up existing memory file: {exc}",
+                            **details)
+                return
+            if backup is not None:
+                details["backup"] = str(backup)
+            atomic_write_text(
+                destination,
                 ENTRY_DELIMITER.join(merged) + ("\n" if merged else ""),
-                encoding="utf-8",
             )
             self.record(kind, source, destination, "imported", **details)
         else:

--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -450,14 +450,21 @@ def rebrand_text(text: str) -> str:
 
 
 def parse_existing_memory_entries(path: Path) -> List[str]:
+    """Parse a DESTINATION Hermes memory store (memories/MEMORY.md, USER.md).
+
+    Splits on ``ENTRY_DELIMITER`` only, matching ``MemoryStore._parse_entries``
+    in ``tools/memory_tool.py``: a store with no delimiter is ONE intact entry.
+    Do NOT fall back to :func:`extract_markdown_entries` — it is the *source*
+    parser (workspace/MEMORY.md and friends), it drops fenced code blocks and
+    table rows and splits a block into one entry per bullet, and the merged
+    result is written back over the destination.
+    """
     if not path.exists():
         return []
     raw = read_text(path)
     if not raw.strip():
         return []
-    if ENTRY_DELIMITER in raw:
-        return [e.strip() for e in raw.split(ENTRY_DELIMITER) if e.strip()]
-    return extract_markdown_entries(raw)
+    return [e.strip() for e in raw.split(ENTRY_DELIMITER) if e.strip()]
 
 
 def extract_markdown_entries(text: str) -> List[str]:

--- a/tests/hermes_cli/test_agent_import.py
+++ b/tests/hermes_cli/test_agent_import.py
@@ -17,11 +17,13 @@ import pytest
 import yaml
 
 from hermes_cli.agent_import import (
+    ENTRY_DELIMITER,
     AgentImporter,
     claude_rule_to_command_pattern,
     detect_agents,
     extract_markdown_entries,
     is_secret_key,
+    parse_existing_memory_entries,
     sanitize_mcp_env,
 )
 
@@ -484,6 +486,86 @@ class TestMergeSemantics:
         assert (hermes_home / "memories" / "MEMORY.md").read_text() == first
         memory_items = [i for i in report["items"] if i["kind"] == "claude-md"]
         assert memory_items[0]["status"] == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# The DESTINATION memories/MEMORY.md is a §-delimited store, not a document
+# ---------------------------------------------------------------------------
+
+# A realistic hand-edited store: one entry, no "§", with a fenced code block
+# and a markdown table — exactly the content extract_markdown_entries() drops.
+EXISTING_MEMORY = """Homelab runbook. Restart the ingress controller with:
+
+```bash
+kubectl -n ingress rollout restart deploy/nginx
+```
+
+Escalation ladder:
+
+| Severity | Contact | Window |
+|----------|---------|--------|
+| SEV1     | on-call | 15m    |
+| SEV2     | #ops    | 4h     |
+
+Never page for SEV3.
+"""
+
+
+class TestExistingMemoryStorePreserved:
+    """An import must not shred the memory store it merges into.
+
+    ``memories/MEMORY.md`` is the entry-delimited store written by
+    ``MemoryStore._write_file``; a single-entry or hand-edited store contains
+    no ``§`` delimiter.  Parsing it with the *source* markdown extractor drops
+    code blocks and table rows and splits one entry into fragments, and the
+    merged result is written straight back over the file.
+    """
+
+    @pytest.fixture()
+    def seeded_home(self, hermes_home):
+        memory = hermes_home / "memories" / "MEMORY.md"
+        memory.parent.mkdir(parents=True, exist_ok=True)
+        memory.write_text(EXISTING_MEMORY, encoding="utf-8")
+        return hermes_home
+
+    def test_undelimited_store_is_one_entry(self, seeded_home):
+        path = seeded_home / "memories" / "MEMORY.md"
+        assert ENTRY_DELIMITER not in path.read_text(encoding="utf-8")
+        assert parse_existing_memory_entries(path) == [EXISTING_MEMORY.strip()]
+
+    def test_agrees_with_memory_store_parser(self, seeded_home):
+        from tools.memory_tool import MemoryStore
+
+        path = seeded_home / "memories" / "MEMORY.md"
+        raw = path.read_text(encoding="utf-8")
+        assert parse_existing_memory_entries(path) == MemoryStore._parse_entries(raw)
+
+    def test_import_preserves_existing_entry_verbatim(
+            self, claude_tree, seeded_home):
+        path = seeded_home / "memories" / "MEMORY.md"
+        run_import("claude-code", claude_tree, seeded_home, execute=True)
+        entries = path.read_text(encoding="utf-8").split(ENTRY_DELIMITER)
+        # The pre-existing store survives byte-intact as a SINGLE entry ...
+        assert entries[0] == EXISTING_MEMORY.strip()
+        # ... including the parts the markdown extractor would have dropped.
+        assert "kubectl -n ingress rollout restart deploy/nginx" in entries[0]
+        assert "| SEV1     | on-call | 15m    |" in entries[0]
+        # ... and the imported entries are still appended after it.
+        assert any("type hints" in e for e in entries[1:])
+
+    def test_import_backs_up_the_previous_store(self, claude_tree, seeded_home):
+        memories = seeded_home / "memories"
+        run_import("claude-code", claude_tree, seeded_home, execute=True)
+        backups = sorted(memories.glob("MEMORY.md.bak.*"))
+        assert len(backups) == 1
+        assert backups[0].read_text(encoding="utf-8") == EXISTING_MEMORY
+
+    def test_dry_run_leaves_the_store_untouched(self, claude_tree, seeded_home):
+        memories = seeded_home / "memories"
+        run_import("claude-code", claude_tree, seeded_home, execute=False)
+        assert (memories / "MEMORY.md").read_text(
+            encoding="utf-8") == EXISTING_MEMORY
+        assert not list(memories.glob("MEMORY.md.bak.*"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/skills/test_openclaw_migration.py
+++ b/tests/skills/test_openclaw_migration.py
@@ -56,6 +56,32 @@ def test_extract_markdown_entries_promotes_heading_context():
     assert "Tyler Williams > Active Projects: Hermes Agent" in entries
 
 
+def test_parse_existing_memory_entries_keeps_undelimited_store_intact(tmp_path):
+    """The DESTINATION store is §-delimited, not a markdown document.
+
+    ``migrate_memory`` and ``migrate_daily_memory`` read the Hermes-side
+    memories/MEMORY.md (and USER.md) and write the merged result back over it.
+    A store with no delimiter is ONE entry — running the source markdown
+    extractor over it would drop the code block and the table row below.
+    """
+    mod = load_module()
+    raw = (
+        "Homelab runbook. Restart the ingress controller with:\n"
+        "\n"
+        "```bash\n"
+        "kubectl -n ingress rollout restart deploy/nginx\n"
+        "```\n"
+        "\n"
+        "| Severity | Contact | Window |\n"
+        "| SEV1     | on-call | 15m    |\n"
+    )
+    path = tmp_path / "MEMORY.md"
+    path.write_text(raw, encoding="utf-8")
+
+    assert mod.ENTRY_DELIMITER not in raw
+    assert mod.parse_existing_memory_entries(path) == [raw.strip()]
+
+
 def test_merge_entries_respects_limit_and_reports_overflow():
     mod = load_module()
     existing = ["alpha"]

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -25,15 +25,13 @@ Design:
 
 import json
 import logging
-import os
-import tempfile
 import time
 from contextlib import contextmanager
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Dict, Any, List, Optional, Tuple
 
-from utils import atomic_replace
+from utils import atomic_write_text
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 msvcrt = None
@@ -873,23 +871,7 @@ class MemoryStore:
         """
         content = ENTRY_DELIMITER.join(entries) if entries else ""
         try:
-            # Write to temp file in same directory (same filesystem for atomic rename)
-            fd, tmp_path = tempfile.mkstemp(
-                dir=str(path.parent), suffix=".tmp", prefix=".mem_"
-            )
-            try:
-                with os.fdopen(fd, "w", encoding="utf-8") as f:
-                    f.write(content)
-                    f.flush()
-                    os.fsync(f.fileno())
-                atomic_replace(tmp_path, path)
-            except BaseException:
-                # Clean up temp file on any failure
-                try:
-                    os.unlink(tmp_path)
-                except OSError:
-                    pass
-                raise
+            atomic_write_text(path, content, tmp_prefix=".mem_")
         except (OSError, IOError) as e:
             raise RuntimeError(f"Failed to write memory file {path}: {e}")
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -34,16 +34,14 @@ Directory layout for user skills:
 
 import json
 import logging
-import os
 import re
 import shutil
-import tempfile
 import contextvars as _ctxvars
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_constants import get_hermes_home, display_hermes_home
-from utils import atomic_replace, is_truthy_value
+from utils import atomic_write_text, is_truthy_value
 from hermes_cli.config import cfg_get
 from agent.skill_utils import (
     extract_skill_description,
@@ -817,35 +815,13 @@ def _resolve_skill_target(skill_dir: Path, file_path: str) -> Tuple[Optional[Pat
 
 
 def _atomic_write_text(file_path: Path, content: str, encoding: str = "utf-8") -> None:
+    """Atomically write text content to a file.
+
+    Thin wrapper around :func:`utils.atomic_write_text` so that every
+    destructive file rewrite in the codebase shares one implementation.
     """
-    Atomically write text content to a file.
-    
-    Uses a temporary file in the same directory and os.replace() to ensure
-    the target file is never left in a partially-written state if the process
-    crashes or is interrupted.
-    
-    Args:
-        file_path: Target file path
-        content: Content to write
-        encoding: Text encoding (default: utf-8)
-    """
-    file_path.parent.mkdir(parents=True, exist_ok=True)
-    fd, temp_path = tempfile.mkstemp(
-        dir=str(file_path.parent),
-        prefix=f".{file_path.name}.tmp.",
-        suffix="",
-    )
-    try:
-        with os.fdopen(fd, "w", encoding=encoding) as f:
-            f.write(content)
-        atomic_replace(temp_path, file_path)
-    except Exception:
-        # Clean up temp file on error
-        try:
-            os.unlink(temp_path)
-        except OSError:
-            logger.error("Failed to remove temporary file %s during atomic write", temp_path, exc_info=True)
-        raise
+    atomic_write_text(file_path, content, encoding=encoding,
+                      tmp_prefix=f".{file_path.name}.tmp.")
 
 
 # =============================================================================

--- a/utils.py
+++ b/utils.py
@@ -136,6 +136,41 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     return real_path
 
 
+def atomic_write_text(
+    path: Union[str, Path],
+    content: str,
+    *,
+    encoding: str = "utf-8",
+    tmp_prefix: str = ".tmp_",
+) -> None:
+    """Write *content* to *path* via temp file + fsync + atomic rename.
+
+    Ensures the target file is never left in a partially-written state if
+    the process crashes or is interrupted.  ``atomic_replace`` preserves
+    symlinks and handles cross-device / busy-file fallbacks.
+
+    Used by the memory store, skill manager, and agent importer so that
+    every destructive file rewrite in the codebase shares one implementation.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent), prefix=tmp_prefix, suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding=encoding) as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        atomic_replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
 def atomic_json_write(
     path: Union[str, Path],
     data: Any,


### PR DESCRIPTION
## Summary
`hermes import-agent` no longer silently destroys an existing `memories/MEMORY.md` when the store has no `§` delimiter — the lossy markdown-extractor fallback is replaced with delimiter-only parsing matching `MemoryStore._parse_entries`, plus a `.bak` snapshot and atomic write before the rewrite.

Root cause: `parse_existing_memory_entries()` fell back to `extract_markdown_entries()` (the *source* parser for CLAUDE.md/AGENTS.md) when the destination store had no delimiter. That extractor drops fenced code blocks, strips table rows, and splits one entry into fragments per bullet — and the result was written straight back over the file.

## Changes
- `hermes_cli/agent_import.py` — `parse_existing_memory_entries()` now splits on `ENTRY_DELIMITER` only (matching `MemoryStore._parse_entries`); new `backup_memory_file()` snapshots the store before rewrite; `atomic_write_text()` write via temp+fsync+rename (now calls shared `utils.atomic_write_text`); write-failure path now records a per-item error instead of propagating uncaught
- `optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py` — same delimiter-only parse fix for the sibling `parse_existing_memory_entries()`
- `utils.py` — new shared `atomic_write_text()` helper, consolidating the mkstemp→fsync→atomic_replace pattern from 3 files into one
- `tools/memory_tool.py` — `MemoryStore._write_file` now calls shared `utils.atomic_write_text`
- `tools/skill_manager_tool.py` — `_atomic_write_text` now delegates to shared `utils.atomic_write_text`
- `tests/hermes_cli/test_agent_import.py` — 5 new tests (`TestExistingMemoryStorePreserved`)
- `tests/skills/test_openclaw_migration.py` — 1 new test for the sibling site

## Follow-up commit (on top of @briandevans's original fix)
- Extracted `atomic_write_text` to `utils.py` — the PR's copy was the 3rd instance of the same pattern (also in `MemoryStore._write_file` and `skill_manager_tool._atomic_write_text`). All three now call the shared helper.
- Wrapped `atomic_write_text` call in `_merge_memory_entries` with `try/except OSError` — if the write fails after backup succeeds, a per-item error is now recorded with the backup path, instead of the exception propagating uncaught and aborting the entire import with no record.

## Validation
| | Before | After |
|---|---|---|
| `parse_existing_memory_entries` on undelimited store | 3 fragments (code block + table dropped) | 1 intact entry |
| Write failure handling | Exception propagates, no record | Per-item error record with backup path |
| `atomic_write_text` copies | 3 (agent_import, memory_tool, skill_manager) | 1 (utils.py) |
| Tests | 103 passed | 103 passed + 223 memory/skill tests passed |

Closes #72983
