### PR TITLE
fix(browser): check .cmd shim on Windows before falling back to bare agent-browser

### DIFF
--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -158,6 +158,7 @@ def _toolset_enabled(config: Dict[str, object], toolset_key: str) -> bool:
 
 def _has_agent_browser() -> bool:
     import shutil
+    import sys
 
     from hermes_constants import agent_browser_runnable
 
@@ -166,9 +167,13 @@ def _has_agent_browser() -> bool:
     # the local node_modules copy, which the validator also checks.
     if agent_browser_runnable(shutil.which("agent-browser")):
         return True
-    local_bin = (
-        Path(__file__).parent.parent / "node_modules" / ".bin" / "agent-browser"
-    )
+
+    bin_dir = Path(__file__).parent.parent / "node_modules" / ".bin"
+    if sys.platform == "win32":
+        cmd_candidate = bin_dir / "agent-browser.cmd"
+        if cmd_candidate.exists() and agent_browser_runnable(str(cmd_candidate)):
+            return True
+    local_bin = bin_dir / "agent-browser"
     return agent_browser_runnable(str(local_bin)) if local_bin.exists() else False
 
 

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -854,3 +854,69 @@ def test_apply_gateway_defaults_sets_stt_use_gateway(monkeypatch):
     assert "stt" in changed
     assert config["stt"]["provider"] == "openai"
     assert config["stt"]["use_gateway"] is True
+
+
+class TestHasAgentBrowser:
+    def test_detects_local_cmd_shim_on_windows(self, monkeypatch, tmp_path):
+        import shutil
+
+        bin_dir = tmp_path / "node_modules" / ".bin"
+        bin_dir.mkdir(parents=True)
+        cmd_file = bin_dir / "agent-browser.cmd"
+        cmd_file.touch()
+
+        monkeypatch.setattr("sys.platform", "win32")
+        monkeypatch.setattr(shutil, "which", lambda name: None)
+
+        def _fake_runnable(path):
+            return path is not None and ".cmd" in str(path)
+
+        import hermes_constants
+        monkeypatch.setattr(hermes_constants, "agent_browser_runnable", _fake_runnable)
+
+        import hermes_cli.nous_subscription as mod
+        fake_file = tmp_path / "hermes_cli" / "nous_subscription.py"
+        monkeypatch.setattr(mod, "__file__", str(fake_file))
+
+        result = mod._has_agent_browser()
+        assert result is True
+
+    def test_falls_back_to_bare_binary_on_non_windows(self, monkeypatch, tmp_path):
+        import shutil
+
+        bin_dir = tmp_path / "node_modules" / ".bin"
+        bin_dir.mkdir(parents=True)
+        bare_file = bin_dir / "agent-browser"
+        bare_file.touch()
+
+        monkeypatch.setattr("sys.platform", "darwin")
+        monkeypatch.setattr(shutil, "which", lambda name: None)
+
+        def _fake_runnable(path):
+            return path is not None and ".cmd" not in str(path)
+
+        import hermes_constants
+        monkeypatch.setattr(hermes_constants, "agent_browser_runnable", _fake_runnable)
+
+        import hermes_cli.nous_subscription as mod
+        fake_file = tmp_path / "hermes_cli" / "nous_subscription.py"
+        monkeypatch.setattr(mod, "__file__", str(fake_file))
+
+        result = mod._has_agent_browser()
+        assert result is True
+
+    def test_global_binary_takes_precedence(self, monkeypatch):
+        import shutil
+
+        monkeypatch.setattr("sys.platform", "win32")
+        monkeypatch.setattr(shutil, "which", lambda name: "/usr/local/bin/agent-browser")
+
+        def _fake_runnable(path):
+            return path is not None
+
+        import hermes_constants
+        monkeypatch.setattr(hermes_constants, "agent_browser_runnable", _fake_runnable)
+
+        import hermes_cli.nous_subscription as mod
+        result = mod._has_agent_browser()
+        assert result is True


### PR DESCRIPTION
## Summary

This PR fixes #73395 — `_has_agent_browser()` fails on Windows because npm creates `.cmd` shims (e.g. `node_modules/.bin/agent-browser.cmd`) but the function only checks for the bare `agent-browser` Unix shell script, which fails with `OSError: [WinError 193] %1 is not a valid Win32 application`.

## Changes
- **`hermes_cli/nous_subscription.py::_has_agent_browser()`**: On `sys.platform == "win32"`, check `node_modules/.bin/agent-browser.cmd` first, then fall back to the bare `agent-browser` shim. Global `shutil.which("agent-browser")` still runs first and works normally because the OS PATH resolver prefers the `.cmd` wrapper on Windows automatically.
- **`tests/hermes_cli/test_nous_subscription.py`**: Added 3 regression tests:
  - `test_detects_local_cmd_shim_on_windows`: verifies `.cmd`-first Windows branch
  - `test_falls_back_to_bare_binary_on_non_windows`: verifies bare shim still works on Unix
  - `test_global_binary_takes_precedence`: verifies global install wins over local node_modules

## Testing
- [x] 38/38 tests pass in `tests/hermes_cli/test_nous_subscription.py`
- [x] 3 new regression tests cover the Windows .cmd shim path
- [x] No production changes on non-Windows platforms (branch gated on sys.platform)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes