### PR TITLE
fix(slack): tolerate JSON-array strings in channel-list config keys

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2418,6 +2418,7 @@ class SlackAdapter(BasePlatformAdapter):
             raw = os.getenv("SLACK_IGNORED_CHANNELS")
         if raw is None:
             return set()
+        raw = _coerce_channel_list(raw)
         if isinstance(raw, list):
             return {str(part).strip() for part in raw if str(part).strip()}
         return {part.strip() for part in str(raw).split(",") if part.strip()}
@@ -8343,6 +8344,7 @@ class SlackAdapter(BasePlatformAdapter):
         raw = self.config.extra.get("free_response_channels")
         if raw is None:
             raw = os.getenv("SLACK_FREE_RESPONSE_CHANNELS", "")
+        raw = _coerce_channel_list(raw)
         if isinstance(raw, list):
             return {str(part).strip() for part in raw if str(part).strip()}
         # Coerce non-list scalars (str/int/float) to str before splitting.
@@ -8381,6 +8383,7 @@ class SlackAdapter(BasePlatformAdapter):
         raw = self.config.extra.get("allowed_channels")
         if raw is None:
             raw = os.getenv("SLACK_ALLOWED_CHANNELS", "")
+        raw = _coerce_channel_list(raw)
         if isinstance(raw, list):
             return {str(part).strip() for part in raw if str(part).strip()}
         if isinstance(raw, str) and raw.strip():
@@ -8400,6 +8403,7 @@ class SlackAdapter(BasePlatformAdapter):
         raw = self.config.extra.get("require_mention_channels")
         if raw is None:
             raw = os.getenv("SLACK_REQUIRE_MENTION_CHANNELS", "")
+        raw = _coerce_channel_list(raw)
         if isinstance(raw, list):
             return {str(part).strip() for part in raw if str(part).strip()}
         if isinstance(raw, str) and raw.strip():
@@ -8956,6 +8960,56 @@ def interactive_setup() -> None:
             print_info("Home channel cleared.")
 
 
+def _coerce_channel_list(raw):
+    """Decode channel-list values that arrive as a JSON-array string.
+
+    Config writers (agents editing config.yaml on the user's behalf, hand
+    edits, copy-pasted examples) sometimes serialize a channel list as JSON
+    inside a YAML string::
+
+        allowed_channels: '["C0AAAAAAA", "C0BBBBBBB"]'
+
+    The CSV split in the channel-set readers keeps the brackets and quotes on
+    each entry (``'["C0AAAAAAA"'`` …), so a non-empty whitelist matches no
+    real channel ID and the bot goes silent in every channel with no error
+    anywhere. Accept the JSON form by decoding it back into a list; any value
+    that doesn't parse as a JSON list is returned unchanged and flows through
+    the existing CSV path.
+    """
+    if isinstance(raw, str):
+        s = raw.strip()
+        if s.startswith("[") and s.endswith("]"):
+            try:
+                parsed = json.loads(s)
+            except ValueError:
+                return raw
+            if isinstance(parsed, list):
+                return parsed
+    return raw
+
+
+def _warn_malformed_channel_entries(key: str, csv: str) -> None:
+    """Log entries that can never match a Slack conversation ID.
+
+    Leftover quotes/brackets in a channel-list entry mean the value was
+    mis-serialized (e.g. a JSON string that failed to decode). Matching is
+    exact, so such entries silently gate the bot off — surface them once at
+    config-translation time instead.
+    """
+    bad = [
+        part.strip()
+        for part in csv.split(",")
+        if part.strip() and any(ch in part for ch in "[]\"'")
+    ]
+    if bad:
+        logger.warning(
+            "[Slack] %s entries %s contain quote/bracket characters and will "
+            "never match a channel ID — use a YAML list or comma-separated IDs",
+            key,
+            bad,
+        )
+
+
 def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
     """Translate ``config.yaml`` ``slack:`` keys into ``SLACK_*`` env vars.
 
@@ -8988,16 +9042,18 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
         ).lower()
     if "allow_bots" in slack_cfg and not os.getenv("SLACK_ALLOW_BOTS"):
         os.environ["SLACK_ALLOW_BOTS"] = str(slack_cfg["allow_bots"]).lower()
-    frc = slack_cfg.get("free_response_channels")
+    frc = _coerce_channel_list(slack_cfg.get("free_response_channels"))
     if frc is not None and not os.getenv("SLACK_FREE_RESPONSE_CHANNELS"):
         if isinstance(frc, list):
             frc = ",".join(str(v) for v in frc)
         os.environ["SLACK_FREE_RESPONSE_CHANNELS"] = str(frc)
-    rmc = slack_cfg.get("require_mention_channels")
+        _warn_malformed_channel_entries("free_response_channels", str(frc))
+    rmc = _coerce_channel_list(slack_cfg.get("require_mention_channels"))
     if rmc is not None and not os.getenv("SLACK_REQUIRE_MENTION_CHANNELS"):
         if isinstance(rmc, list):
             rmc = ",".join(str(v) for v in rmc)
         os.environ["SLACK_REQUIRE_MENTION_CHANNELS"] = str(rmc)
+        _warn_malformed_channel_entries("require_mention_channels", str(rmc))
     if "reactions" in slack_cfg and not os.getenv("SLACK_REACTIONS"):
         os.environ["SLACK_REACTIONS"] = str(slack_cfg["reactions"]).lower()
     rt = slack_cfg.get("reaction_triggers")
@@ -9011,17 +9067,19 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
 
     if "disable_dms" in slack_cfg and not os.getenv("SLACK_DISABLE_DMS"):
         os.environ["SLACK_DISABLE_DMS"] = str(slack_cfg["disable_dms"]).lower()
-    ac = slack_cfg.get("allowed_channels")
+    ac = _coerce_channel_list(slack_cfg.get("allowed_channels"))
     if ac is not None and not os.getenv("SLACK_ALLOWED_CHANNELS"):
         if isinstance(ac, list):
             ac = ",".join(str(v) for v in ac)
         os.environ["SLACK_ALLOWED_CHANNELS"] = str(ac)
+        _warn_malformed_channel_entries("allowed_channels", str(ac))
     # ignored_channels: blacklist channels where Slack must never respond.
-    ic = slack_cfg.get("ignored_channels")
+    ic = _coerce_channel_list(slack_cfg.get("ignored_channels"))
     if ic is not None and not os.getenv("SLACK_IGNORED_CHANNELS"):
         if isinstance(ic, list):
             ic = ",".join(str(v) for v in ic)
         os.environ["SLACK_IGNORED_CHANNELS"] = str(ic)
+        _warn_malformed_channel_entries("ignored_channels", str(ic))
     return None  # all settings flow through env; nothing to merge into extras
 
 

--- a/tests/gateway/test_slack_channel_list_coercion.py
+++ b/tests/gateway/test_slack_channel_list_coercion.py
@@ -1,0 +1,201 @@
+"""
+Tests for JSON-array-string tolerance in Slack channel-list settings.
+
+A channel list serialized as JSON inside a YAML string —
+
+    allowed_channels: '["C0AAAAAAA", "C0BBBBBBB"]'
+
+— used to be CSV-split verbatim, leaving brackets/quotes on every entry.
+A non-empty whitelist of garbage IDs matches nothing, so the bot went
+silent in every channel with no error anywhere. ``_coerce_channel_list``
+decodes the JSON form back into a list at both boundaries (the YAML→env
+translation in ``_apply_yaml_config`` and the ``config.extra`` readers),
+and ``_warn_malformed_channel_entries`` surfaces leftover garbage at
+startup instead of failing silently.
+
+Follows the mock pattern of test_slack_mention.py.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+
+
+# ---------------------------------------------------------------------------
+# Mock slack-bolt if not installed (same as test_slack.py)
+# ---------------------------------------------------------------------------
+
+def _ensure_slack_mock():
+    if "slack_bolt" in sys.modules and hasattr(sys.modules["slack_bolt"], "__file__"):
+        return
+
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    slack_bolt.adapter.socket_mode.async_handler.AsyncSocketModeHandler = MagicMock
+
+    slack_sdk = MagicMock()
+    slack_sdk.web.async_client.AsyncWebClient = MagicMock
+
+    for name, mod in [
+        ("slack_bolt", slack_bolt),
+        ("slack_bolt.async_app", slack_bolt.async_app),
+        ("slack_bolt.adapter", slack_bolt.adapter),
+        ("slack_bolt.adapter.socket_mode", slack_bolt.adapter.socket_mode),
+        ("slack_bolt.adapter.socket_mode.async_handler", slack_bolt.adapter.socket_mode.async_handler),
+        ("slack_sdk", slack_sdk),
+        ("slack_sdk.web", slack_sdk.web),
+        ("slack_sdk.web.async_client", slack_sdk.web.async_client),
+    ]:
+        sys.modules.setdefault(name, mod)
+
+
+_ensure_slack_mock()
+
+import plugins.platforms.slack.adapter as _slack_mod
+_slack_mod.SLACK_AVAILABLE = True
+
+from plugins.platforms.slack.adapter import (  # noqa: E402
+    SlackAdapter,
+    _apply_yaml_config,
+    _coerce_channel_list,
+)
+
+
+CHANNEL_A = "C0AAAAAAAAA"
+CHANNEL_B = "C0BBBBBBBBB"
+
+CHANNEL_ENV_VARS = [
+    "SLACK_ALLOWED_CHANNELS",
+    "SLACK_IGNORED_CHANNELS",
+    "SLACK_FREE_RESPONSE_CHANNELS",
+    "SLACK_REQUIRE_MENTION_CHANNELS",
+]
+
+
+def _make_adapter(**extra):
+    adapter = object.__new__(SlackAdapter)
+    adapter.platform = Platform.SLACK
+    adapter.config = PlatformConfig(enabled=True, extra=extra)
+    adapter._bot_user_id = "U_BOT_123"
+    adapter._team_bot_user_ids = {}
+    return adapter
+
+
+@pytest.fixture(autouse=True)
+def _clean_channel_env(monkeypatch):
+    for var in CHANNEL_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# _coerce_channel_list
+# ---------------------------------------------------------------------------
+
+def test_coerce_decodes_json_array_string():
+    raw = f'["{CHANNEL_A}", "{CHANNEL_B}"]'
+    assert _coerce_channel_list(raw) == [CHANNEL_A, CHANNEL_B]
+
+
+def test_coerce_leaves_csv_string_unchanged():
+    raw = f"{CHANNEL_A},{CHANNEL_B}"
+    assert _coerce_channel_list(raw) == raw
+
+
+def test_coerce_leaves_plain_id_unchanged():
+    assert _coerce_channel_list(CHANNEL_A) == CHANNEL_A
+
+
+def test_coerce_leaves_invalid_json_unchanged():
+    raw = '["unterminated'
+    assert _coerce_channel_list(raw) == raw
+
+
+def test_coerce_decodes_edge_json_arrays():
+    assert _coerce_channel_list("[]") == []
+    assert _coerce_channel_list('["only"]') == ["only"]
+    assert _coerce_channel_list("[1, 2]") == [1, 2]
+
+
+def test_coerce_passes_through_lists_and_none():
+    assert _coerce_channel_list([CHANNEL_A]) == [CHANNEL_A]
+    assert _coerce_channel_list(None) is None
+
+
+# ---------------------------------------------------------------------------
+# _apply_yaml_config: YAML→env translation tolerates JSON-array strings
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "yaml_key, env_var",
+    [
+        ("allowed_channels", "SLACK_ALLOWED_CHANNELS"),
+        ("ignored_channels", "SLACK_IGNORED_CHANNELS"),
+        ("free_response_channels", "SLACK_FREE_RESPONSE_CHANNELS"),
+        ("require_mention_channels", "SLACK_REQUIRE_MENTION_CHANNELS"),
+    ],
+)
+def test_apply_yaml_config_decodes_json_array_string(yaml_key, env_var, monkeypatch):
+    import os
+
+    slack_cfg = {yaml_key: f'["{CHANNEL_A}", "{CHANNEL_B}"]'}
+    _apply_yaml_config({}, slack_cfg)
+    assert os.environ[env_var] == f"{CHANNEL_A},{CHANNEL_B}"
+
+
+def test_apply_yaml_config_keeps_csv_and_list_forms(monkeypatch):
+    import os
+
+    _apply_yaml_config({}, {"allowed_channels": [CHANNEL_A, CHANNEL_B]})
+    assert os.environ["SLACK_ALLOWED_CHANNELS"] == f"{CHANNEL_A},{CHANNEL_B}"
+
+    monkeypatch.delenv("SLACK_ALLOWED_CHANNELS", raising=False)
+    _apply_yaml_config({}, {"allowed_channels": f"{CHANNEL_A},{CHANNEL_B}"})
+    assert os.environ["SLACK_ALLOWED_CHANNELS"] == f"{CHANNEL_A},{CHANNEL_B}"
+
+
+def test_apply_yaml_config_warns_on_garbage_entries(caplog):
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        # Broken JSON falls through to the CSV path and keeps its brackets —
+        # the startup warning must name the offending entries.
+        _apply_yaml_config({}, {"allowed_channels": f'["{CHANNEL_A}", "{CHANNEL_B}'})
+    assert any("allowed_channels" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Adapter readers: config.extra path tolerates JSON-array strings too
+# ---------------------------------------------------------------------------
+
+def test_allowed_channels_reader_decodes_json_string():
+    adapter = _make_adapter(allowed_channels=f'["{CHANNEL_A}", "{CHANNEL_B}"]')
+    assert adapter._slack_allowed_channels() == {CHANNEL_A, CHANNEL_B}
+
+
+def test_ignored_channels_reader_decodes_json_string():
+    adapter = _make_adapter(ignored_channels=f'["{CHANNEL_A}"]')
+    assert adapter._slack_ignored_channels() == {CHANNEL_A}
+
+
+def test_free_response_channels_reader_decodes_json_string():
+    adapter = _make_adapter(free_response_channels=f'["{CHANNEL_A}"]')
+    assert adapter._slack_free_response_channels() == {CHANNEL_A}
+
+
+def test_require_mention_channels_reader_decodes_json_string():
+    adapter = _make_adapter(require_mention_channels=f'["{CHANNEL_A}"]')
+    assert adapter._slack_require_mention_channels() == {CHANNEL_A}
+
+
+def test_allowed_channels_reader_env_json_string(monkeypatch):
+    monkeypatch.setenv("SLACK_ALLOWED_CHANNELS", f'["{CHANNEL_A}", "{CHANNEL_B}"]')
+    adapter = _make_adapter()
+    assert adapter._slack_allowed_channels() == {CHANNEL_A, CHANNEL_B}
+
+
+def test_allowed_channels_reader_csv_unchanged():
+    adapter = _make_adapter(allowed_channels=f"{CHANNEL_A},{CHANNEL_B}")
+    assert adapter._slack_allowed_channels() == {CHANNEL_A, CHANNEL_B}


### PR DESCRIPTION
Fixes #73831.

## Problem

A Slack channel list serialized as JSON inside a YAML string —

```yaml
slack:
  allowed_channels: '["C0AAAAAAA", "C0BBBBBBB"]'
```

— is CSV-split verbatim, leaving brackets/quotes on every entry. A non-empty whitelist of garbage IDs matches no real channel, so the bot goes silent in **every** channel with no error anywhere. Agents editing `config.yaml` on a user's behalf produce exactly this shape (hit in production; took manual code-tracing to find).

## Fix

- New module helper `_coerce_channel_list()`: if a channel-list value is a string that parses as a JSON list, decode it back into a list; anything else flows through the existing CSV path unchanged.
- Applied at both boundaries for `allowed_channels`, `ignored_channels`, `free_response_channels`, `require_mention_channels`:
  - the YAML→env bridge `_apply_yaml_config` (so `SLACK_*` env vars come out as clean CSV), and
  - the `config.extra` readers (`_slack_allowed_channels`, `_slack_ignored_channels`, `_slack_free_response_channels`, `_slack_require_mention_channels`), which bypass the env bridge.
- New `_warn_malformed_channel_entries()`: at config-translation time, log a warning naming any entry that still carries quote/bracket characters — those can never match a Slack channel ID, so surface them instead of failing silently. (Same silent-failure family as #14920 and #50732.)

## Tests

`tests/gateway/test_slack_channel_list_coercion.py` (18 tests): coercion unit cases (JSON string, CSV, plain ID, broken JSON, edge arrays, list/None passthrough), env-bridge translation for all four keys, garbage-entry warning, and extra/env reader paths.

```
scripts/run_tests.sh tests/gateway/test_slack_channel_list_coercion.py tests/gateway/test_slack_mention.py \
  tests/test_slack_thread_require_mention.py tests/gateway/test_slack_peer_agent_smoke.py \
  tests/gateway/test_slack_require_mention_channels.py tests/gateway/test_config.py \
  tests/gateway/test_slack_runner_ignored_channels.py
# 276 passed, 0 failed
```

Backward compatible: list and CSV forms are untouched; only strings that parse as a JSON list change behavior — and today that shape can only produce a broken gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)