### PR TITLE
fix(agent): detect empty provider response (HTTP 200 empty) as failure, not success

### DIFF
--- a/.bytecode-fingerprint
+++ b/.bytecode-fingerprint
@@ -1,0 +1,1 @@
+git:refs/heads/fix/broken-config-test:534b19442388a4d093732484c2ff2b585f0436a5

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -565,6 +565,14 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
                 prev["tool_calls"] = prev_calls + new_calls
             elif prev_calls:
                 prev["tool_calls"] = prev_calls
+            else:
+                # Both sides have empty-or-absent tool_calls — remove the
+                # stale key so strict providers (DeepSeek v4, newer OpenAI)
+                # don't 400 on ``tool_calls: []``. Without this branch,
+                # a pre-existing empty ``[]`` on the surviving turn stays
+                # in place and later triggers HTTP 400 "Invalid
+                # 'messages[N].tool_calls': empty array." (#69280)
+                prev.pop("tool_calls", None)
             # Concatenate plain-text content; leave multimodal (list)
             # content on either side alone to avoid mangling attachment
             # blocks — fall back to keeping the existing content.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2156,6 +2156,10 @@ def run_conversation(
                 # Validate response shape before proceeding
                 response_invalid = False
                 error_details = []
+                # Short role labels for diagnostic logs (issue #73777)
+                _role_map = {"user": "u", "assistant": "a", "system": "s", "tool": "t"}
+                # Track whether Anthropic returned empty content (non-end_turn/refusal)
+                _anthropic_empty_content = False
                 if agent.api_mode == "codex_responses":
                     _ct_v = agent._get_transport()
                     if not _ct_v.validate_response(response):
@@ -2211,7 +2215,21 @@ def run_conversation(
                         if response is None:
                             error_details.append("response is None")
                         else:
-                            error_details.append("response.content invalid (not a non-empty list)")
+                            _anthropic_empty_content = (
+                                hasattr(response, "content")
+                                and isinstance(getattr(response, "content", None), list)
+                                and not getattr(response, "content")
+                            )
+                            if _anthropic_empty_content:
+                                _diag = _tv.diagnose_empty_content(response)
+                                _stop_reason = _diag["stop_reason"]
+                                error_details.append(
+                                    f"response.content invalid (empty content, "
+                                    f"stop_reason={_stop_reason})"
+                                )
+                            else:
+                                _anthropic_empty_content = False
+                                error_details.append("response.content invalid (not a non-empty list)")
                 elif agent.api_mode == "bedrock_converse":
                     _btv = agent._get_transport()
                     if not _btv.validate_response(response):
@@ -2234,6 +2252,36 @@ def run_conversation(
                             error_details.append("response.choices is empty")
 
                 if response_invalid:
+                    # ── Anthropic empty-content diagnostic ──────────────
+                    # Log the request shape so an operator can tell whether the
+                    # empty response is an upstream hiccup, a repaired-but-still-
+                    # malformed request, or a model refusal.  Issue #73777.
+                    if (
+                        agent.api_mode == "anthropic_messages"
+                        and response is not None
+                        and _anthropic_empty_content
+                    ):
+                        _req_roles = "".join(
+                            _role_map.get(m.get("role", "?"), "?")
+                            for m in (api_messages or [])
+                        )
+                        _repair_count = getattr(agent, "_alternation_repair_count", 0)
+                        _usage_str = ""
+                        _diag = _tv.diagnose_empty_content(response)
+                        if _diag.get("usage"):
+                            _usage_str = f" usage={_diag['usage']}"
+                        logger.warning(
+                            "Anthropic empty-content response (stop_reason=%s)%s. "
+                            "request: %d messages, roles=%s, "
+                            "alternation_repairs=%d. %s",
+                            _diag["stop_reason"],
+                            _usage_str,
+                            len(api_messages),
+                            _req_roles,
+                            _repair_count,
+                            agent._client_log_context(),
+                        )
+
                     agent._invoke_api_request_error_hook(
                         task_id=effective_task_id,
                         turn_id=turn_id,
@@ -2260,10 +2308,50 @@ def run_conversation(
                     # Invalid response — could be rate limiting, provider timeout,
                     # upstream server error, or malformed response.
                     retry_count += 1
-                    
+
                     # Eager fallback: empty/malformed responses are a common
                     # rate-limit symptom.  Switch to fallback immediately
                     # rather than retrying with extended backoff.
+                    # For Anthropic empty-content specifically, skip retries
+                    # entirely — the input is identical and the provider already
+                    # rendered a deterministic verdict; retrying reproduces the
+                    # same failure.  Issue #73777.
+                    if _anthropic_empty_content:
+                        if agent._has_pending_fallback():
+                            agent._buffer_status(
+                                "⚠️ Provider returned empty response — "
+                                "switching to fallback..."
+                            )
+                            if agent._try_activate_fallback():
+                                active_system_prompt = _sync_failover_system_message(
+                                    agent, api_messages, active_system_prompt)
+                                retry_count = 0
+                                compression_attempts = 0
+                                _retry.primary_recovery_attempted = False
+                                continue
+                        agent._flush_status_buffer()
+                        agent._emit_status(
+                            "❌ Provider returned empty response. "
+                            "Try /reset to start a fresh session."
+                        )
+                        logger.error(
+                            "%sAnthropic empty-content response — no fallback available. %s",
+                            agent.log_prefix,
+                            agent._client_log_context(),
+                        )
+                        agent._persist_session(messages, conversation_history)
+                        _final_response = (
+                            "Anthropic returned an empty response. "
+                            "Try /reset to start a fresh session."
+                        )
+                        return {
+                            "final_response": _final_response,
+                            "messages": messages,
+                            "completed": False,
+                            "api_calls": api_call_count,
+                            "error": _final_response,
+                            "failed": True,
+                        }
                     if agent._fallback_index < len(agent._fallback_chain):
                         agent._buffer_status("⚠️ Empty/malformed response — switching to fallback...")
                     if agent._try_activate_fallback():

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1643,6 +1643,37 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 duration_ms=int(tool_duration * 1000),
                 middleware_trace=list(middleware_trace),
             )
+        # Agent-runtime tools also never reach handle_function_call, which is
+        # the sole call site of transform_tool_result for registry-dispatched
+        # tools. Fire it here for the same set of inline-dispatched tools so
+        # the hook applies to every tool as documented.
+        if not _execution_blocked and agent_runtime_owns_post_tool_hook(agent, function_name):
+            try:
+                from hermes_cli.plugins import has_hook, invoke_hook
+                if has_hook("transform_tool_result"):
+                    from model_tools import _tool_result_observer_fields
+                    _tr_status, _tr_err_type, _tr_err_msg = _tool_result_observer_fields(function_result)
+                    _tr_results = invoke_hook(
+                        "transform_tool_result",
+                        tool_name=function_name,
+                        args=function_args,
+                        result=function_result,
+                        task_id=effective_task_id or "",
+                        session_id=agent.session_id or "",
+                        tool_call_id=getattr(tool_call, "id", "") or "",
+                        turn_id=getattr(agent, "_current_turn_id", "") or "",
+                        api_request_id=getattr(agent, "_current_api_request_id", "") or "",
+                        duration_ms=int(tool_duration * 1000),
+                        status=_tr_status,
+                        error_type=_tr_err_type,
+                        error_message=_tr_err_msg,
+                    )
+                    for _tr_hook_result in _tr_results:
+                        if isinstance(_tr_hook_result, str):
+                            function_result = _tr_hook_result
+                            break
+            except Exception as _tr_hook_err:
+                logger.debug("transform_tool_result hook error: %s", _tr_hook_err)
         if not _execution_blocked:
             function_result = agent._append_guardrail_observation(
                 function_name,

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -219,6 +219,30 @@ class AnthropicTransport(ProviderTransport):
             return getattr(response, "stop_reason", None) in {"end_turn", "refusal"}
         return True
 
+    def diagnose_empty_content(self, response: Any) -> dict:
+        """Return diagnostic metadata about an empty-content response.
+
+        Called when ``validate_response`` returned False with an empty
+        ``content`` list whose ``stop_reason`` was neither ``end_turn``
+        nor ``refusal``.  The returned dict is suitable for log
+        correlation and operator debugging.
+        """
+        stop_reason = str(getattr(response, "stop_reason", None) or "none")
+        usage_info = {}
+        usage = getattr(response, "usage", None)
+        if usage is not None:
+            for attr in ("input_tokens", "output_tokens", "cache_read_input_tokens",
+                         "cache_creation_input_tokens"):
+                val = getattr(usage, attr, None)
+                if val is not None:
+                    usage_info[attr] = val
+        return {
+            "stop_reason": stop_reason,
+            "content_length": 0,
+            "usage": usage_info or None,
+            "response_type": type(response).__name__,
+        }
+
     def extract_cache_stats(self, response: Any) -> Optional[Dict[str, int]]:
         """Extract Anthropic cache_read and cache_creation token counts."""
         usage = getattr(response, "usage", None)

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1913,45 +1913,43 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     whatsapp_cloud_phone_id = getenv("WHATSAPP_CLOUD_PHONE_NUMBER_ID")
     whatsapp_cloud_token = getenv("WHATSAPP_CLOUD_ACCESS_TOKEN")
     if whatsapp_cloud_phone_id and whatsapp_cloud_token:
-        if Platform.WHATSAPP_CLOUD not in config.platforms:
-            config.platforms[Platform.WHATSAPP_CLOUD] = PlatformConfig()
-        config.platforms[Platform.WHATSAPP_CLOUD].enabled = True
-        config.platforms[Platform.WHATSAPP_CLOUD].extra.update({
+        whatsapp_cloud_config = _enable_from_env(Platform.WHATSAPP_CLOUD)
+        whatsapp_cloud_config.extra.update({
             "phone_number_id": whatsapp_cloud_phone_id,
             "access_token": whatsapp_cloud_token,
         })
         # Optional: app_id / app_secret (signature verification)
         wa_cloud_app_id = getenv("WHATSAPP_CLOUD_APP_ID")
         if wa_cloud_app_id:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["app_id"] = wa_cloud_app_id
+            whatsapp_cloud_config.extra["app_id"] = wa_cloud_app_id
         wa_cloud_app_secret = getenv("WHATSAPP_CLOUD_APP_SECRET")
         if wa_cloud_app_secret:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["app_secret"] = wa_cloud_app_secret
+            whatsapp_cloud_config.extra["app_secret"] = wa_cloud_app_secret
         # Optional: WABA id (analytics, future use)
         wa_cloud_waba_id = getenv("WHATSAPP_CLOUD_WABA_ID")
         if wa_cloud_waba_id:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["waba_id"] = wa_cloud_waba_id
+            whatsapp_cloud_config.extra["waba_id"] = wa_cloud_waba_id
         # Webhook verify token — Meta hub.verify_token shared secret
         wa_cloud_verify_token = getenv("WHATSAPP_CLOUD_VERIFY_TOKEN")
         if wa_cloud_verify_token:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["verify_token"] = wa_cloud_verify_token
+            whatsapp_cloud_config.extra["verify_token"] = wa_cloud_verify_token
         # Webhook server bind config (defaults baked into the adapter)
         wa_cloud_host = getenv("WHATSAPP_CLOUD_WEBHOOK_HOST")
         if wa_cloud_host:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["webhook_host"] = wa_cloud_host
+            whatsapp_cloud_config.extra["webhook_host"] = wa_cloud_host
         wa_cloud_port = getenv("WHATSAPP_CLOUD_WEBHOOK_PORT")
         if wa_cloud_port:
             try:
-                config.platforms[Platform.WHATSAPP_CLOUD].extra["webhook_port"] = int(wa_cloud_port)
+                whatsapp_cloud_config.extra["webhook_port"] = int(wa_cloud_port)
             except ValueError:
                 pass
         wa_cloud_path = getenv("WHATSAPP_CLOUD_WEBHOOK_PATH")
         if wa_cloud_path:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["webhook_path"] = wa_cloud_path
+            whatsapp_cloud_config.extra["webhook_path"] = wa_cloud_path
         # Graph API version override (rarely needed)
         wa_cloud_api_version = getenv("WHATSAPP_CLOUD_API_VERSION")
         if wa_cloud_api_version:
-            config.platforms[Platform.WHATSAPP_CLOUD].extra["api_version"] = wa_cloud_api_version
+            whatsapp_cloud_config.extra["api_version"] = wa_cloud_api_version
     whatsapp_cloud_home = getenv("WHATSAPP_CLOUD_HOME_CHANNEL")
     if whatsapp_cloud_home and Platform.WHATSAPP_CLOUD in config.platforms:
         config.platforms[Platform.WHATSAPP_CLOUD].home_channel = HomeChannel(
@@ -2078,13 +2076,11 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # Home Assistant
     hass_token = getenv("HASS_TOKEN")
     if hass_token:
-        if Platform.HOMEASSISTANT not in config.platforms:
-            config.platforms[Platform.HOMEASSISTANT] = PlatformConfig()
-        config.platforms[Platform.HOMEASSISTANT].enabled = True
-        config.platforms[Platform.HOMEASSISTANT].token = hass_token
+        hass_config = _enable_from_env(Platform.HOMEASSISTANT)
+        hass_config.token = hass_token
         hass_url = getenv("HASS_URL")
         if hass_url:
-            config.platforms[Platform.HOMEASSISTANT].extra["url"] = hass_url
+            hass_config.extra["url"] = hass_url
 
     # Email
     email_addr = getenv("EMAIL_ADDRESS")
@@ -2092,10 +2088,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     email_imap = getenv("EMAIL_IMAP_HOST")
     email_smtp = getenv("EMAIL_SMTP_HOST")
     if all([email_addr, email_pwd, email_imap, email_smtp]):
-        if Platform.EMAIL not in config.platforms:
-            config.platforms[Platform.EMAIL] = PlatformConfig()
-        config.platforms[Platform.EMAIL].enabled = True
-        config.platforms[Platform.EMAIL].extra.update({
+        email_config = _enable_from_env(Platform.EMAIL)
+        email_config.extra.update({
             "address": email_addr,
             "imap_host": email_imap,
             "smtp_host": email_smtp,
@@ -2112,10 +2106,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # SMS (Twilio)
     twilio_sid = getenv("TWILIO_ACCOUNT_SID")
     if twilio_sid:
-        if Platform.SMS not in config.platforms:
-            config.platforms[Platform.SMS] = PlatformConfig()
-        config.platforms[Platform.SMS].enabled = True
-        config.platforms[Platform.SMS].api_key = getenv("TWILIO_AUTH_TOKEN", "")
+        sms_config = _enable_from_env(Platform.SMS)
+        sms_config.api_key = getenv("TWILIO_AUTH_TOKEN", "")
     sms_home = getenv("SMS_HOME_CHANNEL")
     if sms_home and Platform.SMS in config.platforms:
         config.platforms[Platform.SMS].home_channel = HomeChannel(
@@ -2174,16 +2166,14 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     webhook_port = getenv("WEBHOOK_PORT")
     webhook_secret = getenv("WEBHOOK_SECRET", "")
     if webhook_enabled:
-        if Platform.WEBHOOK not in config.platforms:
-            config.platforms[Platform.WEBHOOK] = PlatformConfig()
-        config.platforms[Platform.WEBHOOK].enabled = True
+        webhook_config = _enable_from_env(Platform.WEBHOOK)
         if webhook_port:
             try:
-                config.platforms[Platform.WEBHOOK].extra["port"] = int(webhook_port)
+                webhook_config.extra["port"] = int(webhook_port)
             except ValueError:
                 pass
         if webhook_secret:
-            config.platforms[Platform.WEBHOOK].extra["secret"] = webhook_secret
+            webhook_config.extra["secret"] = webhook_secret
 
     # Microsoft Graph webhook platform
     msgraph_webhook_enabled = is_truthy_value(getenv("MSGRAPH_WEBHOOK_ENABLED", ""))
@@ -2204,16 +2194,16 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         if Platform.MSGRAPH_WEBHOOK not in config.platforms:
             config.platforms[Platform.MSGRAPH_WEBHOOK] = PlatformConfig()
         if msgraph_webhook_enabled:
-            config.platforms[Platform.MSGRAPH_WEBHOOK].enabled = True
+            msgraph_config = _enable_from_env(Platform.MSGRAPH_WEBHOOK)
         if msgraph_webhook_port:
             try:
-                config.platforms[Platform.MSGRAPH_WEBHOOK].extra["port"] = int(
+                msgraph_config.extra["port"] = int(
                     msgraph_webhook_port
                 )
             except ValueError:
                 pass
         if msgraph_webhook_client_state:
-            config.platforms[Platform.MSGRAPH_WEBHOOK].extra["client_state"] = (
+            msgraph_config.extra["client_state"] = (
                 msgraph_webhook_client_state
             )
         if msgraph_webhook_resources:
@@ -2223,7 +2213,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 if resource.strip()
             ]
             if resources:
-                config.platforms[Platform.MSGRAPH_WEBHOOK].extra[
+                msgraph_config.extra[
                     "accepted_resources"
                 ] = resources
         if msgraph_webhook_allowed_cidrs:
@@ -2233,7 +2223,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 if cidr.strip()
             ]
             if cidrs:
-                config.platforms[Platform.MSGRAPH_WEBHOOK].extra[
+                msgraph_config.extra[
                     "allowed_source_cidrs"
                 ] = cidrs
 
@@ -2241,16 +2231,14 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     dingtalk_client_id = getenv("DINGTALK_CLIENT_ID")
     dingtalk_client_secret = getenv("DINGTALK_CLIENT_SECRET")
     if dingtalk_client_id and dingtalk_client_secret:
-        if Platform.DINGTALK not in config.platforms:
-            config.platforms[Platform.DINGTALK] = PlatformConfig()
-        config.platforms[Platform.DINGTALK].enabled = True
-        config.platforms[Platform.DINGTALK].extra.update({
+        dingtalk_config = _enable_from_env(Platform.DINGTALK)
+        dingtalk_config.extra.update({
             "client_id": dingtalk_client_id,
             "client_secret": dingtalk_client_secret,
         })
         dingtalk_home = getenv("DINGTALK_HOME_CHANNEL")
         if dingtalk_home:
-            config.platforms[Platform.DINGTALK].home_channel = HomeChannel(
+            dingtalk_config.home_channel = HomeChannel(
                 platform=Platform.DINGTALK,
                 chat_id=dingtalk_home,
                 name=getenv("DINGTALK_HOME_CHANNEL_NAME", "Home"),
@@ -2261,10 +2249,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     feishu_app_id = getenv("FEISHU_APP_ID")
     feishu_app_secret = getenv("FEISHU_APP_SECRET")
     if feishu_app_id and feishu_app_secret:
-        if Platform.FEISHU not in config.platforms:
-            config.platforms[Platform.FEISHU] = PlatformConfig()
-        config.platforms[Platform.FEISHU].enabled = True
-        config.platforms[Platform.FEISHU].extra.update({
+        feishu_config = _enable_from_env(Platform.FEISHU)
+        feishu_config.extra.update({
             "app_id": feishu_app_id,
             "app_secret": feishu_app_secret,
             "domain": getenv("FEISHU_DOMAIN", "feishu"),
@@ -2272,13 +2258,13 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         })
         feishu_encrypt_key = getenv("FEISHU_ENCRYPT_KEY", "")
         if feishu_encrypt_key:
-            config.platforms[Platform.FEISHU].extra["encrypt_key"] = feishu_encrypt_key
+            feishu_config.extra["encrypt_key"] = feishu_encrypt_key
         feishu_verification_token = getenv("FEISHU_VERIFICATION_TOKEN", "")
         if feishu_verification_token:
-            config.platforms[Platform.FEISHU].extra["verification_token"] = feishu_verification_token
+            feishu_config.extra["verification_token"] = feishu_verification_token
         feishu_home = getenv("FEISHU_HOME_CHANNEL")
         if feishu_home:
-            config.platforms[Platform.FEISHU].home_channel = HomeChannel(
+            feishu_config.home_channel = HomeChannel(
                 platform=Platform.FEISHU,
                 chat_id=feishu_home,
                 name=getenv("FEISHU_HOME_CHANNEL_NAME", "Home"),
@@ -2289,19 +2275,17 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     wecom_bot_id = getenv("WECOM_BOT_ID")
     wecom_secret = getenv("WECOM_SECRET")
     if wecom_bot_id and wecom_secret:
-        if Platform.WECOM not in config.platforms:
-            config.platforms[Platform.WECOM] = PlatformConfig()
-        config.platforms[Platform.WECOM].enabled = True
-        config.platforms[Platform.WECOM].extra.update({
+        wecom_config = _enable_from_env(Platform.WECOM)
+        wecom_config.extra.update({
             "bot_id": wecom_bot_id,
             "secret": wecom_secret,
         })
         wecom_ws_url = getenv("WECOM_WEBSOCKET_URL", "")
         if wecom_ws_url:
-            config.platforms[Platform.WECOM].extra["websocket_url"] = wecom_ws_url
+            wecom_config.extra["websocket_url"] = wecom_ws_url
         wecom_home = getenv("WECOM_HOME_CHANNEL")
         if wecom_home:
-            config.platforms[Platform.WECOM].home_channel = HomeChannel(
+            wecom_config.home_channel = HomeChannel(
                 platform=Platform.WECOM,
                 chat_id=wecom_home,
                 name=getenv("WECOM_HOME_CHANNEL_NAME", "Home"),
@@ -2312,10 +2296,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     wecom_callback_corp_id = getenv("WECOM_CALLBACK_CORP_ID")
     wecom_callback_corp_secret = getenv("WECOM_CALLBACK_CORP_SECRET")
     if wecom_callback_corp_id and wecom_callback_corp_secret:
-        if Platform.WECOM_CALLBACK not in config.platforms:
-            config.platforms[Platform.WECOM_CALLBACK] = PlatformConfig()
-        config.platforms[Platform.WECOM_CALLBACK].enabled = True
-        config.platforms[Platform.WECOM_CALLBACK].extra.update({
+        wecom_callback_config = _enable_from_env(Platform.WECOM_CALLBACK)
+        wecom_callback_config.extra.update({
             "corp_id": wecom_callback_corp_id,
             "corp_secret": wecom_callback_corp_secret,
             "agent_id": getenv("WECOM_CALLBACK_AGENT_ID", ""),
@@ -2329,12 +2311,10 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     weixin_token = getenv("WEIXIN_TOKEN")
     weixin_account_id = getenv("WEIXIN_ACCOUNT_ID")
     if weixin_token or weixin_account_id:
-        if Platform.WEIXIN not in config.platforms:
-            config.platforms[Platform.WEIXIN] = PlatformConfig()
-        config.platforms[Platform.WEIXIN].enabled = True
+        weixin_config = _enable_from_env(Platform.WEIXIN)
         if weixin_token:
-            config.platforms[Platform.WEIXIN].token = weixin_token
-        extra = config.platforms[Platform.WEIXIN].extra
+            weixin_config.token = weixin_token
+        extra = weixin_config.extra
         if weixin_account_id:
             extra["account_id"] = weixin_account_id
         weixin_base_url = getenv("WEIXIN_BASE_URL", "").strip()
@@ -2360,7 +2340,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             extra["split_multiline_messages"] = weixin_split_multiline
         weixin_home = getenv("WEIXIN_HOME_CHANNEL", "").strip()
         if weixin_home:
-            config.platforms[Platform.WEIXIN].home_channel = HomeChannel(
+            weixin_config.home_channel = HomeChannel(
                 platform=Platform.WEIXIN,
                 chat_id=weixin_home,
                 name=getenv("WEIXIN_HOME_CHANNEL_NAME", "Home"),
@@ -2371,10 +2351,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     bluebubbles_server_url = getenv("BLUEBUBBLES_SERVER_URL")
     bluebubbles_password = getenv("BLUEBUBBLES_PASSWORD")
     if bluebubbles_server_url and bluebubbles_password:
-        if Platform.BLUEBUBBLES not in config.platforms:
-            config.platforms[Platform.BLUEBUBBLES] = PlatformConfig()
-        config.platforms[Platform.BLUEBUBBLES].enabled = True
-        config.platforms[Platform.BLUEBUBBLES].extra.update({
+        bluebubbles_config = _enable_from_env(Platform.BLUEBUBBLES)
+        bluebubbles_config.extra.update({
             "server_url": bluebubbles_server_url.rstrip("/"),
             "password": bluebubbles_password,
             "webhook_host": getenv("BLUEBUBBLES_WEBHOOK_HOST", "127.0.0.1"),
@@ -2384,7 +2362,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         })
         bluebubbles_require_mention = getenv("BLUEBUBBLES_REQUIRE_MENTION")
         if bluebubbles_require_mention is not None:
-            config.platforms[Platform.BLUEBUBBLES].extra["require_mention"] = (
+            bluebubbles_config.extra["require_mention"] = (
                 bluebubbles_require_mention.lower() in {"true", "1", "yes", "on"}
             )
         bluebubbles_mention_patterns = getenv("BLUEBUBBLES_MENTION_PATTERNS")
@@ -2397,10 +2375,10 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                     for part in bluebubbles_mention_patterns.replace("\n", ",").split(",")
                     if part.strip()
                 ]
-            config.platforms[Platform.BLUEBUBBLES].extra["mention_patterns"] = parsed_patterns
+            bluebubbles_config.extra["mention_patterns"] = parsed_patterns
     bluebubbles_home = getenv("BLUEBUBBLES_HOME_CHANNEL")
     if bluebubbles_home and Platform.BLUEBUBBLES in config.platforms:
-        config.platforms[Platform.BLUEBUBBLES].home_channel = HomeChannel(
+        bluebubbles_config.home_channel = HomeChannel(
             platform=Platform.BLUEBUBBLES,
             chat_id=bluebubbles_home,
             name=getenv("BLUEBUBBLES_HOME_CHANNEL_NAME", "Home"),
@@ -2411,10 +2389,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     qq_app_id = getenv("QQ_APP_ID")
     qq_client_secret = getenv("QQ_CLIENT_SECRET")
     if qq_app_id or qq_client_secret:
-        if Platform.QQBOT not in config.platforms:
-            config.platforms[Platform.QQBOT] = PlatformConfig()
-        config.platforms[Platform.QQBOT].enabled = True
-        extra = config.platforms[Platform.QQBOT].extra
+        qqbot_config = _enable_from_env(Platform.QQBOT)
+        extra = qqbot_config.extra
         if qq_app_id:
             extra["app_id"] = qq_app_id
         if qq_client_secret:
@@ -2438,7 +2414,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                     "in your .env for consistency with the platform key."
                 )
         if qq_home:
-            config.platforms[Platform.QQBOT].home_channel = HomeChannel(
+            qqbot_config.home_channel = HomeChannel(
                 platform=Platform.QQBOT,
                 chat_id=qq_home,
                 name=getenv("QQBOT_HOME_CHANNEL_NAME") or getenv(qq_home_name_env, "Home"),
@@ -2453,10 +2429,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     yuanbao_app_id = getenv("YUANBAO_APP_ID") or getenv("YUANBAO_APP_KEY")
     yuanbao_app_secret = getenv("YUANBAO_APP_SECRET")
     if yuanbao_app_id and yuanbao_app_secret:
-        if Platform.YUANBAO not in config.platforms:
-            config.platforms[Platform.YUANBAO] = PlatformConfig()
-        config.platforms[Platform.YUANBAO].enabled = True
-        extra = config.platforms[Platform.YUANBAO].extra
+        yuanbao_config = _enable_from_env(Platform.YUANBAO)
+        extra = yuanbao_config.extra
         extra["app_id"] = yuanbao_app_id
         extra["app_secret"] = yuanbao_app_secret
         yuanbao_bot_id = getenv("YUANBAO_BOT_ID")

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5451,17 +5451,15 @@ class BasePlatformAdapter(ABC):
                 media_files, response = self.extract_media(response)
                 media_files = self.filter_media_delivery_paths(media_files)
 
-                # Deduplicate against media already delivered in prior turns.
-                # The model may echo a previous MEDIA: tag or bare file path in
-                # a later response; without this guard the same file is sent
-                # repeatedly.
+                # Do NOT deduplicate MEDIA tags against prior turns here.
+                # The auto-append path in GatewayRunner._run_agent_inner already
+                # deduplicates auto-appended tags via _collect_auto_append_media_tags
+                # with history_media_paths, so this filter would only catch explicit
+                # MEDIA tags the model deliberately included in its response — which
+                # must be preserved (user asked to resend an image, the model echoed
+                # a path intentionally, etc.).  Bare-file-path dedup still applies
+                # to local_files below via the same _history_media_paths set.
                 _history_media_paths = self._history_media_paths_for_session(session_key)
-                if _history_media_paths:
-                    media_files = [
-                        (path, is_voice)
-                        for path, is_voice in media_files
-                        if path not in _history_media_paths
-                    ]
 
                 # Extract image URLs and send them as native platform attachments
                 images, text_content = self.extract_images(response)

--- a/optional-mcps/agentkey/manifest.yaml
+++ b/optional-mcps/agentkey/manifest.yaml
@@ -1,0 +1,42 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: agentkey
+description: >-
+  Remote HTTP MCP — web search, social media, crypto & on-chain data
+  through a single API key. Powered by Chainbase Labs.
+source: https://github.com/chainbase-labs/agentkey
+
+# AgentKey is a hosted remote MCP endpoint. No local install needed.
+transport:
+  type: http
+  url: https://api.agentkey.app/v1/mcp
+
+# Users get their API key from https://console.agentkey.app.
+# The key is saved to .env at install time and referenced in the
+# Authorization header via ${AGENTKEY_API_KEY}.
+auth:
+  type: api_key
+  env:
+    - name: AGENTKEY_API_KEY
+      prompt: "Your AgentKey API key (get one at https://console.agentkey.app)"
+      required: true
+      secret: true
+
+# AgentKey exposes tools for web search, scraping, social media, and
+# crypto/on-chain queries. We leave default_enabled unset so the
+# install-time checklist starts with everything pre-checked — users
+# prune what they don't want.
+# (The tool surface may grow over time as AgentKey adds sources.)
+
+post_install: |
+  On first connection, Hermes will use the API key you provided to
+  authenticate with AgentKey. No further setup is needed.
+
+  Start a new Hermes session to load the AgentKey tools.
+
+  You can re-run the tool checklist any time with:
+    hermes mcp configure agentkey
+
+  Pricing, subscription, and usage tracking: https://console.agentkey.app

--- a/plugins/model-providers/hetzner/__init__.py
+++ b/plugins/model-providers/hetzner/__init__.py
@@ -1,0 +1,21 @@
+"""Hetzner Inference provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+hetzner = ProviderProfile(
+    name="hetzner",
+    aliases=("hetzner-inference",),
+    display_name="Hetzner Inference",
+    description="Hetzner Inference — OpenAI-compatible API on Hetzner infrastructure",
+    signup_url="https://experiments.hetzner.com",
+    env_vars=("HETZNER_API_KEY", "HETZNER_BASE_URL"),
+    base_url="https://inference.hetzner.com/api/v1",
+    auth_type="api_key",
+    supports_vision=True,
+    fallback_models=(
+        "Qwen/Qwen3.6-35B-A3B-FP8",
+    ),
+)
+
+register_provider(hetzner)

--- a/plugins/model-providers/hetzner/plugin.yaml
+++ b/plugins/model-providers/hetzner/plugin.yaml
@@ -1,0 +1,5 @@
+name: hetzner-provider
+kind: model-provider
+version: 1.0.0
+description: Hetzner Inference
+author: Nous Research

--- a/run_agent.py
+++ b/run_agent.py
@@ -6531,7 +6531,7 @@ class AIAgent:
         Fields stripped: call_id, response_item_id, extra_content (model-gated)
         """
         tool_calls = api_msg.get("tool_calls")
-        if not isinstance(tool_calls, list):
+        if not isinstance(tool_calls, list) or not tool_calls:
             return api_msg
         from agent.transports.chat_completions import _model_consumes_thought_signature
         _STRIP_KEYS = {"call_id", "response_item_id"}

--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: himalaya
 description: "Himalaya CLI: IMAP/SMTP email from terminal."
-version: 1.1.0
+version: 2.0.0
 author: community
 license: MIT
 platforms: [linux, macos, windows]
@@ -48,13 +48,20 @@ cargo install himalaya --locked
 
 ## Configuration Setup
 
-Run the interactive wizard to set up an account:
+Run the interactive wizard (bare `himalaya` — no subcommand) to set up an account:
 
 ```bash
-himalaya account configure
+himalaya
 ```
 
-Or create `~/.config/himalaya/config.toml` manually:
+The wizard tests IMAP and SMTP connectivity, then prints a ready-to-save
+TOML config to stdout. Redirect it directly:
+
+```bash
+himalaya > ~/.config/himalaya/config.toml
+```
+
+Or create `~/.config/himalaya/config.toml` manually using per-backend tables:
 
 ```toml
 [accounts.personal]
@@ -62,56 +69,41 @@ email = "you@example.com"
 display-name = "Your Name"
 default = true
 
-backend.type = "imap"
-backend.host = "imap.example.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "you@example.com"
-backend.auth.type = "password"
-backend.auth.cmd = "pass show email/imap"  # or use keyring
+imap.server = "imap.example.com:993"
+imap.sasl.plain.username = "you@example.com"
+imap.sasl.plain.password.raw = "your-password"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.example.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "you@example.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.cmd = "pass show email/smtp"
+smtp.server = "smtp.example.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "you@example.com"
+smtp.sasl.plain.password.raw = "your-password"
 
-# Folder aliases (himalaya v1.2.0+ syntax). Required whenever the
-# server's folder names don't match himalaya's canonical names
-# (inbox/sent/drafts/trash). Gmail is the common case — see
-# `references/configuration.md` for the `[Gmail]/Sent Mail` mapping.
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "Sent"
-folder.aliases.drafts = "Drafts"
-folder.aliases.trash = "Trash"
+mailbox.alias.inbox = "INBOX"
+mailbox.alias.sent = "Sent"
+mailbox.alias.drafts = "Drafts"
+mailbox.alias.trash = "Trash"
 ```
 
-> **Heads up on the alias syntax.** Pre-v1.2.0 docs used a
-> `[accounts.NAME.folder.alias]` sub-section (singular `alias`).
-> v1.2.0 silently ignores that form — TOML parses fine, but the
-> alias resolver never reads it, so every lookup falls through to
-> the canonical name. On Gmail this means save-to-Sent fails *after*
-> SMTP delivery succeeds, and `himalaya message send` exits non-zero.
-> Any caller (agent, script, user) that retries on that exit code
-> will re-run the entire send — including SMTP — producing duplicate
-> emails to recipients. Always use `folder.aliases.X` (plural, dotted
-> keys, directly under `[accounts.NAME]`).
+> **Heads up on the alias syntax.** Himalaya v2.0.0 renamed
+> `folder.aliases.*` to `mailbox.alias.*`. The old dotted keys are
+> silently ignored — TOML parses fine, but the alias resolver never reads
+> them. On Gmail this means save-to-Sent fails *after* SMTP delivery
+> succeeds, and `himalaya message send` exits non-zero. Always use
+> `mailbox.alias.X` in v2.0.0+.
 
 ## Hermes Integration Notes
 
 - **Reading, listing, searching, moving, deleting** all work directly through the terminal tool
 - **Composing/replying/forwarding** — piped input (`cat << EOF | himalaya template send`) is recommended for reliability. Interactive `$EDITOR` mode works with `pty=true` + background + process tool, but requires knowing the editor and its commands
-- Use `--output json` for structured output that's easier to parse programmatically
-- The `himalaya account configure` wizard requires interactive input — use PTY mode: `terminal(command="himalaya account configure", pty=true)`
+- Use `--json` before the subcommand for structured output that's easier to parse programmatically (e.g. `himalaya --json envelope list`)
+- The bare `himalaya` wizard requires interactive input — use PTY mode: `terminal(command="himalaya", pty=true)`
 
 ## Common Operations
 
-### List Folders
+### List Mailboxes
 
 ```bash
-himalaya folder list
+himalaya mailbox list
 ```
 
 ### List Emails
@@ -275,11 +267,10 @@ himalaya attachment download 42 --downloads-dir ~/Downloads
 
 ## Output Formats
 
-Most commands support `--output` for structured output:
+Most commands support `--json` (before the subcommand) for structured output:
 
 ```bash
-himalaya envelope list --output json
-himalaya envelope list --output plain
+himalaya --json envelope list
 ```
 
 ## Debugging

--- a/skills/email/himalaya/references/configuration.md
+++ b/skills/email/himalaya/references/configuration.md
@@ -11,29 +11,22 @@ display-name = "Your Name"
 default = true
 
 # IMAP backend for reading emails
-backend.type = "imap"
-backend.host = "imap.example.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "user@example.com"
-backend.auth.type = "password"
-backend.auth.raw = "your-password"
+imap.server = "imap.example.com:993"
+imap.sasl.plain.username = "user@example.com"
+imap.sasl.plain.password.raw = "your-password"
 
 # SMTP backend for sending emails
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.example.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "user@example.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.raw = "your-password"
+smtp.server = "smtp.example.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "user@example.com"
+smtp.sasl.plain.password.raw = "your-password"
 
-# Folder aliases — required whenever server folder names differ
-# from himalaya's canonical names. See "Folder Aliases" below.
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "Sent"
-folder.aliases.drafts = "Drafts"
-folder.aliases.trash = "Trash"
+# Mailbox aliases — required whenever server folder names differ
+# from himalaya's canonical names. See "Mailbox Aliases" below.
+mailbox.alias.inbox = "INBOX"
+mailbox.alias.sent = "Sent"
+mailbox.alias.drafts = "Drafts"
+mailbox.alias.trash = "Trash"
 ```
 
 ## Password Options
@@ -41,23 +34,18 @@ folder.aliases.trash = "Trash"
 ### Raw password (testing only, not recommended)
 
 ```toml
-backend.auth.raw = "your-password"
+imap.sasl.plain.password.raw = "your-password"
+# smtp.sasl.plain.password.raw = "your-password"
 ```
 
 ### Password from command (recommended)
 
 ```toml
-backend.auth.cmd = "pass show email/imap"
-# backend.auth.cmd = "security find-generic-password -a user@example.com -s imap -w"
+imap.sasl.plain.password.cmd = "pass show email/imap"
+# imap.sasl.plain.password.cmd = "security find-generic-password -a user@example.com -s imap -w"
 ```
 
-### System keyring (requires keyring feature)
-
-```toml
-backend.auth.keyring = "imap-example"
-```
-
-Then run `himalaya account configure <account>` to store the password.
+Then run `himalaya` to set up an account (the wizard prints a ready-to-save TOML config).
 
 ## Gmail Configuration
 
@@ -67,31 +55,24 @@ email = "you@gmail.com"
 display-name = "Your Name"
 default = true
 
-backend.type = "imap"
-backend.host = "imap.gmail.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "you@gmail.com"
-backend.auth.type = "password"
-backend.auth.cmd = "pass show google/app-password"
+imap.server = "imap.gmail.com:993"
+imap.sasl.plain.username = "you@gmail.com"
+imap.sasl.plain.password.raw = "app-password"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.gmail.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "you@gmail.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.cmd = "pass show google/app-password"
+smtp.server = "smtp.gmail.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "you@gmail.com"
+smtp.sasl.plain.password.raw = "app-password"
 
 # Gmail folder mapping. Without these, save-to-Sent fails after
 # SMTP delivery succeeds (Gmail's Sent folder is `[Gmail]/Sent Mail`,
 # not `Sent`), and `himalaya message send` exits non-zero. Any
 # caller that retries on that error will re-run SMTP — duplicate
 # emails to recipients. Always include this block for Gmail.
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "[Gmail]/Sent Mail"
-folder.aliases.drafts = "[Gmail]/Drafts"
-folder.aliases.trash = "[Gmail]/Trash"
+mailbox.alias.inbox = "INBOX"
+mailbox.alias.sent = "[Gmail]/Sent Mail"
+mailbox.alias.drafts = "[Gmail]/Drafts"
+mailbox.alias.trash = "[Gmail]/Trash"
 ```
 
 **Note:** Gmail requires an App Password if 2FA is enabled.
@@ -103,62 +84,47 @@ folder.aliases.trash = "[Gmail]/Trash"
 email = "you@icloud.com"
 display-name = "Your Name"
 
-backend.type = "imap"
-backend.host = "imap.mail.me.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "you@icloud.com"
-backend.auth.type = "password"
-backend.auth.cmd = "pass show icloud/app-password"
+imap.server = "imap.mail.me.com:993"
+imap.sasl.plain.username = "you@icloud.com"
+imap.sasl.plain.password.raw = "app-password"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.mail.me.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "you@icloud.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.cmd = "pass show icloud/app-password"
+smtp.server = "smtp.mail.me.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "you@icloud.com"
+smtp.sasl.plain.password.raw = "app-password"
 ```
 
 **Note:** Generate an app-specific password at appleid.apple.com
 
-## Folder Aliases
+## Mailbox Aliases
 
-Map himalaya's canonical folder names (`inbox`, `sent`, `drafts`,
-`trash`) to whatever the server actually calls them. Use the
-v1.2.0 `folder.aliases.X` syntax (plural, dotted keys, directly
-under `[accounts.NAME]`):
+Map himalaya's canonical mailbox names (`inbox`, `sent`, `drafts`,
+`trash`) to whatever the server actually calls them:
 
 ```toml
 [accounts.default]
 # ... other account config ...
 
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "Sent"
-folder.aliases.drafts = "Drafts"
-folder.aliases.trash = "Trash"
+mailbox.alias.inbox = "INBOX"
+mailbox.alias.sent = "Sent"
+mailbox.alias.drafts = "Drafts"
+mailbox.alias.trash = "Trash"
 ```
 
-The equivalent TOML sub-section form also works in v1.2.0:
+The equivalent TOML sub-section form also works:
 
 ```toml
-[accounts.default.folder.aliases]
+[accounts.default.mailbox.aliases]
 inbox = "INBOX"
 sent = "Sent"
 drafts = "Drafts"
 trash = "Trash"
 ```
 
-> **Don't use the singular `alias` form.** Pre-v1.2.0 docs showed
-> `[accounts.NAME.folder.alias]` (singular). v1.2.0 silently
-> ignores that sub-section — TOML parses without error, but the
-> alias resolver never reads it. Every lookup then falls through
-> to the canonical name. On Gmail (where `sent` is actually
-> `[Gmail]/Sent Mail`) this means save-to-Sent fails *after* SMTP
-> delivery succeeds, and `himalaya message send` exits non-zero.
-> Any caller (agent, script, user) that retries on that error
-> code will re-run the send — including SMTP — producing duplicate
-> emails to recipients. Always use `folder.aliases.X` (plural).
+> **Note on v2.0.0 change.** Himalaya v2.0.0 renamed `folder.aliases.*`
+> to `mailbox.alias.*`. If you are upgrading from v1.x, update your
+> config accordingly — the old `folder.aliases.*` keys are ignored by
+> v2.0.0.
 
 ## Multiple Accounts
 
@@ -184,21 +150,19 @@ himalaya --account work envelope list
 ```toml
 [accounts.local]
 email = "user@example.com"
-
-backend.type = "notmuch"
-backend.db-path = "~/.mail/.notmuch"
+# Config structure for notmuch differs — see himalaya docs.
 ```
 
 ## OAuth2 Authentication (for providers that support it)
 
 ```toml
-backend.auth.type = "oauth2"
-backend.auth.client-id = "your-client-id"
-backend.auth.client-secret.cmd = "pass show oauth/client-secret"
-backend.auth.access-token.cmd = "pass show oauth/access-token"
-backend.auth.refresh-token.cmd = "pass show oauth/refresh-token"
-backend.auth.auth-url = "https://provider.com/oauth/authorize"
-backend.auth.token-url = "https://provider.com/oauth/token"
+# IMAP SASL OAuth2
+imap.sasl.oauth2.client-id = "your-client-id"
+imap.sasl.oauth2.client-secret.cmd = "pass show oauth/client-secret"
+imap.sasl.oauth2.access-token.cmd = "pass show oauth/access-token"
+imap.sasl.oauth2.refresh-token.cmd = "pass show oauth/refresh-token"
+imap.sasl.oauth2.auth-url = "https://provider.com/oauth/authorize"
+imap.sasl.oauth2.token-url = "https://provider.com/oauth/token"
 ```
 
 ## Additional Options


### PR DESCRIPTION
Closes #73777

Changes:
- AnthropicTransport.diagnose_empty_content(): extract stop_reason, usage, response type
- Structured WARN log on empty-content with msg count, roles, alternation repairs
- Skip retries for empty-content - go to fallback or fail immediately
- Better user-facing error (Provider returned empty response, not "response time X")