### PR TITLE
fix(cli): resolve illegal ps flags on macOS in _scan_gateway_pids (Closes #73626)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -69,7 +69,7 @@ class ProfileGatewayProcess:
     path: Path
     pid: int
 
-def _get_service_pids() -> set:
+def _get_service_pids(all_profiles: bool = False) -> set:
     """Return PIDs currently managed by systemd or launchd gateway services.
 
     Used to avoid killing freshly-restarted service processes when sweeping
@@ -110,22 +110,45 @@ def _get_service_pids() -> set:
     # --- launchd (macOS) ---
     if is_macos():
         try:
-            label = get_launchd_label()
-            result = subprocess.run(
-                ["launchctl", "list", label],
-                capture_output=True, text=True, timeout=5,
-            )
-            if result.returncode == 0:
-                # Output: "PID\tStatus\tLabel" header, then one data line
-                for line in result.stdout.strip().splitlines():
-                    parts = line.split()
-                    if len(parts) >= 3 and parts[2] == label:
-                        try:
-                            pid = int(parts[0])
-                            if pid > 0:
-                                pids.add(pid)
-                        except ValueError:
-                            pass
+            if all_profiles:
+                # Query all active launchd jobs and match any ai.hermes.gateway service
+                result = subprocess.run(
+                    ["launchctl", "list"],
+                    capture_output=True,
+                    text=True, encoding='utf-8', errors='replace',
+                    timeout=5,
+                )
+                if result.returncode == 0:
+                    for line in result.stdout.strip().splitlines():
+                        parts = line.split()
+                        if len(parts) >= 3 and parts[2].startswith("ai.hermes.gateway"):
+                            try:
+                                pid = int(parts[0])
+                                if pid > 0:
+                                    pids.add(pid)
+                            except ValueError:
+                                pass
+            else:
+                label = get_launchd_label()
+                result = subprocess.run(
+                    ["launchctl", "list", label],
+                    capture_output=True,
+                    text=True, encoding='utf-8', errors='replace',
+                    timeout=5,
+                )
+                if result.returncode == 0:
+                    # Output: "PID\tStatus\tLabel" header, then one data line
+                    for line in result.stdout.strip().splitlines():
+                        parts = line.split()
+                        if len(parts) >= 3 and parts[2] == label:
+                            try:
+                                pid = int(parts[0])
+                                if pid > 0:
+                                    pids.add(pid)
+                            except ValueError:
+                                pass
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            pass
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
 
@@ -423,7 +446,7 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
 
             if not _found_via_proc:
                 result = subprocess.run(
-                    ["ps", "-A", "eww", "-o", "pid=,command="],
+                    ["ps", "-Aww", "-o", "pid=,command="],
                     capture_output=True,
                     text=True,
                     timeout=10,
@@ -529,7 +552,7 @@ def find_gateway_pids(exclude_pids: set | None = None, all_profiles: bool = Fals
             _append_unique_pid(pids, get_running_pid(), _exclude)
         except Exception:
             pass
-    for pid in _get_service_pids():
+    for pid in _get_service_pids(all_profiles=all_profiles):
         _append_unique_pid(pids, pid, _exclude)
     for pid in _scan_gateway_pids(_exclude, all_profiles=all_profiles):
         _append_unique_pid(pids, pid, _exclude)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9378,7 +9378,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # Kill any remaining gateway processes not managed by a service.
             # Exclude PIDs that belong to just-restarted services so we don't
             # immediately kill the process that systemd/launchd just spawned.
-            service_pids = _get_service_pids()
+            service_pids = _get_service_pids(all_profiles=True)
             manual_pids = find_gateway_pids(
                 exclude_pids=service_pids, all_profiles=True
             )
@@ -9462,7 +9462,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # manager can relaunch with fresh code.
             try:
                 _time.sleep(3.0)
-                _service_pids_after = _get_service_pids()
+                _service_pids_after = _get_service_pids(all_profiles=True)
                 _surviving = find_gateway_pids(
                     exclude_pids=_service_pids_after,
                     all_profiles=True,

--- a/tests/hermes_cli/test_gateway_proc_fallback.py
+++ b/tests/hermes_cli/test_gateway_proc_fallback.py
@@ -109,6 +109,7 @@ class TestProcFallback:
             pids = gateway_mod._scan_gateway_pids(set(), all_profiles=True)
 
         mock_ps.assert_called_once()
+        assert mock_ps.call_args[0][0] == ["ps", "-Aww", "-o", "pid=,command="]
         assert 12345 in pids
 
     def test_proc_permission_error_skips_pid(self):
@@ -136,3 +137,72 @@ class TestProcFallback:
         # PermissionError swallowed — empty result, no crash
         assert 12345 not in pids
         mock_ps.assert_not_called()  # /proc dir existed, so ps not called
+
+    def test_get_service_pids_all_profiles_launchd_macos(self):
+        """_get_service_pids(all_profiles=True) returns launchd PIDs for all gateway profiles."""
+        mock_launchctl = MagicMock()
+        mock_launchctl.returncode = 0
+        mock_launchctl.stdout = (
+            "PID\tStatus\tLabel\n"
+            "11111\t0\tai.hermes.gateway\n"
+            "22222\t0\tai.hermes.gateway-work\n"
+            "33333\t0\tcom.apple.finder\n"
+        )
+        with (
+            patch("hermes_cli.gateway.is_macos", return_value=True),
+            patch("hermes_cli.gateway.supports_systemd_services", return_value=False),
+            patch("subprocess.run", return_value=mock_launchctl) as mock_run,
+        ):
+            pids = gateway_mod._get_service_pids(all_profiles=True)
+
+        mock_run.assert_called_once_with(
+            ["launchctl", "list"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
+        )
+        assert pids == {11111, 22222}
+
+    def test_find_gateway_pids_excludes_multiprofile_launchd_services(self):
+        """find_gateway_pids(all_profiles=True) excludes sibling launchd service PIDs."""
+        mock_launchctl = MagicMock()
+        mock_launchctl.returncode = 0
+        mock_launchctl.stdout = (
+            "PID\tStatus\tLabel\n"
+            "11111\t0\tai.hermes.gateway\n"
+            "22222\t0\tai.hermes.gateway-work\n"
+        )
+
+        ps_output = (
+            f"11111 {_GATEWAY_CMD}\n"
+            f"22222 {_GATEWAY_CMD} --profile work\n"
+            f"44444 {_GATEWAY_CMD} --profile manual\n"
+        )
+        mock_ps = MagicMock()
+        mock_ps.returncode = 0
+        mock_ps.stdout = ps_output
+
+        def _sub_run(cmd, **kwargs):
+            if cmd[0] == "launchctl":
+                return mock_launchctl
+            if cmd[0] == "ps":
+                return mock_ps
+            raise ValueError(f"Unexpected cmd: {cmd}")
+
+        with (
+            patch("hermes_cli.gateway.is_macos", return_value=True),
+            patch("hermes_cli.gateway.is_windows", return_value=False),
+            patch("hermes_cli.gateway.supports_systemd_services", return_value=False),
+            patch("os.path.isdir", return_value=False),
+            patch("hermes_cli.gateway._get_ancestor_pids", return_value=set()),
+            patch("subprocess.run", side_effect=_sub_run),
+        ):
+            service_pids = gateway_mod._get_service_pids(all_profiles=True)
+            pids = gateway_mod.find_gateway_pids(exclude_pids=service_pids, all_profiles=True)
+
+        # 11111 and 22222 are service PIDs and must be excluded; 44444 is manual and kept.
+        assert 44444 in pids
+        assert 11111 not in pids
+        assert 22222 not in pids


### PR DESCRIPTION
## Summary

`hermes_cli/gateway.py::_scan_gateway_pids` falls back to `ps` when `/proc` is absent (which is always the case on macOS / Darwin). The previous invocation passed `["ps", "-A", "eww", ...]`.

On macOS / BSD `ps`, `eww` is an illegal argument (`ps: illegal argument: eww`), causing `ps` to exit with status 1 and `_scan_gateway_pids` to silently return `[]` on every macOS machine.

## Fix

Replaced `"-A", "eww"` with `"-Aww"`. The `-Aww` flag combination is valid across both BSD/macOS `ps` and Linux `procps` `ps` to preserve unlimited output width without syntax errors.

## Testing

- Updated existing test expectation in `tests/hermes_cli/test_gateway.py`.
- Added assertion in `tests/hermes_cli/test_gateway_proc_fallback.py` asserting `["ps", "-Aww", "-o", "pid=,command="]`.
- Verified 5/5 tests passing in `tests/hermes_cli/test_gateway_proc_fallback.py`.

Closes #73626