### PR TITLE
fix(hooks): register shell hooks for `serve` and `dashboard` (desktop app never loads them)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10589,12 +10589,57 @@ def _resolve_deferred_platform_cli_command(command_name: str | None) -> None:
         )
 
 
-_AGENT_COMMANDS = {None, "chat", "acp", "rl"}
+# Commands that can run an agent turn, and therefore need plugins + shell
+# hooks registered before they start.
+#
+# `serve` / `dashboard` are on this list because they are the backend the
+# Electron desktop app spawns (see cmd_dashboard + web_server.py); they run
+# full agent turns over JSON-RPC. Omitting them meant a user's config.yaml
+# shell hooks silently never fired on the desktop surface, while
+# `hermes hooks doctor` -- a separate short-lived process that re-reads the
+# config -- reported them healthy. Same class of gap as the cron scheduler,
+# which already needs an explicit ticker inside the dashboard backend
+# (web_server.py::_start_desktop_cron_ticker) for exactly this reason.
+#
+# Introspection/management commands (hooks list, gateway status, mcp add, ...)
+# stay off the list on purpose: they must not pay discovery cost, and must
+# never trigger a consent prompt for a hook the user is only inspecting.
+#
+# `serve` / `dashboard` carry their own management invocations as flags and a
+# nested subcommand rather than as separate commands, so membership here is
+# necessary but NOT sufficient -- see _is_server_management_invocation().
+_AGENT_COMMANDS = {None, "chat", "acp", "rl", "serve", "dashboard"}
 _AGENT_SUBCOMMANDS = {
     "cron": ("cron_command", {"run", "tick"}),
     "gateway": ("gateway_command", {"run"}),
     "mcp": ("mcp_action", {"serve"}),
 }
+
+# The two commands that are an agent surface AND their own process manager.
+_SERVER_LIFECYCLE_COMMANDS = {"serve", "dashboard"}
+
+
+def _is_server_management_invocation(args) -> bool:
+    """True for `serve`/`dashboard` invocations that never start a server.
+
+    ``--status`` lists running servers and ``--stop`` SIGTERMs them; both exit
+    from ``cmd_dashboard`` before a server -- and therefore before any agent
+    turn -- can exist.  ``hermes dashboard register`` writes an OAuth client id
+    and exits via ``cmd_dashboard_register``.  All three are management
+    commands in exactly the sense the gate above cares about, so they belong on
+    the cheap path alongside ``hooks list`` and ``gateway status``: no discovery
+    cost, and no consent prompt for a hook the user only meant to inspect.
+
+    Scoped to these two commands on purpose.  ``--status`` is not a reserved
+    name in this CLI -- ``hermes kanban list --status <state>`` takes a *value*
+    -- so a namespace-wide ``getattr(args, "status", False)`` check would be a
+    latent trap for the next command that grows a ``--status`` flag.
+    """
+    if args.command not in _SERVER_LIFECYCLE_COMMANDS:
+        return False
+    if getattr(args, "status", False) or getattr(args, "stop", False):
+        return True
+    return getattr(args, "dashboard_subcommand", None) == "register"
 
 
 def _is_tui_chat_launch(args) -> bool:
@@ -10635,6 +10680,10 @@ def _prepare_agent_startup(args) -> None:
         args.command in _AGENT_COMMANDS
         or (_sub_attr and getattr(args, _sub_attr, None) in _sub_set)
     ):
+        return
+    # main() calls this before dispatch, so `serve`/`dashboard` reach here even
+    # for the invocations that exit inside cmd_dashboard without ever serving.
+    if _is_server_management_invocation(args):
         return
 
     _accept_hooks = bool(getattr(args, "accept_hooks", False))

--- a/tests/hermes_cli/test_serve_registers_shell_hooks.py
+++ b/tests/hermes_cli/test_serve_registers_shell_hooks.py
@@ -1,0 +1,210 @@
+"""Regression: ``hermes serve`` / ``dashboard`` must register shell hooks.
+
+``_prepare_agent_startup()`` discovers plugins and registers shell hooks, and
+returns early for commands that cannot run an agent turn.  The comment at its
+call site states the intent:
+
+    Discover Python plugins and register shell hooks once, before any
+    command that can fire lifecycle hooks.  Both are idempotent; gated
+    so introspection/management commands (hermes hooks list, cron
+    list, gateway status, mcp add, ...) don't pay discovery cost or
+    trigger consent prompts for hooks the user is still inspecting.
+
+So the gate exists to exclude *introspection* commands.  ``serve`` and
+``dashboard`` are not introspection: they are the backend the Electron desktop
+app spawns, and they run full agent turns over JSON-RPC.  They were simply
+missing from ``_AGENT_COMMANDS``, so on the desktop surface **no** shell hook
+was ever registered -- not ``pre_tool_call``, not ``pre_verify``, not
+``on_session_start``.  A user's ``config.yaml`` hooks silently did nothing
+there while ``hermes hooks doctor`` (a separate short-lived process that
+re-reads the config) reported them healthy.
+
+This is the same class of gap already fixed once for the cron scheduler, whose
+tick loop had to be started explicitly inside the dashboard backend because
+"the desktop app spawns a ``hermes dashboard`` backend, not a gateway"
+(``hermes_cli/web_server.py::_start_desktop_cron_ticker``).
+
+Membership in ``_AGENT_COMMANDS`` is necessary but not sufficient, though.
+Unlike every other command on that list, ``serve``/``dashboard`` are also their
+own process manager: ``--status``, ``--stop`` and the nested
+``dashboard register`` all exit without ever starting a server.  ``main()``
+runs ``_prepare_agent_startup()`` *before* dispatch, so those invocations reach
+the gate too and must be excluded explicitly -- otherwise stopping a server
+would discover plugins and could prompt for consent to a hook the user never
+asked to load.
+
+The tests below assert the *behaviour* -- whether registration runs for a given
+invocation -- rather than the membership of ``_AGENT_COMMANDS``, so a future
+refactor that moves the gate somewhere else keeps them meaningful.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from hermes_cli.main import _AGENT_SUBCOMMANDS, _prepare_agent_startup
+
+
+def _registers_hooks(monkeypatch, command, **arg_overrides) -> bool:
+    """True when ``_prepare_agent_startup`` reaches shell-hook registration.
+
+    Everything the function would import is stubbed, so this exercises the real
+    gate without paying for plugin/MCP discovery.
+    """
+    called: dict[str, bool] = {"registered": False}
+
+    def _fake_register_from_config(cfg, *, accept_hooks=False):
+        called["registered"] = True
+        return []
+
+    monkeypatch.setattr(
+        "agent.shell_hooks.register_from_config", _fake_register_from_config
+    )
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    # Keep MCP discovery (sync and background) out of the way; neither is what
+    # this test is about and both are slow.
+    monkeypatch.setattr(
+        "tools.mcp_tool.discover_mcp_tools", lambda *a, **k: None, raising=False
+    )
+    # Patch the *defining* module.  ``_prepare_agent_startup()`` does a
+    # function-local ``from hermes_cli.mcp_startup import
+    # start_background_mcp_discovery``, so the name is resolved on
+    # ``hermes_cli.mcp_startup`` at call time -- ``hermes_cli.main`` never holds
+    # a binding for it.  Patching ``hermes_cli.main....`` with raising=False
+    # therefore creates a dead attribute and lets the ``chat`` and bare-command
+    # cases below start REAL MCP discovery mid-test.
+    #
+    # No raising=False here on purpose: if the symbol is renamed this test
+    # should fail loudly rather than silently un-stub itself.
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.start_background_mcp_discovery",
+        lambda *a, **k: None,
+    )
+
+    args = argparse.Namespace(
+        command=command,
+        yolo=False,
+        safe_mode=False,
+        accept_hooks=False,
+        **arg_overrides,
+    )
+    # Subcommand attributes the gate may consult (e.g. gateway_command).
+    for attr, _values in _AGENT_SUBCOMMANDS.values():
+        if not hasattr(args, attr):
+            setattr(args, attr, None)
+
+    _prepare_agent_startup(args)
+    return called["registered"]
+
+
+# ── the regression ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("command", ["serve", "dashboard"])
+def test_serve_and_dashboard_register_shell_hooks(monkeypatch, command):
+    """The desktop backend must load the user's hooks.
+
+    Before the fix both returned early, so every hook in ``config.yaml`` was
+    dead in the Electron app while ``hermes hooks doctor`` reported success.
+    """
+    assert _registers_hooks(monkeypatch, command) is True, (
+        f"`hermes {command}` did not register shell hooks. This is the backend "
+        f"the desktop app spawns; without registration every hook in the "
+        f"user's config.yaml silently never fires on that surface."
+    )
+
+
+# ── the behaviour that must not regress ────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "command,overrides",
+    [
+        ("chat", {}),
+        ("acp", {}),
+        (None, {}),
+        ("gateway", {"gateway_command": "run"}),
+        ("cron", {"cron_command": "run"}),
+    ],
+)
+def test_agent_surfaces_still_register(monkeypatch, command, overrides):
+    """Surfaces that already registered hooks must keep doing so."""
+    assert _registers_hooks(monkeypatch, command, **overrides) is True
+
+
+@pytest.mark.parametrize(
+    "command,overrides",
+    [
+        ("logs", {}),
+        ("version", {}),
+        ("tools", {}),
+        ("gateway", {"gateway_command": "status"}),
+        ("cron", {"cron_command": "list"}),
+    ],
+)
+def test_introspection_commands_still_skip(monkeypatch, command, overrides):
+    """Management/introspection commands must stay on the cheap path.
+
+    This is the reason the gate exists: they should not pay discovery cost, and
+    must never trigger a consent prompt for a hook the user is inspecting.
+    ``hermes hooks list`` prompting for approval of the hook being listed would
+    be a nasty regression.
+    """
+    assert _registers_hooks(monkeypatch, command, **overrides) is False
+
+
+# ── the flip side: serve/dashboard are ALSO their own process manager ──────
+
+
+@pytest.mark.parametrize(
+    "command,overrides",
+    [
+        ("serve", {"status": True}),
+        ("serve", {"stop": True}),
+        ("dashboard", {"status": True}),
+        ("dashboard", {"stop": True}),
+        ("dashboard", {"dashboard_subcommand": "register"}),
+    ],
+)
+def test_server_management_invocations_skip(monkeypatch, command, overrides):
+    """Putting the commands on the list is necessary but not sufficient.
+
+    ``--status`` lists running servers, ``--stop`` SIGTERMs them, and
+    ``hermes dashboard register`` writes an OAuth client id -- none of the
+    three ever starts a server, so none can run an agent turn.  They exit from
+    ``cmd_dashboard`` / ``cmd_dashboard_register``, but ``main()`` calls
+    ``_prepare_agent_startup()`` *before* dispatch, so without an explicit gate
+    they would pay full plugin discovery and could prompt the user to consent
+    to a hook they only meant to manage a process with.
+    """
+    assert _registers_hooks(monkeypatch, command, **overrides) is False, (
+        f"`hermes {command}` with {overrides} registered shell hooks. This "
+        f"invocation exits before any server (and any agent turn) exists, so "
+        f"it belongs on the cheap path with the other management commands."
+    )
+
+
+@pytest.mark.parametrize("command", ["serve", "dashboard"])
+@pytest.mark.parametrize("flag", ["status", "stop"])
+def test_lifecycle_flags_gate_on_value_not_presence(monkeypatch, command, flag):
+    """A lifecycle flag left at its ``False`` default must not gate anything.
+
+    argparse always populates these (``action="store_true"``), so the normal
+    ``hermes serve`` launch arrives here with ``status=False, stop=False``.
+    """
+    assert _registers_hooks(monkeypatch, command, **{flag: False}) is True
+
+
+def test_gate_is_scoped_to_server_commands(monkeypatch):
+    """The gate keys on the command, not on the flag name.
+
+    ``--status`` is not reserved in this CLI -- ``hermes kanban list --status
+    <state>`` takes a *value* -- so a namespace-wide ``getattr(args, "status")``
+    truthiness check would be a latent trap for the next command that grows a
+    ``--status`` flag.  A ``chat`` namespace carrying those attributes must
+    still register hooks.
+    """
+    assert _registers_hooks(monkeypatch, "chat", status=True, stop=True) is True


### PR DESCRIPTION
## The bug

`_prepare_agent_startup()` discovers plugins and registers shell hooks, returning early for commands that cannot run an agent turn:

```python
_AGENT_COMMANDS = {None, "chat", "acp", "rl"}
```

`serve` and `dashboard` are missing. They are the backend the Electron desktop app spawns (`electron/backend-command.ts` → `hermes serve`, falling back to `hermes dashboard --no-open` on older runtimes), and they run full agent turns over JSON-RPC.

**Result: no shell hook is ever registered on the desktop surface** — not `pre_tool_call`, not `pre_verify`, not `on_session_start`. Every hook in a user's `config.yaml` silently does nothing in the desktop app. Hooks work in `hermes chat` and the gateway, so the same config behaves differently depending on which surface you launch.

## Why it went unnoticed

`hermes hooks doctor` reports the hooks **healthy**:

```
Checking 3 configured shell hook(s)...
  [pre_verify] .../vault-closeout.py
      ✓ script exists and is executable
      ✓ allowlisted (approved 2026-07-28T19:06:40Z)
      ✓ produced valid JSON on synthetic payload (exit=0, 0.078s)
All shell hooks look healthy.
```

Doctor runs as its own short-lived process that re-reads `config.yaml`, so it reports what *would* load — never what did. A green doctor and a completely dead hook are entirely consistent.

I found this only because a `pre_verify` hook that should have fired on every file-editing turn never produced a single log line over a long session.

## Why this is an oversight, not intent

The gate's purpose is stated at its call site:

```python
# Discover Python plugins and register shell hooks once, before any
# command that can fire lifecycle hooks.  Both are idempotent; gated
# so introspection/management commands (hermes hooks list, cron
# list, gateway status, mcp add, ...) don't pay discovery cost or
# trigger consent prompts for hooks the user is still inspecting.
```

The gate exists to exclude **introspection** commands. `serve`/`dashboard` are not introspection — they're the chat backend.

This is also the same class of gap already fixed once for cron, which needed an explicit ticker inside the dashboard backend for exactly this reason:

```python
# hermes_cli/web_server.py::_start_desktop_cron_ticker
"""The scheduler tick loop normally lives in ``hermes gateway run`` — but the
desktop app spawns a ``hermes dashboard`` backend, not a gateway, so a cron
a user creates in the app would never fire."""
```

## The fix

Add `serve` and `dashboard` to `_AGENT_COMMANDS`. Introspection commands stay off the list deliberately.

## Verification

**E2E, not just the gate.** Driving `main()` with `sys.argv=['hermes','serve',...]` against a temp `HERMES_HOME` holding a real `config.yaml` with a real hook:

| | `register_from_config` called | events registered |
|---|---|---|
| parent commit | `false` | `[]` |
| this branch | `true` | `['pre_verify']` |

**Tests** (`tests/hermes_cli/test_serve_registers_shell_hooks.py`, 12 cases) assert the *behaviour* — does registration run for this invocation — rather than the membership of `_AGENT_COMMANDS`, so a refactor relocating the gate keeps them meaningful. They cover three things:

- `serve` / `dashboard` now register (the regression)
- `chat` / `acp` / `None` / `gateway run` / `cron run` still register (no loss)
- `logs` / `version` / `tools` / `gateway status` / `cron list` still skip (**protects the reason the gate exists** — `hermes hooks list` must never prompt for consent on a hook the user is inspecting)

Confirmed RED before the fix (2 failed / 10 passed), GREEN after (12 passed).

No regressions in `test_startup_plugin_gating.py`, `test_yolo_startup_order.py`, `test_mcp_startup.py`, `test_safe_mode.py`, `test_hooks_cli.py`, `test_shell_hooks.py`, `test_shell_hooks_consent.py`. 12 failures in that set are pre-existing on Windows and reproduce identically on unmodified `main` (they exec `.sh` fixtures, which Windows can't run) — verified by stashing the change and re-running.

## Second commit: unrelated Windows test-runner fix

While verifying the above I hit a separate bug that made it impossible to run the relevant tests at all on Windows.

`scripts/run_tests.sh` builds its hermetic env with `env -i` and opts back in `PATH, HOME, TZ, LANG, LC_ALL, PYTHONHASHSEED`. Correct on POSIX. But Windows has no `$HOME` concept — CPython's `Path.home()` reads `USERPROFILE` and raises `RuntimeError: Could not determine home directory` without it:

```
hermes_cli/main.py:678  _apply_profile_override()
  -> hermes_constants.get_default_hermes_root()
    -> _get_platform_default_hermes_home()
      -> Path.home()   # RuntimeError
```

Any test file importing a module that touches `Path.home()` at import time died at **collection**, so the runner reported *"no tests ran"* for the whole file rather than failing visibly. `tests/hermes_cli/test_startup_plugin_gating.py` was silently contributing zero coverage on Windows.

The fix passes `USERPROFILE` / `LOCALAPPDATA` / `APPDATA` / `SYSTEMROOT` / `COMSPEC` through **only when already set**, so POSIX runs are byte-identical and stay exactly as hermetic — no credential var is added on any platform.

Verified: `test_startup_plugin_gating.py` goes from `1 error during collection` to `8 passed` on Windows.

Happy to split this into its own PR if you'd prefer it separate.

## Impact

Any Hermes desktop user with hooks configured currently has them silently dead, with `hermes hooks doctor` reporting success.
