### PR TITLE
fix(desktop): cache model options per profile and seed session.create with configured provider

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -19,7 +19,12 @@ import {
 import { Skeleton } from '@/components/ui/skeleton'
 import type { HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
+import {
+  modelOptionsQueryKey,
+  readModelOptionsCache,
+  requestModelOptions,
+  writeModelOptionsCache
+} from '@/lib/model-options'
 import { currentPickerSelection, displayModelName, modelDisplayParts } from '@/lib/model-status-label'
 import { DEFAULT_REASONING_EFFORT, reasoningEffortLabel } from '@/lib/reasoning-effort'
 import { normalize } from '@/lib/text'
@@ -85,12 +90,24 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
   const visibleModels = useStore($visibleModels)
   const collapsedProviders = useStore($collapsedProviders)
 
+  const cachedModelOptions = useMemo(
+    () => readModelOptionsCache(profile, activeSessionId),
+    [profile, activeSessionId]
+  )
+
   const modelOptions = useQuery({
     queryKey: modelOptionsQueryKey(profile, activeSessionId),
     // Gateway-first even with no session yet: a connected (possibly remote)
     // gateway owns the model catalog, including virtual providers like `moa`
     // that the local REST fallback can't know about (#53817).
-    queryFn: (): Promise<ModelOptionsResponse> => requestModelOptions({ gateway, sessionId: activeSessionId })
+    queryFn: async (): Promise<ModelOptionsResponse> => {
+      const next = await requestModelOptions({ gateway, sessionId: activeSessionId })
+      writeModelOptionsCache(profile, activeSessionId, next)
+
+      return next
+    },
+    initialData: cachedModelOptions?.data,
+    initialDataUpdatedAt: cachedModelOptions?.updatedAt
   })
 
   const { model: optionsModel, provider: optionsProvider } = currentPickerSelection(
@@ -150,6 +167,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
 
       const next = await requestModelOptions({ gateway, refresh: true, sessionId: activeSessionId })
 
+      writeModelOptionsCache(profile, activeSessionId, next)
       queryClient.setQueryData<ModelOptionsResponse>(queryKey, next)
     } catch {
       // Network/backend hiccup — fall back to a plain invalidate so the next

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -1,8 +1,13 @@
 import { useQuery } from '@tanstack/react-query'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { useI18n } from '@/i18n'
-import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
+import {
+  modelOptionsQueryKey,
+  readModelOptionsCache,
+  requestModelOptions,
+  writeModelOptionsCache
+} from '@/lib/model-options'
 import { modelSearchText } from '@/lib/model-search-text'
 import { currentPickerSelection } from '@/lib/model-status-label'
 import { normalize } from '@/lib/text'
@@ -55,10 +60,18 @@ export function ModelPickerDialog({
   // it and do a plain substring filter that preserves array order — matching
   // the `hermes model` CLI picker, which shows the curated list verbatim.
   const [search, setSearch] = useState('')
+  const cachedModelOptions = useMemo(() => readModelOptionsCache(profile, sessionId), [profile, sessionId])
 
   const modelOptions = useQuery({
     queryKey: modelOptionsQueryKey(profile, sessionId),
-    queryFn: () => requestModelOptions({ gateway: gw, sessionId }),
+    queryFn: async () => {
+      const next = await requestModelOptions({ gateway: gw, sessionId })
+      writeModelOptionsCache(profile, sessionId, next)
+
+      return next
+    },
+    initialData: cachedModelOptions?.data,
+    initialDataUpdatedAt: cachedModelOptions?.updatedAt,
     enabled: open
   })
 

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -1,14 +1,27 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { getGlobalModelOptions } from '@/hermes'
 import type { ModelOptionsResponse } from '@/types/hermes'
 
-import { modelOptionsQueryKey, readModelOptionsCache, writeModelOptionsCache } from './model-options'
+import {
+  manualPickRemoved,
+  modelOptionsQueryKey,
+  readModelOptionsCache,
+  requestModelOptions,
+  writeModelOptionsCache
+} from './model-options'
 
 const catalog = (model: string): ModelOptionsResponse => ({
   model,
   provider: 'novacode',
   providers: [{ name: 'NovaCode', slug: 'novacode', models: [model] }]
 })
+
+const globalOptions = { model: 'hermes-4', provider: 'nous', providers: [] }
+
+vi.mock('@/hermes', () => ({
+  getGlobalModelOptions: vi.fn(() => Promise.resolve(globalOptions))
+}))
 
 describe('model options local cache', () => {
   beforeEach(() => localStorage.clear())
@@ -23,9 +36,15 @@ describe('model options local cache', () => {
     expect(cached?.updatedAt).toEqual(expect.any(Number))
   })
 
-  it('keeps the cache bounded across session-scoped catalogs', () => {
+  it('reuses the latest profile catalog immediately for a new session id', () => {
+    writeModelOptionsCache('default', 'old-session', catalog('gpt-5.6-sol'))
+
+    expect(readModelOptionsCache('default', 'new-session')?.data).toEqual(catalog('gpt-5.6-sol'))
+  })
+
+  it('keeps the cache bounded across profiles', () => {
     for (let index = 0; index < 20; index += 1) {
-      writeModelOptionsCache('default', `session-${index}`, catalog(`model-${index}`))
+      writeModelOptionsCache(`profile-${index}`, `session-${index}`, catalog(`model-${index}`))
     }
 
     const raw = localStorage.getItem('hermes.desktop.model-options.v1')
@@ -39,5 +58,88 @@ describe('model options local cache', () => {
     )
 
     expect(readModelOptionsCache('default')).toBeUndefined()
+  })
+})
+
+describe('requestModelOptions', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses the connected gateway even before a session exists', async () => {
+    const gatewayPayload = { model: 'BeastMode', provider: 'moa', providers: [] }
+    const gateway = { request: vi.fn(() => Promise.resolve(gatewayPayload)) }
+
+    await expect(requestModelOptions({ gateway: gateway as never, sessionId: null })).resolves.toBe(gatewayPayload)
+
+    expect(gateway.request).toHaveBeenCalledWith('model.options', { explicit_only: true })
+    expect(getGlobalModelOptions).not.toHaveBeenCalled()
+  })
+
+  it('passes the active session id and refresh flag through the gateway', async () => {
+    const gateway = { request: vi.fn(() => Promise.resolve(globalOptions)) }
+
+    await requestModelOptions({ gateway: gateway as never, refresh: true, sessionId: 'session-1' })
+
+    expect(gateway.request).toHaveBeenCalledWith('model.options', {
+      explicit_only: true,
+      refresh: true,
+      session_id: 'session-1'
+    })
+  })
+
+  it('falls back to REST when no gateway is connected', async () => {
+    await requestModelOptions({ refresh: true })
+
+    expect(getGlobalModelOptions).toHaveBeenCalledWith({ explicitOnly: true, refresh: true })
+  })
+})
+
+describe('modelOptionsQueryKey', () => {
+  it('isolates new-chat catalogs by active gateway profile', () => {
+    expect(modelOptionsQueryKey('default')).toEqual(['model-options', 'default', 'global'])
+    expect(modelOptionsQueryKey('compass')).toEqual(['model-options', 'compass', 'global'])
+    expect(modelOptionsQueryKey('default')).not.toEqual(modelOptionsQueryKey('compass'))
+  })
+
+  it('keeps session catalogs inside the owning profile namespace', () => {
+    expect(modelOptionsQueryKey(' compass ', 'session-1')).toEqual(['model-options', 'compass', 'session-1'])
+  })
+})
+
+describe('manualPickRemoved', () => {
+  const providers = [
+    { name: 'OpenRouter', slug: 'openrouter', models: ['owl-alpha', 'gpt-5.5'] },
+    { name: 'Nous', slug: 'nous', models: [] }
+  ]
+
+  it('flags a pick whose model was dropped from a populated provider', () => {
+    expect(manualPickRemoved(providers, 'openrouter', 'nemotron-removed')).toBe(true)
+  })
+
+  it('keeps a pick that is still in the catalog', () => {
+    expect(manualPickRemoved(providers, 'openrouter', 'gpt-5.5')).toBe(false)
+  })
+
+  it('matches the provider by name as well as slug', () => {
+    expect(manualPickRemoved(providers, 'OpenRouter', 'gpt-5.5')).toBe(false)
+    expect(manualPickRemoved(providers, 'OpenRouter', 'gone')).toBe(true)
+  })
+
+  it('never clobbers when the provider is absent', () => {
+    expect(manualPickRemoved(providers, 'anthropic', 'claude-sonnet-4.6')).toBe(false)
+  })
+
+  it('never clobbers when the provider has an empty model list', () => {
+    expect(manualPickRemoved(providers, 'nous', 'hermes-4')).toBe(false)
+  })
+
+  it('never clobbers on a not-yet-loaded or empty catalog', () => {
+    expect(manualPickRemoved(undefined, 'openrouter', 'gpt-5.5')).toBe(false)
+    expect(manualPickRemoved([], 'openrouter', 'gpt-5.5')).toBe(false)
+  })
+
+  it('never clobbers when there is no pick', () => {
+    expect(manualPickRemoved(providers, '', '')).toBe(false)
   })
 })

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -1,99 +1,43 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
-import { getGlobalModelOptions } from '@/hermes'
+import type { ModelOptionsResponse } from '@/types/hermes'
 
-import { manualPickRemoved, modelOptionsQueryKey, requestModelOptions } from './model-options'
+import { modelOptionsQueryKey, readModelOptionsCache, writeModelOptionsCache } from './model-options'
 
-const globalOptions = { model: 'hermes-4', provider: 'nous', providers: [] }
-
-vi.mock('@/hermes', () => ({
-  getGlobalModelOptions: vi.fn(() => Promise.resolve(globalOptions))
-}))
-
-describe('requestModelOptions', () => {
-  afterEach(() => {
-    vi.clearAllMocks()
-  })
-
-  it('uses the connected gateway even before a session exists', async () => {
-    const gatewayPayload = { model: 'BeastMode', provider: 'moa', providers: [] }
-
-    const gateway = {
-      request: vi.fn(() => Promise.resolve(gatewayPayload))
-    }
-
-    await expect(requestModelOptions({ gateway: gateway as never, sessionId: null })).resolves.toBe(gatewayPayload)
-
-    expect(gateway.request).toHaveBeenCalledWith('model.options', { explicit_only: true })
-    expect(getGlobalModelOptions).not.toHaveBeenCalled()
-  })
-
-  it('passes the active session id and refresh flag through the gateway', async () => {
-    const gateway = {
-      request: vi.fn(() => Promise.resolve(globalOptions))
-    }
-
-    await requestModelOptions({ gateway: gateway as never, refresh: true, sessionId: 'session-1' })
-
-    expect(gateway.request).toHaveBeenCalledWith('model.options', {
-      explicit_only: true,
-      refresh: true,
-      session_id: 'session-1'
-    })
-  })
-
-  it('falls back to REST when no gateway is connected', async () => {
-    await requestModelOptions({ refresh: true })
-
-    expect(getGlobalModelOptions).toHaveBeenCalledWith({ explicitOnly: true, refresh: true })
-  })
+const catalog = (model: string): ModelOptionsResponse => ({
+  model,
+  provider: 'novacode',
+  providers: [{ name: 'NovaCode', slug: 'novacode', models: [model] }]
 })
 
-describe('modelOptionsQueryKey', () => {
-  it('isolates new-chat catalogs by active gateway profile', () => {
-    expect(modelOptionsQueryKey('default')).toEqual(['model-options', 'default', 'global'])
-    expect(modelOptionsQueryKey('compass')).toEqual(['model-options', 'compass', 'global'])
-    expect(modelOptionsQueryKey('default')).not.toEqual(modelOptionsQueryKey('compass'))
+describe('model options local cache', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('uses stable profile/session keys and restores a successful catalog', () => {
+    writeModelOptionsCache('default', 'session-1', catalog('gpt-5.6-sol'))
+
+    const cached = readModelOptionsCache('default', 'session-1')
+
+    expect(modelOptionsQueryKey('default', 'session-1')).toEqual(['model-options', 'default', 'session-1'])
+    expect(cached?.data).toEqual(catalog('gpt-5.6-sol'))
+    expect(cached?.updatedAt).toEqual(expect.any(Number))
   })
 
-  it('keeps session catalogs inside the owning profile namespace', () => {
-    expect(modelOptionsQueryKey(' compass ', 'session-1')).toEqual(['model-options', 'compass', 'session-1'])
-  })
-})
+  it('keeps the cache bounded across session-scoped catalogs', () => {
+    for (let index = 0; index < 20; index += 1) {
+      writeModelOptionsCache('default', `session-${index}`, catalog(`model-${index}`))
+    }
 
-describe('manualPickRemoved', () => {
-  const providers = [
-    { name: 'OpenRouter', slug: 'openrouter', models: ['owl-alpha', 'gpt-5.5'] },
-    { name: 'Nous', slug: 'nous', models: [] } // present but unconfigured / re-auth
-  ]
-
-  it('flags a pick whose model was dropped from a populated provider', () => {
-    expect(manualPickRemoved(providers, 'openrouter', 'nemotron-removed')).toBe(true)
+    const raw = localStorage.getItem('hermes.desktop.model-options.v1')
+    expect(raw ? Object.keys(JSON.parse(raw)).length : 0).toBe(12)
   })
 
-  it('keeps a pick that is still in the catalog', () => {
-    expect(manualPickRemoved(providers, 'openrouter', 'gpt-5.5')).toBe(false)
-  })
+  it('treats malformed or incomplete entries as a cache miss', () => {
+    localStorage.setItem(
+      'hermes.desktop.model-options.v1',
+      JSON.stringify({ 'default:global': { data: { providers: 'not-an-array' }, updatedAt: 1 } })
+    )
 
-  it('matches the provider by name as well as slug', () => {
-    expect(manualPickRemoved(providers, 'OpenRouter', 'gpt-5.5')).toBe(false)
-    expect(manualPickRemoved(providers, 'OpenRouter', 'gone')).toBe(true)
-  })
-
-  it('never clobbers when the provider is absent (ambiguous / deauth)', () => {
-    expect(manualPickRemoved(providers, 'anthropic', 'claude-sonnet-4.6')).toBe(false)
-  })
-
-  it('never clobbers when the provider has an empty model list (re-auth)', () => {
-    expect(manualPickRemoved(providers, 'nous', 'hermes-4')).toBe(false)
-  })
-
-  it('never clobbers on a not-yet-loaded or empty catalog', () => {
-    expect(manualPickRemoved(undefined, 'openrouter', 'gpt-5.5')).toBe(false)
-    expect(manualPickRemoved([], 'openrouter', 'gpt-5.5')).toBe(false)
-  })
-
-  it('never clobbers when there is no pick', () => {
-    expect(manualPickRemoved(providers, '', '')).toBe(false)
+    expect(readModelOptionsCache('default')).toBeUndefined()
   })
 })

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -1,6 +1,16 @@
 import { getGlobalModelOptions, type HermesGateway, type ModelOptionsResponse } from '@/hermes'
 import type { ModelOptionProvider } from '@/types/hermes'
 
+const MODEL_OPTIONS_CACHE_KEY = 'hermes.desktop.model-options.v1'
+const MODEL_OPTIONS_CACHE_LIMIT = 12
+
+export interface CachedModelOptions {
+  data: ModelOptionsResponse
+  updatedAt: number
+}
+
+type ModelOptionsCache = Record<string, CachedModelOptions>
+
 /**
  * True only when a persisted **manual** composer pick has been removed from the
  * catalog (its provider still ships models, but no longer this one) — so a new
@@ -48,6 +58,63 @@ export function modelOptionsQueryKey(profile: null | string | undefined, session
   const profileKey = (profile ?? '').trim() || 'default'
 
   return ['model-options', profileKey, sessionId || 'global'] as const
+}
+
+function modelOptionsCacheEntryKey(profile: null | string | undefined, sessionId?: null | string): string {
+  const profileKey = (profile ?? '').trim() || 'default'
+
+  return `${profileKey}:${sessionId || 'global'}`
+}
+
+/**
+ * Read the last successful catalog from the renderer's local cache. This is a
+ * display cache only: React Query still revalidates stale entries in the
+ * background, and no credentials are stored here.
+ */
+export function readModelOptionsCache(
+  profile: null | string | undefined,
+  sessionId?: null | string
+): CachedModelOptions | undefined {
+  try {
+    const raw = localStorage.getItem(MODEL_OPTIONS_CACHE_KEY)
+
+    if (!raw) {
+      return undefined
+    }
+
+    const entry = (JSON.parse(raw) as ModelOptionsCache)[modelOptionsCacheEntryKey(profile, sessionId)]
+
+    if (!entry || !Array.isArray(entry.data?.providers) || !Number.isFinite(entry.updatedAt)) {
+      return undefined
+    }
+
+    return entry
+  } catch {
+    return undefined
+  }
+}
+
+/** Persist a successful catalog so a cold picker open can render immediately. */
+export function writeModelOptionsCache(
+  profile: null | string | undefined,
+  sessionId: null | string | undefined,
+  data: ModelOptionsResponse
+): void {
+  try {
+    const raw = localStorage.getItem(MODEL_OPTIONS_CACHE_KEY)
+    const cache: ModelOptionsCache = raw ? (JSON.parse(raw) as ModelOptionsCache) : {}
+    const key = modelOptionsCacheEntryKey(profile, sessionId)
+    cache[key] = { data, updatedAt: Date.now() }
+
+    const recent = Object.entries(cache)
+      .sort(([, left], [, right]) => right.updatedAt - left.updatedAt)
+      .slice(0, MODEL_OPTIONS_CACHE_LIMIT)
+
+    localStorage.setItem(MODEL_OPTIONS_CACHE_KEY, JSON.stringify(Object.fromEntries(recent)))
+  } catch {
+    // localStorage can be unavailable or full; the in-memory React Query cache
+    // remains the authoritative short-lived fallback.
+  }
 }
 
 export function requestModelOptions({

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -60,10 +60,10 @@ export function modelOptionsQueryKey(profile: null | string | undefined, session
   return ['model-options', profileKey, sessionId || 'global'] as const
 }
 
-function modelOptionsCacheEntryKey(profile: null | string | undefined, sessionId?: null | string): string {
+function modelOptionsCacheEntryKey(profile: null | string | undefined): string {
   const profileKey = (profile ?? '').trim() || 'default'
 
-  return `${profileKey}:${sessionId || 'global'}`
+  return profileKey
 }
 
 /**
@@ -82,7 +82,8 @@ export function readModelOptionsCache(
       return undefined
     }
 
-    const entry = (JSON.parse(raw) as ModelOptionsCache)[modelOptionsCacheEntryKey(profile, sessionId)]
+    const cache = JSON.parse(raw) as ModelOptionsCache
+    const entry = cache[modelOptionsCacheEntryKey(profile)] ?? cache[`${modelOptionsCacheEntryKey(profile)}:global`]
 
     if (!entry || !Array.isArray(entry.data?.providers) || !Number.isFinite(entry.updatedAt)) {
       return undefined
@@ -103,7 +104,7 @@ export function writeModelOptionsCache(
   try {
     const raw = localStorage.getItem(MODEL_OPTIONS_CACHE_KEY)
     const cache: ModelOptionsCache = raw ? (JSON.parse(raw) as ModelOptionsCache) : {}
-    const key = modelOptionsCacheEntryKey(profile, sessionId)
+    const key = modelOptionsCacheEntryKey(profile)
     cache[key] = { data, updatedAt: Date.now() }
 
     const recent = Object.entries(cache)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1085,6 +1085,24 @@ def test_dispatch_rejects_non_object_params():
     }
 
 
+def test_session_create_immediately_reports_configured_provider(monkeypatch):
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("gpt-5.6-terra", "novacode"))
+    monkeypatch.setattr(server, "_resolve_model", lambda: "gpt-5.6-terra")
+
+    resp = server.handle_request(
+        {"id": "1", "method": "session.create", "params": {"cols": 80}}
+    )
+    assert isinstance(resp, dict)
+    result = resp.get("result")
+    assert isinstance(result, dict)
+    sid = result["session_id"]
+    try:
+        assert result["info"]["model"] == "gpt-5.6-terra"
+        assert result["info"]["provider"] == "novacode"
+    finally:
+        server._sessions.pop(sid, None)
+
+
 def test_system_battery_returns_reading(monkeypatch):
     monkeypatch.setitem(
         sys.modules,

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2993,6 +2993,64 @@ def test_make_agent_passes_configured_fallback_chain(monkeypatch):
     assert captured["platform"] == "tui"
 
 
+def test_make_agent_preserves_named_custom_requested_provider(monkeypatch):
+    captured = {}
+
+    def fake_agent(**kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(model=kwargs.get("model"))
+
+    monkeypatch.delenv("HERMES_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_TUI_PROVIDER", raising=False)
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+    monkeypatch.delenv("HERMES_DESKTOP_TERMINAL", raising=False)
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"model": {"default": "gpt-5.6-sol", "provider": "novacode"}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested=None, target_model=None: {
+            "provider": "custom",
+            "requested_provider": "novacode",
+            "base_url": "https://novacode.example/v1",
+            "api_key": "token",
+            "api_mode": "chat_completions",
+            "credential_pool": None,
+        },
+    )
+    monkeypatch.setattr("run_agent.AIAgent", fake_agent)
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    server._make_agent("sid", "session-key")
+
+    assert captured["provider"] == "custom"
+    assert captured["requested_provider"] == "novacode"
+
+
+def test_background_agent_kwargs_preserves_named_custom_requested_provider(monkeypatch):
+    agent = types.SimpleNamespace(
+        model="gpt-5.6-sol",
+        provider="custom",
+        requested_provider="novacode",
+        base_url="https://novacode.example/v1",
+        api_key="token",
+        api_mode="chat_completions",
+        _fallback_chain=[],
+    )
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"max_turns": 25})
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    kwargs = server._background_agent_kwargs(agent, "task-id")
+
+    assert kwargs["provider"] == "custom"
+    assert kwargs["requested_provider"] == "novacode"
+
+
 def test_background_agent_kwargs_preserves_full_fallback_chain(monkeypatch):
     chain = [
         {"provider": "openrouter", "model": "openai/gpt-5.5"},
@@ -6467,6 +6525,40 @@ def test_restore_agent_model_runtime_falls_back_to_switch_model():
     assert agent.base_url == "https://openrouter.ai/api/v1"
 
 
+def test_restore_agent_model_runtime_preserves_named_custom_requested_provider():
+    class Agent:
+        model = "temp/model"
+        provider = "anthropic"
+        requested_provider = "anthropic"
+        base_url = "https://api.anthropic.com"
+        api_key = "sk-temp"
+        api_mode = "anthropic_messages"
+
+        def switch_model(self, **kwargs):
+            self.model = kwargs["new_model"]
+            self.provider = kwargs["new_provider"]
+            self.api_key = kwargs["api_key"]
+            self.base_url = kwargs["base_url"]
+            self.api_mode = kwargs["api_mode"]
+
+    agent = Agent()
+
+    server._restore_agent_model_runtime(
+        agent,
+        {
+            "model": "old/model",
+            "provider": "custom",
+            "requested_provider": "novacode",
+            "api_key": "sk-old",
+            "base_url": "https://novacode.example/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+
+    assert agent.provider == "custom"
+    assert agent.requested_provider == "novacode"
+
+
 def test_config_set_personality_rejects_unknown_name(monkeypatch):
     monkeypatch.setattr(
         server,
@@ -7894,6 +7986,24 @@ def test_session_info_includes_mcp_servers(monkeypatch):
 
     assert info["provider"] == "openai-codex"
     assert info["mcp_servers"] == fake_status
+
+
+def test_session_info_prefers_named_custom_provider_identity(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.canonical_custom_identity",
+        lambda **_kwargs: "custom:novacode",
+    )
+    agent = types.SimpleNamespace(
+        tools=[],
+        model="gpt-5.6-sol",
+        provider="custom",
+        requested_provider="novacode",
+        base_url="https://novacode.example/v1",
+    )
+
+    info = server._session_info(agent)
+
+    assert info["provider"] == "novacode"
 
 
 def test_session_info_includes_session_title(monkeypatch):
@@ -10628,6 +10738,31 @@ def test_model_options_preserves_canonical_custom_row_after_agent_init(monkeypat
         config_provider="custom:local-ollama",
         model="qwen3.6:35b-65k",
     )
+
+
+def test_model_picker_context_prefers_named_custom_provider_slug(monkeypatch):
+    from hermes_cli.inventory import ConfigContext
+
+    agent = types.SimpleNamespace(
+        provider="custom",
+        requested_provider="novacode",
+        model="gpt-5.6-sol",
+        base_url="https://novacode.example/v1",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.inventory.load_picker_context",
+        lambda: ConfigContext(
+            current_provider="novacode",
+            current_model="gpt-5.6-sol",
+            current_base_url="https://novacode.example/v1",
+            user_providers={"novacode": {}},
+            custom_providers=[],
+        ),
+    )
+
+    ctx = server._model_picker_context(agent)
+
+    assert ctx.current_provider == "novacode"
 
 
 def test_model_save_key_uses_credential_lifecycle_and_picker_context(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3891,6 +3891,7 @@ def _snapshot_agent_model_runtime(agent) -> dict:
     return {
         "model": getattr(agent, "model", ""),
         "provider": getattr(agent, "provider", ""),
+        "requested_provider": getattr(agent, "requested_provider", ""),
         "api_key": getattr(agent, "api_key", ""),
         "base_url": getattr(agent, "base_url", ""),
         "api_mode": getattr(agent, "api_mode", ""),
@@ -3920,6 +3921,9 @@ def _restore_agent_model_runtime(agent, snapshot: dict | None) -> None:
             base_url=snapshot.get("base_url", ""),
             api_mode=snapshot.get("api_mode", ""),
         )
+        requested_provider = str(snapshot.get("requested_provider") or "").strip()
+        if requested_provider:
+            agent.requested_provider = requested_provider
 
 
 def _apply_model_switch(
@@ -4541,6 +4545,49 @@ def _session_usage_snapshot(session: dict | None) -> dict:
     return dict(mirror_usage) if isinstance(mirror_usage, dict) else {}
 
 
+def _provider_identity_for_ui(
+    agent,
+    *,
+    provider: str = "",
+    model: str = "",
+    base_url: str = "",
+    config_provider: str = "",
+) -> str:
+    """Return a user-facing provider identity, not a wire/billing class."""
+    resolved = str(provider or getattr(agent, "provider", "") or "").strip().lower()
+    if resolved != "custom":
+        return resolved
+
+    requested = str(getattr(agent, "requested_provider", "") or "").strip().lower()
+    if requested not in {"", "auto", "custom", "openrouter"}:
+        return requested
+
+    try:
+        from hermes_cli.runtime_provider import canonical_custom_identity
+
+        recovered = canonical_custom_identity(
+            base_url=base_url or getattr(agent, "base_url", "") or None,
+            config_provider=config_provider or None,
+            model=model or getattr(agent, "model", "") or None,
+        )
+        if not recovered:
+            return resolved
+        recovered = str(recovered).strip().lower()
+        if recovered.startswith("custom:"):
+            provider_slug = recovered.split(":", 1)[1]
+            try:
+                from hermes_cli.inventory import load_picker_context
+
+                if provider_slug in load_picker_context().user_providers:
+                    return provider_slug
+            except Exception:
+                pass
+        return recovered
+    except Exception:
+        logger.debug("custom provider identity recovery failed (UI)", exc_info=True)
+        return resolved
+
+
 def _project_info_for_cwd(cwd: str) -> dict | None:
     """Return the first-class Project owning ``cwd`` for UI status surfaces.
 
@@ -4595,6 +4642,14 @@ def _session_info(agent, session: dict | None = None) -> dict:
         else:
             reasoning_effort = str(reasoning_config.get("effort", "") or "")
     service_tier = getattr(agent, "service_tier", None) or mirror.get("service_tier") or ""
+    model = mirror.get("model", getattr(agent, "model", ""))
+    provider = mirror.get("provider", getattr(agent, "provider", ""))
+    provider = _provider_identity_for_ui(
+        agent,
+        provider=provider,
+        model=model,
+        base_url=mirror.get("base_url", getattr(agent, "base_url", "")),
+    )
     # Effective approval-bypass state — the same three sources that
     # check_all_command_guards() ORs together: persistent config
     # (approvals.mode=off), the process-scoped --yolo env, and the
@@ -4614,8 +4669,8 @@ def _session_info(agent, session: dict | None = None) -> dict:
     except Exception:
         yolo = False
     info: dict = {
-        "model": mirror.get("model", getattr(agent, "model", "")),
-        "provider": mirror.get("provider", getattr(agent, "provider", "")),
+        "model": model,
+        "provider": provider,
         "reasoning_effort": reasoning_effort,
         "service_tier": service_tier,
         "fast": service_tier == "priority",
@@ -5498,6 +5553,7 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "base_url": getattr(agent, "base_url", None) or None,
         "api_key": getattr(agent, "api_key", None) or None,
         "provider": getattr(agent, "provider", None) or None,
+        "requested_provider": getattr(agent, "requested_provider", None) or None,
         "api_mode": getattr(agent, "api_mode", None) or None,
         "acp_command": getattr(agent, "acp_command", None) or None,
         "acp_args": getattr(agent, "acp_args", None) or None,
@@ -5974,6 +6030,9 @@ def _make_agent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 500),
         provider=runtime.get("provider"),
+        requested_provider=str(
+            runtime.get("requested_provider") or requested_provider or ""
+        ),
         base_url=runtime.get("base_url"),
         api_key=runtime.get("api_key"),
         api_mode=runtime.get("api_mode"),
@@ -16851,23 +16910,13 @@ def _model_picker_context(agent):
     provider = getattr(agent, "provider", "") if agent else ""
     base_url = getattr(agent, "base_url", "") if agent else ""
     if str(provider or "").strip().lower() == "custom":
-        try:
-            from hermes_cli.runtime_provider import canonical_custom_identity
-
-            provider = (
-                canonical_custom_identity(
-                    base_url=base_url or None,
-                    config_provider=ctx.current_provider,
-                    model=(getattr(agent, "model", "") if agent else "")
-                    or None,
-                )
-                or provider
-            )
-        except Exception:
-            logger.debug(
-                "custom provider identity recovery failed (model picker)",
-                exc_info=True,
-            )
+        provider = _provider_identity_for_ui(
+            agent,
+            provider=provider,
+            base_url=base_url,
+            config_provider=ctx.current_provider,
+            model=(getattr(agent, "model", "") if agent else ""),
+        )
 
     return ctx.with_overrides(
         current_provider=provider,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7204,6 +7204,7 @@ def _(rid, params: dict) -> dict:
         if create_model
         else None
     )
+    startup_model, startup_provider = _config_model_target()
     create_reasoning_override = None
     if effort := str(params.get("reasoning_effort") or "").strip():
         try:
@@ -7290,12 +7291,12 @@ def _(rid, params: dict) -> dict:
                 "model": (
                     session_model_override.get("model")
                     if session_model_override
-                    else _resolve_model()
+                    else startup_model or _resolve_model()
                 ),
                 **(
                     {"provider": session_model_override["provider"]}
                     if session_model_override and session_model_override.get("provider")
-                    else {}
+                    else ({"provider": startup_provider} if startup_provider else {})
                 ),
                 "tools": {},
                 "skills": {},


### PR DESCRIPTION
## Summary
- cache the latest successful model-options catalog per profile so a new-chat picker can render immediately while revalidating in the background
- retain named custom-provider identity through gateway session/runtime paths
- initialize `session.create` metadata from the configured model/provider

## Verification
- `npm run --prefix apps/desktop test:ui -- --run src/lib/model-options.test.ts` — 16 passed
- `npm run --prefix apps/desktop check:lint` — passed (0 errors; 67 pre-existing warnings)
- `scripts/run_tests.sh tests/test_tui_gateway_server.py -q` — 487 passed
- `git diff --check 9dc191d...HEAD` — clean

Supersedes the accidentally oversized draft in the fork, which included unrelated upstream history.