### PR TITLE
fix(photon): reconcile FFFC placeholder handling + deps-check fixtures (post-wave)

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -875,19 +875,12 @@ class PhotonAdapter(BasePlatformAdapter):
             )
 
         ctype = content.get("type")
-        if ctype == "text":
-            raw_text = content.get("text") or ""
-            # iMessage emits U+FFFC OBJECT REPLACEMENT CHARACTER as a transient
-            # placeholder for some media bubbles (notably voice notes). Photon
-            # can then deliver the real attachment/voice event immediately
-            # afterwards with a different message id. If we dispatch the
-            # placeholder as a standalone text turn, the subsequent media event
-            # arrives while that turn is active and the gateway sends a bogus
-            # "Interrupting current task" busy ack. Drop placeholder-only text
-            # at the platform boundary; the real media event carries the bytes.
-            if raw_text.strip() == "\ufffc":
-                logger.debug("[photon] ignoring iMessage object-placeholder text event")
-                return
+        # NOTE: U+FFFC OBJECT REPLACEMENT CHARACTER placeholders (transient
+        # stand-ins for media bubbles) are handled below by the pending-FFFC
+        # machinery, which both suppresses the bogus text turn AND waits for
+        # the real attachment with a timeout. Do not early-drop them here —
+        # that would make the wait/timeout path unreachable (#54514 originally
+        # dropped them at this boundary; superseded by the FFFC wait).
         if ctype == "reaction":
             # Route only tapbacks on messages WE sent — those are implicitly
             # addressed to the bot (feishu precedent: synthetic text event).

--- a/tests/plugins/platforms/photon/test_runtime_record.py
+++ b/tests/plugins/platforms/photon/test_runtime_record.py
@@ -120,7 +120,8 @@ def _patch_spawn(
 ) -> None:
     """Stub everything _start_sidecar touches before the healthz loop."""
     sidecar_dir = tmp_path / "sidecar"
-    (sidecar_dir / "node_modules").mkdir(parents=True)
+    # sidecar_deps_installed() requires node_modules/spectrum-ts (partial-install guard)
+    (sidecar_dir / "node_modules" / "spectrum-ts").mkdir(parents=True)
     monkeypatch.setattr(photon_adapter, "_SIDECAR_DIR", sidecar_dir)
     monkeypatch.setattr(photon_adapter, "_sidecar_deps_stale", lambda: False)
 


### PR DESCRIPTION
## Summary
Reconciles two cross-PR collisions from today's Photon wave that left main's photon suite red at 158/164: the #54514 early U+FFFC drop shadowed the pending-FFFC wait/timeout machinery (making its attachment-wait path unreachable and orphaning 4 tests), and the new partial-install deps guard broke the runtime-record test fixtures.

## Changes
- `adapter.py`: remove the early U+FFFC return at the text-normalization boundary — the pending-FFFC machinery (detected later in `_dispatch_inbound`) both suppresses the bogus text turn AND waits for the real attachment with a timeout, strictly superseding the early drop. Comment documents why it must not be re-added.
- `test_runtime_record.py`: fixtures create `node_modules/spectrum-ts` to satisfy `sidecar_deps_installed()`'s partial-install guard.

## Validation
| | Before | After |
|---|---|---|
| tests/plugins/platforms/photon/ | 158 passed, 6 failed | 164 passed, 0 failed |

## Infographic

![photon wave reconciliation](https://v3b.fal.media/files/b/0aa4224b/H-YWfredUQszYS2LiYTne_f9lpPPmd.png)
