### PR TITLE
fix(run): skip eviction if new agent inserted during expiry cleanup await

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9264,13 +9264,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         if _cached_agent is None:
                             _cached_agent = self._running_agents.get(key)
                         if _cached_agent and _cached_agent is not _AGENT_PENDING_SENTINEL:
+                            # Snapshot the agent before the await.  During
+                            # the yield a new inbound message can insert a
+                            # NEW agent into _agent_cache for the same key.
+                            _agent_before_await = _cached_agent
                             await self._cleanup_agent_resources_off_loop(
                                 _cached_agent, context="session expiry"
                             )
-                        # Drop the cache entry so the AIAgent (and its LLM
-                        # clients, tool schemas, memory provider refs) can
-                        # be garbage-collected.  Otherwise the cache grows
-                        # unbounded across the gateway's lifetime.
+                            # Drop the cache entry ONLY if it still holds
+                            # the original agent.  If a new agent was
+                            # inserted during the await, _evict_cached_agent
+                            # would destroy the new agent's LLM pool while
+                            # its turn is wiring callbacks.
+                            if _cache_lock is not None:
+                                with _cache_lock:
+                                    _current = self._agent_cache.get(key)
+                                    _current_agent = _current[0] if isinstance(_current, tuple) else _current if _current else None
+                                    if _current_agent is not _agent_before_await:
+                                        logger.debug(
+                                            "Session expiry: skipping eviction "
+                                            "for %s -- new agent inserted "
+                                            "during cleanup", key,
+                                        )
+                                        self._clear_conversation_scope(
+                                            key, reason="expiry_finalized"
+                                        )
+                                        await self.async_session_store.set_expiry_finalized(entry)
+                                        _finalize_failures.pop(entry.session_id, None)
+                                        continue
                         self._evict_cached_agent(key)
                         # Permanently finalizing this session — one funnel
                         # call drops every conversation-scoped dict AND the


### PR DESCRIPTION
## Summary

`_session_expiry_watcher` processes expired sessions in a loop. For each expired session, it reads the cached agent from `_agent_cache`, then calls `await _cleanup_agent_resources_off_loop(agent)` which yields to the event loop. After the yield, it calls `_evict_cached_agent(key)` to remove the cache entry and release LLM clients.

The problem: during the `await` yield, a new inbound message for the same session key can trigger `_handle_message_with_agent`, which inserts a NEW agent into `_agent_cache`. When the expiry watcher resumes, `_evict_cached_agent` pops whatever is currently in the cache -- which is now the NEW agent, not the OLD one we saved before the await. The eviction then spawns a daemon thread that calls `release_clients()` on the new agent, destroying its httpx connection pool while the new turn is still wiring callbacks and streaming the API response.

## Impact

- User-visible turn failure with connection errors
- The message is consumed but the response is lost
- Retry works (transcript is in SQLite)
- Window: ~50ms between cache insertion and `_running_agents` promotion via `track_agent()` polling

## Root Cause

No coordination between the expiry watcher's read-agent reference and the message handler's insert-agent path. The `_evict_cached_agent` call assumes the cache still holds the original agent, but the `await` yield allows the cache to be mutated.

## Fix

1. Snapshot the cached agent reference before the `await` yield
2. After the yield, re-acquire `_agent_cache_lock` and verify the cache still holds the same agent (by identity, not equality)
3. If a new agent was inserted during the yield, skip eviction -- the new turn owns its lifecycle
4. Finalize the session (set `expiry_finalized`, clear conversation scope) regardless of whether eviction occurred

## Tests

- 145/145 `tests/gateway/test_session.py` pass