### PR TITLE
test(tts): fix stale xAI fake_post stubs broken by streaming bound

### DIFF
--- a/tests/tools/test_tts_xai_speech_tags.py
+++ b/tests/tools/test_tts_xai_speech_tags.py
@@ -143,7 +143,7 @@ def test_generate_xai_tts_uses_oauth_pinned_base_url(tmp_path, monkeypatch):
         def raise_for_status(self):
             pass
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["url"] = url
         captured["headers"] = headers
         return FakeResponse()
@@ -590,7 +590,7 @@ def test_generate_xai_tts_omits_text_normalization_by_default(tmp_path, monkeypa
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
         return fake_response
 
@@ -614,7 +614,7 @@ def test_generate_xai_tts_sends_text_normalization_when_enabled(tmp_path, monkey
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
         return fake_response
 
@@ -640,7 +640,7 @@ def test_generate_xai_tts_omits_text_normalization_when_explicit_false(
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
         return fake_response
 


### PR DESCRIPTION
## Summary
Fixes 4 tests in `tests/tools/test_tts_xai_speech_tags.py` that fail on current main with `TypeError: fake_post() got an unexpected keyword argument 'stream'` — breaking Python tests slice 1/8 for every open PR.

Root cause: 60b841bbfb ("fix(tts): bound upstream response bodies") added `stream=True` to the xAI `requests.post` call, but 4 of the file's 14 `fake_post` stubs were not updated to accept the new kwarg. Sibling-test blast radius, zero-arg stub shape.

## Changes
- `tests/tools/test_tts_xai_speech_tags.py`: the 4 stale `fake_post` stubs now accept `stream=False`, matching the other 10

## Validation
| | Before | After |
|---|---|---|
| `pytest tests/tools/test_tts_xai_speech_tags.py` on main | 4 failed, 26 passed | 30 passed |

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa419d5/wUuQGlvwkmiFhCIyKwPph_a8zpw0H4.png)
