### PR TITLE
fix(discord): prevent first-turn STT hallucinations after voice join

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -465,6 +465,10 @@ class VoiceReceiver:
         # Opus decoder per SSRC (each user needs own decoder state)
         self._decoders: Dict[int, object] = {}
 
+        # Content-free counters: packets dropped because DAVE is active but
+        # the sender SSRC is neither mapped nor inferable (no user IDs).
+        self._dave_unresolved_drops: Dict[int, int] = {}
+
         # Pause flag: don't capture while bot is playing TTS
         self._paused = False
 
@@ -499,6 +503,7 @@ class VoiceReceiver:
             self._last_packet_time.clear()
             self._decoders.clear()
             self._ssrc_to_user.clear()
+            self._dave_unresolved_drops.clear()
         logger.info("VoiceReceiver stopped")
 
     def pause(self):
@@ -532,7 +537,7 @@ class VoiceReceiver:
                 ssrc = data.get("ssrc")
                 user_id = data.get("user_id")
                 if ssrc and user_id:
-                    logger.info("SPEAKING event: ssrc=%d -> user=%s", ssrc, user_id)
+                    logger.info("SPEAKING event: ssrc=%d mapped to user", ssrc)
                     receiver_self.map_ssrc(int(ssrc), int(user_id))
             if original_hook:
                 await original_hook(ws, msg)
@@ -658,7 +663,19 @@ class VoiceReceiver:
         if self._dave_session:
             with self._lock:
                 user_id = self._ssrc_to_user.get(ssrc, 0)
+            if not user_id:
+                # SPEAKING can lag or be missing after a (re)join.  Resolve
+                # the sender now, at packet time: DAVE needs the sender's
+                # user_id to pick the right ratchet, and waiting for the
+                # silence flush is too late for the first utterance.
+                # NOTE: _infer_user_for_ssrc writes _ssrc_to_user without
+                # the lock — a single GIL-atomic dict store, idempotent,
+                # and _on_packet runs on the single SocketReader thread.
+                user_id = self._infer_user_for_ssrc(ssrc)
             if user_id:
+                # Resolved — reset the drop counter so the dict only ever
+                # holds currently-unresolved SSRCs.
+                self._dave_unresolved_drops.pop(ssrc, None)
                 try:
                     import davey
                     decrypted = self._dave_session.decrypt(
@@ -670,9 +687,22 @@ class VoiceReceiver:
                         if self._packet_debug_count <= 10:
                             logger.warning("DAVE decrypt failed for ssrc=%d: %s", ssrc, e)
                         return
-            # If SSRC unknown (no SPEAKING event yet), skip DAVE and try
-            # Opus decode directly — audio may be in passthrough mode.
-            # Buffer will get a user_id when SPEAKING event arrives later.
+            else:
+                # Sender unknown and not inferable: with DAVE active the
+                # payload is almost certainly still DAVE-encrypted.  Feeding
+                # it to the Opus decoder buffers noise that survives the
+                # energy gate and corrupts the first utterance (live repro).
+                # Drop until SPEAKING/inference maps the SSRC; no decoder is
+                # created, so a later mapping starts from a clean state.
+                drops = self._dave_unresolved_drops.get(ssrc, 0) + 1
+                self._dave_unresolved_drops[ssrc] = drops
+                if drops == 1 or drops % 50 == 0:
+                    logger.info(
+                        "DAVE active with unresolved sender: dropping "
+                        "encrypted packets (ssrc=%d drops=%d)",
+                        ssrc, drops,
+                    )
+                return
 
         # --- Opus decode -> PCM ---
         try:
@@ -770,7 +800,9 @@ class VoiceReceiver:
             if len(candidates) == 1:
                 uid = candidates[0]
                 self._ssrc_to_user[ssrc] = uid
-                logger.info("Auto-mapped ssrc=%d -> user=%d (sole allowed member)", ssrc, uid)
+                logger.info(
+                    "Auto-mapped ssrc=%d to sole allowed member", ssrc,
+                )
                 return uid
         except Exception:
             pass

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -437,6 +437,12 @@ class VoiceReceiver:
     MIN_SPEECH_DURATION = 0.5  # minimum seconds to process (skip noise)
     SAMPLE_RATE = 48000        # Discord native rate
     CHANNELS = 2               # Discord sends stereo
+    PCM_FRAME_DURATION = 0.02  # Discord/Opus frame duration in seconds
+    # A deliberately permissive floor (~-50 dBFS) excludes decoded comfort
+    # noise/silence without depending on the user's microphone route or gain.
+    ACTIVE_FRAME_RMS = 100
+    # Require sustained energy so a join-time pop/click cannot reach STT.
+    MIN_ACTIVE_SPEECH_DURATION = 0.1
 
     def __init__(self, voice_client, allowed_user_ids: set = None):
         self._vc = voice_client
@@ -690,6 +696,60 @@ class VoiceReceiver:
     # Silence detection
     # ------------------------------------------------------------------
 
+    @classmethod
+    def _pcm_speech_activity(cls, pcm_data: bytes) -> Tuple[bool, dict]:
+        """Classify structurally valid PCM using sustained frame energy.
+
+        This is not language/transcript filtering.  It rejects only segments
+        that contain too little acoustic activity to be speech, which prevents
+        OpenAI/Whisper from inventing text for Discord's join-time Opus comfort
+        frames while preserving the first real utterance regardless of order.
+        """
+        bytes_per_frame = int(
+            cls.SAMPLE_RATE * cls.CHANNELS * 2 * cls.PCM_FRAME_DURATION
+        )
+        active_frames = 0
+        total_frames = 0
+        peak = 0
+        sum_squares = 0
+        sample_count = 0
+
+        for offset in range(0, len(pcm_data), bytes_per_frame):
+            frame = pcm_data[offset:offset + bytes_per_frame]
+            # Ignore an odd trailing byte rather than treating malformed PCM
+            # as activity. pcm_to_wav uses the same signed 16-bit LE shape.
+            frame = frame[:len(frame) - (len(frame) % 2)]
+            if not frame:
+                continue
+            frame_sum_squares = 0
+            frame_samples = 0
+            for (sample,) in struct.iter_unpack("<h", frame):
+                magnitude = abs(sample)
+                peak = max(peak, magnitude)
+                square = sample * sample
+                frame_sum_squares += square
+                sum_squares += square
+                frame_samples += 1
+                sample_count += 1
+            total_frames += 1
+            frame_rms = math.sqrt(frame_sum_squares / frame_samples)
+            if frame_rms >= cls.ACTIVE_FRAME_RMS:
+                active_frames += 1
+
+        required_active_frames = math.ceil(
+            cls.MIN_ACTIVE_SPEECH_DURATION / cls.PCM_FRAME_DURATION
+        )
+        total_rms = (
+            math.sqrt(sum_squares / sample_count) if sample_count else 0.0
+        )
+        stats = {
+            "duration_ms": round(total_frames * cls.PCM_FRAME_DURATION * 1000),
+            "active_ms": round(active_frames * cls.PCM_FRAME_DURATION * 1000),
+            "rms": round(total_rms),
+            "peak": peak,
+        }
+        return active_frames >= required_active_frames, stats
+
     def _infer_user_for_ssrc(self, ssrc: int) -> int:
         """Try to infer user_id for an unmapped SSRC.
 
@@ -733,13 +793,27 @@ class VoiceReceiver:
                 buf_duration = len(buf) / (self.SAMPLE_RATE * self.CHANNELS * 2)
 
                 if silence_duration >= self.SILENCE_THRESHOLD and buf_duration >= self.MIN_SPEECH_DURATION:
+                    pcm_data = bytes(buf)
+                    has_speech, stats = self._pcm_speech_activity(pcm_data)
+                    if not has_speech:
+                        logger.info(
+                            "Discarded non-speech PCM segment "
+                            "(duration_ms=%d active_ms=%d rms=%d peak=%d)",
+                            stats["duration_ms"],
+                            stats["active_ms"],
+                            stats["rms"],
+                            stats["peak"],
+                        )
+                        self._buffers[ssrc] = bytearray()
+                        self._last_packet_time.pop(ssrc, None)
+                        continue
                     user_id = ssrc_user_map.get(ssrc, 0)
                     if not user_id:
                         # SSRC not mapped (SPEAKING event missing after bot rejoin).
                         # Infer from allowed users in the voice channel.
                         user_id = self._infer_user_for_ssrc(ssrc)
                     if user_id:
-                        completed.append((user_id, bytes(buf)))
+                        completed.append((user_id, pcm_data))
                     self._buffers[ssrc] = bytearray()
                     self._last_packet_time.pop(ssrc, None)
                 elif silence_duration >= self.SILENCE_THRESHOLD * 2:

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -2836,7 +2836,8 @@ class TestVoiceReception:
 
     # -- _on_packet DAVE passthrough behavior --
 
-    def _make_receiver_with_nacl(self, dave_session=None, mapped_ssrcs=None):
+    def _make_receiver_with_nacl(self, dave_session=None, mapped_ssrcs=None,
+                                 allowed_ids=None, members=None):
         """Create a receiver that can process _on_packet with mocked NaCl + Opus."""
         from plugins.platforms.discord.adapter import VoiceReceiver
         vc = MagicMock()
@@ -2848,8 +2849,8 @@ class TestVoiceReception:
         vc._connection.hook = None
         vc.user = SimpleNamespace(id=9999)
         vc.channel = MagicMock()
-        vc.channel.members = []
-        receiver = VoiceReceiver(vc)
+        vc.channel.members = members if members is not None else []
+        receiver = VoiceReceiver(vc, allowed_user_ids=allowed_ids)
         receiver.start()
         # Pre-map SSRCs if provided
         if mapped_ssrcs:
@@ -2895,18 +2896,96 @@ class TestVoiceReception:
         assert len(receiver._buffers[100]) > 0
         dave.decrypt.assert_called_once()
 
-    def test_on_packet_dave_unknown_ssrc_passthrough(self):
-        """Unknown SSRC + DAVE → skip DAVE, attempt Opus decode (passthrough)."""
+    def test_on_packet_dave_unknown_ssrc_encrypted_dropped(self):
+        """Unknown SSRC + DAVE + identity not inferable → payload never decoded.
+
+        Regression: with DAVE active, an unmapped SSRC means the payload is
+        still DAVE-encrypted.  Feeding it to the Opus decoder buffers noise
+        that survives the energy gate and corrupts the first utterance.
+        """
+        dave = MagicMock()
+        # Members present but two candidates → inference cannot resolve.
+        members = [
+            SimpleNamespace(id=9999, name="Bot"),
+            SimpleNamespace(id=42, name="Alice"),
+            SimpleNamespace(id=43, name="Bob"),
+        ]
+        receiver = self._make_receiver_with_nacl(
+            dave_session=dave, members=members,
+        )
+
+        with patch("nacl.secret.Aead") as mock_aead, \
+                patch("discord.opus.Decoder") as mock_decoder_cls:
+            mock_aead.return_value.decrypt.return_value = b"\xf8\xff\xfe"
+            receiver._on_packet(self._build_rtp_packet(ssrc=100))
+
+        dave.decrypt.assert_not_called()
+        mock_decoder_cls.assert_not_called()
+        assert len(receiver._buffers.get(100, b"")) == 0
+        assert 100 not in receiver._decoders
+
+    def test_on_packet_dave_unknown_ssrc_drop_logged_content_free(self, caplog):
+        """The unknown-SSRC drop is instrumented without user ID or payload."""
         dave = MagicMock()
         receiver = self._make_receiver_with_nacl(dave_session=dave)
-        self._inject_mock_decoder(receiver, 100)
+
+        with caplog.at_level("INFO"), patch("nacl.secret.Aead") as mock_aead:
+            mock_aead.return_value.decrypt.return_value = b"\xf8\xff\xfe"
+            receiver._on_packet(self._build_rtp_packet(ssrc=100))
+
+        drop_lines = [r.getMessage() for r in caplog.records
+                      if "unresolved sender" in r.getMessage()]
+        assert drop_lines, "expected a content-free drop log line"
+        for line in drop_lines:
+            assert "42" not in line  # no user ID
+            assert "f8fffe" not in line  # no payload bytes
+
+    def test_on_packet_dave_unknown_ssrc_inferred_user_decrypts(self):
+        """Unknown SSRC + DAVE + sole allowed member → infer at packet time.
+
+        The first real utterance must be preserved when identity is
+        inferable: SSRC mapped immediately, DAVE decrypt runs with the
+        inferred sender, PCM buffered under the mapped SSRC.
+        """
+        dave = MagicMock()
+        dave.decrypt.return_value = b"\xf8\xff\xfe"
+        members = [
+            SimpleNamespace(id=9999, name="Bot"),
+            SimpleNamespace(id=42, name="Alice"),
+        ]
+        receiver = self._make_receiver_with_nacl(
+            dave_session=dave, allowed_ids={"42"}, members=members,
+        )
+        mock_decoder = self._inject_mock_decoder(receiver, 100)
 
         with patch("nacl.secret.Aead") as mock_aead:
             mock_aead.return_value.decrypt.return_value = b"\xf8\xff\xfe"
             receiver._on_packet(self._build_rtp_packet(ssrc=100))
 
-        dave.decrypt.assert_not_called()
-        assert 100 in receiver._buffers
+        assert receiver._ssrc_to_user[100] == 42
+        dave.decrypt.assert_called_once()
+        assert dave.decrypt.call_args[0][0] == 42
+        mock_decoder.decode.assert_called_once()
+        assert len(receiver._buffers[100]) > 0
+
+    def test_on_packet_dave_unknown_ssrc_recovers_after_speaking(self):
+        """Packets dropped while unresolved; SPEAKING maps → normal decrypt."""
+        dave = MagicMock()
+        dave.decrypt.return_value = b"\xf8\xff\xfe"
+        receiver = self._make_receiver_with_nacl(dave_session=dave)
+
+        with patch("nacl.secret.Aead") as mock_aead:
+            mock_aead.return_value.decrypt.return_value = b"\xf8\xff\xfe"
+            # First packet: unresolved → dropped, no decoder created.
+            receiver._on_packet(self._build_rtp_packet(ssrc=100, seq=1))
+            assert len(receiver._buffers.get(100, b"")) == 0
+
+            # SPEAKING event arrives late.
+            receiver.map_ssrc(100, 42)
+            self._inject_mock_decoder(receiver, 100)
+            receiver._on_packet(self._build_rtp_packet(ssrc=100, seq=2))
+
+        dave.decrypt.assert_called_once()
         assert len(receiver._buffers[100]) > 0
 
     def test_on_packet_dave_unencrypted_error_passthrough(self):
@@ -2973,6 +3052,59 @@ class TestVoiceReception:
 
         assert 100 in receiver._buffers
         assert 200 in receiver._buffers
+
+
+class TestSpeechActivityProbes:
+    """Calibration probes for the sustained-energy speech gate.
+
+    Documents which representative mic-route signals pass or are rejected
+    by ACTIVE_FRAME_RMS / MIN_ACTIVE_SPEECH_DURATION.  RMS of a full-scale
+    square wave equals its amplitude; amplitude A ≈ 20*log10(A/32768) dBFS:
+
+      - desktop/headset speech:   1000-8000  (-30 to -12 dBFS)  → pass
+      - quiet mobile/low-gain:     200-400   (-44 to -38 dBFS)  → pass
+      - gate floor:                100       (-50 dBFS)         → pass
+      - comfort noise / hiss:       10-40    (-70 to -58 dBFS)  → reject
+      - digital silence:             0                          → reject
+      - join pop/click (one frame):  any amplitude              → reject
+
+    Residual risk: a mic route delivering sustained speech below -50 dBFS
+    RMS (very low gain, heavy OS-level suppression) is rejected as
+    non-speech.  The floor stays deliberately permissive; raising it would
+    let decoded comfort noise reach STT again.
+    """
+
+    @staticmethod
+    def _gate(pcm: bytes):
+        from plugins.platforms.discord.adapter import VoiceReceiver
+        return VoiceReceiver._pcm_speech_activity(pcm)
+
+    @pytest.mark.parametrize("amplitude", [1000, 4000, 8000])
+    def test_desktop_headset_speech_passes(self, amplitude):
+        has_speech, stats = self._gate(_voice_like_pcm(0.6, amplitude))
+        assert has_speech, stats
+
+    @pytest.mark.parametrize("amplitude", [200, 400])
+    def test_quiet_mobile_low_gain_speech_passes(self, amplitude):
+        has_speech, stats = self._gate(_voice_like_pcm(0.6, amplitude))
+        assert has_speech, stats
+
+    def test_gate_floor_amplitude_passes(self):
+        has_speech, stats = self._gate(_voice_like_pcm(0.6, 100))
+        assert has_speech, stats
+
+    @pytest.mark.parametrize("amplitude", [0, 10, 40])
+    def test_comfort_noise_and_silence_rejected(self, amplitude):
+        has_speech, stats = self._gate(_voice_like_pcm(0.6, amplitude))
+        assert not has_speech, stats
+
+    @pytest.mark.parametrize("amplitude", [1000, 8000, 30000])
+    def test_single_frame_click_rejected(self, amplitude):
+        """A lone 20ms pop amid silence never reaches STT, however loud."""
+        frame = _voice_like_pcm(0.02, amplitude)
+        silence = b"\x00" * (len(_voice_like_pcm(0.6)) - len(frame))
+        has_speech, stats = self._gate(frame + silence)
+        assert not has_speech, stats
 
 
 class TestVoiceTTSPlayback:

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -72,6 +72,16 @@ def _make_event(text: str = "", message_type=MessageType.TEXT, chat_id="123") ->
     return event
 
 
+def _voice_like_pcm(duration_s: float, amplitude: int = 1000) -> bytes:
+    """Return deterministic 48 kHz stereo s16le PCM with sustained energy."""
+    sample_count = int(48000 * 2 * duration_s)
+    pair = (
+        int(amplitude).to_bytes(2, "little", signed=True)
+        + int(-amplitude).to_bytes(2, "little", signed=True)
+    )
+    return (pair * ((sample_count + 1) // 2))[:sample_count * 2]
+
+
 def _make_runner(tmp_path):
     """Create a bare GatewayRunner without calling __init__."""
     from gateway.run import GatewayRunner
@@ -689,7 +699,7 @@ class TestVoiceReceiver:
         receiver.map_ssrc(100, 42)
         # 48kHz, stereo, 16-bit = 192000 bytes/sec
         # MIN_SPEECH_DURATION = 0.5s → need 96000 bytes
-        pcm_data = bytearray(b"\x00" * 96000)
+        pcm_data = bytearray(_voice_like_pcm(0.5))
         receiver._buffers[100] = pcm_data
         # Set last_packet_time far enough in the past to exceed SILENCE_THRESHOLD
         receiver._last_packet_time[100] = time.monotonic() - 3.0
@@ -700,6 +710,43 @@ class TestVoiceReceiver:
         assert len(data) == 96000
         # Buffer should be cleared after extraction
         assert len(receiver._buffers[100]) == 0
+
+    def test_check_silence_rejects_join_warmup_silence(self, caplog):
+        receiver = self._make_receiver()
+        receiver.map_ssrc(100, 42)
+        receiver._buffers[100] = bytearray(b"\x00" * 192000)
+        receiver._last_packet_time[100] = time.monotonic() - 3.0
+
+        with caplog.at_level(logging.INFO):
+            completed = receiver.check_silence()
+
+        assert completed == []
+        assert len(receiver._buffers[100]) == 0
+        assert "non-speech PCM segment" in caplog.text
+
+    def test_check_silence_rejects_join_warmup_transient(self):
+        receiver = self._make_receiver()
+        receiver.map_ssrc(100, 42)
+        transient = _voice_like_pcm(0.02, amplitude=3000)
+        receiver._buffers[100] = bytearray(
+            transient + b"\x00" * (192000 - len(transient))
+        )
+        receiver._last_packet_time[100] = time.monotonic() - 3.0
+
+        assert receiver.check_silence() == []
+
+    def test_first_and_followup_voice_segments_are_preserved(self):
+        receiver = self._make_receiver()
+        receiver.map_ssrc(100, 42)
+
+        for amplitude in (400, 1200):
+            pcm_data = _voice_like_pcm(0.6, amplitude=amplitude)
+            receiver._buffers[100] = bytearray(pcm_data)
+            receiver._last_packet_time[100] = time.monotonic() - 3.0
+
+            completed = receiver.check_silence()
+
+            assert completed == [(42, pcm_data)]
 
     def test_check_silence_ignores_short_buffer(self):
         receiver = self._make_receiver()
@@ -2625,8 +2672,7 @@ class TestVoiceReception:
     @staticmethod
     def _fill_buffer(receiver, ssrc, duration_s=1.0, age_s=3.0):
         """Add PCM data to buffer. 48kHz stereo 16-bit = 192000 bytes/sec."""
-        size = int(192000 * duration_s)
-        receiver._buffers[ssrc] = bytearray(b"\x00" * size)
+        receiver._buffers[ssrc] = bytearray(_voice_like_pcm(duration_s))
         receiver._last_packet_time[ssrc] = time.monotonic() - age_s
 
     # -- Known SSRC (normal flow) --

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -3,6 +3,7 @@
 import asyncio
 import importlib.util
 import json
+import logging
 import os
 import queue
 import sys

--- a/tests/integration/test_voice_channel_flow.py
+++ b/tests/integration/test_voice_channel_flow.py
@@ -7,6 +7,7 @@ packet processing pipeline end-to-end.
 Requires: PyNaCl>=1.5.0, discord.py[voice] (opus codec)
 """
 
+import math
 import struct
 import time
 import pytest
@@ -132,6 +133,39 @@ def _make_voice_receiver(secret_key, dave_session=None, bot_ssrc=9999,
     receiver = VoiceReceiver(vc, allowed_user_ids=allowed_user_ids)
     receiver.start()
     return receiver
+
+
+def _opus_tone_payloads(frame_count=30, amplitude=1000, frequency=440.0):
+    """Encode deterministic speech-energy PCM through the real Opus codec."""
+    encoder = discord.opus.Encoder()
+    payloads = []
+    samples_per_frame = discord.opus.Encoder.SAMPLES_PER_FRAME
+    for frame_index in range(frame_count):
+        pcm = bytearray()
+        for sample_offset in range(samples_per_frame):
+            sample_index = frame_index * samples_per_frame + sample_offset
+            sample = round(
+                amplitude
+                * math.sin(2 * math.pi * frequency * sample_index / 48000)
+            )
+            pcm.extend(struct.pack("<hh", sample, sample))
+        payloads.append(encoder.encode(bytes(pcm), samples_per_frame))
+    return payloads
+
+
+def _send_opus_tone(receiver, secret_key, ssrc, frame_count=30, seq_start=1):
+    for seq, opus_payload in enumerate(
+        _opus_tone_payloads(frame_count=frame_count), start=seq_start,
+    ):
+        receiver._on_packet(
+            _build_encrypted_rtp_packet(
+                secret_key,
+                opus_payload,
+                ssrc=ssrc,
+                seq=seq,
+                timestamp=960 * seq,
+            )
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -365,32 +399,26 @@ class TestRTPPaddingStrip:
 class TestFullVoiceFlow:
     """End-to-end: encrypt → receive → buffer → silence detect → complete."""
 
-    def test_single_utterance_flow(self):
-        """Encrypt packets → buffer → silence → check_silence returns utterance."""
+    def test_join_warmup_opus_silence_is_rejected(self):
+        """Real encrypted Opus comfort frames never become an STT utterance."""
         key = _make_secret_key()
         receiver = _make_voice_receiver(key)
         receiver.map_ssrc(100, 42)
 
-        # Send enough packets to exceed MIN_SPEECH_DURATION (0.5s)
-        # At 48kHz stereo 16-bit, each Opus silence frame decodes to ~3840 bytes
-        # Need 96000 bytes = ~25 frames
         for seq in range(1, 30):
             packet = _build_encrypted_rtp_packet(
                 key, b'\xf8\xff\xfe', ssrc=100, seq=seq, timestamp=960 * seq
             )
             receiver._on_packet(packet)
 
-        # Simulate silence by setting last_packet_time in the past
         receiver._last_packet_time[100] = time.monotonic() - 3.0
 
         completed = receiver.check_silence()
-        assert len(completed) == 1
-        user_id, pcm_data = completed[0]
-        assert user_id == 42
-        assert len(pcm_data) > 0
+        assert completed == []
+        assert len(receiver._buffers[100]) == 0
 
     def test_utterance_with_ssrc_automap(self):
-        """No SPEAKING event → auto-map sole allowed user → utterance processed."""
+        """First real Opus utterance survives the gate and SSRC auto-map."""
         key = _make_secret_key()
         members = [
             SimpleNamespace(id=9999, name="Bot"),
@@ -401,9 +429,9 @@ class TestFullVoiceFlow:
         )
         # No map_ssrc call — simulating missing SPEAKING event
 
-        for seq in range(1, 30):
+        for seq, opus_payload in enumerate(_opus_tone_payloads(), start=1):
             packet = _build_encrypted_rtp_packet(
-                key, b'\xf8\xff\xfe', ssrc=100, seq=seq, timestamp=960 * seq
+                key, opus_payload, ssrc=100, seq=seq, timestamp=960 * seq
             )
             receiver._on_packet(packet)
 
@@ -502,11 +530,7 @@ class TestSPEAKINGHook:
         receiver = _make_voice_receiver(key)
         receiver.map_ssrc(100, 42)
 
-        for seq in range(1, 30):
-            packet = _build_encrypted_rtp_packet(
-                key, b'\xf8\xff\xfe', ssrc=100, seq=seq, timestamp=960 * seq
-            )
-            receiver._on_packet(packet)
+        _send_opus_tone(receiver, key, ssrc=100)
 
         receiver._last_packet_time[100] = time.monotonic() - 3.0
         completed = receiver.check_silence()
@@ -529,11 +553,7 @@ class TestAuthFiltering:
         )
         receiver.map_ssrc(100, 42)
 
-        for seq in range(1, 30):
-            packet = _build_encrypted_rtp_packet(
-                key, b'\xf8\xff\xfe', ssrc=100, seq=seq, timestamp=960 * seq
-            )
-            receiver._on_packet(packet)
+        _send_opus_tone(receiver, key, ssrc=100)
 
         receiver._last_packet_time[100] = time.monotonic() - 3.0
         completed = receiver.check_silence()
@@ -553,11 +573,7 @@ class TestAuthFiltering:
         )
         # No map_ssrc — SSRC unknown, auto-map should reject
 
-        for seq in range(1, 30):
-            packet = _build_encrypted_rtp_packet(
-                key, b'\xf8\xff\xfe', ssrc=100, seq=seq, timestamp=960 * seq
-            )
-            receiver._on_packet(packet)
+        _send_opus_tone(receiver, key, ssrc=100)
 
         receiver._last_packet_time[100] = time.monotonic() - 3.0
         completed = receiver.check_silence()
@@ -574,11 +590,7 @@ class TestAuthFiltering:
             key, allowed_user_ids=None, members=members,
         )
 
-        for seq in range(1, 30):
-            packet = _build_encrypted_rtp_packet(
-                key, b'\xf8\xff\xfe', ssrc=100, seq=seq, timestamp=960 * seq
-            )
-            receiver._on_packet(packet)
+        _send_opus_tone(receiver, key, ssrc=100)
 
         receiver._last_packet_time[100] = time.monotonic() - 3.0
         completed = receiver.check_silence()
@@ -621,11 +633,7 @@ class TestRejoinFlow:
         receiver2 = _make_voice_receiver(key)
         receiver2.map_ssrc(200, 42)  # new SSRC after rejoin
 
-        for seq in range(1, 30):
-            packet = _build_encrypted_rtp_packet(
-                key, b'\xf8\xff\xfe', ssrc=200, seq=seq, timestamp=960 * seq
-            )
-            receiver2._on_packet(packet)
+        _send_opus_tone(receiver2, key, ssrc=200)
 
         receiver2._last_packet_time[200] = time.monotonic() - 3.0
         completed = receiver2.check_silence()
@@ -653,11 +661,7 @@ class TestRejoinFlow:
         )
         # No map_ssrc — simulating missing SPEAKING event
 
-        for seq in range(1, 30):
-            packet = _build_encrypted_rtp_packet(
-                new_key, b'\xf8\xff\xfe', ssrc=300, seq=seq, timestamp=960 * seq
-            )
-            receiver2._on_packet(packet)
+        _send_opus_tone(receiver2, new_key, ssrc=300)
 
         receiver2._last_packet_time[300] = time.monotonic() - 3.0
         completed = receiver2.check_silence()
@@ -748,11 +752,7 @@ class TestEchoPreventionFlow:
         assert len(receiver._buffers.get(100, b"")) == 0
 
         receiver.resume()
-        for seq in range(5, 35):
-            packet = _build_encrypted_rtp_packet(
-                key, b'\xf8\xff\xfe', ssrc=100, seq=seq, timestamp=960 * seq
-            )
-            receiver._on_packet(packet)
+        _send_opus_tone(receiver, key, ssrc=100, seq_start=5)
 
         assert len(receiver._buffers[100]) > 0
         receiver._last_packet_time[100] = time.monotonic() - 3.0

--- a/tests/integration/test_voice_channel_flow.py
+++ b/tests/integration/test_voice_channel_flow.py
@@ -242,20 +242,69 @@ class TestRealNaClDecrypt:
 class TestRealNaClWithDAVE:
     """NaCl decrypt + DAVE passthrough scenarios with real crypto."""
 
-    def test_dave_unknown_ssrc_passthrough(self):
-        """DAVE enabled but SSRC unknown → skip DAVE, buffer audio."""
+    def test_dave_unknown_ssrc_encrypted_never_decoded(self):
+        """DAVE + unknown SSRC + non-inferable → payload never Opus-decoded.
+
+        Regression for the live first-utterance corruption: with DAVE
+        active, an unmapped SSRC payload is still DAVE-encrypted.  It must
+        never reach the Opus decoder, the PCM buffer, or a completed
+        utterance — regardless of how much energy the ciphertext carries.
+        """
         key = _make_secret_key()
         dave = MagicMock()  # DAVE session present but SSRC not mapped
-        receiver = _make_voice_receiver(key, dave_session=dave)
+        members = [
+            SimpleNamespace(id=9999, name="Bot"),
+            SimpleNamespace(id=42, name="Alice"),
+            SimpleNamespace(id=43, name="Bob"),
+        ]
+        receiver = _make_voice_receiver(key, dave_session=dave, members=members)
 
-        packet = _build_encrypted_rtp_packet(key, b'\xf8\xff\xfe', ssrc=100)
-        receiver._on_packet(packet)
+        # Full utterance worth of frames (real Opus tone payloads standing
+        # in for still-DAVE-encrypted bytes from the receiver's viewpoint).
+        _send_opus_tone(receiver, key, ssrc=100)
 
-        # DAVE decrypt not called (SSRC unknown)
         dave.decrypt.assert_not_called()
-        # Audio still buffered via passthrough
-        assert 100 in receiver._buffers
-        assert len(receiver._buffers[100]) > 0
+        assert 100 not in receiver._decoders
+        assert len(receiver._buffers.get(100, b"")) == 0
+
+        # Even after the silence window, nothing completes.
+        receiver._last_packet_time[100] = time.monotonic() - 3.0
+        assert receiver.check_silence() == []
+
+    def test_dave_unknown_ssrc_inferred_first_utterance_preserved(self):
+        """DAVE + unknown SSRC + sole allowed member → first utterance kept.
+
+        Identity is inferred at packet time, DAVE decrypt runs with the
+        inferred sender, and the flushed utterance is attributed to that
+        user with its speech energy intact.
+        """
+        key = _make_secret_key()
+        dave = MagicMock()
+        dave.decrypt.side_effect = lambda user_id, media_type, data: data
+        members = [
+            SimpleNamespace(id=9999, name="Bot"),
+            SimpleNamespace(id=42, name="Alice"),
+        ]
+        receiver = _make_voice_receiver(
+            key, dave_session=dave, allowed_user_ids={"42"}, members=members,
+        )
+        # No map_ssrc call — simulating missing SPEAKING event after join.
+
+        _send_opus_tone(receiver, key, ssrc=100)
+
+        assert receiver._ssrc_to_user[100] == 42
+        assert dave.decrypt.call_count > 0
+        assert all(
+            call.args[0] == 42 for call in dave.decrypt.call_args_list
+        )
+
+        receiver._last_packet_time[100] = time.monotonic() - 3.0
+        completed = receiver.check_silence()
+        assert len(completed) == 1
+        assert completed[0][0] == 42
+        # Real tone PCM survived both DAVE and the speech gate.
+        has_speech, _ = VoiceReceiver._pcm_speech_activity(completed[0][1])
+        assert has_speech
 
     def test_dave_unencrypted_error_passthrough(self):
         """DAVE raises 'Unencrypted' → use NaCl-decrypted data as-is."""
@@ -326,13 +375,19 @@ class TestRTPPaddingStrip:
         """Padding stripped before DAVE → passthrough buffers cleanly."""
         key = _make_secret_key()
         opus_silence = b"\xf8\xff\xfe"
-        dave = MagicMock()  # SSRC unmapped → DAVE skipped, passthrough used
+        dave = MagicMock()
+        dave.decrypt.side_effect = Exception(
+            "DecryptionFailed(UnencryptedWhenPassthroughDisabled)"
+        )
         receiver = _make_voice_receiver(key, dave_session=dave)
+        receiver.map_ssrc(100, 42)
 
         packet = _build_padded_rtp_packet(key, opus_silence, pad_len=4, ssrc=100)
         receiver._on_packet(packet)
 
-        dave.decrypt.assert_not_called()
+        # DAVE saw the padding-stripped payload and declared it unencrypted.
+        dave.decrypt.assert_called_once()
+        assert dave.decrypt.call_args[0][2] == opus_silence
         assert 100 in receiver._buffers
         assert len(receiver._buffers[100]) > 0
 

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -484,6 +484,25 @@ class TestTranscribeOpenAIExtended:
         assert result["transcript"] == "hello"
         mock_client.close.assert_called_once()
 
+    def test_provider_language_hint_is_forwarded(self, monkeypatch, sample_wav):
+        monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
+        monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = {"text": "bonjour"}
+
+        with patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("openai.OpenAI", return_value=mock_client), \
+             patch(
+                 "tools.transcription_tools._load_stt_config",
+                 return_value={"openai": {"language": "fr"}},
+             ):
+            from tools.transcription_tools import _transcribe_openai
+            result = _transcribe_openai(sample_wav, "gpt-4o-transcribe")
+
+        assert result["success"] is True
+        kwargs = mock_client.audio.transcriptions.create.call_args.kwargs
+        assert kwargs["language"] == "fr"
+
     def test_permission_error(self, monkeypatch, sample_wav):
         monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
 


### PR DESCRIPTION
## Summary
- reject decoded Opus comfort/silence segments before they reach STT using a permissive PCM activity gate
- resolve inferable Discord SSRC identities before DAVE decryption and Opus decoding
- drop unresolved encrypted DAVE packets instead of decoding ciphertext as Opus
- preserve first valid utterances, explicit `Unencrypted` passthrough, multi-user attribution, and the configured STT language hint

## Root cause
After `/voice join`, an unknown SSRC could bypass DAVE decryption and send encrypted payloads to the Opus decoder before sender inference occurred. Separately, decoded Opus comfort frames could exceed the duration-only speech gate. Both paths produced low-information or corrupted WAVs that STT turned into plausible foreign-language text.

## Validation
- independent implementation review and re-QA: `PASS_FOR_REVIEW`
- fresh post-rebase targeted suite: **403 passed, 0 failed**
- fresh post-rebase Discord-expanded suite: **839 passed, 0 failed** across 44 files
- `git diff --check origin/main..HEAD`: clean

## Residual risk
Sustained real speech below roughly -50 dBFS may be rejected by the activity gate. In multi-user channels where sender identity cannot yet be inferred, initial encrypted packets are dropped until Discord supplies a SPEAKING mapping; this is fail-closed and avoids misattribution or ciphertext decoding.

## Live verification
No live deployment was performed. Recommended pilot after review: one profile, fresh `/voice join`, then verify comfort frames are discarded and the first real utterance is preserved.