### PR TITLE
feat(desktop): auto-format numbered lists in composer

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -66,9 +66,11 @@ import {
   composerPlainText,
   deleteChipBeforeCaret,
   deleteSelectionInEditor,
+  handleNumberedListKey,
   insertComposerContentsAtCaret,
   normalizeComposerEditorDom,
-  RICH_INPUT_SLOT
+  RICH_INPUT_SLOT,
+  type NumberedListKey
 } from './rich-editor'
 import { useComposerScope } from './scope'
 import { ComposerStatusStack } from './status-stack'
@@ -746,6 +748,25 @@ export function ChatBar({
 
         return
       }
+    }
+
+    const plainKey = !event.metaKey && !event.ctrlKey && !event.altKey
+    const numberedListKey: NumberedListKey | null =
+      event.key === 'Enter' && event.shiftKey
+        ? 'Enter'
+        : !event.shiftKey && (event.key === 'Backspace' || event.key === 'Tab')
+          ? (event.key as NumberedListKey)
+          : null
+
+    if (
+      plainKey &&
+      numberedListKey &&
+      withUndoPoint(() => handleNumberedListKey(event.currentTarget, numberedListKey))
+    ) {
+      event.preventDefault()
+      flushEditorToDraft(event.currentTarget)
+
+      return
     }
 
     // ArrowUp/ArrowDown navigate, in priority order: the queue (edit entries in

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -62,9 +62,11 @@ import {
   composerPlainText,
   deleteChipBeforeCaret,
   deleteSelectionInEditor,
+  handleNumberedListKey,
   insertComposerContentsAtCaret,
   normalizeComposerEditorDom,
-  RICH_INPUT_SLOT
+  RICH_INPUT_SLOT,
+  type NumberedListKey
 } from './rich-editor'
 import { useComposerScope } from './scope'
 import { ComposerStatusStack } from './status-stack'
@@ -676,6 +678,25 @@ export function ChatBar({
 
         return
       }
+    }
+
+    const plainKey = !event.metaKey && !event.ctrlKey && !event.altKey
+    const numberedListKey: NumberedListKey | null =
+      event.key === 'Enter' && event.shiftKey
+        ? 'Enter'
+        : !event.shiftKey && (event.key === 'Backspace' || event.key === 'Tab')
+          ? (event.key as NumberedListKey)
+          : null
+
+    if (
+      plainKey &&
+      numberedListKey &&
+      withUndoPoint(() => handleNumberedListKey(event.currentTarget, numberedListKey))
+    ) {
+      event.preventDefault()
+      flushEditorToDraft(event.currentTarget)
+
+      return
     }
 
     // ArrowUp/ArrowDown navigate, in priority order: the queue (edit entries in

--- a/apps/desktop/src/app/chat/composer/rich-editor.test.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, it } from 'vitest'
 
 import { insertInlineRefsIntoEditor } from './inline-refs'
 import {
+  caretOffsetInEditor,
   composerPlainText,
   deleteSelectionInEditor,
+  handleNumberedListKey,
   insertComposerContentsAtCaret,
   normalizeComposerEditorDom,
+  placeCaretAtOffset,
   refChipElement,
   renderComposerContents,
   replaceBeforeCaret,
@@ -353,6 +356,72 @@ describe('replaceBeforeCaret', () => {
 
     expect(replaceBeforeCaret(editor, 20, fragment)).toBe(false)
     expect(composerPlainText(editor)).toBe('hi')
+
+    editor.remove()
+  })
+})
+
+describe('handleNumberedListKey', () => {
+  const editorWithCaret = (text: string) => {
+    const editor = document.createElement('div')
+    editor.dataset.slot = RICH_INPUT_SLOT
+    document.body.append(editor)
+    renderComposerContents(editor, text)
+    caretIn(editor)
+
+    return editor
+  }
+
+  it('continues a numbered item and exits on a second blank marker', () => {
+    const editor = editorWithCaret('1. first')
+
+    expect(handleNumberedListKey(editor, 'Enter')).toBe(true)
+    expect(composerPlainText(editor)).toBe('1. first\n2. ')
+    expect(caretOffsetInEditor(editor)).toBe('1. first\n2. '.length)
+
+    expect(handleNumberedListKey(editor, 'Enter')).toBe(true)
+    expect(composerPlainText(editor)).toBe('1. first\n\n')
+    expect(caretOffsetInEditor(editor)).toBe('1. first\n\n'.length)
+
+    editor.remove()
+  })
+
+  it('clears a blank marker with Backspace', () => {
+    const editor = editorWithCaret('1. first\n2. ')
+
+    expect(handleNumberedListKey(editor, 'Backspace')).toBe(true)
+    expect(composerPlainText(editor)).toBe('1. first\n')
+    expect(caretOffsetInEditor(editor)).toBe('1. first\n'.length)
+
+    editor.remove()
+  })
+
+  it('keeps one paragraph gap when the blank marker precedes text', () => {
+    const editor = editorWithCaret('1. first\n2. \nnext')
+
+    expect(handleNumberedListKey(editor, 'Enter')).toBe(true)
+    expect(composerPlainText(editor)).toBe('1. first\n\nnext')
+    expect(caretOffsetInEditor(editor)).toBe('1. first\n\n'.length)
+
+    editor.remove()
+  })
+
+  it('converts a blank marker into an indented sub-bullet with Tab', () => {
+    const editor = editorWithCaret('1. first\n2. ')
+
+    expect(handleNumberedListKey(editor, 'Tab')).toBe(true)
+    expect(composerPlainText(editor)).toBe('1. first\n   - ')
+    expect(caretOffsetInEditor(editor)).toBe('1. first\n   - '.length)
+
+    editor.remove()
+  })
+
+  it('leaves non-terminal numbered lines alone', () => {
+    const editor = editorWithCaret('1. first')
+    placeCaretAtOffset(editor, 3)
+
+    expect(handleNumberedListKey(editor, 'Enter')).toBe(false)
+    expect(composerPlainText(editor)).toBe('1. first')
 
     editor.remove()
   })

--- a/apps/desktop/src/app/chat/composer/rich-editor.test.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.test.ts
@@ -362,12 +362,16 @@ describe('replaceBeforeCaret', () => {
 })
 
 describe('handleNumberedListKey', () => {
-  const editorWithCaret = (text: string) => {
+  const editorWithCaret = (text: string, caretOffset?: number) => {
     const editor = document.createElement('div')
     editor.dataset.slot = RICH_INPUT_SLOT
     document.body.append(editor)
     renderComposerContents(editor, text)
-    caretIn(editor)
+    if (caretOffset === undefined) {
+      caretIn(editor)
+    } else {
+      placeCaretAtOffset(editor, caretOffset)
+    }
 
     return editor
   }
@@ -397,7 +401,7 @@ describe('handleNumberedListKey', () => {
   })
 
   it('keeps one paragraph gap when the blank marker precedes text', () => {
-    const editor = editorWithCaret('1. first\n2. \nnext')
+    const editor = editorWithCaret('1. first\n2. \nnext', '1. first\n2. '.length)
 
     expect(handleNumberedListKey(editor, 'Enter')).toBe(true)
     expect(composerPlainText(editor)).toBe('1. first\n\nnext')

--- a/apps/desktop/src/app/chat/composer/rich-editor.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.ts
@@ -20,6 +20,68 @@ import { referenceKind, referenceRe } from '@/components/assistant-ui/reference-
 import { slashCommandMatches, type SlashCommandScanOptions } from './slash-refs'
 
 export const RICH_INPUT_SLOT = 'composer-rich-input'
+export type NumberedListKey = 'Enter' | 'Backspace' | 'Tab'
+const NUMBERED_LIST_LINE_RE = /^([ \t]*)(\d+)\. (.*)$/
+// numbered list helpers
+export function handleNumberedListKey(editor: HTMLElement, key: NumberedListKey): boolean {
+  const hit = composerSelectionRange(editor)
+
+  if (!hit?.range.collapsed) {
+    return false
+  }
+
+  const text = composerPlainText(editor)
+  const caret = caretOffsetInEditor(editor)
+  const lineStart = text.lastIndexOf('\n', caret - 1) + 1
+  const lineEndIndex = text.indexOf('\n', caret)
+  const lineEnd = lineEndIndex === -1 ? text.length : lineEndIndex
+
+  if (caret !== lineEnd) {
+    return false
+  }
+
+  const match = NUMBERED_LIST_LINE_RE.exec(text.slice(lineStart, lineEnd))
+
+  if (!match) {
+    return false
+  }
+
+  const indent = match[1] || ''
+  const content = match[3] || ''
+  const blankMarker = content.trim() === ''
+  let nextText: string
+  let nextCaret: number
+
+  if (key === 'Enter') {
+    if (blankMarker) {
+      const prefix = text.slice(0, lineStart)
+      const suffix = text.slice(lineEnd)
+
+      // A non-terminal line already has its separator in `suffix`; adding
+      // another one would create two blank lines before the following text.
+      nextText = lineEndIndex === -1 ? `${prefix}\n${suffix}` : `${prefix}${suffix}`
+      nextCaret = lineStart + 1
+    } else {
+      const nextMarker = `${indent}${Number(match[2]) + 1}. `
+      nextText = `${text.slice(0, caret)}\n${nextMarker}${text.slice(caret)}`
+      nextCaret = caret + nextMarker.length + 1
+    }
+  } else if (blankMarker && key === 'Backspace') {
+    nextText = text.slice(0, lineStart) + text.slice(lineEnd)
+    nextCaret = lineStart
+  } else if (blankMarker && key === 'Tab') {
+    const subBullet = `${indent}${' '.repeat(match[2]!.length + 2)}- `
+    nextText = `${text.slice(0, lineStart)}${subBullet}${text.slice(lineEnd)}`
+    nextCaret = lineStart + subBullet.length
+  } else {
+    return false
+  }
+
+  renderComposerContents(editor, nextText)
+  placeCaretAtOffset(editor, nextCaret)
+
+  return true
+}
 
 /** Chromium's litter: editing beside a `contenteditable=false` chip splits the
  *  line and leaves zero-length text nodes behind. They render as nothing and


### PR DESCRIPTION
## Summary

- continue numbered Markdown lists when pressing Enter
- exit a list on a blank marker
- make Backspace remove a blank marker and Tab create an indented sub-bullet
- preserve the caret and integrate edits with composer undo/draft state
- add focused rich-editor regression tests

## Validation

- `git diff --check`
- Prettier check passed
- Vitest and ESLint require workspace dependencies that are unavailable in this checkout

Closes #73025