### PR TITLE
fix(gateway): trust fresh runtime state when PID probes fail (#73796)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1271,6 +1271,19 @@ def resolve_gateway_liveness(
             health_body=health_body,
         )
 
+    # Rung 4: trust the runtime state file when it claims "running" and is
+    # fresh — covers cross-container Docker where the PID namespace is
+    # separate and all PID-based probes fail (issue #73796).
+    if runtime is not None and isinstance(runtime, dict):
+        state = runtime.get("gateway_state")
+        if state in {"running", "draining"} and not runtime_status_is_stale(runtime):
+            return GatewayLiveness(
+                running=True,
+                pid=None,
+                source="runtime_state",
+                health_body=health_body,
+            )
+
     return GatewayLiveness(
         running=False,
         pid=None,


### PR DESCRIPTION
## Summary

Fixes #73796. Dashboard reports gateway as "stopped" in split-container Docker deployments because PID-based liveness probes fail across container PID namespace boundaries.

## Root Cause

`resolve_gateway_liveness` has a 3-rung ladder (PID file, HTTP health probe, runtime status PID) — all fail when the dashboard and gateway run in separate containers with separate PID namespaces. The `gateway_state.json` correctly says `"running"` but was never consulted as a fallback.

## Fix

Add rung 4: when the runtime state file claims `"running"` or `"draining"` and is fresh (within the existing 120s `_RUNTIME_STATUS_STALE_TTL_S`), trust it even when all PID verification fails. Uses the existing `runtime_status_is_stale()` function for the freshness check.

A stale state file (gateway crashed without cleanup) is correctly reported as stopped — the TTL guard prevents false positives.

## Changes

- `gateway/status.py`: Add 13-line rung 4 block in `resolve_gateway_liveness` between rung 3 and the final `running=False` return.

## Testing

- `python3 -m py_compile gateway/status.py` — OK
- `python3 -m ruff check gateway/status.py` — clean
