### PR TITLE
fix(desktop): match Edit Models row hover to the model picker

### DIFF
--- a/apps/desktop/src/components/model-visibility-dialog.tsx
+++ b/apps/desktop/src/components/model-visibility-dialog.tsx
@@ -140,7 +140,10 @@ export function ModelVisibilityDialog({
                       const key = modelVisibilityKey(provider.slug, family.id)
 
                       return (
-                        <label className="flex cursor-pointer items-center gap-2 px-3 py-1 text-xs" key={key}>
+                        <label
+                          className="flex cursor-pointer items-center gap-2 px-3 py-1 text-xs hover:bg-(--ui-control-active-background)"
+                          key={key}
+                        >
                           <span className="min-w-0 flex-1 truncate">
                             {name}
                             {tag ? <span className="text-(--ui-text-tertiary)"> {tag}</span> : null}


### PR DESCRIPTION
The Edit Models dialog's model rows were plain labels with no hover feedback, while the model picker itself highlights each row on hover with `--ui-control-active-background`. That mismatch made the two surfaces feel unrelated even though they list the same models.

This gives the dialog rows the same hover background so the two surfaces read identically.