### PR TITLE
fix(gateway): attach observed group images to the next addressed turn

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16967,6 +16967,49 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if transcript.strip()
         )
 
+    async def _history_with_observed_tail(
+        self, history: List[Dict[str, Any]], source
+    ) -> List[Dict[str, Any]]:
+        """Append the persisted trailing observed rows to an agent message list.
+
+        ``_build_gateway_agent_history`` lifts observed group rows out of the
+        replayed history into the text-only context prefix, so the agent's
+        returned ``messages`` never contain them.  The queued-follow-up path
+        reuses that list as history, which means a photo observed *while the
+        previous turn was running* would be invisible when the follow-up is
+        prepared — the idle path handles it, the queued path did not (#47415).
+
+        Re-read the persisted tail so both paths see the same observed rows.
+        Best-effort: any store failure returns the history unchanged rather
+        than dropping a queued turn.
+        """
+        if source is None:
+            return history
+        try:
+            store = self.async_session_store
+            session_entry = await store.get_or_create_session(source)
+            persisted = await store.load_transcript(session_entry.session_id)
+        except Exception:
+            logger.debug(
+                "Observed-tail reload failed for queued follow-up; using agent history",
+                exc_info=True,
+            )
+            return history
+
+        tail: List[Dict[str, Any]] = []
+        for msg in reversed(persisted or []):
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("role") in {"session_meta", "system"}:
+                continue
+            if not msg.get("observed"):
+                break
+            tail.append(msg)
+        if not tail:
+            return history
+        tail.reverse()
+        return list(history) + tail
+
     def _consume_pending_native_image_paths(self, session_key: str) -> List[str]:
         state = self._peek_session_state(session_key)
         if state is None or not state.persistent.native_image_paths:
@@ -26920,7 +26963,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     next_message = await self._prepare_profile_scoped_inbound_message_text(
                         event=pending_event,
                         source=next_source,
-                        history=updated_history,
+                        history=await self._history_with_observed_tail(
+                            updated_history, next_source
+                        ),
                         session_key=next_session_key,
                     )
                     if next_message is None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1496,6 +1496,62 @@ def _select_cached_agent_history(
     return persisted_history
 
 
+# Cap on cached observed-group images re-attached to a later addressed turn.
+# Observed context accumulates for the whole session, so without a bound a busy
+# group would re-upload every photo it has ever seen on every single reply.
+_MAX_OBSERVED_IMAGE_ATTACHMENTS = 4
+
+
+def _collect_observed_image_paths(
+    history: Optional[List[Dict[str, Any]]],
+    limit: int = _MAX_OBSERVED_IMAGE_ATTACHMENTS,
+) -> List[str]:
+    """Cached image paths from the *trailing* observed rows, oldest first.
+
+    Scoped to observed chatter that arrived since the last real exchange, so a
+    photo is attached on the turn that follows it and not re-uploaded on every
+    later reply — the text note continues to carry it in context after that.
+
+    Only rows written by the observe path carry ``media_urls``; transcripts
+    written before that field existed yield nothing and keep their text note,
+    so this is a no-op on existing sessions.
+    """
+    from agent.image_routing import _IMAGE_EXTS
+
+    trailing: List[Dict[str, Any]] = []
+    for msg in reversed(history or []):
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if role in {"session_meta", "system"}:
+            continue
+        if not msg.get("observed"):
+            break
+        trailing.append(msg)
+    trailing.reverse()
+
+    paths: List[str] = []
+    for msg in trailing:
+        if msg.get("role") != "user":
+            continue
+        urls = msg.get("media_urls") or []
+        types = msg.get("media_types") or []
+        for i, path in enumerate(urls):
+            if not path:
+                continue
+            # Trust the recorded MIME; fall back to the extension only when the
+            # observe path could not determine one, mirroring
+            # ``_event_media_is_image`` for live events.
+            mime = str(types[i]) if i < len(types) else ""
+            if mime:
+                if not mime.startswith("image/"):
+                    continue
+            elif not str(path).lower().endswith(_IMAGE_EXTS):
+                continue
+            paths.append(str(path))
+    return paths[-limit:] if limit and len(paths) > limit else paths
+
+
 def _wrap_current_message_with_observed_context(message: Any, observed_context: Optional[str]) -> Any:
     """Prepend observed Telegram context to the API-only current user turn."""
 
@@ -16533,10 +16589,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         audio_file_paths: list[str] = []
         video_paths: list[str] = []
 
-        if event.media_urls:
-            image_paths = []
+        # Photos sent to a group without an @mention are cached at observe
+        # time but persisted as a text note only, so a later addressed turn
+        # ("what was in that image?") had nothing to look at while the same
+        # photo re-sent *with* a mention worked (#47415).  Re-attach the most
+        # recent cached observed images so both paths reach the model alike.
+        observed_image_paths = _collect_observed_image_paths(history)
+
+        if event.media_urls or observed_image_paths:
+            image_paths = list(observed_image_paths)
             audio_paths = []
-            for i, path in enumerate(event.media_urls):
+            for i, path in enumerate(event.media_urls or []):
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
                 # Classify images per-attachment: trust this attachment's own
                 # MIME, and only honour the message-level PHOTO type when the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15506,6 +15506,49 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if transcript.strip()
         )
 
+    async def _history_with_observed_tail(
+        self, history: List[Dict[str, Any]], source
+    ) -> List[Dict[str, Any]]:
+        """Append the persisted trailing observed rows to an agent message list.
+
+        ``_build_gateway_agent_history`` lifts observed group rows out of the
+        replayed history into the text-only context prefix, so the agent's
+        returned ``messages`` never contain them.  The queued-follow-up path
+        reuses that list as history, which means a photo observed *while the
+        previous turn was running* would be invisible when the follow-up is
+        prepared — the idle path handles it, the queued path did not (#47415).
+
+        Re-read the persisted tail so both paths see the same observed rows.
+        Best-effort: any store failure returns the history unchanged rather
+        than dropping a queued turn.
+        """
+        if source is None:
+            return history
+        try:
+            store = self.async_session_store
+            session_entry = await store.get_or_create_session(source)
+            persisted = await store.load_transcript(session_entry.session_id)
+        except Exception:
+            logger.debug(
+                "Observed-tail reload failed for queued follow-up; using agent history",
+                exc_info=True,
+            )
+            return history
+
+        tail: List[Dict[str, Any]] = []
+        for msg in reversed(persisted or []):
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("role") in {"session_meta", "system"}:
+                continue
+            if not msg.get("observed"):
+                break
+            tail.append(msg)
+        if not tail:
+            return history
+        tail.reverse()
+        return list(history) + tail
+
     def _consume_pending_native_image_paths(self, session_key: str) -> List[str]:
         state = self._peek_session_state(session_key)
         if state is None or not state.persistent.native_image_paths:
@@ -24485,7 +24528,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     next_message = await self._prepare_profile_scoped_inbound_message_text(
                         event=pending_event,
                         source=next_source,
-                        history=updated_history,
+                        history=await self._history_with_observed_tail(
+                            updated_history, next_source
+                        ),
                         session_key=next_session_key,
                     )
                     if next_message is None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1281,6 +1281,62 @@ def _select_cached_agent_history(
     return persisted_history
 
 
+# Cap on cached observed-group images re-attached to a later addressed turn.
+# Observed context accumulates for the whole session, so without a bound a busy
+# group would re-upload every photo it has ever seen on every single reply.
+_MAX_OBSERVED_IMAGE_ATTACHMENTS = 4
+
+
+def _collect_observed_image_paths(
+    history: Optional[List[Dict[str, Any]]],
+    limit: int = _MAX_OBSERVED_IMAGE_ATTACHMENTS,
+) -> List[str]:
+    """Cached image paths from the *trailing* observed rows, oldest first.
+
+    Scoped to observed chatter that arrived since the last real exchange, so a
+    photo is attached on the turn that follows it and not re-uploaded on every
+    later reply — the text note continues to carry it in context after that.
+
+    Only rows written by the observe path carry ``media_urls``; transcripts
+    written before that field existed yield nothing and keep their text note,
+    so this is a no-op on existing sessions.
+    """
+    from agent.image_routing import _IMAGE_EXTS
+
+    trailing: List[Dict[str, Any]] = []
+    for msg in reversed(history or []):
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if role in {"session_meta", "system"}:
+            continue
+        if not msg.get("observed"):
+            break
+        trailing.append(msg)
+    trailing.reverse()
+
+    paths: List[str] = []
+    for msg in trailing:
+        if msg.get("role") != "user":
+            continue
+        urls = msg.get("media_urls") or []
+        types = msg.get("media_types") or []
+        for i, path in enumerate(urls):
+            if not path:
+                continue
+            # Trust the recorded MIME; fall back to the extension only when the
+            # observe path could not determine one, mirroring
+            # ``_event_media_is_image`` for live events.
+            mime = str(types[i]) if i < len(types) else ""
+            if mime:
+                if not mime.startswith("image/"):
+                    continue
+            elif not str(path).lower().endswith(_IMAGE_EXTS):
+                continue
+            paths.append(str(path))
+    return paths[-limit:] if limit and len(paths) > limit else paths
+
+
 def _wrap_current_message_with_observed_context(message: Any, observed_context: Optional[str]) -> Any:
     """Prepend observed Telegram context to the API-only current user turn."""
 
@@ -15072,10 +15128,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         audio_file_paths: list[str] = []
         video_paths: list[str] = []
 
-        if event.media_urls:
-            image_paths = []
+        # Photos sent to a group without an @mention are cached at observe
+        # time but persisted as a text note only, so a later addressed turn
+        # ("what was in that image?") had nothing to look at while the same
+        # photo re-sent *with* a mention worked (#47415).  Re-attach the most
+        # recent cached observed images so both paths reach the model alike.
+        observed_image_paths = _collect_observed_image_paths(history)
+
+        if event.media_urls or observed_image_paths:
+            image_paths = list(observed_image_paths)
             audio_paths = []
-            for i, path in enumerate(event.media_urls):
+            for i, path in enumerate(event.media_urls or []):
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
                 # Classify images per-attachment: trust this attachment's own
                 # MIME, and only honour the message-level PHOTO type when the

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8502,6 +8502,14 @@ class TelegramAdapter(BasePlatformAdapter):
             }
             if event.message_id:
                 entry["message_id"] = str(event.message_id)
+            # Record cached attachment paths structurally, not just as the
+            # text note ``_cache_observed_media`` appends.  The note tells the
+            # model a file existed; only these let the gateway re-attach the
+            # image on a later addressed turn (#47415).  Omitted entirely for
+            # plain chatter so text-only rows keep their existing shape.
+            if event.media_urls:
+                entry["media_urls"] = list(event.media_urls)
+                entry["media_types"] = list(event.media_types or [])
             store.append_to_transcript(session_entry.session_id, entry)
             adapter_name = getattr(self, "name", "telegram")
             logger.info(

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8745,6 +8745,14 @@ class TelegramAdapter(BasePlatformAdapter):
             }
             if event.message_id:
                 entry["message_id"] = str(event.message_id)
+            # Record cached attachment paths structurally, not just as the
+            # text note ``_cache_observed_media`` appends.  The note tells the
+            # model a file existed; only these let the gateway re-attach the
+            # image on a later addressed turn (#47415).  Omitted entirely for
+            # plain chatter so text-only rows keep their existing shape.
+            if event.media_urls:
+                entry["media_urls"] = list(event.media_urls)
+                entry["media_types"] = list(event.media_types or [])
             store.append_to_transcript(session_entry.session_id, entry)
             adapter_name = getattr(self, "name", "telegram")
             logger.info(

--- a/tests/gateway/test_observed_group_image_attachment.py
+++ b/tests/gateway/test_observed_group_image_attachment.py
@@ -1,0 +1,192 @@
+"""Observed (unmentioned) group images must reach the model on a later turn.
+
+Regression coverage for the asymmetry reported in #47415: the @mention path
+dispatches with ``media_urls`` and the model sees the photo natively, while the
+observed path only ever persisted a text note pointing at the cached file.  A
+follow-up "what was in that image?" therefore had no image to look at.
+"""
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+
+
+def _make_runner() -> GatewayRunner:
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+    )
+    runner.adapters = {}
+    runner._model = "openai/gpt-4.1-mini"
+    runner._base_url = None
+    runner._decide_image_input_mode = lambda **_: "native"
+    return runner
+
+
+def _group_source(chat_id: str = "group-1") -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        chat_type="group",
+        user_name="alice",
+    )
+
+
+def _observed_row(path: str, *, mime: str = "image/png") -> dict:
+    return {
+        "role": "user",
+        "observed": True,
+        "content": (
+            "[Alice Example|111]\nveja esta foto\n\n"
+            f"[image 'observed.png' saved at: {path}]"
+        ),
+        "media_urls": [path],
+        "media_types": [mime],
+    }
+
+
+@pytest.mark.asyncio
+async def test_observed_group_image_is_attached_to_next_addressed_turn():
+    """An addressed turn carrying no media of its own still sees the observed photo."""
+    runner = _make_runner()
+    source = _group_source()
+
+    await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="@bot what was in that image?", source=source),
+        source=source,
+        history=[_observed_row("/tmp/observed.png")],
+    )
+
+    assert runner._consume_pending_native_image_paths(build_session_key(source)) == [
+        "/tmp/observed.png"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_observed_image_precedes_current_turn_image():
+    """Observed history attaches before the current message's own attachment."""
+    runner = _make_runner()
+    source = _group_source()
+
+    await runner._prepare_inbound_message_text(
+        event=MessageEvent(
+            text="@bot compare this with the earlier one",
+            message_type=MessageType.PHOTO,
+            source=source,
+            media_urls=["/tmp/current.png"],
+            media_types=["image/png"],
+        ),
+        source=source,
+        history=[_observed_row("/tmp/observed.png")],
+    )
+
+    assert runner._consume_pending_native_image_paths(build_session_key(source)) == [
+        "/tmp/observed.png",
+        "/tmp/current.png",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_observed_non_image_media_is_not_attached():
+    """Only images are attachable; observed documents stay as their text note."""
+    runner = _make_runner()
+    source = _group_source()
+
+    await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="@bot anything useful there?", source=source),
+        source=source,
+        history=[_observed_row("/tmp/observed.pdf", mime="application/pdf")],
+    )
+
+    assert runner._consume_pending_native_image_paths(build_session_key(source)) == []
+
+
+@pytest.mark.asyncio
+async def test_observed_images_are_capped_to_most_recent():
+    """A busy group must not replay every cached photo on every addressed turn."""
+    runner = _make_runner()
+    source = _group_source()
+    history = [_observed_row(f"/tmp/observed-{i}.png") for i in range(10)]
+
+    await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="@bot what did you see?", source=source),
+        source=source,
+        history=history,
+    )
+
+    attached = runner._consume_pending_native_image_paths(build_session_key(source))
+    assert attached == [
+        "/tmp/observed-6.png",
+        "/tmp/observed-7.png",
+        "/tmp/observed-8.png",
+        "/tmp/observed-9.png",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_observed_image_is_not_reattached_after_an_addressed_exchange():
+    """Attach on the turn that follows the photo, not on every later reply.
+
+    Re-uploading the same pixels on every subsequent group message would put
+    vision cost on the whole conversation; the text note keeps carrying it.
+    """
+    runner = _make_runner()
+    source = _group_source()
+    history = [
+        _observed_row("/tmp/observed.png"),
+        {"role": "user", "content": "@bot what was in that image?"},
+        {"role": "assistant", "content": "A desk sheet."},
+    ]
+
+    await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="@bot thanks, and what about the totals?", source=source),
+        source=source,
+        history=history,
+    )
+
+    assert runner._consume_pending_native_image_paths(build_session_key(source)) == []
+
+
+@pytest.mark.asyncio
+async def test_observed_image_after_an_exchange_is_attached_again():
+    """A freshly observed photo still attaches even with older turns behind it."""
+    runner = _make_runner()
+    source = _group_source()
+    history = [
+        {"role": "user", "content": "@bot hello"},
+        {"role": "assistant", "content": "Hi!"},
+        _observed_row("/tmp/newer.png"),
+    ]
+
+    await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="@bot what did Alice just post?", source=source),
+        source=source,
+        history=history,
+    )
+
+    assert runner._consume_pending_native_image_paths(build_session_key(source)) == [
+        "/tmp/newer.png"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_legacy_observed_rows_without_media_urls_attach_nothing():
+    """Transcripts written before this fix carry only the text note — no crash."""
+    runner = _make_runner()
+    source = _group_source()
+    legacy = {
+        "role": "user",
+        "observed": True,
+        "content": "[Alice Example|111]\nveja esta foto\n\n[image 'observed.png' saved at: /tmp/old.png]",
+    }
+
+    await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="@bot what was in that image?", source=source),
+        source=source,
+        history=[legacy],
+    )
+
+    assert runner._consume_pending_native_image_paths(build_session_key(source)) == []

--- a/tests/gateway/test_queued_observed_image_attachment.py
+++ b/tests/gateway/test_queued_observed_image_attachment.py
@@ -1,0 +1,182 @@
+"""Observed photos must survive the queued-follow-up path too (#47415).
+
+`_build_gateway_agent_history` lifts observed group rows out of the replayed
+history into a text-only context prefix, so `result["messages"]` — what the
+queued path reuses as history — never contains them.  A photo observed while a
+previous turn was still running would therefore be invisible when the queued
+`@bot` follow-up is prepared, even though the idle path handles it.
+"""
+
+import base64
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.session import SessionSource
+
+
+_ONE_BY_ONE_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO6L2ioAAAAASUVORK5CYII="
+)
+
+
+class CaptureAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+        self.sent = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append({"chat_id": chat_id, "content": content})
+        return SendResult(success=True, message_id="sent-1")
+
+    async def send_typing(self, chat_id, metadata=None) -> None:
+        return None
+
+    async def stop_typing(self, chat_id) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+
+class CaptureAgent:
+    calls = []
+
+    def __init__(self, **kwargs):
+        self.tools = []
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        type(self).calls.append(message)
+        # The agent returns its own message list, which never carries observed
+        # rows — this is the condition that loses the photo.
+        return {
+            "final_response": f"done-{len(type(self).calls)}",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class _FakeAsyncStore:
+    """Minimal async session store exposing the persisted observed transcript."""
+
+    def __init__(self, transcript):
+        self._transcript = transcript
+
+    async def get_or_create_session(self, source):
+        return SimpleNamespace(session_id="sess-observed")
+
+    async def load_transcript(self, session_id):
+        return list(self._transcript)
+
+
+def _make_runner(adapter):
+    gateway_run = importlib.import_module("gateway.run")
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {adapter.platform: adapter}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._session_run_generation = {}
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(
+        thread_sessions_per_user=False,
+        group_sessions_per_user=False,
+        stt_enabled=False,
+    )
+    runner._model = "openai/gpt-4.1-mini"
+    runner._base_url = None
+    runner._decide_image_input_mode = lambda **_kw: "native"
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_queued_followup_attaches_photo_observed_during_previous_turn(monkeypatch, tmp_path):
+    CaptureAgent.calls = []
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = CaptureAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    observed_image = tmp_path / "observed.png"
+    observed_image.write_bytes(_ONE_BY_ONE_PNG)
+
+    # Persisted while the first turn was mid-flight: an unmentioned group photo.
+    transcript = [
+        {
+            "role": "user",
+            "observed": True,
+            "content": (
+                "[Alice Example|111]\nveja esta foto\n\n"
+                f"[image 'observed.png' saved at: {observed_image}]"
+            ),
+            "media_urls": [str(observed_image)],
+            "media_types": ["image/png"],
+        },
+    ]
+
+    adapter = CaptureAdapter()
+    runner = _make_runner(adapter)
+    # ``async_session_store`` is a read-only property that builds a facade over
+    # the real SessionStore; swap it for the fake transcript.
+    monkeypatch.setattr(
+        gateway_run.GatewayRunner,
+        "async_session_store",
+        property(lambda self: _FakeAsyncStore(transcript)),
+    )
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+    )
+
+    # The addressed follow-up carries no media of its own.
+    adapter._pending_messages["agent:main:telegram:group:-1001"] = MessageEvent(
+        text="@bot what was in that photo?",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="queued-1",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-observed",
+        session_key="agent:main:telegram:group:-1001",
+    )
+
+    assert result["final_response"] == "done-2"
+    assert len(CaptureAgent.calls) == 2
+
+    queued_message = CaptureAgent.calls[1]
+    assert isinstance(queued_message, list), (
+        "queued follow-up should be multimodal once the observed photo is attached"
+    )
+    assert any(part.get("type") == "image_url" for part in queued_message)

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -769,6 +769,54 @@ def _group_document_message(*, chat_id=-100, caption="Este arquivo", document=No
     )
 
 
+def test_unmentioned_photo_observed_entry_records_media_for_replay(monkeypatch, tmp_path):
+    """The cached image path is persisted structurally, not just in the note.
+
+    Without this the gateway can only replay the text note, so a later
+    addressed turn has no image to attach and the model asks for a re-send
+    (#47415).
+    """
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=True, allowed_chats=["-100"],
+            group_allowed_chats=["-100"], observe_unmentioned_group_messages=True,
+        )
+        store = _FakeSessionStore()
+        adapter._session_store = store
+        cached_path = tmp_path / "img_abc_observed.png"
+        monkeypatch.setattr(
+            "gateway.platforms.base.cache_image_from_bytes",
+            lambda _data, ext=".jpg": str(cached_path),
+        )
+        update = SimpleNamespace(update_id=3005, message=_group_photo_message(), effective_message=None)
+
+        await adapter._handle_media_message(update, SimpleNamespace())
+
+        _, message, _ = store.messages[0]
+        assert message["media_urls"] == [str(cached_path)]
+        assert message["media_types"] and message["media_types"][0].startswith("image/")
+
+    asyncio.run(_run())
+
+
+def test_unmentioned_text_observed_entry_has_no_media_keys(monkeypatch, tmp_path):
+    """Plain observed chatter stays exactly as it was — no empty media keys."""
+    adapter = _make_adapter(
+        require_mention=True, allowed_chats=["-100"],
+        group_allowed_chats=["-100"], observe_unmentioned_group_messages=True,
+    )
+    store = _FakeSessionStore()
+    adapter._session_store = store
+
+    adapter._observe_unmentioned_group_message(
+        _group_message("just chatting"), MessageType.TEXT, update_id=3006,
+    )
+
+    _, message, _ = store.messages[0]
+    assert "media_urls" not in message
+    assert "media_types" not in message
+
+
 # ── Bot identity: renames and non-"bot"-suffixed handles ────────────────────
 # Two failure modes fixed together (both break the mention gate):
 #   1. PTB caches getMe() in Bot._bot_user and only rewrites it inside


### PR DESCRIPTION
Fixes #47415.

### Corrected premise

The original issue blamed `str()` mangling a multimodal parts list in `_build_gateway_agent_history`. **That diagnosis was wrong** and I retracted it on the issue — the earlier PR built on it (#47416) was a no-op and is closed. Observed content is persisted as a plain `str`; nothing is being stringified.

The real defect is an asymmetry at the persistence boundary.

`_cache_observed_media()` downloads an unmentioned group photo, caches it, sets `event.media_urls` / `event.media_types`, and appends a `[image '...' saved at: <path>]` note to the observed text (`plugins/platforms/telegram/adapter.py:8306-8311`). But `_observe_unmentioned_group_message()` persists only `role` / `content` / `timestamp` / `observed` / `message_id` — **the media fields are dropped on the floor**.

The @mention path survives because `_prepare_inbound_message_text` buffers `event.media_urls` into `_pending_native_image_paths_by_session`, which the `run_conversation` call site turns into multimodal content parts. Observed messages never dispatch a run, so they never reach that buffer. The model only ever sees a text note naming a file it cannot open — hence the agent asking for a re-send, while the same photo re-sent *with* a mention works.

### Fix

Two halves:

- **`plugins/platforms/telegram/adapter.py`** — persist `media_urls` / `media_types` on observed transcript rows. Set only when media is present, so text-only chatter keeps its existing shape.
- **`gateway/run.py`** — new `_collect_observed_image_paths()` feeds those paths into the *existing* native-image buffer, so observed photos ride the same routing decision (native attach vs. `vision_analyze` text path) as mentioned ones. No parallel delivery path, no new config surface.

### Two scoping decisions worth review

**Trailing block only.** Images are collected from observed rows since the last real exchange, not the whole session. Attaching on every subsequent turn would put vision cost on every reply in a busy group. The trade-off: asking about a photo several turns later gets the text note rather than the pixels. This covers the reported repro (photo posted → user asks) exactly, but I'd take direction if you'd prefer the looser behavior.

**Capped at 4** (`_MAX_OBSERVED_IMAGE_ATTACHMENTS`) so a burst of photos can't turn one reply into a bulk upload.

Transcripts written before this change carry no media fields and are unaffected — `_collect_observed_image_paths` returns nothing for them and the text note continues to carry context.

### Verification

9 new tests, each watched fail first:

- `tests/gateway/test_observed_group_image_attachment.py` (7) — attach on the next addressed turn, ordering vs. the current turn's own attachment, non-image media excluded, cap, no re-attach after an exchange, re-attach for a fresh photo, legacy rows.
- `tests/gateway/test_telegram_group_gating.py` (2) — observed photo rows record media; observed text rows gain no empty media keys.

Full gateway suite, run against a clean `main` control on the same machine:

| | Failed | Passed |
|---|---|---|
| `main` @ `f228e145b` | 27 | 11309 |
| this branch | 27 | 11318 |

The exact failing test IDs `diff` identical between the two runs — all 27 are pre-existing on `main` (`test_channel_directory`, `test_wecom_callback`, `test_discord_send`, et al., several order-dependent). Pass delta is exactly +9, the new tests.

`ruff check gateway/run.py plugins/platforms/telegram/adapter.py tests/gateway/test_observed_group_image_attachment.py tests/gateway/test_telegram_group_gating.py` → clean.
