### PR TITLE
fix(session): hold drain lock during transcript rewrite/rewind to prevent race

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3183,16 +3183,25 @@ class SessionStore:
         change on top of a failed write — e.g. /compress repointing the live
         session onto a fresh session_id — must check it so they can surface an
         error instead of silently dropping the conversation.
+
+        Acquires ``_transcript_drain_lock`` for the duration so a concurrent
+        ``append_to_transcript`` cannot slip a stale message into the DB after
+        the replace completes (race between /retry and an in-flight turn).
         """
         if not self._db:
             return True
-        self._clear_dirty_transcript(session_id)
-        try:
-            self._db.replace_messages(session_id, messages)
-            return True
-        except Exception as e:
-            logger.debug("Failed to rewrite transcript in DB: %s", e)
-            return False
+        drain_lock = getattr(self, "_transcript_drain_lock", None)
+        if drain_lock is None:
+            drain_lock = threading.RLock()
+            self._transcript_drain_lock = drain_lock
+        with drain_lock:
+            self._clear_dirty_transcript(session_id)
+            try:
+                self._db.replace_messages(session_id, messages)
+                return True
+            except Exception as e:
+                logger.debug("Failed to rewrite transcript in DB: %s", e)
+                return False
 
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript.
@@ -3226,47 +3235,56 @@ class SessionStore:
         Returns a dict ``{"rewound_count", "turns_undone", "target_text"}`` on
         success, or ``None`` if there's no DB or no user message to back up to.
         ``n`` clamps to the oldest user turn when it exceeds the turn count.
+
+        Acquires ``_transcript_drain_lock`` for the duration so a concurrent
+        ``append_to_transcript`` cannot append a stale message to the session
+        being rewound (race between /undo and an in-flight turn).
         """
         if not self._db:
             return None
-        self._clear_dirty_transcript(session_id)
-        if n < 1:
-            n = 1
-        try:
-            recents = self._db.list_recent_user_messages(session_id, limit=max(n, 10))
-        except Exception as e:
-            logger.debug("rewind_session: failed to list user messages: %s", e)
-            return None
-        if not recents:
-            return None
-        target_idx = min(n - 1, len(recents) - 1)
-        target_id = recents[target_idx]["id"]
-        try:
-            result = self._db.rewind_to_message(session_id, target_id)
-        except ValueError as e:
-            logger.debug("rewind_session: %s", e)
-            return None
-        except Exception as e:
-            logger.debug("rewind_session: rewind_to_message failed: %s", e)
-            return None
-        target_msg = result.get("target_message") or {}
-        content = target_msg.get("content") or ""
-        if isinstance(content, list):
-            parts = [
-                p.get("text", "")
-                for p in content
-                if isinstance(p, dict) and p.get("type") == "text"
-            ]
-            target_text = "\n".join(t for t in parts if t)
-        elif isinstance(content, str):
-            target_text = content
-        else:
-            target_text = ""
-        return {
-            "rewound_count": result.get("rewound_count", 0),
-            "turns_undone": target_idx + 1,
-            "target_text": target_text,
-        }
+        drain_lock = getattr(self, "_transcript_drain_lock", None)
+        if drain_lock is None:
+            drain_lock = threading.RLock()
+            self._transcript_drain_lock = drain_lock
+        with drain_lock:
+            self._clear_dirty_transcript(session_id)
+            if n < 1:
+                n = 1
+            try:
+                recents = self._db.list_recent_user_messages(session_id, limit=max(n, 10))
+            except Exception as e:
+                logger.debug("rewind_session: failed to list user messages: %s", e)
+                return None
+            if not recents:
+                return None
+            target_idx = min(n - 1, len(recents) - 1)
+            target_id = recents[target_idx]["id"]
+            try:
+                result = self._db.rewind_to_message(session_id, target_id)
+            except ValueError as e:
+                logger.debug("rewind_session: %s", e)
+                return None
+            except Exception as e:
+                logger.debug("rewind_session: rewind_to_message failed: %s", e)
+                return None
+            target_msg = result.get("target_message") or {}
+            content = target_msg.get("content") or ""
+            if isinstance(content, list):
+                parts = [
+                    p.get("text", "")
+                    for p in content
+                    if isinstance(p, dict) and p.get("type") == "text"
+                ]
+                target_text = "\n".join(t for t in parts if t)
+            elif isinstance(content, str):
+                target_text = content
+            else:
+                target_text = ""
+            return {
+                "rewound_count": result.get("rewound_count", 0),
+                "turns_undone": target_idx + 1,
+                "target_text": target_text,
+            }
 
 
 def build_session_context(


### PR DESCRIPTION
## Summary

rewrite_transcript (/retry, /compress) and rewind_session (/undo) did not acquire _transcript_drain_lock, while append_to_transcript holds it for the entire append cycle. A concurrent append after a rewrite/rewind would slip a stale message into the newly rewritten transcript.

## Impact

Under concurrent load (e.g. user sends /retry while an in-flight turn is still appending), the transcript can end up with messages that should have been removed by the rewrite/rewind operation. This corrupts the conversation state.

## Fix

Acquire _transcript_drain_lock for the duration of both rewrite_transcript and rewind_session. This blocks append_to_transcript until the destructive DB write completes.

## Tests

- 503/503 tests/test_hermes_state.py + tests/gateway/test_session_hygiene.py pass