### PR TITLE
fix(runtime): don't leak another provider's persisted api_mode into OpenRouter

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1280,11 +1280,27 @@ def _resolve_openrouter_runtime(
     if effective_provider == "custom" and not api_key and not _is_openrouter_url:
         api_key = "no-key-required"
 
+    # Honor a persisted ``model.api_mode`` only when the config block that
+    # carries it actually describes THIS provider. Without the gate, a config
+    # whose default is e.g. direct Anthropic (``provider: anthropic``,
+    # ``api_mode: anthropic_messages``) pins every OpenRouter runtime onto the
+    # Anthropic Messages wire after a mid-session /model switch — the model
+    # then talks to OpenRouter's ``/v1/messages`` route instead of
+    # ``/v1/chat/completions``. Mirrors the guard already applied to Copilot
+    # (``_copilot_runtime_api_mode``) and to plain custom endpoints
+    # (``_resolve_plain_custom_api_mode``).
+    _configured_provider = str(model_cfg.get("provider") or "").strip().lower()
+    _configured_mode = (
+        _parse_api_mode(model_cfg.get("api_mode"))
+        if _provider_supports_explicit_api_mode(effective_provider, _configured_provider)
+        else None
+    )
+
     return {
         "provider": effective_provider,
         "api_mode": _resolve_plain_custom_api_mode(model_cfg, base_url)
         if effective_provider == "custom"
-        else _parse_api_mode(model_cfg.get("api_mode"))
+        else _configured_mode
         or _detect_api_mode_for_url(base_url)
         or "chat_completions",
         "base_url": base_url,

--- a/tests/hermes_cli/test_openrouter_runtime_api_mode.py
+++ b/tests/hermes_cli/test_openrouter_runtime_api_mode.py
@@ -1,0 +1,99 @@
+"""OpenRouter runtime api_mode must not inherit another provider's persisted mode."""
+
+from __future__ import annotations
+
+import pytest
+
+OPENROUTER_URL = "https://openrouter.ai/api/v1"
+
+
+def _resolve(model_cfg, monkeypatch):
+    """Resolve an OpenRouter runtime with the arguments the CLI actually passes.
+
+    ``_ensure_runtime_credentials`` forwards ``explicit_api_key`` /
+    ``explicit_base_url`` (staged by the /model switch), which is what routes
+    resolution into ``_resolve_openrouter_runtime``.
+    """
+    from hermes_cli import runtime_provider as rp
+
+    monkeypatch.setattr(rp, "load_config", lambda *a, **k: {"model": model_cfg})
+    return rp.resolve_runtime_provider(
+        requested="openrouter",
+        explicit_api_key="sk-or-test",
+        explicit_base_url=OPENROUTER_URL,
+    )
+
+
+def test_anthropic_config_does_not_pin_openrouter_to_messages_wire(monkeypatch):
+    """A direct-Anthropic default must not force OpenRouter onto the Messages wire.
+
+    Repro: config.yaml defaults to direct Anthropic
+    (``provider: anthropic`` + ``api_mode: anthropic_messages``). A
+    mid-session ``/model moonshotai/kimi-k3`` correctly restages
+    provider/base_url to OpenRouter, but the persisted ``api_mode`` was
+    honored unconditionally — so the agent was built on the Anthropic
+    Messages transport and talked to OpenRouter's ``/v1/messages`` route
+    instead of ``/v1/chat/completions``.
+    """
+    runtime = _resolve(
+        {
+            "default": "claude-sonnet-5",
+            "provider": "anthropic",
+            "base_url": "https://api.anthropic.com",
+            "api_mode": "anthropic_messages",
+        },
+        monkeypatch,
+    )
+
+    assert runtime["provider"] == "openrouter"
+    assert runtime["api_mode"] == "chat_completions", (
+        "a persisted api_mode from a DIFFERENT provider's config block must not "
+        f"leak into the OpenRouter runtime: {runtime['api_mode']}"
+    )
+
+
+def test_openrouter_config_still_honors_its_own_api_mode(monkeypatch):
+    """The gate must not break a config that genuinely describes OpenRouter."""
+    runtime = _resolve(
+        {
+            "default": "moonshotai/kimi-k3",
+            "provider": "openrouter",
+            "api_mode": "anthropic_messages",
+        },
+        monkeypatch,
+    )
+
+    assert runtime["api_mode"] == "anthropic_messages"
+
+
+def test_openrouter_config_without_provider_still_honors_api_mode(monkeypatch):
+    """No recorded provider = nothing to contradict; keep the persisted mode.
+
+    Matches ``_provider_supports_explicit_api_mode``'s "no configured
+    provider" allowance, so pre-existing configs that only set ``api_mode``
+    keep working.
+    """
+    runtime = _resolve(
+        {"default": "moonshotai/kimi-k3", "api_mode": "anthropic_messages"},
+        monkeypatch,
+    )
+
+    assert runtime["api_mode"] == "anthropic_messages"
+
+
+@pytest.mark.parametrize(
+    "configured_provider",
+    ["anthropic", "openai", "copilot", "bedrock", "openai-codex"],
+)
+def test_foreign_provider_modes_never_leak(monkeypatch, configured_provider):
+    """Any foreign provider's persisted mode falls back to the endpoint default."""
+    runtime = _resolve(
+        {
+            "default": "some-model",
+            "provider": configured_provider,
+            "api_mode": "codex_responses",
+        },
+        monkeypatch,
+    )
+
+    assert runtime["api_mode"] == "chat_completions"


### PR DESCRIPTION
## What does this PR do?

Stops a persisted `model.api_mode` belonging to **one** provider from being applied to an **OpenRouter** runtime, which silently puts OpenRouter traffic on the wrong wire protocol after a mid-session `/model` switch.

`_resolve_openrouter_runtime` reads `model.api_mode` straight out of `config.yaml` with no check that the config block carrying it actually describes the provider being resolved:

```python
"api_mode": _resolve_plain_custom_api_mode(model_cfg, base_url)
    if effective_provider == "custom"
    else _parse_api_mode(model_cfg.get("api_mode"))   # <- no provider gate
    or _detect_api_mode_for_url(base_url)
    or "chat_completions",
```

So a config whose default is **direct Anthropic**:

```yaml
model:
  default: claude-sonnet-5
  provider: anthropic
  base_url: https://api.anthropic.com
  api_mode: anthropic_messages
```

pins *every* OpenRouter runtime to `anthropic_messages`. After `/model moonshotai/kimi-k3`, provider and base_url are correctly restaged to OpenRouter, but the stale mode survives — the agent is built on the Anthropic Messages transport and sends requests to OpenRouter's `/v1/messages` route instead of `/v1/chat/completions`.

The `custom` branch on the very next line already guards against this exact class of leak (`_resolve_plain_custom_api_mode` ignores a stale `codex_responses` for non-OpenAI endpoints), and `_copilot_runtime_api_mode` guards it via `_provider_supports_explicit_api_mode`. The OpenRouter branch is the one that never got the gate.

### Why it's easy to miss

The leak only fires when the CLI passes `explicit_api_key` / `explicit_base_url` — which is exactly what `_ensure_runtime_credentials` does after a `/model` switch stages them. Resolving without those arguments takes a different path and returns the correct mode, so the bug is invisible to the obvious direct call:

```python
resolve_runtime_provider(requested="openrouter")                     # -> chat_completions  (correct)
resolve_runtime_provider(requested="openrouter",                     # -> anthropic_messages (leak)
                         explicit_base_url="https://openrouter.ai/api/v1",
                         explicit_api_key="sk-or-...")
```

## Related Issue

No existing issue. Found while debugging a Kimi model that appeared to "stop working" after the first turn on OpenRouter; the wire-protocol mismatch is the upstream cause of that routing. (The separate replay defect that made the mismatch *fatal* is #73609 — independent fix, different file.)

Happy to open a tracking issue first if maintainers prefer that order.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/runtime_provider.py` — `_resolve_openrouter_runtime`: gate the persisted `model.api_mode` behind the existing `_provider_supports_explicit_api_mode(effective_provider, configured_provider)` helper before using it. Falls through to `_detect_api_mode_for_url(base_url)` then `chat_completions`, exactly as before, when the config block belongs to a different provider.
- `tests/hermes_cli/test_openrouter_runtime_api_mode.py` — new regression tests.

Deliberately **not** changed: a config that genuinely records `provider: openrouter`, or that records no provider at all, still honors its `api_mode` verbatim. The helper's "no configured provider → allow" branch keeps existing single-provider configs working.

## How to Test

**1. Reproduce** — with a direct-Anthropic default in `config.yaml` (block above):

```python
from hermes_cli.runtime_provider import resolve_runtime_provider
resolve_runtime_provider(
    requested="openrouter",
    explicit_base_url="https://openrouter.ai/api/v1",
    explicit_api_key="sk-or-...",
)["api_mode"]
# before: 'anthropic_messages'   <- wrong wire for OpenRouter
# after:  'chat_completions'
```

**2. End to end** — same config, then `/model moonshotai/kimi-k3` in an interactive session. The client built for the turn flips from the Anthropic transport to the OpenAI one:

```
# before
run_agent: Anthropic client closed (stream_request_complete) provider=openrouter model=moonshotai/kimi-k3
# after
run_agent: OpenAI client created (agent_init, shared=True) provider=openrouter
           base_url=https://openrouter.ai/api/v1 model=moonshotai/kimi-k3
```

**3. Regression tests** — red on `main`, green with this patch:

```bash
pytest tests/hermes_cli/test_openrouter_runtime_api_mode.py -q
# before: 6 failed, 2 passed
# after:  8 passed
```

The 2 that pass on `main` are the guards asserting a legitimate OpenRouter config keeps its own `api_mode` — they must stay green in both directions, and do.

**4. No collateral damage** across the api_mode / runtime-resolution suites:

```bash
pytest tests/hermes_cli/test_openrouter_runtime_api_mode.py \
       tests/hermes_cli/test_copilot_runtime_api_mode.py \
       tests/hermes_cli/test_runtime_provider_resolution.py \
       tests/hermes_cli/test_detect_api_mode_for_url.py \
       tests/hermes_cli/test_determine_api_mode_hostname.py \
       tests/hermes_cli/test_25106_global_switch_persists_base_url_api_mode.py -q
# 211 passed
```

**5. Every provider config resolves correctly** — five real Hermes homes with
differing `model.provider` / `model.api_mode` defaults (direct Anthropic,
OpenRouter, Ollama), all resolving an OpenRouter runtime through the CLI's
argument shape:

```
ares (provider: anthropic)      -> chat_completions   # was anthropic_messages
via  (provider: anthropic)      -> chat_completions   # was anthropic_messages
fortunas (provider: openrouter) -> chat_completions
automata (provider: ollama)     -> chat_completions
default  (provider: openrouter) -> chat_completions
```

**6. Before/after over the wider suite** — two worktrees off the same
`upstream/main` commit, deterministic order:

| | tests executed | failures |
|---|---|---|
| `main` (baseline) | 8421 | **217** |
| this PR | 8429 | **217** |

Identical failure count; the +8 are this PR's new tests, all passing.

Note this reports "tests executed" rather than a pytest summary line because
`tests/hermes_cli/` **cannot complete on macOS** —
`test_gateway_service.py` terminates the interpreter mid-run (exit 0, no
summary), and a second order-dependent abort follows around 83%. That is
pre-existing, reproduces identically with and without this patch, and is
detailed [in a comment below](#issuecomment-5109863686).

## Note for maintainers — a possible sibling site

While auditing every `_parse_api_mode(model_cfg.get("api_mode"))` call in `runtime_provider.py`, the other reads are gated one way or another — `_resolve_azure_foundry_runtime` by `cfg_provider == "azure-foundry"`, `_resolve_runtime_from_pool_entry` by `configured_provider == provider`, and `resolve_runtime_provider` by an explicit "only honor persisted api_mode when it belongs to the same provider family" check.

The exception is the `else` branch of `_resolve_explicit_runtime` (registry providers with `auth_type == "api_key"`), which honors the persisted mode with no provider check — structurally the same hole this PR closes.

I have **not** touched it: I could not reproduce a user-visible failure through that path, and I'd rather not widen a routing change on speculation. Flagging it in case it's worth a follow-up, or in case you'd prefer both gated in one go — happy to extend this PR if so.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/inline comment explaining the gate) — or N/A
- [x] `cli-config.yaml.example` — N/A, no config keys added or changed (this makes an existing key behave as documented)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A, pure config/string resolution
- [x] Tool descriptions/schemas — N/A
