### PR TITLE
feat(gateway): add public participant plugin hooks

### DIFF
--- a/gateway/message_hooks.py
+++ b/gateway/message_hooks.py
@@ -14,6 +14,7 @@ from hermes_constants import GATEWAY_MESSAGE_HOOK_API_VERSION
 
 
 DeliveryStatus = Literal["sent", "failed", "unknown"]
+GATEWAY_DELIVERY_CAPABILITY_TTL_SECONDS = 300.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -249,8 +250,11 @@ class _DeliveryRequest:
 @dataclass(slots=True)
 class _DeliveryChannel:
     queue: asyncio.Queue[_DeliveryRequest]
+    wake: asyncio.Event
+    participant_settled: asyncio.Event
     binding: _DeliveryBinding
     worker: Optional[asyncio.Task[None]] = None
+    terminal_callback: Optional[Callable[[Any], None]] = None
     revoked: bool = False
     consumed: bool = False
     invocation_started: bool = False
@@ -286,11 +290,15 @@ class GatewayDelivery:
         profile: str,
         self_actor_id: Optional[str],
         source_message_id: Optional[str],
+        on_terminal: Callable[[Any], None] | None = None,
+        hold_until_participant_settled: bool = False,
     ) -> None:
         if not callable(send_callback):
             raise TypeError("send_callback must be callable")
         channel = _DeliveryChannel(
             queue=asyncio.Queue(maxsize=1),
+            wake=asyncio.Event(),
+            participant_settled=asyncio.Event(),
             binding=_DeliveryBinding(
                 platform=str(platform),
                 room_id=str(room_id),
@@ -298,7 +306,10 @@ class GatewayDelivery:
                 self_actor_id=_optional_text(self_actor_id),
                 source_message_id=_optional_text(source_message_id),
             ),
+            terminal_callback=on_terminal,
         )
+        if not hold_until_participant_settled:
+            channel.participant_settled.set()
         _DELIVERY_CHANNELS[self] = channel
         worker = asyncio.create_task(
             _delivery_worker(
@@ -309,7 +320,11 @@ class GatewayDelivery:
             )
         )
         channel.worker = worker
-        worker.add_done_callback(_consume_delivery_worker_result)
+        worker.add_done_callback(
+            lambda task, delivery_ref=weakref.ref(self), worker_channel=channel: (
+                _finalize_delivery_worker(task, delivery_ref, worker_channel)
+            )
+        )
 
     async def send(self, content: str) -> GatewayDeliveryReceipt:
         """Send text to the bound source and normalize the native acknowledgement."""
@@ -350,9 +365,27 @@ class GatewayDelivery:
                     future=future,
                 )
             )
+            channel.wake.set()
         except asyncio.QueueFull:
             return GatewayDeliveryReceipt(status="failed")
         return await future
+
+    def _set_terminal_callback(
+        self,
+        callback: Callable[[Any], None],
+    ) -> None:
+        """Bind host cleanup after registration, including terminal races."""
+        channel = _DELIVERY_CHANNELS.get(self)
+        if channel is None:
+            callback(self)
+            return
+        channel.terminal_callback = callback
+
+    def _release_participant_hold(self) -> None:
+        """Start the unused-capability TTL after participant handling."""
+        channel = _DELIVERY_CHANNELS.get(self)
+        if channel is not None:
+            channel.participant_settled.set()
 
     def _revoke(self) -> None:
         """Begin invalidation synchronously; async boundaries must await settle."""
@@ -403,6 +436,7 @@ class GatewayDelivery:
                         future=future,
                     )
                 )
+                channel.wake.set()
             except (RuntimeError, asyncio.QueueFull):
                 pass
         return worker
@@ -469,16 +503,39 @@ async def _delivery_worker(
     reply_callback: Callable[[str], Awaitable[Any] | Any] | None,
     react_callback: Callable[[str, str], Awaitable[Any] | Any] | None,
 ) -> None:
-    request: _DeliveryRequest | None = None
-    while request is None:
+    if not channel.participant_settled.is_set():
+        wake_waiter = asyncio.create_task(channel.wake.wait())
+        settled_waiter = asyncio.create_task(channel.participant_settled.wait())
+        waiters = {wake_waiter, settled_waiter}
+        done: set[asyncio.Task[bool]] = set()
         try:
-            request = channel.queue.get_nowait()
-        except asyncio.QueueEmpty:
-            if channel.revoked:
-                return
-            # Polling deliberately leaves no queue waiter that can be traversed
-            # from the public capability into this host task's callback frame.
-            await asyncio.sleep(0.01)
+            done, _pending = await asyncio.wait(
+                waiters,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            for waiter in waiters:
+                if not waiter.done():
+                    waiter.cancel()
+            await asyncio.gather(*waiters, return_exceptions=True)
+        for waiter in done:
+            waiter.result()
+    try:
+        if not channel.wake.is_set():
+            await asyncio.wait_for(
+                channel.wake.wait(),
+                timeout=GATEWAY_DELIVERY_CAPABILITY_TTL_SECONDS,
+            )
+    except TimeoutError:
+        channel.revoked = True
+        channel.consumed = True
+        return
+    try:
+        request = channel.queue.get_nowait()
+    except asyncio.QueueEmpty:
+        channel.revoked = True
+        channel.consumed = True
+        return
     if channel.revoked:
         if not request.future.done():
             request.future.set_result(GatewayDeliveryReceipt(status="failed"))
@@ -491,12 +548,18 @@ async def _delivery_worker(
         channel.invocation_started = True
         if request.kind == "reply":
             if not callable(reply_callback):
-                native_result = SendResult(success=False)
+                native_result = SendResult(
+                    success=False,
+                    native_delivery_non_occurrence_attested=True,
+                )
             else:
                 native_result = reply_callback(request.content)
         elif request.kind == "react":
             if not callable(react_callback):
-                native_result = SendResult(success=False)
+                native_result = SendResult(
+                    success=False,
+                    native_delivery_non_occurrence_attested=True,
+                )
             else:
                 native_result = react_callback(request.content, request.operation)
         else:
@@ -539,9 +602,25 @@ def _normalize_delivery_receipt(
     if not isinstance(native_result, SendResult):
         return GatewayDeliveryReceipt(status="unknown")
     if native_result.success is False:
-        return GatewayDeliveryReceipt(status="failed")
+        return GatewayDeliveryReceipt(
+            status=(
+                "failed"
+                if native_result.native_delivery_non_occurrence_attested is True
+                else "unknown"
+            )
+        )
     if native_result.success is not True or binding.self_actor_id is None:
         return GatewayDeliveryReceipt(status="unknown")
+    raw_response = native_result.raw_response
+    if isinstance(raw_response, dict):
+        delivered_chunks = raw_response.get("delivered_chunks")
+        total_chunks = raw_response.get("total_chunks")
+        if raw_response.get("partial_overflow") is True or (
+            isinstance(delivered_chunks, int)
+            and isinstance(total_chunks, int)
+            and delivered_chunks < total_chunks
+        ):
+            return GatewayDeliveryReceipt(status="unknown")
     ack = native_result.native_delivery_ack
     if not isinstance(ack, NativeDeliveryAck):
         return GatewayDeliveryReceipt(status="unknown")
@@ -603,6 +682,28 @@ def _consume_delivery_worker_result(task: asyncio.Task[None]) -> None:
         task.exception()
     except Exception:
         pass
+
+
+def _finalize_delivery_worker(
+    task: asyncio.Task[None],
+    delivery_ref: "weakref.ReferenceType[GatewayDelivery]",
+    channel: _DeliveryChannel,
+) -> None:
+    """Close one terminal capability and release every host registry edge."""
+    _consume_delivery_worker_result(task)
+    channel.revoked = True
+    channel.consumed = True
+    delivery = delivery_ref()
+    if delivery is None:
+        return
+    _DELIVERY_CHANNELS.pop(delivery, None)
+    callback = channel.terminal_callback
+    channel.terminal_callback = None
+    if callback is not None:
+        try:
+            callback(delivery)
+        except Exception:
+            pass
 
 
 def _optional_text(value: Any) -> Optional[str]:

--- a/gateway/message_hooks.py
+++ b/gateway/message_hooks.py
@@ -1,0 +1,661 @@
+"""Narrow immutable contracts for plugin handling of ordinary gateway messages."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import weakref
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Literal, Optional
+
+from gateway.platforms.base import MessageEvent, NativeDeliveryAck, SendResult
+from gateway.session import SessionSource
+from hermes_constants import GATEWAY_MESSAGE_HOOK_API_VERSION
+
+
+DeliveryStatus = Literal["sent", "failed", "unknown"]
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayDeliveryReceipt:
+    """Truthful platform-neutral result of a route-bound host send."""
+
+    status: DeliveryStatus
+    platform: Optional[str] = None
+    room_id: Optional[str] = None
+    profile: Optional[str] = None
+    self_actor_id: Optional[str] = None
+    effect_kind: Optional[Literal["send", "reply", "react"]] = None
+    submitted_content: Optional[str] = None
+    reply_to_message_id: Optional[str] = None
+    target_message_id: Optional[str] = None
+    reaction: Optional[str] = None
+    reaction_operation: Optional[Literal["add", "remove"]] = None
+    message_id: Optional[str] = None
+    effect_id: Optional[str] = None
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayMessageEvent:
+    """Immutable normalized snapshot of an inbound user message."""
+
+    text: str
+    message_id: Optional[str]
+    message_type: str
+    timestamp: str
+    media_urls: tuple[str, ...]
+    media_types: tuple[str, ...]
+    mentioned_user_ids: tuple[str, ...] | None
+    mentions_room: bool | None
+    reply_to_message_id: Optional[str]
+    reply_to_text: Optional[str]
+    reply_to_author_id: Optional[str]
+    reply_to_author_name: Optional[str]
+    reply_to_is_own_message: bool
+    coverage_gaps: tuple[str, ...] = ()
+
+    @classmethod
+    def from_event(cls, event: MessageEvent) -> "GatewayMessageEvent":
+        gaps: set[str] = set()
+        timestamp = getattr(event, "timestamp", None)
+        timestamp_text = timestamp.isoformat() if hasattr(timestamp, "isoformat") else ""
+        message_type = getattr(getattr(event, "message_type", None), "value", None)
+        metadata = getattr(event, "metadata", None)
+        raw_mentioned_user_ids = (
+            metadata.get("mentioned_user_ids") if isinstance(metadata, dict) else None
+        )
+        mentioned_user_ids = None
+        if isinstance(raw_mentioned_user_ids, (list, tuple)):
+            mention_values = raw_mentioned_user_ids[:129]
+            if len(raw_mentioned_user_ids) > 128:
+                gaps.add("mention-count-overflow")
+            if all(isinstance(item, str) and item for item in mention_values[:128]):
+                mentioned_user_ids = tuple(
+                    _bounded_text(
+                        item,
+                        512,
+                        "mention-id-overflow",
+                        gaps,
+                    )
+                    for item in mention_values[:128]
+                )
+        raw_mentions_room = metadata.get("mentions_room") if isinstance(metadata, dict) else None
+        mentions_room = raw_mentions_room if isinstance(raw_mentions_room, bool) else None
+        media_urls = _bounded_items(
+            getattr(event, "media_urls", None),
+            count_limit=16,
+            item_limit=4_096,
+            count_gap="media-count-overflow",
+            item_gap="media-url-overflow",
+            gaps=gaps,
+        )
+        media_types = _bounded_items(
+            getattr(event, "media_types", None),
+            count_limit=16,
+            item_limit=256,
+            count_gap="media-count-overflow",
+            item_gap="media-type-overflow",
+            gaps=gaps,
+        )
+        return cls(
+            text=_bounded_text(
+                getattr(event, "text", "") or "",
+                65_536,
+                "text-overflow",
+                gaps,
+            ),
+            message_id=_bounded_optional_text(
+                getattr(event, "message_id", None),
+                512,
+                "message-id-overflow",
+                gaps,
+            ),
+            message_type=_bounded_text(
+                message_type or "",
+                64,
+                "message-type-overflow",
+                gaps,
+            ),
+            timestamp=_bounded_text(
+                timestamp_text,
+                128,
+                "timestamp-overflow",
+                gaps,
+            ),
+            media_urls=media_urls,
+            media_types=media_types,
+            mentioned_user_ids=mentioned_user_ids,
+            mentions_room=mentions_room,
+            reply_to_message_id=_bounded_optional_text(
+                getattr(event, "reply_to_message_id", None),
+                512,
+                "reply-message-id-overflow",
+                gaps,
+            ),
+            reply_to_text=_bounded_optional_text(
+                getattr(event, "reply_to_text", None),
+                16_384,
+                "reply-text-overflow",
+                gaps,
+            ),
+            reply_to_author_id=_bounded_optional_text(
+                getattr(event, "reply_to_author_id", None),
+                512,
+                "reply-author-id-overflow",
+                gaps,
+            ),
+            reply_to_author_name=_bounded_optional_text(
+                getattr(event, "reply_to_author_name", None),
+                4_096,
+                "reply-author-name-overflow",
+                gaps,
+            ),
+            reply_to_is_own_message=bool(
+                getattr(event, "reply_to_is_own_message", False)
+            ),
+            coverage_gaps=tuple(sorted(gaps)),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayMessageRoute:
+    """Immutable normalized route for the current inbound source."""
+
+    session_key: str
+    platform: str
+    profile: Optional[str]
+    scope_id: Optional[str]
+    chat_id: str
+    chat_name: Optional[str]
+    chat_type: str
+    thread_id: Optional[str]
+    user_id: Optional[str]
+    user_name: Optional[str]
+    coverage_gaps: tuple[str, ...] = ()
+
+    @classmethod
+    def from_source(
+        cls,
+        source: SessionSource,
+        *,
+        session_key: str,
+    ) -> "GatewayMessageRoute":
+        gaps: set[str] = set()
+        platform = getattr(getattr(source, "platform", None), "value", None)
+        profile_value = getattr(source, "profile", None)
+        profile = _optional_text(profile_value)
+        if profile is None:
+            from hermes_cli.profiles import get_active_profile_name
+
+            profile = _optional_text(get_active_profile_name())
+        return cls(
+            session_key=_bounded_text(
+                session_key or "", 2_048, "session-key-overflow", gaps
+            ),
+            platform=_bounded_text(
+                platform or "", 64, "platform-overflow", gaps
+            ),
+            profile=_bounded_optional_text(
+                profile, 256, "profile-overflow", gaps
+            ),
+            scope_id=_bounded_optional_text(
+                getattr(source, "scope_id", None), 512, "scope-id-overflow", gaps
+            ),
+            chat_id=_bounded_text(
+                getattr(source, "chat_id", "") or "",
+                512,
+                "chat-id-overflow",
+                gaps,
+            ),
+            chat_name=_bounded_optional_text(
+                getattr(source, "chat_name", None),
+                4_096,
+                "chat-name-overflow",
+                gaps,
+            ),
+            chat_type=_bounded_text(
+                getattr(source, "chat_type", "") or "",
+                64,
+                "chat-type-overflow",
+                gaps,
+            ),
+            thread_id=_bounded_optional_text(
+                getattr(source, "thread_id", None),
+                512,
+                "thread-id-overflow",
+                gaps,
+            ),
+            user_id=_bounded_optional_text(
+                getattr(source, "user_id", None), 512, "user-id-overflow", gaps
+            ),
+            user_name=_bounded_optional_text(
+                getattr(source, "user_name", None),
+                4_096,
+                "user-name-overflow",
+                gaps,
+            ),
+            coverage_gaps=tuple(sorted(gaps)),
+        )
+
+
+@dataclass(slots=True)
+class _DeliveryRequest:
+    kind: Literal["send", "reply", "react"]
+    content: str
+    operation: str
+    future: asyncio.Future[GatewayDeliveryReceipt]
+
+
+@dataclass(slots=True)
+class _DeliveryChannel:
+    queue: asyncio.Queue[_DeliveryRequest]
+    binding: _DeliveryBinding
+    worker: Optional[asyncio.Task[None]] = None
+    revoked: bool = False
+    consumed: bool = False
+    invocation_started: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class _DeliveryBinding:
+    platform: str
+    room_id: str
+    profile: str
+    self_actor_id: Optional[str]
+    source_message_id: Optional[str]
+
+
+class GatewayDelivery:
+    """One-shot, route-bound delivery facade for trusted in-process plugins.
+
+    This narrows ordinary plugin use to the captured route and does not expose
+    adapters or native clients as API. It is not a sandbox against hostile
+    Python code running in the same interpreter.
+    """
+
+    __slots__ = ("__weakref__",)
+
+    def __init__(
+        self,
+        send_callback: Callable[[str], Awaitable[Any] | Any],
+        *,
+        reply_callback: Callable[[str], Awaitable[Any] | Any] | None = None,
+        react_callback: Callable[[str, str], Awaitable[Any] | Any] | None = None,
+        platform: str,
+        room_id: str,
+        profile: str,
+        self_actor_id: Optional[str],
+        source_message_id: Optional[str],
+    ) -> None:
+        if not callable(send_callback):
+            raise TypeError("send_callback must be callable")
+        channel = _DeliveryChannel(
+            queue=asyncio.Queue(maxsize=1),
+            binding=_DeliveryBinding(
+                platform=str(platform),
+                room_id=str(room_id),
+                profile=str(profile),
+                self_actor_id=_optional_text(self_actor_id),
+                source_message_id=_optional_text(source_message_id),
+            ),
+        )
+        _DELIVERY_CHANNELS[self] = channel
+        worker = asyncio.create_task(
+            _delivery_worker(
+                channel,
+                send_callback,
+                reply_callback=reply_callback,
+                react_callback=react_callback,
+            )
+        )
+        channel.worker = worker
+        worker.add_done_callback(_consume_delivery_worker_result)
+
+    async def send(self, content: str) -> GatewayDeliveryReceipt:
+        """Send text to the bound source and normalize the native acknowledgement."""
+        return await self._submit("send", str(content), "")
+
+    async def reply(self, content: str) -> GatewayDeliveryReceipt:
+        """Reply only to the native message captured by this capability."""
+        return await self._submit("reply", str(content), "")
+
+    async def react(
+        self,
+        reaction: str,
+        *,
+        operation: str = "add",
+    ) -> GatewayDeliveryReceipt:
+        """Add/remove one reaction on the captured native message."""
+        if operation not in {"add", "remove"}:
+            return GatewayDeliveryReceipt(status="failed")
+        return await self._submit("react", str(reaction), operation)
+
+    async def _submit(
+        self,
+        kind: Literal["send", "reply", "react"],
+        content: str,
+        operation: str,
+    ) -> GatewayDeliveryReceipt:
+        channel = _DELIVERY_CHANNELS.get(self)
+        if channel is None or channel.revoked or channel.consumed:
+            return GatewayDeliveryReceipt(status="failed")
+        channel.consumed = True
+        future = asyncio.get_running_loop().create_future()
+        try:
+            channel.queue.put_nowait(
+                _DeliveryRequest(
+                    kind=kind,
+                    content=content,
+                    operation=operation,
+                    future=future,
+                )
+            )
+        except asyncio.QueueFull:
+            return GatewayDeliveryReceipt(status="failed")
+        return await future
+
+    def _revoke(self) -> None:
+        """Begin invalidation synchronously; async boundaries must await settle."""
+        self._begin_revocation()
+
+    async def _settle_revocation(self) -> None:
+        """Invalidate, then wait for any in-flight native effect to settle.
+
+        This is the full lifecycle boundary for a single capability: after
+        it returns, no revoked native invocation is still live. A caller
+        unwinding inside the delivery worker's own callback frame skips the
+        wait to avoid self-await deadlock.
+        """
+        worker = self._begin_revocation()
+        if worker is None:
+            return
+        await _await_delivery_settlement(
+            worker, owner=asyncio.current_task()
+        )
+
+    def _begin_revocation(self) -> Optional["asyncio.Task[None]"]:
+        """Prevent new invocations, then return the worker to await, if any.
+
+        The revocation flag is applied in one synchronous segment, so this is
+        the commit side of the
+        revocation/invocation race: a request whose native invocation has
+        not started never starts. A native invocation that already won is not
+        cancelled: adapter cancellation is not proof that a detached or
+        transport-owned effect was aborted. The returned worker is therefore
+        retained as the settlement handle and the lifecycle boundary waits
+        for the adapter callback to finish before returning. A worker that
+        has already finished is returned as well so callers settle uniformly.
+        """
+        channel = _DELIVERY_CHANNELS.get(self)
+        if channel is None:
+            return None
+        channel.revoked = True
+        worker = channel.worker
+        if not channel.consumed:
+            channel.consumed = True
+            try:
+                future = asyncio.get_running_loop().create_future()
+                channel.queue.put_nowait(
+                    _DeliveryRequest(
+                        kind="send",
+                        content="",
+                        operation="",
+                        future=future,
+                    )
+                )
+            except (RuntimeError, asyncio.QueueFull):
+                pass
+        return worker
+
+
+_DELIVERY_CHANNELS: weakref.WeakKeyDictionary[
+    GatewayDelivery,
+    _DeliveryChannel,
+] = weakref.WeakKeyDictionary()
+
+
+async def _await_delivery_settlement(
+    worker: asyncio.Task[None],
+    *,
+    owner: Optional[asyncio.Task[Any]] = None,
+) -> None:
+    """Wait for a delivery worker's native invocation to finish.
+
+    ``worker`` is awaited shielded so cancellation of the lifecycle path
+    cannot detach the settlement wait and let the boundary return while
+    the native effect is still live. When the awaiting lifecycle path is
+    itself cancelled mid-wait, propagation is deferred: the cancellation
+    is consumed and the shield-await is re-entered until the worker
+    settles, and only then is ``CancelledError`` re-raised so the caller
+    observes cancellation strictly after no revoked native effect remains
+    live. The only legitimate escape is the worker awaiting itself (host
+    lifecycle code unwinding inside the delivery callback frame), which
+    would otherwise self-deadlock.
+    """
+    if worker.done():
+        return
+    if owner is not None and owner is worker:
+        return
+    waiter = asyncio.current_task()
+    deferred = False
+    while not worker.done():
+        try:
+            await asyncio.shield(worker)
+        except asyncio.CancelledError:
+            if worker.done():
+                # The worker itself completed as cancelled (revocation's own
+                # cancellation request won the race): the invocation is
+                # settled and the boundary may proceed. Preserve a concurrent
+                # outer cancellation rather than mistaking it for the worker's.
+                if waiter is not None and waiter.cancelling():
+                    deferred = True
+                    waiter.uncancel()
+                break
+            # The awaiting lifecycle path was cancelled while the worker is
+            # still live. Consume the cancellation so it cannot detach the
+            # settlement wait, keep shield-awaiting until the worker
+            # settles, and re-raise afterwards.
+            deferred = True
+            if waiter is not None and waiter.cancelling():
+                waiter.uncancel()
+    if deferred:
+        raise asyncio.CancelledError()
+
+
+async def _delivery_worker(
+    channel: _DeliveryChannel,
+    send_callback: Callable[[str], Awaitable[Any] | Any],
+    *,
+    reply_callback: Callable[[str], Awaitable[Any] | Any] | None,
+    react_callback: Callable[[str, str], Awaitable[Any] | Any] | None,
+) -> None:
+    request: _DeliveryRequest | None = None
+    while request is None:
+        try:
+            request = channel.queue.get_nowait()
+        except asyncio.QueueEmpty:
+            if channel.revoked:
+                return
+            # Polling deliberately leaves no queue waiter that can be traversed
+            # from the public capability into this host task's callback frame.
+            await asyncio.sleep(0.01)
+    if channel.revoked:
+        if not request.future.done():
+            request.future.set_result(GatewayDeliveryReceipt(status="failed"))
+        return
+    try:
+        # Revocation and native invocation share one synchronous commit
+        # boundary. Once this flag is set the host deliberately does not
+        # cancel the adapter callback: cancellation cannot prove that an
+        # already-submitted external effect was aborted.
+        channel.invocation_started = True
+        if request.kind == "reply":
+            if not callable(reply_callback):
+                native_result = SendResult(success=False)
+            else:
+                native_result = reply_callback(request.content)
+        elif request.kind == "react":
+            if not callable(react_callback):
+                native_result = SendResult(success=False)
+            else:
+                native_result = react_callback(request.content, request.operation)
+        else:
+            native_result = send_callback(request.content)
+        if inspect.isawaitable(native_result):
+            native_result = await native_result
+        # If revocation arrived after invocation started, the effect may have
+        # committed. Awaiting the callback settles the adapter-owned operation,
+        # but attribution remains unknown rather than fabricated failure.
+        if channel.revoked:
+            if not request.future.done():
+                request.future.set_result(GatewayDeliveryReceipt(status="unknown"))
+            return
+    except asyncio.CancelledError:
+        # Core revocation never cancels an invocation that already started.
+        # If an unrelated owner cancels this worker, native non-occurrence is
+        # unprovable after invocation and the only truthful receipt is unknown.
+        if not request.future.done():
+            request.future.set_result(
+                GatewayDeliveryReceipt(
+                    status="unknown" if channel.invocation_started else "failed"
+                )
+            )
+        return
+    except Exception:
+        receipt = GatewayDeliveryReceipt(status="unknown")
+    else:
+        receipt = _normalize_delivery_receipt(native_result, request, channel.binding)
+        if channel.revoked and receipt.status == "sent":
+            receipt = GatewayDeliveryReceipt(status="unknown")
+    if not request.future.done():
+        request.future.set_result(receipt)
+
+
+def _normalize_delivery_receipt(
+    native_result: Any,
+    request: _DeliveryRequest,
+    binding: _DeliveryBinding,
+) -> GatewayDeliveryReceipt:
+    if not isinstance(native_result, SendResult):
+        return GatewayDeliveryReceipt(status="unknown")
+    if native_result.success is False:
+        return GatewayDeliveryReceipt(status="failed")
+    if native_result.success is not True or binding.self_actor_id is None:
+        return GatewayDeliveryReceipt(status="unknown")
+    ack = native_result.native_delivery_ack
+    if not isinstance(ack, NativeDeliveryAck):
+        return GatewayDeliveryReceipt(status="unknown")
+    expected_kind = {"send": "send", "reply": "reply", "react": "react"}[request.kind]
+    expected_reply = binding.source_message_id if request.kind == "reply" else None
+    expected_target = binding.source_message_id if request.kind == "react" else None
+    expected_content = request.content if request.kind != "react" else None
+    expected_reaction = request.content if request.kind == "react" else None
+    expected_operation = request.operation if request.kind == "react" else None
+    if (
+        ack.platform != binding.platform
+        or ack.room_id != binding.room_id
+        or ack.self_actor_id != binding.self_actor_id
+        or ack.effect_kind != expected_kind
+        or ack.submitted_content != expected_content
+        or ack.reply_to_message_id != expected_reply
+        or ack.target_message_id != expected_target
+        or ack.reaction != expected_reaction
+        or ack.reaction_operation != expected_operation
+    ):
+        return GatewayDeliveryReceipt(status="unknown")
+    if request.kind == "react":
+        if (
+            ack.message_id is not None
+            or not ack.effect_id
+            or not ack.effect_id.startswith(f"{binding.platform}:reaction:")
+        ):
+            return GatewayDeliveryReceipt(status="unknown")
+    else:
+        native_message_id = _optional_text(native_result.message_id)
+        if (
+            not native_message_id
+            or ack.message_id != native_message_id
+            or ack.effect_id != native_message_id
+            or native_message_id == binding.source_message_id
+        ):
+            return GatewayDeliveryReceipt(status="unknown")
+    return GatewayDeliveryReceipt(
+        status="sent",
+        platform=ack.platform,
+        room_id=ack.room_id,
+        profile=binding.profile,
+        self_actor_id=ack.self_actor_id,
+        effect_kind=ack.effect_kind,
+        submitted_content=ack.submitted_content,
+        reply_to_message_id=ack.reply_to_message_id,
+        target_message_id=ack.target_message_id,
+        reaction=ack.reaction,
+        reaction_operation=ack.reaction_operation,
+        message_id=ack.message_id,
+        effect_id=ack.effect_id,
+    )
+
+
+def _consume_delivery_worker_result(task: asyncio.Task[None]) -> None:
+    if task.cancelled():
+        return
+    try:
+        task.exception()
+    except Exception:
+        pass
+
+
+def _optional_text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None
+
+
+def _bounded_text(
+    value: Any,
+    byte_limit: int,
+    gap: str,
+    gaps: set[str],
+) -> str:
+    text = str(value)
+    encoded = text.encode("utf-8", errors="replace")
+    if len(encoded) <= byte_limit:
+        return text
+    gaps.add(gap)
+    return encoded[:byte_limit].decode("utf-8", errors="ignore")
+
+
+def _bounded_optional_text(
+    value: Any,
+    byte_limit: int,
+    gap: str,
+    gaps: set[str],
+) -> Optional[str]:
+    if value is None:
+        return None
+    text = _bounded_text(value, byte_limit, gap, gaps)
+    return text if text else None
+
+
+def _bounded_items(
+    values: Any,
+    *,
+    count_limit: int,
+    item_limit: int,
+    count_gap: str,
+    item_gap: str,
+    gaps: set[str],
+) -> tuple[str, ...]:
+    if not values:
+        return ()
+    items = list(values[: count_limit + 1]) if isinstance(values, (list, tuple)) else []
+    if not isinstance(values, (list, tuple)):
+        gaps.add(count_gap)
+        return ()
+    if len(values) > count_limit:
+        gaps.add(count_gap)
+    return tuple(
+        _bounded_text(item, item_limit, item_gap, gaps)
+        for item in items[:count_limit]
+    )

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2153,7 +2153,6 @@ class SendResult:
     message_id: Optional[str] = None
     error: Optional[str] = None
     raw_response: Any = None
-    native_delivery_ack: Optional[NativeDeliveryAck] = None
     # Adapter-specific metadata.  Cross-layer contracts that affect delivery
     # semantics must be documented at the producer and consumer sites.  Current
     # known contract: Telegram edit overflow partials set
@@ -2179,6 +2178,12 @@ class SendResult:
     # ``None`` (unset / not classified).  Producers should set this via
     # :func:`classify_send_error`.
     error_kind: Optional[str] = None
+    # Participant-host extensions are appended so legacy positional
+    # construction keeps binding the fifth argument to ``retryable``.
+    native_delivery_ack: Optional[NativeDeliveryAck] = None
+    # Positive adapter attestation that no native effect occurred. A bare
+    # ``success=False`` is ambiguous after transport submission.
+    native_delivery_non_occurrence_attested: bool = False
 
 
 # Machine-readable send-failure categories.  Kept platform-neutral so every

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -541,7 +541,7 @@ import dataclasses
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Any, Callable, Awaitable, Tuple, Union
+from typing import Dict, List, Optional, Any, Callable, Awaitable, Tuple, Union, Literal
 from enum import Enum
 
 from pathlib import Path as _Path
@@ -2129,6 +2129,23 @@ def coerce_plaintext_gateway_command(event: "MessageEvent") -> None:
         return
 
 
+@dataclass(frozen=True)
+class NativeDeliveryAck:
+    """Adapter-produced attestation for one committed native platform effect."""
+
+    platform: str
+    room_id: str
+    self_actor_id: str
+    effect_kind: Literal["send", "reply", "react"]
+    submitted_content: Optional[str] = None
+    reply_to_message_id: Optional[str] = None
+    target_message_id: Optional[str] = None
+    reaction: Optional[str] = None
+    reaction_operation: Optional[Literal["add", "remove"]] = None
+    message_id: Optional[str] = None
+    effect_id: Optional[str] = None
+
+
 @dataclass
 class SendResult:
     """Result of sending a message."""
@@ -2136,6 +2153,7 @@ class SendResult:
     message_id: Optional[str] = None
     error: Optional[str] = None
     raw_response: Any = None
+    native_delivery_ack: Optional[NativeDeliveryAck] = None
     # Adapter-specific metadata.  Cross-layer contracts that affect delivery
     # semantics must be documented at the producer and consumer sites.  Current
     # known contract: Telegram edit overflow partials set
@@ -3404,6 +3422,17 @@ class BasePlatformAdapter(ABC):
             SendResult with success status and message ID
         """
         pass
+
+    async def react(
+        self,
+        chat_id: str,
+        message_id: str,
+        reaction: str,
+        *,
+        operation: str = "add",
+    ) -> SendResult:
+        """Apply one route-bound reaction when the adapter supports it."""
+        return SendResult(success=False, error="Reactions are unavailable")
 
     # Default: the adapter treats ``finalize=True`` on edit_message as a
     # no-op and is happy to have the stream consumer skip redundant final
@@ -5253,11 +5282,19 @@ class BasePlatformAdapter(ABC):
         # Offloaded: the sync hook must not block the loop.
         await asyncio.to_thread(self._apply_topic_recovery, event)
 
-        session_key = build_session_key(
-            event.source,
-            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+        runner_session_key = getattr(
+            getattr(self, "gateway_runner", None),
+            "_session_key_for_source",
+            None,
         )
+        if callable(runner_session_key):
+            session_key = runner_session_key(event.source)
+        else:
+            session_key = build_session_key(
+                event.source,
+                group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
+                thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+            )
 
         # On-entry self-heal: if the adapter still has an _active_sessions
         # entry for this key but the owner task has already exited (done or

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2651,6 +2651,7 @@ _INTERRUPT_REASON_STOP = "Stop requested"
 _INTERRUPT_REASON_RESET = "Session reset requested"
 _INTERRUPT_REASON_TIMEOUT = "Execution timed out (inactivity)"
 _INTERRUPT_REASON_SSE_DISCONNECT = "SSE client disconnected"
+GATEWAY_SESSION_CANCEL_TIMEOUT_SECONDS = 2.0
 _INTERRUPT_REASON_GATEWAY_SHUTDOWN = "Gateway shutting down"
 _INTERRUPT_REASON_GATEWAY_RESTART = "Gateway restarting"
 
@@ -6214,6 +6215,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return True  # handled (silently dropped); do not fall through
 
+        # Busy ingress bypasses the cold _handle_message entry. Apply the
+        # existing pre-dispatch policy after authorization but before drain,
+        # approval, queue, steer, redirect, or interrupt effects. Mark it
+        # one-shot so a later queue fallback cannot invoke it twice.
+        if self._run_pre_gateway_dispatch(event):
+            return True
+
         # --- Draining case (gateway restarting/stopping) ---
         if self._draining:
             adapter = self._adapter_for_source(event.source)
@@ -6335,6 +6343,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # cascade after the current turn finishes.
         if getattr(event, "internal", False):
             return False
+
+        # Slash commands that are not in the adapter's immediate bypass set
+        # remain queued for canonical runner command interception. They are
+        # never ordinary participant-visible conversation ingress.
+        if event.is_command():
+            return False
+
+        if self._external_drain_active:
+            logger.info(
+                "Refusing busy-session follow-up for %s — external drain active.",
+                session_key,
+            )
+            reply_anchor = self._reply_anchor_for_event(event)
+            await adapter._send_with_retry(
+                chat_id=event.source.chat_id,
+                content=(
+                    "⏳ This agent is draining for a maintenance action and isn't "
+                    "accepting new turns right now. It'll be back in a moment — "
+                    "please resend shortly."
+                ),
+                reply_to=reply_anchor,
+                metadata=self._thread_metadata_for_source(event.source, reply_anchor),
+            )
+            return True
+
+        # Real busy-session ingress returns from BasePlatformAdapter after this
+        # handler. Invoke the post-authorization participant seam before any
+        # host queue, steer, redirect, or interrupt effect so ordinary live
+        # follow-ups are neither invisible nor duplicated.
+        if await self._run_gateway_message_hook(event, event.source, session_key):
+            return True
 
         running_agent = self._running_agents.get(session_key)
 
@@ -7590,10 +7629,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     getattr(getattr(source, "platform", None), "value", None),
                 )
                 continue
-            # Mark this replay so _handle_message does not queue it again while
-            # the restore gate remains closed for any fresh inbound arrivals.
+            # This is accepted live ingress, not recovery replay. Mark it only
+            # to bypass this still-closed startup gate; participant and ordinary
+            # dispatch must both see it exactly once.
             try:
-                setattr(event, "_hermes_startup_restore_replay", True)
+                setattr(event, "_hermes_startup_restore_queued_live", True)
             except Exception:
                 pass
             await adapter.handle_message(event)
@@ -9823,6 +9863,41 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             self._running = False
             self._draining = True
+            # Revoke route capabilities synchronously before awaiting any
+            # plugin or adapter code. Async shutdown hooks may persist/cancel
+            # plugin-owned work, but cannot use a retained delivery meanwhile.
+            _revoke_deliveries = getattr(
+                self,
+                "_revoke_all_gateway_deliveries",
+                None,
+            )
+            if callable(_revoke_deliveries):
+                _revoke_deliveries()
+            try:
+                from hermes_cli.plugins import invoke_hook_async as _invoke_hook_async
+
+                await _invoke_hook_async(
+                    "gateway_shutdown",
+                    reason="restart" if restart else "stop",
+                    raise_exceptions=False,
+                    offload_sync=True,
+                )
+            except Exception:
+                logger.exception("gateway_shutdown lifecycle hook failed")
+            # Shutdown acceptance closes only after every retained participant
+            # delivery is invalid AND every native invocation that already
+            # won the race has settled, including sessions with no currently
+            # running host agent. Already-started adapter work is not cancelled:
+            # cancellation is not proof that an external effect was aborted.
+            _revoke_and_settle = getattr(
+                self,
+                "_revoke_all_gateway_deliveries_and_settle",
+                None,
+            )
+            if callable(_revoke_and_settle):
+                await _revoke_and_settle()
+            elif callable(_revoke_deliveries):
+                _revoke_deliveries()
 
             stop_watchdog = getattr(self, "_stop_systemd_watchdog", None)
             if callable(stop_watchdog):
@@ -10992,6 +11067,68 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         return switched
 
+    def _run_pre_gateway_dispatch(self, event: MessageEvent) -> bool:
+        """Apply legacy pre-dispatch only when no V2 message seam is active."""
+        marker = "_hermes_pre_gateway_dispatch_done"
+        if getattr(event, marker, False):
+            return False
+        setattr(event, marker, True)
+        if (
+            getattr(event, "_hermes_startup_restore_replay", False)
+            or getattr(event, "_hermes_historical_replay", False)
+        ):
+            return False
+        try:
+            from hermes_cli.plugins import has_hook as _has_hook
+
+            if _has_hook("gateway_message") and _has_hook("pre_gateway_dispatch"):
+                logger.error(
+                    "Refusing ordinary ingress: gateway_message conflicts with "
+                    "legacy pre_gateway_dispatch"
+                )
+                return True
+        except Exception:
+            # Hook-registry uncertainty cannot authorize a legacy behavior-changing
+            # path in front of participant-owned attention.
+            logger.exception("Could not verify gateway-message hook isolation")
+            return True
+        try:
+            from hermes_cli.lifecycle import invoke_hook as _invoke_hook
+
+            hook_results = _invoke_hook(
+                "pre_gateway_dispatch",
+                event=event,
+                gateway=self,
+                # Bare-runner tests and partially initialized gateways may not
+                # have attached a store yet; the legacy hook still has to run.
+                session_store=getattr(self, "session_store", None),
+            )
+        except Exception as hook_exc:
+            logger.warning("pre_gateway_dispatch invocation failed: %s", hook_exc)
+            hook_results = []
+
+        for result in hook_results:
+            if not isinstance(result, dict):
+                continue
+            action = result.get("action")
+            if action == "skip":
+                source = event.source
+                logger.info(
+                    "pre_gateway_dispatch skip: reason=%s platform=%s chat=%s",
+                    result.get("reason"),
+                    source.platform.value if source.platform else "unknown",
+                    source.chat_id or "unknown",
+                )
+                return True
+            if action == "rewrite":
+                new_text = result.get("text")
+                if isinstance(new_text, str):
+                    event.text = new_text
+                break
+            if action == "allow":
+                break
+        return False
+
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """
         Handle an incoming message from any platform.
@@ -11051,6 +11188,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             getattr(self, "_startup_restore_in_progress", False)
             and not is_internal
             and not getattr(event, "_hermes_startup_restore_replay", False)
+            and not getattr(event, "_hermes_startup_restore_queued_live", False)
         ):
             self._queue_startup_restore_event(event)
             return None
@@ -11063,49 +11201,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not is_internal:
             self._scale_to_zero_note_real_inbound()
 
-        # Fire pre_gateway_dispatch plugin hook for user-originated messages.
-        # Plugins receive the MessageEvent and may return a dict influencing flow:
-        #   {"action": "skip",    "reason": ...}    -> drop (no reply, plugin handled)
-        #   {"action": "rewrite", "text":  ...}     -> replace event.text, continue
-        #   {"action": "allow"}   /   None          -> normal dispatch
-        # Hook runs BEFORE auth so plugins can handle unauthorized senders
-        # (e.g. customer handover ingest) without triggering the pairing flow.
-        if not is_internal:
-            try:
-                from hermes_cli.lifecycle import invoke_hook as _invoke_hook
-                _hook_results = _invoke_hook(
-                    "pre_gateway_dispatch",
-                    event=event,
-                    gateway=self,
-                    # getattr: bare-runner tests build GatewayRunner via
-                    # object.__new__ without __init__ (pitfall #17), and the
-                    # hook must not fail dispatch over a missing attribute.
-                    session_store=getattr(self, "session_store", None),
-                )
-            except Exception as _hook_exc:
-                logger.warning("pre_gateway_dispatch invocation failed: %s", _hook_exc)
-                _hook_results = []
-
-            for _result in _hook_results:
-                if not isinstance(_result, dict):
-                    continue
-                _action = _result.get("action")
-                if _action == "skip":
-                    logger.info(
-                        "pre_gateway_dispatch skip: reason=%s platform=%s chat=%s",
-                        _result.get("reason"),
-                        source.platform.value if source.platform else "unknown",
-                        source.chat_id or "unknown",
-                    )
-                    return None
-                if _action == "rewrite":
-                    _new_text = _result.get("text")
-                    if isinstance(_new_text, str):
-                        event = dataclasses.replace(event, text=_new_text)
-                        source = event.source
-                    break
-                if _action == "allow":
-                    break
+        # Apply the legacy user-ingress policy exactly once. Busy ingress may
+        # already have passed through this seam in BasePlatformAdapter.
+        if not is_internal and self._run_pre_gateway_dispatch(event):
+            return None
 
         if is_internal:
             pass
@@ -11160,6 +11259,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # Record rate limit so subsequent messages are silently ignored
                     self.pairing_store._record_rate_limit(platform_name, source.user_id)
             return None
+
+        # Resolve Telegram topic-mode routing before deriving the session key or
+        # exposing the immutable post-authorization plugin route. A stale or
+        # foreign thread ID must not escape through a route-bound capability.
+        recovered = None
+        if not event.is_command():
+            recovered = await asyncio.to_thread(
+                self._recover_telegram_topic_thread_id,
+                source,
+            )
+        if recovered is not None:
+            logger.info(
+                "telegram topic recovery: chat=%s user=%s %r -> %s",
+                source.chat_id,
+                source.user_id,
+                source.thread_id,
+                recovered,
+            )
+            source = dataclasses.replace(source, thread_id=recovered)
+            event = dataclasses.replace(event, source=source)
         
         # Intercept messages that are responses to a pending /update prompt.
         # The update process (detached) wrote .update_prompt.json; the watcher
@@ -11451,6 +11570,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # _interrupt_requested.  Force-clean _running_agents so the session
             # is unlocked and subsequent messages are processed normally.
             if _cmd_def_inner and _cmd_def_inner.name == "stop":
+                await self._notify_gateway_session_cancel(
+                    _quick_key,
+                    source,
+                    reason="stop",
+                )
                 await self._interrupt_and_clear_session(
                     _quick_key,
                     source,
@@ -11468,6 +11592,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # doesn't get re-processed as a user message after the
             # interrupt completes.
             if _cmd_def_inner and _cmd_def_inner.name == "new":
+                # Notify plugin-owned work before the hard host interruption.
+                # The reset handler is told not to emit the same boundary twice.
+                await self._notify_gateway_session_cancel(
+                    _quick_key,
+                    source,
+                    reason="reset",
+                )
                 # Clear any pending messages so the old text doesn't replay
                 await self._interrupt_and_clear_session(
                     _quick_key,
@@ -11477,7 +11608,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 # Clean up the running agent entry so the reset handler
                 # doesn't think an agent is still active.
-                return await self._handle_reset_command(event)
+                return await self._handle_reset_command(event, cancel_notified=True)
 
             # /queue <prompt> — queue without interrupting.
             # Semantics: each /queue invocation produces its own full agent
@@ -11678,6 +11809,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"mid-turn. Wait for the current response or `/stop` first."
                 )
 
+            # Ordinary user messages reach the plugin seam only after access
+            # checks and every active-session control intercept above. During
+            # shutdown draining, no participant hook may create side effects.
+            if self._draining:
+                if self._queue_during_drain_enabled():
+                    self._queue_or_replace_pending_event(_quick_key, event)
+                return (
+                    f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
+                    if self._queue_during_drain_enabled()
+                    else f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
+                )
+            if (
+                not is_internal
+                and not event.is_command()
+                and await self._run_gateway_message_hook(event, source, _quick_key)
+            ):
+                return None
+
             if event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key)
                 adapter = self._adapter_for_source(source)
@@ -11733,14 +11882,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         merge_text=True,
                     )
                 return None
-            if self._draining:
-                if self._queue_during_drain_enabled():
-                    self._queue_or_replace_pending_event(_quick_key, event)
-                return (
-                    f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
-                    if self._queue_during_drain_enabled()
-                    else f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
-                )
             if self._busy_input_mode == "queue":
                 logger.debug("PRIORITY queue follow-up for session %s", _quick_key)
                 self._queue_or_replace_pending_event(_quick_key, event)
@@ -12568,6 +12709,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _run_generation = self._begin_session_run_generation(_quick_key)
 
         try:
+            # This is the cold-session counterpart to the active-session seam.
+            # Claim before awaiting a plugin so a pass-through hook cannot
+            # reopen the duplicate-agent race protected by the sentinel.
+            if (
+                not is_internal
+                and not event.is_command()
+                and await self._run_gateway_message_hook(event, source, _quick_key)
+            ):
+                return None
             _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
             # Goal continuation: after the agent returns a final response
             # for this turn, check any standing /goal — the judge will
@@ -13153,6 +13303,464 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
         return source
 
+    def _source_for_session_cancel(
+        self,
+        session_key: str,
+        fallback: SessionSource,
+    ) -> SessionSource:
+        """Recover the target route identity for a session cancellation."""
+        cached = self._get_cached_session_source(session_key)
+        if cached is not None:
+            return cached
+        thread_id = str(fallback.thread_id or "")
+        marker = f":{thread_id}:" if thread_id else ""
+        if marker and marker in session_key:
+            target_user = session_key.rsplit(marker, 1)[-1]
+            if target_user and ":" not in target_user:
+                return dataclasses.replace(
+                    fallback,
+                    user_id=target_user,
+                    user_id_alt=None,
+                )
+        return fallback
+
+    async def _run_gateway_message_hook(
+        self,
+        event: MessageEvent,
+        source: SessionSource,
+        session_key: str,
+    ) -> bool:
+        """Run ordinary-message hooks in the route's profile scope.
+
+        Platform adapters may batch adjacent native messages for the host agent.
+        The participant seam expands retained native snapshots so event IDs,
+        route actors, and mention facts remain attributable to each native event.
+        """
+        if getattr(event, "_hermes_startup_restore_replay", False) or getattr(
+            event,
+            "_hermes_historical_replay",
+            False,
+        ):
+            # Recovery is context-only.  Returning True terminally consumes the
+            # replay at both cold and busy call sites; False would bypass only
+            # participant hooks and fall through to the ordinary Hermes agent.
+            return True
+
+        async def _run_scoped() -> bool:
+            native_events = event.metadata.get("_gateway_native_events", ())
+            if native_events:
+                if not isinstance(native_events, tuple) or not all(
+                    isinstance(item, MessageEvent) for item in native_events
+                ):
+                    logger.warning(
+                        "invalid native-event batch metadata; suppressing normal dispatch"
+                    )
+                    return True
+                suppressed = False
+                for native_event in native_events:
+                    # Continue through the entire batch even after one terminal
+                    # result so no authorized native identity disappears.
+                    suppressed = (
+                        await self._run_gateway_message_hook_scoped(
+                            native_event,
+                            native_event.source,
+                            session_key,
+                        )
+                        or suppressed
+                    )
+                return suppressed
+            return await self._run_gateway_message_hook_scoped(
+                event,
+                source,
+                session_key,
+            )
+
+        if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            profile_home = self._resolve_profile_home_for_source(source)
+            with _profile_runtime_scope(profile_home):
+                return await _run_scoped()
+        return await _run_scoped()
+
+    async def _run_gateway_message_hook_scoped(
+        self,
+        event: MessageEvent,
+        source: SessionSource,
+        session_key: str,
+    ) -> bool:
+        """Return True when an ordinary user-message hook suppresses dispatch."""
+        result_marker = "_hermes_gateway_message_hook_result"
+        prior_result = getattr(event, result_marker, None)
+        if prior_result == "suppress":
+            return True
+        if prior_result == "continue":
+            return False
+        if prior_result == "pending":
+            # The same mutable host event must never enter participant hooks
+            # concurrently. Fail closed until its first invocation resolves.
+            return True
+
+        def _finish(suppress: bool) -> bool:
+            setattr(event, result_marker, "suppress" if suppress else "continue")
+            return suppress
+
+        from gateway.message_hooks import (
+            GatewayDelivery,
+            GatewayMessageEvent,
+            GatewayMessageRoute,
+        )
+        from gateway.platforms.base import SendResult
+        from hermes_cli.plugins import invoke_hook_async
+
+        adapter = self._adapter_for_source(source)
+        delivery_platform = source.platform
+        delivery_chat_id = str(source.chat_id)
+        delivery_room_id = delivery_chat_id
+        if delivery_platform == Platform.TELEGRAM and source.thread_id is not None:
+            delivery_thread_id = str(source.thread_id)
+            if delivery_thread_id:
+                delivery_room_id = f"{delivery_chat_id}:topic:{delivery_thread_id}"
+        delivery_message_id = str(event.message_id or "")
+        delivery_metadata = self._thread_metadata_for_source(source, event.message_id)
+        if delivery_room_id != delivery_chat_id:
+            delivery_metadata = dict(delivery_metadata or {})
+            delivery_metadata["_hermes_require_topic_route"] = True
+        delivery_via_relay = (
+            getattr(source, "delivered_via_upstream_relay", False) is True
+        )
+        delivery_profile = str(getattr(source, "profile", None) or "")
+        if not delivery_profile:
+            from hermes_cli.profiles import get_active_profile_name
+
+            delivery_profile = str(get_active_profile_name())
+        authenticated_actor: Optional[str] = None
+        actor_identity: Any = getattr(adapter, "authenticated_actor_id", None)
+        if callable(actor_identity):
+            try:
+                authenticated_actor = str(actor_identity() or "") or None
+            except Exception:
+                authenticated_actor = None
+        if delivery_via_relay:
+            delivery_metadata = dict(delivery_metadata or {})
+            if source.scope_id:
+                delivery_metadata["scope_id"] = str(source.scope_id)
+            if source.user_id:
+                delivery_metadata["user_id"] = str(source.user_id)
+
+        async def _send_to_source(content: str):
+            if adapter is None:
+                return SendResult(success=False)
+            metadata = dict(delivery_metadata) if delivery_metadata else None
+            if delivery_via_relay:
+                send_for_platform: Any = getattr(adapter, "send_for_platform", None)
+                if not callable(send_for_platform):
+                    return SendResult(success=False)
+                return await send_for_platform(
+                    delivery_platform,
+                    delivery_chat_id,
+                    content,
+                    metadata=metadata,
+                )
+            return await adapter.send(
+                delivery_chat_id,
+                content,
+                metadata=metadata,
+            )
+
+        async def _reply_to_source(content: str):
+            if adapter is None or not delivery_message_id:
+                return SendResult(success=False)
+            metadata = dict(delivery_metadata) if delivery_metadata else None
+            if delivery_via_relay:
+                send_for_platform: Any = getattr(adapter, "send_for_platform", None)
+                if not callable(send_for_platform):
+                    return SendResult(success=False)
+                return await send_for_platform(
+                    delivery_platform,
+                    delivery_chat_id,
+                    content,
+                    reply_to=delivery_message_id,
+                    metadata=metadata,
+                )
+            return await adapter.send(
+                delivery_chat_id,
+                content,
+                reply_to=delivery_message_id,
+                metadata=metadata,
+            )
+
+        async def _react_to_source(reaction: str, operation: str):
+            if adapter is None or delivery_via_relay or not delivery_message_id:
+                return SendResult(success=False)
+            react: Any = getattr(adapter, "react", None)
+            if not callable(react):
+                return SendResult(success=False)
+            if delivery_platform == Platform.TELEGRAM:
+                metadata = dict(delivery_metadata) if delivery_metadata else None
+                return await react(
+                    delivery_chat_id,
+                    delivery_message_id,
+                    reaction,
+                    operation=operation,
+                    metadata=metadata,
+                )
+            return await react(
+                delivery_chat_id,
+                delivery_message_id,
+                reaction,
+                operation=operation,
+            )
+
+        def _stop_after_terminal_result(result: Any) -> bool:
+            if not isinstance(result, dict):
+                return True
+            decision = str(result.get("decision", "")).strip().lower()
+            return decision not in {"continue", "pass"}
+
+        # Register each ordinary event's immutable route capability separately.
+        # New ingress may replace the scheduler's newest pending anchor, but it
+        # does not cancel an already-active participant turn.  Capabilities are
+        # revoked only by consumption, expiry, or an explicit session boundary.
+        delivery = GatewayDelivery(
+            _send_to_source,
+            reply_callback=_reply_to_source,
+            react_callback=_react_to_source,
+            platform=str(getattr(delivery_platform, "value", delivery_platform)),
+            room_id=delivery_room_id,
+            profile=delivery_profile,
+            self_actor_id=authenticated_actor,
+            source_message_id=delivery_message_id or None,
+        )
+        self._register_gateway_delivery(session_key, delivery)
+        setattr(event, result_marker, "pending")
+        try:
+            results = await invoke_hook_async(
+                "gateway_message",
+                event=GatewayMessageEvent.from_event(event),
+                route=GatewayMessageRoute.from_source(
+                    source,
+                    session_key=session_key,
+                ),
+                delivery=delivery,
+                raise_exceptions=True,
+                stop_when=_stop_after_terminal_result,
+            )
+        except asyncio.CancelledError:
+            await delivery._settle_revocation()
+            if getattr(event, result_marker, None) == "pending":
+                delattr(event, result_marker)
+            raise
+        except Exception as exc:
+            await delivery._settle_revocation()
+            logger.warning(
+                "gateway_message hook failed; suppressing normal dispatch (%s)",
+                type(exc).__name__,
+            )
+            return _finish(True)
+
+        for result in results:
+            if not isinstance(result, dict):
+                await delivery._settle_revocation()
+                logger.warning(
+                    "gateway_message hook returned invalid terminal result type %s; "
+                    "suppressing normal dispatch",
+                    type(result).__name__,
+                )
+                return _finish(True)
+            decision = str(result.get("decision", "")).strip().lower()
+            if decision in {"handled", "suppress"}:
+                return _finish(True)
+            if decision in {"continue", "pass"}:
+                continue
+            await delivery._settle_revocation()
+            logger.warning(
+                "gateway_message hook returned an invalid decision; "
+                "suppressing normal dispatch"
+            )
+            return _finish(True)
+        await delivery._settle_revocation()
+        return _finish(False)
+
+    def _register_gateway_delivery(self, session_key: str, delivery: Any) -> None:
+        deliveries = getattr(self, "_gateway_deliveries_by_session", None)
+        if deliveries is None:
+            deliveries = {}
+            self._gateway_deliveries_by_session = deliveries
+        deliveries.setdefault(str(session_key), set()).add(delivery)
+
+    def _revoke_gateway_deliveries(self, session_key: str) -> None:
+        deliveries = getattr(self, "_gateway_deliveries_by_session", None)
+        if not deliveries:
+            return
+        for delivery in deliveries.pop(str(session_key), ()):
+            try:
+                delivery._revoke()
+            except Exception:
+                logger.debug("gateway delivery revocation failed", exc_info=True)
+
+    def _begin_revoking_gateway_deliveries(
+        self, session_key: str
+    ) -> "list[asyncio.Task[None]]":
+        """Synchronously invalidate one session's deliveries; return workers.
+
+        The returned workers own any native invocations that already won
+        the race against revocation. A lifecycle boundary must not be
+        considered returned until those workers settle.
+        """
+        deliveries = getattr(self, "_gateway_deliveries_by_session", None)
+        if not deliveries:
+            return []
+        workers: "list[asyncio.Task[None]]" = []
+        for delivery in deliveries.pop(str(session_key), ()):
+            try:
+                worker = delivery._begin_revocation()
+            except Exception:
+                logger.debug("gateway delivery revocation failed", exc_info=True)
+                continue
+            if worker is not None:
+                workers.append(worker)
+        return workers
+
+    def _begin_revoking_all_gateway_deliveries(self) -> "list[asyncio.Task[None]]":
+        deliveries = getattr(self, "_gateway_deliveries_by_session", None)
+        if not deliveries:
+            return []
+        workers: "list[asyncio.Task[None]]" = []
+        for session_key in tuple(deliveries):
+            workers.extend(self._begin_revoking_gateway_deliveries(session_key))
+        return workers
+
+    async def _await_gateway_delivery_settlement(
+        self, workers: "list[asyncio.Task[None]]"
+    ) -> None:
+        """Await in-flight native effects before a lifecycle boundary returns.
+
+        Each worker is awaited shielded so cancellation of the boundary
+        path itself cannot detach the settlement wait: a boundary never
+        returns while a native effect it revoked is still live. Cancellation
+        propagation is deferred across the whole worker collection, rather
+        than escaping after the first settled worker and abandoning later
+        effects. A worker that unwinds into this wait from its own callback
+        frame is skipped to avoid self-await deadlock.
+        """
+        if not workers:
+            return
+        from gateway.message_hooks import _await_delivery_settlement
+
+        owner = asyncio.current_task()
+        deferred_cancel = False
+        for worker in workers:
+            try:
+                await _await_delivery_settlement(worker, owner=owner)
+            except asyncio.CancelledError:
+                deferred_cancel = True
+            except Exception:
+                logger.debug(
+                    "gateway delivery settlement wait failed", exc_info=True
+                )
+        if deferred_cancel:
+            raise asyncio.CancelledError()
+
+    def _revoke_all_gateway_deliveries(self) -> None:
+        deliveries = getattr(self, "_gateway_deliveries_by_session", None)
+        if not deliveries:
+            return
+        for session_key in tuple(deliveries):
+            self._revoke_gateway_deliveries(session_key)
+
+    async def _revoke_all_gateway_deliveries_and_settle(self) -> None:
+        """Shutdown acceptance: invalidate every retained delivery, then wait.
+
+        Every retained participant delivery is invalid synchronously; any
+        native invocation that already won the race must settle before
+        shutdown acceptance returns, so no revoked effect can remain live
+        past the boundary.
+        """
+        workers = self._begin_revoking_all_gateway_deliveries()
+        await self._await_gateway_delivery_settlement(workers)
+
+    async def _revoke_gateway_deliveries_and_settle(
+        self, session_key: str
+    ) -> None:
+        """Invalidate one session's deliveries, then await in-flight effects."""
+        workers = self._begin_revoking_gateway_deliveries(session_key)
+        await self._await_gateway_delivery_settlement(workers)
+
+    async def _notify_gateway_session_cancel(
+        self,
+        session_key: str,
+        source: SessionSource,
+        *,
+        reason: str,
+    ) -> None:
+        """Invalidate effects, settle in-flight native calls, then notify.
+
+        Invalidation is authoritative and synchronous. The bounded plugin
+        observer below cannot delay it or keep a stale route capability
+        live. A native invocation that already won the race against
+        revocation is awaited before this boundary returns, even if the
+        third-party callback suppresses cancellation; only self-await from
+        inside the delivery callback frame skips the settlement wait.
+        """
+        from gateway.message_hooks import GatewayMessageRoute
+        from hermes_cli.plugins import invoke_hook_async
+
+        workers = self._begin_revoking_gateway_deliveries(session_key)
+        await self._await_gateway_delivery_settlement(workers)
+
+        async def _invoke_cancel_observer() -> None:
+            observer_task = asyncio.create_task(
+                invoke_hook_async(
+                    "gateway_session_cancel",
+                    route=GatewayMessageRoute.from_source(
+                        source,
+                        session_key=session_key,
+                    ),
+                    reason=str(reason),
+                    offload_callbacks=True,
+                )
+            )
+            try:
+                done, _pending = await asyncio.wait(
+                    {observer_task},
+                    timeout=GATEWAY_SESSION_CANCEL_TIMEOUT_SECONDS,
+                )
+            except asyncio.CancelledError:
+                observer_task.cancel()
+                observer_task.add_done_callback(consume_detached_task_result)
+                raise
+            if not done:
+                # asyncio.wait_for() cannot enforce a hard boundary when a
+                # third-party coroutine suppresses cancellation: it waits for
+                # cancellation cleanup forever. Leave the same-loop observer
+                # detached instead; delivery revocation above is already the
+                # authoritative stale-effect fence.
+                observer_task.add_done_callback(consume_detached_task_result)
+                raise TimeoutError
+            await observer_task
+
+        try:
+            if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+                profile_home = self._resolve_profile_home_for_source(source)
+                with _profile_runtime_scope(profile_home):
+                    await _invoke_cancel_observer()
+            else:
+                await _invoke_cancel_observer()
+        except asyncio.CancelledError:
+            raise
+        except TimeoutError:
+            logger.warning(
+                "gateway_session_cancel hook exceeded %.1fs for %s; "
+                "continuing the host session boundary",
+                GATEWAY_SESSION_CANCEL_TIMEOUT_SECONDS,
+                session_key,
+            )
+        except Exception as exc:
+            logger.warning(
+                "gateway_session_cancel hook failed for %s (%s)",
+                session_key,
+                type(exc).__name__,
+            )
+
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
@@ -13166,22 +13774,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             source.chat_id or "unknown", _msg_preview, _reply_id, _reply_txt,
         )
 
-        # Get or create session
-        # Topic-mode DMs: rewrite a stale/foreign thread_id to the user's
-        # last-active topic so a cross-topic Reply or stripped plain reply
-        # doesn't fragment the conversation across sessions.
-        recovered = await asyncio.to_thread(self._recover_telegram_topic_thread_id, source)
-        if recovered is not None:
-            logger.info(
-                "telegram topic recovery: chat=%s user=%s %r -> %s",
-                source.chat_id, source.user_id, source.thread_id, recovered,
-            )
-            source = dataclasses.replace(source, thread_id=recovered)
-            try:
-                event.source = source
-            except Exception:
-                pass
-
+        # Get or create session. Telegram topic-mode recovery has already run
+        # before the post-authorization hook and session-key derivation.
         session_entry = await self.async_session_store.get_or_create_session(source)
         session_key = session_entry.session_key
         pinned_session_id = str(
@@ -23425,6 +24019,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _interrupt_detected.set()
 
             if _inactivity_timeout:
+                # A timed-out turn is a session boundary for plugin-owned
+                # route capabilities: retained deliveries must be invalid
+                # before the timeout turn is considered returned, exactly as
+                # with an explicit stop/reset or shutdown. An in-flight
+                # native invocation that already won the race is awaited so
+                # its effect cannot remain live past this boundary.
+                if session_key:
+                    _timeout_workers = self._begin_revoking_gateway_deliveries(
+                        session_key
+                    )
+                    await self._await_gateway_delivery_settlement(
+                        _timeout_workers
+                    )
                 # Build a diagnostic summary from the agent's activity tracker.
                 _timed_out_agent = agent_holder[0]
                 _activity = {}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2652,6 +2652,7 @@ _INTERRUPT_REASON_RESET = "Session reset requested"
 _INTERRUPT_REASON_TIMEOUT = "Execution timed out (inactivity)"
 _INTERRUPT_REASON_SSE_DISCONNECT = "SSE client disconnected"
 GATEWAY_SESSION_CANCEL_TIMEOUT_SECONDS = 2.0
+GATEWAY_SESSION_CANCEL_DETACHED_LIMIT = 64
 _INTERRUPT_REASON_GATEWAY_SHUTDOWN = "Gateway shutting down"
 _INTERRUPT_REASON_GATEWAY_RESTART = "Gateway restarting"
 
@@ -11517,6 +11518,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _quick_key, _stale_age, _stale_idle,
                     _raw_stale_timeout, _stale_detail,
                 )
+                await self._notify_gateway_session_cancel(
+                    _quick_key,
+                    source,
+                    reason="stale_running_agent_eviction",
+                )
                 self._invalidate_session_run_generation(
                     _quick_key,
                     reason="stale_running_agent_eviction",
@@ -11820,12 +11826,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if self._queue_during_drain_enabled()
                     else f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
                 )
-            if (
-                not is_internal
-                and not event.is_command()
-                and await self._run_gateway_message_hook(event, source, _quick_key)
-            ):
-                return None
+            if not is_internal and not event.is_command():
+                if await self._run_gateway_message_hook(
+                    event, source, _quick_key
+                ):
+                    return None
+                # Mixed native batches may retain only a passed subset. Its
+                # first native event is now the authoritative dispatch source.
+                source = event.source
 
             if event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key)
@@ -12712,12 +12720,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # This is the cold-session counterpart to the active-session seam.
             # Claim before awaiting a plugin so a pass-through hook cannot
             # reopen the duplicate-agent race protected by the sentinel.
-            if (
-                not is_internal
-                and not event.is_command()
-                and await self._run_gateway_message_hook(event, source, _quick_key)
-            ):
-                return None
+            if not is_internal and not event.is_command():
+                if await self._run_gateway_message_hook(
+                    event, source, _quick_key
+                ):
+                    return None
+                # Mixed native batches may retain only a passed subset. Its
+                # first native event is now the authoritative dispatch source.
+                source = event.source
             _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
             # Goal continuation: after the agent returns a final response
             # for this turn, check any standing /goal — the judge will
@@ -13356,19 +13366,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "invalid native-event batch metadata; suppressing normal dispatch"
                     )
                     return True
-                suppressed = False
+                passed_events: list[MessageEvent] = []
                 for native_event in native_events:
                     # Continue through the entire batch even after one terminal
                     # result so no authorized native identity disappears.
-                    suppressed = (
-                        await self._run_gateway_message_hook_scoped(
-                            native_event,
-                            native_event.source,
-                            session_key,
-                        )
-                        or suppressed
+                    suppressed = await self._run_gateway_message_hook_scoped(
+                        native_event,
+                        native_event.source,
+                        session_key,
                     )
-                return suppressed
+                    if not suppressed:
+                        passed_events.append(native_event)
+                if not passed_events:
+                    return True
+                if len(passed_events) != len(native_events):
+                    self._replace_gateway_native_batch_for_dispatch(
+                        event,
+                        passed_events,
+                    )
+                return False
             return await self._run_gateway_message_hook_scoped(
                 event,
                 source,
@@ -13380,6 +13396,70 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             with _profile_runtime_scope(profile_home):
                 return await _run_scoped()
         return await _run_scoped()
+
+    @staticmethod
+    def _replace_gateway_native_batch_for_dispatch(
+        event: MessageEvent,
+        passed_events: "list[MessageEvent]",
+    ) -> None:
+        """Rewrite a host batch to the exact passed native subset, in order."""
+        first = passed_events[0]
+        event.text = "\n".join(
+            str(native.text or "")
+            for native in passed_events
+            if native.text
+        )
+        event.message_type = first.message_type
+        event.source = first.source
+        event.raw_message = first.raw_message
+        event.message_id = first.message_id
+        event.platform_update_id = first.platform_update_id
+        event.media_urls = [
+            item for native in passed_events for item in native.media_urls
+        ]
+        event.media_types = [
+            item for native in passed_events for item in native.media_types
+        ]
+        event.reply_to_message_id = first.reply_to_message_id
+        event.reply_to_text = first.reply_to_text
+        event.reply_to_author_id = first.reply_to_author_id
+        event.reply_to_author_name = first.reply_to_author_name
+        event.reply_to_is_own_message = first.reply_to_is_own_message
+        event.prompt_response = first.prompt_response
+        event.auto_skill = first.auto_skill
+        event.channel_prompt = first.channel_prompt
+        event.channel_context = first.channel_context
+        event.internal = first.internal
+        event.timestamp = first.timestamp
+
+        # Rebuild metadata from the passed subset. Starting from the aggregate
+        # batch would preserve fields contributed only by a handled event.
+        metadata = dict(first.metadata)
+        metadata["_gateway_native_events"] = tuple(passed_events)
+        mentioned_ids: list[str] = []
+        seen_mentions: set[str] = set()
+        mentions_attested = True
+        mentions_room: Optional[bool] = False
+        for native in passed_events:
+            native_mentions = native.metadata.get("mentioned_user_ids")
+            if not isinstance(native_mentions, (list, tuple)):
+                mentions_attested = False
+            else:
+                for mentioned_id in native_mentions:
+                    value = str(mentioned_id)
+                    if value not in seen_mentions:
+                        seen_mentions.add(value)
+                        mentioned_ids.append(value)
+            native_mentions_room = native.metadata.get("mentions_room")
+            if not isinstance(native_mentions_room, bool):
+                mentions_room = None
+            elif mentions_room is not None:
+                mentions_room = mentions_room or native_mentions_room
+        metadata["mentioned_user_ids"] = (
+            tuple(mentioned_ids) if mentions_attested else None
+        )
+        metadata["mentions_room"] = mentions_room
+        event.metadata = metadata
 
     async def _run_gateway_message_hook_scoped(
         self,
@@ -13400,6 +13480,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return True
 
         def _finish(suppress: bool) -> bool:
+            delivery._release_participant_hold()
             setattr(event, result_marker, "suppress" if suppress else "continue")
             return suppress
 
@@ -13448,12 +13529,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         async def _send_to_source(content: str):
             if adapter is None:
-                return SendResult(success=False)
+                return SendResult(
+                    success=False,
+                    native_delivery_non_occurrence_attested=True,
+                )
             metadata = dict(delivery_metadata) if delivery_metadata else None
             if delivery_via_relay:
                 send_for_platform: Any = getattr(adapter, "send_for_platform", None)
                 if not callable(send_for_platform):
-                    return SendResult(success=False)
+                    return SendResult(
+                        success=False,
+                        native_delivery_non_occurrence_attested=True,
+                    )
                 return await send_for_platform(
                     delivery_platform,
                     delivery_chat_id,
@@ -13468,12 +13555,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         async def _reply_to_source(content: str):
             if adapter is None or not delivery_message_id:
-                return SendResult(success=False)
+                return SendResult(
+                    success=False,
+                    native_delivery_non_occurrence_attested=True,
+                )
             metadata = dict(delivery_metadata) if delivery_metadata else None
             if delivery_via_relay:
                 send_for_platform: Any = getattr(adapter, "send_for_platform", None)
                 if not callable(send_for_platform):
-                    return SendResult(success=False)
+                    return SendResult(
+                        success=False,
+                        native_delivery_non_occurrence_attested=True,
+                    )
                 return await send_for_platform(
                     delivery_platform,
                     delivery_chat_id,
@@ -13490,10 +13583,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         async def _react_to_source(reaction: str, operation: str):
             if adapter is None or delivery_via_relay or not delivery_message_id:
-                return SendResult(success=False)
+                return SendResult(
+                    success=False,
+                    native_delivery_non_occurrence_attested=True,
+                )
             react: Any = getattr(adapter, "react", None)
             if not callable(react):
-                return SendResult(success=False)
+                return SendResult(
+                    success=False,
+                    native_delivery_non_occurrence_attested=True,
+                )
             if delivery_platform == Platform.TELEGRAM:
                 metadata = dict(delivery_metadata) if delivery_metadata else None
                 return await react(
@@ -13529,6 +13628,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             profile=delivery_profile,
             self_actor_id=authenticated_actor,
             source_message_id=delivery_message_id or None,
+            on_terminal=lambda terminal_delivery: (
+                self._unregister_gateway_delivery(
+                    session_key,
+                    terminal_delivery,
+                )
+            ),
+            hold_until_participant_settled=True,
         )
         self._register_gateway_delivery(session_key, delivery)
         setattr(event, result_marker, "pending")
@@ -13585,17 +13691,102 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if deliveries is None:
             deliveries = {}
             self._gateway_deliveries_by_session = deliveries
-        deliveries.setdefault(str(session_key), set()).add(delivery)
+        key = str(session_key)
+        deliveries.setdefault(key, set()).add(delivery)
+        set_terminal_callback = getattr(
+            delivery,
+            "_set_terminal_callback",
+            None,
+        )
+        if callable(set_terminal_callback):
+            set_terminal_callback(
+                lambda terminal_delivery: self._unregister_gateway_delivery(
+                    key,
+                    terminal_delivery,
+                )
+            )
 
-    def _revoke_gateway_deliveries(self, session_key: str) -> None:
+    def _unregister_gateway_delivery(
+        self,
+        session_key: str,
+        delivery: Any,
+    ) -> None:
         deliveries = getattr(self, "_gateway_deliveries_by_session", None)
         if not deliveries:
             return
-        for delivery in deliveries.pop(str(session_key), ()):
-            try:
-                delivery._revoke()
-            except Exception:
-                logger.debug("gateway delivery revocation failed", exc_info=True)
+        key = str(session_key)
+        retained = deliveries.get(key)
+        if retained is None:
+            return
+        retained.discard(delivery)
+        if not retained:
+            deliveries.pop(key, None)
+
+    def _retain_gateway_delivery_workers(
+        self,
+        session_key: str,
+        workers: "list[asyncio.Task[None]]",
+    ) -> None:
+        if not workers:
+            return
+        retained_by_session = getattr(
+            self,
+            "_gateway_delivery_settlement_workers",
+            None,
+        )
+        if retained_by_session is None:
+            retained_by_session = {}
+            self._gateway_delivery_settlement_workers = retained_by_session
+        retained = retained_by_session.setdefault(str(session_key), set())
+        for worker in workers:
+            retained.add(worker)
+            worker.add_done_callback(
+                lambda done, key=str(session_key): (
+                    self._discard_gateway_delivery_worker(key, done)
+                )
+            )
+
+    def _discard_gateway_delivery_worker(
+        self,
+        session_key: str,
+        worker: "asyncio.Task[None]",
+    ) -> None:
+        retained_by_session = getattr(
+            self,
+            "_gateway_delivery_settlement_workers",
+            None,
+        )
+        if not retained_by_session:
+            return
+        retained = retained_by_session.get(str(session_key))
+        if retained is None:
+            return
+        retained.discard(worker)
+        if not retained:
+            retained_by_session.pop(str(session_key), None)
+
+    def _retained_gateway_delivery_workers(
+        self,
+        session_key: Optional[str] = None,
+    ) -> "list[asyncio.Task[None]]":
+        retained_by_session = getattr(
+            self,
+            "_gateway_delivery_settlement_workers",
+            None,
+        )
+        if not retained_by_session:
+            return []
+        if session_key is not None:
+            return list(retained_by_session.get(str(session_key), ()))
+        return [
+            worker
+            for retained in retained_by_session.values()
+            for worker in retained
+        ]
+
+    def _revoke_gateway_deliveries(self, session_key: str) -> None:
+        workers = self._begin_revoking_gateway_deliveries(session_key)
+        self._retain_gateway_delivery_workers(session_key, workers)
 
     def _begin_revoking_gateway_deliveries(
         self, session_key: str
@@ -13675,15 +13866,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         shutdown acceptance returns, so no revoked effect can remain live
         past the boundary.
         """
-        workers = self._begin_revoking_all_gateway_deliveries()
+        workers = self._retained_gateway_delivery_workers()
+        workers.extend(self._begin_revoking_all_gateway_deliveries())
         await self._await_gateway_delivery_settlement(workers)
 
     async def _revoke_gateway_deliveries_and_settle(
         self, session_key: str
     ) -> None:
         """Invalidate one session's deliveries, then await in-flight effects."""
-        workers = self._begin_revoking_gateway_deliveries(session_key)
+        workers = self._retained_gateway_delivery_workers(session_key)
+        workers.extend(self._begin_revoking_gateway_deliveries(session_key))
         await self._await_gateway_delivery_settlement(workers)
+
+    async def _handle_gateway_inactivity_boundary(
+        self,
+        session_key: str,
+        source: SessionSource,
+    ) -> None:
+        """Notify participant plugins before an inactive host session ends."""
+        await self._notify_gateway_session_cancel(
+            session_key,
+            source,
+            reason="inactivity_timeout",
+        )
 
     async def _notify_gateway_session_cancel(
         self,
@@ -13704,10 +13909,38 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         from gateway.message_hooks import GatewayMessageRoute
         from hermes_cli.plugins import invoke_hook_async
 
-        workers = self._begin_revoking_gateway_deliveries(session_key)
-        await self._await_gateway_delivery_settlement(workers)
+        await self._revoke_gateway_deliveries_and_settle(session_key)
 
         async def _invoke_cancel_observer() -> None:
+            observer_tasks = getattr(
+                self, "_gateway_cancel_observer_tasks", None
+            )
+            if observer_tasks is None:
+                observer_tasks = {}
+                self._gateway_cancel_observer_tasks = observer_tasks
+
+            for tracked_key, tracked_task in tuple(observer_tasks.items()):
+                if tracked_task.done():
+                    observer_tasks.pop(tracked_key, None)
+                    consume_detached_task_result(tracked_task)
+
+            existing = observer_tasks.get(session_key)
+            if existing is not None and not existing.done():
+                logger.warning(
+                    "gateway_session_cancel observer is still running for %s; "
+                    "suppressing duplicate lifecycle notification",
+                    session_key,
+                )
+                return
+            if len(observer_tasks) >= GATEWAY_SESSION_CANCEL_DETACHED_LIMIT:
+                logger.warning(
+                    "gateway_session_cancel detached observer limit (%d) "
+                    "reached; suppressing notification for %s",
+                    GATEWAY_SESSION_CANCEL_DETACHED_LIMIT,
+                    session_key,
+                )
+                return
+
             observer_task = asyncio.create_task(
                 invoke_hook_async(
                     "gateway_session_cancel",
@@ -13719,6 +13952,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     offload_callbacks=True,
                 )
             )
+            observer_tasks[session_key] = observer_task
+
+            def _forget_observer(task: asyncio.Task) -> None:
+                current = observer_tasks.get(session_key)
+                if current is task:
+                    observer_tasks.pop(session_key, None)
+                consume_detached_task_result(task)
+
+            observer_task.add_done_callback(_forget_observer)
             try:
                 done, _pending = await asyncio.wait(
                     {observer_task},
@@ -13726,15 +13968,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             except asyncio.CancelledError:
                 observer_task.cancel()
-                observer_task.add_done_callback(consume_detached_task_result)
                 raise
             if not done:
-                # asyncio.wait_for() cannot enforce a hard boundary when a
-                # third-party coroutine suppresses cancellation: it waits for
-                # cancellation cleanup forever. Leave the same-loop observer
-                # detached instead; delivery revocation above is already the
-                # authoritative stale-effect fence.
-                observer_task.add_done_callback(consume_detached_task_result)
+                # Request cancellation, then retain any callback that refuses
+                # to settle. The bounded registry above prevents repeated
+                # participant boundaries from leaking unbounded detached work.
+                observer_task.cancel()
                 raise TimeoutError
             await observer_task
 
@@ -24026,11 +24265,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # native invocation that already won the race is awaited so
                 # its effect cannot remain live past this boundary.
                 if session_key:
-                    _timeout_workers = self._begin_revoking_gateway_deliveries(
-                        session_key
-                    )
-                    await self._await_gateway_delivery_settlement(
-                        _timeout_workers
+                    await self._handle_gateway_inactivity_boundary(
+                        session_key,
+                        source,
                     )
                 # Build a diagnostic summary from the agent's activity tracker.
                 _timed_out_agent = agent_holder[0]

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -116,12 +116,23 @@ class GatewaySlashCommandsMixin:
         adapter = self.adapters.get(platform) if getattr(self, "adapters", None) else None
         return getattr(adapter, "typed_command_prefix", "/") if adapter is not None else "/"
 
-    async def _handle_reset_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
+    async def _handle_reset_command(
+        self,
+        event: MessageEvent,
+        *,
+        cancel_notified: bool = False,
+    ) -> Union[str, EphemeralReply]:
         """Handle /new or /reset command."""
         source = event.source
         
         # Get existing session key
         session_key = self._session_key_for_source(source)
+        if not cancel_notified:
+            await self._notify_gateway_session_cancel(
+                session_key,
+                source,
+                reason="reset",
+            )
         self._invalidate_session_run_generation(session_key, reason="session_reset")
         # Evict the running-agent slot now that the generation is bumped. The
         # in-flight run's own guarded release (run_generation=old) will return
@@ -1357,6 +1368,11 @@ class GatewaySlashCommandsMixin:
 
         agent = self._running_agents.get(session_key)
         if agent is _AGENT_PENDING_SENTINEL:
+            await self._notify_gateway_session_cancel(
+                session_key,
+                source,
+                reason="stop",
+            )
             # Force-clean the sentinel so the session is unlocked.
             await self._interrupt_and_clear_session(
                 session_key,
@@ -1367,6 +1383,11 @@ class GatewaySlashCommandsMixin:
             logger.info("STOP (pending) for session %s — sentinel cleared", session_key)
             return EphemeralReply(t("gateway.stop.stopped_pending"))
         if agent:
+            await self._notify_gateway_session_cancel(
+                session_key,
+                source,
+                reason="stop",
+            )
             # Force-clean the session lock so a truly hung agent doesn't
             # keep it locked forever.
             await self._interrupt_and_clear_session(
@@ -1385,6 +1406,23 @@ class GatewaySlashCommandsMixin:
         # agent(s) that share this thread, gated on authorization.
         sibling_keys = self._sibling_thread_run_keys(source, session_key)
         if sibling_keys and self._is_user_authorized(source):
+            cancel_routes = [(session_key, source)] + [
+                (
+                    sibling_key,
+                    self._source_for_session_cancel(sibling_key, source),
+                )
+                for sibling_key in sibling_keys
+            ]
+            await asyncio.gather(
+                *(
+                    self._notify_gateway_session_cancel(
+                        key,
+                        route_source,
+                        reason="stop",
+                    )
+                    for key, route_source in cancel_routes
+                )
+            )
             for sibling_key in sibling_keys:
                 await self._interrupt_and_clear_session(
                     sibling_key,
@@ -1399,6 +1437,12 @@ class GatewaySlashCommandsMixin:
                 ", ".join(sibling_keys),
             )
             return EphemeralReply(t("gateway.stop.stopped"))
+
+        await self._notify_gateway_session_cancel(
+            session_key,
+            source,
+            reason="stop",
+        )
 
         # No running agent anywhere for this scope. A platform status
         # indicator can still be stuck — e.g. Slack's persistent

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -47,7 +47,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Union
 
-from hermes_constants import GATEWAY_MESSAGE_HOOK_API_VERSION, get_hermes_home
+from hermes_constants import (
+    GATEWAY_MESSAGE_HOOK_API_VERSION,
+    PARTICIPANT_HOST_API_VERSION,
+    get_hermes_home,
+)
 from utils import env_var_enabled, fast_safe_load
 from hermes_cli.config import cfg_get
 from hermes_cli.middleware import OBSERVER_SCHEMA_VERSION, VALID_MIDDLEWARE
@@ -342,6 +346,7 @@ class LoadedPlugin:
     middleware_registered: List[str] = field(default_factory=list)
     commands_registered: List[str] = field(default_factory=list)
     enabled: bool = False
+    active: bool = False
     error: Optional[str] = None
     # True for a bundled platform plugin recorded as a deferred (not-yet-
     # imported) loader. The module loads on first real use via the
@@ -426,6 +431,11 @@ class PluginContext:
     def gateway_message_hook_api_version(self) -> int:
         """Return the semantic version of the immutable gateway-message hook API."""
         return GATEWAY_MESSAGE_HOOK_API_VERSION
+
+    @property
+    def participant_host_api_version(self) -> int:
+        """Return the independent major version of the participant host API."""
+        return PARTICIPANT_HOST_API_VERSION
 
     # -- tool registration --------------------------------------------------
 
@@ -1283,7 +1293,10 @@ class PluginContext:
 
 
 async def _invoke_hook_off_thread(
-    callback: Callable[..., Any], kwargs: Dict[str, Any]
+    callback: Callable[..., Any],
+    kwargs: Dict[str, Any],
+    *,
+    settle_after_cancel: bool = False,
 ) -> Any:
     """Invoke a synchronous hook in a disposable daemon thread.
 
@@ -1326,7 +1339,30 @@ async def _invoke_hook_off_thread(
         name="hermes-plugin-hook",
         daemon=True,
     ).start()
-    return await result_future
+    if not settle_after_cancel:
+        return await result_future
+
+    try:
+        return await asyncio.shield(result_future)
+    except asyncio.CancelledError:
+        # A gateway cancellation observer may be synchronous third-party code.
+        # Cancelling its asyncio wrapper cannot stop the daemon thread, so keep
+        # the wrapper pending until that work really exits. The gateway tracks
+        # these pending wrappers in a bounded registry and deduplicates future
+        # lifecycle events for the same participant session.
+        while not result_future.done():
+            try:
+                await asyncio.shield(result_future)
+            except asyncio.CancelledError:
+                continue
+        try:
+            detached_result = result_future.result()
+        except BaseException:
+            pass
+        else:
+            if inspect.iscoroutine(detached_result):
+                detached_result.close()
+        raise
 
 
 # ---------------------------------------------------------------------------
@@ -1850,13 +1886,42 @@ class PluginManager:
 
     def _load_plugin(self, manifest: PluginManifest) -> None:
         """Import a plugin module and call its ``register(ctx)`` function."""
-        loaded = LoadedPlugin(manifest=manifest)
+        loaded = LoadedPlugin(manifest=manifest, enabled=True)
         logger.debug(
             "Loading plugin '%s' (source=%s, kind=%s, path=%s)",
             manifest.key or manifest.name, manifest.source, manifest.kind, manifest.path,
         )
 
+        from gateway.platform_registry import platform_registry as _platform_registry
         from tools.registry import registry as _registry
+
+        manager_snapshot = {
+            "hooks": {key: list(value) for key, value in self._hooks.items()},
+            "middleware": {
+                key: list(value) for key, value in self._middleware.items()
+            },
+            "plugin_tool_names": set(self._plugin_tool_names),
+            "plugin_platform_names": set(self._plugin_platform_names),
+            "cli_commands": dict(self._cli_commands),
+            "context_engine": self._context_engine,
+            "plugin_commands": dict(self._plugin_commands),
+            "plugin_skills": dict(self._plugin_skills),
+            "aux_tasks": dict(self._aux_tasks),
+            "slack_action_handlers": list(self._slack_action_handlers),
+        }
+        with _registry._lock:
+            tool_snapshot = {
+                "tools": dict(_registry._tools),
+                "toolset_checks": dict(_registry._toolset_checks),
+                "toolset_aliases": dict(_registry._toolset_aliases),
+                "plugin_override_policy": dict(
+                    _registry._plugin_override_policy
+                ),
+            }
+        platform_snapshot = {
+            "entries": dict(_platform_registry._entries),
+            "deferred": dict(_platform_registry._deferred),
+        }
         _plugin_id = manifest.key or manifest.name
         _slug = _plugin_id.replace("/", "__").replace("-", "_")
         _registry.register_plugin_override_policy(
@@ -1874,8 +1939,7 @@ class PluginManager:
             # Call register()
             register_fn = getattr(module, "register", None)
             if register_fn is None:
-                loaded.error = "no register() function"
-                logger.warning("Plugin '%s' has no register() function", manifest.name)
+                raise AttributeError("no register() function")
             else:
                 ctx = PluginContext(manifest, self)
                 # Snapshot registry state BEFORE register() so each registry's
@@ -1912,6 +1976,7 @@ class PluginManager:
                     if self._plugin_commands[c].get("plugin") == manifest.name
                 ]
                 loaded.enabled = True
+                loaded.active = True
                 logger.debug(
                     "  registered: %d tool(s), %d hook(s), %d middleware, %d slash command(s), %d CLI command(s)",
                     len(loaded.tools_registered),
@@ -1925,6 +1990,30 @@ class PluginManager:
                 )
 
         except Exception as exc:
+            self._hooks = manager_snapshot["hooks"]
+            self._middleware = manager_snapshot["middleware"]
+            self._plugin_tool_names = manager_snapshot["plugin_tool_names"]
+            self._plugin_platform_names = manager_snapshot[
+                "plugin_platform_names"
+            ]
+            self._cli_commands = manager_snapshot["cli_commands"]
+            self._context_engine = manager_snapshot["context_engine"]
+            self._plugin_commands = manager_snapshot["plugin_commands"]
+            self._plugin_skills = manager_snapshot["plugin_skills"]
+            self._aux_tasks = manager_snapshot["aux_tasks"]
+            self._slack_action_handlers = manager_snapshot[
+                "slack_action_handlers"
+            ]
+            with _registry._lock:
+                _registry._tools = tool_snapshot["tools"]
+                _registry._toolset_checks = tool_snapshot["toolset_checks"]
+                _registry._toolset_aliases = tool_snapshot["toolset_aliases"]
+                _registry._plugin_override_policy = tool_snapshot[
+                    "plugin_override_policy"
+                ]
+                _registry._generation += 1
+            _platform_registry._entries = platform_snapshot["entries"]
+            _platform_registry._deferred = platform_snapshot["deferred"]
             loaded.error = str(exc)
             logger.warning(
                 "Failed to load plugin '%s': %s",
@@ -2054,7 +2143,11 @@ class PluginManager:
         for cb in callbacks:
             try:
                 ret = (
-                    await _invoke_hook_off_thread(cb, kwargs)
+                    await _invoke_hook_off_thread(
+                        cb,
+                        kwargs,
+                        settle_after_cancel=offload_callbacks,
+                    )
                     if (offload_callbacks or offload_sync)
                     and not inspect.iscoroutinefunction(cb)
                     else cb(**kwargs)
@@ -2142,6 +2235,18 @@ class PluginManager:
                     "description": loaded.manifest.description,
                     "source": loaded.manifest.source,
                     "enabled": loaded.enabled,
+                    "active": loaded.active,
+                    "status": (
+                        "error"
+                        if loaded.enabled and loaded.error
+                        else "active"
+                        if loaded.active
+                        else "deferred"
+                        if loaded.enabled and loaded.deferred
+                        else "inactive"
+                        if loaded.enabled
+                        else "disabled"
+                    ),
                     "tools": len(loaded.tools_registered),
                     "hooks": len(loaded.hooks_registered),
                     "middleware": len(loaded.middleware_registered),

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -42,11 +42,12 @@ import os
 import sys
 import threading
 import types
+from contextvars import copy_context
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Union
 
-from hermes_constants import get_hermes_home
+from hermes_constants import GATEWAY_MESSAGE_HOOK_API_VERSION, get_hermes_home
 from utils import env_var_enabled, fast_safe_load
 from hermes_cli.config import cfg_get
 from hermes_cli.middleware import OBSERVER_SCHEMA_VERSION, VALID_MIDDLEWARE
@@ -74,6 +75,10 @@ class PluginToolOverrideError(PermissionError):
     """Raised when a plugin attempts to override a built-in tool without
     operator opt-in via ``plugins.entries.<plugin_id>.allow_tool_override``.
     """
+
+
+class PluginHookConflictError(RuntimeError):
+    """Raised when mutually exclusive behavior-changing hooks coexist."""
 
 
 logger = logging.getLogger(__name__)
@@ -171,6 +176,18 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Ordinary user-message interception after user access and gateway control
+    # handling, before either cold or busy-session agent behavior. Callbacks
+    # receive only immutable normalized event/route snapshots plus a route-bound
+    # delivery capability. Decisions: handled/suppress or continue/pass.
+    "gateway_message",
+    # Best-effort notification when a user explicitly cancels or resets a
+    # gateway session. Async plugin-owned work can stop at the same boundary.
+    "gateway_session_cancel",
+    # Awaited host lifecycle fence fired after route-delivery revocation and
+    # before adapter teardown. Sync and async callbacks may invalidate and
+    # persist plugin-owned work; returns are ignored.
+    "gateway_shutdown",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs an approval decision -- fires for CLI-interactive prompts,
     # gateway/ACP approvals, and smart-mode auxiliary-LLM decisions.
@@ -404,6 +421,11 @@ class PluginContext:
             return get_active_profile_name()
         except Exception:
             return "default"
+
+    @property
+    def gateway_message_hook_api_version(self) -> int:
+        """Return the semantic version of the immutable gateway-message hook API."""
+        return GATEWAY_MESSAGE_HOOK_API_VERSION
 
     # -- tool registration --------------------------------------------------
 
@@ -1260,6 +1282,53 @@ class PluginContext:
         )
 
 
+async def _invoke_hook_off_thread(
+    callback: Callable[..., Any], kwargs: Dict[str, Any]
+) -> Any:
+    """Invoke a synchronous hook in a disposable daemon thread.
+
+    Cancellation observers are advisory and may be third-party code. A daemon
+    thread keeps a stuck synchronous callback from blocking the event loop,
+    consuming the shared asyncio executor indefinitely, or preventing process
+    shutdown. Awaitables returned by a synchronous wrapper are handed back to
+    the gateway loop; they are never awaited on a foreign event loop.
+    """
+
+    loop = asyncio.get_running_loop()
+    result_future = loop.create_future()
+
+    def publish_result(result: Any = None, error: BaseException | None = None) -> None:
+        if result_future.done():
+            return
+        if error is not None:
+            result_future.set_exception(error)
+        else:
+            result_future.set_result(result)
+
+    def run() -> None:
+        try:
+            result = callback(**kwargs)
+        except BaseException as exc:
+            try:
+                loop.call_soon_threadsafe(publish_result, None, exc)
+            except RuntimeError:
+                return
+        else:
+            try:
+                loop.call_soon_threadsafe(publish_result, result, None)
+            except RuntimeError:
+                return
+
+    callback_context = copy_context()
+    threading.Thread(
+        target=callback_context.run,
+        args=(run,),
+        name="hermes-plugin-hook",
+        daemon=True,
+    ).start()
+    return await result_future
+
+
 # ---------------------------------------------------------------------------
 # PluginManager
 # ---------------------------------------------------------------------------
@@ -1294,6 +1363,16 @@ class PluginManager:
     # -----------------------------------------------------------------------
     # Public
     # -----------------------------------------------------------------------
+
+    def validate_hook_configuration(self) -> None:
+        """Reject incompatible behavior-changing ingress hooks deterministically."""
+        if self._hooks.get("gateway_message") and self._hooks.get(
+            "pre_gateway_dispatch"
+        ):
+            raise PluginHookConflictError(
+                "gateway_message and pre_gateway_dispatch are mutually exclusive; "
+                "disable one plugin before starting the gateway"
+            )
 
     def discover_and_load(self, force: bool = False) -> None:
         """Scan all plugin sources and load each plugin found.
@@ -1486,6 +1565,11 @@ class PluginManager:
                 )
                 continue
             self._load_plugin(manifest)
+
+        # This is a configuration error, not an ingress-time policy decision.
+        # Validate after the complete sweep so plugin discovery order cannot
+        # decide which behavior-changing hook silently wins.
+        self.validate_hook_configuration()
 
         if manifests:
             logger.info(
@@ -1945,6 +2029,55 @@ class PluginManager:
                 )
         return results
 
+    async def invoke_hook_async(
+        self,
+        hook_name: str,
+        *,
+        raise_exceptions: bool = False,
+        stop_when: Optional[Callable[[Any], bool]] = None,
+        offload_sync: bool = False,
+        offload_callbacks: bool = False,
+        **kwargs: Any,
+    ) -> List[Any]:
+        """Await sync or async callbacks registered for *hook_name*.
+
+        Callback failures are isolated by default, matching :meth:`invoke_hook`.
+        Decision-style callers may request fail-fast behavior with
+        ``raise_exceptions=True``. Task cancellation always propagates.
+        ``offload_callbacks=True`` moves synchronous callback invocation to a
+        context-preserving disposable daemon thread so advisory hooks can be
+        abandoned by a hard host timeout. Async callbacks and awaitables
+        returned by sync wrappers always run on the caller's event loop.
+        """
+        callbacks = self._hooks.get(hook_name, [])
+        results: List[Any] = []
+        for cb in callbacks:
+            try:
+                ret = (
+                    await _invoke_hook_off_thread(cb, kwargs)
+                    if (offload_callbacks or offload_sync)
+                    and not inspect.iscoroutinefunction(cb)
+                    else cb(**kwargs)
+                )
+                if inspect.isawaitable(ret):
+                    ret = await ret
+                if ret is not None:
+                    results.append(ret)
+                    if stop_when is not None and stop_when(ret):
+                        break
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning(
+                    "Async hook '%s' callback %s raised: %s",
+                    hook_name,
+                    getattr(cb, "__name__", repr(cb)),
+                    exc,
+                )
+                if raise_exceptions:
+                    raise
+        return results
+
     def has_hook(self, hook_name: str) -> bool:
         """Return True when at least one callback is registered for a hook."""
         return bool(self._hooks.get(hook_name))
@@ -2071,6 +2204,26 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     Returns a list of non-``None`` return values from plugin callbacks.
     """
     return get_plugin_manager().invoke_hook(hook_name, **kwargs)
+
+
+async def invoke_hook_async(
+    hook_name: str,
+    *,
+    raise_exceptions: bool = False,
+    stop_when: Optional[Callable[[Any], bool]] = None,
+    offload_sync: bool = False,
+    offload_callbacks: bool = False,
+    **kwargs: Any,
+) -> List[Any]:
+    """Invoke sync or async lifecycle-hook callbacks and await completion."""
+    return await get_plugin_manager().invoke_hook_async(
+        hook_name,
+        raise_exceptions=raise_exceptions,
+        stop_when=stop_when,
+        offload_sync=offload_sync,
+        offload_callbacks=offload_callbacks,
+        **kwargs,
+    )
 
 
 def invoke_middleware(kind: str, **kwargs: Any) -> List[Any]:

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1130,6 +1130,44 @@ def _filter_plugin_entries(entries: list, args: Any, enabled: set, disabled: set
     return filtered
 
 
+def _get_runtime_plugin_states() -> dict[str, dict[str, Any]]:
+    """Load enabled plugins and return installer-facing activation state."""
+    from hermes_cli.plugins import get_plugin_manager
+
+    manager = get_plugin_manager()
+    try:
+        manager.discover_and_load()
+    except Exception:
+        # Individual registration failures are isolated by PluginManager.
+        # Keep the status command usable even if a broader discovery/config
+        # error occurs, and expose every state the manager did collect.
+        logger.warning("Plugin runtime discovery failed during status", exc_info=True)
+
+    states: dict[str, dict[str, Any]] = {}
+    for state in manager.list_plugins():
+        states[str(state["key"])] = state
+        states.setdefault(str(state["name"]), state)
+    return states
+
+
+def _plugin_runtime_fields(
+    name: str,
+    key: str,
+    configured_status: str,
+    runtime_states: dict[str, dict[str, Any]],
+) -> tuple[bool, str, Optional[str]]:
+    if configured_status != "enabled":
+        return False, "disabled", None
+    state = runtime_states.get(key) or runtime_states.get(name)
+    if state is None:
+        return False, "inactive", None
+    return (
+        bool(state.get("active")),
+        str(state.get("status") or "inactive"),
+        str(state["error"]) if state.get("error") else None,
+    )
+
+
 def cmd_list(args: Any | None = None) -> None:
     """List all plugins (bundled + user) with enabled/disabled state."""
     from rich.console import Console
@@ -1145,25 +1183,40 @@ def cmd_list(args: Any | None = None) -> None:
     enabled = _get_enabled_set()
     disabled = _get_disabled_set()
     entries = _filter_plugin_entries(entries, args, enabled, disabled)
+    runtime_states = _get_runtime_plugin_states()
 
     if getattr(args, "json", False):
-        payload = [
-            {
-                "name": name,
-                "status": _plugin_status(name, enabled, disabled, key=key),
-                "version": str(version),
-                "description": description,
-                "source": source,
-            }
-            for name, version, description, source, _dir, key in entries
-        ]
+        payload = []
+        for name, version, description, source, _dir, key in entries:
+            status = _plugin_status(name, enabled, disabled, key=key)
+            active, runtime_status, error = _plugin_runtime_fields(
+                name, key, status, runtime_states
+            )
+            payload.append(
+                {
+                    "name": name,
+                    "status": status,
+                    "active": active,
+                    "runtime_status": runtime_status,
+                    "error": error,
+                    "version": str(version),
+                    "description": description,
+                    "source": source,
+                }
+            )
         print(json.dumps(payload, indent=2))
         return
 
     if getattr(args, "plain", False):
         for name, version, _description, source, _dir, key in entries:
             status = _plugin_status(name, enabled, disabled, key=key)
-            print(f"{status:12} {source:8} {str(version):8} {name}")
+            _active, runtime_status, _error = _plugin_runtime_fields(
+                name, key, status, runtime_states
+            )
+            display_status = (
+                f"{status}/{runtime_status}" if status == "enabled" else status
+            )
+            print(f"{display_status:18} {source:8} {str(version):8} {name}")
         return
 
     if not entries:
@@ -1179,10 +1232,14 @@ def cmd_list(args: Any | None = None) -> None:
 
     for name, version, description, source, _dir, key in entries:
         status_name = _plugin_status(name, enabled, disabled, key=key)
+        _active, runtime_status, _error = _plugin_runtime_fields(
+            name, key, status_name, runtime_states
+        )
         if status_name == "disabled":
             status = "[red]disabled[/red]"
         elif status_name == "enabled":
-            status = "[green]enabled[/green]"
+            color = "green" if runtime_status == "active" else "red"
+            status = f"[{color}]enabled/{runtime_status}[/{color}]"
         else:
             status = "[yellow]not enabled[/yellow]"
         table.add_row(name, status, str(version), description, source)

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -15,6 +15,10 @@ from pathlib import Path
 # Public, versioned contract for terminal gateway-message hooks and their
 # immutable route-bound delivery capabilities.
 GATEWAY_MESSAGE_HOOK_API_VERSION = 2
+# Public umbrella contract for participant plugins. This major is independent
+# of Hermes package releases; compatible additions stay on 2 and breaking
+# host-contract changes require a new major.
+PARTICIPANT_HOST_API_VERSION = 2
 
 
 _profile_fallback_warned: bool = False

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -12,6 +12,11 @@ from contextvars import ContextVar, Token
 from pathlib import Path
 
 
+# Public, versioned contract for terminal gateway-message hooks and their
+# immutable route-bound delivery capabilities.
+GATEWAY_MESSAGE_HOOK_API_VERSION = 2
+
+
 _profile_fallback_warned: bool = False
 _UNSET = object()
 _HERMES_HOME_OVERRIDE: ContextVar[str | object] = ContextVar(

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -127,6 +127,7 @@ from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
+    NativeDeliveryAck,
     ProcessingOutcome,
     SendResult,
     cache_image_from_url,
@@ -883,6 +884,14 @@ def _read_discord_prompt_timeout() -> int:
     return seconds
 
 
+def _attested_discord_mentions(message) -> tuple[tuple[str, ...], bool]:
+    """Extract immutable Discord user and room mention facts from native ingress."""
+    mentioned_user_ids = tuple(
+        sorted({str(user.id) for user in (getattr(message, "mentions", None) or ())})
+    )
+    return mentioned_user_ids, bool(getattr(message, "mention_everyone", False))
+
+
 class DiscordAdapter(BasePlatformAdapter):
     """
     Discord bot adapter.
@@ -900,6 +909,7 @@ class DiscordAdapter(BasePlatformAdapter):
     # Discord message limits
     MAX_MESSAGE_LENGTH = 2000
     _SPLIT_THRESHOLD = 1900  # near the 2000-char split point
+    _MAX_GATEWAY_NATIVE_EVENTS_PER_BATCH = 64
     supports_code_blocks = True  # Discord markdown renders fenced code blocks natively
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
 
@@ -2855,6 +2865,57 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.debug("[%s] remove_reaction failed (%s): %s", self.name, emoji, e)
             return False
 
+    async def react(
+        self,
+        chat_id: str,
+        message_id: str,
+        reaction: str,
+        *,
+        operation: str = "add",
+    ) -> SendResult:
+        """Apply one reaction to an exact Discord message."""
+        if not self._client or operation not in {"add", "remove"}:
+            return SendResult(success=False, error="Reaction is unavailable")
+        try:
+            channel = self._client.get_channel(int(chat_id))
+            if channel is None:
+                channel = await self._client.fetch_channel(int(chat_id))
+            message = await channel.fetch_message(int(message_id))
+            succeeded = (
+                await self._add_reaction(message, reaction)
+                if operation == "add"
+                else await self._remove_reaction(message, reaction)
+            )
+            actor_id = self.authenticated_actor_id()
+            ack = None
+            if succeeded and actor_id is not None:
+                identity = "\x00".join(
+                    ("discord", str(chat_id), actor_id, str(message_id), operation, reaction)
+                )
+                ack = NativeDeliveryAck(
+                    platform="discord",
+                    room_id=str(chat_id),
+                    self_actor_id=actor_id,
+                    effect_kind="react",
+                    target_message_id=str(message_id),
+                    reaction=reaction,
+                    reaction_operation="add" if operation == "add" else "remove",
+                    effect_id=f"discord:reaction:{hashlib.sha256(identity.encode()).hexdigest()}",
+                )
+            return SendResult(
+                success=succeeded,
+                message_id=str(message_id) if succeeded else None,
+                native_delivery_ack=ack,
+            )
+        except Exception:
+            return SendResult(success=False, error="Reaction failed")
+
+    def authenticated_actor_id(self) -> Optional[str]:
+        """Return the immutable actor id for the authenticated Discord bot."""
+        actor = getattr(getattr(self, "_client", None), "user", None)
+        actor_id = getattr(actor, "id", None)
+        return str(actor_id) if actor_id is not None else None
+
     def _reactions_enabled(self) -> bool:
         """Check if message reactions are enabled via config/env."""
         return os.getenv("DISCORD_REACTIONS", "true").lower() not in {"false", "0", "no"}
@@ -2947,6 +3008,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
             message_ids = []
             reference = None
+            reply_attested = False
 
             if reply_to and self._reply_to_mode != "off":
                 try:
@@ -2986,12 +3048,16 @@ class DiscordAdapter(BasePlatformAdapter):
                             reply_to,
                         )
                         reference = None
+                        chunk_reference = None
+                        reply_attested = False
                         msg = await channel.send(
                             content=chunk,
                             reference=None,
                         )
                     else:
                         raise
+                if i == 0 and chunk_reference is not None:
+                    reply_attested = True
                 message_ids.append(str(msg.id))
 
             # Track the last message we sent in this channel for history
@@ -3003,10 +3069,24 @@ class DiscordAdapter(BasePlatformAdapter):
                 elif not _looks_like_nonconversational_history_message(content):
                     self._last_self_message_id[_target_id] = message_ids[-1]
 
+            actor_id = self.authenticated_actor_id()
+            native_ack = None
+            if message_ids and actor_id is not None:
+                native_ack = NativeDeliveryAck(
+                    platform="discord",
+                    room_id=str(getattr(channel, "id", chat_id)),
+                    self_actor_id=actor_id,
+                    effect_kind="reply" if reply_attested else "send",
+                    submitted_content=content,
+                    reply_to_message_id=str(reply_to) if reply_attested else None,
+                    message_id=message_ids[0],
+                    effect_id=message_ids[0],
+                )
             result = SendResult(
                 success=True,
                 message_id=message_ids[0] if message_ids else None,
-                raw_response={"message_ids": message_ids}
+                raw_response={"message_ids": message_ids},
+                native_delivery_ack=native_ack,
             )
             await asyncio.to_thread(
                 self._record_discord_response,
@@ -7848,6 +7928,7 @@ class DiscordAdapter(BasePlatformAdapter):
             if message.reference.resolved:
                 reply_to_text = getattr(message.reference.resolved, "content", None) or None
 
+        mentioned_user_ids, mentions_room = _attested_discord_mentions(message)
         event = MessageEvent(
             text=event_text,
             message_type=msg_type,
@@ -7862,12 +7943,19 @@ class DiscordAdapter(BasePlatformAdapter):
             auto_skill=_skills,
             channel_prompt=_channel_prompt,
             channel_context=_channel_context,
+            metadata={
+                "mentioned_user_ids": mentioned_user_ids,
+                "mentions_room": mentions_room,
+            },
         )
 
         # Track thread participation so the bot won't require @mention for
         # follow-up messages in threads it has already engaged in.
         if thread_id:
             self._threads.mark(thread_id)
+
+        if recovered:
+            setattr(event, "_hermes_historical_replay", True)
 
         # Only live plain text messages use split-message batching. Recovery
         # candidates are already complete historical messages; coalescing them
@@ -7903,6 +7991,33 @@ class DiscordAdapter(BasePlatformAdapter):
             profile=event.source.profile,
         )
 
+    def _native_gateway_event_snapshot(self, event: MessageEvent) -> MessageEvent:
+        """Retain one bounded-to-hook native identity before agent-text batching."""
+        mentioned_user_ids = event.metadata.get("mentioned_user_ids")
+        return MessageEvent(
+            text=str(event.text or ""),
+            message_type=event.message_type,
+            source=event.source,
+            raw_message=None,
+            message_id=event.message_id,
+            media_urls=list(event.media_urls),
+            media_types=list(event.media_types),
+            reply_to_message_id=event.reply_to_message_id,
+            reply_to_text=event.reply_to_text,
+            reply_to_author_id=event.reply_to_author_id,
+            reply_to_author_name=event.reply_to_author_name,
+            reply_to_is_own_message=event.reply_to_is_own_message,
+            metadata={
+                "mentioned_user_ids": (
+                    None
+                    if mentioned_user_ids is None
+                    else tuple(mentioned_user_ids)
+                ),
+                "mentions_room": event.metadata.get("mentions_room"),
+            },
+            timestamp=event.timestamp,
+        )
+
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text event and reset the flush timer.
 
@@ -7912,17 +8027,39 @@ class DiscordAdapter(BasePlatformAdapter):
         """
         key = self._text_batch_key(event)
         existing = self._pending_text_batches.get(key)
+        if existing is not None and len(
+            existing.metadata.get("_gateway_native_events", ())
+        ) >= self._MAX_GATEWAY_NATIVE_EVENTS_PER_BATCH:
+            self._dispatch_full_gateway_native_batch(
+                key,
+                self._pending_text_batches,
+                self._pending_text_batch_tasks,
+            )
+            existing = None
         chunk_len = len(event.text or "")
+        native_snapshot = self._native_gateway_event_snapshot(event)
         if existing is None:
             event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            event.metadata["_gateway_native_events"] = (native_snapshot,)
             self._pending_text_batches[key] = event
         else:
+            existing.metadata["_gateway_native_events"] = (
+                *existing.metadata.get("_gateway_native_events", ()),
+                native_snapshot,
+            )
             if event.text:
                 existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
             existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
             if event.media_urls:
                 existing.media_urls.extend(event.media_urls)
                 existing.media_types.extend(event.media_types)
+            existing_mentions = set(existing.metadata.get("mentioned_user_ids", ()))
+            existing_mentions.update(event.metadata.get("mentioned_user_ids", ()))
+            existing.metadata["mentioned_user_ids"] = sorted(existing_mentions)
+            existing.metadata["mentions_room"] = bool(
+                existing.metadata.get("mentions_room")
+                or event.metadata.get("mentions_room")
+            )
 
         prior_task = self._pending_text_batch_tasks.get(key)
         if prior_task and not prior_task.done():
@@ -7930,6 +8067,16 @@ class DiscordAdapter(BasePlatformAdapter):
         self._pending_text_batch_tasks[key] = asyncio.create_task(
             self._flush_text_batch(key)
         )
+
+    def _dispatch_full_gateway_native_batch(self, key, batches, tasks) -> None:
+        """Split a full aggregation batch without dropping native ingress."""
+        batch = batches.pop(key)
+        prior_task = tasks.pop(key, None)
+        if prior_task and not prior_task.done():
+            prior_task.cancel()
+        dispatch_task = asyncio.create_task(self.handle_message(batch))
+        self._background_tasks.add(dispatch_task)
+        dispatch_task.add_done_callback(self._background_tasks.discard)
 
     async def _flush_text_batch(self, key: str) -> None:
         """Wait for the quiet period then dispatch the aggregated text.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -10,6 +10,7 @@ Uses python-telegram-bot library for:
 import asyncio
 import dataclasses
 import faulthandler
+import hashlib
 import inspect
 import json
 import logging
@@ -266,6 +267,7 @@ from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
+    NativeDeliveryAck,
     ProcessingOutcome,
     SendResult,
     classify_send_error,
@@ -589,6 +591,24 @@ class _PollingLifecycleAbort(RuntimeError):
     """Internal control flow for polling startup fenced by teardown."""
 
 
+def _attested_mention_user_ids(entities) -> tuple[str, ...] | None:
+    """Return transport-bound mention IDs, or None when Telegram cannot attest them."""
+    mentioned_user_ids: set[str] = set()
+    for entity in entities or ():
+        entity_type = str(getattr(entity, "type", "")).split(".")[-1].lower()
+        if entity_type == "mention":
+            # Username mentions carry text offsets but no immutable Telegram user ID.
+            return None
+        if entity_type != "text_mention":
+            continue
+        mentioned_user = getattr(entity, "user", None)
+        mentioned_user_id = getattr(mentioned_user, "id", None)
+        if mentioned_user_id is None:
+            return None
+        mentioned_user_ids.add(str(mentioned_user_id))
+    return tuple(sorted(mentioned_user_ids))
+
+
 class TelegramAdapter(BasePlatformAdapter):
     """
     Telegram bot adapter.
@@ -613,6 +633,7 @@ class TelegramAdapter(BasePlatformAdapter):
     # Threshold for detecting Telegram client-side message splits.
     # When a chunk is near this limit, a continuation is almost certain.
     _SPLIT_THRESHOLD = 4000
+    _MAX_GATEWAY_NATIVE_EVENTS_PER_BATCH = 64
     MEDIA_GROUP_WAIT_SECONDS = 0.8
     _GENERAL_TOPIC_THREAD_ID = "1"
 
@@ -1100,6 +1121,18 @@ class TelegramAdapter(BasePlatformAdapter):
             return None
         thread_id = metadata.get("thread_id") or metadata.get("message_thread_id")
         return str(thread_id) if thread_id is not None else None
+
+    @classmethod
+    def _native_delivery_room_id(
+        cls,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]],
+    ) -> str:
+        """Return the route identity attested by a native Telegram effect."""
+        thread_id = cls._metadata_thread_id(metadata)
+        if thread_id:
+            return f"{chat_id}:topic:{thread_id}"
+        return str(chat_id)
 
     @classmethod
     def _metadata_direct_messages_topic_id(cls, metadata: Optional[Dict[str, Any]]) -> Optional[str]:
@@ -1869,9 +1902,24 @@ class TelegramAdapter(BasePlatformAdapter):
                 rich_sent_store.record(str(chat_id), str(message_id), content)
             except Exception:
                 pass
+        actor_id = self.authenticated_actor_id()
+        native_message_id = str(message_id) if message_id is not None else None
+        native_ack = None
+        if native_message_id is not None and actor_id is not None:
+            native_ack = NativeDeliveryAck(
+                platform="telegram",
+                room_id=self._native_delivery_room_id(str(chat_id), metadata),
+                self_actor_id=actor_id,
+                effect_kind="reply" if reply_to_id is not None else "send",
+                submitted_content=content,
+                reply_to_message_id=str(reply_to_id) if reply_to_id is not None else None,
+                message_id=native_message_id,
+                effect_id=native_message_id,
+            )
         return SendResult(
             success=True,
-            message_id=str(message_id) if message_id is not None else None,
+            message_id=native_message_id,
+            native_delivery_ack=native_ack,
         )
 
     async def _try_edit_rich(
@@ -4361,8 +4409,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 ]
             
             message_ids = []
+            reply_attested_id = None
             thread_id = self._metadata_thread_id(metadata)
             requested_thread_id = self._message_thread_id_for_send(thread_id)
+            require_topic_route = bool(
+                metadata and metadata.get("_hermes_require_topic_route")
+            )
             used_thread_fallback = False
             
             try:
@@ -4481,6 +4533,16 @@ class TelegramAdapter(BasePlatformAdapter):
                                     )
                                     continue
                                 # Second failure: the thread is genuinely gone.
+                                # Route-bound participant effects may never fall
+                                # back into the root chat after authorizing a topic.
+                                if require_topic_route:
+                                    return SendResult(
+                                        success=False,
+                                        error=_redact_telegram_error_text(send_err),
+                                        retryable=False,
+                                    )
+                                # Ordinary Hermes delivery retains its historical
+                                # fallback behavior outside the strict V2 seam.
                                 # Retry without ``message_thread_id`` so the
                                 # message still reaches the chat, and prune
                                 # the stale binding so future inbound
@@ -4499,7 +4561,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 continue
                             err_lower = str(send_err).lower()
                             if "message to be replied not found" in err_lower and reply_to_id is not None:
-                                if private_dm_topic_send:
+                                if private_dm_topic_send or require_topic_route:
                                     safe_send_error = _redact_telegram_error_text(send_err)
                                     return SendResult(
                                         success=False,
@@ -4572,6 +4634,8 @@ class TelegramAdapter(BasePlatformAdapter):
                                 await asyncio.sleep(wait)
                                 continue
                         raise
+                if i == 0 and reply_to_id is not None:
+                    reply_attested_id = str(reply_to_id)
                 message_ids.append(str(msg.message_id))
 
             # Re-trigger typing indicator after sending a message.
@@ -4590,14 +4654,29 @@ class TelegramAdapter(BasePlatformAdapter):
                 except Exception:
                     pass  # Typing failures are non-fatal
 
+            actor_id = self.authenticated_actor_id()
+            native_message_id = message_ids[0] if message_ids else None
+            native_ack = None
+            if native_message_id is not None and actor_id is not None:
+                native_ack = NativeDeliveryAck(
+                    platform="telegram",
+                    room_id=self._native_delivery_room_id(str(chat_id), metadata),
+                    self_actor_id=actor_id,
+                    effect_kind="reply" if reply_attested_id is not None else "send",
+                    submitted_content=content,
+                    reply_to_message_id=reply_attested_id,
+                    message_id=native_message_id,
+                    effect_id=native_message_id,
+                )
             return SendResult(
                 success=True,
-                message_id=message_ids[0] if message_ids else None,
+                message_id=native_message_id,
                 raw_response={
                     "message_ids": message_ids,
                     "requested_thread_id": requested_thread_id,
                     "thread_fallback": used_thread_fallback,
                 },
+                native_delivery_ack=native_ack,
             )
             
         except Exception as e:
@@ -8780,6 +8859,34 @@ class TelegramAdapter(BasePlatformAdapter):
             profile=event.source.profile,
         )
 
+    def _native_gateway_event_snapshot(self, event: MessageEvent) -> MessageEvent:
+        """Retain one native identity before host-agent batching mutates it."""
+        mentioned_user_ids = event.metadata.get("mentioned_user_ids")
+        return MessageEvent(
+            text=str(event.text or ""),
+            message_type=event.message_type,
+            source=event.source,
+            raw_message=None,
+            message_id=event.message_id,
+            platform_update_id=event.platform_update_id,
+            media_urls=list(event.media_urls),
+            media_types=list(event.media_types),
+            reply_to_message_id=event.reply_to_message_id,
+            reply_to_text=event.reply_to_text,
+            reply_to_author_id=event.reply_to_author_id,
+            reply_to_author_name=event.reply_to_author_name,
+            reply_to_is_own_message=event.reply_to_is_own_message,
+            metadata={
+                "mentioned_user_ids": (
+                    None
+                    if mentioned_user_ids is None
+                    else tuple(mentioned_user_ids)
+                ),
+                "mentions_room": event.metadata.get("mentions_room"),
+            },
+            timestamp=event.timestamp,
+        )
+
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text event and reset the flush timer.
 
@@ -8794,11 +8901,26 @@ class TelegramAdapter(BasePlatformAdapter):
 
         key = self._text_batch_key(event)
         existing = self._pending_text_batches.get(key)
+        if existing is not None and len(
+            existing.metadata.get("_gateway_native_events", ())
+        ) >= self._MAX_GATEWAY_NATIVE_EVENTS_PER_BATCH:
+            self._dispatch_full_gateway_native_batch(
+                key,
+                self._pending_text_batches,
+                self._pending_text_batch_tasks,
+            )
+            existing = None
         chunk_len = len(event.text or "")
+        native_snapshot = self._native_gateway_event_snapshot(event)
         if existing is None:
             event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            event.metadata["_gateway_native_events"] = (native_snapshot,)
             self._pending_text_batches[key] = event
         else:
+            existing.metadata["_gateway_native_events"] = (
+                *existing.metadata.get("_gateway_native_events", ()),
+                native_snapshot,
+            )
             # Append text from the follow-up chunk
             if event.text:
                 existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
@@ -8815,6 +8937,16 @@ class TelegramAdapter(BasePlatformAdapter):
         self._pending_text_batch_tasks[key] = asyncio.create_task(
             self._flush_text_batch(key)
         )
+
+    def _dispatch_full_gateway_native_batch(self, key, batches, tasks) -> None:
+        """Split a full aggregation batch without dropping native ingress."""
+        batch = batches.pop(key)
+        prior_task = tasks.pop(key, None)
+        if prior_task and not prior_task.done():
+            prior_task.cancel()
+        dispatch_task = asyncio.create_task(self.handle_message(batch))
+        self._background_tasks.add(dispatch_task)
+        dispatch_task.add_done_callback(self._background_tasks.discard)
 
     async def _flush_text_batch(self, key: str) -> None:
         """Wait for the quiet period then dispatch the aggregated text.
@@ -8903,10 +9035,30 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.debug("[Telegram] Dropping photo batch enqueue after disconnect started")
             return
 
+        # Retain the same recovered route on the outer batch and every native
+        # participant snapshot. BasePlatformAdapter will apply this again at
+        # dispatch, but the immutable snapshots must not preserve a stale DM
+        # topic in the meantime.
+        self._apply_topic_recovery(event)
         existing = self._pending_photo_batches.get(batch_key)
+        if existing is not None and len(
+            existing.metadata.get("_gateway_native_events", ())
+        ) >= self._MAX_GATEWAY_NATIVE_EVENTS_PER_BATCH:
+            self._dispatch_full_gateway_native_batch(
+                batch_key,
+                self._pending_photo_batches,
+                self._pending_photo_batch_tasks,
+            )
+            existing = None
+        native_snapshot = self._native_gateway_event_snapshot(event)
         if existing is None:
+            event.metadata["_gateway_native_events"] = (native_snapshot,)
             self._pending_photo_batches[batch_key] = event
         else:
+            existing.metadata["_gateway_native_events"] = (
+                *existing.metadata.get("_gateway_native_events", ()),
+                native_snapshot,
+            )
             existing.media_urls.extend(event.media_urls)
             existing.media_types.extend(event.media_types)
             if event.text:
@@ -9230,10 +9382,26 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.debug("[Telegram] Dropping media group enqueue after disconnect started")
             return
 
+        self._apply_topic_recovery(event)
         existing = self._media_group_events.get(media_group_id)
+        if existing is not None and len(
+            existing.metadata.get("_gateway_native_events", ())
+        ) >= self._MAX_GATEWAY_NATIVE_EVENTS_PER_BATCH:
+            self._dispatch_full_gateway_native_batch(
+                media_group_id,
+                self._media_group_events,
+                self._media_group_tasks,
+            )
+            existing = None
+        native_snapshot = self._native_gateway_event_snapshot(event)
         if existing is None:
+            event.metadata["_gateway_native_events"] = (native_snapshot,)
             self._media_group_events[media_group_id] = event
         else:
+            existing.metadata["_gateway_native_events"] = (
+                *existing.metadata.get("_gateway_native_events", ()),
+                native_snapshot,
+            )
             existing.media_urls.extend(event.media_urls)
             existing.media_types.extend(event.media_types)
             if event.text:
@@ -9654,8 +9822,14 @@ class TelegramAdapter(BasePlatformAdapter):
             _chat_id_str if thread_id_str else None,
         )
 
+        mention_entities = (
+            *(getattr(message, "entities", None) or ()),
+            *(getattr(message, "caption_entities", None) or ()),
+        )
+        mentioned_user_ids = _attested_mention_user_ids(mention_entities)
+
         return MessageEvent(
-            text=message.text or "",
+            text=message.text or getattr(message, "caption", None) or "",
             message_type=msg_type,
             source=source,
             raw_message=message,
@@ -9666,6 +9840,10 @@ class TelegramAdapter(BasePlatformAdapter):
             auto_skill=topic_skill,
             channel_prompt=_channel_prompt,
             timestamp=message.date,
+            metadata={
+                "mentioned_user_ids": mentioned_user_ids,
+                "mentions_room": False,
+            },
         )
 
     # ── Message reactions (processing lifecycle) ──────────────────────────
@@ -9709,6 +9887,51 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.debug("[%s] clear reactions failed: %s", self.name, _redact_telegram_error_text(e))
             return False
+
+    async def react(
+        self,
+        chat_id: str,
+        message_id: str,
+        reaction: str,
+        *,
+        operation: str = "add",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Apply one reaction to an exact Telegram message."""
+        if operation not in {"add", "remove"}:
+            return SendResult(success=False, error="Reaction is unavailable")
+        succeeded = (
+            await self._set_reaction(chat_id, message_id, reaction)
+            if operation == "add"
+            else await self._clear_reactions(chat_id, message_id)
+        )
+        actor_id = self.authenticated_actor_id()
+        ack = None
+        if succeeded and actor_id is not None:
+            native_room_id = self._native_delivery_room_id(str(chat_id), metadata)
+            identity = "\x00".join(
+                ("telegram", native_room_id, actor_id, str(message_id), operation, reaction)
+            )
+            ack = NativeDeliveryAck(
+                platform="telegram",
+                room_id=native_room_id,
+                self_actor_id=actor_id,
+                effect_kind="react",
+                target_message_id=str(message_id),
+                reaction=reaction,
+                reaction_operation="add" if operation == "add" else "remove",
+                effect_id=f"telegram:reaction:{hashlib.sha256(identity.encode()).hexdigest()}",
+            )
+        return SendResult(
+            success=succeeded,
+            message_id=str(message_id) if succeeded else None,
+            native_delivery_ack=ack,
+        )
+
+    def authenticated_actor_id(self) -> Optional[str]:
+        """Return the immutable actor id for the authenticated Telegram bot."""
+        actor_id = getattr(getattr(self, "_bot", None), "id", None)
+        return str(actor_id) if actor_id is not None else None
 
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction when message processing begins."""

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1135,6 +1135,73 @@ class TelegramAdapter(BasePlatformAdapter):
         return str(chat_id)
 
     @classmethod
+    def _native_delivery_ack_from_message(
+        cls,
+        message: object,
+        *,
+        expected_chat_id: str,
+        expected_thread_id: Optional[object],
+        expected_content: str,
+        expected_reply_to_message_id: Optional[object],
+        expected_actor_id: Optional[str],
+    ) -> Optional[NativeDeliveryAck]:
+        """Attest a send only from complete, route-matching Telegram output."""
+        if isinstance(message, dict) or expected_actor_id is None:
+            return None
+        try:
+            message_id = getattr(message, "message_id")
+            chat_id = getattr(getattr(message, "chat"), "id")
+            actor_id = getattr(getattr(message, "from_user"), "id")
+            thread_id = getattr(message, "message_thread_id", None)
+            returned_content = getattr(message, "text")
+            reply_message = getattr(message, "reply_to_message", None)
+            reply_to_message_id = (
+                getattr(reply_message, "message_id")
+                if reply_message is not None
+                else None
+            )
+        except (AttributeError, TypeError):
+            return None
+
+        expected_chat = str(normalize_telegram_chat_id(expected_chat_id))
+        expected_thread = (
+            str(expected_thread_id) if expected_thread_id is not None else None
+        )
+        expected_reply = (
+            str(expected_reply_to_message_id)
+            if expected_reply_to_message_id is not None
+            else None
+        )
+        actual_thread = str(thread_id) if thread_id is not None else None
+        actual_reply = (
+            str(reply_to_message_id) if reply_to_message_id is not None else None
+        )
+        if (
+            message_id is None
+            or str(chat_id) != expected_chat
+            or actual_thread != expected_thread
+            or str(actor_id) != str(expected_actor_id)
+            or returned_content != expected_content
+            or actual_reply != expected_reply
+        ):
+            return None
+
+        native_message_id = str(message_id)
+        actual_room_id = str(chat_id)
+        if actual_thread is not None:
+            actual_room_id = f"{actual_room_id}:topic:{actual_thread}"
+        return NativeDeliveryAck(
+            platform="telegram",
+            room_id=actual_room_id,
+            self_actor_id=str(actor_id),
+            effect_kind="reply" if actual_reply is not None else "send",
+            submitted_content=returned_content,
+            reply_to_message_id=actual_reply,
+            message_id=native_message_id,
+            effect_id=native_message_id,
+        )
+
+    @classmethod
     def _metadata_direct_messages_topic_id(cls, metadata: Optional[Dict[str, Any]]) -> Optional[str]:
         if not metadata:
             return None
@@ -1902,20 +1969,15 @@ class TelegramAdapter(BasePlatformAdapter):
                 rich_sent_store.record(str(chat_id), str(message_id), content)
             except Exception:
                 pass
-        actor_id = self.authenticated_actor_id()
         native_message_id = str(message_id) if message_id is not None else None
-        native_ack = None
-        if native_message_id is not None and actor_id is not None:
-            native_ack = NativeDeliveryAck(
-                platform="telegram",
-                room_id=self._native_delivery_room_id(str(chat_id), metadata),
-                self_actor_id=actor_id,
-                effect_kind="reply" if reply_to_id is not None else "send",
-                submitted_content=content,
-                reply_to_message_id=str(reply_to_id) if reply_to_id is not None else None,
-                message_id=native_message_id,
-                effect_id=native_message_id,
-            )
+        native_ack = self._native_delivery_ack_from_message(
+            msg,
+            expected_chat_id=str(chat_id),
+            expected_thread_id=thread_kwargs.get("message_thread_id"),
+            expected_content=content,
+            expected_reply_to_message_id=reply_to_id,
+            expected_actor_id=self.authenticated_actor_id(),
+        )
         return SendResult(
             success=True,
             message_id=native_message_id,
@@ -4409,6 +4471,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 ]
             
             message_ids = []
+            native_messages = []
             reply_attested_id = None
             thread_id = self._metadata_thread_id(metadata)
             requested_thread_id = self._message_thread_id_for_send(thread_id)
@@ -4637,6 +4700,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 if i == 0 and reply_to_id is not None:
                     reply_attested_id = str(reply_to_id)
                 message_ids.append(str(msg.message_id))
+                native_messages.append(msg)
 
             # Re-trigger typing indicator after sending a message.
             # Telegram clears the typing state when a new message is delivered,
@@ -4654,19 +4718,16 @@ class TelegramAdapter(BasePlatformAdapter):
                 except Exception:
                     pass  # Typing failures are non-fatal
 
-            actor_id = self.authenticated_actor_id()
             native_message_id = message_ids[0] if message_ids else None
             native_ack = None
-            if native_message_id is not None and actor_id is not None:
-                native_ack = NativeDeliveryAck(
-                    platform="telegram",
-                    room_id=self._native_delivery_room_id(str(chat_id), metadata),
-                    self_actor_id=actor_id,
-                    effect_kind="reply" if reply_attested_id is not None else "send",
-                    submitted_content=content,
-                    reply_to_message_id=reply_attested_id,
-                    message_id=native_message_id,
-                    effect_id=native_message_id,
+            if len(native_messages) == 1:
+                native_ack = self._native_delivery_ack_from_message(
+                    native_messages[0],
+                    expected_chat_id=str(chat_id),
+                    expected_thread_id=effective_thread_id,
+                    expected_content=content,
+                    expected_reply_to_message_id=reply_attested_id,
+                    expected_actor_id=self.authenticated_actor_id(),
                 )
             return SendResult(
                 success=True,

--- a/tests/gateway/test_delivery_revocation_boundary.py
+++ b/tests/gateway/test_delivery_revocation_boundary.py
@@ -331,6 +331,90 @@ async def test_shutdown_fences_inflight_native_send():
 
 
 @pytest.mark.asyncio
+async def test_shutdown_sync_revoke_retains_inflight_worker_for_later_settlement():
+    """The eager shutdown revoke must not discard its settlement handle."""
+    runner, entered, release = _runner_for_inflight()
+    delivery, _source = _retained_delivery(runner)
+
+    submit = asyncio.create_task(delivery.send("payload"))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    runner._revoke_all_gateway_deliveries()
+    boundary = asyncio.create_task(
+        runner._revoke_all_gateway_deliveries_and_settle()
+    )
+    await asyncio.sleep(0.05)
+
+    assert not boundary.done()
+    release.set()
+    await asyncio.wait_for(boundary, timeout=1)
+    assert (await asyncio.wait_for(submit, timeout=1)).status == "unknown"
+    assert runner._gateway_deliveries_by_session == {}
+
+
+@pytest.mark.asyncio
+async def test_consumed_deliveries_unregister_and_leave_no_worker_registry():
+    import gateway.message_hooks as message_hooks
+
+    runner, _entered, _release = _runner_for_inflight()
+    created = []
+
+    async def send_native(_chat_id, content):
+        return SendResult(
+            success=True,
+            message_id=f"out-{content}",
+            native_delivery_ack=_ack(
+                "send",
+                self_actor_id="9",
+                submitted_content=content,
+                message_id=f"out-{content}",
+                effect_id=f"out-{content}",
+            ),
+        )
+
+    runner.adapters[next(iter(runner.adapters))].send = send_native
+    for index in range(300):
+        delivery, _source = _retained_delivery(
+            runner,
+            session_key=f"session-{index}",
+        )
+        created.append(delivery)
+        receipt = await delivery.send(str(index))
+        assert receipt.status == "sent"
+
+    await asyncio.sleep(0)
+    assert runner._gateway_deliveries_by_session == {}
+    assert getattr(runner, "_gateway_delivery_settlement_workers", {}) == {}
+    assert all(
+        delivery not in message_hooks._DELIVERY_CHANNELS
+        for delivery in created
+    )
+
+
+@pytest.mark.asyncio
+async def test_unused_delivery_has_bounded_nonpolling_lifetime(monkeypatch):
+    """An unused one-shot capability expires without a polling task leak."""
+    import gateway.message_hooks as message_hooks
+
+    monkeypatch.setattr(
+        message_hooks,
+        "GATEWAY_DELIVERY_CAPABILITY_TTL_SECONDS",
+        0.01,
+        raising=False,
+    )
+    delivery = _make_delivery(
+        lambda _content: SendResult(
+            success=False,
+            native_delivery_non_occurrence_attested=True,
+        )
+    )
+
+    await asyncio.sleep(0.03)
+
+    assert await delivery.send("too late") == GatewayDeliveryReceipt(status="failed")
+    assert delivery not in message_hooks._DELIVERY_CHANNELS
+
+@pytest.mark.asyncio
 async def test_timeout_boundary_revokes_session_deliveries():
     """The inactivity-timeout path invalidates retained route capabilities."""
     runner, entered, release = _runner_for_inflight()

--- a/tests/gateway/test_delivery_revocation_boundary.py
+++ b/tests/gateway/test_delivery_revocation_boundary.py
@@ -1,0 +1,706 @@
+"""Barrier-controlled regression tests for the delivery revocation boundary.
+
+These tests prove that synchronous invalidation prevents new work, while
+externally observable async lifecycle boundaries wait for any invocation that
+already won to settle before returning. Already-started transport work is not
+cancelled because cancellation cannot prove external non-occurrence.
+"""
+
+import asyncio
+
+import pytest
+
+from gateway.message_hooks import GatewayDelivery, GatewayDeliveryReceipt
+from gateway.platforms.base import NativeDeliveryAck, SendResult
+
+
+def _runner_for_inflight():
+    """Minimal GatewayRunner double with a barrier-controlled adapter send."""
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from gateway.config import GatewayConfig, Platform, PlatformConfig
+    from gateway.run import GatewayRunner
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def send_native(chat_id, content, reply_to=None, metadata=None):
+        entered.set()
+        await release.wait()
+        return SendResult(
+            success=True,
+            message_id="out-1",
+            native_delivery_ack=NativeDeliveryAck(
+                platform="discord",
+                room_id=str(chat_id),
+                self_actor_id="9",
+                effect_kind="reply" if reply_to is not None else "send",
+                submitted_content=content,
+                reply_to_message_id=str(reply_to) if reply_to is not None else None,
+                message_id="out-1",
+                effect_id="out-1",
+            ),
+        )
+
+    adapter = SimpleNamespace(
+        send=send_native,
+        authenticated_actor_id=MagicMock(return_value="9"),
+    )
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.DISCORD: PlatformConfig(enabled=True)}
+    )
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._gateway_deliveries_by_session = {}
+    return runner, entered, release
+
+
+def _retained_delivery(runner, session_key="session-1"):
+    from gateway.config import Platform
+    from gateway.session import SessionSource
+
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        profile="work",
+        scope_id=None,
+        chat_id="room-1",
+        chat_name=None,
+        chat_type="group",
+        thread_id=None,
+        user_id="user-1",
+        user_name=None,
+    )
+    adapter = runner.adapters[Platform.DISCORD]
+    delivery = GatewayDelivery(
+        lambda content: adapter.send("room-1", content),
+        platform="discord",
+        room_id="room-1",
+        profile="work",
+        self_actor_id="9",
+        source_message_id="source-1",
+    )
+    runner._register_gateway_delivery(session_key, delivery)
+    return delivery, source
+
+
+def _ack(effect_kind, **overrides):
+    fields = {
+        "platform": "discord",
+        "room_id": "room-1",
+        "self_actor_id": "bot-9",
+        "effect_kind": effect_kind,
+        "submitted_content": None,
+        "reply_to_message_id": None,
+        "target_message_id": None,
+        "reaction": None,
+        "reaction_operation": None,
+        "message_id": None,
+        "effect_id": None,
+    }
+    fields.update(overrides)
+    return NativeDeliveryAck(**fields)
+
+
+def _make_delivery(send_callback, *, reply_callback=None, react_callback=None):
+    return GatewayDelivery(
+        send_callback,
+        reply_callback=reply_callback,
+        react_callback=react_callback,
+        platform="discord",
+        room_id="room-1",
+        profile="work",
+        self_actor_id="bot-9",
+        source_message_id="source-1",
+    )
+
+
+async def _settle(delivery):
+    """Let the delivery worker drain before the loop closes."""
+    await asyncio.wait_for(delivery._settle_revocation(), timeout=1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["send", "reply", "react"])
+async def test_direct_revoke_marks_inflight_native_effect_unknown(kind):
+    """Begin-only invalidation does not pretend an in-flight effect was aborted.
+
+    ``_revoke()`` is deliberately synchronous and is not itself a completed
+    lifecycle boundary. The adapter operation is allowed to settle and its
+    receipt becomes unknown because revocation arrived after invocation.
+    """
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def native_call(*_args):
+        entered.set()
+        await release.wait()
+        if kind == "react":
+            return SendResult(
+                success=True,
+                message_id="source-1",
+                native_delivery_ack=_ack(
+                    "react",
+                    target_message_id="source-1",
+                    reaction="+1",
+                    reaction_operation="add",
+                    effect_id="discord:reaction:inflight",
+                ),
+            )
+        return SendResult(
+            success=True,
+            message_id="out-1",
+            native_delivery_ack=_ack(
+                kind,
+                submitted_content="payload",
+                reply_to_message_id="source-1" if kind == "reply" else None,
+                message_id="out-1",
+                effect_id="out-1",
+            ),
+        )
+
+    delivery = _make_delivery(
+        native_call,
+        reply_callback=native_call,
+        react_callback=native_call,
+    )
+
+    if kind == "send":
+        submit = asyncio.create_task(delivery.send("payload"))
+    elif kind == "reply":
+        submit = asyncio.create_task(delivery.reply("payload"))
+    else:
+        submit = asyncio.create_task(delivery.react("+1", operation="add"))
+
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    delivery._revoke()
+    release.set()
+
+    receipt = await asyncio.wait_for(submit, timeout=1)
+    await _settle(delivery)
+
+    assert receipt.status == "unknown"
+    assert receipt.message_id is None
+
+
+@pytest.mark.asyncio
+async def test_revocation_wins_over_not_yet_started_invocation():
+    """Revocation before native invocation prevents the adapter call."""
+    native_calls = []
+
+    async def native_call(content):
+        native_calls.append(content)
+        return SendResult(success=False)
+
+    delivery = _make_delivery(native_call)
+    submit = asyncio.create_task(delivery.send("payload"))
+    # The request may already sit in the queue, but the worker has not
+    # entered the native callback yet.
+    delivery._revoke()
+
+    receipt = await asyncio.wait_for(submit, timeout=1)
+    await _settle(delivery)
+
+    assert receipt.status == "failed"
+    assert native_calls == []
+
+
+@pytest.mark.asyncio
+async def test_delivery_settles_exactly_once_without_hang_or_raise():
+    """Concurrent revocation and invocation leave one settled outcome."""
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def native_call(_content):
+        entered.set()
+        await release.wait()
+        return SendResult(
+            success=True,
+            message_id="out-1",
+            native_delivery_ack=_ack(
+                "send",
+                submitted_content="payload",
+                message_id="out-1",
+                effect_id="out-1",
+            ),
+        )
+
+    delivery = _make_delivery(native_call)
+    submit = asyncio.create_task(delivery.send("payload"))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    delivery._revoke()
+    # Repeated revocation is idempotent and cannot unsettle the request.
+    delivery._revoke()
+    release.set()
+
+    receipt = await asyncio.wait_for(submit, timeout=1)
+    await _settle(delivery)
+
+    assert receipt.status in {"failed", "unknown"}
+    # The capability remains consumed: no second effect can ever start.
+    followup = await delivery.send("second")
+    assert followup == GatewayDeliveryReceipt(status="failed")
+
+
+@pytest.mark.asyncio
+async def test_cancellation_of_submit_cannot_block_revocation_or_leak_effect():
+    """A cancelled submitter still cannot leave an unbounded in-flight effect."""
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def native_call(_content):
+        entered.set()
+        await release.wait()
+        return SendResult(
+            success=True,
+            message_id="out-1",
+            native_delivery_ack=_ack(
+                "send",
+                submitted_content="payload",
+                message_id="out-1",
+                effect_id="out-1",
+            ),
+        )
+
+    delivery = _make_delivery(native_call)
+    submit = asyncio.create_task(delivery.send("payload"))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    delivery._revoke()
+    submit.cancel()
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await submit
+    await _settle(delivery)
+
+    # After the boundary, the capability is terminally closed.
+    assert (await delivery.send("later")) == GatewayDeliveryReceipt(status="failed")
+
+
+@pytest.mark.asyncio
+async def test_session_cancel_fences_inflight_native_send(monkeypatch):
+    """An in-flight send cannot complete after session cancellation returns."""
+    runner, entered, release = _runner_for_inflight()
+    delivery, source = _retained_delivery(runner)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", None, raising=False)
+
+    async def no_observer(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr(
+        "hermes_cli.plugins.invoke_hook_async", no_observer, raising=False
+    )
+
+    submit = asyncio.create_task(delivery.send("payload"))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    boundary = asyncio.create_task(
+        runner._notify_gateway_session_cancel(
+            "session-1", source, reason="stop"
+        )
+    )
+    await asyncio.sleep(0.05)
+    assert not boundary.done()
+    release.set()
+    await asyncio.wait_for(boundary, timeout=1)
+
+    receipt = await asyncio.wait_for(submit, timeout=1)
+    await _settle(delivery)
+
+    assert receipt.status == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_shutdown_fences_inflight_native_send():
+    """An in-flight send settles before shutdown's awaited boundary can return."""
+    runner, entered, release = _runner_for_inflight()
+    delivery, _source = _retained_delivery(runner)
+
+    submit = asyncio.create_task(delivery.send("payload"))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    runner._revoke_all_gateway_deliveries()
+    release.set()
+
+    receipt = await asyncio.wait_for(submit, timeout=1)
+    await _settle(delivery)
+
+    assert receipt.status == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_timeout_boundary_revokes_session_deliveries():
+    """The inactivity-timeout path invalidates retained route capabilities."""
+    runner, entered, release = _runner_for_inflight()
+    delivery, _source = _retained_delivery(runner)
+
+    submit = asyncio.create_task(delivery.send("payload"))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    # The timeout boundary in _handle_message_with_agent revokes before the
+    # timed-out turn is considered returned.
+    runner._revoke_gateway_deliveries("session-1")
+    release.set()
+
+    receipt = await asyncio.wait_for(submit, timeout=1)
+    await _settle(delivery)
+
+    assert receipt.status == "unknown"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["send", "reply", "react"])
+async def test_boundary_awaits_native_invocation_that_won_before_revocation(kind):
+    """A callback already in flight must finish before lifecycle return.
+
+    The settlement wait must stay pending until the native effect actually
+    completes; only then may the lifecycle boundary return.
+    """
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    effects = []
+    boundary_holder = {}
+
+    async def native_call(*_args):
+        entered.set()
+        await release.wait()
+        boundary = boundary_holder.get("task")
+        if boundary is not None and boundary.done():
+            # The lifecycle boundary returned while this native effect was
+            # still live: the revocation boundary is broken. Fail fast
+            # instead of hanging against a regression that never awaits.
+            pytest.fail(
+                f"{kind} lifecycle boundary returned before the "
+                "already-started native effect settled"
+            )
+        effects.append(f"{kind}-effect-completed")
+        return SendResult(
+            success=True,
+            message_id="out-1",
+            native_delivery_ack=_ack(
+                kind,
+                submitted_content="payload",
+                reply_to_message_id="source-1" if kind == "reply" else None,
+                target_message_id="source-1" if kind == "react" else None,
+                reaction="+1" if kind == "react" else None,
+                reaction_operation="add" if kind == "react" else None,
+                message_id="out-1",
+                effect_id="out-1",
+            ),
+        )
+
+    runner, _entered, _release = _runner_for_inflight()
+    delivery, source = _retained_delivery(runner)
+    # Replace the runner-built capability with one bound to the suppressing
+    # callback, still retained under the same session.
+    runner._gateway_deliveries_by_session["session-1"].discard(delivery)
+    delivery = _make_delivery(
+        native_call,
+        reply_callback=native_call,
+        react_callback=native_call,
+    )
+    runner._register_gateway_delivery("session-1", delivery)
+
+    if kind == "send":
+        submit = asyncio.create_task(delivery.send("payload"))
+    elif kind == "reply":
+        submit = asyncio.create_task(delivery.reply("payload"))
+    else:
+        submit = asyncio.create_task(delivery.react("+1", operation="add"))
+
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    boundary = asyncio.create_task(
+        runner._revoke_gateway_deliveries_and_settle("session-1")
+    )
+    boundary_holder["task"] = boundary
+    # Revocation is synchronous: it prevents anything new, but an invocation
+    # that already won is not cancelled and must settle before return.
+    await asyncio.sleep(0.05)
+    assert not boundary.done()
+    assert effects == []
+
+    release.set()
+    await asyncio.wait_for(boundary, timeout=1)
+    assert effects == [f"{kind}-effect-completed"]
+
+    receipt = await asyncio.wait_for(submit, timeout=1)
+    # Exactly-once settlement: the requester sees the truthful pre-commit
+    # state, never a fabricated success and never a second settlement.
+    assert receipt.status == "unknown"
+    assert receipt.message_id is None
+
+
+@pytest.mark.asyncio
+async def test_boundary_tracks_shielded_native_effect_after_invocation_wins():
+    """Revocation must not detach a shielded transport effect from settlement."""
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    effects = []
+    effect_tasks = []
+
+    async def external_effect(content):
+        entered.set()
+        await release.wait()
+        effects.append(content)
+
+    async def native_call(content):
+        effect = asyncio.create_task(external_effect(content))
+        effect_tasks.append(effect)
+        await asyncio.shield(effect)
+        return SendResult(
+            success=True,
+            message_id="out-1",
+            native_delivery_ack=_ack(
+                "send",
+                submitted_content=content,
+                message_id="out-1",
+                effect_id="out-1",
+            ),
+        )
+
+    delivery = _make_delivery(native_call)
+    submit = asyncio.create_task(delivery.send("payload"))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    boundary = asyncio.create_task(delivery._settle_revocation())
+    await asyncio.sleep(0.05)
+
+    assert not boundary.done()
+    assert not submit.done()
+    assert len(effect_tasks) == 1
+    assert not effect_tasks[0].done()
+    assert effects == []
+
+    release.set()
+    await asyncio.wait_for(boundary, timeout=1)
+    receipt = await asyncio.wait_for(submit, timeout=1)
+
+    assert effects == ["payload"]
+    assert receipt.status == "unknown"
+    assert receipt.message_id is None
+
+
+@pytest.mark.asyncio
+async def test_settlement_preserves_outer_cancel_when_worker_also_cancels():
+    """A settled worker must not swallow a concurrent boundary cancellation."""
+    from gateway.message_hooks import _await_delivery_settlement
+
+    worker = asyncio.create_task(asyncio.sleep(3600))
+    boundary = asyncio.create_task(_await_delivery_settlement(worker))
+    await asyncio.sleep(0)
+
+    worker.cancel()
+    boundary.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await boundary
+    assert worker.done()
+
+
+@pytest.mark.asyncio
+async def test_boundary_settlement_is_shielded_from_outer_cancellation():
+    """Cancelling the boundary defers propagation until the effect settles."""
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    effects = []
+
+    async def native_call(_content):
+        entered.set()
+        await release.wait()
+        effects.append("send-effect-completed")
+        return SendResult(success=True, message_id="out-1")
+
+    runner, _entered, _release = _runner_for_inflight()
+    delivery, _source = _retained_delivery(runner)
+    runner._gateway_deliveries_by_session["session-1"].discard(delivery)
+    delivery = _make_delivery(native_call)
+    runner._register_gateway_delivery("session-1", delivery)
+
+    submit = asyncio.create_task(delivery.send("payload"))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    boundary = asyncio.create_task(
+        runner._revoke_gateway_deliveries_and_settle("session-1")
+    )
+    await asyncio.sleep(0.05)
+    assert not boundary.done()
+
+    # Cancellation of the lifecycle task must not let the boundary complete
+    # while the native effect is still live.
+    boundary.cancel()
+    await asyncio.sleep(0.05)
+    assert not boundary.done()
+    assert effects == []
+    assert not submit.done()
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(boundary, timeout=1)
+    assert effects == ["send-effect-completed"]
+
+    receipt = await asyncio.wait_for(submit, timeout=1)
+    assert receipt.status == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_aggregate_settlement_defers_cancel_until_all_workers_finish():
+    """Boundary cancellation settles every retained worker before propagating."""
+    from gateway.run import GatewayRunner
+
+    entered = [asyncio.Event(), asyncio.Event()]
+    release = [asyncio.Event(), asyncio.Event()]
+    effects = []
+
+    async def cancellation_suppressing_worker(index):
+        entered[index].set()
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            pass
+        await release[index].wait()
+        effects.append(index)
+
+    workers = [
+        asyncio.create_task(cancellation_suppressing_worker(index))
+        for index in range(2)
+    ]
+    await asyncio.gather(*(event.wait() for event in entered))
+    for worker in workers:
+        worker.cancel()
+
+    runner = object.__new__(GatewayRunner)
+    boundary = asyncio.create_task(
+        runner._await_gateway_delivery_settlement(workers)
+    )
+    await asyncio.sleep(0)
+    boundary.cancel()
+    await asyncio.sleep(0)
+
+    release[0].set()
+    await asyncio.sleep(0.05)
+    assert effects == [0]
+    assert workers[0].done()
+    assert not workers[1].done()
+    assert not boundary.done()
+
+    release[1].set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(boundary, timeout=1)
+    assert effects == [0, 1]
+    assert all(worker.done() for worker in workers)
+
+
+@pytest.mark.asyncio
+async def test_message_hook_fallthrough_settles_suppressing_native_effect(
+    monkeypatch,
+):
+    """Hook fallthrough cannot return while its revoked native effect is live."""
+    from types import SimpleNamespace
+
+    from gateway.config import GatewayConfig, Platform, PlatformConfig
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    effects = []
+
+    async def send_native(_chat_id, _content, **_kwargs):
+        entered.set()
+        await release.wait()
+        effects.append("send-effect-completed")
+        return SendResult(success=False)
+
+    adapter = SimpleNamespace(
+        send=send_native,
+        authenticated_actor_id=lambda: "9",
+    )
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.DISCORD: PlatformConfig(enabled=True)}
+    )
+    setattr(runner, "adapters", {Platform.DISCORD: adapter})
+    runner._gateway_deliveries_by_session = {}
+    setattr(runner, "_adapter_for_source", lambda source: adapter)
+    setattr(
+        runner,
+        "_thread_metadata_for_source",
+        lambda source, reply_to_message_id=None: None,
+    )
+
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        profile="work",
+        scope_id=None,
+        chat_id="room-1",
+        chat_name=None,
+        chat_type="group",
+        thread_id=None,
+        user_id="user-1",
+        user_name=None,
+    )
+    event = MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="source-1",
+    )
+    submissions = []
+
+    async def hook(*_args, **kwargs):
+        submissions.append(asyncio.create_task(kwargs["delivery"].send("payload")))
+        await entered.wait()
+        return [{"decision": "pass"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook)
+    boundary = asyncio.create_task(
+        runner._run_gateway_message_hook(event, source, "session-1")
+    )
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    await asyncio.sleep(0.05)
+
+    assert not boundary.done()
+    assert effects == []
+
+    release.set()
+    assert await asyncio.wait_for(boundary, timeout=1) is False
+    assert effects == ["send-effect-completed"]
+    receipt = await asyncio.wait_for(submissions[0], timeout=1)
+    assert receipt.status == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_boundary_await_skips_own_worker_to_avoid_self_deadlock():
+    """A lifecycle path unwinding inside the callback frame must not hang."""
+    entered = asyncio.Event()
+    finished = asyncio.Event()
+
+    runner, _entered, _release = _runner_for_inflight()
+    holder = {}
+
+    async def native_call(_content):
+        entered.set()
+        # Simulate host lifecycle code reached from inside the delivery
+        # worker's own callback frame: awaiting its own settlement would be
+        # a self-deadlock, so the boundary skips it.
+        await runner._revoke_gateway_deliveries_and_settle("session-1")
+        finished.set()
+        return SendResult(success=True, message_id="out-1")
+
+    delivery = _make_delivery(native_call)
+    holder["delivery"] = delivery
+    runner._register_gateway_delivery("session-1", delivery)
+
+    submit = asyncio.create_task(delivery.send("payload"))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    await asyncio.wait_for(finished.wait(), timeout=1)
+
+    receipt = await asyncio.wait_for(submit, timeout=1)
+    await _settle(delivery)
+    # The effect completed before the outer revocation could fence it, but
+    # revocation won while the invocation was in flight: no success receipt.
+    assert receipt.status == "unknown"

--- a/tests/gateway/test_discord_approval_mentions.py
+++ b/tests/gateway/test_discord_approval_mentions.py
@@ -8,6 +8,7 @@ import pytest
 from plugins.platforms.discord.adapter import (
     DiscordAdapter,
     _apply_yaml_config,
+    _attested_discord_mentions,
 )
 
 
@@ -26,6 +27,19 @@ class _FakeClient:
 
     def get_channel(self, channel_id):
         return self.channel
+
+
+def test_attested_discord_mentions_are_exact_and_deduplicated():
+    message = SimpleNamespace(
+        mentions=[SimpleNamespace(id=9), SimpleNamespace(id=7), SimpleNamespace(id=9)],
+        mention_everyone=True,
+    )
+
+    assert _attested_discord_mentions(message) == (("7", "9"), True)
+
+
+def test_attested_discord_mentions_default_to_transport_attested_empty():
+    assert _attested_discord_mentions(SimpleNamespace()) == ((), False)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_pending_text_batch_shutdown.py
+++ b/tests/gateway/test_discord_pending_text_batch_shutdown.py
@@ -3,7 +3,7 @@
 import asyncio
 import sys
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -48,6 +48,88 @@ def _ensure_discord_mock():
 _ensure_discord_mock()
 
 from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_text_batch_retains_each_native_event_identity_and_mentions():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    adapter._text_batch_delay_seconds = 99
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="chat",
+        chat_type="group",
+        user_id="7",
+    )
+    first = MessageEvent(
+        text="ordinary",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+        metadata={"mentioned_user_ids": (), "mentions_room": False},
+    )
+    second = MessageEvent(
+        text="@bot",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m2",
+        metadata={"mentioned_user_ids": ("9",), "mentions_room": False},
+    )
+
+    adapter._enqueue_text_event(first)
+    adapter._enqueue_text_event(second)
+    merged = next(iter(adapter._pending_text_batches.values()))
+    native_events = merged.metadata["_gateway_native_events"]
+
+    assert [(item.message_id, item.text) for item in native_events] == [
+        ("m1", "ordinary"),
+        ("m2", "@bot"),
+    ]
+    assert native_events[0].metadata["mentioned_user_ids"] == ()
+    assert native_events[1].metadata["mentioned_user_ids"] == ("9",)
+
+    for task in adapter._pending_text_batch_tasks.values():
+        task.cancel()
+    await asyncio.gather(*adapter._pending_text_batch_tasks.values(), return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_text_batch_bound_splits_without_dropping_native_events():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    adapter._text_batch_delay_seconds = 99
+    adapter._MAX_GATEWAY_NATIVE_EVENTS_PER_BATCH = 2
+    adapter.handle_message = AsyncMock()
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="chat",
+        chat_type="group",
+        user_id="7",
+    )
+    events = [
+        MessageEvent(
+            text=f"part-{index}",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id=f"m{index}",
+            metadata={"mentioned_user_ids": (), "mentions_room": False},
+        )
+        for index in range(3)
+    ]
+
+    for event in events:
+        adapter._enqueue_text_event(event)
+    await asyncio.sleep(0)
+
+    adapter.handle_message.assert_awaited_once()
+    dispatched = adapter.handle_message.await_args.args[0]
+    assert [
+        item.message_id for item in dispatched.metadata["_gateway_native_events"]
+    ] == ["m0", "m1"]
+    pending = adapter._pending_text_batches[adapter._text_batch_key(events[-1])]
+    assert [
+        item.message_id for item in pending.metadata["_gateway_native_events"]
+    ] == ["m2"]
+
+    await adapter.cancel_background_tasks()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -159,6 +159,7 @@ async def test_send_retries_without_reference_when_reply_target_is_system_messag
         send=AsyncMock(side_effect=fake_send),
     )
     adapter._client = SimpleNamespace(
+        user=SimpleNamespace(id=9),
         get_channel=lambda _chat_id: channel,
         fetch_channel=AsyncMock(),
     )
@@ -172,6 +173,9 @@ async def test_send_retries_without_reference_when_reply_target_is_system_messag
     ref_msg.to_reference.assert_called_once_with(fail_if_not_exists=False)
     assert send_calls[0]["reference"] is reference_obj
     assert send_calls[1]["reference"] is None
+    assert result.native_delivery_ack is not None
+    assert result.native_delivery_ack.effect_kind == "send"
+    assert result.native_delivery_ack.reply_to_message_id is None
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_gateway_message_hooks.py
+++ b/tests/gateway/test_gateway_message_hooks.py
@@ -1,0 +1,1755 @@
+"""Public contract tests for the generic gateway user-message hook."""
+
+import asyncio
+import dataclasses
+import threading
+from dataclasses import FrozenInstanceError
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.message_hooks import (
+    GatewayDelivery,
+    GatewayDeliveryReceipt,
+    GatewayMessageEvent,
+    GatewayMessageRoute,
+)
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    NativeDeliveryAck,
+    SendResult,
+)
+from gateway.session import SessionSource, build_session_key
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        profile="work",
+        scope_id="guild-1",
+        chat_id="channel-1",
+        chat_name="general",
+        chat_type="thread",
+        thread_id="thread-1",
+        user_id="user-1",
+        user_name="Tester",
+    )
+
+
+def _event() -> MessageEvent:
+    return MessageEvent(
+        text="hello",
+        message_type=MessageType.PHOTO,
+        source=_source(),
+        message_id="incoming-1",
+        media_urls=["/tmp/a.png"],
+        media_types=["image/png"],
+        reply_to_message_id="prior-1",
+        reply_to_text="prior text",
+        metadata={
+            "secret": "must-not-leak",
+            "mentioned_user_ids": ["user-2", "user-3"],
+            "mentions_room": True,
+        },
+        raw_message={"token": "must-not-leak"},
+    )
+
+
+def test_message_and_route_contexts_are_immutable_normalized_snapshots():
+    event = _event()
+
+    normalized_event = GatewayMessageEvent.from_event(event)
+    route = GatewayMessageRoute.from_source(event.source, session_key="route-key")
+
+    assert normalized_event.text == "hello"
+    assert normalized_event.message_type == "photo"
+    assert normalized_event.media_urls == ("/tmp/a.png",)
+    assert normalized_event.media_types == ("image/png",)
+    assert normalized_event.mentioned_user_ids == ("user-2", "user-3")
+    assert normalized_event.mentions_room is True
+    assert normalized_event.reply_to_message_id == "prior-1"
+    assert route.platform == "discord"
+    assert route.profile == "work"
+    assert route.scope_id == "guild-1"
+    assert route.session_key == "route-key"
+
+    with pytest.raises(FrozenInstanceError):
+        normalized_event.text = "changed"
+    with pytest.raises(FrozenInstanceError):
+        route.chat_id = "elsewhere"
+
+    assert not hasattr(normalized_event, "raw_message")
+    assert not hasattr(normalized_event, "metadata")
+    assert not hasattr(normalized_event, "source")
+    assert not hasattr(route, "role_authorized")
+    assert not hasattr(route, "delivered_via_upstream_relay")
+
+
+def test_message_snapshot_marks_unattested_mentions_unknown():
+    event = _event()
+    event.metadata["mentioned_user_ids"] = None
+    event.metadata["mentions_room"] = "unknown"
+
+    normalized_event = GatewayMessageEvent.from_event(event)
+
+    assert normalized_event.mentioned_user_ids is None
+    assert normalized_event.mentions_room is None
+
+
+def test_message_hook_snapshot_bounds_oversized_fields_and_declares_gaps():
+    event = _event()
+    event.text = "x" * 2_000_000
+    event.reply_to_text = "r" * 100_000
+    event.message_id = "m" * 5_000
+    event.media_urls = [f"https://example.invalid/{index}/" + "u" * 5_000 for index in range(50)]
+    event.media_types = ["t" * 500 for _ in range(50)]
+    event.metadata["mentioned_user_ids"] = [f"user-{index}" for index in range(500)]
+
+    snapshot = GatewayMessageEvent.from_event(event)
+
+    assert len(snapshot.text.encode("utf-8")) <= 65_536
+    assert len((snapshot.reply_to_text or "").encode("utf-8")) <= 16_384
+    assert len((snapshot.message_id or "").encode("utf-8")) <= 512
+    assert len(snapshot.media_urls) <= 16
+    assert all(len(item.encode("utf-8")) <= 4_096 for item in snapshot.media_urls)
+    assert len(snapshot.media_types) <= 16
+    assert len(snapshot.mentioned_user_ids or ()) <= 128
+    assert {
+        "text-overflow",
+        "reply-text-overflow",
+        "message-id-overflow",
+        "media-count-overflow",
+        "media-url-overflow",
+        "media-type-overflow",
+        "mention-count-overflow",
+    }.issubset(set(snapshot.coverage_gaps))
+
+
+def test_route_snapshot_bounds_oversized_fields_and_declares_gaps():
+    source = _source()
+    source.chat_id = "c" * 5_000
+    source.user_name = "u" * 10_000
+
+    route = GatewayMessageRoute.from_source(source, session_key="s" * 10_000)
+
+    assert len(route.session_key.encode("utf-8")) <= 2_048
+    assert len(route.chat_id.encode("utf-8")) <= 512
+    assert len((route.user_name or "").encode("utf-8")) <= 4_096
+    assert {
+        "session-key-overflow",
+        "chat-id-overflow",
+        "user-name-overflow",
+    }.issubset(set(route.coverage_gaps))
+
+
+def test_route_snapshot_fills_resolved_active_profile_when_source_is_unset(monkeypatch):
+    source = _source()
+    source.profile = None
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name",
+        lambda: "default",
+    )
+
+    route = GatewayMessageRoute.from_source(source, session_key="route-key")
+
+    assert route.profile == "default"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("native_result", "expected"),
+    [
+        (
+            SendResult(
+                success=True,
+                message_id="out-1",
+                native_delivery_ack=NativeDeliveryAck(
+                    platform="discord",
+                    room_id="room-1",
+                    self_actor_id="bot-9",
+                    effect_kind="send",
+                    submitted_content="host delivery",
+                    message_id="out-1",
+                    effect_id="out-1",
+                ),
+            ),
+            GatewayDeliveryReceipt(
+                status="sent",
+                platform="discord",
+                room_id="room-1",
+                profile="work",
+                self_actor_id="bot-9",
+                effect_kind="send",
+                submitted_content="host delivery",
+                message_id="out-1",
+                effect_id="out-1",
+            ),
+        ),
+        (
+            SendResult(success=False, error="rejected with credential-shaped detail"),
+            GatewayDeliveryReceipt(status="failed"),
+        ),
+        (
+            SendResult(success=True, message_id=None),
+            GatewayDeliveryReceipt(status="unknown"),
+        ),
+        (None, GatewayDeliveryReceipt(status="unknown")),
+        (True, GatewayDeliveryReceipt(status="unknown")),
+    ],
+)
+async def test_route_delivery_returns_truthful_normalized_receipts(native_result, expected):
+    sent_content = []
+
+    async def send_native(content: str):
+        sent_content.append(content)
+        return native_result
+
+    delivery = GatewayDelivery(
+        send_native,
+        platform="discord",
+        room_id="room-1",
+        profile="work",
+        self_actor_id="bot-9",
+        source_message_id="source-1",
+    )
+
+    assert await delivery.send("host delivery") == expected
+    assert sent_content == ["host delivery"]
+    assert not hasattr(delivery, "adapter")
+    assert not hasattr(delivery, "_adapter")
+    assert not hasattr(delivery, "runner")
+    assert not hasattr(delivery, "gateway")
+    assert not hasattr(delivery, "credentials")
+    assert not hasattr(delivery, "event")
+    assert not hasattr(delivery, "_send_callback")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "native_result",
+    [
+        SendResult(success=True, message_id="out-1"),
+        SendResult(
+            success=True,
+            message_id="foreign-1",
+            native_delivery_ack=NativeDeliveryAck(
+                platform="discord",
+                room_id="foreign-room",
+                self_actor_id="foreign-bot",
+                effect_kind="send",
+                submitted_content="host delivery",
+                message_id="foreign-1",
+                effect_id="foreign-1",
+            ),
+        ),
+        SendResult(
+            success=True,
+            message_id="source-1",
+            native_delivery_ack=NativeDeliveryAck(
+                platform="discord",
+                room_id="room-1",
+                self_actor_id="bot-9",
+                effect_kind="send",
+                submitted_content="host delivery",
+                message_id="source-1",
+                effect_id="source-1",
+            ),
+        ),
+    ],
+)
+async def test_route_delivery_rejects_missing_mismatched_or_reused_native_attestation(
+    native_result,
+):
+    async def send_native(_content: str):
+        return native_result
+
+    receipt = await GatewayDelivery(
+        send_native,
+        platform="discord",
+        room_id="room-1",
+        profile="work",
+        self_actor_id="bot-9",
+        source_message_id="source-1",
+    ).send("host delivery")
+
+    assert receipt == GatewayDeliveryReceipt(status="unknown")
+
+
+@pytest.mark.asyncio
+async def test_route_delivery_cannot_report_sent_without_authenticated_self_actor():
+    async def send_native(_content: str):
+        return SendResult(success=True, message_id="out-1")
+
+    receipt = await GatewayDelivery(
+        send_native,
+        platform="discord",
+        room_id="room-1",
+        profile="work",
+        self_actor_id=None,
+        source_message_id="source-1",
+    ).send("hello")
+
+    assert receipt == GatewayDeliveryReceipt(status="unknown")
+
+
+def test_discord_and_telegram_expose_authenticated_native_actor_ids():
+    from plugins.platforms.discord.adapter import DiscordAdapter
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    discord = object.__new__(DiscordAdapter)
+    discord._client = SimpleNamespace(user=SimpleNamespace(id=123))
+    telegram = object.__new__(TelegramAdapter)
+    telegram._bot = SimpleNamespace(id=456)
+
+    assert discord.authenticated_actor_id() == "123"
+    assert telegram.authenticated_actor_id() == "456"
+
+
+@pytest.mark.asyncio
+async def test_route_delivery_reports_raised_send_as_unknown_without_native_details():
+    async def send_native(_content: str):
+        raise RuntimeError("transport down")
+
+    receipt = await GatewayDelivery(
+        send_native,
+        platform="discord",
+        room_id="room-1",
+        profile="work",
+        self_actor_id="bot-9",
+        source_message_id="source-1",
+    ).send("hello")
+
+    assert receipt.status == "unknown"
+    assert receipt.message_id is None
+    assert not hasattr(receipt, "error")
+
+
+@pytest.mark.asyncio
+async def test_route_delivery_does_not_expose_native_send_callback():
+    import gateway.message_hooks as message_hooks
+
+    async def send_native(_content: str):
+        return SendResult(success=True, message_id="out-1")
+
+    delivery = GatewayDelivery(
+        send_native,
+        platform="discord",
+        room_id="room-1",
+        profile="work",
+        self_actor_id="bot-9",
+        source_message_id="source-1",
+    )
+
+    assert not hasattr(delivery, "_send_callback")
+    assert not hasattr(delivery, "_worker")
+    assert not hasattr(delivery, "__dict__")
+    assert not hasattr(message_hooks, "_DELIVERY_SEND_CALLBACKS")
+    assert send_native not in vars(message_hooks).values()
+    channels = list(message_hooks._DELIVERY_CHANNELS.values())
+    assert channels
+    await asyncio.sleep(0)
+    assert all(not channel.queue._getters for channel in channels)
+    assert all(
+        not any(callable(value) for value in (channel.queue, channel.revoked, channel.consumed))
+        for channel in channels
+    )
+    assert delivery.send.__func__.__closure__ is None
+    delivery._revoke()
+
+
+def _runner_for_dispatch():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.DISCORD: PlatformConfig(enabled=True)}
+    )
+    async def send_native(chat_id, content, reply_to=None, metadata=None):
+        return SendResult(
+            success=True,
+            message_id="out-1",
+            native_delivery_ack=NativeDeliveryAck(
+                platform="discord",
+                room_id=str(chat_id),
+                self_actor_id="9",
+                effect_kind="reply" if reply_to is not None else "send",
+                submitted_content=content,
+                reply_to_message_id=str(reply_to) if reply_to is not None else None,
+                message_id="out-1",
+                effect_id="out-1",
+            ),
+        )
+
+    async def react_native(chat_id, message_id, reaction, *, operation="add"):
+        return SendResult(
+            success=True,
+            message_id=str(message_id),
+            native_delivery_ack=NativeDeliveryAck(
+                platform="discord",
+                room_id=str(chat_id),
+                self_actor_id="9",
+                effect_kind="react",
+                target_message_id=str(message_id),
+                reaction=reaction,
+                reaction_operation="add" if operation == "add" else "remove",
+                effect_id="discord:reaction:test-effect",
+            ),
+        )
+
+    adapter = SimpleNamespace(
+        send=AsyncMock(side_effect=send_native),
+        react=AsyncMock(side_effect=react_native),
+        authenticated_actor_id=MagicMock(return_value="9"),
+        _pending_messages={},
+    )
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._profile_adapters = {"work": {Platform.DISCORD: adapter}}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store._is_rate_limited.return_value = False
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._update_prompt_pending = {}
+    runner._startup_restore_in_progress = False
+    runner._external_drain_active = False
+    runner._draining = False
+    runner._busy_input_mode = "queue"
+    runner._scale_to_zero_note_real_inbound = lambda: None
+    runner._is_user_authorized = lambda _source: True
+    runner._is_telegram_topic_root_lobby = lambda _source: False
+    runner._claim_active_session_slot = lambda *_args, **_kwargs: (None, None)
+    runner._persist_active_agents = lambda: None
+    runner._begin_session_run_generation = lambda _key: 1
+    runner._release_running_agent_state = MagicMock()
+    runner._release_turn_lease = MagicMock()
+    runner._restore_moa_one_shot = MagicMock()
+    runner._restore_pending_one_turn_model_override = MagicMock()
+    runner._handle_message_with_agent = AsyncMock(return_value="")
+    runner._queue_or_replace_pending_event = MagicMock()
+    runner.session_store = MagicMock()
+    runner.hooks = SimpleNamespace(emit_collect=AsyncMock(return_value=[]))
+    return runner, adapter
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("decision", ["handled", "suppress"])
+async def test_terminal_hook_handling_suppresses_cold_agent_dispatch(
+    monkeypatch, decision
+):
+    runner, adapter = _runner_for_dispatch()
+    captured = {}
+
+    async def hook(name, **kwargs):
+        captured["name"] = name
+        captured["kwargs"] = kwargs
+        receipt = await kwargs["delivery"].send("plugin reply")
+        assert receipt == GatewayDeliveryReceipt(status="sent", message_id="out-1")
+        return [{"decision": decision}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    raw_event = _event()
+    result = await runner._handle_message(raw_event)
+
+    assert result is None
+    runner._handle_message_with_agent.assert_not_awaited()
+    assert captured["name"] == "gateway_message"
+    assert set(captured["kwargs"]) == {
+        "event",
+        "route",
+        "delivery",
+        "raise_exceptions",
+        "stop_when",
+    }
+    assert captured["kwargs"]["raise_exceptions"] is True
+    assert captured["kwargs"]["stop_when"]({"decision": "handled"}) is True
+    assert captured["kwargs"]["stop_when"]({"decision": "pass"}) is False
+    assert not isinstance(captured["kwargs"]["event"], MessageEvent)
+    assert captured["kwargs"]["route"].session_key == build_session_key(_source())
+    adapter.send.assert_awaited_once_with(
+        "channel-1", "plugin reply", metadata={"thread_id": "thread-1"}
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("decision", ["continue", "pass"])
+async def test_continue_hook_decisions_reach_cold_agent_dispatch(monkeypatch, decision):
+    runner, _adapter = _runner_for_dispatch()
+
+    async def hook(_name, **_kwargs):
+        return [{"decision": decision}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    await runner._handle_message(_event())
+
+    runner._handle_message_with_agent.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_route_multiplexed_hook_runs_inside_resolved_profile_scope(
+    monkeypatch, tmp_path
+):
+    from hermes_cli.config import get_hermes_home
+
+    runner, _adapter = _runner_for_dispatch()
+    runner.config.multiplex_profiles = True
+    default_home = tmp_path / "default"
+    work_home = tmp_path / "profiles" / "work"
+    default_home.mkdir(parents=True)
+    work_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.setattr(
+        runner,
+        "_resolve_profile_home_for_source",
+        lambda _source: work_home,
+    )
+    observed = {}
+
+    async def hook(_name, **kwargs):
+        observed["home"] = get_hermes_home()
+        observed["profile"] = kwargs["route"].profile
+        return [{"decision": "handled"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    await runner._handle_message(_event())
+
+    assert observed == {"home": work_home, "profile": "work"}
+
+
+@pytest.mark.asyncio
+async def test_route_multiplexed_cancel_hook_runs_inside_resolved_profile_scope(
+    monkeypatch,
+    tmp_path,
+):
+    from hermes_cli.config import get_hermes_home
+
+    runner, _adapter = _runner_for_dispatch()
+    runner.config.multiplex_profiles = True
+    profile_home = tmp_path / "profiles" / "work"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(
+        runner,
+        "_resolve_profile_home_for_source",
+        lambda _source: profile_home,
+    )
+    observed_homes = []
+
+    async def hook(name, **_kwargs):
+        if name == "gateway_session_cancel":
+            observed_homes.append(get_hermes_home())
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+    source = _source()
+    source.profile = "work"
+
+    await runner._notify_gateway_session_cancel(
+        build_session_key(source, profile="work"),
+        source,
+        reason="stop",
+    )
+
+    assert observed_homes == [profile_home.resolve()]
+
+
+@pytest.mark.asyncio
+async def test_route_delivery_reply_is_bound_to_ingress_message(monkeypatch):
+    runner, adapter = _runner_for_dispatch()
+    receipts = []
+
+    async def hook(name, **kwargs):
+        if name == "gateway_message":
+            receipts.append(await kwargs["delivery"].reply("threaded"))
+            return [{"decision": "handled"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+    event = _event()
+    event.message_id = "in-1"
+
+    await runner._handle_message(event)
+
+    assert receipts == [
+        GatewayDeliveryReceipt(
+            status="sent",
+            platform="discord",
+            room_id="channel-1",
+            profile="work",
+            self_actor_id="9",
+            effect_kind="reply",
+            submitted_content="threaded",
+            reply_to_message_id="in-1",
+            message_id="out-1",
+            effect_id="out-1",
+        )
+    ]
+    adapter.send.assert_awaited_once_with(
+        "channel-1",
+        "threaded",
+        reply_to="in-1",
+        metadata={"thread_id": "thread-1"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_route_delivery_reaction_is_bound_to_ingress_message(monkeypatch):
+    runner, adapter = _runner_for_dispatch()
+    receipts = []
+
+    async def hook(name, **kwargs):
+        if name == "gateway_message":
+            receipts.append(
+                await kwargs["delivery"].react("👍", operation="add")
+            )
+            return [{"decision": "handled"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+    event = _event()
+    event.message_id = "in-1"
+
+    await runner._handle_message(event)
+
+    assert len(receipts) == 1
+    assert receipts[0].status == "sent"
+    assert receipts[0].platform == "discord"
+    assert receipts[0].room_id == "channel-1"
+    assert receipts[0].profile == "work"
+    assert receipts[0].self_actor_id == "9"
+    assert receipts[0].effect_kind == "react"
+    assert receipts[0].target_message_id == "in-1"
+    assert receipts[0].reaction == "👍"
+    assert receipts[0].reaction_operation == "add"
+    assert receipts[0].message_id is None
+    assert receipts[0].effect_id.startswith("discord:reaction:")
+    adapter.react.assert_awaited_once_with(
+        "channel-1",
+        "in-1",
+        "👍",
+        operation="add",
+    )
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_session_cancel_revokes_retained_delivery_before_observer(monkeypatch):
+    runner, adapter = _runner_for_dispatch()
+    retained = []
+    cancel_observed_revoked = []
+
+    async def hook(name, **kwargs):
+        if name == "gateway_message":
+            retained.append(kwargs["delivery"])
+            return [{"decision": "handled"}]
+        if name == "gateway_session_cancel":
+            cancel_observed_revoked.append(
+                (await retained[0].send("too late")).status
+            )
+            return []
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    event = _event()
+    await runner._handle_message(event)
+    session_key = build_session_key(event.source)
+    await runner._notify_gateway_session_cancel(
+        session_key,
+        event.source,
+        reason="stop",
+    )
+
+    assert cancel_observed_revoked == ["failed"]
+    assert (await retained[0].send("still too late")).status == "failed"
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_revokes_retained_delivery_without_active_agent(monkeypatch):
+    runner, adapter = _runner_for_dispatch()
+    retained = []
+
+    async def hook(name, **kwargs):
+        if name == "gateway_message":
+            retained.append(kwargs["delivery"])
+            return [{"decision": "handled"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+    await runner._handle_message(_event())
+
+    runner._revoke_all_gateway_deliveries()
+
+    assert (await retained[0].send("after drain")).status == "failed"
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_new_ingress_preserves_prior_retained_delivery_until_boundary(monkeypatch):
+    runner, adapter = _runner_for_dispatch()
+    retained = []
+
+    async def hook(name, **kwargs):
+        if name == "gateway_message":
+            retained.append(kwargs["delivery"])
+            return [{"decision": "handled"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    first = _event()
+    first.message_id = "m1"
+    second = _event()
+    second.message_id = "m2"
+    await runner._handle_message(first)
+    await runner._handle_message(second)
+
+    assert len(retained) == 2
+    assert (await retained[0].send("still-current")).status == "sent"
+    assert (await retained[1].send("current")).status == "sent"
+    assert adapter.send.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_native_batch_preserves_each_retained_delivery_until_consumed(
+    monkeypatch,
+):
+    runner, adapter = _runner_for_dispatch()
+    retained = []
+
+    async def hook(name, **kwargs):
+        if name == "gateway_message":
+            retained.append(kwargs["delivery"])
+            return [{"decision": "handled"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+    first = _event()
+    first.message_id = "m1"
+    second = _event()
+    second.message_id = "m2"
+    merged = _event()
+    merged.metadata["_gateway_native_events"] = (first, second)
+
+    await runner._handle_message(merged)
+
+    assert len(retained) == 2
+    assert (await retained[0].reply("first reply")).status == "sent"
+    assert (await retained[1].send("second message")).status == "sent"
+    assert adapter.send.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_discord_text_batch_invokes_hook_once_per_native_event(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+    first = _event()
+    first.message_id = "m1"
+    first.text = "ordinary"
+    first.metadata["mentioned_user_ids"] = ()
+    second = _event()
+    second.message_id = "m2"
+    second.text = "@bot"
+    second.source.user_id = "8"
+    second.source.user_name = "second-user"
+    second.metadata["mentioned_user_ids"] = ("9",)
+    merged = _event()
+    merged.message_id = "m1"
+    merged.text = "ordinary\n@bot"
+    merged.metadata.update(
+        {
+            "mentioned_user_ids": ("9",),
+            "_gateway_native_events": (first, second),
+        }
+    )
+    observed = []
+
+    async def hook(_name, **kwargs):
+        observed.append(
+            (
+                kwargs["event"].message_id,
+                kwargs["event"].text,
+                kwargs["event"].mentioned_user_ids,
+                kwargs["route"].user_id,
+            )
+        )
+        return [{"decision": "handled"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    await runner._handle_message(merged)
+
+    assert observed == [
+        ("m1", "ordinary", (), "user-1"),
+        ("m2", "@bot", ("9",), "8"),
+    ]
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_busy_legacy_predispatch_conflict_fails_closed_before_any_hook(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+    event = _event()
+    session_key = build_session_key(event.source)
+    participant_hook = AsyncMock()
+    pre_hook = MagicMock(return_value=[{"action": "skip", "reason": "legacy-v1"}])
+
+    monkeypatch.setattr(
+        "hermes_cli.plugins.has_hook",
+        lambda name: name in {"gateway_message", "pre_gateway_dispatch"},
+    )
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", pre_hook)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", participant_hook)
+
+    handled = await runner._handle_active_session_busy_message(event, session_key)
+
+    assert handled is True
+    pre_hook.assert_not_called()
+    participant_hook.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "marker",
+    ["_hermes_startup_restore_replay", "_hermes_historical_replay"],
+)
+def test_replay_never_executes_legacy_predispatch_hook(monkeypatch, marker):
+    runner, _adapter = _runner_for_dispatch()
+    event = _event()
+    setattr(event, marker, True)
+    legacy_hook = MagicMock(return_value=[{"action": "skip", "reason": "legacy-v1"}])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", legacy_hook)
+
+    assert runner._run_pre_gateway_dispatch(event) is False
+    legacy_hook.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_busy_pre_dispatch_skip_runs_before_plaintext_approval(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+    event = _event()
+    event.text = "yes"
+    session_key = build_session_key(event.source)
+    runner._handle_approve_command = AsyncMock(return_value=None)
+
+    monkeypatch.setattr(
+        "tools.approval.has_blocking_approval",
+        lambda key: key == session_key,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.plugins.invoke_hook",
+        lambda name, **_kwargs: (
+            [{"action": "skip", "reason": "fixture"}]
+            if name == "pre_gateway_dispatch"
+            else []
+        ),
+    )
+
+    handled = await runner._handle_active_session_busy_message(event, session_key)
+
+    assert handled is True
+    runner._handle_approve_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "marker",
+    ["_hermes_startup_restore_replay", "_hermes_historical_replay"],
+)
+async def test_replayed_ingress_never_reaches_gateway_message(monkeypatch, marker):
+    runner, _adapter = _runner_for_dispatch()
+    event = _event()
+    setattr(event, marker, True)
+    participant_hook = AsyncMock()
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", participant_hook)
+
+    suppressed = await runner._run_gateway_message_hook(
+        event,
+        event.source,
+        build_session_key(event.source),
+    )
+
+    assert suppressed is True
+    participant_hook.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "marker",
+    ["_hermes_startup_restore_replay", "_hermes_historical_replay"],
+)
+async def test_replayed_cold_ingress_is_consumed_before_ordinary_agent(
+    monkeypatch, marker
+):
+    runner, _adapter = _runner_for_dispatch()
+    event = _event()
+    setattr(event, marker, True)
+    participant_hook = AsyncMock()
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", participant_hook)
+
+    result = await runner._handle_message(event)
+
+    assert result is None
+    participant_hook.assert_not_awaited()
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "marker",
+    ["_hermes_startup_restore_replay", "_hermes_historical_replay"],
+)
+async def test_replayed_busy_ingress_is_consumed_before_queue_or_interrupt(
+    monkeypatch, marker
+):
+    runner, _adapter = _runner_for_dispatch()
+    event = _event()
+    setattr(event, marker, True)
+    session_key = build_session_key(event.source)
+    running_agent = MagicMock()
+    runner._running_agents[session_key] = running_agent
+    participant_hook = AsyncMock()
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", participant_hook)
+
+    handled = await runner._handle_active_session_busy_message(event, session_key)
+
+    assert handled is True
+    participant_hook.assert_not_awaited()
+    running_agent.interrupt.assert_not_called()
+    runner._queue_or_replace_pending_event.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_live_ingress_queued_during_startup_restore_is_observed_once(monkeypatch):
+    runner, adapter = _runner_for_dispatch()
+    runner._startup_restore_in_progress = True
+    runner._startup_restore_queue = []
+    adapter.handle_message = AsyncMock(side_effect=runner._handle_message)
+    participant_hook = AsyncMock(return_value=[{"decision": "pass"}])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", participant_hook)
+    event = _event()
+
+    await runner._handle_message(event)
+
+    participant_hook.assert_not_awaited()
+    runner._handle_message_with_agent.assert_not_awaited()
+    assert runner._startup_restore_queue == [event]
+
+    drained = await runner._drain_startup_restore_queue()
+
+    assert drained == 1
+    assert runner._startup_restore_queue == []
+    participant_hook.assert_awaited_once()
+    runner._handle_message_with_agent.assert_awaited_once()
+    assert runner._handle_message_with_agent.await_args.args[0] is event
+
+
+def test_telegram_native_ack_room_includes_topic_identity():
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    assert (
+        TelegramAdapter._native_delivery_room_id(
+            "-100", {"thread_id": "42"}
+        )
+        == "-100:topic:42"
+    )
+    assert TelegramAdapter._native_delivery_room_id("-100", None) == "-100"
+
+
+@pytest.mark.asyncio
+async def test_telegram_strict_topic_effect_never_falls_back_to_root_chat():
+    from telegram.error import BadRequest
+
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    config = PlatformConfig(enabled=True, token="fake-token")
+    adapter.config = config
+    adapter._config = config
+    adapter._platform = Platform.TELEGRAM
+    adapter.platform = Platform.TELEGRAM
+    adapter._connected = True
+    adapter._dm_topics = {}
+    adapter._dm_topics_config = []
+    adapter._reply_to_mode = "first"
+    adapter._fallback_ips = []
+    adapter._polling_conflict_count = 0
+    adapter._polling_network_error_count = 0
+    adapter._polling_error_callback_ref = None
+    call_log = []
+
+    async def send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        raise BadRequest("Message thread not found")
+
+    adapter._bot = SimpleNamespace(send_message=send_message)
+    result = await adapter.send(
+        chat_id="-100",
+        content="participant effect",
+        metadata={
+            "thread_id": "42",
+            "_hermes_require_topic_route": True,
+        },
+    )
+
+    assert result.success is False
+    assert result.retryable is False
+    assert len(call_log) == 2
+    assert all(call["message_thread_id"] == 42 for call in call_log)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["send", "reply", "react"])
+async def test_telegram_topic_delivery_uses_canonical_room_identity(
+    monkeypatch, operation
+):
+    runner, adapter = _runner_for_dispatch()
+    source = dataclasses.replace(
+        _source(),
+        platform=Platform.TELEGRAM,
+        scope_id=None,
+        chat_id="-100",
+        chat_type="group",
+        thread_id="42",
+    )
+    event = dataclasses.replace(_event(), source=source)
+
+    async def send_native(chat_id, content, reply_to=None, metadata=None):
+        assert metadata["_hermes_require_topic_route"] is True
+        return SendResult(
+            success=True,
+            message_id="telegram-out-1",
+            native_delivery_ack=NativeDeliveryAck(
+                platform="telegram",
+                room_id=f"{chat_id}:topic:{metadata['thread_id']}",
+                self_actor_id="9",
+                effect_kind="reply" if reply_to is not None else "send",
+                submitted_content=content,
+                reply_to_message_id=str(reply_to) if reply_to is not None else None,
+                message_id="telegram-out-1",
+                effect_id="telegram-out-1",
+            ),
+        )
+
+    async def react_native(
+        chat_id, message_id, reaction, *, operation="add", metadata=None
+    ):
+        assert metadata["_hermes_require_topic_route"] is True
+        return SendResult(
+            success=True,
+            message_id=str(message_id),
+            native_delivery_ack=NativeDeliveryAck(
+                platform="telegram",
+                room_id=f"{chat_id}:topic:{metadata['thread_id']}",
+                self_actor_id="9",
+                effect_kind="react",
+                target_message_id=str(message_id),
+                reaction=reaction,
+                reaction_operation=operation,
+                effect_id="telegram:reaction:topic-effect",
+            ),
+        )
+
+    adapter.send = AsyncMock(side_effect=send_native)
+    adapter.react = AsyncMock(side_effect=react_native)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._profile_adapters = {"work": {Platform.TELEGRAM: adapter}}
+    receipts = []
+
+    async def hook(_name, **kwargs):
+        assert kwargs["route"].chat_id == "-100"
+        assert kwargs["route"].thread_id == "42"
+        if operation == "send":
+            receipts.append(await kwargs["delivery"].send("topic message"))
+        elif operation == "reply":
+            receipts.append(await kwargs["delivery"].reply("topic reply"))
+        else:
+            receipts.append(await kwargs["delivery"].react("+1"))
+        return [{"decision": "handled"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook)
+
+    await runner._handle_message(event)
+
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt.status == "sent"
+    assert receipt.room_id == "-100:topic:42"
+    assert receipt.effect_kind == operation
+    if operation == "react":
+        assert receipt.target_message_id == "incoming-1"
+        assert receipt.effect_id == "telegram:reaction:topic-effect"
+    else:
+        assert receipt.message_id == "telegram-out-1"
+
+
+@pytest.mark.asyncio
+async def test_real_base_adapter_busy_ingress_reaches_gateway_message_hook_once(monkeypatch):
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, _chat_id, _content, **_kwargs):
+        return SendResult(success=True, message_id="busy-out")
+
+    Adapter = type(
+        "BusyHookAdapter",
+        (BasePlatformAdapter,),
+        {"connect": connect, "disconnect": disconnect, "send": send},
+    )
+    Adapter.__abstractmethods__ = frozenset()
+
+    runner, _old_adapter = _runner_for_dispatch()
+    adapter = Adapter(PlatformConfig(enabled=True), Platform.DISCORD)
+    adapter._message_handler = AsyncMock()
+    adapter._busy_session_handler = runner._handle_active_session_busy_message
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._profile_adapters = {"work": {Platform.DISCORD: adapter}}
+    runner._busy_ack_ts = {}
+
+    event = MessageEvent(
+        text="busy follow-up",
+        message_type=MessageType.TEXT,
+        source=_source(),
+        message_id="busy-in",
+    )
+    session_key = build_session_key(event.source)
+    running_agent = MagicMock()
+    running_agent.get_activity_summary.return_value = {}
+    runner._running_agents[session_key] = running_agent
+    adapter._active_sessions[session_key] = asyncio.Event()
+    calls = []
+
+    async def hook(name, **kwargs):
+        calls.append((name, kwargs["route"].session_key))
+        return [{"decision": "handled"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook)
+
+    await adapter.handle_message(event)
+
+    assert calls == [("gateway_message", session_key)]
+    running_agent.interrupt.assert_not_called()
+    assert session_key not in adapter._pending_messages
+
+
+@pytest.mark.asyncio
+async def test_busy_pass_event_crosses_gateway_message_hook_only_once_after_replay(monkeypatch):
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, _chat_id, _content, **_kwargs):
+        return SendResult(success=True, message_id="busy-pass-out")
+
+    Adapter = type(
+        "BusyPassAdapter",
+        (BasePlatformAdapter,),
+        {"connect": connect, "disconnect": disconnect, "send": send},
+    )
+    Adapter.__abstractmethods__ = frozenset()
+
+    runner, _old_adapter = _runner_for_dispatch()
+    runner._busy_text_mode = "queue"
+    adapter = Adapter(PlatformConfig(enabled=True), Platform.DISCORD)
+    adapter._message_handler = runner._handle_message
+    adapter._busy_session_handler = runner._handle_active_session_busy_message
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._profile_adapters = {"work": {Platform.DISCORD: adapter}}
+    runner._busy_ack_ts = {}
+
+    event = MessageEvent(
+        text="busy passing follow-up",
+        message_type=MessageType.TEXT,
+        source=_source(),
+        message_id="busy-pass-in",
+    )
+    session_key = build_session_key(event.source)
+    running_agent = MagicMock()
+    running_agent.get_activity_summary.return_value = {}
+    runner._running_agents[session_key] = running_agent
+    adapter._active_sessions[session_key] = asyncio.Event()
+    calls = []
+
+    async def hook(name, **kwargs):
+        calls.append((name, kwargs["event"].message_id))
+        return [{"decision": "pass"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+
+    await adapter.handle_message(event)
+    assert calls == [("gateway_message", "busy-pass-in")]
+    queued = adapter._pending_messages.pop(session_key)
+
+    adapter._active_sessions.pop(session_key, None)
+    runner._running_agents.pop(session_key, None)
+    await adapter.handle_message(queued)
+    await adapter._session_tasks[session_key]
+
+    assert calls == [("gateway_message", "busy-pass-in")]
+
+
+@pytest.mark.asyncio
+async def test_busy_external_drain_rejects_before_gateway_message_hook(monkeypatch):
+    runner, adapter = _runner_for_dispatch()
+    runner._external_drain_active = True
+    adapter._send_with_retry = AsyncMock(
+        return_value=SendResult(success=True, message_id="drain-refusal")
+    )
+    event = _event()
+    event.message_id = "busy-drain-in"
+    session_key = build_session_key(event.source)
+    calls = []
+
+    async def hook(name, **_kwargs):
+        calls.append(name)
+        return [{"decision": "handled"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook)
+
+    handled = await runner._handle_active_session_busy_message(event, session_key)
+
+    assert handled is True
+    assert calls == []
+    adapter._send_with_retry.assert_awaited_once()
+    assert "draining for a maintenance action" in adapter._send_with_retry.await_args.kwargs["content"]
+
+
+@pytest.mark.asyncio
+async def test_busy_multiplexed_route_uses_profile_scoped_session_key(monkeypatch):
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, _chat_id, _content, **_kwargs):
+        return SendResult(success=True, message_id="profile-out")
+
+    Adapter = type(
+        "BusyProfileAdapter",
+        (BasePlatformAdapter,),
+        {"connect": connect, "disconnect": disconnect, "send": send},
+    )
+    Adapter.__abstractmethods__ = frozenset()
+
+    runner, _old_adapter = _runner_for_dispatch()
+    runner.config.multiplex_profiles = True
+    adapter = Adapter(PlatformConfig(enabled=True), Platform.DISCORD)
+    adapter.gateway_runner = runner
+    adapter._message_handler = runner._handle_message
+    adapter._busy_session_handler = runner._handle_active_session_busy_message
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._profile_adapters = {"work": {Platform.DISCORD: adapter}}
+
+    event = _event()
+    event.source.profile = "work"
+    event.message_id = "busy-profile-in"
+    profile_key = runner._session_key_for_source(event.source)
+    legacy_key = build_session_key(event.source)
+    assert profile_key != legacy_key
+    adapter._active_sessions[profile_key] = asyncio.Event()
+    adapter._active_sessions[legacy_key] = asyncio.Event()
+    runner._running_agents[profile_key] = MagicMock()
+    runner._running_agents[legacy_key] = MagicMock()
+    seen = []
+
+    async def hook(_name, **kwargs):
+        seen.append(kwargs["route"].session_key)
+        return [{"decision": "handled"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook)
+
+    await adapter.handle_message(event)
+
+    assert seen == [profile_key]
+
+
+@pytest.mark.asyncio
+async def test_busy_slash_command_queues_without_gateway_message_hook(monkeypatch):
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, _chat_id, _content, **_kwargs):
+        return SendResult(success=True, message_id="command-out")
+
+    Adapter = type(
+        "BusyCommandAdapter",
+        (BasePlatformAdapter,),
+        {"connect": connect, "disconnect": disconnect, "send": send},
+    )
+    Adapter.__abstractmethods__ = frozenset()
+
+    runner, _old_adapter = _runner_for_dispatch()
+    adapter = Adapter(PlatformConfig(enabled=True), Platform.DISCORD)
+    adapter._message_handler = AsyncMock(return_value="unknown command")
+    adapter._busy_session_handler = runner._handle_active_session_busy_message
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._profile_adapters = {"work": {Platform.DISCORD: adapter}}
+    event = _event()
+    event.text = "/plugin-command"
+    event.message_id = "busy-command-in"
+    session_key = build_session_key(event.source)
+    adapter._active_sessions[session_key] = asyncio.Event()
+    seen = []
+
+    async def hook(name, **_kwargs):
+        seen.append(name)
+        return [{"decision": "handled"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook)
+
+    await adapter.handle_message(event)
+
+    assert seen == []
+    adapter._message_handler.assert_not_awaited()
+    assert adapter._pending_messages[session_key] is event
+
+
+@pytest.mark.asyncio
+async def test_awaited_cold_hook_cannot_start_duplicate_agents(monkeypatch):
+    runner, adapter = _runner_for_dispatch()
+    first_hook_entered = asyncio.Event()
+    release_first_hook = asyncio.Event()
+    hook_calls = 0
+    active_agent_calls = 0
+    max_concurrent_agent_calls = 0
+
+    async def hook(_name, **_kwargs):
+        nonlocal hook_calls
+        hook_calls += 1
+        if hook_calls == 1:
+            first_hook_entered.set()
+            await release_first_hook.wait()
+        return [{"decision": "pass"}]
+
+    async def run_agent(*_args, **_kwargs):
+        nonlocal active_agent_calls, max_concurrent_agent_calls
+        active_agent_calls += 1
+        max_concurrent_agent_calls = max(
+            max_concurrent_agent_calls,
+            active_agent_calls,
+        )
+        await asyncio.sleep(0)
+        active_agent_calls -= 1
+        return ""
+
+    runner._handle_message_with_agent = run_agent
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    first = asyncio.create_task(runner._handle_message(_event()))
+    await first_hook_entered.wait()
+    second = asyncio.create_task(runner._handle_message(_event()))
+    for _ in range(100):
+        if hook_calls == 2:
+            break
+        await asyncio.sleep(0)
+    release_first_hook.set()
+    await asyncio.gather(first, second)
+
+    assert hook_calls == 2
+    assert max_concurrent_agent_calls == 1
+    assert build_session_key(_source()) in adapter._pending_messages
+
+
+@pytest.mark.asyncio
+async def test_route_delivery_binds_relay_to_ingress_logical_platform(monkeypatch):
+    runner, _native_adapter = _runner_for_dispatch()
+    relay = SimpleNamespace(
+        send=AsyncMock(return_value=SendResult(success=True, message_id="wrong-route")),
+        send_for_platform=AsyncMock(
+            return_value=SendResult(success=True, message_id="relay-out")
+        ),
+        _pending_messages={},
+    )
+    runner.adapters = {Platform.RELAY: relay}
+    event = _event()
+    event.source.delivered_via_upstream_relay = True
+
+    async def hook(_name, **kwargs):
+        receipt = await kwargs["delivery"].send("relay reply")
+        assert receipt == GatewayDeliveryReceipt(status="sent", message_id="relay-out")
+        return [{"decision": "handled"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    await runner._handle_message(event)
+
+    relay.send_for_platform.assert_awaited_once_with(
+        Platform.DISCORD,
+        "channel-1",
+        "relay reply",
+        metadata={
+            "thread_id": "thread-1",
+            "scope_id": "guild-1",
+            "user_id": "user-1",
+        },
+    )
+    relay.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unmatched_none_hook_reaches_cold_agent_dispatch(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+
+    async def hook(_name, **_kwargs):
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    await runner._handle_message(_event())
+
+    runner._handle_message_with_agent.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_result", ["handled", {}, {"decision": "other"}])
+async def test_invalid_terminal_hook_results_fail_closed(monkeypatch, invalid_result):
+    runner, _adapter = _runner_for_dispatch()
+
+    async def hook(_name, **_kwargs):
+        return [invalid_result]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    assert await runner._handle_message(_event()) is None
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_terminal_hook_exception_fails_closed(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+
+    async def hook(_name, **_kwargs):
+        raise RuntimeError("hook failed")
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    assert await runner._handle_message(_event()) is None
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_terminal_hook_runs_on_active_session_before_busy_queue(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+    session_key = build_session_key(_source())
+    running_agent = MagicMock()
+    runner._running_agents[session_key] = running_agent
+
+    async def hook(_name, **_kwargs):
+        return [{"decision": "handled"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    assert await runner._handle_message(_event()) is None
+    runner._queue_or_replace_pending_event.assert_not_called()
+    running_agent.interrupt.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_active_session_drain_gate_prevents_hook_side_effects(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+    session_key = build_session_key(_source())
+    runner._running_agents[session_key] = MagicMock()
+    runner._draining = True
+    hook = AsyncMock(return_value=[])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    result = await runner._handle_message(_event())
+
+    hook.assert_not_awaited()
+    assert "not accepting" in str(result).lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("event_mutation", "authorized"),
+    [
+        (lambda event: setattr(event, "internal", True), True),
+        (lambda _event: None, False),
+        (lambda event: setattr(event, "text", "/help"), True),
+    ],
+)
+async def test_hook_never_runs_for_internal_unauthorized_or_slash_events(
+    monkeypatch, event_mutation, authorized
+):
+    runner, _adapter = _runner_for_dispatch()
+    runner._is_user_authorized = lambda _source: authorized
+    runner._handle_help_command = AsyncMock(return_value="help")
+    hook = AsyncMock(return_value=[{"decision": "handled"}])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+    event = _event()
+    if not authorized:
+        event.source.chat_type = "group"
+    event_mutation(event)
+
+    await runner._handle_message(event)
+
+    hook.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_hook_runs_after_pending_update_response_intercept(monkeypatch, tmp_path):
+    runner, _adapter = _runner_for_dispatch()
+    event = _event()
+    event.text = "yes"
+    session_key = build_session_key(event.source)
+    runner._update_prompt_pending[session_key] = True
+    hook = AsyncMock(return_value=[{"decision": "handled"}])
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    result = await runner._handle_message(event)
+
+    assert "Sent" in result
+    hook.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_active_session_stop_notifies_cancel_hook_before_interrupt(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+    source = _source()
+    session_key = build_session_key(source)
+    runner._running_agents[session_key] = MagicMock()
+    runner._notify_gateway_session_cancel = AsyncMock()
+    runner._interrupt_and_clear_session = AsyncMock()
+    event = _event()
+    event.text = "/stop"
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+
+    await runner._handle_message(event)
+
+    runner._notify_gateway_session_cancel.assert_awaited_once_with(
+        session_key,
+        source,
+        reason="stop",
+    )
+    runner._interrupt_and_clear_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_active_session_new_notifies_cancel_hook_before_interrupt(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+    source = _source()
+    session_key = build_session_key(source)
+    runner._running_agents[session_key] = MagicMock()
+    order = []
+
+    async def notify(*_args, **_kwargs):
+        order.append("notify")
+
+    async def interrupt(*_args, **_kwargs):
+        order.append("interrupt")
+
+    async def reset(*_args, **kwargs):
+        order.append(("reset", kwargs))
+        return "reset"
+
+    runner._notify_gateway_session_cancel = notify
+    runner._interrupt_and_clear_session = interrupt
+    runner._handle_reset_command = reset
+    event = _event()
+    event.text = "/new"
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+
+    assert await runner._handle_message(event) == "reset"
+
+    assert order == ["notify", "interrupt", ("reset", {"cancel_notified": True})]
+
+
+@pytest.mark.asyncio
+async def test_cold_hook_sees_recovered_telegram_route(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        profile="default",
+        scope_id="scope-1",
+        chat_id="chat-1",
+        chat_name="Room",
+        chat_type="dm",
+        thread_id="stale-thread",
+        user_id="user-1",
+        user_name="User",
+    )
+    adapter = SimpleNamespace(
+        send=AsyncMock(return_value=SendResult(success=True, message_id="native-1")),
+        _pending_messages={},
+        _active_sessions={},
+        _session_locks={},
+        _stop_typing=AsyncMock(),
+        _pending_lock=threading.Lock(),
+        cancel_pending_drain=lambda _key: None,
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.config.platforms[Platform.TELEGRAM] = PlatformConfig(enabled=True, token="***")
+    runner._recover_telegram_topic_thread_id = lambda _source: "canonical-thread"
+    runner._is_telegram_topic_root_lobby = lambda _source: False
+    captured = {}
+
+    async def hook(_name, **kwargs):
+        captured.update(kwargs)
+        return [{"decision": "handled"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook)
+    event = MessageEvent(text="hello", source=source, message_id="in-1")
+
+    await runner._handle_message(event)
+
+    assert captured["route"].thread_id == "canonical-thread"
+    assert captured["route"].session_key == build_session_key(
+        dataclasses.replace(source, thread_id="canonical-thread")
+    )
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_gateway_session_cancel_hook_receives_only_route_and_reason(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+    captured = {}
+
+    async def hook(name, **kwargs):
+        captured["name"] = name
+        captured["kwargs"] = kwargs
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+    source = _source()
+    session_key = build_session_key(source)
+
+    await runner._notify_gateway_session_cancel(session_key, source, reason="stop")
+
+    assert captured["name"] == "gateway_session_cancel"
+    assert set(captured["kwargs"]) == {"route", "reason", "offload_callbacks"}
+    assert captured["kwargs"]["offload_callbacks"] is True
+    assert captured["kwargs"]["reason"] == "stop"
+    assert captured["kwargs"]["route"] == GatewayMessageRoute.from_source(
+        source, session_key=session_key
+    )
+
+
+@pytest.mark.asyncio
+async def test_gateway_session_cancel_hook_timeout_does_not_block_stop(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+    entered = asyncio.Event()
+
+    async def stuck_hook(_name, **_kwargs):
+        entered.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", stuck_hook)
+    monkeypatch.setattr("gateway.run.GATEWAY_SESSION_CANCEL_TIMEOUT_SECONDS", 0.01)
+    source = _source()
+
+    await runner._notify_gateway_session_cancel(
+        build_session_key(source),
+        source,
+        reason="stop",
+    )
+
+    assert entered.is_set()
+
+
+@pytest.mark.asyncio
+async def test_gateway_session_cancel_timeout_survives_cancel_suppressing_async_observer(
+    monkeypatch,
+):
+    from gateway import run as run_module
+    from hermes_cli.plugins import get_plugin_manager
+
+    runner, _adapter = _runner_for_dispatch()
+    manager = get_plugin_manager()
+    original = list(manager._hooks.get("gateway_session_cancel", []))
+    entered = threading.Event()
+    release = threading.Event()
+
+    async def cancellation_suppressing_observer(**_kwargs):
+        entered.set()
+        try:
+            while not release.is_set():
+                await asyncio.sleep(0.01)
+        except asyncio.CancelledError:
+            while not release.is_set():
+                await asyncio.sleep(0.01)
+
+    manager._hooks["gateway_session_cancel"] = [cancellation_suppressing_observer]
+    monkeypatch.setattr(run_module, "GATEWAY_SESSION_CANCEL_TIMEOUT_SECONDS", 0.01)
+    source = _source()
+    started = asyncio.get_running_loop().time()
+    try:
+        await asyncio.wait_for(
+            runner._notify_gateway_session_cancel(
+                build_session_key(source),
+                source,
+                reason="stop",
+            ),
+            timeout=0.1,
+        )
+        elapsed = asyncio.get_running_loop().time() - started
+        assert entered.is_set()
+        assert elapsed < 0.1
+    finally:
+        release.set()
+        manager._hooks["gateway_session_cancel"] = original
+
+
+@pytest.mark.asyncio
+async def test_gateway_session_cancel_timeout_bounds_blocking_sync_observer(monkeypatch):
+    from gateway import run as run_module
+    from hermes_cli.plugins import get_plugin_manager
+
+    runner, _adapter = _runner_for_dispatch()
+    manager = get_plugin_manager()
+    original = list(manager._hooks.get("gateway_session_cancel", []))
+    entered = threading.Event()
+    release = threading.Event()
+
+    def blocking_observer(**_kwargs):
+        entered.set()
+        release.wait(1)
+
+    manager._hooks["gateway_session_cancel"] = [blocking_observer]
+    monkeypatch.setattr(run_module, "GATEWAY_SESSION_CANCEL_TIMEOUT_SECONDS", 0.01)
+    source = _source()
+    session_key = build_session_key(source)
+    started = asyncio.get_running_loop().time()
+    try:
+        await runner._notify_gateway_session_cancel(session_key, source, reason="stop")
+        elapsed = asyncio.get_running_loop().time() - started
+        assert entered.is_set()
+        assert elapsed < 0.1
+    finally:
+        release.set()
+        manager._hooks["gateway_session_cancel"] = original

--- a/tests/gateway/test_gateway_message_hooks.py
+++ b/tests/gateway/test_gateway_message_hooks.py
@@ -191,6 +191,14 @@ def test_route_snapshot_fills_resolved_active_profile_when_source_is_unset(monke
         ),
         (
             SendResult(success=False, error="rejected with credential-shaped detail"),
+            GatewayDeliveryReceipt(status="unknown"),
+        ),
+        (
+            SendResult(
+                success=False,
+                error="rejected before native submit",
+                native_delivery_non_occurrence_attested=True,
+            ),
             GatewayDeliveryReceipt(status="failed"),
         ),
         (
@@ -226,6 +234,56 @@ async def test_route_delivery_returns_truthful_normalized_receipts(native_result
     assert not hasattr(delivery, "credentials")
     assert not hasattr(delivery, "event")
     assert not hasattr(delivery, "_send_callback")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "native_result",
+    [
+        SendResult(success=False, error="request timed out after submit"),
+        SendResult(
+            success=True,
+            message_id="chunk-1",
+            raw_response={
+                "partial_overflow": True,
+                "delivered_chunks": 1,
+                "total_chunks": 2,
+            },
+            native_delivery_ack=NativeDeliveryAck(
+                platform="discord",
+                room_id="room-1",
+                self_actor_id="bot-9",
+                effect_kind="send",
+                submitted_content="host delivery",
+                message_id="chunk-1",
+                effect_id="chunk-1",
+            ),
+        ),
+    ],
+)
+async def test_route_delivery_normalizes_timeout_and_partial_send_to_unknown(
+    native_result,
+):
+    async def send_native(_content: str):
+        return native_result
+
+    receipt = await GatewayDelivery(
+        send_native,
+        platform="discord",
+        room_id="room-1",
+        profile="work",
+        self_actor_id="bot-9",
+        source_message_id="source-1",
+    ).send("host delivery")
+
+    assert receipt == GatewayDeliveryReceipt(status="unknown")
+
+
+def test_send_result_fifth_positional_argument_remains_retryable():
+    result = SendResult(False, None, "retry", None, True)
+
+    assert result.retryable is True
+    assert result.native_delivery_ack is None
 
 
 @pytest.mark.asyncio
@@ -445,8 +503,7 @@ async def test_terminal_hook_handling_suppresses_cold_agent_dispatch(
     async def hook(name, **kwargs):
         captured["name"] = name
         captured["kwargs"] = kwargs
-        receipt = await kwargs["delivery"].send("plugin reply")
-        assert receipt == GatewayDeliveryReceipt(status="sent", message_id="out-1")
+        captured["receipt"] = await kwargs["delivery"].send("plugin reply")
         return [{"decision": decision}]
 
     monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
@@ -470,9 +527,36 @@ async def test_terminal_hook_handling_suppresses_cold_agent_dispatch(
     assert captured["kwargs"]["stop_when"]({"decision": "pass"}) is False
     assert not isinstance(captured["kwargs"]["event"], MessageEvent)
     assert captured["kwargs"]["route"].session_key == build_session_key(_source())
+    assert captured["receipt"].status == "sent"
+    assert captured["receipt"].message_id == "out-1"
     adapter.send.assert_awaited_once_with(
         "channel-1", "plugin reply", metadata={"thread_id": "thread-1"}
     )
+
+
+@pytest.mark.asyncio
+async def test_delivery_ttl_starts_after_participant_hook_finishes(monkeypatch):
+    import gateway.message_hooks as message_hooks
+
+    runner, _adapter = _runner_for_dispatch()
+    receipts = []
+
+    async def hook(_name, **kwargs):
+        await asyncio.sleep(0.03)
+        receipts.append(await kwargs["delivery"].send("still live"))
+        return [{"decision": "handled"}]
+
+    monkeypatch.setattr(
+        message_hooks,
+        "GATEWAY_DELIVERY_CAPABILITY_TTL_SECONDS",
+        0.01,
+    )
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    await runner._handle_message(_event())
+
+    assert receipts[0].status == "sent"
 
 
 @pytest.mark.asyncio
@@ -801,6 +885,65 @@ async def test_discord_text_batch_invokes_hook_once_per_native_event(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_mixed_native_batch_dispatches_only_passed_subset_in_order(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+    first = _event()
+    first.message_id = "m1"
+    first.text = "handled-first"
+    first.media_urls = ["/tmp/handled.png"]
+    first.media_types = ["image/png"]
+    first.metadata["handled_only"] = "must-not-dispatch"
+    second = _event()
+    second.message_id = "m2"
+    second.text = "pass-second"
+    second.source.user_id = "pass-user"
+    second.source.user_name = "Passed User"
+    second.media_urls = ["/tmp/pass-2.png"]
+    second.media_types = ["image/png"]
+    third = _event()
+    third.message_id = "m3"
+    third.text = "pass-third"
+    third.media_urls = ["/tmp/pass-3.png"]
+    third.media_types = ["image/png"]
+    merged = _event()
+    merged.text = "handled-first\npass-second\npass-third"
+    merged.media_urls = [
+        "/tmp/handled.png",
+        "/tmp/pass-2.png",
+        "/tmp/pass-3.png",
+    ]
+    merged.media_types = ["image/png", "image/png", "image/png"]
+    merged.metadata["handled_only"] = "must-not-dispatch"
+    merged.metadata["_gateway_native_events"] = (first, second, third)
+
+    async def hook(_name, **kwargs):
+        decision = (
+            "handled"
+            if kwargs["event"].message_id == "m1"
+            else "pass"
+        )
+        return [{"decision": decision}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    await runner._handle_message(merged)
+
+    runner._handle_message_with_agent.assert_awaited_once()
+    dispatched = runner._handle_message_with_agent.await_args.args[0]
+    dispatched_source = runner._handle_message_with_agent.await_args.args[1]
+    assert dispatched.text == "pass-second\npass-third"
+    assert dispatched.message_id == "m2"
+    assert dispatched_source is second.source
+    assert dispatched.media_urls == ["/tmp/pass-2.png", "/tmp/pass-3.png"]
+    assert "handled_only" not in dispatched.metadata
+    assert tuple(
+        item.message_id
+        for item in dispatched.metadata["_gateway_native_events"]
+    ) == ("m2", "m3")
+
+
+@pytest.mark.asyncio
 async def test_busy_legacy_predispatch_conflict_fails_closed_before_any_hook(monkeypatch):
     runner, _adapter = _runner_for_dispatch()
     event = _event()
@@ -1015,6 +1158,137 @@ async def test_telegram_strict_topic_effect_never_falls_back_to_root_chat():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "returned_message",
+    [
+        SimpleNamespace(
+            message_id=701,
+            chat=SimpleNamespace(id=-200),
+            message_thread_id=42,
+            text="participant effect",
+            from_user=SimpleNamespace(id=9),
+            reply_to_message=None,
+        ),
+        SimpleNamespace(
+            message_id=702,
+            chat=SimpleNamespace(id=-100),
+            message_thread_id=99,
+            text="participant effect",
+            from_user=SimpleNamespace(id=9),
+            reply_to_message=None,
+        ),
+        SimpleNamespace(
+            message_id=703,
+            chat=SimpleNamespace(id=-100),
+            message_thread_id=42,
+            text="different content",
+            from_user=SimpleNamespace(id=9),
+            reply_to_message=None,
+        ),
+        SimpleNamespace(message_id=704),
+    ],
+)
+async def test_telegram_native_ack_rejects_wrong_route_or_partial_message(
+    returned_message,
+):
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    config = PlatformConfig(
+        enabled=True,
+        token="fake-token",
+        extra={"rich_messages": False},
+    )
+    adapter.config = config
+    adapter._config = config
+    adapter._platform = Platform.TELEGRAM
+    adapter.platform = Platform.TELEGRAM
+    adapter._connected = True
+    adapter._dm_topics = {}
+    adapter._dm_topics_config = []
+    adapter._reply_to_mode = "first"
+    adapter._fallback_ips = []
+    adapter._polling_conflict_count = 0
+    adapter._polling_network_error_count = 0
+    adapter._polling_error_callback_ref = None
+    adapter._bot = SimpleNamespace(
+        id=9,
+        send_message=AsyncMock(return_value=returned_message),
+    )
+
+    result = await adapter.send(
+        chat_id="-100",
+        content="participant effect",
+        metadata={
+            "thread_id": "42",
+            "_hermes_require_topic_route": True,
+            "notify": True,
+        },
+    )
+
+    assert result.success is True
+    assert result.native_delivery_ack is None
+
+
+@pytest.mark.asyncio
+async def test_telegram_native_ack_uses_returned_message_facts():
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    returned = SimpleNamespace(
+        message_id=705,
+        chat=SimpleNamespace(id=-100),
+        message_thread_id=42,
+        text="participant effect",
+        from_user=SimpleNamespace(id=9),
+        reply_to_message=SimpleNamespace(message_id=600),
+    )
+    adapter = object.__new__(TelegramAdapter)
+    config = PlatformConfig(
+        enabled=True,
+        token="fake-token",
+        extra={"rich_messages": False},
+    )
+    adapter.config = config
+    adapter._config = config
+    adapter._platform = Platform.TELEGRAM
+    adapter.platform = Platform.TELEGRAM
+    adapter._connected = True
+    adapter._dm_topics = {}
+    adapter._dm_topics_config = []
+    adapter._reply_to_mode = "first"
+    adapter._fallback_ips = []
+    adapter._polling_conflict_count = 0
+    adapter._polling_network_error_count = 0
+    adapter._polling_error_callback_ref = None
+    adapter._bot = SimpleNamespace(
+        id=9,
+        send_message=AsyncMock(return_value=returned),
+    )
+
+    result = await adapter.send(
+        chat_id="-100",
+        content="participant effect",
+        reply_to="600",
+        metadata={
+            "thread_id": "42",
+            "_hermes_require_topic_route": True,
+            "notify": True,
+        },
+    )
+
+    assert result.native_delivery_ack == NativeDeliveryAck(
+        platform="telegram",
+        room_id="-100:topic:42",
+        self_actor_id="9",
+        effect_kind="reply",
+        submitted_content="participant effect",
+        reply_to_message_id="600",
+        message_id="705",
+        effect_id="705",
+    )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("operation", ["send", "reply", "react"])
 async def test_telegram_topic_delivery_uses_canonical_room_identity(
     monkeypatch, operation
@@ -1071,10 +1345,10 @@ async def test_telegram_topic_delivery_uses_canonical_room_identity(
     runner.adapters = {Platform.TELEGRAM: adapter}
     runner._profile_adapters = {"work": {Platform.TELEGRAM: adapter}}
     receipts = []
+    routes = []
 
     async def hook(_name, **kwargs):
-        assert kwargs["route"].chat_id == "-100"
-        assert kwargs["route"].thread_id == "42"
+        routes.append(kwargs["route"])
         if operation == "send":
             receipts.append(await kwargs["delivery"].send("topic message"))
         elif operation == "reply":
@@ -1088,6 +1362,9 @@ async def test_telegram_topic_delivery_uses_canonical_room_identity(
 
     await runner._handle_message(event)
 
+    assert [(route.chat_id, route.thread_id) for route in routes] == [
+        ("-100", "42")
+    ]
     assert len(receipts) == 1
     receipt = receipts[0]
     assert receipt.status == "sent"
@@ -1391,10 +1668,10 @@ async def test_route_delivery_binds_relay_to_ingress_logical_platform(monkeypatc
     runner.adapters = {Platform.RELAY: relay}
     event = _event()
     event.source.delivered_via_upstream_relay = True
+    receipts = []
 
     async def hook(_name, **kwargs):
-        receipt = await kwargs["delivery"].send("relay reply")
-        assert receipt == GatewayDeliveryReceipt(status="sent", message_id="relay-out")
+        receipts.append(await kwargs["delivery"].send("relay reply"))
         return [{"decision": "handled"}]
 
     monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
@@ -1402,6 +1679,7 @@ async def test_route_delivery_binds_relay_to_ingress_logical_platform(monkeypatc
 
     await runner._handle_message(event)
 
+    assert receipts == [GatewayDeliveryReceipt(status="unknown")]
     relay.send_for_platform.assert_awaited_once_with(
         Platform.DISCORD,
         "channel-1",
@@ -1726,6 +2004,179 @@ async def test_gateway_session_cancel_timeout_survives_cancel_suppressing_async_
 
 
 @pytest.mark.asyncio
+async def test_gateway_session_cancel_timeout_requests_cancel_and_deduplicates_detached_work(
+    monkeypatch,
+):
+    from gateway import run as run_module
+    from hermes_cli.plugins import get_plugin_manager
+
+    runner, _adapter = _runner_for_dispatch()
+    manager = get_plugin_manager()
+    original = list(manager._hooks.get("gateway_session_cancel", []))
+    entered = asyncio.Event()
+    cancel_requested = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def cancellation_suppressing_observer(**_kwargs):
+        nonlocal calls
+        calls += 1
+        entered.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancel_requested.set()
+            await release.wait()
+
+    manager._hooks["gateway_session_cancel"] = [cancellation_suppressing_observer]
+    monkeypatch.setattr(run_module, "GATEWAY_SESSION_CANCEL_TIMEOUT_SECONDS", 0.01)
+    source = _source()
+    session_key = build_session_key(source)
+    try:
+        await runner._notify_gateway_session_cancel(
+            session_key,
+            source,
+            reason="stop",
+        )
+        await asyncio.wait_for(cancel_requested.wait(), timeout=0.1)
+        assert len(runner._gateway_cancel_observer_tasks) == 1
+
+        await runner._notify_gateway_session_cancel(
+            session_key,
+            source,
+            reason="reset",
+        )
+
+        assert calls == 1
+        assert len(runner._gateway_cancel_observer_tasks) == 1
+    finally:
+        release.set()
+        manager._hooks["gateway_session_cancel"] = original
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_inactivity_boundary_notifies_plugin_before_participant_state_is_destroyed():
+    runner, _adapter = _runner_for_dispatch()
+    source = _source()
+    session_key = build_session_key(source)
+    participant_state = {session_key: "live"}
+    observed = []
+
+    async def notify(key, routed_source, *, reason):
+        observed.append((key, routed_source, reason, participant_state.get(key)))
+        participant_state.pop(key, None)
+
+    runner._notify_gateway_session_cancel = notify
+
+    await runner._handle_gateway_inactivity_boundary(session_key, source)
+
+    assert observed == [
+        (session_key, source, "inactivity_timeout", "live")
+    ]
+    assert session_key not in participant_state
+
+
+@pytest.mark.asyncio
+async def test_stale_running_agent_eviction_notifies_before_host_state_release(
+    monkeypatch,
+):
+    runner, _adapter = _runner_for_dispatch()
+    source = _source()
+    session_key = build_session_key(source)
+    stale_agent = MagicMock()
+    stale_agent.get_activity_summary.return_value = {
+        "seconds_since_activity": 10,
+        "last_activity_desc": "stuck",
+        "api_call_count": 1,
+        "max_iterations": 10,
+    }
+    runner._running_agents[session_key] = stale_agent
+    runner._running_agents_ts[session_key] = 1
+    participant_state = {session_key: "live"}
+    observed = []
+    lifecycle_order = []
+
+    def release_host_state(key):
+        lifecycle_order.append("release")
+        runner._running_agents.pop(key, None)
+
+    runner._release_running_agent_state.side_effect = release_host_state
+
+    async def notify(key, routed_source, *, reason):
+        lifecycle_order.append("notify")
+        observed.append(
+            (
+                key,
+                routed_source,
+                reason,
+                runner._running_agents.get(key),
+                participant_state.get(key),
+            )
+        )
+        participant_state.pop(key, None)
+
+    runner._notify_gateway_session_cancel = notify
+    monkeypatch.setenv("HERMES_AGENT_TIMEOUT", "1")
+    monkeypatch.setattr("gateway.run.time.time", lambda: 10_000)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        "hermes_cli.plugins.invoke_hook_async",
+        AsyncMock(return_value=[{"decision": "handled"}]),
+    )
+
+    await runner._handle_message(_event())
+
+    assert observed == [
+        (
+            session_key,
+            source,
+            "stale_running_agent_eviction",
+            stale_agent,
+            "live",
+        )
+    ]
+    assert session_key not in participant_state
+    assert lifecycle_order[:2] == ["notify", "release"]
+    assert all(
+        call.args == (session_key,)
+        for call in runner._release_running_agent_state.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_ordinary_busy_interrupt_is_not_participant_session_cancel(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+    source = _source()
+    session_key = build_session_key(source)
+    running_agent = MagicMock()
+    runner._running_agents[session_key] = running_agent
+    participant_state = {session_key: "live"}
+    runner._busy_input_mode = "interrupt"
+    runner._agent_has_active_subagents = lambda _agent: False
+    runner._session_has_compression_in_flight = AsyncMock(return_value=False)
+    runner._notify_gateway_session_cancel = AsyncMock()
+    monkeypatch.setenv("HERMES_GATEWAY_BUSY_ACK_ENABLED", "false")
+    monkeypatch.setattr(
+        "hermes_cli.plugins.invoke_hook_async",
+        AsyncMock(return_value=[{"decision": "pass"}]),
+    )
+
+    handled = await runner._handle_active_session_busy_message(
+        _event(),
+        session_key,
+    )
+
+    assert handled is True
+    running_agent.interrupt.assert_called_once()
+    runner._notify_gateway_session_cancel.assert_not_awaited()
+    assert session_key in runner._running_agents
+    assert participant_state[session_key] == "live"
+    queued_event = runner._queue_or_replace_pending_event.call_args.args[1]
+    assert queued_event.text == "hello"
+
+
+@pytest.mark.asyncio
 async def test_gateway_session_cancel_timeout_bounds_blocking_sync_observer(monkeypatch):
     from gateway import run as run_module
     from hermes_cli.plugins import get_plugin_manager
@@ -1750,6 +2201,44 @@ async def test_gateway_session_cancel_timeout_bounds_blocking_sync_observer(monk
         elapsed = asyncio.get_running_loop().time() - started
         assert entered.is_set()
         assert elapsed < 0.1
+        assert len(runner._gateway_cancel_observer_tasks) == 1
     finally:
         release.set()
+        manager._hooks["gateway_session_cancel"] = original
+        for _ in range(100):
+            if not runner._gateway_cancel_observer_tasks:
+                break
+            await asyncio.sleep(0.001)
+
+
+@pytest.mark.asyncio
+async def test_gateway_session_cancel_detached_observer_registry_is_bounded(
+    monkeypatch,
+):
+    from gateway import run as run_module
+    from hermes_cli.plugins import get_plugin_manager
+
+    runner, _adapter = _runner_for_dispatch()
+    manager = get_plugin_manager()
+    original = list(manager._hooks.get("gateway_session_cancel", []))
+    observer = AsyncMock()
+    manager._hooks["gateway_session_cancel"] = [observer]
+    monkeypatch.setattr(run_module, "GATEWAY_SESSION_CANCEL_DETACHED_LIMIT", 1)
+    blocker = asyncio.create_task(asyncio.Event().wait())
+    runner._gateway_cancel_observer_tasks = {"other-session": blocker}
+    source = _source()
+    try:
+        await runner._notify_gateway_session_cancel(
+            build_session_key(source),
+            source,
+            reason="stop",
+        )
+        observer.assert_not_awaited()
+        assert runner._gateway_cancel_observer_tasks == {
+            "other-session": blocker
+        }
+    finally:
+        blocker.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await blocker
         manager._hooks["gateway_session_cancel"] = original

--- a/tests/gateway/test_session_boundary_hooks.py
+++ b/tests/gateway/test_session_boundary_hooks.py
@@ -125,8 +125,8 @@ async def test_finalize_before_reset(mock_invoke_hook):
 
 @pytest.mark.asyncio
 @patch("hermes_cli.plugins.invoke_hook")
-async def test_shutdown_fires_finalize_for_active_agents(mock_invoke_hook):
-    """Gateway stop() must fire on_session_finalize for each active agent."""
+async def test_shutdown_invalidates_plugin_lifecycle_before_finalizing_agents(mock_invoke_hook):
+    """Gateway stop must invalidate plugin effects before agent finalization."""
     from gateway.run import GatewayRunner
 
     runner = object.__new__(GatewayRunner)
@@ -154,10 +154,25 @@ async def test_shutdown_fires_finalize_for_active_agents(mock_invoke_hook):
     agent2.session_id = "sess-b"
     runner._running_agents = {"key-a": agent1, "key-b": agent2}
 
-    with patch("gateway.status.remove_pid_file"), \
-         patch("gateway.status.write_runtime_status"):
+    with (
+        patch("gateway.status.remove_pid_file"),
+        patch("gateway.status.write_runtime_status"),
+        patch(
+            "hermes_cli.plugins.invoke_hook_async",
+            new_callable=AsyncMock,
+        ) as mock_invoke_hook_async,
+    ):
         await runner.stop()
 
+    mock_invoke_hook_async.assert_awaited_once_with(
+        "gateway_shutdown",
+        reason="stop",
+        raise_exceptions=False,
+        offload_sync=True,
+    )
+    hook_names = [call.args[0] for call in mock_invoke_hook.call_args_list]
+    assert "gateway_shutdown" not in hook_names
+    assert hook_names.count("on_session_finalize") == 2
     finalize_calls = [
         c for c in mock_invoke_hook.call_args_list
         if c[0][0] == "on_session_finalize"
@@ -176,6 +191,23 @@ async def test_hook_error_does_not_break_reset(mock_invoke_hook):
 
     # Should still return a success message despite hook errors
     assert "Session reset" in result or "New session" in result
+
+
+@pytest.mark.asyncio
+async def test_reset_notifies_gateway_session_cancel_hook():
+    """The confirmed reset path must notify async plugin-owned work."""
+    runner = _make_runner()
+    runner._notify_gateway_session_cancel = AsyncMock()
+    event = _make_event("/new")
+    session_key = build_session_key(event.source)
+
+    await runner._handle_reset_command(event)
+
+    runner._notify_gateway_session_cancel.assert_awaited_once_with(
+        session_key,
+        event.source,
+        reason="reset",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_stop_thread_sibling.py
+++ b/tests/gateway/test_stop_thread_sibling.py
@@ -8,7 +8,10 @@ nothing and reply "no active task to stop".  Authorized users should be able to
 stop any run in the same thread.
 """
 
+import asyncio
+
 import pytest
+from unittest.mock import AsyncMock
 
 from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL, _INTERRUPT_REASON_STOP
 from gateway.session import SessionSource, build_session_key
@@ -122,6 +125,7 @@ async def test_stop_interrupts_sibling_thread_run_when_authorized(monkeypatch):
 
     runner._interrupt_and_clear_session = _fake_interrupt
     runner._is_user_authorized = lambda source: True
+    runner._notify_gateway_session_cancel = AsyncMock()
 
     event = MessageEvent(
         text="/stop", message_type=MessageType.TEXT, source=_thread_source("userA")
@@ -129,8 +133,42 @@ async def test_stop_interrupts_sibling_thread_run_when_authorized(monkeypatch):
     result = await runner._handle_stop_command(event)
 
     assert interrupted == [(key_b, _INTERRUPT_REASON_STOP, "stop_command_thread_sibling")]
+    cancel_calls = runner._notify_gateway_session_cancel.await_args_list
+    assert [item.args[0] for item in cancel_calls] == [key_a, key_b]
+    assert cancel_calls[0].args[1].user_id == "userA"
+    assert cancel_calls[1].args[1].user_id == "userB"
     # EphemeralReply or str — both carry the "stopped" message, not "no_active".
     assert "no active" not in str(getattr(result, "text", result)).lower()
+
+
+@pytest.mark.asyncio
+async def test_sibling_stop_notifies_all_routes_concurrently(monkeypatch):
+    runner = object.__new__(GatewayRunner)
+    key_a = _per_user_key("userA")
+    key_b = _per_user_key("userB")
+    key_c = _per_user_key("userC")
+    runner._running_agents = {key_b: _FakeAgent(), key_c: _FakeAgent()}
+    runner.session_store = _FakeStore(key_a)
+    runner._is_user_authorized = lambda source: True
+    runner._interrupt_and_clear_session = AsyncMock()
+
+    entered = []
+    all_entered = asyncio.Event()
+
+    async def notify(session_key, _source, *, reason):
+        entered.append(session_key)
+        if len(entered) == 3:
+            all_entered.set()
+        await all_entered.wait()
+
+    runner._notify_gateway_session_cancel = notify
+    event = MessageEvent(
+        text="/stop", message_type=MessageType.TEXT, source=_thread_source("userA")
+    )
+
+    await asyncio.wait_for(runner._handle_stop_command(event), timeout=0.2)
+
+    assert set(entered) == {key_a, key_b, key_c}
 
 
 @pytest.mark.asyncio
@@ -161,6 +199,28 @@ async def test_stop_does_not_interrupt_sibling_when_unauthorized(monkeypatch):
 # ---------------------------------------------------------------------------
 # /stop with no active agent still clears a stuck platform status (#32295)
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_notifies_gateway_session_cancel_hook():
+    runner = object.__new__(GatewayRunner)
+    key = _per_user_key("userA")
+    runner._running_agents = {}
+    runner.session_store = _FakeStore(key)
+    runner._is_user_authorized = lambda source: True
+    runner.adapters = {}
+    runner._notify_gateway_session_cancel = AsyncMock()
+    event = MessageEvent(
+        text="/stop", message_type=MessageType.TEXT, source=_thread_source("userA")
+    )
+
+    await runner._handle_stop_command(event)
+
+    runner._notify_gateway_session_cancel.assert_awaited_once_with(
+        key,
+        event.source,
+        reason="stop",
+    )
 
 
 class _FakeStatusAdapter:

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -228,6 +228,27 @@ def test_observed_group_context_uses_shared_source_and_prompt_for_later_mentions
     asyncio.run(_run())
 
 
+def test_caption_mentions_are_transport_attested_in_gateway_metadata():
+    adapter = _make_adapter(require_mention=True)
+    caption = "photo for Bob"
+    entity = SimpleNamespace(
+        type="text_mention",
+        offset=10,
+        length=3,
+        user=SimpleNamespace(id=222),
+    )
+    message = _group_message(
+        text=None,
+        caption=caption,
+        caption_entities=[entity],
+    )
+
+    event = adapter._build_message_event(message, MessageType.PHOTO, update_id=1004)
+
+    assert event.text == caption
+    assert event.metadata["mentioned_user_ids"] == ("222",)
+
+
 def test_observed_group_context_replays_as_current_message_context_not_user_turns():
     from gateway.run import (
         _build_gateway_agent_history,

--- a/tests/gateway/test_telegram_mention_boundaries.py
+++ b/tests/gateway/test_telegram_mention_boundaries.py
@@ -14,7 +14,7 @@ those contexts.
 from types import SimpleNamespace
 
 from gateway.config import Platform, PlatformConfig
-from plugins.platforms.telegram.adapter import TelegramAdapter
+from plugins.platforms.telegram.adapter import TelegramAdapter, _attested_mention_user_ids
 
 
 def _make_adapter():
@@ -183,3 +183,17 @@ class TestCaseInsensitivity:
         text = "hi @Hermes_Bot"
         msg = _message(text=text, entities=[_mention_entity(text, mention="@Hermes_Bot")])
         assert adapter._message_mentions_bot(msg) is True
+
+
+class TestAttestedMentionIdentityExtraction:
+    def test_text_mentions_return_exact_transport_user_ids(self):
+        entities = [
+            _text_mention_entity(0, 3, user_id=123),
+            _text_mention_entity(4, 3, user_id=456),
+        ]
+        assert _attested_mention_user_ids(entities) == ("123", "456")
+
+    def test_username_mention_without_transport_user_id_is_unattested(self):
+        text = "@someone hello"
+        entities = [_mention_entity(text, mention="@someone")]
+        assert _attested_mention_user_ids(entities) is None

--- a/tests/gateway/test_telegram_text_batching.py
+++ b/tests/gateway/test_telegram_text_batching.py
@@ -45,6 +45,7 @@ def _make_adapter():
     adapter._text_batch_delay_seconds = 0.1  # fast for tests
     adapter._active_sessions = {}
     adapter._pending_messages = {}
+    adapter._background_tasks = set()
     adapter._message_handler = AsyncMock()
     adapter.handle_message = AsyncMock()
     return adapter
@@ -95,6 +96,201 @@ class TestTextBatching:
         dispatched = adapter.handle_message.call_args[0][0]
         assert "part one" in dispatched.text
         assert "split by Telegram" in dispatched.text
+
+    @pytest.mark.asyncio
+    async def test_split_batch_retains_each_native_identity_and_mentions(self):
+        adapter = _make_adapter()
+        first = _make_event("ordinary")
+        first.message_id = "m1"
+        first.metadata["mentioned_user_ids"] = ()
+        second = _make_event("@bot")
+        second.message_id = "m2"
+        second.source.user_id = "user-2"
+        second.metadata["mentioned_user_ids"] = ("9",)
+
+        adapter._enqueue_text_event(first)
+        adapter._enqueue_text_event(second)
+        pending = next(iter(adapter._pending_text_batches.values()))
+        native = pending.metadata["_gateway_native_events"]
+
+        assert [(item.message_id, item.text) for item in native] == [
+            ("m1", "ordinary"),
+            ("m2", "@bot"),
+        ]
+        assert native[0].metadata["mentioned_user_ids"] == ()
+        assert native[1].metadata["mentioned_user_ids"] == ("9",)
+        assert native[1].source.user_id == "user-2"
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_unattested_username_mention_remains_unknown_in_snapshot(self):
+        adapter = _make_adapter()
+        event = _make_event("@someone")
+        event.message_id = "m-unknown"
+        event.metadata["mentioned_user_ids"] = None
+
+        adapter._enqueue_text_event(event)
+        pending = next(iter(adapter._pending_text_batches.values()))
+        native = pending.metadata["_gateway_native_events"]
+
+        assert native[0].metadata["mentioned_user_ids"] is None
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_native_event_batch_bound_splits_without_dropping_events(self):
+        adapter = _make_adapter()
+        adapter._MAX_GATEWAY_NATIVE_EVENTS_PER_BATCH = 2
+        events = []
+        for index in range(3):
+            event = _make_event(f"part-{index}")
+            event.message_id = f"m{index}"
+            events.append(event)
+
+        for event in events:
+            adapter._enqueue_text_event(event)
+        await asyncio.sleep(0)
+
+        adapter.handle_message.assert_awaited_once()
+        dispatched = adapter.handle_message.await_args.args[0]
+        assert [
+            item.message_id
+            for item in dispatched.metadata["_gateway_native_events"]
+        ] == ["m0", "m1"]
+        pending = adapter._pending_text_batches[
+            adapter._text_batch_key(events[-1])
+        ]
+        assert [
+            item.message_id for item in pending.metadata["_gateway_native_events"]
+        ] == ["m2"]
+
+        adapter.handle_message.reset_mock()
+        photos = []
+        for index in range(3):
+            photo = _make_event(f"photo-{index}")
+            photo.message_type = MessageType.PHOTO
+            photo.message_id = f"p{index}"
+            photo.media_urls = [f"file:///p{index}.jpg"]
+            photo.media_types = ["image/jpeg"]
+            photos.append(photo)
+            adapter._enqueue_photo_event("photos", photo)
+        await asyncio.sleep(0)
+
+        adapter.handle_message.assert_awaited_once()
+        dispatched_photo = adapter.handle_message.await_args.args[0]
+        assert [
+            item.message_id
+            for item in dispatched_photo.metadata["_gateway_native_events"]
+        ] == ["p0", "p1"]
+        assert [
+            item.message_id
+            for item in adapter._pending_photo_batches["photos"].metadata[
+                "_gateway_native_events"
+            ]
+        ] == ["p2"]
+
+        adapter.handle_message.reset_mock()
+        for index in range(3):
+            album = _make_event("")
+            album.message_type = MessageType.PHOTO
+            album.message_id = f"a{index}"
+            album.media_urls = [f"file:///a{index}.jpg"]
+            album.media_types = ["image/jpeg"]
+            await adapter._queue_media_group_event("album", album)
+        await asyncio.sleep(0)
+
+        adapter.handle_message.assert_awaited_once()
+        dispatched_album = adapter.handle_message.await_args.args[0]
+        assert [
+            item.message_id
+            for item in dispatched_album.metadata["_gateway_native_events"]
+        ] == ["a0", "a1"]
+        assert [
+            item.message_id
+            for item in adapter._media_group_events["album"].metadata[
+                "_gateway_native_events"
+            ]
+        ] == ["a2"]
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_photo_and_media_group_batches_retain_native_ids(self):
+        adapter = _make_adapter()
+
+        first_photo = _make_event("caption one")
+        first_photo.message_type = MessageType.PHOTO
+        first_photo.message_id = "p1"
+        first_photo.media_urls = ["file:///p1.jpg"]
+        first_photo.media_types = ["image/jpeg"]
+        second_photo = _make_event("caption two")
+        second_photo.message_type = MessageType.PHOTO
+        second_photo.message_id = "p2"
+        second_photo.media_urls = ["file:///p2.jpg"]
+        second_photo.media_types = ["image/jpeg"]
+        adapter._enqueue_photo_event("photos", first_photo)
+        adapter._enqueue_photo_event("photos", second_photo)
+        photo_native = adapter._pending_photo_batches["photos"].metadata[
+            "_gateway_native_events"
+        ]
+        assert [item.message_id for item in photo_native] == ["p1", "p2"]
+
+        first_album = _make_event("")
+        first_album.message_type = MessageType.PHOTO
+        first_album.message_id = "a1"
+        first_album.media_urls = ["file:///a1.jpg"]
+        first_album.media_types = ["image/jpeg"]
+        second_album = _make_event("")
+        second_album.message_type = MessageType.PHOTO
+        second_album.message_id = "a2"
+        second_album.media_urls = ["file:///a2.jpg"]
+        second_album.media_types = ["image/jpeg"]
+        await adapter._queue_media_group_event("album", first_album)
+        await adapter._queue_media_group_event("album", second_album)
+        album_native = adapter._media_group_events["album"].metadata[
+            "_gateway_native_events"
+        ]
+        assert [item.message_id for item in album_native] == ["a1", "a2"]
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_photo_and_media_group_native_routes_are_recovered_before_snapshot(self):
+        adapter = _make_adapter()
+        adapter.set_topic_recovery_fn(
+            lambda source: "canonical" if source.thread_id == "stale" else None
+        )
+
+        photo = _make_event("photo")
+        photo.message_type = MessageType.PHOTO
+        photo.source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="dm",
+            user_id="user-1",
+            thread_id="stale",
+        )
+        adapter._enqueue_photo_event("photos", photo)
+        photo_native = adapter._pending_photo_batches["photos"].metadata[
+            "_gateway_native_events"
+        ]
+
+        album = _make_event("album")
+        album.message_type = MessageType.PHOTO
+        album.source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="dm",
+            user_id="user-1",
+            thread_id="stale",
+        )
+        await adapter._queue_media_group_event("album", album)
+        album_native = adapter._media_group_events["album"].metadata[
+            "_gateway_native_events"
+        ]
+
+        assert photo.source.thread_id == "canonical"
+        assert photo_native[0].source.thread_id == "canonical"
+        assert album.source.thread_id == "canonical"
+        assert album_native[0].source.thread_id == "canonical"
+        await adapter.disconnect()
 
     @pytest.mark.asyncio
     async def test_three_way_split_aggregated(self):

--- a/tests/hermes_cli/test_async_plugin_hooks.py
+++ b/tests/hermes_cli/test_async_plugin_hooks.py
@@ -1,0 +1,196 @@
+"""Behavior tests for asynchronous plugin hook invocation."""
+
+import asyncio
+import threading
+import time
+from contextvars import ContextVar
+
+import pytest
+
+from hermes_cli.plugins import (
+    PluginContext,
+    PluginHookConflictError,
+    PluginManager,
+    PluginManifest,
+)
+from hermes_constants import GATEWAY_MESSAGE_HOOK_API_VERSION
+
+
+def test_plugin_context_exposes_gateway_message_capability_version():
+    context = PluginContext(
+        PluginManifest(name="capability-probe", source="entrypoint"),
+        PluginManager(),
+    )
+
+    assert context.gateway_message_hook_api_version == GATEWAY_MESSAGE_HOOK_API_VERSION
+
+
+@pytest.mark.asyncio
+async def test_async_hook_invocation_supports_sync_and_async_callbacks():
+    manager = PluginManager()
+    calls = []
+
+    def sync_callback(**kwargs):
+        calls.append(("sync", kwargs["value"]))
+        return {"decision": "pass"}
+
+    async def async_callback(**kwargs):
+        await asyncio.sleep(0)
+        calls.append(("async", kwargs["value"]))
+        return {"decision": "handled"}
+
+    manager._hooks["gateway_message"] = [sync_callback, async_callback]
+
+    results = await manager.invoke_hook_async("gateway_message", value="hello")
+
+    assert calls == [("sync", "hello"), ("async", "hello")]
+    assert results == [{"decision": "pass"}, {"decision": "handled"}]
+
+
+@pytest.mark.asyncio
+async def test_async_hook_can_offload_blocking_sync_callback_for_host_timeout():
+    manager = PluginManager()
+    finished = False
+    daemon = None
+
+    def blocking_callback(**_kwargs):
+        nonlocal daemon, finished
+        daemon = threading.current_thread().daemon
+        time.sleep(0.2)
+        finished = True
+
+    manager._hooks["gateway_session_cancel"] = [blocking_callback]
+
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(
+            manager.invoke_hook_async(
+                "gateway_session_cancel",
+                offload_sync=True,
+            ),
+            timeout=0.01,
+        )
+
+    assert daemon is True
+    assert finished is False
+
+
+@pytest.mark.asyncio
+async def test_async_hook_keeps_async_callbacks_on_gateway_loop_when_sync_callbacks_offload():
+    manager = PluginManager()
+    profile = ContextVar("profile", default="default")
+    seen = []
+    gateway_loop = asyncio.get_running_loop()
+    gateway_future = gateway_loop.create_future()
+
+    async def async_callback(**_kwargs):
+        seen.append(
+            (
+                profile.get(),
+                threading.current_thread().daemon,
+                asyncio.get_running_loop() is gateway_loop,
+            )
+        )
+        return await gateway_future
+
+    manager._hooks["gateway_session_cancel"] = [async_callback]
+    token = profile.set("work")
+    try:
+        task = asyncio.create_task(
+            manager.invoke_hook_async(
+                "gateway_session_cancel",
+                offload_callbacks=True,
+            )
+        )
+        await asyncio.sleep(0)
+        gateway_future.set_result("done")
+        results = await task
+    finally:
+        profile.reset(token)
+
+    assert results == ["done"]
+    assert seen == [("work", False, True)]
+
+
+@pytest.mark.asyncio
+async def test_async_hook_invocation_can_stop_before_later_callbacks():
+    manager = PluginManager()
+    calls = []
+
+    def handled(**_kwargs):
+        calls.append("handled")
+        return {"decision": "handled"}
+
+    def must_not_run(**_kwargs):
+        calls.append("later")
+        return {"decision": "pass"}
+
+    manager._hooks["gateway_message"] = [handled, must_not_run]
+
+    results = await manager.invoke_hook_async(
+        "gateway_message",
+        stop_when=lambda result: result == {"decision": "handled"},
+    )
+
+    assert results == [{"decision": "handled"}]
+    assert calls == ["handled"]
+
+
+@pytest.mark.asyncio
+async def test_async_hook_invocation_excludes_unmatched_none_results():
+    manager = PluginManager()
+    manager._hooks["gateway_message"] = [lambda **_kwargs: None]
+
+    assert await manager.invoke_hook_async("gateway_message") == []
+
+
+@pytest.mark.asyncio
+async def test_async_hook_invocation_can_fail_fast_for_terminal_hooks():
+    manager = PluginManager()
+
+    def broken(**_kwargs):
+        raise RuntimeError("broken hook")
+
+    manager._hooks["gateway_message"] = [broken]
+
+    with pytest.raises(RuntimeError, match="broken hook"):
+        await manager.invoke_hook_async("gateway_message", raise_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_async_hook_invocation_reraises_cancelled_error():
+    manager = PluginManager()
+
+    async def cancelled(**_kwargs):
+        raise asyncio.CancelledError
+
+    manager._hooks["gateway_message"] = [cancelled]
+
+    with pytest.raises(asyncio.CancelledError):
+        await manager.invoke_hook_async("gateway_message")
+
+
+@pytest.mark.parametrize(
+    "order",
+    [
+        ("gateway_message", "pre_gateway_dispatch"),
+        ("pre_gateway_dispatch", "gateway_message"),
+    ],
+)
+def test_behavior_changing_gateway_hooks_conflict_at_configuration_time(order):
+    manager = PluginManager()
+    callbacks = {
+        "gateway_message": lambda **_kwargs: {"decision": "pass"},
+        "pre_gateway_dispatch": lambda **_kwargs: {"action": "allow"},
+    }
+    for index, hook_name in enumerate(order):
+        context = PluginContext(
+            PluginManifest(name=f"plugin-{index}", source="entrypoint"),
+            manager,
+        )
+        context.register_hook(hook_name, callbacks[hook_name])
+
+    with pytest.raises(
+        PluginHookConflictError,
+        match="gateway_message.*pre_gateway_dispatch|pre_gateway_dispatch.*gateway_message",
+    ):
+        manager.validate_hook_configuration()

--- a/tests/hermes_cli/test_async_plugin_hooks.py
+++ b/tests/hermes_cli/test_async_plugin_hooks.py
@@ -13,7 +13,10 @@ from hermes_cli.plugins import (
     PluginManager,
     PluginManifest,
 )
-from hermes_constants import GATEWAY_MESSAGE_HOOK_API_VERSION
+from hermes_constants import (
+    GATEWAY_MESSAGE_HOOK_API_VERSION,
+    PARTICIPANT_HOST_API_VERSION,
+)
 
 
 def test_plugin_context_exposes_gateway_message_capability_version():
@@ -23,6 +26,15 @@ def test_plugin_context_exposes_gateway_message_capability_version():
     )
 
     assert context.gateway_message_hook_api_version == GATEWAY_MESSAGE_HOOK_API_VERSION
+
+
+def test_plugin_context_exposes_umbrella_participant_host_api_version():
+    context = PluginContext(
+        PluginManifest(name="participant-capability-probe", source="entrypoint"),
+        PluginManager(),
+    )
+
+    assert context.participant_host_api_version == PARTICIPANT_HOST_API_VERSION == 2
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -535,7 +535,8 @@ class TestPluginLoading:
         mgr.discover_and_load()
 
         assert "bad_plugin" in mgr._plugins
-        assert not mgr._plugins["bad_plugin"].enabled
+        assert mgr._plugins["bad_plugin"].enabled
+        assert not mgr._plugins["bad_plugin"].active
         assert mgr._plugins["bad_plugin"].error is not None
         # Should be the missing-init error, not "not enabled".
         assert "not enabled" not in mgr._plugins["bad_plugin"].error
@@ -558,7 +559,8 @@ class TestPluginLoading:
         mgr.discover_and_load()
 
         assert "no_reg" in mgr._plugins
-        assert not mgr._plugins["no_reg"].enabled
+        assert mgr._plugins["no_reg"].enabled
+        assert not mgr._plugins["no_reg"].active
         assert "no register()" in mgr._plugins["no_reg"].error
 
     def test_load_registers_namespace_module(self, tmp_path, monkeypatch):
@@ -1672,6 +1674,43 @@ class TestPluginManagerList:
             assert "enabled" in p
             assert "tools" in p
             assert "hooks" in p
+
+    def test_registration_failure_is_enabled_but_inactive_and_machine_readable(
+        self, tmp_path, monkeypatch
+    ):
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+        _make_plugin_dir(
+            plugins_dir,
+            "broken_participant",
+            register_body=(
+                "ctx.register_hook('gateway_message', lambda **kw: "
+                "{'decision': 'handled'})\n"
+                "    raise RuntimeError('registration exploded')"
+            ),
+        )
+        _make_plugin_dir(
+            plugins_dir,
+            "healthy_participant",
+            register_body=(
+                "ctx.register_hook('post_tool_call', lambda **kw: None)"
+            ),
+        )
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        by_name = {p["name"]: p for p in mgr.list_plugins()}
+        broken = by_name["broken_participant"]
+        healthy = by_name["healthy_participant"]
+        assert broken["enabled"] is True
+        assert broken["active"] is False
+        assert broken["status"] == "error"
+        assert "registration exploded" in broken["error"]
+        assert healthy["enabled"] is True
+        assert healthy["active"] is True
+        assert healthy["status"] == "active"
+        assert mgr._hooks.get("gateway_message", []) == []
 
     def test_shared_hook_name_credited_to_every_plugin(self, tmp_path, monkeypatch):
         """Two plugins registering the SAME hook name are each credited.

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -59,6 +59,7 @@ def test_cmd_list_plain_compact_output(monkeypatch, capsys):
     monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
     monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"web-search-plus"})
     monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+    monkeypatch.setattr(plugins_cmd, "_get_runtime_plugin_states", lambda: {})
 
     plugins_cmd.cmd_list(_args(plain=True, no_bundled=True))
 
@@ -74,6 +75,7 @@ def test_cmd_list_json_output(monkeypatch, capsys):
     monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
     monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"web-search-plus"})
     monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+    monkeypatch.setattr(plugins_cmd, "_get_runtime_plugin_states", lambda: {})
 
     plugins_cmd.cmd_list(_args(json=True))
 
@@ -82,11 +84,112 @@ def test_cmd_list_json_output(monkeypatch, capsys):
         {
             "name": "web-search-plus",
             "status": "enabled",
+            "active": False,
+            "runtime_status": "inactive",
+            "error": None,
             "version": "2.2.0",
             "description": "Search",
             "source": "git",
         }
     ]
+
+
+def test_cmd_list_json_exposes_enabled_plugin_registration_error(
+    monkeypatch, capsys
+):
+    entries = [
+        (
+            "broken-participant",
+            "2.0.0",
+            "Participant",
+            "user",
+            None,
+            "broken-participant",
+        )
+    ]
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_get_enabled_set",
+        lambda: {"broken-participant"},
+    )
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_get_runtime_plugin_states",
+        lambda: {
+            "broken-participant": {
+                "enabled": True,
+                "active": False,
+                "status": "error",
+                "error": "registration exploded",
+            }
+        },
+        raising=False,
+    )
+
+    plugins_cmd.cmd_list(_args(json=True))
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["status"] == "enabled"
+    assert payload[0]["active"] is False
+    assert payload[0]["runtime_status"] == "error"
+    assert payload[0]["error"] == "registration exploded"
+
+
+def test_cmd_list_json_reports_real_registration_failure_end_to_end(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    import hermes_cli.plugins as plugins_module
+
+    hermes_home = tmp_path / "hermes"
+    plugin_dir = hermes_home / "plugins" / "broken-e2e"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        "name: broken-e2e\nversion: 2.0.0\n"
+    )
+    (plugin_dir / "__init__.py").write_text(
+        "def register(ctx):\n"
+        "    ctx.register_hook('gateway_message', lambda **kwargs: None)\n"
+        "    raise RuntimeError('e2e registration exploded')\n"
+    )
+    (hermes_home / "config.yaml").write_text(
+        "plugins:\n  enabled:\n    - broken-e2e\n"
+    )
+    bundled = tmp_path / "bundled"
+    bundled.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        plugins_module,
+        "get_bundled_plugins_dir",
+        lambda: bundled,
+    )
+    monkeypatch.setattr(
+        plugins_cmd.importlib.metadata,
+        "entry_points",
+        lambda: [],
+    )
+    manager = plugins_module.PluginManager()
+    monkeypatch.setattr(plugins_module, "_plugin_manager", manager)
+
+    plugins_cmd.cmd_list(_args(json=True))
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == [
+        {
+            "name": "broken-e2e",
+            "status": "enabled",
+            "active": False,
+            "runtime_status": "error",
+            "error": "e2e registration exploded",
+            "version": "2.0.0",
+            "description": "",
+            "source": "user",
+        }
+    ]
+    assert manager._hooks.get("gateway_message", []) == []
 
 
 def test_discover_all_plugins_includes_entrypoint_plugins(monkeypatch, tmp_path):
@@ -145,6 +248,7 @@ def test_cmd_list_json_output_includes_entrypoint_source(monkeypatch, capsys):
     monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
     monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"wiki"})
     monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+    monkeypatch.setattr(plugins_cmd, "_get_runtime_plugin_states", lambda: {})
 
     plugins_cmd.cmd_list(_args(json=True))
 
@@ -153,6 +257,9 @@ def test_cmd_list_json_output_includes_entrypoint_source(monkeypatch, capsys):
         {
             "name": "wiki",
             "status": "enabled",
+            "active": False,
+            "runtime_status": "inactive",
+            "error": None,
             "version": "0.1.0",
             "description": "Karpathy-style LLM Wikis for Hermes",
             "source": "entrypoint",

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -327,6 +327,18 @@ Plugins (1):
   ✓ calculator v1.0.0 (2 tools, 1 hooks)
 ```
 
+For machine-readable activation health, use:
+
+```bash
+hermes plugins list --json
+```
+
+An enabled plugin is healthy only when its entry also has `"active": true`.
+Registration failures appear as `"status": "enabled"`,
+`"runtime_status": "error"`, `"active": false`, plus an `error` string.
+Hermes rolls back that plugin's partial registrations and continues loading
+unrelated plugins.
+
 ### Debugging plugin discovery
 
 If your plugin doesn't show up — or shows up but isn't loading — set `HERMES_PLUGINS_DEBUG=1` to get verbose discovery logs on stderr:
@@ -595,6 +607,15 @@ def register(ctx):
 
 ### Hook reference
 
+Participant plugins should gate on `ctx.participant_host_api_version == 2`,
+not a Hermes package release. This independently versioned umbrella contract
+includes the three gateway participant hooks, immutable profile/session
+routing, route-bound delivery receipts, `ctx.llm.complete_structured`,
+`ctx.dispatch_tool`, `ctx.register_command`, and plugin activation/failure
+semantics. Compatible additions retain major 2; breaking changes increment the
+major. `ctx.gateway_message_hook_api_version` remains available for older
+gateway-message-only integrations.
+
 Each hook is documented in full on the **[Event Hooks reference](/user-guide/features/hooks#plugin-hooks)** — callback signatures, parameter tables, exactly when each fires, and examples. Here's the summary:
 
 | Hook | Fires when | Callback signature | Returns |
@@ -608,7 +629,7 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 | [`on_session_finalize`](/user-guide/features/hooks#on_session_finalize) | CLI/gateway tears down an active session | `session_id: str \| None, platform: str` | ignored |
 | [`on_session_reset`](/user-guide/features/hooks#on_session_reset) | Gateway swaps in a new session key (`/new`, `/reset`) | `session_id: str, platform: str` | ignored |
 | [`gateway_message`](/user-guide/features/hooks#gateway_message) | Authorized, routed ordinary gateway message after control interception and before normal agent dispatch | `event: GatewayMessageEvent, route: GatewayMessageRoute, delivery: GatewayDelivery` | `{"decision": "handled" \| "suppress" \| "continue" \| "pass"}` or `None` when unmatched |
-| [`gateway_session_cancel`](/user-guide/features/hooks#gateway_session_cancel) | Confirmed gateway `/stop` or `/new`/reset boundary | `route: GatewayMessageRoute, reason: str` | ignored |
+| [`gateway_session_cancel`](/user-guide/features/hooks#gateway_session_cancel) | Participant session ends via stop/reset, inactivity timeout, or stale-agent eviction | `route: GatewayMessageRoute, reason: str` | ignored |
 | [`gateway_shutdown`](/user-guide/features/hooks#gateway_shutdown) | Stop/restart after delivery revocation, before adapter teardown | `reason: "stop" \| "restart"` | ignored |
 | `kanban_task_claimed` | A kanban task is claimed (dispatcher process, before the worker spawns) | `task_id: str, board: str \| None, assignee: str \| None, run_id: int \| None, profile_name: str` | ignored |
 | `kanban_task_completed` | A kanban task completes (worker process) | `task_id, board, assignee, run_id, profile_name, summary: str \| None` | ignored |

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -607,19 +607,22 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 | [`on_session_end`](/user-guide/features/hooks#on_session_end) | End of every `run_conversation` call + CLI exit | `session_id: str, completed: bool, interrupted: bool, model: str, platform: str` | ignored |
 | [`on_session_finalize`](/user-guide/features/hooks#on_session_finalize) | CLI/gateway tears down an active session | `session_id: str \| None, platform: str` | ignored |
 | [`on_session_reset`](/user-guide/features/hooks#on_session_reset) | Gateway swaps in a new session key (`/new`, `/reset`) | `session_id: str, platform: str` | ignored |
+| [`gateway_message`](/user-guide/features/hooks#gateway_message) | Authorized, routed ordinary gateway message after control interception and before normal agent dispatch | `event: GatewayMessageEvent, route: GatewayMessageRoute, delivery: GatewayDelivery` | `{"decision": "handled" \| "suppress" \| "continue" \| "pass"}` or `None` when unmatched |
+| [`gateway_session_cancel`](/user-guide/features/hooks#gateway_session_cancel) | Confirmed gateway `/stop` or `/new`/reset boundary | `route: GatewayMessageRoute, reason: str` | ignored |
+| [`gateway_shutdown`](/user-guide/features/hooks#gateway_shutdown) | Stop/restart after delivery revocation, before adapter teardown | `reason: "stop" \| "restart"` | ignored |
 | `kanban_task_claimed` | A kanban task is claimed (dispatcher process, before the worker spawns) | `task_id: str, board: str \| None, assignee: str \| None, run_id: int \| None, profile_name: str` | ignored |
 | `kanban_task_completed` | A kanban task completes (worker process) | `task_id, board, assignee, run_id, profile_name, summary: str \| None` | ignored |
 | `kanban_task_blocked` | A kanban task is blocked (worker process) | `task_id, board, assignee, run_id, profile_name, reason: str \| None` | ignored |
 
-Most hooks are fire-and-forget observers — their return values are ignored. The exception is `pre_llm_call`, which can inject context into the conversation.
+Most hooks are fire-and-forget observers — their return values are ignored. `pre_llm_call` can inject context into the conversation, and `gateway_message` makes a terminal handled/continue decision before normal gateway dispatch.
 
-All callbacks should accept `**kwargs` for forward compatibility. If a hook callback crashes, it's logged and skipped. Other hooks and the agent continue normally.
+All callbacks should accept `**kwargs` for forward compatibility. Observer-hook failures are logged and skipped. A matched `gateway_message` failure or invalid terminal result fails closed and suppresses normal-agent dispatch; task cancellation still propagates.
 
 The kanban lifecycle hooks fire **after** the board DB change commits, so a callback always sees durable state and can never hold the SQLite write lock. Because kanban workers run as separate `hermes -p <profile> chat -q` subprocesses, `kanban_task_claimed` fires in the **dispatcher** process while `kanban_task_completed` / `kanban_task_blocked` fire in the **worker** process — hook in the dispatcher to observe every transition centrally, or in the worker for per-task in-session context.
 
 ### `pre_llm_call` context injection
 
-This is the only hook whose return value matters. When a `pre_llm_call` callback returns a dict with a `"context"` key (or a plain string), Hermes injects that text into the **current turn's user message**. This is the mechanism for memory plugins, RAG integrations, guardrails, and any plugin that needs to provide the model with additional context.
+For `pre_llm_call`, a callback return value can inject context into the current turn. When it returns a dict with a `"context"` key (or a plain string), Hermes prepends that text to the **current turn's user message**. This is the mechanism for memory plugins, RAG integrations, guardrails, and any plugin that needs to provide the model with additional context. (`gateway_message` has its separate terminal-decision contract above.)
 
 #### Return format
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -393,7 +393,7 @@ def register(ctx):
 | [`subagent_stop`](#subagent_stop) | A `delegate_task` child has exited | ignored |
 | [`pre_gateway_dispatch`](#pre_gateway_dispatch) | Gateway received a user message, before auth + dispatch | `{"action": "skip" \| "rewrite" \| "allow", ...}` to influence flow |
 | [`gateway_message`](#gateway_message) | Authorized, routed ordinary user message after control interception, before normal agent dispatch | terminal handled/continue decision |
-| [`gateway_session_cancel`](#gateway_session_cancel) | Confirmed `/stop` or `/new`/reset gateway boundary | ignored |
+| [`gateway_session_cancel`](#gateway_session_cancel) | Participant session ends via stop/reset, inactivity timeout, or stale-agent eviction | ignored |
 | [`gateway_shutdown`](#gateway_shutdown) | Gateway stop/restart after route revocation, before adapter teardown | ignored |
 | [`pre_approval_request`](#pre_approval_request) | An approval decision is requested, including smart-mode auto decisions | ignored |
 | [`post_approval_response`](#post_approval_response) | An approval decision is made (or a prompt times out) | ignored |
@@ -1006,13 +1006,18 @@ With heavy delegation (e.g. orchestrator roles × 5 leaves × nested depth), `su
 
 Fires for an ordinary user message only after Hermes has admitted and authorized the native source, resolved its profile/session route, and intercepted slash commands and other gateway controls. It runs on both cold and active/busy session paths before normal agent dispatch.
 
-The host contract is capability-versioned independently of the Hermes package
-version. Plugins can inspect `ctx.gateway_message_hook_api_version` during
-`register(ctx)` and refuse activation with an actionable update message when
-the capability is absent or has an unsupported major version. Version 2 is the
-contract documented in this section. Backward-compatible additions retain the
-same major version; a future incompatible contract uses a new major version so
-plugins can fail visibly instead of relying on an exact Hermes release pin.
+The public participant host contract is capability-versioned independently of
+the Hermes package version. Plugins can inspect
+`ctx.participant_host_api_version` during `register(ctx)` and refuse activation
+with an actionable update message when the capability is absent or has an
+unsupported major version. Major version 2 covers the complete participant
+surface: `gateway_message`, `gateway_session_cancel`, and `gateway_shutdown`;
+immutable profile/session routing; route-bound delivery and receipts;
+`ctx.llm.complete_structured`; `ctx.dispatch_tool`; `ctx.register_command`; and
+plugin loading, failure isolation, and activation-status semantics.
+Backward-compatible additions retain major 2; a breaking change increments the
+major. `ctx.gateway_message_hook_api_version` remains available as the
+gateway-message-specific compatibility marker.
 
 The callback receives public immutable snapshots and a one-shot, route-bound
 delivery facade. Hermes plugins are trusted in-process Python code: this API
@@ -1046,7 +1051,24 @@ This hook is not invoked for unauthorized, internal, slash-command, or already-i
 
 ### `gateway_session_cancel`
 
-Fires after Hermes confirms an explicit `/stop` or `/new`/reset boundary. The callback receives the immutable `route` and a `reason` (`"stop"` or `"reset"`) so plugin-owned schedulers can invalidate active and pending work. It is a bounded best-effort observer notification: returns are ignored, callback failures are logged, and Hermes proceeds with the host interruption/reset if callbacks do not finish within two seconds. Caller task cancellation still propagates.
+Fires before Hermes destroys participant-scoped host state at `/stop`,
+`/new`/reset, an agent inactivity timeout, or stale running-agent eviction. The
+callback receives the immutable `route` and one of the explicit reasons
+`"stop"`, `"reset"`, `"inactivity_timeout"`, or
+`"stale_running_agent_eviction"` so plugin-owned schedulers can invalidate
+active and pending work.
+
+It is a bounded best-effort observer notification: returns are ignored,
+callback failures are logged, and Hermes proceeds with the host boundary if
+callbacks do not finish within two seconds. Timed-out callbacks receive a
+cancellation request. Work that suppresses cancellation remains visible in a
+bounded, per-session registry; duplicate notifications for that session are
+suppressed until it settles.
+
+An ordinary message interrupting a busy turn is not a participant session
+boundary: the same route, session key, and participant-owned state continue
+into the queued next turn. Hermes therefore does not emit this hook for that
+case.
 
 ```python
 async def cancel_plugin_work(route, reason, **kwargs):

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -372,9 +372,9 @@ def register(ctx):
 **General rules for all hooks:**
 
 - Callbacks receive **keyword arguments**. Always accept `**kwargs` for forward compatibility — new parameters may be added in future versions without breaking your plugin.
-- If a callback **crashes**, it's logged and skipped. Other hooks and the agent continue normally. A misbehaving plugin can never break the agent.
-- Two hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, and [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call. All other hooks are fire-and-forget observers.
-- Observer callbacks receive `telemetry_schema_version` automatically. When present, `turn_id`, `api_request_id`, `task_id`, `session_id`, and `api_call_count` are separate correlation fields. Treat `api_request_id` as an opaque identifier; do not parse its string format.
+- Callback failures are normally logged and skipped. `gateway_message` is deliberately stricter: once a callback matches, an exception or invalid terminal result suppresses normal dispatch. Task cancellation always propagates.
+- Three hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call, and [`gateway_message`](#gateway_message) can terminate or continue gateway dispatch. Other hooks are observers.
+- Observer callbacks invoked through the synchronous observer path receive `telemetry_schema_version` automatically. Async gateway hooks receive only the arguments documented for their specific contracts. When present, `turn_id`, `api_request_id`, `task_id`, `session_id`, and `api_call_count` are separate correlation fields. Treat `api_request_id` as an opaque identifier; do not parse its string format.
 
 ### Quick reference
 
@@ -392,6 +392,9 @@ def register(ctx):
 | [`subagent_start`](#subagent_start) | A `delegate_task` child has been constructed and is about to run | ignored |
 | [`subagent_stop`](#subagent_stop) | A `delegate_task` child has exited | ignored |
 | [`pre_gateway_dispatch`](#pre_gateway_dispatch) | Gateway received a user message, before auth + dispatch | `{"action": "skip" \| "rewrite" \| "allow", ...}` to influence flow |
+| [`gateway_message`](#gateway_message) | Authorized, routed ordinary user message after control interception, before normal agent dispatch | terminal handled/continue decision |
+| [`gateway_session_cancel`](#gateway_session_cancel) | Confirmed `/stop` or `/new`/reset gateway boundary | ignored |
+| [`gateway_shutdown`](#gateway_shutdown) | Gateway stop/restart after route revocation, before adapter teardown | ignored |
 | [`pre_approval_request`](#pre_approval_request) | An approval decision is requested, including smart-mode auto decisions | ignored |
 | [`post_approval_response`](#post_approval_response) | An approval decision is made (or a prompt times out) | ignored |
 | [`transform_tool_result`](#transform_tool_result) | After any tool returns, before the result is handed back to the model | `str` to replace the result, `None` to leave unchanged |
@@ -996,6 +999,79 @@ def register(ctx):
 :::info
 With heavy delegation (e.g. orchestrator roles × 5 leaves × nested depth), `subagent_stop` fires many times per turn. Keep your callback fast; push expensive work to a background queue.
 :::
+
+---
+
+### `gateway_message`
+
+Fires for an ordinary user message only after Hermes has admitted and authorized the native source, resolved its profile/session route, and intercepted slash commands and other gateway controls. It runs on both cold and active/busy session paths before normal agent dispatch.
+
+The host contract is capability-versioned independently of the Hermes package
+version. Plugins can inspect `ctx.gateway_message_hook_api_version` during
+`register(ctx)` and refuse activation with an actionable update message when
+the capability is absent or has an unsupported major version. Version 2 is the
+contract documented in this section. Backward-compatible additions retain the
+same major version; a future incompatible contract uses a new major version so
+plugins can fail visibly instead of relying on an exact Hermes release pin.
+
+The callback receives public immutable snapshots and a one-shot, route-bound
+delivery facade. Hermes plugins are trusted in-process Python code: this API
+narrows ordinary use but is not a sandbox against a hostile plugin importing
+private implementation modules or inspecting interpreter state.
+
+```python
+async def on_gateway_message(event, route, delivery, **kwargs):
+    if route.platform != "discord":
+        return None  # this handler did not match
+
+    receipt = await delivery.send("Handled by the plugin")
+    return {"decision": "handled"}
+
+def register(ctx):
+    ctx.register_hook("gateway_message", on_gateway_message)
+```
+
+- `event` is a frozen `GatewayMessageEvent`; it contains normalized message/reply/media facts but no raw native message, metadata, credentials, adapter, or mutable `MessageEvent`.
+- `route` is a frozen `GatewayMessageRoute` containing the resolved profile/session and current platform/chat/thread/user identity.
+- `delivery.send(text)`, `delivery.reply(text)`, and `delivery.react(reaction)`
+  can affect only that captured native route and are one-shot as a group. A
+  receipt is `sent` only when the adapter positively attests the requested
+  native effect, `failed` when non-occurrence is explicit, and `unknown` when
+  acknowledgement is missing, malformed, unattributable, or revocation raced
+  an already-started native invocation. Native error text is not exposed.
+
+Matched handlers return `{"decision": "handled"}` or `{"decision": "suppress"}` to stop normal dispatch, or `{"decision": "continue"}` / `{"decision": "pass"}` to allow it. `None` means the callback did not match. Callbacks may be synchronous or asynchronous. An exception or invalid non-`None` terminal result fails closed and suppresses normal dispatch; `asyncio.CancelledError` propagates.
+
+This hook is not invoked for unauthorized, internal, slash-command, or already-intercepted control events. Use it for extensions that need an authorized post-routing participant turn. Use `pre_gateway_dispatch` only for policies that intentionally operate before authorization. Enabling plugins that register both behavior-changing hooks is an invalid configuration: Hermes rejects it during plugin discovery regardless of load order.
+
+### `gateway_session_cancel`
+
+Fires after Hermes confirms an explicit `/stop` or `/new`/reset boundary. The callback receives the immutable `route` and a `reason` (`"stop"` or `"reset"`) so plugin-owned schedulers can invalidate active and pending work. It is a bounded best-effort observer notification: returns are ignored, callback failures are logged, and Hermes proceeds with the host interruption/reset if callbacks do not finish within two seconds. Caller task cancellation still propagates.
+
+```python
+async def cancel_plugin_work(route, reason, **kwargs):
+    await scheduler.cancel(route.session_key, reason=reason)
+
+def register(ctx):
+    ctx.register_hook("gateway_session_cancel", cancel_plugin_work)
+```
+
+### `gateway_shutdown`
+
+Fires during gateway stop or restart after all retained route-delivery facades
+have been synchronously revoked and before adapters disconnect. Sync and async
+callbacks are supported and awaited. Returns are ignored and callback failures
+are logged. After callbacks finish, Hermes waits for any adapter invocation
+that had already started to settle; it does not treat task cancellation as
+proof that an external native effect was aborted.
+
+```python
+async def close_plugin_runtime(reason, **kwargs):
+    await scheduler.close(reason=reason)  # reason is "stop" or "restart"
+
+def register(ctx):
+    ctx.register_hook("gateway_shutdown", close_plugin_runtime)
+```
 
 ---
 

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -264,7 +264,8 @@ Declarative plugins are symlinked with a `nix-managed-` prefix — they coexist 
 
 ```bash
 hermes plugins                               # unified interactive UI
-hermes plugins list                          # table: enabled / disabled / not enabled
+hermes plugins list                          # configured + runtime activation state
+hermes plugins list --json                   # machine-readable installer health status
 hermes plugins install user/repo             # install from Git, then prompt Enable? [y/N]
 hermes plugins install user/repo --enable    # install AND enable (no prompt)
 hermes plugins install user/repo --no-enable # install but leave disabled (no prompt)
@@ -306,7 +307,7 @@ context:
   engine: "compressor"    # default built-in compressor
 ```
 
-### Enabled vs. disabled vs. neither
+### Configuration and runtime activation
 
 Plugins occupy one of three states:
 
@@ -316,7 +317,18 @@ Plugins occupy one of three states:
 | `disabled` | Explicitly off — won't load even if also in `enabled` | (irrelevant) | Yes |
 | `not enabled` | Discovered but never opted in | No | No |
 
-The default for a newly-installed or bundled plugin is `not enabled`. `hermes plugins list` shows all three distinct states so you can tell what's been explicitly turned off vs. what's just waiting to be enabled.
+The default for a newly-installed or bundled plugin is `not enabled`.
+`hermes plugins list` preserves these configuration states and also reports
+the runtime state for enabled plugins as `enabled/active`,
+`enabled/inactive`, or `enabled/error`. An exception from one plugin's
+`register(ctx)` is isolated: its partial registrations are rolled back, it is
+reported as enabled but inactive with the error text, and unrelated plugins
+continue loading.
+
+Installers and health checks should use `hermes plugins list --json` and
+require both `"status": "enabled"` and `"active": true`. The
+`runtime_status` and `error` fields distinguish a successful activation from
+an enabled plugin that failed registration.
 
 In a running session, `/plugins` shows which plugins are currently loaded.
 


### PR DESCRIPTION
## What this changes

Adds public plugin hooks that run after Hermes has authenticated and routed an incoming message. A plugin can then:

- handle or pass the message;
- receive session-cancel and shutdown notices;
- send once through the already-selected native route;
- wait for an admitted send to finish before cancellation or shutdown completes.

It also adds `PluginContext.participant_host_api_version = 2`. Plugins check this interface version rather than pinning a Hermes package release.

`hermes plugins list --json` now reports whether an enabled plugin actually loaded, including registration errors. Failed registration rolls back that plugin's partial hooks and leaves unrelated Hermes behavior running.

## Why

Nunchi V2 uses the same plugin approach as V1, but its V2 contracts need cancellation, shutdown, and confirmed native sending that the existing plugin API did not expose. This adds those missing hooks instead of patching Hermes source or replacing platform adapters.

Hermes behaves as before when no plugin registers these hooks.

## Verification

- 411 tests passed across every changed Hermes test file on current `main` (`58708c706`).
- Ruff passed for every changed Python file.
- `git diff --check` passed.
- In an isolated environment, the Nunchi wheel loaded and reported `nunchi-v2 is enabled and active` against this branch.
- The same wheel stayed inactive against released Hermes 0.19.0 and told the operator to update Hermes.

Nunchi consumer: https://github.com/mentatzoe/nunchi/pull/34
