### PR TITLE
feat(web): add ordered provider fallback chains

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -326,6 +326,11 @@ DEFAULT_CONFIG = {
         "backend": "",           # shared fallback — applies to both search and extract
         "search_backend": "",    # per-capability override for web_search (e.g. "searxng")
         "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
+        # Opt-in ordered fallback chains. Empty lists preserve the legacy
+        # scalar/auto-detection behavior for existing installs.
+        "search_backends": [],
+        "extract_backends": [],
+        "fallback_on_empty_search": False,
         "extract_char_limit": 15000,  # per-page char budget for web_extract; larger pages truncate + store full text in cache/web
     },
 

--- a/tests/tools/test_web_tools_fallback_chains.py
+++ b/tests/tools/test_web_tools_fallback_chains.py
@@ -1,0 +1,1206 @@
+"""Regression coverage for quota-aware web backend fallback chains."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agent.web_search_provider import WebSearchProvider
+from agent import web_search_registry
+
+
+class FakeWebProvider(WebSearchProvider):
+    def __init__(
+        self,
+        name: str,
+        *,
+        search_response: dict[str, Any] | Exception | None = None,
+        extract_response: list[dict[str, Any]] | Exception | None = None,
+        available: bool = True,
+    ) -> None:
+        self._name = name
+        self.search_response = search_response
+        self.extract_response = extract_response
+        self.available = available
+        self.search_calls: list[tuple[str, int]] = []
+        self.extract_calls: list[tuple[list[str], dict[str, Any]]] = []
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def is_available(self) -> bool:
+        return self.available
+
+    def supports_search(self) -> bool:
+        return self.search_response is not None
+
+    def supports_extract(self) -> bool:
+        return self.extract_response is not None
+
+    def search(self, query: str, limit: int = 5) -> dict[str, Any]:
+        self.search_calls.append((query, limit))
+        if isinstance(self.search_response, Exception):
+            raise self.search_response
+        assert self.search_response is not None
+        return self.search_response
+
+    def extract(self, urls: list[str], **kwargs: Any) -> list[dict[str, Any]]:
+        self.extract_calls.append((urls, kwargs))
+        if isinstance(self.extract_response, Exception):
+            raise self.extract_response
+        assert self.extract_response is not None
+        return self.extract_response
+
+
+def _write_user_chain_plugin(hermes_home: Path) -> None:
+    """Install a deterministic user web plugin for subprocess E2E tests."""
+    plugin_dir = hermes_home / "plugins" / "web" / "test_chain"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        "name: web-test-chain\n"
+        "version: 1.0.0\n"
+        "kind: backend\n"
+        "provides_web_providers:\n"
+        "  - discovered-primary\n"
+        "  - discovered-fallback\n",
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        textwrap.dedent(
+            """
+            from agent.web_search_provider import WebSearchProvider
+
+
+            class DiscoveredProvider(WebSearchProvider):
+                def __init__(self, name, succeeds):
+                    self._name = name
+                    self._succeeds = succeeds
+
+                @property
+                def name(self):
+                    return self._name
+
+                def is_available(self):
+                    return True
+
+                def search(self, query, limit=5):
+                    if not self._succeeds:
+                        return {"success": False, "error": "primary exhausted"}
+                    return {
+                        "success": True,
+                        "data": {
+                            "web": [{
+                                "title": "discovered fallback",
+                                "url": "https://example.test/discovered",
+                                "description": query,
+                                "position": 1,
+                            }]
+                        },
+                    }
+
+
+            def register(ctx):
+                ctx.register_web_search_provider(
+                    DiscoveredProvider("discovered-primary", False)
+                )
+                ctx.register_web_search_provider(
+                    DiscoveredProvider("discovered-fallback", True)
+                )
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+def _run_discovered_chain_subprocess(hermes_home: Path) -> dict[str, Any]:
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    env.pop("HERMES_BUNDLED_PLUGINS", None)
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from tools.web_tools import web_search_tool; "
+                "print(web_search_tool('real discovery path', limit=1))"
+            ),
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+        timeout=30,
+    )
+    return json.loads(completed.stdout)
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    web_search_registry._reset_for_tests()
+    yield
+    web_search_registry._reset_for_tests()
+
+
+def test_parse_backend_chain_accepts_lists_and_comma_strings():
+    import tools.web_tools as wt
+
+    assert wt._parse_backend_chain(["Primary", "secondary", "exa", "unknown", "exa"]) == [
+        "primary",
+        "secondary",
+        "exa",
+        "unknown",
+    ]
+    assert wt._parse_backend_chain("primary, secondary exa parallel  tavily") == [
+        "primary",
+        "secondary",
+        "exa",
+        "parallel",
+        "tavily",
+    ]
+
+
+def test_web_search_falls_back_to_next_provider_on_error(monkeypatch):
+    import tools.web_tools as wt
+
+    brave = FakeWebProvider(
+        "brave-free",
+        search_response={"success": False, "error": "Brave Search returned HTTP 429"},
+    )
+    exa = FakeWebProvider(
+        "exa",
+        search_response={
+            "success": True,
+            "data": {"web": [{"title": "Exa hit", "url": "https://example.com", "description": "ok"}]},
+        },
+    )
+    web_search_registry.register_provider(brave)
+    web_search_registry.register_provider(exa)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(wt, "_load_web_config", lambda: {"search_backends": ["brave-free", "exa"]})
+    monkeypatch.setattr(wt, "_provider_available_for_chain", lambda name: True)
+
+    result = json.loads(wt.web_search_tool("agent search", limit=3))
+
+    assert result["success"] is True
+    assert result["data"]["web"][0]["title"] == "Exa hit"
+    assert brave.search_calls == [("agent search", 3)]
+    assert exa.search_calls == [("agent search", 3)]
+
+
+def test_web_search_falls_back_after_provider_exception(monkeypatch):
+    import tools.web_tools as wt
+
+    class RaisingProvider(FakeWebProvider):
+        def search(self, query: str, limit: int = 5):
+            self.search_calls.append((query, limit))
+            raise RuntimeError("primary exploded")
+
+    primary = RaisingProvider(
+        "primary",
+        search_response={"success": False, "error": "placeholder"},
+    )
+    secondary = FakeWebProvider(
+        "secondary",
+        search_response={
+            "success": True,
+            "data": {"web": [{"title": "Recovered", "url": "https://example.com"}]},
+        },
+    )
+    web_search_registry.register_provider(primary)
+    web_search_registry.register_provider(secondary)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(wt, "_load_web_config", lambda: {"search_backends": ["primary", "secondary"]})
+    monkeypatch.setattr(wt, "_provider_available_for_chain", lambda name: True)
+
+    result = json.loads(wt.web_search_tool("agent search", limit=3))
+
+    assert result["success"] is True
+    assert result["data"]["web"][0]["title"] == "Recovered"
+    assert primary.search_calls == [("agent search", 3)]
+    assert secondary.search_calls == [("agent search", 3)]
+
+
+def test_web_search_does_not_spend_fallback_on_clean_empty_by_default(monkeypatch):
+    import tools.web_tools as wt
+
+    brave = FakeWebProvider("brave-free", search_response={"success": True, "data": {"web": []}})
+    exa = FakeWebProvider(
+        "exa",
+        search_response={"success": True, "data": {"web": [{"title": "would cost", "url": "https://example.com"}]}},
+    )
+    web_search_registry.register_provider(brave)
+    web_search_registry.register_provider(exa)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(wt, "_load_web_config", lambda: {"search_backends": ["brave-free", "exa"]})
+    monkeypatch.setattr(wt, "_provider_available_for_chain", lambda name: True)
+
+    result = json.loads(wt.web_search_tool("definitely empty", limit=2))
+
+    assert result == {"success": True, "data": {"web": []}}
+    assert brave.search_calls == [("definitely empty", 2)]
+    assert exa.search_calls == []
+
+
+def test_web_search_can_opt_in_to_fallback_on_clean_empty(monkeypatch):
+    import tools.web_tools as wt
+
+    primary = FakeWebProvider(
+        "primary",
+        search_response={"success": True, "data": {"web": []}},
+    )
+    secondary = FakeWebProvider(
+        "secondary",
+        search_response={
+            "success": True,
+            "data": {"web": [{"title": "found", "url": "https://example.com"}]},
+        },
+    )
+    web_search_registry.register_provider(primary)
+    web_search_registry.register_provider(secondary)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        wt,
+        "_load_web_config",
+        lambda: {
+            "search_backends": ["primary", "secondary"],
+            "fallback_on_empty_search": True,
+        },
+    )
+    monkeypatch.setattr(wt, "_provider_available_for_chain", lambda name: True)
+
+    result = json.loads(wt.web_search_tool("empty then recover", limit=2))
+
+    assert result["data"]["web"][0]["title"] == "found"
+    assert primary.search_calls == [("empty then recover", 2)]
+    assert secondary.search_calls == [("empty then recover", 2)]
+
+
+def test_web_extract_skips_search_only_and_falls_back_to_exa(monkeypatch):
+    import tools.web_tools as wt
+
+    brave = FakeWebProvider("brave-free", search_response={"success": True, "data": {"web": []}})
+    firecrawl = FakeWebProvider(
+        "firecrawl",
+        extract_response=[{"url": "https://example.com", "title": "", "content": "", "error": "quota exhausted"}],
+    )
+    exa = FakeWebProvider(
+        "exa",
+        extract_response=[{"url": "https://example.com", "title": "Example", "content": "clean markdown"}],
+    )
+    web_search_registry.register_provider(brave)
+    web_search_registry.register_provider(firecrawl)
+    web_search_registry.register_provider(exa)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        wt,
+        "_load_web_config",
+        lambda: {"extract_backends": ["brave-free", "firecrawl", "exa"]},
+    )
+    monkeypatch.setattr(wt, "_provider_available_for_chain", lambda name: True)
+    monkeypatch.setattr(wt, "async_is_safe_url", lambda url: asyncio.sleep(0, result=True))
+
+    result = json.loads(asyncio.run(wt.web_extract_tool(["https://example.com"])))
+
+    assert result["results"][0]["title"] == "Example"
+    assert result["results"][0]["content"] == "clean markdown"
+    assert brave.extract_calls == []
+    assert firecrawl.extract_calls
+    assert exa.extract_calls
+
+
+def test_xai_can_remain_first_in_search_chain(monkeypatch):
+    import tools.web_tools as wt
+
+    xai = FakeWebProvider(
+        "xai",
+        search_response={"success": True, "data": {"web": [{"title": "Grok hit", "url": "https://x.ai"}]}},
+    )
+    brave = FakeWebProvider(
+        "brave-free",
+        search_response={"success": True, "data": {"web": [{"title": "Brave hit", "url": "https://brave.com"}]}},
+    )
+    web_search_registry.register_provider(xai)
+    web_search_registry.register_provider(brave)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(wt, "_load_web_config", lambda: {"search_backends": ["xai", "brave-free"]})
+    monkeypatch.setattr(wt, "_provider_available_for_chain", lambda name: True)
+
+    result = json.loads(wt.web_search_tool("X post context", limit=1))
+
+    assert result["data"]["web"][0]["title"] == "Grok hit"
+    assert xai.search_calls == [("X post context", 1)]
+    assert brave.search_calls == []
+
+
+def test_default_config_keeps_fallback_chains_opt_in():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["web"]["search_backends"] == []
+    assert DEFAULT_CONFIG["web"]["extract_backends"] == []
+    assert DEFAULT_CONFIG["web"]["fallback_on_empty_search"] is False
+
+
+def test_parse_backend_chain_preserves_unknown_names_for_diagnostics():
+    import tools.web_tools as wt
+
+    assert wt._parse_backend_chain(["not-installed", "EXA", "not-installed"]) == [
+        "not-installed",
+        "exa",
+    ]
+
+
+def test_unknown_explicit_chain_does_not_fall_back_to_legacy_auto(monkeypatch):
+    import tools.web_tools as wt
+
+    exa = FakeWebProvider(
+        "exa",
+        search_response={
+            "success": True,
+            "data": {"web": [{"title": "must not run", "url": "https://example.com"}]},
+        },
+    )
+    web_search_registry.register_provider(exa)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(wt, "_load_web_config", lambda: {"search_backends": ["typo-provider"]})
+    monkeypatch.setattr(wt, "_get_search_backend", lambda: "exa")
+
+    result = json.loads(wt.web_search_tool("policy boundary"))
+
+    assert result["success"] is False
+    assert "typo-provider" in result["error"]
+    assert "not registered" in result["error"]
+    assert exa.search_calls == []
+
+
+def test_malformed_explicit_chain_fails_closed(monkeypatch):
+    import tools.web_tools as wt
+
+    exa = FakeWebProvider(
+        "exa",
+        search_response={
+            "success": True,
+            "data": {"web": [{"title": "must not run", "url": "https://example.com"}]},
+        },
+    )
+    web_search_registry.register_provider(exa)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(wt, "_load_web_config", lambda: {"search_backends": {"exa": 1}})
+    monkeypatch.setattr(wt, "_get_search_backend", lambda: "exa")
+
+    result = json.loads(wt.web_search_tool("invalid policy"))
+
+    assert "error" in result
+    assert "search_backends" in result["error"]
+    assert "list" in result["error"].lower()
+    assert exa.search_calls == []
+
+
+def test_extract_fallback_preserves_successes_and_retries_only_failed_urls(monkeypatch):
+    import tools.web_tools as wt
+
+    first_url = "https://example.com/first"
+    second_url = "https://example.com/second"
+
+    primary = FakeWebProvider(
+        "primary",
+        extract_response=[
+            # Parallel/Tavily group successes before failures, so this order
+            # intentionally differs from the input URL order.
+            {"url": second_url, "title": "Second", "content": "primary content"},
+            {"url": first_url, "title": "", "content": "", "error": "quota exhausted"},
+        ],
+    )
+    fallback = FakeWebProvider(
+        "fallback",
+        extract_response=[
+            {"url": first_url, "title": "First", "content": "fallback content"},
+        ],
+    )
+    web_search_registry.register_provider(primary)
+    web_search_registry.register_provider(fallback)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        wt,
+        "_load_web_config",
+        lambda: {"extract_backends": ["primary", "fallback"]},
+    )
+    monkeypatch.setattr(wt, "_provider_available_for_chain", lambda name: True)
+    monkeypatch.setattr(wt, "async_is_safe_url", lambda url: asyncio.sleep(0, result=True))
+
+    result = json.loads(asyncio.run(wt.web_extract_tool([first_url, second_url])))
+
+    assert [item["content"] for item in result["results"]] == [
+        "fallback content",
+        "primary content",
+    ]
+    assert primary.extract_calls == [([first_url, second_url], {"format": None})]
+    assert fallback.extract_calls == [([first_url], {"format": None})]
+
+
+def test_scalar_search_preserves_provider_failure_response(monkeypatch):
+    import tools.web_tools as wt
+
+    provider_response = {"success": False, "error": "primary quota exhausted"}
+    primary = FakeWebProvider("primary", search_response=provider_response)
+    web_search_registry.register_provider(primary)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(wt, "_load_web_config", lambda: {"search_backend": "primary"})
+
+    assert json.loads(wt.web_search_tool("legacy scalar")) == provider_response
+    assert primary.search_calls == [("legacy scalar", 5)]
+
+
+def test_scalar_capability_mismatch_preserves_active_provider_walk(monkeypatch):
+    import tools.web_tools as wt
+
+    extract_only = FakeWebProvider(
+        "extract-only",
+        extract_response=[{"url": "https://example.test", "content": "extract"}],
+    )
+    search_fallback = FakeWebProvider(
+        "search-fallback",
+        search_response={
+            "success": True,
+            "data": {"web": [{"title": "legacy walk", "url": "https://example.test"}]},
+        },
+    )
+    web_search_registry.register_provider(extract_only)
+    web_search_registry.register_provider(search_fallback)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        wt,
+        "_load_web_config",
+        lambda: {"search_backend": "extract-only"},
+    )
+    monkeypatch.setattr(
+        web_search_registry,
+        "get_active_search_provider",
+        lambda: search_fallback,
+    )
+
+    result = json.loads(wt.web_search_tool("scalar capability mismatch"))
+
+    assert result["data"]["web"][0]["title"] == "legacy walk"
+    assert search_fallback.search_calls == [("scalar capability mismatch", 5)]
+
+
+def test_each_search_call_restarts_at_primary(monkeypatch):
+    import tools.web_tools as wt
+
+    class RecoveringPrimary(FakeWebProvider):
+        def search(self, query, limit=5):
+            self.search_calls.append((query, limit))
+            if len(self.search_calls) == 1:
+                return {"success": False, "error": "temporary quota"}
+            return {
+                "success": True,
+                "data": {"web": [{"title": "primary recovered", "url": "https://primary.test"}]},
+            }
+
+    primary = RecoveringPrimary(
+        "primary",
+        search_response={"success": False, "error": "placeholder"},
+    )
+    fallback = FakeWebProvider(
+        "fallback",
+        search_response={
+            "success": True,
+            "data": {"web": [{"title": "fallback", "url": "https://fallback.test"}]},
+        },
+    )
+    web_search_registry.register_provider(primary)
+    web_search_registry.register_provider(fallback)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        wt,
+        "_load_web_config",
+        lambda: {"search_backends": ["primary", "fallback"]},
+    )
+    monkeypatch.setattr(wt, "_provider_available_for_chain", lambda name: True)
+
+    first = json.loads(wt.web_search_tool("first"))
+    second = json.loads(wt.web_search_tool("second"))
+
+    assert first["data"]["web"][0]["title"] == "fallback"
+    assert second["data"]["web"][0]["title"] == "primary recovered"
+    assert fallback.search_calls == [("first", 5)]
+
+
+def test_check_web_api_key_keeps_global_availability_with_malformed_chain(monkeypatch):
+    import tools.web_tools as wt
+
+    monkeypatch.setattr(wt, "_load_web_config", lambda: {"search_backends": {"exa": 1}})
+    monkeypatch.setattr(wt, "_is_backend_available", lambda name: name == "exa")
+
+    assert wt.check_web_api_key() is True
+
+
+def test_check_web_api_key_keeps_global_availability_with_unknown_scalar(monkeypatch):
+    import tools.web_tools as wt
+
+    monkeypatch.setattr(wt, "_load_web_config", lambda: {"search_backend": "typo-provider"})
+    monkeypatch.setattr(wt, "_is_backend_available", lambda name: name == "exa")
+
+    assert wt.check_web_api_key() is True
+
+
+def test_unavailable_search_chain_does_not_hide_active_extract_provider(monkeypatch):
+    import tools.web_tools as wt
+
+    monkeypatch.setattr(wt, "_load_web_config", lambda: {"search_backends": ["unavailable"]})
+    monkeypatch.setattr(wt, "_is_backend_available", lambda name: False)
+    monkeypatch.setattr(web_search_registry, "get_active_search_provider", lambda: None)
+    monkeypatch.setattr(web_search_registry, "get_active_extract_provider", object)
+
+    assert wt.check_web_api_key() is True
+
+
+def test_temp_hermes_home_config_drives_real_chain_resolution(tmp_path, monkeypatch):
+    import hermes_cli.config as hermes_config
+    import tools.web_tools as wt
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "web:\n"
+        "  search_backends:\n"
+        "    - primary\n"
+        "    - fallback\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(hermes_config, "get_hermes_home", lambda: hermes_home)
+
+    primary = FakeWebProvider(
+        "primary",
+        search_response={"success": False, "error": "quota exhausted"},
+    )
+    fallback = FakeWebProvider(
+        "fallback",
+        search_response={
+            "success": True,
+            "data": {"web": [{"title": "from real config", "url": "https://example.com"}]},
+        },
+    )
+    web_search_registry.register_provider(primary)
+    web_search_registry.register_provider(fallback)
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+
+    assert wt._load_web_config()["search_backends"] == ["primary", "fallback"]
+    result = json.loads(wt.web_search_tool("config propagation"))
+
+    assert result["data"]["web"][0]["title"] == "from real config"
+    assert primary.search_calls == [("config propagation", 5)]
+    assert fallback.search_calls == [("config propagation", 5)]
+
+
+def test_real_temp_home_discovers_and_dispatches_user_plugin_chain(tmp_path):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    _write_user_chain_plugin(hermes_home)
+    (hermes_home / "config.yaml").write_text(
+        "plugins:\n"
+        "  enabled:\n"
+        "    - web/test_chain\n"
+        "web:\n"
+        "  search_backends:\n"
+        "    - discovered-primary\n"
+        "    - discovered-fallback\n",
+        encoding="utf-8",
+    )
+
+    result = _run_discovered_chain_subprocess(hermes_home)
+
+    assert result["success"] is True
+    assert result["data"]["web"] == [
+        {
+            "title": "discovered fallback",
+            "url": "https://example.test/discovered",
+            "description": "real discovery path",
+            "position": 1,
+        }
+    ]
+
+
+def test_plural_chain_reports_real_disabled_bundled_plugin(tmp_path):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "plugins:\n"
+        "  disabled:\n"
+        "    - web/brave_free\n"
+        "web:\n"
+        "  search_backends:\n"
+        "    - brave-free\n",
+        encoding="utf-8",
+    )
+
+    result = _run_discovered_chain_subprocess(hermes_home)
+
+    assert result["success"] is False
+    assert "web.search_backends includes 'brave-free'" in result["error"]
+    assert "plugin ('web/brave_free') is disabled" in result["error"]
+    assert "hermes plugins enable web/brave_free" in result["error"]
+
+
+def test_search_interruption_is_terminal_for_chain(monkeypatch):
+    import tools.web_tools as wt
+
+    primary = FakeWebProvider(
+        "primary",
+        search_response={"success": False, "error": "Interrupted"},
+    )
+    fallback = FakeWebProvider(
+        "fallback",
+        search_response={
+            "success": True,
+            "data": {"web": [{"title": "must not run", "url": "https://fallback.test"}]},
+        },
+    )
+    web_search_registry.register_provider(primary)
+    web_search_registry.register_provider(fallback)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        wt,
+        "_load_web_config",
+        lambda: {"search_backends": ["primary", "fallback"]},
+    )
+    monkeypatch.setattr(wt, "_provider_available_for_chain", lambda name: True)
+
+    result = json.loads(wt.web_search_tool("stop"))
+
+    assert result == {"success": False, "error": "Interrupted"}
+    assert primary.search_calls == [("stop", 5)]
+    assert fallback.search_calls == []
+
+
+def test_extract_policy_block_is_terminal_per_url(monkeypatch):
+    import tools.web_tools as wt
+
+    blocked_url = "https://public.example/redirects-private"
+    retry_url = "https://public.example/transient"
+    primary = FakeWebProvider(
+        "primary",
+        extract_response=[
+            {
+                "url": "http://127.0.0.1/private",
+                "title": "",
+                "content": "",
+                "error": "Blocked: URL targets a private or internal network address",
+            },
+            {"url": retry_url, "title": "", "content": "", "error": "HTTP 503"},
+        ],
+    )
+    fallback = FakeWebProvider(
+        "fallback",
+        extract_response=[
+            {"url": retry_url, "title": "retry", "content": "recovered"},
+        ],
+    )
+    web_search_registry.register_provider(primary)
+    web_search_registry.register_provider(fallback)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        wt,
+        "_load_web_config",
+        lambda: {"extract_backends": ["primary", "fallback"]},
+    )
+    monkeypatch.setattr(wt, "_provider_available_for_chain", lambda name: True)
+
+    async def _safe_url(_url):
+        return True
+
+    monkeypatch.setattr(wt, "async_is_safe_url", _safe_url)
+
+    result = json.loads(asyncio.run(wt.web_extract_tool([blocked_url, retry_url])))
+
+    assert result["results"][0]["error"] == (
+        "Blocked: URL targets a private or internal network address"
+    )
+    assert result["results"][1]["content"] == "recovered"
+    assert primary.extract_calls == [([blocked_url, retry_url], {"format": None})]
+    assert fallback.extract_calls == [([retry_url], {"format": None})]
+
+
+def test_availability_exception_skips_to_configured_fallback(monkeypatch):
+    import tools.web_tools as wt
+
+    class BrokenAvailability(FakeWebProvider):
+        def is_available(self):
+            raise RuntimeError("credential probe exploded")
+
+    primary = BrokenAvailability(
+        "primary",
+        search_response={
+            "success": True,
+            "data": {"web": [{"title": "must not run", "url": "https://primary.test"}]},
+        },
+    )
+    fallback = FakeWebProvider(
+        "fallback",
+        search_response={
+            "success": True,
+            "data": {"web": [{"title": "fallback", "url": "https://fallback.test"}]},
+        },
+    )
+    web_search_registry.register_provider(primary)
+    web_search_registry.register_provider(fallback)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        wt,
+        "_load_web_config",
+        lambda: {"search_backends": ["primary", "fallback"]},
+    )
+
+    result = json.loads(wt.web_search_tool("availability"))
+
+    assert result["data"]["web"][0]["title"] == "fallback"
+    assert primary.search_calls == []
+    assert fallback.search_calls == [("availability", 5)]
+
+
+def test_unknown_entry_skips_only_to_later_configured_provider(monkeypatch):
+    import tools.web_tools as wt
+
+    fallback = FakeWebProvider(
+        "fallback",
+        search_response={
+            "success": True,
+            "data": {"web": [{"title": "configured", "url": "https://fallback.test"}]},
+        },
+    )
+    auto = FakeWebProvider(
+        "auto",
+        search_response={
+            "success": True,
+            "data": {"web": [{"title": "must not auto", "url": "https://auto.test"}]},
+        },
+    )
+    web_search_registry.register_provider(fallback)
+    web_search_registry.register_provider(auto)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        wt,
+        "_load_web_config",
+        lambda: {"search_backends": ["typo", "fallback"]},
+    )
+    monkeypatch.setattr(wt, "_get_search_backend", lambda: "auto")
+
+    result = json.loads(wt.web_search_tool("configured only"))
+
+    assert result["data"]["web"][0]["title"] == "configured"
+    assert fallback.search_calls == [("configured only", 5)]
+    assert auto.search_calls == []
+
+
+def test_extract_fallback_correlates_omitted_rows_by_url(monkeypatch):
+    import tools.web_tools as wt
+
+    first_url = "https://example.com/omitted"
+    second_url = "https://example.com/success"
+    primary = FakeWebProvider(
+        "primary",
+        # Exa may return only successful rows.
+        extract_response=[
+            {"url": second_url, "title": "Second", "content": "primary success"},
+        ],
+    )
+    fallback = FakeWebProvider(
+        "fallback",
+        extract_response=[
+            {"url": first_url, "title": "First", "content": "fallback success"},
+        ],
+    )
+    web_search_registry.register_provider(primary)
+    web_search_registry.register_provider(fallback)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        wt,
+        "_load_web_config",
+        lambda: {"extract_backends": ["primary", "fallback"]},
+    )
+    monkeypatch.setattr(wt, "_provider_available_for_chain", lambda name: True)
+    monkeypatch.setattr(wt, "async_is_safe_url", lambda url: asyncio.sleep(0, result=True))
+
+    result = json.loads(asyncio.run(wt.web_extract_tool([first_url, second_url])))
+
+    assert [item["content"] for item in result["results"]] == [
+        "fallback success",
+        "primary success",
+    ]
+    assert fallback.extract_calls == [([first_url], {"format": None})]
+
+
+def test_extract_correlation_preserves_duplicate_input_occurrences(monkeypatch):
+    import tools.web_tools as wt
+
+    url = "https://example.com/duplicate"
+    primary = FakeWebProvider(
+        "primary",
+        extract_response=[
+            {"url": url, "title": "first", "content": "first occurrence"},
+            {"url": url, "title": "", "content": "", "error": "HTTP 503"},
+        ],
+    )
+    fallback = FakeWebProvider(
+        "fallback",
+        extract_response=[
+            {"url": url, "title": "second", "content": "second occurrence"},
+        ],
+    )
+    web_search_registry.register_provider(primary)
+    web_search_registry.register_provider(fallback)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        wt,
+        "_load_web_config",
+        lambda: {"extract_backends": ["primary", "fallback"]},
+    )
+    monkeypatch.setattr(wt, "_provider_available_for_chain", lambda name: True)
+    monkeypatch.setattr(wt, "async_is_safe_url", lambda value: asyncio.sleep(0, result=True))
+
+    result = json.loads(asyncio.run(wt.web_extract_tool([url, url])))
+
+    assert [item["content"] for item in result["results"]] == [
+        "first occurrence",
+        "second occurrence",
+    ]
+    assert fallback.extract_calls == [([url], {"format": None})]
+
+
+def test_multiple_unmatched_redirect_rows_are_not_positionally_guessed(monkeypatch):
+    import tools.web_tools as wt
+
+    first_url = "https://example.com/redirect-one"
+    second_url = "https://example.com/redirect-two"
+    primary = FakeWebProvider(
+        "primary",
+        extract_response=[
+            {"url": "https://final.example/two", "title": "", "content": "ambiguous"},
+            {
+                "url": "https://final.example/one",
+                "title": "",
+                "content": "",
+                "error": "HTTP 503",
+            },
+        ],
+    )
+    fallback = FakeWebProvider(
+        "fallback",
+        extract_response=[
+            {"url": first_url, "title": "one", "content": "fallback one"},
+            {"url": second_url, "title": "two", "content": "fallback two"},
+        ],
+    )
+    web_search_registry.register_provider(primary)
+    web_search_registry.register_provider(fallback)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        wt,
+        "_load_web_config",
+        lambda: {"extract_backends": ["primary", "fallback"]},
+    )
+    monkeypatch.setattr(wt, "_provider_available_for_chain", lambda name: True)
+    monkeypatch.setattr(wt, "async_is_safe_url", lambda value: asyncio.sleep(0, result=True))
+
+    result = json.loads(asyncio.run(wt.web_extract_tool([first_url, second_url])))
+
+    assert [item["content"] for item in result["results"]] == [
+        "fallback one",
+        "fallback two",
+    ]
+    assert fallback.extract_calls == [([first_url, second_url], {"format": None})]
+
+
+def test_uncorrelated_redirect_policy_result_stops_all_fallback(monkeypatch):
+    import tools.web_tools as wt
+
+    first_url = "https://example.com/redirect-one"
+    second_url = "https://example.com/redirect-two"
+    primary = FakeWebProvider(
+        "primary",
+        extract_response=[
+            {
+                "url": "http://127.0.0.1/private",
+                "title": "",
+                "content": "",
+                "error": "Blocked: URL targets a private or internal network address",
+            },
+            {"url": "https://final.example/two", "title": "", "content": "ambiguous"},
+        ],
+    )
+    fallback = FakeWebProvider(
+        "fallback",
+        extract_response=[
+            {"url": first_url, "title": "must not run", "content": "must not run"},
+            {"url": second_url, "title": "must not run", "content": "must not run"},
+        ],
+    )
+    web_search_registry.register_provider(primary)
+    web_search_registry.register_provider(fallback)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        wt,
+        "_load_web_config",
+        lambda: {"extract_backends": ["primary", "fallback"]},
+    )
+    monkeypatch.setattr(wt, "_provider_available_for_chain", lambda name: True)
+    monkeypatch.setattr(wt, "async_is_safe_url", lambda value: asyncio.sleep(0, result=True))
+
+    result = json.loads(asyncio.run(wt.web_extract_tool([first_url, second_url])))
+
+    assert all(
+        item["error"].startswith("Blocked: extract provider returned")
+        for item in result["results"]
+    )
+    assert fallback.extract_calls == []
+
+
+def test_one_interrupted_extract_row_terminates_whole_batch(monkeypatch):
+    import tools.web_tools as wt
+
+    first_url = "https://example.com/transient"
+    second_url = "https://example.com/interrupted"
+    primary = FakeWebProvider(
+        "primary",
+        extract_response=[
+            {"url": first_url, "title": "", "content": "", "error": "HTTP 503"},
+            {"url": second_url, "title": "", "content": "", "error": "Interrupted"},
+        ],
+    )
+    fallback = FakeWebProvider(
+        "fallback",
+        extract_response=[
+            {"url": first_url, "title": "must not run", "content": "must not run"},
+            {"url": second_url, "title": "must not run", "content": "must not run"},
+        ],
+    )
+    web_search_registry.register_provider(primary)
+    web_search_registry.register_provider(fallback)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        wt,
+        "_load_web_config",
+        lambda: {"extract_backends": ["primary", "fallback"]},
+    )
+    monkeypatch.setattr(wt, "_provider_available_for_chain", lambda name: True)
+    monkeypatch.setattr(wt, "async_is_safe_url", lambda url: asyncio.sleep(0, result=True))
+
+    result = json.loads(asyncio.run(wt.web_extract_tool([first_url, second_url])))
+
+    assert [item["error"] for item in result["results"]] == ["HTTP 503", "Interrupted"]
+    assert fallback.extract_calls == []
+
+
+def test_surplus_interrupted_extract_row_terminates_before_alignment(monkeypatch):
+    import tools.web_tools as wt
+
+    url = "https://example.com/duplicate-provider-row"
+    primary = FakeWebProvider(
+        "primary",
+        extract_response=[
+            {"url": url, "title": "", "content": "", "error": "HTTP 503"},
+            {"url": url, "title": "", "content": "", "error": "Interrupted"},
+        ],
+    )
+    fallback = FakeWebProvider(
+        "fallback",
+        extract_response=[
+            {"url": url, "title": "must not run", "content": "must not run"},
+        ],
+    )
+    web_search_registry.register_provider(primary)
+    web_search_registry.register_provider(fallback)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        wt,
+        "_load_web_config",
+        lambda: {"extract_backends": ["primary", "fallback"]},
+    )
+    monkeypatch.setattr(wt, "_provider_available_for_chain", lambda name: True)
+    monkeypatch.setattr(wt, "async_is_safe_url", lambda value: asyncio.sleep(0, result=True))
+
+    result = json.loads(asyncio.run(wt.web_extract_tool([url])))
+
+    assert result["results"][0]["error"] == "Interrupted"
+    assert fallback.extract_calls == []
+
+
+def test_post_search_interrupt_flag_stops_fallback(monkeypatch):
+    import tools.interrupt as interrupt
+    import tools.web_tools as wt
+
+    state = {"interrupted": False}
+
+    class InterruptingProvider(FakeWebProvider):
+        def search(self, query: str, limit: int = 5):
+            self.search_calls.append((query, limit))
+            state["interrupted"] = True
+            return {"success": False, "error": "transient provider error"}
+
+    primary = InterruptingProvider(
+        "primary",
+        search_response={"success": False, "error": "placeholder"},
+    )
+    fallback = FakeWebProvider(
+        "fallback",
+        search_response={
+            "success": True,
+            "data": {"web": [{"title": "must not run", "url": "https://fallback.test"}]},
+        },
+    )
+    web_search_registry.register_provider(primary)
+    web_search_registry.register_provider(fallback)
+
+    monkeypatch.setattr(interrupt, "is_interrupted", lambda: state["interrupted"])
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        wt,
+        "_load_web_config",
+        lambda: {"search_backends": ["primary", "fallback"]},
+    )
+    monkeypatch.setattr(wt, "_provider_available_for_chain", lambda name: True)
+
+    result = json.loads(wt.web_search_tool("stop after primary"))
+
+    assert result == {"success": False, "error": "Interrupted"}
+    assert fallback.search_calls == []
+
+
+def test_registered_override_of_builtin_name_controls_availability(monkeypatch):
+    import tools.web_tools as wt
+
+    override = FakeWebProvider(
+        "exa",
+        search_response={
+            "success": True,
+            "data": {"web": [{"title": "override", "url": "https://override.test"}]},
+        },
+    )
+    web_search_registry.register_provider(override)
+
+    monkeypatch.delenv("EXA_API_KEY", raising=False)
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(wt, "_load_web_config", lambda: {"search_backends": ["exa"]})
+    monkeypatch.setattr("hermes_cli.config.get_env_value", lambda key: None)
+
+    result = json.loads(wt.web_search_tool("registry override"))
+
+    assert result["data"]["web"][0]["title"] == "override"
+    assert override.search_calls == [("registry override", 5)]
+
+
+def test_malformed_extract_chain_fails_closed(monkeypatch):
+    import tools.web_tools as wt
+
+    provider = FakeWebProvider(
+        "extractor",
+        extract_response=[
+            {"url": "https://example.com", "title": "must not run", "content": "must not run"},
+        ],
+    )
+    web_search_registry.register_provider(provider)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(wt, "_load_web_config", lambda: {"extract_backends": {"extractor": 1}})
+    monkeypatch.setattr(wt, "async_is_safe_url", lambda url: asyncio.sleep(0, result=True))
+
+    result = json.loads(asyncio.run(wt.web_extract_tool(["https://example.com"])))
+
+    assert "extract_backends" in result["error"]
+    assert provider.extract_calls == []
+
+
+def test_all_search_providers_failed_reports_each_attempt(monkeypatch):
+    import tools.web_tools as wt
+
+    primary = FakeWebProvider(
+        "primary",
+        search_response={"success": False, "error": "quota"},
+    )
+    secondary = FakeWebProvider(
+        "secondary",
+        search_response={"success": False, "error": "timeout"},
+    )
+    web_search_registry.register_provider(primary)
+    web_search_registry.register_provider(secondary)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        wt,
+        "_load_web_config",
+        lambda: {"search_backends": ["primary", "secondary"]},
+    )
+    monkeypatch.setattr(wt, "_provider_available_for_chain", lambda name: True)
+
+    result = json.loads(wt.web_search_tool("all fail"))
+
+    assert result["success"] is False
+    assert "primary: quota" in result["error"]
+    assert "secondary: timeout" in result["error"]
+
+
+def test_non_list_extract_response_falls_through_and_reports_all_failures(monkeypatch):
+    import tools.web_tools as wt
+
+    class NonListProvider(FakeWebProvider):
+        def extract(self, urls: list[str], **kwargs) -> Any:
+            self.extract_calls.append((list(urls), dict(kwargs)))
+            return {"error": "wrong envelope"}
+
+    url = "https://example.com"
+    primary = NonListProvider("primary", extract_response=[])
+    secondary = FakeWebProvider(
+        "secondary",
+        extract_response=[
+            {"url": url, "title": "", "content": "", "error": "timeout"},
+        ],
+    )
+    web_search_registry.register_provider(primary)
+    web_search_registry.register_provider(secondary)
+
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        wt,
+        "_load_web_config",
+        lambda: {"extract_backends": ["primary", "secondary"]},
+    )
+    monkeypatch.setattr(wt, "_provider_available_for_chain", lambda name: True)
+    monkeypatch.setattr(wt, "async_is_safe_url", lambda value: asyncio.sleep(0, result=True))
+
+    result = json.loads(asyncio.run(wt.web_extract_tool([url])))
+
+    assert "primary: returned a non-list response" in result["results"][0]["error"]
+    assert "secondary: timeout" in result["results"][0]["error"]

--- a/tests/tools/test_web_tools_fallback_chains.py
+++ b/tests/tools/test_web_tools_fallback_chains.py
@@ -577,6 +577,47 @@ def test_unavailable_search_chain_does_not_hide_active_extract_provider(monkeypa
     assert wt.check_web_api_key() is True
 
 
+@pytest.mark.parametrize("chain_key", ["search_backends", "extract_backends"])
+def test_explicit_nonlegacy_chain_exposes_web_schemas(monkeypatch, chain_key):
+    import tools.web_tools as wt
+    from tools.registry import invalidate_check_fn_cache, registry
+
+    for name in ("custom-primary", "custom-fallback"):
+        web_search_registry.register_provider(
+            FakeWebProvider(
+                name,
+                search_response={"success": True, "data": {"web": []}},
+                extract_response=[],
+            )
+        )
+
+    monkeypatch.setattr(
+        wt,
+        "_load_web_config",
+        lambda: {chain_key: ["custom-primary", "custom-fallback"]},
+    )
+    monkeypatch.setattr(wt, "_is_backend_available", lambda name: False)
+
+    # Two available non-legacy providers do not activate the scalar resolver;
+    # schema exposure must therefore come from the explicit chain itself.
+    assert web_search_registry.get_active_search_provider() is None
+    assert web_search_registry.get_active_extract_provider() is None
+
+    invalidate_check_fn_cache()
+    try:
+        definitions = registry.get_definitions(
+            {"web_search", "web_extract"},
+            quiet=True,
+        )
+    finally:
+        invalidate_check_fn_cache()
+
+    assert {definition["function"]["name"] for definition in definitions} == {
+        "web_search",
+        "web_extract",
+    }
+
+
 def test_temp_hermes_home_config_drives_real_chain_resolution(tmp_path, monkeypatch):
     import hermes_cli.config as hermes_config
     import tools.web_tools as wt

--- a/tests/tools/test_web_tools_tavily.py
+++ b/tests/tools/test_web_tools_tavily.py
@@ -181,7 +181,8 @@ class TestWebSearchTavily:
         }
         mock_response.raise_for_status = MagicMock()
 
-        with patch("tools.web_tools._get_backend", return_value="tavily"), \
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch("tools.web_tools._get_backend", return_value="tavily"), \
              patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}), \
              patch("tools.web_tools.httpx.post", return_value=mock_response), \
              patch("tools.interrupt.is_interrupted", return_value=False):
@@ -213,7 +214,8 @@ class TestWebExtractTavily:
         }
         mock_response.raise_for_status = MagicMock()
 
-        with patch("tools.web_tools._get_backend", return_value="tavily"), \
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch("tools.web_tools._get_backend", return_value="tavily"), \
              patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}), \
              patch("tools.web_tools.httpx.post", return_value=mock_response):
             from tools.web_tools import web_extract_tool

--- a/tests/tools/test_web_tools_truncate.py
+++ b/tests/tools/test_web_tools_truncate.py
@@ -114,6 +114,7 @@ class TestEndToEnd:
                          "raw_content": big, "metadata": {}}]
 
         with patch("tools.web_tools._ensure_web_plugins_loaded"), \
+             patch("tools.web_tools._load_web_config", return_value={}), \
              patch("tools.web_tools._get_extract_backend", return_value="fake"), \
              patch("tools.web_tools.async_is_safe_url", new=_AsyncTrue()), \
              patch("agent.web_search_registry.get_provider", return_value=FakeProvider()):

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1500,15 +1500,30 @@ def check_web_api_key() -> bool:
     """Check whether the configured web backend is available.
 
     Used as the ``check_fn`` gate for the ``web_search`` and ``web_extract``
-    tool registry entries — so a plugin-registered provider that reports
-    ``is_available()`` must light the tools up even when no built-in backend
-    has credentials (issues #28651, #31873). Resolution funnels through
-    :func:`_is_backend_available`, which delegates non-legacy names to the
+    tool registry entries — so an available provider selected by an explicit
+    chain, or a plugin-registered scalar provider, must light the tools up even
+    when no built-in backend has credentials (issues #28651, #31873).
+    Resolution funnels through :func:`_provider_available_for_chain` and
+    :func:`_is_backend_available`, which delegate non-legacy names to the
     registry.
     """
+    cfg = _load_web_config()
+    # Explicit chains are policy inputs to dispatch, but the scalar registry
+    # resolvers below do not read them. Probe the same parsed provider names
+    # here so the shared check_fn does not hide both schemas before dispatch
+    # can reach an otherwise available chain. Malformed chains still fall
+    # through to global availability, preserving legacy schema exposure.
+    for chain_key in ("search_backends", "extract_backends"):
+        try:
+            chain = _parse_backend_chain(cfg.get(chain_key))
+        except ValueError:
+            continue
+        if any(_provider_available_for_chain(name) for name in chain):
+            return True
+
     # ``or ""``: a null ``web.backend`` value yields None from ``.get``, and
     # ``None.lower()`` would raise. Mirrors ``_get_backend``.
-    configured = (_load_web_config().get("backend") or "").lower().strip()
+    configured = (cfg.get("backend") or "").lower().strip()
     if configured and _is_backend_available(configured):
         return True
     # Any built-in backend with credentials present. This is a boolean OR, so

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -169,7 +169,16 @@ def _load_web_config() -> dict:
 # WebSearchProvider. Keep the two sets aligned by hand: if xai ever ships as
 # a registered provider, drop it here so the registry path takes over.
 _LEGACY_WEB_BACKENDS = frozenset(
-    {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}
+    {
+        "parallel",
+        "firecrawl",
+        "tavily",
+        "exa",
+        "searxng",
+        "brave-free",
+        "ddgs",
+        "xai",
+    }
 )
 
 
@@ -270,6 +279,79 @@ def _get_backend() -> str:
     return "firecrawl"  # default (backward compat)
 
 
+def _parse_backend_chain(value: Any) -> list[str]:
+    """Parse an ordered backend chain from config.
+
+    Accepts either a YAML list (preferred) or a comma/whitespace separated
+    string so ``hermes config set web.search_backends brave-free,exa`` remains
+    usable from the CLI. Names are normalized and deduplicated while preserving
+    order. Unknown names remain in the result so explicit policy typos produce
+    diagnostics instead of silently collapsing into legacy auto-routing.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        raw_parts = re.split(r"[,\s]+", value)
+    elif isinstance(value, (list, tuple)):
+        raw_parts = value
+    else:
+        raise ValueError("must be a list or comma-separated string")
+
+    seen: set[str] = set()
+    chain: list[str] = []
+    for raw in raw_parts:
+        if not isinstance(raw, str):
+            raise ValueError("entries must be provider-name strings")
+        backend = raw.lower().strip()
+        if not backend or backend in seen:
+            continue
+        seen.add(backend)
+        chain.append(backend)
+    return chain
+
+
+def _get_backend_chain(capability: str) -> tuple[list[str], bool]:
+    """Return (ordered backend names, explicit_chain_configured).
+
+    New config keys ``web.search_backends`` and ``web.extract_backends`` are
+    additive. If absent, keep the historic scalar behavior exactly:
+    ``web.<capability>_backend`` → ``web.backend`` → auto-detected single
+    backend from :func:`_get_backend`.
+    """
+    cfg = _load_web_config()
+    chain_key = f"{capability}_backends"
+    try:
+        chain = _parse_backend_chain(cfg.get(chain_key))
+    except ValueError as exc:
+        raise ValueError(f"web.{chain_key} {exc}") from exc
+    if chain:
+        return chain, True
+
+    # Delegate the scalar path to the established selectors verbatim. Besides
+    # preserving behavior, this keeps monkeypatch/instrumentation contracts and
+    # any future scalar precedence changes in one place.
+    if capability == "search":
+        return [_get_search_backend()], False
+    if capability == "extract":
+        return [_get_extract_backend()], False
+    return [_get_backend()], False
+
+
+def _get_search_backend_chain() -> list[str]:
+    """Return the ordered search backend names for the current config."""
+    return _get_backend_chain("search")[0]
+
+
+def _get_extract_backend_chain() -> list[str]:
+    """Return the ordered extract backend names for the current config."""
+    return _get_backend_chain("extract")[0]
+
+
+def _fallback_on_empty_search() -> bool:
+    """Whether search should spend the next backend on a clean empty result."""
+    return bool(_load_web_config().get("fallback_on_empty_search", False))
+
+
 def _get_search_backend() -> str:
     """Determine which backend to use for web_search specifically.
 
@@ -352,6 +434,185 @@ def _is_backend_available(backend: str) -> bool:
     return False
 
 
+def _provider_available_for_chain(name: str) -> bool:
+    """Return explicit-chain availability, honoring registry overrides first."""
+    registered = _registered_web_provider_available(name)
+    if registered is not None:
+        return registered
+    try:
+        return _is_backend_available(name)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("availability check failed for %s: %s", name, exc)
+        return False
+
+
+def _provider_candidates(capability: str) -> tuple[list[Any], list[str], bool]:
+    """Return ordered providers, skipped-attempt notes, and list-config flag."""
+    _ensure_web_plugins_loaded()
+    from agent.web_search_registry import (
+        get_active_extract_provider,
+        get_active_search_provider,
+        get_provider as _wsp_get_provider,
+    )
+
+    names, explicit_chain = _get_backend_chain(capability)
+    providers: list[Any] = []
+    skipped: list[str] = []
+    seen: set[str] = set()
+
+    for name in names:
+        provider = _wsp_get_provider(name) if name else None
+        if provider is None:
+            skipped.append(f"{name or '<empty>'}: not registered")
+            continue
+        supports = provider.supports_search() if capability == "search" else provider.supports_extract()
+        if not supports:
+            if capability == "extract" and provider.supports_search():
+                skipped.append(f"{provider.name}: search-only, does not support extract")
+            else:
+                skipped.append(f"{provider.name}: does not support {capability}")
+            continue
+        # List-style chains are quota/fallback policy, not hard pins. Skip
+        # unavailable providers so a missing Exa key does not block Brave/DDGS
+        # or a missing Firecrawl key does not block Tavily/Parallel extract.
+        # Scalar configs keep legacy behavior and let the provider surface its
+        # precise missing-credential error.
+        if explicit_chain and not _provider_available_for_chain(provider.name):
+            skipped.append(f"{provider.name}: unavailable")
+            continue
+        if provider.name in seen:
+            continue
+        seen.add(provider.name)
+        providers.append(provider)
+
+    if providers:
+        return providers, skipped, explicit_chain
+
+    # Legacy scalar/auto path fallback: preserve old active-provider walk when
+    # no explicit list was configured. For an explicit list, returning no
+    # providers is intentional — the list is the user's policy boundary.
+    if not explicit_chain:
+        active = get_active_search_provider() if capability == "search" else get_active_extract_provider()
+        if active is not None:
+            return [active], skipped, explicit_chain
+
+    return [], skipped, explicit_chain
+
+
+def _disabled_plugin_for_selection(
+    capability: str,
+    explicit_chain: bool,
+) -> tuple[str, str, str] | None:
+    """Return disabled plugin key, provider name, and config field.
+
+    The registry's scalar diagnostic can reread ``web.<capability>_backend``.
+    Plural chains are different: each configured name must be checked directly
+    or a disabled plugin is misreported as merely unregistered.
+    """
+    from agent.web_search_registry import _disabled_web_plugin_for
+
+    if explicit_chain:
+        names, _ = _get_backend_chain(capability)
+        for name in names:
+            disabled_key = _disabled_web_plugin_for(configured=name)
+            if disabled_key:
+                return disabled_key, name, f"web.{capability}_backends"
+        return None
+
+    disabled_key = _disabled_web_plugin_for(capability=capability)
+    if not disabled_key:
+        return None
+    provider_name = disabled_key.split("/", 1)[-1].replace("_", "-")
+    return disabled_key, provider_name, f"web.{capability}_backend"
+
+
+def _summarize_provider_error(provider_name: str, response: Any) -> str:
+    if isinstance(response, dict):
+        err = response.get("error")
+        if err:
+            return f"{provider_name}: {err}"
+        if response.get("success") is False:
+            return f"{provider_name}: failed without an error message"
+    return f"{provider_name}: no usable result"
+
+
+def _search_response_count(response: dict[str, Any]) -> int:
+    try:
+        return len(response.get("data", {}).get("web", []) or [])
+    except Exception:
+        return 0
+
+
+def _extract_result_has_usable_content(result: Any) -> bool:
+    """Return whether one provider result is a successful extraction."""
+    if not isinstance(result, dict) or result.get("error"):
+        return False
+    content = result.get("raw_content") or result.get("content")
+    return isinstance(content, str) and bool(content.strip())
+
+
+def _align_extract_results(
+    candidate_results: list[Any],
+    pending_positions: list[int],
+    safe_urls: list[str],
+) -> dict[int, Any]:
+    """Correlate provider rows to input positions.
+
+    Bundled providers differ: some group successes before failures, some omit
+    failures, and Firecrawl may replace an input URL with a redirected final
+    URL. Exact input-URL matches are authoritative. A single unmatched row may
+    fill a single remaining position for redirect compatibility; multiple
+    unmatched rows are deliberately left unresolved because generic code has
+    no immutable request identity with which to order them safely.
+    """
+    unmatched_positions = list(pending_positions)
+    aligned: dict[int, Any] = {}
+    deferred: list[Any] = []
+
+    for candidate in candidate_results:
+        candidate_url = candidate.get("url") if isinstance(candidate, dict) else None
+        matched_position = next(
+            (
+                position
+                for position in unmatched_positions
+                if candidate_url and safe_urls[position] == candidate_url
+            ),
+            None,
+        )
+        if matched_position is None:
+            deferred.append(candidate)
+            continue
+        aligned[matched_position] = candidate
+        unmatched_positions.remove(matched_position)
+
+    if len(unmatched_positions) == 1 and len(deferred) == 1:
+        aligned[unmatched_positions[0]] = deferred[0]
+
+    return aligned
+
+
+def _provider_result_is_interrupted(result: Any) -> bool:
+    if not isinstance(result, dict):
+        return False
+    error = str(result.get("error") or "").strip().lower()
+    return error == "interrupted" or error.startswith("interrupted:")
+
+
+def _provider_result_is_terminal_failure(result: Any) -> bool:
+    """Return whether a provider failure must never fall through.
+
+    Policy denials may be discovered only after a provider follows a redirect;
+    retrying the same URL through another extractor would bypass that decision.
+    Interruption similarly means stop work, not spend another provider call.
+    """
+    if not isinstance(result, dict):
+        return False
+    if "blocked_by_policy" in result:
+        return True
+    error = str(result.get("error") or "").strip().lower()
+    return error.startswith("blocked:") or _provider_result_is_interrupted(result)
+
+
 def _ddgs_package_importable() -> bool:
     """Return True when the ``ddgs`` Python package can be imported.
 
@@ -395,6 +656,7 @@ def _web_requires_env() -> list[str]:
         "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL",
         "FIRECRAWL_GATEWAY_URL",
+        "BRAVE_SEARCH_API_KEY",
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_SCHEME",
         "TOOL_GATEWAY_USER_TOKEN",
@@ -671,55 +933,96 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         if is_interrupted():
             return tool_error("Interrupted", success=False)
 
-        # Dispatch through the web search registry. All 7 providers
-        # (brave-free, ddgs, searxng, exa, parallel, tavily, firecrawl)
-        # now live as plugins; the dispatcher is just a registry lookup +
-        # delegation. Sync only — every provider's search() is sync.
+        # Dispatch through the web search registry. Bundled web providers
+        # (brave-free, ddgs, searxng, exa, parallel, tavily,
+        # firecrawl, xai) live as plugins; the dispatcher builds an ordered
+        # provider chain from web.search_backends/web.extract_backends and
+        # tries fallbacks only when that policy allows it.
         _ensure_web_plugins_loaded()
-        from agent.web_search_registry import (
-            get_active_search_provider,
-            get_provider as _wsp_get_provider,
-            _disabled_web_plugin_for,
-        )
 
-        backend = _get_search_backend()
-        provider = _wsp_get_provider(backend) if backend else None
-        if provider is None or not provider.supports_search():
-            # Fall back to availability-walked active provider when the
-            # configured backend isn't a registered search provider (typo,
-            # uninstalled plugin, or capability mismatch).
-            provider = get_active_search_provider()
-
-        if provider is None:
-            # A bundled web plugin the user explicitly disabled looks
-            # identical to "no provider" here — point at the real cause
-            # (re-enable the plugin) rather than a generic setup hint.
-            disabled_key = _disabled_web_plugin_for(capability="search")
-            if disabled_key:
-                _vendor = disabled_key.split("/", 1)[-1]
+        providers, skipped, explicit_chain = _provider_candidates("search")
+        if not providers:
+            disabled = _disabled_plugin_for_selection("search", explicit_chain)
+            if disabled:
+                disabled_key, provider_name, config_field = disabled
+                relation = "includes" if explicit_chain else "is set to"
                 response_data = {
                     "success": False,
                     "error": (
-                        f"web.search_backend is set to '{_vendor}', but its "
+                        f"{config_field} {relation} '{provider_name}', but its "
                         f"plugin ('{disabled_key}') is disabled in config. "
                         f"Re-enable it with `hermes plugins enable {disabled_key}` "
                         "(or remove it from plugins.disabled)."
                     ),
                 }
             else:
+                detail = "; ".join(skipped)
                 response_data = {
                     "success": False,
                     "error": (
-                        "No web search provider configured. "
+                        "No web search provider configured or available. "
                         "Run `hermes tools` to set one up."
+                        + (f" Skipped: {detail}" if detail else "")
                     ),
                 }
         else:
-            logger.info(
-                "Web search via %s: '%s' (limit: %d)",
-                provider.name, query, limit,
-            )
-            response_data = provider.search(query, limit)
+            if not explicit_chain:
+                # Preserve the pre-chain scalar/auto path exactly: call one
+                # selected provider and return its response unchanged. Ordered
+                # failover is opt-in, never an implicit behavior change.
+                provider = providers[0]
+                logger.info(
+                    "Web search via %s: '%s' (limit: %d)",
+                    provider.name, query, limit,
+                )
+                response_data = provider.search(query, limit)
+            else:
+                attempt_errors: list[str] = []
+                response_data = None
+                for provider in providers:
+                    logger.info(
+                        "Web search via %s: '%s' (limit: %d)",
+                        provider.name, query, limit,
+                    )
+                    try:
+                        candidate = provider.search(query, limit)
+                    except Exception as exc:  # noqa: BLE001
+                        if is_interrupted():
+                            response_data = {"success": False, "error": "Interrupted"}
+                            break
+                        logger.info("Web search provider %s failed, trying fallback: %s", provider.name, exc)
+                        attempt_errors.append(f"{provider.name}: {exc}")
+                        continue
+
+                    if is_interrupted():
+                        response_data = (
+                            candidate
+                            if _provider_result_is_interrupted(candidate)
+                            else {"success": False, "error": "Interrupted"}
+                        )
+                        break
+                    if _provider_result_is_terminal_failure(candidate):
+                        response_data = candidate
+                        break
+
+                    if isinstance(candidate, dict) and candidate.get("success"):
+                        result_count = _search_response_count(candidate)
+                        if result_count > 0 or not _fallback_on_empty_search():
+                            response_data = candidate
+                            break
+                        attempt_errors.append(f"{provider.name}: empty result")
+                        continue
+
+                    attempt_errors.append(_summarize_provider_error(provider.name, candidate))
+
+                if response_data is None:
+                    response_data = {
+                        "success": False,
+                        "error": (
+                            "All configured web search providers failed: "
+                            + "; ".join(attempt_errors + skipped)
+                        ),
+                    }
 
         debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
@@ -772,6 +1075,13 @@ async def web_extract_tool(
     Raises:
         Exception: If extraction fails or API key is not set
     """
+    # Interruption is terminal for the whole chain. Providers also check this
+    # flag, but the wrapper must not convert an interrupted primary into a
+    # fallback call.
+    from tools.interrupt import is_interrupted
+    if is_interrupted():
+        return tool_error("Interrupted", success=False)
+
     # Block URLs containing embedded secrets (exfiltration prevention).
     # URL-decode first so percent-encoded secrets (%73k- = sk-) are caught.
     from agent.redact import _PREFIX_RE
@@ -854,97 +1164,237 @@ async def web_extract_tool(
         if not safe_urls:
             results = []
         else:
-            backend = _get_extract_backend()
-
-            # All seven providers (brave-free, ddgs, searxng, exa, parallel,
-            # tavily, firecrawl) now live as plugins. The dispatcher is a
-            # registry lookup + delegation. Some providers' extract() is
-            # async (parallel, firecrawl), others sync (exa, tavily) — we
-            # detect coroutine functions and await; sync functions run
-            # inline (the policy gate, SSRF re-check, etc. live inside the
-            # provider itself for the firecrawl per-URL loop).
+            # All bundled providers now live as plugins. The dispatcher builds
+            # an ordered extract chain from web.extract_backends; search-only
+            # providers in list-style chains are skipped, and extract-capable
+            # providers are tried until one returns usable content.
             _ensure_web_plugins_loaded()
-            from agent.web_search_registry import (
-                get_active_extract_provider,
-                get_provider as _wsp_get_provider,
-                _disabled_web_plugin_for,
-            )
 
-            provider = _wsp_get_provider(backend) if backend else None
-            if provider is None or not provider.supports_extract():
-                # When the configured name IS registered but doesn't support
-                # extract (search-only providers like brave-free / ddgs /
-                # searxng), surface that as a typed "search-only" error
-                # rather than silently switching backends. When the name
-                # isn't registered at all (typo / uninstalled plugin), fall
-                # through to the active-provider walk.
-                if provider is not None and not provider.supports_extract():
+            providers, skipped, explicit_chain = _provider_candidates("extract")
+            if not providers:
+                disabled = _disabled_plugin_for_selection("extract", explicit_chain)
+                if disabled:
+                    disabled_key, provider_name, config_field = disabled
+                    relation = "includes" if explicit_chain else "is set to"
                     return json.dumps(
                         {
                             "success": False,
                             "error": (
-                                f"{provider.display_name} is a search-only "
-                                "backend and cannot extract URL content. "
-                                "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
+                                f"{config_field} {relation} '{provider_name}', "
+                                f"but its plugin ('{disabled_key}') is disabled "
+                                "in config. Re-enable it with "
+                                f"`hermes plugins enable {disabled_key}` "
+                                "(or remove it from plugins.disabled)."
                             ),
                         },
                         ensure_ascii=False,
                     )
-                provider = get_active_extract_provider()
-                if provider is None:
-                    # If the configured backend is a bundled web plugin the
-                    # user explicitly disabled, the backend is set correctly
-                    # and the real fix is to re-enable the plugin — say so
-                    # instead of telling them to set web.extract_backend
-                    # (which they already did). #40190 follow-up.
-                    disabled_key = _disabled_web_plugin_for(capability="extract")
-                    if disabled_key:
-                        _vendor = disabled_key.split("/", 1)[-1]
-                        return json.dumps(
-                            {
-                                "success": False,
-                                "error": (
-                                    f"web.extract_backend is set to '{_vendor}', "
-                                    f"but its plugin ('{disabled_key}') is disabled "
-                                    "in config. Re-enable it with "
-                                    f"`hermes plugins enable {disabled_key}` "
-                                    "(or remove it from plugins.disabled)."
-                                ),
-                            },
-                            ensure_ascii=False,
-                        )
-                    return json.dumps(
-                        {
-                            "success": False,
-                            "error": (
-                                "No web extract provider configured. "
-                                "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
-                            ),
-                        },
-                        ensure_ascii=False,
-                    )
-
-            logger.info(
-                "Web extract via %s: %d URL(s)", provider.name, len(safe_urls)
-            )
+                detail = "; ".join(skipped)
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": (
+                            "No web extract provider configured or available. "
+                            "Set web.extract_backend to firecrawl, tavily, exa, or parallel."
+                            + (f" Skipped: {detail}" if detail else "")
+                        ),
+                    },
+                    ensure_ascii=False,
+                )
 
             # Async-or-sync dispatch: parallel + firecrawl have async
             # extract(); exa + tavily are sync.
             import inspect
-            if inspect.iscoroutinefunction(provider.extract):
-                results = await provider.extract(safe_urls, format=format)
-            else:
-                # Run sync extract() in a thread so we don't block the
-                # event loop on network I/O.
-                results = await asyncio.to_thread(
-                    provider.extract, safe_urls, format=format
+
+            async def _call_extract_provider(provider: Any, pending_urls: list[str]) -> Any:
+                if inspect.iscoroutinefunction(provider.extract):
+                    return await provider.extract(pending_urls, format=format)
+                # Run sync extract() in a thread so we don't block the event loop
+                # on network I/O.
+                return await asyncio.to_thread(
+                    provider.extract, pending_urls, format=format
                 )
 
+            if not explicit_chain:
+                # Preserve the pre-chain scalar/auto path exactly: one provider
+                # receives the entire safe URL batch and its response is returned
+                # unchanged.
+                provider = providers[0]
+                logger.info(
+                    "Web extract via %s: %d URL(s)", provider.name, len(safe_urls)
+                )
+                results = await _call_extract_provider(provider, safe_urls)
+            else:
+                # Explicit chains fail over per URL. A success is final; only
+                # failed/missing results advance to the next provider.
+                remaining = list(range(len(safe_urls)))
+                resolved: dict[int, dict[str, Any]] = {}
+                attempt_errors: dict[int, list[str]] = {
+                    position: [] for position in remaining
+                }
+
+                for provider in providers:
+                    if not remaining:
+                        break
+                    pending_urls = [safe_urls[position] for position in remaining]
+                    logger.info(
+                        "Web extract via %s: %d URL(s)",
+                        provider.name,
+                        len(pending_urls),
+                    )
+                    try:
+                        candidate_results = await _call_extract_provider(
+                            provider, pending_urls
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        if is_interrupted():
+                            for position in remaining:
+                                resolved[position] = {
+                                    "url": safe_urls[position],
+                                    "title": "",
+                                    "content": "",
+                                    "error": "Interrupted",
+                                }
+                            remaining = []
+                            break
+                        logger.info(
+                            "Web extract provider %s failed, trying fallback: %s",
+                            provider.name,
+                            exc,
+                        )
+                        for position in remaining:
+                            attempt_errors[position].append(f"{provider.name}: {exc}")
+                        continue
+
+                    if isinstance(candidate_results, list):
+                        # Terminal signals must be inspected before URL alignment:
+                        # alignment is intentionally lossy for malformed duplicate/
+                        # surplus rows, but terminal failures must never disappear.
+                        raw_interrupted = any(
+                            _provider_result_is_interrupted(candidate)
+                            for candidate in candidate_results
+                        )
+                        raw_policy_failures = [
+                            candidate
+                            for candidate in candidate_results
+                            if _provider_result_is_terminal_failure(candidate)
+                            and not _provider_result_is_interrupted(candidate)
+                        ]
+                        aligned_results = _align_extract_results(
+                            candidate_results,
+                            remaining,
+                            safe_urls,
+                        )
+                    else:
+                        raw_interrupted = False
+                        raw_policy_failures = []
+                        aligned_results = {}
+
+                    aligned_values = list(aligned_results.values())
+                    aligned_interrupted = any(
+                        _provider_result_is_interrupted(candidate)
+                        for candidate in aligned_values
+                    )
+                    unaligned_policy_failure = next(
+                        (
+                            candidate
+                            for candidate in raw_policy_failures
+                            if all(candidate is not aligned for aligned in aligned_values)
+                        ),
+                        None,
+                    )
+                    batch_interrupted = (
+                        is_interrupted() or raw_interrupted or aligned_interrupted
+                    )
+                    if batch_interrupted:
+                        unaligned_interruption = raw_interrupted and not aligned_interrupted
+                        for safe_position in remaining:
+                            candidate = aligned_results.get(safe_position)
+                            resolved[safe_position] = (
+                                candidate
+                                if isinstance(candidate, dict) and not unaligned_interruption
+                                else {
+                                    "url": safe_urls[safe_position],
+                                    "title": "",
+                                    "content": "",
+                                    "error": "Interrupted",
+                                }
+                            )
+                        remaining = []
+                        break
+
+                    if unaligned_policy_failure is not None:
+                        # A redirect-rewritten terminal result without request
+                        # identity cannot be assigned safely. Preserve any exact
+                        # success/terminal matches, but stop fallback for every
+                        # unresolved occurrence rather than risk bypassing policy.
+                        for safe_position in remaining:
+                            candidate = aligned_results.get(safe_position)
+                            if isinstance(candidate, dict) and (
+                                _extract_result_has_usable_content(candidate)
+                                or _provider_result_is_terminal_failure(candidate)
+                            ):
+                                resolved[safe_position] = candidate
+                            else:
+                                resolved[safe_position] = {
+                                    "url": safe_urls[safe_position],
+                                    "title": "",
+                                    "content": "",
+                                    "error": (
+                                        "Blocked: extract provider returned an "
+                                        "uncorrelated terminal policy result"
+                                    ),
+                                }
+                        remaining = []
+                        break
+
+                    next_remaining: list[int] = []
+                    for safe_position in remaining:
+                        if not isinstance(candidate_results, list):
+                            detail = "returned a non-list response"
+                            candidate = None
+                        elif safe_position not in aligned_results:
+                            detail = "returned no result for this URL"
+                            candidate = None
+                        else:
+                            candidate = aligned_results[safe_position]
+                            if _provider_result_is_terminal_failure(candidate):
+                                # Preserve policy denials as terminal per-URL
+                                # results. Retrying through another provider
+                                # could bypass a post-redirect safety decision.
+                                resolved[safe_position] = candidate
+                                continue
+                            if _extract_result_has_usable_content(candidate):
+                                resolved[safe_position] = candidate
+                                continue
+                            if isinstance(candidate, dict) and candidate.get("error"):
+                                detail = str(candidate["error"])
+                            else:
+                                detail = "no usable extracted content"
+
+                        attempt_errors[safe_position].append(
+                            f"{provider.name}: {detail}"
+                        )
+                        next_remaining.append(safe_position)
+                    remaining = next_remaining
+
+                for safe_position in remaining:
+                    details = attempt_errors[safe_position] + skipped
+                    resolved[safe_position] = {
+                        "url": safe_urls[safe_position],
+                        "title": "",
+                        "content": "",
+                        "error": (
+                            "All configured web extract providers failed: "
+                            + "; ".join(details or ["no usable extracted content"])
+                        ),
+                    }
+
+                results = [resolved[position] for position in range(len(safe_urls))]
+
         # Reconstruct the original input order across invalid, blocked, and
-        # provider-processed entries. Providers are expected to preserve the
-        # order of the safe URL list they receive.
+        # provider-processed entries. Explicit-chain rows were already
+        # correlated to safe input positions by _align_extract_results().
         if invalid_urls or ssrf_blocked:
             safe_results = {
                 index: (
@@ -1110,7 +1560,7 @@ if __name__ == "__main__":
         elif backend == "searxng":
             print(f"   Using SearXNG (search only): {_env_value('SEARXNG_URL')}")
         elif backend == "brave-free":
-            print("   Using Brave Search free tier (search only)")
+            print("   Using Brave Search (search only)")
         elif backend == "ddgs":
             print("   Using DuckDuckGo via ddgs package (search only)")
         elif firecrawl_url_available:

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -342,10 +342,34 @@ web:
 
 When per-capability keys are empty, both fall through to `web.backend`. When `web.backend` is also empty, the backend is auto-detected from whichever API key/URL is present.
 
+### Ordered fallback chains
+
+Use plural `search_backends` / `extract_backends` when you want Hermes to try providers in a fixed order. These lists are empty by default, so existing scalar and auto-detected setups do not start retrying or spending another provider after an upgrade.
+
+```yaml
+# ~/.hermes/config.yaml
+web:
+  search_backends:
+    - brave-free    # BRAVE_SEARCH_API_KEY
+    - searxng
+    - ddgs
+  extract_backends:
+    - firecrawl
+    - exa
+    - tavily
+    - parallel
+  fallback_on_empty_search: false
+```
+
+Search chains fall through when a provider raises or returns `success: false`. By default, a clean empty result does **not** spend the next backend; set `fallback_on_empty_search: true` only when empty results should trigger fallback.
+
+Extract chains fail over per URL: successful pages stay fixed while only failed or missing pages move to the next provider. Results are correlated to exact requested URLs; one remaining redirected row can fill one remaining request, but ambiguous multi-redirect batches are left unresolved rather than assigned by position. An uncorrelated safety denial stops fallback for every unresolved URL in that batch. Provider-level safety or policy denials and user interruption are terminal and never fall through. Unknown, incapable, or unavailable entries are reported as skipped; configured disabled plugins are named with the exact `hermes plugins enable …` recovery command. If an explicit chain has no usable provider, Hermes returns an error instead of silently switching to auto-detection.
+
 **Priority order (per capability):**
-1. `web.search_backend` / `web.extract_backend` (explicit per-capability)
-2. `web.backend` (shared fallback)
-3. Auto-detect from environment variables
+1. Non-empty `web.search_backends` / `web.extract_backends` (explicit ordered policy)
+2. `web.search_backend` / `web.extract_backend` (explicit per-capability scalar)
+3. `web.backend` (shared scalar fallback)
+4. Auto-detect from environment variables
 
 ### Auto-detection
 


### PR DESCRIPTION
## Summary

Hermes users can now opt into ordered search and extraction provider chains without changing existing scalar or auto-detected setups. Provider failures can fall through to the next configured backend, while clean empty search results remain final unless `fallback_on_empty_search` is explicitly enabled.

Extraction fallback works per URL: successful pages stay fixed and only failed or missing pages advance. Safety-policy denials and interruption remain terminal, including malformed, surplus, redirect-rewritten, or otherwise uncorrelatable provider rows.

## Design decisions

- Treat non-empty `search_backends` and `extract_backends` as explicit policy boundaries; invalid, unknown, disabled, incapable, or unavailable chains fail clearly instead of silently auto-detecting another backend.
- Preserve the existing scalar and automatic dispatch paths, including current-main availability checks and registered custom-provider overrides.
- Correlate extraction rows to exact requested URL occurrences. A single unmatched redirect may fill a single unresolved request; ambiguous multi-redirect batches are retried rather than assigned by position.
- Stop fallback for uncorrelated terminal policy results rather than risk bypassing a post-redirect safety decision.
- Report disabled plugins with the precise config field and `hermes plugins enable …` recovery command.

## Validation

- `348/348` affected web/provider/plugin/integration/model-tool tests passed on the review-fix head.
- `38/38` dedicated fallback-chain tests cover explicit search/extract-chain schema exposure plus provider exceptions, unsuccessful and optionally empty searches, malformed configuration, real temporary-`HERMES_HOME` plugin discovery, disabled plugins, scalar compatibility, registry overrides, duplicate/reordered/omitted/redirected extraction rows, policy denials, and interruption.
- Ruff, Python compilation, and `git diff --check` passed.

No live paid-provider calls were made; external API payload variations remain provider-dependent.

## Post-Deploy Monitoring & Validation

- **Window/owner:** Hermes maintainers and contributor during the first release cycle after merge.
- **Healthy signals:** legacy scalar/auto-detected configurations keep selecting one provider; explicit chains attempt providers in configured order; extraction retains successful URLs and retries only unresolved failures.
- **Watch for:** `No configured web ... provider is available`, exhausted-chain errors, unexpected duplicate provider calls, URL/result correlation mismatches, or a policy/interruption result advancing to another backend.
- **Rollback trigger:** any safety-policy bypass, interruption fallback, incorrect URL attribution, or legacy scalar regression. Revert the commit; users can immediately restore legacy dispatch by removing the plural chain keys or leaving them empty.

## Context

This revisits the routing goal from closed PR #56916 against the current provider registry, but deliberately drops the obsolete Brave free/paid credential and subscription-tier model in favor of generic opt-in provider chains.
