### PR TITLE
fix(photon): un-shadow U+FFFC deferred-wait handler + stale sidecar-deps fixture (red on main)

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -875,19 +875,6 @@ class PhotonAdapter(BasePlatformAdapter):
             )
 
         ctype = content.get("type")
-        if ctype == "text":
-            raw_text = content.get("text") or ""
-            # iMessage emits U+FFFC OBJECT REPLACEMENT CHARACTER as a transient
-            # placeholder for some media bubbles (notably voice notes). Photon
-            # can then deliver the real attachment/voice event immediately
-            # afterwards with a different message id. If we dispatch the
-            # placeholder as a standalone text turn, the subsequent media event
-            # arrives while that turn is active and the gateway sends a bogus
-            # "Interrupting current task" busy ack. Drop placeholder-only text
-            # at the platform boundary; the real media event carries the bytes.
-            if raw_text.strip() == "\ufffc":
-                logger.debug("[photon] ignoring iMessage object-placeholder text event")
-                return
         if ctype == "reaction":
             # Route only tapbacks on messages WE sent — those are implicitly
             # addressed to the bot (feishu precedent: synthetic text event).

--- a/tests/plugins/platforms/photon/test_runtime_record.py
+++ b/tests/plugins/platforms/photon/test_runtime_record.py
@@ -120,7 +120,9 @@ def _patch_spawn(
 ) -> None:
     """Stub everything _start_sidecar touches before the healthz loop."""
     sidecar_dir = tmp_path / "sidecar"
-    (sidecar_dir / "node_modules").mkdir(parents=True)
+    # sidecar_deps_installed() checks the dependency's own directory, not just
+    # node_modules/ (9cf2046081) — mirror a real completed install.
+    (sidecar_dir / "node_modules" / "spectrum-ts").mkdir(parents=True)
     monkeypatch.setattr(photon_adapter, "_SIDECAR_DIR", sidecar_dir)
     monkeypatch.setattr(photon_adapter, "_sidecar_deps_stale", lambda: False)
 


### PR DESCRIPTION
## Summary

Repairs 6 Photon tests red on current main (CI slice 8/8, failing unrelated PRs — first seen on #73761): two independent cross-PR collisions.

1. **Shadowed U+FFFC handler:** fd4f756492 (salvaged from stale #54514, written before the deferred-wait handler existed) added an early "drop U+FFFC placeholder" return at the top of `_dispatch_inbound`. It shadowed the deferred-wait handler further down the same function (6b91b50c6e/afab7ed46e): `_pending_fffc` never populated, no attachment-timeout tracking or cancellation — 4 tests red, and the regression is real behavior loss, not just test drift (a placeholder with no follow-up attachment now timed out silently with no warning). Removing the duplicate restores the full handler; it already drops the placeholder.
2. **Stale fixture:** 9cf2046081 tightened `sidecar_deps_installed()` to require `node_modules/spectrum-ts` (empty node_modules from aborted npm installs read as "installed"), but `test_runtime_record`'s `_patch_spawn` fixture still created bare `node_modules/` — 2 tests red.

## Changes

- `plugins/platforms/photon/adapter.py`: remove the duplicate early-return placeholder block (deferred-wait handler is the single owner)
- `tests/plugins/platforms/photon/test_runtime_record.py`: fixture mirrors a real completed install

## Validation

| | Before | After |
|---|---|---|
| tests/plugins/platforms/photon/ on main | 158 pass / 6 fail | 164 pass / 0 fail |

## Infographic

![photon fffc fix](https://v3b.fal.media/files/b/0aa4226a/imTrj6OaXavyg-NQ0XmdQ_FCn3TzTM.png)
