### PR TITLE
Align the composer status lane with the surface

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -273,7 +273,10 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
       // Sits in the overlay lane above the composer. The composer root has pt-2
       // before the actual surface; translate by that amount so the stack returns
       // to its original attachment point without intruding into the repo strip.
-      className="absolute inset-x-0 bottom-full z-3 flex max-h-[40vh] flex-col translate-y-2"
+      // pl matches the surface's own left edge: `inset-x-0` resolves against the
+      // root's PADDING box, while the surface and the underside strip sit in its
+      // CONTENT box, so without it the lane hangs 5px further left than both.
+      className="absolute inset-x-0 bottom-full z-3 flex max-h-[40vh] flex-col translate-y-2 pl-[0.3125rem]"
       onPointerDownCapture={() => blurComposerInput()}
       ref={stackRef}
     >


### PR DESCRIPTION
## Summary

Follow-up to [#73711](https://github.com/NousResearch/hermes-agent/pull/73711), which merged before this last fix landed.

The status lane is `absolute inset-x-0`, so it resolves against the composer root's **padding** box, while the composer surface and the `composer.underside` strip sit in its **content** box. The micro-action pills therefore hung 5px further left than everything they were supposed to line up with.

Measured left edges before the fix — the chip and surface already agreed, the pills were the outlier:

| element | left |
|---|---|
| pills | 321.83 |
| chip | 326.83 |
| surface | 326.83 |

`pl-[0.3125rem]` is that 5px exactly.

## Test plan

- [x] Pills, underside chip, and composer surface share one left edge
- [x] `tsc --noEmit` and `eslint` clean