### PR TITLE
Add run-hermes-agent Claude Code skill (build/run/test driver)

### DIFF
--- a/.claude/skills/run-hermes-agent/SKILL.md
+++ b/.claude/skills/run-hermes-agent/SKILL.md
@@ -48,7 +48,9 @@ run unattended. What it does, in order:
 | health | `uv run hermes doctor` | config/deps/dirs check; exits 0 even with warnings |
 | oneshot, no key | `uv run hermes -z "say hi"` | fails fast with a clear message, **exit 1** |
 | oneshot, dummy key | `OPENROUTER_API_KEY=<dummy> uv run hermes -z "say hi"` | request path reaches the provider; prints the HTTP error as if it were the reply, **exit 0** (see Gotchas) |
-| tests | `uv run pytest tests/test_account_usage.py -q` | test harness works |
+| tests | `scripts/run_tests.sh tests/test_account_usage.py -q` | test harness works, CI-parity |
+
+The no-key and dummy-key rows above are verified against current `main` (`hermes_cli/oneshot.py`), run inside an isolated `HERMES_HOME` — see the next paragraph for why that isolation matters.
 
 To actually get a real answer out of `-z`/`hermes chat -q`, set a real
 key first — `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, etc. (env var, or
@@ -74,8 +76,18 @@ uv run hermes         # interactive chat once configured
 
 ```bash
 uv sync --extra dev
-uv run pytest tests/test_account_usage.py -q   # → 4 passed
+scripts/run_tests.sh tests/test_account_usage.py -q   # → 4 passed
 ```
+
+Use `scripts/run_tests.sh`, not raw `pytest` — it enforces hermetic
+CI-parity (unset credential vars, `TZ=UTC`, `LANG=C.UTF-8`, per-file
+subprocess isolation) per `AGENTS.md`'s Testing section. A bare `pytest`
+invocation on a dev machine with real API keys set can diverge from CI in
+ways that pass locally and fail (or vice versa) upstream. It only looks
+for an interpreter at `./.venv`, `./venv`, or `$HERMES_PYTHON` — if
+you've relocated the venv per the OneDrive Gotcha below, export
+`HERMES_PYTHON=$UV_PROJECT_ENVIRONMENT/Scripts/python.exe` (or
+`.../bin/python` on POSIX) first. `smoke.sh` does this automatically.
 
 The full `tests/` tree is large; run a targeted subset rather than the
 whole suite unless you specifically need full coverage. Note: any test
@@ -99,10 +111,28 @@ without Developer Mode / admin (see Gotchas) — not a code bug.
   "succeeds" but leaves a half-replaced package — don't trust a retry,
   relocate instead.
 - **`hermes -z` exits 0 even when the LLM call itself fails upstream**
-  (e.g. bad API key → `HTTP 401: User not found.` printed to stdout).
-  Only a *local* config problem (no provider configured at all) exits
-  1. A script checking "did this succeed" by exit code alone will
-  treat a 401 as success — check the printed text too.
+  (e.g. bad API key → `HTTP 401: ...` printed to stdout as if it were
+  the reply). Only a *local* config problem (no provider configured at
+  all) exits 1. Verified directly against current `main`
+  (`hermes_cli/oneshot.py`) with an isolated `HERMES_HOME` — the 401
+  response text makes `response` non-empty, so the failure never reaches
+  the `result.get("failed")` / empty-response checks that would otherwise
+  return 1 or 2. A script checking "did this succeed" by exit code alone
+  will treat a 401 as success — check the printed text too.
+- **`hermes` loads `~/.hermes/.env` (or `$HERMES_HOME/.env`)
+  unconditionally on every invocation** (`hermes_cli/main.py`, before
+  dispatch). On a machine that already has a real provider configured,
+  the "no key" / "dummy key" smoke steps above would silently call the
+  real provider instead of exercising the failure path — `smoke.sh`
+  isolates this by pointing `HERMES_HOME` at a fresh `mktemp -d` for its
+  own run. Do the same (`HERMES_HOME=$(mktemp -d) ...`) if you run the
+  oneshot steps manually outside the script.
+- **`scripts/run_tests.sh` prints a `UnicodeEncodeError` traceback from
+  `run_tests_parallel.py`'s progress printer on stock Windows consoles**
+  (cp1252 can't encode the `✓` progress character), but the run still
+  completes and reports `N passed, 0 failed` with exit 0 — cosmetic, not
+  a real failure. Pre-existing in the repo's test runner, not specific to
+  this skill.
 - **`tests/test_atomic_replace_symlinks.py` fails on stock Windows**
   with `OSError: [WinError 1314] A required privilege is not held by
   the client` — creating symlinks needs Developer Mode or admin.

--- a/.claude/skills/run-hermes-agent/SKILL.md
+++ b/.claude/skills/run-hermes-agent/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: run-hermes-agent
+description: Build, run, and drive the Hermes Agent CLI (NousResearch/hermes-agent). Use when asked to run hermes, test the hermes CLI, verify it's installed correctly, or check `hermes doctor`/`hermes -z`/`hermes chat` behavior.
+---
+
+Hermes Agent is a Python CLI (`hermes`, entrypoint `hermes_cli.main:main`)
+managed with `uv`. Drive it via `.claude/skills/run-hermes-agent/smoke.sh`
+— it builds the venv, checks version/doctor, exercises the non-interactive
+`-z`/`--oneshot` invocation path (the scriptable surface most PRs touch,
+as opposed to the interactive TUI/REPL), and runs a pytest subset.
+
+All paths below are relative to the repo root.
+
+## Prerequisites
+
+- `uv` (any recent version — tested with `uv 0.12.0`). Node.js present
+  but not required for the CLI itself (only for the separate `apps/desktop`
+  Electron app and the `--tui`/`ui-tui` frontend, which this skill does
+  not cover).
+- Python is installed *by* `uv`, not by you — no manual Python setup needed.
+
+## Setup / Build
+
+```bash
+bash .claude/skills/run-hermes-agent/smoke.sh
+```
+
+This is the whole build+verify path: pins Python 3.12.13 (`requires-python
+>=3.11,<3.14`), runs `uv sync --extra dev`, then drives the CLI (see below).
+Takes ~1-2 min cold (dependency download), seconds on a warm cache.
+
+If you want the steps individually instead of the script:
+
+```bash
+uv python pin 3.12.13
+uv sync --extra dev        # base deps + pytest/ruff/ty (the `dev` extra)
+uv run hermes --version    # → Hermes Agent v0.19.0 (...) · upstream <sha>
+```
+
+## Run (agent path)
+
+The smoke script is the driver. It has no interactive prompts — safe to
+run unattended. What it does, in order:
+
+| step | command | what it proves |
+|---|---|---|
+| version | `uv run hermes --version` | entrypoint resolves, venv is sane |
+| health | `uv run hermes doctor` | config/deps/dirs check; exits 0 even with warnings |
+| oneshot, no key | `uv run hermes -z "say hi"` | fails fast with a clear message, **exit 1** |
+| oneshot, dummy key | `OPENROUTER_API_KEY=<dummy> uv run hermes -z "say hi"` | request path reaches the provider; prints the HTTP error as if it were the reply, **exit 0** (see Gotchas) |
+| tests | `uv run pytest tests/test_account_usage.py -q` | test harness works |
+
+To actually get a real answer out of `-z`/`hermes chat -q`, set a real
+key first — `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, etc. (env var, or
+`~/.hermes/.env` via `hermes setup`) — then:
+
+```bash
+uv run hermes -z "say hi"                    # one-shot, prints only the final text
+uv run hermes chat -q "say hi" -Q            # same idea, quiet mode
+```
+
+Both are the scriptable/programmatic path. `hermes` with no args, or
+`hermes chat`/`hermes --tui`, launch an interactive REPL/TUI instead —
+those need a real terminal (tmux) and aren't covered by this skill.
+
+## Run (human path)
+
+```bash
+uv run hermes setup   # interactive wizard: pick provider, enter API key
+uv run hermes         # interactive chat once configured
+```
+
+## Test
+
+```bash
+uv sync --extra dev
+uv run pytest tests/test_account_usage.py -q   # → 4 passed
+```
+
+The full `tests/` tree is large; run a targeted subset rather than the
+whole suite unless you specifically need full coverage. Note: any test
+under `tests/test_atomic_replace_symlinks.py` will fail on Windows
+without Developer Mode / admin (see Gotchas) — not a code bug.
+
+---
+
+## Gotchas
+
+- **`uv sync` fails with `error: failed to remove directory ... Access
+  is denied. (os error 5)` when the checkout lives under a
+  OneDrive-synced folder.** OneDrive's cloud-sync file locking races
+  with uv's atomic package-directory replace. Fix: point the venv
+  outside OneDrive before syncing:
+  ```bash
+  export UV_PROJECT_ENVIRONMENT="$HOME/.venvs/hermes-agent"
+  uv sync --extra dev
+  ```
+  `smoke.sh` already does this. Retrying `uv sync` in place sometimes
+  "succeeds" but leaves a half-replaced package — don't trust a retry,
+  relocate instead.
+- **`hermes -z` exits 0 even when the LLM call itself fails upstream**
+  (e.g. bad API key → `HTTP 401: User not found.` printed to stdout).
+  Only a *local* config problem (no provider configured at all) exits
+  1. A script checking "did this succeed" by exit code alone will
+  treat a 401 as success — check the printed text too.
+- **`tests/test_atomic_replace_symlinks.py` fails on stock Windows**
+  with `OSError: [WinError 1314] A required privilege is not held by
+  the client` — creating symlinks needs Developer Mode or admin.
+  Unrelated to the app; skip that file when smoke-testing.
+- **`uv sync` (no `--extra dev`) does not install pytest.** `pytest`
+  and friends live in the `dev` optional-dependency group in
+  `pyproject.toml` — use `uv sync --extra dev` for anything test-related.
+
+## Troubleshooting
+
+- **`Python was not found; run without arguments to install from the
+  Microsoft Store...`** when invoking `python`/`python3` directly:
+  Windows' App Execution Alias is shadowing the command. Ignore it —
+  use `uv run hermes ...` / `uv python pin` instead of calling `python`
+  directly; `uv` manages its own interpreter and doesn't go through
+  that alias.
+- **`hermes doctor` reports `⚠ .env file missing` / `config.yaml not
+  found`**: expected on a fresh clone. Not an error — `hermes doctor`
+  still exits 0. Run `hermes setup` to fix, or ignore if you only need
+  the CLI to *launch*, not actually chat.

--- a/.claude/skills/run-hermes-agent/smoke.sh
+++ b/.claude/skills/run-hermes-agent/smoke.sh
@@ -19,6 +19,16 @@ cd "$(dirname "${BASH_SOURCE[0]}")/../../.." # repo root
 export UV_PROJECT_ENVIRONMENT="${UV_PROJECT_ENVIRONMENT:-$HOME/.venvs/hermes-agent}"
 mkdir -p "$(dirname "$UV_PROJECT_ENVIRONMENT")"
 
+# Isolate the two oneshot invocations below from any real config the
+# developer already has at ~/.hermes/.env (or HERMES_HOME elsewhere).
+# main.py loads that file unconditionally on every invocation, so without
+# this, "no provider configured" / "bogus key" runs against a machine with
+# a real key already set up would silently call a real provider instead of
+# exercising the failure paths this script is meant to prove out.
+HERMES_SMOKE_HOME="$(mktemp -d)"
+trap 'rm -rf "$HERMES_SMOKE_HOME"' EXIT
+export HERMES_HOME="$HERMES_SMOKE_HOME"
+
 echo "== uv python pin =="
 uv python pin 3.12.13
 
@@ -45,6 +55,17 @@ echo "exit: $?"
 set -e
 
 echo "== pytest smoke subset (skip anything symlink-based — see Gotchas) =="
-uv run pytest tests/test_account_usage.py -q
+# AGENTS.md requires scripts/run_tests.sh over raw pytest: it enforces
+# hermetic CI-parity (unset credential vars, TZ=UTC, LANG=C.UTF-8,
+# per-file subprocess isolation) that a bare `pytest` invocation skips.
+# It only probes ./.venv, ./venv, and $HERMES_PYTHON for an interpreter
+# with pytest — since UV_PROJECT_ENVIRONMENT above relocates the venv
+# outside OneDrive, point HERMES_PYTHON at it so run_tests.sh finds it.
+if [ -x "$UV_PROJECT_ENVIRONMENT/Scripts/python.exe" ]; then
+  export HERMES_PYTHON="$UV_PROJECT_ENVIRONMENT/Scripts/python.exe"
+elif [ -x "$UV_PROJECT_ENVIRONMENT/bin/python" ]; then
+  export HERMES_PYTHON="$UV_PROJECT_ENVIRONMENT/bin/python"
+fi
+scripts/run_tests.sh tests/test_account_usage.py -q
 
 echo "== done =="

--- a/.claude/skills/run-hermes-agent/smoke.sh
+++ b/.claude/skills/run-hermes-agent/smoke.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Smoke-drives the Hermes Agent CLI: build, version/doctor checks,
+# a one-shot agent invocation (with and without a provider key), and
+# a quick pytest subset. Run from the repo root (git-bash / WSL / Linux).
+#
+# Why this file exists instead of just typing the commands: this repo
+# lives under a OneDrive-synced path on the reference machine, and
+# `uv sync` intermittently fails there (see UV_PROJECT_ENVIRONMENT
+# below) — this script encodes the fix so it isn't rediscovered every run.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.." # repo root
+
+# uv's package-replace step collides with OneDrive's file-lock-on-sync
+# behavior ("error: failed to remove directory ... Access is denied.
+# (os error 5)") when .venv lives inside a OneDrive folder. Relocating
+# the venv outside OneDrive fixes it. Harmless (and unnecessary) if
+# your checkout isn't under OneDrive.
+export UV_PROJECT_ENVIRONMENT="${UV_PROJECT_ENVIRONMENT:-$HOME/.venvs/hermes-agent}"
+mkdir -p "$(dirname "$UV_PROJECT_ENVIRONMENT")"
+
+echo "== uv python pin =="
+uv python pin 3.12.13
+
+echo "== uv sync (base + dev extras) =="
+uv sync --extra dev
+
+echo "== hermes --version =="
+uv run hermes --version
+
+echo "== hermes doctor =="
+uv run hermes doctor || true # exits 0 normally; `|| true` only guards flaky CI hosts
+
+echo "== one-shot invocation, no provider configured (expect exit 1, clear error) =="
+set +e
+uv run hermes -z "say hi"
+echo "exit: $?"
+set -e
+
+echo "== one-shot invocation, bogus provider key (expect exit 0, upstream 401 text as the 'response') =="
+set +e
+OPENROUTER_API_KEY=not-a-real-key \
+  uv run hermes -z "say hi"
+echo "exit: $?"
+set -e
+
+echo "== pytest smoke subset (skip anything symlink-based — see Gotchas) =="
+uv run pytest tests/test_account_usage.py -q
+
+echo "== done =="


### PR DESCRIPTION
## What does this PR do?

Adds `.claude/skills/run-hermes-agent/` — a **Claude Code** agent skill (the
`.claude/skills/` convention Claude Code and similar coding agents pick up
automatically), not a Hermes-internal skill. It documents a verified
build/run/test path for the `hermes` CLI itself via `uv`, plus a driver
script, so an agent (or a human) working in this repo doesn't have to
rediscover the setup from scratch each time.

Note up front: this isn't a Hermes "skill" in the `agentskills.io` /
`hermes skills` sense, so the "For New Skills" checklist below (which
is about that system) doesn't really apply — I've left it unchecked
and am flagging that explicitly rather than checking boxes that don't
fit.

## Related Issue

No related issue — this is a small, self-contained tooling addition
discovered while getting the CLI running from a fresh clone.

## Type of Change

- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage) — a smoke-test driver, not new unit tests

## Changes Made

- `.claude/skills/run-hermes-agent/SKILL.md` — build/run/test instructions for the `hermes` CLI (not the desktop app or `--tui`), with a Gotchas/Troubleshooting section covering:
  - `uv sync` failing with `Access is denied` when the checkout lives under a OneDrive-synced folder on Windows (fix: relocate `UV_PROJECT_ENVIRONMENT` outside OneDrive)
  - `hermes -z`/`--oneshot` exiting 0 even when the upstream LLM call itself fails (e.g. bad API key), vs. exiting 1 only when no provider is configured at all
  - `pytest` needing `uv sync --extra dev` (not installed by the base sync)
  - `tests/test_atomic_replace_symlinks.py` failing on stock Windows without Developer Mode/admin (unrelated to the app)
- `.claude/skills/run-hermes-agent/smoke.sh` — the driver script: pins Python 3.12.13, runs `uv sync --extra dev`, then `hermes --version`, `hermes doctor`, two `hermes -z` invocations (no key / bad key) to demonstrate the exit-code behavior above, and a pytest smoke subset.

## How to Test

1. `bash .claude/skills/run-hermes-agent/smoke.sh` from repo root on a fresh clone
2. Confirm it completes with `== done ==` and the documented exit codes at each step
3. (Windows + OneDrive specifically) confirm `uv sync` no longer hits `Access is denied` once `UV_PROJECT_ENVIRONMENT` is relocated

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits where applicable
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this addition (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran a **targeted subset** (`tests/test_account_usage.py`), not the full suite; the full suite is large and `tests/test_atomic_replace_symlinks.py` fails on stock Windows for unrelated Developer-Mode/symlink-privilege reasons (documented in the skill's Gotchas)
- [ ] N/A — no new unit tests added; this is a smoke/driver script for agent tooling
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A — no README/docs/config-key changes
- [x] N/A — no `cli-config.yaml.example` changes
- [x] N/A — no architecture/workflow changes to CONTRIBUTING.md/AGENTS.md
- [x] Considered cross-platform impact — this was written and verified specifically because of a Windows/OneDrive-only failure mode
- [x] N/A — no tool schema changes

## For New Skills

N/A — see note at the top; this is a Claude Code agent skill, not a Hermes-internal skill, so this section's criteria (bundling, `hermes --toolsets skills` testing, etc.) don't apply.
