### PR TITLE
fix(telegram): pass width/height/duration on sendVideo so portrait videos keep their aspect ratio

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7150,6 +7150,54 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return await super().send_document(chat_id, file_path, caption, file_name, reply_to, metadata=metadata)
 
+    @staticmethod
+    def _probe_video_meta(video_path: str) -> Dict[str, int]:
+        """Best-effort width/height/duration probe for outgoing videos.
+
+        Telegram's Bot API treats ``width``/``height``/``duration`` as optional
+        on ``sendVideo``, but when they are omitted the server has to guess the
+        aspect ratio from the file and sometimes falls back to a square player
+        (portrait 9:16 videos are the usual casualty). Passing the real
+        dimensions makes every client render the video exactly as encoded.
+
+        Uses ``ffprobe`` when available (checking PATH plus the common Homebrew
+        and /usr/local install locations); returns ``{}`` when it is not, which
+        preserves the previous behavior.
+        """
+        import shutil
+        import subprocess
+
+        ffprobe = shutil.which("ffprobe")
+        if not ffprobe:
+            for candidate in ("/opt/homebrew/bin/ffprobe", "/usr/local/bin/ffprobe"):
+                if os.path.exists(candidate):
+                    ffprobe = candidate
+                    break
+        if not ffprobe:
+            return {}
+        try:
+            out = subprocess.run(
+                [
+                    ffprobe, "-v", "error", "-select_streams", "v:0",
+                    "-show_entries", "stream=width,height:format=duration",
+                    "-of", "json", video_path,
+                ],
+                capture_output=True,
+                timeout=10,
+            )
+            data = json.loads(out.stdout or b"{}")
+            meta: Dict[str, int] = {}
+            stream = (data.get("streams") or [{}])[0]
+            width, height = stream.get("width"), stream.get("height")
+            if width and height:
+                meta["width"], meta["height"] = int(width), int(height)
+            duration = (data.get("format") or {}).get("duration")
+            if duration:
+                meta["duration"] = int(round(float(duration)))
+            return meta
+        except Exception:
+            return {}
+
     async def send_video(
         self,
         chat_id: str,
@@ -7176,6 +7224,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 reply_to_message_id=reply_to_id,
                 reply_to_mode=self._reply_to_mode
             )
+            video_meta = self._probe_video_meta(video_path)
             with open(video_path, "rb") as f:
                 msg = await self._send_with_dm_topic_reply_anchor_retry(
                     self._bot.send_video,
@@ -7184,6 +7233,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         "video": f,
                         "caption": caption[:1024] if caption else None,
                         "reply_to_message_id": reply_to_id,
+                        **video_meta,
                         **thread_kwargs,
                         **self._notification_kwargs(metadata),
                     },


### PR DESCRIPTION
## Problem

The Telegram adapter's `send_video` omits the optional `width`/`height`/`duration` parameters on `sendVideo`. When they are missing, Telegram's server guesses the aspect ratio from the uploaded file — and sometimes gives up and renders the video in a square player. We hit this deterministically with portrait 9:16 (1080x1920) H.264 MP4s: some uploads displayed correctly, others (byte-structure identical: same encoder, same faststart layout, same SAR/DAR) were shown square on every resend. The agent's own `ffprobe` checks kept truthfully reporting 1080x1920, which made the failure confusing to debug from the chat side.

## Fix

Probe the real dimensions and duration with `ffprobe` right before sending and pass them explicitly — Telegram then renders every video exactly as encoded, on every client.

- Best-effort: if `ffprobe` is not installed, the probe returns `{}` and the previous behavior is preserved unchanged.
- Looks for `ffprobe` on `PATH` plus the common Homebrew (`/opt/homebrew/bin`) and `/usr/local/bin` locations, since launchd/systemd service environments often have a minimal `PATH`.
- 10s subprocess timeout; any probe failure degrades silently to the old behavior.

## Testing

- Verified the probe returns `{'width': 1080, 'height': 1920, 'duration': 18}` for the affected files.
- With the patch applied, the previously-square portrait video renders 9:16 in Telegram (iOS + macOS clients).
- `ast.parse` clean; no new dependencies.