### PR TITLE
feat(desktop): make thinking disclosures scrollable

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
@@ -165,9 +165,10 @@ const ThinkingDisclosure: FC<{
             // Body sits flush with the "Thinking" header — no left indent —
             // and inherits the disclosure-level opacity fade defined in
             // styles.css (~0.67 at rest, 1 on hover/focus).
-            'mt-0.5 w-full min-w-0 max-w-full overflow-hidden wrap-anywhere pb-1',
-            isPreview && 'max-h-40'
+            'mt-0.5 w-full min-w-0 max-w-full overflow-x-hidden overflow-y-auto overscroll-contain wrap-anywhere pb-1',
+            isPreview ? 'max-h-40' : 'max-h-[40dvh]'
           )}
+          data-slot="aui_thinking-body"
           ref={scrollRef}
         >
           <div ref={contentRef}>{children}</div>

--- a/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
@@ -20,6 +20,10 @@ class TestResizeObserver {
     this.target = target
   }
 
+  get observedTarget(): Element | null {
+    return this.target
+  }
+
   unobserve() {}
 
   disconnect() {
@@ -612,6 +616,35 @@ describe('assistant-ui streaming renderer', () => {
     expect(container.querySelector('[data-slot="aui_reasoning-text"]')?.textContent).toBe(
       'The user is asking what this file is.'
     )
+  })
+
+  it('bounds completed expanded reasoning in an inner scroll container', () => {
+    const { container } = render(<ReasoningHarness />)
+    const ui = within(container)
+
+    fireEvent.click(ui.getByRole('button', { name: /thought/i }))
+
+    const reasoningText = container.querySelector('[data-slot="aui_reasoning-text"]')
+    const body = container.querySelector('[data-slot="aui_thinking-body"]')
+
+    expect(body?.classList.contains('max-h-[40dvh]')).toBe(true)
+    expect(body?.classList.contains('overflow-y-auto')).toBe(true)
+    expect(body?.classList.contains('overscroll-contain')).toBe(true)
+    expect(reasoningText?.textContent).toBe('The user is asking what this file is.')
+  })
+
+  it('keeps live reasoning in the observed inner scroll container', async () => {
+    const { container } = render(<RunningReasoningHarness />)
+
+    await waitFor(() => {
+      const reasoningText = container.querySelector('[data-slot="aui_reasoning-text"]')
+      const body = container.querySelector('[data-slot="aui_thinking-body"]')
+
+      expect(body?.classList.contains('max-h-40')).toBe(true)
+      expect(body?.classList.contains('overflow-y-auto')).toBe(true)
+      expect(body?.classList.contains('overscroll-contain')).toBe(true)
+      expect([...resizeObservers].some(observer => observer.observedTarget === reasoningText?.parentElement)).toBe(true)
+    })
   })
 
   it('groups consecutive reasoning parts under one thinking disclosure', () => {


### PR DESCRIPTION
## Context

Desktop renders model reasoning inline with the final response. Long expanded reasoning can consume the entire chat viewport, leaving the response below the fold and forcing users to move the transcript just to inspect it.

## Solution

Bound each expanded Thinking body independently: live reasoning keeps its compact preview height, while completed reasoning can use up to 40% of the viewport and scroll internally. This preserves the existing live-follow behavior and lets users review reasoning without displacing the surrounding conversation.