### PR TITLE
feat(gateway): add native Buzz platform plugin

### DIFF
--- a/plugins/platforms/buzz/__init__.py
+++ b/plugins/platforms/buzz/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -12,6 +12,7 @@ import importlib.util
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -59,6 +60,29 @@ WS_AUTH_TIMEOUT = 20.0
 WS_MAX_MESSAGE_BYTES = 2_000_000
 MAX_TRACKED_EVENT_IDS = 10_000
 MAX_TRACKED_SENT_IDS = 2_000
+_SLASH_CONFIRM_COMMANDS = frozenset({"/approve", "/always", "/cancel"})
+_EXEC_APPROVAL_COMMANDS = frozenset({"/approve", "/deny"})
+_EXEC_APPROVAL_RESPONSES = frozenset({
+    "approve",
+    "yes",
+    "ok",
+    "okay",
+    "confirm",
+    "y",
+    "👍",
+    "deny",
+    "no",
+    "reject",
+    "cancel",
+    "n",
+    "👎",
+    "always",
+    "approve always",
+    "always approve",
+    "session",
+    "approve session",
+    "session approve",
+})
 
 
 class BuzzCliError(RuntimeError):
@@ -106,6 +130,44 @@ def _thread_id(tags: Any) -> Optional[str]:
     return reply
 
 
+def _wake_word_pattern(wake_word: str, *, at_start: bool = False) -> re.Pattern:
+    normalized = wake_word.strip().lstrip("@").strip()
+    if not normalized:
+        return re.compile(r"(?!x)x")
+    prefix = r"^\s*" if at_start else r"(?<![\w@'-])"
+    return re.compile(
+        rf"{prefix}@{re.escape(normalized)}(?![\w'-])",
+        flags=re.IGNORECASE,
+    )
+
+
+def _contains_wake_word(content: str, wake_words: list[str]) -> bool:
+    return any(
+        _wake_word_pattern(wake_word).search(content) is not None
+        for wake_word in wake_words
+    )
+
+
+def _strip_leading_wake_word(content: str, wake_words: list[str]) -> str:
+    for wake_word in wake_words:
+        match = _wake_word_pattern(wake_word, at_start=True).match(content)
+        if match is None:
+            continue
+        remainder = content[match.end() :]
+        remainder = re.sub(r"^[ \t]*[:,][ \t]*", "", remainder, count=1)
+        return remainder.lstrip()
+    return content
+
+
+def _event_timestamp(value: Any, *, now: Optional[int] = None) -> int:
+    current = int(time.time()) if now is None else int(now)
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return current
+    return min(max(parsed, 0), current)
+
+
 def _is_for_agent(
     event: dict[str, Any],
     *,
@@ -120,8 +182,8 @@ def _is_for_agent(
         return True
     if sent_ids.intersection(_tag_values(tags, "e")):
         return True
-    content = str(event.get("content") or "").lower()
-    return any(f"@{word.lower()}" in content for word in wake_words)
+    content = str(event.get("content") or "")
+    return _contains_wake_word(content, wake_words)
 
 
 def _private_key() -> str:
@@ -137,6 +199,18 @@ def _relay_url(config: Optional[PlatformConfig] = None) -> str:
     return str(extra.get("relay_url") or os.getenv("BUZZ_RELAY_URL", "")).strip()
 
 
+def _default_cli_paths() -> tuple[Path, ...]:
+    hermes_home = Path(os.getenv("HERMES_HOME", "~/.hermes")).expanduser()
+    user_home = Path.home()
+    return (
+        hermes_home / "bin" / "buzz",
+        user_home / ".local" / "bin" / "buzz",
+        user_home / ".cargo" / "bin" / "buzz",
+        Path("/opt/homebrew/bin/buzz"),
+        Path("/usr/local/bin/buzz"),
+    )
+
+
 def _resolve_cli(config: Optional[PlatformConfig] = None) -> Optional[str]:
     extra = getattr(config, "extra", {}) or {}
     configured = str(extra.get("cli") or os.getenv("BUZZ_CLI", "")).strip()
@@ -148,7 +222,13 @@ def _resolve_cli(config: Optional[PlatformConfig] = None) -> Optional[str]:
         if path.is_file() and os.access(path, os.X_OK):
             return str(path)
         return None
-    return shutil.which("buzz")
+    resolved = shutil.which("buzz")
+    if resolved:
+        return resolved
+    for path in _default_cli_paths():
+        if path.is_file() and os.access(path, os.X_OK):
+            return str(path)
+    return None
 
 
 def _websocket_url(relay_url: str) -> str:
@@ -277,15 +357,21 @@ class BuzzAdapter(BasePlatformAdapter):
             extra.get("require_mention", os.getenv("BUZZ_REQUIRE_MENTION")),
             default=True,
         )
-        self._wake_words = _split_csv(
-            extra.get("wake_words") or os.getenv("BUZZ_WAKE_WORDS", "Hermes,Maximus")
-        )
         self._profile_name = str(
             extra.get("profile_name") or os.getenv("BUZZ_PROFILE_NAME", "")
         ).strip()
         self._profile_about = str(
             extra.get("profile_about") or os.getenv("BUZZ_PROFILE_ABOUT", "")
         ).strip()
+        configured_wake_words = _split_csv(
+            extra.get("wake_words") or os.getenv("BUZZ_WAKE_WORDS", "Hermes,Maximus")
+        )
+        self._wake_words = list(
+            dict.fromkeys([
+                *configured_wake_words,
+                *([self._profile_name] if self._profile_name else []),
+            ])
+        )
 
         self._ws_task: Optional[asyncio.Task] = None
         self._ws_ready = asyncio.Event()
@@ -325,20 +411,14 @@ class BuzzAdapter(BasePlatformAdapter):
             )
             return False
 
-        try:
-            from gateway.status import acquire_scoped_lock
-
-            self._lock_key = f"{self._relay_url}:{self._agent_pubkey}"
-            if not acquire_scoped_lock("buzz", self._lock_key):
-                self._set_fatal_error(
-                    "buzz_identity_in_use",
-                    "This Buzz identity is already used by another Hermes profile",
-                    retryable=False,
-                )
-                self._lock_key = None
-                return False
-        except ImportError:
+        self._lock_key = f"{self._relay_url}:{self._agent_pubkey}"
+        if not self._acquire_platform_lock(
+            "buzz",
+            self._lock_key,
+            "Buzz identity",
+        ):
             self._lock_key = None
+            return False
 
         try:
             await self._run_cli(["channels", "list", "--member"], timeout=20.0)
@@ -412,9 +492,7 @@ class BuzzAdapter(BasePlatformAdapter):
         if not self._lock_key:
             return
         try:
-            from gateway.status import release_scoped_lock
-
-            release_scoped_lock("buzz", self._lock_key)
+            self._release_platform_lock()
         except Exception:
             logger.debug("[Buzz] Failed to release identity lock", exc_info=True)
         self._lock_key = None
@@ -550,7 +628,7 @@ class BuzzAdapter(BasePlatformAdapter):
         subscriptions: dict[str, Optional[str]],
         event: dict[str, Any],
     ) -> None:
-        created_at = int(event.get("created_at") or time.time())
+        created_at = _event_timestamp(event.get("created_at"))
         self._membership_since = max(self._membership_since, created_at)
         dm_ids = _tag_values(event.get("tags") or [], "h")
         if not dm_ids or not dm_ids[0].strip():
@@ -600,7 +678,11 @@ class BuzzAdapter(BasePlatformAdapter):
                     backoff = 1.0
 
                     async for raw in websocket:
-                        message = json.loads(raw)
+                        try:
+                            message = json.loads(raw)
+                        except (json.JSONDecodeError, TypeError):
+                            logger.warning("[Buzz] Ignoring malformed WebSocket frame")
+                            continue
                         if not isinstance(message, list) or not message:
                             continue
                         if message[0] == "EVENT" and len(message) >= 3:
@@ -615,7 +697,7 @@ class BuzzAdapter(BasePlatformAdapter):
                                 continue
                             channel = subscriptions.get(subscription_id)
                             if channel:
-                                created_at = int(event.get("created_at") or 0)
+                                created_at = _event_timestamp(event.get("created_at"))
                                 self._since[channel] = max(
                                     self._since.get(channel, 0), created_at
                                 )
@@ -674,18 +756,6 @@ class BuzzAdapter(BasePlatformAdapter):
             return
 
         chat_type = "dm" if channel in self._dm_channels else "group"
-        if (
-            chat_type == "group"
-            and self._require_mention
-            and not _is_for_agent(
-                event,
-                agent_pubkey=self._agent_pubkey,
-                wake_words=self._wake_words,
-                sent_ids=self._sent_ids,
-            )
-        ):
-            return
-
         tags = event.get("tags") or []
         source = self.build_source(
             chat_id=channel,
@@ -695,7 +765,24 @@ class BuzzAdapter(BasePlatformAdapter):
             user_name=author[:12],
             thread_id=_thread_id(tags),
         )
-        created_at = int(event.get("created_at") or time.time())
+        addressed = _is_for_agent(
+            event,
+            agent_pubkey=self._agent_pubkey,
+            wake_words=self._wake_words,
+            sent_ids=self._sent_ids,
+        )
+        if (
+            chat_type == "group"
+            and self._require_mention
+            and not addressed
+            and not self._is_pending_control_reply(source, text)
+        ):
+            return
+
+        text = _strip_leading_wake_word(text, self._wake_words)
+        if not text:
+            return
+        created_at = _event_timestamp(event.get("created_at"))
         message_event = MessageEvent(
             text=text,
             message_type=MessageType.TEXT,
@@ -705,6 +792,60 @@ class BuzzAdapter(BasePlatformAdapter):
             timestamp=datetime.fromtimestamp(created_at, tz=timezone.utc),
         )
         await self.handle_message(message_event)
+
+    def _is_pending_control_reply(self, source, text: str) -> bool:
+        from gateway.session import build_session_key
+
+        extra = self.config.extra or {}
+        session_key = build_session_key(
+            source,
+            group_sessions_per_user=extra.get("group_sessions_per_user", True),
+            thread_sessions_per_user=extra.get("thread_sessions_per_user", False),
+        )
+        command = (text.lstrip().split(maxsplit=1) or [""])[0].lower()
+        normalized_text = text.strip().lower()
+
+        if (
+            command in _EXEC_APPROVAL_COMMANDS
+            or normalized_text in _EXEC_APPROVAL_RESPONSES
+        ):
+            try:
+                from tools.approval import has_blocking_approval
+
+                if has_blocking_approval(session_key):
+                    return True
+            except Exception:
+                logger.debug(
+                    "[Buzz] Could not inspect pending exec approval", exc_info=True
+                )
+
+        if command in _SLASH_CONFIRM_COMMANDS:
+            try:
+                from tools.slash_confirm import get_pending
+
+                if get_pending(session_key) is not None:
+                    return True
+            except Exception:
+                logger.debug(
+                    "[Buzz] Could not inspect pending slash confirm", exc_info=True
+                )
+
+        if not command.startswith("/"):
+            try:
+                from tools.clarify_gateway import get_pending_for_session
+
+                return (
+                    get_pending_for_session(
+                        session_key,
+                        include_choice_prompts=True,
+                    )
+                    is not None
+                )
+            except Exception:
+                logger.debug(
+                    "[Buzz] Could not inspect pending clarification", exc_info=True
+                )
+        return False
 
     async def send(
         self,

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1,0 +1,873 @@
+"""Buzz platform adapter for the Hermes gateway.
+
+Inbound messages arrive through a long-lived, NIP-42-authenticated Nostr
+WebSocket subscription. Signed outbound writes use the Buzz CLI so one-shot
+delivery never races a temporary WebSocket authentication handshake.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import time
+from collections import deque
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+from urllib.parse import urlsplit, urlunsplit
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+
+
+try:
+    from .nostr_auth import build_auth_event, public_key_hex
+except ImportError:
+    # tests/gateway/_plugin_adapter_loader.py loads adapter.py directly under a
+    # unique module name. Load the sibling without modifying sys.path.
+    _auth_path = Path(__file__).with_name("nostr_auth.py")
+    _auth_spec = importlib.util.spec_from_file_location(
+        "plugin_adapter_buzz_nostr_auth", _auth_path
+    )
+    if _auth_spec is None or _auth_spec.loader is None:
+        raise ImportError(f"Could not load Buzz Nostr auth module: {_auth_path}")
+    _auth_module = importlib.util.module_from_spec(_auth_spec)
+    sys.modules[_auth_spec.name] = _auth_module
+    _auth_spec.loader.exec_module(_auth_module)
+    build_auth_event = _auth_module.build_auth_event
+    public_key_hex = _auth_module.public_key_hex
+
+
+logger = logging.getLogger(__name__)
+
+MAX_MESSAGE_LENGTH = 60_000
+MESSAGE_KINDS = (9, 45001, 45003)
+MEMBERSHIP_ADDED_KIND = 44100
+MEMBERSHIP_SUBSCRIPTION_ID = "hermes-buzz-membership"
+WS_AUTH_TIMEOUT = 20.0
+WS_MAX_MESSAGE_BYTES = 2_000_000
+MAX_TRACKED_EVENT_IDS = 10_000
+MAX_TRACKED_SENT_IDS = 2_000
+
+
+class BuzzCliError(RuntimeError):
+    """Raised when the Buzz CLI cannot complete an operation."""
+
+
+def _split_csv(value: Any) -> list[str]:
+    if isinstance(value, (list, tuple, set)):
+        parts = value
+    else:
+        parts = str(value or "").split(",")
+    return [str(part).strip() for part in parts if str(part).strip()]
+
+
+def _bool(value: Any, default: bool = False) -> bool:
+    if value is None or value == "":
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _tag_values(tags: Any, name: str) -> list[str]:
+    values: list[str] = []
+    if not isinstance(tags, list):
+        return values
+    for tag in tags:
+        if isinstance(tag, list) and len(tag) >= 2 and tag[0] == name:
+            values.append(str(tag[1]))
+    return values
+
+
+def _thread_id(tags: Any) -> Optional[str]:
+    if not isinstance(tags, list):
+        return None
+    reply: Optional[str] = None
+    for tag in tags:
+        if not isinstance(tag, list) or len(tag) < 2 or tag[0] != "e":
+            continue
+        marker = str(tag[3]) if len(tag) >= 4 else ""
+        if marker == "root":
+            return str(tag[1])
+        if marker == "reply":
+            reply = str(tag[1])
+    return reply
+
+
+def _is_for_agent(
+    event: dict[str, Any],
+    *,
+    agent_pubkey: str,
+    wake_words: list[str],
+    sent_ids: set[str],
+) -> bool:
+    tags = event.get("tags") or []
+    if agent_pubkey and agent_pubkey.lower() in {
+        value.lower() for value in _tag_values(tags, "p")
+    }:
+        return True
+    if sent_ids.intersection(_tag_values(tags, "e")):
+        return True
+    content = str(event.get("content") or "").lower()
+    return any(f"@{word.lower()}" in content for word in wake_words)
+
+
+def _private_key() -> str:
+    return os.getenv("BUZZ_PRIVATE_KEY", "").strip()
+
+
+def _auth_tag() -> str:
+    return os.getenv("BUZZ_AUTH_TAG", "").strip()
+
+
+def _relay_url(config: Optional[PlatformConfig] = None) -> str:
+    extra = getattr(config, "extra", {}) or {}
+    return str(extra.get("relay_url") or os.getenv("BUZZ_RELAY_URL", "")).strip()
+
+
+def _resolve_cli(config: Optional[PlatformConfig] = None) -> Optional[str]:
+    extra = getattr(config, "extra", {}) or {}
+    configured = str(extra.get("cli") or os.getenv("BUZZ_CLI", "")).strip()
+    if configured:
+        resolved = shutil.which(configured)
+        if resolved:
+            return resolved
+        path = Path(configured).expanduser()
+        if path.is_file() and os.access(path, os.X_OK):
+            return str(path)
+        return None
+    return shutil.which("buzz")
+
+
+def _websocket_url(relay_url: str) -> str:
+    parsed = urlsplit(relay_url.strip())
+    scheme = {"http": "ws", "https": "wss"}.get(parsed.scheme, parsed.scheme)
+    if scheme not in {"ws", "wss"} or not parsed.netloc:
+        raise ValueError("Buzz relay URL must use http(s) or ws(s)")
+    return urlunsplit((scheme, parsed.netloc, parsed.path or "", parsed.query, ""))
+
+
+def _command_env(relay_url: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env["BUZZ_RELAY_URL"] = relay_url
+    private_key = _private_key()
+    if private_key:
+        env["BUZZ_PRIVATE_KEY"] = private_key
+    auth_tag = _auth_tag()
+    if auth_tag:
+        env["BUZZ_AUTH_TAG"] = auth_tag
+    return env
+
+
+def _run_cli_sync(
+    cli: str,
+    relay_url: str,
+    args: list[str],
+    *,
+    input_text: Optional[str] = None,
+    timeout: float = 30.0,
+) -> Any:
+    proc = subprocess.run(
+        [cli, "--format", "json", *args],
+        input=input_text,
+        text=True,
+        capture_output=True,
+        env=_command_env(relay_url),
+        timeout=timeout,
+        check=False,
+    )
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "Buzz CLI failed").strip()
+        try:
+            parsed = json.loads(detail)
+            detail = str(parsed.get("message") or detail)
+        except (json.JSONDecodeError, AttributeError):
+            pass
+        raise BuzzCliError(detail[:500])
+    try:
+        return json.loads(proc.stdout or "null")
+    except json.JSONDecodeError as exc:
+        raise BuzzCliError("Buzz CLI returned invalid JSON") from exc
+
+
+async def _run_cli(
+    cli: str,
+    relay_url: str,
+    args: list[str],
+    *,
+    input_text: Optional[str] = None,
+    timeout: float = 30.0,
+) -> Any:
+    return await asyncio.to_thread(
+        _run_cli_sync,
+        cli,
+        relay_url,
+        args,
+        input_text=input_text,
+        timeout=timeout,
+    )
+
+
+def check_requirements() -> bool:
+    """Return true only when the two required Buzz credentials are present."""
+    return bool(os.getenv("BUZZ_RELAY_URL", "").strip() and _private_key())
+
+
+def validate_config(config: PlatformConfig) -> bool:
+    relay_url = _relay_url(config)
+    private_key = _private_key()
+    if not (relay_url and private_key and _resolve_cli(config)):
+        return False
+    try:
+        _websocket_url(relay_url)
+        public_key_hex(private_key)
+    except ValueError:
+        return False
+    return True
+
+
+def is_connected(config: PlatformConfig) -> bool:
+    return validate_config(config)
+
+
+class BuzzAdapter(BasePlatformAdapter):
+    """Subscribe to Buzz channels and route addressed messages into Hermes."""
+
+    MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config=config, platform=Platform("buzz"))
+        extra = config.extra or {}
+        self._cli = _resolve_cli(config) or "buzz"
+        self._relay_url = _relay_url(config)
+        try:
+            self._agent_pubkey = public_key_hex(_private_key()).lower()
+        except ValueError:
+            self._agent_pubkey = ""
+
+        configured_channels = _split_csv(
+            extra.get("channels")
+            or os.getenv("BUZZ_CHANNELS")
+            or os.getenv("BUZZ_HOME_CHANNEL")
+        )
+        explicit_dm_channels = _split_csv(
+            extra.get("dm_channels") or os.getenv("BUZZ_DM_CHANNELS")
+        )
+        self._channels = list(
+            dict.fromkeys([*configured_channels, *explicit_dm_channels])
+        )
+        self._dm_channels = set(explicit_dm_channels)
+        self._discover_dms = _bool(
+            extra.get("discover_dms", os.getenv("BUZZ_DISCOVER_DMS")),
+            default=True,
+        )
+        self._require_mention = _bool(
+            extra.get("require_mention", os.getenv("BUZZ_REQUIRE_MENTION")),
+            default=True,
+        )
+        self._wake_words = _split_csv(
+            extra.get("wake_words") or os.getenv("BUZZ_WAKE_WORDS", "Hermes,Maximus")
+        )
+        self._profile_name = str(
+            extra.get("profile_name") or os.getenv("BUZZ_PROFILE_NAME", "")
+        ).strip()
+        self._profile_about = str(
+            extra.get("profile_about") or os.getenv("BUZZ_PROFILE_ABOUT", "")
+        ).strip()
+
+        self._ws_task: Optional[asyncio.Task] = None
+        self._ws_ready = asyncio.Event()
+        self._seen_ids: set[str] = set()
+        self._seen_order: deque[str] = deque()
+        self._sent_ids: set[str] = set()
+        self._sent_order: deque[str] = deque()
+        self._since: dict[str, int] = {}
+        self._membership_since = 0
+        self._lock_key: Optional[str] = None
+
+    @property
+    def name(self) -> str:
+        return "Buzz"
+
+    async def _run_cli(
+        self,
+        args: list[str],
+        *,
+        input_text: Optional[str] = None,
+        timeout: float = 30.0,
+    ) -> Any:
+        return await _run_cli(
+            self._cli,
+            self._relay_url,
+            args,
+            input_text=input_text,
+            timeout=timeout,
+        )
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        if not validate_config(self.config):
+            self._set_fatal_error(
+                "buzz_config_missing",
+                "Buzz requires BUZZ_RELAY_URL, BUZZ_PRIVATE_KEY, and the Buzz CLI",
+                retryable=False,
+            )
+            return False
+
+        try:
+            from gateway.status import acquire_scoped_lock
+
+            self._lock_key = f"{self._relay_url}:{self._agent_pubkey}"
+            if not acquire_scoped_lock("buzz", self._lock_key):
+                self._set_fatal_error(
+                    "buzz_identity_in_use",
+                    "This Buzz identity is already used by another Hermes profile",
+                    retryable=False,
+                )
+                self._lock_key = None
+                return False
+        except ImportError:
+            self._lock_key = None
+
+        try:
+            await self._run_cli(["channels", "list", "--member"], timeout=20.0)
+            if public_key_hex(_private_key()).lower() != self._agent_pubkey:
+                raise ValueError("Buzz private key changed during connection setup")
+        except Exception as exc:
+            logger.error("[Buzz] Relay/auth probe failed: %s", exc)
+            await self._release_lock()
+            self._set_fatal_error("buzz_probe_failed", str(exc), retryable=True)
+            return False
+
+        if self._discover_dms:
+            await self._discover_dm_channels()
+
+        now = int(time.time())
+        if not is_reconnect:
+            self._since = {channel: now for channel in self._channels}
+            self._membership_since = now
+        else:
+            for channel in self._channels:
+                self._since.setdefault(channel, now - 5)
+            if not self._membership_since:
+                self._membership_since = now - 5
+
+        if not is_reconnect:
+            await self._publish_profile_best_effort()
+        await self._set_presence_best_effort("online")
+
+        self._running = True
+        self._ws_ready.clear()
+        self._ws_task = asyncio.create_task(self._websocket_loop())
+        try:
+            await asyncio.wait_for(self._ws_ready.wait(), timeout=WS_AUTH_TIMEOUT + 5)
+        except TimeoutError:
+            self._running = False
+            self._ws_task.cancel()
+            try:
+                await self._ws_task
+            except asyncio.CancelledError:
+                pass
+            self._ws_task = None
+            await self._release_lock()
+            self._set_fatal_error(
+                "buzz_websocket_auth_failed",
+                "Buzz WebSocket did not authenticate before the timeout",
+                retryable=True,
+            )
+            return False
+
+        self._mark_connected()
+        logger.info(
+            "[Buzz] Subscribed to %d channel(s) over WebSocket",
+            len(self._channels),
+        )
+        return True
+
+    async def disconnect(self) -> None:
+        self._running = False
+        self._mark_disconnected()
+        if self._ws_task and not self._ws_task.done():
+            self._ws_task.cancel()
+            try:
+                await self._ws_task
+            except asyncio.CancelledError:
+                pass
+        self._ws_task = None
+        await self._set_presence_best_effort("offline")
+        await self._release_lock()
+
+    async def _release_lock(self) -> None:
+        if not self._lock_key:
+            return
+        try:
+            from gateway.status import release_scoped_lock
+
+            release_scoped_lock("buzz", self._lock_key)
+        except Exception:
+            logger.debug("[Buzz] Failed to release identity lock", exc_info=True)
+        self._lock_key = None
+
+    async def _discover_dm_channels(self) -> int:
+        try:
+            conversations = await self._run_cli(
+                [
+                    "channels",
+                    "search",
+                    "--query",
+                    "DM",
+                    "--include-archived",
+                    "--limit",
+                    "1000",
+                ],
+                timeout=20.0,
+            )
+        except Exception as exc:
+            logger.warning("[Buzz] Could not discover direct messages: %s", exc)
+            return 0
+
+        added = 0
+        if not isinstance(conversations, list):
+            return added
+        for conversation in conversations:
+            if not isinstance(conversation, dict):
+                continue
+            if conversation.get("channel_type") != "dm":
+                continue
+            dm_id = str(conversation.get("channel_id") or "").strip()
+            if not dm_id:
+                continue
+            self._dm_channels.add(dm_id)
+            if dm_id not in self._channels:
+                self._channels.append(dm_id)
+                added += 1
+        if added:
+            logger.info("[Buzz] Discovered %d direct-message conversation(s)", added)
+        return added
+
+    async def _publish_profile_best_effort(self) -> None:
+        args = ["users", "set-profile"]
+        if self._profile_name:
+            args.extend(["--name", self._profile_name])
+        if self._profile_about:
+            args.extend(["--about", self._profile_about])
+        if len(args) == 2:
+            return
+        try:
+            await self._run_cli(args, timeout=20.0)
+        except Exception as exc:
+            logger.warning("[Buzz] Could not publish identity profile: %s", exc)
+
+    async def _set_presence_best_effort(self, status: str) -> None:
+        try:
+            await self._run_cli(
+                ["users", "set-presence", "--status", status], timeout=10.0
+            )
+        except Exception as exc:
+            logger.debug("[Buzz] Could not set presence to %s: %s", status, exc)
+
+    async def _authenticate_websocket(self, websocket) -> None:
+        raw = await asyncio.wait_for(websocket.recv(), timeout=WS_AUTH_TIMEOUT)
+        message = json.loads(raw)
+        if not isinstance(message, list) or len(message) < 2 or message[0] != "AUTH":
+            raise BuzzCliError("Buzz relay did not send a NIP-42 AUTH challenge")
+
+        event = build_auth_event(
+            private_key=_private_key(),
+            challenge=str(message[1]),
+            relay_url=_websocket_url(self._relay_url),
+            auth_tag_json=_auth_tag(),
+        )
+        await websocket.send(json.dumps(["AUTH", event], separators=(",", ":")))
+
+        while True:
+            raw = await asyncio.wait_for(websocket.recv(), timeout=WS_AUTH_TIMEOUT)
+            response = json.loads(raw)
+            if not isinstance(response, list) or not response:
+                continue
+            if (
+                response[0] == "OK"
+                and len(response) >= 4
+                and response[1] == event["id"]
+            ):
+                if response[2] is True:
+                    return
+                raise BuzzCliError(f"Buzz WebSocket AUTH rejected: {response[3]}")
+            if response[0] in {"NOTICE", "CLOSED"}:
+                detail = response[-1] if len(response) > 1 else "authentication failed"
+                raise BuzzCliError(f"Buzz WebSocket AUTH failed: {detail}")
+
+    async def _send_channel_subscription(
+        self, websocket, subscription_id: str, channel: str
+    ) -> None:
+        since = max(self._since.get(channel, int(time.time())) - 1, 0)
+        request = [
+            "REQ",
+            subscription_id,
+            {
+                "kinds": list(MESSAGE_KINDS),
+                "#h": [channel],
+                "since": since,
+            },
+        ]
+        await websocket.send(json.dumps(request, separators=(",", ":")))
+
+    async def _subscribe_websocket(self, websocket) -> dict[str, Optional[str]]:
+        subscriptions: dict[str, Optional[str]] = {}
+        for index, channel in enumerate(self._channels):
+            subscription_id = f"hermes-buzz-{index}"
+            subscriptions[subscription_id] = channel
+            await self._send_channel_subscription(websocket, subscription_id, channel)
+
+        if self._discover_dms:
+            request = [
+                "REQ",
+                MEMBERSHIP_SUBSCRIPTION_ID,
+                {
+                    "kinds": [MEMBERSHIP_ADDED_KIND],
+                    "#p": [self._agent_pubkey],
+                    "since": max(self._membership_since - 1, 0),
+                },
+            ]
+            await websocket.send(json.dumps(request, separators=(",", ":")))
+            subscriptions[MEMBERSHIP_SUBSCRIPTION_ID] = None
+        return subscriptions
+
+    async def _handle_dm_discovery(
+        self,
+        websocket,
+        subscriptions: dict[str, Optional[str]],
+        event: dict[str, Any],
+    ) -> None:
+        created_at = int(event.get("created_at") or time.time())
+        self._membership_since = max(self._membership_since, created_at)
+        dm_ids = _tag_values(event.get("tags") or [], "h")
+        if not dm_ids or not dm_ids[0].strip():
+            return
+
+        subscribed_before = set(self._channels)
+        await self._discover_dm_channels()
+        new_dm_ids = [
+            channel
+            for channel in self._channels
+            if channel in self._dm_channels and channel not in subscribed_before
+        ]
+        for new_dm_id in new_dm_ids:
+            self._since[new_dm_id] = created_at
+            subscription_id = f"hermes-buzz-dm-{len(subscriptions)}"
+            subscriptions[subscription_id] = new_dm_id
+            await self._send_channel_subscription(websocket, subscription_id, new_dm_id)
+            logger.info(
+                "[Buzz] Subscribed to new direct-message conversation %s",
+                new_dm_id,
+            )
+
+    async def _websocket_loop(self) -> None:
+        import websockets
+
+        backoff = 1.0
+        has_subscribed = False
+        while self._running:
+            try:
+                async with websockets.connect(
+                    _websocket_url(self._relay_url),
+                    open_timeout=WS_AUTH_TIMEOUT,
+                    close_timeout=5,
+                    ping_interval=20,
+                    ping_timeout=20,
+                    max_size=WS_MAX_MESSAGE_BYTES,
+                ) as websocket:
+                    await self._authenticate_websocket(websocket)
+                    subscriptions = await self._subscribe_websocket(websocket)
+                    if has_subscribed:
+                        logger.info(
+                            "[Buzz] WebSocket reconnected; restored %d channel subscription(s)",
+                            len(self._channels),
+                        )
+                    has_subscribed = True
+                    self._ws_ready.set()
+                    backoff = 1.0
+
+                    async for raw in websocket:
+                        message = json.loads(raw)
+                        if not isinstance(message, list) or not message:
+                            continue
+                        if message[0] == "EVENT" and len(message) >= 3:
+                            subscription_id = str(message[1])
+                            event = message[2]
+                            if not isinstance(event, dict):
+                                continue
+                            if subscription_id == MEMBERSHIP_SUBSCRIPTION_ID:
+                                await self._handle_dm_discovery(
+                                    websocket, subscriptions, event
+                                )
+                                continue
+                            channel = subscriptions.get(subscription_id)
+                            if channel:
+                                created_at = int(event.get("created_at") or 0)
+                                self._since[channel] = max(
+                                    self._since.get(channel, 0), created_at
+                                )
+                                await self._dispatch_event(channel, event)
+                        elif message[0] == "CLOSED":
+                            detail = (
+                                message[-1]
+                                if len(message) > 2
+                                else "subscription closed"
+                            )
+                            raise BuzzCliError(str(detail))
+                        elif message[0] == "NOTICE":
+                            logger.warning("[Buzz] Relay notice: %s", message[-1])
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                if not self._running:
+                    return
+                logger.warning(
+                    "[Buzz] WebSocket disconnected; retrying in %.1fs: %s",
+                    backoff,
+                    exc,
+                )
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 30.0)
+
+    def _remember_event_id(self, event_id: str) -> bool:
+        if event_id in self._seen_ids:
+            return False
+        self._seen_ids.add(event_id)
+        self._seen_order.append(event_id)
+        while len(self._seen_order) > MAX_TRACKED_EVENT_IDS:
+            self._seen_ids.discard(self._seen_order.popleft())
+        return True
+
+    def _remember_sent_id(self, event_id: str) -> None:
+        if not event_id or event_id in self._sent_ids:
+            return
+        self._sent_ids.add(event_id)
+        self._sent_order.append(event_id)
+        while len(self._sent_order) > MAX_TRACKED_SENT_IDS:
+            self._sent_ids.discard(self._sent_order.popleft())
+
+    async def _dispatch_event(self, channel: str, event: dict[str, Any]) -> None:
+        event_id = str(event.get("id") or "")
+        author = str(event.get("pubkey") or "").lower()
+        text = str(event.get("content") or "").strip()
+        if (
+            not event_id
+            or not author
+            or not text
+            or not self._remember_event_id(event_id)
+        ):
+            return
+        if author == self._agent_pubkey:
+            return
+
+        chat_type = "dm" if channel in self._dm_channels else "group"
+        if (
+            chat_type == "group"
+            and self._require_mention
+            and not _is_for_agent(
+                event,
+                agent_pubkey=self._agent_pubkey,
+                wake_words=self._wake_words,
+                sent_ids=self._sent_ids,
+            )
+        ):
+            return
+
+        tags = event.get("tags") or []
+        source = self.build_source(
+            chat_id=channel,
+            chat_name=channel,
+            chat_type=chat_type,
+            user_id=author,
+            user_name=author[:12],
+            thread_id=_thread_id(tags),
+        )
+        created_at = int(event.get("created_at") or time.time())
+        message_event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id=event_id,
+            raw_message=event,
+            timestamp=datetime.fromtimestamp(created_at, tz=timezone.utc),
+        )
+        await self.handle_message(message_event)
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> SendResult:
+        args = ["messages", "send", "--channel", chat_id, "--content", "-"]
+        explicit_thread = (metadata or {}).get("thread_id")
+        parent = explicit_thread or (
+            reply_to if chat_id not in self._dm_channels else None
+        )
+        if parent:
+            args.extend(["--reply-to", str(parent)])
+        try:
+            result = await self._run_cli(args, input_text=content, timeout=60.0)
+            message_id = str((result or {}).get("event_id") or "")
+            self._remember_sent_id(message_id)
+            accepted = bool((result or {}).get("accepted", True))
+            return SendResult(
+                success=accepted,
+                message_id=message_id or None,
+                error=None
+                if accepted
+                else str((result or {}).get("message") or "Relay rejected message"),
+            )
+        except Exception as exc:
+            logger.error("[Buzz] Send failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
+        return {
+            "name": chat_id,
+            "type": "dm" if chat_id in self._dm_channels else "group",
+            "chat_id": chat_id,
+        }
+
+
+def _env_enablement() -> Optional[dict[str, Any]]:
+    relay_url = os.getenv("BUZZ_RELAY_URL", "").strip()
+    if not (relay_url and _private_key()):
+        return None
+
+    channels = _split_csv(os.getenv("BUZZ_CHANNELS") or os.getenv("BUZZ_HOME_CHANNEL"))
+    seed: dict[str, Any] = {
+        "relay_url": relay_url,
+        "channels": channels,
+        "dm_channels": _split_csv(os.getenv("BUZZ_DM_CHANNELS")),
+        "discover_dms": _bool(os.getenv("BUZZ_DISCOVER_DMS"), default=True),
+        "require_mention": _bool(os.getenv("BUZZ_REQUIRE_MENTION"), default=True),
+        "wake_words": _split_csv(os.getenv("BUZZ_WAKE_WORDS", "Hermes,Maximus")),
+    }
+    home = os.getenv("BUZZ_HOME_CHANNEL", "").strip()
+    if home:
+        seed["home_channel"] = {"chat_id": home, "name": "Buzz"}
+    return seed
+
+
+def _apply_yaml_config(
+    yaml_cfg: dict[str, Any], platform_cfg: dict[str, Any]
+) -> Optional[dict[str, Any]]:
+    del yaml_cfg
+    extra = platform_cfg.get("extra") if isinstance(platform_cfg, dict) else {}
+    if not isinstance(extra, dict):
+        extra = {}
+
+    def seed(name: str, value: Any) -> None:
+        if value is None or value == "" or os.getenv(name):
+            return
+        if name == "BUZZ_HOME_CHANNEL" and isinstance(value, dict):
+            value = value.get("chat_id")
+            if not value:
+                return
+        if isinstance(value, (list, tuple, set)):
+            value = ",".join(str(item) for item in value)
+        os.environ[name] = str(value)
+
+    seed("BUZZ_RELAY_URL", extra.get("relay_url"))
+    seed("BUZZ_CHANNELS", extra.get("channels"))
+    seed("BUZZ_HOME_CHANNEL", extra.get("home_channel"))
+    seed("BUZZ_DM_CHANNELS", extra.get("dm_channels"))
+    seed("BUZZ_DISCOVER_DMS", extra.get("discover_dms"))
+    seed("BUZZ_ALLOWED_USERS", extra.get("allowed_users"))
+    seed("BUZZ_ALLOW_ALL_USERS", extra.get("allow_all_users"))
+    seed("BUZZ_REQUIRE_MENTION", extra.get("require_mention"))
+    seed("BUZZ_WAKE_WORDS", extra.get("wake_words"))
+    seed("BUZZ_PROFILE_NAME", extra.get("profile_name"))
+    seed("BUZZ_PROFILE_ABOUT", extra.get("profile_about"))
+    seed("BUZZ_CLI", extra.get("cli"))
+    return None
+
+
+async def _standalone_send(
+    pconfig: PlatformConfig,
+    chat_id: str,
+    message: str,
+    *,
+    thread_id: Optional[str] = None,
+    media_files: Optional[list[str]] = None,
+    force_document: bool = False,
+) -> dict[str, Any]:
+    del force_document
+    if media_files:
+        return {"error": "Buzz standalone delivery does not support media files"}
+    cli = _resolve_cli(pconfig)
+    relay_url = _relay_url(pconfig)
+    if not cli:
+        return {"error": "Buzz CLI not found"}
+    if not relay_url or not _private_key():
+        return {"error": "BUZZ_RELAY_URL and BUZZ_PRIVATE_KEY are required"}
+
+    args = ["messages", "send", "--channel", chat_id, "--content", "-"]
+    if thread_id:
+        args.extend(["--reply-to", str(thread_id)])
+    try:
+        result = await _run_cli(
+            cli,
+            relay_url,
+            args,
+            input_text=message,
+            timeout=60.0,
+        )
+    except Exception as exc:
+        return {"error": f"Buzz standalone send failed: {exc}"}
+
+    accepted = bool((result or {}).get("accepted", True))
+    if not accepted:
+        return {"error": str((result or {}).get("message") or "Relay rejected message")}
+    return {
+        "success": True,
+        "platform": "buzz",
+        "chat_id": chat_id,
+        "message_id": str((result or {}).get("event_id") or "") or None,
+    }
+
+
+def register(ctx) -> None:
+    ctx.register_platform(
+        name="buzz",
+        label="Buzz",
+        adapter_factory=lambda cfg: BuzzAdapter(cfg),
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        required_env=["BUZZ_RELAY_URL", "BUZZ_PRIVATE_KEY"],
+        install_hint="Install the Buzz CLI from https://github.com/block/buzz",
+        env_enablement_fn=_env_enablement,
+        apply_yaml_config_fn=_apply_yaml_config,
+        cron_deliver_env_var="BUZZ_HOME_CHANNEL",
+        standalone_sender_fn=_standalone_send,
+        allowed_users_env="BUZZ_ALLOWED_USERS",
+        allow_all_env="BUZZ_ALLOW_ALL_USERS",
+        max_message_length=MAX_MESSAGE_LENGTH,
+        emoji="🐝",
+        pii_safe=True,
+        allow_update_command=False,
+        platform_hint=(
+            "You are communicating through Buzz. Buzz supports markdown, mentions, "
+            "and threaded replies. Treat the sender pubkey as the authenticated user "
+            "identity. Use the normal Hermes memory, tools, approvals, and sessions."
+        ),
+    )

--- a/plugins/platforms/buzz/nostr_auth.py
+++ b/plugins/platforms/buzz/nostr_auth.py
@@ -1,0 +1,230 @@
+"""Dependency-free Nostr signing for Buzz WebSocket authentication."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import secrets
+import time
+from typing import Any, Optional
+
+
+FIELD_ORDER = 2**256 - 2**32 - 977
+CURVE_ORDER = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+GENERATOR = (
+    0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798,
+    0x483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8,
+)
+BECH32_CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+
+Point = Optional[tuple[int, int]]
+
+
+def _bech32_polymod(values: list[int]) -> int:
+    generators = (0x3B6A57B2, 0x26508E6D, 0x1EA119FA, 0x3D4233DD, 0x2A1462B3)
+    checksum = 1
+    for value in values:
+        top = checksum >> 25
+        checksum = ((checksum & 0x1FFFFFF) << 5) ^ value
+        for index, generator in enumerate(generators):
+            if (top >> index) & 1:
+                checksum ^= generator
+    return checksum
+
+
+def _bech32_hrp_expand(hrp: str) -> list[int]:
+    return [ord(char) >> 5 for char in hrp] + [0] + [ord(char) & 31 for char in hrp]
+
+
+def _decode_nsec(value: str) -> bytes:
+    if value.lower() != value and value.upper() != value:
+        raise ValueError("nsec cannot mix upper- and lowercase")
+    normalized = value.lower()
+    separator = normalized.rfind("1")
+    if separator < 1 or separator + 7 > len(normalized):
+        raise ValueError("invalid nsec encoding")
+    hrp = normalized[:separator]
+    if hrp != "nsec":
+        raise ValueError("private key must use the nsec prefix")
+    try:
+        data = [BECH32_CHARSET.index(char) for char in normalized[separator + 1 :]]
+    except ValueError as exc:
+        raise ValueError("invalid character in nsec") from exc
+    if _bech32_polymod(_bech32_hrp_expand(hrp) + data) != 1:
+        raise ValueError("invalid nsec checksum")
+
+    accumulator = 0
+    bits = 0
+    decoded = bytearray()
+    for value5 in data[:-6]:
+        accumulator = (accumulator << 5) | value5
+        bits += 5
+        while bits >= 8:
+            bits -= 8
+            decoded.append((accumulator >> bits) & 0xFF)
+    if bits and (accumulator & ((1 << bits) - 1)):
+        raise ValueError("non-zero nsec padding")
+    if len(decoded) != 32:
+        raise ValueError("nsec must encode exactly 32 bytes")
+    return bytes(decoded)
+
+
+def decode_private_key(value: str) -> int:
+    raw = value.strip()
+    if raw.lower().startswith("nsec1"):
+        key_bytes = _decode_nsec(raw)
+    else:
+        try:
+            key_bytes = bytes.fromhex(raw)
+        except ValueError as exc:
+            raise ValueError("private key must be 64 hex characters or nsec") from exc
+        if len(key_bytes) != 32:
+            raise ValueError("private key must be 32 bytes")
+    key = int.from_bytes(key_bytes, "big")
+    if not 1 <= key < CURVE_ORDER:
+        raise ValueError("private key is outside the secp256k1 range")
+    return key
+
+
+def _point_add(left: Point, right: Point) -> Point:
+    if left is None:
+        return right
+    if right is None:
+        return left
+    x1, y1 = left
+    x2, y2 = right
+    if x1 == x2:
+        if (y1 + y2) % FIELD_ORDER == 0:
+            return None
+        slope = (3 * x1 * x1) * pow(2 * y1, FIELD_ORDER - 2, FIELD_ORDER)
+    else:
+        slope = (y2 - y1) * pow(x2 - x1, FIELD_ORDER - 2, FIELD_ORDER)
+    slope %= FIELD_ORDER
+    x3 = (slope * slope - x1 - x2) % FIELD_ORDER
+    y3 = (slope * (x1 - x3) - y1) % FIELD_ORDER
+    return x3, y3
+
+
+def _point_multiply(scalar: int, point: Point = GENERATOR) -> Point:
+    result: Point = None
+    addend = point
+    while scalar:
+        if scalar & 1:
+            result = _point_add(result, addend)
+        addend = _point_add(addend, addend)
+        scalar >>= 1
+    return result
+
+
+def _tagged_hash(tag: str, payload: bytes) -> bytes:
+    tag_hash = hashlib.sha256(tag.encode()).digest()
+    return hashlib.sha256(tag_hash + tag_hash + payload).digest()
+
+
+def public_key_hex(private_key: str) -> str:
+    point = _point_multiply(decode_private_key(private_key))
+    if point is None:  # pragma: no cover - range validation makes this unreachable
+        raise ValueError("invalid private key")
+    return point[0].to_bytes(32, "big").hex()
+
+
+def schnorr_sign(
+    message: bytes,
+    private_key: str,
+    *,
+    auxiliary_randomness: Optional[bytes] = None,
+) -> bytes:
+    if len(message) != 32:
+        raise ValueError("BIP-340 signs a 32-byte message")
+    secret = decode_private_key(private_key)
+    public_point = _point_multiply(secret)
+    if public_point is None:  # pragma: no cover
+        raise ValueError("invalid private key")
+    public_x = public_point[0].to_bytes(32, "big")
+    adjusted_secret = secret if public_point[1] % 2 == 0 else CURVE_ORDER - secret
+
+    aux = (
+        auxiliary_randomness
+        if auxiliary_randomness is not None
+        else secrets.token_bytes(32)
+    )
+    if len(aux) != 32:
+        raise ValueError("auxiliary randomness must be 32 bytes")
+    masked = bytes(
+        left ^ right
+        for left, right in zip(
+            adjusted_secret.to_bytes(32, "big"),
+            _tagged_hash("BIP0340/aux", aux),
+        )
+    )
+    nonce = (
+        int.from_bytes(
+            _tagged_hash("BIP0340/nonce", masked + public_x + message), "big"
+        )
+        % CURVE_ORDER
+    )
+    if nonce == 0:
+        raise RuntimeError("BIP-340 produced a zero nonce")
+    nonce_point = _point_multiply(nonce)
+    if nonce_point is None:  # pragma: no cover
+        raise RuntimeError("BIP-340 produced an invalid nonce point")
+    adjusted_nonce = nonce if nonce_point[1] % 2 == 0 else CURVE_ORDER - nonce
+    nonce_x = nonce_point[0].to_bytes(32, "big")
+    challenge = (
+        int.from_bytes(
+            _tagged_hash("BIP0340/challenge", nonce_x + public_x + message), "big"
+        )
+        % CURVE_ORDER
+    )
+    signature_scalar = (adjusted_nonce + challenge * adjusted_secret) % CURVE_ORDER
+    return nonce_x + signature_scalar.to_bytes(32, "big")
+
+
+def build_auth_event(
+    *,
+    private_key: str,
+    challenge: str,
+    relay_url: str,
+    auth_tag_json: str = "",
+    created_at: Optional[int] = None,
+    auxiliary_randomness: Optional[bytes] = None,
+) -> dict[str, Any]:
+    tags: list[list[str]] = [
+        ["relay", relay_url],
+        ["challenge", challenge],
+    ]
+    if auth_tag_json.strip():
+        try:
+            auth_tag = json.loads(auth_tag_json)
+        except json.JSONDecodeError as exc:
+            raise ValueError("BUZZ_AUTH_TAG is not valid JSON") from exc
+        if (
+            not isinstance(auth_tag, list)
+            or len(auth_tag) != 4
+            or auth_tag[0] != "auth"
+            or not all(isinstance(part, str) for part in auth_tag)
+        ):
+            raise ValueError("BUZZ_AUTH_TAG must be a four-string auth tag")
+        tags.append(auth_tag)
+
+    pubkey = public_key_hex(private_key)
+    timestamp = int(time.time()) if created_at is None else int(created_at)
+    serialized = json.dumps(
+        [0, pubkey, timestamp, 22242, tags, ""],
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode()
+    event_id = hashlib.sha256(serialized).digest()
+    return {
+        "id": event_id.hex(),
+        "pubkey": pubkey,
+        "created_at": timestamp,
+        "kind": 22242,
+        "tags": tags,
+        "content": "",
+        "sig": schnorr_sign(
+            event_id,
+            private_key,
+            auxiliary_randomness=auxiliary_randomness,
+        ).hex(),
+    }

--- a/plugins/platforms/buzz/plugin.yaml
+++ b/plugins/platforms/buzz/plugin.yaml
@@ -1,0 +1,69 @@
+name: buzz-platform
+label: Buzz
+kind: platform
+version: 1.0.0
+description: >
+  Native Buzz gateway transport for Hermes Agent. Receives authenticated
+  Nostr events over WebSocket and uses the Buzz CLI for signed outbound
+  delivery.
+author: Chris Brisson (ScaleLeanChris)
+requires_env:
+  - name: BUZZ_RELAY_URL
+    description: "Buzz relay URL, such as https://buzz.example.com"
+    prompt: "Buzz relay URL"
+    url: "https://github.com/block/buzz"
+    password: false
+  - name: BUZZ_PRIVATE_KEY
+    description: "Nostr private key for the Hermes identity in Buzz"
+    prompt: "Buzz private key"
+    password: true
+optional_env:
+  - name: BUZZ_AUTH_TAG
+    description: "NIP-OA owner attestation issued by the Buzz relay"
+    prompt: "Buzz owner attestation"
+    password: true
+  - name: BUZZ_CHANNELS
+    description: "Comma-separated Buzz channel IDs Hermes should monitor"
+    prompt: "Buzz channel IDs"
+    password: false
+  - name: BUZZ_DM_CHANNELS
+    description: "Comma-separated Buzz DM channel IDs to subscribe to explicitly"
+    prompt: "Buzz DM channel IDs"
+    password: false
+  - name: BUZZ_DISCOVER_DMS
+    description: "Discover and subscribe to Buzz DMs automatically"
+    prompt: "Discover Buzz DMs? (true/false)"
+    password: false
+  - name: BUZZ_HOME_CHANNEL
+    description: "Default Buzz channel ID for cron and proactive messages"
+    prompt: "Buzz home channel"
+    password: false
+  - name: BUZZ_ALLOWED_USERS
+    description: "Comma-separated Buzz pubkeys allowed to direct Hermes"
+    prompt: "Allowed Buzz pubkeys"
+    password: false
+  - name: BUZZ_ALLOW_ALL_USERS
+    description: "Allow any Buzz member to direct Hermes"
+    prompt: "Allow all Buzz users? (true/false)"
+    password: false
+  - name: BUZZ_REQUIRE_MENTION
+    description: "Require an address tag, reply, or wake word in shared channels"
+    prompt: "Require a mention? (true/false)"
+    password: false
+  - name: BUZZ_WAKE_WORDS
+    description: "Comma-separated text wake words, default Hermes,Maximus"
+    prompt: "Buzz wake words"
+    password: false
+  - name: BUZZ_PROFILE_NAME
+    description: "Display name published for the Hermes Buzz identity"
+    prompt: "Buzz profile name"
+    password: false
+  - name: BUZZ_PROFILE_ABOUT
+    description: "Short profile description for the Hermes Buzz identity"
+    prompt: "Buzz profile description"
+    password: false
+  - name: BUZZ_CLI
+    description: "Path or command name for the Buzz CLI"
+    prompt: "Buzz CLI path"
+    url: "https://github.com/block/buzz"
+    password: false

--- a/tests/gateway/test_buzz.py
+++ b/tests/gateway/test_buzz.py
@@ -1,0 +1,476 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from gateway.config import PlatformConfig
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+
+buzz = load_plugin_adapter("buzz")
+nostr_auth = sys.modules["plugin_adapter_buzz_nostr_auth"]
+TEST_PRIVATE_KEY = "00" * 31 + "01"
+
+
+def _config(**extra):
+    return PlatformConfig(enabled=True, extra=extra)
+
+
+def test_split_csv_normalizes_strings_and_lists():
+    assert buzz._split_csv(" a, ,b ") == ["a", "b"]
+    assert buzz._split_csv([" a ", "", "b"]) == ["a", "b"]
+
+
+def test_thread_id_prefers_root_marker():
+    tags = [["e", "parent", "", "reply"], ["e", "root", "", "root"]]
+    assert buzz._thread_id(tags) == "root"
+
+
+def test_addressing_accepts_pubkey_reply_or_wake_word():
+    pubkey = "a" * 64
+    assert buzz._is_for_agent(
+        {"content": "hello", "tags": [["p", pubkey]]},
+        agent_pubkey=pubkey,
+        wake_words=["Hermes"],
+        sent_ids=set(),
+    )
+    assert buzz._is_for_agent(
+        {"content": "following up", "tags": [["e", "sent"]]},
+        agent_pubkey=pubkey,
+        wake_words=["Hermes"],
+        sent_ids={"sent"},
+    )
+    assert buzz._is_for_agent(
+        {"content": "@Hermes please check", "tags": []},
+        agent_pubkey=pubkey,
+        wake_words=["Hermes"],
+        sent_ids=set(),
+    )
+    assert not buzz._is_for_agent(
+        {"content": "general discussion", "tags": []},
+        agent_pubkey=pubkey,
+        wake_words=["Hermes"],
+        sent_ids=set(),
+    )
+
+
+def test_check_requirements_needs_relay_and_private_key_only(monkeypatch):
+    monkeypatch.delenv("BUZZ_RELAY_URL", raising=False)
+    monkeypatch.delenv("BUZZ_PRIVATE_KEY", raising=False)
+    monkeypatch.setattr(buzz, "_resolve_cli", lambda config=None: None)
+    assert buzz.check_requirements() is False
+
+    monkeypatch.setenv("BUZZ_RELAY_URL", "https://buzz.example.test")
+    assert buzz.check_requirements() is False
+
+    monkeypatch.setenv("BUZZ_PRIVATE_KEY", TEST_PRIVATE_KEY)
+    assert buzz.check_requirements() is True
+
+
+def test_validate_config_checks_cli_url_and_private_key(monkeypatch):
+    monkeypatch.setenv("BUZZ_PRIVATE_KEY", TEST_PRIVATE_KEY)
+    monkeypatch.setattr(buzz, "_resolve_cli", lambda config=None: "/tmp/buzz")
+    assert buzz.validate_config(_config(relay_url="https://buzz.example.test"))
+
+    monkeypatch.setenv("BUZZ_PRIVATE_KEY", "invalid")
+    assert not buzz.validate_config(_config(relay_url="https://buzz.example.test"))
+
+
+def test_cli_send_uses_stdin_and_never_places_content_in_arguments(monkeypatch):
+    monkeypatch.setenv("BUZZ_PRIVATE_KEY", TEST_PRIVATE_KEY)
+    completed = SimpleNamespace(
+        returncode=0, stdout='{"event_id":"abc","accepted":true}', stderr=""
+    )
+    with patch.object(buzz.subprocess, "run", return_value=completed) as run:
+        result = buzz._run_cli_sync(
+            "/tmp/buzz",
+            "https://buzz.example.test",
+            ["messages", "send", "--channel", "channel-1", "--content", "-"],
+            input_text="secret-looking $content",
+        )
+
+    assert result["event_id"] == "abc"
+    called_args = run.call_args.args[0]
+    assert "secret-looking $content" not in called_args
+    assert run.call_args.kwargs["input"] == "secret-looking $content"
+
+
+def test_dm_send_stays_flat_unless_source_has_explicit_thread():
+    instance = object.__new__(buzz.BuzzAdapter)
+    instance._dm_channels = {"dm-id"}
+    instance._sent_ids = set()
+    instance._sent_order = buzz.deque()
+    calls = []
+
+    async def run_cli(args, *, input_text, timeout):
+        calls.append((args, input_text, timeout))
+        return {"event_id": f"sent-{len(calls)}", "accepted": True}
+
+    instance._run_cli = run_cli
+
+    asyncio.run(instance.send("dm-id", "flat reply", reply_to="trigger-id"))
+    asyncio.run(
+        instance.send(
+            "dm-id",
+            "thread reply",
+            reply_to="trigger-id",
+            metadata={"thread_id": "root-id"},
+        )
+    )
+    asyncio.run(instance.send("group-id", "group reply", reply_to="trigger-id"))
+
+    assert "--reply-to" not in calls[0][0]
+    assert calls[1][0][-2:] == ["--reply-to", "root-id"]
+    assert calls[2][0][-2:] == ["--reply-to", "trigger-id"]
+
+
+def test_profile_publication_is_opt_in():
+    instance = object.__new__(buzz.BuzzAdapter)
+    instance._profile_name = ""
+    instance._profile_about = ""
+    calls = []
+
+    async def run_cli(args, *, timeout):
+        calls.append((args, timeout))
+
+    instance._run_cli = run_cli
+    asyncio.run(instance._publish_profile_best_effort())
+    assert calls == []
+
+    instance._profile_name = "Maximus"
+    asyncio.run(instance._publish_profile_best_effort())
+    assert calls == [(["users", "set-profile", "--name", "Maximus"], 20.0)]
+
+
+def test_env_enablement_requires_complete_identity(monkeypatch):
+    for name in (
+        "BUZZ_RELAY_URL",
+        "BUZZ_PRIVATE_KEY",
+        "BUZZ_CHANNELS",
+        "BUZZ_HOME_CHANNEL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    assert buzz._env_enablement() is None
+
+    monkeypatch.setenv("BUZZ_RELAY_URL", "https://buzz.example.test")
+    monkeypatch.setenv("BUZZ_PRIVATE_KEY", TEST_PRIVATE_KEY)
+    monkeypatch.setenv("BUZZ_CHANNELS", "channel-1")
+    monkeypatch.setenv("BUZZ_HOME_CHANNEL", "channel-home")
+    seed = buzz._env_enablement()
+
+    assert seed is not None
+    assert seed["channels"] == ["channel-1"]
+    assert seed["home_channel"]["chat_id"] == "channel-home"
+
+
+def test_yaml_bridge_seeds_transport_and_auth_environment(monkeypatch):
+    for name in (
+        "BUZZ_RELAY_URL",
+        "BUZZ_CHANNELS",
+        "BUZZ_DM_CHANNELS",
+        "BUZZ_DISCOVER_DMS",
+        "BUZZ_HOME_CHANNEL",
+        "BUZZ_ALLOWED_USERS",
+        "BUZZ_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    buzz._apply_yaml_config(
+        {},
+        {
+            "extra": {
+                "relay_url": "https://buzz.example.test",
+                "channels": ["general-id"],
+                "dm_channels": ["dm-id"],
+                "discover_dms": False,
+                "home_channel": {"chat_id": "home-id", "name": "Buzz"},
+                "allowed_users": ["owner-id"],
+                "allow_all_users": False,
+            }
+        },
+    )
+    assert os.environ["BUZZ_RELAY_URL"] == "https://buzz.example.test"
+    assert os.environ["BUZZ_CHANNELS"] == "general-id"
+    assert os.environ["BUZZ_DM_CHANNELS"] == "dm-id"
+    assert os.environ["BUZZ_DISCOVER_DMS"] == "False"
+    assert os.environ["BUZZ_HOME_CHANNEL"] == "home-id"
+    assert os.environ["BUZZ_ALLOWED_USERS"] == "owner-id"
+    assert os.environ["BUZZ_ALLOW_ALL_USERS"] == "False"
+
+
+def test_websocket_url_converts_rest_relay_schemes():
+    assert buzz._websocket_url("http://localhost:3000") == "ws://localhost:3000"
+    assert buzz._websocket_url("https://buzz.example.test/community") == (
+        "wss://buzz.example.test/community"
+    )
+
+
+def _lift_x(x: int):
+    y_squared = (pow(x, 3, nostr_auth.FIELD_ORDER) + 7) % nostr_auth.FIELD_ORDER
+    y = pow(y_squared, (nostr_auth.FIELD_ORDER + 1) // 4, nostr_auth.FIELD_ORDER)
+    if pow(y, 2, nostr_auth.FIELD_ORDER) != y_squared:
+        return None
+    return x, y if y % 2 == 0 else nostr_auth.FIELD_ORDER - y
+
+
+def _verify_schnorr(message: bytes, pubkey_hex: str, signature: bytes) -> bool:
+    if len(signature) != 64:
+        return False
+    r = int.from_bytes(signature[:32], "big")
+    scalar = int.from_bytes(signature[32:], "big")
+    public_point = _lift_x(int(pubkey_hex, 16))
+    if (
+        public_point is None
+        or r >= nostr_auth.FIELD_ORDER
+        or scalar >= nostr_auth.CURVE_ORDER
+    ):
+        return False
+    challenge = (
+        int.from_bytes(
+            nostr_auth._tagged_hash(
+                "BIP0340/challenge",
+                signature[:32] + bytes.fromhex(pubkey_hex) + message,
+            ),
+            "big",
+        )
+        % nostr_auth.CURVE_ORDER
+    )
+    negative_public = (public_point[0], (-public_point[1]) % nostr_auth.FIELD_ORDER)
+    point = nostr_auth._point_add(
+        nostr_auth._point_multiply(scalar),
+        nostr_auth._point_multiply(challenge, negative_public),
+    )
+    return point is not None and point[1] % 2 == 0 and point[0] == r
+
+
+def test_nostr_auth_event_has_valid_bip340_signature_and_owner_tag():
+    auth_tag = ["auth", "b" * 64, "", "c" * 128]
+    event = buzz.build_auth_event(
+        private_key=TEST_PRIVATE_KEY,
+        challenge="challenge-1",
+        relay_url="wss://relay.example.test",
+        auth_tag_json=json.dumps(auth_tag),
+        created_at=1_700_000_000,
+        auxiliary_randomness=b"\x00" * 32,
+    )
+
+    assert event["pubkey"] == (
+        "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+    )
+    assert event["kind"] == 22242
+    assert event["tags"] == [
+        ["relay", "wss://relay.example.test"],
+        ["challenge", "challenge-1"],
+        auth_tag,
+    ]
+    serialized = json.dumps(
+        [
+            0,
+            event["pubkey"],
+            event["created_at"],
+            event["kind"],
+            event["tags"],
+            event["content"],
+        ],
+        separators=(",", ":"),
+    ).encode()
+    event_id = hashlib.sha256(serialized).digest()
+    assert event["id"] == event_id.hex()
+    assert _verify_schnorr(event_id, event["pubkey"], bytes.fromhex(event["sig"]))
+
+
+class _FakeWebSocket:
+    def __init__(self):
+        self.sent = []
+
+    async def recv(self):
+        if self.sent:
+            auth_event = self.sent[0][1]
+            return json.dumps(["OK", auth_event["id"], True, "authenticated"])
+        return json.dumps(["AUTH", "relay-challenge"])
+
+    async def send(self, raw):
+        self.sent.append(json.loads(raw))
+
+
+def test_websocket_auth_uses_nip42_and_nip_oa(monkeypatch):
+    instance = object.__new__(buzz.BuzzAdapter)
+    instance._relay_url = "https://buzz.example.test"
+    websocket = _FakeWebSocket()
+    auth_tag = json.dumps(["auth", "b" * 64, "", "c" * 128])
+    monkeypatch.setenv("BUZZ_PRIVATE_KEY", TEST_PRIVATE_KEY)
+    monkeypatch.setenv("BUZZ_AUTH_TAG", auth_tag)
+
+    asyncio.run(instance._authenticate_websocket(websocket))
+
+    assert websocket.sent[0][0] == "AUTH"
+    event = websocket.sent[0][1]
+    assert ["relay", "wss://buzz.example.test"] in event["tags"]
+    assert ["challenge", "relay-challenge"] in event["tags"]
+    assert json.loads(auth_tag) in event["tags"]
+
+
+def test_dm_discovery_merges_relay_confirmed_conversations():
+    instance = object.__new__(buzz.BuzzAdapter)
+    instance._channels = ["general-id"]
+    instance._dm_channels = set()
+
+    async def run_cli(args, *, timeout):
+        assert args == [
+            "channels",
+            "search",
+            "--query",
+            "DM",
+            "--include-archived",
+            "--limit",
+            "1000",
+        ]
+        assert timeout == 20.0
+        return [
+            {"channel_id": "dm-one", "channel_type": "dm"},
+            {"channel_id": "not-a-dm", "channel_type": "stream"},
+            {"channel_id": "dm-two", "channel_type": "dm"},
+        ]
+
+    instance._run_cli = run_cli
+    added = asyncio.run(instance._discover_dm_channels())
+
+    assert added == 2
+    assert instance._channels == ["general-id", "dm-one", "dm-two"]
+    assert instance._dm_channels == {"dm-one", "dm-two"}
+
+
+def test_websocket_subscriptions_resume_from_last_timestamp():
+    instance = object.__new__(buzz.BuzzAdapter)
+    instance._channels = ["general-id", "dm-one"]
+    instance._since = {"general-id": 100, "dm-one": 200}
+    instance._discover_dms = True
+    instance._membership_since = 300
+    instance._agent_pubkey = "a" * 64
+    websocket = _FakeWebSocket()
+
+    subscriptions = asyncio.run(instance._subscribe_websocket(websocket))
+
+    assert subscriptions == {
+        "hermes-buzz-0": "general-id",
+        "hermes-buzz-1": "dm-one",
+        buzz.MEMBERSHIP_SUBSCRIPTION_ID: None,
+    }
+    assert websocket.sent[0][2]["#h"] == ["general-id"]
+    assert websocket.sent[0][2]["since"] == 99
+    assert websocket.sent[1][2]["#h"] == ["dm-one"]
+    assert websocket.sent[1][2]["since"] == 199
+    assert websocket.sent[2][2]["since"] == 299
+
+
+def test_event_id_dedup_routes_only_once(monkeypatch):
+    monkeypatch.setenv("BUZZ_PRIVATE_KEY", TEST_PRIVATE_KEY)
+    monkeypatch.setattr(buzz, "_resolve_cli", lambda config=None: "/tmp/buzz")
+    instance = buzz.BuzzAdapter(_config(relay_url="https://buzz.example.test"))
+    instance._dm_channels = {"dm-id"}
+    received = []
+
+    async def handle_message(event):
+        received.append(event)
+
+    instance.handle_message = handle_message
+    event = {
+        "id": "event-1",
+        "pubkey": "b" * 64,
+        "content": "hello",
+        "created_at": 1_700_000_000,
+        "tags": [["h", "dm-id"]],
+    }
+    asyncio.run(instance._dispatch_event("dm-id", event))
+    asyncio.run(instance._dispatch_event("dm-id", event))
+
+    assert len(received) == 1
+    assert received[0].message_id == "event-1"
+
+
+def test_connect_and_disconnect_acquire_and_release_scoped_lock(monkeypatch):
+    monkeypatch.setenv("BUZZ_PRIVATE_KEY", TEST_PRIVATE_KEY)
+    monkeypatch.setattr(buzz, "_resolve_cli", lambda config=None: "/tmp/buzz")
+    instance = buzz.BuzzAdapter(_config(relay_url="https://buzz.example.test"))
+    acquired = []
+    released = []
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda platform, key: acquired.append((platform, key)) or True,
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda platform, key: released.append((platform, key)),
+    )
+
+    async def run_cli(args, **kwargs):
+        return []
+
+    async def no_op(*args, **kwargs):
+        return None
+
+    async def websocket_loop():
+        instance._ws_ready.set()
+        await asyncio.Future()
+
+    instance._run_cli = run_cli
+    instance._discover_dm_channels = no_op
+    instance._publish_profile_best_effort = no_op
+    instance._set_presence_best_effort = no_op
+    instance._websocket_loop = websocket_loop
+
+    async def exercise():
+        assert await instance.connect()
+        await instance.disconnect()
+
+    asyncio.run(exercise())
+
+    assert acquired == [("buzz", f"https://buzz.example.test:{instance._agent_pubkey}")]
+    assert released == acquired
+
+
+def test_standalone_sender_uses_cli_without_constructing_adapter(monkeypatch):
+    monkeypatch.setenv("BUZZ_PRIVATE_KEY", TEST_PRIVATE_KEY)
+    monkeypatch.setattr(buzz, "_resolve_cli", lambda config=None: "/tmp/buzz")
+    calls = []
+
+    async def run_cli(cli, relay_url, args, *, input_text, timeout):
+        calls.append((cli, relay_url, args, input_text, timeout))
+        return {"event_id": "sent-1", "accepted": True}
+
+    monkeypatch.setattr(buzz, "_run_cli", run_cli)
+    result = asyncio.run(
+        buzz._standalone_send(
+            _config(relay_url="https://buzz.example.test"),
+            "channel-1",
+            "hello",
+            thread_id="root-1",
+        )
+    )
+
+    assert result["success"] is True
+    assert result["message_id"] == "sent-1"
+    assert calls[0][2][-2:] == ["--reply-to", "root-1"]
+    assert calls[0][3] == "hello"
+
+
+def test_register_declares_plugin_only_integration_contract():
+    captured = {}
+
+    class Context:
+        def register_platform(self, **kwargs):
+            captured.update(kwargs)
+
+    buzz.register(Context())
+
+    assert captured["name"] == "buzz"
+    assert captured["env_enablement_fn"] is buzz._env_enablement
+    assert captured["cron_deliver_env_var"] == "BUZZ_HOME_CHANNEL"
+    assert captured["standalone_sender_fn"] is buzz._standalone_send
+    assert captured["allowed_users_env"] == "BUZZ_ALLOWED_USERS"
+    assert captured["allow_all_env"] == "BUZZ_ALLOW_ALL_USERS"

--- a/tests/gateway/test_buzz.py
+++ b/tests/gateway/test_buzz.py
@@ -57,6 +57,50 @@ def test_addressing_accepts_pubkey_reply_or_wake_word():
         wake_words=["Hermes"],
         sent_ids=set(),
     )
+    assert not buzz._is_for_agent(
+        {"content": "@HermesExtended please check", "tags": []},
+        agent_pubkey=pubkey,
+        wake_words=["Hermes"],
+        sent_ids=set(),
+    )
+    assert not buzz._is_for_agent(
+        {"content": "email me at person@Hermes.test", "tags": []},
+        agent_pubkey=pubkey,
+        wake_words=["Hermes"],
+        sent_ids=set(),
+    )
+
+
+def test_strip_leading_wake_word_preserves_real_command():
+    assert (
+        buzz._strip_leading_wake_word(
+            "@Maximus: /status",
+            ["Hermes", "Maximus"],
+        )
+        == "/status"
+    )
+    assert (
+        buzz._strip_leading_wake_word(
+            "Please ask @Maximus about status",
+            ["Maximus"],
+        )
+        == "Please ask @Maximus about status"
+    )
+    assert (
+        buzz._strip_leading_wake_word(
+            "@MaximusExtended /status",
+            ["Maximus"],
+        )
+        == "@MaximusExtended /status"
+    )
+
+
+def test_event_timestamp_rejects_invalid_values_and_future_high_water_marks():
+    assert buzz._event_timestamp("not-a-timestamp", now=1_000) == 1_000
+    assert buzz._event_timestamp(-20, now=1_000) == 0
+    assert buzz._event_timestamp(900, now=1_000) == 900
+    assert buzz._event_timestamp(1_100, now=1_000) == 1_000
+    assert buzz._event_timestamp(99_999, now=1_000) == 1_000
 
 
 def test_check_requirements_needs_relay_and_private_key_only(monkeypatch):
@@ -79,6 +123,19 @@ def test_validate_config_checks_cli_url_and_private_key(monkeypatch):
 
     monkeypatch.setenv("BUZZ_PRIVATE_KEY", "invalid")
     assert not buzz.validate_config(_config(relay_url="https://buzz.example.test"))
+
+
+def test_cli_resolution_handles_service_path_without_interactive_shell(
+    monkeypatch, tmp_path
+):
+    cli = tmp_path / "buzz"
+    cli.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    cli.chmod(0o755)
+    monkeypatch.delenv("BUZZ_CLI", raising=False)
+    monkeypatch.setattr(buzz.shutil, "which", lambda command: None)
+    monkeypatch.setattr(buzz, "_default_cli_paths", lambda: (cli,))
+
+    assert buzz._resolve_cli() == str(cli)
 
 
 def test_cli_send_uses_stdin_and_never_places_content_in_arguments(monkeypatch):
@@ -145,6 +202,26 @@ def test_profile_publication_is_opt_in():
     instance._profile_name = "Maximus"
     asyncio.run(instance._publish_profile_best_effort())
     assert calls == [(["users", "set-profile", "--name", "Maximus"], 20.0)]
+
+
+def test_explicit_profile_name_is_also_a_typed_wake_word(monkeypatch):
+    monkeypatch.setenv("BUZZ_PRIVATE_KEY", TEST_PRIVATE_KEY)
+    monkeypatch.setattr(buzz, "_resolve_cli", lambda config=None: "/tmp/buzz")
+    instance = buzz.BuzzAdapter(
+        _config(
+            relay_url="https://buzz.example.test",
+            profile_name="Jessica",
+            wake_words=["Hermes"],
+        )
+    )
+
+    assert instance._wake_words == ["Hermes", "Jessica"]
+    assert buzz._is_for_agent(
+        {"content": "@Jessica please check", "tags": []},
+        agent_pubkey=instance._agent_pubkey,
+        wake_words=instance._wake_words,
+        sent_ids=set(),
+    )
 
 
 def test_env_enablement_requires_complete_identity(monkeypatch):
@@ -283,6 +360,24 @@ def test_nostr_auth_event_has_valid_bip340_signature_and_owner_tag():
     assert _verify_schnorr(event_id, event["pubkey"], bytes.fromhex(event["sig"]))
 
 
+def test_schnorr_sign_matches_official_bip340_vector_zero():
+    private_key = "00" * 31 + "03"
+    message = bytes(32)
+    signature = nostr_auth.schnorr_sign(
+        message,
+        private_key,
+        auxiliary_randomness=bytes(32),
+    )
+
+    assert nostr_auth.public_key_hex(private_key).upper() == (
+        "F9308A019258C31049344F85F89D5229B531C845836F99B08601F113BCE036F9"
+    )
+    assert signature.hex().upper() == (
+        "E907831F80848D1069A5371B402410364BDF1C5F8307B0084C55F1CE2DCA8215"
+        "25F66A4A85EA8B71E482A74F382D2CE5EBEEE8FDB2172F477DF4900D310536C0"
+    )
+
+
 class _FakeWebSocket:
     def __init__(self):
         self.sent = []
@@ -367,6 +462,44 @@ def test_websocket_subscriptions_resume_from_last_timestamp():
     assert websocket.sent[2][2]["since"] == 299
 
 
+def test_websocket_loop_ignores_malformed_json_frames(monkeypatch):
+    monkeypatch.setenv("BUZZ_PRIVATE_KEY", TEST_PRIVATE_KEY)
+    monkeypatch.setattr(buzz, "_resolve_cli", lambda config=None: "/tmp/buzz")
+    instance = buzz.BuzzAdapter(_config(relay_url="https://buzz.example.test"))
+    instance._channels = []
+    instance._running = True
+
+    class MalformedStream:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if not instance._running:
+                raise StopAsyncIteration
+            instance._running = False
+            return "{malformed"
+
+    async def no_op(*args, **kwargs):
+        return None
+
+    async def subscribe(*args, **kwargs):
+        return {}
+
+    instance._authenticate_websocket = no_op
+    instance._subscribe_websocket = subscribe
+    monkeypatch.setattr("websockets.connect", lambda *args, **kwargs: MalformedStream())
+
+    asyncio.run(instance._websocket_loop())
+
+    assert instance._ws_ready.is_set()
+
+
 def test_event_id_dedup_routes_only_once(monkeypatch):
     monkeypatch.setenv("BUZZ_PRIVATE_KEY", TEST_PRIVATE_KEY)
     monkeypatch.setattr(buzz, "_resolve_cli", lambda config=None: "/tmp/buzz")
@@ -392,6 +525,105 @@ def test_event_id_dedup_routes_only_once(monkeypatch):
     assert received[0].message_id == "event-1"
 
 
+def test_group_dispatch_strips_address_before_slash_command(monkeypatch):
+    monkeypatch.setenv("BUZZ_PRIVATE_KEY", TEST_PRIVATE_KEY)
+    monkeypatch.setattr(buzz, "_resolve_cli", lambda config=None: "/tmp/buzz")
+    instance = buzz.BuzzAdapter(_config(relay_url="https://buzz.example.test"))
+    instance._channels = ["group-id"]
+    instance._wake_words = ["Maximus"]
+    received = []
+
+    async def handle_message(event):
+        received.append(event)
+
+    instance.handle_message = handle_message
+    event = {
+        "id": "command-1",
+        "pubkey": "b" * 64,
+        "content": "@Maximus: /status",
+        "created_at": 1_700_000_000,
+        "tags": [["h", "group-id"]],
+    }
+    asyncio.run(instance._dispatch_event("group-id", event))
+
+    assert len(received) == 1
+    assert received[0].text == "/status"
+    assert received[0].is_command()
+
+
+def test_group_dispatch_only_bypasses_mention_gate_for_pending_control(monkeypatch):
+    monkeypatch.setenv("BUZZ_PRIVATE_KEY", TEST_PRIVATE_KEY)
+    monkeypatch.setattr(buzz, "_resolve_cli", lambda config=None: "/tmp/buzz")
+    instance = buzz.BuzzAdapter(_config(relay_url="https://buzz.example.test"))
+    instance._channels = ["group-id"]
+    received = []
+
+    async def handle_message(event):
+        received.append(event)
+
+    instance.handle_message = handle_message
+    instance._is_pending_control_reply = lambda source, text: text == "2"
+    base_event = {
+        "pubkey": "b" * 64,
+        "created_at": 1_700_000_000,
+        "tags": [["h", "group-id"]],
+    }
+
+    asyncio.run(
+        instance._dispatch_event(
+            "group-id",
+            {**base_event, "id": "control-1", "content": "2"},
+        )
+    )
+    asyncio.run(
+        instance._dispatch_event(
+            "group-id",
+            {**base_event, "id": "control-2", "content": "general discussion"},
+        )
+    )
+
+    assert [event.text for event in received] == ["2"]
+
+
+def test_pending_control_reply_uses_sender_scoped_gateway_state(monkeypatch):
+    monkeypatch.setenv("BUZZ_PRIVATE_KEY", TEST_PRIVATE_KEY)
+    monkeypatch.setattr(buzz, "_resolve_cli", lambda config=None: "/tmp/buzz")
+    instance = buzz.BuzzAdapter(_config(relay_url="https://buzz.example.test"))
+    source = instance.build_source(
+        chat_id="group-id",
+        chat_type="group",
+        user_id="owner-pubkey",
+    )
+    seen = []
+
+    monkeypatch.setattr(
+        "tools.approval.has_blocking_approval",
+        lambda session_key: seen.append(("approval", session_key)) or True,
+    )
+    assert instance._is_pending_control_reply(source, "/approve")
+    assert instance._is_pending_control_reply(source, "yes")
+    assert instance._is_pending_control_reply(source, "approve always")
+    assert seen[0][0] == "approval"
+    assert "owner-pubkey" in seen[0][1]
+
+    monkeypatch.setattr(
+        "tools.approval.has_blocking_approval",
+        lambda session_key: False,
+    )
+    monkeypatch.setattr(
+        "tools.slash_confirm.get_pending",
+        lambda session_key: {"confirm_id": "pending"},
+    )
+    assert instance._is_pending_control_reply(source, "/always")
+
+    monkeypatch.setattr(
+        "tools.clarify_gateway.get_pending_for_session",
+        lambda session_key, include_choice_prompts: object(),
+    )
+    assert instance._is_pending_control_reply(source, "2")
+    assert not instance._is_pending_control_reply(source, "/new")
+
+
 def test_connect_and_disconnect_acquire_and_release_scoped_lock(monkeypatch):
     monkeypatch.setenv("BUZZ_PRIVATE_KEY", TEST_PRIVATE_KEY)
     monkeypatch.setattr(buzz, "_resolve_cli", lambda config=None: "/tmp/buzz")
@@ -399,14 +631,14 @@ def test_connect_and_disconnect_acquire_and_release_scoped_lock(monkeypatch):
     acquired = []
     released = []
 
-    monkeypatch.setattr(
-        "gateway.status.acquire_scoped_lock",
-        lambda platform, key: acquired.append((platform, key)) or True,
+    instance._acquire_platform_lock = lambda scope, identity, resource_desc: (
+        acquired.append((scope, identity, resource_desc)) or True
     )
-    monkeypatch.setattr(
-        "gateway.status.release_scoped_lock",
-        lambda platform, key: released.append((platform, key)),
-    )
+    instance._release_platform_lock = lambda: released.append((
+        "buzz",
+        instance._lock_key,
+        "Buzz identity",
+    ))
 
     async def run_cli(args, **kwargs):
         return []
@@ -430,8 +662,35 @@ def test_connect_and_disconnect_acquire_and_release_scoped_lock(monkeypatch):
 
     asyncio.run(exercise())
 
-    assert acquired == [("buzz", f"https://buzz.example.test:{instance._agent_pubkey}")]
+    assert acquired == [
+        (
+            "buzz",
+            f"https://buzz.example.test:{instance._agent_pubkey}",
+            "Buzz identity",
+        )
+    ]
     assert released == acquired
+
+
+def test_connect_stops_before_relay_probe_when_identity_lock_is_held(monkeypatch):
+    monkeypatch.setenv("BUZZ_PRIVATE_KEY", TEST_PRIVATE_KEY)
+    monkeypatch.setattr(buzz, "_resolve_cli", lambda config=None: "/tmp/buzz")
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (False, {"pid": 98765}),
+    )
+    instance = buzz.BuzzAdapter(_config(relay_url="https://buzz.example.test"))
+    probes = []
+
+    async def run_cli(*args, **kwargs):
+        probes.append((args, kwargs))
+        return []
+
+    instance._run_cli = run_cli
+
+    assert asyncio.run(instance.connect()) is False
+    assert probes == []
+    assert instance._lock_key is None
 
 
 def test_standalone_sender_uses_cli_without_constructing_adapter(monkeypatch):

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -1,0 +1,140 @@
+---
+title: "Buzz"
+description: "Connect the full Hermes gateway to a Buzz workspace through authenticated Nostr WebSockets"
+---
+
+# Buzz
+
+The Buzz platform plugin connects the full Hermes gateway to a
+[Buzz](https://github.com/block/buzz) workspace. Buzz is the messaging
+transport. Hermes keeps its normal profile, memory, tools, approvals, sessions,
+and runtime host.
+
+Inbound events use a persistent authenticated Nostr WebSocket. Outbound
+messages use the Buzz CLI so scheduled and one-shot delivery do not depend on a
+temporary WebSocket connection.
+
+## Prerequisites
+
+- A Buzz relay that the Hermes host can reach over HTTPS and WebSockets.
+- The `buzz` CLI on the Hermes host's `PATH`, or an executable path in
+  `BUZZ_CLI`.
+- A dedicated Buzz identity that is already authorized for the workspace.
+- The identity's Nostr private key in the Hermes secret store or
+  `~/.hermes/.env`.
+- Channel membership for each shared channel Hermes should monitor.
+
+Do not configure the same Buzz identity as both a Buzz-managed ACP agent and an
+external Hermes gateway. Two runtimes using one identity can produce duplicate
+replies. Use a different keypair for each independently running Hermes gateway.
+
+## Configure Hermes
+
+The required settings are:
+
+```dotenv title="~/.hermes/.env"
+BUZZ_RELAY_URL=https://buzz.example.com
+BUZZ_PRIVATE_KEY=nsec1...
+```
+
+Keep `BUZZ_PRIVATE_KEY` out of `config.yaml`, shell history, logs, and source
+control.
+
+You can place non-secret settings in `config.yaml`:
+
+```yaml title="~/.hermes/config.yaml"
+gateway:
+  platforms:
+    buzz:
+      enabled: true
+      extra:
+        relay_url: https://buzz.example.com
+        channels:
+          - your-shared-channel-id
+        home_channel:
+          chat_id: your-shared-channel-id
+          name: Buzz
+        discover_dms: true
+        require_mention: true
+        wake_words:
+          - Hermes
+          - Maximus
+        allowed_users:
+          - your-owner-pubkey
+        allow_all_users: false
+```
+
+Environment variables override values bridged from `config.yaml`.
+
+| Variable | Required | Description |
+|----------|:--------:|-------------|
+| `BUZZ_RELAY_URL` | yes | Buzz relay HTTP(S) or WebSocket URL |
+| `BUZZ_PRIVATE_KEY` | yes | Dedicated Hermes identity as `nsec` or 64-character hex |
+| `BUZZ_AUTH_TAG` | no | NIP-OA owner attestation required by some relays |
+| `BUZZ_CHANNELS` | no | Comma-separated shared-channel IDs |
+| `BUZZ_DM_CHANNELS` | no | Comma-separated DM IDs to subscribe to explicitly |
+| `BUZZ_DISCOVER_DMS` | no | Discover relay-confirmed DMs automatically; default `true` |
+| `BUZZ_HOME_CHANNEL` | no | Default channel for cron and proactive delivery |
+| `BUZZ_ALLOWED_USERS` | recommended | Comma-separated sender pubkeys allowed to direct Hermes |
+| `BUZZ_ALLOW_ALL_USERS` | no | Permit all workspace members; default `false` |
+| `BUZZ_REQUIRE_MENTION` | no | Require addressing in shared channels; default `true` |
+| `BUZZ_WAKE_WORDS` | no | Comma-separated display names accepted as typed mentions |
+| `BUZZ_PROFILE_NAME` | no | Profile name to publish; unset preserves the existing name |
+| `BUZZ_PROFILE_ABOUT` | no | Profile description to publish |
+| `BUZZ_CLI` | no | Executable Buzz CLI path or command name |
+
+Set profile fields only when Hermes should intentionally change the public Buzz
+profile. Leaving them unset prevents an existing identity such as Maximus from
+being renamed during startup.
+
+## Start and verify
+
+```bash
+hermes gateway start
+hermes gateway status
+```
+
+Verify each behavior before relying on the connection:
+
+1. Send a DM and confirm exactly one Hermes reply.
+2. In a shared channel, send `@Maximus /status` using the configured wake word.
+3. Restart the gateway and repeat the DM.
+4. Confirm the first message did not replay after reconnection.
+5. If approvals are enabled, verify an approval or clarification response
+   returns to the waiting session.
+
+Direct messages do not require a mention. Shared channels require a Nostr
+`p` tag, a reply to a Hermes message, or a configured typed wake word when
+`BUZZ_REQUIRE_MENTION=true`.
+
+## Remote Hermes gateways
+
+The plugin runs on the Hermes gateway host, not on the device that sends the
+Buzz message. A remote Hermes instance can therefore stay available while a
+laptop is off:
+
+```text
+Buzz phone or desktop -> Buzz relay -> remote Hermes gateway
+```
+
+The remote host needs the Buzz CLI, its own protected Buzz identity, outbound
+relay access, and a continuously running Hermes gateway service.
+
+## Capabilities and limits
+
+| Capability | Support |
+|------------|---------|
+| Text and Markdown | yes |
+| Direct messages | yes |
+| Shared channels | yes |
+| Explicit threads | yes |
+| Mention gating | yes |
+| Approvals and clarification text | yes |
+| Cron and standalone delivery | yes |
+| Attachments | not yet |
+| Reactions | not yet |
+| Typing indicators | not yet |
+
+The adapter keeps bounded event-ID deduplication and per-channel resume
+timestamps. It reconnects with exponential backoff and restores subscriptions
+after a transient WebSocket failure.

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 1
 title: "Messaging Gateway"
-description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Yuanbao, Microsoft Teams, LINE, Raft, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
+description: "Chat with Hermes from Telegram, Discord, Slack, Buzz, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Yuanbao, Microsoft Teams, LINE, Raft, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
 ---
 
 # Messaging Gateway
 
-Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, Yuanbao, Microsoft Teams, LINE, ntfy, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
+Chat with Hermes from Telegram, Discord, Slack, Buzz, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, Yuanbao, Microsoft Teams, LINE, ntfy, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
 
 For the full voice feature set — including CLI microphone mode, spoken replies in messaging, and Discord voice-channel conversations — see [Voice Mode](/user-guide/features/voice-mode) and [Use Voice Mode with Hermes](/guides/use-voice-mode-with-hermes).
 
@@ -21,6 +21,7 @@ Bots need both a model provider and tool providers (TTS, web). A [Nous Portal](/
 | Telegram | ✅ | ✅ | ✅ | ✅ | — | ✅ | ✅ |
 | Discord | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Slack | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Buzz | — | — | — | ✅ | — | — | — |
 | Google Chat | — | ✅ | ✅ | ✅ | — | ✅ | — |
 | WhatsApp | — | ✅ | ✅ | — | — | ✅ | ✅ |
 | Signal | — | ✅ | ✅ | — | — | ✅ | ✅ |
@@ -55,6 +56,7 @@ flowchart TB
             dc[Discord]
             wa[WhatsApp]
             sl[Slack]
+            bz[Buzz]
             gc[Google Chat]
             sig[Signal]
             sms[SMS]
@@ -84,6 +86,7 @@ flowchart TB
     dc --> store
     wa --> store
     sl --> store
+    bz --> store
     gc --> store
     sig --> store
     sms --> store

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -655,6 +655,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/messaging/homeassistant',
             'user-guide/messaging/mattermost',
             'user-guide/messaging/matrix',
+            'user-guide/messaging/buzz',
             'user-guide/messaging/bluebubbles',
             'user-guide/messaging/photon',
             'user-guide/messaging/google_chat',


### PR DESCRIPTION
## What does this PR do?

Adds Buzz as a bundled Hermes messaging platform at
`plugins/platforms/buzz/`.

Buzz becomes a transport for the full Hermes gateway. Hermes keeps its normal
profile, memory, tools, approvals, sessions, cron delivery, and runtime host.
Inbound events use a persistent NIP-42-authenticated Nostr WebSocket.
Outbound events use the Buzz CLI so ordinary replies and one-shot delivery do
not race a temporary WebSocket authentication handshake.

This is a plugin integration. It does not add a `Platform` enum member or
special-case Buzz in Hermes core.

## Related Issue

Fixes #68871

Related Buzz lifecycle issue: block/buzz#2349

Related implementation: #73610 uses CLI polling for inbound events. This PR
keeps the native WebSocket path requested in the maintainer green light. The
two approaches should be consolidated rather than merged independently.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added a bundled `buzz-platform` plugin with rich required and optional
  environment metadata.
- Added NIP-42 authentication and optional NIP-OA owner attestation.
- Added dependency-free BIP-340 signing, including the official vector 0
  regression test.
- Added persistent WebSocket subscriptions for shared channels, direct-message
  discovery, reconnect backoff, in-process timestamp resume, and bounded event
  deduplication.
- Added signed outbound delivery through the Buzz CLI. Message content is sent
  through stdin, never command arguments.
- Added shared-channel mention gating through Nostr tags, replies, and
  word-bounded typed wake words.
- Preserved slash commands after a leading mention, such as
  `@Maximus /status`.
- Allowed approval and clarification replies through the mention gate only
  when the same sender and session has matching pending gateway state.
- Used the current `BasePlatformAdapter` lock helpers so a second Hermes
  profile cannot acquire the same Buzz identity.
- Rejected invalid private keys and relay URLs. Malformed WebSocket frames are
  ignored. Invalid or future event timestamps cannot poison resume state.
- Added service-friendly Buzz CLI path discovery without relying on an
  interactive shell.
- Added a complete Buzz setup page, messaging index entry, sidebar entry,
  remote-gateway topology, identity-collision warning, configuration reference,
  and capability limits.

## How to Test

1. Configure `BUZZ_RELAY_URL`, `BUZZ_PRIVATE_KEY`, the Buzz CLI, one channel,
   and an allowed sender pubkey.
2. Start `hermes gateway`.
3. Send a direct message. Confirm exactly one Hermes reply.
4. In a shared channel, send `@Maximus /status`. Confirm one threaded status
   reply.
5. Restart the gateway. Confirm the earlier event does not replay, then send a
   second direct message and confirm one reply.
6. Exercise standalone delivery and confirm one signed Buzz event.

Automated validation on the final source:

- `uv run pytest -q tests/gateway/test_buzz.py tests/gateway/test_plugin_platform_interface.py tests/gateway/test_platform_registry.py tests/gateway/test_adapter_connect_is_reconnect_contract.py tests/gateway/test_gateway_utf8_encoding.py tests/gateway/test_stale_platform_lock_retryable.py tests/gateway/test_startup_no_eager_platform_install.py tests/gateway/test_platform_http_client_limits.py`
  - 120 passed, 7 skipped
- `uv run ruff check plugins/platforms/buzz tests/gateway/test_buzz.py`
- `uv run ruff format --check plugins/platforms/buzz tests/gateway/test_buzz.py`
- `python3 scripts/check-windows-footguns.py plugins/platforms/buzz tests/gateway/test_buzz.py`
  - no findings
- `uvx --from 'ascii-guard==2.3.0' ascii-guard lint --exclude-code-blocks docs`
  - 378 files, 0 errors
- `npm run build` in `website/`
  - English and Chinese production builds succeeded
  - Existing repository broken-link warnings remain. None point to the new
    Buzz page.

A subsequent clean full-suite run completed successfully:

- `pytest tests/ -q`
  - all tests passed

Live validation used the exact uncommitted adapter source against Hermes Agent
v0.19.0 on macOS 26.5.1 and the real Buzz relay:

- authenticated WebSocket connection and two subscriptions
- one exact owner-to-Maximus direct-message reply
- one threaded `@Maximus /status` response
- one signed standalone event
- clean disconnect, reconnect, and resubscription
- no replay of the pre-restart direct message
- one exact post-restart direct-message reply
- configured public profile published as `Maximus`
- Telegram remained connected in the same gateway
- independent Cordy and Jessica gateway processes were unchanged
- the normal supervised Hermes gateway was restored and passed a final Buzz
  direct-message check

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs and documented the overlap with #73610
- [x] My PR contains only changes related to the Buzz gateway integration
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on macOS 26.5.1 with Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated the relevant user documentation
- [x] `cli-config.yaml.example` is N/A; plugin settings are declared in
  `plugin.yaml` and documented on the Buzz page
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no workflow changed
- [x] I've considered Windows, macOS, and Linux impact and ran the Windows
  footgun scanner
- [x] Tool descriptions and schemas are N/A; no tool contract changed

## Screenshots / Logs

The live verification summary above records the externally observable results.
No private keys, owner attestations, or message payloads containing secrets are
included.
