### PR TITLE
fix(send_message): wire WhatsApp outbound mentions producer

### DIFF
--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -62,5 +62,6 @@ def test_send_message_routes_whatsapp_group_jid_without_home_fallback() -> None:
         thread_id=None,
         media_files=[],
         force_document=False,
+        mentions=None,
     )
 

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -309,6 +309,7 @@ class TestSendMessageTool:
             thread_id=None,
             media_files=[],
             force_document=False,
+            mentions=None,
         )
 
 
@@ -348,6 +349,7 @@ class TestSendMessageTool:
             thread_id=None,
             media_files=[],
             force_document=False,
+            mentions=None,
         )
 
     def test_top_level_send_failure_redacts_query_token(self):
@@ -709,6 +711,111 @@ class TestSendToPlatformWhatsapp:
         _call = async_mock.await_args
         assert _call.args[1] == chat_id
         assert _call.args[2] == "hello from hermes"
+
+    def test_whatsapp_non_media_send_forwards_mentions(self):
+        """A non-empty mentions list is forwarded to the WhatsApp
+        standalone sender (affirmative propagation, not just the
+        mentions=None default)."""
+        from hermes_cli.plugins import discover_plugins
+        from gateway.platform_registry import platform_registry
+        discover_plugins()
+        chat_id = "test-user@lid"
+        mentions = ["+15551234567", "15551239876@s.whatsapp.net"]
+        async_mock = AsyncMock(return_value={"success": True, "platform": "whatsapp", "chat_id": chat_id, "message_id": "abc123"})
+
+        wa_entry = platform_registry.get("whatsapp")
+        original_sender = wa_entry.standalone_sender_fn
+        wa_entry.standalone_sender_fn = async_mock
+        try:
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.WHATSAPP,
+                    SimpleNamespace(enabled=True, token=None, extra={"bridge_port": 3000}),
+                    chat_id,
+                    "hello from hermes",
+                    mentions=mentions,
+                )
+            )
+        finally:
+            wa_entry.standalone_sender_fn = original_sender
+
+        assert result["success"] is True
+        async_mock.assert_awaited_once()
+        assert async_mock.await_args.kwargs.get("mentions") == mentions
+
+    def test_whatsapp_non_media_chunked_mentions_first_chunk_only(self):
+        """A long non-media WhatsApp message is chunked; mentions must be
+        forwarded on the first chunk only so continuation chunks don't
+        re-ping the same recipients (mirrors the media path guard)."""
+        from hermes_cli.plugins import discover_plugins
+        from gateway.platform_registry import platform_registry
+        discover_plugins()
+        chat_id = "test-user@lid"
+        mentions = ["+15551234567"]
+        long_msg = "word " * 3000  # ~15k chars -> 4 chunks over WhatsApp's 4096 limit
+        async_mock = AsyncMock(return_value={"success": True, "platform": "whatsapp", "chat_id": chat_id, "message_id": "abc123"})
+
+        wa_entry = platform_registry.get("whatsapp")
+        original_sender = wa_entry.standalone_sender_fn
+        wa_entry.standalone_sender_fn = async_mock
+        try:
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.WHATSAPP,
+                    SimpleNamespace(enabled=True, token=None, extra={"bridge_port": 3000}),
+                    chat_id,
+                    long_msg,
+                    mentions=mentions,
+                )
+            )
+        finally:
+            wa_entry.standalone_sender_fn = original_sender
+
+        assert result["success"] is True
+        calls = async_mock.await_args_list
+        assert len(calls) >= 3  # actually chunked, not a single send
+        assert calls[0].kwargs.get("mentions") == mentions
+        for call in calls[1:]:
+            assert "mentions" not in call.kwargs
+
+    def test_whatsapp_media_chunked_mentions_first_chunk_only(self, tmp_path):
+        """A long WhatsApp media send (text too long for a native caption)
+        is chunked; mentions are forwarded on the first chunk only."""
+        from hermes_cli.plugins import discover_plugins
+        from gateway.platform_registry import platform_registry
+        discover_plugins()
+        chat_id = "test-user@lid"
+        mentions = ["+15551234567"]
+        long_msg = "word " * 3000  # > 4096 caption limit -> chunked media path
+        media = tmp_path / "photo.png"
+        media.write_bytes(b"\x89PNG\r\n\x1a\n")
+        async_mock = AsyncMock(return_value={"success": True, "platform": "whatsapp", "chat_id": chat_id, "message_id": "abc123"})
+
+        wa_entry = platform_registry.get("whatsapp")
+        original_sender = wa_entry.standalone_sender_fn
+        wa_entry.standalone_sender_fn = async_mock
+        try:
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.WHATSAPP,
+                    SimpleNamespace(enabled=True, token=None, extra={"bridge_port": 3000}),
+                    chat_id,
+                    long_msg,
+                    media_files=[(str(media), False)],
+                    mentions=mentions,
+                )
+            )
+        finally:
+            wa_entry.standalone_sender_fn = original_sender
+
+        assert result["success"] is True
+        calls = async_mock.await_args_list
+        assert len(calls) >= 3  # actually chunked, not a single send
+        assert calls[0].kwargs.get("mentions") == mentions
+        for call in calls[1:]:
+            assert "mentions" not in call.kwargs
+        # media rides the last chunk
+        assert calls[-1].kwargs.get("media_files") == [(str(media), False)]
 
 
 class TestSendTelegramHtmlDetection:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -231,6 +231,11 @@ SEND_MESSAGE_SCHEMA = {
             "message_id": {
                 "type": "string",
                 "description": "For action='react'/'unreact': id of the message to react to. Omit to target the most recent message received in that chat (usually the one being replied to)."
+            },
+            "mentions": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "For WhatsApp group sends: list of phone numbers or JIDs to @-mention. Each entry is normalized to a WhatsApp JID and forwarded to the bridge on the first chunk only so the message pings those participants in the group without the ping repeating across continuation chunks."
             }
         },
         "required": []
@@ -359,6 +364,7 @@ def _handle_send(args):
     """Send a message to a platform target."""
     target = args.get("target", "")
     message = args.get("message", "")
+    mentions = args.get("mentions")
     if not target or not message:
         return tool_error("Both 'target' and 'message' are required when action='send'")
 
@@ -496,6 +502,7 @@ def _handle_send(args):
                 thread_id=thread_id,
                 media_files=media_files,
                 force_document=force_document_attachments,
+                mentions=mentions,
             )
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
@@ -780,7 +787,7 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, mentions=None):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -1058,6 +1065,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 thread_id=thread_id,
                 force_document=force_document,
                 caption=_wa_caption,
+                **({"mentions": mentions} if mentions else {}),
             )
             if isinstance(result, dict) and result.get("error"):
                 return result
@@ -1071,6 +1079,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 media_files=media_files if is_last else None,
                 thread_id=thread_id,
                 force_document=force_document,
+                **({"mentions": mentions} if mentions and i == 0 else {}),
             )
             if isinstance(result, dict) and result.get("error"):
                 return result
@@ -1119,9 +1128,12 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         )
 
     last_result = None
-    for chunk in chunks:
+    for i, chunk in enumerate(chunks):
         if platform == Platform.WHATSAPP:
-            result = await _registry_standalone_send("whatsapp", pconfig, chat_id, chunk, thread_id)
+            result = await _registry_standalone_send(
+                "whatsapp", pconfig, chat_id, chunk, thread_id,
+                **({"mentions": mentions} if mentions else {}),
+            )
         elif platform == Platform.SIGNAL:
             result = await _send_signal(pconfig.extra, chat_id, chunk)
         elif platform == Platform.EMAIL:
@@ -1497,12 +1509,16 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
 # (plugins/platforms/slack/adapter.py), wired via standalone_sender_fn. #41112.
 
 
-async def _registry_standalone_send(platform_name, pconfig, chat_id, message, thread_id=None):
+async def _registry_standalone_send(platform_name, pconfig, chat_id, message, thread_id=None, **kwargs):
     """Dispatch a one-shot send through a migrated platform plugin's
     standalone_sender_fn (registry hook).  Used for platforms whose adapter
     moved out of gateway/platforms/ into plugins/platforms/<name>/ (#41112):
     the legacy inline ``_send_<platform>`` helper now lives in the plugin as
     ``_standalone_send`` and is reached via the platform registry.
+
+    Extra keyword arguments (e.g. ``mentions`` for WhatsApp) are forwarded
+    to the plugin's ``_standalone_send`` so platform-specific features can
+    be added without patching this registry dispatcher.
     """
     from gateway.platform_registry import platform_registry
     from hermes_cli.plugins import discover_plugins
@@ -1510,7 +1526,7 @@ async def _registry_standalone_send(platform_name, pconfig, chat_id, message, th
     entry = platform_registry.get(platform_name)
     if entry is None or entry.standalone_sender_fn is None:
         return {"error": f"{platform_name} plugin not registered or missing standalone_sender_fn"}
-    return await entry.standalone_sender_fn(pconfig, chat_id, message, thread_id=thread_id)
+    return await entry.standalone_sender_fn(pconfig, chat_id, message, thread_id=thread_id, **kwargs)
 
 
 # _send_whatsapp moved to plugins/platforms/whatsapp/adapter.py::_standalone_send,

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1132,7 +1132,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         if platform == Platform.WHATSAPP:
             result = await _registry_standalone_send(
                 "whatsapp", pconfig, chat_id, chunk, thread_id,
-                **({"mentions": mentions} if mentions else {}),
+                **({"mentions": mentions} if mentions and i == 0 else {}),
             )
         elif platform == Platform.SIGNAL:
             result = await _send_signal(pconfig.extra, chat_id, chunk)


### PR DESCRIPTION
PR #67179 adds WhatsApp outbound mention delivery plumbing (`WhatsAppAdapter.send` reads `metadata["mentions"]`, `_standalone_send` accepts a `mentions=` kwarg, `_normalize_outbound_mentions` normalizes phone numbers to JIDs), but nothing in the codebase populates the input — no call site passes mentions, and the `send_message` tool schema lacks the parameter entirely. The feature is unreachable. (Reported in #69634.)

This PR adds the missing producer so the `send_message` tool can pass `mentions` through to WhatsApp.

## Changes

- **Schema**: Add optional `mentions` (array of strings — bare phone numbers or JIDs) to the `send_message` tool JSON schema.
- **`_handle_send`**: Extract `mentions` from args.
- **All three WhatsApp pathways** now thread `mentions` through:
  1. Media send (caption path) — single call, forwards `mentions` when truthy.
  2. Media send (chunked path) — forwards `mentions` on the first chunk only.
  3. Non-media standalone send (via `_registry_standalone_send`) — forwards `mentions` when truthy.
- **`_registry_standalone_send`**: Accept `**kwargs` and forward to `standalone_sender_fn`, so platform-specific parameters like `mentions` can flow through without patching the registry dispatcher.
- **Compatibility**: `mentions` is only forwarded when truthy (conditional dict spread `**({"mentions": ...} if mentions else {})`), so non-WhatsApp platforms and `_standalone_send` implementations that don't accept `mentions` are unaffected.

## Verification

```
python -m pytest tests/tools/test_send_message_tool.py -q  → 50 passed
python -m pytest tests/tools/test_send_message_target_parse.py -q → 3 passed
python -m pytest tests/tools/test_whatsapp_send_message_media.py -q → 19 passed
```

All three suites pass (72 total), confirming the new field propagates correctly through all WhatsApp sending paths. Test counts reflect main's post-prune suite. Review-driven additions: non-media chunk loop now forwards `mentions` on the first chunk only (`mentions and i == 0`, mirroring the media path), plus three mocked-sender tests covering non-empty propagation and the first-chunk-only contract for both chunked paths (mutation-verified).

## Notes

- **Depends on PR #67179** (delivery plumbing) — `_standalone_send` on main does not yet accept the `mentions=` kwarg. This PR is the producer half; both must land for the feature to be reachable.
- Gateway reply path (adapter `send()` via `metadata["mentions"]`) is deferred — that's a cross-platform mention semantics question (per the issue author's recommendation in #69634).
- Mentions are gated to the first chunk only (matching the adapter's own pattern in #67179), avoiding duplicate pings on continuation chunks.

Closes #69634.

