### PR TITLE
fix(photon): unblock main — restore U+FFFC deferral, mock deps check in runtime-record tests

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -875,19 +875,12 @@ class PhotonAdapter(BasePlatformAdapter):
             )
 
         ctype = content.get("type")
-        if ctype == "text":
-            raw_text = content.get("text") or ""
-            # iMessage emits U+FFFC OBJECT REPLACEMENT CHARACTER as a transient
-            # placeholder for some media bubbles (notably voice notes). Photon
-            # can then deliver the real attachment/voice event immediately
-            # afterwards with a different message id. If we dispatch the
-            # placeholder as a standalone text turn, the subsequent media event
-            # arrives while that turn is active and the gateway sends a bogus
-            # "Interrupting current task" busy ack. Drop placeholder-only text
-            # at the platform boundary; the real media event carries the bytes.
-            if raw_text.strip() == "\ufffc":
-                logger.debug("[photon] ignoring iMessage object-placeholder text event")
-                return
+        # NOTE: U+FFFC placeholder-only text is handled further down by the
+        # _pending_fffc deferral (register timeout, wait for the real
+        # attachment/voice event, cancel on arrival). It must NOT be dropped
+        # here at the boundary: an unconditional early return starves that
+        # machinery, losing the timeout fallback for voice notes whose media
+        # event never arrives.
         if ctype == "reaction":
             # Route only tapbacks on messages WE sent — those are implicitly
             # addressed to the bot (feishu precedent: synthetic text event).

--- a/tests/plugins/platforms/photon/test_runtime_record.py
+++ b/tests/plugins/platforms/photon/test_runtime_record.py
@@ -123,6 +123,9 @@ def _patch_spawn(
     (sidecar_dir / "node_modules").mkdir(parents=True)
     monkeypatch.setattr(photon_adapter, "_SIDECAR_DIR", sidecar_dir)
     monkeypatch.setattr(photon_adapter, "_sidecar_deps_stale", lambda: False)
+    # The unified deps check requires spectrum-ts inside node_modules; these
+    # tests exercise the runtime record, not dependency installation.
+    monkeypatch.setattr(photon_adapter, "sidecar_deps_installed", lambda: True)
 
     async def _no_reap(self: PhotonAdapter) -> None:
         return None


### PR DESCRIPTION
## Problem

Fixes #73783 — `main`'s `Python tests / Run tests slice 2/8` and `7/8` are red (which also fails every open PR's required checks). Two independent causes in the photon platform, both bisected in the issue.

## Change

**1. Restore the U+FFFC deferral** (`plugins/platforms/photon/adapter.py`)

The early return added by the #54514 salvage drops placeholder-only text at the platform boundary, *before* the `_pending_fffc` deferral (from `afab7ed46`) can register it. The deferral already achieves the salvage's goal — a placeholder is never dispatched as a standalone text turn — while additionally keeping the timeout fallback for voice notes whose media event never arrives, and cancel-on-attachment. Removing the early return lets the deferral own the placeholder again; a NOTE comment marks the boundary so the next salvage doesn't reintroduce the drop.

**2. Mock the deps seam in the runtime-record tests** (`tests/plugins/platforms/photon/test_runtime_record.py`)

`_patch_spawn` stubs `_SIDECAR_DIR` with an *empty* `node_modules/`, which the unified `sidecar_deps_installed()` check (spectrum-ts probe) rejects — so `_start_sidecar()` raises before the record write on any runner without real sidecar deps (all CI slices). One `monkeypatch.setattr(photon_adapter, "sidecar_deps_installed", lambda: True)` in the shared helper; these tests exercise the runtime record, not dependency installation.

## Tests

Full photon suite: `tests/plugins/platforms/photon/` — **164 passed** (was 6 failing on main tip). The four fffc tests pin the restored deferral contract; both runtime-record tests reach the record write.

Note: `tests/conformance/test_vector_generator.py::test_committed_vectors_match_regeneration` also shows red on the same slices but passes locally for me — likely a separate CI-env drift, not addressed here.
