### PR TITLE
fix(middleware): chain request rewrites sequentially

### DIFF
--- a/docs/middleware/README.md
+++ b/docs/middleware/README.md
@@ -62,6 +62,12 @@ return {
 Hermes stores those trace entries in later observer hook payloads as
 `middleware_trace`.
 
+If multiple plugins register the same request middleware kind, Hermes applies
+them in registration order. Each callback receives the effective request or
+arguments returned by the previous callback, while `original_request` or
+`original_args` remains the pre-middleware snapshot. Callback failures are
+fail-open and do not discard rewrites already applied by earlier middleware.
+
 Execution middleware receives a `next_call` callback. Call it to continue the
 chain:
 

--- a/hermes_cli/middleware.py
+++ b/hermes_cli/middleware.py
@@ -83,7 +83,8 @@ def apply_llm_request_middleware(
     Middleware may return ``{"request": {...}}`` to replace the effective
     provider kwargs before Hermes sends them.
     """
-    if not _has_middleware(LLM_REQUEST_MIDDLEWARE):
+    callbacks = _get_middleware_callbacks(LLM_REQUEST_MIDDLEWARE)
+    if not callbacks:
         return RequestMiddlewareResult(
             payload=request,
             original_payload=request,
@@ -91,29 +92,13 @@ def apply_llm_request_middleware(
             trace=[],
         )
 
-    original_request = _safe_copy(request)
-    current_request = _safe_copy(original_request)
-    trace: List[Dict[str, Any]] = []
-
-    for result in _invoke_middleware(
+    return _run_request_chain(
         LLM_REQUEST_MIDDLEWARE,
-        request=current_request,
-        original_request=original_request,
+        callbacks,
+        request,
+        payload_key="request",
+        original_key="original_request",
         **context,
-    ):
-        if not isinstance(result, dict):
-            continue
-        next_request = result.get("request")
-        if not isinstance(next_request, dict):
-            continue
-        current_request = _safe_copy(next_request)
-        trace.append(_trace_entry(result))
-
-    return RequestMiddlewareResult(
-        payload=current_request,
-        original_payload=original_request,
-        changed=bool(trace),
-        trace=trace,
     )
 
 
@@ -145,7 +130,8 @@ def apply_tool_request_middleware(
             current_args = _safe_copy(relay_args)
             trace.append({"source": "nemo_relay"})
 
-    if not _has_middleware(TOOL_REQUEST_MIDDLEWARE):
+    callbacks = _get_middleware_callbacks(TOOL_REQUEST_MIDDLEWARE)
+    if not callbacks:
         return RequestMiddlewareResult(
             payload=args if not trace else current_args,
             original_payload=args,
@@ -153,26 +139,16 @@ def apply_tool_request_middleware(
             trace=trace,
         )
 
-    for result in _invoke_middleware(
+    return _run_request_chain(
         TOOL_REQUEST_MIDDLEWARE,
-        tool_name=tool_name,
-        args=current_args,
-        original_args=original_args,
-        **context,
-    ):
-        if not isinstance(result, dict):
-            continue
-        next_args = result.get("args")
-        if not isinstance(next_args, dict):
-            continue
-        current_args = _safe_copy(next_args)
-        trace.append(_trace_entry(result))
-
-    return RequestMiddlewareResult(
-        payload=current_args,
+        callbacks,
+        current_args,
+        payload_key="args",
+        original_key="original_args",
         original_payload=original_args,
-        changed=bool(trace),
-        trace=trace,
+        initial_trace=trace,
+        tool_name=tool_name,
+        **context,
     )
 
 
@@ -233,22 +209,61 @@ def run_api_execution_middleware(
     return run_llm_execution_middleware(request, next_call, **context)
 
 
-def _invoke_middleware(kind: str, **kwargs: Any) -> List[Any]:
-    from hermes_cli.plugins import invoke_middleware
-
-    return invoke_middleware(kind, **middleware_payload(**kwargs))
-
-
-def _has_middleware(kind: str) -> bool:
-    from hermes_cli.plugins import has_middleware
-
-    return has_middleware(kind)
-
-
 def _get_middleware_callbacks(kind: str) -> List[Callable]:
     from hermes_cli.plugins import get_plugin_manager
 
     return list(get_plugin_manager()._middleware.get(kind, []))
+
+
+def _run_request_chain(
+    kind: str,
+    callbacks: List[Callable],
+    payload: Dict[str, Any],
+    *,
+    payload_key: str,
+    original_key: str,
+    original_payload: Optional[Dict[str, Any]] = None,
+    initial_trace: Optional[List[Dict[str, Any]]] = None,
+    **context: Any,
+) -> RequestMiddlewareResult:
+    """Apply request middleware serially to the current effective payload."""
+    if original_payload is None:
+        original_payload = _safe_copy(payload)
+    current_payload = _safe_copy(payload)
+    trace = list(initial_trace or [])
+
+    for callback in callbacks:
+        callback_payload = middleware_payload(
+            **context,
+            **{
+                payload_key: _safe_copy(current_payload),
+                original_key: _safe_copy(original_payload),
+            },
+        )
+        try:
+            result = callback(**callback_payload)
+        except Exception as exc:
+            logger.warning(
+                "Middleware '%s' callback %s raised: %s",
+                kind,
+                getattr(callback, "__name__", repr(callback)),
+                exc,
+            )
+            continue
+        if not isinstance(result, dict):
+            continue
+        next_payload = result.get(payload_key)
+        if not isinstance(next_payload, dict):
+            continue
+        current_payload = _safe_copy(next_payload)
+        trace.append(_trace_entry(result))
+
+    return RequestMiddlewareResult(
+        payload=current_payload,
+        original_payload=original_payload,
+        changed=bool(trace),
+        trace=trace,
+    )
 
 
 def _run_execution_chain(

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -122,6 +122,25 @@ class TestPluginDiscovery:
         assert mgr.has_middleware("llm_request") is True
 
 
+
+    def test_execution_middleware_does_not_retry_downstream_failure(self, monkeypatch):
+        calls = []
+
+        def middleware(**kwargs):
+            return kwargs["next_call"](kwargs["args"])
+
+        manager = types.SimpleNamespace(_middleware={"tool_execution": [middleware]})
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+        def terminal(args):
+            calls.append(args)
+            raise RuntimeError("tool failed")
+
+        with pytest.raises(RuntimeError, match="tool failed"):
+            run_tool_execution_middleware("terminal", {"command": "false"}, terminal)
+
+        assert calls == [{"command": "false"}]
+
     def test_middleware_helpers_skip_no_listener_work(self, monkeypatch):
         manager = types.SimpleNamespace(_middleware={})
         monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
@@ -143,13 +162,305 @@ class TestPluginDiscovery:
         assert run_tool_execution_middleware("terminal", args, lambda payload: payload) is args
         assert has_middleware("tool_request") is False
 
+    def test_request_middleware_changed_tracks_trace_not_deep_equality(self, monkeypatch):
+        def same_payload_middleware(**kwargs):
+            return {"args": kwargs["args"], "source": "same-payload"}
 
+        manager = types.SimpleNamespace(
+            _middleware={"tool_request": [same_payload_middleware]},
+            invoke_middleware=lambda kind, **kwargs: [same_payload_middleware(**kwargs)],
+        )
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
 
+        args = {"path": "README.md"}
+        result = apply_tool_request_middleware("read_file", args)
 
+        assert result.payload == args
+        assert result.original_payload == args
+        assert result.changed is True
+        assert result.trace == [{"source": "same-payload"}]
 
+    def test_tool_request_middleware_hides_internal_skip_relay_flag(
+        self,
+        monkeypatch,
+    ):
+        observed = []
 
+        def middleware(**kwargs):
+            observed.append(kwargs)
+            return {"args": kwargs["args"]}
 
+        manager = types.SimpleNamespace(
+            _middleware={"tool_request": [middleware]},
+            invoke_middleware=lambda kind, **kwargs: [middleware(**kwargs)],
+        )
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
 
+        apply_tool_request_middleware(
+            "read_file",
+            {"path": "README.md"},
+            session_id="",
+            skip_relay=True,
+        )
+
+        assert len(observed) == 1
+        assert "skip_relay" not in observed[0]
+
+    def test_llm_request_middleware_chains_effective_request_in_order(self, monkeypatch):
+        seen = []
+
+        def first(**kwargs):
+            seen.append(("first", kwargs["request"], kwargs["original_request"]))
+            return {
+                "request": {**kwargs["request"], "first": True},
+                "source": "first",
+            }
+
+        def second(**kwargs):
+            seen.append(("second", kwargs["request"], kwargs["original_request"]))
+            return {
+                "request": {**kwargs["request"], "second": True},
+                "source": "second",
+            }
+
+        manager = PluginManager()
+        manager._middleware = {"llm_request": [first, second]}
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+        request = {"messages": []}
+        result = apply_llm_request_middleware(request)
+
+        assert result.payload == {"messages": [], "first": True, "second": True}
+        assert result.original_payload == request
+        assert result.trace == [{"source": "first"}, {"source": "second"}]
+        assert seen[0] == ("first", request, request)
+        assert seen[1] == (
+            "second",
+            {"messages": [], "first": True},
+            request,
+        )
+
+    def test_tool_request_middleware_chains_relay_and_plugin_rewrites(
+        self,
+        monkeypatch,
+    ):
+        seen = []
+
+        monkeypatch.setattr(
+            "agent.relay_runtime.apply_tool_request_intercepts",
+            lambda **kwargs: {**kwargs["args"], "relay": True},
+        )
+
+        def first(**kwargs):
+            seen.append(("first", kwargs["args"], kwargs["original_args"]))
+            return {
+                "args": {**kwargs["args"], "first": True},
+                "source": "first",
+            }
+
+        def second(**kwargs):
+            seen.append(("second", kwargs["args"], kwargs["original_args"]))
+            return {
+                "args": {**kwargs["args"], "second": True},
+                "source": "second",
+            }
+
+        manager = PluginManager()
+        manager._middleware = {"tool_request": [first, second]}
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+        args = {"path": "README.md"}
+        result = apply_tool_request_middleware("read_file", args, session_id="s1")
+
+        assert result.payload == {
+            "path": "README.md",
+            "relay": True,
+            "first": True,
+            "second": True,
+        }
+        assert result.original_payload == args
+        assert result.trace == [
+            {"source": "nemo_relay"},
+            {"source": "first"},
+            {"source": "second"},
+        ]
+        assert seen == [
+            ("first", {"path": "README.md", "relay": True}, args),
+            (
+                "second",
+                {"path": "README.md", "relay": True, "first": True},
+                args,
+            ),
+        ]
+
+    def test_request_middleware_failure_keeps_prior_rewrite_isolated(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        seen = []
+
+        def first(**kwargs):
+            return {
+                "request": {**kwargs["request"], "first": True},
+                "source": "first",
+            }
+
+        def failing(**kwargs):
+            assert kwargs["request"]["first"] is True
+            kwargs["request"]["failed_mutation"] = True
+            raise RuntimeError("broken plugin")
+
+        def third(**kwargs):
+            seen.append(kwargs["request"])
+            return {
+                "request": {**kwargs["request"], "third": True},
+                "source": "third",
+            }
+
+        manager = PluginManager()
+        manager._middleware = {"llm_request": [first, failing, third]}
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+        with caplog.at_level(logging.WARNING):
+            result = apply_llm_request_middleware({"messages": []})
+
+        assert seen == [{"messages": [], "first": True}]
+        assert result.payload == {"messages": [], "first": True, "third": True}
+        assert result.trace == [{"source": "first"}, {"source": "third"}]
+        assert "Middleware 'llm_request' callback failing raised: broken plugin" in caplog.text
+
+    def test_execution_middleware_post_next_call_error_does_not_retry(self, monkeypatch):
+        calls = []
+
+        def middleware(**kwargs):
+            result = kwargs["next_call"](kwargs["args"])
+            raise RuntimeError(f"post-processing failed after {result}")
+
+        manager = types.SimpleNamespace(_middleware={"tool_execution": [middleware]})
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+        def terminal(args):
+            calls.append(args)
+            return "terminal-result"
+
+        result = run_tool_execution_middleware("terminal", {"command": "printf ok"}, terminal)
+
+        assert result == "terminal-result"
+        assert calls == [{"command": "printf ok"}]
+
+    def test_execution_middleware_pre_next_call_error_fails_open_to_remaining_chain(self, monkeypatch):
+        calls = []
+
+        def failing_middleware(**kwargs):
+            calls.append("failing")
+            raise RuntimeError("middleware setup failed")
+
+        def downstream_middleware(**kwargs):
+            calls.append("downstream")
+            return kwargs["next_call"]({**kwargs["args"], "rewritten": True})
+
+        manager = types.SimpleNamespace(_middleware={"tool_execution": [failing_middleware, downstream_middleware]})
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+        def terminal(args):
+            calls.append(("terminal", args))
+            return args
+
+        result = run_tool_execution_middleware("terminal", {"command": "printf ok"}, terminal)
+
+        assert result == {"command": "printf ok", "rewritten": True}
+        assert calls == ["failing", "downstream", ("terminal", {"command": "printf ok", "rewritten": True})]
+
+    def test_execution_middleware_translated_downstream_failure_is_not_masked(self, monkeypatch):
+        calls = []
+
+        def middleware(**kwargs):
+            try:
+                return kwargs["next_call"](kwargs["args"])
+            except Exception as exc:
+                raise RuntimeError(f"translated downstream failure: {exc}") from exc
+
+        manager = types.SimpleNamespace(_middleware={"tool_execution": [middleware]})
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+        def terminal(args):
+            calls.append(args)
+            raise RuntimeError("terminal failed")
+
+        with pytest.raises(RuntimeError, match="translated downstream failure: terminal failed"):
+            run_tool_execution_middleware("terminal", {"command": "false"}, terminal)
+
+        assert calls == [{"command": "false"}]
+
+    def test_execution_middleware_downstream_base_exception_is_not_wrapped(self, monkeypatch):
+        calls = []
+
+        def middleware(**kwargs):
+            try:
+                return kwargs["next_call"](kwargs["args"])
+            except Exception as exc:
+                raise RuntimeError(f"middleware should not catch base exception: {exc}") from exc
+
+        manager = types.SimpleNamespace(_middleware={"tool_execution": [middleware]})
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+        def terminal(args):
+            calls.append(args)
+            raise KeyboardInterrupt()
+
+        with pytest.raises(KeyboardInterrupt):
+            run_tool_execution_middleware("terminal", {"command": "interrupt"}, terminal)
+
+        assert calls == [{"command": "interrupt"}]
+
+    def test_execution_middleware_double_next_call_does_not_run_terminal_twice(self, monkeypatch):
+        calls = []
+
+        def middleware(**kwargs):
+            first = kwargs["next_call"](kwargs["args"])
+            # Deliberate misuse: a second next_call() must not re-run the
+            # downstream tool. The chain surfaces it as an error and preserves
+            # the first (successful) downstream result.
+            kwargs["next_call"](kwargs["args"])
+            return first
+
+        manager = types.SimpleNamespace(_middleware={"tool_execution": [middleware]})
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+        def terminal(args):
+            calls.append(args)
+            return "terminal-result"
+
+        result = run_tool_execution_middleware("terminal", {"command": "printf ok"}, terminal)
+
+        assert result == "terminal-result"
+        assert calls == [{"command": "printf ok"}]
+
+    def test_request_middleware_tolerates_non_deepcopyable_payload(self, monkeypatch):
+        import threading
+
+        recorded = {}
+
+        def middleware(**kwargs):
+            recorded["args"] = kwargs["args"]
+            return None
+
+        manager = types.SimpleNamespace(
+            _middleware={"tool_request": [middleware]},
+            invoke_middleware=lambda kind, **kwargs: [middleware(**kwargs)],
+        )
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+        # threading.Lock is not deepcopyable; a hard deepcopy would raise.
+        args = {"command": "noop", "lock": threading.Lock()}
+        result = apply_tool_request_middleware("terminal", args)
+
+        # Middleware ran (payload was copied via the shallow fallback) and the
+        # non-deepcopyable member is shared by reference rather than aborting.
+        assert recorded["args"]["command"] == "noop"
+        assert result.payload["command"] == "noop"
+        assert result.payload["lock"] is args["lock"]
 
     def test_failed_discovery_is_not_cached(self, tmp_path, monkeypatch):
         """A sweep that raises must not cache 'discovered' with no plugins.

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -64,14 +64,12 @@ class TestHandleFunctionCall:
     def test_tool_request_and_execution_middleware_wrap_registry_dispatch(self, monkeypatch):
         seen = {}
 
-        def fake_invoke_middleware(kind, **kwargs):
-            if kind == "tool_request":
-                return [{
-                    "args": {**kwargs["args"], "rewritten": True},
-                    "source": "test-middleware",
-                    "reason": "rewrite",
-                }]
-            return []
+        def request_middleware(**kwargs):
+            return {
+                "args": {**kwargs["args"], "rewritten": True},
+                "source": "test-middleware",
+                "reason": "rewrite",
+            }
 
         def execution_middleware(**kwargs):
             seen["execution_args"] = kwargs["args"]
@@ -84,9 +82,8 @@ class TestHandleFunctionCall:
         manager = type(
             "Manager",
             (),
-            {"_middleware": {"tool_request": [fake_invoke_middleware], "tool_execution": [execution_middleware]}},
+            {"_middleware": {"tool_request": [request_middleware], "tool_execution": [execution_middleware]}},
         )()
-        monkeypatch.setattr("hermes_cli.plugins.invoke_middleware", fake_invoke_middleware)
         monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
         hook_calls = []
         monkeypatch.setattr(


### PR DESCRIPTION
## What does this PR do?

Request middleware is documented as composable, but the current implementation invokes every callback against the same original payload and only folds their results afterward. A later plugin therefore cannot observe an earlier plugin's rewrite, and whichever callback is folded last can silently discard prior changes.

This changes LLM and tool request middleware to run as a sequential fail-open chain. Each callback receives the current effective payload plus an immutable snapshot of the original payload. NeMo Relay's tool rewrite remains the first chain entry, so enabled plugins now compose with it instead of replacing it.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/middleware.py`: compose request rewrites in registration order while isolating callback mutation and preserving fail-open behavior.
- `tests/hermes_cli/test_plugins.py`: cover LLM chaining, Relay-plus-plugin chaining, malformed results, mutation isolation, callback failures, and immutable original payloads.
- `tests/test_model_tools.py`: assert tool-request middleware receives the current effective arguments at execution boundaries.
- `docs/middleware/README.md`: document sequential composition and original-payload semantics.

## How to Test

1. Register two `llm_request` callbacks where the second asserts on a field added by the first.
2. Register Relay and two `tool_request` callbacks and verify each layer sees the preceding rewrite.
3. Run:
   - `scripts/run_tests.sh tests/hermes_cli/test_plugins.py tests/test_model_tools.py`
   - `scripts/run_tests.sh tests/plugins/test_nemo_relay_plugin.py`
   - `python -m ruff check hermes_cli/middleware.py tests/hermes_cli/test_plugins.py tests/test_model_tools.py`

Validation: 153 middleware/model-tool tests and 29 NeMo Relay tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the entire test suite
- [x] I've added tests for the change
- [x] Tested on Fedora Linux

### Documentation & Housekeeping

- [x] Updated relevant middleware documentation
- [x] Config example update: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A
- [x] Considered cross-platform impact; the change is platform-neutral Python
- [x] Tool schema update: N/A
