### PR TITLE
fix(photon): restore placeholder and sidecar tests

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -885,9 +885,9 @@ class PhotonAdapter(BasePlatformAdapter):
             # arrives while that turn is active and the gateway sends a bogus
             # "Interrupting current task" busy ack. Drop placeholder-only text
             # at the platform boundary; the real media event carries the bytes.
-            if raw_text.strip() == "\ufffc":
-                logger.debug("[photon] ignoring iMessage object-placeholder text event")
-                return
+            # Placeholder-only text is handled just below: create a short-lived
+            # pending entry so a following attachment can cancel the timeout.
+            # Do not return here or the timeout/correlation state is skipped.
         if ctype == "reaction":
             # Route only tapbacks on messages WE sent — those are implicitly
             # addressed to the bot (feishu precedent: synthetic text event).

--- a/tests/plugins/platforms/photon/test_runtime_record.py
+++ b/tests/plugins/platforms/photon/test_runtime_record.py
@@ -120,7 +120,7 @@ def _patch_spawn(
 ) -> None:
     """Stub everything _start_sidecar touches before the healthz loop."""
     sidecar_dir = tmp_path / "sidecar"
-    (sidecar_dir / "node_modules").mkdir(parents=True)
+    (sidecar_dir / "node_modules" / "spectrum-ts").mkdir(parents=True)
     monkeypatch.setattr(photon_adapter, "_SIDECAR_DIR", sidecar_dir)
     monkeypatch.setattr(photon_adapter, "_sidecar_deps_stale", lambda: False)
 


### PR DESCRIPTION
## Summary
- keep Photon U+FFFC placeholder handling in the pending-timeout path instead of returning before state is recorded
- update the sidecar runtime-record test stub to satisfy the stricter spectrum-ts dependency check

## Verification
- PYTHONPATH=$WT python -m pytest -o addopts= tests/plugins/platforms/photon/test_inbound.py tests/plugins/platforms/photon/test_runtime_record.py -q
- ruff check plugins/platforms/photon/adapter.py tests/plugins/platforms/photon/test_inbound.py tests/plugins/platforms/photon/test_runtime_record.py
- python scripts/check-windows-footguns.py --all
- git diff --check

This unblocks current main CI failures observed while refreshing #49757.