### PR TITLE
fix(secrets): isolate capture callbacks by execution context

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6917,13 +6917,29 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
 
 
+    def _bind_secret_capture_lifecycle(self) -> None:
+        """Bind this CLI's secret callback until lifecycle shutdown."""
+        if getattr(self, "_secret_capture_context_token", None) is not None:
+            return
+        self._secret_capture_context_token = bind_secret_capture_callback(
+            self._secret_capture_callback
+        )
+
+    def _reset_secret_capture_lifecycle(self) -> None:
+        """Restore the callback that preceded this CLI lifecycle."""
+        token = getattr(self, "_secret_capture_context_token", None)
+        if token is None:
+            return
+        self._secret_capture_context_token = None
+        reset_secret_capture_callback(token)
+
     def _install_tool_callbacks(self) -> None:
         """Install tool callbacks that need the live prompt UI."""
         if getattr(self, "_tool_callbacks_installed", False):
             return
         set_sudo_password_callback(self._sudo_password_callback)
         set_approval_callback(self._approval_callback)
-        set_secret_capture_callback(self._secret_capture_callback)
+        self._bind_secret_capture_lifecycle()
         try:
             from tools.computer_use_tool import set_approval_callback as _set_cu_cb
 
@@ -13125,8 +13141,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             The agent's response, or None on error
         """
         # Single-query and direct chat callers do not go through run(), so
-        # register secure secret capture here as well.
-        set_secret_capture_callback(self._secret_capture_callback)
+        # establish the same scoped lifecycle binding here as well.
+        self._bind_secret_capture_lifecycle()
 
         # Reset the per-turn interrupt flag. Any subsequent path that
         # discovers an interrupt (below, after run_conversation) will flip
@@ -16968,7 +16984,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # Unregister callbacks to avoid dangling references
             set_sudo_password_callback(None)
             set_approval_callback(None)
-            set_secret_capture_callback(None)
+            self._reset_secret_capture_lifecycle()
             # Flush any in-memory turn transcript before marking the session
             # closed.  On SIGHUP/SIGTERM/window close the agent thread may not
             # reach its normal run_conversation() persistence path before the

--- a/cli.py
+++ b/cli.py
@@ -977,6 +977,22 @@ def set_secret_capture_callback(*args, **kwargs):
     return _set_secret_capture_callback(*args, **kwargs)
 
 
+def bind_secret_capture_callback(*args, **kwargs):
+    from tools.skills_tool import (
+        bind_secret_capture_callback as _bind_secret_capture_callback,
+    )
+
+    return _bind_secret_capture_callback(*args, **kwargs)
+
+
+def reset_secret_capture_callback(*args, **kwargs):
+    from tools.skills_tool import (
+        reset_secret_capture_callback as _reset_secret_capture_callback,
+    )
+
+    return _reset_secret_capture_callback(*args, **kwargs)
+
+
 def _cleanup_all_browsers(*args, **kwargs):
     from tools.browser_tool import _emergency_cleanup_all_sessions
 
@@ -13346,8 +13362,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 # by acp_adapter/server.py for ACP sessions.
                 set_sudo_password_callback(self._sudo_password_callback)
                 set_approval_callback(self._approval_callback)
+                _secret_capture_token = None
                 try:
-                    set_secret_capture_callback(self._secret_capture_callback)
+                    _secret_capture_token = bind_secret_capture_callback(
+                        self._secret_capture_callback
+                    )
                 except Exception:
                     pass
                 # Bind this turn's approval session key into the contextvar so
@@ -13445,7 +13464,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     try:
                         set_sudo_password_callback(None)
                         set_approval_callback(None)
-                        set_secret_capture_callback(None)
+                    except Exception:
+                        pass
+                    try:
+                        if _secret_capture_token is not None:
+                            reset_secret_capture_callback(_secret_capture_token)
                     except Exception:
                         pass
                     # Release the per-turn approval session key. ``_session_yolo``

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1842,7 +1842,7 @@ class CLICommandsMixin:
         When it completes, prints the result to the CLI without modifying
         the active session's conversation history.
         """
-        from cli import AIAgent, ChatConsole, _accent_hex, _cprint, _maybe_remap_for_light_mode, _render_final_assistant_content, set_approval_callback, set_secret_capture_callback, set_sudo_password_callback
+        from cli import AIAgent, ChatConsole, _accent_hex, _cprint, _maybe_remap_for_light_mode, _render_final_assistant_content, bind_secret_capture_callback, reset_secret_capture_callback, set_approval_callback, set_sudo_password_callback
         parts = cmd.strip().split(maxsplit=1)
         if len(parts) < 2 or not parts[1].strip():
             _cprint("  Usage: /background <prompt>")
@@ -1869,8 +1869,11 @@ class CLICommandsMixin:
         def run_background():
             set_sudo_password_callback(self._sudo_password_callback)
             set_approval_callback(self._approval_callback)
+            secret_capture_token = None
             try:
-                set_secret_capture_callback(self._secret_capture_callback)
+                secret_capture_token = bind_secret_capture_callback(
+                    self._secret_capture_callback
+                )
             except Exception:
                 pass
             try:
@@ -1976,7 +1979,11 @@ class CLICommandsMixin:
                 try:
                     set_sudo_password_callback(None)
                     set_approval_callback(None)
-                    set_secret_capture_callback(None)
+                except Exception:
+                    pass
+                try:
+                    if secret_capture_token is not None:
+                        reset_secret_capture_callback(secret_capture_token)
                 except Exception:
                     pass
                 self._background_tasks.pop(task_id, None)

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -1,6 +1,7 @@
 """Tests for agent/skill_commands.py — skill slash command scanning and platform filtering."""
 
 import os
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
@@ -13,6 +14,15 @@ from agent.skill_commands import (
     resolve_skill_command_key,
     scan_skill_commands,
 )
+
+
+@contextmanager
+def _secret_capture(callback):
+    token = skills_tool_module.bind_secret_capture_callback(callback)
+    try:
+        yield
+    finally:
+        skills_tool_module.reset_secret_capture_callback(token)
 
 
 def _make_skill(
@@ -627,14 +637,9 @@ Generate some audio.
                 "skipped": False,
             }
 
-        monkeypatch.setattr(
-            skills_tool_module,
-            "_secret_capture_callback",
-            fake_secret_callback,
-            raising=False,
-        )
-
-        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        with _secret_capture(fake_secret_callback), patch(
+            "tools.skills_tool.SKILLS_DIR", tmp_path
+        ):
             _make_skill(
                 tmp_path,
                 "test-skill",
@@ -662,14 +667,9 @@ Generate some audio.
                 "gateway flow should not try secure in-band secret capture"
             )
 
-        monkeypatch.setattr(
-            skills_tool_module,
-            "_secret_capture_callback",
-            fail_if_called,
-            raising=False,
-        )
-
-        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        with _secret_capture(fail_if_called), patch(
+            "tools.skills_tool.SKILLS_DIR", tmp_path
+        ):
             from gateway.session_context import clear_session_vars, set_session_vars
 
             tokens = set_session_vars(platform="telegram")
@@ -694,14 +694,7 @@ Generate some audio.
     def test_preserves_remaining_remote_setup_warning(self, tmp_path, monkeypatch):
         monkeypatch.setenv("TERMINAL_ENV", "ssh")
         monkeypatch.delenv("TENOR_API_KEY", raising=False)
-        monkeypatch.setattr(
-            skills_tool_module,
-            "_secret_capture_callback",
-            None,
-            raising=False,
-        )
-
-        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        with _secret_capture(None), patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             _make_skill(
                 tmp_path,
                 "test-skill",

--- a/tests/cli/test_cli_secret_capture.py
+++ b/tests/cli/test_cli_secret_capture.py
@@ -4,10 +4,13 @@ import time
 from unittest.mock import patch
 
 import cli as cli_module
-import tools.skills_tool as skills_tool_module
 from cli import HermesCLI
 from hermes_cli.callbacks import prompt_for_secret
-from tools.skills_tool import set_secret_capture_callback
+from tools.skills_tool import (
+    _get_secret_capture_callback,
+    bind_secret_capture_callback,
+    reset_secret_capture_callback,
+)
 
 
 class _FakeBuffer:
@@ -122,7 +125,7 @@ def test_secret_capture_timeout_clears_hidden_input_buffer():
     assert cleared["value"] is True
 
 
-def test_cli_chat_registers_secret_capture_callback():
+def test_cli_chat_restores_outer_secret_capture_callback_on_lifecycle_reset():
     clean_config = {
         "model": {
             "default": "anthropic/claude-opus-4.6",
@@ -134,17 +137,25 @@ def test_cli_chat_registers_secret_capture_callback():
         "terminal": {"env_type": "local"},
     }
 
-    with patch("cli.get_tool_definitions", return_value=[]), patch.dict(
-        "os.environ", {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}, clear=False
-    ), patch.dict(cli_module.__dict__, {"CLI_CONFIG": clean_config}):
-        cli_obj = HermesCLI()
-        with patch.object(cli_obj, "_ensure_runtime_credentials", return_value=False):
-            cli_obj.chat("hello")
-
+    outer_callback = object()
+    outer_token = bind_secret_capture_callback(outer_callback)
+    cli_obj = None
     try:
-        assert (
-            skills_tool_module._get_secret_capture_callback()
-            == cli_obj._secret_capture_callback
-        )
+        with patch("cli.get_tool_definitions", return_value=[]), patch.dict(
+            "os.environ", {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}, clear=False
+        ), patch.dict(cli_module.__dict__, {"CLI_CONFIG": clean_config}):
+            cli_obj = HermesCLI()
+            with patch.object(cli_obj, "_ensure_runtime_credentials", return_value=False):
+                cli_obj.chat("hello")
+                cli_obj.chat("hello again")
+
+        assert _get_secret_capture_callback() == cli_obj._secret_capture_callback
+        cli_obj._reset_secret_capture_lifecycle()
+        assert _get_secret_capture_callback() is outer_callback
     finally:
-        set_secret_capture_callback(None)
+        if (
+            cli_obj is not None
+            and getattr(cli_obj, "_secret_capture_context_token", None) is not None
+        ):
+            cli_obj._reset_secret_capture_lifecycle()
+        reset_secret_capture_callback(outer_token)

--- a/tests/cli/test_cli_secret_capture.py
+++ b/tests/cli/test_cli_secret_capture.py
@@ -142,6 +142,9 @@ def test_cli_chat_registers_secret_capture_callback():
             cli_obj.chat("hello")
 
     try:
-        assert skills_tool_module._secret_capture_callback == cli_obj._secret_capture_callback
+        assert (
+            skills_tool_module._get_secret_capture_callback()
+            == cli_obj._secret_capture_callback
+        )
     finally:
         set_secret_capture_callback(None)

--- a/tests/tools/test_secret_capture_context.py
+++ b/tests/tools/test_secret_capture_context.py
@@ -1,0 +1,177 @@
+"""Concurrency regressions for secure skill secret-capture routing."""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
+
+import pytest
+
+from tools.skills_tool import (
+    _capture_required_environment_variables,
+    _get_secret_capture_callback,
+    bind_secret_capture_callback,
+    reset_secret_capture_callback,
+    set_secret_capture_callback,
+)
+from tools.thread_context import propagate_context_to_thread
+
+
+def _missing_entry(name: str) -> list[dict[str, str]]:
+    return [{"name": name, "prompt": "[REDACTED]"}]
+
+
+def test_secret_capture_callbacks_are_isolated_between_concurrent_sessions(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    names = {
+        "session-a": "HERMES_TEST_SECRET_CAPTURE_A",
+        "session-b": "HERMES_TEST_SECRET_CAPTURE_B",
+    }
+    for name in names.values():
+        monkeypatch.delenv(name, raising=False)
+
+    barrier = threading.Barrier(2)
+    observed = []
+    observed_lock = threading.Lock()
+
+    def run_session(label: str):
+        def callback(var_name, _prompt, metadata=None):
+            with observed_lock:
+                observed.append((label, var_name, metadata["skill_name"]))
+            return {"success": True, "skipped": True}
+
+        assert set_secret_capture_callback(callback) is None
+        try:
+            barrier.wait(timeout=5)
+            result = _capture_required_environment_variables(
+                label, _missing_entry(names[label])
+            )
+            assert _get_secret_capture_callback() is callback
+            return result
+        finally:
+            set_secret_capture_callback(None)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(run_session, names))
+
+    assert set(observed) == {
+        ("session-a", names["session-a"], "session-a"),
+        ("session-b", names["session-b"], "session-b"),
+    }
+    assert all(result["setup_skipped"] is True for result in results)
+    assert _get_secret_capture_callback() is None
+
+
+def test_secret_capture_context_propagates_to_worker_and_does_not_leak(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    var_name = "HERMES_TEST_SECRET_CAPTURE_WORKER"
+    monkeypatch.delenv(var_name, raising=False)
+    caller_thread = threading.get_ident()
+    callback_threads = []
+
+    def callback(_var_name, _prompt, metadata=None):
+        callback_threads.append((threading.get_ident(), metadata["skill_name"]))
+        return {"success": True, "skipped": True}
+
+    token = bind_secret_capture_callback(callback)
+    try:
+        worker_call = propagate_context_to_thread(
+            lambda: _capture_required_environment_variables(
+                "worker-session", _missing_entry(var_name)
+            )
+        )
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            result = pool.submit(worker_call).result(timeout=5)
+            worker_after = pool.submit(_get_secret_capture_callback).result(timeout=5)
+    finally:
+        reset_secret_capture_callback(token)
+
+    assert result["setup_skipped"] is True
+    assert callback_threads == [(callback_threads[0][0], "worker-session")]
+    assert callback_threads[0][0] != caller_thread
+    assert worker_after is None
+    assert _get_secret_capture_callback() is None
+
+
+def test_secret_capture_binding_restores_outer_context_after_exception(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    var_name = "HERMES_TEST_SECRET_CAPTURE_FAILURE"
+    monkeypatch.delenv(var_name, raising=False)
+
+    def outer_callback(*_args, **_kwargs):
+        return {"success": True, "skipped": True}
+
+    def failing_callback(*_args, **_kwargs):
+        raise RuntimeError("synthetic callback failure")
+
+    outer_token = bind_secret_capture_callback(outer_callback)
+    try:
+        inner_token = bind_secret_capture_callback(failing_callback)
+        try:
+            result = _capture_required_environment_variables(
+                "failing-session", _missing_entry(var_name)
+            )
+            assert result["setup_skipped"] is True
+            assert result["missing_names"] == [var_name]
+        finally:
+            reset_secret_capture_callback(inner_token)
+
+        assert _get_secret_capture_callback() is outer_callback
+    finally:
+        reset_secret_capture_callback(outer_token)
+
+    assert _get_secret_capture_callback() is None
+
+
+def test_worker_context_is_clean_after_timeout_and_interrupt(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+
+    def callback(*_args, **_kwargs):
+        return {"success": True, "skipped": True}
+
+    entered = threading.Event()
+    release = threading.Event()
+
+    def blocked_worker():
+        assert _get_secret_capture_callback() is callback
+        entered.set()
+        assert release.wait(timeout=5)
+
+    def interrupted_worker():
+        assert _get_secret_capture_callback() is callback
+        raise KeyboardInterrupt("synthetic interrupt")
+
+    token = bind_secret_capture_callback(callback)
+    try:
+        blocked_call = propagate_context_to_thread(blocked_worker)
+        interrupted_call = propagate_context_to_thread(interrupted_worker)
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            blocked_future = pool.submit(blocked_call)
+            assert entered.wait(timeout=5)
+            with pytest.raises(FutureTimeout):
+                blocked_future.result(timeout=0.01)
+            release.set()
+            blocked_future.result(timeout=5)
+            assert pool.submit(_get_secret_capture_callback).result(timeout=5) is None
+
+            with pytest.raises(KeyboardInterrupt, match="synthetic interrupt"):
+                pool.submit(interrupted_call).result(timeout=5)
+            assert pool.submit(_get_secret_capture_callback).result(timeout=5) is None
+    finally:
+        release.set()
+        reset_secret_capture_callback(token)
+
+    assert _get_secret_capture_callback() is None

--- a/tests/tools/test_skill_env_passthrough.py
+++ b/tests/tools/test_skill_env_passthrough.py
@@ -1,12 +1,22 @@
 """Test that skill_view registers required env vars in the passthrough registry."""
 
 import json
-from unittest.mock import patch
+from contextlib import contextmanager
 
 import pytest
 
 import tools.env_passthrough as _ep_mod
+import tools.skills_tool as skills_tool_module
 from tools.env_passthrough import clear_env_passthrough, is_env_passthrough
+
+
+@contextmanager
+def _secret_capture(callback):
+    token = skills_tool_module.bind_secret_capture_callback(callback)
+    try:
+        yield
+    finally:
+        skills_tool_module.reset_secret_capture_callback(token)
 
 
 @pytest.fixture(autouse=True)
@@ -54,7 +64,7 @@ class TestSkillViewRegistersPassthrough:
         monkeypatch.setenv("TENOR_API_KEY", "test-value-123")
 
         # Patch the secret capture callback to not prompt
-        with patch("tools.skills_tool._secret_capture_callback", None):
+        with _secret_capture(None):
             from tools.skills_tool import skill_view
 
             result = json.loads(skill_view(name="test-skill"))
@@ -81,7 +91,7 @@ class TestSkillViewRegistersPassthrough:
         save_env_value("TENOR_API_KEY", "persisted-value-123")
         monkeypatch.delenv("TENOR_API_KEY", raising=False)
 
-        with patch("tools.skills_tool._secret_capture_callback", None):
+        with _secret_capture(None):
             from tools.skills_tool import skill_view
 
             result = json.loads(skill_view(name="test-skill"))
@@ -108,7 +118,7 @@ class TestSkillViewRegistersPassthrough:
         )
         monkeypatch.delenv("NONEXISTENT_SKILL_KEY_XYZ", raising=False)
 
-        with patch("tools.skills_tool._secret_capture_callback", None):
+        with _secret_capture(None):
             from tools.skills_tool import skill_view
 
             result = json.loads(skill_view(name="test-skill"))
@@ -123,7 +133,7 @@ class TestSkillViewRegistersPassthrough:
             "tools.skills_tool.SKILLS_DIR", tmp_path
         )
 
-        with patch("tools.skills_tool._secret_capture_callback", None):
+        with _secret_capture(None):
             from tools.skills_tool import skill_view
 
             result = json.loads(skill_view(name="simple-skill"))

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
@@ -19,6 +20,15 @@ from tools.skills_tool import (
     skill_view,
     MAX_DESCRIPTION_LENGTH,
 )
+
+
+@contextmanager
+def _secret_capture(callback):
+    token = skills_tool_module.bind_secret_capture_callback(callback)
+    try:
+        yield
+    finally:
+        skills_tool_module.reset_secret_capture_callback(token)
 
 
 def _make_skill(
@@ -604,14 +614,9 @@ class TestSkillViewSecureSetupOnLoad:
                 "skipped": False,
             }
 
-        monkeypatch.setattr(
-            skills_tool_module,
-            "_secret_capture_callback",
-            fake_secret_callback,
-            raising=False,
-        )
-
-        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        with _secret_capture(fake_secret_callback), patch(
+            "tools.skills_tool.SKILLS_DIR", tmp_path
+        ):
             _make_skill(
                 tmp_path,
                 "gif-search",
@@ -653,14 +658,9 @@ class TestSkillViewSecureSetupOnLoad:
                 "skipped": True,
             }
 
-        monkeypatch.setattr(
-            skills_tool_module,
-            "_secret_capture_callback",
-            fake_secret_callback,
-            raising=False,
-        )
-
-        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        with _secret_capture(fake_secret_callback), patch(
+            "tools.skills_tool.SKILLS_DIR", tmp_path
+        ):
             _make_skill(
                 tmp_path,
                 "gif-search",
@@ -1008,14 +1008,9 @@ class TestSkillViewPrerequisites:
                 "skipped": False,
             }
 
-        monkeypatch.setattr(
-            skills_tool_module,
-            "_secret_capture_callback",
-            fake_secret_callback,
-            raising=False,
-        )
-
-        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        with _secret_capture(fake_secret_callback), patch(
+            "tools.skills_tool.SKILLS_DIR", tmp_path
+        ):
             _make_skill(
                 tmp_path,
                 "gif-search",
@@ -1106,14 +1101,9 @@ Do the legacy thing.
                 "skipped": False,
             }
 
-        monkeypatch.setattr(
-            skills_tool_module,
-            "_secret_capture_callback",
-            fake_secret_callback,
-            raising=False,
-        )
-
-        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        with _secret_capture(fake_secret_callback), patch(
+            "tools.skills_tool.SKILLS_DIR", tmp_path
+        ):
             _make_skill(
                 tmp_path,
                 "gif-search",

--- a/tests/tui_gateway/test_secret_capture_context.py
+++ b/tests/tui_gateway/test_secret_capture_context.py
@@ -1,0 +1,29 @@
+import tui_gateway.server as server
+from tools.skills_tool import (
+    _get_secret_capture_callback,
+    bind_secret_capture_callback,
+    reset_secret_capture_callback,
+)
+
+
+def test_wire_callbacks_returns_token_and_restores_outer_secret_callback():
+    outer_callback = object()
+    outer_token = bind_secret_capture_callback(outer_callback)
+    turn_token = None
+    try:
+        turn_token = server._wire_callbacks("session-a")
+        turn_callback = _get_secret_capture_callback()
+        assert callable(turn_callback)
+        assert turn_callback is not outer_callback
+
+        server._reset_secret_capture_token(turn_token)
+        turn_token = None
+        assert _get_secret_capture_callback() is outer_callback
+    finally:
+        if turn_token is not None:
+            server._reset_secret_capture_token(turn_token)
+        reset_secret_capture_callback(outer_token)
+
+
+def test_reset_secret_capture_token_accepts_no_binding():
+    server._reset_secret_capture_token(None)

--- a/tests/tui_gateway/test_secret_capture_context.py
+++ b/tests/tui_gateway/test_secret_capture_context.py
@@ -1,3 +1,7 @@
+import sys
+import threading
+import types
+
 import tui_gateway.server as server
 from tools.skills_tool import (
     _get_secret_capture_callback,
@@ -27,3 +31,126 @@ def test_wire_callbacks_returns_token_and_restores_outer_secret_callback():
 
 def test_reset_secret_capture_token_accepts_no_binding():
     server._reset_secret_capture_token(None)
+
+
+def _fake_agent_namespace():
+    """Minimal agent namespace for background/preview callback lifecycle tests."""
+    return types.SimpleNamespace(
+        base_url=None,
+        api_key=None,
+        provider=None,
+        api_mode=None,
+        acp_command=None,
+        acp_args=None,
+        model="test-model",
+        enabled_toolsets=None,
+        ephemeral_system_prompt=None,
+        providers_allowed=None,
+        providers_ignored=None,
+        providers_order=None,
+        provider_sort=None,
+        provider_require_parameters=False,
+        provider_data_collection=None,
+        openrouter_min_coding_score=None,
+        reasoning_config=None,
+        service_tier=None,
+        request_overrides={},
+        _fallback_model=None,
+    )
+
+
+def _install_worker_test_doubles(monkeypatch, sid, reset_done):
+    wired = []
+    reset = []
+
+    class FakeAIAgent:
+        def __init__(self, **kwargs):
+            pass
+
+        def run_conversation(self, **kwargs):
+            return {"final_response": "ok"}
+
+    server._sessions[sid] = {
+        "agent": _fake_agent_namespace(),
+        "session_key": "test-key",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "running": False,
+        "cwd": "/tmp",
+    }
+    monkeypatch.setattr(
+        server,
+        "_wire_callbacks",
+        lambda target: wired.append(target) or "secret-token",
+    )
+
+    def record_reset(token):
+        reset.append(token)
+        reset_done.set()
+
+    monkeypatch.setattr(server, "_reset_secret_capture_token", record_reset)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["terminal"])
+    monkeypatch.setattr(server, "_load_reasoning_config", lambda: None)
+    monkeypatch.setattr(server, "_load_service_tier", lambda: None)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_session_cwd", lambda session: "/tmp")
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAIAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    return wired, reset
+
+
+# Regression coverage adapted from the worker-thread gap identified by
+# upstream PR #38672. ContextVar callbacks must be bound and restored inside
+# each new thread; they do not propagate from the session-build thread.
+def test_prompt_background_binds_and_resets_secret_callback_on_worker(monkeypatch):
+    sid = "background-secret-sid"
+    reset_done = threading.Event()
+    wired, reset = _install_worker_test_doubles(monkeypatch, sid, reset_done)
+    try:
+        response = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.background",
+                "params": {"session_id": sid, "text": "run something"},
+            }
+        )
+        assert response.get("result"), response.get("error")
+        assert reset_done.wait(timeout=3.0)
+        assert wired == [sid]
+        assert reset == ["secret-token"]
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_preview_restart_binds_and_resets_secret_callback_on_worker(monkeypatch):
+    sid = "preview-secret-sid"
+    reset_done = threading.Event()
+    wired, reset = _install_worker_test_doubles(monkeypatch, sid, reset_done)
+
+    fake_terminal = types.ModuleType("tools.terminal_tool")
+    fake_terminal.register_task_env_overrides = lambda *args, **kwargs: None
+    fake_terminal.clear_task_env_overrides = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "tools.terminal_tool", fake_terminal)
+    try:
+        response = server.handle_request(
+            {
+                "id": "1",
+                "method": "preview.restart",
+                "params": {
+                    "session_id": sid,
+                    "url": "http://localhost:3000",
+                    "cwd": "",
+                    "context": "",
+                },
+            }
+        )
+        assert response.get("result"), response.get("error")
+        assert reset_done.wait(timeout=3.0)
+        assert wired == [sid]
+        assert reset == ["secret-token"]
+    finally:
+        server._sessions.pop(sid, None)

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -69,6 +69,7 @@ Usage:
 import json
 import logging
 import time
+from contextvars import ContextVar, Token
 
 from hermes_constants import get_hermes_home, display_hermes_home
 import os
@@ -173,7 +174,9 @@ _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _REMOTE_ENV_BACKENDS = frozenset(
     {"docker", "singularity", "modal", "ssh", "daytona"}
 )
-_secret_capture_callback = None
+_secret_capture_callback: ContextVar[Any] = ContextVar(
+    "skills_secret_capture_callback", default=None
+)
 
 
 def _skill_lookup_path_error(name: str) -> Optional[str]:
@@ -241,9 +244,23 @@ _INJECTION_PATTERNS: list = [
 ]
 
 
+def bind_secret_capture_callback(callback) -> Token:
+    """Bind secret prompting and return a token for scoped restoration."""
+    return _secret_capture_callback.set(callback)
+
+
 def set_secret_capture_callback(callback) -> None:
-    global _secret_capture_callback
-    _secret_capture_callback = callback
+    """Bind secret prompting to the current session/task context."""
+    bind_secret_capture_callback(callback)
+
+
+def reset_secret_capture_callback(token: Token) -> None:
+    """Restore the callback binding that preceded *token*."""
+    _secret_capture_callback.reset(token)
+
+
+def _get_secret_capture_callback():
+    return _secret_capture_callback.get()
 
 
 def skill_matches_platform(frontmatter: Dict[str, Any]) -> bool:
@@ -427,7 +444,8 @@ def _capture_required_environment_variables(
             "gateway_setup_hint": _gateway_setup_hint(),
         }
 
-    if _secret_capture_callback is None:
+    secret_capture_callback = _get_secret_capture_callback()
+    if secret_capture_callback is None:
         return {
             "missing_names": missing_names,
             "setup_skipped": False,
@@ -445,7 +463,7 @@ def _capture_required_environment_variables(
             metadata["required_for"] = entry["required_for"]
 
         try:
-            callback_result = _secret_capture_callback(
+            callback_result = secret_capture_callback(
                 entry["name"],
                 entry["prompt"],
                 metadata,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -13296,8 +13296,10 @@ def _(rid, params: dict) -> dict:
     task_id = f"bg_{uuid.uuid4().hex[:6]}"
 
     def run():
+        secret_capture_token = None
         session_tokens = _set_session_context(task_id, cwd=_session_cwd(session))
         try:
+            secret_capture_token = _wire_callbacks(parent)
             from run_agent import AIAgent
 
             result = AIAgent(
@@ -13325,6 +13327,7 @@ def _(rid, params: dict) -> dict:
                 {"task_id": task_id, "text": f"error: {e}"},
             )
         finally:
+            _reset_secret_capture_token(secret_capture_token)
             _clear_session_context(session_tokens)
 
     threading.Thread(target=run, daemon=True).start()
@@ -13393,8 +13396,10 @@ def _(rid, params: dict) -> dict:
     def run():
         # Pin the validated preview cwd, else the parent workspace — never an
         # invalid client path, which would silently fall back to the launch dir.
+        secret_capture_token = None
         session_tokens = _set_session_context(task_id, cwd=(preview_cwd or _session_cwd(session)))
         try:
+            secret_capture_token = _wire_callbacks(parent)
             from run_agent import AIAgent
             from tools.terminal_tool import register_task_env_overrides
 
@@ -13438,6 +13443,7 @@ def _(rid, params: dict) -> dict:
                 clear_task_env_overrides(task_id)
             except Exception:
                 pass
+            _reset_secret_capture_token(secret_capture_token)
             _clear_session_context(session_tokens)
 
     threading.Thread(target=run, daemon=True).start()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12000,8 +12000,8 @@ def _run_prompt_submit(
             # _callback_tls), so wiring it on the build thread doesn't reach this
             # turn thread — terminal sudo prompts would fall through to /dev/tty
             # and hang the headless gateway. Re-wire here so the prompt routes to
-            # the sudo.request overlay. (secret capture is a module global, so
-            # re-running is a harmless no-op.)
+            # the sudo.request overlay. Secret capture is context-local, so
+            # re-running binds this turn to the correct session.
             _wire_callbacks(sid)
             # Skip the config-model sync while a /model --once override is
             # active: the once-model is intentionally not pinned as a session

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1897,6 +1897,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
         notify_registered = False
         home_token = None
         secret_token = None
+        secret_capture_token = None
         profile_home = current.get("profile_home")
         try:
             tokens = _set_session_context(key)
@@ -1987,7 +1988,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
             except Exception:
                 pass
 
-            _wire_callbacks(sid)
+            secret_capture_token = _wire_callbacks(sid)
             # Surface the self-improvement review's "💾 …" summary as an event
             # the TUI/desktop render in-transcript, honoring
             # display.memory_notifications. _init_session wires this for the
@@ -2030,6 +2031,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
             current["agent_error"] = str(e)
             _emit("error", sid, {"message": f"agent init failed: {e}"})
         finally:
+            _reset_secret_capture_token(secret_capture_token)
             if home_token is not None:
                 reset_hermes_home_override(home_token)
             if secret_token is not None:
@@ -5317,7 +5319,7 @@ def _apply_project_workspace(task_id: str, path: str, _name: str = "") -> None:
 
 def _wire_callbacks(sid: str):
     from tools.terminal_tool import set_sudo_password_callback
-    from tools.skills_tool import set_secret_capture_callback
+    from tools.skills_tool import bind_secret_capture_callback
     from tools.project_tools import set_project_workspace_callback
 
     set_sudo_password_callback(lambda: _block("sudo.request", sid, {}, timeout=120))
@@ -5344,7 +5346,15 @@ def _wire_callbacks(sid: str):
             "message": "ok",
         }
 
-    set_secret_capture_callback(secret_cb)
+    return bind_secret_capture_callback(secret_cb)
+
+
+def _reset_secret_capture_token(token) -> None:
+    if token is None:
+        return
+    from tools.skills_tool import reset_secret_capture_callback
+
+    reset_secret_capture_callback(token)
 
 
 def _render_personality_prompt(value) -> str:
@@ -6135,7 +6145,8 @@ def _init_session(
         # Bare AIAgents that don't expose the attribute (unlikely, but keep
         # session startup resilient).
         pass
-    _wire_callbacks(sid)
+    secret_capture_token = _wire_callbacks(sid)
+    _reset_secret_capture_token(secret_capture_token)
     with _sessions_lock:
         if sid in _sessions:
             _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
@@ -11962,6 +11973,7 @@ def _run_prompt_submit(
         session_tokens = []
         home_token = None  # per-turn HERMES_HOME override for a resumed remote profile
         secret_token = None
+        secret_capture_token = None
         goal_followup = None  # set by the post-turn goal hook below
         result = None  # turn outcome; read after the finally for leftover /steer
         tts_queue = None  # streaming-TTS feed for this turn (voice mode)
@@ -12002,7 +12014,7 @@ def _run_prompt_submit(
             # and hang the headless gateway. Re-wire here so the prompt routes to
             # the sudo.request overlay. Secret capture is context-local, so
             # re-running binds this turn to the correct session.
-            _wire_callbacks(sid)
+            secret_capture_token = _wire_callbacks(sid)
             # Skip the config-model sync while a /model --once override is
             # active: the once-model is intentionally not pinned as a session
             # model_override (it must not persist), so without this guard the
@@ -12536,6 +12548,7 @@ def _run_prompt_submit(
                     reset_current_session_key(approval_token)
             except Exception:
                 pass
+            _reset_secret_capture_token(secret_capture_token)
             if home_token is not None:
                 reset_hermes_home_override(home_token)
             if secret_token is not None:


### PR DESCRIPTION
## Summary

Make skill secret-capture callbacks execution-context scoped instead of process-global, then bind and restore them across CLI, TUI, background, preview-restart, and worker lifecycles.

This is a broader root-cause alternative to the narrower routing fix in #68271 and incorporates the worker-thread gap independently identified in #38672. It intentionally does **not** claim or auto-close #68261 while maintainers decide which scope they prefer.

## Problem

`tools.skills_tool` stored one process-global secret-capture callback. Concurrent sessions or nested/background execution could overwrite that callback, route prompts to another session, or leave stale state after shutdown/exception paths.

A `ContextVar` fixes cross-context isolation, but new threads do not inherit it automatically. Therefore every worker lifecycle that may prompt for skill secrets must bind its owning callback inside the worker and restore the preceding binding in `finally`.

## Changes

- Replace the module-global callback with a `ContextVar`.
- Add token-returning bind/reset APIs while keeping `set_secret_capture_callback()` compatible.
- Bind/reset the callback across CLI startup/shutdown, background tasks, TUI session setup/turn cleanup, `prompt.background`, and `preview.restart`.
- Preserve callback context for skill environment checks executed through worker helpers.
- Add regressions for concurrent isolation, nested restoration, timeout/interrupt cleanup, CLI lifecycle, TUI lifecycle, and TUI worker-thread bind/reset.

## Compatibility

- Existing callers of `set_secret_capture_callback()` continue to work.
- No config, schema, tool description, or user-facing command changes.
- No secret values or new telemetry are introduced.

## Verification

Against `main@e807b7106cd271e211df9fb29a6192eef8be9f11`:

- `py_compile`: pass
- `git diff --check`: pass
- Ruff on touched files: pass
- focused affected + security/multiplex suite: `225 passed in 5.67s`
- post-freshness smoke: `20 passed in 1.54s`
- Gitleaks over the three commits: no leaks

## Related work and credit

- #68271 / @PRATHAMESH75 — independently identified the TUI cross-session routing symptom and proposed per-turn SID routing.
- #38672 / @AhmetArif0 — independently identified missing callback wiring in `prompt.background` and `preview.restart`; this PR binds **and restores** the ContextVar token in those workers.

Opening as a draft because those PRs overlap parts of the bug class and maintainer guidance on preferred scope is valuable before merge.
