### PR TITLE
fix(web_server): remove GIL-holding gateway prewarm from desktop lifespan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,4 +189,5 @@ infographic/
 infographics/
 infograficos/
 infografico/
+infografics/
 native/fts5_cjk/*.so

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -168,13 +168,6 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
     provider.start(stop_event, interval=interval)
 
 
-def _warm_gateway_module() -> None:
-    try:
-        import hermes_cli.gateway  # noqa: F401
-    except Exception:
-        pass
-
-
 def _resolve_restart_drain_timeout() -> float:
     try:
         from hermes_cli.gateway import _get_restart_drain_timeout
@@ -194,14 +187,6 @@ async def _lifespan(app: "FastAPI"):
     # On app.state (not a module global) so the Lock binds to the running
     # event loop during lifespan startup — see _get_event_state's docstring.
     app.state.chat_argv_lock = asyncio.Lock()
-
-    # Fire hermes_cli.gateway import into a background thread so the event
-    # loop is not blocked and HERMES_DASHBOARD_READY fires without delay.
-    # On a cold Windows install the module chain triggers .pyc compilation
-    # and Defender real-time scans that can stall the event loop for 15-30s.
-    # Running in an executor means the cost is paid in a worker thread while
-    # the server socket is already open and accepting probes.
-    asyncio.get_event_loop().run_in_executor(None, _warm_gateway_module)
 
     # Desktop-spawned backends (HERMES_DESKTOP=1) fire cron jobs themselves,
     # since the app has no gateway running the scheduler. Server `hermes

--- a/tests/hermes_cli/test_web_server_boot_handshake.py
+++ b/tests/hermes_cli/test_web_server_boot_handshake.py
@@ -2,14 +2,13 @@
 Integration tests for the desktop boot handshake fix (PR #50231 / issue #50209).
 
 Simulates a slow hermes_cli.gateway import (15-30 s on a fresh Windows install
-with Defender scanning every new .pyc) by patching the two helpers that touch
-the blocking import and measuring event-loop freedom + response latency.
+with Defender scanning every new .pyc) and measures event-loop freedom +
+response latency.
 
 Three scenarios are covered:
 
-1. _lifespan fire-and-forget: patched _warm_gateway_module sleeps N seconds in
-   a thread; TestClient startup must complete in << N seconds (event loop not
-   blocked, HERMES_DASHBOARD_READY would fire immediately).
+1. _lifespan must not launch a gateway prewarm that can retain the GIL and
+   starve health/WebSocket handling despite running in an executor thread.
 
 2. get_status run_in_executor: patched _resolve_restart_drain_timeout sleeps N
    seconds in a thread; a concurrent fast endpoint (/api/version) must respond
@@ -22,6 +21,7 @@ Three scenarios are covered:
 from __future__ import annotations
 
 import asyncio
+import sys
 import time
 import threading
 from unittest.mock import patch
@@ -38,9 +38,16 @@ SLOW_SECONDS = 3  # represents the Defender worst-case (scaled down for CI speed
 # ---------------------------------------------------------------------------
 
 def _make_slow_warm(seconds: float):
-    """Return a _warm_gateway_module replacement that sleeps in the caller thread."""
+    """Return a cold-import stand-in that retains the GIL for ``seconds``."""
     def _slow():
-        time.sleep(seconds)
+        old_interval = sys.getswitchinterval()
+        try:
+            sys.setswitchinterval(seconds * 2)
+            deadline = time.perf_counter() + seconds
+            while time.perf_counter() < deadline:
+                pass
+        finally:
+            sys.setswitchinterval(old_interval)
     return _slow
 
 
@@ -53,30 +60,32 @@ def _make_slow_drain(seconds: float):
 
 
 # ---------------------------------------------------------------------------
-# Test 1 — _lifespan fire-and-forget does not block the event loop
+# Test 1 — lifespan does not start a GIL-holding gateway prewarm
 # ---------------------------------------------------------------------------
 
-def test_lifespan_warmup_is_nonblocking():
+def test_lifespan_does_not_start_gil_holding_gateway_warmup():
     """
-    _warm_gateway_module runs in an executor (fire-and-forget).
-    Even if it sleeps for SLOW_SECONDS, TestClient startup must complete
-    in well under that time — proving the event loop was never blocked and
-    HERMES_DASHBOARD_READY would have fired without delay.
+    A worker thread is not an isolation boundary for GIL-holding imports.
+    Health must respond without waiting for the synthetic cold import.
     """
     from fastapi.testclient import TestClient
 
-    with patch.object(web_server_mod, "_warm_gateway_module", _make_slow_warm(SLOW_SECONDS)):
+    with patch.object(
+        web_server_mod,
+        "_warm_gateway_module",
+        _make_slow_warm(SLOW_SECONDS),
+        create=True,
+    ):
         t0 = time.perf_counter()
-        with TestClient(web_server_mod.app, raise_server_exceptions=False) as _client:
-            startup_ms = (time.perf_counter() - t0) * 1000
+        with TestClient(web_server_mod.app, raise_server_exceptions=False) as client:
+            response = client.get("/api/health")
+        health_ms = (time.perf_counter() - t0) * 1000
 
-    # Startup must complete in under half of SLOW_SECONDS (generous margin).
-    # If the import were synchronous, startup would block for >= SLOW_SECONDS.
+    assert response.status_code == 200
     threshold_ms = (SLOW_SECONDS * 1000) / 2
-    assert startup_ms < threshold_ms, (
-        f"_lifespan blocked the event loop: startup took {startup_ms:.0f} ms "
-        f"but slow import is {SLOW_SECONDS * 1000:.0f} ms — "
-        f"fire-and-forget is not working."
+    assert health_ms < threshold_ms, (
+        f"gateway prewarm starved the health path for {health_ms:.0f} ms; "
+        "executor threads do not isolate GIL-holding imports"
     )
 
 


### PR DESCRIPTION
## Summary

Fixes #71226 — desktop boot loop under GIL pressure.

- `_lifespan()` fired `_warm_gateway_module()` (imports `hermes_cli.gateway`) via `run_in_executor`. A worker thread is **not** an isolation boundary against GIL retention — on a cold Windows install (`.pyc` compilation, Defender real-time scan), the import can hold the GIL long enough to freeze the asyncio event loop.
- While frozen, `/api/health` and the WebSocket accept/`gateway.ready` handshake stop making progress. The desktop client's connect timeout fires, it disconnects, and the backend later logs `ready_send_failed` — the boot loop.
- The prewarm had no functional requirement left: desktop readiness already uses `/api/health`, not the heavier `/api/status` path the prewarm was originally speeding up. Minimal fix: remove it.

## Root cause (verified, not just asserted)

The existing regression test used `time.sleep()` to simulate the slow import — `time.sleep` **releases** the GIL, so that test only proved a thread sleeping doesn't block the loop. It never exercised the actual failure mode.

Replaced it with a busy-loop + `sys.setswitchinterval()` that genuinely retains the GIL for the duration, then asserts `/api/health` responds within budget:

- **RED** (before fix): `/api/health` starved for **3012ms** against a 1500ms budget.
- **GREEN** (after fix): passes, health responds in low single-digit ms.

 

## What this PR deliberately does NOT touch

Scoped out to keep this fix attributable and reviewable on its own:
- PR #71398 / #72044 (MCP-discovery-before-ready ordering) — already obsolete; MCP discovery was moved out of the WebSocket handler by `c6e811e48` on a different architecture.
- #72292 (pending `connect()` vs `close()` race) — independent bug.
- #73722 (boot retry) — complementary defense, not this stall's root cause.
- Messaging-gateway watchdog, gateway/PID stale-state handling — unrelated subsystems.

## Infographic

Root-cause + fix walkthrough (hosted externally per this repo's infographic policy — **not** committed, see `.github/workflows/infographic-check.yml` / `.gitignore`):

![Issue #71226 infographic: GIL-holding gateway prewarm causes desktop boot loop](https://github.com/JoaoMarcos44/hermes-agent/releases/download/infographic-71226/infographic.png)

## Test plan

- [x] `tests/hermes_cli/test_web_server_boot_handshake.py` — RED confirmed pre-fix (3012ms starvation), GREEN post-fix, 3/3 passed
- [x] `tests/hermes_cli/test_web_server_boot_handshake.py` + `tests/test_tui_gateway_ws.py` — 13 passed
- [x] `tests/hermes_cli/test_web_server.py` + `tests/test_web_server.py` — 515 passed, 1 pre-existing unrelated failure (`test_put_honcho_first_save_merges_into_resolved_config`), confirmed failing on baseline `main` too via `git stash`
- [x] `ruff check` on both changed files — clean
- [ ] Cold-start manual verification on Windows with Defender active (not run in this environment)

 
