### PR TITLE
test(tts): fix stale xAI fake_post doubles broken by stream=True (red on main)

### DIFF
--- a/tests/tools/test_tts_xai_speech_tags.py
+++ b/tests/tools/test_tts_xai_speech_tags.py
@@ -143,7 +143,7 @@ def test_generate_xai_tts_uses_oauth_pinned_base_url(tmp_path, monkeypatch):
         def raise_for_status(self):
             pass
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["url"] = url
         captured["headers"] = headers
         return FakeResponse()
@@ -590,7 +590,7 @@ def test_generate_xai_tts_omits_text_normalization_by_default(tmp_path, monkeypa
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
         return fake_response
 
@@ -614,7 +614,7 @@ def test_generate_xai_tts_sends_text_normalization_when_enabled(tmp_path, monkey
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
         return fake_response
 
@@ -640,7 +640,7 @@ def test_generate_xai_tts_omits_text_normalization_when_explicit_false(
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
         return fake_response
 


### PR DESCRIPTION
## Summary

Repairs 4 tests in `tests/tools/test_tts_xai_speech_tags.py` that are red on current main: commit 60b841bbfb ("fix(tts): bound upstream response bodies") switched the xAI TTS request to `requests.post(..., stream=True)`, but four `fake_post` doubles in this file still had the old 4-arg signature, so they crash with `TypeError: unexpected keyword argument 'stream'` on every run — failing CI slice 5/8 for unrelated PRs (first seen on docs-only #73571).

## Changes

- tests/tools/test_tts_xai_speech_tags.py: add `stream=False` to the 4 stale `fake_post` signatures (the other 10 fakes in the file were already updated)

## Validation

| | Before | After |
|---|---|---|
| test_tts_xai_speech_tags.py on main | 26 pass / 4 fail | 30 pass / 0 fail |

## Infographic

![stale TTS fakes fix](https://v3b.fal.media/files/b/0aa41a0d/tbE1SlWdUpEqWHfAUmxPp_rK8QGmqK.png)
