### PR TITLE
fix(ui-tui): flush the buffered streaming tail at message.complete

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -605,6 +605,57 @@ describe('createGatewayEventHandler', () => {
     expect(assistant?.text).toBe('First. second.')
   })
 
+  // Narration → tool → tool-complete → more narration → message.complete with
+  // its own `payload.text`. Nothing flushes the second narration block, so
+  // before the fix message.complete cleared the buffer and the transcript lost
+  // a block the user had already watched render.
+  const streamTailTurn = (onEvent: ReturnType<typeof createGatewayEventHandler>) => {
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    onEvent({ payload: { text: 'Checking the config first.' }, type: 'message.delta' } as any)
+    onEvent({ payload: { context: 'config.yaml', name: 'read_file', tool_id: 'tool-1' }, type: 'tool.start' } as any)
+    onEvent({ payload: { name: 'read_file', summary: 'read', tool_id: 'tool-1' }, type: 'tool.complete' } as any)
+    onEvent({ payload: { text: 'The provider block looks wrong.' }, type: 'message.delta' } as any)
+  }
+
+  it('keeps streaming text buffered after a tool call, in order, at message.complete (#61520)', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    streamTailTurn(onEvent)
+    onEvent({ payload: { text: 'Final answer.' }, type: 'message.complete' } as any)
+
+    expect(appended.filter(msg => msg.role === 'assistant').map(msg => msg.text)).toEqual([
+      'Checking the config first.',
+      'The provider block looks wrong.',
+      'Final answer.'
+    ])
+
+    // The tail is flushed through the normal segment path, so the pending tool
+    // shelf lands on it exactly once instead of being duplicated or dropped.
+    const toolRows = appended.flatMap(msg => msg.tools ?? [])
+    expect(toolRows).toHaveLength(1)
+    expect(toolRows[0]).toContain('Read File')
+  })
+
+  it('does not duplicate the buffered tail when message.complete text already contains it (#61520)', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    streamTailTurn(onEvent)
+    // Gateway replays the streamed tail as part of its authoritative final text.
+    onEvent({
+      payload: { text: 'The provider block looks wrong.\n\nFinal answer.' },
+      type: 'message.complete'
+    } as any)
+
+    expect(appended.filter(msg => msg.role === 'assistant').map(msg => msg.text)).toEqual([
+      'Checking the config first.',
+      'The provider block looks wrong.',
+      'Final answer.'
+    ])
+    expect(appended.filter(msg => msg.text.includes('The provider block looks wrong.'))).toHaveLength(1)
+  })
+
   it('anchors inline_diff as its own segment where the edit happened', () => {
     const appended: Msg[] = []
     const onEvent = createGatewayEventHandler(buildCtx(appended))

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -569,7 +569,27 @@ class TurnController {
     // `display.final_response_markdown: render` because raw ANSI escapes
     // pass through into the React tree.  Prefer raw text and fall back
     // only when the gateway elected not to send any (#16391).
-    const rawText = (payload.text ?? payload.rendered ?? this.bufRef).trimStart()
+    const completionText = payload.text ?? payload.rendered
+    const rawText = (completionText ?? this.bufRef).trimStart()
+
+    // When the gateway sent its own final text, whatever is still sitting in
+    // `this.bufRef` is text the user watched stream AFTER the last segment
+    // flush — typically narration between a tool call and the end of the turn.
+    // `recordMessageComplete` was the only turn-end site that never flushed it,
+    // so `idle()` below wiped it and the transcript lost a block the user had
+    // already seen (#61520).
+    //
+    // Flush it as a segment rather than appending it to `finalMessages`: the
+    // segment spread below already sits ahead of the final assistant text, so
+    // stream order is preserved structurally, and `finalTail()` then strips the
+    // tail out of `finalText` when the completion payload already contains it.
+    // Skipped when `completionText` is absent, because then `rawText` IS the
+    // buffer (the #16391 fallback) and flushing would publish the final answer
+    // as a segment instead of the final message.
+    if (completionText !== undefined && this.bufRef.trim()) {
+      this.flushStreamingSegment()
+    }
+
     const split = splitReasoning(rawText)
     // Only dedupe segments AFTER the interim boundary — interim-sealed
     // segments are preserved even if the final text includes them.


### PR DESCRIPTION
## What does this PR do?

**Symptom (#61520):** the agent streams some text, calls a tool, streams more text, then the turn ends. The second block — which the user watched render live — disappears from the TUI transcript. Only the pre-tool narration and the final answer survive.

**Root cause:** `TurnController.recordMessageComplete` (`ui-tui/src/app/turnController.ts`) is the only turn-end site in the class that never calls `flushStreamingSegment()`. Every other site that ends or seals a stream does — `pushInlineDiffSegment`, the interim seal in `recordInterimAssistant`, `recordToolStart`, `recordInlineDiffToolComplete` — and `interruptTurn` preserves the buffer explicitly via its `partial` local. So when the gateway supplies its own final answer through `payload.text` (or `payload.rendered`), `this.bufRef` is not the source of that answer, and any text streamed after the last flush is still in the buffer when `idle()` clears it. It is dropped, silently.

**Fix:** flush the buffer as a segment, before the final message is assembled — rather than appending it to `finalMessages` afterwards. This is deliberately *removing* a special case instead of adding one, and it gets ordering and dedup for free from machinery that already exists:

- **Ordering** — the tail lands in `segmentMessages`, and the `...segments` spread already sits *ahead* of the `finalText` push. Order becomes `prior segment → streamed tail → final answer` structurally, with no hand-ordered push to get wrong.
- **Deduplication** — `finalTail()` already strips leading assistant-segment text off `finalText`. Once the tail is a segment, a completion payload that contains it is deduped by the existing helper; no new containment predicate is needed.
- **Tool rows** — `flushStreamingSegment()` drains `pendingSegmentTools` onto the flushed segment through the same `pushSegment` path used at every other flush site, so a tool shelf still renders exactly once (covered by an assertion in the first new test).

The flush is **conditional**: it is skipped when neither `payload.text` nor `payload.rendered` is present, because in that case `rawText` *is* the buffer (the #16391 fallback) and flushing would publish the final answer as a segment instead of as the final assistant message.

### Supersedes #61541

**Supersedes #61541.** Credit where it is due: @liuhao1024 identified this defect correctly and localized it to exactly the right method — that diagnosis is theirs. That PR has had no pushes since 2026-07-09, and the review on it named two correctness defects plus a coverage gap. This PR re-does the work to those stated acceptance criteria:

| Review finding on #61541 | Addressed here |
| --- | --- |
| Tail pushed *after* `finalText`, producing `prior → final answer → tail` | Tail is a segment, so the existing spread orders it *before* `finalText` |
| No containment dedup — a completion payload containing the tail renders it twice | `finalTail()` strips it; covered by the second regression test |
| No regression test | Two added, both verified red before / green after |

### Scope check

`bufRef` handling was swept across `ui-tui/src` for sibling sites with the same root cause. `interruptTurn` already preserves the buffer, `recordError` intentionally discards the whole turn (segments included, so it is a different concern), and the remaining `bufRef` reads are display-only (`scheduleStreaming`, `hydrateStreamingText`) or turn-start resets. `recordMessageComplete` is the only site that keeps segments but drops the tail, so this is a one-site fix.

## Related Issue

Fixes #61520

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/src/app/turnController.ts` — in `recordMessageComplete`, hoist the completion-text selection into a `completionText` local and, when it is present and `this.bufRef` is non-empty, call `flushStreamingSegment()` before `splitReasoning`/`dedupeStart`/`finalTail` run. Placement is load-bearing: it must be *after* `rawText` is read (the fallback still needs the buffer) and *before* the dedupe, so `finalTail()` sees the new segment.
- `ui-tui/src/__tests__/createGatewayEventHandler.test.ts` — two regression tests plus a shared `streamTailTurn` helper that drives the interleaved turn.

## How to Test

1. `cd ui-tui && npm run test` — 130 files, 1398 passed, 1 skipped.
2. Red-before / green-after, verified in both directions: with only the production guard reverted (tests kept), exactly the two new tests fail and the other 89 in the file still pass —
   `AssertionError: expected [ 'Checking the config first.', …(1) ] to deeply equal [ 'Checking the config first.', …(2) ]`
   — i.e. the middle block is missing. Restoring the guard turns both green with no other test changing state.
3. The two cases:
   - **Tool-interleaving order** — stream text → `tool.start` (flushes a segment) → `tool.complete` → stream a tail → `message.complete` with a separate `payload.text`. Asserts the transcript is `prior segment → tail → final answer`, in that order, and that the tool row appears exactly once.
   - **Completion-includes-tail dedup** — same turn, but `payload.text` already contains the tail. Asserts the tail renders exactly once and the ordering still holds.
4. Manually: run the TUI against a turn that narrates, calls a tool, narrates again, and finishes. The middle narration stays in the transcript instead of vanishing at turn end.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #61541 is the only PR on this defect and this PR supersedes it (see above). #55602, #59673, #47649, #22946 and #22953 also touch `turnController.ts`, but each targets a different bug (scroll flash, duplicate `message.complete` emits, `showReasoning` gating) and none preserves the buffered tail.
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the suite that covers this change — `cd ui-tui && npm run test` (1398 passed), `npm run typecheck` (clean) and `npm run lint` (clean). This PR touches no Python, so `pytest tests/` is unaffected.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure TypeScript control flow, no platform-dependent behavior)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
