### PR TITLE
fix(timeouts): Codex event-idle + Grok-4.5 reasoning floor for xAI mid-think stalls

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -164,6 +164,7 @@ def resolve_codex_event_idle_timeout(
     default_seconds: float,
     env_raw: object = None,
     model: object = None,
+    reasoning_config: object = None,
 ) -> tuple[float, bool]:
     """Resolve Codex Responses post-first-byte event-idle budget.
 
@@ -171,11 +172,14 @@ def resolve_codex_event_idle_timeout(
 
     * Explicit ``HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS`` (including ``0``
       to disable) always wins.
-    * On the implicit default path, known reasoning models raise the
-      timeout to :func:`get_reasoning_stale_timeout_floor` so xAI Grok and
-      peers are not killed mid-think after an opening SSE frame.
+    * On the implicit default path, raise via
+      :func:`get_effective_reasoning_stale_timeout_floor` (model allowlist
+      **or** elevated ``reasoning_effort``). Watchdogs measure silence —
+      not SKU — so xhigh on any model needs the same patience as o1.
     """
-    from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+    from agent.reasoning_timeouts import (
+        get_effective_reasoning_stale_timeout_floor,
+    )
 
     explicit = env_raw is not None and str(env_raw).strip() != ""
     if explicit:
@@ -191,7 +195,9 @@ def resolve_codex_event_idle_timeout(
         return timeout, False
 
     if not explicit:
-        floor = get_reasoning_stale_timeout_floor(model)
+        floor = get_effective_reasoning_stale_timeout_floor(
+            model, reasoning_config
+        )
         if floor is not None:
             timeout = max(timeout, float(floor))
     return timeout, True
@@ -358,17 +364,34 @@ def _derive_stream_stale_timeout(agent, api_kwargs: dict) -> float:
         _timeout = max(_base, 240.0)
     else:
         _timeout = _base
-    from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+    from agent.reasoning_timeouts import (
+        get_effective_reasoning_stale_timeout_floor,
+    )
     # Resolve the model id from BOTH the OpenAI/Anthropic key (``model``) and
     # the Bedrock key (``modelId``). OpenAI/Anthropic wins first via the ``or``
     # chain, so those paths are unchanged. Bedrock carries the model as a
     # dotted, region-prefixed inference-profile id (e.g.
     # ``us.anthropic.claude-opus-4-6-v1:0``) that the floor's start-of-slug
     # regex cannot match directly — normalize it to a canonical slug first.
+    # Effort floor is model-independent (high/xhigh silent thinking).
     _model_id = api_kwargs.get("model") or api_kwargs.get("modelId") or ""
-    _reasoning_floor = get_reasoning_stale_timeout_floor(_model_id)
+    _effort = getattr(agent, "reasoning_config", None)
+    _reasoning_floor = get_effective_reasoning_stale_timeout_floor(
+        _model_id, _effort
+    )
     if _reasoning_floor is None and api_kwargs.get("modelId"):
         _reasoning_floor = _bedrock_reasoning_stale_floor(api_kwargs["modelId"])
+        # Still apply effort floor if only Bedrock model floor was missing.
+        if _reasoning_floor is None:
+            _reasoning_floor = get_effective_reasoning_stale_timeout_floor(
+                None, _effort
+            )
+        elif _effort is not None:
+            _effort_only = get_effective_reasoning_stale_timeout_floor(
+                None, _effort
+            )
+            if _effort_only is not None:
+                _reasoning_floor = max(_reasoning_floor, _effort_only)
     if _reasoning_floor is not None:
         _timeout = max(_timeout, _reasoning_floor)
     return _timeout
@@ -873,6 +896,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
         default_seconds=_codex_idle_timeout_default,
         env_raw=_codex_idle_env_raw,
         model=api_kwargs.get("model") or getattr(agent, "model", None),
+        reasoning_config=getattr(agent, "reasoning_config", None),
     )
     _codex_idle_enabled = bool(_codex_watchdog_enabled and _codex_idle_enabled_flag)
     if (
@@ -4061,15 +4085,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             _stream_stale_timeout = max(_stream_stale_timeout_base, 240.0)
         else:
             _stream_stale_timeout = _stream_stale_timeout_base
-        # Reasoning-model floor: known reasoning models (Nemotron 3 Ultra,
-        # OpenAI o1/o3, Anthropic Opus 4.x thinking, DeepSeek R1, Qwen QwQ,
-        # xAI Grok reasoning, etc.) routinely exceed the default 180s chat-
-        # model threshold during their thinking phase.  The cloud gateway
-        # upstream kills the socket first, surfacing as BrokenPipeError.
-        # Raises the floor only — never overrides explicit user config
-        # (handled by get_provider_stale_timeout above).
-        from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
-        _reasoning_floor = get_reasoning_stale_timeout_floor(api_kwargs.get("model"))
+        # Reasoning silence floor: known reasoning SKUs *or* elevated
+        # reasoning_effort (high/xhigh/…) — detectors measure silence, not
+        # model identity. Raises only; explicit user config already won via
+        # get_provider_stale_timeout above.
+        from agent.reasoning_timeouts import (
+            get_effective_reasoning_stale_timeout_floor,
+        )
+        _reasoning_floor = get_effective_reasoning_stale_timeout_floor(
+            api_kwargs.get("model") or getattr(agent, "model", None),
+            getattr(agent, "reasoning_config", None),
+        )
         if _reasoning_floor is not None:
             _stream_stale_timeout = max(_stream_stale_timeout, _reasoning_floor)
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -159,6 +159,44 @@ def openai_codex_stale_timeout_floor(est_tokens: int) -> float:
     return 0.0
 
 
+def resolve_codex_event_idle_timeout(
+    *,
+    default_seconds: float,
+    env_raw: object = None,
+    model: object = None,
+) -> tuple[float, bool]:
+    """Resolve Codex Responses post-first-byte event-idle budget.
+
+    Returns ``(timeout_seconds, enabled)``.
+
+    * Explicit ``HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS`` (including ``0``
+      to disable) always wins.
+    * On the implicit default path, known reasoning models raise the
+      timeout to :func:`get_reasoning_stale_timeout_floor` so xAI Grok and
+      peers are not killed mid-think after an opening SSE frame.
+    """
+    from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+
+    explicit = env_raw is not None and str(env_raw).strip() != ""
+    if explicit:
+        try:
+            timeout = float(env_raw)
+        except (TypeError, ValueError):
+            timeout = float(default_seconds)
+            explicit = False
+    else:
+        timeout = float(default_seconds)
+
+    if timeout <= 0:
+        return timeout, False
+
+    if not explicit:
+        floor = get_reasoning_stale_timeout_floor(model)
+        if floor is not None:
+            timeout = max(timeout, float(floor))
+    return timeout, True
+
+
 def _validated_openrouter_provider_sort(raw_sort: Any) -> Optional[str]:
     """Return a normalized OpenRouter provider.sort value or None."""
     if not isinstance(raw_sort, str):
@@ -830,13 +868,28 @@ def interruptible_api_call(agent, api_kwargs: dict):
             )
             _ttfb_timeout = _ttfb_cap
 
-    _codex_idle_enabled = _codex_watchdog_enabled
-    _codex_idle_timeout = _env_float(
-        "HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS",
-        _codex_idle_timeout_default,
+    _codex_idle_env_raw = os.environ.get("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS")
+    _codex_idle_timeout, _codex_idle_enabled_flag = resolve_codex_event_idle_timeout(
+        default_seconds=_codex_idle_timeout_default,
+        env_raw=_codex_idle_env_raw,
+        model=api_kwargs.get("model") or getattr(agent, "model", None),
     )
-    if _codex_idle_timeout <= 0:
-        _codex_idle_enabled = False
+    _codex_idle_enabled = bool(_codex_watchdog_enabled and _codex_idle_enabled_flag)
+    if (
+        _codex_watchdog_enabled
+        and _codex_idle_enabled
+        and (_codex_idle_env_raw is None or str(_codex_idle_env_raw).strip() == "")
+        and _codex_idle_timeout > _codex_idle_timeout_default
+    ):
+        logger.info(
+            "Raised Codex event-idle watchdog from %.0fs to %.0fs for "
+            "reasoning model %s (context=~%s tokens). Set "
+            "HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS to override.",
+            _codex_idle_timeout_default,
+            _codex_idle_timeout,
+            api_kwargs.get("model") or getattr(agent, "model", None),
+            f"{_est_tokens_for_codex_watchdog:,}",
+        )
 
     if _codex_watchdog_enabled:
         # Reset before the worker starts so a marker left over from a previous

--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -116,12 +116,23 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
     ("claude-fable", 600),
     # xAI Grok reasoning variants.  Explicit reasoning-only keys
     # plus one for the ``non-reasoning`` variant so users picking
-    # the fast variant don't get the 300s floor.  Bare ``grok-3``,
+    # the fast variant don't get the deep floor.  Bare ``grok-3``,
     # ``grok-4`` etc. don't match — only the explicit reasoning /
-    # non-reasoning pairs.
+    # non-reasoning pairs and current GA flagship SKUs that accept
+    # ``reasoning_effort`` (high/xhigh routinely needs multi-minute
+    # silent thinking before the next content/SSE token).
+    #
+    # Floor is 600s (same tier as o1 / deepseek-r1 / nemotron-3-ultra):
+    # 300s was still too short for grok-4.5 + reasoning_effort=xhigh on
+    # ~50–70k-token sessions over xai-oauth codex_responses — the
+    # non-stream detector and the Codex event-idle watchdog both killed
+    # healthy mid-think calls (observed: 120s stream idle then 150s
+    # non-stream fallback when the model was not on the allowlist, and
+    # multi-minute TTFB/gaps even when it was).
     ("grok-4-fast-reasoning", 300),
     ("grok-4.20-reasoning", 300),
-    ("grok-4.5", 300),
+    ("grok-4.5", 600),
+    ("grok-build", 600),
     ("grok-4-fast-non-reasoning", 180),
 )
 

--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -204,6 +204,13 @@ def get_reasoning_stale_timeout_floor(model: object) -> Optional[float]:
     and only when no explicit user-configured per-model
     ``stale_timeout_seconds`` exists.
 
+    Model allowlist alone is incomplete: the stale detectors measure
+    **silence** (no SSE / no non-stream response), not model identity.
+    Elevated ``reasoning_effort`` causes the same silent mid-think gap
+    on any provider that buffers thinking. Prefer
+    :func:`get_effective_reasoning_stale_timeout_floor` when the agent's
+    reasoning config is available.
+
     >>> get_reasoning_stale_timeout_floor("nvidia/nemotron-3-ultra-550b-a55b")
     600.0
     >>> get_reasoning_stale_timeout_floor("openai/o3-mini")
@@ -240,3 +247,90 @@ def get_reasoning_stale_timeout_floor(model: object) -> Optional[float]:
     if "/" in name:
         name = name.rsplit("/", 1)[1]
     return _match_any(name)
+
+
+# Effort tiers that routinely produce multi-minute silent thinking
+# phases (no content token / no SSE) across providers.  Independent of
+# the model allowlist — a gpt-family or Grok call with xhigh has the
+# same failure mode as o1 even when the slug is not in the table.
+_REASONING_EFFORT_STALE_TIMEOUT_FLOORS: dict[str, float] = {
+    "high": 600.0,
+    "xhigh": 900.0,
+    "max": 900.0,
+    "ultra": 900.0,
+}
+
+
+def _normalize_effort_level(effort_or_config: object) -> Optional[str]:
+    """Extract a bare effort level string from config dict / raw string."""
+    if effort_or_config is None or effort_or_config is False:
+        return None
+    if isinstance(effort_or_config, dict):
+        if effort_or_config.get("enabled") is False:
+            return None
+        raw = effort_or_config.get("effort")
+    else:
+        raw = effort_or_config
+    if raw is None or raw is False:
+        return None
+    level = str(raw).strip().lower()
+    if not level or level in {"none", "false", "disabled"}:
+        return None
+    return level
+
+
+def get_reasoning_effort_stale_timeout_floor(
+    effort_or_config: object,
+) -> Optional[float]:
+    """Return a silence-timeout floor from ``reasoning_effort`` alone.
+
+    Model-independent.  Watchdogs measure time-since-last-byte / last-SSE,
+    not which SKU is thinking.  Elevated effort (high / xhigh / max / ultra)
+    is the common cause of multi-minute silent mid-think gaps on any
+    provider that buffers reasoning before the next stream event.
+
+    Returns ``None`` for medium/low/minimal/disabled/unknown so default
+    chat models keep their existing short stale budgets.
+
+    >>> get_reasoning_effort_stale_timeout_floor("xhigh")
+    900.0
+    >>> get_reasoning_effort_stale_timeout_floor({"enabled": True, "effort": "high"})
+    600.0
+    >>> get_reasoning_effort_stale_timeout_floor("medium") is None
+    True
+    >>> get_reasoning_effort_stale_timeout_floor({"enabled": False}) is None
+    True
+    """
+    level = _normalize_effort_level(effort_or_config)
+    if level is None:
+        return None
+    return _REASONING_EFFORT_STALE_TIMEOUT_FLOORS.get(level)
+
+
+def get_effective_reasoning_stale_timeout_floor(
+    model: object = None,
+    effort_or_config: object = None,
+) -> Optional[float]:
+    """Combine model-allowlist floor and effort floor (max of both).
+
+    Prefer this at every stale-detector call site when the agent's
+    ``reasoning_config`` is available.  Either input alone may raise the
+    floor; both absent → ``None`` (caller keeps the generic default).
+
+    >>> get_effective_reasoning_stale_timeout_floor("gpt-4o", "xhigh")
+    900.0
+    >>> get_effective_reasoning_stale_timeout_floor("openai/o3-mini", "medium")
+    300.0
+    >>> get_effective_reasoning_stale_timeout_floor("gpt-4o", "medium") is None
+    True
+    """
+    floors: list[float] = []
+    model_floor = get_reasoning_stale_timeout_floor(model)
+    if model_floor is not None:
+        floors.append(float(model_floor))
+    effort_floor = get_reasoning_effort_stale_timeout_floor(effort_or_config)
+    if effort_floor is not None:
+        floors.append(float(effort_floor))
+    if not floors:
+        return None
+    return max(floors)

--- a/run_agent.py
+++ b/run_agent.py
@@ -1377,16 +1377,20 @@ class AIAgent:
         if env_timeout is not None:
             return float(env_timeout), False
 
-        # Reasoning-model floor: auto-mitigation for known reasoning models
-        # (Nemotron 3 Ultra, OpenAI o1/o3, Anthropic Opus 4.x thinking,
-        # DeepSeek R1, Qwen QwQ, xAI Grok reasoning, etc.) whose cloud
-        # gateways idle-kill before the model's thinking phase ends.
+        # Reasoning silence floor: auto-mitigation for (a) known reasoning
+        # model slugs and (b) elevated reasoning_effort (high/xhigh/…), which
+        # is model-independent — stale detectors measure silence, not SKU.
         # uses_implicit_default is False here so the local-endpoint
         # short-circuit in _compute_non_stream_stale_timeout does not
         # disable stale detection for users running reasoning models on a
         # local NIM endpoint.
-        from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
-        reasoning_floor = get_reasoning_stale_timeout_floor(self.model)
+        from agent.reasoning_timeouts import (
+            get_effective_reasoning_stale_timeout_floor,
+        )
+        reasoning_floor = get_effective_reasoning_stale_timeout_floor(
+            self.model,
+            getattr(self, "reasoning_config", None),
+        )
         if reasoning_floor is not None:
             return reasoning_floor, False
 

--- a/tests/agent/test_codex_event_idle_reasoning_floor.py
+++ b/tests/agent/test_codex_event_idle_reasoning_floor.py
@@ -1,0 +1,78 @@
+"""Codex event-idle watchdog must honor the reasoning-model floor.
+
+Regression for xAI Grok on ``codex_responses`` / xai-oauth:
+
+After the first SSE frame arrives, Grok with ``reasoning_effort=high|xhigh``
+can go silent for minutes while thinking. The context-tier idle defaults
+(12 / 60 / 120 / 180s) killed those healthy mid-think streams with:
+
+  Codex stream produced no SSE events for 120s after first byte
+
+before the non-stream fallback (and its own reasoning floor) ever ran.
+``resolve_codex_event_idle_timeout`` raises the *implicit* default to the
+reasoning floor; explicit ``HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS`` still
+wins (including 0 to disable).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "model,default,expected",
+    [
+        ("grok-4.5", 120.0, 600.0),
+        ("x-ai/grok-4.5", 120.0, 600.0),
+        ("grok-build-0.1", 60.0, 600.0),
+        ("nvidia/nemotron-3-ultra-550b-a55b", 120.0, 600.0),
+        ("gpt-4o", 120.0, 120.0),  # non-reasoning: unchanged
+        ("x-ai/grok-4", 120.0, 120.0),  # bare grok-4 still not on floor
+    ],
+)
+def test_implicit_default_raises_for_reasoning_models(model, default, expected):
+    from agent.chat_completion_helpers import resolve_codex_event_idle_timeout
+
+    timeout, enabled = resolve_codex_event_idle_timeout(
+        default_seconds=default,
+        env_raw=None,
+        model=model,
+    )
+    assert enabled is True
+    assert timeout == expected
+
+
+def test_explicit_env_wins_over_reasoning_floor():
+    from agent.chat_completion_helpers import resolve_codex_event_idle_timeout
+
+    timeout, enabled = resolve_codex_event_idle_timeout(
+        default_seconds=120.0,
+        env_raw="45",
+        model="grok-4.5",
+    )
+    assert enabled is True
+    assert timeout == 45.0
+
+
+def test_explicit_zero_disables_watchdog():
+    from agent.chat_completion_helpers import resolve_codex_event_idle_timeout
+
+    timeout, enabled = resolve_codex_event_idle_timeout(
+        default_seconds=120.0,
+        env_raw="0",
+        model="grok-4.5",
+    )
+    assert enabled is False
+    assert timeout == 0.0
+
+
+def test_invalid_env_falls_back_to_default_plus_floor():
+    from agent.chat_completion_helpers import resolve_codex_event_idle_timeout
+
+    timeout, enabled = resolve_codex_event_idle_timeout(
+        default_seconds=120.0,
+        env_raw="not-a-number",
+        model="grok-4.5",
+    )
+    assert enabled is True
+    assert timeout == 600.0

--- a/tests/agent/test_codex_event_idle_reasoning_floor.py
+++ b/tests/agent/test_codex_event_idle_reasoning_floor.py
@@ -26,8 +26,8 @@ import pytest
         ("x-ai/grok-4.5", 120.0, 600.0),
         ("grok-build-0.1", 60.0, 600.0),
         ("nvidia/nemotron-3-ultra-550b-a55b", 120.0, 600.0),
-        ("gpt-4o", 120.0, 120.0),  # non-reasoning: unchanged
-        ("x-ai/grok-4", 120.0, 120.0),  # bare grok-4 still not on floor
+        ("gpt-4o", 120.0, 120.0),  # non-reasoning, no elevated effort: unchanged
+        ("x-ai/grok-4", 120.0, 120.0),  # bare grok-4 still not on model floor
     ],
 )
 def test_implicit_default_raises_for_reasoning_models(model, default, expected):
@@ -40,6 +40,33 @@ def test_implicit_default_raises_for_reasoning_models(model, default, expected):
     )
     assert enabled is True
     assert timeout == expected
+
+
+def test_elevated_reasoning_effort_raises_even_for_non_allowlisted_model():
+    """Silence floor is effort-driven, not SKU-driven.
+
+    gpt-4o is intentionally off the model allowlist, but xhigh still
+    produces multi-minute silent thinking on many providers — the Codex
+    event-idle watchdog must not kill at 120s.
+    """
+    from agent.chat_completion_helpers import resolve_codex_event_idle_timeout
+
+    timeout, enabled = resolve_codex_event_idle_timeout(
+        default_seconds=120.0,
+        env_raw=None,
+        model="gpt-4o",
+        reasoning_config={"enabled": True, "effort": "xhigh"},
+    )
+    assert enabled is True
+    assert timeout == 900.0
+
+    timeout_high, _ = resolve_codex_event_idle_timeout(
+        default_seconds=120.0,
+        env_raw=None,
+        model="some-unknown-chat-model",
+        reasoning_config="high",
+    )
+    assert timeout_high == 600.0
 
 
 def test_explicit_env_wins_over_reasoning_floor():

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -79,9 +79,14 @@ import pytest
     ("claude-fable-5", 600.0),
     ("claude-fable", 600.0),
     # xAI Grok reasoning variants — explicit, not bare `grok`.
+    # grok-4.5 / grok-build are GA flagships that accept reasoning_effort
+    # (high/xhigh); floor is 600s deep-reasoning tier (see #52217 follow-up).
     ("x-ai/grok-4-fast-reasoning", 300.0),
     ("x-ai/grok-4.20-reasoning", 300.0),
-    ("x-ai/grok-4.5", 300.0),
+    ("x-ai/grok-4.5", 600.0),
+    ("grok-4.5", 600.0),
+    ("grok-build-0.1", 600.0),
+    ("x-ai/grok-build", 600.0),
     ("x-ai/grok-4-fast-non-reasoning", 180.0),
 ])
 def test_reasoning_stale_timeout_floor_positive_cases(model, expected):

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -382,3 +382,55 @@ def test_stream_stale_timeout_unchanged_for_non_reasoning_models():
         est_tokens=5_000,
     )
     assert timeout == 180.0
+
+
+# ── effort-based floor (model-independent) ────────────────────────────────
+
+
+def test_effort_floor_xhigh_independent_of_model():
+    from agent.reasoning_timeouts import (
+        get_effective_reasoning_stale_timeout_floor,
+        get_reasoning_effort_stale_timeout_floor,
+    )
+
+    assert get_reasoning_effort_stale_timeout_floor("xhigh") == 900.0
+    assert get_reasoning_effort_stale_timeout_floor("high") == 600.0
+    assert get_reasoning_effort_stale_timeout_floor("medium") is None
+    assert get_reasoning_effort_stale_timeout_floor({"enabled": False}) is None
+    # gpt-4o is off the model allowlist, but xhigh still raises.
+    assert get_effective_reasoning_stale_timeout_floor("gpt-4o", "xhigh") == 900.0
+    assert get_effective_reasoning_stale_timeout_floor("gpt-4o", "medium") is None
+    # Model floor + effort floor → max.
+    assert (
+        get_effective_reasoning_stale_timeout_floor("openai/o3-mini", "xhigh")
+        == 900.0
+    )
+    assert (
+        get_effective_reasoning_stale_timeout_floor("openai/o3-mini", "medium")
+        == 300.0
+    )
+
+
+def test_non_stream_resolver_uses_effort_when_model_not_on_allowlist(
+    monkeypatch, tmp_path
+):
+    """xhigh on an unknown chat model must not fall through to the 90s default."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+    _write_config(tmp_path, "")
+
+    import run_agent
+
+    monkeypatch.setattr(run_agent, "get_provider_stale_timeout", lambda *a, **k: None)
+
+    agent = _make_agent(
+        tmp_path,
+        provider="openai",
+        base_url="https://api.openai.com/v1",
+        model="gpt-4o",  # not on model allowlist
+        reasoning_config={"enabled": True, "effort": "xhigh"},
+    )
+    base, implicit = agent._resolved_api_call_stale_timeout_base()
+    assert base == 900.0
+    assert implicit is False


### PR DESCRIPTION
## Summary

xAI Grok (`xai-oauth` / `api.x.ai`, `codex_responses`) with `reasoning_effort=high|xhigh` routinely emits an opening SSE frame, then goes silent for minutes while thinking. Hermes killed those healthy mid-think streams in two places:

1. **Codex event-idle watchdog** (post-first-byte) used only context-tier defaults (12 / 60 / **120** / 180s) and did **not** consult the reasoning-model floor →  
   `Codex stream produced no SSE events for 120s after first byte`
2. Non-stream fallback then used a too-short budget for current GA SKUs under deep reasoning (and older trees missed `grok-4.5` entirely → 90s base + 50k context tier = **150s**).

Observed locally (Hermes Desktop, `grok-4.5`, `reasoning_effort=xhigh`, ~70k tokens, 3 retries):

```
Codex stream produced no SSE events for 120s after first byte (threshold: 120s)
…
Non-streaming API call timed out after 150s with no response (threshold: 150s)
API call failed after 3 retries
```

This is **not** a Polymarket/tool timeout — it is the LLM transport watchdog.

### Changes

| Area | Change |
|------|--------|
| `resolve_codex_event_idle_timeout()` | New pure helper: on **implicit** default, raise idle budget to `get_reasoning_stale_timeout_floor(model)`. Explicit `HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS` (incl. `0` disable) still wins. |
| `interruptible_api_call` | Wire Codex event-idle through that helper + log when raised |
| `reasoning_timeouts` | `grok-4.5` floor **300 → 600s** (deep-reasoning tier with o1 / R1 / Nemotron ultra); add **`grok-build`** (Hermes default build SKU family) at 600s. Bare `grok-4` still **not** matched (existing negative test). |
| Tests | Floor table updates + new `test_codex_event_idle_reasoning_floor.py` |

### Why 600s for grok-4.5

Even with the model on the allowlist at 300s, xhigh + large sessions still exceed a 5-minute silent gap after the first SSE frame. Align with other multi-minute thinking models (`o1`, `deepseek-r1`, `nemotron-3-ultra`) at 600s.

## Test plan

- [x] `pytest tests/agent/test_reasoning_stale_timeout_floor.py tests/agent/test_codex_event_idle_reasoning_floor.py` → **73 passed**
- [ ] Manual: `xai-oauth` + `grok-4.5` + `reasoning_effort=xhigh` + long session — no 120s event-idle kill during thinking
- [ ] Explicit `HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS=45` still forces 45s (override path)
- [ ] `HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS=0` still disables idle watchdog
- [ ] Non-reasoning models (e.g. `gpt-4o`) keep 120s default at 50k+ ctx

## Related

- Follows the reasoning-floor design in #52217 / `agent/reasoning_timeouts.py`
- Complements stream + non-stream floor application; this PR closes the **Codex event-idle gap** that those detectors did not cover

## Risk

Low. Floor only **raises** timeouts for allowlisted reasoning models on the **implicit** default path. Explicit env overrides unchanged. Bare `grok-4` remains unfloored.