### PR TITLE
feat: add native Omnious model provider

### DIFF
--- a/plugins/model-providers/omnious/__init__.py
+++ b/plugins/model-providers/omnious/__init__.py
@@ -1,0 +1,26 @@
+"""Omnious provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+omnious = ProviderProfile(
+    name="omnious",
+    aliases=("omnious-market",),
+    display_name="Omnious",
+    description="Omnious — live-market routing for OpenAI-compatible inference",
+    signup_url="https://www.omnious.xyz/integrations?side=customer",
+    env_vars=("OMNIOUS_CREDIT_KEY",),
+    base_url="https://api.omnious.xyz/v1",
+    auth_type="api_key",
+    default_aux_model="auto",
+    fallback_models=(
+        "auto",
+        "glm-5.2",
+        "kimi-k2.7-code",
+        "kimi-k3",
+        "minimax-m3",
+    ),
+)
+
+register_provider(omnious)

--- a/plugins/model-providers/omnious/plugin.yaml
+++ b/plugins/model-providers/omnious/plugin.yaml
@@ -1,0 +1,5 @@
+name: omnious-provider
+kind: model-provider
+version: 1.0.0
+description: Omnious live-market inference
+author: Omnious

--- a/tests/providers/test_omnious_provider.py
+++ b/tests/providers/test_omnious_provider.py
@@ -1,0 +1,29 @@
+"""Contract tests for the bundled Omnious model-provider plugin."""
+
+from __future__ import annotations
+
+from providers import get_provider_profile
+
+
+def test_omnious_profile_is_discoverable():
+    profile = get_provider_profile("omnious")
+
+    assert profile is not None
+    assert profile.display_name == "Omnious"
+    assert profile.base_url == "https://api.omnious.xyz/v1"
+    assert profile.env_vars == ("OMNIOUS_CREDIT_KEY",)
+    assert profile.default_aux_model == "auto"
+    assert profile.fallback_models == (
+        "auto",
+        "glm-5.2",
+        "kimi-k2.7-code",
+        "kimi-k3",
+        "minimax-m3",
+    )
+
+
+def test_omnious_market_alias_resolves_to_native_profile():
+    profile = get_provider_profile("omnious-market")
+
+    assert profile is not None
+    assert profile.name == "omnious"


### PR DESCRIPTION
## What

Adds Omnious as a bundled `model-provider` plugin with:

- the canonical `OMNIOUS_CREDIT_KEY` inference credential
- the OpenAI-compatible `https://api.omnious.xyz/v1` endpoint
- `auto` as the default auxiliary route
- a curated offline fallback model list
- focused discovery and alias contract tests

## Why

Hermes users currently have to configure Omnious as a generic `custom` endpoint. A native provider profile makes it available through Hermes' existing provider discovery, setup, and model-selection surfaces without adding core special cases.

## Impact

No existing provider behavior changes. The plugin uses the standard provider registry and does not make network calls at import time.

## Checks

- `pytest -q tests/providers/test_omnious_provider.py tests/providers/test_plugin_discovery.py` (6 passed)
- rebased on current `upstream/main`