### PR TITLE
fix(kimi): clamp xhigh/max reasoning_effort to the model family's ceiling (+ correct stale Kimi thinking-replay docstring)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2457,11 +2457,21 @@ def _manage_thinking_signatures(
 
     Signatures are Anthropic-proprietary.  Third-party endpoints (MiniMax,
     Azure AI Foundry, AWS Bedrock, self-hosted proxies) cannot validate them
-    and will reject them outright.  Kimi's /coding and DeepSeek's /anthropic
-    endpoints speak the Anthropic protocol upstream but require unsigned
-    thinking blocks (synthesised from ``reasoning_content``) to round-trip on
-    replayed assistant tool-call messages.  See hermes-agent#13848 (Kimi) and
-    hermes-agent#16748 (DeepSeek).
+    and will reject them outright.  DeepSeek's /anthropic endpoint speaks the
+    Anthropic protocol upstream but requires unsigned thinking blocks
+    (synthesised from ``reasoning_content``) to round-trip on replayed
+    assistant tool-call messages.  See hermes-agent#16748 (DeepSeek).
+
+    Kimi is NOT signature-blind (this docstring said otherwise until
+    2026-07-28 — corrected): Kimi signs its own thinking blocks — the
+    signature carries the encrypted reasoning — and validates them on
+    replay, so the Kimi branch below replays as-is.  Verbatim round-trip is
+    required for K3 preserved-thinking continuity (platform.kimi.ai
+    thinking-model guide); stripping Kimi's own signed blocks amputates K3's
+    reasoning history and measurably destabilises multi-turn tool loops.
+    Unsigned blocks synthesised from ``reasoning_content`` remain the
+    fallback for Kimi messages whose thinking was never captured.  See
+    hermes-agent#13848 (Kimi).
 
     Nous Portal's ``/v1/messages`` route is the exception among third-party
     hosts: it proxies Claude to Anthropic/Vertex/Bedrock and validates the

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -550,6 +550,22 @@ def _is_known_provider_base_url(base_url: str) -> bool:
     return _infer_provider_from_url(base_url) is not None
 
 
+def is_kimi_k3_family(model: Optional[str]) -> bool:
+    """Return True for Kimi K3-family model slugs.
+
+    Kimi Coding serves K3 under the bare slug ``k3`` plus the public-facing
+    aliases ``kimi-k3`` / ``kimi-k3-cot`` (see
+    ``_endpoint_scoped_context_length``).  The distinction matters for
+    ``reasoning_effort``: K3's documented effort set is low/high/max
+    (default ``max`` — platform.kimi.ai thinking-model guide), while the
+    K2 era tops out at ``high``.
+    """
+    if not model:
+        return False
+    m = model.strip().lower().split("/")[-1]
+    return m == "k3" or m.startswith("kimi-k3")
+
+
 def _endpoint_scoped_context_length(model: str, base_url: str) -> Optional[int]:
     """Return metadata confirmed only for the Kimi Coding endpoint.
 

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -12,6 +12,7 @@ reasoning configuration, temperature handling, and extra_body assembly.
 from typing import Any, Dict
 
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
+from agent.model_metadata import is_kimi_k3_family
 from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
@@ -401,7 +402,12 @@ class ChatCompletionsTransport(ProviderTransport):
                 _kimi_effort = "medium"
                 if reasoning_config and isinstance(reasoning_config, dict):
                     _e = (reasoning_config.get("effort") or "").strip().lower()
-                    if _e in {"low", "medium", "high"}:
+                    if _e in {"low", "medium", "high", "xhigh", "max"}:
+                        # Clamp Hermes-only top tiers to the model family's
+                        # documented ceiling (K3: "max", K2-era: "high") so
+                        # xhigh/max aren't silently flattened to medium.
+                        if _e in {"xhigh", "max"}:
+                            _e = "max" if is_kimi_k3_family(model) else "high"
                         _kimi_effort = _e
                 api_kwargs["reasoning_effort"] = _kimi_effort
 

--- a/plugins/model-providers/kimi-coding/__init__.py
+++ b/plugins/model-providers/kimi-coding/__init__.py
@@ -87,7 +87,22 @@ class KimiProfile(ProviderProfile):
         # Enabled: prefer an explicit effort; only fall back to extra_body
         # thinking when no recognized effort is requested.
         effort = (reasoning_config.get("effort") or "").strip().lower()
-        if effort in {"low", "medium", "high"}:
+        if effort in {"low", "medium", "high", "xhigh", "max"}:
+            # Hermes-only top tiers clamp to the model family's documented
+            # ceiling — "max" for K3 (platform.kimi.ai thinking-model guide:
+            # low/high/max, default max), "high" for K2-era slugs — so the
+            # configured tier is honoured at the strongest level the model
+            # accepts instead of being silently dropped to the binary
+            # thinking toggle.
+            if effort in {"xhigh", "max"}:
+                # Lazy import: a top-level import of agent.model_metadata
+                # here circularly breaks plugin discovery (model_metadata's
+                # own import chain triggers provider-plugin loading).
+                from agent.model_metadata import is_kimi_k3_family
+
+                effort = (
+                    "max" if is_kimi_k3_family(context.get("model")) else "high"
+                )
             top_level["reasoning_effort"] = effort
         else:
             extra_body["thinking"] = {"type": "enabled"}

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -2075,3 +2075,21 @@ class TestMoAContextLength:
 
         assert ctx == 999_999
         endpoint_probe.assert_not_called()
+
+
+class TestIsKimiK3Family:
+    """K3-family slug detection drives the reasoning_effort clamp ceiling
+    ("max" on K3, "high" on the K2 era)."""
+
+    @pytest.mark.parametrize("model", ["k3", "K3", "kimi-k3", "kimi-k3-cot",
+                                       "kimi-k3-thinking", "moonshotai/kimi-k3"])
+    def test_k3_slugs_match(self, model):
+        from agent.model_metadata import is_kimi_k3_family
+        assert is_kimi_k3_family(model)
+
+    @pytest.mark.parametrize("model", [None, "", "kimi-k2", "kimi-k2.5",
+                                       "kimi-k2-turbo-preview", "k30", "k3s",
+                                       "moonshot-v1-8k", "kimi-latest"])
+    def test_non_k3_slugs_do_not_match(self, model):
+        from agent.model_metadata import is_kimi_k3_family
+        assert not is_kimi_k3_family(model)

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -691,6 +691,33 @@ class TestChatCompletionsKimi:
         # Kimi requires reasoning_effort as a top-level parameter
         assert kw["reasoning_effort"] == "high"
 
+    @pytest.mark.parametrize("effort", ["xhigh", "max"])
+    def test_kimi_legacy_xhigh_max_clamps_to_high_on_k2(self, transport, effort):
+        """Legacy (unregistered-profile) Kimi path clamps Hermes-only top
+        tiers to the K2-era "high" ceiling instead of flattening to the
+        default medium."""
+        kw = transport.build_kwargs(
+            model="kimi-k2", messages=[{"role": "user", "content": "Hi"}],
+            is_kimi=True,
+            reasoning_config={"enabled": True, "effort": effort},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["reasoning_effort"] == "high"
+
+    @pytest.mark.parametrize("effort", ["xhigh", "max"])
+    @pytest.mark.parametrize("model", ["k3", "kimi-k3", "kimi-k3-cot"])
+    def test_kimi_legacy_xhigh_max_clamps_to_max_on_k3(self, transport, effort, model):
+        """K3's documented effort ceiling is "max" (platform.kimi.ai
+        thinking-model guide) — clamping to the K2-era "high" would
+        undershoot the model's top tier."""
+        kw = transport.build_kwargs(
+            model=model, messages=[{"role": "user", "content": "Hi"}],
+            is_kimi=True,
+            reasoning_config={"enabled": True, "effort": effort},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["reasoning_effort"] == "max"
+
     def test_kimi_reasoning_effort_omitted_when_thinking_disabled(self, transport):
         kw = transport.build_kwargs(
             model="kimi-k2", messages=[{"role": "user", "content": "Hi"}],

--- a/tests/plugins/model_providers/test_kimi_profile.py
+++ b/tests/plugins/model_providers/test_kimi_profile.py
@@ -60,7 +60,36 @@ class TestKimiReasoningWireShape:
         assert extra_body == {"thinking": {"type": "enabled"}}
         assert top_level == {}
 
-    @pytest.mark.parametrize("effort", ["", "garbage", "xhigh", "max"])
+    @pytest.mark.parametrize("effort", ["xhigh", "max"])
+    @pytest.mark.parametrize(
+        "model", [None, "kimi-k2", "kimi-k2.5", "kimi-k2-turbo-preview"]
+    )
+    def test_hermes_top_tier_effort_clamps_to_high_on_k2(
+        self, kimi_profile, effort, model
+    ):
+        """K2-era ceiling is ``high``: Hermes-only tiers above it clamp down
+        instead of being silently dropped to the thinking toggle."""
+        extra_body, top_level = kimi_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort}, model=model
+        )
+        assert top_level == {"reasoning_effort": "high"}
+        assert "thinking" not in extra_body
+
+    @pytest.mark.parametrize("effort", ["xhigh", "max"])
+    @pytest.mark.parametrize("model", ["k3", "kimi-k3", "kimi-k3-cot"])
+    def test_hermes_top_tier_effort_clamps_to_max_on_k3(
+        self, kimi_profile, effort, model
+    ):
+        """K3's documented effort set is low/high/max (default ``max`` —
+        platform.kimi.ai thinking-model guide), so Hermes-only top tiers
+        clamp to ``max``, not the K2-era ``high``."""
+        extra_body, top_level = kimi_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort}, model=model
+        )
+        assert top_level == {"reasoning_effort": "max"}
+        assert "thinking" not in extra_body
+
+    @pytest.mark.parametrize("effort", ["", "garbage"])
     def test_unrecognized_effort_falls_back_to_thinking(self, kimi_profile, effort):
         """Unknown/strong efforts aren't in Moonshot's low|medium|high set, so
         we drop to the thinking toggle rather than sending an invalid effort."""


### PR DESCRIPTION
## Bug: Hermes `xhigh`/`max` reasoning effort is silently dropped on Kimi

Hermes exposes five reasoning-effort tiers (`low`/`medium`/`high`/`xhigh`/`max`), but both
Kimi OpenAI-compat gates only recognise `{low, medium, high}`. Configuring `xhigh` or `max`
on a Kimi model silently loses the tier — there is no warning, no error, and the wire shape
changes meaning:

- **`plugins/model-providers/kimi-coding`** (`KimiProfile.build_api_kwargs_extras`): the
  unrecognised effort falls through to the binary `extra_body.thinking` toggle. The user
  asked for the strongest tier; the request carries no effort at all.
- **Legacy `is_kimi` branch** in `agent/transports/chat_completions.py`: the effort flattens
  to `reasoning_effort="medium"` — actively *less* reasoning than configured.

Before / after wire shapes (effort `xhigh`, K2 slug):

```
before (profile):  {..., "extra_body": {"thinking": {"type": "enabled"}}}   # tier gone
after  (profile):  {..., "reasoning_effort": "high"}                        # clamped to K2 ceiling

before (legacy):   {..., "reasoning_effort": "medium"}                      # flattened
after  (legacy):   {..., "reasoning_effort": "high"}                        # clamped to K2 ceiling
```

## Related PRs

- #69648 adds a bare `max` passthrough in the kimi-coding plugin only. This PR supersedes/extends
  it: it also maps `xhigh`, makes the clamp family-aware (K2-era slugs must not receive `max` —
  their documented ceiling is `high`), covers the legacy `is_kimi` branch in
  `chat_completions.py`, and ships tests across all three surfaces.

## Clamp target is family-aware: `max` on K3, `high` on K2-era

The two families have different documented ceilings, so a single clamp target undershoots one
of them:

- **K3 family** (bare slug `k3` served by Kimi Coding, plus public aliases `kimi-k3` /
  `kimi-k3-cot`): the official thinking-model guide (platform.kimi.ai) documents
  `reasoning_effort` = **low / high / max, default `max`**. Clamping Hermes `xhigh`/`max` to
  `high` here would undershoot the model's own default.
- **K2 era** (`kimi-k2*`, `moonshot-v1-*`, …): documented ceiling is **`high`**.

Family detection is a new `agent.model_metadata.is_kimi_k3_family()` helper
(vendor-prefix-tolerant: `moonshotai/kimi-k3` matches). The kimi-coding plugin imports it
lazily inside `build_api_kwargs_extras` — a top-level import circularly breaks plugin
discovery because `model_metadata`'s own import chain triggers provider-plugin loading
(reproduced in tests: the profile silently unregisters).

## Changes (commit 1)

- `agent/model_metadata.py`: new `is_kimi_k3_family()` helper (next to the existing K3 slug
  set in `_endpoint_scoped_context_length`).
- `plugins/model-providers/kimi-coding/__init__.py`: accept `xhigh`/`max`, clamp to
  family ceiling; `low`/`medium`/`high` pass through unchanged; unrecognised efforts still
  fall back to the thinking toggle.
- `agent/transports/chat_completions.py` (legacy `is_kimi` branch): same acceptance + clamp.
- Tests: family-parametrized clamp tests in `tests/plugins/model_providers/test_kimi_profile.py`
  (K2 slugs + no-model -> `high`; `k3`/`kimi-k3`/`kimi-k3-cot` -> `max`) and
  `tests/agent/transports/test_chat_completions.py`; helper unit tests in
  `tests/agent/test_model_metadata.py`.

## Changes (commit 2 — docs only)

`_manage_thinking_signatures`' docstring claimed Kimi's `/coding` "requires unsigned thinking
blocks (synthesised from `reasoning_content`) to round-trip". That is stale: the Kimi branch
replays thinking blocks **as-is**, and Kimi signs its own thinking blocks — the signature
carries the encrypted reasoning — and validates them on replay. Verbatim round-trip is
required for K3 preserved-thinking continuity (platform.kimi.ai thinking-model guide);
stripping Kimi's own signed blocks amputates K3's reasoning history. The unsigned-only rule
is DeepSeek's (#16748). Dated correction, no behaviour change.

## Notes on the existing Kimi replay carve-out (no change needed)

Current main already replays Kimi-family signed thinking blocks verbatim
(`agent/anthropic_adapter.py`, `_manage_thinking_signatures` — the
`_is_kimi_family_endpoint(base_url, model)` branch, "Kimi does not enforce thinking
signatures — replay as-is"), with dedicated coverage in
`tests/agent/test_anthropic_kimi_signed_thinking_replay.py` (signed keep, unsigned keep,
foreign-gateway keep, DeepSeek strip, orphan-marker no-leak). This PR deliberately does **not**
duplicate that logic; commit 2 only corrects the docstring that still contradicts it.

Production validation of that carve-out (a downstream deployment that had locally patched
the same rule before it landed upstream): on a live K3 tool-loop session, 21/22 assistant
tool-call turns reached the wire carrying their signed thinking block after the fix vs 0/22
before (the 1 bare turn had no captured reasoning — a separate capture-side gap). A general
follow-up worth considering separately: provenance-tagging captured thinking blocks so
same-provider signed blocks replay verbatim while foreign-signed blocks strip — the current
Kimi branch is the kimi-family instance of that design.

## Wire-test notes (api.kimi.com/coding, 2026-07-28)

- The historically documented HTTP 400 ("thinking + tool_use history lacking
  `reasoning_content`") does **not** reproduce as of 2026-07-28 — the canonical shape
  returns HTTP 200 with thinking. Phrased historically-observed, not current.
- `/coding` thinks by default: thinking blocks appear on every response, with or without an
  explicit thinking parameter.
- `budget_tokens` does not modulate thinking depth on `/coding` (measured 4763/4308/3787
  chars of thinking for none/1024/8000 budgets).

## Testing

```
pytest tests/plugins/model_providers/test_kimi_profile.py \
       tests/agent/transports/test_chat_completions.py \
       tests/agent/test_anthropic_kimi_signed_thinking_replay.py \
       tests/agent/test_model_metadata.py
# 288 passed

pytest tests/agent/test_anthropic_adapter.py tests/agent/test_anthropic_thinking_block_order.py
# 206 passed

ruff check <touched files>   # All checks passed
```

Non-vacuity: with the three source files reverted (tests kept), 27 of the new/updated tests
fail; all pass with the fix.

Per CONTRIBUTING, `scripts/run_tests.sh` (full CI-parity suite) was **not** run on the
authoring machine — only the directly touched modules (494 tests total). Recommend a
full-suite run or reliance on CI.

## Out of scope

- Capture-side at-rest blanking of Kimi thinking text (stored `thinking:""` with signature
  intact — matters for transcripts/compaction, not model quality). Tracked separately
  downstream.
- Provenance-tagging of captured thinking blocks (general cross-provider design, see above).
