### PR TITLE
fix(gateway): /sessions returns empty for threaded callers with legacy NULL-thread sessions

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1105,7 +1105,7 @@ class GatewaySlashCommandsMixin:
             origin_ok = (
                 bool(row_src) and bool(caller_src)
                 and str(row_src) == str(caller_src)
-                and row_thread == caller_thread
+                and (row_thread == caller_thread or not row_thread)
             )
             if not origin_ok:
                 return False


### PR DESCRIPTION
## Problem

Telegram users with topic/thread mode enabled see "No sessions found" when they type `/sessions` from inside a thread. The `_resume_target_allowed` origin check rejects every pre-threading session because legacy sessions have `thread_id=NULL` and the check requires exact match with the caller's thread ID.

## Reproduction

1. Enable Telegram topic mode
2. Open any thread
3. Type `/sessions`
4. → "No sessions found." even with 30+ named Telegram sessions in state.db

## Root Cause

The thread-ID check at line 1108 of `gateway/slash_commands.py`:

```python
and row_thread == caller_thread
```

was added with the threading feature but never accounted for legacy sessions with `thread_id=NULL`. From inside a thread, `NULL != "16899"`, so every pre-threading session is filtered out.

## Fix

One-line change:

```python
and (row_thread == caller_thread or not row_thread)
```

Legacy NULL-thread sessions pass through when the source matches. Thread isolation is still enforced for sessions that have explicit thread IDs.

## Testing

- Existing `test_resume_row_visible_blocks_cross_thread` test is unaffected — it exercises the live-origin path (`_same_origin_chat`), not the persisted-row path where this fix lives.
- Verified against live state.db with 30 Telegram sessions (29 with `thread_id=NULL`, 1 in thread 16899): before fix returns 0 rows, after fix returns all 29 named sessions.