### PR TITLE
fix(utils): handle EACCES in atomic_replace on Windows

### DIFF
--- a/tests/test_atomic_replace_symlinks.py
+++ b/tests/test_atomic_replace_symlinks.py
@@ -220,7 +220,12 @@ def test_atomic_replace_eacces_falls_back_to_copy(
 ) -> None:
     """Windows: os.replace fails with EACCES when the target is open in
     another handle (config migrate after update). Must fall back to the
-    copy+unlink path instead of re-raising (regression for PR #73807)."""
+    copy+unlink path instead of re-raising (regression for PR #73807).
+
+    ``os.name`` is patched to ``nt`` so the Windows-only fallback path is
+    exercised on Linux CI too.
+    """
+    monkeypatch.setattr(os, "name", "nt")
     target = tmp_path / "config.yaml"
     target.write_text("old\n", encoding="utf-8")
     tmp = _write_tmp(tmp_path, "new\n")
@@ -233,6 +238,28 @@ def test_atomic_replace_eacces_falls_back_to_copy(
     assert Path(atomic_replace(tmp, target)) == target
     assert target.read_text(encoding="utf-8") == "new\n"
     assert not tmp.exists()
+
+
+def test_atomic_replace_eacces_propagates_on_posix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """POSIX: EACCES is a genuine permission denial and must keep
+    propagating — the copy fallback is Windows-only (PR #73807)."""
+    monkeypatch.setattr(os, "name", "posix")
+    target = tmp_path / "config.yaml"
+    target.write_text("old\n", encoding="utf-8")
+    tmp = _write_tmp(tmp_path, "new\n")
+
+    def fail_replace(src: str, dst: str) -> None:
+        raise OSError(errno.EACCES, os.strerror(errno.EACCES), src, None, dst)
+
+    monkeypatch.setattr("utils.os.replace", fail_replace)
+
+    with pytest.raises(OSError) as excinfo:
+        atomic_replace(tmp, target)
+    assert excinfo.value.errno == errno.EACCES
+    # Nothing was written through the fallback on POSIX.
+    assert target.read_text(encoding="utf-8") == "old\n"
 
 
 

--- a/tests/test_atomic_replace_symlinks.py
+++ b/tests/test_atomic_replace_symlinks.py
@@ -215,6 +215,26 @@ def test_atomic_replace_copy_fallback_preserves_symlink(
     assert not tmp.exists()
 
 
+def test_atomic_replace_eacces_falls_back_to_copy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Windows: os.replace fails with EACCES when the target is open in
+    another handle (config migrate after update). Must fall back to the
+    copy+unlink path instead of re-raising (regression for PR #73807)."""
+    target = tmp_path / "config.yaml"
+    target.write_text("old\n", encoding="utf-8")
+    tmp = _write_tmp(tmp_path, "new\n")
+
+    def fail_replace(src: str, dst: str) -> None:
+        raise OSError(errno.EACCES, os.strerror(errno.EACCES), src, None, dst)
+
+    monkeypatch.setattr("utils.os.replace", fail_replace)
+
+    assert Path(atomic_replace(tmp, target)) == target
+    assert target.read_text(encoding="utf-8") == "new\n"
+    assert not tmp.exists()
+
+
 
 
 

--- a/utils.py
+++ b/utils.py
@@ -117,7 +117,11 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
         # Windows: os.replace fails with EACCES when the target file is open
         # in another handle (e.g. the running process has config.yaml
         # mmap'd or loaded). Fall back to copy+unlink like EXDEV/EBUSY.
-        if exc.errno not in (errno.EXDEV, errno.EBUSY, errno.EACCES):
+        # On POSIX, EACCES means a genuine permission denial — propagate it
+        # rather than silently broadening the fallback.
+        if exc.errno not in (errno.EXDEV, errno.EBUSY) and not (
+            exc.errno == errno.EACCES and os.name == "nt"
+        ):
             raise
         logger.debug(
             "atomic_replace: %s -> %s failed with %s; falling back to copy",

--- a/utils.py
+++ b/utils.py
@@ -114,7 +114,10 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     try:
         os.replace(tmp_str, real_path)
     except OSError as exc:
-        if exc.errno not in (errno.EXDEV, errno.EBUSY):
+        # Windows: os.replace fails with EACCES when the target file is open
+        # in another handle (e.g. the running process has config.yaml
+        # mmap'd or loaded). Fall back to copy+unlink like EXDEV/EBUSY.
+        if exc.errno not in (errno.EXDEV, errno.EBUSY, errno.EACCES):
             raise
         logger.debug(
             "atomic_replace: %s -> %s failed with %s; falling back to copy",


### PR DESCRIPTION
os.replace() fails with PermissionError (EACCES) on Windows when the target config file is open in another handle (e.g. during config migration after update). Only EXDEV and EBUSY were handled, causing 'hermes config migrate' to crash with 'PermissionError: [WinError 5]'.

Add EACCES to the fallback set so atomic_replace falls through to the copy+fsync+unlink path on Windows instead of raising.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

