### PR TITLE
feat(mcp): add Nessie to the catalog

### DIFF
--- a/optional-mcps/nessie/manifest.yaml
+++ b/optional-mcps/nessie/manifest.yaml
@@ -1,0 +1,49 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: nessie
+description: >-
+  Search and read your own and your team's AI conversation history, notes,
+  profiles, and shared context from Hermes.
+source: https://nessielabs.com/docs/mcp-setup
+
+# Hosted Streamable HTTP endpoint. Auth is a per-user API key sent as a
+# bearer Authorization header - the same header template that
+# `hermes mcp add nessie --auth header` produces manually today.
+transport:
+  type: http
+  url: https://mcp.nessielabs.com/mcp
+
+auth:
+  type: api_key
+  env:
+    - name: MCP_NESSIE_API_KEY
+      prompt: "Nessie API key (create one under Settings → API Keys)"
+      required: true
+      secret: true
+
+# Start with the modern read-only surface. Context/profile writes, modality
+# corrections, deletion, and deprecated compatibility aliases remain available
+# in the install-time checklist and can be enabled explicitly.
+tools:
+  default_enabled:
+    - nessie_check_in
+    - nessie_who_am_i
+    - nessie_team_list
+    - nessie_integration_list
+    - nessie_ls
+    - nessie_grep
+    - nessie_cat
+    - nessie_head
+    - nessie_tail
+    - nessie_stat
+    - nessie_asset_get
+
+post_install: |
+  Enable Cloud Sync in Nessie, create an API key under Settings → API Keys,
+  and paste it at the prompt above. Verify the connection with:
+    hermes mcp test nessie
+  Then start a fresh session (/new) so the Nessie tools load. The default
+  tool set is read-only; run `hermes mcp configure nessie` to opt into
+  context/profile writes or deletion tools.


### PR DESCRIPTION
## What does this PR do?

Adds Nessie to the official Hermes MCP catalog as a data-only manifest.

Nessie is a hosted Streamable HTTP MCP server for searching and reading a user's or team's AI conversation history, notes, profiles, and shared context. The manifest uses the HTTP API-key bearer-header convention already supported on current `main` through #77356, so this refresh no longer carries installer code.

The default tool set is deliberately curated to 11 modern, read-only operations. Profile/context writes, modality corrections, deletion, and deprecated aliases remain available only when a user explicitly opts into them with `hermes mcp configure nessie`.

## Related Issue

Related to #77356, which supplied the generic HTTP API-key catalog support this manifest uses. There is no separate issue for this catalog submission.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `optional-mcps/nessie/manifest.yaml` with the hosted `https://mcp.nessielabs.com/mcp` endpoint.
- Declared `MCP_NESSIE_API_KEY` as the required secret and used Hermes' generated `Authorization: Bearer ${MCP_NESSIE_API_KEY}` configuration.
- Enabled 11 read-only tools by default and documented Cloud Sync, API-key creation, connection testing, and explicit opt-in for write/delete tools.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py -q`.
2. Run `hermes mcp install nessie`, enter a scratch Nessie API key, and inspect `~/.hermes/mcp_config.json` for the HTTPS URL and bearer-header reference.
3. Run `hermes mcp test nessie`, then start a new Hermes session and ask Nessie to identify the current user or search conversation history.

Validation performed for this refresh:

- Hermes catalog suite: 21 passed.
- Manifest parse/config contract: passed; generated config matches the endpoint and bearer-header reference, with 11 read-only defaults.
- Nessie MCP server registration suite: 12 passed.
- Hosted endpoint without a bearer token: HTTP 401, confirming the authentication boundary.
- The full prescribed Hermes runner completed. It reported 66 failures across 21 unrelated optional/platform test files (for example service permissions, optional provider SDKs, media backends, and OS command behavior); the catalog suite and all Nessie-related validation remained green.

An authenticated live test was not repeated during this refresh because no scratch Nessie key was present in the validation environment.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1 (24G90)

The existing catalog invariant suite covers every manifest, including this one; no new test code is needed for a data-only entry. The full-suite exceptions are documented above.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the manifest links the focused Nessie MCP setup documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the entry is data-only and uses the existing cross-platform HTTP MCP installer
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A — this is a data-only catalog manifest.
