### PR TITLE
Rank the slash menu by the skills you actually use

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.test.tsx
@@ -18,6 +18,29 @@ const CATALOG = {
   ]
 }
 
+// A catalog shaped like a real install: a couple of skills the user lives in,
+// a bundled one they have never opened, and one of their own they haven't
+// either.
+const RANKED_CATALOG = {
+  categories: [{ name: 'Session', pairs: [['/new', 'Start a new session']] }],
+  pairs: [
+    ['/new', 'Start a new session'],
+    ['/docx', 'Edit Word documents'],
+    ['/research', 'Look it up before answering'],
+    ['/research-paper-writing', 'Write an academic paper'],
+    ['/work', 'Kick off a task in a fresh worktree']
+  ],
+  skills: {
+    '/docx': { usage: 0, origin: 'local' },
+    '/research': { usage: 60, origin: 'local' },
+    '/research-paper-writing': { usage: 0, origin: 'bundled' },
+    '/work': { usage: 172, origin: 'local' }
+  }
+}
+
+const commandsOf = (items: readonly Unstable_TriggerItem[]) =>
+  items.map(item => (item.metadata as { command?: string })?.command)
+
 function harness(gateway: HermesGateway) {
   const api: { search?: (query: string) => readonly Unstable_TriggerItem[] } = {}
 
@@ -94,5 +117,41 @@ describe('useSlashCompletions', () => {
     const inline = (await completions(api, '')).filter(isSkillItem)
 
     expect(inline.map(item => (item.metadata as { command?: string })?.command)).toEqual(['/work'])
+  })
+
+  // An alphabetical `/` menu buries the skills someone runs daily under the
+  // ones that shipped with Hermes and were never opened.
+  it('orders skills by use and hides never-used built-ins on a bare slash', async () => {
+    const request = vi.fn().mockResolvedValue(RANKED_CATALOG)
+    const api = harness({ request } as unknown as HermesGateway)
+
+    const skills = commandsOf((await completions(api, '')).filter(isSkillItem))
+
+    expect(skills).toEqual(['/work', '/research', '/docx'])
+  })
+
+  // Typing is a search, and a search that hides a match is broken — the
+  // never-used built-in still shows, just below the one she actually uses.
+  it('ranks a typed query by use without hiding anything', async () => {
+    const request = vi.fn().mockImplementation((method: string) =>
+      Promise.resolve(
+        method === 'commands.catalog'
+          ? RANKED_CATALOG
+          : {
+              items: [
+                { text: '/research-paper-writing', display: '/research-paper-writing', meta: 'Write a paper' },
+                { text: '/research', display: '/research', meta: 'Look it up' }
+              ]
+            }
+      )
+    )
+
+    const api = harness({ request } as unknown as HermesGateway)
+
+    // Warm the catalog first: the popover always opens on a bare `/` before a
+    // query is typed, which is where the usage map comes from.
+    await completions(api, '')
+
+    expect(commandsOf(await completions(api, 'research'))).toEqual(['/research', '/research-paper-writing'])
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
@@ -11,9 +11,15 @@ import {
   type DesktopThemeCommandOption,
   filterDesktopCommandsCatalog,
   isDesktopSlashExtensionCommand,
-  isDesktopSlashSuggestion
+  isDesktopSlashSuggestion,
+  rankSkillCommands
 } from '@/lib/desktop-slash-commands'
-import { $slashCompletionsEpoch, cachedSlashCompletion, hasCachedSlashCompletion } from '@/lib/slash-completion-cache'
+import {
+  $slashCompletionsEpoch,
+  cachedSlashCompletion,
+  hasCachedSlashCompletion,
+  peekCachedSlashCompletion
+} from '@/lib/slash-completion-cache'
 import { normalize } from '@/lib/text'
 import { $sessions } from '@/store/session'
 
@@ -145,7 +151,7 @@ export function useSlashCompletions(options: {
           // backend didn't categorize.
           const sections = catalog.categories?.length ? catalog.categories : [{ name: '', pairs: catalog.pairs ?? [] }]
 
-          const items = sections.flatMap(section =>
+          const items = sections.flatMap<CompletionEntry>(section =>
             section.pairs.map(([command, meta]) => ({
               text: command,
               display: command,
@@ -161,12 +167,18 @@ export function useSlashCompletions(options: {
           // Re-add the leftovers under one Skills header (which also gives them
           // the skill pill accent and makes them offerable mid-message).
           const categorized = new Set(items.map(item => item.text.toLowerCase()))
+          const skillRows: CompletionEntry[] = []
 
           for (const [command, meta] of catalog.pairs ?? []) {
             if (!categorized.has(command.toLowerCase()) && isDesktopSlashExtensionCommand(command)) {
-              items.push({ text: command, display: command, group: 'Skills', meta })
+              skillRows.push({ text: command, display: command, group: 'Skills', meta })
             }
           }
+
+          // Browsing, not searching: rank the skills the user actually reaches
+          // for to the top and drop never-used built-ins entirely. Typing a
+          // query takes the other branch, where nothing is hidden.
+          items.push(...rankSkillCommands(skillRows, catalog.skills, { pruneUnusedBuiltins: true }))
 
           return { items, query }
         }
@@ -210,9 +222,27 @@ export function useSlashCompletions(options: {
         // Skills (stable within a group, preserving backend relevance order).
         const groupOrder = ['Commands', 'Skills', 'Options']
 
-        const items = isArgCompletion
-          ? decorated
-          : [...decorated].sort((a, b) => groupOrder.indexOf(a.group) - groupOrder.indexOf(b.group))
+        if (isArgCompletion) {
+          return { items: decorated, query }
+        }
+
+        // Rank the matched skills by use — `/re` should lead with the /research
+        // the user lives in, not the /research-paper-writing they've never
+        // opened. Nothing is pruned here: a typed query is a search, and a
+        // search that hides a match is broken. Usage rides along on the catalog
+        // response, which the popover has already fetched by the time anyone
+        // types; if it somehow hasn't, order falls back to the backend's.
+        const catalogSkills = peekCachedSlashCompletion<CommandsCatalogLike>('catalog')?.skills
+
+        const ranked = [
+          ...decorated.filter(item => item.group !== 'Skills'),
+          ...rankSkillCommands(
+            decorated.filter(item => item.group === 'Skills'),
+            catalogSkills
+          )
+        ]
+
+        const items = [...ranked].sort((a, b) => groupOrder.indexOf(a.group) - groupOrder.indexOf(b.group))
 
         return { items, query }
       } catch {

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -10,6 +10,7 @@ import {
   isDesktopSlashSuggestion,
   isModelPickerCommand,
   isPickerCommand,
+  rankSkillCommands,
   resolveDesktopCommand
 } from './desktop-slash-commands'
 
@@ -290,5 +291,58 @@ describe('desktop slash command curation', () => {
     expect(resolveDesktopCommand('/clear')?.surface).toEqual({ kind: 'unavailable', reason: 'terminal' })
     // Skill / quick commands aren't in the registry.
     expect(resolveDesktopCommand('/gif-search')).toBeNull()
+  })
+})
+
+describe('rankSkillCommands', () => {
+  const rows = [
+    { text: '/research' },
+    { text: '/research-paper-writing' },
+    { text: '/work' },
+    { text: '/ship-it' },
+    { text: '/manim-video' },
+    { text: '/docx' }
+  ]
+
+  const skills = {
+    '/research': { usage: 60, origin: 'local' as const },
+    '/research-paper-writing': { usage: 0, origin: 'bundled' as const },
+    '/work': { usage: 172, origin: 'local' as const },
+    '/manim-video': { usage: 0, origin: 'bundled' as const },
+    '/docx': { usage: 0, origin: 'local' as const }
+  }
+
+  it('puts the most-used skill first and breaks ties alphabetically', () => {
+    expect(rankSkillCommands(rows, skills).map(row => row.text)).toEqual([
+      '/work',
+      '/research',
+      '/docx',
+      '/manim-video',
+      '/research-paper-writing',
+      '/ship-it'
+    ])
+  })
+
+  it('drops never-used built-ins when browsing, keeping everything else', () => {
+    const browsing = rankSkillCommands(rows, skills, { pruneUnusedBuiltins: true }).map(row => row.text)
+
+    expect(browsing).toEqual(['/work', '/research', '/docx', '/ship-it'])
+    // A user's own unused skill survives — only shipped-and-ignored goes.
+    expect(browsing).toContain('/docx')
+    // Unclassified rows (quick commands, skills newer than the map) survive too.
+    expect(browsing).toContain('/ship-it')
+  })
+
+  it('leaves the backend order untouched when the catalog carries no usage', () => {
+    expect(rankSkillCommands(rows, undefined, { pruneUnusedBuiltins: true })).toEqual(rows)
+  })
+
+  it('ranks an alias by the canonical command it resolves to', () => {
+    const ranked = rankSkillCommands([{ text: '/sessions' }, { text: '/research' }], {
+      '/research': { usage: 5, origin: 'local' },
+      '/resume': { usage: 900, origin: 'local' }
+    })
+
+    expect(ranked.map(row => row.text)).toEqual(['/sessions', '/research'])
   })
 })

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -7,8 +7,23 @@ export interface CommandsCatalogLike {
   categories?: CommandsCatalogSection[]
   pairs?: [string, string][]
   skill_count?: number
+  skills?: SkillCatalogMap
   warning?: string
 }
+
+/**
+ * Per-skill ranking data from `commands.catalog`, keyed by slash command.
+ * Absent on older backends — every helper below degrades to "no ranking,
+ * hide nothing".
+ */
+export interface SkillCatalogEntry {
+  /** Where the skill came from; matches `/api/skills` provenance ('agent' = 'local'). */
+  origin?: 'bundled' | 'hub' | 'local'
+  /** Observed activity (use + view + patch) — the same number Capabilities shows. */
+  usage?: number
+}
+
+export type SkillCatalogMap = Record<string, SkillCatalogEntry>
 
 export interface DesktopSlashCompletion {
   display: string
@@ -516,6 +531,43 @@ export function desktopSkinSlashCompletions(
   }
 
   return commands.filter(item => item.text.slice('/skin '.length).toLowerCase().startsWith(prefix))
+}
+
+/**
+ * Order skill rows by how much the user actually uses them, most-used first,
+ * A–Z within a tie. A `/` menu sorted alphabetically buries the handful of
+ * skills someone reaches for daily under a hundred they have never opened.
+ *
+ * `pruneUnusedBuiltins` additionally drops bundled skills with no recorded
+ * activity — the ones that ship with Hermes and were never asked for. It is
+ * for BROWSING (a bare `/`) only: typing a query is a search, and a search
+ * must never hide a match.
+ *
+ * Older backends send no `skills` map; then nothing is reordered or dropped.
+ */
+export function rankSkillCommands<T extends { text: string }>(
+  rows: readonly T[],
+  skills: SkillCatalogMap | undefined,
+  { pruneUnusedBuiltins = false }: { pruneUnusedBuiltins?: boolean } = {}
+): T[] {
+  if (!skills) {
+    return [...rows]
+  }
+
+  const entryOf = (row: T): SkillCatalogEntry | undefined => skills[canonicalDesktopSlashCommand(row.text)]
+  const usageOf = (row: T): number => entryOf(row)?.usage ?? 0
+
+  const kept = pruneUnusedBuiltins
+    ? rows.filter(row => {
+        const entry = entryOf(row)
+
+        // Unknown to the map (a quick command, a newer skill the catalog
+        // hasn't classified) stays — only a confirmed never-used built-in goes.
+        return !entry || entry.origin !== 'bundled' || (entry.usage ?? 0) > 0
+      })
+    : [...rows]
+
+  return kept.sort((a, b) => usageOf(b) - usageOf(a) || a.text.localeCompare(b.text))
 }
 
 export function filterDesktopCommandsCatalog(catalog: CommandsCatalogLike): CommandsCatalogLike {

--- a/apps/desktop/src/lib/slash-completion-cache.ts
+++ b/apps/desktop/src/lib/slash-completion-cache.ts
@@ -38,6 +38,16 @@ export function hasCachedSlashCompletion(key: string): boolean {
 }
 
 /**
+ * Read a cached completion response without fetching. For data that improves a
+ * response but must not cost a round trip to get — the catalog's per-skill
+ * usage map, which refines the ordering of a typed query but is not worth
+ * delaying that query for.
+ */
+export function peekCachedSlashCompletion<T>(key: string): T | undefined {
+  return hasCachedSlashCompletion(key) ? queryClient.getQueryData<T>([SLASH_COMPLETIONS_KEY, key]) : undefined
+}
+
+/**
  * Bumped on every invalidation. The composer's completion adapter de-dupes by
  * query, so an unchanged `/` would never re-ask on its own — it watches this
  * instead to know the answer it's holding is no longer current.

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7338,6 +7338,66 @@ def test_commands_catalog_surfaces_quick_commands(monkeypatch):
     assert resp["result"]["canon"]["/notes"] == "/notes"
 
 
+def test_commands_catalog_ranks_skill_commands_by_recorded_usage(monkeypatch):
+    """Skill entries carry the usage + origin the `/` menu ranks on.
+
+    Without it the menu is alphabetical, so a bundled skill the user has never
+    opened outranks the one they invoke daily.
+    """
+    monkeypatch.setattr(
+        server,
+        "_skill_usage_lookup",
+        lambda: (
+            lambda name: {"research": 60, "work": 172}.get(name, 0),
+            lambda name: "bundled" if name == "research-paper-writing" else "local",
+        ),
+    )
+    monkeypatch.setattr(
+        "agent.skill_commands.scan_skill_commands",
+        lambda: {
+            "/research": {"name": "research", "description": "Look it up"},
+            "/research-paper-writing": {
+                "name": "research-paper-writing",
+                "description": "Write a paper",
+            },
+            "/work": {"name": "work", "description": "Fresh worktree"},
+        },
+    )
+
+    resp = server.handle_request(
+        {"id": "1", "method": "commands.catalog", "params": {}}
+    )
+
+    skills = resp["result"]["skills"]
+    assert skills["/work"] == {"usage": 172, "origin": "local"}
+    assert skills["/research"] == {"usage": 60, "origin": "local"}
+    assert skills["/research-paper-writing"] == {"usage": 0, "origin": "bundled"}
+
+    # Every advertised skill command is rankable — a missing entry silently
+    # sorts that skill to the bottom of the menu.
+    advertised = {name for name, _ in resp["result"]["pairs"]}
+    assert set(skills) <= advertised
+    assert resp["result"]["skill_count"] == len(skills)
+
+
+def test_commands_catalog_survives_an_unreadable_usage_sidecar(monkeypatch):
+    """A broken/absent .usage.json degrades to no ranking, never a broken menu."""
+    monkeypatch.setattr(
+        "tools.skill_usage.load_usage",
+        lambda: (_ for _ in ()).throw(OSError("sidecar is gone")),
+    )
+
+    resp = server.handle_request(
+        {"id": "1", "method": "commands.catalog", "params": {}}
+    )
+
+    assert "error" not in resp
+    assert all(
+        entry == {"usage": 0, "origin": "local"}
+        for entry in resp["result"]["skills"].values()
+    )
+
+
 def test_commands_catalog_includes_tui_mouse_command():
     resp = server.handle_request(
         {"id": "1", "method": "commands.catalog", "params": {}}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -15411,6 +15411,47 @@ _PENDING_INPUT_COMMANDS: frozenset[str] = frozenset(
 _WORKER_BLOCKED_COMMANDS: frozenset[str] = frozenset({"snapshot", "snap"})
 
 
+def _skill_usage_lookup():
+    """Build ``(usage, origin)`` callables for the skill-command catalog.
+
+    ``usage(name)`` is the skill's observed activity count (use + view +
+    patch); ``origin(name)`` is ``"hub"``, ``"bundled"``, or ``"local"`` — the
+    same classification ``/api/skills`` reports as ``provenance`` (where
+    "local" is spelled "agent"). Both read sidecar files that are cheap and
+    already parsed once per catalog build. Any failure degrades to zero usage
+    and ``"local"`` so a missing/corrupt sidecar can never break the catalog.
+    """
+    try:
+        from tools.skill_usage import (
+            _read_bundled_manifest_names,
+            _read_hub_installed_names,
+            activity_count,
+            load_usage,
+        )
+
+        records = load_usage()
+        bundled = _read_bundled_manifest_names()
+        hub = _read_hub_installed_names()
+    except Exception as e:
+        logger.debug("skill usage lookup unavailable: %s", e)
+        return (lambda _name: 0), (lambda _name: "local")
+
+    def usage(name: str) -> int:
+        try:
+            return activity_count(records.get(name) or {})
+        except Exception:
+            return 0
+
+    def origin(name: str) -> str:
+        if name in hub:
+            return "hub"
+        if name in bundled:
+            return "bundled"
+        return "local"
+
+    return usage, origin
+
+
 @method("commands.catalog")
 def _(rid, params: dict) -> dict:
     """Registry-backed slash metadata for the TUI — categorized, no aliases."""
@@ -15488,12 +15529,21 @@ def _(rid, params: dict) -> dict:
                 warning = f"quick_commands discovery unavailable: {e}"
 
         skill_count = 0
+        skills: dict[str, dict] = {}
         try:
             from agent.skill_commands import scan_skill_commands
+
+            # Usage + origin per skill command. Surfaces here rather than in a
+            # second RPC because every consumer that renders the catalog also
+            # wants to rank it, and both reads are cheap sidecar files already
+            # loaded once per catalog build.
+            usage, origin_of = _skill_usage_lookup()
 
             for k, info in sorted(scan_skill_commands().items()):
                 d = str(info.get("description", "Skill"))
                 all_pairs.append([k, d[:120] + ("…" if len(d) > 120 else "")])
+                name = str(info.get("name") or k.lstrip("/"))
+                skills[k] = {"usage": usage(name), "origin": origin_of(name)}
                 skill_count += 1
         except Exception as e:
             warning = f"skill discovery unavailable: {e}"
@@ -15509,6 +15559,7 @@ def _(rid, params: dict) -> dict:
                 "sub": sub,
                 "canon": canon,
                 "categories": categories,
+                "skills": skills,
                 "skill_count": skill_count,
                 "warning": warning,
             },


### PR DESCRIPTION
The `/` menu listed skills alphabetically, which means the ordering carries no information about what the user actually does. On a 200-skill install that buries the handful of skills someone invokes daily under a wall of skills that shipped with Hermes and were never opened — `/research-paper-writing` (0 activity) sorted above `/research` (60 invocations).

Hermes already tracks per-skill activity in `~/.hermes/skills/.usage.json` and surfaces it on the Capabilities page; the slash menu just never saw it. This plumbs that number into the command catalog and ranks on it.

**Gateway.** `commands.catalog` gains a `skills` map keyed by slash command, each entry carrying `usage` (use + view + patch, the same count Capabilities shows) and `origin` (`hub` / `bundled` / `local`, matching `/api/skills` provenance). Both come from sidecar files read once per catalog build. The field is additive — older clients ignore it — and an unreadable sidecar degrades to zero usage rather than failing the catalog.

**Desktop.** The Skills section sorts most-used first, A–Z within a tie. On a bare `/` — browsing, not searching — bundled skills with no recorded activity are dropped: shipped-and-ignored is noise, but the user's own unused skills and anything the catalog hasn't classified stay. Typing a query only reorders and never hides, because a search that drops a match is broken. The usage map rides along on the catalog response the popover has already fetched, so ranking a typed query costs no extra round trip.

Measured against a real 200-skill install: 125 skills used at least once, 75 never — 38 of which are bundled and now stay out of the browse list.
