### PR TITLE
fix(run): do not fall back to _running_agents in session expiry watcher

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9253,17 +9253,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         # Shut down memory provider and close tool resources
                         # on the cached agent.  Idle agents live in
                         # _agent_cache (not _running_agents), so look there.
+                        # Do NOT fall back to _running_agents: an agent
+                        # still in _running_agents is actively mid-turn
+                        # and cleaning it up would crash the in-flight
+                        # request by tearing down its terminal sandbox,
+                        # browser daemon, and httpx clients.
                         _cached_agent = None
                         _cache_lock = getattr(self, "_agent_cache_lock", None)
                         if _cache_lock is not None:
                             with _cache_lock:
                                 _cached = self._agent_cache.get(key)
                                 _cached_agent = _cached[0] if isinstance(_cached, tuple) else _cached if _cached else None
-                        # Fall back to _running_agents in case the agent is
-                        # still mid-turn when the expiry fires.
-                        if _cached_agent is None:
-                            _cached_agent = self._running_agents.get(key)
-                        if _cached_agent and _cached_agent is not _AGENT_PENDING_SENTINEL:
+                        if _cached_agent is not None and _cached_agent is not _AGENT_PENDING_SENTINEL:
                             await self._cleanup_agent_resources_off_loop(
                                 _cached_agent, context="session expiry"
                             )


### PR DESCRIPTION
## Summary

`_session_expiry_watcher` looks up the cached agent in `_agent_cache`. If not found, it fell back to `_running_agents.get(key)` and called `_cleanup_agent_resources_off_loop(agent)` on whatever it found. This function ultimately calls `agent.close()`, which tears down terminal sandboxes, browser daemons, httpx clients, and background processes.

An agent in `_running_agents` is actively mid-turn -- its resources are in use by the running request. Closing them crashes the turn with resource-unavailable errors.

## Impact

- Active conversation terminated by background watcher
- Triggered when long-running tool calls (multi-minute terminal commands) leave `entry.updated_at` stale enough for the expiry policy to fire
- `updated_at` is only refreshed at turn start (`get_or_create_session` at session.py:2347/2361), NOT during tool execution -- `_touch_activity` only updates `agent._last_activity_ts` (run_agent.py:3479), not the session store's `updated_at`
- User sees their turn crash mid-execution with no warning

## Root Cause

The expiry watcher's `_running_agents` fallback was designed to handle agents that are "still mid-turn when the expiry fires" (per the code comment at line 9262-9263). But cleaning up an active agent is never safe -- the expiry watcher has no way to coordinate with the running turn's resource usage.

## Fix

Remove the `_running_agents` fallback entirely. If the agent is not in `_agent_cache`, it is either:
1. Actively running (promoted to `_running_agents`) -- the running turn owns its lifecycle
2. Already evicted by another path -- nothing to clean up

In both cases, the expiry watcher skips cleanup and proceeds to `_evict_cached_agent` (which is a no-op if the key is already gone) and `set_expiry_finalized`.

## Tests

- 145/145 `tests/gateway/test_session.py` pass