### PR TITLE
fix: aux-slot endpoint persistence, empty-response failure_reason, #72285 docs (sibling wave)

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -316,6 +316,41 @@ describe('ModelSettings', () => {
     )
   })
 
+  it('carries the user-defined endpoint when an aux slot is set to a local main model', async () => {
+    getGlobalModelOptions.mockResolvedValueOnce({
+      providers: [
+        {
+          name: 'Ollama',
+          slug: 'local-ollama',
+          models: ['qwen3:latest'],
+          authenticated: true,
+          is_user_defined: true,
+          api_url: 'http://localhost:11434/v1'
+        }
+      ]
+    })
+    getGlobalModelInfo.mockResolvedValueOnce({ provider: 'local-ollama', model: 'qwen3:latest' })
+    getAuxiliaryModels.mockResolvedValueOnce({
+      main: { provider: 'local-ollama', model: 'qwen3:latest' },
+      tasks: [{ task: 'vision', provider: 'auto', model: '', base_url: '' }]
+    })
+
+    await renderModelSettings()
+
+    const setToMainButtons = await screen.findAllByRole('button', { name: 'Set to main' })
+    fireEvent.click(setToMainButtons[0])
+
+    await waitFor(() =>
+      expect(setModelAssignment).toHaveBeenCalledWith({
+        model: 'qwen3:latest',
+        provider: 'local-ollama',
+        scope: 'auxiliary',
+        task: 'vision',
+        base_url: 'http://localhost:11434/v1'
+      })
+    )
+  })
+
   it('warns when a main switch leaves auxiliary tasks pinned to another provider', async () => {
     setModelAssignment.mockResolvedValueOnce({
       provider: 'openrouter',

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -643,6 +643,20 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
     }
   }, [onMainModelChanged, refresh, selectedModel, selectedProvider, selectedProviderRow])
 
+  // Sibling of the applyMainModel endpoint passthrough (#65254): auxiliary
+  // assignments targeting a user-defined provider must carry that provider's
+  // endpoint too, or the backend pins the slot without a base_url and the
+  // aux resolver falls back to the (possibly different, possibly cleared)
+  // main endpoint.
+  const endpointForProvider = useCallback(
+    (provider: string) => {
+      const row = providers.find(entry => entry.slug === provider)
+
+      return row?.api_url ? { base_url: row.api_url } : {}
+    },
+    [providers]
+  )
+
   const setAuxiliaryToMain = useCallback(
     async (task: string) => {
       if (!mainModel) {
@@ -653,7 +667,13 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
       setError('')
 
       try {
-        await setModelAssignment({ model: mainModel.model, provider: mainModel.provider, scope: 'auxiliary', task })
+        await setModelAssignment({
+          model: mainModel.model,
+          provider: mainModel.provider,
+          scope: 'auxiliary',
+          task,
+          ...endpointForProvider(mainModel.provider)
+        })
         await refresh()
       } catch (err) {
         setError(err instanceof Error ? err.message : String(err))
@@ -661,7 +681,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
         setApplying(false)
       }
     },
-    [mainModel, refresh]
+    [endpointForProvider, mainModel, refresh]
   )
 
   const applyAuxiliaryDraft = useCallback(
@@ -674,7 +694,13 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
       setError('')
 
       try {
-        await setModelAssignment({ model: auxDraft.model, provider: auxDraft.provider, scope: 'auxiliary', task })
+        await setModelAssignment({
+          model: auxDraft.model,
+          provider: auxDraft.provider,
+          scope: 'auxiliary',
+          task,
+          ...endpointForProvider(auxDraft.provider)
+        })
         setEditingAuxTask(null)
         await refresh()
       } catch (err) {
@@ -683,7 +709,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
         setApplying(false)
       }
     },
-    [auxDraft, refresh]
+    [auxDraft, endpointForProvider, refresh]
   )
 
   const beginAuxiliaryEdit = useCallback(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20875,8 +20875,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             resolve_display_setting(user_config, platform_key, "cleanup_progress")
         )
         _cleanup_adapter = self._adapter_for_source(source) if _cleanup_progress else None
+        # getattr, not attribute access — same duck-typed-adapter guard as the
+        # edit_message check in send_progress_messages below: a fake/minimal
+        # adapter without delete_message means "can't delete", not a crash.
+        _cleanup_delete = getattr(type(_cleanup_adapter), "delete_message", None) if _cleanup_adapter is not None else None
         if _cleanup_adapter is not None and (
-            type(_cleanup_adapter).delete_message is BasePlatformAdapter.delete_message
+            _cleanup_delete is None
+            or _cleanup_delete is BasePlatformAdapter.delete_message
         ):
             # Adapter doesn't support deletion — silently disable.
             _cleanup_progress = False
@@ -21254,7 +21259,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Skip tool progress for platforms that don't support message
             # editing (e.g. iMessage/BlueBubbles) — each progress update
             # would become a separate message bubble, which is noisy.
-            if type(adapter).edit_message is BasePlatformAdapter.edit_message:
+            # getattr, not attribute access: duck-typed adapters (test fakes,
+            # minimal plugin adapters) may not define edit_message at all —
+            # "missing" means the same thing as "base no-op": can't edit.
+            _adapter_edit = getattr(type(adapter), "edit_message", None)
+            if _adapter_edit is None or _adapter_edit is BasePlatformAdapter.edit_message:
                 while not progress_queue.empty():
                     try:
                         progress_queue.get_nowait()
@@ -22881,6 +22890,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "messages": result.get("messages", []),
                     "api_calls": result.get("api_calls", 0),
                     "failed": result.get("failed", False),
+                    # Sibling of the non-empty-response return below (#64686):
+                    # the classifier's failure_reason must survive the
+                    # empty-response normalization path too, or downstream
+                    # consumers (TUI billing surface, transient-failure
+                    # persistence) lose the structured reason exactly when
+                    # the run produced no text.
+                    "failure_reason": result.get("failure_reason"),
                     "partial": result.get("partial", False),
                     "completed": result.get("completed"),
                     "interrupted": result.get("interrupted", False),

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1392,17 +1392,18 @@ class ModelAssignment(BaseModel):
     provider: str
     model: str
     task: str = ""
-    # Optional OpenAI-compatible endpoint URL. Only honored for custom/local
-    # providers on the main slot — lets the GUI configure a self-hosted endpoint
-    # (vLLM, llama.cpp, Ollama, …) that needs no API key. The runtime resolver
-    # reads model.base_url from config (it ignores OPENAI_BASE_URL), so this is
-    # the path that actually wires a local endpoint into resolution.
+    # Optional OpenAI-compatible endpoint URL. Honored for custom/local
+    # providers on the main slot AND on auxiliary slots — lets the GUI wire a
+    # self-hosted endpoint (vLLM, llama.cpp, Ollama, …) that needs no API key.
+    # The runtime resolvers read model.base_url / auxiliary.<task>.base_url
+    # from config (they ignore OPENAI_BASE_URL), so this is the path that
+    # actually wires a local endpoint into resolution.
     base_url: str = ""
     # Optional API key for a custom/local endpoint. Persisted to
-    # ``model.api_key`` (where the runtime resolver reads it) so a self-hosted
-    # endpoint that requires auth works from the GUI — mirrors the key the
-    # ``hermes model`` custom flow collects. Honored only on the main slot for
-    # custom/local providers.
+    # ``model.api_key`` (main slot) or ``auxiliary.<task>.api_key`` (aux
+    # slots) — where the runtime resolvers read it — so a self-hosted
+    # endpoint that requires auth works from the GUI. Mirrors the key the
+    # ``hermes model`` custom flow collects.
     api_key: str = ""
     confirm_expensive_model: bool = False
     profile: Optional[str] = None
@@ -7244,7 +7245,19 @@ def _apply_model_assignment_sync(
         new_provider = provider.strip().lower()
         slot_cfg["provider"] = provider
         slot_cfg["model"] = model
-        if new_provider != prev_provider and new_provider != "custom":
+        if base_url:
+            # Sibling of the main-slot endpoint handling (#65254): an aux
+            # assignment for a custom/local endpoint must carry its own
+            # base_url, or the slot silently rebinds to whatever
+            # model.base_url happens to hold — and breaks entirely once the
+            # main slot switches away and clears it. The auxiliary resolver
+            # already reads auxiliary.<task>.base_url/api_key
+            # (_resolve_task_provider_model), so persisting them here is
+            # what actually wires the endpoint in.
+            slot_cfg["base_url"] = base_url
+            if api_key:
+                slot_cfg["api_key"] = api_key
+        elif new_provider != prev_provider and new_provider != "custom":
             slot_cfg.pop("base_url", None)
             clear_model_endpoint_credentials(slot_cfg)
         aux[slot] = slot_cfg

--- a/tests/gateway/test_compression_failure_session_sync.py
+++ b/tests/gateway/test_compression_failure_session_sync.py
@@ -268,6 +268,45 @@ def test_nonempty_rate_limit_response_preserves_failure_metadata(monkeypatch):
     assert result["failure_reason"] == "rate_limit"
     assert result["completed"] is False
 
+
+class _EmptyRateLimitFailureAgent(_CompressionThenFailureAgent):
+    def run_conversation(self, user_message, conversation_history=None, task_id=None, **_kwargs):
+        return {
+            "final_response": "",
+            "failed": True,
+            "completed": False,
+            "error": "429 Too Many Requests",
+            "failure_reason": "rate_limit",
+            "messages": [
+                *(conversation_history or []),
+                {"role": "user", "content": user_message},
+            ],
+            "api_calls": 3,
+        }
+
+
+def test_empty_rate_limit_response_preserves_failure_metadata(monkeypatch):
+    """Sibling of the non-empty path (#64686): the empty-response return
+    branch in _run_agent must also forward failure_reason, or downstream
+    consumers lose the structured reason exactly when the run produced no
+    text at all."""
+    _install_compression_failure_agent(monkeypatch, _EmptyRateLimitFailureAgent)
+
+    session_store = _SessionStore()
+    runner = _runner(session_store)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="user-1",
+    )
+
+    result = _run_compression_failure_turn(runner, source)
+
+    assert result["failed"] is True
+    assert result["failure_reason"] == "rate_limit"
+    assert result["completed"] is False
+
 class _ProviderSwitchAgent(_CompressionThenFailureAgent):
     created_providers = []
     second_turn_history = None

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4616,6 +4616,67 @@ class TestWebServerEndpoints:
         assert model_cfg["provider"] == "openrouter"
         assert model_cfg.get("base_url", "") == ""
 
+    def test_set_model_auxiliary_persists_base_url_and_api_key(self):
+        """Aux assignments for a custom/local endpoint must persist the slot's
+        own base_url/api_key (sibling of the main-slot fix, #65254). Without
+        them the aux resolver falls back to model.base_url — which breaks the
+        moment the main slot switches away and clears it."""
+        from hermes_cli.config import load_config
+
+        resp = self.client.post(
+            "/api/model/set",
+            json={
+                "scope": "auxiliary",
+                "task": "vision",
+                "provider": "custom",
+                "model": "qwen3:latest",
+                "base_url": "http://localhost:11434/v1",
+                "api_key": "sk-local",
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+        slot = load_config()["auxiliary"]["vision"]
+        assert slot["provider"] == "custom"
+        assert slot["model"] == "qwen3:latest"
+        assert slot["base_url"] == "http://localhost:11434/v1"
+        assert slot["api_key"] == "sk-local"
+
+    def test_set_model_auxiliary_provider_switch_still_clears_stale_endpoint(self):
+        """The existing stale-endpoint scrub on provider switch is preserved
+        when the new assignment carries no base_url."""
+        from hermes_cli.config import load_config, save_config
+
+        cfg = load_config()
+        cfg["auxiliary"] = {
+            "vision": {
+                "provider": "custom",
+                "model": "qwen3:latest",
+                "base_url": "http://localhost:11434/v1",
+                "api_key": "sk-local",
+            },
+        }
+        save_config(cfg)
+
+        resp = self.client.post(
+            "/api/model/set",
+            json={
+                "scope": "auxiliary",
+                "task": "vision",
+                "provider": "openrouter",
+                "model": "google/gemini-2.5-flash",
+            },
+        )
+        assert resp.status_code == 200
+
+        slot = load_config()["auxiliary"]["vision"]
+        assert slot["provider"] == "openrouter"
+        # load_config deep-merges DEFAULT_CONFIG, which re-materializes the
+        # keys as empty strings — assert the stale endpoint VALUES are gone.
+        assert not slot.get("base_url")
+        assert not slot.get("api_key")
+
     def test_custom_endpoints_list_includes_direct_custom_config(self):
         """A bare model.provider=custom config should show up in Desktop even
         before the user has materialized it under providers.

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -517,6 +517,27 @@ Authorization: Bearer ***
 
 Configure the key via `API_SERVER_KEY` env var. If you need a browser to call Hermes directly, also set `API_SERVER_CORS_ORIGINS` to an explicit allowlist.
 
+### Multi-profile routing (`/p/<profile>/…`)
+
+When [multi-profile gateway routing](/user-guide/multi-profile-gateways) is
+enabled (`gateway.multiplex_profiles`), the shared listener serves every
+profile through a `/p/<profile>/` URL prefix — and **authentication is bound
+to the routed profile**:
+
+- Requests to `/p/<profile>/v1/...` must present that profile's own
+  `API_SERVER_KEY` (from `~/.hermes/profiles/<profile>/.env`). The default
+  listener's key is rejected on named-profile prefixes.
+- Unprefixed routes and `/p/default/...` keep using the default profile's key.
+- A named profile with no `API_SERVER_KEY` of its own fails closed — its
+  prefix is unreachable until you set one.
+
+:::warning Breaking change (July 2026)
+Before this fix, a valid default-profile key was accepted on any
+`/p/<profile>/` prefix. If you relied on one shared key across profile
+prefixes, set a distinct `API_SERVER_KEY` in each profile's `.env` — reused
+default keys on named prefixes now return `401`.
+:::
+
 :::warning Security
 The API server gives full access to hermes-agent's toolset, **including terminal commands**. `API_SERVER_KEY` is **required for every deployment**, including the default loopback bind on `127.0.0.1`. Keep `API_SERVER_CORS_ORIGINS` narrow to control browser access when you explicitly allow browser callers.
 :::


### PR DESCRIPTION
## Summary

Three sibling follow-ups from this week's merges: auxiliary model assignments now persist their endpoint (sibling of #65254), the gateway's empty-response return path now forwards `failure_reason` (sibling of #64686), and the #72285 profile-bound HTTP auth breaking change is documented for the next release notes.

## Changes

- `hermes_cli/web_server.py`: the auxiliary scope of `POST /api/model/set` persists `base_url`/`api_key` into `auxiliary.<task>.*` (previously dropped — the aux resolver at `_resolve_task_provider_model` already reads them). Stale-endpoint scrub on provider switch preserved. `ModelAssignment` docstrings updated.
- `apps/desktop/.../model-settings.tsx`: `setAuxiliaryToMain` / `applyAuxiliaryDraft` carry the user-defined provider's `api_url` as `base_url`, mirroring `applyMainModel` (#65254).
- `gateway/run.py`: the empty-`final_response` early return in `_run_agent` forwards `failure_reason` (#64686 fixed only the non-empty path). Also hardened both `BasePlatformAdapter` identity checks (`edit_message`, `delete_message`) with `getattr` so duck-typed adapters without the attribute mean "capability absent," not `AttributeError`.
- `website/docs/user-guide/features/api-server.md`: new "Multi-profile routing" section with an explicit breaking-change callout — default `API_SERVER_KEY` is now rejected on `/p/<profile>/` prefixes (#72285).

## Validation

| Suite | Result |
|---|---|
| `tests/gateway/test_compression_failure_session_sync.py` + `test_42039_duplicate_user_message.py` | 12 passed |
| `tests/hermes_cli/test_web_server.py -k set_model` | 17 passed |
| `apps/desktop` vitest `model-settings.test.tsx` | 20 passed |
| `npx tsc --noEmit` (touched files) | clean |
| `docusaurus build` | pass |

## Infographic

![sibling-fix-wave](https://v3b.fal.media/files/b/0aa4228c/7SoRzh0VfQyNU2faEmgke_WShQXnfK.png)
