### PR TITLE
fix: replace assert statements with runtime guards

### DIFF
--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -1238,7 +1238,8 @@ def recover_session_database(
         output_path=output_path,
         work_dir=work_dir,
     )
-    assert output is not None
+    if output is None:
+        raise SessionRecoverySourceError("output path could not be resolved")
     disk_space = _disk_space_preflight(source, work_root, output.parent)
 
     temp_dir, snapshot_source, inspection = _snapshot_and_inspect(source, work_root)

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -394,7 +394,8 @@ class HostSupervisor:
             proc.stdin.flush()
 
     def _drain_stdout(self, proc: subprocess.Popen[str]) -> None:
-        assert proc.stdout is not None
+        if proc.stdout is None:
+            return
         for raw in proc.stdout:
             try:
                 frame = json.loads(raw)
@@ -405,7 +406,8 @@ class HostSupervisor:
                 self._handle_host_frame(frame)
 
     def _drain_stderr(self, proc: subprocess.Popen[str]) -> None:
-        assert proc.stderr is not None
+        if proc.stderr is None:
+            return
         for raw in proc.stderr:
             text = raw.rstrip("\n")
             if text:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8197,7 +8197,8 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait({"session_id": sid}, rid)
     if err:
         return err
-    assert session is not None
+    if session is None:
+        return _error(rid, -32602, "session not found")
 
     return _ok(
         rid,
@@ -10307,7 +10308,8 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
-    assert session is not None
+    if session is None:
+        return _error(rid, -32602, "session not found")
     if _session_uses_compute_host(session):
         sid = str(params.get("session_id") or "")
         focus_topic = str(params.get("focus_topic", "") or "").strip()


### PR DESCRIPTION
## Summary

Replace assert statements that crash in production with proper runtime guards across 3 files.

## Problem

Assert statements are stripped in optimized mode (`python -O`) and crash the process with bare `AssertionError` in production. Five assert sites were identified as uncovered by existing PRs (#56736, #56866, #61983, #62001, #62006, #62659, #64063, #64071, #64808, #64818).

## Changes

- **`tui_gateway/host_supervisor.py`**: `_drain_stdout` and `_drain_stderr` return early if `proc.stdout`/`proc.stderr` is None instead of asserting
- **`hermes_cli/session_recovery.py`**: Raise `SessionRecoverySourceError` with descriptive message if output path resolution returns None
- **`tui_gateway/server.py`** (2 locations): Return JSON-RPC error (`-32602 session not found`) if `_sess_nowait` returns None session after passing the error check

## Testing

- `python3 -m py_compile` passes for all 3 files
- `python3 -m ruff check` clean
