### PR TITLE
fix(config): keep managed env loading fail-open

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -366,15 +366,15 @@ def _apply_managed_env() -> None:
         from hermes_cli import managed_scope
 
         managed_dir = managed_scope.get_managed_dir()
+        if managed_dir is None:
+            return
+        managed_env = managed_dir / ".env"
+        if not managed_env.exists():
+            return
+        _sanitize_env_file_if_needed(managed_env)
+        _load_dotenv_with_fallback(managed_env, override=True)
     except Exception:  # noqa: BLE001 — managed scope must never block startup
         return
-    if managed_dir is None:
-        return
-    managed_env = managed_dir / ".env"
-    if not managed_env.exists():
-        return
-    _sanitize_env_file_if_needed(managed_env)
-    _load_dotenv_with_fallback(managed_env, override=True)
 
 
 def _apply_external_secret_sources(home_path: Path) -> None:

--- a/tests/hermes_cli/test_managed_scope_env.py
+++ b/tests/hermes_cli/test_managed_scope_env.py
@@ -1,5 +1,6 @@
 """Env integration tests — managed .env applied last with override."""
 import os
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -56,3 +57,15 @@ def test_no_managed_env_is_noop(env_homes, monkeypatch):
     (home / ".env").write_text("SOME_VALUE=from_user\n", encoding="utf-8")
     load_hermes_dotenv(hermes_home=str(home))
     assert os.environ["SOME_VALUE"] == "from_user"
+
+
+def test_managed_env_permission_error_is_fail_open(monkeypatch):
+    from hermes_cli import env_loader, managed_scope
+
+    managed_env = MagicMock()
+    managed_env.exists.side_effect = PermissionError("managed env is unreadable")
+    managed_dir = MagicMock()
+    managed_dir.__truediv__.return_value = managed_env
+    monkeypatch.setattr(managed_scope, "get_managed_dir", lambda: managed_dir)
+
+    env_loader._apply_managed_env()


### PR DESCRIPTION
## What does this PR do?

Restores the documented fail-open behavior of managed-scope environment loading. A `PermissionError` from checking an unreadable managed `.env` currently escapes `_apply_managed_env()` and can abort Hermes startup because only directory resolution is inside the exception boundary.

This change keeps the complete managed-file operation inside the existing fail-open boundary. Successful managed-env precedence is unchanged.

## Related Issue

Fixes #73401

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Extended the existing fail-open boundary in `hermes_cli/env_loader.py` across the managed `.env` existence check, sanitization, and load.
- Added a regression test in `tests/hermes_cli/test_managed_scope_env.py` that injects `PermissionError` at the existence check.

## How to Test

1. Before the implementation change, run the focused regression test and observe the injected `PermissionError` escape.
2. Apply this change and run:
   `python -m pytest tests/hermes_cli/test_managed_scope_env.py::test_managed_env_permission_error_is_fail_open -q -o addopts=`
3. Run the related modules and static checks:
   - `python -m pytest tests/hermes_cli/test_managed_scope_env.py tests/hermes_cli/test_env_loader.py -q -o addopts=` — 22 passed
   - `python -m ruff check hermes_cli/env_loader.py tests/hermes_cli/test_managed_scope_env.py`
   - `python scripts/check-windows-footguns.py --all` — 849 files scanned

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing issues and PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` (targeted env-loader suites passed: 22 tests)
- [x] I've added tests for my changes
- [x] I've tested on Windows

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered: fail-open exception behavior is platform-independent
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

Not applicable; this is startup error handling with automated regression coverage.