### PR TITLE
fix(desktop): settle the gateway connect on gateway.ready and keep a stale boot from finishing after a switch

### DIFF
--- a/apps/desktop/src/api/client.ts
+++ b/apps/desktop/src/api/client.ts
@@ -28,6 +28,10 @@ export const PROMPT_SUBMIT_REQUEST_TIMEOUT_MS = 1_800_000
 export class HermesGateway extends JsonRpcGatewayClient {
   constructor() {
     super({
+      // boot-failure-reauth.ts recognizes this canonical text and routes the
+      // failure overlay to the remote Gateway sign-in recovery path.
+      authRejectedErrorMessage:
+        'Your remote gateway session has expired. Open Settings → Gateway and click "Sign in" again.',
       closedErrorMessage: 'Hermes gateway connection closed',
       connectErrorMessage: 'Could not connect to Hermes gateway',
       createRequestId: nextId => nextId,

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -3,7 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { DesktopConnectionsRegistry } from '@/global'
 import { createClientSessionState } from '@/lib/chat-runtime'
-import { $desktopBoot } from '@/store/boot'
+import type * as BootStore from '@/store/boot'
+import { $desktopBoot, completeDesktopBoot } from '@/store/boot'
 import {
   $connectionsRegistry,
   _resetConnectionsForTests,
@@ -52,6 +53,15 @@ vi.mock(import('@/store/notifications'), async importOriginal => ({
   notifyError: vi.fn()
 }))
 
+vi.mock('@/store/boot', async importOriginal => {
+  const actual = await importOriginal<typeof BootStore>()
+
+  return {
+    ...actual,
+    completeDesktopBoot: vi.fn(actual.completeDesktopBoot)
+  }
+})
+
 // End-to-end-ish repro of the "remote VPS → stuck on CONNECTING, no Settings"
 // bug that drives the REAL useGatewayBoot hook + REAL HermesGateway through a
 // fake WebSocket we fully control. No Docker / no real port: from the desktop's
@@ -82,13 +92,14 @@ describe('primaryRuntimeConnectionId', () => {
 })
 
 // Minimal WebSocket stand-in implementing only what json-rpc-gateway.connect()
-// touches: readyState, add/removeEventListener('open'|'error'|'close'), close().
+// touches: readyState, add/removeEventListener, close(), and readiness frames.
 class FakeWebSocket {
   static OPEN = 1
   static CLOSED = 3
-  // Flipped by the test: 'open' = next socket connects; 'fail' = next socket
-  // errors (a dead remote). Mirrors a VPS going away after the first connect.
-  static mode: 'open' | 'fail' = 'open'
+  // Flipped by the test: 'open' emits transport open + gateway.ready; 'fail'
+  // errors (a dead remote); 'reject' opens then closes during the handshake.
+  static mode: 'fail' | 'open' | 'reject' = 'open'
+  static rejectCode = 4401
   static instances: FakeWebSocket[] = []
   // Ping behavior: 'pong' answers with a healthy pong frame; 'silent' swallows
   // the request (the half-open-socket simulation — connection looks OPEN but
@@ -102,13 +113,25 @@ class FakeWebSocket {
 
   constructor(public url: string) {
     FakeWebSocket.instances.push(this)
-    const willOpen = FakeWebSocket.mode === 'open'
-    // Resolve on the next microtask/macrotask so connect()'s promise wiring is
-    // in place before open/error fires (matches real async socket handshake).
+    const mode = FakeWebSocket.mode
+    // Resolve on the next task so connect()'s promise wiring is in place before
+    // open/error/close/readiness fires (matches the real async handshake).
     setTimeout(() => {
-      if (willOpen) {
+      if (mode === 'open') {
         this.readyState = FakeWebSocket.OPEN
         this.emit('open', {})
+        this.emit('message', {
+          data: JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'event',
+            params: { type: 'gateway.ready' }
+          })
+        })
+      } else if (mode === 'reject') {
+        this.readyState = FakeWebSocket.OPEN
+        this.emit('open', {})
+        this.readyState = FakeWebSocket.CLOSED
+        this.emit('close', { code: FakeWebSocket.rejectCode })
       } else {
         this.readyState = FakeWebSocket.CLOSED
         this.emit('error', {})
@@ -126,13 +149,13 @@ class FakeWebSocket {
 
   close() {
     this.readyState = FakeWebSocket.CLOSED
-    this.emit('close', {})
+    this.emit('close', { code: 1005 })
   }
 
   // Force-drop an open socket, as a sleeping laptop / restarted remote would.
   drop() {
     this.readyState = FakeWebSocket.CLOSED
-    this.emit('close', {})
+    this.emit('close', { code: 1006 })
   }
 
   send(data: string) {
@@ -244,17 +267,19 @@ function fakeDesktop() {
 
 function Harness({
   beforeConnectionSwitch = () => undefined,
+  onConnectionReady = () => undefined,
   refreshHermesConfig = async () => undefined,
   refreshSessions
 }: {
   beforeConnectionSwitch?: () => void
+  onConnectionReady?: (connection: Parameters<Parameters<typeof useGatewayBoot>[0]['onConnectionReady']>[0]) => void
   refreshHermesConfig?: (force?: boolean, shouldPublish?: () => boolean) => Promise<void>
   refreshSessions?: (shouldPublish?: () => boolean) => Promise<void>
 } = {}) {
   useGatewayBoot({
     beforeConnectionSwitch,
     handleGatewayEvent: () => undefined,
-    onConnectionReady: () => undefined,
+    onConnectionReady,
     onGatewayReady: () => undefined,
     refreshHermesConfig,
     refreshSessions: refreshSessions ?? (async () => undefined)
@@ -284,6 +309,7 @@ beforeEach(() => {
   $sessionTiles.set([])
   vi.useFakeTimers()
   FakeWebSocket.mode = 'open'
+  FakeWebSocket.rejectCode = 4401
   FakeWebSocket.instances = []
   FakeWebSocket.pingMode = 'pong'
   connectionApplied = null
@@ -304,6 +330,7 @@ beforeEach(() => {
     timestamp: Date.now(),
     visible: true
   })
+  vi.mocked(completeDesktopBoot).mockClear()
 })
 
 afterEach(() => {
@@ -1782,5 +1809,180 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
       await vi.advanceTimersByTimeAsync(20_000)
     })
     expect($gatewayState.get()).toBe('open')
+  })
+
+  it('a 4401 boot handshake fails with the canonical reauth message and never retries', async () => {
+    const desktop = fakeDesktop()
+    desktop.getBootProgress = vi.fn(async () => ({
+      error: 'transient remote failure',
+      fakeMode: false,
+      message: 'Desktop boot failed: transient remote failure',
+      phase: 'backend.error',
+      progress: 24,
+      retryable: true,
+      running: false,
+      timestamp: Date.now()
+    }))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+    FakeWebSocket.mode = 'reject'
+    FakeWebSocket.rejectCode = 4401
+
+    render(<Harness />)
+    await flushAsync()
+
+    expect($desktopBoot.get().error).toBe(
+      'Your remote gateway session has expired. Open Settings → Gateway and click "Sign in" again.'
+    )
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+    expect(FakeWebSocket.instances).toHaveLength(1)
+
+    await advanceBackoff()
+
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+    expect(FakeWebSocket.instances).toHaveLength(1)
+  })
+
+  it('a 4403 boot handshake fails generically and never retries', async () => {
+    const desktop = fakeDesktop()
+    desktop.getBootProgress = vi.fn(async () => ({
+      error: 'transient remote failure',
+      fakeMode: false,
+      message: 'Desktop boot failed: transient remote failure',
+      phase: 'backend.error',
+      progress: 24,
+      retryable: true,
+      running: false,
+      timestamp: Date.now()
+    }))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+    FakeWebSocket.mode = 'reject'
+    FakeWebSocket.rejectCode = 4403
+
+    render(<Harness />)
+    await flushAsync()
+
+    expect($desktopBoot.get().error).toBe('Could not connect to Hermes gateway')
+    expect($desktopBoot.get().error).not.toMatch(/remote gateway session has expired/i)
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+    expect(FakeWebSocket.instances).toHaveLength(1)
+
+    await advanceBackoff()
+
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+    expect(FakeWebSocket.instances).toHaveLength(1)
+  })
+
+  it('a soft switch prevents a pending older boot from publishing, adopting, or completing', async () => {
+    const desktop = fakeDesktop()
+
+    const staleBootConnection = {
+      authMode: 'token' as const,
+      baseUrl: 'https://stale.example.com',
+      profile: 'stale',
+      token: 'stale',
+      wsUrl: 'wss://stale.example.com/api/ws?token=stale'
+    }
+
+    const switchConnection = {
+      authMode: 'token' as const,
+      baseUrl: 'https://switch.example.com',
+      profile: 'switch',
+      token: 'switch',
+      wsUrl: 'wss://switch.example.com/api/ws?token=switch'
+    }
+
+    const pendingBootConnection = deferred<typeof staleBootConnection>()
+
+    desktop.getConnection = vi
+      .fn()
+      .mockImplementationOnce(() => pendingBootConnection.promise)
+      .mockResolvedValue(switchConnection) as unknown as typeof desktop.getConnection
+    desktop.profile.get = vi.fn(async () => ({ profile: 'switch' }))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    const onConnectionReady = vi.fn()
+    const refreshHermesConfig = vi.fn(async () => undefined)
+    const refreshSessions = vi.fn(async () => undefined)
+
+    render(
+      <Harness
+        onConnectionReady={onConnectionReady}
+        refreshHermesConfig={refreshHermesConfig}
+        refreshSessions={refreshSessions}
+      />
+    )
+    await flushAsync()
+
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+    expect(connectionApplied).not.toBeNull()
+
+    act(() => connectionApplied?.())
+    await flushAsync()
+    await flushAsync()
+
+    expect($connection.get()).toEqual(switchConnection)
+    expect(onConnectionReady).toHaveBeenCalledTimes(1)
+    expect(desktop.profile.get).toHaveBeenCalledTimes(1)
+    expect(refreshHermesConfig).toHaveBeenCalledTimes(1)
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+    expect(completeDesktopBoot).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      pendingBootConnection.resolve(staleBootConnection)
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect($connection.get()).toEqual(switchConnection)
+    expect(onConnectionReady).toHaveBeenCalledTimes(1)
+    expect(desktop.profile.get).toHaveBeenCalledTimes(1)
+    expect(refreshHermesConfig).toHaveBeenCalledTimes(1)
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+    expect(completeDesktopBoot).toHaveBeenCalledTimes(1)
+    expect(FakeWebSocket.instances.some(socket => socket.url === staleBootConnection.wsUrl)).toBe(false)
+  })
+
+  it('a queued retry from an older boot generation cannot restart after a soft switch', async () => {
+    const desktop = fakeDesktop()
+    desktop.getBootProgress = vi.fn(async () => ({
+      error: 'Could not verify the existing SSH backend.',
+      fakeMode: false,
+      message: 'Desktop boot failed: Could not verify the existing SSH backend.',
+      phase: 'backend.error',
+      progress: 24,
+      retryable: true,
+      running: false,
+      timestamp: Date.now()
+    }))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    FakeWebSocket.mode = 'fail'
+    render(<Harness />)
+    await flushAsync()
+
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    expect($desktopBoot.get().error).toBeNull()
+
+    // Model a timer callback already queued when softSwitch clears its handle.
+    // The generation check in the callback remains the final ownership gate.
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout').mockImplementation(() => undefined)
+
+    try {
+      FakeWebSocket.mode = 'open'
+      act(() => connectionApplied?.())
+      await flushAsync()
+      await flushAsync()
+
+      expect($gatewayState.get()).toBe('open')
+      expect(desktop.getConnection).toHaveBeenCalledTimes(2)
+      expect(FakeWebSocket.instances).toHaveLength(2)
+
+      await advanceBackoff()
+
+      expect(desktop.getConnection).toHaveBeenCalledTimes(2)
+      expect(FakeWebSocket.instances).toHaveLength(2)
+    } finally {
+      clearTimeoutSpy.mockRestore()
+    }
   })
 })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -241,6 +241,9 @@ export function useGatewayBoot({
     // Bounded automatic boot retry for transient REMOTE failures (#82679).
     let bootRetryAttempt = 0
     let bootRetryTimer: ReturnType<typeof setTimeout> | null = null
+    let bootGeneration = 0
+
+    const bootIsStale = (gen: number) => cancelled || gen !== bootGeneration
 
     const clearBootRetryTimer = () => {
       if (bootRetryTimer !== null) {
@@ -570,6 +573,12 @@ export function useGatewayBoot({
       if (cancelled) {
         return
       }
+
+      // Invalidate any in-flight boot() — including a queued retry timer — so
+      // a switch that lands mid-boot can never let a stale attempt finish and
+      // clobber the connection this switch is about to establish. Counterpart
+      // to bootIsStale(gen) in boot() itself.
+      bootGeneration += 1
 
       let switchToken: null | ReturnType<typeof beginGatewaySwitch> = null
 
@@ -967,7 +976,7 @@ export function useGatewayBoot({
       })
     })
 
-    async function boot() {
+    async function boot(gen: number) {
       try {
         // A profile-pinned helper window (the HUD) dials its target profile's
         // backend directly — ensureBackend spawns/reuses it from the pool.
@@ -982,7 +991,7 @@ export function useGatewayBoot({
           'Timed out connecting to Hermes backend'
         )
 
-        if (cancelled) {
+        if (bootIsStale(gen)) {
           return
         }
 
@@ -991,6 +1000,11 @@ export function useGatewayBoot({
           message: translateNow('boot.steps.connectingGateway'),
           progress: 95
         })
+
+        if (bootIsStale(gen)) {
+          return
+        }
+
         publish(conn)
         setPrimaryGatewayConnection(conn)
 
@@ -1003,8 +1017,16 @@ export function useGatewayBoot({
         // post-connect pass retries the sync.
         try {
           await ensureDefaultWorkspaceCwd()
+
+          if (bootIsStale(gen)) {
+            return
+          }
         } catch (err) {
           console.warn('Failed to seed default workspace cwd pre-connect', err)
+        }
+
+        if (bootIsStale(gen)) {
+          return
         }
 
         // Mint a fresh WS URL right before connecting. For OAuth gateways the
@@ -1020,9 +1042,13 @@ export function useGatewayBoot({
           'Timed out minting the gateway WebSocket URL'
         )
 
+        if (bootIsStale(gen)) {
+          return
+        }
+
         await gateway.connect(wsUrl)
 
-        if (cancelled) {
+        if (bootIsStale(gen)) {
           return
         }
 
@@ -1031,7 +1057,11 @@ export function useGatewayBoot({
         // (cwd seed, config, sessions) are independent REST calls — running
         // them serially added their sum to time-to-populated-sidebar when only
         // the max is needed.
-        await adoptPrimaryProfile()
+        await adoptPrimaryProfile(() => !bootIsStale(gen))
+
+        if (bootIsStale(gen)) {
+          return
+        }
 
         setDesktopBootStep({
           phase: 'renderer.config',
@@ -1039,11 +1069,17 @@ export function useGatewayBoot({
           progress: 97
         })
 
+        if (bootIsStale(gen)) {
+          return
+        }
+
         await Promise.all([
           // The pre-connect seed already applied the configured default; this
           // post-connect pass covers the remote backend default. Non-fatal: a
           // failed sync must not abort boot (the remembered cwd remains).
-          seedDefaultCwd().catch(err => console.warn('Failed to sync default workspace cwd post-connect', err)),
+          seedDefaultCwd(() => !bootIsStale(gen)).catch(err =>
+            console.warn('Failed to sync default workspace cwd post-connect', err)
+          ),
           callbacksRef.current.refreshHermesConfig(),
           // Session-list population is never boot-fatal. The gateway WS is
           // already open by this point — a failed sidebar fetch (transient
@@ -1056,7 +1092,7 @@ export function useGatewayBoot({
           })
         ])
 
-        if (cancelled) {
+        if (bootIsStale(gen)) {
           return
         }
 
@@ -1064,34 +1100,57 @@ export function useGatewayBoot({
         bootCompleted = true
         bootRetryAttempt = 0
       } catch (err) {
-        if (!cancelled) {
-          const message = err instanceof Error ? err.message : String(err)
+        if (bootIsStale(gen)) {
+          return
+        }
 
-          // Transient remote failure (dropped SSH/HTTP registered connection,
-          // mint timeout): self-heal with bounded, jittered retries instead of
-          // parking on "Desktop boot failed" until the user re-enters the same
-          // connection details (#82679). Main already cleared the failed cached
-          // descriptor, so the next getConnection() rebuilds the connection —
-          // exactly what manual re-entry forced. Exhausted retries, local
-          // failures, and confirmed reauth rejections end in the real recovery
-          // affordance (the boot-failure overlay), never an infinite spinner.
-          if (bootRetryAttempt < BOOT_RETRY_MAX_ATTEMPTS && (await bootFailureIsRetryable()) && !cancelled) {
+        const message = err instanceof Error ? err.message : String(err)
+        const wsCloseCode = (err as { wsCloseCode?: number }).wsCloseCode
+
+        const explicitRefusal = isGatewayReauthRequired(err) || wsCloseCode === 4400 || wsCloseCode === 4403
+
+        // Transient remote failure (dropped SSH/HTTP registered connection,
+        // mint timeout): self-heal with bounded, jittered retries instead of
+        // parking on "Desktop boot failed" until the user re-enters the same
+        // connection details (#82679). Main already cleared the failed cached
+        // descriptor, so the next getConnection() rebuilds the connection —
+        // exactly what manual re-entry forced. Exhausted retries, local
+        // failures, and confirmed reauth/policy rejections end in the real
+        // recovery affordance (the boot-failure overlay), never an infinite
+        // spinner.
+        if (!explicitRefusal && bootRetryAttempt < BOOT_RETRY_MAX_ATTEMPTS) {
+          const retryable = await bootFailureIsRetryable()
+
+          if (bootIsStale(gen)) {
+            return
+          }
+
+          if (retryable) {
             const delay = reconnectBackoffDelayMs(bootRetryAttempt, { baseDelayMs: BOOT_RETRY_BASE_DELAY_MS })
             bootRetryAttempt += 1
             resumeDesktopBootForRetry(translateNow('boot.steps.retryingRemoteBackend'))
             clearBootRetryTimer()
             bootRetryTimer = setTimeout(() => {
               bootRetryTimer = null
-              void boot()
+
+              if (gen !== bootGeneration || cancelled) {
+                return
+              }
+
+              void boot(gen)
             }, delay)
 
             return
           }
-
-          failDesktopBoot(message)
-          notifyError(err, translateNow('boot.errors.desktopBootFailed'))
-          setSessionsLoading(false)
         }
+
+        if (bootIsStale(gen)) {
+          return
+        }
+
+        failDesktopBoot(message)
+        notifyError(err, translateNow('boot.errors.desktopBootFailed'))
+        setSessionsLoading(false)
       }
     }
 
@@ -1130,7 +1189,7 @@ export function useGatewayBoot({
     if (adoptedFromHmr) {
       void adoptBoot()
     } else {
-      void boot()
+      void boot(++bootGeneration)
     }
 
     return () => {

--- a/apps/desktop/src/lib/json-rpc-gateway-heartbeat.test.ts
+++ b/apps/desktop/src/lib/json-rpc-gateway-heartbeat.test.ts
@@ -82,12 +82,13 @@ describe('JsonRpcGatewayClient heartbeat recovery', () => {
 
     const connected = client.connect('ws://gateway.test/api/ws')
     socket.emit('open')
-    await connected
+    // connect() now resolves on gateway.ready, not on raw open — send it first.
     socket.message({
       jsonrpc: '2.0',
       method: 'event',
       params: { type: 'gateway.ready', payload: { heartbeat: true } }
     })
+    await connected
 
     await vi.advanceTimersByTimeAsync(61)
 
@@ -116,12 +117,13 @@ describe('JsonRpcGatewayClient heartbeat recovery', () => {
 
     const connected = client.connect('ws://gateway.test/api/ws')
     socket.emit('open')
-    await connected
+    // connect() now resolves on gateway.ready, not on raw open — send it first.
     socket.message({
       jsonrpc: '2.0',
       method: 'event',
       params: { type: 'gateway.ready', payload: {} }
     })
+    await connected
 
     await vi.advanceTimersByTimeAsync(1_000)
     expect(client.connectionState).toBe('open')

--- a/apps/desktop/src/lib/json-rpc-gateway-url-guard.test.ts
+++ b/apps/desktop/src/lib/json-rpc-gateway-url-guard.test.ts
@@ -1,23 +1,78 @@
 // connect() must reject before WebSocket coerces garbage into
 // `ws://<origin>/[object%20Object]` (#68250 stale-emit boot loop).
 
-import { JsonRpcGatewayClient, JsonRpcGatewayError } from '@hermes/shared'
+import { type GatewayEvent, isGatewayReauthRequired, JsonRpcGatewayClient, JsonRpcGatewayError } from '@hermes/shared'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type FakeEvent = {
+  code?: number
+  data?: string
+}
+
+type FakeListener = (event: FakeEvent) => void
+
+const gatewayReadyFrame = JSON.stringify({
+  jsonrpc: '2.0',
+  method: 'event',
+  params: { type: 'gateway.ready' }
+})
 
 class FakeSocket {
   static OPEN = 1
+  static CLOSED = 3
+
   readyState = 0
-  addEventListener = vi.fn((type: string, handler: () => void) => {
-    if (type === 'open') {
-      setTimeout(() => {
-        this.readyState = FakeSocket.OPEN
-        handler()
-      }, 0)
+  private listeners = new Map<string, Set<FakeListener>>()
+
+  addEventListener = vi.fn((type: string, handler: FakeListener) => {
+    let handlers = this.listeners.get(type)
+
+    if (!handlers) {
+      handlers = new Set()
+      this.listeners.set(type, handlers)
     }
+
+    handlers.add(handler)
   })
-  removeEventListener = vi.fn()
-  close = vi.fn()
+
+  removeEventListener = vi.fn((type: string, handler: FakeListener) => {
+    this.listeners.get(type)?.delete(handler)
+  })
+
+  close = vi.fn(() => {
+    if (this.readyState === FakeSocket.CLOSED) {
+      return
+    }
+
+    this.readyState = FakeSocket.CLOSED
+    this.emit('close', { code: 1005 })
+  })
+
   send = vi.fn()
+
+  emitOpen() {
+    this.readyState = FakeSocket.OPEN
+    this.emit('open', {})
+  }
+
+  emitMessage(data: string) {
+    this.emit('message', { data })
+  }
+
+  emitClose(code: number) {
+    this.readyState = FakeSocket.CLOSED
+    this.emit('close', { code })
+  }
+
+  emitError() {
+    this.emit('error', {})
+  }
+
+  private emit(type: string, event: FakeEvent) {
+    for (const handler of this.listeners.get(type) ?? []) {
+      handler(event)
+    }
+  }
 }
 
 describe('JsonRpcGatewayClient connect() URL guard', () => {
@@ -26,6 +81,7 @@ describe('JsonRpcGatewayClient connect() URL guard', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.unstubAllGlobals()
   })
 
@@ -55,12 +111,227 @@ describe('JsonRpcGatewayClient connect() URL guard', () => {
     expect(client.connectionState).toBe('idle')
   })
 
-  it('accepts ws:// and wss://', async () => {
+  it('accepts ws:// and wss:// after gateway.ready', async () => {
     for (const url of ['ws://127.0.0.1:1234/api/ws?token=t', 'wss://gw.example.com/api/ws?ticket=t']) {
-      const client = new JsonRpcGatewayClient({ socketFactory: () => new FakeSocket() as unknown as WebSocket })
-      await client.connect(url)
+      const socket = new FakeSocket()
+
+      const client = new JsonRpcGatewayClient({
+        socketFactory: () => socket as unknown as WebSocket
+      })
+
+      const connectPromise = client.connect(url)
+
+      socket.emitOpen()
+      socket.emitMessage(gatewayReadyFrame)
+
+      await connectPromise
       expect(client.connectionState).toBe('open')
+      client.close()
     }
+  })
+
+  it('keeps the connection pending and connecting after raw open', async () => {
+    const socket = new FakeSocket()
+
+    const client = new JsonRpcGatewayClient({
+      socketFactory: () => socket as unknown as WebSocket
+    })
+
+    const connectPromise = client.connect('ws://127.0.0.1:1234/api/ws?token=t')
+    let resolved = false
+
+    void connectPromise.then(
+      () => {
+        resolved = true
+      },
+      () => undefined
+    )
+
+    socket.emitOpen()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(resolved).toBe(false)
+    expect(client.connectionState).toBe('connecting')
+
+    client.close()
+    await expect(connectPromise).rejects.toThrow('WebSocket closed')
+  })
+
+  it('opens on gateway.ready and dispatches the readiness event before resolving', async () => {
+    const socket = new FakeSocket()
+
+    const client = new JsonRpcGatewayClient({
+      socketFactory: () => socket as unknown as WebSocket
+    })
+
+    const events: GatewayEvent[] = []
+    const offEvent = client.onEvent(event => events.push(event))
+    const connectPromise = client.connect('ws://127.0.0.1:1234/api/ws?token=t')
+
+    socket.emitOpen()
+    socket.emitMessage(gatewayReadyFrame)
+    await connectPromise
+
+    expect(client.connectionState).toBe('open')
+    expect(events).toEqual([expect.objectContaining({ type: 'gateway.ready' })])
+    offEvent()
+  })
+
+  it('rejects requests before gateway.ready without sending', async () => {
+    const socket = new FakeSocket()
+
+    const client = new JsonRpcGatewayClient({
+      notConnectedErrorMessage: 'Hermes gateway is not connected',
+      socketFactory: () => socket as unknown as WebSocket
+    })
+
+    const connectPromise = client.connect('ws://127.0.0.1:1234/api/ws?token=t')
+
+    socket.emitOpen()
+
+    await expect(client.request('session.list')).rejects.toThrow('Hermes gateway is not connected')
+    expect(socket.send).not.toHaveBeenCalled()
+
+    client.close()
+    await expect(connectPromise).rejects.toThrow()
+  })
+
+  it('classifies a 4401 handshake close as requiring OAuth login', async () => {
+    const socket = new FakeSocket()
+
+    const authRejectedErrorMessage =
+      'Your remote gateway session has expired. Open Settings → Gateway and click "Sign in" again.'
+
+    const client = new JsonRpcGatewayClient({
+      authRejectedErrorMessage,
+      connectErrorMessage: 'Could not connect to Hermes gateway',
+      socketFactory: () => socket as unknown as WebSocket
+    })
+
+    const connectPromise = client.connect('wss://gw.example.com/api/ws?ticket=stale')
+
+    socket.emitOpen()
+    socket.emitClose(4401)
+
+    const error = await connectPromise.catch(reason => reason)
+
+    expect(error).toEqual(
+      expect.objectContaining({
+        message: authRejectedErrorMessage,
+        needsOauthLogin: true,
+        wsCloseCode: 4401
+      })
+    )
+    expect(isGatewayReauthRequired(error)).toBe(true)
+    expect(client.connectionState).toBe('closed')
+  })
+
+  it('preserves a 4403 handshake close without classifying it as reauth', async () => {
+    const socket = new FakeSocket()
+
+    const client = new JsonRpcGatewayClient({
+      connectErrorMessage: 'Could not connect to Hermes gateway',
+      socketFactory: () => socket as unknown as WebSocket
+    })
+
+    const connectPromise = client.connect('wss://gw.example.com/api/ws?ticket=t')
+
+    socket.emitOpen()
+    socket.emitClose(4403)
+
+    const error = await connectPromise.catch(reason => reason)
+
+    expect(error).toEqual(
+      expect.objectContaining({
+        message: 'Could not connect to Hermes gateway',
+        wsCloseCode: 4403
+      })
+    )
+    expect(isGatewayReauthRequired(error)).toBe(false)
+    expect(client.connectionState).toBe('closed')
+  })
+
+  it('rejects a non-ready first frame as a protocol failure', async () => {
+    const socket = new FakeSocket()
+
+    const client = new JsonRpcGatewayClient({
+      connectErrorMessage: 'Could not connect to Hermes gateway',
+      socketFactory: () => socket as unknown as WebSocket
+    })
+
+    const connectPromise = client.connect('ws://127.0.0.1:1234/api/ws?token=t')
+
+    socket.emitOpen()
+    socket.emitMessage(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'event',
+        params: { type: 'session.event' }
+      })
+    )
+
+    await expect(connectPromise).rejects.toThrow('Could not connect to Hermes gateway')
+    expect(client.connectionState).toBe('error')
+    expect(socket.close).toHaveBeenCalledOnce()
+  })
+
+  it('close() rejects an in-flight handshake and its timeout cannot poison the next connection', async () => {
+    vi.useFakeTimers()
+
+    const sockets: FakeSocket[] = []
+
+    const client = new JsonRpcGatewayClient({
+      closedErrorMessage: 'Hermes gateway connection closed',
+      socketFactory: () => {
+        const socket = new FakeSocket()
+        sockets.push(socket)
+
+        return socket as unknown as WebSocket
+      }
+    })
+
+    const firstConnect = client.connect('ws://127.0.0.1:1234/api/ws?token=first')
+    sockets[0].emitOpen()
+
+    client.close()
+
+    await expect(firstConnect).rejects.toThrow('Hermes gateway connection closed')
+    expect(client.connectionState).toBe('closed')
+
+    const secondConnect = client.connect('ws://127.0.0.1:1234/api/ws?token=second')
+    sockets[1].emitOpen()
+    sockets[1].emitMessage(gatewayReadyFrame)
+    await secondConnect
+
+    expect(client.connectionState).toBe('open')
+
+    await vi.advanceTimersByTimeAsync(15_000)
+
+    expect(client.connectionState).toBe('open')
+  })
+
+  it('shares a same-URL attempt and rejects a different URL while connecting', async () => {
+    const socket = new FakeSocket()
+
+    const client = new JsonRpcGatewayClient({
+      socketFactory: () => socket as unknown as WebSocket
+    })
+
+    const firstConnect = client.connect('ws://127.0.0.1:1234/api/ws?token=t')
+    const sameUrlConnect = client.connect('ws://127.0.0.1:1234/api/ws?token=t')
+
+    expect(sameUrlConnect).toBe(firstConnect)
+
+    await expect(client.connect('ws://127.0.0.1:4321/api/ws?token=t')).rejects.toThrow(
+      'gateway connect() already in progress'
+    )
+
+    socket.emitOpen()
+    socket.emitMessage(gatewayReadyFrame)
+
+    await expect(Promise.all([firstConnect, sameUrlConnect])).resolves.toEqual([undefined, undefined])
+    expect(client.connectionState).toBe('open')
   })
 })
 
@@ -76,6 +347,7 @@ describe('JsonRpcGatewayClient structured errors', () => {
           setTimeout(() => {
             this.readyState = RespondingSocket.OPEN
             handler()
+            this.messageHandler?.({ data: gatewayReadyFrame })
           }, 0)
         }
 

--- a/apps/shared/src/index.ts
+++ b/apps/shared/src/index.ts
@@ -49,6 +49,7 @@ export {
 export {
   type ConnectionState,
   type GatewayClientOptions,
+  GatewayConnectError,
   type GatewayEvent,
   type GatewayEventName,
   type GatewayRequestId,

--- a/apps/shared/src/json-rpc-gateway-replay.test.ts
+++ b/apps/shared/src/json-rpc-gateway-replay.test.ts
@@ -69,6 +69,8 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
     const client = makeClient()
     const p = client.connect('ws://x')
     sockets[0].open()
+    // connect() now resolves on gateway.ready, not on raw open — send it first.
+    sockets[0].serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'gateway.ready', payload: {} } })
     await p
 
     sockets[0].serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'message.delta', session_id: 's1', seq: 4 } })
@@ -86,6 +88,8 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
     const first = client.connect('ws://x')
     let sock = sockets[sockets.length - 1]
     sock.open()
+    // connect() now resolves on gateway.ready, not on raw open — send it first.
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'gateway.ready', payload: {} } })
     await first
 
     sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'message.start', session_id: 's1', seq: 1 } })
@@ -96,6 +100,8 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
     const second = client.connect('ws://x')
     sock = sockets[sockets.length - 1]
     sock.open()
+    // connect() now resolves on gateway.ready, not on raw open — send it first.
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'gateway.ready', payload: {} } })
     await second
 
     // The reconnect triggered a replay fetch — flush microtasks.
@@ -116,6 +122,8 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
     const first = client.connect('ws://x')
     let sock = sockets[sockets.length - 1]
     sock.open()
+    // connect() now resolves on gateway.ready, not on raw open — send it first.
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'gateway.ready', payload: {} } })
     await first
     sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'message.delta', session_id: 's1', seq: 3 } })
 
@@ -123,6 +131,8 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
     const second = client.connect('ws://x')
     sock = sockets[sockets.length - 1]
     sock.open()
+    // connect() now resolves on gateway.ready, not on raw open — send it first.
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'gateway.ready', payload: {} } })
     await second
 
     await vi.waitFor(async () => {
@@ -154,11 +164,15 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
     const client = makeClient()
     const p = client.connect('ws://x')
     sockets[0].open()
+    // connect() now resolves on gateway.ready, not on raw open — send it first.
+    sockets[0].serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'gateway.ready', payload: {} } })
     await p
     // No events ever seen → close+reconnect must NOT fire a replay RPC.
     client.invalidate('drop')
     const p2 = client.connect('ws://x')
     sockets[sockets.length - 1].open()
+    // connect() now resolves on gateway.ready, not on raw open — send it first.
+    sockets[sockets.length - 1].serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'gateway.ready', payload: {} } })
     await p2
     await new Promise(r => setTimeout(r, 20))
 
@@ -171,6 +185,8 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
     const first = client.connect('ws://x')
     let sock = sockets[sockets.length - 1]
     sock.open()
+    // connect() now resolves on gateway.ready, not on raw open — send it first.
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'gateway.ready', payload: {} } })
     await first
     sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'status.update', session_id: 's1', seq: 10 } })
 
@@ -178,6 +194,8 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
     const second = client.connect('ws://x')
     sock = sockets[sockets.length - 1]
     sock.open()
+    // connect() now resolves on gateway.ready, not on raw open — send it first.
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'gateway.ready', payload: {} } })
     await second
 
     await vi.waitFor(() => {
@@ -203,6 +221,8 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
     const first = client.connect('ws://x')
     let sock = sockets[sockets.length - 1]
     sock.open()
+    // connect() now resolves on gateway.ready, not on raw open — send it first.
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'gateway.ready', payload: {} } })
     await first
     sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'message.delta', session_id: 's1', seq: 1 } })
     expect(seen).toEqual(['delta']) // the pre-drop live frame
@@ -211,6 +231,8 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
     const second = client.connect('ws://x')
     sock = sockets[sockets.length - 1]
     sock.open()
+    // connect() now resolves on gateway.ready, not on raw open — send it first.
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'gateway.ready', payload: {} } })
     await second
 
     await vi.waitFor(() => {
@@ -244,6 +266,8 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
     const first = client.connect('ws://x')
     let sock = sockets[sockets.length - 1]
     sock.open()
+    // connect() now resolves on gateway.ready, not on raw open — send it first.
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'gateway.ready', payload: {} } })
     await first
     sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'message.delta', session_id: 's1', seq: 2 } })
     expect(seen).toEqual([2]) // pre-drop live frame dispatches normally
@@ -252,6 +276,8 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
     const second = client.connect('ws://x')
     sock = sockets[sockets.length - 1]
     sock.open()
+    // connect() now resolves on gateway.ready, not on raw open — send it first.
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'gateway.ready', payload: {} } })
     await second
 
     await vi.waitFor(() => {
@@ -295,13 +321,14 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
     const first = client.connect('ws://x')
     let sock = sockets[sockets.length - 1]
     sock.open()
-    await first
-    // Learn epoch A and a high watermark.
+    // connect() now resolves on gateway.ready, not on raw open — send it first.
+    // Learn epoch A via the same frame that settles the handshake.
     sock.serverFrame({
       jsonrpc: '2.0',
       method: 'event',
       params: { type: 'gateway.ready', payload: { replay_epoch: 'epoch-A' } }
     })
+    await first
     sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'message.delta', session_id: 's1', seq: 97 } })
     expect(client.getSeqWatermarks()).toEqual({ s1: 97 })
 
@@ -312,6 +339,8 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
     const second = client.connect('ws://x')
     sock = sockets[sockets.length - 1]
     sock.open()
+    // connect() now resolves on gateway.ready, not on raw open — send it first.
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'gateway.ready', payload: {} } })
     await second
 
     await vi.waitFor(() => {

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -64,6 +64,19 @@ export class JsonRpcGatewayError extends Error {
   }
 }
 
+/** Connection-handshake failure with optional WebSocket close metadata. */
+export class GatewayConnectError extends Error {
+  readonly wsCloseCode?: number
+  readonly needsOauthLogin?: boolean
+
+  constructor(message: string, options?: { wsCloseCode?: number; needsOauthLogin?: boolean }) {
+    super(message)
+    this.name = 'GatewayConnectError'
+    this.wsCloseCode = options?.wsCloseCode
+    this.needsOauthLogin = options?.needsOauthLogin
+  }
+}
+
 export type WebSocketLike = WebSocket
 
 type PendingCall = {
@@ -72,7 +85,18 @@ type PendingCall = {
   timer?: ReturnType<typeof setTimeout>
 }
 
+type ConnectAttempt = {
+  socket: WebSocketLike
+  url: string
+  promise: Promise<void>
+  resolve: () => void
+  reject: (error: Error) => void
+  timer?: ReturnType<typeof setTimeout>
+  settled: boolean
+}
+
 export interface GatewayClientOptions {
+  authRejectedErrorMessage?: string
   closedErrorMessage?: string
   connectErrorMessage?: string
   connectTimeoutMs?: number
@@ -127,15 +151,19 @@ export class JsonRpcGatewayClient {
    * silently believe nothing was missed.
    */
   private replayEpoch: string | null = null
+  private attempt: ConnectAttempt | null = null
   private readonly eventHandlers = new Map<string, Set<(event: GatewayEvent) => void>>()
   private readonly stateHandlers = new Set<(state: ConnectionState) => void>()
   private readonly options: Required<Omit<GatewayClientOptions, 'socketFactory'>> &
     Pick<GatewayClientOptions, 'socketFactory'>
 
   constructor(options: GatewayClientOptions = {}) {
+    const connectErrorMessage = options.connectErrorMessage ?? 'WebSocket connection failed'
+
     this.options = {
+      authRejectedErrorMessage: options.authRejectedErrorMessage ?? connectErrorMessage,
       closedErrorMessage: options.closedErrorMessage ?? 'WebSocket closed',
-      connectErrorMessage: options.connectErrorMessage ?? 'WebSocket connection failed',
+      connectErrorMessage,
       connectTimeoutMs: options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS,
       createRequestId: options.createRequestId ?? ((nextId: number) => `${options.requestIdPrefix ?? 'r'}${nextId}`),
       heartbeatDeadlineMs: options.heartbeatDeadlineMs ?? DEFAULT_HEARTBEAT_DEADLINE_MS,
@@ -152,7 +180,7 @@ export class JsonRpcGatewayClient {
     return this.state
   }
 
-  async connect(wsUrl: string): Promise<void> {
+  connect(wsUrl: string): Promise<void> {
     // Refuse garbage; WebSocket coerces non-strings into
     // `ws://<origin>/[object%20Object]` (#68250 stale-emit boot loop).
     const invalidUrl = () => {
@@ -162,7 +190,7 @@ export class JsonRpcGatewayClient {
     }
 
     if (typeof wsUrl !== 'string') {
-      throw invalidUrl()
+      return Promise.reject(invalidUrl())
     }
 
     let url: URL
@@ -170,22 +198,80 @@ export class JsonRpcGatewayClient {
     try {
       url = new URL(wsUrl)
     } catch {
-      throw invalidUrl()
+      return Promise.reject(invalidUrl())
     }
 
     if (url.protocol !== 'ws:' && url.protocol !== 'wss:') {
-      throw invalidUrl()
+      return Promise.reject(invalidUrl())
     }
 
-    if (this.socket?.readyState === WebSocket.OPEN || this.state === 'connecting') {
-      return
+    if (this.state === 'open' && this.socket?.readyState === WebSocket.OPEN) {
+      return Promise.resolve()
+    }
+
+    if (this.attempt && !this.attempt.settled) {
+      if (this.attempt.url === wsUrl) {
+        return this.attempt.promise
+      }
+
+      return Promise.reject(new Error('gateway connect() already in progress'))
     }
 
     this.setState('connecting')
 
-    const socket = this.options.socketFactory?.(wsUrl) ?? new WebSocket(wsUrl)
+    let socket: WebSocketLike
+
+    try {
+      socket = this.options.socketFactory?.(wsUrl) ?? new WebSocket(wsUrl)
+    } catch {
+      this.setState('error')
+
+      return Promise.reject(new GatewayConnectError(this.options.connectErrorMessage))
+    }
+
     this.socket = socket
     this.stopHeartbeat()
+
+    let resolveAttempt!: () => void
+    let rejectAttempt!: (error: Error) => void
+
+    const promise = new Promise<void>((resolve, reject) => {
+      resolveAttempt = resolve
+      rejectAttempt = reject
+    })
+
+    const attempt: ConnectAttempt = {
+      socket,
+      url: wsUrl,
+      promise,
+      resolve: resolveAttempt,
+      reject: rejectAttempt,
+      settled: false
+    }
+
+    this.attempt = attempt
+
+    const onOpen = () => {
+      if (this.socket !== socket || this.attempt !== attempt || attempt.settled) {
+        return
+      }
+
+      // A raw WebSocket open is only transport readiness. The connection stays
+      // in 'connecting' until the gateway identifies itself with gateway.ready.
+    }
+
+    const onError = () => {
+      if (this.socket !== socket || this.attempt !== attempt || attempt.settled) {
+        return
+      }
+
+      if (!this.settleConnectAttempt(attempt)) {
+        return
+      }
+
+      this.setState('error')
+      attempt.reject(new GatewayConnectError(this.options.connectErrorMessage))
+    }
 
     socket.addEventListener('message', message => {
       if (this.socket !== socket) {
@@ -193,7 +279,62 @@ export class JsonRpcGatewayClient {
       }
 
       this.lastInboundAt = Date.now()
-      this.handleMessage(message.data)
+
+      const frame = this.parseMessage(message.data)
+
+      if (this.attempt === attempt && !attempt.settled) {
+        if (frame?.method === 'event' && frame.params?.type === 'gateway.ready') {
+          if (!this.settleConnectAttempt(attempt)) {
+            return
+          }
+
+          this.setState('open')
+
+          if (this.gatewayReadyAdvertisesHeartbeat(frame.params.payload)) {
+            this.startHeartbeat(socket)
+          }
+
+          const epoch = (frame.params.payload as { replay_epoch?: unknown } | undefined)?.replay_epoch
+
+          if (typeof epoch === 'string' && epoch) {
+            this.adoptReplayEpoch(epoch)
+          }
+
+          this.dispatchEvent(frame.params)
+          attempt.resolve()
+
+          // Lossless resume: drain events emitted while we were disconnected.
+          // Fire-and-forget so connect() latency is unaffected; only runs when
+          // we actually observed seq'd events before the drop.
+          void this.fetchReplay()
+
+          return
+        }
+
+        if (!this.settleConnectAttempt(attempt)) {
+          return
+        }
+
+        this.setState('error')
+
+        try {
+          socket.close()
+        } catch {
+          // ignore
+        } finally {
+          if (this.socket === socket) {
+            this.socket = null
+          }
+        }
+
+        attempt.reject(new GatewayConnectError(this.options.connectErrorMessage))
+
+        return
+      }
+
+      if (frame) {
+        this.handleFrame(frame)
+      }
     })
 
     socket.addEventListener('close', event => {
@@ -201,87 +342,105 @@ export class JsonRpcGatewayClient {
         return
       }
 
-      if (this.options.onSocketClose(event)) {
+      if (this.attempt === attempt && !attempt.settled) {
+        if (!this.settleConnectAttempt(attempt)) {
+          return
+        }
+
+        this.socket = null
+        this.setState('closed')
+
+        const needsOauthLogin = event.code === 4401
+        attempt.reject(
+          new GatewayConnectError(
+            needsOauthLogin ? this.options.authRejectedErrorMessage : this.options.connectErrorMessage,
+            {
+              wsCloseCode: event.code,
+              needsOauthLogin: needsOauthLogin || undefined
+            }
+          )
+        )
+
         return
       }
 
+      // onSocketClose is an established-connection interception hook. Handshake
+      // closes are classified above and never flow through it.
+      if (this.state === 'open') {
+        if (this.options.onSocketClose(event)) {
+          return
+        }
+
+        this.socket = null
+        this.setState('closed')
+        this.rejectAllPending(new Error(this.options.closedErrorMessage))
+
+        return
+      }
+
+      // A failed handshake may close after its error/protocol-failure path has
+      // already settled. Release that socket without overwriting 'error'.
       this.socket = null
       this.stopHeartbeat()
-      this.setState('closed')
-      this.rejectAllPending(new Error(this.options.closedErrorMessage))
     })
 
-    await new Promise<void>((resolve, reject) => {
-      let settled = false
-      let timer: ReturnType<typeof setTimeout> | undefined
+    socket.addEventListener('open', onOpen, { once: true })
+    socket.addEventListener('error', onError, { once: true })
 
-      const cleanup = () => {
-        if (timer !== undefined) {
-          clearTimeout(timer)
-        }
-
-        socket.removeEventListener('open', onOpen)
-        socket.removeEventListener('error', onError)
-      }
-
-      const onOpen = () => {
-        if (settled || this.socket !== socket) {
+    if (this.options.connectTimeoutMs > 0) {
+      attempt.timer = setTimeout(() => {
+        if (this.socket !== socket || this.attempt !== attempt || attempt.settled) {
           return
         }
 
-        settled = true
-        cleanup()
-        this.setState('open')
-        resolve()
-        // Lossless resume: drain events emitted while we were disconnected.
-        // Fire-and-forget so connect() latency is unaffected; only runs when
-        // we actually observed seq'd events before the drop.
-        void this.fetchReplay()
-      }
-
-      const onError = () => {
-        if (settled || this.socket !== socket) {
+        if (!this.settleConnectAttempt(attempt)) {
           return
         }
 
-        settled = true
-        cleanup()
-        this.setState('error')
-        reject(new Error(this.options.connectErrorMessage))
-      }
-
-      socket.addEventListener('open', onOpen, { once: true })
-      socket.addEventListener('error', onError, { once: true })
-
-      if (this.options.connectTimeoutMs > 0) {
-        timer = setTimeout(() => {
-          if (settled) {
-            return
-          }
-
-          settled = true
-          cleanup()
-
-          // Drop the half-open socket so the next connect() starts clean
-          // instead of short-circuiting on a zombie 'connecting' state.
+        // Drop the half-open socket so the next connect() starts clean
+        // instead of short-circuiting on a zombie 'connecting' state.
+        try {
+          socket.close()
+        } catch {
+          // ignore
+        } finally {
           if (this.socket === socket) {
-            try {
-              socket.close()
-            } catch {
-              // ignore
-            }
-
             this.socket = null
             this.setState('error')
           }
+        }
 
-          reject(new Error(this.options.connectErrorMessage))
-        }, this.options.connectTimeoutMs)
-      }
-    })
+        this.setState('error')
+        attempt.reject(new GatewayConnectError(this.options.connectErrorMessage))
+      }, this.options.connectTimeoutMs)
+    }
+
+    return promise
   }
 
   close(): void {
+    const attempt = this.attempt
+
+    // Settle a pending attempt eagerly in both cases — close() nulls the
+    // socket below, after which the connect close-listener and timeout both
+    // bail on `this.socket !== socket`, so nothing else would ever settle it
+    // (real sockets queue their 'close' event; only the test fakes emit it
+    // synchronously). Only the message depends on how far the handshake got:
+    // a socket at raw 'open' (transport established, still waiting on
+    // gateway.ready) is a real close; a still-CONNECTING socket never had a
+    // live transport, and per the WebSocket spec closing it fails the
+    // connection rather than closing it, so it reports connectErrorMessage.
+    if (attempt && !attempt.settled && this.settleConnectAttempt(attempt)) {
+      this.setState('closed')
+      attempt.reject(
+        new GatewayConnectError(
+          this.socket?.readyState === WebSocket.OPEN
+            ? this.options.closedErrorMessage
+            : this.options.connectErrorMessage
+        )
+      )
+    }
+
     const socket = this.socket
 
     if (!socket) {
@@ -348,7 +507,7 @@ export class JsonRpcGatewayClient {
   ): Promise<T> {
     const socket = this.socket
 
-    if (!socket || socket.readyState !== WebSocket.OPEN) {
+    if (!socket || this.state !== 'open' || socket.readyState !== WebSocket.OPEN) {
       return Promise.reject(new Error(this.options.notConnectedErrorMessage))
     }
 
@@ -428,16 +587,24 @@ export class JsonRpcGatewayClient {
     })
   }
 
-  private handleMessage(raw: unknown): void {
+  private parseMessage(raw: unknown): JsonRpcFrame | null {
     const text = typeof raw === 'string' ? raw : String(raw)
-    let frame: JsonRpcFrame
+    let parsed: unknown
 
     try {
-      frame = JSON.parse(text) as JsonRpcFrame
+      parsed = JSON.parse(text)
     } catch {
-      return
+      return null
     }
 
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return null
+    }
+
+    return parsed as JsonRpcFrame
+  }
+
+  private handleFrame(frame: JsonRpcFrame): void {
     if (frame.id !== undefined && frame.id !== null) {
       const call = this.pending.get(frame.id)
 
@@ -644,6 +811,23 @@ export class JsonRpcGatewayClient {
         this.dispatchIfNewer(event)
       }
     }
+  }
+
+  private settleConnectAttempt(attempt: ConnectAttempt): boolean {
+    if (attempt.settled || this.attempt !== attempt) {
+      return false
+    }
+
+    attempt.settled = true
+
+    if (attempt.timer !== undefined) {
+      clearTimeout(attempt.timer)
+      attempt.timer = undefined
+    }
+
+    this.attempt = null
+
+    return true
   }
 
   private gatewayReadyAdvertisesHeartbeat(payload: unknown): boolean {

--- a/web/src/lib/gatewayClient.test.ts
+++ b/web/src/lib/gatewayClient.test.ts
@@ -52,6 +52,7 @@ class FakeWebSocket {
 
 type EventLike = {
   code?: number;
+  data?: string;
 };
 
 beforeEach(() => {
@@ -84,6 +85,13 @@ describe("GatewayClient", () => {
     const socket = FakeWebSocket.instances[0];
     socket.readyState = 1;
     socket.emit("open", {});
+    socket.emit("message", {
+      data: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "event",
+        params: { type: "gateway.ready" },
+      }),
+    });
     await connectPromise;
 
     socket.emit("close", { code: 4401 });


### PR DESCRIPTION
## What does this PR do?

Reworked on current main (the earlier version of this branch retried the boot-time WS dial with its own ladder; upstream 2b7f49673f now owns boot retry policy, so that part is gone).

`JsonRpcGatewayClient.connect()` resolved on the raw WebSocket `open` and `connectionState` became `'open'` at the same time. The desktop boot in `use-gateway-boot.ts` treats a resolved `connect()` as a usable gateway (adopts the profile, hydrates config/sessions, calls `completeDesktopBoot()`), and its reconnect bookkeeping (`reconnectAttempt`, `reconnectFailingSince`, `escalated`) resets on every `'open'`. So a gateway that accepts the upgrade and closes right away looks healthy: boot can complete on a dead socket, and a persistently rejected socket never reaches the 45 s escalation because each `'open'` clears the failure clock. `request()` only checked the socket's `readyState`, so callers could send during the handshake. This is the client half of #88607: once `/api/ws` rejections are delivered as close codes (as #88619 does for the other endpoints), the client has to treat `open` followed by a close as a rejection, not a connection.

Every `/api/ws` connection starts with a `gateway.ready` event (`tui_gateway/ws.py::handle_ws` writes it right after `accept()`), so that frame is where the connection is known to be usable.

- `connect()` resolves, and the state becomes `'open'`, only on the first frame, which must be `gateway.ready`. A different first frame is a protocol failure (state `'error'`, generic connect error). Raw `open` leaves the state `'connecting'` and the promise pending. `request()` requires the semantic `'open'`.
- A close during the handshake settles the attempt immediately with a `GatewayConnectError` (exported from `@hermes/shared`) carrying `wsCloseCode`. 4401 sets `needsOauthLogin` and uses the new `authRejectedErrorMessage` option, so `isGatewayReauthRequired()` is true and the boot-failure overlay routes to the sign-in path (`HermesGateway` passes the canonical "Your remote gateway session has expired…" text that `isRemoteReauthError()` matches). 4403/4400 keep the code without the auth marker. `onSocketClose` still applies to established connections only.
- One connect-attempt record owns the socket, timer and promise: a concurrent `connect()` for the same URL awaits the in-flight attempt, a different URL is rejected, `close()` during the handshake rejects it at once, and the abandoned connect timeout can no longer flip a newer, ready connection to `'error'`.
- Desktop boot: `boot(gen)` carries a boot generation. `softSwitch()` increments it before doing anything else, so an older boot still awaiting `getConnection()` / `connect()` / hydration cannot publish its connection, adopt a profile, commit the boot-owned cwd, schedule a retry, report a failure or complete boot after the switch. Upstream's bounded retry timer re-checks the generation when it fires. Reauth (4401) and explicit refusals (4400/4403) skip the automatic boot retry and go to the recovery overlay. Retry policy, jitter, limits and the 45 s reconnect escalation are unchanged.

## How was it tested?

- Fail-before: 12 new tests, 11 of which fail on main and pass here. `apps/desktop/src/lib/json-rpc-gateway-url-guard.test.ts`: raw open keeps `connecting` and the promise pending; `gateway.ready` opens and resolves; `request()` before readiness rejects without sending; open→4401 close rejects with `needsOauthLogin`, `wsCloseCode` and the auth message; open→4403 keeps the code without the auth marker; a non-ready first frame is a protocol failure; `close()` during the handshake rejects at once and the old timeout cannot poison the next connection; same-URL concurrent connect shares the attempt, different URL is rejected. `use-gateway-boot.test.tsx`: 4401 at boot fails with the reauth message and never auto-retries; 4403 fails generically and never retries; a soft switch keeps a pending older boot from publishing/adopting/completing; a queued retry from an older generation cannot restart boot after a switch.
- Existing fixtures now emit `gateway.ready` after `open`, which is the actual protocol; all existing tests in the two files still pass (31/31). Web vitest 275/275. Full desktop vitest shows only the same environment-specific failures as main. Web `tsc` clean; desktop `tsc` clean apart from a fixture that is missing in my sparse checkout.
- Against today's server (`/api/ws` still closes before accept, which uvicorn turns into HTTP 403) behaviour is unchanged: rejected upgrades still reject via `error`, successful ones still send `gateway.ready`.

## Compatibility

New client + current server: unchanged behaviour. New client + a server that never sends `gateway.ready` first (an old or custom gateway): `connect()` times out after the existing 15 s instead of resolving on `open`. `tui_gateway/ws.py` has emitted `gateway.ready` since it was added (April 2026, f49afd3122), so this only affects gateways that are not this repo's. Old client + a server that moves `/api/ws` to accept-then-close: the false-success this PR fixes, which is why the server switch (#88607) waits for this to ship.

## Follow-up (separate PR)

Move the three `/api/ws` gates in `hermes_cli/web_server.py` to `_ws_reject` and drop the allowlist entry in `tests/hermes_cli/test_web_server_ws_reject.py`, once #88619 has landed and a desktop with this client is out. In the same change, teach the web dashboard's `GatewayClient` to route a 4401 that arrives during the handshake to `maybeReloadForLoopbackWsAuthFailure` (today that hook only sees post-ready closes; against the current server a handshake rejection is an `error`, so nothing changes yet).

Relates to #73722 (mechanism 1 was superseded by 2b7f49673f; this covers what was left of it).
