### PR TITLE
feat(web_server): warm gateway module via subprocess instead of thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,4 +189,5 @@ infographic/
 infographics/
 infograficos/
 infografico/
+infografics/
 native/fts5_cjk/*.so

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -168,6 +168,28 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
     provider.start(stop_event, interval=interval)
 
 
+def _spawn_gateway_prewarm_subprocess() -> "subprocess.Popen | None":
+    """Warm hermes_cli.gateway's cold-import cost in an isolated subprocess.
+
+    A worker thread shares this process's GIL, so a thread importing the
+    (large) gateway module tree can still stall the event loop while CPython
+    compiles bytecode or Defender scans new .pyc files — that's what caused
+    the #71226 desktop boot loop. A subprocess has its own GIL: it can
+    pre-compile .pyc and warm the OS page cache with zero risk of starving
+    this process's event loop. Best-effort only — if spawning fails, the
+    cold import just happens lazily on first real use (e.g. the first
+    /api/status call) instead. See issue #73830.
+    """
+    try:
+        return subprocess.Popen(
+            [sys.executable, "-c", "import hermes_cli.gateway"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception:
+        return None
+
+
 def _resolve_restart_drain_timeout() -> float:
     try:
         from hermes_cli.gateway import _get_restart_drain_timeout
@@ -193,6 +215,7 @@ async def _lifespan(app: "FastAPI"):
     # dashboard` is unaffected — it relies on its own gateway.
     cron_stop: "threading.Event | None" = None
     cron_thread: "threading.Thread | None" = None
+    gateway_prewarm_proc: "subprocess.Popen | None" = None
     if os.getenv("HERMES_DESKTOP") == "1":
         cron_stop = threading.Event()
         cron_thread = threading.Thread(
@@ -202,6 +225,13 @@ async def _lifespan(app: "FastAPI"):
             name="desktop-cron-ticker",
         )
         cron_thread.start()
+
+        # Warm hermes_cli.gateway's cold-import cost (.pyc compile + OS page
+        # cache) in an isolated subprocess so the first /api/status call
+        # doesn't have to pay it. Desktop-only: this targets the cold fresh-
+        # Windows-install scenario that caused #71226; gating it here also
+        # keeps it off `hermes serve`/dashboard boots and the test suite.
+        gateway_prewarm_proc = _spawn_gateway_prewarm_subprocess()
 
     # Reap idle/dead keep-alive PTY sessions in the background (30-min TTL).
     pty_reaper_task = asyncio.create_task(run_reaper(PTY_REGISTRY))
@@ -223,6 +253,8 @@ async def _lifespan(app: "FastAPI"):
         await PTY_REGISTRY.close_all()
         if cron_stop is not None:
             cron_stop.set()
+        if gateway_prewarm_proc is not None and gateway_prewarm_proc.poll() is None:
+            gateway_prewarm_proc.terminate()
 
 
 def _get_event_state(app: "FastAPI"):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -168,13 +168,6 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
     provider.start(stop_event, interval=interval)
 
 
-def _warm_gateway_module() -> None:
-    try:
-        import hermes_cli.gateway  # noqa: F401
-    except Exception:
-        pass
-
-
 def _resolve_restart_drain_timeout() -> float:
     try:
         from hermes_cli.gateway import _get_restart_drain_timeout
@@ -194,14 +187,6 @@ async def _lifespan(app: "FastAPI"):
     # On app.state (not a module global) so the Lock binds to the running
     # event loop during lifespan startup — see _get_event_state's docstring.
     app.state.chat_argv_lock = asyncio.Lock()
-
-    # Fire hermes_cli.gateway import into a background thread so the event
-    # loop is not blocked and HERMES_DASHBOARD_READY fires without delay.
-    # On a cold Windows install the module chain triggers .pyc compilation
-    # and Defender real-time scans that can stall the event loop for 15-30s.
-    # Running in an executor means the cost is paid in a worker thread while
-    # the server socket is already open and accepting probes.
-    asyncio.get_event_loop().run_in_executor(None, _warm_gateway_module)
 
     # Desktop-spawned backends (HERMES_DESKTOP=1) fire cron jobs themselves,
     # since the app has no gateway running the scheduler. Server `hermes

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -255,6 +255,10 @@ async def _lifespan(app: "FastAPI"):
             cron_stop.set()
         if gateway_prewarm_proc is not None and gateway_prewarm_proc.poll() is None:
             gateway_prewarm_proc.terminate()
+            try:
+                await asyncio.to_thread(gateway_prewarm_proc.wait, timeout=2)
+            except Exception:
+                pass
 
 
 def _get_event_state(app: "FastAPI"):

--- a/tests/hermes_cli/test_web_server_boot_handshake.py
+++ b/tests/hermes_cli/test_web_server_boot_handshake.py
@@ -2,14 +2,13 @@
 Integration tests for the desktop boot handshake fix (PR #50231 / issue #50209).
 
 Simulates a slow hermes_cli.gateway import (15-30 s on a fresh Windows install
-with Defender scanning every new .pyc) by patching the two helpers that touch
-the blocking import and measuring event-loop freedom + response latency.
+with Defender scanning every new .pyc) and measures event-loop freedom +
+response latency.
 
 Three scenarios are covered:
 
-1. _lifespan fire-and-forget: patched _warm_gateway_module sleeps N seconds in
-   a thread; TestClient startup must complete in << N seconds (event loop not
-   blocked, HERMES_DASHBOARD_READY would fire immediately).
+1. _lifespan must not launch a gateway prewarm that can retain the GIL and
+   starve health/WebSocket handling despite running in an executor thread.
 
 2. get_status run_in_executor: patched _resolve_restart_drain_timeout sleeps N
    seconds in a thread; a concurrent fast endpoint (/api/version) must respond
@@ -22,6 +21,7 @@ Three scenarios are covered:
 from __future__ import annotations
 
 import asyncio
+import sys
 import time
 import threading
 from unittest.mock import patch
@@ -38,9 +38,16 @@ SLOW_SECONDS = 3  # represents the Defender worst-case (scaled down for CI speed
 # ---------------------------------------------------------------------------
 
 def _make_slow_warm(seconds: float):
-    """Return a _warm_gateway_module replacement that sleeps in the caller thread."""
+    """Return a cold-import stand-in that retains the GIL for ``seconds``."""
     def _slow():
-        time.sleep(seconds)
+        old_interval = sys.getswitchinterval()
+        try:
+            sys.setswitchinterval(seconds * 2)
+            deadline = time.perf_counter() + seconds
+            while time.perf_counter() < deadline:
+                pass
+        finally:
+            sys.setswitchinterval(old_interval)
     return _slow
 
 
@@ -53,30 +60,32 @@ def _make_slow_drain(seconds: float):
 
 
 # ---------------------------------------------------------------------------
-# Test 1 — _lifespan fire-and-forget does not block the event loop
+# Test 1 — lifespan does not start a GIL-holding gateway prewarm
 # ---------------------------------------------------------------------------
 
-def test_lifespan_warmup_is_nonblocking():
+def test_lifespan_does_not_start_gil_holding_gateway_warmup():
     """
-    _warm_gateway_module runs in an executor (fire-and-forget).
-    Even if it sleeps for SLOW_SECONDS, TestClient startup must complete
-    in well under that time — proving the event loop was never blocked and
-    HERMES_DASHBOARD_READY would have fired without delay.
+    A worker thread is not an isolation boundary for GIL-holding imports.
+    Health must respond without waiting for the synthetic cold import.
     """
     from fastapi.testclient import TestClient
 
-    with patch.object(web_server_mod, "_warm_gateway_module", _make_slow_warm(SLOW_SECONDS)):
+    with patch.object(
+        web_server_mod,
+        "_warm_gateway_module",
+        _make_slow_warm(SLOW_SECONDS),
+        create=True,
+    ):
         t0 = time.perf_counter()
-        with TestClient(web_server_mod.app, raise_server_exceptions=False) as _client:
-            startup_ms = (time.perf_counter() - t0) * 1000
+        with TestClient(web_server_mod.app, raise_server_exceptions=False) as client:
+            response = client.get("/api/health")
+        health_ms = (time.perf_counter() - t0) * 1000
 
-    # Startup must complete in under half of SLOW_SECONDS (generous margin).
-    # If the import were synchronous, startup would block for >= SLOW_SECONDS.
+    assert response.status_code == 200
     threshold_ms = (SLOW_SECONDS * 1000) / 2
-    assert startup_ms < threshold_ms, (
-        f"_lifespan blocked the event loop: startup took {startup_ms:.0f} ms "
-        f"but slow import is {SLOW_SECONDS * 1000:.0f} ms — "
-        f"fire-and-forget is not working."
+    assert health_ms < threshold_ms, (
+        f"gateway prewarm starved the health path for {health_ms:.0f} ms; "
+        "executor threads do not isolate GIL-holding imports"
     )
 
 

--- a/tests/hermes_cli/test_web_server_gateway_prewarm_subprocess.py
+++ b/tests/hermes_cli/test_web_server_gateway_prewarm_subprocess.py
@@ -1,0 +1,109 @@
+"""
+Tests for the #73830 gateway-prewarm-subprocess follow-up to #71226.
+
+_spawn_gateway_prewarm_subprocess() replaces the removed thread-based
+_warm_gateway_module() prewarm for Desktop backends (HERMES_DESKTOP=1): it
+warms hermes_cli.gateway's cold-import cost (.pyc compile + OS page cache) in
+an isolated subprocess instead of a thread, so it structurally cannot retain
+this process's GIL the way the removed thread-based prewarm did.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from unittest.mock import MagicMock, patch
+
+import hermes_cli.web_server as web_server_mod
+
+
+def test_spawn_gateway_prewarm_subprocess_uses_subprocess_not_thread():
+    """The prewarm must use subprocess.Popen, not a thread — a thread shares
+    this process's GIL and can starve the event loop; a subprocess cannot."""
+    with patch.object(web_server_mod.subprocess, "Popen") as mock_popen:
+        mock_popen.return_value = MagicMock()
+        result = web_server_mod._spawn_gateway_prewarm_subprocess()
+
+    assert mock_popen.called
+    args, _kwargs = mock_popen.call_args
+    cmd = args[0]
+    assert cmd[0] == web_server_mod.sys.executable
+    assert "import hermes_cli.gateway" in cmd
+    assert result is mock_popen.return_value
+
+
+def test_spawn_gateway_prewarm_subprocess_is_best_effort():
+    """If spawning fails (e.g. permission error, no python on PATH), the
+    prewarm degrades to None instead of raising — the cold import just
+    happens lazily on first real use instead."""
+    with patch.object(web_server_mod.subprocess, "Popen", side_effect=OSError("boom")):
+        result = web_server_mod._spawn_gateway_prewarm_subprocess()
+
+    assert result is None
+
+
+def test_desktop_lifespan_spawns_prewarm_subprocess_and_health_stays_fast():
+    """Under HERMES_DESKTOP=1, the lifespan spawns the prewarm subprocess but
+    /api/health must still respond immediately — spawning a subprocess is a
+    non-blocking syscall, unlike the removed thread-based prewarm."""
+    from fastapi.testclient import TestClient
+
+    mock_proc = MagicMock()
+    mock_proc.poll.return_value = None  # still "running"
+
+    with patch.object(web_server_mod.subprocess, "Popen", return_value=mock_proc) as mock_popen:
+        with patch.dict(os.environ, {"HERMES_DESKTOP": "1"}):
+            t0 = time.perf_counter()
+            with TestClient(web_server_mod.app, raise_server_exceptions=False) as client:
+                response = client.get("/api/health")
+            health_ms = (time.perf_counter() - t0) * 1000
+
+    assert mock_popen.called
+    assert response.status_code == 200
+    assert health_ms < 500, f"/api/health took {health_ms:.0f}ms under HERMES_DESKTOP=1 prewarm"
+
+
+def test_desktop_lifespan_terminates_prewarm_subprocess_on_shutdown():
+    """A still-running prewarm subprocess must be terminated when the
+    lifespan shuts down, so it doesn't leak past the backend's lifetime."""
+    from fastapi.testclient import TestClient
+
+    mock_proc = MagicMock()
+    mock_proc.poll.return_value = None  # still running at shutdown time
+
+    with patch.object(web_server_mod.subprocess, "Popen", return_value=mock_proc):
+        with patch.dict(os.environ, {"HERMES_DESKTOP": "1"}):
+            with TestClient(web_server_mod.app, raise_server_exceptions=False):
+                pass
+
+    mock_proc.terminate.assert_called_once()
+
+
+def test_desktop_lifespan_does_not_terminate_prewarm_subprocess_that_already_exited():
+    """A prewarm subprocess that already finished on its own must not be
+    terminated again — poll() returning an exit code means it's done."""
+    from fastapi.testclient import TestClient
+
+    mock_proc = MagicMock()
+    mock_proc.poll.return_value = 0  # already exited cleanly
+
+    with patch.object(web_server_mod.subprocess, "Popen", return_value=mock_proc):
+        with patch.dict(os.environ, {"HERMES_DESKTOP": "1"}):
+            with TestClient(web_server_mod.app, raise_server_exceptions=False):
+                pass
+
+    mock_proc.terminate.assert_not_called()
+
+
+def test_lifespan_does_not_spawn_prewarm_subprocess_without_desktop_env():
+    """Non-desktop boots (`hermes serve`/dashboard, and the test suite by
+    default) must not spawn the prewarm subprocess at all."""
+    from fastapi.testclient import TestClient
+
+    with patch.object(web_server_mod.subprocess, "Popen") as mock_popen:
+        with patch.dict(os.environ):
+            os.environ.pop("HERMES_DESKTOP", None)
+            with TestClient(web_server_mod.app, raise_server_exceptions=False):
+                pass
+
+    mock_popen.assert_not_called()

--- a/tests/hermes_cli/test_web_server_gateway_prewarm_subprocess.py
+++ b/tests/hermes_cli/test_web_server_gateway_prewarm_subprocess.py
@@ -64,8 +64,9 @@ def test_desktop_lifespan_spawns_prewarm_subprocess_and_health_stays_fast():
 
 
 def test_desktop_lifespan_terminates_prewarm_subprocess_on_shutdown():
-    """A still-running prewarm subprocess must be terminated when the
-    lifespan shuts down, so it doesn't leak past the backend's lifetime."""
+    """A still-running prewarm subprocess must be terminated AND reaped when
+    the lifespan shuts down — terminate() alone leaves a zombie/defunct
+    process on POSIX until something calls wait() on it."""
     from fastapi.testclient import TestClient
 
     mock_proc = MagicMock()
@@ -77,6 +78,7 @@ def test_desktop_lifespan_terminates_prewarm_subprocess_on_shutdown():
                 pass
 
     mock_proc.terminate.assert_called_once()
+    mock_proc.wait.assert_called_once()
 
 
 def test_desktop_lifespan_does_not_terminate_prewarm_subprocess_that_already_exited():


### PR DESCRIPTION
## Summary

Fixes #73830 — follow-up to #71226 / PR #73809.

⚠️ **Depends on #73809 (not yet merged).** This branch is stacked on top of it, so the diff/commit list below currently includes #73809's changes too. The change specific to *this* PR is a single commit: `009a9ca50` (`feat(web_server): warm gateway module via subprocess, not thread`). Once #73809 merges, this PR's diff will shrink to just that commit.

## What this adds

PR #73809 removed the thread-based `_warm_gateway_module()` prewarm to close the #71226 boot-loop race, but that deferred the cold `hermes_cli.gateway` import to first real use (e.g. the first `/api/status` call) instead of eliminating it. That first call can still briefly retain the GIL the same way the removed thread-based prewarm did — see #73830 for the full writeup.

This restores the prewarm, but as an isolated **subprocess** instead of a thread:

- A thread shares this process's GIL — that's exactly what caused #71226.
- A subprocess has its own GIL — it can pre-compile `.pyc` and warm the OS page cache with zero risk of starving this process's event loop, no matter how long the cold import takes.

 

## Design decisions

- **Desktop-only (`HERMES_DESKTOP=1`)**, gated the same way as the existing cron-ticker thread in the same `_lifespan`. This targets the actual risk population (fresh Windows installs, per the original #71226 report) without spawning a subprocess on every `hermes serve`/dashboard boot — or, critically, on every test that constructs the app via `TestClient`.
- **Best-effort**: if `subprocess.Popen` raises (e.g. sandboxed environment, no interpreter reachable), `_spawn_gateway_prewarm_subprocess()` returns `None` and the cold import just happens lazily later, same as before this PR.
- **Cleanup**: the child is `.terminate()`'d on lifespan shutdown if still running, so it doesn't outlive the backend.

## Test plan

- [x] New file `tests/hermes_cli/test_web_server_gateway_prewarm_subprocess.py`, 6 tests, all passing:
  - subprocess (not thread) is used, with the correct command
  - spawn failure degrades to `None` instead of raising
  - `/api/health` stays fast (<500ms) even while the prewarm subprocess is "running" under `HERMES_DESKTOP=1`
  - still-running subprocess is terminated on lifespan shutdown
  - already-exited subprocess is *not* re-terminated
  - prewarm is **not** spawned at all without `HERMES_DESKTOP=1` (protects `hermes serve`/dashboard boots and the test suite from subprocess overhead)
- [x] All mock `subprocess.Popen` — spawning a real interpreter per test would be slow across hundreds of `TestClient` boots in CI.
- [x] `tests/hermes_cli/test_web_server_boot_handshake.py` + this new file + `tests/test_tui_gateway_ws.py` — 19 passed
- [x] `tests/hermes_cli/test_web_server.py -k "desktop or cron"` — 7 passed (existing `HERMES_DESKTOP=1` cron-ticker test unaffected)
- [x] `ruff check` on both changed files — clean
- [ ] Cold-start manual verification on Windows with Defender active (not run in this environment)

 