### PR TITLE
fix(doctor): allow vendor slugs for custom OpenAI endpoints

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1056,6 +1056,12 @@ def run_doctor(args):
             # aggregator (e.g. custom:hpc-ai serving deepseek/deepseek-v4-flash) requires the prefix.
             provider_for_policy = runtime_provider or catalog_provider
             provider_policy_id = str(provider_for_policy or "").strip().lower()
+            model_base_url = str(model_section.get("base_url") or "").strip()
+            uses_custom_openai_endpoint = (
+                provider_policy_id == "openai-api"
+                and bool(model_base_url)
+                and not base_url_host_matches(model_base_url, "api.openai.com")
+            )
             providers_accepting_vendor_slugs = {
                 "openrouter",
                 "auto",
@@ -1078,6 +1084,7 @@ def run_doctor(args):
                 provider_policy_id in providers_accepting_vendor_slugs
                 or provider_policy_id == "custom"
                 or provider_policy_id.startswith("custom:")
+                or uses_custom_openai_endpoint
             )
             if (
                 default_model

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -659,6 +659,57 @@ def test_run_doctor_accepts_vendor_slugs_for_named_custom_provider(monkeypatch, 
 
 
 
+@pytest.mark.parametrize(
+    ("base_url", "expects_warning"),
+    [
+        ("http://localhost:20128/v1", False),
+        ("https://api.openai.com/v1", True),
+    ],
+)
+def test_run_doctor_vendor_slug_policy_for_openai_api_endpoint(
+    monkeypatch, tmp_path, base_url, expects_warning
+):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: openai-api\n"
+        "  default: nvidia/z-ai/glm-5.2\n"
+        f"  base_url: {base_url}\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    warning = (
+        "model.default 'nvidia/z-ai/glm-5.2' uses a vendor/model slug "
+        "but provider is 'openai-api'"
+    )
+    assert (warning in buf.getvalue()) is expects_warning
+
+
 def test_run_doctor_accepts_kimi_coding_cn_provider(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

- recognize vendor-prefixed model IDs as valid when `openai-api` targets an explicit non-OpenAI endpoint
- retain the existing warning for the official OpenAI API
- add focused regression coverage for both endpoint classes

## Testing

- `python -m pytest tests/hermes_cli/test_doctor.py -q -o addopts=` — 81 passed
- `python -m ruff check hermes_cli/doctor.py tests/hermes_cli/test_doctor.py` — passed
- `python scripts/check-windows-footguns.py --all` — passed
- `git diff --check origin/main..HEAD` — passed

## Issue

Addresses the `hermes doctor` false-positive reported in #69912.

This intentionally does not close #69912 because that issue also tracks unrelated Desktop, compression, reasoning, and session-state problems.