### PR TITLE
fix(update): never block `hermes update` on a git credential prompt

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -66,7 +66,10 @@ except ModuleNotFoundError:
 # any dependency touching ``platform.uname()`` at import time flashes a
 # visible console when this process is windowless (pythonw gateway + every
 # kanban worker).  No-op on POSIX; never raises.
-from hermes_cli._subprocess_compat import suppress_platform_ver_console
+from hermes_cli._subprocess_compat import (
+    noninteractive_git_env,
+    suppress_platform_ver_console,
+)
 
 suppress_platform_ver_console()
 
@@ -8715,6 +8718,8 @@ def _sync_fork_with_upstream(git_cmd: list[str], cwd: Path) -> bool:
             cwd=cwd,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
+            stdin=subprocess.DEVNULL,
+            env=noninteractive_git_env(),
         )
         return result.returncode == 0
     except Exception:
@@ -8778,6 +8783,8 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
             cwd=cwd,
             capture_output=True,
             check=True,
+            stdin=subprocess.DEVNULL,
+            env=noninteractive_git_env(),
         )
     except subprocess.CalledProcessError:
         print("  ✗ Failed to fetch upstream. Skipping upstream sync.")
@@ -8817,6 +8824,8 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
             git_cmd + ["pull", "--ff-only", "upstream", "main"],
             cwd=cwd,
             check=True,
+            stdin=subprocess.DEVNULL,
+            env=noninteractive_git_env(),
         )
     except subprocess.CalledProcessError:
         print(
@@ -11017,6 +11026,8 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
             cwd=PROJECT_ROOT,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
+            stdin=subprocess.DEVNULL,
+            env=noninteractive_git_env(),
         )
         if fetch_result.returncode != 0:
             # Fallback to origin if upstream doesn't exist
@@ -11026,6 +11037,8 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
                 cwd=PROJECT_ROOT,
                 capture_output=True,
                 text=True, encoding="utf-8", errors="replace",
+                stdin=subprocess.DEVNULL,
+                env=noninteractive_git_env(),
             )
             upstream_exists = False
             compare_branch = f"origin/{branch}"
@@ -11040,6 +11053,8 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
             cwd=PROJECT_ROOT,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
+            stdin=subprocess.DEVNULL,
+            env=noninteractive_git_env(),
         )
         upstream_exists = False
         compare_branch = f"origin/{branch}"
@@ -12319,6 +12334,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
             cwd=PROJECT_ROOT,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
+            stdin=subprocess.DEVNULL,
+            env=noninteractive_git_env(),
         )
         if fetch_result.returncode != 0:
             stderr = fetch_result.stderr.strip()
@@ -12537,6 +12554,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 cwd=PROJECT_ROOT,
                 capture_output=True,
                 text=True, encoding="utf-8", errors="replace",
+                stdin=subprocess.DEVNULL,
+                env=noninteractive_git_env(),
             )
             if pull_result.returncode != 0:
                 # ff-only failed — local and remote have diverged (e.g. upstream

--- a/tests/hermes_cli/test_noninteractive_git.py
+++ b/tests/hermes_cli/test_noninteractive_git.py
@@ -216,3 +216,47 @@ def test_mcp_catalog_git_install_runs_noninteractively(monkeypatch, tmp_path):
     for call in calls:
         if call["argv"][0].endswith("git") or "git" in call["argv"][0]:
             _assert_noninteractive(call)
+
+
+# ---------------------------------------------------------------------------
+# 4. `hermes update` — the same class, on the update path's own remote calls.
+#
+# These run in exactly the "nobody attached" contexts the helper exists for:
+# desktop auto-update, a supervised backend restarting itself, `hermes update`
+# from a launchd/systemd unit. They also capture output, so a credential
+# prompt is invisible: the user sees "→ Fetching updates..." and nothing else.
+# Updating from a (possibly private) fork is a first-class, detected case.
+# ---------------------------------------------------------------------------
+
+
+_REMOTE_GIT_VERBS = {"fetch", "pull", "push", "clone", "ls-remote"}
+
+
+def _remote_calls(calls: list[dict]) -> list[dict]:
+    """Captured runs whose argv drives a remote (auth-capable) git operation."""
+    return [c for c in calls if _REMOTE_GIT_VERBS & set(c["argv"])]
+
+
+def test_update_fork_push_runs_noninteractively(monkeypatch, tmp_path):
+    from hermes_cli import main
+
+    calls = _capture_run(monkeypatch, main)
+    main._sync_fork_with_upstream(["git"], tmp_path)
+
+    remote = _remote_calls(calls)
+    assert remote, calls
+    for call in remote:
+        _assert_noninteractive(call)
+
+
+def test_update_upstream_sync_runs_noninteractively(monkeypatch, tmp_path):
+    from hermes_cli import main
+
+    monkeypatch.setattr(main, "_has_upstream_remote", lambda *a, **k: True)
+    calls = _capture_run(monkeypatch, main)
+    main._sync_with_upstream_if_needed(["git"], tmp_path)
+
+    remote = _remote_calls(calls)
+    assert remote, calls
+    for call in remote:
+        _assert_noninteractive(call)


### PR DESCRIPTION
## What does this PR do?

58708c706 / #73709 hardened Hermes's internal git plumbing so a private, misconfigured, or auth-requiring remote fails fast instead of blocking on a prompt nobody can answer. Its sweep covered MCP catalog installs, plugin install/update, profile distribution staging, worktree base fetches and the desktop review pane.

**The update path was not in it** — and it is where users touch a remote most. `hermes update` and `hermes update --check` run eight remote git operations, none of which passed the hardened env, a timeout, or stdin:

| function | operation |
|---|---|
| `_sync_fork_with_upstream` | `push origin main --force-with-lease` |
| `_sync_with_upstream_if_needed` | `fetch upstream main`, `pull --ff-only upstream main` |
| `_cmd_update_check` | `fetch upstream <branch>`, `fetch origin <branch>` ×2 |
| `_cmd_update_impl` | `fetch origin <branch>`, `pull --ff-only origin <branch>` |

Every one also uses `capture_output=True`, so the prompt itself is invisible: the user sees

```
→ Fetching updates...
```

and nothing else, indefinitely. And this runs unattended — desktop auto-update, a supervised backend restarting itself, a launchd/systemd unit — while **updating from a fork is a detected, first-class case** (`_is_fork` prints "⚠ Updating from fork"), so a private fork remote or an expired token is the ordinary trigger, not an exotic one. On Windows, Git Credential Manager pops its own dialog for the same reason.

Fail-fast is already the intended contract at these exact call sites: both fetch error handlers special-case

```python
elif "Authentication failed" in stderr or "could not read Username" in stderr:
```

`could not read Username` is precisely what git prints when terminal prompts are **disabled** — the branch can only be reached once `GIT_TERMINAL_PROMPT=0` is set, which is what this PR does.

Reproduced against `main` (`58708c706`) with the same per-call-site plumbing assertions the original sweep used:

```
E   assert None is -3      # stdin
E    +  where {'argv': ['git', 'fetch', 'upstream', 'main', '--quiet'],
E              'capture_output': True, 'check': True, 'cwd': ...}.get('stdin')
E    +  and   -3 = subprocess.DEVNULL
```

## Related Issue

No issue — found by auditing the call-site coverage of 58708c706 (#73709), which introduced `noninteractive_git_env()` and listed the sites it wired.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: pass `stdin=subprocess.DEVNULL` and `env=noninteractive_git_env()` to all eight remote git invocations in the update path (the table above), and import the helper alongside the existing `_subprocess_compat` import.
- Local-only git calls are deliberately untouched — including `git stash push --include-untracked`, where "push" is the stash subcommand and no remote is contacted.
- `tests/hermes_cli/test_noninteractive_git.py`: two plumbing tests in the file's existing style, filtering captured runs to remote verbs (`fetch`/`pull`/`push`/`clone`/`ls-remote`) so local git calls in the same helper aren't over-constrained.

## How to Test

1. Point `origin` (or `upstream`) at a private repo you have no cached credentials for, then run `hermes update --check`. Before this change it hangs after "→ Fetching from upstream..." with no output; after, git exits immediately and the existing handler prints "✗ Authentication failed — check your git credentials or SSH key."
2. `pytest tests/hermes_cli/test_noninteractive_git.py -q` → 13 passed (2 new). Both new tests fail on `main` without the code change (captured above).
3. Coverage check: every `subprocess.run` in `hermes_cli/main.py` whose argv carries a remote git verb now passes the hardened env — 8/8.
4. Wider run: `pytest tests/hermes_cli/ -q -k "update or git" --ignore=tests/hermes_cli/test_gateway.py` → 504 passed / 55 failed, versus baseline 502 passed / **the same 55** with the change stashed; the delta is exactly the two new tests. (`test_gateway.py` is excluded because it fails to collect on this machine — `termios` — independently of this change.)
5. Tested on Ubuntu 24.04.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate — #73709 is the closed PR that introduced the helper; no open PR or issue covers the update path's git calls
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suites and they pass (see step 4 for the pre-existing, unrelated failures)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no user-facing contract change; this makes the documented failure path reachable instead of hanging)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys added or changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — the helper also sets `GCM_INTERACTIVE=Never`, which is what stops Git Credential Manager's dialog on Windows installs; `GIT_ASKPASS`/`SSH_ASKPASS` stay untouched so working non-interactive auth still succeeds
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool schemas touched)
