### PR TITLE
fix(agent): prevent replay after partial stream transport failures

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2402,15 +2402,27 @@ def cleanup_task_resources(agent, task_id: str) -> None:
 def _build_partial_stream_stub(
     role, full_content, full_reasoning, model_name, usage_obj, *,
     dropped_tool_names=None,
+    no_retry=False,
+    uncertain_tool_call=False,
 ):
     """Build a partial-stream-stub response for mid-stream drop scenarios.
 
     Used when the SSE stream ends without a ``finish_reason`` after
     delivering content (text-only drops, tool-call-arg drops).  The stub
     is tagged ``PARTIAL_STREAM_STUB_ID`` with ``FINISH_REASON_LENGTH`` so
-    the conversation loop enters its continuation/retry path instead of
-    silently accepting truncated output as a complete turn (#32086).
+    callers can distinguish an incomplete turn from a clean completion.
     """
+    dropped_tool_names = dropped_tool_names or None
+    if uncertain_tool_call and dropped_tool_names:
+        _name_str = ", ".join(dropped_tool_names[:3])
+        if len(dropped_tool_names) > 3:
+            _name_str += f", +{len(dropped_tool_names) - 3} more"
+        _warning = (
+            f"\n\n⚠ Stream ended before tool-call completion "
+            f"({_name_str}); the action was not executed."
+        )
+        full_content = (full_content or "") + _warning
+
     mock_message = SimpleNamespace(
         role=role,
         content=full_content,
@@ -2427,7 +2439,9 @@ def _build_partial_stream_stub(
         model=model_name,
         choices=[mock_choice],
         usage=usage_obj,
-        _dropped_tool_names=dropped_tool_names or None,
+        _dropped_tool_names=dropped_tool_names,
+        _stream_no_retry=bool(no_retry),
+        _uncertain_tool_call=bool(uncertain_tool_call),
     )
 
 
@@ -2696,7 +2710,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             _reset_stale_streak(agent)
         return result["response"]
 
-    result = {"response": None, "error": None, "partial_tool_names": []}
+    result = {
+        "response": None,
+        "error": None,
+        "partial_tool_names": [],
+        "partial_content": "",
+        "partial_reasoning": "",
+        "response_tail_transport_error": False,
+    }
 
     # Cross-turn stale-stream circuit breaker (#58962) — see the canonical
     # comment block above ``_stale_streak()``.  Raises past the give-up
@@ -2979,6 +3000,78 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         role = "assistant"
         reasoning_parts: list = []
         usage_obj = None
+
+        def _record_partial_stream() -> None:
+            """Snapshot progress before the retry policy handles a stream error."""
+            result["partial_content"] = "".join(content_parts)
+            result["partial_reasoning"] = "".join(reasoning_parts)
+            names = list(result.get("partial_tool_names") or [])
+            for idx in sorted(tool_calls_acc):
+                name = tool_calls_acc[idx]["function"]["name"] or "?"
+                if name not in names:
+                    names.append(name)
+            result["partial_tool_names"] = names
+
+        def _build_terminal_response_after_tail_error():
+            """Return an authoritative terminal response after a noisy close."""
+            if finish_reason is None:
+                return None
+
+            mock_tool_calls = None
+            if finish_reason == "tool_calls":
+                if not tool_calls_acc:
+                    return None
+                mock_tool_calls = []
+                for idx in sorted(tool_calls_acc):
+                    tc = tool_calls_acc[idx]
+                    name = tc["function"]["name"]
+                    if not name:
+                        return None
+                    arguments = tc["function"]["arguments"] or "{}"
+                    try:
+                        json.loads(arguments)
+                    except (TypeError, json.JSONDecodeError):
+                        return None
+                    mock_tool_calls.append(
+                        SimpleNamespace(
+                            id=tc["id"],
+                            type=tc["type"],
+                            extra_content=tc.get("extra_content"),
+                            function=SimpleNamespace(
+                                name=name,
+                                arguments=arguments,
+                            ),
+                        )
+                    )
+
+            return SimpleNamespace(
+                id="stream-" + str(uuid.uuid4()),
+                model=model_name,
+                choices=[
+                    SimpleNamespace(
+                        index=0,
+                        message=SimpleNamespace(
+                            role=role,
+                            content="".join(content_parts) or None,
+                            tool_calls=mock_tool_calls,
+                            reasoning_content="".join(reasoning_parts) or None,
+                        ),
+                        finish_reason=finish_reason,
+                    )
+                ],
+                usage=usage_obj,
+            )
+
+        def _iter_stream_chunks():
+            try:
+                yield from stream
+            except Exception:
+                _record_partial_stream()
+                terminal_response = _build_terminal_response_after_tail_error()
+                if terminal_response is not None:
+                    result["terminal_response_candidate"] = terminal_response
+                raise
+
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
         _writer_token = {"value": None}
@@ -3097,7 +3190,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # Hermes interrupts the managed stream; Relay retains sole
             # ownership of closing the underlying provider stream.
             _set_request_stream_handle(stream)
-        for chunk in stream:
+        for chunk in _iter_stream_chunks():
             last_chunk_time["t"] = time.time()
             agent._touch_activity("receiving stream response")
 
@@ -3162,6 +3255,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             reasoning_text = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
             if reasoning_text:
                 reasoning_parts.append(reasoning_text)
+                deltas_were_sent["yes"] = True
                 _fire_first_delta()
                 agent._fire_reasoning_delta(reasoning_text)
 
@@ -3192,6 +3286,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
             # Accumulate tool call deltas — notify display on first name
             if delta and delta.tool_calls:
+                deltas_were_sent["yes"] = True
                 for tc_delta in delta.tool_calls:
                     raw_idx = tc_delta.index if tc_delta.index is not None else 0
                     delta_id = tc_delta.id or ""
@@ -3400,27 +3495,55 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 "".join(reasoning_parts) or None,
                 model_name, usage_obj,
                 dropped_tool_names=_dropped_names or None,
+                no_retry=True,
+                uncertain_tool_call=True,
             )
 
-        # Text-only stream drop: the upstream closed the connection (or the
-        # SSE stream simply ended) with no finish_reason after delivering
-        # text content but no tool calls.  Without this guard the partial
-        # text is silently stamped finish_reason="stop" and the turn ends as
-        # if complete — the model's intended next step is lost (#32086).
-        _text_only_dropped_no_finish = (
+        # A tool call without a provider terminal reason is never safe to
+        # execute, even when its JSON happens to be complete.  The missing
+        # finish_reason leaves the request outcome uncertain; surface a
+        # diagnostic partial instead of replaying or dispatching a side effect.
+        _tool_call_dropped_no_finish = bool(tool_calls_acc) and finish_reason is None
+        if _tool_call_dropped_no_finish:
+            _dropped_names = [
+                (tool_calls_acc[idx]["function"]["name"] or "?")
+                for idx in sorted(tool_calls_acc)
+            ]
+            logger.warning(
+                "Stream ended without finish_reason after a tool call "
+                "(tools=%s); treating the outcome as uncertain and refusing "
+                "tool execution.",
+                _dropped_names,
+            )
+            return _build_partial_stream_stub(
+                role,
+                full_content,
+                "".join(reasoning_parts) or None,
+                model_name,
+                usage_obj,
+                dropped_tool_names=_dropped_names or None,
+                no_retry=True,
+                uncertain_tool_call=True,
+            )
+
+        # A clean EOF without a terminal frame is still an incomplete stream.
+        # Once text or reasoning was observed, replaying the request can
+        # duplicate paid output just like an explicit transport exception.
+        _content_dropped_no_finish = (
             finish_reason is None
-            and content_parts
+            and (content_parts or reasoning_parts)
             and not tool_calls_acc
         )
-        if _text_only_dropped_no_finish:
+        if _content_dropped_no_finish:
             logger.warning(
-                "Stream ended with no finish_reason after delivering text "
+                "Stream ended with no finish_reason after delivering content "
                 "with no tool calls; treating as a mid-stream drop."
             )
             return _build_partial_stream_stub(
                 role, full_content,
                 "".join(reasoning_parts) or None,
                 model_name, usage_obj,
+                no_retry=True,
             )
 
         effective_finish_reason = finish_reason or "stop"
@@ -3460,17 +3583,21 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         stream's socket without closing the shared client mid-flight (#67142).
         """
         has_tool_use = False
-        # Zero-event guard parity with the chat_completions path: track
-        # whether the provider delivered ANY stream event. On an eventless
-        # stream the real Anthropic SDK's get_final_message() raises
-        # AssertionError (no message_start ⇒ no final-message snapshot);
-        # OpenAI-compat shims may instead fabricate a contentless Message
-        # with no stop_reason, or return None under ``python -O`` (assert
-        # stripped). Every one of those shapes is normalized below to
-        # EmptyStreamError so the shared _call() retry loop treats it as
-        # transient instead of surfacing a raw AssertionError or a
-        # fabricated "successful" empty turn.
-        saw_stream_event = False
+
+        def _anthropic_partial_stub():
+            dropped_names = list(result["partial_tool_names"])
+            if has_tool_use and not dropped_names:
+                dropped_names = ["?"]
+            return _build_partial_stream_stub(
+                "assistant",
+                result["partial_content"] or None,
+                result["partial_reasoning"] or None,
+                api_kwargs.get("model"),
+                None,
+                dropped_tool_names=dropped_names or None,
+                no_retry=True,
+                uncertain_tool_call=has_tool_use,
+            )
 
         last_chunk_time["t"] = time.time()
         _diag = agent._stream_diag_init()
@@ -3478,6 +3605,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         _writer_token = {"value": None}
         _stream_context = {"manager": None, "stream": None}
         base_final_message = None
+        saw_stream_event = False
 
         from agent import relay_llm
         from agent.anthropic_adapter import sanitize_anthropic_kwargs
@@ -3561,41 +3689,60 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     break
 
                 event_type = getattr(event, "type", None)
+
+                # The logical Anthropic response is complete at message_stop.
+                # Do not keep reading a noisy transport tail after it.
+                if event_type == "message_stop":
+                    break
+
                 if event_type == "content_block_start":
                     block = getattr(event, "content_block", None)
                     if block and getattr(block, "type", None) == "tool_use":
+                        deltas_were_sent["yes"] = True
                         has_tool_use = True
                         tool_name = getattr(block, "name", None)
                         if tool_name:
+                            if tool_name not in result["partial_tool_names"]:
+                                result["partial_tool_names"].append(tool_name)
                             _fire_first_delta()
                             agent._fire_tool_gen_started(tool_name)
+                        elif "?" not in result["partial_tool_names"]:
+                            result["partial_tool_names"].append("?")
                 elif event_type == "content_block_delta":
                     delta = getattr(event, "delta", None)
                     if delta:
                         delta_type = getattr(delta, "type", None)
                         if delta_type == "text_delta":
                             text = getattr(delta, "text", "")
-                            if text and not has_tool_use:
-                                _fire_first_delta()
-                                agent._fire_stream_delta(text)
+                            if text:
+                                result["partial_content"] += text
                                 deltas_were_sent["yes"] = True
+                                if not has_tool_use:
+                                    _fire_first_delta()
+                                    agent._fire_stream_delta(text)
                         elif delta_type == "thinking_delta":
                             thinking_text = getattr(delta, "thinking", "")
                             if thinking_text:
+                                result["partial_reasoning"] += thinking_text
                                 _fire_first_delta()
                                 agent._fire_reasoning_delta(thinking_text)
+                                deltas_were_sent["yes"] = True
+                        elif delta_type == "input_json_delta":
+                            deltas_were_sent["yes"] = True
+
             if not agent._interrupt_requested:
                 raw_stream = _stream_context["stream"]
                 if raw_stream is not None:
                     try:
                         base_final_message = raw_stream.get_final_message()
                     except AssertionError:
-                        if not saw_stream_event:
-                            raise EmptyStreamError(
-                                "Provider returned an empty stream with no events "
-                                "(possible upstream error or malformed event stream)."
-                            ) from None
-                        raise
+                        if deltas_were_sent["yes"]:
+                            return _anthropic_partial_stub()
+                        detail = "no events" if not saw_stream_event else "no completed response"
+                        raise EmptyStreamError(
+                            f"Provider returned an empty stream with {detail} "
+                            "(possible upstream error or malformed event stream)."
+                        ) from None
         finally:
             try:
                 _close_managed_stream()
@@ -3608,20 +3755,29 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             return None
         if (
             base_final_message is not None
-            and not getattr(base_final_message, "content", None)
             and getattr(base_final_message, "stop_reason", None) is None
         ):
+            if deltas_were_sent["yes"]:
+                return _anthropic_partial_stub()
             raise EmptyStreamError(
                 "Provider returned an empty stream with no stop_reason "
+                "(possible upstream error or malformed event stream)."
+            )
+        if base_final_message is None:
+            if deltas_were_sent["yes"]:
+                return _anthropic_partial_stub()
+            raise EmptyStreamError(
+                "Provider returned an empty stream with no completed response "
                 "(possible upstream error or malformed event stream)."
             )
         if base_final_message is not None and not stream.output_modified:
             return base_final_message
         final_message = accumulator.response(base_final_message)
         if (
-            not getattr(final_message, "content", None)
-            and getattr(final_message, "stop_reason", None) is None
+            getattr(final_message, "stop_reason", None) is None
         ):
+            if deltas_were_sent["yes"]:
+                return _anthropic_partial_stub()
             raise EmptyStreamError(
                 "Provider returned an empty stream with no stop_reason "
                 "(possible upstream error or malformed event stream)."
@@ -3677,129 +3833,28 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             type(e).__name__,
                         )
                         return
+                    # The provider already emitted a terminal frame before
+                    # the socket failed.  The accumulator is authoritative;
+                    # do not classify the tail close as a retryable error.
+                    if result.get("response") is not None:
+                        return
                     _is_timeout = isinstance(
                         e, (_httpx.ReadTimeout, _httpx.ConnectTimeout, _httpx.PoolTimeout)
                     )
                     _is_conn_err = isinstance(
-                        e, (_httpx.ConnectError, _httpx.RemoteProtocolError, ConnectionError)
+                        e,
+                        (
+                            _httpx.ConnectError,
+                            _httpx.ReadError,
+                            _httpx.RemoteProtocolError,
+                            ConnectionError,
+                        ),
                     )
                     _is_stream_parse_err = agent._is_provider_stream_parse_error(e)
                     _is_empty_stream = isinstance(e, EmptyStreamError)
 
-                    # If the stream died AFTER some tokens were delivered:
-                    # normally we don't retry (the user already saw text,
-                    # retrying would duplicate it).  BUT: if a tool call
-                    # was in-flight when the stream died, silently aborting
-                    # discards the tool call entirely.  In that case we
-                    # prefer to retry — the user sees a brief
-                    # "reconnecting" marker + duplicated preamble text,
-                    # which is strictly better than a failed action with
-                    # a "retry manually" message.  Limit this to transient
-                    # connection errors (Clawdbot-style narrow gate): no
-                    # tool has executed yet within this API call, so
-                    # silent retry is safe wrt side-effects.
-                    if deltas_were_sent["yes"]:
-                        _partial_tool_in_flight = bool(
-                            result.get("partial_tool_names")
-                        ) or provider_tool_in_flight["yes"]
-                        _is_sse_conn_err_preview = False
-                        if not _is_timeout and not _is_conn_err:
-                            from openai import APIError as _APIError
-                            if isinstance(e, _APIError) and not getattr(e, "status_code", None):
-                                _err_lower_preview = str(e).lower()
-                                _SSE_PREVIEW_PHRASES = (
-                                    "connection lost",
-                                    "connection reset",
-                                    "connection closed",
-                                    "connection terminated",
-                                    "network error",
-                                    "network connection",
-                                    "terminated",
-                                    "peer closed",
-                                    "broken pipe",
-                                    "upstream connect error",
-                                )
-                                _is_sse_conn_err_preview = any(
-                                    phrase in _err_lower_preview
-                                    for phrase in _SSE_PREVIEW_PHRASES
-                                )
-                        _is_transient = (
-                            _is_timeout
-                            or _is_conn_err
-                            or _is_sse_conn_err_preview
-                            or _is_stream_parse_err
-                        )
-                        _can_silent_retry = (
-                            _partial_tool_in_flight
-                            and _is_transient
-                            and _stream_attempt < _max_stream_retries
-                        )
-                        if not _can_silent_retry:
-                            # Either no tool call was in-flight (so the
-                            # turn was a pure text response — current
-                            # stub-with-recovered-text behaviour is
-                            # correct), or retries are exhausted, or the
-                            # error isn't transient.  Fall through to the
-                            # stub path.
-                            logger.warning(
-                                "Streaming failed after partial delivery, not retrying: %s", e
-                            )
-                            result["error"] = e
-                            return
-                        # Tool call was in-flight AND error is transient:
-                        # retry silently.  Clear per-attempt state so the
-                        # next stream starts clean.  Fire a "reconnecting"
-                        # marker so the user sees why the preamble is
-                        # about to be re-streamed.  Structured WARNING is
-                        # emitted by ``_emit_stream_drop`` below; no
-                        # additional INFO line needed.
-                        try:
-                            agent._fire_stream_delta(
-                                "\n\n⚠ Connection dropped mid tool-call; "
-                                "reconnecting…\n\n"
-                            )
-                        except Exception:
-                            pass
-                        # Reset the streamed-text buffer so the retry's
-                        # fresh preamble doesn't get double-recorded in
-                        # _current_streamed_assistant_text (which would
-                        # pollute the interim-visible-text comparison).
-                        try:
-                            agent._reset_stream_delivery_tracking()
-                        except Exception:
-                            pass
-                        # Reset in-memory accumulators so the next
-                        # attempt's chunks don't concat onto the dead
-                        # stream's partial JSON.
-                        result["partial_tool_names"] = []
-                        deltas_were_sent["yes"] = False
-                        first_delta_fired["done"] = False
-                        agent._emit_stream_drop(
-                            error=e,
-                            attempt=_stream_attempt + 2,
-                            max_attempts=_max_stream_retries + 1,
-                            mid_tool_call=True,
-                            diag=request_client_holder.get("diag"),
-                        )
-                        _cancel_current_stream_attempt("stream_mid_tool_retry_cleanup")
-                        _close_request_client_once("stream_mid_tool_retry_cleanup")
-                        # #67142: anthropic streams on a request-local client,
-                        # already worker-owned-closed by _close_request_client_once
-                        # above; the next attempt builds a fresh one. The shared
-                        # _anthropic_client is never closed from inside a request.
-                        # #70773: same FD-recycle corruption vector for OpenAI.
-                        # The shared client will be replaced lazily by
-                        # _ensure_primary_openai_client on the next attempt.
-                        continue
-
-                    # SSE error events from proxies (e.g. OpenRouter sends
-                    # {"error":{"message":"Network connection lost."}}) are
-                    # raised as APIError by the OpenAI SDK.  These are
-                    # semantically identical to httpx connection drops —
-                    # the upstream stream died — and should be retried with
-                    # a fresh connection.  Distinguish from HTTP errors:
-                    # APIError from SSE has no status_code, while
-                    # APIStatusError (4xx/5xx) always has one.
+                    # SSE error events from proxies are transport failures
+                    # even though the SDK raises APIError.
                     _is_sse_conn_err = False
                     if not _is_timeout and not _is_conn_err:
                         from openai import APIError as _APIError
@@ -3821,14 +3876,60 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                                 phrase in _err_lower_sse
                                 for phrase in _SSE_CONN_PHRASES
                             )
+                    _classified_reason = None
+                    try:
+                        from agent.error_classifier import classify_api_error
+                        _partial_classified = classify_api_error(
+                            e,
+                            provider=str(getattr(agent, "provider", "") or ""),
+                            model=str(getattr(agent, "model", "") or ""),
+                        )
+                        _classified_reason = _partial_classified.reason
+                    except Exception:
+                        pass
 
-                    if (
+                    _is_content_filter_error = (
+                        _classified_reason == FailoverReason.content_policy_blocked
+                    )
+                    _is_transport_error = not _is_content_filter_error and (
                         _is_timeout
                         or _is_conn_err
+                        or isinstance(e, _httpx.TransportError)
+                        or _classified_reason == FailoverReason.timeout
                         or _is_sse_conn_err
                         or _is_stream_parse_err
-                        or _is_empty_stream
+                    )
+                    result["partial_error_is_transport"] = _is_transport_error
+                    result["partial_error_is_content_filter"] = (
+                        _is_content_filter_error
+                    )
+
+                    # A terminal tool-call frame followed by a transport
+                    # close is a completed response, not a retry opportunity.
+                    # Never accept this shape for arbitrary exceptions.
+                    _terminal_response = result.get("terminal_response_candidate")
+                    if _terminal_response is not None and _is_transport_error:
+                        result["response"] = _terminal_response
+                        result["response_tail_transport_error"] = True
+                        return
+
+                    # Once any text, reasoning, or tool delta was delivered,
+                    # the logical request is no longer replayable.  Retrying
+                    # duplicates visible output and can duplicate a
+                    # side-effectful tool call.  Preserve the accumulator and
+                    # return a diagnostic partial instead.
+                    if (
+                        _is_transport_error
+                        and deltas_were_sent["yes"]
                     ):
+                        logger.warning(
+                            "Streaming failed after partial delivery; not retrying: %s",
+                            e,
+                        )
+                        result["error"] = e
+                        return
+
+                    if _is_transport_error or _is_empty_stream:
                         # Transient network / timeout error. Retry the
                         # streaming request with a fresh connection first.
                         if _stream_attempt < _max_stream_retries:
@@ -3956,7 +4057,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # fresh pool (see _REQUEST_CLIENT_REUSE_REASONS).
             _close_request_client_once(
                 "stream_request_complete"
-                if result["response"] is not None
+                if (
+                    result["response"] is not None
+                    and not result["response_tail_transport_error"]
+                )
                 else "stream_error_cleanup"
             )
 
@@ -4148,14 +4252,25 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     if agent._interrupt_requested:
         raise InterruptedError("Agent interrupted during streaming API call (post-worker)")
     if result["error"] is not None:
-        if deltas_were_sent["yes"]:
+        if (
+            deltas_were_sent["yes"]
+            and (
+                result.get("partial_error_is_transport")
+                or result.get("partial_error_is_content_filter")
+            )
+        ):
             # Streaming failed AFTER some tokens were already delivered to
             # the platform.  Re-raising would let the outer retry loop make
             # Return a partial response stub with finish_reason="length"
             # so the conversation loop's continuation machinery fires.
             # tool_calls=None prevents auto-execution of incomplete calls.
             _partial_text = (
-                getattr(agent, "_current_streamed_assistant_text", "") or ""
+                result.get("partial_content")
+                or getattr(agent, "_current_streamed_assistant_text", "")
+                or ""
+            ).strip() or None
+            _partial_reasoning = (
+                result.get("partial_reasoning") or ""
             ).strip() or None
 
             # Append a user-visible warning if tool calls were dropped so
@@ -4185,27 +4300,18 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             else:
                 logger.warning(
                     "Partial stream delivered before error; returning "
-                    "length-truncated stub with %s chars of recovered "
-                    "content so the loop can continue from where the "
-                    "stream died: %s",
+                    "partial stub with %s chars of recovered content after "
+                    "the stream died: %s",
                     len(_partial_text or ""),
                     result["error"],
                 )
                 _stub_finish_reason = FINISH_REASON_LENGTH
-            # NOTE (empty-content class fix): the stub is deliberately allowed
-            # to carry empty content here.  The conversation loop's truncation
-            # path detects an EMPTY partial-stream stub (PARTIAL_STREAM_STUB_ID
-            # + no content) and skips appending it to history entirely — only
-            # the continuation nudge is sent.  Substituting placeholder text at
-            # this site was tried and reverted: it defeats that guard (the stub
-            # no longer looks empty), gets appended to history, and the
-            # placeholder leaks into the stitched final response via
-            # truncated_response_parts.  Transcripts that already carry a
-            # persisted empty turn are healed at the send boundary by
-            # ``repair_empty_non_final_messages`` (the single owner).
+            # Preserve the captured content as the only response; the
+            # conversation loop sees ``_stream_no_retry`` and will not replay
+            # this logical request.
             _stub_msg = SimpleNamespace(
                 role="assistant", content=_partial_text, tool_calls=None,
-                reasoning_content=None,
+                reasoning_content=_partial_reasoning,
             )
             # Detect provider output-layer content filtering (e.g. MiniMax
             # "output new_sensitive (1027)", Azure/OpenAI content_filter,
@@ -4219,7 +4325,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # as a content filter" (#32421).
             _content_filter_terminated = False
             try:
-                from agent.error_classifier import classify_api_error, FailoverReason
+                from agent.error_classifier import classify_api_error
                 _cls = classify_api_error(
                     result["error"],
                     provider=str(getattr(agent, "provider", "") or ""),
@@ -4238,6 +4344,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 )],
                 usage=None,
                 _dropped_tool_names=_partial_names or None,
+                _stream_no_retry=bool(result.get("partial_error_is_transport")),
+                _uncertain_tool_call=bool(_partial_names),
             )
             if _content_filter_terminated:
                 _stub._content_filter_terminated = True

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2380,13 +2380,14 @@ def run_conversation(
                                     response_invalid = True
                                     error_details.append("response.output is empty")
                 elif agent.api_mode == "anthropic_messages":
-                    _tv = agent._get_transport()
-                    if not _tv.validate_response(response):
-                        response_invalid = True
-                        if response is None:
-                            error_details.append("response is None")
-                        else:
-                            error_details.append("response.content invalid (not a non-empty list)")
+                    if getattr(response, "id", "") != PARTIAL_STREAM_STUB_ID:
+                        _tv = agent._get_transport()
+                        if not _tv.validate_response(response):
+                            response_invalid = True
+                            if response is None:
+                                error_details.append("response is None")
+                            else:
+                                error_details.append("response.content invalid (not a non-empty list)")
                 elif agent.api_mode == "bedrock_converse":
                     _btv = agent._get_transport()
                     if not _btv.validate_response(response):
@@ -2611,8 +2612,11 @@ def run_conversation(
                     else:
                         finish_reason = "stop"
                 elif agent.api_mode == "anthropic_messages":
-                    _tfr = agent._get_transport()
-                    finish_reason = _tfr.map_finish_reason(response.stop_reason)
+                    if getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID:
+                        finish_reason = response.choices[0].finish_reason
+                    else:
+                        _tfr = agent._get_transport()
+                        finish_reason = _tfr.map_finish_reason(response.stop_reason)
                 elif agent.api_mode == "bedrock_converse":
                     # Bedrock response already normalized at dispatch — use transport
                     _bt_fr = agent._get_transport()
@@ -2736,6 +2740,54 @@ def run_conversation(
                         error_detail=_refusal_text or "model declined (content_filter)",
                     )
 
+                # A stream that delivered content/reasoning or a tool delta
+                # and then lost its terminal frame is not replayable.  The
+                # wrapper marks this response explicitly so the conversation
+                # loop does not turn a preserved partial into a second
+                # provider request (or execute an uncertain tool call).
+                if getattr(response, "_stream_no_retry", False):
+                    _partial_msg = response.choices[0].message
+                    _partial_content = getattr(_partial_msg, "content", None) or ""
+                    _partial_reasoning = (
+                        getattr(_partial_msg, "reasoning_content", None)
+                        or getattr(_partial_msg, "reasoning", None)
+                        or ""
+                    )
+                    if _partial_content or _partial_reasoning:
+                        messages.append(
+                            agent._build_assistant_message(
+                                _partial_msg, finish_reason
+                            )
+                        )
+                    _partial_final = agent._strip_think_blocks(
+                        "".join([
+                            *truncated_response_parts,
+                            _partial_content,
+                        ])
+                    ).strip()
+                    if not _partial_final:
+                        _partial_final = (
+                            "The provider stream ended before completion; "
+                            "no tool was executed."
+                        )
+                    from agent import relay_llm
+
+                    relay_llm.complete_logical_call(
+                        api_request_id,
+                        outcome="failed",
+                    )
+                    agent._cleanup_task_resources(effective_task_id)
+                    agent._persist_session(messages, conversation_history)
+                    return {
+                        "final_response": _partial_final,
+                        "messages": messages,
+                        "api_calls": api_call_count,
+                        "completed": False,
+                        "partial": True,
+                        "failed": False,
+                        "error": "network_stream_interrupted_after_partial_response",
+                    }
+
                 if finish_reason == "length":
                     if getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID:
                         agent._vprint(
@@ -2759,7 +2811,9 @@ def run_conversation(
                     # would have been appended in the non-truncated path.
                     _trunc_msg = None
                     _trunc_transport = agent._get_transport()
-                    if agent.api_mode == "anthropic_messages":
+                    if getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID:
+                        _trunc_result = response.choices[0].message
+                    elif agent.api_mode == "anthropic_messages":
                         _trunc_result = _trunc_transport.normalize_response(
                             response, strip_tool_prefix=agent._is_anthropic_oauth
                         )

--- a/tests/run_agent/test_70773_shared_client_fd_corruption.py
+++ b/tests/run_agent/test_70773_shared_client_fd_corruption.py
@@ -23,6 +23,8 @@ Fix (mirrors the #67142 Anthropic ownership discipline):
    FD release is deferred to GC so it cannot happen under a borrowing
    thread's live SSL BIO.
 """
+import socket
+import struct
 import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -155,11 +157,11 @@ class TestStaleWatchdogNeverClosesSharedClient:
     @patch("run_agent.AIAgent._replace_primary_openai_client")
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
-    def test_mid_tool_retry_cleanup_does_not_replace_primary(
+    def test_mid_tool_partial_cleanup_does_not_replace_primary(
         self, mock_close, mock_create, mock_replace, monkeypatch,
     ):
-        """Connection drop mid tool-call → silent retry closes only the
-        request-local client; the shared primary is left alone."""
+        """Connection drop mid tool-call preserves a partial and closes only
+        the request-local client; the shared primary is left alone."""
         from tests.run_agent.test_streaming import _make_tool_call_delta
 
         monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
@@ -193,8 +195,10 @@ class TestStaleWatchdogNeverClosesSharedClient:
         agent = _make_agent()
         response = agent._interruptible_streaming_api_call({})
 
-        assert attempts["n"] == 2
-        assert response.choices[0].message.tool_calls
+        assert attempts["n"] == 1
+        assert response.choices[0].message.tool_calls is None
+        assert getattr(response, "_stream_no_retry", False) is True
+        assert "Stream stalled" in (response.choices[0].message.content or "")
         mock_replace.assert_not_called()
 
 
@@ -241,3 +245,115 @@ class TestReplacePrimaryRetiresInsteadOfClosing:
         agent = _make_agent()
         # Must not raise.
         agent._retire_shared_openai_client(None, reason="unit_test")
+
+
+class TestRealSocketTerminationSignals:
+    """Drive real incomplete chunked reads through the wrapper."""
+
+    @pytest.mark.parametrize("termination", ["fin", "rst"])
+    def test_partial_sse_fin_or_rst_does_not_retry(
+        self, termination, monkeypatch,
+    ):
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            listener.bind(("127.0.0.1", 0))
+        except PermissionError:
+            listener.close()
+            pytest.skip("sandbox forbids loopback bind for the RST probe")
+        listener.listen(1)
+        listener.settimeout(0.2)
+        port = listener.getsockname()[1]
+        attempts = []
+        server_errors = []
+        stop = threading.Event()
+        delta_seen = threading.Event()
+
+        payload = (
+            b'data: {"id":"chatcmpl-real","object":"chat.completion.chunk",'
+            b'"created":1,"model":"test/model","choices":[{"index":0,'
+            b'"delta":{"role":"assistant","content":"partial over socket"},'
+            b'"finish_reason":null}]}\n\n'
+        )
+        response = (
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Type: text/event-stream\r\n"
+            b"Transfer-Encoding: chunked\r\n"
+            b"Connection: close\r\n\r\n"
+            + f"{len(payload):X}\r\n".encode()
+            + payload
+            + b"\r\n"
+        )
+
+        def _serve():
+            while not stop.is_set():
+                try:
+                    peer, _ = listener.accept()
+                except socket.timeout:
+                    continue
+                except OSError:
+                    return
+                attempts.append(1)
+                try:
+                    peer.settimeout(2)
+                    request = b""
+                    while b"\r\n\r\n" not in request:
+                        request += peer.recv(4096)
+                    headers, body = request.split(b"\r\n\r\n", 1)
+                    content_length = 0
+                    for line in headers.split(b"\r\n")[1:]:
+                        name, _, value = line.partition(b":")
+                        if name.lower() == b"content-length":
+                            content_length = int(value.strip())
+                            break
+                    while len(body) < content_length:
+                        body += peer.recv(4096)
+                    peer.sendall(response)
+                    delta_seen.wait(timeout=2)
+                    if termination == "rst":
+                        peer.setsockopt(
+                            socket.SOL_SOCKET,
+                            socket.SO_LINGER,
+                            struct.pack("ii", 1, 0),
+                        )
+                    else:
+                        peer.shutdown(socket.SHUT_WR)
+                except Exception as exc:  # pragma: no cover - diagnostic only
+                    server_errors.append(exc)
+                finally:
+                    peer.close()
+
+        server = threading.Thread(target=_serve, daemon=True)
+        server.start()
+
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+        monkeypatch.setenv("NO_PROXY", "127.0.0.1")
+        monkeypatch.setenv("no_proxy", "127.0.0.1")
+        from openai import OpenAI
+
+        client = OpenAI(
+            api_key="test-key",
+            base_url=f"http://127.0.0.1:{port}/v1",
+            max_retries=0,
+        )
+        agent = _make_agent()
+        agent._create_request_openai_client = lambda **_kwargs: client
+        agent._close_request_openai_client = (
+            lambda request_client, **_kwargs: request_client.close()
+        )
+        agent.stream_delta_callback = lambda _text: delta_seen.set()
+
+        try:
+            wrapper_response = agent._interruptible_streaming_api_call({
+                "model": "test/model",
+                "messages": [{"role": "user", "content": "test"}],
+            })
+        finally:
+            stop.set()
+            listener.close()
+            server.join(timeout=2)
+
+        assert server_errors == []
+        assert len(attempts) == 1
+        assert wrapper_response.choices[0].message.content == "partial over socket"
+        assert wrapper_response.choices[0].message.tool_calls is None
+        assert getattr(wrapper_response, "_stream_no_retry", False) is True

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
@@ -69,7 +70,7 @@ class TestPartialStreamStubFinishReason:
 
         def _stalling_stream():
             yield _make_stream_chunk(content="Here's my answer so far")
-            raise RuntimeError("simulated upstream stall")
+            raise httpx.RemoteProtocolError("simulated upstream stall")
 
         mock_client = MagicMock()
         mock_client.chat.completions.create.side_effect = lambda *a, **kw: _stalling_stream()
@@ -106,7 +107,7 @@ class TestPartialStreamStubFinishReason:
             yield _make_stream_chunk(tool_calls=[
                 _make_tool_call_delta(index=0, arguments='{"path": "/tmp/x", '),
             ])
-            raise RuntimeError("simulated upstream stall")
+            raise httpx.RemoteProtocolError("simulated upstream stall")
 
         mock_client = MagicMock()
         mock_client.chat.completions.create.side_effect = lambda *a, **kw: _stalling_stream()
@@ -264,6 +265,7 @@ class TestCleanStreamEndMidToolCall:
         assert response.choices[0].finish_reason == FINISH_REASON_LENGTH
         assert response.choices[0].message.content == "Let me compare the vision configs:"
         assert response.choices[0].message.tool_calls is None
+        assert getattr(response, "_stream_no_retry", False) is True
         assert getattr(response, "_dropped_tool_names", None) is None, (
             "Text-only drops must not carry dropped tool names — there "
             "were no tool calls in flight."
@@ -402,6 +404,219 @@ class TestConversationLoopPartialStreamContinuation:
         assert "first half of" in result["final_response"]
         assert "forty-two" in result["final_response"]
 
+    def test_transport_partial_runs_wrapper_to_loop_once(
+        self, loop_agent, monkeypatch,
+    ):
+        """A real ReadError preserves the accumulator without a continuation."""
+        attempts = {"count": 0}
+
+        def _stream():
+            yield _make_stream_chunk(content="Recovered before disconnect")
+            raise httpx.ReadError("incomplete chunked read")
+
+        request_client = MagicMock()
+
+        def _create(*_args, **_kwargs):
+            attempts["count"] += 1
+            return _stream()
+
+        request_client.chat.completions.create.side_effect = _create
+        loop_agent.stream_delta_callback = lambda _text: None
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+
+        with (
+            patch.object(
+                loop_agent,
+                "_create_request_openai_client",
+                return_value=request_client,
+            ),
+            patch.object(loop_agent, "_close_request_openai_client"),
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+            patch("agent.relay_llm.complete_logical_call") as complete_logical,
+        ):
+            result = loop_agent.run_conversation("keep the partial")
+
+        assert attempts["count"] == 1
+        assert result["final_response"] == "Recovered before disconnect"
+        assert result["partial"] is True
+        assert result["failed"] is False
+        assert result["messages"][-1]["finish_reason"] == FINISH_REASON_LENGTH
+        assert result["messages"][-1]["content"] == "Recovered before disconnect"
+        complete_logical.assert_called_once()
+        assert complete_logical.call_args.kwargs == {"outcome": "failed"}
+
+    def test_anthropic_transport_partial_runs_to_loop_once(self, monkeypatch):
+        """The OpenAI-shaped recovery stub bypasses native validation."""
+        from run_agent import AIAgent
+
+        attempts = {"count": 0}
+
+        class _BrokenStream:
+            response = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def __iter__(self):
+                yield SimpleNamespace(
+                    type="content_block_delta",
+                    delta=SimpleNamespace(
+                        type="text_delta",
+                        text="anthropic partial",
+                    ),
+                )
+                raise httpx.ReadError("incomplete chunked read")
+
+        request_client = MagicMock()
+
+        def _make_stream(**_kwargs):
+            attempts["count"] += 1
+            return _BrokenStream()
+
+        request_client.messages.stream.side_effect = _make_stream
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://api.anthropic.com",
+                provider="anthropic",
+                model="claude-test",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        agent.api_mode = "anthropic_messages"
+        agent._interrupt_requested = False
+        agent.stream_delta_callback = lambda _text: None
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+
+        with (
+            patch.object(
+                agent,
+                "_create_request_anthropic_client",
+                return_value=request_client,
+            ),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("keep the partial")
+
+        assert attempts["count"] == 1
+        assert result["partial"] is True
+        assert result["final_response"] == "anthropic partial"
+        assert result["messages"][-1]["finish_reason"] == FINISH_REASON_LENGTH
+        assert "tool_calls" not in result["messages"][-1]
+
+    def test_anthropic_clean_eof_tool_is_not_executed(self, monkeypatch):
+        """A complete-looking tool without stop_reason remains uncertain."""
+        from run_agent import AIAgent
+
+        attempts = {"count": 0}
+
+        class _CleanToolEOF:
+            response = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def __iter__(self):
+                yield SimpleNamespace(
+                    type="content_block_start",
+                    content_block=SimpleNamespace(
+                        type="tool_use",
+                        name="terminal",
+                    ),
+                )
+                yield SimpleNamespace(
+                    type="content_block_delta",
+                    delta=SimpleNamespace(
+                        type="input_json_delta",
+                        partial_json='{"command":"ls"}',
+                    ),
+                )
+
+            def get_final_message(self):
+                return SimpleNamespace(
+                    content=[
+                        SimpleNamespace(
+                            type="tool_use",
+                            id="tool_1",
+                            name="terminal",
+                            input={"command": "ls"},
+                        ),
+                    ],
+                    stop_reason=None,
+                )
+
+        request_client = MagicMock()
+
+        def _make_stream(**_kwargs):
+            attempts["count"] += 1
+            return _CleanToolEOF()
+
+        request_client.messages.stream.side_effect = _make_stream
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://api.anthropic.com",
+                provider="anthropic",
+                model="claude-test",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        agent.api_mode = "anthropic_messages"
+        agent._interrupt_requested = False
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+
+        with (
+            patch.object(
+                agent,
+                "_create_request_anthropic_client",
+                return_value=request_client,
+            ),
+            patch.object(agent, "_execute_tool_calls") as execute_tools,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("do not replay this tool")
+
+        assert attempts["count"] == 1
+        assert result["partial"] is True
+        assert "tool_calls" not in result["messages"][-1]
+        execute_tools.assert_not_called()
+
 
 class TestContentFilterStallActivatesFallback:
     """Regression for #32421: a provider output-layer content safety filter
@@ -458,6 +673,7 @@ class TestContentFilterStallActivatesFallback:
             "MiniMax new_sensitive stream stall must tag the stub so the loop "
             "can route to fallback (#32421)."
         )
+        assert getattr(response, "_stream_no_retry", False) is False
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
@@ -470,7 +686,7 @@ class TestContentFilterStallActivatesFallback:
 
         def _network_stall():
             yield _make_stream_chunk(content="Writing the file: ")
-            raise RuntimeError("connection reset by peer")
+            raise httpx.RemoteProtocolError("connection reset by peer")
 
         mock_client = MagicMock()
         mock_client.chat.completions.create.side_effect = (

--- a/tests/run_agent/test_stream_interrupt_retry.py
+++ b/tests/run_agent/test_stream_interrupt_retry.py
@@ -180,7 +180,8 @@ class TestStreamInterruptBeforeRetry:
 
         This reproduces the race where the outer stale detector aborts an SSE
         connection, but the old iterator still yields one more chunk before
-        surfacing the connection error that triggers the retry.
+        surfacing the connection error.  Once a delta was delivered the
+        wrapper must preserve that partial and never replay the request.
         """
         import httpx
         import time
@@ -237,6 +238,8 @@ class TestStreamInterruptBeforeRetry:
 
         delivered = "".join(deltas)
         assert "old late" not in delivered
-        assert "new final" in delivered
-        assert response.choices[0].message.content == "new final"
+        assert "new final" not in delivered
+        assert "old start" in (response.choices[0].message.content or "")
+        assert response.choices[0].message.tool_calls is None
+        assert getattr(response, "_stream_no_retry", False) is True
         assert mock_abort.called

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -7,6 +7,7 @@ import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 
@@ -1313,6 +1314,69 @@ class TestAnthropicStreamCallbacks:
         assert touch_calls.count("receiving stream response") == len(events)
         mock_stream.close.assert_called_once()
 
+    def test_anthropic_tool_input_read_error_does_not_retry(self, monkeypatch):
+        """A tool-input delta is observable even when no text was emitted."""
+        from hermes_constants import PARTIAL_STREAM_STUB_ID
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://api.anthropic.com",
+            provider="anthropic",
+            model="claude-test",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "anthropic_messages"
+        agent._interrupt_requested = False
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+
+        class _PartialStream:
+            response = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def __iter__(self):
+                yield SimpleNamespace(
+                    type="content_block_start",
+                    content_block=SimpleNamespace(
+                        type="tool_use",
+                        name="terminal",
+                    ),
+                )
+                yield SimpleNamespace(
+                    type="content_block_delta",
+                    delta=SimpleNamespace(
+                        type="input_json_delta",
+                        partial_json='{"cmd":',
+                    ),
+                )
+                yield SimpleNamespace(
+                    type="content_block_delta",
+                    delta=SimpleNamespace(
+                        type="text_delta",
+                        text="after-tool",
+                    ),
+                )
+                raise httpx.ReadError("incomplete chunked read")
+
+        client = MagicMock()
+        client.messages.stream.return_value = _PartialStream()
+        agent._create_request_anthropic_client = lambda *a, **k: client
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert client.messages.stream.call_count == 1
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert "after-tool" in response.choices[0].message.content
+        assert response.choices[0].message.tool_calls is None
+        assert getattr(response, "_stream_no_retry", False) is True
+
     @patch("run_agent.AIAgent._rebuild_anthropic_client")
     @patch("run_agent.AIAgent._replace_primary_openai_client")
     def test_anthropic_stream_parser_valueerror_retries_before_delivery(
@@ -1531,7 +1595,7 @@ class TestPartialToolCallWarning:
             yield _make_stream_chunk(tool_calls=[
                 _make_tool_call_delta(index=0, arguments='{"path": "/tmp/x", '),
             ])
-            raise _StallError("simulated upstream stall")
+            raise httpx.RemoteProtocolError("simulated upstream stall")
 
         mock_client = MagicMock()
         mock_client.chat.completions.create.side_effect = lambda *a, **kw: _stalling_stream()
@@ -1592,7 +1656,7 @@ class TestPartialToolCallWarning:
 
         def _stalling_stream():
             yield _make_stream_chunk(content="Here's my answer so far")
-            raise _StallError("simulated upstream stall")
+            raise httpx.RemoteProtocolError("simulated upstream stall")
 
         mock_client = MagicMock()
         mock_client.chat.completions.create.side_effect = lambda *a, **kw: _stalling_stream()
@@ -1631,21 +1695,14 @@ class TestPartialToolCallWarning:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
-    def test_empty_partial_stream_stub_stays_empty_for_loop_guard(
+    def test_partial_stream_stub_preserves_accumulator_for_loop_guard(
         self, mock_close, mock_create,
     ):
-        """Stream dies with 0 recovered chars and no tool call → the stub
-        keeps its empty content ON PURPOSE.
+        """A transport partial keeps the accumulator and is not replayed.
 
-        The conversation loop's truncation path detects an EMPTY
-        partial-stream stub (PARTIAL_STREAM_STUB_ID + no content) and skips
-        appending it to history entirely — only the continuation nudge is
-        sent (the #68041 class fix).  An earlier iteration substituted
-        '[response interrupted]' placeholder text HERE, which defeated that
-        guard: the stub no longer looked empty, entered history, and the
-        placeholder leaked into the stitched final response.  Transcripts
-        that already carry a persisted empty turn are healed at the send
-        boundary by repair_empty_non_final_messages instead.
+        The old wrapper selected the mutable display buffer, which could be
+        empty when a callback was replaced by a test/client.  The stream
+        accumulator is the source of truth for the diagnostic partial.
         """
         from run_agent import AIAgent
         from hermes_constants import PARTIAL_STREAM_STUB_ID
@@ -1655,7 +1712,7 @@ class TestPartialToolCallWarning:
 
         def _stalling_stream():
             yield _make_stream_chunk(content="partial token")
-            raise _StallError("simulated upstream stall after a delta")
+            raise httpx.RemoteProtocolError("simulated upstream stall after a delta")
 
         mock_client = MagicMock()
         mock_client.chat.completions.create.side_effect = (
@@ -1674,8 +1731,8 @@ class TestPartialToolCallWarning:
         agent.api_mode = "chat_completions"
         agent._interrupt_requested = False
         agent._fire_stream_delta = lambda text: None
-        # Empty recovered text — the exact "0 chars recovered, no tool call"
-        # production condition.
+        # Deliberately leave the display buffer empty: the wrapper must use
+        # its own accumulator instead of silently dropping the token.
         agent._current_streamed_assistant_text = ""
 
         import os as _os
@@ -1689,26 +1746,22 @@ class TestPartialToolCallWarning:
             else:
                 _os.environ["HERMES_STREAM_RETRIES"] = _prev
 
-        # The stub must be RECOGNIZABLY empty so the loop guard can skip it.
+        # The stub must preserve the delivered token and opt out of replay.
         assert getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
         content = response.choices[0].message.content
-        assert not content, (
-            f"Empty-partial-stream stub must keep empty content so the "
-            f"conversation loop's empty-stub guard can detect and skip it — "
-            f"substituted text defeats the guard and leaks into the final "
-            f"response. Got content={content!r}"
+        assert content == "partial token", (
+            f"Transport partial must preserve accumulator content. "
+            f"Got content={content!r}"
         )
         assert response.choices[0].message.tool_calls is None
+        assert getattr(response, "_stream_no_retry", False) is True
 
 
 class TestSilentRetryMidToolCall:
     """Regression: when the stream dies mid tool-call JSON after text was
-    already delivered, we previously stubbed the turn with a "retry manually"
-    warning.  Now: if the error is a transient connection error AND a tool
-    call was in flight, silently retry the stream (the user sees a brief
-    reconnect marker + duplicated preamble, which is strictly better than
-    a lost action).  If no tool call was in flight, or the error isn't
-    transient, the existing stub-with-warning behaviour is preserved.
+    already delivered, replaying the request can duplicate paid output or a
+    side effect.  Preserve one diagnostic partial and never execute the
+    uncertain tool call.
     """
 
     @patch("run_agent.AIAgent._replace_primary_openai_client")
@@ -1717,9 +1770,7 @@ class TestSilentRetryMidToolCall:
     def test_silent_retry_recovers_tool_call(
         self, mock_close, mock_create, mock_replace,
     ):
-        """First attempt: text + partial tool-call + connection drop.
-        Second attempt: text + complete tool-call.  Response should contain
-        the recovered tool call; no warning stub should be returned."""
+        """A partial tool-call is diagnostic, never silently replayed."""
         from run_agent import AIAgent
         import httpx as _httpx
 
@@ -1780,31 +1831,16 @@ class TestSilentRetryMidToolCall:
             else:
                 _os.environ["HERMES_STREAM_RETRIES"] = _prev
 
-        assert attempts["n"] == 2, (
-            f"Expected silent retry (2 attempts), got {attempts['n']}"
+        assert attempts["n"] == 1, (
+            f"Partial tool-call must not replay (got {attempts['n']} attempts)"
         )
-        # Response should carry the recovered tool call, not a warning stub.
+        # Response must refuse tool execution and explain the dropped call.
         msg = response.choices[0].message
         tool_calls = getattr(msg, "tool_calls", None)
-        assert tool_calls, (
-            f"Silent retry should recover the tool call, got tool_calls={tool_calls!r} "
-            f"content={getattr(msg, 'content', None)!r}"
-        )
-        _tc0 = tool_calls[0]
-        _name = (
-            _tc0["function"]["name"] if isinstance(_tc0, dict)
-            else _tc0.function.name
-        )
-        assert _name == "write_file"
-        # User saw a reconnect marker between attempts.
-        assert any("reconnecting" in d.lower() for d in fired_deltas), (
-            f"Expected a reconnect marker delta, fired_deltas={fired_deltas}"
-        )
-        # Stub-path warning must NOT appear (this was the whole point).
+        assert tool_calls is None
         joined = "".join(fired_deltas)
-        assert "Stream stalled" not in joined, (
-            f"Stub-path warning leaked into silent-retry path: {joined!r}"
-        )
+        assert "Stream stalled" in joined
+        assert getattr(response, "_stream_no_retry", False) is True
 
     @patch("run_agent.AIAgent._replace_primary_openai_client")
     @patch("run_agent.AIAgent._create_request_openai_client")
@@ -2366,3 +2402,328 @@ class TestBedrockReasoningStaleFloor:
         from agent.chat_completion_helpers import _bedrock_reasoning_stale_floor
 
         assert _bedrock_reasoning_stale_floor(model_id) is None
+
+
+class TestWrapperPartialStreamContract:
+    """The six-case wrapper contract is pinned at the stream boundary."""
+
+    @staticmethod
+    def _agent():
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://example.com/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+        return agent
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_completed_tool_tail_error_is_accepted_once(
+        self, mock_close, mock_create, monkeypatch,
+    ):
+        """finish_reason=tool_calls makes a noisy transport tail safe."""
+        attempts = {"n": 0}
+
+        def _stream():
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_1", name="terminal"),
+            ])
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, arguments='{"command":"ls"}'),
+            ])
+            yield _make_stream_chunk(finish_reason="tool_calls")
+            raise httpx.RemoteProtocolError("tail reset after terminal frame")
+
+        def _create(*args, **kwargs):
+            attempts["n"] += 1
+            return _stream()
+
+        client = MagicMock()
+        client.chat.completions.create.side_effect = _create
+        mock_create.return_value = client
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+
+        response = self._agent()._interruptible_streaming_api_call({})
+
+        assert attempts["n"] == 1
+        assert response.choices[0].finish_reason == "tool_calls"
+        assert response.choices[0].message.tool_calls
+        assert response.choices[0].message.tool_calls[0].function.arguments == '{"command":"ls"}'
+        assert mock_close.call_args.kwargs["reason"] == "stream_error_cleanup"
+
+    @pytest.mark.parametrize(
+        ("finish_reason", "content"),
+        [
+            ("stop", "done"),
+            ("length", "truncated"),
+            ("content_filter", None),
+        ],
+    )
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_terminal_non_tool_tail_error_is_accepted_once(
+        self,
+        _mock_close,
+        mock_create,
+        monkeypatch,
+        finish_reason,
+        content,
+    ):
+        """Any provider terminal frame is authoritative despite a noisy tail."""
+        attempts = {"n": 0}
+
+        def _stream():
+            yield _make_stream_chunk(
+                content=content,
+                finish_reason=finish_reason,
+            )
+            raise httpx.RemoteProtocolError("tail reset after terminal frame")
+
+        def _create(*_args, **_kwargs):
+            attempts["n"] += 1
+            return _stream()
+
+        client = MagicMock()
+        client.chat.completions.create.side_effect = _create
+        mock_create.return_value = client
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+
+        response = self._agent()._interruptible_streaming_api_call({})
+
+        assert attempts["n"] == 1
+        assert response.choices[0].finish_reason == finish_reason
+        assert response.choices[0].message.content == content
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_complete_tool_without_finish_reason_is_uncertain(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        """Complete-looking tool JSON without a terminal reason is not run."""
+        attempts = {"n": 0}
+
+        def _create(*args, **kwargs):
+            attempts["n"] += 1
+            return iter([
+                _make_stream_chunk(tool_calls=[
+                    _make_tool_call_delta(index=0, tc_id="call_1", name="terminal"),
+                ]),
+                _make_stream_chunk(tool_calls=[
+                    _make_tool_call_delta(index=0, arguments='{"command":"ls"}'),
+                ]),
+            ])
+
+        client = MagicMock()
+        client.chat.completions.create.side_effect = _create
+        mock_create.return_value = client
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+
+        response = self._agent()._interruptible_streaming_api_call({})
+
+        assert attempts["n"] == 1
+        assert response.choices[0].message.tool_calls is None
+        assert getattr(response, "_uncertain_tool_call", False) is True
+        assert getattr(response, "_stream_no_retry", False) is True
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_reasoning_partial_transport_is_preserved_without_retry(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        """Reasoning-only progress is still a non-replayable partial."""
+        attempts = {"n": 0}
+
+        def _stream():
+            yield _make_stream_chunk(reasoning_content="thinking so far")
+            raise httpx.RemoteProtocolError("peer closed")
+
+        def _create(*args, **kwargs):
+            attempts["n"] += 1
+            return _stream()
+
+        client = MagicMock()
+        client.chat.completions.create.side_effect = _create
+        mock_create.return_value = client
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+
+        response = self._agent()._interruptible_streaming_api_call({})
+
+        assert attempts["n"] == 1
+        assert response.choices[0].message.reasoning_content == "thinking so far"
+        assert getattr(response, "_stream_no_retry", False) is True
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_sdk_connection_error_after_partial_is_not_retried(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        """The OpenAI SDK's transport wrapper is non-replayable after output."""
+        from openai import APIConnectionError
+
+        attempts = {"n": 0}
+        error = APIConnectionError(
+            request=httpx.Request(
+                "POST",
+                "https://example.com/v1/chat/completions",
+            ),
+        )
+
+        def _stream():
+            yield _make_stream_chunk(content="already delivered")
+            raise error
+
+        def _create(*_args, **_kwargs):
+            attempts["n"] += 1
+            return _stream()
+
+        client = MagicMock()
+        client.chat.completions.create.side_effect = _create
+        mock_create.return_value = client
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+
+        response = self._agent()._interruptible_streaming_api_call({})
+
+        assert attempts["n"] == 1
+        assert response.choices[0].message.content == "already delivered"
+        assert getattr(response, "_stream_no_retry", False) is True
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_terminal_tool_non_transport_error_propagates(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        """A non-transport tail error must not be silently accepted."""
+
+        def _stream():
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_1", name="terminal"),
+            ])
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, arguments='{"command":"ls"}'),
+            ])
+            yield _make_stream_chunk(finish_reason="tool_calls")
+            raise ValueError("provider parser bug")
+
+        client = MagicMock()
+        client.chat.completions.create.side_effect = lambda *a, **k: _stream()
+        mock_create.return_value = client
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+
+        with pytest.raises(ValueError, match="parser bug"):
+            self._agent()._interruptible_streaming_api_call({})
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_content_filter_wins_over_transport_phrasing(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        """A filter error cannot promote a terminal tool candidate."""
+        from openai import APIError
+
+        error = APIError(
+            message="connection terminated: output new_sensitive (1027)",
+            request=httpx.Request(
+                "POST",
+                "https://example.com/v1/chat/completions",
+            ),
+            body={"message": "output new_sensitive (1027)"},
+        )
+        attempts = {"n": 0}
+
+        def _stream():
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(
+                    index=0,
+                    tc_id="call_1",
+                    name="terminal",
+                ),
+            ])
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(
+                    index=0,
+                    arguments='{"command":"ls"}',
+                ),
+            ])
+            yield _make_stream_chunk(finish_reason="tool_calls")
+            raise error
+
+        def _create(*_args, **_kwargs):
+            attempts["n"] += 1
+            return _stream()
+
+        client = MagicMock()
+        client.chat.completions.create.side_effect = _create
+        mock_create.return_value = client
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+
+        response = self._agent()._interruptible_streaming_api_call({})
+
+        assert attempts["n"] == 1
+        assert response.choices[0].message.tool_calls is None
+        assert getattr(response, "_content_filter_terminated", False) is True
+        assert getattr(response, "_stream_no_retry", False) is False
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_read_error_before_first_delta_retries(
+        self, mock_close, mock_create, monkeypatch,
+    ):
+        """An eventless incomplete read keeps the bounded retry path."""
+        attempts = {"n": 0}
+
+        def _create(*_args, **_kwargs):
+            attempts["n"] += 1
+
+            def _stream():
+                if attempts["n"] == 1:
+                    raise httpx.ReadError("incomplete chunked read")
+                yield _make_stream_chunk(
+                    content="recovered",
+                    finish_reason="stop",
+                )
+
+            return _stream()
+
+        client = MagicMock()
+        client.chat.completions.create.side_effect = _create
+        mock_create.return_value = client
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "1")
+
+        response = self._agent()._interruptible_streaming_api_call({})
+
+        assert attempts["n"] == 2
+        assert response.choices[0].message.content == "recovered"
+        assert getattr(response, "_stream_no_retry", False) is False
+        assert mock_close.call_args.kwargs["reason"] == "stream_request_complete"
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_reasoning_clean_eof_is_partial_without_retry(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        """A clean EOF without finish_reason is not a completed turn."""
+        attempts = {"n": 0}
+
+        def _create(*_args, **_kwargs):
+            attempts["n"] += 1
+            return iter([
+                _make_stream_chunk(reasoning_content="thinking so far"),
+            ])
+
+        client = MagicMock()
+        client.chat.completions.create.side_effect = _create
+        mock_create.return_value = client
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+
+        response = self._agent()._interruptible_streaming_api_call({})
+
+        assert attempts["n"] == 1
+        assert response.choices[0].message.reasoning_content == "thinking so far"
+        assert getattr(response, "_stream_no_retry", False) is True


### PR DESCRIPTION
## Summary

Fix the wrapper-level replay bug where a stream can emit useful output, end with `incomplete chunked read`, lose the accumulated body, and retry the same logical request.

- retry only when zero text/reasoning/tool/input deltas were accepted
- preserve one diagnostic partial after any accepted delta; never replay it
- treat clean EOF after progress as incomplete and non-replayable
- never execute a tool call without an authoritative terminal reason
- accept a completed terminal response once when only the transport tail fails
- keep content-policy classification ahead of transport-looking wording
- preserve cancellation/stale-attempt fences and request-local client ownership
- close deferred Relay logical calls as `failed` when returning a partial
- keep OpenAI and Anthropic behavior aligned

No new dependency is introduced. Scope is exactly two runtime files and four regression-test files.

## Verification

- wrapper + real `nemo-relay==0.6.0` focused suite: **160 passed**
- post-push isolated wrapper regression suite: **112 passed, 2 skipped**
- related run-loop retry/streaming/Relay classes: **35 passed**
- Ruff: pass
- `py_compile`: pass
- `git diff --check`: pass
- earlier candidate/baseline full-suite differential: 2,394 test files per side, exactly 3 Seedance selectors excluded; no changed wrapper test failed; three candidate-only raw failures passed isolated reruns and were classified as flaky/global-state
- post-push exact-SHA full execution: **50,459 nodes scheduled, 128/128 shards completed, 0 timeouts**, with the same 3 Seedance selectors excluded
- the post-push full run reported 2,361 unique failing nodes; failures were dominated by sandbox `PermissionError` plus missing optional wake-word tflite/OpenViking dependencies, so this is execution coverage rather than a green full-suite gate
- changed wrapper tests that appeared in the full run failed only during the same environment/setup paths; the isolated post-push wrapper run is green

## Review status

- independent code review: `CLEAR`
- independent stream/Relay semantic review: `APPROVE`
- Hermes Fable (`claude-fable-5`, `custom:oxo`) single-request review was attempted with wrapper retries disabled, but hit the 600s hard timeout and produced no usage/verdict artifact. It was not retried; this is recorded as an explicit review-channel blocker, not a PASS.
- GitHub Actions is currently `action_required`: fork workflows await upstream maintainer approval and no CI jobs have started

Commit: `f37ffeda8442bb76066d66442cd01238acb62bf9`

Diff SHA-256: `ff3992c2528d52befccef140f470859ca9c3388eb3440d676e5422b71a205e4b`