### PR TITLE
fix(runtime): route credentials by effective model

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -629,6 +629,9 @@ class HermesACPAgent(acp.Agent):
         _MODE_ACCEPT_EDITS: "workspace_session",
         _MODE_DONT_ASK: "session",
     }
+    _MODEL_DEPENDENT_RUNTIME_PROVIDERS = frozenset(
+        {"azure-foundry", "bedrock", "copilot", "nous", "opencode-go", "opencode-zen"}
+    )
     _EDIT_APPROVAL_POLICY_TO_MODE = {
         value: key for key, value in _MODE_TO_EDIT_APPROVAL_POLICY.items()
     }
@@ -2346,17 +2349,20 @@ class HermesACPAgent(acp.Agent):
                 current_provider or "openrouter",
             )
             state.model = resolved_model
+            make_agent_kwargs: dict[str, Any] = {
+                "session_id": session_id,
+                "cwd": state.cwd,
+                "model": resolved_model,
+                "requested_provider": requested_provider,
+            }
             provider_changed = bool(current_provider and requested_provider != current_provider)
-            current_base_url = None if provider_changed else getattr(state.agent, "base_url", None)
-            current_api_mode = None if provider_changed else getattr(state.agent, "api_mode", None)
-            state.agent = self.session_manager._make_agent(
-                session_id=session_id,
-                cwd=state.cwd,
-                model=resolved_model,
-                requested_provider=requested_provider,
-                base_url=current_base_url,
-                api_mode=current_api_mode,
-            )
+            if (
+                not provider_changed
+                and requested_provider not in self._MODEL_DEPENDENT_RUNTIME_PROVIDERS
+            ):
+                make_agent_kwargs["base_url"] = getattr(state.agent, "base_url", None)
+                make_agent_kwargs["api_mode"] = getattr(state.agent, "api_mode", None)
+            state.agent = self.session_manager._make_agent(**make_agent_kwargs)
             self.session_manager.save_session(session_id)
             logger.info(
                 "Session %s: model switched to %s via provider %s",

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -633,7 +633,10 @@ class SessionManager:
         }
 
         try:
-            runtime = resolve_runtime_provider(requested=requested_provider or config_provider)
+            runtime = resolve_runtime_provider(
+                requested=requested_provider or config_provider,
+                target_model=model or default_model or None,
+            )
             kwargs.update(
                 {
                     "provider": runtime.get("provider"),

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -40,6 +40,7 @@ class CLIAgentSetupMixin:
         try:
             runtime = resolve_runtime_provider(
                 requested=self.requested_provider,
+                target_model=self.model or None,
                 explicit_api_key=self._explicit_api_key,
                 explicit_base_url=self._explicit_base_url,
             )
@@ -59,7 +60,10 @@ class CLIAgentSetupMixin:
                     try:
                         from hermes_cli.fallback_config import resolve_entry_api_key
 
-                        _fb_kwargs = {"requested": _fb_provider}
+                        _fb_kwargs = {
+                            "requested": _fb_provider,
+                            "target_model": _fb_model,
+                        }
                         if _fb.get("base_url"):
                             _fb_kwargs["explicit_base_url"] = _fb["base_url"]
                         _fb_api_key = resolve_entry_api_key(_fb)

--- a/tests/hermes_cli/test_cli_runtime_target_model.py
+++ b/tests/hermes_cli/test_cli_runtime_target_model.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+from acp_adapter.server import HermesACPAgent
+from acp_adapter.session import SessionManager
+from hermes_cli import runtime_provider as rp
+from hermes_cli.auth import AuthError
+from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
+
+
+class _NoopDb:
+    pass
+
+
+class _RuntimeCLI(CLIAgentSetupMixin):
+    def __init__(self) -> None:
+        self.model = "deepseek-v4-flash"
+        self.requested_provider = "opencode-go"
+        self.provider = "opencode-go"
+        self.api_key = None
+        self.base_url = None
+        self.api_mode = "chat_completions"
+        self.acp_command = None
+        self.acp_args = []
+        self._credential_pool = None
+        self._provider_source = None
+        self._explicit_api_key = None
+        self._explicit_base_url = None
+        self._fallback_model = []
+        self.agent = None
+        self._active_agent_route_signature = None
+        self.service_tier = None
+
+    def _normalize_model_for_provider(self, _provider: str) -> bool:
+        return False
+
+
+def _runtime() -> dict:
+    return {
+        "provider": "opencode-go",
+        "api_mode": "chat_completions",
+        "base_url": "https://opencode.ai/zen/go/v1",
+        "api_key": "test-key",
+        "source": "test",
+    }
+
+
+def test_cli_primary_resolution_uses_effective_model(monkeypatch):
+    calls: list[dict] = []
+
+    def fake_resolver(**kwargs):
+        calls.append(kwargs)
+        return _runtime()
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", fake_resolver)
+
+    cli = _RuntimeCLI()
+    assert cli._ensure_runtime_credentials() is True
+    assert calls[0]["target_model"] == "deepseek-v4-flash"
+
+
+def test_cli_fallback_resolution_uses_fallback_model(monkeypatch):
+    calls: list[dict] = []
+
+    def fake_resolver(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise AuthError("primary unavailable", provider="opencode-go")
+        return _runtime()
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", fake_resolver)
+
+    cli = _RuntimeCLI()
+    cli.model = "qwen3.7-plus"
+    cli._fallback_model = [
+        {"provider": "opencode-go", "model": "deepseek-v4-flash"}
+    ]
+    assert cli._ensure_runtime_credentials() is True
+    assert calls[0]["target_model"] == "qwen3.7-plus"
+    assert calls[1]["target_model"] == "deepseek-v4-flash"
+
+
+def test_acp_resolution_uses_effective_model(monkeypatch):
+    calls: list[dict] = []
+    captured: dict = {}
+
+    class CapturingAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    def resolver(**kwargs):
+        calls.append(kwargs)
+        return _runtime()
+
+    def module(name: str, **attrs):
+        result = ModuleType(name)
+        for key, value in attrs.items():
+            setattr(result, key, value)
+        return result
+
+    monkeypatch.setitem(sys.modules, "run_agent", module("run_agent", AIAgent=CapturingAgent))
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        module(
+            "hermes_cli.config",
+            load_config=lambda: {
+                "model": {"default": "qwen3.7-plus", "provider": "opencode-go"}
+            },
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        module("hermes_cli.runtime_provider", resolve_runtime_provider=resolver),
+    )
+
+    manager = SessionManager(db=_NoopDb())
+    manager._make_agent(
+        session_id="routing-test",
+        cwd=".",
+        model="deepseek-v4-flash",
+        requested_provider="opencode-go",
+    )
+
+    assert calls[0]["target_model"] == "deepseek-v4-flash"
+    assert captured["model"] == "deepseek-v4-flash"
+    assert captured["api_mode"] == "chat_completions"
+    assert captured["base_url"] == "https://opencode.ai/zen/go/v1"
+
+
+def test_opencode_go_effective_model_override_drives_real_runtime_mode(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *args, **kwargs: "opencode-go")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "opencode-go",
+            "default": "qwen3.7-plus",
+            "api_mode": "anthropic_messages",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: None)
+    monkeypatch.setenv("OPENCODE_GO_API_KEY", "test-opencode-go-key")
+    monkeypatch.delenv("OPENCODE_GO_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(
+        requested="opencode-go",
+        target_model="deepseek-v4-flash",
+    )
+
+    assert resolved["provider"] == "opencode-go"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://opencode.ai/zen/go/v1"
+
+
+@pytest.mark.parametrize(
+    "provider",
+    ["azure-foundry", "bedrock", "copilot", "nous", "opencode-go", "opencode-zen"],
+)
+@pytest.mark.asyncio
+async def test_acp_model_switch_recomputes_model_dependent_transport(
+    monkeypatch, provider
+):
+    captured: dict = {}
+    old_agent = SimpleNamespace(
+        provider=provider,
+        base_url="https://opencode.ai/zen/go",
+        api_mode="anthropic_messages",
+    )
+    state = SimpleNamespace(agent=old_agent, cwd=".", model="qwen3.7-plus")
+
+    class Manager:
+        def get_session(self, _session_id):
+            return state
+
+        def _make_agent(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(provider=provider)
+
+        def save_session(self, _session_id):
+            return None
+
+    acp_agent = HermesACPAgent(session_manager=Manager())
+    monkeypatch.setattr(
+        acp_agent,
+        "_resolve_model_selection",
+        lambda _model_id, _provider: (provider, "deepseek-v4-flash"),
+    )
+
+    await acp_agent.set_session_model("deepseek-v4-flash", "routing-session")
+
+    assert captured["model"] == "deepseek-v4-flash"
+    assert "base_url" not in captured
+    assert "api_mode" not in captured


### PR DESCRIPTION
## Summary

- pass the effective target model into runtime resolution for CLI primary and fallback routes
- pass the effective model through ACP agent construction
- recompute ACP transport on provider changes and model-dependent same-provider switches
- preserve active `base_url` / `api_mode` continuity for stable providers and named custom endpoints

## Problem

`resolve_runtime_provider()` supports `target_model`, but several callers omitted it. Those paths therefore derived provider transport from the persisted default model rather than the model actually being created or switched to.

This is observable when one provider serves models over different API surfaces. For example, an OpenCode session switching from an Anthropic-routed model to an OpenAI-compatible model could retain `anthropic_messages` and a base URL without `/v1`, causing the next request to hit the wrong endpoint.

The same omission affected CLI fallback resolution and ACP agent construction.

## Approach

The CLI primary route, each fallback route, and ACP `_make_agent()` now pass their effective model as `target_model`.

ACP model switching drops stale transport for providers whose runtime depends on the selected model:

- Azure Foundry
- Bedrock
- Copilot
- Nous
- OpenCode Go
- OpenCode Zen

Stable same-provider switches continue to preserve the active runtime. Cross-provider switches continue to resolve a fresh runtime.

## Test plan

- Added regression coverage for CLI primary/fallback propagation, ACP propagation, real OpenCode runtime derivation, and model-dependent ACP switches.
- Ran the canonical per-file test wrapper across the affected provider, CLI, and ACP suites:

  `scripts/run_tests.sh tests/hermes_cli/test_cli_runtime_target_model.py tests/hermes_cli/test_runtime_provider_resolution.py tests/cli/test_cli_provider_resolution.py tests/acp/test_session.py tests/acp/test_server.py tests/acp/test_named_provider_catalogs.py tests/acp_adapter/test_acp_commands.py -q`

  Result: **345 passed, 0 failed**.

- `ruff check acp_adapter/server.py acp_adapter/session.py hermes_cli/cli_agent_setup_mixin.py tests/hermes_cli/test_cli_runtime_target_model.py`

  Result: **all checks passed**.

- Verified a fresh-process OpenCode Go resolution under an isolated Hermes home: switching the effective model from `qwen3.7-plus` to `deepseek-v4-flash` selected `chat_completions` and restored the `/v1` base URL.
