### PR TITLE
fix(cron): treat localhost ≡ 127.0.0.1 for base_url host match

### DIFF
--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -327,6 +327,22 @@ class TestGuardJobCredentialExfil:
         assert "blocked for safety" in str(exc.value)
 
 
+
+    def test_named_custom_loopback_alias_is_allowed(self, monkeypatch):
+        """localhost and 127.0.0.1 are the same loopback host for cron guards."""
+        import hermes_cli.runtime_provider as rp
+        from cron.scheduler import _guard_job_credential_exfil
+
+        monkeypatch.setattr(rp, "has_named_custom_provider", lambda n: True)
+        monkeypatch.setattr(
+            rp, "_get_named_custom_provider",
+            lambda n: {"name": "ollama-local", "base_url": "http://127.0.0.1:11434/v1",
+                       "api_key": "ollama"},
+        )
+        job = {"id": "j-loopback", "provider": "ollama-local",
+               "base_url": "http://localhost:11434/v1"}
+        assert _guard_job_credential_exfil(job) is None
+
     def test_bare_custom_is_allowed(self):
         from cron.scheduler import _guard_job_credential_exfil
 

--- a/tests/test_base_url_hostname.py
+++ b/tests/test_base_url_hostname.py
@@ -118,3 +118,19 @@ class TestOllamaUrlHostCheck:
             "https://ollama.com/api/generate", "ollama.com"
         ) is True
 
+
+
+def test_loopback_aliases_match_each_other():
+    from utils import base_url_host_matches
+
+    assert base_url_host_matches("http://localhost:11434/v1", "127.0.0.1")
+    assert base_url_host_matches("http://127.0.0.1:11434/v1", "localhost")
+    assert base_url_host_matches("http://[::1]:11434/v1", "127.0.0.1")
+    assert base_url_host_matches("http://0.0.0.0:11434/v1", "localhost")
+
+
+def test_loopback_does_not_match_offhost():
+    from utils import base_url_host_matches
+
+    assert not base_url_host_matches("http://localhost:11434/v1", "evil.example")
+    assert not base_url_host_matches("https://evil.example/v1", "127.0.0.1")

--- a/utils.py
+++ b/utils.py
@@ -601,6 +601,11 @@ def model_forces_max_completion_tokens(model: str) -> bool:
     )
 
 
+def _loopback_hostnames() -> frozenset[str]:
+    """Hostnames that all refer to the local machine loopback interface."""
+    return frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0"})
+
+
 def base_url_host_matches(base_url: str, domain: str) -> bool:
     """Return True when the base URL's hostname is ``domain`` or a subdomain.
 
@@ -608,10 +613,17 @@ def base_url_host_matches(base_url: str, domain: str) -> bool:
     false-positive class documented on ``base_url_hostname``. Accepts bare
     hosts, full URLs, and URLs with paths.
 
+    Loopback aliases are treated as equivalent (``localhost`` ≡ ``127.0.0.1``
+    ≡ ``::1`` ≡ ``0.0.0.0``), so a cron job override of
+    ``http://localhost:11434/v1`` matches a named custom provider configured
+    at ``http://127.0.0.1:11434/v1`` without weakening the off-host credential
+    exfil guard.
+
         base_url_host_matches("https://api.moonshot.ai/v1", "moonshot.ai") == True
         base_url_host_matches("https://moonshot.ai", "moonshot.ai")        == True
         base_url_host_matches("https://evil.com/moonshot.ai/v1", "moonshot.ai") == False
         base_url_host_matches("https://moonshot.ai.evil/v1", "moonshot.ai")     == False
+        base_url_host_matches("http://localhost:11434/v1", "127.0.0.1")    == True
     """
     hostname = base_url_hostname(base_url)
     if not hostname:
@@ -619,4 +631,7 @@ def base_url_host_matches(base_url: str, domain: str) -> bool:
     domain = (domain or "").strip().lower().rstrip(".")
     if not domain:
         return False
+    loopback = _loopback_hostnames()
+    if hostname in loopback and domain in loopback:
+        return True
     return hostname == domain or hostname.endswith("." + domain)


### PR DESCRIPTION
## Summary
- Cron credential-exfil guard compares job `base_url` hostname to a named custom provider's configured endpoint via `base_url_host_matches`.
- `localhost` and `127.0.0.1` (plus `::1` / `0.0.0.0`) are the same loopback interface, but exact string match treated them as different — blocking safe local Ollama jobs that store one form and override with the other.
- Treat loopback aliases as equivalent; off-host overrides remain refused.

Fixes #73694

## Test plan
- [x] Added unit tests for loopback alias equivalence / off-host refusal
- [x] Added cron `_guard_job_credential_exfil` regression for `ollama-local` @ `127.0.0.1` + job `localhost`
- [ ] CI green