### PR TITLE
fix(agent): preserve empty-string thinking signatures on Anthropic-wire replay

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1989,8 +1989,17 @@ def _sanitize_replay_block(b: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         return out
     if btype == "thinking":
         out = {"type": "thinking", "thinking": b.get("thinking", "")}
-        if b.get("signature"):
-            out["signature"] = b["signature"]
+        # Preserve the signature whenever the upstream sent one AS A STRING —
+        # including the empty string. A truthiness check here silently drops
+        # ``signature: ""``, which is what OpenRouter returns for Kimi/Moonshot
+        # reasoning on its Anthropic-Messages route. Its validator accepts the
+        # empty value but requires the KEY, so the de-signed block replays as
+        # invalid input (HTTP 400 invalid_union at ``messages[N].content``) and
+        # wedges every turn after the first. Anthropic itself never emits "",
+        # so widening the check is inert on the native path.
+        sig = b.get("signature")
+        if isinstance(sig, str):
+            out["signature"] = sig
         return out
     if btype == "redacted_thinking":
         # Only valid with its data payload; drop if missing.

--- a/tests/agent/test_anthropic_kimi_signed_thinking_replay.py
+++ b/tests/agent/test_anthropic_kimi_signed_thinking_replay.py
@@ -10,6 +10,7 @@ SIG = "sig-k3"
 KIMI = "https://api.kimi.com/coding"
 MOONSHOT = "https://api.moonshot.cn/anthropic"
 DEEPSEEK = "https://api.deepseek.com/anthropic"
+OPENROUTER = "https://openrouter.ai/api/v1"
 
 
 def _thinking_on_replay(base_url, signature=SIG, model="k3"):
@@ -41,6 +42,27 @@ def _thinking_on_replay(base_url, signature=SIG, model="k3"):
 
 
 
+
+
+def test_empty_signature_key_survives_replay():
+    """An empty-string signature must round-trip as ``signature: ""``, not vanish.
+
+    OpenRouter returns Kimi's reasoning as ``{"type": "thinking", ...,
+    "signature": ""}``. Its Anthropic-Messages validator accepts the empty
+    string but requires the KEY to be present — a thinking block with no
+    ``signature`` field at all is rejected with HTTP 400 ``invalid_union``
+    at ``messages[N].content``. Dropping the key on a falsy check therefore
+    wedges every turn after the first. See hermes-agent#17992 for the
+    adjacent DeepSeek case (signed blocks wrongly stripped on replay).
+    """
+    for base_url in (OPENROUTER, KIMI):
+        thinking = _thinking_on_replay(base_url, signature="", model="moonshotai/kimi-k3")
+        assert thinking, f"unsigned thinking block dropped entirely: {base_url}"
+        assert "signature" in thinking[0], (
+            "empty-string signature key must be preserved verbatim — dropping it "
+            f"makes the block invalid input on replay: {thinking[0]}"
+        )
+        assert thinking[0]["signature"] == ""
 
 
 def test_moonshot_keeps_signed_thinking():


### PR DESCRIPTION
## What does this PR do?

Fixes a one-character-class bug in `_sanitize_replay_block` that makes **any Kimi/Moonshot model unusable past the first turn** when routed over an Anthropic-Messages endpoint that returns unsigned reasoning — notably OpenRouter's `/api/v1/messages`.

The thinking-block `signature` was gated on a **truthiness** check:

```python
if btype == "thinking":
    out = {"type": "thinking", "thinking": b.get("thinking", "")}
    if b.get("signature"):          # "" is falsy → key dropped entirely
        out["signature"] = b["signature"]
    return out
```

OpenRouter returns Kimi's reasoning as `{"type": "thinking", "thinking": "...", "signature": ""}` — an **empty string**, not a missing field. The truthiness check drops the key, so the block persisted to `state.db` has no `signature` at all. On the next turn it replays as invalid request input:

```
HTTP 400: Invalid Anthropic Messages API request
  code: invalid_union
  path: ["messages", 1, "content"]
  [0, "signature"]: Invalid input: expected string, received undefined
```

OpenRouter's validator **accepts the empty value but requires the key to be present**. Confirmed empirically — see the matrix below.

### Why this is worth fixing

The failure is quiet and expensive. API call #1 of a session succeeds (there is no assistant turn to replay yet), so the model looks healthy; every call after it 400s in ~0.2s and silently burns a fallback. From the user's side the model simply "doesn't work" and the bill lands on the fallback model instead:

```
API call #1: model=moonshotai/kimi-k3 provider=openrouter in=19583 out=254 latency=10.3s
API call failed (attempt 1/3) error_type=BadRequestError provider=openrouter
  model=moonshotai/kimi-k3 summary=HTTP 400: Invalid Anthropic Messages API request
Fallback activated: moonshotai/kimi-k3 → anthropic/claude-sonnet-5 (openrouter)
```

The existing Kimi-family replay policy (`_is_kimi_family_endpoint` → "replay as-is") is already correct and does fire here — `moonshotai/kimi-k3` normalizes to `kimi-k3` and matches. The block is faithfully replayed; it has just already been stripped of its signature at **capture** time, one layer earlier, before it ever reached the replay policy.

## Related Issue

No existing issue covers this. Adjacent but **distinct** from #17992 / closed PR #17991 (DeepSeek `/anthropic`): that one is about *truthy* provider signatures being wrongly **stripped by the DeepSeek replay branch** in `convert_messages_to_anthropic`. This one is about an *empty-string* signature being wrongly **dropped at capture** in `_sanitize_replay_block`. Different function, different predicate, no overlap — #17991 would not have fixed this.

Happy to open a tracking issue first if maintainers prefer that order.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/anthropic_adapter.py` — `_sanitize_replay_block`: preserve `signature` whenever the upstream sent one **as a string**, including `""`, instead of only when truthy. Anthropic itself never emits an empty signature, so this is inert on the native path; it only stops discarding a field a third-party upstream did send.
- `tests/agent/test_anthropic_kimi_signed_thinking_replay.py` — regression test `test_empty_signature_key_survives_replay`, covering both the OpenRouter and Kimi base URLs.

The adjacent existing test `test_kimi_coding_keeps_unsigned_thinking` asserted only that the block *survives* replay, never that the `signature` key round-trips — which is why this slipped through.

## How to Test

**1. Confirm the endpoint contract** (no Hermes involved — plain curl, any OpenRouter key):

```bash
# A) replay a thinking block with NO signature key  ->  HTTP 400
curl -s -o /dev/null -w '%{http_code}\n' https://openrouter.ai/api/v1/messages \
  -H "Authorization: Bearer $OPENROUTER_API_KEY" -H 'content-type: application/json' \
  -d '{"model":"moonshotai/kimi-k3","max_tokens":32,"messages":[
       {"role":"user","content":"hi"},
       {"role":"assistant","content":[{"type":"thinking","thinking":"user said hi"},
                                      {"type":"text","text":"Hello!"}]},
       {"role":"user","content":"say ok"}]}'

# B) identical, but with the empty-string signature Kimi actually returns  ->  HTTP 200
#    (add "signature":"" to the thinking block above)
```

| Replayed thinking block | Result |
| --- | --- |
| no `signature` key | **HTTP 400** `invalid_union` |
| `"signature": ""` | **HTTP 200** |
| block removed entirely | HTTP 200 |

A live `max_tokens: 32` response confirms the source of the empty value:

```json
{"content":[{"type":"thinking","thinking":"The user just said \"say ok\"...","signature":""}],
 "model":"moonshotai/kimi-k3"}
```

**2. Regression test** — red on `main`, green with this patch:

```bash
pytest tests/agent/test_anthropic_kimi_signed_thinking_replay.py -q
# before: 1 failed, 7 passed
# after:  8 passed
```

**3. No collateral damage** in the surrounding replay/thinking suites:

```bash
pytest tests/agent/test_anthropic_kimi_signed_thinking_replay.py \
       tests/agent/test_deepseek_anthropic_thinking.py \
       tests/agent/test_kimi_coding_anthropic_thinking.py \
       tests/agent/test_anthropic_thinking_block_order.py \
       tests/agent/test_replay_cleanup.py \
       tests/agent/test_anthropic_kwargs_sanitize.py -q
# 63 passed
```

A broader sweep, run with and without the one-line change on the same tree,
shows the fix flips exactly one test and nothing else:

```bash
pytest tests/agent/ -q -k "anthropic or thinking or reasoning or signature or replay or kimi or moonshot"
# without fix: 15 failed, 914 passed
# with fix:    14 failed, 915 passed
```

The 14 residual failures are pre-existing on `main` and unrelated (OAuth
setup-token creds, reasoning stale-timeout floors, compression locks); they
fail identically with and without this patch.

**4. End to end**: set `model.api_mode: anthropic_messages` with `provider: openrouter` and `moonshotai/kimi-k3`, then run any prompt that triggers a tool call. Before: turn 2 falls back to the configured fallback model. After: the full thinking → tool_use → tool_result → answer sequence completes on Kimi.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (nearest neighbour #17991 is closed and touches a different function — see above)
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [ ] I've run `pytest tests/ -q` and all tests pass — the full suite has pre-existing failures on `main` unrelated to this change; I verified **no delta** instead (see "How to Test" step 3)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — the fix is self-documenting via an inline comment explaining why the predicate is `isinstance`, not truthiness
- [x] `cli-config.yaml.example` — N/A, no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture change
- [x] Cross-platform impact — N/A, pure dict manipulation
- [x] Tool descriptions/schemas — N/A
