### PR TITLE
test(tts): accept stream kwarg in the 4 stale xAI fake_post mocks

### DIFF
--- a/tests/tools/test_tts_xai_speech_tags.py
+++ b/tests/tools/test_tts_xai_speech_tags.py
@@ -143,7 +143,7 @@ def test_generate_xai_tts_uses_oauth_pinned_base_url(tmp_path, monkeypatch):
         def raise_for_status(self):
             pass
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["url"] = url
         captured["headers"] = headers
         return FakeResponse()
@@ -590,7 +590,7 @@ def test_generate_xai_tts_omits_text_normalization_by_default(tmp_path, monkeypa
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
         return fake_response
 
@@ -614,7 +614,7 @@ def test_generate_xai_tts_sends_text_normalization_when_enabled(tmp_path, monkey
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
         return fake_response
 
@@ -640,7 +640,7 @@ def test_generate_xai_tts_omits_text_normalization_when_explicit_false(
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
         return fake_response
 


### PR DESCRIPTION
## Summary
Fixes the 4 pre-existing failures in `Python tests / Run tests slice 5/8` on `main`.

`_generate_xai_tts` passes `stream=True` to `requests.post` (`tools/tts_tool.py:1659`) since the TTS speaker pipeline moved to the streaming core. Four `fake_post` mocks in `tests/tools/test_tts_xai_speech_tags.py` still used the pre-streaming signature and raised `TypeError: fake_post() got an unexpected keyword argument 'stream'`.

The other 20+ `fake_post` mocks in the same file already accept `stream=False` — this aligns the four stragglers.

## Changes
- `tests/tools/test_tts_xai_speech_tags.py`: add `stream=False` to the 4 stale `fake_post` signatures (lines 146, 593, 617, 643).

## Validation
| | Before | After |
|---|---|---|
| `test_tts_xai_speech_tags.py` | 4 failed, 26 passed | **30 passed** |
| TTS suite (kittentts + plugin_dispatch + xai) | 4 failed | **75 passed** |
| ruff | clean | clean |

Reproduced on a clean worktree at current `upstream/main` before the fix, confirming this is pre-existing breakage and not PR-induced.

Test-only change — no production code touched.
