### PR TITLE
fix(teams): authenticate inline image attachment downloads

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -497,6 +497,29 @@ def _validate_teams_service_url(raw: str) -> Optional[str]:
     return normalized
 
 
+def _is_bot_connector_url(raw: str) -> bool:
+    """True if ``raw`` points at the Bot Connector attachment service.
+
+    Images pasted or dragged into a Teams message do not arrive as
+    SharePoint links.  Their ``contentUrl`` is a Bot Connector endpoint
+    (``https://smba.trafficmanager.net/<region>/<tenant>/v3/attachments/
+    <id>/views/original``) which rejects unauthenticated GETs with 401.
+    Callers use this to decide whether a bearer token has to be attached.
+    """
+    if not raw:
+        return False
+    try:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(raw)
+    except Exception:
+        return False
+    return (
+        parsed.scheme == "https"
+        and parsed.hostname in _ALLOWED_TEAMS_SERVICE_HOSTS
+    )
+
+
 async def _standalone_send(
     pconfig,
     chat_id: str,
@@ -711,6 +734,8 @@ class TeamsAdapter(BasePlatformAdapter):
         # Maps chat_id → ConversationReference captured from incoming messages.
         # Used to send cards with the correct conversation type (personal/group/channel).
         self._conv_refs: Dict[str, Any] = {}
+        # Cached Bot Connector token for attachment downloads: (token, expiry_monotonic).
+        self._bf_token: Optional[tuple] = None
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         # Lazy-install the Teams SDK on demand (parity with Slack/Discord/etc.),
@@ -804,11 +829,68 @@ class TeamsAdapter(BasePlatformAdapter):
         self._mark_disconnected()
         logger.info("[teams] Disconnected")
 
+    async def _bot_connector_token(self, timeout: float = 15.0) -> Optional[str]:
+        """Mint (and briefly cache) a Bot Connector bearer token.
+
+        Same client-credentials grant the outbound activity path uses.  The
+        token is cached until shortly before expiry so a burst of attachments
+        on one message does not hit the STS once per file.
+        """
+        import time
+
+        if self._bf_token:
+            token, expires_at = self._bf_token
+            if time.monotonic() < expires_at:
+                return token
+
+        if not (self._client_id and self._client_secret and self._tenant_id):
+            return None
+        if not _TEAMS_CONV_ID_RE.match(self._tenant_id):
+            return None
+        if not AIOHTTP_AVAILABLE:
+            return None
+
+        import aiohttp as _aiohttp
+
+        token_url = (
+            f"https://login.microsoftonline.com/{self._tenant_id}/oauth2/v2.0/token"
+        )
+        async with _aiohttp.ClientSession(trust_env=True) as session:
+            async with session.post(
+                token_url,
+                data={
+                    "grant_type": "client_credentials",
+                    "client_id": self._client_id,
+                    "client_secret": self._client_secret,
+                    "scope": "https://api.botframework.com/.default",
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=_aiohttp.ClientTimeout(total=timeout),
+            ) as resp:
+                if resp.status >= 400:
+                    body = await resp.text()
+                    raise RuntimeError(
+                        f"Bot Connector token request failed ({resp.status}): {body[:200]}"
+                    )
+                payload = await resp.json()
+
+        token = payload.get("access_token")
+        if not token:
+            raise RuntimeError("Bot Connector token response missing access_token")
+        # Refresh a minute early rather than racing the hard expiry.
+        expires_in = float(payload.get("expires_in") or 3600)
+        self._bf_token = (token, time.monotonic() + max(expires_in - 60.0, 60.0))
+        return token
+
     async def _fetch_attachment_bytes(self, url: str, timeout: float = 30.0) -> bytes:
         """Download attachment bytes with SSRF protection.
 
-        Teams file attachments carry pre-authenticated SharePoint download
-        URLs (no extra auth header needed). Validates the URL against the
+        Teams *file* attachments carry pre-authenticated SharePoint download
+        URLs.  Inline images (paste / drag-and-drop) instead point at the Bot
+        Connector attachment service, which answers unauthenticated GETs with
+        401 — those get a freshly minted bearer token.  The token is only ever
+        sent to hosts on ``_ALLOWED_TEAMS_SERVICE_HOSTS`` so a tampered
+        ``contentUrl`` cannot exfiltrate it.  Validates the URL against the
         SSRF guard and follows redirects through the shared redirect guard,
         matching the cache_*_from_url helpers in gateway.platforms.base.
         """
@@ -818,15 +900,18 @@ class TeamsAdapter(BasePlatformAdapter):
         if not is_safe_url(url):
             raise ValueError("Blocked unsafe attachment URL (SSRF protection)")
 
+        headers = {"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"}
+        if _is_bot_connector_url(url):
+            token = await self._bot_connector_token()
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+
         async with create_ssrf_safe_async_client(
             timeout=timeout,
             follow_redirects=True,
             event_hooks={"response": [_ssrf_redirect_guard]},
         ) as client:
-            response = await client.get(
-                url,
-                headers={"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"},
-            )
+            response = await client.get(url, headers=headers)
             response.raise_for_status()
             return response.content
 
@@ -888,6 +973,9 @@ class TeamsAdapter(BasePlatformAdapter):
         media_urls = []
         media_types = []
         media_kinds = []
+        # Attachments the user sent that never reached the agent. Surfaced in
+        # the message text so neither side silently assumes they were seen.
+        dropped_media: list = []
         for att in getattr(activity, "attachments", None) or []:
             content_url = getattr(att, "content_url", None)
             content_type = (getattr(att, "content_type", None) or "").lower()
@@ -920,22 +1008,43 @@ class TeamsAdapter(BasePlatformAdapter):
                         media_types.append(cached.media_type)
                         media_kinds.append(cached.kind)
                     else:
+                        dropped_media.append(filename)
                         logger.warning(
                             "[teams] Unsupported document type for attachment '%s', skipping",
                             filename,
                         )
                 except Exception as e:
+                    dropped_media.append(filename)
                     logger.warning("[teams] Failed to cache file attachment '%s': %s", filename, e)
                 continue
 
             if content_url and content_type.startswith("image/"):
                 try:
-                    cached = await cache_image_from_url(content_url)
+                    if _is_bot_connector_url(content_url):
+                        # Pasted/inline image: needs a bearer token, so it
+                        # cannot go through the plain-URL cache helper.
+                        data = await self._fetch_attachment_bytes(content_url)
+                        media = cache_media_bytes(
+                            data,
+                            filename=att_name or "image",
+                            mime_type=content_type,
+                            default_kind="image",
+                        )
+                        cached = media.path if media else None
+                    else:
+                        cached = await cache_image_from_url(content_url)
                     if cached:
                         media_urls.append(cached)
                         media_types.append(content_type)
                         media_kinds.append("image")
+                    else:
+                        dropped_media.append(att_name or "image")
+                        logger.warning(
+                            "[teams] Image attachment '%s' could not be cached, skipping",
+                            att_name or content_url,
+                        )
                 except Exception as e:
+                    dropped_media.append(att_name or "image")
                     logger.warning("[teams] Failed to cache image attachment: %s", e)
                 continue
 
@@ -950,7 +1059,10 @@ class TeamsAdapter(BasePlatformAdapter):
                         media_urls.append(cached.path)
                         media_types.append(cached.media_type)
                         media_kinds.append(cached.kind)
+                    else:
+                        dropped_media.append(att_name or content_type or "file")
                 except Exception as e:
+                    dropped_media.append(att_name or content_type or "file")
                     logger.warning(
                         "[teams] Failed to cache attachment '%s' (%s): %s",
                         att_name or content_url, content_type, e,
@@ -971,6 +1083,20 @@ class TeamsAdapter(BasePlatformAdapter):
             msg_type = MessageType.AUDIO
         else:
             msg_type = MessageType.TEXT
+
+        # A dropped attachment used to be a WARNING in the log and nothing
+        # else: the agent answered as though it had seen an image it never
+        # received. Tell it plainly so it can say so instead of guessing.
+        if dropped_media:
+            names = ", ".join(dropped_media[:5])
+            if len(dropped_media) > 5:
+                names += f", +{len(dropped_media) - 5} more"
+            notice = (
+                f"[system: {len(dropped_media)} attachment(s) from this message "
+                f"could not be downloaded and are NOT visible to you ({names}). "
+                f"Say so instead of guessing at their contents.]"
+            )
+            text = f"{text}\n\n{notice}" if text.strip() else notice
 
         event = MessageEvent(
             text=text,

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -1125,3 +1125,175 @@ class TestTeamsMediaAttachments:
         result = await adapter.send_document("19:abc@thread.v2", "/no/such/file.pdf")
         assert not result.success
         adapter._app.send.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Tests: Inline image attachments (Bot Connector auth)
+# ---------------------------------------------------------------------------
+
+_CONNECTOR_IMAGE_URL = (
+    "https://smba.trafficmanager.net/apac/tenant-789/v3/attachments/"
+    "0-ea-d12-abcdef/views/original"
+)
+
+
+def _image_attachment(url=_CONNECTOR_IMAGE_URL, name="pasted.png"):
+    att = MagicMock()
+    att.content_url = url
+    att.content_type = "image/png"
+    att.name = name
+    return att
+
+
+class TestTeamsInlineImageAuth:
+    """Pasted images arrive on the Bot Connector, which needs a bearer token.
+
+    Fetching them unauthenticated returns 401 and the image is dropped, so the
+    agent answers about a picture it never saw.
+    """
+
+    def _make_adapter(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant-789",
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter.handle_message = AsyncMock()
+        return adapter
+
+    def _activity(self, attachments):
+        handler = TestTeamsMessageHandling()
+        return handler._make_activity(attachments=attachments), handler
+
+    def test_connector_url_is_recognized(self):
+        assert _teams_mod._is_bot_connector_url(_CONNECTOR_IMAGE_URL)
+
+    def test_sharepoint_url_is_not_a_connector_url(self):
+        assert not _teams_mod._is_bot_connector_url(
+            "https://contoso.sharepoint.com/sites/x/doc.png"
+        )
+
+    def test_attacker_host_is_not_a_connector_url(self):
+        # The bearer token must never follow a tampered contentUrl.
+        assert not _teams_mod._is_bot_connector_url(
+            "https://smba.trafficmanager.net.evil.example/v3/attachments/1/views/original"
+        )
+        assert not _teams_mod._is_bot_connector_url(
+            "http://smba.trafficmanager.net/v3/attachments/1/views/original"
+        )
+
+    @pytest.mark.anyio
+    async def test_inline_image_is_fetched_with_bearer_token(self):
+        adapter = self._make_adapter()
+        adapter._bot_connector_token = AsyncMock(return_value="tok-123")
+
+        captured = {}
+
+        class _Resp:
+            content = b"\x89PNG\r\n\x1a\n fake"
+
+            def raise_for_status(self):
+                return None
+
+        class _Client:
+            async def __aenter__(self_inner):
+                return self_inner
+
+            async def __aexit__(self_inner, *a):
+                return False
+
+            async def get(self_inner, url, headers=None):
+                captured["url"] = url
+                captured["headers"] = headers
+                return _Resp()
+
+        import tools.url_safety as _url_safety
+        orig_client = _url_safety.create_ssrf_safe_async_client
+        orig_safe = _url_safety.is_safe_url
+        _url_safety.create_ssrf_safe_async_client = lambda **kw: _Client()
+        _url_safety.is_safe_url = lambda u: True
+        try:
+            data = await adapter._fetch_attachment_bytes(_CONNECTOR_IMAGE_URL)
+        finally:
+            _url_safety.create_ssrf_safe_async_client = orig_client
+            _url_safety.is_safe_url = orig_safe
+
+        assert data == b"\x89PNG\r\n\x1a\n fake"
+        assert captured["headers"]["Authorization"] == "Bearer tok-123"
+
+    @pytest.mark.anyio
+    async def test_no_token_sent_to_non_connector_host(self):
+        adapter = self._make_adapter()
+        adapter._bot_connector_token = AsyncMock(return_value="tok-123")
+
+        captured = {}
+
+        class _Resp:
+            content = b"data"
+
+            def raise_for_status(self):
+                return None
+
+        class _Client:
+            async def __aenter__(self_inner):
+                return self_inner
+
+            async def __aexit__(self_inner, *a):
+                return False
+
+            async def get(self_inner, url, headers=None):
+                captured["headers"] = headers
+                return _Resp()
+
+        import tools.url_safety as _url_safety
+        orig_client = _url_safety.create_ssrf_safe_async_client
+        orig_safe = _url_safety.is_safe_url
+        _url_safety.create_ssrf_safe_async_client = lambda **kw: _Client()
+        _url_safety.is_safe_url = lambda u: True
+        try:
+            await adapter._fetch_attachment_bytes("https://contoso.sharepoint.com/a.png")
+        finally:
+            _url_safety.create_ssrf_safe_async_client = orig_client
+            _url_safety.is_safe_url = orig_safe
+
+        assert "Authorization" not in captured["headers"]
+        adapter._bot_connector_token.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_inline_image_reaches_the_agent(self):
+        adapter = self._make_adapter()
+        adapter._fetch_attachment_bytes = AsyncMock(return_value=b"bytes")
+
+        cached = SimpleNamespace(
+            path="/cache/pasted.png", media_type="image/png", kind="image"
+        )
+        orig = _teams_mod.cache_media_bytes
+        _teams_mod.cache_media_bytes = lambda *a, **kw: cached
+        try:
+            activity, handler = self._activity([_image_attachment()])
+            await adapter._on_message(handler._make_ctx(activity))
+        finally:
+            _teams_mod.cache_media_bytes = orig
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.media_urls == ["/cache/pasted.png"]
+        assert "could not be downloaded" not in event.text
+
+    @pytest.mark.anyio
+    async def test_failed_image_is_reported_not_silently_dropped(self):
+        adapter = self._make_adapter()
+        adapter._fetch_attachment_bytes = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "401", request=MagicMock(), response=MagicMock()
+            )
+        )
+
+        activity, handler = self._activity([_image_attachment()])
+        await adapter._on_message(handler._make_ctx(activity))
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.media_urls == []
+        assert "could not be downloaded" in event.text
+        assert "pasted.png" in event.text
+        # The user's own words survive alongside the notice.
+        assert "Hello" in event.text


### PR DESCRIPTION
## Problem

Images pasted or dragged into a Teams message do not arrive as SharePoint links. Their `contentUrl` points at the Bot Connector attachment service:

```
https://smba.trafficmanager.net/<region>/<tenant>/v3/attachments/<id>/views/original
```

That endpoint requires a Bot Framework bearer token. Both the image path (`cache_image_from_url`) and `_fetch_attachment_bytes` send plain unauthenticated GETs, so every pasted image comes back `401 Unauthorized` and is dropped with only a WARNING in the log:

```
WARNING hermes_plugins.teams_platform.adapter: [teams] Failed to cache image attachment:
  Client error '401 Unauthorized' for url
  'https://smba.trafficmanager.net/apac/<tenant>/v3/attachments/<id>/views/original'
```

Because the drop is silent from the agent's point of view, it goes on to answer about a picture it never received. In the case that surfaced this, a user pasted a screenshot of a broken diagram and asked what was wrong with it; the agent never saw the image and guessed.

`_fetch_attachment_bytes`' docstring assumes Teams attachments always carry pre-authenticated SharePoint URLs. That holds for the file-upload path, not for inline images.

## Fix

- Mint the same client-credentials token the outbound activity path already uses (`scope=https://api.botframework.com/.default`), cached until shortly before expiry so a burst of attachments on one message does not hit the STS once per file.
- Attach it **only** for hosts on `_ALLOWED_TEAMS_SERVICE_HOSTS`, so a tampered `contentUrl` cannot exfiltrate it. httpx drops `Authorization` on cross-origin redirects, and the existing SSRF guard plus `_ssrf_redirect_guard` still apply.
- Report dropped attachments in the message text instead of letting them vanish, so the agent can say it could not read the file rather than guessing. This covers the document and direct-URL branches too, which had the same silent-drop behaviour.

## Tests

7 new tests in `tests/gateway/test_teams.py`:

- connector-host detection, including a look-alike host (`smba.trafficmanager.net.evil.example`) and a plaintext-scheme URL
- bearer header present for connector URLs, absent for SharePoint URLs (and no token minted at all in that case)
- an inline image reaching the agent as a media URL
- a failed download surfacing in the message text, with the user's own words preserved alongside the notice

`tests/gateway/test_teams.py`, `tests/plugins/test_teams_pipeline_plugin.py` and `tests/hermes_cli/test_teams_pipeline_plugin_cli.py`: 87 passed.

## Not verified here

The live 401 → 200 transition needs a real Bot Connector and a deployed gateway; that is not covered by the test suite. The tests pin the header behaviour and the notice, not the round trip.