### PR TITLE
fix(cli): keep the kanban task workspace authoritative over profile terminal.cwd

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -695,10 +695,30 @@ def load_cli_config() -> Dict[str, Any]:
     # UNLESS we're inside a gateway process (detected by _HERMES_GATEWAY marker)
     # where it was already set correctly by gateway/run.py's config bridge.
     _is_gateway = os.environ.get("_HERMES_GATEWAY") == "1"
+    # …or unless this process IS a dispatcher-spawned kanban worker. The
+    # dispatcher pins TERMINAL_CWD to the task's workspace in
+    # kanban_db._default_spawn (#41312 / #34619); force-exporting the assignee
+    # profile's terminal.cwd over it replaces a task-scoped boundary with a
+    # profile-wide one, and because the Docker backend bind-mounts
+    # os.getenv("TERMINAL_CWD") when docker_mount_cwd_to_workspace is on, that
+    # turns a bounded worktree mount into a broad writable host mount (#73556).
+    # The profile still supplies backend/image/network/resource policy below —
+    # only the workspace boundary is protected. Validated the same way the
+    # dispatcher validates it, so an unusable workspace changes nothing.
+    _kanban_workspace_pin = ""
+    if os.environ.get("HERMES_KANBAN_TASK", "").strip():
+        _ws = os.environ.get("HERMES_KANBAN_WORKSPACE", "").strip()
+        if _ws and os.path.isabs(_ws) and os.path.isdir(_ws):
+            _kanban_workspace_pin = _ws
     for config_key, env_var in env_mappings.items():
         if config_key in terminal_config:
             if env_var == "TERMINAL_CWD":
                 if _is_gateway:
+                    continue
+                if _kanban_workspace_pin:
+                    os.environ[env_var] = _kanban_workspace_pin
+                    terminal_config[config_key] = _kanban_workspace_pin
+                    defaults["terminal"]["cwd"] = _kanban_workspace_pin
                     continue
                 # CLI: always export (overrides stale .env or inherited values)
                 os.environ[env_var] = str(terminal_config[config_key])

--- a/tests/cli/test_cwd_env_respect.py
+++ b/tests/cli/test_cwd_env_respect.py
@@ -97,3 +97,137 @@ class TestGatewayLazyImport:
         d = {"terminal": {"cwd": "/home/user"}}
         result = _resolve_cwd(tc, d, env)
         assert result == "/fake/getcwd"
+
+
+# ---------------------------------------------------------------------------
+# Kanban worker workspace pin (real load_cli_config, not the mirror above).
+#
+# The dispatcher pins TERMINAL_CWD to the task workspace in
+# hermes_cli/kanban_db.py::_default_spawn (#41312 / #34619). The child CLI's
+# config bridge then force-exports the assignee profile's terminal.cwd over
+# it, which silently replaces the task-scoped boundary — and with
+# docker_mount_cwd_to_workspace that becomes a broad host mount (#73556).
+# ---------------------------------------------------------------------------
+
+
+def _write_terminal_config(hermes_home, cwd, backend="docker"):
+    import yaml
+
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"terminal": {"backend": backend, "cwd": cwd}}),
+        encoding="utf-8",
+    )
+
+
+class TestKanbanWorkerWorkspacePin:
+    def test_profile_cwd_does_not_override_task_workspace(self, tmp_path, monkeypatch):
+        """A dispatcher-owned worker keeps its task workspace as TERMINAL_CWD."""
+        import os
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        workspace = tmp_path / "task-repair"
+        workspace.mkdir()
+        profile_cwd = tmp_path / "home-example"
+        profile_cwd.mkdir()
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        _write_terminal_config(hermes_home, str(profile_cwd))
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_abc123")
+        monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
+        monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+
+        import cli
+
+        monkeypatch.setattr(cli, "_hermes_home", hermes_home)
+        cli.load_cli_config()
+
+        assert os.environ["TERMINAL_CWD"] == str(workspace)
+
+    def test_plain_cli_still_exports_profile_cwd(self, tmp_path, monkeypatch):
+        """Without a dispatcher task the profile cwd keeps winning."""
+        import os
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        profile_cwd = tmp_path / "home-example"
+        profile_cwd.mkdir()
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        _write_terminal_config(hermes_home, str(profile_cwd))
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        monkeypatch.delenv("HERMES_KANBAN_WORKSPACE", raising=False)
+        monkeypatch.setenv("TERMINAL_CWD", "/stale/from/dotenv")
+
+        import cli
+
+        monkeypatch.setattr(cli, "_hermes_home", hermes_home)
+        cli.load_cli_config()
+
+        assert os.environ["TERMINAL_CWD"] == str(profile_cwd)
+
+    def test_unusable_workspace_falls_back_to_profile_cwd(self, tmp_path, monkeypatch):
+        """Only a real absolute directory pins — mirrors _default_spawn's own rule."""
+        import os
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        profile_cwd = tmp_path / "home-example"
+        profile_cwd.mkdir()
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        _write_terminal_config(hermes_home, str(profile_cwd))
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_abc123")
+        monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(tmp_path / "does-not-exist"))
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+        import cli
+
+        monkeypatch.setattr(cli, "_hermes_home", hermes_home)
+        cli.load_cli_config()
+
+        assert os.environ["TERMINAL_CWD"] == str(profile_cwd)
+
+    def test_docker_mount_source_is_the_task_workspace(self, tmp_path, monkeypatch):
+        """The bind-mount source follows TERMINAL_CWD, so pin it end-to-end.
+
+        ``docker_mount_cwd_to_workspace`` mounts ``os.getenv("TERMINAL_CWD")``
+        into the container at /workspace (rw). If the profile cwd wins, the
+        worker gets the whole profile directory instead of its task worktree.
+        """
+        import os
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        workspace = tmp_path / "task-repair"
+        workspace.mkdir()
+        profile_cwd = tmp_path / "home-example"
+        profile_cwd.mkdir()
+
+        import yaml
+
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({
+                "terminal": {
+                    "backend": "docker",
+                    "cwd": str(profile_cwd),
+                    "docker_mount_cwd_to_workspace": True,
+                }
+            }),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_abc123")
+        monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
+        monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+
+        import cli
+
+        monkeypatch.setattr(cli, "_hermes_home", hermes_home)
+        cli.load_cli_config()
+
+        from tools.terminal_tool import _get_env_config
+
+        cfg = _get_env_config()
+        assert cfg["host_cwd"] == str(workspace)
+        assert cfg["docker_mount_cwd_to_workspace"] is True


### PR DESCRIPTION
## What does this PR do?

Fixes #73556, and provides the repro it was labelled `needs-repro` for.

The dispatcher pins a Kanban worker to its task workspace in `hermes_cli/kanban_db.py::_default_spawn`:

```python
env["HERMES_KANBAN_WORKSPACE"] = workspace
# Pin TERMINAL_CWD to the task's workspace so the worker's file tools and
# context-file loader anchor on the workspace, not whatever cwd the
# dispatching gateway happened to export.  (#41312 / #34619)
if workspace and os.path.isabs(workspace) and os.path.isdir(workspace):
    env["TERMINAL_CWD"] = workspace
```

The worker is a **child CLI**, so `load_cli_config()` then runs its terminal config→env bridge — which force-exports the assignee profile's `terminal.cwd` over any inherited value, with exactly one exemption:

```python
_is_gateway = os.environ.get("_HERMES_GATEWAY") == "1"
...
if env_var == "TERMINAL_CWD":
    if _is_gateway:
        continue
    # CLI: always export (overrides stale .env or inherited values)
    os.environ[env_var] = str(terminal_config[config_key])
```

So the task pin is silently replaced by a profile-wide directory, undoing #41312 / #34619 for any assignee profile that sets an explicit cwd.

**This is a containment escape, not just a cwd surprise.** The Docker backend takes its bind-mount source straight from that variable (`tools/terminal_tool.py::_get_env_config`):

```python
docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
...
host_cwd = candidate     # → bind-mounted to /workspace, read-write
cwd = "/workspace"
```

With `docker_mount_cwd_to_workspace: true`, a bounded repair worktree therefore becomes a broad writable host mount — which is what the reporter observed (sibling repositories exposed, a frozen baseline worktree edited from outside the assigned worktree).

Reproduced against `main` (`7bfbfa3e3`) by driving the real `load_cli_config()` with a dispatcher-worker environment and a docker profile whose `terminal.cwd` differs from the task workspace:

```
assert os.environ["TERMINAL_CWD"] == str(workspace)
E   AssertionError: assert '...\home-example' == '...	ask-repair'

assert cfg["host_cwd"] == str(workspace)          # the /workspace mount source
E   AssertionError: assert '...\home-example' == '...	ask-repair'
```

The fix extends the existing gateway exemption with a dispatcher-worker one: when `HERMES_KANBAN_TASK` is set and `HERMES_KANBAN_WORKSPACE` is a real absolute directory — the *same* validation the dispatcher applies before pinning — the workspace wins. Every other terminal setting still bridges from the profile.

Scope note: this implements items 1–2 of the issue's proposed fix (plus a test on the resolved mount source, its item 5). Items 3–4 — a pre-flight fail-closed check and mount diagnostics — are defence-in-depth on top of this and are deliberately left out to keep the change reviewable; happy to follow up.

## Related Issue

Fixes #73556

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py` (`load_cli_config`): compute a `_kanban_workspace_pin` from `HERMES_KANBAN_TASK` + a validated `HERMES_KANBAN_WORKSPACE`, and let it win over the profile's `terminal.cwd` in the `TERMINAL_CWD` branch of the config→env bridge. The resolved value is also written back into the in-memory terminal config so config-reading consumers agree with the env.
- `tests/cli/test_cwd_env_respect.py`: four tests driving the **real** `load_cli_config()` (the file's existing tests mirror the logic locally) — the workspace survives the profile cwd; a plain CLI still exports the profile cwd; an unusable workspace changes nothing; and, end-to-end, `_get_env_config()["host_cwd"]` (the Docker `/workspace` bind-mount source) resolves to the task workspace.

## How to Test

1. Create a Kanban task with an explicit workspace, assign it to a profile with `terminal: {backend: docker, cwd: /home/example, docker_mount_cwd_to_workspace: true}`, and dispatch it.
2. Inspect the container mounts: before this change `/home/example → /workspace (rw)`; after, the task workspace is mounted instead.
3. `pytest tests/cli/test_cwd_env_respect.py -q` → 13 passed (4 new). Two of the new tests fail on `main` without the code change (captured above) — including the mount-source one.
4. Wider run: `pytest tests/cli/test_cwd_env_respect.py tests/gateway/test_config_cwd_bridge.py tests/cli/test_cli_init.py -q` → 97 passed; `pytest tests/tools/test_terminal_tool.py tests/tools/test_kanban_tools.py -q` → 147 passed.
5. Full `pytest tests/cli/ -q` → 1217 passed, 13 failed, 2 errors; that failure set is pre-existing on `main` (worktree/pet-pane suites) — verified by re-running the same directory with this change stashed (1213 passed, same 13 failed + 2 errors).
6. Tested on Ubuntu 24.04.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate — #73556 has no linked PR
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suites and they pass (see step 5 for the pre-existing, unrelated failures)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (restores the documented workspace guarantee; no configuration contract changes)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys added or changed; the precedence is derived from the dispatcher's existing env pins)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — the pin is validated with `os.path.isabs`/`isdir`, mirroring the dispatcher; tests run on both POSIX and Windows path shapes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool schema touched)
