### PR TITLE
fix(cron): run no-agent workdir jobs on parallel pool (#73804)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4157,8 +4157,14 @@ def tick(
         # That alone only keeps workdir jobs from overlapping EACH OTHER;
         # run_job's _terminal_cwd_lock is what additionally stops a concurrently
         # firing workdir-less parallel-pool job from observing the override.
-        sequential_jobs = [j for j in due_jobs if (j.get("workdir") or "").strip()]
-        parallel_jobs = [j for j in due_jobs if not (j.get("workdir") or "").strip()]
+        #
+        # no_agent script jobs never touch TERMINAL_CWD — their workdir is
+        # applied only as the subprocess cwd (process-local), so they are safe
+        # to run on the parallel pool even when workdir is set (#73804).
+        sequential_jobs = [j for j in due_jobs
+                           if (j.get("workdir") or "").strip()
+                           and not j.get("no_agent")]
+        parallel_jobs = [j for j in due_jobs if j not in sequential_jobs]
 
         _results: list = []
         _all_futures: list = []


### PR DESCRIPTION
## Summary

Fixes #73804. No-agent script jobs with a `workdir` are needlessly serialized on the single-thread sequential pool, starving other workdir jobs.

## Root Cause

The cron scheduler partitions due jobs by `workdir` presence. Jobs with `workdir` run on the sequential pool to protect the process-global `TERMINAL_CWD` override. But `no_agent` script jobs never touch `TERMINAL_CWD` — their workdir is applied only as the subprocess `cwd=` parameter (process-local), so they are safe to run concurrently.

## Fix

Exclude `no_agent` jobs from the sequential partition. They run on the parallel pool alongside other parallel jobs.

```python
# Before:
sequential_jobs = [j for j in due_jobs if (j.get("workdir") or "").strip()]

# After:
sequential_jobs = [j for j in due_jobs
                   if (j.get("workdir") or "").strip()
                   and not j.get("no_agent")]
```

## Impact

A long-running no_agent maintenance script (e.g. merge-queue drain, DB health watchdog) no longer blocks other workdir jobs from executing.

## Testing

- `python3 -m py_compile cron/scheduler.py` — OK
- `python3 -m ruff check cron/scheduler.py` — clean
