### PR TITLE
fix(send): report rejected media and delivery receipts

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5868,7 +5868,8 @@ class BasePlatformAdapter(ABC):
                         response = (
                             "⚠️ The file was generated, but its path is not authorized "
                             "for attachment delivery, so it was not uploaded.\n"
-                            "Write the file under $HERMES_HOME/output/ and try again."
+                            "Write the file under $HERMES_HOME/cache/documents/ "
+                            "or a configured MEDIA allow directory and try again."
                         )
 
                 # Do NOT deduplicate MEDIA tags against prior turns here.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5856,8 +5856,20 @@ class BasePlatformAdapter(ABC):
                 _response_pre_extract = response
 
                 # Extract MEDIA:<path> tags (from TTS tool) before other processing
-                media_files, response = self.extract_media(response)
-                media_files = self.filter_media_delivery_paths(media_files)
+                _extracted_media_files, response = self.extract_media(response)
+                media_files = self.filter_media_delivery_paths(_extracted_media_files)
+                if _extracted_media_files and not media_files:
+                    logger.warning(
+                        "[%s] response_delivery_blocked: all %d MEDIA attachment(s) "
+                        "were rejected by delivery path policy for %s",
+                        self.name, len(_extracted_media_files), event.source.chat_id,
+                    )
+                    if not response.strip():
+                        response = (
+                            "⚠️ The file was generated, but its path is not authorized "
+                            "for attachment delivery, so it was not uploaded.\n"
+                            "Write the file under $HERMES_HOME/output/ and try again."
+                        )
 
                 # Do NOT deduplicate MEDIA tags against prior turns here.
                 # The auto-append path in GatewayRunner._run_agent_inner already

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18388,8 +18388,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             from gateway.platforms.base import BasePlatformAdapter, should_send_media_as_audio
 
-            media_files, cleaned = adapter.extract_media(response)
-            media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+            extracted_media_files, cleaned = adapter.extract_media(response)
+            media_files = BasePlatformAdapter.filter_media_delivery_paths(extracted_media_files)
+            if extracted_media_files and not media_files:
+                logger.warning(
+                    "[%s] post_stream_delivery_blocked: all %d MEDIA attachment(s) "
+                    "were rejected by delivery path policy for %s",
+                    adapter.name, len(extracted_media_files), event.source.chat_id,
+                )
+                notice = (
+                    "⚠️ The attachment was not uploaded because its path is not "
+                    "authorized for MEDIA delivery. Write the file under "
+                    "$HERMES_HOME/cache/documents/ or a configured MEDIA allow "
+                    "directory and try again."
+                )
+                await adapter.send(
+                    chat_id=event.source.chat_id,
+                    content=notice,
+                    metadata=self._thread_metadata_for_source(
+                        event.source, self._reply_anchor_for_event(event)
+                    ),
+                )
+                return
             # Do NOT deduplicate explicit MEDIA tags against prior turns here
             # (#73771). This rescan is already EXPLICIT-ONLY (see docstring):
             # a MEDIA: directive in the final streamed reply is the model

--- a/tests/gateway/test_post_stream_media_delivery.py
+++ b/tests/gateway/test_post_stream_media_delivery.py
@@ -51,6 +51,7 @@ def _adapter():
         extract_media=BasePlatformAdapter.extract_media,
         extract_images=BasePlatformAdapter.extract_images,
         extract_local_files=BasePlatformAdapter.extract_local_files,
+        send=AsyncMock(return_value=SendResult(success=True, message_id="notice")),
         send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
         send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
         send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
@@ -109,5 +110,56 @@ async def test_explicit_media_tag_still_delivers_post_stream(tmp_path, monkeypat
     images_kwargs = adapter.send_multiple_images.await_args.kwargs
     assert images_kwargs["chat_id"] == "C123CHAN"
     assert str(media_file) in images_kwargs["images"][0][0]
+
+
+@pytest.mark.asyncio
+async def test_all_rejected_explicit_media_sends_post_stream_notice(tmp_path, monkeypatch):
+    """A streamed MEDIA directive must not disappear silently when policy rejects it."""
+    blocked_file = tmp_path / "blocked" / "report.pdf"
+    blocked_file.parent.mkdir(parents=True)
+    blocked_file.write_bytes(b"pdf")
+    allowed_root = tmp_path / "allowed"
+    allowed_root.mkdir()
+    monkeypatch.setattr(
+        "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+        (allowed_root,),
+    )
+    monkeypatch.setenv("HERMES_MEDIA_DELIVERY_STRICT", "1")
+    monkeypatch.setenv("HERMES_MEDIA_TRUST_RECENT_FILES", "0")
+    adapter = _adapter()
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({"thread_id": "thread-1"}),
+        f"MEDIA:{blocked_file.resolve()}",
+        _event(),
+        adapter,
+    )
+
+    adapter.send.assert_awaited_once()
+    notice_kwargs = adapter.send.await_args.kwargs
+    assert notice_kwargs["chat_id"] == "C123CHAN"
+    assert "$HERMES_HOME/cache/documents/" in notice_kwargs["content"]
+    adapter.send_document.assert_not_awaited()
+    adapter.send_multiple_images.assert_not_awaited()
+
+
+def test_cache_documents_allowed_in_strict_mode_without_recency(tmp_path, monkeypatch):
+    """The remediation path must remain valid in pure-allowlist strict mode."""
+    documents = tmp_path / "cache" / "documents"
+    document = documents / "report.pdf"
+    documents.mkdir(parents=True)
+    document.write_bytes(b"pdf")
+    monkeypatch.setattr(
+        "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+        (documents,),
+    )
+    monkeypatch.setenv("HERMES_MEDIA_DELIVERY_STRICT", "1")
+    monkeypatch.setenv("HERMES_MEDIA_TRUST_RECENT_FILES", "0")
+
+    accepted = BasePlatformAdapter.filter_media_delivery_paths(
+        [(str(document.resolve()), False)]
+    )
+
+    assert accepted == [(str(document.resolve()), False)]
 
 

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -339,16 +339,12 @@ class TestSendMessageTool:
                 )
             )
 
-        assert result["success"] is True
-        send_mock.assert_awaited_once_with(
-            Platform.TELEGRAM,
-            telegram_cfg,
-            "12345",
-            "hello",
-            thread_id=None,
-            media_files=[],
-            force_document=False,
-        )
+        # A stripped MEDIA directive must not degrade into a successful
+        # text-only send when its only attachment is rejected by policy.
+        assert "error" in result
+        assert "rejected" in result["error"].lower()
+        assert str(secret) in result["rejected_media"]
+        send_mock.assert_not_awaited()
 
     def test_top_level_send_failure_redacts_query_token(self):
         config, _telegram_cfg = _make_config()

--- a/tests/tools/test_telegram_send_message_caption.py
+++ b/tests/tools/test_telegram_send_message_caption.py
@@ -99,3 +99,43 @@ def test_multi_file_keeps_separate_text(monkeypatch: pytest.MonkeyPatch) -> None
     finally:
         os.unlink(img)
         os.unlink(img2)
+
+
+def test_chinese_pdf_name_returns_document_receipt(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    from tools.send_message_tool import _send_telegram
+
+    _no_proxy(monkeypatch)
+    bot = _make_bot()
+    _install_telegram_mock(monkeypatch, MagicMock(return_value=bot))
+    pdf = tmp_path / "中文报价合同.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n% test\n")
+
+    res = asyncio.run(
+        _send_telegram("tok", "123", "合同附件", media_files=[(str(pdf), False)])
+    )
+
+    assert res["success"] is True
+    assert res["attachments_sent"] == 1
+    assert res["media_receipts"] == [{
+        "message_id": "4",
+        "kind": "document",
+        "file_name": "中文报价合同.pdf",
+        "file_size": pdf.stat().st_size,
+    }]
+    bot.send_document.assert_awaited_once()
+
+
+def test_text_success_is_not_reported_as_attachment_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tools.send_message_tool import _send_telegram
+
+    _no_proxy(monkeypatch)
+    bot = _make_bot()
+    _install_telegram_mock(monkeypatch, MagicMock(return_value=bot))
+
+    res = asyncio.run(_send_telegram("tok", "123", "只有文件名称", media_files=[]))
+
+    assert res["success"] is True
+    assert res["attachments_sent"] == 0
+    assert res["media_receipts"] == []
+    assert res["text_message_ids"] == ["1"]
+    bot.send_document.assert_not_awaited()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -446,7 +446,7 @@ def _handle_send(args):
         return json.dumps({
             "error": "All MEDIA attachments were rejected by the delivery path policy",
             "rejected_media": rejected,
-            "hint": "Write deliverable files under $HERMES_HOME/output/ or another configured MEDIA allow directory.",
+            "hint": "Write deliverable files under $HERMES_HOME/cache/documents/ or another configured MEDIA allow directory.",
         }, ensure_ascii=False)
     mirror_text = cleaned_message.strip() or _describe_media_for_mirror(media_files)
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -439,8 +439,15 @@ def _handle_send(args):
     # JPGs where Telegram's sendPhoto recompresses to 1280px).
     force_document_attachments = "[[as_document]]" in message
 
-    media_files, cleaned_message = BasePlatformAdapter.extract_media(message)
-    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    extracted_media_files, cleaned_message = BasePlatformAdapter.extract_media(message)
+    media_files = BasePlatformAdapter.filter_media_delivery_paths(extracted_media_files)
+    if extracted_media_files and not media_files:
+        rejected = [path for path, _is_voice in extracted_media_files]
+        return json.dumps({
+            "error": "All MEDIA attachments were rejected by the delivery path policy",
+            "rejected_media": rejected,
+            "hint": "Write deliverable files under $HERMES_HOME/output/ or another configured MEDIA allow directory.",
+        }, ensure_ascii=False)
     mirror_text = cleaned_message.strip() or _describe_media_for_mirror(media_files)
 
     used_home_channel = False
@@ -1266,6 +1273,8 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             text_kwargs["disable_web_page_preview"] = True
 
         last_msg = None
+        text_message_ids = []
+        media_receipts = []
         warnings = []
 
         # MEDIA:<path> caption: when a single captionable file is accompanied
@@ -1340,6 +1349,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                         )
                     else:
                         raise
+                text_message_ids.append(str(last_msg.message_id))
 
         for media_path, is_voice in media_files:
             if not os.path.exists(media_path):
@@ -1467,6 +1477,19 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                                 )
                         else:
                             raise
+                    media_kind = (
+                        "photo" if ext in _IMAGE_EXTS and not force_document
+                        else "video" if ext in _VIDEO_EXTS
+                        else "voice" if ext in _VOICE_EXTS and is_voice
+                        else "audio" if ext in _TELEGRAM_SEND_AUDIO_EXTS
+                        else "document"
+                    )
+                    media_receipts.append({
+                        "message_id": str(last_msg.message_id),
+                        "kind": media_kind,
+                        "file_name": os.path.basename(media_path),
+                        "file_size": os.path.getsize(media_path),
+                    })
             except Exception as e:
                 warning = _sanitize_error_text(f"Failed to send media {media_path}: {e}")
                 logger.error(warning)
@@ -1483,6 +1506,9 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             "platform": "telegram",
             "chat_id": chat_id,
             "message_id": str(last_msg.message_id),
+            "text_message_ids": text_message_ids,
+            "media_receipts": media_receipts,
+            "attachments_sent": len(media_receipts),
         }
         if warnings:
             result["warnings"] = warnings


### PR DESCRIPTION
## What does this PR do?

Fixes a false-success path in standalone message delivery: when a response contains `MEDIA:` directives but every attachment is rejected by the delivery path policy, Hermes previously stripped the directives and continued as a successful text-only send. Automation could therefore report that a document was delivered even though no attachment upload was attempted.

The send path now fails closed with the rejected paths and a safe-output hint. Telegram standalone delivery also returns structured receipts so callers can distinguish text delivery from actual attachment delivery.

The gateway's non-streaming path now emits an explicit user-visible notice when all extracted attachments are blocked and no text remains.

## Related Issue

No existing issue found after searching open and closed issues/PRs for rejected `MEDIA:` attachments and delivery receipts.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/send_message_tool.py`
  - Return an explicit error when all extracted `MEDIA:` paths are rejected.
  - Include `rejected_media` and a safe output-directory hint.
  - Return `text_message_ids`, `media_receipts`, and `attachments_sent` for Telegram standalone sends.
- `gateway/platforms/base.py`
  - Log `response_delivery_blocked` and show a user-visible notice when every attachment is rejected and no text remains.
- `tests/tools/test_send_message_tool.py`
  - Assert rejected paths do not degrade into a successful text-only send.
- `tests/tools/test_telegram_send_message_caption.py`
  - Verify Unicode PDF filenames and structured document receipts.
  - Verify a text-only success reports zero attachments.

## How to Test

1. Run syntax checks:
   ```bash
   python -m py_compile gateway/platforms/base.py tools/send_message_tool.py tests/tools/test_send_message_tool.py tests/tools/test_telegram_send_message_caption.py
   ```
2. Run focused tests:
   ```bash
   python -m pytest -q tests/tools/test_telegram_send_message_caption.py tests/tools/test_send_message_tool.py
   ```
3. Send a `MEDIA:` path outside the allowed roots in strict mode and verify the result contains `error` and `rejected_media`, with no platform send attempted.
4. Send a Unicode-named PDF from an allowed output directory and verify `attachments_sent == 1` and the `media_receipts` entry contains the original filename, document kind, size, and message ID.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu 22.04 ARM64 with Telegram

Focused test result: `168 passed, 1 warning in 4.75s`.

### Documentation & Housekeeping

- [x] Documentation update — N/A
- [x] `cli-config.yaml.example` update — N/A, no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A, no architecture or workflow change
- [x] Cross-platform impact considered: only platform-neutral path filtering and additive Telegram result fields are changed
- [x] Tool schema update — N/A, tool arguments are unchanged; result fields are additive

## Screenshots / Logs

Observed production failure mode before the fix: the standalone send returned a successful message ID for the remaining text while the PDF was not uploaded. After the fix, allowed Unicode PDF attachments produce a document receipt, and blocked paths return an explicit error instead of success.
