### PR TITLE
fix(terminal): keep a per-command workdir out of the session's cwd

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -521,3 +521,78 @@ class TestCwdMarker:
         env1 = _TestableEnv()
         env2 = _TestableEnv()
         assert env1._cwd_marker != env2._cwd_marker
+
+
+class TestPerCommandWorkdirIsNotSessionScoped:
+    """``workdir=`` is documented as a PER-COMMAND cwd (terminal_tool.py).
+
+    ``execute()`` tracks the directory a command finished in so a plain ``cd``
+    moves the session. A command that was explicitly pointed elsewhere must not
+    move it: terminal_tool dual-writes ``env.cwd`` into the durable per-session
+    record, so a single ``workdir=`` otherwise relocates the session for good
+    (and the desktop session row follows it). See #73683.
+    """
+
+    @staticmethod
+    def _env_emitting_cwd(env, final_cwd):
+        """Point ``env._run_bash`` at a process whose output carries the marker."""
+        def mock_run_bash(cmd, *, login=False, timeout=120, stdin_data=None):
+            mock = MagicMock()
+            mock.poll.return_value = 0
+            mock.returncode = 0
+            mock.stdout = iter([
+                "command output\n",
+                f"{env._cwd_marker}{final_cwd}{env._cwd_marker}\n",
+            ])
+            return mock
+
+        env._run_bash = mock_run_bash
+
+    def test_explicit_cwd_does_not_move_the_session(self):
+        env = _TestableEnv(cwd="/home/me/project")
+        self._env_emitting_cwd(env, "/tmp")
+
+        result = env.execute("pwd", cwd="/tmp")
+
+        assert env.cwd == "/home/me/project", (
+            "a per-command workdir must not become the session's cwd"
+        )
+        # The marker is still stripped from what the model sees.
+        assert env._cwd_marker not in result.get("output", "")
+
+    def test_cd_without_explicit_cwd_still_moves_the_session(self):
+        env = _TestableEnv(cwd="/home/me/project")
+        self._env_emitting_cwd(env, "/tmp")
+
+        env.execute("cd /tmp && pwd")
+
+        assert env.cwd == "/tmp", "an in-command cd must still update the session"
+
+    def test_later_commands_run_in_the_original_directory(self):
+        """The reporter's step 3: a plain command after a workdir= one-off."""
+        env = _TestableEnv(cwd="/home/me/project")
+        wrapped_with = []
+        real_wrap = env._wrap_command
+
+        def spy_wrap(command, cwd):
+            wrapped_with.append(cwd)
+            return real_wrap(command, cwd)
+
+        env._wrap_command = spy_wrap
+
+        # Like a real shell: the command reports the directory it ran in.
+        def mock_run_bash(cmd, *, login=False, timeout=120, stdin_data=None):
+            mock = MagicMock()
+            mock.poll.return_value = 0
+            mock.returncode = 0
+            marker = env._cwd_marker
+            mock.stdout = iter([f"{marker}{wrapped_with[-1]}{marker}\n"])
+            return mock
+
+        env._run_bash = mock_run_bash
+
+        env.execute("pwd")                 # 1. session home
+        env.execute("pwd", cwd="/tmp")     # 2. one-off override
+        env.execute("pwd")                 # 3. must be home again
+
+        assert wrapped_with == ["/home/me/project", "/tmp", "/home/me/project"]

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -1162,7 +1162,21 @@ class BaseEnvironment(ABC):
         result = self._wait_for_process(
             proc, timeout=effective_timeout, bounded_capture=bounded_capture
         )
+        # Track where the command finished so a plain ``cd`` moves the session
+        # — but a command that was explicitly pointed somewhere else is a
+        # PER-COMMAND override (terminal_tool's documented ``workdir=``), so it
+        # must not become the session's cwd. terminal_tool dual-writes
+        # ``env.cwd`` into the durable per-session record, so without this a
+        # single ``workdir=`` relocates the session permanently (#73683).
+        # _update_cwd still runs: it also strips the cwd marker from the
+        # output the model sees, and subclasses hook their own normalization
+        # into it — only the resulting session move is undone here.
+        # ``cwd`` defaults to "" — use the same truthiness test that selected
+        # ``effective_cwd`` above so an omitted argument keeps tracking.
+        _cwd_before_update = self.cwd
         self._update_cwd(result)
+        if cwd:
+            self.cwd = _cwd_before_update
 
         return result
 


### PR DESCRIPTION
## What does this PR do?

`workdir=` on the terminal tool is documented as a **per-command** override — "Working directory: Use 'workdir' for per-command cwd" (`tools/terminal_tool.py`) — but it permanently relocates the session:

```
1. terminal(command="pwd")                  -> /home/me/project     (session home)
2. terminal(command="pwd", workdir="/tmp")  -> /tmp                 (expected)
3. terminal(command="pwd")                  -> /tmp                 (BUG: expected the project)
```

Why: `BaseEnvironment.execute()` runs the command in `cwd or self.cwd`, then calls `_update_cwd(result)`, which sets `self.cwd` from wherever the command finished. That tracker exists so a plain `cd` moves the session — it cannot tell "the user cd-ed here" from "this one command was pointed here". `terminal_tool` then dual-writes that env cwd into the durable per-session record (`record_session_cwd(session_key, getattr(env, "cwd", None))`), and `_resolve_command_cwd()` reads it back for every later command. One override has become the session's home, and the only way back is an explicit `cd`.

Since the desktop began surfacing a session's folder/branch, this is also visible: a single `workdir=` moves the user's session out of their project in the UI (file pane and branch readout follow), which reads as a broken workspace.

Reproduced against `main` (`9dc191d43`) at the layer that owns the state — the third command is still wrapped with `/tmp`:

```
assert wrapped_with == ["/home/me/project", "/tmp", "/home/me/project"]
E   AssertionError: assert ['/home/me/project', '/tmp', '/tmp'] == [...]

assert env.cwd == "/home/me/project"
E   AssertionError: a per-command workdir must not become the session's cwd
E   assert '/tmp' == '/home/me/project'
```

The fix snapshots the cwd around `_update_cwd` and restores it when the command carried an explicit `cwd`. `_update_cwd` still runs, deliberately: it also **strips the cwd marker from the output the model sees**, and subclasses hook their own normalization into it (`LocalEnvironment` does Windows MSYS conversion + stale-path rollback there). Only the session move is undone, so a plain `cd` still moves the session — pinned by its own test.

One detail worth flagging for review: the guard tests `if cwd:`, not `if cwd is not None`, because the parameter defaults to `""` — the same truthiness test the line above already uses for `effective_cwd = cwd or self.cwd`. My first attempt used `is not None` and the "cd still tracks" test caught it.

Fixing it here rather than in `terminal_tool` (the issue's second suggestion) also keeps the in-memory env correct: `self.cwd` feeds `effective_cwd` for the next command directly, so skipping only the durable write would still leave the live env pointing at the one-off directory.

## Related Issue

Fixes #73683

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/environments/base.py` (`BaseEnvironment.execute`): restore the pre-command `self.cwd` after `_update_cwd()` when the call supplied an explicit `cwd`. No signature change, so third-party `_update_cwd` overrides keep working and marker stripping is untouched.
- `tests/tools/test_base_environment.py`: three tests — an explicit `cwd` does not move the session (and the marker is still stripped from the output), an in-command `cd` still does, and the issue's three-step sequence ends back in the original directory.

## How to Test

1. In one session: `terminal(command="pwd")`, then `terminal(command="pwd", workdir="/tmp")`, then `terminal(command="pwd")` again.
2. Before this change the third command runs in `/tmp` and the session record / desktop session row have moved there; after, it runs in the original directory and only the middle command saw `/tmp`.
3. `pytest tests/tools/test_base_environment.py -q` → 32 passed (3 new); 3 pre-existing failures (snapshot-concurrency / 0600 file-mode suites) unchanged from `main` (baseline 30 passed, same 3 failures).
4. Two of the three new tests fail on `main` without the code change (captured above).
5. Affected-surface sweep: `pytest tests/tools/ -q -k "environment or env_ or terminal or cwd or docker or ssh"` → 1103 passed / 47 failed, versus baseline 1100 passed / **the same 47** failed with the change stashed — the delta is exactly the three new tests.
6. Tested on Ubuntu 24.04.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate — #73683 has no linked PR
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suites and they pass (see steps 3 and 5 for the pre-existing, unrelated failures)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (this makes the behaviour match the documented per-command contract; the tool description is already correct)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys added or changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — the change is backend-agnostic (it sits in the shared `execute()`); `LocalEnvironment`'s Windows normalization still runs inside `_update_cwd` and is simply not applied to a one-off command
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (the `workdir` schema and description already describe per-command semantics)
