### PR TITLE
fix(mcp): suppress "Event loop is closed" RuntimeError on shutdown for parked servers

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2199,9 +2199,19 @@ class MCPServerTask:
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
-                    t.cancel()
                     try:
+                        t.cancel()
                         await t
+                    except RuntimeError as exc:
+                        # Event loop may be closed during shutdown — the
+                        # cancel() call tries to schedule via call_soon on
+                        # a loop that was already stopped and closed
+                        # (shutdown_mcp_servers -> _stop_mcp_loop ->
+                        # loop.close()).  Swallow gracefully instead of
+                        # producing "Exception ignored in: <coroutine
+                        # object MCPServerTask.run>" on every parked server.
+                        if "Event loop is closed" not in str(exc):
+                            raise
                     except (asyncio.CancelledError, Exception):
                         pass
         if self._shutdown_event.is_set():


### PR DESCRIPTION
## Problem

When shutting down Hermes, parked MCP servers (those that failed initial connection and are waiting in `_wait_for_reconnect_or_shutdown`) can outlive the background event loop. Their `finally` block calls `t.cancel()` which tries to schedule via `call_soon` on a loop that `shutdown_mcp_servers` → `_stop_mcp_loop` → `loop.close()` already stopped and closed, producing:

```
Exception ignored in: <coroutine object MCPServerTask.run at 0x...>
...
RuntimeError: Event loop is closed
```

This happens for every parked server — if 3 MCP servers are in parked state, you get 3 tracebacks on every clean shutdown.

## Root cause

In `MCPServerTask._wait_for_reconnect_or_shutdown()` (line 2202), the `finally` block unconditionally calls `t.cancel()` on pending tasks. When the event loop has already been closed by the shutdown sequence, the asyncio internals raise `RuntimeError: Event loop is closed` because `cancel()` must schedule a callback via `call_soon`.

## Fix

Catch `RuntimeError` in the `finally` block before the generic `except (CancelledError, Exception)` handler. Only suppress the specific `"Event loop is closed"` message — any other `RuntimeError` during cancel is re-raised so legitimate errors are not silently swallowed.

## Testing

- `tests/tools/test_mcp_tool.py::TestShutdown` — 5/5 passed (no regression)
- `tests/tools/test_mcp_parked_self_probe.py` — 1/1 passed (parking/revival unchanged)
- `tests/tools/test_mcp_tool.py` — 215/215 passed (full MCP tool suite)

## Verification

Before the fix, the user saw 3 `RuntimeError: Event loop is closed` tracebacks on every `hermes` exit. After the patch, shutdown is clean with no exceptions.