### PR TITLE
fix(cli): treat a fork's upstream sync as an update so the gateway restart runs

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4129,12 +4129,27 @@ def _cmd_update_impl(args, gateway_mode: bool):
         )
         commit_count = int(result.stdout.strip())
 
+        # A fork can match origin while still trailing upstream. The sync can
+        # therefore advance HEAD even though the origin comparison found no
+        # commits. Detect that before taking the no-update return so dependency
+        # refreshes and gateway restarts still run for the pulled code.
+        if commit_count == 0 and is_fork and branch == "main":
+            pre_sync_sha = _capture_head_sha(git_cmd, _m().PROJECT_ROOT)
+            _m()._sync_with_upstream_if_needed(git_cmd, _m().PROJECT_ROOT)
+            post_sync_sha = _capture_head_sha(git_cmd, _m().PROJECT_ROOT)
+            if pre_sync_sha and post_sync_sha and pre_sync_sha != post_sync_sha:
+                synced_count = _count_commits_between(
+                    git_cmd,
+                    _m().PROJECT_ROOT,
+                    pre_sync_sha,
+                    post_sync_sha,
+                )
+                # HEAD moving is itself proof of an update. Keep the update
+                # path active even if the informational count cannot be read.
+                commit_count = max(1, synced_count)
+
         if commit_count == 0:
             _invalidate_update_cache()
-
-            # Even if origin is up to date, the fork may be behind upstream
-            if is_fork and branch == "main":
-                _m()._sync_with_upstream_if_needed(git_cmd, _m().PROJECT_ROOT)
 
             # Restore stash and switch back to original branch if we moved
             if auto_stash_ref is not None:

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -234,6 +234,42 @@ class TestCmdUpdateBranchFallback:
         captured = capsys.readouterr()
         assert "Already up to date!" in captured.out
 
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_fork_upstream_sync_that_moves_head_runs_post_update_steps(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        """A fork sync that pulls code must continue through post-update work."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="0"
+        )
+
+        # The first two reads bracket the upstream sync; later reads see the
+        # new HEAD while the normal update path finishes.
+        shas = iter(["aaaaaaa", "bbbbbbb"])
+
+        with patch.object(
+            hm,
+            "_get_origin_url",
+            return_value="https://github.com/example/hermes-agent.git",
+        ), patch.object(
+            update_cmd,
+            "_capture_head_sha",
+            side_effect=lambda *_args, **_kwargs: next(shas, "bbbbbbb"),
+        ), patch.object(
+            hm, "_sync_with_upstream_if_needed"
+        ), patch.object(
+            hm, "_reload_updated_runtime_modules"
+        ) as post_update_step:
+            cmd_update(mock_args)
+
+        post_update_step.assert_called_once_with()
+        captured = capsys.readouterr()
+        assert "Already up to date!" not in captured.out
+
 
     def test_update_non_interactive_runs_safe_config_migrations(self, mock_args, capsys):
         """Dashboard/web updates apply non-interactive migrations before restart."""


### PR DESCRIPTION
## What does this PR do?

On a fork, `hermes update` decides "is there anything to do?" by comparing `HEAD..origin/main`, and *only then* syncs the fork from upstream — inside the `commit_count == 0` branch, which returns immediately after. So an update that pulls hundreds of commits from upstream prints **"Already up to date!"** and skips everything the post-update path does, including the dependency sync and the gateway restart.

This decides before the branch: capture HEAD, run the sync, and if HEAD moved, set `commit_count` from the moved range so the normal post-update path runs.

## Related Issue

Refs #73108 — that issue originally blamed `_resume_windows_gateways_after_update` being Windows-gated. [The triage there](https://github.com/NousResearch/hermes-agent/issues/73108#issuecomment-5110251582) correctly rejected that: the general restart block is not Windows-gated, and it should have run. This is the actual reason it didn't.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`hermes_cli/update_cmd.py`**: hoist the fork upstream sync above the "no updates" branch in the extracted update pipeline. If HEAD moved across the sync, derive `commit_count` from the pre/post SHAs so the run continues into the post-update path instead of returning. The subsequent fast-forward merge from `origin/main` is a no-op when the fork push succeeded — reaching dependency refresh and restart work is the point.
  `commit_count` is floored at 1: HEAD moving *is* the update, so a failed or zero count query must not send the run back down the early return.
- **`tests/hermes_cli/test_cmd_update.py`**: the regression test now proves that a fork sync which moves HEAD reaches a post-update-only runtime reload operation, in addition to not printing "Already up to date!". The neighboring test covers the complementary case (sync is a no-op → the message is correct).
- Removed the accidentally committed **`.lazy-refresh-incomplete`** runtime marker; it remains ignored and is not part of the PR history after the rebase.

## How to Test

```bash
scripts/run_tests.sh tests/hermes_cli/test_cmd_update.py -k fork -v
scripts/run_tests.sh \
  tests/hermes_cli/test_cmd_update.py \
  tests/hermes_cli/test_update_concurrent_quarantine.py -v
```

The new regression test fails without the change and passes with it. Current-main validation: **26 passed** across the two focused test files; targeted Ruff lint also passes.

Real-world reproduction (fork-based deployment, macOS, launchd-supervised gateway):

```
=== hermes update started 2026-07-27T18:12:23 ===
→ Fork is 1654 commit(s) behind upstream
→ Pulling from upstream...   ✓ Updated from upstream
→ Syncing fork...            ✓ Fork synced with upstream
✓ Already up to date!
```

No `✓ Restarted ai.hermes.gateway`, no `draining gateway PID …`, no `Stopped N manual gateway process(es)` — the block was never reached. The gateway then held pre-update modules while lazily importing post-update ones and failed later with an `AttributeError` for a method that plainly exists on disk.

Correlating every run in `~/.hermes/logs/update.log` on that install:

| pulled from upstream | printed "Already up to date" | restart lines |
|---|---|---|
| yes | no  | 1 |
| yes | yes | **0** (every run since 2026-05-31) |
| no  | yes | 0 |

## Platforms tested

macOS 26.5, Python 3.11, fork-based install (`origin` = fork, `upstream` = NousResearch). The change is platform-independent git/flow logic; the restart block it now reaches already handles systemd, launchd and manual PIDs.

## Notes

#26172 / #4873 fixed the missing *fetch* on forks — the pull happens now. This fixes the post-update steps still being skipped afterwards. #72789 ("Update banner is silently blind on fork-based deployments") looks like the same family.
