### PR TITLE
docs(web): clarify standalone provider plugin path

### DIFF
--- a/website/docs/developer-guide/web-search-provider-plugin.md
+++ b/website/docs/developer-guide/web-search-provider-plugin.md
@@ -6,7 +6,7 @@ description: "How to build a web-search/extract/crawl backend plugin for Hermes 
 
 # Building a Web Search Provider Plugin
 
-Web-search provider plugins register a backend that services `web_search`, `web_extract`, and (optionally) deep-crawl tool calls. Built-in providers — Firecrawl, SearXNG, Tavily, Exa, Parallel, Brave Search (free tier), xAI, and DDGS — all ship as plugins under `plugins/web/<name>/`. You can add a new one, or override a bundled one, by dropping a directory next to them.
+Web-search provider plugins register a backend that services `web_search`, `web_extract`, and (optionally) deep-crawl tool calls. Built-in providers — Firecrawl, SearXNG, Tavily, Exa, Parallel, Brave Search (free tier), xAI, and DDGS — all ship as plugins under `plugins/web/<name>/`. Third-party product providers should be published as standalone plugins outside this repository and installed under `~/.hermes/plugins/web/<name>/`.
 
 :::tip
 Web search is one of several **backend plugins** Hermes supports. The others (with their own ABCs) are [Image Generation Provider Plugins](/developer-guide/image-gen-provider-plugin), [Video Generation Provider Plugins](/developer-guide/video-gen-provider-plugin), [Memory Provider Plugins](/developer-guide/memory-provider-plugin), [Context Engine Plugins](/developer-guide/context-engine-plugin), and [Model Provider Plugins](/developer-guide/model-provider-plugin). General tool/hook/CLI plugins live in [Build a Hermes Plugin](/developer-guide/plugins).
@@ -17,8 +17,14 @@ Web search is one of several **backend plugins** Hermes supports. The others (wi
 Hermes scans for web-search backends in three places:
 
 1. **Bundled** — `<repo>/plugins/web/<name>/` (auto-loaded with `kind: backend`, always available)
-2. **User** — `~/.hermes/plugins/web/<name>/` (opt-in via `plugins.enabled` or `hermes plugins enable <name>`)
+2. **User** — `~/.hermes/plugins/web/<name>/` (opt-in via `plugins.enabled` or `hermes plugins enable web/<name>`)
 3. **Pip** — packages declaring a `hermes_agent.plugins` entry point
+
+:::note Third-party providers
+
+Do not add a third-party vendor directory under this repository's `plugins/web/`. Users can copy or install a standalone provider under `~/.hermes/plugins/web/<name>/`, enable it with `hermes plugins enable web/<name>`, and select its provider name in `web.search_backend` and/or `web.extract_backend` in `~/.hermes/config.yaml`.
+
+:::
 
 Each plugin's `register(ctx)` function calls `ctx.register_web_search_provider(...)` — that puts the instance into the registry in `agent/web_search_registry.py`. The active provider for each capability is picked by config:
 


### PR DESCRIPTION
## Summary

- clarify that third-party web providers belong in standalone plugin repositories
- document the user-installed path under `~/.hermes/plugins/web/<name>`
- show the explicit enable command and per-capability backend configuration

## Validation

- `git diff --check`
- Docusaurus build passed with pre-existing unrelated broken-link warnings

Closes #73488
