### PR TITLE
fix(mcp): suppress 'Event loop is closed' during shutdown race

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2201,6 +2201,13 @@ class MCPServerTask:
                     self.name,
                 )
 
+    def _safe_ready_set(self) -> None:
+        """Set _ready safely, ignoring RuntimeError if the event loop is closed during shutdown."""
+        try:
+            self._ready.set()
+        except RuntimeError:
+            pass
+
     async def _wait_for_lifecycle_event(self) -> str:
         """Block until either _shutdown_event or _reconnect_event fires.
 
@@ -2293,13 +2300,15 @@ class MCPServerTask:
                     # Clear the rapid-drop budget (#62212).
                     self._mark_session_proven()
         finally:
-            for t in (shutdown_task, reconnect_task):
-                if not t.done():
-                    t.cancel()
-                    try:
-                        await t
-                    except (asyncio.CancelledError, Exception):
-                        pass
+            loop = asyncio.get_event_loop_policy().get_event_loop()
+            if not loop.is_closed():
+                for t in (shutdown_task, reconnect_task):
+                    if not t.done():
+                        t.cancel()
+                        try:
+                            await t
+                        except (asyncio.CancelledError, Exception):
+                            pass
 
         if self._shutdown_event.is_set():
             return "shutdown"
@@ -2337,13 +2346,15 @@ class MCPServerTask:
                 timeout=timeout,
             )
         finally:
-            for t in (shutdown_task, reconnect_task):
-                if not t.done():
-                    t.cancel()
-                    try:
-                        await t
-                    except (asyncio.CancelledError, Exception):
-                        pass
+            loop = asyncio.get_event_loop_policy().get_event_loop()
+            if not loop.is_closed():
+                for t in (shutdown_task, reconnect_task):
+                    if not t.done():
+                        t.cancel()
+                        try:
+                            await t
+                        except (asyncio.CancelledError, Exception):
+                            pass
         if self._shutdown_event.is_set():
             return "shutdown"
         self._reconnect_event.clear()
@@ -2502,7 +2513,7 @@ class MCPServerTask:
                     self.session = session
                     self._mark_lifecycle_started()
                     await self._discover_tools()
-                    self._ready.set()
+                    self._safe_ready_set()
                     # Session is live again: clear any breaker state from a
                     # prior outage so the first call after recovery isn't
                     # gated on a stale consecutive-failure count (#16788).
@@ -2844,7 +2855,7 @@ class MCPServerTask:
                         )
                         self.session = session
                         await self._discover_tools()
-                        self._ready.set()
+                        self._safe_ready_set()
                         # Session is live again: clear any breaker state from a
                         # prior outage so the first call after recovery isn't
                         # gated on a stale consecutive-failure count (#16788).
@@ -2907,7 +2918,7 @@ class MCPServerTask:
                             )
                             self.session = session
                             await self._discover_tools()
-                            self._ready.set()
+                            self._safe_ready_set()
                             # Session is live again: clear any breaker state from
                             # a prior outage so the first call after recovery
                             # isn't gated on a stale failure count (#16788).
@@ -2945,7 +2956,7 @@ class MCPServerTask:
                         )
                         self.session = session
                         await self._discover_tools()
-                        self._ready.set()
+                        self._safe_ready_set()
                         # Session is live again: clear any breaker state from a
                         # prior outage so the first call after recovery isn't
                         # gated on a stale consecutive-failure count (#16788).
@@ -3064,7 +3075,7 @@ class MCPServerTask:
             except InvalidMcpUrlError as exc:
                 logger.warning("%s", exc)
                 self._error = exc
-                self._ready.set()
+                self._safe_ready_set()
                 return
 
             # Pre-flight content-type probe (Streamable HTTP only; SSE is
@@ -3091,7 +3102,7 @@ class MCPServerTask:
                 except NonMcpEndpointError as exc:
                     logger.warning("%s", exc)
                     self._error = exc
-                    self._ready.set()
+                    self._safe_ready_set()
                     return
 
         self._reconnect_retries = 0
@@ -3223,7 +3234,7 @@ class MCPServerTask:
                             self.name, type(root).__name__, root,
                         )
                         self._error = exc
-                        self._ready.set()
+                        self._safe_ready_set()
                         return
 
                     if failure_class == "permanent":
@@ -3238,7 +3249,7 @@ class MCPServerTask:
                             self.name, type(root).__name__, root,
                         )
                         self._error = exc
-                        self._ready.set()
+                        self._safe_ready_set()
                         self._was_parked = True
                         self._deregister_tools()
                         self._reconnect_event.clear()
@@ -3270,7 +3281,7 @@ class MCPServerTask:
                             type(root).__name__, root,
                         )
                         self._error = exc
-                        self._ready.set()
+                        self._safe_ready_set()
                         self._was_parked = True
                         self._deregister_tools()
                         self._reconnect_event.clear()
@@ -3305,7 +3316,7 @@ class MCPServerTask:
                     # Check if shutdown was requested during the sleep
                     if self._shutdown_event.is_set():
                         self._error = exc
-                        self._ready.set()
+                        self._safe_ready_set()
                         return
                     continue
 


### PR DESCRIPTION
When the MCP background event loop is shut down, MCPServerTask coroutines can still be running in wait loops. Their _ready.set() calls invoke loop.call_soon() which raises RuntimeError when the loop is already closed. Similarly, task.cancel() in finally blocks hits the same issue.

Two-layer fix:
1. _safe_ready_set() wraps all 10 _ready.set() call sites in a try/except RuntimeError, preventing the exception from propagating during shutdown.
2. Add loop.is_closed() guard before task.cancel() in both _wait_for_lifecycle_event and _wait_for_reconnect_or_shutdown finally blocks, addressing the issue-reported path.

Fixes #60197, fixes #66228