### PR TITLE
fix(tools): prevent disabled_toolsets: [browser] from removing web_search

### DIFF
--- a/tests/hermes_cli/test_tool_token_estimation.py
+++ b/tests/hermes_cli/test_tool_token_estimation.py
@@ -137,7 +137,7 @@ def test_status_fn_returns_formatted_token_count(monkeypatch):
 
 
 def test_status_fn_deduplicates_overlapping_tools(monkeypatch):
-    """When toolsets overlap (browser includes web_search), tokens should not double-count."""
+    """When toolsets overlap should not double-count."""
     import hermes_cli.tools_config as tc
     from hermes_cli.tools_config import CONFIGURABLE_TOOLSETS
 
@@ -159,7 +159,7 @@ def test_status_fn_deduplicates_overlapping_tools(monkeypatch):
 
     # web alone
     web_only = status_fn({idx_map["web"]})
-    # browser includes web_search, so browser + web should not double-count web_search
+    # browser no longer includes web_search, so browser + web should not have overlap
     browser_only = status_fn({idx_map["browser"]})
     both = status_fn({idx_map["web"], idx_map["browser"]})
 

--- a/toolset_distributions.py
+++ b/toolset_distributions.py
@@ -178,9 +178,9 @@ DISTRIBUTIONS = {
     
     # Browser-focused tasks distribution (for browser-use-tasks.jsonl)
     "browser_tasks": {
-        "description": "Browser-focused distribution (browser toolset includes web_search for finding URLs since Google blocks direct browser searches)",
+        "description": "Browser-focused distribution (browser toolset does not include web_search)",
         "toolsets": {
-            "browser": 97,   # 97% - browser tools (includes web_search) almost always available
+            "browser": 97,   # 97% - browser tools almost always available
             "vision": 12,    # 12% - vision analysis occasionally
             "terminal": 15   # 15% - terminal occasionally for local operations
         }

--- a/toolsets.py
+++ b/toolsets.py
@@ -173,13 +173,13 @@ TOOLSETS = {
     },
     
     "browser": {
-        "description": "Browser automation for web interaction (navigate, click, type, scroll, iframes, hold-click) with web search for finding URLs",
+        "description": "Browser automation for web interaction (navigate, click, type, scroll, iframes, hold-click). web_search is available separately under the \"web\" toolset.",
         "tools": [
             "browser_navigate", "browser_snapshot", "browser_click",
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
             "browser_vision", "browser_console", "browser_cdp",
-            "browser_dialog", "web_search"
+            "browser_dialog"
         ],
         "includes": []
     },


### PR DESCRIPTION
Closes #73692

## Problem
Disabling the browser toolset via `agent.disabled_toolsets: [browser]` also silently removes `web_search`, even though `web_search` is not a browser tool.

## Root Cause
The `browser` toolset definition in `toolsets.py` included `"web_search"` in its tools list. When `agent.disabled_toolsets: [browser]` is resolved in `model_tools.py`, all tools belonging to the `browser` toolset are removed — including `web_search`.

## Fix
- Remove `web_search` from the `browser` toolset tools list
- Update the description to clarify `web_search` is available under the `"web"` toolset
- Update references in `toolset_distributions.py` and test docs

`web_search` remains available through its own `"web"` toolset, which is included in all platform default toolsets (`hermes-cli`, `hermes-telegram`, etc.) independently of the browser toolset.