### PR TITLE
test(tts): accept streamed xAI requests in mocks

### DIFF
--- a/tests/tools/test_tts_xai_speech_tags.py
+++ b/tests/tools/test_tts_xai_speech_tags.py
@@ -143,7 +143,7 @@ def test_generate_xai_tts_uses_oauth_pinned_base_url(tmp_path, monkeypatch):
         def raise_for_status(self):
             pass
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["url"] = url
         captured["headers"] = headers
         return FakeResponse()
@@ -590,7 +590,7 @@ def test_generate_xai_tts_omits_text_normalization_by_default(tmp_path, monkeypa
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
         return fake_response
 
@@ -614,7 +614,7 @@ def test_generate_xai_tts_sends_text_normalization_when_enabled(tmp_path, monkey
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
         return fake_response
 
@@ -640,7 +640,7 @@ def test_generate_xai_tts_omits_text_normalization_when_explicit_false(
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
         return fake_response
 


### PR DESCRIPTION
## Summary

- update the four stale xAI TTS request mocks to accept the production `stream` keyword
- restore the xAI speech-tag test file after `_generate_xai_tts` switched to streamed response handling

## Reproduction

On current `main`:

```text
pytest tests/tools/test_tts_xai_speech_tags.py -q
4 failed, 26 passed
TypeError: fake_post() got an unexpected keyword argument 'stream'\n```\n\n## Validation\n\n- `pytest tests/tools/test_tts_xai_speech_tags.py -q` (30 passed)\n- `ruff check tests/tools/test_tts_xai_speech_tags.py`\n- `git diff --check`\n\nThis is kept separate from #59168, #59161, and #59190; their Python slices are currently hitting this same baseline failure.