### PR TITLE
fix(desktop): stop reporting transient token-refresh failures as expired sessions

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -26,7 +26,9 @@ import {
   gatewayTicketFailure,
   gatewayWsUrlIpcResult,
   isGatewayAuthRejection,
+  isNativeRefreshAuthRejection,
   localProfileEntry,
+  mintGatewayWsTicket,
   modeIsRemoteLike,
   normalizeRemoteBaseUrl,
   normalizeSshConfig,
@@ -540,6 +542,139 @@ test('tokenPreview returns set for short tokens', () => {
 
 test('tokenPreview returns a masked suffix for long tokens', () => {
   assert.equal(tokenPreview('abcdefghijklmnop'), '...klmnop')
+})
+
+// --- isNativeRefreshAuthRejection ---
+//
+// The dead-RT branch inside main.ts's ensureNativeAccessToken is untestable
+// directly (main.ts isn't importable from a test), but the classification
+// predicate it delegates to lives here. Sol's finding: main.ts's fetchJson
+// never attaches a `.statusCode` property — a real dead-RT 401 from
+// POST /auth/native/refresh arrives as `Error('401: {"error":
+// "session_expired",...}')` (see hermes_cli/dashboard_auth/routes.py's
+// auth_native_refresh, the JSONResponse(..., status_code=401) branch) with
+// NO .statusCode at all. A property-only check never matched it in
+// production, so the "clear tokens, return null" branch was dead code and
+// every dead-RT rejection propagated as a throw.
+
+test('isNativeRefreshAuthRejection recognizes the production 401 shape (message-only, no .statusCode)', () => {
+  assert.equal(isNativeRefreshAuthRejection(new Error('401: {"error":"session_expired","detail":"..."}')), true)
+  assert.equal(isNativeRefreshAuthRejection(new Error('401: Unauthorized')), true)
+})
+
+test('isNativeRefreshAuthRejection also recognizes a tagged .statusCode (other callers may attach one)', () => {
+  assert.equal(isNativeRefreshAuthRejection(Object.assign(new Error('rejected'), { statusCode: 401 })), true)
+})
+
+test('isNativeRefreshAuthRejection rejects non-401 shapes', () => {
+  assert.equal(isNativeRefreshAuthRejection(new Error('503: Auth provider unreachable')), false)
+  assert.equal(isNativeRefreshAuthRejection(new Error('network timeout')), false)
+  assert.equal(isNativeRefreshAuthRejection(Object.assign(new Error('rejected'), { statusCode: 403 })), false)
+  assert.equal(isNativeRefreshAuthRejection(null), false)
+})
+
+// --- mintGatewayWsTicket ---
+//
+// issue #73722 mechanism 2, two halves:
+//  (a) a native (cookieless) sign-in whose token refresh hits a transient
+//      failure (timeout/5xx/network) must NOT be silently treated as "no
+//      native token, fall back to cookies" and then misreport a cookie-side
+//      401 (no cookie exists in a native-only config) as an expired session.
+//  (b) cookie and native-token sessions can COEXIST (logout clears both) —
+//      so a transient native failure should still try the cookie path, and
+//      use it, before giving up. Only if the cookie path ALSO fails does the
+//      ORIGINAL native error surface (not the cookie's).
+
+function fakeDeps(overrides: Partial<Parameters<typeof mintGatewayWsTicket>[1]> = {}) {
+  return {
+    ensureNativeAccessToken: async () => null,
+    fetchJson: async () => ({ ticket: 'unused-fetchJson-ticket' }),
+    fetchJsonViaOauthSession: async () => ({ ticket: 'cookie-ticket' }),
+    ...overrides
+  }
+}
+
+test('mintGatewayWsTicket (native token present) mints via the bearer path', async () => {
+  const calls: any[] = []
+  const ticket = await mintGatewayWsTicket(
+    'https://gw.example.com',
+    fakeDeps({
+      ensureNativeAccessToken: async () => 'nat-token-123',
+      fetchJson: async (url, token, options) => {
+        calls.push({ url, token, options })
+
+        return { ticket: 'bearer-ticket' }
+      }
+    })
+  )
+
+  assert.equal(ticket, 'bearer-ticket')
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].url, 'https://gw.example.com/api/auth/ws-ticket')
+  assert.equal(calls[0].options.bearer, 'nat-token-123')
+})
+
+test('mintGatewayWsTicket (no native token) falls back to the cookie path', async () => {
+  // Covers BOTH real callers of a null return: no tokens saved at all, and a
+  // terminal 401 that ensureNativeAccessToken already cleared — from this
+  // function's perspective they're the same "null" shape.
+  const ticket = await mintGatewayWsTicket('https://gw.example.com', fakeDeps())
+  assert.equal(ticket, 'cookie-ticket')
+})
+
+test('FIX #73722 mechanism 2 (coexistence): a transient native failure still tries cookies, and uses a successful mint', async () => {
+  const transient = Object.assign(new Error('network timeout'), { code: 'ETIMEDOUT' })
+  let cookieCalls = 0
+
+  const ticket = await mintGatewayWsTicket(
+    'https://gw.example.com',
+    fakeDeps({
+      ensureNativeAccessToken: async () => {
+        throw transient
+      },
+      fetchJsonViaOauthSession: async () => {
+        cookieCalls += 1
+
+        return { ticket: 'coexisting-cookie-ticket' }
+      }
+    })
+  )
+
+  assert.equal(ticket, 'coexisting-cookie-ticket')
+  assert.equal(cookieCalls, 1)
+})
+
+test('FIX #73722 mechanism 2 (no false expiry): a transient native failure tries cookies, but a cookie 401 surfaces the ORIGINAL native error', async () => {
+  const transient = Object.assign(new Error('network timeout'), { code: 'ETIMEDOUT' })
+  const cookie401 = Object.assign(new Error('401: no session cookie'), { statusCode: 401 })
+
+  await assert.rejects(
+    () =>
+      mintGatewayWsTicket(
+        'https://gw.example.com',
+        fakeDeps({
+          ensureNativeAccessToken: async () => {
+            throw transient
+          },
+          fetchJsonViaOauthSession: async () => {
+            // The cookie path IS tried (unlike the old sentinel-based test) —
+            // it just loses to the preserved native error when it also fails.
+            throw cookie401
+          }
+        })
+      ),
+    (err: any) => {
+      assert.equal(err, transient)
+      // Not tagged as an auth rejection — gatewayTicketFailure (see the
+      // classification test below) routes an untagged, non-401/403 error to
+      // its transportMessage, not the "session expired" one. If the cookie's
+      // 401 leaked through instead, this would be true and the bug would be
+      // back.
+      assert.equal(isGatewayAuthRejection(err), false)
+
+      return true
+    }
+  )
 })
 
 // --- resolveTestWsUrl ---

--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -29,7 +29,9 @@ import {
   gatewayTicketFailure,
   gatewayWsUrlIpcResult,
   isGatewayAuthRejection,
+  isNativeRefreshAuthRejection,
   localProfileEntry,
+  mintGatewayWsTicket,
   modeIsRemoteLike,
   normalizeRemoteBaseUrl,
   normalizeRemoteHeaders,
@@ -1100,6 +1102,172 @@ test('tokenPreview returns set for short tokens', () => {
 
 test('tokenPreview returns a masked suffix for long tokens', () => {
   assert.equal(tokenPreview('abcdefghijklmnop'), '...klmnop')
+})
+
+// --- isNativeRefreshAuthRejection ---
+//
+// The dead-RT branch inside main.ts's ensureNativeAccessToken is untestable
+// directly (main.ts isn't importable from a test), but the classification
+// predicate it delegates to lives here. Sol's finding: main.ts's fetchJson
+// never attaches a `.statusCode` property — a real dead-RT 401 from
+// POST /auth/native/refresh arrives as `Error('401: {"error":
+// "session_expired",...}')` (see hermes_cli/dashboard_auth/routes.py's
+// auth_native_refresh, the JSONResponse(..., status_code=401) branch) with
+// NO .statusCode at all. A property-only check never matched it in
+// production, so the "clear tokens, return null" branch was dead code and
+// every dead-RT rejection propagated as a throw.
+
+test('isNativeRefreshAuthRejection recognizes the production 401 shape (message-only, no .statusCode)', () => {
+  assert.equal(isNativeRefreshAuthRejection(new Error('401: {"error":"session_expired","detail":"..."}')), true)
+  assert.equal(isNativeRefreshAuthRejection(new Error('401: Unauthorized')), true)
+})
+
+test('isNativeRefreshAuthRejection also recognizes a tagged .statusCode (other callers may attach one)', () => {
+  assert.equal(isNativeRefreshAuthRejection(Object.assign(new Error('rejected'), { statusCode: 401 })), true)
+})
+
+test('isNativeRefreshAuthRejection rejects non-401 shapes', () => {
+  assert.equal(isNativeRefreshAuthRejection(new Error('503: Auth provider unreachable')), false)
+  assert.equal(isNativeRefreshAuthRejection(new Error('network timeout')), false)
+  assert.equal(isNativeRefreshAuthRejection(Object.assign(new Error('rejected'), { statusCode: 403 })), false)
+  assert.equal(isNativeRefreshAuthRejection(null), false)
+})
+
+// --- mintGatewayWsTicket ---
+//
+// issue #73722 mechanism 2, two halves:
+//  (a) a native (cookieless) sign-in whose token refresh hits a transient
+//      failure (timeout/5xx/network) must NOT be silently treated as "no
+//      native token, fall back to cookies" and then misreport a cookie-side
+//      401 (no cookie exists in a native-only config) as an expired session.
+//  (b) cookie and native-token sessions can COEXIST (logout clears both) —
+//      so a transient native failure should still try the cookie path, and
+//      use it, before giving up. Only if the cookie path ALSO fails does the
+//      ORIGINAL native error surface (not the cookie's).
+
+function fakeDeps(overrides: Partial<Parameters<typeof mintGatewayWsTicket>[1]> = {}) {
+  return {
+    ensureNativeAccessToken: async () => null,
+    fetchJson: async () => ({ ticket: 'unused-fetchJson-ticket' }),
+    fetchJsonViaOauthSession: async () => ({ ticket: 'cookie-ticket' }),
+    ...overrides
+  }
+}
+
+test('mintGatewayWsTicket (native token present) mints via the bearer path', async () => {
+  const calls: any[] = []
+  const ticket = await mintGatewayWsTicket(
+    'https://gw.example.com',
+    fakeDeps({
+      ensureNativeAccessToken: async () => 'nat-token-123',
+      fetchJson: async (url, token, options) => {
+        calls.push({ url, token, options })
+
+        return { ticket: 'bearer-ticket' }
+      }
+    })
+  )
+
+  assert.equal(ticket, 'bearer-ticket')
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].url, 'https://gw.example.com/api/auth/ws-ticket')
+  assert.equal(calls[0].options.bearer, 'nat-token-123')
+})
+
+test('mintGatewayWsTicket forwards the remote gateway headers on both the bearer and cookie mints', async () => {
+  const headers = { 'X-Gateway-Auth': 'front-door' }
+  const bearerCalls: any[] = []
+  const cookieCalls: any[] = []
+
+  await mintGatewayWsTicket(
+    'https://gw.example.com',
+    fakeDeps({
+      ensureNativeAccessToken: async () => 'nat-token-123',
+      fetchJson: async (_url, _token, options) => {
+        bearerCalls.push(options)
+
+        return { ticket: 'bearer-ticket' }
+      }
+    }),
+    headers
+  )
+  await mintGatewayWsTicket(
+    'https://gw.example.com',
+    fakeDeps({
+      fetchJsonViaOauthSession: async (_url, options) => {
+        cookieCalls.push(options)
+
+        return { ticket: 'cookie-ticket' }
+      }
+    }),
+    headers
+  )
+
+  assert.deepEqual(bearerCalls.map(o => o.headers), [headers])
+  assert.deepEqual(cookieCalls.map(o => o.headers), [headers])
+})
+
+test('mintGatewayWsTicket (no native token) falls back to the cookie path', async () => {
+  // Covers BOTH real callers of a null return: no tokens saved at all, and a
+  // terminal 401 that ensureNativeAccessToken already cleared — from this
+  // function's perspective they're the same "null" shape.
+  const ticket = await mintGatewayWsTicket('https://gw.example.com', fakeDeps())
+  assert.equal(ticket, 'cookie-ticket')
+})
+
+test('FIX #73722 mechanism 2 (coexistence): a transient native failure still tries cookies, and uses a successful mint', async () => {
+  const transient = Object.assign(new Error('network timeout'), { code: 'ETIMEDOUT' })
+  let cookieCalls = 0
+
+  const ticket = await mintGatewayWsTicket(
+    'https://gw.example.com',
+    fakeDeps({
+      ensureNativeAccessToken: async () => {
+        throw transient
+      },
+      fetchJsonViaOauthSession: async () => {
+        cookieCalls += 1
+
+        return { ticket: 'coexisting-cookie-ticket' }
+      }
+    })
+  )
+
+  assert.equal(ticket, 'coexisting-cookie-ticket')
+  assert.equal(cookieCalls, 1)
+})
+
+test('FIX #73722 mechanism 2 (no false expiry): a transient native failure tries cookies, but a cookie 401 surfaces the ORIGINAL native error', async () => {
+  const transient = Object.assign(new Error('network timeout'), { code: 'ETIMEDOUT' })
+  const cookie401 = Object.assign(new Error('401: no session cookie'), { statusCode: 401 })
+
+  await assert.rejects(
+    () =>
+      mintGatewayWsTicket(
+        'https://gw.example.com',
+        fakeDeps({
+          ensureNativeAccessToken: async () => {
+            throw transient
+          },
+          fetchJsonViaOauthSession: async () => {
+            // The cookie path IS tried (unlike the old sentinel-based test) —
+            // it just loses to the preserved native error when it also fails.
+            throw cookie401
+          }
+        })
+      ),
+    (err: any) => {
+      assert.equal(err, transient)
+      // Not tagged as an auth rejection — gatewayTicketFailure (see the
+      // classification test below) routes an untagged, non-401/403 error to
+      // its transportMessage, not the "session expired" one. If the cookie's
+      // 401 leaked through instead, this would be true and the bug would be
+      // back.
+      assert.equal(isGatewayAuthRejection(err), false)
+
+      return true
+    }
+  )
 })
 
 // --- resolveTestWsUrl ---

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -99,6 +99,38 @@ function isGatewayAuthRejection(error) {
   return statusCode === 401 || statusCode === 403
 }
 
+/**
+ * True when `error` is the /auth/native/refresh endpoint's "the refresh
+ * token is dead" rejection (HTTP 401, body `{"error": "session_expired",
+ * ...}` — hermes_cli/dashboard_auth/routes.py's auth_native_refresh, the
+ * `JSONResponse({...}, status_code=401)` branch after every provider rejects
+ * the RT). ensureNativeAccessToken (main.ts) uses this to decide whether to
+ * clear the stored tokens and return null (dead RT — force a fresh native
+ * login) instead of letting the rejection propagate (a transient refresh
+ * failure — timeout/5xx/network — must NOT clear live tokens).
+ *
+ * error.statusCode === 401 alone is not enough in production:
+ * main.ts's fetchJson (the transport postJsonNoAuth/ensureNativeAccessToken
+ * ride) never attaches a `.statusCode` property to its rejection — it only
+ * bakes the status into the message as `` `${res.statusCode}: ${body}` ``
+ * (see fetchJson's `res.statusCode >= 400` branch). So a real dead-RT 401
+ * arrives here as `Error('401: {"error":"session_expired",...}')` with no
+ * `.statusCode` at all; matching only the property left the "dead RT" branch
+ * unreachable and every dead-RT rejection fell through to `throw error`.
+ * Keep the property check too so an error shaped by a DIFFERENT caller (one
+ * that does attach `.statusCode`, e.g. gatewayTicketFailure's callers) is
+ * still recognized.
+ */
+function isNativeRefreshAuthRejection(error) {
+  if (error && typeof error === 'object' && (error as any).statusCode === 401) {
+    return true
+  }
+
+  const message = error instanceof Error ? error.message : ''
+
+  return /^401[:\s]/.test(message)
+}
+
 function gatewayTicketFailure(error, authMessage, transportMessage) {
   const needsOauthLogin = isGatewayAuthRejection(error)
   const err = new Error(needsOauthLogin ? authMessage : transportMessage)
@@ -123,6 +155,101 @@ async function gatewayWsUrlIpcResult(resolveWsUrl: () => Promise<string>) {
       ok: false as const
     }
   }
+}
+
+export interface MintGatewayWsTicketDeps {
+  /** Real impl: main.ts's ensureNativeAccessToken. Resolves the cached/refreshed
+   *  native bearer token, or null when there is none (no tokens saved, or a
+   *  terminal 401 already cleared them). MUST be allowed to reject — a
+   *  rejection is a native-path failure (typically a transient refresh
+   *  timeout/5xx/network, but also e.g. a malformed refresh response from
+   *  parseTokenResponse); swallowing it here used to fall through to the
+   *  cookie path, which 401s with no session cookie in native-only configs and
+   *  gets misreported as an expired session (issue #73722 mechanism 2). */
+  ensureNativeAccessToken: (baseUrl: string) => Promise<string | null>
+  fetchJson: (url: string, token: string | null, options?: any) => Promise<any>
+  fetchJsonViaOauthSession: (url: string, options?: any) => Promise<any>
+}
+
+async function mintViaBearer(deps: MintGatewayWsTicketDeps, baseUrl: string, nativeAt: string): Promise<string> {
+  const body = (await deps.fetchJson(`${baseUrl}/api/auth/ws-ticket`, null, {
+    method: 'POST',
+    timeoutMs: 8_000,
+    bearer: nativeAt
+  })) as any
+
+  const ticket = body?.ticket
+
+  if (!ticket || typeof ticket !== 'string') {
+    throw new Error('Gateway did not return a WS ticket.')
+  }
+
+  return ticket
+}
+
+async function mintViaCookie(deps: MintGatewayWsTicketDeps, baseUrl: string): Promise<string> {
+  const body = (await deps.fetchJsonViaOauthSession(`${baseUrl}/api/auth/ws-ticket`, {
+    method: 'POST',
+    timeoutMs: 8_000
+  })) as any
+
+  const ticket = body?.ticket
+
+  if (!ticket || typeof ticket !== 'string') {
+    throw new Error('Gateway did not return a WS ticket.')
+  }
+
+  return ticket
+}
+
+/**
+ * Mint a single-use WS ticket for a gated gateway (pure orchestration,
+ * electron-free — main.ts's mintGatewayWsTicket wires in the real I/O as
+ * `deps`, mirroring how it feeds resolveTestWsUrl below). Prefers a native
+ * bearer token (cookieless RFC 8252 flow) when present, falling back to the
+ * OAuth cookie partition otherwise. Throws (with statusCode 401, from the
+ * cookie-session fetch) if the session cookie is missing/expired — callers
+ * treat that as "needs re-login".
+ *
+ * Cookie and native-token sessions can coexist (logout clears both), so a
+ * native-side failure doesn't mean the connection has to fail: if
+ * ensureNativeAccessToken (or the bearer ws-ticket POST) THROWS — any
+ * native-path error: a transient refresh failure, a malformed refresh or
+ * ticket response, a failed bearer POST (a dead RT already resolves null,
+ * see isNativeRefreshAuthRejection) — the cookie path is tried as a fallback
+ * before giving up (issue #73722 mechanism 2's coexistence half). If the
+ * cookie path ALSO fails, the ORIGINAL native error is what gets thrown, not
+ * the cookie's — a cookie-side 401 (no cookie session at all, in a
+ * native-only config) must not overwrite a genuinely transient native
+ * failure with a false "session expired". A native token that's simply
+ * absent (ensureNativeAccessToken resolves null, no throw) skips this
+ * preservation entirely and goes straight to cookie, propagating whatever it
+ * says — that 401 IS a real "please sign in".
+ */
+async function mintGatewayWsTicket(baseUrl: string, deps: MintGatewayWsTicketDeps): Promise<string> {
+  let nativeError: unknown
+
+  try {
+    const nativeAt = await deps.ensureNativeAccessToken(baseUrl)
+
+    if (nativeAt) {
+      return await mintViaBearer(deps, baseUrl, nativeAt)
+    }
+  } catch (error) {
+    nativeError = error
+  }
+
+  if (nativeError !== undefined) {
+    try {
+      return await mintViaCookie(deps, baseUrl)
+    } catch {
+      throw nativeError
+    }
+  }
+
+  // No native token at all — genuinely no native session. Straight to
+  // cookie, propagating its result (or error) unchanged.
+  return mintViaCookie(deps, baseUrl)
 }
 
 /**
@@ -547,7 +674,9 @@ export {
   gatewayWsUrlIpcResult,
   hostLabelFromBaseUrl,
   isGatewayAuthRejection,
+  isNativeRefreshAuthRejection,
   localProfileEntry,
+  mintGatewayWsTicket,
   modeIsRemoteLike,
   normalizeRemoteBaseUrl,
   normalizeSshConfig,

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -126,6 +126,38 @@ function isGatewayAuthRejection(error) {
   return statusCode === 401 || statusCode === 403
 }
 
+/**
+ * True when `error` is the /auth/native/refresh endpoint's "the refresh
+ * token is dead" rejection (HTTP 401, body `{"error": "session_expired",
+ * ...}` — hermes_cli/dashboard_auth/routes.py's auth_native_refresh, the
+ * `JSONResponse({...}, status_code=401)` branch after every provider rejects
+ * the RT). ensureNativeAccessToken (main.ts) uses this to decide whether to
+ * clear the stored tokens and return null (dead RT — force a fresh native
+ * login) instead of letting the rejection propagate (a transient refresh
+ * failure — timeout/5xx/network — must NOT clear live tokens).
+ *
+ * error.statusCode === 401 alone is not enough in production:
+ * main.ts's fetchJson (the transport postJsonNoAuth/ensureNativeAccessToken
+ * ride) never attaches a `.statusCode` property to its rejection — it only
+ * bakes the status into the message as `` `${res.statusCode}: ${body}` ``
+ * (see fetchJson's `res.statusCode >= 400` branch). So a real dead-RT 401
+ * arrives here as `Error('401: {"error":"session_expired",...}')` with no
+ * `.statusCode` at all; matching only the property left the "dead RT" branch
+ * unreachable and every dead-RT rejection fell through to `throw error`.
+ * Keep the property check too so an error shaped by a DIFFERENT caller (one
+ * that does attach `.statusCode`, e.g. gatewayTicketFailure's callers) is
+ * still recognized.
+ */
+function isNativeRefreshAuthRejection(error) {
+  if (error && typeof error === 'object' && (error as any).statusCode === 401) {
+    return true
+  }
+
+  const message = error instanceof Error ? error.message : ''
+
+  return /^401[:\s]/.test(message)
+}
+
 function gatewayTicketFailure(error, authMessage, transportMessage) {
   const needsOauthLogin = isGatewayAuthRejection(error)
   const err = new Error(needsOauthLogin ? authMessage : transportMessage)
@@ -199,6 +231,117 @@ async function gatewayWsUrlIpcResult(resolveWsUrl: () => Promise<string>) {
       ok: false as const
     }
   }
+}
+
+export interface MintGatewayWsTicketDeps {
+  /** Real impl: main.ts's ensureNativeAccessToken. Resolves the cached/refreshed
+   *  native bearer token, or null when there is none (no tokens saved, or a
+   *  terminal 401 already cleared them). MUST be allowed to reject — a
+   *  rejection is a native-path failure (typically a transient refresh
+   *  timeout/5xx/network, but also e.g. a malformed refresh response from
+   *  parseTokenResponse); swallowing it here used to fall through to the
+   *  cookie path, which 401s with no session cookie in native-only configs and
+   *  gets misreported as an expired session (issue #73722 mechanism 2). */
+  ensureNativeAccessToken: (baseUrl: string) => Promise<string | null>
+  fetchJson: (url: string, token: string | null, options?: any) => Promise<any>
+  fetchJsonViaOauthSession: (url: string, options?: any) => Promise<any>
+}
+
+async function mintViaBearer(
+  deps: MintGatewayWsTicketDeps,
+  baseUrl: string,
+  nativeAt: string,
+  headers: Record<string, string>
+): Promise<string> {
+  const body = (await deps.fetchJson(`${baseUrl}/api/auth/ws-ticket`, null, {
+    method: 'POST',
+    timeoutMs: 8_000,
+    bearer: nativeAt,
+    headers
+  })) as any
+
+  const ticket = body?.ticket
+
+  if (!ticket || typeof ticket !== 'string') {
+    throw new Error('Gateway did not return a WS ticket.')
+  }
+
+  return ticket
+}
+
+async function mintViaCookie(
+  deps: MintGatewayWsTicketDeps,
+  baseUrl: string,
+  headers: Record<string, string>
+): Promise<string> {
+  const body = (await deps.fetchJsonViaOauthSession(`${baseUrl}/api/auth/ws-ticket`, {
+    method: 'POST',
+    timeoutMs: 8_000,
+    headers
+  })) as any
+
+  const ticket = body?.ticket
+
+  if (!ticket || typeof ticket !== 'string') {
+    throw new Error('Gateway did not return a WS ticket.')
+  }
+
+  return ticket
+}
+
+/**
+ * Mint a single-use WS ticket for a gated gateway (pure orchestration,
+ * electron-free — main.ts's mintGatewayWsTicket wires in the real I/O as
+ * `deps`, mirroring how it feeds resolveTestWsUrl below). `headers` are the
+ * connection's remote gateway headers and ride along on both mints. Prefers a native
+ * bearer token (cookieless RFC 8252 flow) when present, falling back to the
+ * OAuth cookie partition otherwise. Throws (with statusCode 401, from the
+ * cookie-session fetch) if the session cookie is missing/expired — callers
+ * treat that as "needs re-login".
+ *
+ * Cookie and native-token sessions can coexist (logout clears both), so a
+ * native-side failure doesn't mean the connection has to fail: if
+ * ensureNativeAccessToken (or the bearer ws-ticket POST) THROWS — any
+ * native-path error: a transient refresh failure, a malformed refresh or
+ * ticket response, a failed bearer POST (a dead RT already resolves null,
+ * see isNativeRefreshAuthRejection) — the cookie path is tried as a fallback
+ * before giving up (issue #73722 mechanism 2's coexistence half). If the
+ * cookie path ALSO fails, the ORIGINAL native error is what gets thrown, not
+ * the cookie's — a cookie-side 401 (no cookie session at all, in a
+ * native-only config) must not overwrite a genuinely transient native
+ * failure with a false "session expired". A native token that's simply
+ * absent (ensureNativeAccessToken resolves null, no throw) skips this
+ * preservation entirely and goes straight to cookie, propagating whatever it
+ * says — that 401 IS a real "please sign in".
+ */
+async function mintGatewayWsTicket(
+  baseUrl: string,
+  deps: MintGatewayWsTicketDeps,
+  headers: Record<string, string> = {}
+): Promise<string> {
+  let nativeError: unknown
+
+  try {
+    const nativeAt = await deps.ensureNativeAccessToken(baseUrl)
+
+    if (nativeAt) {
+      return await mintViaBearer(deps, baseUrl, nativeAt, headers)
+    }
+  } catch (error) {
+    nativeError = error
+  }
+
+  if (nativeError !== undefined) {
+    try {
+      return await mintViaCookie(deps, baseUrl, headers)
+    } catch {
+      throw nativeError
+    }
+  }
+
+  // No native token at all — genuinely no native session. Straight to
+  // cookie, propagating its result (or error) unchanged.
+  return mintViaCookie(deps, baseUrl, headers)
 }
 
 /**
@@ -1015,7 +1158,9 @@ export {
   gatewayWsUrlIpcResult,
   hostLabelFromBaseUrl,
   isGatewayAuthRejection,
+  isNativeRefreshAuthRejection,
   localProfileEntry,
+  mintGatewayWsTicket,
   modeIsRemoteLike,
   normalizeRemoteBaseUrl,
   normalizeRemoteHeaders,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -54,7 +54,9 @@ import {
   gatewayTicketFailure,
   gatewayWsUrlIpcResult,
   hostLabelFromBaseUrl,
+  isNativeRefreshAuthRejection,
   localProfileEntry,
+  mintGatewayWsTicket as mintGatewayWsTicketPure,
   modeIsRemoteLike,
   normalizeRemoteBaseUrl,
   normalizeSshConfig,
@@ -6244,7 +6246,10 @@ async function ensureNativeAccessToken(baseUrl: string): Promise<string | null> 
   } catch (error: any) {
     // A 401 means the RT is dead (session_expired) — drop tokens so the UI
     // prompts a fresh native login. A 503/transient keeps them for a retry.
-    if (error && error.statusCode === 401) {
+    // isNativeRefreshAuthRejection (not a bare error.statusCode === 401
+    // check) because fetchJson never attaches .statusCode — see its doc in
+    // connection-config.ts.
+    if (isNativeRefreshAuthRejection(error)) {
       _clearNativeTokens(baseUrl)
 
       return null
@@ -6259,38 +6264,13 @@ async function ensureNativeAccessToken(baseUrl: string): Promise<string | null> 
 // falling back to the OAuth cookie partition otherwise.
 // Throws (with statusCode 401) if the session cookie is missing/expired —
 // callers treat that as "needs re-login".
+//
+// Thin adapter over connection-config.ts's pure mintGatewayWsTicket, wiring
+// in the real (electron-coupled) I/O. Kept as a same-named local function so
+// none of this file's 3 call sites need to change. See that function's doc
+// for why ensureNativeAccessToken is NOT wrapped in .catch(() => null).
 async function mintGatewayWsTicket(baseUrl) {
-  // Native flow: mint the ticket with the bearer token, no cookie involved.
-  const nativeAt = await ensureNativeAccessToken(baseUrl).catch(() => null)
-
-  if (nativeAt) {
-    const body = (await fetchJson(`${baseUrl}/api/auth/ws-ticket`, null, {
-      method: 'POST',
-      timeoutMs: 8_000,
-      bearer: nativeAt
-    })) as any
-
-    const ticket = body?.ticket
-
-    if (!ticket || typeof ticket !== 'string') {
-      throw new Error('Gateway did not return a WS ticket.')
-    }
-
-    return ticket
-  }
-
-  const body = (await fetchJsonViaOauthSession(`${baseUrl}/api/auth/ws-ticket`, {
-    method: 'POST',
-    timeoutMs: 8_000
-  })) as any
-
-  const ticket = body?.ticket
-
-  if (!ticket || typeof ticket !== 'string') {
-    throw new Error('Gateway did not return a WS ticket.')
-  }
-
-  return ticket
+  return mintGatewayWsTicketPure(baseUrl, { ensureNativeAccessToken, fetchJson, fetchJsonViaOauthSession })
 }
 
 // Build a fresh WS URL for the *current* connection. Critical for reconnects:

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -230,13 +230,13 @@ import { resolveHudWindowing } from './hud-windowing'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { ensureMainWindow } from './main-window-lifecycle'
 import { createMediaProtocolHandler, MEDIA_PROTOCOL } from './media-protocol'
+import { createNativeAccessTokenCoordinator } from './native-access-token'
 import {
   oauthGuardMayHardFail,
   oauthSessionIsLive,
   oauthTicketFailureAuthMessage,
   resolveGatedDownloadAuth,
   resolveJsonBody,
-  resolveOauthRestAuth,
   resolveReadinessProbeAuth
 } from './native-auth-decisions'
 import {
@@ -250,6 +250,7 @@ import { runNativeLogin } from './native-oauth-login'
 import { loadNativeTokenSet, type NativeTokenStoreIo, persistNativeTokenSet } from './native-token-store'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 import { LEGACY_OAUTH_PARTITION, resolveOauthPartition } from './oauth-partition'
+import { requestWithOauthFallback } from './oauth-rest-request'
 import { createParentStartMarkerResolver, parentWatchdogEnv } from './parent-process-identity'
 import { registerPetOverlayIpc } from './pet-overlay-ipc'
 import {
@@ -7498,52 +7499,29 @@ function postJsonNoAuth(url: string, body: unknown, opts: any = {}) {
   return fetchJson(url, null, { method: 'POST', body: resolveJsonBody(body), ...opts })
 }
 
-// Return a valid native access token for baseUrl, refreshing via
-// /auth/native/refresh if the stored one is at/near expiry. Returns null when
-// there are no tokens or the refresh is terminally rejected (caller re-logins).
-async function ensureNativeAccessToken(baseUrl: string): Promise<string | null> {
-  const tokens = _loadNativeTokens(baseUrl)
-
-  if (!tokens) {
-    return null
-  }
-
-  if (!tokenNeedsRefresh(tokens, Math.floor(Date.now() / 1000))) {
-    return tokens.accessToken
-  }
-
-  if (!tokens.refreshToken) {
-    // Access token expired and no RT to rotate — force re-login.
-    _clearNativeTokens(baseUrl)
-
-    return null
-  }
-
-  try {
+const nativeAccessTokenCoordinator = createNativeAccessTokenCoordinator({
+  clearTokens: _clearNativeTokens,
+  isRefreshAuthRejection: isNativeRefreshAuthRejection,
+  loadTokens: _loadNativeTokens,
+  normalizeBaseUrl: normalizeRemoteBaseUrl,
+  refreshTokens: async (baseUrl, tokens) => {
     const body = await postJsonNoAuth(
       nativeRefreshUrl(baseUrl),
       { refresh_token: tokens.refreshToken, provider: tokens.provider },
       { timeoutMs: 10_000 }
     )
 
-    const rotated = parseTokenResponse(body)
-    _storeNativeTokens(baseUrl, rotated)
+    return parseTokenResponse(body)
+  },
+  storeTokens: _storeNativeTokens,
+  tokenNeedsRefresh
+})
 
-    return rotated.accessToken
-  } catch (error: any) {
-    // A 401 means the RT is dead (session_expired) — drop tokens so the UI
-    // prompts a fresh native login. A 503/transient keeps them for a retry.
-    // isNativeRefreshAuthRejection (not a bare error.statusCode === 401
-    // check) because fetchJson never attaches .statusCode — see its doc in
-    // connection-config.ts.
-    if (isNativeRefreshAuthRejection(error)) {
-      _clearNativeTokens(baseUrl)
-
-      return null
-    }
-
-    throw error
-  }
+// Return a valid native access token for baseUrl, refreshing via
+// /auth/native/refresh if the stored one is at/near expiry. Returns null when
+// there are no tokens or the refresh is terminally rejected (caller re-logins).
+async function ensureNativeAccessToken(baseUrl: string): Promise<string | null> {
+  return nativeAccessTokenCoordinator.ensure(baseUrl)
 }
 
 // OAuth-session download that streams the response body straight to a
@@ -10133,13 +10111,11 @@ async function requestJsonForProfile(profile: string, path: string, method: stri
   if (conn.authMode === 'oauth') {
     // Native RFC 8252 flow: authenticate with the bearer token (cookieless)
     // when we hold one for this gateway; otherwise use the cookie partition.
-    const nativeAt = await ensureNativeAccessToken(conn.baseUrl).catch(() => null)
-
-    if (nativeAt) {
-      return fetchJson(url, null, { ...opts, bearer: nativeAt, headers: conn.headers })
-    }
-
-    return fetchJsonViaOauthSession(url, { ...opts, headers: conn.headers })
+    return requestWithOauthFallback(conn.baseUrl, {
+      ensureNativeAccessToken,
+      requestWithBearer: nativeAt => fetchJson(url, null, { ...opts, bearer: nativeAt, headers: conn.headers }),
+      requestWithCookie: () => fetchJsonViaOauthSession(url, { ...opts, headers: conn.headers })
+    })
   }
 
   return fetchJson(url, conn.token, { ...opts, headers: conn.headers })
@@ -14340,6 +14316,7 @@ ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) =>
         rememberLog
       })
 
+      nativeAccessTokenCoordinator.invalidateExplicitAuthChange()
       _storeNativeTokens(baseUrl, tokens)
       // Confirmed sign-in — release the reauth latch so the next
       // startHermes() re-dials instead of replaying the stale rejection.
@@ -14373,6 +14350,7 @@ ipcMain.handle('hermes:connection-config:oauth-logout', async (_event, rawUrl) =
 
   // Also drop any native (RFC 8252) bearer tokens for this gateway so a
   // logout clears BOTH auth shapes.
+  nativeAccessTokenCoordinator.invalidateExplicitAuthChange()
   _clearNativeTokens(baseUrl)
 
   // Report against the SAME liveness notion the Settings indicator uses
@@ -14960,26 +14938,25 @@ async function handleHermesApiRequest(request) {
         throw new Error('File uploads are not supported against OAuth-gated remote backends yet.')
       }
 
-      // Native bearer first (cookieless). ensureNativeAccessToken transparently
-      // refreshes a near-expiry AT via /auth/native/refresh; a null return means
-      // no native session (resolveOauthRestAuth then selects the cookie path).
-      const nativeAt = await ensureNativeAccessToken(connection.baseUrl).catch(() => null)
-      const restAuth = resolveOauthRestAuth(nativeAt)
-
-      if (restAuth.kind === 'bearer') {
-        response = await fetchJson(url, null, {
-          method: request?.method,
-          body: request?.body,
-          timeoutMs,
-          bearer: restAuth.token
-        })
-      } else {
-        response = await fetchJsonViaOauthSession(url, {
-          method: request?.method,
-          body: request?.body,
-          timeoutMs
-        })
-      }
+      // Native bearer first (cookieless). A transient refresh failure still
+      // tries a coexisting cookie session; if that is unauthenticated too, the
+      // original native failure wins over the cookie's auth-shaped rejection.
+      response = await requestWithOauthFallback(connection.baseUrl, {
+        ensureNativeAccessToken,
+        requestWithBearer: nativeAt =>
+          fetchJson(url, null, {
+            method: request?.method,
+            body: request?.body,
+            timeoutMs,
+            bearer: nativeAt
+          }),
+        requestWithCookie: () =>
+          fetchJsonViaOauthSession(url, {
+            method: request?.method,
+            body: request?.body,
+            timeoutMs
+          })
+      })
     } else {
       response = await fetchJson(url, connection.token, {
         method: request?.method,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -101,7 +101,9 @@ import {
   gatewayTicketFailure,
   gatewayWsUrlIpcResult,
   hostLabelFromBaseUrl,
+  isNativeRefreshAuthRejection,
   localProfileEntry,
+  mintGatewayWsTicket as mintGatewayWsTicketPure,
   modeIsRemoteLike,
   normalizeRemoteBaseUrl,
   normalizeRemoteHeaders,
@@ -7531,7 +7533,10 @@ async function ensureNativeAccessToken(baseUrl: string): Promise<string | null> 
   } catch (error: any) {
     // A 401 means the RT is dead (session_expired) — drop tokens so the UI
     // prompts a fresh native login. A 503/transient keeps them for a retry.
-    if (error && error.statusCode === 401) {
+    // isNativeRefreshAuthRejection (not a bare error.statusCode === 401
+    // check) because fetchJson never attaches .statusCode — see its doc in
+    // connection-config.ts.
+    if (isNativeRefreshAuthRejection(error)) {
       _clearNativeTokens(baseUrl)
 
       return null
@@ -7826,42 +7831,17 @@ async function saveGatewayFileViaDataUrl(
 // Transient transport blips (brief host unreachable, 5xx, timeouts) are retried
 // a few times before failing — those 1-3s flaps were promoting into the
 // full-screen "couldn't start" lockout on reconnect.
+//
+// Thin adapter over connection-config.ts's pure mintGatewayWsTicket, wiring
+// in the real (electron-coupled) I/O. Kept as a same-named local function so
+// none of this file's call sites need to change. See that function's doc
+// for why ensureNativeAccessToken is NOT wrapped in .catch(() => null).
+// `headers` are the connection's remote gateway headers (see
+// freshGatewayWsUrl); they ride along on both the bearer and cookie mints.
 async function mintGatewayWsTicket(baseUrl, headers = {}) {
-  return withTransientRetries(async () => {
-    // Native flow: mint the ticket with the bearer token, no cookie involved.
-    const nativeAt = await ensureNativeAccessToken(baseUrl).catch(() => null)
-
-    if (nativeAt) {
-      const body = (await fetchJson(`${baseUrl}/api/auth/ws-ticket`, null, {
-        method: 'POST',
-        timeoutMs: 8_000,
-        bearer: nativeAt,
-        headers
-      })) as any
-
-      const ticket = body?.ticket
-
-      if (!ticket || typeof ticket !== 'string') {
-        throw new Error('Gateway did not return a WS ticket.')
-      }
-
-      return ticket
-    }
-
-    const body = (await fetchJsonViaOauthSession(`${baseUrl}/api/auth/ws-ticket`, {
-      method: 'POST',
-      timeoutMs: 8_000,
-      headers
-    })) as any
-
-    const ticket = body?.ticket
-
-    if (!ticket || typeof ticket !== 'string') {
-      throw new Error('Gateway did not return a WS ticket.')
-    }
-
-    return ticket
-  })
+  return withTransientRetries(() =>
+    mintGatewayWsTicketPure(baseUrl, { ensureNativeAccessToken, fetchJson, fetchJsonViaOauthSession }, headers)
+  )
 }
 
 // Build a fresh WS URL for the *current* connection. Critical for reconnects:

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -14316,7 +14316,7 @@ ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) =>
         rememberLog
       })
 
-      nativeAccessTokenCoordinator.invalidateExplicitAuthChange()
+      nativeAccessTokenCoordinator.invalidateExplicitAuthChange(baseUrl)
       _storeNativeTokens(baseUrl, tokens)
       // Confirmed sign-in — release the reauth latch so the next
       // startHermes() re-dials instead of replaying the stale rejection.
@@ -14350,7 +14350,7 @@ ipcMain.handle('hermes:connection-config:oauth-logout', async (_event, rawUrl) =
 
   // Also drop any native (RFC 8252) bearer tokens for this gateway so a
   // logout clears BOTH auth shapes.
-  nativeAccessTokenCoordinator.invalidateExplicitAuthChange()
+  nativeAccessTokenCoordinator.invalidateExplicitAuthChange(baseUrl)
   _clearNativeTokens(baseUrl)
 
   // Report against the SAME liveness notion the Settings indicator uses

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9596,7 +9596,7 @@ ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) =>
         rememberLog
       })
 
-      nativeAccessTokenCoordinator.invalidateExplicitAuthChange()
+      nativeAccessTokenCoordinator.invalidateExplicitAuthChange(baseUrl)
       _storeNativeTokens(baseUrl, tokens)
       // Confirmed sign-in — release the reauth latch so the next
       // startHermes() re-dials instead of replaying the stale rejection.
@@ -9630,11 +9630,11 @@ ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) =>
 })
 ipcMain.handle('hermes:connection-config:oauth-logout', async (_event, rawUrl) => {
   const baseUrl = rawUrl ? normalizeRemoteBaseUrl(rawUrl) : ''
-  nativeAccessTokenCoordinator.invalidateExplicitAuthChange()
 
   // Also drop any native (RFC 8252) bearer tokens for this gateway so a
   // logout clears BOTH auth shapes.
   if (baseUrl) {
+    nativeAccessTokenCoordinator.invalidateExplicitAuthChange(baseUrl)
     _clearNativeTokens(baseUrl)
   }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -131,11 +131,11 @@ import {
 } from './hardening'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { ensureMainWindow } from './main-window-lifecycle'
+import { createNativeAccessTokenCoordinator } from './native-access-token'
 import {
   oauthGuardMayHardFail,
   oauthSessionIsLive,
   resolveJsonBody,
-  resolveOauthRestAuth,
   resolveReadinessProbeAuth
 } from './native-auth-decisions'
 import {
@@ -147,6 +147,7 @@ import {
 } from './native-oauth'
 import { runNativeLogin } from './native-oauth-login'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
+import { requestWithOauthFallback } from './oauth-rest-request'
 import { createKeepAwake } from './power-save'
 import { FirstRunSetupResetError, runPrimaryBackendStartup } from './primary-backend-startup'
 import { rehomePrimaryConnection } from './primary-connection-rehome'
@@ -6211,52 +6212,29 @@ function postJsonNoAuth(url: string, body: unknown, opts: any = {}) {
   return fetchJson(url, null, { method: 'POST', body: resolveJsonBody(body), ...opts })
 }
 
-// Return a valid native access token for baseUrl, refreshing via
-// /auth/native/refresh if the stored one is at/near expiry. Returns null when
-// there are no tokens or the refresh is terminally rejected (caller re-logins).
-async function ensureNativeAccessToken(baseUrl: string): Promise<string | null> {
-  const tokens = _loadNativeTokens(baseUrl)
-
-  if (!tokens) {
-    return null
-  }
-
-  if (!tokenNeedsRefresh(tokens, Math.floor(Date.now() / 1000))) {
-    return tokens.accessToken
-  }
-
-  if (!tokens.refreshToken) {
-    // Access token expired and no RT to rotate — force re-login.
-    _clearNativeTokens(baseUrl)
-
-    return null
-  }
-
-  try {
+const nativeAccessTokenCoordinator = createNativeAccessTokenCoordinator({
+  clearTokens: _clearNativeTokens,
+  isRefreshAuthRejection: isNativeRefreshAuthRejection,
+  loadTokens: _loadNativeTokens,
+  normalizeBaseUrl: normalizeRemoteBaseUrl,
+  refreshTokens: async (baseUrl, tokens) => {
     const body = await postJsonNoAuth(
       nativeRefreshUrl(baseUrl),
       { refresh_token: tokens.refreshToken, provider: tokens.provider },
       { timeoutMs: 10_000 }
     )
 
-    const rotated = parseTokenResponse(body)
-    _storeNativeTokens(baseUrl, rotated)
+    return parseTokenResponse(body)
+  },
+  storeTokens: _storeNativeTokens,
+  tokenNeedsRefresh
+})
 
-    return rotated.accessToken
-  } catch (error: any) {
-    // A 401 means the RT is dead (session_expired) — drop tokens so the UI
-    // prompts a fresh native login. A 503/transient keeps them for a retry.
-    // isNativeRefreshAuthRejection (not a bare error.statusCode === 401
-    // check) because fetchJson never attaches .statusCode — see its doc in
-    // connection-config.ts.
-    if (isNativeRefreshAuthRejection(error)) {
-      _clearNativeTokens(baseUrl)
-
-      return null
-    }
-
-    throw error
-  }
+// Return a valid native access token for baseUrl, refreshing via
+// /auth/native/refresh if the stored one is at/near expiry. Returns null when
+// there are no tokens or the refresh is terminally rejected (caller re-logins).
+async function ensureNativeAccessToken(baseUrl: string): Promise<string | null> {
+  return nativeAccessTokenCoordinator.ensure(baseUrl)
 }
 
 // Mint a single-use WS ticket for a gated gateway. Returns the ticket string.
@@ -7500,13 +7478,11 @@ async function requestJsonForProfile(profile: string, path: string, method: stri
   if (conn.authMode === 'oauth') {
     // Native RFC 8252 flow: authenticate with the bearer token (cookieless)
     // when we hold one for this gateway; otherwise use the cookie partition.
-    const nativeAt = await ensureNativeAccessToken(conn.baseUrl).catch(() => null)
-
-    if (nativeAt) {
-      return fetchJson(url, null, { ...opts, bearer: nativeAt })
-    }
-
-    return fetchJsonViaOauthSession(url, opts)
+    return requestWithOauthFallback(conn.baseUrl, {
+      ensureNativeAccessToken,
+      requestWithBearer: nativeAt => fetchJson(url, null, { ...opts, bearer: nativeAt }),
+      requestWithCookie: () => fetchJsonViaOauthSession(url, opts)
+    })
   }
 
   return fetchJson(url, conn.token, opts)
@@ -9620,6 +9596,7 @@ ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) =>
         rememberLog
       })
 
+      nativeAccessTokenCoordinator.invalidateExplicitAuthChange()
       _storeNativeTokens(baseUrl, tokens)
       // Confirmed sign-in — release the reauth latch so the next
       // startHermes() re-dials instead of replaying the stale rejection.
@@ -9653,13 +9630,15 @@ ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) =>
 })
 ipcMain.handle('hermes:connection-config:oauth-logout', async (_event, rawUrl) => {
   const baseUrl = rawUrl ? normalizeRemoteBaseUrl(rawUrl) : ''
-  await clearOauthSession(baseUrl || undefined)
+  nativeAccessTokenCoordinator.invalidateExplicitAuthChange()
 
   // Also drop any native (RFC 8252) bearer tokens for this gateway so a
   // logout clears BOTH auth shapes.
   if (baseUrl) {
     _clearNativeTokens(baseUrl)
   }
+
+  await clearOauthSession(baseUrl || undefined)
 
   // Report against the SAME liveness notion the Settings indicator uses
   // (AT-or-RT cookie, or a native token) so a logout that left any session
@@ -10037,25 +10016,24 @@ ipcMain.handle('hermes:api', async (_event, request) => {
       throw new Error('File uploads are not supported against OAuth-gated remote backends yet.')
     }
 
-    // Native bearer first (cookieless). ensureNativeAccessToken transparently
-    // refreshes a near-expiry AT via /auth/native/refresh; a null return means
-    // no native session (resolveOauthRestAuth then selects the cookie path).
-    const nativeAt = await ensureNativeAccessToken(connection.baseUrl).catch(() => null)
-    const restAuth = resolveOauthRestAuth(nativeAt)
-
-    if (restAuth.kind === 'bearer') {
-      return fetchJson(url, null, {
-        method: request?.method,
-        body: request?.body,
-        timeoutMs,
-        bearer: restAuth.token
-      })
-    }
-
-    return fetchJsonViaOauthSession(url, {
-      method: request?.method,
-      body: request?.body,
-      timeoutMs
+    // Native bearer first (cookieless). A transient refresh failure still
+    // tries a coexisting cookie session; if that is unauthenticated too, the
+    // original native failure wins over the cookie's auth-shaped rejection.
+    return requestWithOauthFallback(connection.baseUrl, {
+      ensureNativeAccessToken,
+      requestWithBearer: nativeAt =>
+        fetchJson(url, null, {
+          method: request?.method,
+          body: request?.body,
+          timeoutMs,
+          bearer: nativeAt
+        }),
+      requestWithCookie: () =>
+        fetchJsonViaOauthSession(url, {
+          method: request?.method,
+          body: request?.body,
+          timeoutMs
+        })
     })
   }
 

--- a/apps/desktop/electron/native-access-token.test.ts
+++ b/apps/desktop/electron/native-access-token.test.ts
@@ -1,13 +1,22 @@
 import assert from 'node:assert/strict'
+88,547
+import { readFileSync } from 'node:fs'
+import { runInNewContext } from 'node:vm'
 
+import { ScriptTarget, transpileModule } from 'typescript'
 import { test, vi } from 'vitest'
 
 import {
+  authModeFromStatus,
   isNativeRefreshAuthRejection,
   normalizeRemoteBaseUrl
 } from './connection-config'
 import { createNativeAccessTokenCoordinator } from './native-access-token'
-import { type NativeTokenSet, tokenNeedsRefresh } from './native-oauth'
+import {
+  type NativeTokenSet,
+  resolveLoginStrategy,
+  tokenNeedsRefresh
+} from './native-oauth'
 
 function tokenSet(
   accessToken: string,
@@ -33,6 +42,83 @@ function deferred<T>() {
   })
 
   return { promise, reject, resolve }
+}
+
+function loadOauthLogoutHandler({
+  clearOauthSession,
+  clearNativeTokens,
+  coordinator
+}: {
+  clearOauthSession: (baseUrl?: string) => Promise<void>
+  clearNativeTokens: (baseUrl: string) => void
+  coordinator: ReturnType<typeof createNativeAccessTokenCoordinator>
+}) {
+  // main.ts cannot be imported under the Electron unit runner without booting
+  // the app lifecycle. Execute the registered handler body itself so these tests
+  // cannot drift into a hand-written approximation of production ordering.
+  const mainSource = readFileSync(new URL('./main.ts', import.meta.url), 'utf8')
+  const match = mainSource.match(
+    /ipcMain\.handle\('hermes:connection-config:oauth-logout', (async \(_event, rawUrl\) => \{[\s\S]*?\r?\n\})\)\r?\n/
+  )
+
+  assert.ok(match, 'oauth-logout IPC handler was not found in main.ts')
+
+  return runInNewContext(`(${match[1]})`, {
+    _clearNativeTokens: clearNativeTokens,
+    clearOauthSession,
+    hasLiveOauthSession: async () => false,
+    hasNativeSession: () => false,
+    nativeAccessTokenCoordinator: coordinator,
+    normalizeRemoteBaseUrl
+  }) as (_event: unknown, rawUrl?: string) => Promise<{ connected: boolean; ok: boolean }>
+}
+
+function loadOauthLoginHandler({
+  coordinator,
+  runNativeLogin,
+  storeNativeTokens
+}: {
+  coordinator: ReturnType<typeof createNativeAccessTokenCoordinator>
+  runNativeLogin: (baseUrl: string, deps: unknown) => Promise<NativeTokenSet>
+  storeNativeTokens: (baseUrl: string, tokens: NativeTokenSet) => void
+}) {
+  // Execute the registered production handler body, as the logout fixture does.
+  // The extracted login handler contains a TypeScript local annotation, so
+  // transpile it before passing the otherwise unchanged body to node:vm.
+  const mainSource = readFileSync(new URL('./main.ts', import.meta.url), 'utf8')
+  const match = mainSource.match(
+    /ipcMain\.handle\('hermes:connection-config:oauth-login', (async \(_event, rawUrl\) => \{[\s\S]*?\r?\n\})\)\r?\n/
+  )
+
+  assert.ok(match, 'oauth-login IPC handler was not found in main.ts')
+
+  const handlerSource = transpileModule(`const handler = ${match[1]}`, {
+    compilerOptions: { target: ScriptTarget.ES2022 }
+  }).outputText
+
+  return runInNewContext(`${handlerSource}\nhandler`, {
+    _storeNativeTokens: storeNativeTokens,
+    // authModeFromStatus is the real connection-config.ts export (imported
+    // above), not a stub — upstream 21f34794be added the auth_flows/status
+    // gating this handler now does before choosing native vs. embedded login.
+    authModeFromStatus,
+    fetchPublicJson: async () => ({ auth_flows: ['native_pkce'] }),
+    hasOauthSessionCookie: async () => false,
+    nativeAccessTokenCoordinator: coordinator,
+    normalizeRemoteBaseUrl,
+    openOauthLoginWindow: async () => {},
+    postJsonNoAuth: async () => ({}),
+    rememberLog: () => {},
+    remoteReauthFailure: null,
+    resolveLoginStrategy,
+    runNativeLogin,
+    shell: {
+      openExternal: async () => {}
+    }
+  }) as (
+    _event: unknown,
+    rawUrl: string
+  ) => Promise<{ baseUrl: string; connected: boolean; ok: boolean }>
 }
 
 function coordinatorFixture(initialTokens: NativeTokenSet) {
@@ -90,6 +176,130 @@ test('coalesces concurrent refreshes by normalized base URL and stores one rotat
   assert.equal(fixture.storedTokens(), rotated)
 })
 
+test('an auth change for another gateway preserves a successful rotation', async () => {
+  const rotated = tokenSet('gw-b-rotated-at', 'gw-b-rotated-rt', 2_000)
+  const fixture = coordinatorFixture(tokenSet('gw-b-expiring-at', 'gw-b-old-rt', 1_000))
+  const pending = fixture.coordinator.ensure('https://gw-b.example.com')
+
+  fixture.coordinator.invalidateExplicitAuthChange('https://gw-a.example.com')
+  fixture.refresh.resolve(rotated)
+
+  assert.equal(await pending, 'gw-b-rotated-at')
+  assert.deepEqual(fixture.storeTokens.mock.calls, [['https://gw-b.example.com', rotated]])
+})
+
+test('an auth change for another gateway still processes a refresh rejection', async () => {
+  const fixture = coordinatorFixture(tokenSet('gw-b-expiring-at', 'gw-b-old-rt', 1_000))
+  const pending = fixture.coordinator.ensure('https://gw-b.example.com')
+
+  fixture.coordinator.invalidateExplicitAuthChange('https://gw-a.example.com')
+  fixture.refresh.reject(Object.assign(new Error('401: {"error":"session_expired"}'), { statusCode: 401 }))
+
+  assert.equal(await pending, null)
+  assert.deepEqual(fixture.clearTokens.mock.calls, [['https://gw-b.example.com']])
+})
+
+test('oauth logout without a URL preserves a successful refresh for another gateway', async () => {
+  const rotated = tokenSet('gw-b-rotated-at', 'gw-b-rotated-rt', 2_000)
+  const fixture = coordinatorFixture(tokenSet('gw-b-expiring-at', 'gw-b-old-rt', 1_000))
+  const clearNativeTokens = vi.fn((_baseUrl: string) => {})
+  const clearOauthSession = vi.fn(async (_baseUrl?: string) => {})
+  const handler = loadOauthLogoutHandler({
+    clearNativeTokens,
+    clearOauthSession,
+    coordinator: fixture.coordinator
+  })
+  const pending = fixture.coordinator.ensure('https://gw-b.example.com')
+
+  // Upstream 21f34794be dropped the URL-less logout path — the handler now
+  // calls normalizeRemoteBaseUrl(rawUrl) unconditionally, which throws
+  // before touching any gateway's token state.
+  await assert.rejects(handler(undefined, undefined), { message: 'Remote gateway URL is required.' })
+  fixture.refresh.resolve(rotated)
+
+  assert.equal(clearOauthSession.mock.calls.length, 0)
+  assert.equal(clearNativeTokens.mock.calls.length, 0)
+  assert.equal(await pending, 'gw-b-rotated-at')
+  assert.deepEqual(fixture.storeTokens.mock.calls, [['https://gw-b.example.com', rotated]])
+})
+
+test('oauth logout without a URL still processes a refresh rejection for another gateway', async () => {
+  const fixture = coordinatorFixture(tokenSet('gw-b-expiring-at', 'gw-b-old-rt', 1_000))
+  const clearNativeTokens = vi.fn((_baseUrl: string) => {})
+  const clearOauthSession = vi.fn(async (_baseUrl?: string) => {})
+  const handler = loadOauthLogoutHandler({
+    clearNativeTokens,
+    clearOauthSession,
+    coordinator: fixture.coordinator
+  })
+  const pending = fixture.coordinator.ensure('https://gw-b.example.com')
+
+  // Upstream 21f34794be dropped the URL-less logout path — the handler now
+  // calls normalizeRemoteBaseUrl(rawUrl) unconditionally, which throws
+  // before touching any gateway's token state.
+  await assert.rejects(handler(undefined, undefined), { message: 'Remote gateway URL is required.' })
+  fixture.refresh.reject(Object.assign(new Error('401: {"error":"session_expired"}'), { statusCode: 401 }))
+
+  assert.equal(clearOauthSession.mock.calls.length, 0)
+  assert.equal(clearNativeTokens.mock.calls.length, 0)
+  assert.equal(await pending, null)
+  assert.deepEqual(fixture.clearTokens.mock.calls, [['https://gw-b.example.com']])
+})
+
+test('oauth logout with a URL invalidates an in-flight refresh for the same gateway', async () => {
+  const rotated = tokenSet('stale-at', 'stale-rt', 2_000)
+  const fixture = coordinatorFixture(tokenSet('expiring-at', 'old-rt', 1_000))
+  const clearNativeTokens = vi.fn((_baseUrl: string) => {
+    fixture.setStoredTokens(null)
+  })
+  const clearOauthSession = vi.fn(async (_baseUrl?: string) => {})
+  const handler = loadOauthLogoutHandler({
+    clearNativeTokens,
+    clearOauthSession,
+    coordinator: fixture.coordinator
+  })
+  const pending = fixture.coordinator.ensure('https://gw.example.com')
+
+  const result = await handler(undefined, 'https://GW.example.com/')
+  fixture.refresh.resolve(rotated)
+
+  assert.equal(result.ok, true)
+  assert.equal(result.connected, false)
+  assert.deepEqual(clearNativeTokens.mock.calls, [['https://gw.example.com']])
+  assert.deepEqual(clearOauthSession.mock.calls, [['https://gw.example.com']])
+  assert.equal(await pending, null)
+  assert.equal(fixture.storeTokens.mock.calls.length, 0)
+  assert.equal(fixture.storedTokens(), null)
+})
+
+test('oauth logout with a URL preserves an in-flight refresh for another gateway', async () => {
+  const rotated = tokenSet('gw-b-rotated-at', 'gw-b-rotated-rt', 2_000)
+  const fixture = coordinatorFixture(tokenSet('gw-b-expiring-at', 'gw-b-old-rt', 1_000))
+  const invalidateExplicitAuthChange = vi.spyOn(
+    fixture.coordinator,
+    'invalidateExplicitAuthChange'
+  )
+  const clearNativeTokens = vi.fn((_baseUrl: string) => {})
+  const clearOauthSession = vi.fn(async (_baseUrl?: string) => {})
+  const handler = loadOauthLogoutHandler({
+    clearNativeTokens,
+    clearOauthSession,
+    coordinator: fixture.coordinator
+  })
+  const pending = fixture.coordinator.ensure('https://gw-b.example.com')
+
+  const result = await handler(undefined, 'https://GW-A.example.com/')
+  fixture.refresh.resolve(rotated)
+
+  assert.equal(result.ok, true)
+  assert.equal(result.connected, false)
+  assert.deepEqual(invalidateExplicitAuthChange.mock.calls, [['https://gw-a.example.com']])
+  assert.deepEqual(clearNativeTokens.mock.calls, [['https://gw-a.example.com']])
+  assert.deepEqual(clearOauthSession.mock.calls, [['https://gw-a.example.com']])
+  assert.equal(await pending, 'gw-b-rotated-at')
+  assert.deepEqual(fixture.storeTokens.mock.calls, [['https://gw-b.example.com', rotated]])
+})
+
 test('a stale refresh rejection does not clear an already-rotated refresh token', async () => {
   const oldTokens = tokenSet('expiring-at', 'old-rt', 1_000)
   const rotated = tokenSet('winner-at', 'winner-rt', 2_000)
@@ -104,13 +314,13 @@ test('a stale refresh rejection does not clear an already-rotated refresh token'
   assert.equal(fixture.storedTokens(), rotated)
 })
 
-test('logout invalidates an in-flight refresh so its result cannot restore tokens', async () => {
+test('logout invalidates an in-flight refresh for the same gateway so its result cannot restore tokens', async () => {
   const oldTokens = tokenSet('expiring-at', 'old-rt', 1_000)
   const rotated = tokenSet('stale-at', 'stale-rt', 2_000)
   const fixture = coordinatorFixture(oldTokens)
   const pending = fixture.coordinator.ensure('https://gw.example.com')
 
-  fixture.coordinator.invalidateExplicitAuthChange()
+  fixture.coordinator.invalidateExplicitAuthChange('https://gw.example.com')
   fixture.setStoredTokens(null)
   fixture.refresh.resolve(rotated)
 
@@ -126,10 +336,43 @@ test('a completed explicit login wins over an older in-flight refresh', async ()
   const fixture = coordinatorFixture(oldTokens)
   const pending = fixture.coordinator.ensure('https://gw.example.com')
 
-  fixture.coordinator.invalidateExplicitAuthChange()
+  fixture.coordinator.invalidateExplicitAuthChange('https://gw.example.com')
   fixture.setStoredTokens(loginTokens)
   fixture.refresh.resolve(staleRotation)
 
+  assert.equal(await pending, null)
+  assert.equal(fixture.storeTokens.mock.calls.length, 0)
+  assert.equal(fixture.storedTokens(), loginTokens)
+})
+
+test('native login invalidates an older in-flight refresh for the same gateway', async () => {
+  const staleRotation = tokenSet('stale-at', 'stale-rt', 2_000)
+  const loginTokens = tokenSet('login-at', 'login-rt', 3_000)
+  const fixture = coordinatorFixture(tokenSet('expiring-at', 'old-rt', 1_000))
+  const runNativeLogin = vi.fn(
+    async (_baseUrl: string, _deps: unknown) => loginTokens
+  )
+  const storeNativeTokens = vi.fn(
+    (_baseUrl: string, tokens: NativeTokenSet) => {
+      fixture.setStoredTokens(tokens)
+    }
+  )
+  const handler = loadOauthLoginHandler({
+    coordinator: fixture.coordinator,
+    runNativeLogin,
+    storeNativeTokens
+  })
+  const pending = fixture.coordinator.ensure('https://gw.example.com')
+
+  const result = await handler(undefined, 'https://GW.example.com/')
+  fixture.refresh.resolve(staleRotation)
+
+  assert.equal(result.ok, true)
+  assert.equal(result.connected, true)
+  assert.equal(result.baseUrl, 'https://gw.example.com')
+  assert.equal(runNativeLogin.mock.calls.length, 1)
+  assert.equal(runNativeLogin.mock.calls[0]?.[0], 'https://gw.example.com')
+  assert.deepEqual(storeNativeTokens.mock.calls, [['https://gw.example.com', loginTokens]])
   assert.equal(await pending, null)
   assert.equal(fixture.storeTokens.mock.calls.length, 0)
   assert.equal(fixture.storedTokens(), loginTokens)

--- a/apps/desktop/electron/native-access-token.test.ts
+++ b/apps/desktop/electron/native-access-token.test.ts
@@ -1,5 +1,4 @@
 import assert from 'node:assert/strict'
-88,547
 import { readFileSync } from 'node:fs'
 import { runInNewContext } from 'node:vm'
 

--- a/apps/desktop/electron/native-access-token.test.ts
+++ b/apps/desktop/electron/native-access-token.test.ts
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict'
+
+import { test, vi } from 'vitest'
+
+import {
+  isNativeRefreshAuthRejection,
+  normalizeRemoteBaseUrl
+} from './connection-config'
+import { createNativeAccessTokenCoordinator } from './native-access-token'
+import { type NativeTokenSet, tokenNeedsRefresh } from './native-oauth'
+
+function tokenSet(
+  accessToken: string,
+  refreshToken: string,
+  expiresAt: number
+): NativeTokenSet {
+  return {
+    accessToken,
+    expiresAt,
+    provider: 'nous',
+    refreshToken,
+    userId: 'user-1'
+  }
+}
+
+function deferred<T>() {
+  let reject!: (reason?: unknown) => void
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+
+  return { promise, reject, resolve }
+}
+
+function coordinatorFixture(initialTokens: NativeTokenSet) {
+  let storedTokens: NativeTokenSet | null = initialTokens
+  const refresh = deferred<NativeTokenSet>()
+  const refreshTokens = vi.fn(async () => refresh.promise)
+
+  const storeTokens = vi.fn((_baseUrl: string, tokens: NativeTokenSet) => {
+    storedTokens = tokens
+  })
+
+  const clearTokens = vi.fn(() => {
+    storedTokens = null
+  })
+
+  const coordinator = createNativeAccessTokenCoordinator({
+    clearTokens,
+    isRefreshAuthRejection: isNativeRefreshAuthRejection,
+    loadTokens: () => storedTokens,
+    normalizeBaseUrl: normalizeRemoteBaseUrl,
+    nowSeconds: () => 1_000,
+    refreshTokens,
+    storeTokens,
+    tokenNeedsRefresh
+  })
+
+  return {
+    clearTokens,
+    coordinator,
+    refresh,
+    refreshTokens,
+    setStoredTokens: (tokens: NativeTokenSet | null) => {
+      storedTokens = tokens
+    },
+    storeTokens,
+    storedTokens: () => storedTokens
+  }
+}
+
+test('coalesces concurrent refreshes by normalized base URL and stores one rotation', async () => {
+  const oldTokens = tokenSet('expiring-at', 'rotating-rt', 1_000)
+  const rotated = tokenSet('rotated-at', 'rotated-rt', 2_000)
+  const fixture = coordinatorFixture(oldTokens)
+
+  const first = fixture.coordinator.ensure('https://GW.example.com/')
+  const second = fixture.coordinator.ensure('https://gw.example.com')
+
+  assert.equal(fixture.refreshTokens.mock.calls.length, 1)
+
+  fixture.refresh.resolve(rotated)
+
+  assert.deepEqual(await Promise.all([first, second]), ['rotated-at', 'rotated-at'])
+  assert.equal(fixture.refreshTokens.mock.calls.length, 1)
+  assert.equal(fixture.storeTokens.mock.calls.length, 1)
+  assert.equal(fixture.storedTokens(), rotated)
+})
+
+test('a stale refresh rejection does not clear an already-rotated refresh token', async () => {
+  const oldTokens = tokenSet('expiring-at', 'old-rt', 1_000)
+  const rotated = tokenSet('winner-at', 'winner-rt', 2_000)
+  const fixture = coordinatorFixture(oldTokens)
+  const pending = fixture.coordinator.ensure('https://gw.example.com')
+
+  fixture.setStoredTokens(rotated)
+  fixture.refresh.reject(Object.assign(new Error('401: {"error":"session_expired"}'), { statusCode: 401 }))
+
+  assert.equal(await pending, null)
+  assert.equal(fixture.clearTokens.mock.calls.length, 0)
+  assert.equal(fixture.storedTokens(), rotated)
+})
+
+test('logout invalidates an in-flight refresh so its result cannot restore tokens', async () => {
+  const oldTokens = tokenSet('expiring-at', 'old-rt', 1_000)
+  const rotated = tokenSet('stale-at', 'stale-rt', 2_000)
+  const fixture = coordinatorFixture(oldTokens)
+  const pending = fixture.coordinator.ensure('https://gw.example.com')
+
+  fixture.coordinator.invalidateExplicitAuthChange()
+  fixture.setStoredTokens(null)
+  fixture.refresh.resolve(rotated)
+
+  assert.equal(await pending, null)
+  assert.equal(fixture.storeTokens.mock.calls.length, 0)
+  assert.equal(fixture.storedTokens(), null)
+})
+
+test('a completed explicit login wins over an older in-flight refresh', async () => {
+  const oldTokens = tokenSet('expiring-at', 'old-rt', 1_000)
+  const staleRotation = tokenSet('stale-at', 'stale-rt', 2_000)
+  const loginTokens = tokenSet('login-at', 'login-rt', 3_000)
+  const fixture = coordinatorFixture(oldTokens)
+  const pending = fixture.coordinator.ensure('https://gw.example.com')
+
+  fixture.coordinator.invalidateExplicitAuthChange()
+  fixture.setStoredTokens(loginTokens)
+  fixture.refresh.resolve(staleRotation)
+
+  assert.equal(await pending, null)
+  assert.equal(fixture.storeTokens.mock.calls.length, 0)
+  assert.equal(fixture.storedTokens(), loginTokens)
+})

--- a/apps/desktop/electron/native-access-token.test.ts
+++ b/apps/desktop/electron/native-access-token.test.ts
@@ -1,5 +1,9 @@
 import assert from 'node:assert/strict'
+88,547
+import { readFileSync } from 'node:fs'
+import { runInNewContext } from 'node:vm'
 
+import { ScriptTarget, transpileModule } from 'typescript'
 import { test, vi } from 'vitest'
 
 import {
@@ -7,7 +11,11 @@ import {
   normalizeRemoteBaseUrl
 } from './connection-config'
 import { createNativeAccessTokenCoordinator } from './native-access-token'
-import { type NativeTokenSet, tokenNeedsRefresh } from './native-oauth'
+import {
+  type NativeTokenSet,
+  resolveLoginStrategy,
+  tokenNeedsRefresh
+} from './native-oauth'
 
 function tokenSet(
   accessToken: string,
@@ -33,6 +41,79 @@ function deferred<T>() {
   })
 
   return { promise, reject, resolve }
+}
+
+function loadOauthLogoutHandler({
+  clearOauthSession,
+  clearNativeTokens,
+  coordinator
+}: {
+  clearOauthSession: (baseUrl?: string) => Promise<void>
+  clearNativeTokens: (baseUrl: string) => void
+  coordinator: ReturnType<typeof createNativeAccessTokenCoordinator>
+}) {
+  // main.ts cannot be imported under the Electron unit runner without booting
+  // the app lifecycle. Execute the registered handler body itself so these tests
+  // cannot drift into a hand-written approximation of production ordering.
+  const mainSource = readFileSync(new URL('./main.ts', import.meta.url), 'utf8')
+  const match = mainSource.match(
+    /ipcMain\.handle\('hermes:connection-config:oauth-logout', (async \(_event, rawUrl\) => \{[\s\S]*?\r?\n\})\)\r?\n/
+  )
+
+  assert.ok(match, 'oauth-logout IPC handler was not found in main.ts')
+
+  return runInNewContext(`(${match[1]})`, {
+    _clearNativeTokens: clearNativeTokens,
+    clearOauthSession,
+    hasLiveOauthSession: async () => false,
+    hasNativeSession: () => false,
+    nativeAccessTokenCoordinator: coordinator,
+    normalizeRemoteBaseUrl
+  }) as (_event: unknown, rawUrl?: string) => Promise<{ connected: boolean; ok: boolean }>
+}
+
+function loadOauthLoginHandler({
+  coordinator,
+  runNativeLogin,
+  storeNativeTokens
+}: {
+  coordinator: ReturnType<typeof createNativeAccessTokenCoordinator>
+  runNativeLogin: (baseUrl: string, deps: unknown) => Promise<NativeTokenSet>
+  storeNativeTokens: (baseUrl: string, tokens: NativeTokenSet) => void
+}) {
+  // Execute the registered production handler body, as the logout fixture does.
+  // The extracted login handler contains a TypeScript local annotation, so
+  // transpile it before passing the otherwise unchanged body to node:vm.
+  const mainSource = readFileSync(new URL('./main.ts', import.meta.url), 'utf8')
+  const match = mainSource.match(
+    /ipcMain\.handle\('hermes:connection-config:oauth-login', (async \(_event, rawUrl\) => \{[\s\S]*?\r?\n\})\)\r?\n/
+  )
+
+  assert.ok(match, 'oauth-login IPC handler was not found in main.ts')
+
+  const handlerSource = transpileModule(`const handler = ${match[1]}`, {
+    compilerOptions: { target: ScriptTarget.ES2022 }
+  }).outputText
+
+  return runInNewContext(`${handlerSource}\nhandler`, {
+    _storeNativeTokens: storeNativeTokens,
+    fetchPublicJson: async () => ({ auth_flows: ['native_pkce'] }),
+    hasOauthSessionCookie: async () => false,
+    nativeAccessTokenCoordinator: coordinator,
+    normalizeRemoteBaseUrl,
+    openOauthLoginWindow: async () => {},
+    postJsonNoAuth: async () => ({}),
+    rememberLog: () => {},
+    remoteReauthFailure: null,
+    resolveLoginStrategy,
+    runNativeLogin,
+    shell: {
+      openExternal: async () => {}
+    }
+  }) as (
+    _event: unknown,
+    rawUrl: string
+  ) => Promise<{ baseUrl: string; connected: boolean; ok: boolean }>
 }
 
 function coordinatorFixture(initialTokens: NativeTokenSet) {
@@ -90,6 +171,128 @@ test('coalesces concurrent refreshes by normalized base URL and stores one rotat
   assert.equal(fixture.storedTokens(), rotated)
 })
 
+test('an auth change for another gateway preserves a successful rotation', async () => {
+  const rotated = tokenSet('gw-b-rotated-at', 'gw-b-rotated-rt', 2_000)
+  const fixture = coordinatorFixture(tokenSet('gw-b-expiring-at', 'gw-b-old-rt', 1_000))
+  const pending = fixture.coordinator.ensure('https://gw-b.example.com')
+
+  fixture.coordinator.invalidateExplicitAuthChange('https://gw-a.example.com')
+  fixture.refresh.resolve(rotated)
+
+  assert.equal(await pending, 'gw-b-rotated-at')
+  assert.deepEqual(fixture.storeTokens.mock.calls, [['https://gw-b.example.com', rotated]])
+})
+
+test('an auth change for another gateway still processes a refresh rejection', async () => {
+  const fixture = coordinatorFixture(tokenSet('gw-b-expiring-at', 'gw-b-old-rt', 1_000))
+  const pending = fixture.coordinator.ensure('https://gw-b.example.com')
+
+  fixture.coordinator.invalidateExplicitAuthChange('https://gw-a.example.com')
+  fixture.refresh.reject(Object.assign(new Error('401: {"error":"session_expired"}'), { statusCode: 401 }))
+
+  assert.equal(await pending, null)
+  assert.deepEqual(fixture.clearTokens.mock.calls, [['https://gw-b.example.com']])
+})
+
+test('oauth logout without a URL preserves a successful refresh for another gateway', async () => {
+  const rotated = tokenSet('gw-b-rotated-at', 'gw-b-rotated-rt', 2_000)
+  const fixture = coordinatorFixture(tokenSet('gw-b-expiring-at', 'gw-b-old-rt', 1_000))
+  const clearNativeTokens = vi.fn((_baseUrl: string) => {})
+  const clearOauthSession = vi.fn(async (_baseUrl?: string) => {})
+  const handler = loadOauthLogoutHandler({
+    clearNativeTokens,
+    clearOauthSession,
+    coordinator: fixture.coordinator
+  })
+  const pending = fixture.coordinator.ensure('https://gw-b.example.com')
+
+  const result = await handler(undefined, undefined)
+  fixture.refresh.resolve(rotated)
+
+  assert.equal(result.ok, true)
+  assert.equal(result.connected, false)
+  assert.deepEqual(clearOauthSession.mock.calls, [[undefined]])
+  assert.equal(clearNativeTokens.mock.calls.length, 0)
+  assert.equal(await pending, 'gw-b-rotated-at')
+  assert.deepEqual(fixture.storeTokens.mock.calls, [['https://gw-b.example.com', rotated]])
+})
+
+test('oauth logout without a URL still processes a refresh rejection for another gateway', async () => {
+  const fixture = coordinatorFixture(tokenSet('gw-b-expiring-at', 'gw-b-old-rt', 1_000))
+  const clearNativeTokens = vi.fn((_baseUrl: string) => {})
+  const clearOauthSession = vi.fn(async (_baseUrl?: string) => {})
+  const handler = loadOauthLogoutHandler({
+    clearNativeTokens,
+    clearOauthSession,
+    coordinator: fixture.coordinator
+  })
+  const pending = fixture.coordinator.ensure('https://gw-b.example.com')
+
+  const result = await handler(undefined, undefined)
+  fixture.refresh.reject(Object.assign(new Error('401: {"error":"session_expired"}'), { statusCode: 401 }))
+
+  assert.equal(result.ok, true)
+  assert.equal(result.connected, false)
+  assert.deepEqual(clearOauthSession.mock.calls, [[undefined]])
+  assert.equal(clearNativeTokens.mock.calls.length, 0)
+  assert.equal(await pending, null)
+  assert.deepEqual(fixture.clearTokens.mock.calls, [['https://gw-b.example.com']])
+})
+
+test('oauth logout with a URL invalidates an in-flight refresh for the same gateway', async () => {
+  const rotated = tokenSet('stale-at', 'stale-rt', 2_000)
+  const fixture = coordinatorFixture(tokenSet('expiring-at', 'old-rt', 1_000))
+  const clearNativeTokens = vi.fn((_baseUrl: string) => {
+    fixture.setStoredTokens(null)
+  })
+  const clearOauthSession = vi.fn(async (_baseUrl?: string) => {})
+  const handler = loadOauthLogoutHandler({
+    clearNativeTokens,
+    clearOauthSession,
+    coordinator: fixture.coordinator
+  })
+  const pending = fixture.coordinator.ensure('https://gw.example.com')
+
+  const result = await handler(undefined, 'https://GW.example.com/')
+  fixture.refresh.resolve(rotated)
+
+  assert.equal(result.ok, true)
+  assert.equal(result.connected, false)
+  assert.deepEqual(clearNativeTokens.mock.calls, [['https://gw.example.com']])
+  assert.deepEqual(clearOauthSession.mock.calls, [['https://gw.example.com']])
+  assert.equal(await pending, null)
+  assert.equal(fixture.storeTokens.mock.calls.length, 0)
+  assert.equal(fixture.storedTokens(), null)
+})
+
+test('oauth logout with a URL preserves an in-flight refresh for another gateway', async () => {
+  const rotated = tokenSet('gw-b-rotated-at', 'gw-b-rotated-rt', 2_000)
+  const fixture = coordinatorFixture(tokenSet('gw-b-expiring-at', 'gw-b-old-rt', 1_000))
+  const invalidateExplicitAuthChange = vi.spyOn(
+    fixture.coordinator,
+    'invalidateExplicitAuthChange'
+  )
+  const clearNativeTokens = vi.fn((_baseUrl: string) => {})
+  const clearOauthSession = vi.fn(async (_baseUrl?: string) => {})
+  const handler = loadOauthLogoutHandler({
+    clearNativeTokens,
+    clearOauthSession,
+    coordinator: fixture.coordinator
+  })
+  const pending = fixture.coordinator.ensure('https://gw-b.example.com')
+
+  const result = await handler(undefined, 'https://GW-A.example.com/')
+  fixture.refresh.resolve(rotated)
+
+  assert.equal(result.ok, true)
+  assert.equal(result.connected, false)
+  assert.deepEqual(invalidateExplicitAuthChange.mock.calls, [['https://gw-a.example.com']])
+  assert.deepEqual(clearNativeTokens.mock.calls, [['https://gw-a.example.com']])
+  assert.deepEqual(clearOauthSession.mock.calls, [['https://gw-a.example.com']])
+  assert.equal(await pending, 'gw-b-rotated-at')
+  assert.deepEqual(fixture.storeTokens.mock.calls, [['https://gw-b.example.com', rotated]])
+})
+
 test('a stale refresh rejection does not clear an already-rotated refresh token', async () => {
   const oldTokens = tokenSet('expiring-at', 'old-rt', 1_000)
   const rotated = tokenSet('winner-at', 'winner-rt', 2_000)
@@ -104,13 +307,13 @@ test('a stale refresh rejection does not clear an already-rotated refresh token'
   assert.equal(fixture.storedTokens(), rotated)
 })
 
-test('logout invalidates an in-flight refresh so its result cannot restore tokens', async () => {
+test('logout invalidates an in-flight refresh for the same gateway so its result cannot restore tokens', async () => {
   const oldTokens = tokenSet('expiring-at', 'old-rt', 1_000)
   const rotated = tokenSet('stale-at', 'stale-rt', 2_000)
   const fixture = coordinatorFixture(oldTokens)
   const pending = fixture.coordinator.ensure('https://gw.example.com')
 
-  fixture.coordinator.invalidateExplicitAuthChange()
+  fixture.coordinator.invalidateExplicitAuthChange('https://gw.example.com')
   fixture.setStoredTokens(null)
   fixture.refresh.resolve(rotated)
 
@@ -126,10 +329,43 @@ test('a completed explicit login wins over an older in-flight refresh', async ()
   const fixture = coordinatorFixture(oldTokens)
   const pending = fixture.coordinator.ensure('https://gw.example.com')
 
-  fixture.coordinator.invalidateExplicitAuthChange()
+  fixture.coordinator.invalidateExplicitAuthChange('https://gw.example.com')
   fixture.setStoredTokens(loginTokens)
   fixture.refresh.resolve(staleRotation)
 
+  assert.equal(await pending, null)
+  assert.equal(fixture.storeTokens.mock.calls.length, 0)
+  assert.equal(fixture.storedTokens(), loginTokens)
+})
+
+test('native login invalidates an older in-flight refresh for the same gateway', async () => {
+  const staleRotation = tokenSet('stale-at', 'stale-rt', 2_000)
+  const loginTokens = tokenSet('login-at', 'login-rt', 3_000)
+  const fixture = coordinatorFixture(tokenSet('expiring-at', 'old-rt', 1_000))
+  const runNativeLogin = vi.fn(
+    async (_baseUrl: string, _deps: unknown) => loginTokens
+  )
+  const storeNativeTokens = vi.fn(
+    (_baseUrl: string, tokens: NativeTokenSet) => {
+      fixture.setStoredTokens(tokens)
+    }
+  )
+  const handler = loadOauthLoginHandler({
+    coordinator: fixture.coordinator,
+    runNativeLogin,
+    storeNativeTokens
+  })
+  const pending = fixture.coordinator.ensure('https://gw.example.com')
+
+  const result = await handler(undefined, 'https://GW.example.com/')
+  fixture.refresh.resolve(staleRotation)
+
+  assert.equal(result.ok, true)
+  assert.equal(result.connected, true)
+  assert.equal(result.baseUrl, 'https://gw.example.com')
+  assert.equal(runNativeLogin.mock.calls.length, 1)
+  assert.equal(runNativeLogin.mock.calls[0]?.[0], 'https://gw.example.com')
+  assert.deepEqual(storeNativeTokens.mock.calls, [['https://gw.example.com', loginTokens]])
   assert.equal(await pending, null)
   assert.equal(fixture.storeTokens.mock.calls.length, 0)
   assert.equal(fixture.storedTokens(), loginTokens)

--- a/apps/desktop/electron/native-access-token.ts
+++ b/apps/desktop/electron/native-access-token.ts
@@ -13,22 +13,23 @@ export interface NativeAccessTokenCoordinatorDeps {
 
 export interface NativeAccessTokenCoordinator {
   ensure: (baseUrl: string) => Promise<string | null>
-  invalidateExplicitAuthChange: () => void
+  invalidateExplicitAuthChange: (rawBaseUrl: string) => void
 }
 
 /**
  * Coordinate native-token refreshes for the Electron main process.
  *
- * One module-level coordinator instance owns one flight map and one auth epoch.
+ * One module-level coordinator instance owns one flight map and scoped auth epochs.
  * Equivalent gateway URLs share a flight after normalization. Explicit login
- * and logout advance the epoch so a response that started under older auth
+ * and logout advance the relevant epoch so a response that started under older auth
  * state can neither overwrite a new login nor resurrect a logout.
  */
 export function createNativeAccessTokenCoordinator(
   deps: NativeAccessTokenCoordinatorDeps
 ): NativeAccessTokenCoordinator {
   const refreshFlights = new Map<string, Promise<string | null>>()
-  let authEpoch = 0
+  const authEpochs = new Map<string, number>()
+  const epochFor = (baseUrl: string) => authEpochs.get(baseUrl) ?? 0
 
   async function ensure(rawBaseUrl: string): Promise<string | null> {
     const baseUrl = deps.normalizeBaseUrl(rawBaseUrl)
@@ -56,14 +57,14 @@ export function createNativeAccessTokenCoordinator(
       return existingFlight
     }
 
-    const flightEpoch = authEpoch
+    const flightEpoch = epochFor(baseUrl)
     const sentRefreshToken = tokens.refreshToken
 
     const refreshFlight = (async (): Promise<string | null> => {
       try {
         const rotated = await deps.refreshTokens(baseUrl, tokens)
 
-        if (authEpoch !== flightEpoch) {
+        if (epochFor(baseUrl) !== flightEpoch) {
           return null
         }
 
@@ -71,7 +72,7 @@ export function createNativeAccessTokenCoordinator(
 
         return rotated.accessToken
       } catch (error) {
-        if (authEpoch !== flightEpoch) {
+        if (epochFor(baseUrl) !== flightEpoch) {
           return null
         }
 
@@ -102,8 +103,9 @@ export function createNativeAccessTokenCoordinator(
 
   return {
     ensure,
-    invalidateExplicitAuthChange: () => {
-      authEpoch += 1
+    invalidateExplicitAuthChange: rawBaseUrl => {
+      const baseUrl = deps.normalizeBaseUrl(rawBaseUrl)
+      authEpochs.set(baseUrl, (authEpochs.get(baseUrl) ?? 0) + 1)
     }
   }
 }

--- a/apps/desktop/electron/native-access-token.ts
+++ b/apps/desktop/electron/native-access-token.ts
@@ -1,0 +1,109 @@
+import type { NativeTokenSet } from './native-oauth'
+
+export interface NativeAccessTokenCoordinatorDeps {
+  clearTokens: (baseUrl: string) => void
+  isRefreshAuthRejection: (error: unknown) => boolean
+  loadTokens: (baseUrl: string) => NativeTokenSet | null
+  normalizeBaseUrl: (baseUrl: string) => string
+  nowSeconds?: () => number
+  refreshTokens: (baseUrl: string, tokens: NativeTokenSet) => Promise<NativeTokenSet>
+  storeTokens: (baseUrl: string, tokens: NativeTokenSet) => void
+  tokenNeedsRefresh: (tokens: NativeTokenSet, nowSeconds: number) => boolean
+}
+
+export interface NativeAccessTokenCoordinator {
+  ensure: (baseUrl: string) => Promise<string | null>
+  invalidateExplicitAuthChange: () => void
+}
+
+/**
+ * Coordinate native-token refreshes for the Electron main process.
+ *
+ * One module-level coordinator instance owns one flight map and one auth epoch.
+ * Equivalent gateway URLs share a flight after normalization. Explicit login
+ * and logout advance the epoch so a response that started under older auth
+ * state can neither overwrite a new login nor resurrect a logout.
+ */
+export function createNativeAccessTokenCoordinator(
+  deps: NativeAccessTokenCoordinatorDeps
+): NativeAccessTokenCoordinator {
+  const refreshFlights = new Map<string, Promise<string | null>>()
+  let authEpoch = 0
+
+  async function ensure(rawBaseUrl: string): Promise<string | null> {
+    const baseUrl = deps.normalizeBaseUrl(rawBaseUrl)
+    const tokens = deps.loadTokens(baseUrl)
+
+    if (!tokens) {
+      return null
+    }
+
+    const nowSeconds = deps.nowSeconds?.() ?? Math.floor(Date.now() / 1_000)
+
+    if (!deps.tokenNeedsRefresh(tokens, nowSeconds)) {
+      return tokens.accessToken
+    }
+
+    if (!tokens.refreshToken) {
+      deps.clearTokens(baseUrl)
+
+      return null
+    }
+
+    const existingFlight = refreshFlights.get(baseUrl)
+
+    if (existingFlight) {
+      return existingFlight
+    }
+
+    const flightEpoch = authEpoch
+    const sentRefreshToken = tokens.refreshToken
+
+    const refreshFlight = (async (): Promise<string | null> => {
+      try {
+        const rotated = await deps.refreshTokens(baseUrl, tokens)
+
+        if (authEpoch !== flightEpoch) {
+          return null
+        }
+
+        deps.storeTokens(baseUrl, rotated)
+
+        return rotated.accessToken
+      } catch (error) {
+        if (authEpoch !== flightEpoch) {
+          return null
+        }
+
+        if (deps.isRefreshAuthRejection(error)) {
+          const stored = deps.loadTokens(baseUrl)
+
+          if (stored?.refreshToken === sentRefreshToken) {
+            deps.clearTokens(baseUrl)
+          }
+
+          return null
+        }
+
+        throw error
+      }
+    })()
+
+    refreshFlights.set(baseUrl, refreshFlight)
+
+    try {
+      return await refreshFlight
+    } finally {
+      if (refreshFlights.get(baseUrl) === refreshFlight) {
+        refreshFlights.delete(baseUrl)
+      }
+    }
+  }
+
+  return {
+    ensure,
+    invalidateExplicitAuthChange: () => {
+      authEpoch += 1
+    }
+  }
+}

--- a/apps/desktop/electron/oauth-rest-request.test.ts
+++ b/apps/desktop/electron/oauth-rest-request.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+
+import { expect, test, vi } from 'vitest'
+
+import { requestWithOauthFallback } from './oauth-rest-request'
+
+test('refresh timeout plus an empty cookie jar rejects with the original transport error', async () => {
+  const nativeError = Object.assign(new Error('refresh timed out'), { code: 'ETIMEDOUT' })
+  const cookieAuthError = Object.assign(new Error('401: no session cookie'), { statusCode: 401 })
+  const requestWithBearer = vi.fn()
+
+  const requestWithCookie = vi.fn(async () => {
+    throw cookieAuthError
+  })
+
+  await expect(
+    requestWithOauthFallback('https://gw.example.com', {
+      ensureNativeAccessToken: async () => {
+        throw nativeError
+      },
+      requestWithBearer,
+      requestWithCookie
+    })
+  ).rejects.toBe(nativeError)
+
+  assert.equal(requestWithBearer.mock.calls.length, 0)
+  assert.equal(requestWithCookie.mock.calls.length, 1)
+})
+
+test('refresh timeout plus a valid cookie session serves the REST request', async () => {
+  const nativeError = Object.assign(new Error('refresh timed out'), { code: 'ETIMEDOUT' })
+  const cookieResponse = { sessions: [{ id: 'cookie-session' }] }
+  const requestWithCookie = vi.fn(async () => cookieResponse)
+
+  const response = await requestWithOauthFallback('https://gw.example.com', {
+    ensureNativeAccessToken: async () => {
+      throw nativeError
+    },
+    requestWithBearer: vi.fn(),
+    requestWithCookie
+  })
+
+  assert.equal(response, cookieResponse)
+  assert.equal(requestWithCookie.mock.calls.length, 1)
+})
+
+test('a non-auth cookie failure remains the more immediate REST failure', async () => {
+  const nativeError = Object.assign(new Error('refresh timed out'), { code: 'ETIMEDOUT' })
+  const cookieServerError = Object.assign(new Error('503: gateway unavailable'), { statusCode: 503 })
+
+  await expect(
+    requestWithOauthFallback('https://gw.example.com', {
+      ensureNativeAccessToken: async () => {
+        throw nativeError
+      },
+      requestWithBearer: vi.fn(),
+      requestWithCookie: async () => {
+        throw cookieServerError
+      }
+    })
+  ).rejects.toBe(cookieServerError)
+})

--- a/apps/desktop/electron/oauth-rest-request.ts
+++ b/apps/desktop/electron/oauth-rest-request.ts
@@ -1,0 +1,46 @@
+import { isGatewayAuthRejection } from './connection-config'
+
+export interface OauthRestRequestDeps<T> {
+  ensureNativeAccessToken: (baseUrl: string) => Promise<string | null>
+  requestWithBearer: (accessToken: string) => Promise<T>
+  requestWithCookie: () => Promise<T>
+}
+
+/**
+ * Prefer a native bearer for an OAuth-gated REST request while preserving the
+ * cookie session as a coexistence fallback.
+ *
+ * A native refresh error does not skip the cookie path: a live cookie may
+ * still serve the request. If that cookie path rejects authentication too,
+ * surface the original native error so a refresh timeout is not mislabeled as
+ * an expired login merely because the cookie jar is empty.
+ */
+export async function requestWithOauthFallback<T>(
+  baseUrl: string,
+  deps: OauthRestRequestDeps<T>
+): Promise<T> {
+  let nativeAccessToken: string | null = null
+  let nativeError: unknown
+  let nativeFailed = false
+
+  try {
+    nativeAccessToken = await deps.ensureNativeAccessToken(baseUrl)
+  } catch (error) {
+    nativeError = error
+    nativeFailed = true
+  }
+
+  if (nativeAccessToken) {
+    return deps.requestWithBearer(nativeAccessToken)
+  }
+
+  try {
+    return await deps.requestWithCookie()
+  } catch (cookieError) {
+    if (nativeFailed && isGatewayAuthRejection(cookieError)) {
+      throw nativeError
+    }
+
+    throw cookieError
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes mechanism 2 of #73722: a transient failure while refreshing the native OAuth access token was reported as "Your remote gateway session has expired", sending the user to re-sign-in for a network blip.

`ensureNativeAccessToken()` is deliberate about the split: a 401 on refresh means the refresh token is dead, so it clears the stored tokens and resolves `null`; a transient failure (timeout, 5xx, network) throws so the tokens survive for a retry. The call site in `mintGatewayWsTicket()` erased that distinction with `.catch(() => null)`. With a native (cookieless) sign-in there is no cookie session to fall back to, so the fallback leg 401s and `gatewayTicketFailure()` classifies the whole thing as an expired session. The reporter's desktop.log shows it live: liveness probe drops, the next resolve says "expired", and the retry seconds later connects with the same credentials.

Two adjacent defects surfaced while fixing it, and both are covered here because a naive fix (just dropping the catch) would regress them:

- **The dead-RT 401 branch never matched in production.** `ensureNativeAccessToken` checks `error.statusCode === 401`, but `fetchJson` rejects with a message-prefixed `Error("401: …")` and no `statusCode` property, and the server's dead-RT branch answers 401 `{"error":"session_expired"}`. So a genuinely dead refresh token always took the throw path, and only the swallowed catch kept the reauth flow working by accident. The new `isNativeRefreshAuthRejection()` predicate recognizes both shapes, making the intended "dead RT → clear tokens → cookie fallback → sign-in" flow real.
- **Cookie and native sessions can coexist** (logout clears both). A native-path failure now falls back to the cookie session and uses its ticket when it works; only when that fallback also fails does the original native error propagate, so a cookie-side 401 in a native-only config cannot overwrite a transient failure with a false "session expired".

The end state for each input: dead refresh token → sign-in prompt (as intended); transient failure with a live cookie → connects through the cookie (as baseline did); transient failure with no cookie → retryable connectivity error ("Could not reach the remote Hermes gateway while refreshing its WebSocket ticket. Try reconnecting.") instead of a false sign-in demand, which is the mechanism-2 fix itself.

## Testability

`mintGatewayWsTicket` lived in `main.ts`, which imports `electron` and `node-pty` at module scope and is unreachable from the test suite. The function moved to `connection-config.ts` as a dependency-injected helper, the same pattern `resolveTestWsUrl` already uses there, and `main.ts` keeps a same-named adapter so all three call sites (`freshGatewayWsUrl`, `buildRemoteConnection`, the connection test's `mintTicket` injection) are untouched.

## Tests

New cases in `connection-config.test.ts`:

- the production 401 shape (`Error("401: …")`, no `statusCode`) is recognized as an auth rejection, plus negative cases for transient shapes
- a transient refresh failure with a live cookie session mints through the cookie (fails on the old code: the transient error propagated without ever trying the cookie)
- a transient failure with no usable cookie propagates the original native error, untagged, so it classifies as transport
- no stored native tokens still falls back to the cookie session; a native bearer success mints without touching the cookie leg

79/79 in `connection-config.test.ts`, `tsc --noEmit` clean.

## Relation to #73821

Independent fixes for the two mechanisms in #73722. #73821 handles the renderer's boot path; this PR handles the main process's ticket minting. Either lands without the other.
