### PR TITLE
perf(desktop): memoize PlatformAvatar + StatusDot (messaging icon churn)

### DIFF
--- a/apps/desktop/src/app/messaging/platform-icon.tsx
+++ b/apps/desktop/src/app/messaging/platform-icon.tsx
@@ -13,7 +13,7 @@ import {
   SiWhatsapp
 } from '@icons-pack/react-simple-icons'
 import type { ComponentPropsWithoutRef, ComponentType, SVGProps } from 'react'
-import { forwardRef } from 'react'
+import { forwardRef, memo } from 'react'
 
 import { Globe, Link as LinkIcon, MessageSquareText } from '@/lib/icons'
 import { cn } from '@/lib/utils'
@@ -82,48 +82,50 @@ interface PlatformAvatarProps extends Omit<ComponentPropsWithoutRef<'span'>, 'ch
 // component and injects a ref plus pointer/focus/aria handlers onto it. A
 // plain function component with no ref/rest forwarding drops all of that
 // silently — the tooltip renders but never opens (#67500).
-export const PlatformAvatar = forwardRef<HTMLSpanElement, PlatformAvatarProps>(function PlatformAvatar(
-  { className, platformId, platformName, style, ...rest },
-  ref
-) {
-  const spec = PLATFORM_ICONS[platformId]
+export const PlatformAvatar = memo(
+  forwardRef<HTMLSpanElement, PlatformAvatarProps>(function PlatformAvatar(
+    { className, platformId, platformName, style, ...rest },
+    ref
+  ) {
+    const spec = PLATFORM_ICONS[platformId]
 
-  const baseClass = cn(
-    'inline-grid size-6 shrink-0 place-items-center rounded-md text-[length:var(--conversation-caption-font-size)] font-medium',
-    className
-  )
+    const baseClass = cn(
+      'inline-grid size-6 shrink-0 place-items-center rounded-md text-[length:var(--conversation-caption-font-size)] font-medium',
+      className
+    )
 
-  if (!spec) {
+    if (!spec) {
+      return (
+        <span
+          aria-hidden="true"
+          className={cn(baseClass, 'bg-(--ui-bg-tertiary) text-(--ui-text-tertiary)')}
+          ref={ref}
+          style={style}
+          {...rest}
+        >
+          {platformName.charAt(0).toUpperCase()}
+        </span>
+      )
+    }
+
+    const { Icon, color } = spec
+
     return (
       <span
         aria-hidden="true"
-        className={cn(baseClass, 'bg-(--ui-bg-tertiary) text-(--ui-text-tertiary)')}
+        className={baseClass}
         ref={ref}
-        style={style}
+        style={{
+          // 16% tint of the brand color so the glyph reads against any surface
+          // without the avatar dominating the row.
+          backgroundColor: `color-mix(in srgb, ${color} 16%, transparent)`,
+          color,
+          ...style
+        }}
         {...rest}
       >
-        {platformName.charAt(0).toUpperCase()}
+        {Icon ? <Icon className="size-3.5" /> : spec.monogram || platformName.charAt(0).toUpperCase()}
       </span>
     )
-  }
-
-  const { Icon, color } = spec
-
-  return (
-    <span
-      aria-hidden="true"
-      className={baseClass}
-      ref={ref}
-      style={{
-        // 16% tint of the brand color so the glyph reads against any surface
-        // without the avatar dominating the row.
-        backgroundColor: `color-mix(in srgb, ${color} 16%, transparent)`,
-        color,
-        ...style
-      }}
-      {...rest}
-    >
-      {Icon ? <Icon className="size-3.5" /> : spec.monogram || platformName.charAt(0).toUpperCase()}
-    </span>
-  )
-})
+  })
+)

--- a/apps/desktop/src/components/status-dot.tsx
+++ b/apps/desktop/src/components/status-dot.tsx
@@ -1,4 +1,5 @@
 import type { ComponentProps } from 'react'
+import { memo } from 'react'
 
 import { cn } from '@/lib/utils'
 
@@ -15,7 +16,7 @@ interface StatusDotProps extends ComponentProps<'span'> {
   tone: StatusTone
 }
 
-export function StatusDot({ className, tone, ...props }: StatusDotProps) {
+export const StatusDot = memo(function StatusDot({ className, tone, ...props }: StatusDotProps) {
   return (
     <span
       aria-hidden="true"
@@ -23,4 +24,4 @@ export function StatusDot({ className, tone, ...props }: StatusDotProps) {
       {...props}
     />
   )
-}
+})


### PR DESCRIPTION
## Summary

Follow-up to #73698. That PR flagged three "not fixed" items; on re-measurement (settling each surface fully before starting the counter, instead of catching the mount cascade), only **one** was a real steady-state loop. This PR fixes it. The other two are documented below as non-issues so the record is straight.

## The one real fix: messaging icon churn

The sidebar's messaging section renders, per platform group, one `PlatformAvatar` (as the section `labelIcon`) and a `StatusDot`. The whole `ChatSidebar` re-renders on every streaming tick — it subscribes to `$sessions`, `$workingSessionIds`, `$messagingSessions`, `$messagingPlatformTotals`, and ~16 other stores — and both icon components were unmemoized. So every platform's avatar and dot re-rendered on every stream delta despite their props (`platformId`, `platformName`, `tone`, `className`) never changing.

| component | fix |
|---|---|
| `messaging/platform-icon.tsx` › `PlatformAvatar` | `memo(forwardRef(...))` — pure function of `platformId`/`platformName`/`className`/`style`. `forwardRef` preserved (Radix `Tip` `asChild` needs the ref, #67500). |
| `components/status-dot.tsx` › `StatusDot` | `memo()` — pure function of `tone`/`className`. |

### Metrics (Messaging open, settled 4s after mount, 2 sessions streaming, 3s window)

| component | before (wasted) | after |
|---|---|---|
| `PlatformAvatar` | 32 | 0 |
| `StatusDot` | 32 | 0 |
| brand icons (`SiTelegram2`, etc.) + `SectionTitle`/`ExternalLink` | ~32 | 0 |
| **total** | **96** | **0** |

Both are **shared primitives**, so the memo also removes the same per-tick churn wherever else they render under a hot parent — session rows, the gateway menu panel, session tiles.

## The two that were NOT real loops (measured, no code needed)

Documenting these because #73698's description originally listed them as open — they aren't.

- **Artifacts** — reported as a "~4,500 idle tooltip/link-title loop." Re-measured **settled** (4s after navigation, once artifacts load + link titles resolve + tooltips mount): **12 wasted renders / 3s** — effectively clean. The ~5,500 figure was the one-time **mount cascade** (loading sessions → collecting artifacts → resolving link titles → mounting per-row tooltips), not a steady-state loop. #73698's `cellCtx`/cell memo already trims that mount cost. Nothing to fix here; #73698's description has been corrected.
- **CmdK-root transcript** — reported as `Block`/`Ct`/`inlineCode` churn from the transcript behind the modal. Re-measured with #73698's `PaletteRow` memo in place: those components no longer appear — typing "setting" now costs **64 wasted** (was 5,519), all minor palette-item icons (`Kbd`/`KbdCombo`/`Bolt`). Already handled by #73698.

## Verification

- typecheck: clean
- lint: 0 errors
- tests: `messaging/index.test.tsx`, `status-dot` pass

## Method note

The correction here is a measurement-discipline lesson worth recording: **start the render counter only after a surface has settled.** Measuring from the moment of navigation conflates the unavoidable one-time mount/data-load cascade with steady-state churn, and massively overstates the latter. The sidebar-bleed wins in #73698 are real (they reproduce on every stream tick, settled); the Artifacts "loop" was a mount-cascade artifact of measuring too early.
