### PR TITLE
fix(matrix): don't require MATRIX_ACCESS_TOKEN if using MATRIX_PASSWORD

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1783,6 +1783,12 @@ def _platform_has_bot_credential(platform: "Platform", platform_config: "Platfor
     api_key = getattr(platform_config, "api_key", None) or ""
     if isinstance(api_key, str) and api_key.strip():
         return True
+    # Matrix accepts password login (extra["password"]) instead of a token.
+    extra = getattr(platform_config, "extra", None) or {}
+    if isinstance(extra, dict):
+        password = extra.get("password") or ""
+        if isinstance(password, str) and password.strip():
+            return True
     return False
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7975,10 +7975,13 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
         "env_vars": (
             "MATRIX_HOMESERVER",
             "MATRIX_ACCESS_TOKEN",
+            "MATRIX_PASSWORD",
             "MATRIX_USER_ID",
             "MATRIX_ALLOWED_USERS",
         ),
-        "required_env": ("MATRIX_HOMESERVER", "MATRIX_ACCESS_TOKEN", "MATRIX_USER_ID"),
+        # Auth is MATRIX_ACCESS_TOKEN *or* MATRIX_USER_ID + MATRIX_PASSWORD,
+        # so only the homeserver is unconditionally required.
+        "required_env": ("MATRIX_HOMESERVER",),
     },
     "signal": {
         "name": "Signal",

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -4785,7 +4785,9 @@ def register(ctx) -> None:
         adapter_factory=_build_adapter,
         check_fn=check_matrix_requirements,
         is_connected=_is_connected,
-        required_env=["MATRIX_HOMESERVER", "MATRIX_ACCESS_TOKEN"],
+        # Auth is MATRIX_ACCESS_TOKEN *or* MATRIX_USER_ID + MATRIX_PASSWORD,
+        # so neither credential var can be listed as unconditionally required.
+        required_env=["MATRIX_HOMESERVER"],
         install_hint="pip install 'mautrix[encryption]'",
         setup_fn=interactive_setup,
         apply_yaml_config_fn=_apply_yaml_config,

--- a/plugins/platforms/matrix/plugin.yaml
+++ b/plugins/platforms/matrix/plugin.yaml
@@ -14,15 +14,19 @@ requires_env:
     description: "Matrix homeserver URL (e.g. https://matrix.org)"
     prompt: "Matrix homeserver URL"
     password: false
+optional_env:
   - name: MATRIX_ACCESS_TOKEN
-    description: "Matrix access token (or use MATRIX_PASSWORD for password login)"
+    description: "Matrix access token (preferred; or use MATRIX_USER_ID + MATRIX_PASSWORD)"
     prompt: "Matrix access token"
     password: true
-optional_env:
   - name: MATRIX_PASSWORD
-    description: "Matrix account password (alternative to MATRIX_ACCESS_TOKEN)"
+    description: "Matrix account password (alternative to MATRIX_ACCESS_TOKEN; requires MATRIX_USER_ID)"
     prompt: "Matrix password"
     password: true
+  - name: MATRIX_USER_ID
+    description: "Full Matrix user ID (@bot:server) — required for password login, auto-detected with a token"
+    prompt: "Matrix user ID (@user:server)"
+    password: false
   - name: MATRIX_ALLOWED_USERS
     description: "Comma-separated Matrix user IDs allowed to talk to the bot"
     prompt: "Allowed users (comma-separated)"


### PR DESCRIPTION
## What does this PR do?

Matrix requires a `MATRIX_HOMESERVER` and either a `MATRIX_USER_ID`+`MATRIX_PASSWORD` OR a `MATRIX_ACCESS_TOKEN` to operate.

The dashboard requires `MATRIX_HOMESERVER` and `MATRIX_ACCESS_TOKEN` to be configured to show Matrix as configured.  Otherwise, it shows up as unconfigured and clicking Test warns that `MATRIX_ACCESS_TOKEN` is not specified.

For my environment, I am specifying user+password instead of an access token due to https://github.com/NousResearch/hermes-agent/issues/6174#issuecomment-5072866041

This change makes it so only `MATRIX_HOMESERVER` is required for the dashboard verification.

## Related Issue

Noticed from https://github.com/NousResearch/hermes-agent/issues/6174#issuecomment-5072866041 but not directly related

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- CLI prompts for password instead of requiring a token
- Dashboard doesn't require `MATRIX_ACCESS_TOKEN` as `MATRIX_USER_ID`+`MATRIX_PASSWORD` is valid

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Configure just `MATRIX_HOMESERVER` and `MATRIX_USER_ID`+`MATRIX_PASSWORD`
2. Go to Channels in dashboard
3. See Matrix shown as unconfigured

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] N/A: I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] N/A: I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] N/A: I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] N/A: I've updated tool descriptions/schemas if I changed tool behavior — or N/A
