### PR TITLE
feat(desktop): add quote-to-reply context action

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -1,4 +1,5 @@
 import {
+import { QuoteSelectionContextMenu } from '@/components/assistant-ui/thread/quote-selection'
   ActionBarPrimitive,
   BranchPickerPrimitive,
   ErrorPrimitive,
@@ -117,6 +118,7 @@ export const AssistantMessage: FC<{
   const onDoubleClick = useTapbackDoubleClick(messageId, 'assistant')
 
   return (
+    <QuoteSelectionContextMenu>
     <MessagePrimitive.Root
       className="group flex w-full min-w-0 max-w-full flex-col gap-0 self-start overflow-hidden"
       data-role="assistant"
@@ -165,6 +167,7 @@ export const AssistantMessage: FC<{
           turn on its summary rather than burying it above the controls. */}
       <ChangedFilesCard parts={settledParts} />
     </MessagePrimitive.Root>
+    </QuoteSelectionContextMenu>
   )
 }
 

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -1,5 +1,4 @@
 import {
-import { QuoteSelectionContextMenu } from '@/components/assistant-ui/thread/quote-selection'
   ActionBarPrimitive,
   BranchPickerPrimitive,
   ErrorPrimitive,
@@ -7,6 +6,7 @@ import { QuoteSelectionContextMenu } from '@/components/assistant-ui/thread/quot
   useAuiState,
   useMessageRuntime
 } from '@assistant-ui/react'
+import { QuoteSelectionContextMenu } from '@/components/assistant-ui/thread/quote-selection'
 import { useStore } from '@nanostores/react'
 import { type FC, useCallback, useMemo, useState } from 'react'
 

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -1,4 +1,5 @@
 import {
+import { QuoteSelectionContextMenu } from '@/components/assistant-ui/thread/quote-selection'
   ActionBarPrimitive,
   BranchPickerPrimitive,
   ErrorPrimitive,
@@ -185,6 +186,7 @@ export const AssistantMessage: FC<{
   }
 
   return (
+    <QuoteSelectionContextMenu>
     <MessagePrimitive.Root
       className="group flex w-full min-w-0 max-w-full flex-col gap-0 self-start overflow-hidden"
       data-role="assistant"
@@ -239,6 +241,7 @@ export const AssistantMessage: FC<{
           turn on its summary rather than burying it above the controls. */}
       <ChangedFilesCard parts={settledParts} />
     </MessagePrimitive.Root>
+    </QuoteSelectionContextMenu>
   )
 }
 

--- a/apps/desktop/src/components/assistant-ui/thread/quote-selection.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/quote-selection.test.tsx
@@ -1,0 +1,68 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { requestComposerFocus, requestComposerInsert } from '@/app/chat/composer/focus'
+
+import { QuoteSelectionContextMenu, quoteSelectedText, selectedTextWithin } from './quote-selection'
+
+vi.mock('@/app/chat/composer/focus', () => ({
+  requestComposerFocus: vi.fn(),
+  requestComposerInsert: vi.fn()
+}))
+
+afterEach(() => {
+  cleanup()
+  window.getSelection()?.removeAllRanges()
+  vi.clearAllMocks()
+})
+
+function selectText(target: HTMLElement) {
+  const selection = window.getSelection()
+  const range = document.createRange()
+
+  range.selectNodeContents(target)
+  selection?.removeAllRanges()
+  selection?.addRange(range)
+}
+
+function openContextMenu(target: HTMLElement) {
+  fireEvent.pointerDown(target, { button: 2, pointerType: 'mouse' })
+  fireEvent.contextMenu(target, { button: 2 })
+}
+
+describe('quoteSelectedText', () => {
+  it('prefixes every selected line, including blank lines', () => {
+    expect(quoteSelectedText('first\n\nthird\r\nfourth')).toBe('> first\n> \n> third\n> fourth')
+  })
+})
+
+describe('QuoteSelectionContextMenu', () => {
+  it('recognizes a selection inside the message so other context actions can yield to quote', () => {
+    render(<div data-testid="message">selected text</div>)
+
+    const message = screen.getByTestId('message')
+    selectText(message)
+
+    expect(selectedTextWithin(message)).toBe('selected text')
+  })
+
+  it('inserts the selected message text into the active composer', async () => {
+    render(
+      <QuoteSelectionContextMenu>
+        <div data-testid="message">first line{`\n`}second line</div>
+      </QuoteSelectionContextMenu>
+    )
+
+    const message = screen.getByTestId('message')
+    selectText(message)
+    openContextMenu(message)
+
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Quote in new message' }))
+
+    expect(requestComposerInsert).toHaveBeenCalledWith('> first line\n> second line', {
+      mode: 'block',
+      target: 'active'
+    })
+    expect(requestComposerFocus).toHaveBeenCalledWith('active')
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/quote-selection.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/quote-selection.tsx
@@ -1,0 +1,63 @@
+import type { MouseEvent, ReactElement } from 'react'
+import { useCallback, useRef } from 'react'
+
+import { requestComposerFocus, requestComposerInsert } from '@/app/chat/composer/focus'
+import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from '@/components/ui/context-menu'
+import { useI18n } from '@/i18n'
+
+export function quoteSelectedText(text: string): string {
+  return text
+    .replace(/\r\n?/g, '\n')
+    .split('\n')
+    .map(line => `> ${line}`)
+    .join('\n')
+}
+
+export function selectedTextWithin(
+  target: Node,
+  selection = typeof window === 'undefined' ? null : window.getSelection()
+): string {
+  const range = selection?.rangeCount ? selection.getRangeAt(0) : null
+  const text = selection?.toString() ?? ''
+
+  return text.trim() && range && target.contains(range.commonAncestorContainer) ? text : ''
+}
+
+export function QuoteSelectionContextMenu({ children }: { children: ReactElement }) {
+  const { t } = useI18n()
+  const selectedTextRef = useRef('')
+
+  const handleContextMenu = useCallback((event: MouseEvent) => {
+    const text = selectedTextWithin(event.currentTarget)
+
+    if (!text) {
+      selectedTextRef.current = ''
+      event.preventDefault()
+      return
+    }
+
+    selectedTextRef.current = text
+  }, [])
+
+  const quote = useCallback(() => {
+    const text = selectedTextRef.current
+
+    if (!text.trim()) {
+      return
+    }
+
+    requestComposerInsert(quoteSelectedText(text), { mode: 'block', target: 'active' })
+    requestComposerFocus('active')
+  }, [])
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild onContextMenu={handleContextMenu}>
+        {children}
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onSelect={quote}>{t.assistant.thread.quoteInNewMessage}</ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-quote.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-quote.test.tsx
@@ -26,7 +26,8 @@ vi.mock('@/components/assistant-ui/thread/use-message-reactions', () => ({
     enabled: true,
     react: vi.fn(),
     reactions: []
-  })
+  }),
+  useTapbackDoubleClick: () => undefined
 }))
 
 const createdAt = new Date('2026-05-01T00:00:00.000Z')

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-quote.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-quote.test.tsx
@@ -1,0 +1,139 @@
+import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+
+import { requestComposerFocus, requestComposerInsert } from '@/app/chat/composer/focus'
+
+import { Thread } from '.'
+
+vi.mock('@/app/chat/composer/focus', () => ({
+  requestComposerFocus: vi.fn(),
+  requestComposerInsert: vi.fn()
+}))
+
+vi.mock('@/components/assistant-ui/thread/message-reactions', () => ({
+  ReactionBadge: () => null,
+  ReactionPicker: ({ children, open }: { children: ReactNode; open: boolean }) => (
+    <div data-open={open ? 'true' : 'false'} data-testid="reaction-picker">
+      {children}
+    </div>
+  )
+}))
+
+vi.mock('@/components/assistant-ui/thread/use-message-reactions', () => ({
+  useMessageReactions: () => ({
+    enabled: true,
+    react: vi.fn(),
+    reactions: []
+  })
+}))
+
+const createdAt = new Date('2026-05-01T00:00:00.000Z')
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+  window.setTimeout(() => callback(performance.now()), 0)
+)
+vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+vi.stubGlobal('CSS', { escape: (str: string) => str })
+
+Element.prototype.scrollTo = function scrollTo() {}
+
+afterEach(() => {
+  cleanup()
+  window.getSelection()?.removeAllRanges()
+  vi.clearAllMocks()
+})
+
+function userMessage(): ThreadMessage {
+  return {
+    id: 'user-1',
+    role: 'user',
+    content: [{ type: 'text', text: 'quote this message' }],
+    attachments: [],
+    createdAt,
+    metadata: { custom: {} }
+  } as ThreadMessage
+}
+
+function assistantMessage(): ThreadMessage {
+  return {
+    id: 'assistant-1',
+    role: 'assistant',
+    content: [{ type: 'text', text: 'done' }],
+    status: { type: 'complete', reason: 'stop' },
+    createdAt,
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {}
+    }
+  } as ThreadMessage
+}
+
+function Harness() {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages: [userMessage(), assistantMessage()],
+    isRunning: false,
+    onNew: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  )
+}
+
+function selectText(target: HTMLElement) {
+  const selection = window.getSelection()
+  const range = document.createRange()
+
+  range.selectNodeContents(target)
+  selection?.removeAllRanges()
+  selection?.addRange(range)
+}
+
+function openContextMenu(target: HTMLElement) {
+  fireEvent.pointerDown(target, { button: 2, pointerType: 'mouse' })
+  fireEvent.contextMenu(target, { button: 2 })
+}
+
+describe('UserMessage quote/reaction context-menu integration', () => {
+  it('lets a local selection open quote while reactions are enabled', async () => {
+    render(<Harness />)
+
+    const bubble = await screen.findByRole('button', { name: 'Edit message' })
+    selectText(bubble)
+    openContextMenu(bubble)
+
+    expect(screen.getByTestId('reaction-picker')).toHaveAttribute('data-open', 'false')
+
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Quote in new message' }))
+
+    expect(requestComposerInsert).toHaveBeenCalledWith('> quote this message', {
+      mode: 'block',
+      target: 'active'
+    })
+    expect(requestComposerFocus).toHaveBeenCalledWith('active')
+  })
+
+  it('opens reactions for an unselected message when reactions are enabled', async () => {
+    render(<Harness />)
+
+    const bubble = await screen.findByRole('button', { name: 'Edit message' })
+    openContextMenu(bubble)
+
+    expect(screen.getByTestId('reaction-picker')).toHaveAttribute('data-open', 'true')
+    expect(screen.queryByRole('menuitem', { name: 'Quote in new message' })).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-quote.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-quote.test.tsx
@@ -110,6 +110,10 @@ function openContextMenu(target: HTMLElement) {
 }
 
 describe('UserMessage quote/reaction context-menu integration', () => {
+  // The user message renders first, so its picker is the first of the mocked
+  // ReactionPicker testids (the assistant message renders one too).
+  const userPicker = () => screen.getAllByTestId('reaction-picker')[0]
+
   it('lets a local selection open quote while reactions are enabled', async () => {
     render(<Harness />)
 
@@ -117,7 +121,7 @@ describe('UserMessage quote/reaction context-menu integration', () => {
     selectText(bubble)
     openContextMenu(bubble)
 
-    expect(screen.getByTestId('reaction-picker')).toHaveAttribute('data-open', 'false')
+    expect(userPicker().getAttribute('data-open')).toBe('false')
 
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Quote in new message' }))
 
@@ -134,7 +138,7 @@ describe('UserMessage quote/reaction context-menu integration', () => {
     const bubble = await screen.findByRole('button', { name: 'Edit message' })
     openContextMenu(bubble)
 
-    expect(screen.getByTestId('reaction-picker')).toHaveAttribute('data-open', 'true')
+    expect(userPicker().getAttribute('data-open')).toBe('true')
     expect(screen.queryByRole('menuitem', { name: 'Quote in new message' })).toBeNull()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -4,6 +4,7 @@ import { type FC, type ReactNode, useCallback, useRef, useState } from 'react'
 import { DirectiveContent } from '@/components/assistant-ui/directive-text'
 import { messageAttachmentRefs, messageContentText } from '@/components/assistant-ui/thread/content'
 import { ReactionBadge, ReactionPicker } from '@/components/assistant-ui/thread/message-reactions'
+import { QuoteSelectionContextMenu, selectedTextWithin } from '@/components/assistant-ui/thread/quote-selection'
 import { type RestoreMessageTarget } from '@/components/assistant-ui/thread/types'
 import { useMessageReactions } from '@/components/assistant-ui/thread/use-message-reactions'
 import { UserMessageText } from '@/components/assistant-ui/thread/user-message-text'
@@ -275,6 +276,7 @@ export const UserMessage: FC<{
         }
         messageId={messageId}
       >
+        <QuoteSelectionContextMenu>
         <ActionBarPrimitive.Root className="relative w-full max-w-full" data-slot="aui_user-bubble-actions">
           <div className="human-message-with-todos-wrapper flex w-full flex-col gap-0">
             <ReactionPicker
@@ -292,7 +294,7 @@ export const UserMessage: FC<{
                   readOnly || !reactionsEnabled
                     ? undefined
                     : event => {
-                        if (hasTextSelection()) {
+                        if (selectedTextWithin(event.currentTarget)) {
                           return
                         }
 
@@ -432,6 +434,7 @@ export const UserMessage: FC<{
             </BranchPickerPrimitive.Root>
           </div>
         </ActionBarPrimitive.Root>
+        </QuoteSelectionContextMenu>
       </StickyHumanMessageContainer>
     </MessagePrimitive.Root>
   )

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -4,6 +4,7 @@ import { type FC, type ReactNode, useCallback, useEffect, useRef, useState } fro
 import { DirectiveContent } from '@/components/assistant-ui/directive-text'
 import { messageAttachmentRefs, messageContentText } from '@/components/assistant-ui/thread/content'
 import { ReactionBadge, ReactionPicker } from '@/components/assistant-ui/thread/message-reactions'
+import { QuoteSelectionContextMenu, selectedTextWithin } from '@/components/assistant-ui/thread/quote-selection'
 import { MessageTimelineTimestamp } from '@/components/assistant-ui/thread/timeline-timestamp'
 import { type RestoreMessageTarget } from '@/components/assistant-ui/thread/types'
 import { useMessageReactions } from '@/components/assistant-ui/thread/use-message-reactions'
@@ -443,6 +444,7 @@ export const UserMessage: FC<{
         }
         messageId={messageId}
       >
+        <QuoteSelectionContextMenu>
         <ActionBarPrimitive.Root className="relative w-full max-w-full" data-slot="aui_user-bubble-actions">
           <div className="human-message-with-todos-wrapper flex w-full flex-col gap-0">
             <ReactionPicker
@@ -460,7 +462,7 @@ export const UserMessage: FC<{
                   readOnly || !reactionsEnabled
                     ? undefined
                     : event => {
-                        if (hasTextSelection()) {
+                        if (selectedTextWithin(event.currentTarget)) {
                           return
                         }
 
@@ -600,6 +602,7 @@ export const UserMessage: FC<{
             </BranchPickerPrimitive.Root>
           </div>
         </ActionBarPrimitive.Root>
+        </QuoteSelectionContextMenu>
       </StickyHumanMessageContainer>
     </MessagePrimitive.Root>
   )

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2292,6 +2292,7 @@ export const ar = defineLocale({
       moreActions: 'إجراءات إضافية',
       branchNewChat: 'تفريع إلى محادثة جديدة',
       react: 'تفاعل',
+      quoteInNewMessage: 'اقتباس في رسالة جديدة',
       dismissError: 'تجاهل الخطأ',
       filesChanged: count => `${count} ملفات تم تغييرها`,
       reviewChanges: 'مراجعة',

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2357,6 +2357,7 @@ export const ar = defineLocale({
       moreActions: 'إجراءات إضافية',
       branchNewChat: 'تفريع إلى محادثة جديدة',
       react: 'تفاعل',
+      quoteInNewMessage: 'اقتباس في رسالة جديدة',
       dismissError: 'تجاهل الخطأ',
       filesChanged: count => `${count} ملفات تم تغييرها`,
       reviewChanges: 'مراجعة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2732,6 +2732,7 @@ export const en: Translations = {
       moreActions: 'More actions',
       branchNewChat: 'Branch in new chat',
       react: 'React',
+      quoteInNewMessage: 'Quote in new message',
       dismissError: 'Dismiss error',
       filesChanged: count => (count === 1 ? '1 file changed' : `${count} files changed`),
       reviewChanges: 'Review',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2946,6 +2946,7 @@ export const en: Translations = {
       moreActions: 'More actions',
       branchNewChat: 'Branch in new chat',
       react: 'React',
+      quoteInNewMessage: 'Quote in new message',
       dismissError: 'Dismiss error',
       filesChanged: count => (count === 1 ? '1 file changed' : `${count} files changed`),
       reviewChanges: 'Review',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2553,6 +2553,7 @@ export const ja = defineLocale({
       moreActions: 'その他のアクション',
       branchNewChat: '新しいチャットでブランチ',
       react: 'リアクション',
+      quoteInNewMessage: '新しいメッセージに引用',
       dismissError: 'エラーを閉じる',
       filesChanged: count => `${count} 件のファイルを変更`,
       reviewChanges: 'レビュー',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2647,6 +2647,7 @@ export const ja = defineLocale({
       moreActions: 'その他のアクション',
       branchNewChat: '新しいチャットでブランチ',
       react: 'リアクション',
+      quoteInNewMessage: '新しいメッセージに引用',
       dismissError: 'エラーを閉じる',
       filesChanged: count => `${count} 件のファイルを変更`,
       reviewChanges: 'レビュー',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2324,6 +2324,7 @@ export interface Translations {
       moreActions: string
       branchNewChat: string
       react: string
+      quoteInNewMessage: string
       dismissError: string
       filesChanged: (count: number) => string
       reviewChanges: string

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2519,6 +2519,7 @@ export interface Translations {
       moreActions: string
       branchNewChat: string
       react: string
+      quoteInNewMessage: string
       dismissError: string
       filesChanged: (count: number) => string
       reviewChanges: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2471,6 +2471,7 @@ export const zhHant = defineLocale({
       moreActions: '更多動作',
       branchNewChat: '在新聊天中分支',
       react: '回應',
+      quoteInNewMessage: '在新訊息中引用',
       dismissError: '关闭错误',
       filesChanged: count => `${count} 個檔案已變更`,
       reviewChanges: '檢視',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2558,6 +2558,7 @@ export const zhHant = defineLocale({
       moreActions: '更多動作',
       branchNewChat: '在新聊天中分支',
       react: '回應',
+      quoteInNewMessage: '在新訊息中引用',
       dismissError: '关闭错误',
       filesChanged: count => `${count} 個檔案已變更`,
       reviewChanges: '檢視',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2908,6 +2908,7 @@ export const zh: Translations = {
       moreActions: '更多操作',
       branchNewChat: '在新对话中分支',
       react: '回应',
+      quoteInNewMessage: '在新消息中引用',
       dismissError: '关闭错误',
       filesChanged: count => `${count} 个文件已更改`,
       reviewChanges: '查看',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3111,6 +3111,7 @@ export const zh: Translations = {
       moreActions: '更多操作',
       branchNewChat: '在新对话中分支',
       react: '回应',
+      quoteInNewMessage: '在新消息中引用',
       dismissError: '关闭错误',
       filesChanged: count => `${count} 个文件已更改`,
       reviewChanges: '查看',


### PR DESCRIPTION
## Summary

- add a selection-aware context menu to Desktop conversation messages
- format selected text as Markdown blockquotes
- insert the quote into the active composer through the existing focus bus
- add localized menu text and focused helper/component tests

## Validation

- Prettier and `git diff --check` passed
- Vitest, typecheck, and ESLint require workspace dependencies that are unavailable in this checkout

Closes #73138
