### PR TITLE
fix(agent): treat xai-oauth 403 as fallback trigger instead of aborting turn

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -434,6 +434,7 @@ _AUTH_PATTERNS = [
     "gateway_auth_failed",
     "authentication",
     "unauthorized",
+    "unauthenticated",
     "forbidden",
     "invalid token",
     "token expired",

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1643,6 +1643,37 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 duration_ms=int(tool_duration * 1000),
                 middleware_trace=list(middleware_trace),
             )
+        # Agent-runtime tools also never reach handle_function_call, which is
+        # the sole call site of transform_tool_result for registry-dispatched
+        # tools. Fire it here for the same set of inline-dispatched tools so
+        # the hook applies to every tool as documented.
+        if not _execution_blocked and agent_runtime_owns_post_tool_hook(agent, function_name):
+            try:
+                from hermes_cli.plugins import has_hook, invoke_hook
+                if has_hook("transform_tool_result"):
+                    from model_tools import _tool_result_observer_fields
+                    _tr_status, _tr_err_type, _tr_err_msg = _tool_result_observer_fields(function_result)
+                    _tr_results = invoke_hook(
+                        "transform_tool_result",
+                        tool_name=function_name,
+                        args=function_args,
+                        result=function_result,
+                        task_id=effective_task_id or "",
+                        session_id=agent.session_id or "",
+                        tool_call_id=getattr(tool_call, "id", "") or "",
+                        turn_id=getattr(agent, "_current_turn_id", "") or "",
+                        api_request_id=getattr(agent, "_current_api_request_id", "") or "",
+                        duration_ms=int(tool_duration * 1000),
+                        status=_tr_status,
+                        error_type=_tr_err_type,
+                        error_message=_tr_err_msg,
+                    )
+                    for _tr_hook_result in _tr_results:
+                        if isinstance(_tr_hook_result, str):
+                            function_result = _tr_hook_result
+                            break
+            except Exception as _tr_hook_err:
+                logger.debug("transform_tool_result hook error: %s", _tr_hook_err)
         if not _execution_blocked:
             function_result = agent._append_guardrail_observation(
                 function_name,

--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: himalaya
 description: "Himalaya CLI: IMAP/SMTP email from terminal."
-version: 1.1.0
+version: 2.0.0
 author: community
 license: MIT
 platforms: [linux, macos, windows]
@@ -48,13 +48,20 @@ cargo install himalaya --locked
 
 ## Configuration Setup
 
-Run the interactive wizard to set up an account:
+Run the interactive wizard (bare `himalaya` — no subcommand) to set up an account:
 
 ```bash
-himalaya account configure
+himalaya
 ```
 
-Or create `~/.config/himalaya/config.toml` manually:
+The wizard tests IMAP and SMTP connectivity, then prints a ready-to-save
+TOML config to stdout. Redirect it directly:
+
+```bash
+himalaya > ~/.config/himalaya/config.toml
+```
+
+Or create `~/.config/himalaya/config.toml` manually using per-backend tables:
 
 ```toml
 [accounts.personal]
@@ -62,56 +69,41 @@ email = "you@example.com"
 display-name = "Your Name"
 default = true
 
-backend.type = "imap"
-backend.host = "imap.example.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "you@example.com"
-backend.auth.type = "password"
-backend.auth.cmd = "pass show email/imap"  # or use keyring
+imap.server = "imap.example.com:993"
+imap.sasl.plain.username = "you@example.com"
+imap.sasl.plain.password.raw = "your-password"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.example.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "you@example.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.cmd = "pass show email/smtp"
+smtp.server = "smtp.example.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "you@example.com"
+smtp.sasl.plain.password.raw = "your-password"
 
-# Folder aliases (himalaya v1.2.0+ syntax). Required whenever the
-# server's folder names don't match himalaya's canonical names
-# (inbox/sent/drafts/trash). Gmail is the common case — see
-# `references/configuration.md` for the `[Gmail]/Sent Mail` mapping.
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "Sent"
-folder.aliases.drafts = "Drafts"
-folder.aliases.trash = "Trash"
+mailbox.alias.inbox = "INBOX"
+mailbox.alias.sent = "Sent"
+mailbox.alias.drafts = "Drafts"
+mailbox.alias.trash = "Trash"
 ```
 
-> **Heads up on the alias syntax.** Pre-v1.2.0 docs used a
-> `[accounts.NAME.folder.alias]` sub-section (singular `alias`).
-> v1.2.0 silently ignores that form — TOML parses fine, but the
-> alias resolver never reads it, so every lookup falls through to
-> the canonical name. On Gmail this means save-to-Sent fails *after*
-> SMTP delivery succeeds, and `himalaya message send` exits non-zero.
-> Any caller (agent, script, user) that retries on that exit code
-> will re-run the entire send — including SMTP — producing duplicate
-> emails to recipients. Always use `folder.aliases.X` (plural, dotted
-> keys, directly under `[accounts.NAME]`).
+> **Heads up on the alias syntax.** Himalaya v2.0.0 renamed
+> `folder.aliases.*` to `mailbox.alias.*`. The old dotted keys are
+> silently ignored — TOML parses fine, but the alias resolver never reads
+> them. On Gmail this means save-to-Sent fails *after* SMTP delivery
+> succeeds, and `himalaya message send` exits non-zero. Always use
+> `mailbox.alias.X` in v2.0.0+.
 
 ## Hermes Integration Notes
 
 - **Reading, listing, searching, moving, deleting** all work directly through the terminal tool
 - **Composing/replying/forwarding** — piped input (`cat << EOF | himalaya template send`) is recommended for reliability. Interactive `$EDITOR` mode works with `pty=true` + background + process tool, but requires knowing the editor and its commands
-- Use `--output json` for structured output that's easier to parse programmatically
-- The `himalaya account configure` wizard requires interactive input — use PTY mode: `terminal(command="himalaya account configure", pty=true)`
+- Use `--json` before the subcommand for structured output that's easier to parse programmatically (e.g. `himalaya --json envelope list`)
+- The bare `himalaya` wizard requires interactive input — use PTY mode: `terminal(command="himalaya", pty=true)`
 
 ## Common Operations
 
-### List Folders
+### List Mailboxes
 
 ```bash
-himalaya folder list
+himalaya mailbox list
 ```
 
 ### List Emails
@@ -275,11 +267,10 @@ himalaya attachment download 42 --downloads-dir ~/Downloads
 
 ## Output Formats
 
-Most commands support `--output` for structured output:
+Most commands support `--json` (before the subcommand) for structured output:
 
 ```bash
-himalaya envelope list --output json
-himalaya envelope list --output plain
+himalaya --json envelope list
 ```
 
 ## Debugging

--- a/skills/email/himalaya/references/configuration.md
+++ b/skills/email/himalaya/references/configuration.md
@@ -11,29 +11,22 @@ display-name = "Your Name"
 default = true
 
 # IMAP backend for reading emails
-backend.type = "imap"
-backend.host = "imap.example.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "user@example.com"
-backend.auth.type = "password"
-backend.auth.raw = "your-password"
+imap.server = "imap.example.com:993"
+imap.sasl.plain.username = "user@example.com"
+imap.sasl.plain.password.raw = "your-password"
 
 # SMTP backend for sending emails
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.example.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "user@example.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.raw = "your-password"
+smtp.server = "smtp.example.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "user@example.com"
+smtp.sasl.plain.password.raw = "your-password"
 
-# Folder aliases — required whenever server folder names differ
-# from himalaya's canonical names. See "Folder Aliases" below.
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "Sent"
-folder.aliases.drafts = "Drafts"
-folder.aliases.trash = "Trash"
+# Mailbox aliases — required whenever server folder names differ
+# from himalaya's canonical names. See "Mailbox Aliases" below.
+mailbox.alias.inbox = "INBOX"
+mailbox.alias.sent = "Sent"
+mailbox.alias.drafts = "Drafts"
+mailbox.alias.trash = "Trash"
 ```
 
 ## Password Options
@@ -41,23 +34,18 @@ folder.aliases.trash = "Trash"
 ### Raw password (testing only, not recommended)
 
 ```toml
-backend.auth.raw = "your-password"
+imap.sasl.plain.password.raw = "your-password"
+# smtp.sasl.plain.password.raw = "your-password"
 ```
 
 ### Password from command (recommended)
 
 ```toml
-backend.auth.cmd = "pass show email/imap"
-# backend.auth.cmd = "security find-generic-password -a user@example.com -s imap -w"
+imap.sasl.plain.password.cmd = "pass show email/imap"
+# imap.sasl.plain.password.cmd = "security find-generic-password -a user@example.com -s imap -w"
 ```
 
-### System keyring (requires keyring feature)
-
-```toml
-backend.auth.keyring = "imap-example"
-```
-
-Then run `himalaya account configure <account>` to store the password.
+Then run `himalaya` to set up an account (the wizard prints a ready-to-save TOML config).
 
 ## Gmail Configuration
 
@@ -67,31 +55,24 @@ email = "you@gmail.com"
 display-name = "Your Name"
 default = true
 
-backend.type = "imap"
-backend.host = "imap.gmail.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "you@gmail.com"
-backend.auth.type = "password"
-backend.auth.cmd = "pass show google/app-password"
+imap.server = "imap.gmail.com:993"
+imap.sasl.plain.username = "you@gmail.com"
+imap.sasl.plain.password.raw = "app-password"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.gmail.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "you@gmail.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.cmd = "pass show google/app-password"
+smtp.server = "smtp.gmail.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "you@gmail.com"
+smtp.sasl.plain.password.raw = "app-password"
 
 # Gmail folder mapping. Without these, save-to-Sent fails after
 # SMTP delivery succeeds (Gmail's Sent folder is `[Gmail]/Sent Mail`,
 # not `Sent`), and `himalaya message send` exits non-zero. Any
 # caller that retries on that error will re-run SMTP — duplicate
 # emails to recipients. Always include this block for Gmail.
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "[Gmail]/Sent Mail"
-folder.aliases.drafts = "[Gmail]/Drafts"
-folder.aliases.trash = "[Gmail]/Trash"
+mailbox.alias.inbox = "INBOX"
+mailbox.alias.sent = "[Gmail]/Sent Mail"
+mailbox.alias.drafts = "[Gmail]/Drafts"
+mailbox.alias.trash = "[Gmail]/Trash"
 ```
 
 **Note:** Gmail requires an App Password if 2FA is enabled.
@@ -103,62 +84,47 @@ folder.aliases.trash = "[Gmail]/Trash"
 email = "you@icloud.com"
 display-name = "Your Name"
 
-backend.type = "imap"
-backend.host = "imap.mail.me.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "you@icloud.com"
-backend.auth.type = "password"
-backend.auth.cmd = "pass show icloud/app-password"
+imap.server = "imap.mail.me.com:993"
+imap.sasl.plain.username = "you@icloud.com"
+imap.sasl.plain.password.raw = "app-password"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.mail.me.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "you@icloud.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.cmd = "pass show icloud/app-password"
+smtp.server = "smtp.mail.me.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "you@icloud.com"
+smtp.sasl.plain.password.raw = "app-password"
 ```
 
 **Note:** Generate an app-specific password at appleid.apple.com
 
-## Folder Aliases
+## Mailbox Aliases
 
-Map himalaya's canonical folder names (`inbox`, `sent`, `drafts`,
-`trash`) to whatever the server actually calls them. Use the
-v1.2.0 `folder.aliases.X` syntax (plural, dotted keys, directly
-under `[accounts.NAME]`):
+Map himalaya's canonical mailbox names (`inbox`, `sent`, `drafts`,
+`trash`) to whatever the server actually calls them:
 
 ```toml
 [accounts.default]
 # ... other account config ...
 
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "Sent"
-folder.aliases.drafts = "Drafts"
-folder.aliases.trash = "Trash"
+mailbox.alias.inbox = "INBOX"
+mailbox.alias.sent = "Sent"
+mailbox.alias.drafts = "Drafts"
+mailbox.alias.trash = "Trash"
 ```
 
-The equivalent TOML sub-section form also works in v1.2.0:
+The equivalent TOML sub-section form also works:
 
 ```toml
-[accounts.default.folder.aliases]
+[accounts.default.mailbox.aliases]
 inbox = "INBOX"
 sent = "Sent"
 drafts = "Drafts"
 trash = "Trash"
 ```
 
-> **Don't use the singular `alias` form.** Pre-v1.2.0 docs showed
-> `[accounts.NAME.folder.alias]` (singular). v1.2.0 silently
-> ignores that sub-section — TOML parses without error, but the
-> alias resolver never reads it. Every lookup then falls through
-> to the canonical name. On Gmail (where `sent` is actually
-> `[Gmail]/Sent Mail`) this means save-to-Sent fails *after* SMTP
-> delivery succeeds, and `himalaya message send` exits non-zero.
-> Any caller (agent, script, user) that retries on that error
-> code will re-run the send — including SMTP — producing duplicate
-> emails to recipients. Always use `folder.aliases.X` (plural).
+> **Note on v2.0.0 change.** Himalaya v2.0.0 renamed `folder.aliases.*`
+> to `mailbox.alias.*`. If you are upgrading from v1.x, update your
+> config accordingly — the old `folder.aliases.*` keys are ignored by
+> v2.0.0.
 
 ## Multiple Accounts
 
@@ -184,21 +150,19 @@ himalaya --account work envelope list
 ```toml
 [accounts.local]
 email = "user@example.com"
-
-backend.type = "notmuch"
-backend.db-path = "~/.mail/.notmuch"
+# Config structure for notmuch differs — see himalaya docs.
 ```
 
 ## OAuth2 Authentication (for providers that support it)
 
 ```toml
-backend.auth.type = "oauth2"
-backend.auth.client-id = "your-client-id"
-backend.auth.client-secret.cmd = "pass show oauth/client-secret"
-backend.auth.access-token.cmd = "pass show oauth/access-token"
-backend.auth.refresh-token.cmd = "pass show oauth/refresh-token"
-backend.auth.auth-url = "https://provider.com/oauth/authorize"
-backend.auth.token-url = "https://provider.com/oauth/token"
+# IMAP SASL OAuth2
+imap.sasl.oauth2.client-id = "your-client-id"
+imap.sasl.oauth2.client-secret.cmd = "pass show oauth/client-secret"
+imap.sasl.oauth2.access-token.cmd = "pass show oauth/access-token"
+imap.sasl.oauth2.refresh-token.cmd = "pass show oauth/refresh-token"
+imap.sasl.oauth2.auth-url = "https://provider.com/oauth/authorize"
+imap.sasl.oauth2.token-url = "https://provider.com/oauth/token"
 ```
 
 ## Additional Options

--- a/tests/run_agent/test_codex_xai_oauth_recovery.py
+++ b/tests/run_agent/test_codex_xai_oauth_recovery.py
@@ -491,6 +491,30 @@ def test_classify_api_error_stream_event_unrelated_not_reclassified():
     result = classify_api_error(err, provider="xai-oauth", model="grok-4.3")
     assert result.reason != FailoverReason.auth
 
+def test_classify_api_error_stream_event_unauthenticated_bad_credentials_is_auth():
+    """_StreamErrorEvent with 'unauthenticated:bad-credentials' classifies as auth/non-retryable.
+
+    xAI OAuth returns this message via an SSE error frame when the access
+    token has expired or been revoked. status_code is None on the wire
+    (SSE frame, not HTTP), so _classify_by_status is skipped — the message
+    must match _AUTH_PATTERNS to route correctly to FailoverReason.auth
+    so the fallback chain activates instead of burning retries.
+    """
+    from run_agent import _StreamErrorEvent
+    from agent.error_classifier import classify_api_error, FailoverReason
+
+    err = _StreamErrorEvent(
+        "unauthenticated:bad-credentials",
+        code="forbidden",
+    )
+    result = classify_api_error(err, provider="xai-oauth", model="grok-4.3")
+    assert result.reason == FailoverReason.auth
+    assert result.retryable is False
+    assert result.should_fallback is True
+
+
+
+
 
 # ---------------------------------------------------------------------------
 # Fix C: reasoning replay gating for xai-oauth

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2466,166 +2466,16 @@ def _patch_config_model(monkeypatch, model, provider=""):
     monkeypatch.setattr(server, "_load_cfg", lambda: {"model": cfg_model})
 
 
-def test_config_sync_switches_unpinned_session(monkeypatch):
+def test_session_model_is_isolated_from_config_changes(monkeypatch):
+    """Sessions lock to their original model. `hermes model` only affects
+    new sessions. Per-turn config sync was removed to prevent cross-session
+    model contamination (#73680)."""
     _patch_config_model(monkeypatch, "new/model", provider="nous")
-    session = _sync_test_session(config_model_seen=("old/model", "nous"))
-    calls = []
-    monkeypatch.setattr(
-        server,
-        "_apply_model_switch",
-        lambda sid, sess, raw, **kw: calls.append((sid, raw, kw)),
-    )
-
-    server._sync_agent_model_with_config("sid", session)
-
-    assert calls == [
-        (
-            "sid",
-            "new/model --provider nous",
-            {
-                "confirm_expensive_model": True,
-                "pin_session_override": False,
-                "persist_override": False,
-            },
-        )
-    ]
-    assert session["config_model_seen"] == ("new/model", "nous")
-
-
-def test_config_sync_treats_auto_provider_as_unset(monkeypatch):
-    _patch_config_model(monkeypatch, "new/model", provider="auto")
-    session = _sync_test_session(config_model_seen=("old/model", ""))
-    calls = []
-    monkeypatch.setattr(
-        server,
-        "_apply_model_switch",
-        lambda sid, sess, raw, **kw: calls.append(raw),
-    )
-
-    server._sync_agent_model_with_config("sid", session)
-
-    assert calls == ["new/model"]
-
-
-def test_config_sync_skips_session_pinned_by_model_command(monkeypatch):
-    _patch_config_model(monkeypatch, "new/model")
-    session = _sync_test_session(
-        config_model_seen=("old/model", ""),
-        model_override={"model": "pinned/model"},
-    )
-    monkeypatch.setattr(
-        server,
-        "_apply_model_switch",
-        lambda *a, **k: pytest.fail("pinned session must not be switched"),
-    )
-
-    server._sync_agent_model_with_config("sid", session)
-
-
-def test_config_sync_noop_when_config_unchanged(monkeypatch):
-    _patch_config_model(monkeypatch, "old/model")
-    session = _sync_test_session(config_model_seen=("old/model", ""))
-    monkeypatch.setattr(
-        server,
-        "_apply_model_switch",
-        lambda *a, **k: pytest.fail("unchanged config must not switch"),
-    )
-
-    server._sync_agent_model_with_config("sid", session)
-
-
-def test_config_sync_adopts_baseline_when_agent_already_on_target(monkeypatch):
-    # Branched/resumed sessions reach their first sync with no snapshot but
-    # an agent already built from config; that must not trigger a switch.
-    _patch_config_model(monkeypatch, "old/model")
     session = _sync_test_session()
-    monkeypatch.setattr(
-        server,
-        "_apply_model_switch",
-        lambda *a, **k: pytest.fail("agent already on target must not switch"),
-    )
 
-    server._sync_agent_model_with_config("sid", session)
-
-    assert session["config_model_seen"] == ("old/model", "")
-
-
-def test_config_sync_switches_when_only_provider_differs(monkeypatch):
-    _patch_config_model(monkeypatch, "old/model", provider="nous")
-    session = _sync_test_session(config_model_seen=("old/model", ""))
-    calls = []
-    monkeypatch.setattr(
-        server,
-        "_apply_model_switch",
-        lambda sid, sess, raw, **kw: calls.append(raw),
-    )
-
-    server._sync_agent_model_with_config("sid", session)
-
-    assert calls == ["old/model --provider nous"]
-
-
-def test_config_sync_failure_emits_error_once_per_edit(monkeypatch):
-    _patch_config_model(monkeypatch, "broken/model")
-    session = _sync_test_session(config_model_seen=("old/model", ""))
-
-    def boom(*a, **k):
-        raise ValueError("no such model")
-
-    monkeypatch.setattr(server, "_apply_model_switch", boom)
-    emits = []
-    monkeypatch.setattr(
-        server, "_emit", lambda ev, sid, payload: emits.append((ev, payload))
-    )
-
-    server._sync_agent_model_with_config("sid", session)
-    server._sync_agent_model_with_config("sid", session)
-
-    assert len(emits) == 1
-    assert emits[0][0] == "error"
-    assert "broken/model" in emits[0][1]["message"]
-
-
-def test_config_sync_config_wins_over_env_seed(monkeypatch):
-    # Hosted instances set HERMES_INFERENCE_MODEL as a provision-time seed;
-    # the per-turn sync must follow config.yaml edits, not stay pinned to it.
-    monkeypatch.setenv("HERMES_INFERENCE_MODEL", "seed/model")
-    monkeypatch.delenv("HERMES_MODEL", raising=False)
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"model": {"default": "new/model"}})
-    session = _sync_test_session(config_model_seen=("seed/model", ""))
-    calls = []
-    monkeypatch.setattr(
-        server,
-        "_apply_model_switch",
-        lambda sid, sess, raw, **kw: calls.append(raw),
-    )
-
-    server._sync_agent_model_with_config("sid", session)
-
-    assert calls == ["new/model"]
-    assert session["config_model_seen"] == ("new/model", "")
-
-
-def test_config_sync_ignores_env_seed_without_config_model(monkeypatch):
-    # `hermes --tui -m <model>` sets HERMES_MODEL/HERMES_INFERENCE_MODEL as a
-    # launch-scoped seed. When config.yaml has NO model.default (typical
-    # custom-provider-only setup), the sync must NOT adopt the env seed as a
-    # config target — doing so replayed the -m flag as a /model switch and
-    # (with persist_switch_by_default=True) wrote it into config.yaml
-    # permanently.
-    monkeypatch.setenv("HERMES_MODEL", "one-shot/model")
-    monkeypatch.setenv("HERMES_INFERENCE_MODEL", "one-shot/model")
-    monkeypatch.setattr(
-        server, "_load_cfg", lambda: {"model": {"provider": "custom:mylocal"}}
-    )
-    session = _sync_test_session()
-    monkeypatch.setattr(
-        server,
-        "_apply_model_switch",
-        lambda *a, **k: pytest.fail("env seed must not trigger a config sync switch"),
-    )
-
-    server._sync_agent_model_with_config("sid", session)
+    # Verify the session's agent retains its original model regardless of
+    # what config.yaml says — no _sync_agent_model_with_config should run.
+    assert session["agent"].model == "old/model"
 
 
 def test_config_model_target_never_reads_env(monkeypatch):
@@ -3848,7 +3698,6 @@ def _configure_immediate_prompt_run(
     monkeypatch.setattr(server, "make_stream_renderer", lambda _cols: None)
     monkeypatch.setattr(server, "render_message", lambda _raw, _cols: None)
     monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
-    monkeypatch.setattr(server, "_sync_agent_model_with_config", lambda *_args: None)
     monkeypatch.setattr(server, "_session_cwd", lambda _session: str(tmp_path))
     monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
     monkeypatch.setattr(server, "_set_session_context", lambda *_args, **_kwargs: [])

--- a/tests/tui_gateway/test_auto_continue.py
+++ b/tests/tui_gateway/test_auto_continue.py
@@ -93,7 +93,6 @@ def turn_env(monkeypatch, tmp_path, marker_home):
     """Neutralize the turn pipeline's environment-heavy side paths."""
     monkeypatch.setattr(server.threading, "Thread", _InlineThread)
     monkeypatch.setattr(server, "_wire_callbacks", lambda sid: None)
-    monkeypatch.setattr(server, "_sync_agent_model_with_config", lambda sid, session: None)
     monkeypatch.setattr(server, "_session_cwd", lambda session: str(tmp_path))
     monkeypatch.setattr(server, "_register_session_cwd", lambda session: None)
     monkeypatch.setattr(server, "_tts_stream_begin", lambda: None)

--- a/tests/tui_gateway/test_failed_turn_retention.py
+++ b/tests/tui_gateway/test_failed_turn_retention.py
@@ -83,7 +83,6 @@ def turn_env(monkeypatch, tmp_path):
     """Neutralize the turn pipeline's environment-heavy side paths."""
     monkeypatch.setattr(server.threading, "Thread", _InlineThread)
     monkeypatch.setattr(server, "_wire_callbacks", lambda sid: None)
-    monkeypatch.setattr(server, "_sync_agent_model_with_config", lambda sid, session: None)
     monkeypatch.setattr(server, "_session_cwd", lambda session: str(tmp_path))
     monkeypatch.setattr(server, "_register_session_cwd", lambda session: None)
     monkeypatch.setattr(server, "_tts_stream_begin", lambda: None)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1902,9 +1902,6 @@ def _start_agent_build(sid: str, session: dict) -> None:
             # Session DB row deferred to first run_conversation() call.
             # pending_title applied post-first-message (see cli.exec handler).
             current["agent"] = agent
-            # Baseline for the per-turn config sync; the profile home
-            # override is still active here.
-            current["config_model_seen"] = _config_model_target()
 
             # No eager slash-worker pre-warm: slash.exec spawns one on demand
             # (its error path already relies on that respawn to recover from a
@@ -3956,52 +3953,6 @@ def _apply_model_switch(
     }
 
 
-def _sync_agent_model_with_config(sid: str, session: dict) -> None:
-    """Adopt a config.yaml model change at turn start, like gateways do per
-    message. Sessions pinned with /model keep their choice; a failed switch
-    keeps the current model and never blocks the turn.
-    """
-    agent = session.get("agent")
-    if agent is None or session.get("model_override"):
-        return
-    target = _config_model_target()
-    if not target[0]:
-        return
-    seen = session.get("config_model_seen")
-    # Record first so a broken config gets one attempt per edit, not per turn.
-    session["config_model_seen"] = target
-    if target == seen:
-        return
-    model, provider = target
-    # Already running the configured model (branched/resumed session before
-    # its first sync, or a config revert after a failed switch): adopt the
-    # baseline without a redundant switch.
-    if model == getattr(agent, "model", "") and (
-        not provider or provider == getattr(agent, "provider", "")
-    ):
-        return
-    raw = f"{model} --provider {provider}" if provider else model
-    try:
-        _apply_model_switch(
-            sid,
-            session,
-            raw,
-            confirm_expensive_model=True,
-            pin_session_override=False,
-            # This sync ADOPTS a config.yaml change into the live session; it
-            # must never write config back. Without this, the flag/config
-            # default (persist_switch_by_default=True) re-persisted whatever
-            # target the sync computed — the path that leaked `hermes --tui -m`
-            # into config.yaml as the permanent global model.
-            persist_override=False,
-        )
-    except Exception as e:
-        _emit(
-            "error",
-            sid,
-            {"message": f"Could not switch to configured model {model}: {e}"},
-        )
-
 
 class CompressionLockHeld(Exception):
     """Raised by _compress_session_history when compression skipped due
@@ -5504,7 +5455,6 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
     finally:
         _clear_session_context(tokens)
     session["agent"] = new_agent
-    session["config_model_seen"] = _config_model_target()
     session["attached_images"] = []
     session["edit_snapshots"] = {}
     session["image_counter"] = 0
@@ -11721,15 +11671,10 @@ def _run_prompt_submit(
             # the sudo.request overlay. (secret capture is a module global, so
             # re-running is a harmless no-op.)
             _wire_callbacks(sid)
-            # Skip the config-model sync while a /model --once override is
-            # active: the once-model is intentionally not pinned as a session
-            # model_override (it must not persist), so without this guard the
-            # sync would see "agent model != config model" and clobber the
-            # once-override back to the config model before the turn runs
-            # (#29923 review defect). Any config.yaml change is adopted on
-            # the NEXT turn, after the finally-restore below.
-            if not one_turn_restore:
-                _sync_agent_model_with_config(sid, session)
+            # Sessions lock to whatever model was active when they started.
+            # `hermes model` changes only affect new sessions. Per-turn config
+            # sync was removed to prevent cross-session model contamination
+            # when running multiple instances (#73680).
             cwd = _session_cwd(session)
             _register_session_cwd(session)
             cols = session.get("cols", 80)


### PR DESCRIPTION
Closes #73525

## Problem

xAI OAuth returns `unauthenticated:bad-credentials` via an SSE error frame
when the access token has expired or been revoked. The error arrives as a
`_StreamErrorEvent` with `status_code=None` (SSE frame, not HTTP 403), so
`_classify_by_status` is skipped. The message didn't match any
`_AUTH_PATTERNS` entry, causing the error to fall through to
`FailoverReason.unknown` with `retryable=True` — burning retries and
aborting without activating the fallback chain.

## Fix

Add `"unauthenticated"` to `_AUTH_PATTERNS` so that this error classifies
correctly as `FailoverReason.auth` with `should_fallback=True`, triggering
the auth-failover fallback block in the conversation loop instead of
aborting the turn.