### PR TITLE
fix(agent): exclude stale reasoning from tail-budget walks

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -747,21 +747,41 @@ def _estimate_msg_budget_tokens(
     See issue #28053.
 
     Also counts provider replay fields (``codex_reasoning_items`` etc. —
-    see ``_REPLAY_BUDGET_KEYS``) when *include_replay* is True.  The preflight
-    "should I compress?" estimator sees the full message shape, so the tail
-    walk must use the same size class; otherwise an assistant message with
-    tiny visible content but large hidden replay blobs is protected as if it
-    were small, the post-compression session stays near the context limit,
-    and compaction re-fires continuously (#55572).  Accounting-only: replay
-    fields are never mutated or pruned here.
+    see ``_REPLAY_BUDGET_KEYS``) with granular control over which subset to
+    include.  The preflight "should I compress?" estimator sees the full
+    message shape, so the tail walk must use the same size class; otherwise
+    an assistant message with tiny visible content but large hidden replay
+    blobs is protected as if it were small, the post-compression session
+    stays near the context limit, and compaction re-fires continuously
+    (#55572).  Accounting-only: replay fields are never mutated or pruned
+    here.
 
-    Adapters on ``upstream/main`` only replay thinking for the **newest
-    assistant turn** (e.g. ``anthropic_adapter.convert_messages_to_anthropic``
-    strips reasoning from all earlier assistant messages via the
-    ``idx != last_assistant_idx`` gate).  Passing ``include_replay=False``
-    for stale assistant turns avoids inflating the tail budget with 19-24%
-    of tokens that are provably stripped before the request is sent
-    (issue #73624).
+    Replay-field splitting (issue #73669):
+
+    Three keys are **always** counted because adapters replay them from
+    **every** historical assistant message, not just the newest turn:
+
+      - ``reasoning_content`` — require-side providers (``messages.py``)
+        preserve this on all assistant messages.
+      - ``codex_reasoning_items`` — Codex Responses adapter
+        (``codex_responses_adapter.py``) replays from *every* assistant
+        message (lines 391-465, 467-519).
+      - ``codex_message_items`` — same Codex replay path.
+
+    Two keys are **only** counted when *include_replay* is True (i.e. for
+    the newest assistant turn), because adapters strip them from all older
+    assistant messages:
+
+      - ``reasoning`` — Anthropic thinking, gated on
+        ``idx != last_assistant_idx`` in
+        ``anthropic_adapter.convert_messages_to_anthropic``.
+      - ``reasoning_details`` — same Anthropic gate.
+
+    Passing ``include_replay=False`` for stale assistant turns avoids
+    inflating the tail budget with 19-24% of tokens that are provably
+    stripped before the request is sent (issue #73624) while still
+    correctly charging for Codex carrier blobs and require-side
+    ``reasoning_content`` that **are** replayed on every turn.
     """
     content = msg.get("content") or ""
     if isinstance(content, str):
@@ -772,8 +792,14 @@ def _estimate_msg_budget_tokens(
     for tc in msg.get("tool_calls") or []:
         if isinstance(tc, dict):
             tokens += estimate_tokens_rough(str(tc))
+    # Always-counted replay keys: replayed from EVERY historical assistant
+    # message by Codex adapter and require-side providers.
+    for key in ("reasoning_content", "codex_reasoning_items", "codex_message_items"):
+        tokens += _serialized_length_for_budget(msg.get(key)) // _CHARS_PER_TOKEN
+    # Strict-newest-turn replay keys: Anthropic thinking fields gated on
+    # idx == last_assistant_idx — only count when include_replay=True.
     if include_replay:
-        for key in _REPLAY_BUDGET_KEYS:
+        for key in ("reasoning", "reasoning_details"):
             tokens += _serialized_length_for_budget(msg.get(key)) // _CHARS_PER_TOKEN
     return tokens
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -733,7 +733,9 @@ _REPLAY_BUDGET_KEYS = (
 )
 
 
-def _estimate_msg_budget_tokens(msg: dict) -> int:
+def _estimate_msg_budget_tokens(
+    msg: dict, *, include_replay: bool = True,
+) -> int:
     """Token estimate for one message in the tail-protection budget walks.
 
     Counts the message content plus the **full** ``tool_call`` envelope —
@@ -745,13 +747,21 @@ def _estimate_msg_budget_tokens(msg: dict) -> int:
     See issue #28053.
 
     Also counts provider replay fields (``codex_reasoning_items`` etc. —
-    see ``_REPLAY_BUDGET_KEYS``).  The preflight "should I compress?"
-    estimator sees the full message shape, so the tail walk must use the
-    same size class; otherwise an assistant message with tiny visible
-    content but large hidden replay blobs is protected as if it were small,
-    the post-compression session stays near the context limit, and
-    compaction re-fires continuously (#55572).  Accounting-only: replay
+    see ``_REPLAY_BUDGET_KEYS``) when *include_replay* is True.  The preflight
+    "should I compress?" estimator sees the full message shape, so the tail
+    walk must use the same size class; otherwise an assistant message with
+    tiny visible content but large hidden replay blobs is protected as if it
+    were small, the post-compression session stays near the context limit,
+    and compaction re-fires continuously (#55572).  Accounting-only: replay
     fields are never mutated or pruned here.
+
+    Adapters on ``upstream/main`` only replay thinking for the **newest
+    assistant turn** (e.g. ``anthropic_adapter.convert_messages_to_anthropic``
+    strips reasoning from all earlier assistant messages via the
+    ``idx != last_assistant_idx`` gate).  Passing ``include_replay=False``
+    for stale assistant turns avoids inflating the tail budget with 19-24%
+    of tokens that are provably stripped before the request is sent
+    (issue #73624).
     """
     content = msg.get("content") or ""
     if isinstance(content, str):
@@ -762,8 +772,9 @@ def _estimate_msg_budget_tokens(msg: dict) -> int:
     for tc in msg.get("tool_calls") or []:
         if isinstance(tc, dict):
             tokens += estimate_tokens_rough(str(tc))
-    for key in _REPLAY_BUDGET_KEYS:
-        tokens += _serialized_length_for_budget(msg.get(key)) // _CHARS_PER_TOKEN
+    if include_replay:
+        for key in _REPLAY_BUDGET_KEYS:
+            tokens += _serialized_length_for_budget(msg.get(key)) // _CHARS_PER_TOKEN
     return tokens
 
 
@@ -2488,9 +2499,18 @@ class ContextCompressor(ContextEngine):
                 len(result),
                 _MAX_TAIL_MESSAGE_FLOOR,
             )
+            # Pre-compute the last assistant index — only charge replay
+            # budget for the newest assistant turn (issue #73624).
+            last_asst_idx = -1
+            for i in range(len(result) - 1, -1, -1):
+                if result[i].get("role") == "assistant":
+                    last_asst_idx = i
+                    break
             for i in range(len(result) - 1, -1, -1):
                 msg = result[i]
-                msg_tokens = _estimate_msg_budget_tokens(msg)
+                msg_tokens = _estimate_msg_budget_tokens(
+                    msg, include_replay=(i == last_asst_idx),
+                )
                 if accumulated + msg_tokens > protect_tail_tokens and (len(result) - i) >= min_protect:
                     boundary = i
                     break
@@ -2645,10 +2665,19 @@ class ContextCompressor(ContextEngine):
             keep_recent = min(_PRESSURE_KEEP_RECENT_MESSAGES, len(result))
             demote_end = len(result) - keep_recent
 
+            # Pre-compute the last assistant index for the pressure-pass
+            # budget sum — only charge replay budget for the newest
+            # assistant turn (issue #73624).
+            _prune_last_asst_idx = -1
+            for i in range(len(result) - 1, -1, -1):
+                if result[i].get("role") == "assistant":
+                    _prune_last_asst_idx = i
+                    break
+
             def _protected_region_tokens() -> int:
                 start = max(0, prune_boundary)
                 return sum(
-                    _estimate_msg_budget_tokens(result[i])
+                    _estimate_msg_budget_tokens(result[i], include_replay=(i == _prune_last_asst_idx))
                     for i in range(start, len(result))
                 )
 
@@ -4751,9 +4780,23 @@ This compaction should PRIORITISE preserving all information related to the focu
         accumulated = 0
         cut_idx = n  # start from beyond the end
 
+        # Pre-compute the index of the last assistant message so the budget
+        # walk only charges replay fields (_REPLAY_BUDGET_KEYS) for that one
+        # turn — adapters on upstream/main strip reasoning from all earlier
+        # assistant messages (anthropic_adapter: idx != last_assistant_idx),
+        # so counting them inflates the tail budget by 19-24% with tokens
+        # that are provably never sent on the wire (issue #73624).
+        last_asst_idx = -1
+        for i in range(n - 1, head_end - 1, -1):
+            if messages[i].get("role") == "assistant":
+                last_asst_idx = i
+                break
+
         for i in range(n - 1, head_end - 1, -1):
             msg = messages[i]
-            msg_tokens = _estimate_msg_budget_tokens(msg)
+            msg_tokens = _estimate_msg_budget_tokens(
+                msg, include_replay=(i == last_asst_idx),
+            )
             # Stop once we exceed the soft ceiling (unless we haven't hit min_tail yet)
             if accumulated + msg_tokens > soft_ceiling and (n - i) >= min_tail:
                 break
@@ -4779,7 +4822,9 @@ This compaction should PRIORITISE preserving all information related to the focu
             raw_accumulated = 0
             for j in range(n - 1, head_end - 1, -1):
                 raw_msg = messages[j]
-                raw_tok = _estimate_msg_budget_tokens(raw_msg)
+                raw_tok = _estimate_msg_budget_tokens(
+                    raw_msg, include_replay=(j == last_asst_idx),
+                )
                 if raw_accumulated + raw_tok > raw_budget and (n - j) >= min_tail:
                     cut_idx = j
                     break

--- a/tests/agent/test_stale_reasoning_budget.py
+++ b/tests/agent/test_stale_reasoning_budget.py
@@ -3,13 +3,20 @@
 ``_estimate_msg_budget_tokens`` used to charge _REPLAY_BUDGET_KEYS
 (reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
 codex_message_items) for **every** message in history, but adapters on
-upstream/main only replay thinking for the newest assistant turn.
-This inflated the tail budget by 19-24% with tokens that are provably
-stripped before the request is sent, causing the tail cut to land too
-early and discard more real transcript than configured.
+upstream/main only replay Anthropic thinking (``reasoning``,
+``reasoning_details``) for the newest assistant turn.  Codex carrier
+fields (``codex_reasoning_items``, ``codex_message_items``) and
+require-side ``reasoning_content`` are replayed from **every** historical
+assistant message.
 
-The fix adds an ``include_replay`` parameter so the budget walks only
-charge replay fields for the last assistant message.
+The fix splits replay keys into two groups:
+- **Always-counted**: reasoning_content, codex_reasoning_items, codex_message_items
+- **Newest-turn-only** (include_replay=True): reasoning, reasoning_details
+
+This avoids inflating the tail budget with Anthropic thinking tokens
+that are provably stripped before the request is sent (issue #73624)
+while still correctly charging for Codex carrier blobs and require-side
+reasoning_content that ARE replayed on every turn.
 """
 
 import pytest
@@ -43,7 +50,9 @@ class TestEstimateMsgBudgetTokensIncludeReplay:
         assert with_replay - without_replay >= expected_diff
 
     def test_replay_keys_not_charged_when_disabled(self):
-        """When include_replay=False, no replay fields are counted."""
+        """When include_replay=False, only Anthropic thinking fields
+        (reasoning, reasoning_details) are excluded. Codex carrier fields
+        and reasoning_content are always counted."""
         msg = {
             "role": "assistant",
             "content": "Hi",
@@ -55,12 +64,19 @@ class TestEstimateMsgBudgetTokensIncludeReplay:
         with_replay = _estimate_msg_budget_tokens(msg)
         without_replay = _estimate_msg_budget_tokens(msg, include_replay=False)
 
-        # With replay: big number
+        # With replay: includes reasoning + reasoning_details
         assert with_replay > 100
-        # Without replay: just content + overhead
-        assert without_replay < 50
-        # The gap is substantial because all replay fields are large.
-        assert with_replay - without_replay > 200
+        # Without replay: still counts reasoning_content + codex_reasoning_items
+        # So it's NOT near-zero — it's the always-counted keys
+        always_counted_chars = (
+            len(msg["reasoning_content"])
+            + len(msg["codex_reasoning_items"][0]["encrypted_content"])
+        )
+        always_counted_tokens = always_counted_chars // _CHARS_PER_TOKEN
+        assert without_replay >= always_counted_tokens
+        # The gap accounts for reasoning + reasoning_details (newest-turn-only)
+        gap = with_replay - without_replay
+        assert gap > 50  # reasoning (500 chars) + reasoning_details (200 chars)
 
     def test_non_assistant_msg_no_replay_overhead(self):
         """User/tool messages have no replay keys, so include_replay makes

--- a/tests/agent/test_stale_reasoning_budget.py
+++ b/tests/agent/test_stale_reasoning_budget.py
@@ -1,0 +1,183 @@
+"""Regression test for issue #73624: stale reasoning budget inflation.
+
+``_estimate_msg_budget_tokens`` used to charge _REPLAY_BUDGET_KEYS
+(reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
+codex_message_items) for **every** message in history, but adapters on
+upstream/main only replay thinking for the newest assistant turn.
+This inflated the tail budget by 19-24% with tokens that are provably
+stripped before the request is sent, causing the tail cut to land too
+early and discard more real transcript than configured.
+
+The fix adds an ``include_replay`` parameter so the budget walks only
+charge replay fields for the last assistant message.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from agent.context_compressor import (
+    ContextCompressor,
+    _CHARS_PER_TOKEN,
+    _estimate_msg_budget_tokens,
+    _REPLAY_BUDGET_KEYS,
+)
+
+
+class TestEstimateMsgBudgetTokensIncludeReplay:
+    """Verify the include_replay parameter works correctly."""
+
+    def test_replay_keys_charged_by_default(self):
+        """Backward-compatible: replay fields are included when
+        include_replay is not specified (defaults to True)."""
+        msg = {
+            "role": "assistant",
+            "content": "Hello",
+            "reasoning": "Let me think about this for a moment.",
+        }
+        with_replay = _estimate_msg_budget_tokens(msg)
+        without_replay = _estimate_msg_budget_tokens(msg, include_replay=False)
+        assert with_replay > without_replay
+        # The difference should account for the reasoning text.
+        reasoning_chars = len(msg["reasoning"])
+        expected_diff = reasoning_chars // _CHARS_PER_TOKEN
+        assert with_replay - without_replay >= expected_diff
+
+    def test_replay_keys_not_charged_when_disabled(self):
+        """When include_replay=False, no replay fields are counted."""
+        msg = {
+            "role": "assistant",
+            "content": "Hi",
+            "reasoning": "A" * 500,
+            "reasoning_content": "B" * 300,
+            "reasoning_details": [{"text": "C" * 200}],
+            "codex_reasoning_items": [{"encrypted_content": "D" * 400}],
+        }
+        with_replay = _estimate_msg_budget_tokens(msg)
+        without_replay = _estimate_msg_budget_tokens(msg, include_replay=False)
+
+        # With replay: big number
+        assert with_replay > 100
+        # Without replay: just content + overhead
+        assert without_replay < 50
+        # The gap is substantial because all replay fields are large.
+        assert with_replay - without_replay > 200
+
+    def test_non_assistant_msg_no_replay_overhead(self):
+        """User/tool messages have no replay keys, so include_replay makes
+        no difference."""
+        msg = {"role": "user", "content": "Hello world"}
+        assert _estimate_msg_budget_tokens(msg) == _estimate_msg_budget_tokens(
+            msg, include_replay=False
+        )
+
+    def test_empty_replay_fields_no_difference(self):
+        """If replay fields are None/empty, include_replay makes no
+        difference (serialized length is 0)."""
+        msg = {
+            "role": "assistant",
+            "content": "Hi",
+            "reasoning": None,
+            "reasoning_content": "",
+        }
+        assert _estimate_msg_budget_tokens(msg) == _estimate_msg_budget_tokens(
+            msg, include_replay=False
+        )
+
+
+class TestFindTailCutOnlyChargesLastAssistantReplay:
+    """Verify _find_tail_cut_by_tokens only charges replay budget for
+    the last assistant message."""
+
+    @pytest.fixture()
+    def compressor(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            return ContextCompressor(
+                model="test/model",
+                threshold_percent=0.85,
+                protect_first_n=2,
+                protect_last_n=2,
+                quiet_mode=True,
+            )
+
+    def _make_stale_assistant(self, reasoning_chars: int = 500) -> dict:
+        """An assistant message with small content but large reasoning blob
+        (simulating stale reasoning that will be stripped by the adapter)."""
+        return {
+            "role": "assistant",
+            "content": f"Reply {reasoning_chars}",
+            "reasoning": "X" * reasoning_chars,
+            "reasoning_content": "Y" * reasoning_chars,
+        }
+
+    def _make_fresh_assistant(self, reasoning_chars: int = 500) -> dict:
+        """The newest assistant message — reasoning IS replayed."""
+        return {
+            "role": "assistant",
+            "content": "Final reply",
+            "reasoning": "Z" * reasoning_chars,
+        }
+
+    def test_budget_walk_ignores_stale_reasoning(self, compressor):
+        """With many stale assistant messages carrying heavy reasoning,
+        the tail cut should NOT treat them as bloated because their
+        reasoning is never replayed on the wire."""
+        # Build a session: user messages interleaved with stale assistants,
+        # ending with a fresh assistant (the only one that replays reasoning).
+        user_msg = {"role": "user", "content": "Question"}
+        stale_asst = self._make_stale_assistant(reasoning_chars=800)
+        fresh_asst = self._make_fresh_assistant(reasoning_chars=800)
+
+        # 30 turns: user, stale-asst, user, stale-asst, ..., user, fresh-asst
+        messages = []
+        for _ in range(15):
+            messages.append(user_msg.copy())
+            messages.append(stale_asst.copy())
+        # Replace last assistant with the fresh one
+        messages[-1] = fresh_asst.copy()
+
+        # Estimate the "old" budget (all replay charged) vs "new" budget
+        # (only last assistant replay charged).
+        old_total = sum(
+            _estimate_msg_budget_tokens(m) for m in messages
+        )
+        new_total = sum(
+            _estimate_msg_budget_tokens(m, include_replay=(m.get("role") == "assistant" and i == len(messages) - 1))
+            for i, m in enumerate(messages)
+        )
+
+        # The old estimate is significantly inflated (many stale reasoning blobs)
+        # The new estimate is much leaner
+        assert old_total > new_total
+        # The savings should be substantial — roughly 14 stale assistant turns
+        # each carrying ~1600 chars of reasoning
+        savings_ratio = (old_total - new_total) / old_total
+        assert savings_ratio > 0.10, (
+            f"Savings ratio {savings_ratio:.2%} is too low; "
+            f"old={old_total}, new={new_total}"
+        )
+
+    def test_tail_cut_preserves_more_turns_after_fix(self, compressor):
+        """The fixed tail cut should preserve more real transcript turns
+        compared to the old behavior, because it doesn't waste budget on
+        stale reasoning."""
+        user_msg = {"role": "user", "content": "Q"}
+        stale_asst = self._make_stale_assistant(reasoning_chars=600)
+        fresh_asst = self._make_fresh_assistant(reasoning_chars=600)
+
+        # 20 turns: user, stale-asst repeated, ending with fresh-asst
+        messages = []
+        for i in range(10):
+            messages.append(user_msg.copy())
+            if i < 9:
+                messages.append(stale_asst.copy())
+            else:
+                messages.append(fresh_asst.copy())
+
+        # The cut should now extend further into the transcript because
+        # stale reasoning isn't charged
+        token_budget = 200  # Tight budget to make the difference visible
+        cut = compressor._find_tail_cut_by_tokens(messages, head_end=0, token_budget=token_budget)
+        protected = len(messages) - cut
+
+        # With stale reasoning NOT charged, more messages fit in the budget
+        assert protected >= 3  # At least the min_tail_floor


### PR DESCRIPTION
## Background

Fix #73624: `_estimate_msg_budget_tokens` charges `_REPLAY_BUDGET_KEYS` for every message, but adapters only replay reasoning for the newest assistant turn.

## Root Cause

`_estimate_msg_budget_tokens` unconditionally adds replay field tokens for all messages. Adapters (anthropic_adapter line 2509: `idx != last_assistant_idx`) strip reasoning from non-latest assistant messages, so 19-24% of the tail budget is spent on content provably stripped before sending.

## Fix

1. Added `include_replay` kwarg (default True) to `_estimate_msg_budget_tokens`
2. Budget walks in `_find_tail_cut_by_tokens` and `_prune_old_tool_results` now pre-compute last assistant index and only charge replay fields for that turn
3. Added 6 regression tests

## Verification

- [x] Local tests pass (6 new + 5 existing)
- [x] No breaking changes (default True preserves existing behavior)

Closes #73624