### PR TITLE
fix(photon): repair two cross-PR collisions from the photon wave (U+FFFC shadow + runtime-record fixture)

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -875,19 +875,6 @@ class PhotonAdapter(BasePlatformAdapter):
             )
 
         ctype = content.get("type")
-        if ctype == "text":
-            raw_text = content.get("text") or ""
-            # iMessage emits U+FFFC OBJECT REPLACEMENT CHARACTER as a transient
-            # placeholder for some media bubbles (notably voice notes). Photon
-            # can then deliver the real attachment/voice event immediately
-            # afterwards with a different message id. If we dispatch the
-            # placeholder as a standalone text turn, the subsequent media event
-            # arrives while that turn is active and the gateway sends a bogus
-            # "Interrupting current task" busy ack. Drop placeholder-only text
-            # at the platform boundary; the real media event carries the bytes.
-            if raw_text.strip() == "\ufffc":
-                logger.debug("[photon] ignoring iMessage object-placeholder text event")
-                return
         if ctype == "reaction":
             # Route only tapbacks on messages WE sent — those are implicitly
             # addressed to the bot (feishu precedent: synthetic text event).

--- a/tests/plugins/platforms/photon/test_runtime_record.py
+++ b/tests/plugins/platforms/photon/test_runtime_record.py
@@ -120,7 +120,10 @@ def _patch_spawn(
 ) -> None:
     """Stub everything _start_sidecar touches before the healthz loop."""
     sidecar_dir = tmp_path / "sidecar"
-    (sidecar_dir / "node_modules").mkdir(parents=True)
+    # sidecar_deps_installed() checks the spectrum-ts package dir, not bare
+    # node_modules/ (9cf2046081 hardened it against partial npm installs) —
+    # the fixture must materialize the dependency dir the probe looks for.
+    (sidecar_dir / "node_modules" / "spectrum-ts").mkdir(parents=True)
     monkeypatch.setattr(photon_adapter, "_SIDECAR_DIR", sidecar_dir)
     monkeypatch.setattr(photon_adapter, "_sidecar_deps_stale", lambda: False)
 


### PR DESCRIPTION
## Summary

Restores main's red CI — two independent cross-PR collisions from yesterday's photon wave: (1) slice 2/8, 4 tests — the #73560 cherry-pick of #54514's early U+FFFC drop landed after the deferred-wait handler and its early `return` made the `_pending_fffc` branch unreachable; (2) slice 7/8, 2 tests — 9cf2046081 hardened `sidecar_deps_installed()` to probe `node_modules/spectrum-ts`, and the later-merged runtime-record tests (e79d316a04) still created only bare `node_modules/`, so `_start_sidecar` raised deps-not-installed before the code under test ran.

## Root cause

Two independent fixes for the same iMessage placeholder bug merged in sequence: the deferred-wait implementation (6b91b50c6e, `_pending_fffc` + 15s timeout + cancel-on-attachment) and later the boundary drop (fd4f756492, early return on `\ufffc`). The drop sits earlier in `_dispatch_inbound`, so the wait branch — and its 4 regression tests — became dead code.

## Changes

- `plugins/platforms/photon/adapter.py`: remove the early drop block. The deferred-wait branch subsumes its intent — the placeholder is still never dispatched as a text turn, and the pending timeout lets the real attachment cancel cleanly. The drop's own regression test still passes unchanged.
- `tests/plugins/platforms/photon/test_runtime_record.py`: spawn fixture materializes `node_modules/spectrum-ts` (the dir the hardened probe checks) instead of bare `node_modules/`.

## Validation

| | Before | After |
|---|---|---|
| `tests/plugins/platforms/photon/test_inbound.py` | 17 passed, 4 failed (matches main CI red) | 21 passed |
| `tests/plugins/platforms/photon/test_runtime_record.py` | 9 passed, 2 failed (matches main CI red) | 11 passed |
| full `tests/plugins/platforms/photon/` | — | 164 passed |

Credit: placeholder drop originally by @kelsia14 (#54514); deferred wait from the #71673 salvage.

## Infographic

![unshadow-the-handler](https://v3b.fal.media/files/b/0aa422d0/R4KsYTWSDNnlZOrCEEga3_zYyaRCKu.png)
