### PR TITLE
fix(runtime): honor OpenRouter's own api_mode on the pooled path

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -454,6 +454,21 @@ def _resolve_runtime_from_pool_entry(
         base_url = cfg_base_url or base_url or "https://api.anthropic.com"
     elif provider == "openrouter":
         base_url = base_url or OPENROUTER_BASE_URL
+        # OpenRouter serves BOTH wires (``/v1/chat/completions`` and the
+        # Anthropic-compatible ``/v1/messages``), so a user who deliberately
+        # records ``provider: openrouter`` + ``api_mode: anthropic_messages``
+        # means it. Honor that here as the generic branch below already does
+        # for every other pooled provider — without this, the same config
+        # resolves to chat_completions on the pooled path but
+        # anthropic_messages via ``_resolve_openrouter_runtime``, so the wire
+        # silently depended on whether the caller passed explicit credentials.
+        # The provider gate keeps a FOREIGN config's mode from leaking in.
+        _or_configured_provider = str(model_cfg.get("provider") or "").strip().lower()
+        _or_configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
+        if _or_configured_mode and _provider_supports_explicit_api_mode(
+            provider, _or_configured_provider
+        ):
+            api_mode = _or_configured_mode
     elif provider == "xai":
         api_mode = "codex_responses"
     elif provider == "nous":

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1280,11 +1280,27 @@ def _resolve_openrouter_runtime(
     if effective_provider == "custom" and not api_key and not _is_openrouter_url:
         api_key = "no-key-required"
 
+    # Honor a persisted ``model.api_mode`` only when the config block that
+    # carries it actually describes THIS provider. Without the gate, a config
+    # whose default is e.g. direct Anthropic (``provider: anthropic``,
+    # ``api_mode: anthropic_messages``) pins every OpenRouter runtime onto the
+    # Anthropic Messages wire after a mid-session /model switch — the model
+    # then talks to OpenRouter's ``/v1/messages`` route instead of
+    # ``/v1/chat/completions``. Mirrors the guard already applied to Copilot
+    # (``_copilot_runtime_api_mode``) and to plain custom endpoints
+    # (``_resolve_plain_custom_api_mode``).
+    _configured_provider = str(model_cfg.get("provider") or "").strip().lower()
+    _configured_mode = (
+        _parse_api_mode(model_cfg.get("api_mode"))
+        if _provider_supports_explicit_api_mode(effective_provider, _configured_provider)
+        else None
+    )
+
     return {
         "provider": effective_provider,
         "api_mode": _resolve_plain_custom_api_mode(model_cfg, base_url)
         if effective_provider == "custom"
-        else _parse_api_mode(model_cfg.get("api_mode"))
+        else _configured_mode
         or _detect_api_mode_for_url(base_url)
         or "chat_completions",
         "base_url": base_url,

--- a/tests/hermes_cli/test_openrouter_pooled_api_mode_consistency.py
+++ b/tests/hermes_cli/test_openrouter_pooled_api_mode_consistency.py
@@ -1,0 +1,78 @@
+"""OpenRouter's wire must not depend on how credentials reached the resolver.
+
+``resolve_runtime_provider`` has two routes to an OpenRouter runtime:
+
+* the pooled/env route, taken at startup (no explicit credentials), and
+* ``_resolve_openrouter_runtime``, taken when the caller passes
+  ``explicit_api_key`` / ``explicit_base_url`` — which is what
+  ``_ensure_runtime_credentials`` does after a ``/model`` switch.
+
+OpenRouter serves BOTH wires (``/v1/chat/completions`` and the
+Anthropic-compatible ``/v1/messages``), so ``model.api_mode`` is a real user
+choice there. Both routes must honor it identically, and both must refuse a
+mode inherited from a DIFFERENT provider's config block.
+
+Regression guard — the pooled route ignored ``model.api_mode`` entirely, so
+the same config produced different wires depending on call shape.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+BOTH_WIRES = ["anthropic_messages", "chat_completions"]
+FOREIGN_PROVIDERS = ["anthropic", "openai", "copilot", "ollama"]
+
+
+@pytest.fixture(autouse=True)
+def _dummy_credentials(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test-dummy")
+
+
+def _resolve(monkeypatch, cfg, *, explicit):
+    from hermes_cli import runtime_provider as rp
+
+    monkeypatch.setattr(rp, "load_config", lambda *a, **k: {"model": dict(cfg)})
+    kwargs = {"requested": "openrouter", "target_model": "moonshotai/kimi-k3"}
+    if explicit:
+        kwargs["explicit_base_url"] = "https://openrouter.ai/api/v1"
+        kwargs["explicit_api_key"] = "sk-or-test-dummy"
+    return rp.resolve_runtime_provider(**kwargs)
+
+
+@pytest.mark.parametrize("mode", BOTH_WIRES)
+def test_own_api_mode_honored_on_both_routes(monkeypatch, mode):
+    """A config that genuinely records OpenRouter is honored either way."""
+    cfg = {"default": "moonshotai/kimi-k3", "provider": "openrouter", "api_mode": mode}
+
+    pooled = _resolve(monkeypatch, cfg, explicit=False)["api_mode"]
+    explicit = _resolve(monkeypatch, cfg, explicit=True)["api_mode"]
+
+    assert pooled == explicit == mode, (
+        f"api_mode={mode!r} must survive both routes — "
+        f"pooled={pooled!r} explicit={explicit!r}"
+    )
+
+
+@pytest.mark.parametrize("mode", BOTH_WIRES)
+@pytest.mark.parametrize("cfg_provider", FOREIGN_PROVIDERS)
+def test_foreign_api_mode_rejected_on_both_routes(monkeypatch, mode, cfg_provider):
+    """A mode belonging to another provider never reaches OpenRouter."""
+    cfg = {"default": "claude-sonnet-5", "provider": cfg_provider, "api_mode": mode}
+
+    pooled = _resolve(monkeypatch, cfg, explicit=False)["api_mode"]
+    explicit = _resolve(monkeypatch, cfg, explicit=True)["api_mode"]
+
+    assert pooled == explicit == "chat_completions", (
+        f"a {cfg_provider!r} config's api_mode={mode!r} must not select "
+        f"OpenRouter's wire — pooled={pooled!r} explicit={explicit!r}"
+    )
+
+
+def test_routes_agree_when_no_api_mode_recorded(monkeypatch):
+    cfg = {"default": "moonshotai/kimi-k3", "provider": "openrouter"}
+
+    pooled = _resolve(monkeypatch, cfg, explicit=False)["api_mode"]
+    explicit = _resolve(monkeypatch, cfg, explicit=True)["api_mode"]
+
+    assert pooled == explicit == "chat_completions"

--- a/tests/hermes_cli/test_openrouter_runtime_api_mode.py
+++ b/tests/hermes_cli/test_openrouter_runtime_api_mode.py
@@ -1,0 +1,99 @@
+"""OpenRouter runtime api_mode must not inherit another provider's persisted mode."""
+
+from __future__ import annotations
+
+import pytest
+
+OPENROUTER_URL = "https://openrouter.ai/api/v1"
+
+
+def _resolve(model_cfg, monkeypatch):
+    """Resolve an OpenRouter runtime with the arguments the CLI actually passes.
+
+    ``_ensure_runtime_credentials`` forwards ``explicit_api_key`` /
+    ``explicit_base_url`` (staged by the /model switch), which is what routes
+    resolution into ``_resolve_openrouter_runtime``.
+    """
+    from hermes_cli import runtime_provider as rp
+
+    monkeypatch.setattr(rp, "load_config", lambda *a, **k: {"model": model_cfg})
+    return rp.resolve_runtime_provider(
+        requested="openrouter",
+        explicit_api_key="sk-or-test",
+        explicit_base_url=OPENROUTER_URL,
+    )
+
+
+def test_anthropic_config_does_not_pin_openrouter_to_messages_wire(monkeypatch):
+    """A direct-Anthropic default must not force OpenRouter onto the Messages wire.
+
+    Repro: config.yaml defaults to direct Anthropic
+    (``provider: anthropic`` + ``api_mode: anthropic_messages``). A
+    mid-session ``/model moonshotai/kimi-k3`` correctly restages
+    provider/base_url to OpenRouter, but the persisted ``api_mode`` was
+    honored unconditionally — so the agent was built on the Anthropic
+    Messages transport and talked to OpenRouter's ``/v1/messages`` route
+    instead of ``/v1/chat/completions``.
+    """
+    runtime = _resolve(
+        {
+            "default": "claude-sonnet-5",
+            "provider": "anthropic",
+            "base_url": "https://api.anthropic.com",
+            "api_mode": "anthropic_messages",
+        },
+        monkeypatch,
+    )
+
+    assert runtime["provider"] == "openrouter"
+    assert runtime["api_mode"] == "chat_completions", (
+        "a persisted api_mode from a DIFFERENT provider's config block must not "
+        f"leak into the OpenRouter runtime: {runtime['api_mode']}"
+    )
+
+
+def test_openrouter_config_still_honors_its_own_api_mode(monkeypatch):
+    """The gate must not break a config that genuinely describes OpenRouter."""
+    runtime = _resolve(
+        {
+            "default": "moonshotai/kimi-k3",
+            "provider": "openrouter",
+            "api_mode": "anthropic_messages",
+        },
+        monkeypatch,
+    )
+
+    assert runtime["api_mode"] == "anthropic_messages"
+
+
+def test_openrouter_config_without_provider_still_honors_api_mode(monkeypatch):
+    """No recorded provider = nothing to contradict; keep the persisted mode.
+
+    Matches ``_provider_supports_explicit_api_mode``'s "no configured
+    provider" allowance, so pre-existing configs that only set ``api_mode``
+    keep working.
+    """
+    runtime = _resolve(
+        {"default": "moonshotai/kimi-k3", "api_mode": "anthropic_messages"},
+        monkeypatch,
+    )
+
+    assert runtime["api_mode"] == "anthropic_messages"
+
+
+@pytest.mark.parametrize(
+    "configured_provider",
+    ["anthropic", "openai", "copilot", "bedrock", "openai-codex"],
+)
+def test_foreign_provider_modes_never_leak(monkeypatch, configured_provider):
+    """Any foreign provider's persisted mode falls back to the endpoint default."""
+    runtime = _resolve(
+        {
+            "default": "some-model",
+            "provider": configured_provider,
+            "api_mode": "codex_responses",
+        },
+        monkeypatch,
+    )
+
+    assert runtime["api_mode"] == "chat_completions"


### PR DESCRIPTION
> **Stacked on #73637 — please review that one first.**
>
> #73637 supplies the provider gate on OpenRouter's *explicit* route; this PR fixes the *pooled* route and adds tests asserting the two agree. Since #73637 is not merged yet and GitHub can't target a fork branch as a base, **this PR's diff contains both commits**. The one to review here is the second:
>
> - `614b3e628` — from #73637, already under review there
> - `1ef225da` — **this PR's change**
>
> Once #73637 merges, rebasing this branch reduces the diff to that single commit. Happy to re-point the base then, or to squash both into #73637 if you'd rather review them together.

## What does this PR do?

Makes OpenRouter's wire protocol independent of *how* the resolver was called.

OpenRouter serves both wires — `/v1/chat/completions` and the Anthropic-compatible `/v1/messages` — so `model.api_mode` is a genuine user choice there, not a redundant field. But `resolve_runtime_provider` reaches an OpenRouter runtime by two routes, and only one of them honored it:

| route | when | honors `model.api_mode`? |
|---|---|---|
| pooled / env | startup, no explicit credentials | **no** |
| `_resolve_openrouter_runtime` | explicit credentials — what `_ensure_runtime_credentials` passes after a `/model` switch | yes |

The cause is control flow. In `_resolve_runtime_from_pool_entry` the OpenRouter branch sets a base URL and exits the `elif` chain:

```python
elif provider == "openrouter":
    base_url = base_url or OPENROUTER_BASE_URL
```

…so it never reaches the generic `else` further down, which *does* consult the persisted mode behind the correct gate:

```python
elif configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
    api_mode = configured_mode
```

Every other pooled provider gets that handling. OpenRouter is the one that falls out early.

**Net effect:** a user who sets `provider: openrouter` + `api_mode: anthropic_messages` silently gets `chat_completions` at startup and `anthropic_messages` after a `/model` switch — same config, same session, different transport.

## Related Issue

No existing issue. Found by sweeping the resolution space and asserting the same config yields the same wire regardless of call shape.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/runtime_provider.py` — `_resolve_runtime_from_pool_entry`: the OpenRouter branch now honors a persisted `model.api_mode`, behind the same `_provider_supports_explicit_api_mode` gate the other branches use.
- `tests/hermes_cli/test_openrouter_pooled_api_mode_consistency.py` — new.

## Behavior change — please sanity-check this call

This is the one judgment call in the PR, so flagging it explicitly rather than burying it.

A user whose config records `provider: openrouter` **and** `api_mode: anthropic_messages` currently gets `chat_completions` on the pooled path. After this change they get `anthropic_messages` — what they asked for, and what the explicit path already gave them.

I believe honoring it is correct: OpenRouter genuinely serves that wire (verified live — the Messages route returns 200 for e.g. `moonshotai/kimi-k3`), the config explicitly names both provider and mode, and the two routes disagreeing is indefensible in either direction. The alternative reading — that OpenRouter should be hard-pinned to `chat_completions` and the *explicit* path is the buggy one — would be a bigger change and would make `api_mode` meaningless for a provider that supports both. If maintainers prefer that direction, say so and I'll invert the fix.

The gate means this cannot resurrect the bug #73637 fixes: a config recording a *different* provider is still rejected on both routes.

## Recommended standing test

The new file is a **standing consistency guard**: it resolves the same config through both routes and asserts they agree, for both wires and for foreign-provider configs.

```
pytest tests/hermes_cli/test_openrouter_pooled_api_mode_consistency.py -q
# before: 1 failed, 10 passed
# after:  11 passed
```

Only one case fails before the fix because the base branch (#73637) already closed the foreign-leak half; this PR closes the config-respect half. The two together pin the full invariant: **the wire depends on the endpoint and the user's config for that provider — never on which internal code path resolved it.**

## How to Test

**1. Reproduce** — config recording OpenRouter plus the Messages wire:

```python
from hermes_cli import runtime_provider as rp
rp.load_config = lambda *a, **k: {"model": {
    "default": "moonshotai/kimi-k3", "provider": "openrouter",
    "api_mode": "anthropic_messages"}}

rp.resolve_runtime_provider(requested="openrouter")["api_mode"]
# before: 'chat_completions'   <- config ignored
# after:  'anthropic_messages'

rp.resolve_runtime_provider(requested="openrouter",
                            explicit_base_url="https://openrouter.ai/api/v1",
                            explicit_api_key="sk-or-...")["api_mode"]
# both:   'anthropic_messages'
```

**2. Regression tests** — counts above.

**3. No collateral damage** — provider/runtime slice, same failure count as the base branch:

```bash
pytest tests/hermes_cli/ -q -p no:randomly \
  -k "runtime or provider or api_mode or model_switch or openrouter or copilot or deepseek or kimi or opencode or azure"
# base:     70 failed, 2306 passed
# this PR:  70 failed, 2317 passed   (+11 = the new tests)
```

**4. Real configs unaffected** — four profiles with differing defaults (direct-Anthropic, OpenRouter, Ollama) all resolve OpenRouter identically on both routes, unchanged by this patch.

> Note: a full `pytest tests/hermes_cli/ -q` cannot complete on macOS (pre-existing `test_gateway_service.py` self-termination, detailed in #73637), hence the `-k` slice.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [ ] I've run `pytest tests/ -q` and all tests pass — blocked by the pre-existing macOS abort; verified no delta on the relevant slice instead
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11

### Documentation & Housekeeping

- [x] Documentation — inline comment explains why OpenRouter honors both wires — or N/A
- [x] `cli-config.yaml.example` — N/A, no new keys (this makes an existing key work on both paths)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A
- [x] Tool descriptions/schemas — N/A
