### PR TITLE
fix(teams): keep hyperlink targets that activity.text drops

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -497,6 +497,66 @@ def _validate_teams_service_url(raw: str) -> Optional[str]:
     return normalized
 
 
+# ``<a href="URL" ...>LABEL</a>`` in the HTML body Teams mirrors alongside a
+# message. ``<a\b`` deliberately does not match Teams' ``<at id="0">`` mention
+# tags, which carry no href and are stripped separately.
+_TEAMS_ANCHOR_RE = _re_teams.compile(
+    r"""<a\b(?:[^>]*?\s)?href\s*=\s*["']([^"']+)["'][^>]*>(.*?)</a>""",
+    _re_teams.IGNORECASE | _re_teams.DOTALL,
+)
+_TEAMS_HTML_TAG_RE = _re_teams.compile(r"<[^>]+>")
+
+
+def _extract_teams_html_links(html_body: str) -> list:
+    """Return ``[(label, url), ...]`` for the http(s) anchors in a Teams body."""
+    if not html_body or "<a" not in html_body.lower():
+        return []
+
+    links = []
+    seen = set()
+    for raw_url, raw_label in _TEAMS_ANCHOR_RE.findall(html_body):
+        url = html.unescape(raw_url).strip()
+        if not url.lower().startswith(("http://", "https://")):
+            continue
+        if url in seen:
+            continue
+        seen.add(url)
+        label = html.unescape(_TEAMS_HTML_TAG_RE.sub("", raw_label)).strip()
+        links.append((label, url))
+    return links
+
+
+def _merge_teams_link_urls(text: str, html_body: str) -> str:
+    """Restore hyperlink targets that Teams strips out of ``activity.text``.
+
+    Teams flattens ``<a href="URL">LABEL</a>`` down to a bare ``LABEL`` in the
+    plain text a bot receives, and its composer turns a pasted URL into exactly
+    that shape whenever the page has a title. The agent then sees a message
+    that visibly contains a link but carries no URL, and answers "paste the
+    URL" — for a message that already has one. The href survives only in the
+    ``text/html`` body Teams mirrors as an attachment, so recover it from
+    there and put it back next to the label the user actually sees.
+    """
+    links = _extract_teams_html_links(html_body)
+    if not links:
+        return text
+
+    merged = text
+    appended = []
+    for label, url in links:
+        if url in merged:
+            continue
+        if label and label in merged:
+            merged = merged.replace(label, f"{label} ({url})", 1)
+        else:
+            appended.append(f"{label} ({url})" if label else url)
+
+    if appended:
+        joined = "\n".join(appended)
+        merged = f"{merged}\n{joined}" if merged.strip() else joined
+    return merged
+
+
 async def _standalone_send(
     pconfig,
     chat_id: str,
@@ -888,6 +948,9 @@ class TeamsAdapter(BasePlatformAdapter):
         media_urls = []
         media_types = []
         media_kinds = []
+        # The mirrored ``text/html`` body, kept so hyperlink targets that
+        # ``activity.text`` drops can be merged back in after this loop.
+        html_body_mirror = ""
         for att in getattr(activity, "attachments", None) or []:
             content_url = getattr(att, "content_url", None)
             content_type = (getattr(att, "content_type", None) or "").lower()
@@ -897,6 +960,10 @@ class TeamsAdapter(BasePlatformAdapter):
             # text/html attachment on every message, and adaptive/hero cards
             # arrive as application/vnd.microsoft.card.* attachments.
             if content_type in ("text/html", "text/plain") and not content_url:
+                if content_type == "text/html" and not html_body_mirror:
+                    raw_html = getattr(att, "content", None)
+                    if isinstance(raw_html, str):
+                        html_body_mirror = raw_html
                 continue
             if content_type.startswith("application/vnd.microsoft.card"):
                 continue
@@ -955,6 +1022,19 @@ class TeamsAdapter(BasePlatformAdapter):
                         "[teams] Failed to cache attachment '%s' (%s): %s",
                         att_name or content_url, content_type, e,
                     )
+
+        # Put hyperlink targets back into the text. Skipped for slash commands
+        # so a command's arguments are never rewritten.
+        if html_body_mirror and not text.lstrip().startswith("/"):
+            merged_text = _merge_teams_link_urls(text, html_body_mirror)
+            if merged_text != text:
+                logger.debug(
+                    "[teams] recovered hyperlink target(s) from the HTML body "
+                    "(text %d -> %d chars)",
+                    len(text),
+                    len(merged_text),
+                )
+                text = merged_text
 
         # Classification: DOCUMENT wins over PHOTO/VIDEO/AUDIO for mixed
         # attachments — run.py's image handling keys off the per-path image/*

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -1125,3 +1125,139 @@ class TestTeamsMediaAttachments:
         result = await adapter.send_document("19:abc@thread.v2", "/no/such/file.pdf")
         assert not result.success
         adapter._app.send.assert_not_awaited()
+
+
+class TestTeamsHyperlinkRecovery:
+    """Teams flattens ``<a href>`` down to its label in ``activity.text``.
+
+    A link pasted into the composer keeps its URL only in the mirrored
+    ``text/html`` body, so without recovery the agent reads a message that
+    visibly contains a link but carries no URL, and asks the user to paste
+    the URL they just pasted.
+    """
+
+    # The shape Teams actually produces for a pasted link that resolves to a
+    # page title: the visible label is the title, the URL lives in the href.
+    PASTED_LINK_HTML = (
+        '<p><at id="0">Hermes</at>&nbsp;'
+        '<a href="https://example.com/start-program" '
+        'itemtype="http://schema.skype.com/HyperLink" rel="noreferrer noopener" '
+        'title="https://example.com/start-program" target="_blank" '
+        'itemid="ab79dfae-3fb9-433e-9f4f-0ef05249a163">'
+        "4ヶ月完全スタートプログラム丨example studio</a>"
+        " 読める？？</p>"
+    )
+    PASTED_LINK_TEXT = "4ヶ月完全スタートプログラム丨example studio 読める？？"
+
+    def test_url_lands_next_to_its_label(self):
+        merged = _teams_mod._merge_teams_link_urls(
+            self.PASTED_LINK_TEXT, self.PASTED_LINK_HTML
+        )
+        assert merged == (
+            "4ヶ月完全スタートプログラム丨example studio "
+            "(https://example.com/start-program) 読める？？"
+        )
+
+    def test_mention_tag_is_not_read_as_a_link(self):
+        links = _teams_mod._extract_teams_html_links(self.PASTED_LINK_HTML)
+        assert links == [
+            ("4ヶ月完全スタートプログラム丨example studio", "https://example.com/start-program")
+        ]
+
+    def test_bare_url_is_not_duplicated(self):
+        text = "have a look https://example.com/a"
+        html_body = (
+            '<p>have a look <a href="https://example.com/a">https://example.com/a</a></p>'
+        )
+        assert _teams_mod._merge_teams_link_urls(text, html_body) == text
+
+    def test_label_absent_from_text_is_appended(self):
+        # Teams drops the label from activity.text for some rich shapes; the
+        # URL still has to reach the agent.
+        text = "have a look"
+        html_body = '<p>have a look<a href="https://example.com/b">the report</a></p>'
+        assert (
+            _teams_mod._merge_teams_link_urls(text, html_body)
+            == "have a look\nthe report (https://example.com/b)"
+        )
+
+    def test_html_entities_in_href_are_decoded(self):
+        text = "the thread"
+        html_body = '<a href="https://example.com/x?a=1&amp;b=2">the thread</a>'
+        assert (
+            _teams_mod._merge_teams_link_urls(text, html_body)
+            == "the thread (https://example.com/x?a=1&b=2)"
+        )
+
+    def test_data_href_attribute_is_not_mistaken_for_a_link(self):
+        text = "click"
+        html_body = '<a data-href="https://example.com/no">click</a>'
+        assert _teams_mod._merge_teams_link_urls(text, html_body) == text
+
+    def test_non_http_schemes_are_ignored(self):
+        text = "contact"
+        html_body = '<a href="mailto:someone@example.com">contact</a>'
+        assert _teams_mod._merge_teams_link_urls(text, html_body) == text
+
+    def test_body_without_anchors_is_left_alone(self):
+        text = "just text"
+        assert _teams_mod._merge_teams_link_urls(text, "<p>just text</p>") == text
+
+    def _make_adapter(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter.handle_message = AsyncMock()
+        return adapter
+
+    def _make_ctx(self, text, html_body):
+        html_att = MagicMock()
+        html_att.content_type = "text/html"
+        html_att.content_url = None
+        html_att.name = ""
+        html_att.content = html_body
+
+        activity = MagicMock()
+        activity.text = text
+        activity.id = "activity-link-001"
+        activity.from_ = MagicMock()
+        activity.from_.id = "user-123"
+        activity.from_.aad_object_id = "aad-456"
+        activity.from_.name = "Test User"
+        activity.conversation = MagicMock()
+        activity.conversation.id = "19:abc@thread.tacv2"
+        activity.conversation.conversation_type = "channel"
+        activity.conversation.name = "Test Channel"
+        activity.conversation.tenant_id = "tenant-789"
+        activity.attachments = [html_att]
+
+        ctx = MagicMock()
+        ctx.activity = activity
+        return ctx
+
+    @pytest.mark.anyio
+    async def test_on_message_recovers_the_url_end_to_end(self):
+        adapter = self._make_adapter()
+        ctx = self._make_ctx(
+            f"<at>Hermes</at> {self.PASTED_LINK_TEXT}", self.PASTED_LINK_HTML
+        )
+
+        await adapter._on_message(ctx)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert "https://example.com/start-program" in event.text
+
+    @pytest.mark.anyio
+    async def test_slash_command_arguments_are_not_rewritten(self):
+        adapter = self._make_adapter()
+        ctx = self._make_ctx(
+            "/model opus",
+            '<p>/model <a href="https://example.com/m">opus</a></p>',
+        )
+
+        await adapter._on_message(ctx)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.text == "/model opus"


### PR DESCRIPTION
## Problem

Teams flattens `<a href="URL">LABEL</a>` down to a bare `LABEL` in the plain text a bot receives, and the composer produces exactly that shape whenever a pasted URL resolves to a page title. The agent then reads a message that visibly contains a link but carries no URL at all, so it replies asking the user to paste the URL they just pasted.

Seen on a live Teams deployment: the inbound `activity.text` was the page title alone, while the message body held `<a href="https://…">…</a>`. Pasting the URL bare still worked, so from the user's side the behaviour looked intermittent rather than broken.

## Fix

The href survives only in the `text/html` body Teams mirrors as an attachment — which `_on_message` skipped outright. Keep that body, pull the http(s) anchors out of it, and put each URL back next to the label the user sees (appending it when the label is not in the text).

- `<at id="0">` mention tags are not anchors and are left alone.
- `mailto:` and other non-http schemes are ignored.
- A bare URL already present in the text is not duplicated.
- Slash commands are skipped, so command arguments are never rewritten.
- No new import: reuses the existing `_re_teams` alias.

## Tests

`tests/gateway/test_teams.py::TestTeamsHyperlinkRecovery` — 11 cases covering the pasted-link shape Teams actually emits, mention tags, entity-encoded hrefs, `data-href`, non-http schemes, bare-URL de-duplication, and two end-to-end `_on_message` cases.

```
$ python -m pytest tests/gateway/test_teams.py -q
67 passed
```