### PR TITLE
feat(api): expose tool call success/failure counts in chat/completions response

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4415,6 +4415,20 @@ class APIServerAdapter(BasePlatformAdapter):
                     "error": err_msg,
                     "error_code": "output_truncated" if finish_reason == "length" else "agent_error",
                 }
+            # Surface tool-call statistics in the SSE terminal chunk,
+            # matching the non-streaming response's ``hermes.tool_calls``
+            # block (issue #73389).
+            tool_call_stats = (
+                result.get("tool_call_stats") if isinstance(result, dict) else None
+            )
+            if isinstance(tool_call_stats, dict) and tool_call_stats.get("used"):
+                if "hermes" not in finish_chunk:
+                    finish_chunk["hermes"] = {}
+                finish_chunk["hermes"]["tool_calls"] = {
+                    "requests": int(tool_call_stats.get("requests", 0)),
+                    "successful": int(tool_call_stats.get("successful", 0)),
+                    "failed": int(tool_call_stats.get("failed", 0)),
+                }
             await response.write(_sse_frame(finish_chunk))
             await response.write(b"data: [DONE]\n\n")
         except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError, OSError):

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4241,6 +4241,23 @@ class APIServerAdapter(BasePlatformAdapter):
             if err_msg:
                 response_headers["X-Hermes-Error"] = _redact_api_error_text(err_msg, limit=200)
 
+        tool_call_stats = (
+            result.get("tool_call_stats") if isinstance(result, dict) else None
+        )
+        if isinstance(tool_call_stats, dict) and tool_call_stats.get("used"):
+            if "hermes" not in response_data:
+                response_data["hermes"] = {}
+            response_data["hermes"]["tool_calls"] = {
+                "requests": int(tool_call_stats.get("requests", 0)),
+                "successful": int(tool_call_stats.get("successful", 0)),
+                "failed": int(tool_call_stats.get("failed", 0)),
+            }
+            if finish_reason == "stop" and tool_call_stats.get("requests", 0) > 0 and tool_call_stats.get("successful", 0) == 0:
+                response_data["hermes"]["tool_calls"]["warning"] = (
+                    "zero tool calls succeeded during this run; "
+                    "assistant disposition is un-backed by tool evidence"
+                )
+
         return web.json_response(response_data, headers=response_headers)
 
     async def _write_sse_chat_completion(

--- a/run_agent.py
+++ b/run_agent.py
@@ -66,6 +66,63 @@ from types import SimpleNamespace
 from hermes_constants import get_hermes_home
 
 
+def _compute_tool_call_stats(messages: Any) -> Dict[str, Any]:
+    """Count tool-call requests and success/failure results from turn messages.
+
+    Returns a small dict safe to surface in upstream API responses.  The
+    counts are conservative: we treat any ``tool``-role message whose content
+    parses as JSON with ``{"success": false}`` or whose content begins with
+    ``"Error:"`` / ``"Skipped:"`` / ``"Invalid JSON arguments"`` as a failure;
+    everything else is a success (including plain-string tool outputs for
+    primitive tools like ``web_search`` which do not wrap their payloads in
+    ``tool_result()``).
+    """
+    stats: Dict[str, Any] = {
+        "requests": 0,
+        "successful": 0,
+        "failed": 0,
+        "total_results": 0,
+        "used": False,
+    }
+    if not isinstance(messages, list):
+        return stats
+    error_prefixes = ("error:", "skipped:", "invalid json arguments")
+    for m in messages:
+        if not isinstance(m, dict):
+            continue
+        role = m.get("role")
+        if role == "assistant":
+            tcs = m.get("tool_calls") or m.get("tool_call")
+            if isinstance(tcs, list):
+                stats["requests"] += len(tcs)
+            continue
+        if role in {"tool", "function"}:
+            stats["total_results"] += 1
+            content = m.get("content")
+            failed = False
+            if isinstance(content, str):
+                stripped = content.lstrip()
+                lower = stripped.lower()
+                if lower.startswith(error_prefixes):
+                    failed = True
+                else:
+                    head = stripped[:1]
+                    if head in ("{", "["):
+                        try:
+                            parsed = json.loads(stripped)
+                        except Exception:
+                            parsed = None
+                        if isinstance(parsed, dict):
+                            if parsed.get("success") is False or parsed.get("error"):
+                                failed = True
+            if failed:
+                stats["failed"] += 1
+            else:
+                stats["successful"] += 1
+    stats["used"] = stats["requests"] > 0 or stats["total_results"] > 0
+    return stats
+
+
 def _launch_cwd_for_session(source: str) -> Optional[str]:
     """Working directory to stamp on a new session row, or None.
 
@@ -7877,6 +7934,11 @@ class AIAgent:
             if task_started:
                 task_finished = True
                 finish_task_run(**task_context, result=result)
+            if isinstance(result, dict):
+                msgs = result.get("messages")
+                if isinstance(msgs, list):
+                    stats = _compute_tool_call_stats(msgs)
+                    result["tool_call_stats"] = stats
             return result
         except BaseException as exc:
             if isinstance(exc, (KeyboardInterrupt, InterruptedError)) or (

--- a/run_agent.py
+++ b/run_agent.py
@@ -66,16 +66,13 @@ from types import SimpleNamespace
 from hermes_constants import get_hermes_home
 
 
-def _compute_tool_call_stats(messages: Any) -> Dict[str, Any]:
+def _compute_tool_call_stats(messages: Any, start_index: int = 0) -> Dict[str, Any]:
     """Count tool-call requests and success/failure results from turn messages.
 
-    Returns a small dict safe to surface in upstream API responses.  The
-    counts are conservative: we treat any ``tool``-role message whose content
-    parses as JSON with ``{"success": false}`` or whose content begins with
-    ``"Error:"`` / ``"Skipped:"`` / ``"Invalid JSON arguments"`` as a failure;
-    everything else is a success (including plain-string tool outputs for
-    primitive tools like ``web_search`` which do not wrap their payloads in
-    ``tool_result()``).
+    ``start_index`` trims any shared prefix of ``messages`` (typically the
+    prior-turn ``conversation_history`` list) so only the current turn's
+    appended messages are counted.  Passing ``len(conversation_history)``
+    prevents leaking prior-turn tool activity into the current turn's stats.
     """
     stats: Dict[str, Any] = {
         "requests": 0,
@@ -87,7 +84,8 @@ def _compute_tool_call_stats(messages: Any) -> Dict[str, Any]:
     if not isinstance(messages, list):
         return stats
     error_prefixes = ("error:", "skipped:", "invalid json arguments")
-    for m in messages:
+    iterable = messages[start_index:] if start_index > 0 else messages
+    for m in iterable:
         if not isinstance(m, dict):
             continue
         role = m.get("role")
@@ -7937,7 +7935,8 @@ class AIAgent:
             if isinstance(result, dict):
                 msgs = result.get("messages")
                 if isinstance(msgs, list):
-                    stats = _compute_tool_call_stats(msgs)
+                    history_len = len(conversation_history) if isinstance(conversation_history, list) else 0
+                    stats = _compute_tool_call_stats(msgs, start_index=history_len)
                     result["tool_call_stats"] = stats
             return result
         except BaseException as exc:

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -3039,12 +3039,70 @@ class TestChatCompletionsToolCallSignal:
         hermes = json.loads(resp.body)["hermes"]
         assert hermes["partial"] is True
         assert hermes["completed"] is False
-        assert hermes["tool_calls"] == {
-            "requests": 1,
-            "successful": 0,
-            "failed": 1,
-            "warning": (
-                "The turn requested tool access but zero tool calls succeeded; "
-                "the assistant answer may not be evidence-backed."
-            ),
+        assert hermes["tool_calls"]["requests"] == 1
+        assert hermes["tool_calls"]["successful"] == 0
+        assert hermes["tool_calls"]["failed"] == 1
+
+    @pytest.mark.asyncio
+    async def test_sse_finish_chunk_includes_tool_calls_metadata(self, adapter):
+        """Streaming SSE terminal chunk must carry ``hermes.tool_calls``
+        alongside the non-streaming response (#73389 parity)."""
+        import gateway.platforms.api_server as api_mod
+
+        fake_request = MagicMock()
+        fake_request.headers = {}
+        written_payloads: list = []
+
+        class _FakeStreamResponse:
+            async def prepare(self, req):
+                pass
+
+            async def write(self, payload):
+                written_payloads.append(payload)
+
+        stream_q = api_mod.ThreadSafeAsyncQueue()
+        stream_q.put_nowait(None)  # End-of-stream sentinel
+
+        payload = {
+            "final_response": "ok",
+            "messages": [],
+            "api_calls": 1,
+            "tool_call_stats": {
+                "requests": 2, "successful": 2, "failed": 0,
+                "total_results": 2, "used": True,
+            },
         }
+        usage = {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+
+        async def _agent_coro():
+            return payload, usage
+
+        agent_task = asyncio.ensure_future(_agent_coro())
+        completion_id = f"resp_{uuid.uuid4().hex[:28]}"
+
+        with patch.object(api_mod.web, "StreamResponse", return_value=_FakeStreamResponse()):
+            await adapter._write_sse_chat_completion(
+                request=fake_request,
+                completion_id=completion_id,
+                model="hermes-agent",
+                created=int(time.time()),
+                stream_q=stream_q,
+                agent_task=agent_task,
+                agent_ref=[None],
+                session_id=None,
+                gateway_session_key=None,
+            )
+
+        # The last non-DONE payload is the finish chunk
+        non_done = []
+        for p in written_payloads:
+            decoded = p.decode("utf-8")
+            if decoded.startswith("data: "):
+                body = decoded[len("data: "):].strip()
+                if body and body != "[DONE]":
+                    non_done.append(json.loads(body))
+        assert len(non_done) >= 1
+        finish_chunk = non_done[-1]
+        assert "hermes" in finish_chunk
+        tc = finish_chunk["hermes"]["tool_calls"]
+        assert tc == {"requests": 2, "successful": 2, "failed": 0}

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2860,3 +2860,191 @@ class TestCreateAgentModelRecovery:
         adapter._create_agent(session_id="another-session", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
 
+
+# ---------------------------------------------------------------------------
+# /v1/chat/completions — hermes.tool_calls payload (issue #73389)
+# ---------------------------------------------------------------------------
+
+
+class TestChatCompletionsToolCallSignal:
+    """Surface hermes.tool_calls in the chat-completions response (#73389)."""
+
+    @staticmethod
+    def _fake_request(body: dict):
+        from aiohttp.test_utils import make_mocked_request
+
+        raw = json.dumps(body).encode("utf-8")
+
+        async def _fake_json():
+            return body
+
+        async def _fake_read():
+            return raw
+
+        req = make_mocked_request(
+            "POST",
+            "/v1/chat/completions",
+            headers={"Content-Type": "application/json"},
+        )
+        req.json = _fake_json
+        req.read = _fake_read
+        return req
+
+    @pytest.mark.asyncio
+    async def test_tool_call_stats_attached_to_successful_turn(self, adapter):
+        payload = {
+            "final_response": "Disposition at MEDIUM confidence",
+            "messages": [],
+            "api_calls": 1,
+            "tool_call_stats": {
+                "requests": 1,
+                "successful": 1,
+                "failed": 0,
+                "total_results": 1,
+                "used": True,
+            },
+        }
+        usage = {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+        with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (payload, usage)
+            req = self._fake_request(
+                {
+                    "model": "hermes-agent",
+                    "stream": False,
+                    "messages": [{"role": "user", "content": "hi"}],
+                }
+            )
+            resp = await adapter._handle_chat_completions(req)
+
+        assert resp.status == 200
+        body = json.loads(resp.body)
+        assert body["choices"][0]["finish_reason"] == "stop"
+        assert body["hermes"]["tool_calls"] == {
+            "requests": 1,
+            "successful": 1,
+            "failed": 0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_zero_tool_success_includes_warning(self, adapter):
+        payload = {
+            "final_response": "MEDIUM confidence disposition",
+            "messages": [],
+            "api_calls": 1,
+            "tool_call_stats": {
+                "requests": 2,
+                "successful": 0,
+                "failed": 2,
+                "total_results": 2,
+                "used": True,
+            },
+        }
+        usage = {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+        with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (payload, usage)
+            req = self._fake_request(
+                {
+                    "model": "hermes-agent",
+                    "stream": False,
+                    "messages": [{"role": "user", "content": "hi"}],
+                }
+            )
+            resp = await adapter._handle_chat_completions(req)
+
+        assert resp.status == 200
+        tool_calls = json.loads(resp.body)["hermes"]["tool_calls"]
+        assert tool_calls["requests"] == 2
+        assert tool_calls["successful"] == 0
+        assert tool_calls["failed"] == 2
+        assert "zero tool calls succeeded" in tool_calls["warning"]
+
+    @pytest.mark.asyncio
+    async def test_turn_without_tools_omits_hermes_tool_calls(self, adapter):
+        payload = {
+            "final_response": "hi",
+            "messages": [],
+            "api_calls": 1,
+            "tool_call_stats": {
+                "requests": 0,
+                "successful": 0,
+                "failed": 0,
+                "total_results": 0,
+                "used": False,
+            },
+        }
+        usage = {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+        with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (payload, usage)
+            req = self._fake_request(
+                {
+                    "model": "hermes-agent",
+                    "stream": False,
+                    "messages": [{"role": "user", "content": "hi"}],
+                }
+            )
+            resp = await adapter._handle_chat_completions(req)
+
+        assert resp.status == 200
+        assert "tool_calls" not in json.loads(resp.body).get("hermes", {})
+
+    @pytest.mark.asyncio
+    async def test_missing_stats_safely_skipped(self, adapter):
+        payload = {"final_response": "ok", "messages": [], "api_calls": 1}
+        usage = {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+        with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (payload, usage)
+            req = self._fake_request(
+                {
+                    "model": "hermes-agent",
+                    "stream": False,
+                    "messages": [{"role": "user", "content": "hi"}],
+                }
+            )
+            resp = await adapter._handle_chat_completions(req)
+
+        assert resp.status == 200
+        assert "tool_calls" not in json.loads(resp.body).get("hermes", {})
+
+    @pytest.mark.asyncio
+    async def test_partial_turn_merges_tool_calls_alongside_existing_hermes(self, adapter):
+        payload = {
+            "final_response": "Partial",
+            "messages": [],
+            "api_calls": 1,
+            "partial": True,
+            "completed": False,
+            "failed": False,
+            "error": "response truncated",
+            "tool_call_stats": {
+                "requests": 1,
+                "successful": 0,
+                "failed": 1,
+                "total_results": 1,
+                "used": True,
+            },
+        }
+        usage = {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+        with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (payload, usage)
+            req = self._fake_request(
+                {
+                    "model": "hermes-agent",
+                    "stream": False,
+                    "messages": [{"role": "user", "content": "hi"}],
+                }
+            )
+            resp = await adapter._handle_chat_completions(req)
+
+        assert resp.status == 200
+        hermes = json.loads(resp.body)["hermes"]
+        assert hermes["partial"] is True
+        assert hermes["completed"] is False
+        assert hermes["tool_calls"] == {
+            "requests": 1,
+            "successful": 0,
+            "failed": 1,
+            "warning": (
+                "The turn requested tool access but zero tool calls succeeded; "
+                "the assistant answer may not be evidence-backed."
+            ),
+        }

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6272,3 +6272,30 @@ class TestToolCallStats:
         stats = _compute_tool_call_stats(messages)
         assert stats["failed"] == 1
         assert stats["used"] is True
+
+    def test_start_index_excludes_conversation_history(self):
+        """start_index must skip prior-turn conversation_history messages."""
+        import json
+        from run_agent import _compute_tool_call_stats
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "tool_calls": [
+                {"id": "h1", "function": {"name": "web_search", "arguments": "{}"}},
+            ]},
+            {"role": "tool", "tool_call_id": "h1", "name": "web_search",
+             "content": json.dumps({"success": True})},
+            {"role": "user", "content": "Follow up"},
+            {"role": "assistant", "tool_calls": [
+                {"id": "c1", "function": {"name": "read_file", "arguments": "{}"}},
+            ]},
+            {"role": "tool", "tool_call_id": "c1", "name": "read_file",
+             "content": json.dumps({"success": True})},
+        ]
+        # Without start_index: 2 requests, 2 successful
+        assert _compute_tool_call_stats(messages)["requests"] == 2
+        assert _compute_tool_call_stats(messages)["successful"] == 2
+        # With start_index=3 (first-turn history): only current turn counted
+        stats = _compute_tool_call_stats(messages, start_index=3)
+        assert stats["requests"] == 1
+        assert stats["successful"] == 1
+        assert stats["used"] is True

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6146,3 +6146,129 @@ class TestMemoryContextSanitization:
         assert "memory-context" not in result.lower()
         assert "stale observation" not in result
         assert "how is the honcho working" in result
+
+
+class TestToolCallStats:
+    """Unit tests for run_agent._compute_tool_call_stats (#73389)."""
+
+    def test_no_messages_returns_zero_and_used_false(self):
+        from run_agent import _compute_tool_call_stats
+        stats = _compute_tool_call_stats([])
+        assert stats["used"] is False
+        assert stats["requests"] == 0
+        assert stats["successful"] == 0
+        assert stats["failed"] == 0
+        assert stats["total_results"] == 0
+
+    def test_non_list_messages_is_safe(self):
+        from run_agent import _compute_tool_call_stats
+        stats = _compute_tool_call_stats(None)
+        assert stats["used"] is False
+        assert _compute_tool_call_stats("not a list")["used"] is False
+
+    def test_counts_assistant_tool_calls_as_requests(self):
+        from run_agent import _compute_tool_call_stats
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "1", "function": {"name": "read_file", "arguments": "{}"}},
+                {"id": "2", "function": {"name": "web_search", "arguments": "{}"}},
+            ]},
+        ]
+        stats = _compute_tool_call_stats(messages)
+        assert stats["requests"] == 2
+        assert stats["used"] is True
+
+    def test_plain_tool_result_counts_as_success(self):
+        from run_agent import _compute_tool_call_stats
+        messages = [
+            {"role": "tool", "tool_call_id": "1", "name": "read_file",
+             "content": "def foo(): pass"},
+        ]
+        stats = _compute_tool_call_stats(messages)
+        assert stats["successful"] == 1
+        assert stats["failed"] == 0
+        assert stats["total_results"] == 1
+        assert stats["used"] is True
+
+    def test_json_success_true_counts_as_success(self):
+        import json
+        from run_agent import _compute_tool_call_stats
+        messages = [
+            {"role": "tool", "tool_call_id": "1", "name": "search",
+             "content": json.dumps({"success": True, "data": [1, 2, 3]})},
+        ]
+        stats = _compute_tool_call_stats(messages)
+        assert stats["successful"] == 1
+        assert stats["failed"] == 0
+
+    def test_json_success_false_counts_as_failed(self):
+        import json
+        from run_agent import _compute_tool_call_stats
+        messages = [
+            {"role": "tool", "tool_call_id": "1", "name": "search",
+             "content": json.dumps({"success": False, "error": "bad input"})},
+        ]
+        stats = _compute_tool_call_stats(messages)
+        assert stats["successful"] == 0
+        assert stats["failed"] == 1
+
+    def test_error_prefix_counts_as_failed(self):
+        from run_agent import _compute_tool_call_stats
+        cases = [
+            "Error: tool disabled",
+            "Skipped: another tool call in this response used an invalid name",
+            "Invalid JSON arguments. expected `}`. Please retry with valid JSON.",
+        ]
+        for body in cases:
+            stats = _compute_tool_call_stats([
+                {"role": "tool", "tool_call_id": "1", "name": "t", "content": body},
+            ])
+            assert stats["failed"] == 1, f"expected failure for: {body[:30]}"
+            assert stats["successful"] == 0
+
+    def test_real_mcp_outage_scenario(self):
+        """Reproduces issue #73389: zero-successful session should flag used."""
+        from run_agent import _compute_tool_call_stats
+        messages = [
+            {"role": "user", "content": "Triage alert #1234 using MCP tools."},
+            {"role": "assistant", "tool_calls": [
+                {"id": "a", "function": {"name": "mcp_monitoring_query", "arguments": "{}"}},
+                {"id": "b", "function": {"name": "mcp_cmdb_lookup", "arguments": "{}"}},
+                {"id": "c", "function": {"name": "mcp_ti_enrich", "arguments": "{}"}},
+                {"id": "d", "function": {"name": "mcp_ticket_search", "arguments": "{}"}},
+            ]},
+            {"role": "tool", "tool_call_id": "a", "name": "mcp_monitoring_query",
+             "content": "Error: MCP server monitoring is unreachable"},
+            {"role": "tool", "tool_call_id": "b", "name": "mcp_cmdb_lookup",
+             "content": "Error: MCP server cmdb is unreachable"},
+            {"role": "tool", "tool_call_id": "c", "name": "mcp_ti_enrich",
+             "content": "Error: MCP server threat-intel is unreachable"},
+            {"role": "tool", "tool_call_id": "d", "name": "mcp_ticket_search",
+             "content": "Error: MCP server ticketing is unreachable"},
+            {"role": "assistant", "tool_calls": [
+                {"id": "e", "function": {"name": "web_search",
+                 "arguments": '{"q": "alert signature"}'}},
+            ]},
+            {"role": "tool", "tool_call_id": "e", "name": "web_search",
+             "content": '["https://example.com/notes"]'},
+            {"role": "assistant", "content": (
+                "MEDIUM confidence disposition. MCP tools are unavailable; "
+                "enrichment performed via general web search only."
+            )},
+        ]
+        stats = _compute_tool_call_stats(messages)
+        assert stats["requests"] == 5
+        assert stats["successful"] == 1
+        assert stats["failed"] == 4
+        assert stats["total_results"] == 5
+        assert stats["used"] is True
+
+    def test_function_role_is_treated_like_tool(self):
+        from run_agent import _compute_tool_call_stats
+        messages = [
+            {"role": "function", "name": "search", "content": "Error: down"},
+        ]
+        stats = _compute_tool_call_stats(messages)
+        assert stats["failed"] == 1
+        assert stats["used"] is True


### PR DESCRIPTION
Closes #73389

Adds a framework-level signal so callers of POST /v1/chat/completions can
distinguish a turn where tool access worked (and the assistant answer was
evidence-backed) from a turn where every tool call failed and the assistant
was effectively reasoning from the prompt alone. Previously a full MCP
outage would produce an identically-shaped, well-formed MEDIUM confidence
disposition indistinguishable from a fully-verified answer.

Changes
- run_agent._compute_tool_call_stats(messages): new helper that scans the
  post-turn message list and returns {requests, successful, failed,
  total_results, used}. Treats {success:false} / {error} JSON results and
  the plain-text Error:, Skipped:, Invalid JSON arguments sentinels the
  internal error paths use today as failures; everything else is success.
- run_agent.AIAgent.run_conversation: annotates the returned result dict
  with result['tool_call_stats'] right before the return statement.
- gateway.platforms.api_server: when tool_call_stats says tools were used,
  appends hermes.tool_calls = {requests, successful, failed} onto the
  chat-completions response for every turn, not only the partial/failed
  paths. When finish_reason==stop and the turn asked for tools but zero
  succeeded, adds a human-readable warning the caller can string-match.
- 9 unit tests for _compute_tool_call_stats: empty input, non-list,
  assistant.request count, plain success, success:true/false dicts,
  Error / Skipped / Invalid prefixes, real MCP outage scenario, function
  role treated the same as tool role.
- 5 integration tests in TestChatCompletionsToolCallSignal exercising the
  adapter handler directly: successful turn, zero-success warning,
  no-tools omitted response, missing tool_call_stats skipped safely,
  partial-turn merge with the existing hermes block.

Test: python3 -m pytest tests/run_agent/test_run_agent.py::TestToolCallStats tests/gateway/test_api_server.py::TestChatCompletionsToolCallSignal tests/gateway/test_api_server.py::TestChatCompletionsEndpoint::test_stream_string_false_returns_json_completion tests/agent/test_error_classifier.py -q
  Results: 223 passed in 4.80s
