### PR TITLE
fix: handle list content in think-block stripping

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -672,6 +672,20 @@ def strip_think_blocks(agent, content: str) -> str:
     """
     if not content:
         return ""
+    if not isinstance(content, str):
+        if isinstance(content, list):
+            text_parts = []
+            for part in content:
+                if isinstance(part, dict):
+                    if isinstance(part.get("text"), str):
+                        text_parts.append(part["text"])
+                    elif isinstance(part.get("content"), str):
+                        text_parts.append(part["content"])
+                elif isinstance(part, str):
+                    text_parts.append(part)
+            content = "\n".join(text_parts)
+        else:
+            content = str(content)
     # 1. Closed tag pairs — case-insensitive for all variants so
     #    mixed-case tags (<THINK>, <Thinking>) don't slip through to
     #    the unterminated-tag pass and take trailing content with them.

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -448,6 +448,22 @@ class TestStripThinkBlocks:
     def test_no_blocks_unchanged(self, agent):
         assert agent._strip_think_blocks("hello world") == "hello world"
 
+    def test_list_content_parts_join_text(self, agent):
+        content = [
+            {"type": "text", "text": "visible"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            {"type": "output_text", "content": "answer"},
+        ]
+
+        assert agent._strip_think_blocks(content) == "visible\nanswer"
+
+    def test_list_content_parts_strip_think_blocks(self, agent):
+        content = [
+            {"type": "text", "text": "<think>hidden</think>shown"},
+        ]
+
+        assert agent._strip_think_blocks(content) == "shown"
+
     def test_single_block_removed(self, agent):
         result = agent._strip_think_blocks("<think>reasoning</think> answer")
         assert "reasoning" not in result


### PR DESCRIPTION
## Summary
- Normalize list-valued assistant content before running think/tool XML stripping
- Preserve visible text/content parts and ignore image-only parts
- Add regression tests for structured content lists and `<think>` cleanup

## Test Plan
- [x] `scripts/run_tests.sh tests/run_agent/test_run_agent.py -k 'StripThinkBlocks' -q`

Closes #73647
