### PR TITLE
fix(gateway): pivot personality on the next turn, not the one after

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2311,6 +2311,7 @@ _CONVERSATION_SCOPED_STATE: tuple = (
     "_session_reasoning_overrides",
     "_session_service_tier_overrides",
     "_pending_model_notes",
+    "_pending_personality_notes",
     "_last_resolved_model",
     "_queued_events",
     # Staged-but-never-consumed sidecar notes (turn aborted between staging
@@ -22552,6 +22553,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _msn = _pending_notes.pop(session_key, None) if session_key else None
             if _msn:
                 message = _msn + "\n\n" + message
+
+            # Prepend pending personality note so the model pivots its style
+            # instead of imitating its own prior turns in the transcript.
+            _pending_pers = getattr(self, '_pending_personality_notes', {})
+            _psn = _pending_pers.pop(session_key, None) if session_key else None
+            if _psn:
+                message = _psn + "\n\n" + message
 
             # Auto-continue: if the loaded history ends with a tool result,
             # the previous agent turn was interrupted mid-work (gateway

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2575,6 +2575,13 @@ class GatewaySlashCommandsMixin:
             except Exception as e:
                 return t("gateway.personality.save_failed", error=str(e))
             self._ephemeral_system_prompt = ""
+            _sk = self._session_key_for_source(event.source)
+            if not hasattr(self, "_pending_personality_notes"):
+                self._pending_personality_notes = {}
+            self._pending_personality_notes[_sk] = (
+                "[Note: the personality overlay was just cleared. "
+                "From this point forward, respond in your normal default style.]"
+            )
             return t("gateway.personality.cleared")
         elif args in personalities:
             new_prompt = _resolve_prompt(personalities[args])
@@ -2590,6 +2597,15 @@ class GatewaySlashCommandsMixin:
 
             # Update in-memory so it takes effect on the very next message.
             self._ephemeral_system_prompt = new_prompt
+
+            _sk = self._session_key_for_source(event.source)
+            if not hasattr(self, "_pending_personality_notes"):
+                self._pending_personality_notes = {}
+            self._pending_personality_notes[_sk] = (
+                f"[Note: the assistant's personality was just changed to '{args}'. "
+                f"From this point forward, adopt this persona and respond "
+                f"accordingly, regardless of the style of earlier replies: {new_prompt}]"
+            )
 
             return t("gateway.personality.set_to", name=args)
 

--- a/tests/gateway/test_personality_pivot_note.py
+++ b/tests/gateway/test_personality_pivot_note.py
@@ -1,0 +1,198 @@
+"""Regression tests: /personality stages a pivot note for the next turn.
+
+``/personality <name>`` writes ``config.yaml`` and sets
+``_ephemeral_system_prompt``, but with a populated transcript the model
+imitates the style of its own prior assistant turns and ignores the new
+system prompt for one more turn.  The handler therefore also stages a note
+under ``_pending_personality_notes[session_key]``, which
+``gateway/run.py`` prepends to the next user message (same mechanism as
+``_pending_model_notes`` for ``/model``).
+
+These lock in:
+
+  * the note is staged, keyed by session, for both set and clear
+  * ``_ephemeral_system_prompt`` still tracks the selected personality
+  * a session boundary (/new) drops the staged note for that session only,
+    via ``_CONVERSATION_SCOPED_STATE``
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+PERSONALITIES = {
+    "chadwick": "You are a loud gym bro. Call the user Champ.",
+    "catgirl": "You are a cheerful cat girl. Use nya~ liberally.",
+}
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner._session_model_overrides = {}
+    runner._session_reasoning_overrides = {}
+    runner._pending_model_notes = {}
+    runner._pending_personality_notes = {}
+    runner._ephemeral_system_prompt = ""
+    runner._background_tasks = set()
+
+    session_key = build_session_key(_make_source())
+    session_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.reset_session.return_value = session_entry
+    runner.session_store._entries = {session_key: session_entry}
+    runner.session_store._generate_session_key.return_value = session_key
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._agent_cache_lock = None  # disables _evict_cached_agent lock path
+    runner._is_user_authorized = lambda _source: True
+    runner._format_session_info = lambda: ""
+    return runner
+
+
+@pytest.fixture
+def personality_config(monkeypatch, tmp_path):
+    """Serve a config with personalities and swallow the config.yaml write.
+
+    ``_handle_personality_command`` imports ``_hermes_home`` and
+    ``_load_gateway_config`` from ``gateway.run`` at call time and writes via
+    ``atomic_config_write``.  Without patching all three the test would
+    overwrite the developer's real ``~/.hermes/config.yaml``.
+    """
+    config = {"agent": {"personalities": dict(PERSONALITIES)}}
+    written = {}
+
+    monkeypatch.setattr("gateway.run._load_gateway_config", lambda: config)
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    monkeypatch.setattr(
+        "gateway.slash_commands.atomic_config_write",
+        lambda path, cfg: written.update({"path": path, "cfg": cfg}),
+    )
+    return SimpleNamespace(config=config, written=written)
+
+
+@pytest.mark.asyncio
+async def test_personality_set_stages_pivot_note(personality_config):
+    """/personality <name> stages a note for that session's next message."""
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+
+    await runner._handle_personality_command(_make_event("/personality chadwick"))
+
+    assert session_key in runner._pending_personality_notes
+    note = runner._pending_personality_notes[session_key]
+    assert "chadwick" in note
+    assert PERSONALITIES["chadwick"] in note
+    assert runner._ephemeral_system_prompt == PERSONALITIES["chadwick"]
+
+
+@pytest.mark.asyncio
+async def test_second_switch_replaces_the_staged_note(personality_config):
+    """Swapping again before the note is consumed must not stack notes.
+
+    This is the reported failure: the second and later swaps in one process
+    were the ones that came back in the previous persona's voice.
+    """
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+
+    await runner._handle_personality_command(_make_event("/personality chadwick"))
+    await runner._handle_personality_command(_make_event("/personality catgirl"))
+
+    note = runner._pending_personality_notes[session_key]
+    assert PERSONALITIES["catgirl"] in note
+    assert PERSONALITIES["chadwick"] not in note
+    assert runner._ephemeral_system_prompt == PERSONALITIES["catgirl"]
+
+
+@pytest.mark.asyncio
+async def test_personality_none_stages_a_clear_note(personality_config):
+    """/personality none must also pivot — not silently keep the old voice."""
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+
+    await runner._handle_personality_command(_make_event("/personality chadwick"))
+    await runner._handle_personality_command(_make_event("/personality none"))
+
+    assert runner._ephemeral_system_prompt == ""
+    note = runner._pending_personality_notes[session_key]
+    assert PERSONALITIES["chadwick"] not in note
+    assert "default" in note.lower()
+
+
+@pytest.mark.asyncio
+async def test_unknown_personality_stages_nothing(personality_config):
+    """An unrecognised name must not leave a note behind."""
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+
+    await runner._handle_personality_command(_make_event("/personality nope"))
+
+    assert session_key not in runner._pending_personality_notes
+
+
+@pytest.mark.asyncio
+async def test_new_command_clears_pending_personality_note():
+    """A staged-but-unconsumed note must not survive a session boundary."""
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    runner._pending_personality_notes[session_key] = "[Note: now chadwick.]"
+
+    await runner._handle_reset_command(_make_event("/new"))
+
+    assert session_key not in runner._pending_personality_notes
+
+
+@pytest.mark.asyncio
+async def test_new_command_only_clears_own_session_note():
+    """/new must leave other sessions' staged notes alone."""
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    other_key = "other_session_key"
+    runner._pending_personality_notes[session_key] = "[Note: now chadwick.]"
+    runner._pending_personality_notes[other_key] = "[Note: now catgirl.]"
+
+    await runner._handle_reset_command(_make_event("/new"))
+
+    assert session_key not in runner._pending_personality_notes
+    assert other_key in runner._pending_personality_notes


### PR DESCRIPTION
/personality wrote config.yaml and set _ephemeral_system_prompt correctly, but the model kept replying in the previous persona's voice for one more turn: with a populated transcript, prior assistant turns act as style exemplars and outweigh the system prompt.

Only visible on the second and later swaps in a process. On a cold gateway the history is empty, nothing to imitate, and the swap looks correct — which is why a restart appears to fix it.

tui_gateway._apply_personality_to_session already handles this by injecting a pivot marker, and documents the cause: "without this, LLMs tend to continue the tone established by earlier messages in the transcript". The gateway path had no equivalent.

Stage a note keyed by session_key and prepend it to the next user message, mirroring _pending_model_notes rather than writing into the transcript — history rows need display_kind bookkeeping, and an untagged marker is the class of bug that broke /retry.

Registered in _CONVERSATION_SCOPED_STATE so a staged-but-unconsumed note cannot leak across a reset or resume into a new conversation.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

