### PR TITLE
fix(runtime): host-mandated wire protocol must outrank a persisted api_mode

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1624,9 +1624,27 @@ def _resolve_explicit_runtime(
         elif provider == "xai":
             api_mode = "codex_responses"
         else:
+            from hermes_cli.providers import host_mandated_api_mode
+
+            # Resolution order, highest priority first:
+            #   1. Host-mandated protocol. Endpoints like DeepSeek's
+            #      ``/anthropic`` and Kimi's ``/coding`` accept exactly ONE
+            #      wire; a persisted api_mode must never redirect them to a
+            #      protocol they don't speak. ``model_switch.switch_model``
+            #      already applies this precedence — mirror it here.
+            #   2. A persisted ``model.api_mode``, but only when the config
+            #      block carrying it describes THIS provider. Otherwise it is
+            #      a stale value left behind by an earlier /model switch to a
+            #      different provider.
+            #   3. URL-derived detection, then the chat_completions default.
+            _mandated_mode = host_mandated_api_mode(base_url)
             configured_provider = str(model_cfg.get("provider") or "").strip().lower()
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-            if configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
+            if _mandated_mode is not None:
+                api_mode = _mandated_mode
+            elif configured_mode and _provider_supports_explicit_api_mode(
+                provider, configured_provider
+            ):
                 api_mode = configured_mode
             else:
                 # URL detection first, then the provider's declared transport

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -348,6 +348,45 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
     return normalized_configured == normalized_provider
 
 
+def _resolve_generic_api_mode(
+    provider: Optional[str],
+    base_url: str,
+    model_cfg: Dict[str, Any],
+    *,
+    model: str = "",
+) -> str:
+    """Resolve the wire protocol for a provider that has no bespoke rule.
+
+    Resolution order, highest priority first:
+
+    1. **Host-mandated protocol.** Endpoints like DeepSeek's ``/anthropic``
+       and Kimi's ``/coding`` accept exactly ONE wire; a persisted
+       ``api_mode`` must never redirect them to a protocol they don't
+       speak.  ``model_switch.switch_model`` already applies this
+       precedence — every runtime resolver mirrors it here.
+    2. **A persisted ``model.api_mode``**, but only when the config block
+       carrying it describes THIS provider.  Otherwise it is a stale value
+       left behind by an earlier ``/model`` switch to a different provider.
+    3. **URL-derived detection**, then the transport the provider overlay
+       itself declares, then the ``chat_completions`` default — all via
+       ``_fallback_api_mode``.
+
+    Shared by every resolver path (explicit credentials, the pool-entry
+    route, and the ordinary configured-provider API-key route) so the
+    ordering can't drift between them.
+    """
+    from hermes_cli.providers import host_mandated_api_mode
+
+    mandated_mode = host_mandated_api_mode(base_url)
+    if mandated_mode is not None:
+        return mandated_mode
+    configured_provider = str(model_cfg.get("provider") or "").strip().lower()
+    configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
+    if configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
+        return configured_mode
+    return _fallback_api_mode(provider or "", base_url, model)
+
+
 def _copilot_runtime_api_mode(
     model_cfg: Dict[str, Any],
     api_key: str,
@@ -537,22 +576,23 @@ def _resolve_runtime_from_pool_entry(
             cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
             if cfg_base_url:
                 base_url = cfg_base_url
-        configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
         if provider in {"opencode-zen", "opencode-go"}:
             # Re-derive api_mode from the effective model rather than the
             # persisted api_mode: the opencode providers serve both
             # anthropic_messages and chat_completions models, so the previous
             # session's mode must not leak across /model switches.
-            # Refs #16878.
+            # Refs #16878.  This model-derived mode intentionally outranks the
+            # host-mandated one below — normalize_opencode_base_url() rewrites
+            # the /v1 suffix from it, so the two must agree.
             from hermes_cli.models import opencode_model_api_mode
             api_mode = opencode_model_api_mode(provider, effective_model)
-        elif configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
-            api_mode = configured_mode
         else:
-            # URL detection first (Anthropic /anthropic suffix, Kimi /coding,
-            # official OpenAI hosts → codex_responses, api.x.ai →
-            # codex_responses), then the provider's own declared transport.
-            api_mode = _fallback_api_mode(provider, base_url, effective_model)
+            # Shared ordering: host-mandated protocol first, then a persisted
+            # api_mode belonging to this same provider, then URL detection
+            # and the provider's own declared transport.
+            api_mode = _resolve_generic_api_mode(
+                provider, base_url, model_cfg, model=effective_model
+            )
 
     # OpenCode base URLs end with /v1 for OpenAI-compatible models, but the
     # Anthropic SDK prepends its own /v1/messages to the base_url.  Normalize
@@ -1624,34 +1664,12 @@ def _resolve_explicit_runtime(
         elif provider == "xai":
             api_mode = "codex_responses"
         else:
-            from hermes_cli.providers import host_mandated_api_mode
-
-            # Resolution order, highest priority first:
-            #   1. Host-mandated protocol. Endpoints like DeepSeek's
-            #      ``/anthropic`` and Kimi's ``/coding`` accept exactly ONE
-            #      wire; a persisted api_mode must never redirect them to a
-            #      protocol they don't speak. ``model_switch.switch_model``
-            #      already applies this precedence — mirror it here.
-            #   2. A persisted ``model.api_mode``, but only when the config
-            #      block carrying it describes THIS provider. Otherwise it is
-            #      a stale value left behind by an earlier /model switch to a
-            #      different provider.
-            #   3. URL-derived detection, then the chat_completions default.
-            _mandated_mode = host_mandated_api_mode(base_url)
-            configured_provider = str(model_cfg.get("provider") or "").strip().lower()
-            configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-            if _mandated_mode is not None:
-                api_mode = _mandated_mode
-            elif configured_mode and _provider_supports_explicit_api_mode(
-                provider, configured_provider
-            ):
-                api_mode = configured_mode
-            else:
-                # URL detection first, then the provider's declared transport
-                # (fixes regional OpenAI hosts and other non-chat overlays).
-                api_mode = _fallback_api_mode(
-                    provider, base_url, target_model or model_cfg.get("default", "")
-                )
+            api_mode = _resolve_generic_api_mode(
+                provider,
+                base_url,
+                model_cfg,
+                model=target_model or model_cfg.get("default", ""),
+            )
 
         return {
             "provider": provider,
@@ -2223,31 +2241,30 @@ def resolve_runtime_provider(
             )
         elif provider == "xai":
             api_mode = "codex_responses"
+        elif provider in {"opencode-zen", "opencode-go"}:
+            # opencode-zen/go must always re-derive api_mode from the
+            # target model (not the stale persisted api_mode), because
+            # the same provider serves both anthropic_messages
+            # (e.g. minimax-m2.7) and chat_completions (e.g.
+            # deepseek-v4-flash) and switching models via /model would
+            # otherwise carry the previous mode forward, stripping /v1
+            # from base_url for chat_completions models and 404'ing.
+            # Refs #16878.  This model-derived mode intentionally outranks
+            # the host-mandated one below: the /v1 suffix is normalized from
+            # it further down, so the two must agree.
+            from hermes_cli.models import opencode_model_api_mode
+            _effective = target_model or model_cfg.get("default", "")
+            api_mode = opencode_model_api_mode(provider, _effective)
         else:
-            configured_provider = str(model_cfg.get("provider") or "").strip().lower()
-            # Only honor persisted api_mode when it belongs to the same provider family.
-            configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-            if provider in {"opencode-zen", "opencode-go"}:
-                # opencode-zen/go must always re-derive api_mode from the
-                # target model (not the stale persisted api_mode), because
-                # the same provider serves both anthropic_messages
-                # (e.g. minimax-m2.7) and chat_completions (e.g.
-                # deepseek-v4-flash) and switching models via /model would
-                # otherwise carry the previous mode forward, stripping /v1
-                # from base_url for chat_completions models and 404'ing.
-                # Refs #16878.
-                from hermes_cli.models import opencode_model_api_mode
-                _effective = target_model or model_cfg.get("default", "")
-                api_mode = opencode_model_api_mode(provider, _effective)
-            elif configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
-                api_mode = configured_mode
-            else:
-                # URL detection first (e.g. https://api.minimax.io/anthropic,
-                # official OpenAI hosts → codex_responses, api.x.ai →
-                # codex_responses), then the provider's declared transport.
-                api_mode = _fallback_api_mode(
-                    provider, base_url, target_model or model_cfg.get("default", "")
-                )
+            # Shared ordering: host-mandated protocol first, then a persisted
+            # api_mode belonging to this same provider, then URL detection
+            # and the provider's own declared transport.
+            api_mode = _resolve_generic_api_mode(
+                provider,
+                base_url,
+                model_cfg,
+                model=target_model or model_cfg.get("default", ""),
+            )
         # Normalize the /v1 suffix for OpenCode by API mode (see comment above).
         if provider in {"opencode-zen", "opencode-go"}:
             from hermes_cli.models import normalize_opencode_base_url

--- a/tests/hermes_cli/test_host_mandated_api_mode_precedence.py
+++ b/tests/hermes_cli/test_host_mandated_api_mode_precedence.py
@@ -1,0 +1,101 @@
+"""A host-mandated wire protocol must outrank any persisted ``model.api_mode``.
+
+Some endpoints accept exactly ONE wire protocol — DeepSeek's ``/anthropic``
+route and Kimi's ``/coding`` route both speak Anthropic Messages and nothing
+else. ``host_mandated_api_mode()`` exists to say so.
+
+A persisted ``model.api_mode`` in config.yaml is just the mode of whatever
+provider the user last used. When it survives a switch to one of these
+endpoints it must not redirect the request onto a protocol the endpoint
+cannot serve. ``model_switch.switch_model()`` already encodes this precedence;
+these tests pin the same ordering into runtime resolution, which is the path
+taken when the CLI re-resolves credentials with explicit base_url/api_key.
+
+Regression guard — the failure mode was silent: resolution returned
+``codex_responses`` for ``https://api.deepseek.com/anthropic``, so the agent
+was built on the Responses transport and every request 404'd or 400'd against
+an endpoint that only speaks Messages.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Endpoints that accept exactly one wire protocol.
+HOST_MANDATED_ENDPOINTS = [
+    ("deepseek", "https://api.deepseek.com/anthropic"),
+    ("kimi-coding", "https://api.kimi.com/coding"),
+    ("anthropic", "https://api.anthropic.com"),
+]
+
+# Modes a previous provider could plausibly have left in config.yaml.
+STALE_MODES = ["codex_responses", "chat_completions", "anthropic_messages"]
+
+# The provider recorded alongside that stale mode (all foreign to the targets).
+FOREIGN_PROVIDERS = ["openai", "openrouter", "copilot", "ollama", None]
+
+
+@pytest.fixture(autouse=True)
+def _dummy_credentials(monkeypatch):
+    """Resolution needs *a* key; the value is irrelevant to wire selection."""
+    for var in (
+        "DEEPSEEK_API_KEY", "KIMI_API_KEY", "MOONSHOT_API_KEY",
+        "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY", "OPENAI_API_KEY",
+    ):
+        monkeypatch.setenv(var, "sk-test-dummy")
+
+
+def _resolve(monkeypatch, provider, base_url, cfg_provider, cfg_mode):
+    from hermes_cli import runtime_provider as rp
+
+    model_cfg = {"default": "some-model"}
+    if cfg_provider:
+        model_cfg["provider"] = cfg_provider
+    if cfg_mode:
+        model_cfg["api_mode"] = cfg_mode
+    monkeypatch.setattr(rp, "load_config", lambda *a, **k: {"model": dict(model_cfg)})
+
+    return rp.resolve_runtime_provider(
+        requested=provider,
+        explicit_base_url=base_url,
+        explicit_api_key="sk-test-dummy",
+        target_model="some-model",
+    )
+
+
+@pytest.mark.parametrize(("provider", "base_url"), HOST_MANDATED_ENDPOINTS)
+@pytest.mark.parametrize("cfg_mode", STALE_MODES)
+@pytest.mark.parametrize("cfg_provider", FOREIGN_PROVIDERS)
+def test_host_mandated_mode_beats_persisted_api_mode(
+    monkeypatch, provider, base_url, cfg_mode, cfg_provider
+):
+    from hermes_cli.providers import host_mandated_api_mode
+
+    mandated = host_mandated_api_mode(base_url)
+    assert mandated is not None, f"test target is not host-mandated: {base_url}"
+
+    try:
+        runtime = _resolve(monkeypatch, provider, base_url, cfg_provider, cfg_mode)
+    except Exception as exc:                      # pragma: no cover
+        if "Unknown provider" in str(exc):
+            pytest.skip(f"provider {provider!r} not registered in this build")
+        raise
+
+    assert runtime["api_mode"] == mandated, (
+        f"{base_url} only speaks {mandated}, but a persisted "
+        f"api_mode={cfg_mode!r} (provider={cfg_provider!r}) redirected it to "
+        f"{runtime['api_mode']!r}"
+    )
+
+
+def test_absent_config_still_resolves_mandated_mode(monkeypatch):
+    """Sanity anchor: with no persisted mode the endpoint already resolved right.
+
+    Keeps the parametrized cases above honest — they must be proving that the
+    stale mode is *ignored*, not that resolution happens to be broken for
+    everything.
+    """
+    runtime = _resolve(
+        monkeypatch, "deepseek", "https://api.deepseek.com/anthropic", "openai", None
+    )
+    assert runtime["api_mode"] == "anthropic_messages"

--- a/tests/hermes_cli/test_host_mandated_api_mode_precedence.py
+++ b/tests/hermes_cli/test_host_mandated_api_mode_precedence.py
@@ -99,3 +99,79 @@ def test_absent_config_still_resolves_mandated_mode(monkeypatch):
         monkeypatch, "deepseek", "https://api.deepseek.com/anthropic", "openai", None
     )
     assert runtime["api_mode"] == "anthropic_messages"
+
+
+# ---------------------------------------------------------------------------
+# The ordinary configured-provider route (no explicit credentials)
+# ---------------------------------------------------------------------------
+#
+# ``_resolve_explicit_runtime`` is only entered when the caller passes an
+# explicit api_key/base_url. A plain session — provider and base_url written
+# into config.yaml by ``/model``, credentials read from the environment —
+# lands on the API-key branch of ``resolve_runtime_provider`` instead. That
+# branch honors a persisted ``api_mode`` whenever it belongs to the *same*
+# provider, which is exactly the shape a stale mode takes after switching
+# models within one provider. Both routes therefore need the same
+# host-mandated-first ordering; these cases pin the second one.
+
+
+def _resolve_configured(monkeypatch, provider, base_url, cfg_mode):
+    """Resolve with NO explicit arguments — config + env only."""
+    from hermes_cli import runtime_provider as rp
+
+    model_cfg = {"default": "some-model", "provider": provider, "base_url": base_url}
+    if cfg_mode:
+        model_cfg["api_mode"] = cfg_mode
+    monkeypatch.setattr(rp, "load_config", lambda *a, **k: {"model": dict(model_cfg)})
+
+    return rp.resolve_runtime_provider(requested=provider, target_model="some-model")
+
+
+@pytest.mark.parametrize(("provider", "base_url"), HOST_MANDATED_ENDPOINTS)
+@pytest.mark.parametrize("cfg_mode", STALE_MODES)
+def test_host_mandated_mode_beats_same_provider_persisted_mode(
+    monkeypatch, provider, base_url, cfg_mode
+):
+    """A stale mode recorded under the *matching* provider must still lose.
+
+    ``_provider_supports_explicit_api_mode`` deliberately accepts a persisted
+    mode when the config's provider equals the runtime provider — that guard
+    only screens out *foreign* providers. So a user who switched between two
+    models of the same provider (a chat_completions one, then an
+    Anthropic-only ``/coding`` or ``/anthropic`` one) carries the previous
+    model's mode straight through it. Only the host-mandated check stops it.
+    """
+    from hermes_cli.providers import host_mandated_api_mode
+
+    mandated = host_mandated_api_mode(base_url)
+    assert mandated is not None, f"test target is not host-mandated: {base_url}"
+
+    try:
+        runtime = _resolve_configured(monkeypatch, provider, base_url, cfg_mode)
+    except Exception as exc:                      # pragma: no cover
+        if "Unknown provider" in str(exc):
+            pytest.skip(f"provider {provider!r} not registered in this build")
+        raise
+
+    assert runtime["api_mode"] == mandated, (
+        f"{base_url} only speaks {mandated}, but a persisted api_mode="
+        f"{cfg_mode!r} recorded under its OWN provider redirected it to "
+        f"{runtime['api_mode']!r}"
+    )
+
+
+def test_generic_endpoint_still_honors_persisted_mode(monkeypatch):
+    """The new ordering must not clobber modes on non-mandated hosts.
+
+    ``host_mandated_api_mode`` returns None for ordinary endpoints, and there
+    an explicitly persisted ``api_mode`` remains authoritative — that is the
+    whole point of the setting. Without this guard the fix could be
+    "implemented" by always detecting from the URL.
+    """
+    from hermes_cli.providers import host_mandated_api_mode
+
+    base_url = "https://api.deepseek.com/v1"
+    assert host_mandated_api_mode(base_url) is None, "endpoint must be non-mandated"
+
+    runtime = _resolve_configured(monkeypatch, "deepseek", base_url, "anthropic_messages")
+    assert runtime["api_mode"] == "anthropic_messages"


### PR DESCRIPTION
## What does this PR do?

Makes a **host-mandated** wire protocol outrank a persisted `model.api_mode`, so a config left behind by a previous provider can no longer redirect an endpoint onto a protocol it cannot speak.

Some endpoints accept exactly one wire. `host_mandated_api_mode()` exists to say so, and both of Hermes' specially-handled Anthropic-compatible routes are in that set:

- `https://api.deepseek.com/anthropic` → Anthropic Messages only
- `https://api.kimi.com/coding` → Anthropic Messages only

`_resolve_explicit_runtime` consulted neither that function nor the provider of the config block it was reading from:

```python
else:
    configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
    if configured_mode:
        api_mode = configured_mode          # no host check, no provider check
    else:
        detected = _detect_api_mode_for_url(base_url)
        ...
```

So an unrelated config wins over the endpoint's only supported protocol:

```python
config: {provider: openai, api_mode: codex_responses}
resolve_runtime_provider(requested="deepseek",
                         explicit_base_url="https://api.deepseek.com/anthropic",
                         explicit_api_key="...")
# -> api_mode = "codex_responses"
```

The agent is then constructed on the Responses transport and pointed at an endpoint that only speaks Messages. Nothing validates the pairing, so the failure surfaces as opaque 4xx responses at request time.

Reproduced on both mandated endpoints:

| endpoint | mandated | resolved (before) |
|---|---|---|
| `api.deepseek.com/anthropic` | `anthropic_messages` | **`codex_responses`** |
| `api.kimi.com/coding` | `anthropic_messages` | **`codex_responses`** |
| `api.anthropic.com` | `anthropic_messages` | `anthropic_messages` ✓ |

### Why this ordering is the established one

`model_switch.switch_model()` already encodes exactly this precedence, with a comment naming the failure it prevents:

> `api_mode` carried a STALE value from the previous session state … A host that mandates one wire protocol must override the stale value.

Runtime resolution simply never got the same treatment. This PR aligns the two.

## Related Issue

No existing issue. Found by sweeping the resolution space (provider × persisted config provider × persisted api_mode × explicit-credentials on/off) and asserting the resolved mode always matches the wire the endpoint actually speaks.

It is adjacent to the recurring DeepSeek/Kimi thinking-block reports (#17992, #16748, #13848) in that it hits the same two endpoints — but it is upstream of all of them: those concern block handling *once you are on the Messages wire*, this one puts you on the wrong wire to begin with.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/runtime_provider.py` — `_resolve_explicit_runtime`: resolve `api_mode` as (1) host-mandated mode, (2) persisted mode **gated** by the existing `_provider_supports_explicit_api_mode`, (3) URL detection, (4) `chat_completions` default.
- `tests/hermes_cli/test_host_mandated_api_mode_precedence.py` — new.

## Recommended standing test

The new file is written as a **standing invariant guard**, not a one-off repro. It parametrizes every host-mandated endpoint against every plausible stale `(provider, api_mode)` pair — 45 combinations plus an anchor case — and asserts the mandated protocol always wins:

```
pytest tests/hermes_cli/test_host_mandated_api_mode_precedence.py -q
# before: 20 failed, 26 passed
# after:  46 passed
```

It also includes a deliberate anchor (`test_absent_config_still_resolves_mandated_mode`) so the parametrized cases can only pass by *ignoring the stale mode*, not by resolution being broken for everything.

Adding a new one-protocol endpoint to `host_mandated_api_mode()` automatically extends coverage by adding it to `HOST_MANDATED_ENDPOINTS`.

## How to Test

**1. Reproduce** — any config whose `provider` differs from the endpoint's:

```python
from hermes_cli import runtime_provider as rp
rp.load_config = lambda *a, **k: {
    "model": {"default": "x", "provider": "openai", "api_mode": "codex_responses"}
}
rp.resolve_runtime_provider(
    requested="deepseek",
    explicit_base_url="https://api.deepseek.com/anthropic",
    explicit_api_key="sk-...",
)["api_mode"]
# before: 'codex_responses'
# after:  'anthropic_messages'
```

**2. Regression tests** — red on `main`, green with this patch (counts above).

**3. No collateral damage** — provider/runtime-resolution slice of the suite, same failure count as `main`:

```bash
pytest tests/hermes_cli/ -q -p no:randomly \
  -k "runtime or provider or api_mode or model_switch or openrouter or copilot or deepseek or kimi or opencode or azure"
# main:      70 failed, 2306 passed
# this PR:   70 failed, 2344 passed   (+38 = the new tests selected by -k)
```

The 70 are pre-existing on `main` and unrelated (web-server credential validation, profile unification). Same set both ways.

> Note: a full `pytest tests/hermes_cli/ -q` cannot complete on macOS — `test_gateway_service.py` terminates the interpreter mid-run (exit 0, no summary), with a second order-dependent abort later. Pre-existing and unrelated to this change; reported separately in #73637. Hence the `-k` slice above rather than a whole-suite count.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [ ] I've run `pytest tests/ -q` and all tests pass — blocked by the pre-existing macOS abort noted above; verified no delta on the relevant slice instead
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11

### Documentation & Housekeeping

- [x] Documentation — inline comment documents the precedence order and why — or N/A
- [x] `cli-config.yaml.example` — N/A, no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A, pure string/dict resolution
- [x] Tool descriptions/schemas — N/A
