### PR TITLE
fix(kanban): extend default claim lease to two hours

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -561,8 +561,10 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Atomically claim a ready task (prints resolved workspace path)",
     )
     p_claim.add_argument("task_id")
-    p_claim.add_argument("--ttl", type=int, default=kb.DEFAULT_CLAIM_TTL_SECONDS,
-                         help="Claim TTL in seconds (default: 900)")
+    p_claim.add_argument(
+        "--ttl", type=int, default=kb.DEFAULT_CLAIM_TTL_SECONDS,
+        help=f"Claim TTL in seconds (default: {kb.DEFAULT_CLAIM_TTL_SECONDS})",
+    )
 
     # --- comment / complete / block / unblock / archive ---
     p_comment = sub.add_parser("comment", help="Append a comment")

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -186,13 +186,11 @@ def _fire_kanban_lifecycle_hook(event: str, task_id: str, **fields: Any) -> None
         _log.debug("kanban lifecycle hook %s failed: %s", event, exc)
 
 
-# A running task's claim is valid for 15 minutes by default; after that the
-# next dispatcher tick reclaims it. Workers that outlive this window should
-# call ``heartbeat_claim(task_id)`` periodically. In practice most kanban
-# workloads either finish within 15m, set a longer claim explicitly, or use
-# ``HERMES_KANBAN_CLAIM_TTL_SECONDS`` to raise the default claim window for
-# long single-call MCP workflows.
-DEFAULT_CLAIM_TTL_SECONDS = 15 * 60
+# A running task's claim is valid for two hours by default; after that the
+# next dispatcher tick reclaims it. Workers should still call
+# ``heartbeat_claim(task_id)`` periodically, because the independent
+# heartbeat-staleness backstop remains one hour.
+DEFAULT_CLAIM_TTL_SECONDS = 2 * 60 * 60
 
 # If a worker's PID is still alive but its ``last_heartbeat_at`` is
 # older than this when ``release_stale_claims`` runs, treat the worker
@@ -241,9 +239,8 @@ def _resolve_claim_ttl_seconds(ttl_seconds: Optional[int] = None) -> int:
 # Grace period after a task transitions to ``running`` during which
 # ``detect_crashed_workers`` skips the ``_pid_alive`` check. Covers the
 # fork() → /proc-visibility window where liveness can transiently report
-# False for a freshly-spawned worker. The 15-minute claim TTL still
-# catches genuinely-crashed workers; this only suppresses false positives
-# during the launch window.
+# False for a freshly-spawned worker. The claim TTL catches genuinely-crashed
+# workers; this only suppresses false positives during the launch window.
 DEFAULT_CRASH_GRACE_SECONDS = 30
 
 
@@ -4092,6 +4089,11 @@ def claim_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        prior_run = conn.execute(
+            "SELECT 1 FROM task_runs WHERE task_id = ? LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        heartbeat_at = now if prior_run else None
         # Structural invariant: never transition ready -> running while any
         # parent is not yet 'done'. This is the single enforcement point
         # regardless of which writer (create_task, link_tasks, unblock_task,
@@ -4143,12 +4145,13 @@ def claim_task(
                SET status        = 'running',
                    claim_lock    = ?,
                    claim_expires = ?,
+                   last_heartbeat_at = ?,
                    started_at    = COALESCE(started_at, ?)
              WHERE id = ?
                AND status = 'ready'
                AND claim_lock IS NULL
             """,
-            (lock, expires, now, task_id),
+            (lock, expires, heartbeat_at, now, task_id),
         )
         if cur.rowcount != 1:
             return None
@@ -4164,8 +4167,8 @@ def claim_task(
             INSERT INTO task_runs (
                 task_id, profile, step_key, status,
                 claim_lock, claim_expires, max_runtime_seconds,
-                started_at
-            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?)
+                last_heartbeat_at, started_at
+            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?)
             """,
             (
                 task_id,
@@ -4174,6 +4177,7 @@ def claim_task(
                 lock,
                 expires,
                 trow["max_runtime_seconds"] if trow else None,
+                heartbeat_at,
                 now,
             ),
         )
@@ -4221,18 +4225,20 @@ def claim_review_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        heartbeat_at = now
         cur = conn.execute(
             """
             UPDATE tasks
                SET status        = 'running',
                    claim_lock    = ?,
                    claim_expires = ?,
+                   last_heartbeat_at = ?,
                    started_at    = COALESCE(started_at, ?)
              WHERE id = ?
                AND status = 'review'
                AND claim_lock IS NULL
             """,
-            (lock, expires, now, task_id),
+            (lock, expires, now, now, task_id),
         )
         if cur.rowcount != 1:
             return None
@@ -4246,8 +4252,8 @@ def claim_review_task(
             INSERT INTO task_runs (
                 task_id, profile, step_key, status,
                 claim_lock, claim_expires, max_runtime_seconds,
-                started_at
-            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?)
+                last_heartbeat_at, started_at
+            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?)
             """,
             (
                 task_id,
@@ -4256,6 +4262,7 @@ def claim_review_task(
                 lock,
                 expires,
                 trow["max_runtime_seconds"] if trow else None,
+                heartbeat_at,
                 now,
             ),
         )
@@ -4282,8 +4289,8 @@ def heartbeat_claim(
 ) -> bool:
     """Extend a running claim.  Returns True if we still own it.
 
-    Workers that know they'll exceed 15 minutes should call this every
-    few minutes to keep ownership.
+    Workers should call this periodically to keep ownership and publish
+    observable progress before the one-hour heartbeat-staleness backstop.
     """
     expires = int(time.time()) + _resolve_claim_ttl_seconds(ttl_seconds)
     lock = claimer or _claimer_id()
@@ -4340,9 +4347,11 @@ def release_stale_claims(
     stale = conn.execute(
         "SELECT id, claim_lock, worker_pid, claim_expires, last_heartbeat_at "
         "FROM tasks "
-        "WHERE status = 'running' AND claim_expires IS NOT NULL "
-        "  AND claim_expires < ?",
-        (now,),
+        "WHERE status = 'running' AND ("
+        "  (claim_expires IS NOT NULL AND claim_expires < ?) OR "
+        "  (last_heartbeat_at IS NOT NULL AND last_heartbeat_at <= ?)"
+        ")",
+        (now, now - DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS),
     ).fetchall()
     for row in stale:
         lock = row["claim_lock"] or ""
@@ -4369,8 +4378,12 @@ def release_stale_claims(
                     "WHERE id = ? AND status = 'running' "
                     "  AND claim_lock IS ? "
                     "  AND claim_expires IS NOT NULL "
-                    "  AND claim_expires < ?",
-                    (new_expires, row["id"], row["claim_lock"], now),
+                    "  AND claim_expires < ? "
+                    "  AND (last_heartbeat_at IS NULL OR last_heartbeat_at > ?)",
+                    (
+                        new_expires, row["id"], row["claim_lock"], now,
+                        now - DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS,
+                    ),
                 )
                 if cur.rowcount != 1:
                     continue
@@ -4414,8 +4427,14 @@ def release_stale_claims(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL "
                 "WHERE id = ? AND status = 'running' AND claim_lock IS ? "
-                "AND claim_expires IS NOT NULL AND claim_expires < ?",
-                (row["id"], row["claim_lock"], now),
+                "AND ("
+                "  (claim_expires IS NOT NULL AND claim_expires < ?) OR "
+                "  (last_heartbeat_at IS NOT NULL AND last_heartbeat_at <= ?)"
+                ")",
+                (
+                    row["id"], row["claim_lock"], now,
+                    now - DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS,
+                ),
             )
             if cur.rowcount != 1:
                 continue

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -157,6 +158,30 @@ def test_run_slash_block_unblock_cycle(kanban_home):
     kc.run_slash(f"claim {tid}")
     assert "Blocked" in kc.run_slash(f"block {tid} 'need decision'")
     assert "Unblocked" in kc.run_slash(f"unblock {tid}")
+
+
+def test_claim_cli_default_and_explicit_ttl(kanban_home):
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+
+    default_args = parser.parse_args(["kanban", "claim", "t_default"])
+    assert default_args.ttl == kb.DEFAULT_CLAIM_TTL_SECONDS == 2 * 60 * 60
+
+    out = kc.run_slash("create 'explicit ttl' --assignee worker")
+    import re
+    match = re.search(r"(t_[a-f0-9]+)", out)
+    assert match is not None
+    task_id = match.group(1)
+    before = int(time.time())
+    assert "Claimed" in kc.run_slash(f"claim {task_id} --ttl 37")
+    after = int(time.time())
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+    assert task is not None
+    assert task.claim_expires is not None
+    assert before + 37 <= task.claim_expires <= after + 37
 
 
 def test_run_slash_json_output(kanban_home):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -453,6 +453,46 @@ def test_stale_claim_reclaimed(kanban_home, monkeypatch):
         assert killed == [signal.SIGTERM]
 
 
+def test_default_claim_ttl_sets_two_hour_expiry(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="default lease", assignee="worker")
+        before = int(time.time())
+        claimed = kb.claim_task(conn, task_id, claimer="test:worker")
+        after = int(time.time())
+
+        assert claimed is not None
+        assert claimed.claim_expires is not None
+        assert before + 2 * 60 * 60 <= claimed.claim_expires <= after + 2 * 60 * 60
+
+
+def test_fresh_retry_resets_prior_run_heartbeat(kanban_home, monkeypatch):
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="retry heartbeat", assignee="worker")
+        first = kb.claim_task(conn, task_id, claimer="test:worker")
+        assert first is not None
+        old_heartbeat = int(time.time()) - (
+            kb.DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS + 10
+        )
+        conn.execute(
+            "UPDATE tasks SET last_heartbeat_at = ? WHERE id = ?",
+            (old_heartbeat, task_id),
+        )
+        assert kb.reclaim_task(conn, task_id, reason="retry test") is True
+
+        second = kb.claim_task(conn, task_id, claimer="test:worker")
+        assert second is not None
+        assert second.last_heartbeat_at is not None
+        assert second.last_heartbeat_at > old_heartbeat
+
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+        assert kb.release_stale_claims(conn, signal_fn=lambda *_args: None) == 0
+        refreshed = kb.get_task(conn, task_id)
+        assert refreshed is not None
+        assert refreshed.status == "running"
+
+
 def test_stale_claim_with_live_pid_extends_instead_of_reclaiming(
     kanban_home, monkeypatch,
 ):

--- a/website/docs/user-guide/features/kanban-worker-lanes.md
+++ b/website/docs/user-guide/features/kanban-worker-lanes.md
@@ -100,7 +100,7 @@ The historical issue for this is [#19931](https://github.com/NousResearch/hermes
 
 So lane authors don't have to reimplement these:
 
-- **Stale claim TTL** — a worker that claims and then never heartbeats / completes / blocks gets reclaimed after `DEFAULT_CLAIM_TTL_SECONDS` (15 min default) — but only if the worker process has actually died. A live worker (slow model spending 20+ min in one tool-free LLM call) gets the claim *extended* instead of killed; only a dead PID is reclaimed.
+- **Stale claim TTL** — a worker that claims and then never heartbeats / completes / blocks gets reclaimed after `DEFAULT_CLAIM_TTL_SECONDS` (2 hours by default). Independently, a heartbeat older than one hour is treated as a stale-progress backstop. A live worker whose claim TTL expires is still extended instead of killed; only a dead PID is reclaimed, while a live worker with a stale heartbeat is still treated as wedged. This remains separate from `max_runtime_seconds` and `dispatch_stale_timeout_seconds`.
 - **Crashed worker** — a worker whose host-local PID has vanished is detected by `detect_crashed_workers` and reaped; the task increments `consecutive_failures` and may auto-block when the breaker trips.
 - **Run-level retry** — when a task is retried (post-block, post-crash, post-reclaim), the worker can use the `expected_run_id` parameter on terminating tools to fail fast if its own run was already superseded.
 - **Per-task max runtime** — `task.max_runtime_seconds` hard-caps wall-clock time per run, regardless of PID liveness. Catches genuinely-deadlocked workers that the live-PID extension would otherwise keep running.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban-worker-lanes.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban-worker-lanes.md
@@ -100,7 +100,7 @@ profile 通道的特化形态：orchestrator 是一个 Hermes profile，其工�
 
 通道作者无需重新实现以下逻辑：
 
-- **Claim TTL 过期** — 已 claim 但从未心跳/完成/阻塞的 worker 在 `DEFAULT_CLAIM_TTL_SECONDS`（默认 15 分钟）后被回收——但仅当 worker 进程确实已死亡时。存活的 worker（慢速模型在一次无工具调用的 LLM 调用中耗时 20 分钟以上）会获得 claim *延期*而非被终止；只有 PID 已消亡时才会被回收。
+- **Claim TTL 过期** — 已 claim 但从未心跳/完成/阻塞的 worker 在 `DEFAULT_CLAIM_TTL_SECONDS`（默认 2 小时）后被回收。同时，超过 1 小时没有心跳会触发独立的进度停滞保护。认领 TTL 到期但仍存活的 worker 仍会被延长认领而不是被杀死；只有死亡的 PID 才会被回收，而 heartbeat 已停滞的存活 worker 仍会按卡死处理。这与 `max_runtime_seconds` 和 `dispatch_stale_timeout_seconds` 相互独立。
 - **Worker 崩溃** — 宿主本地 PID 已消失的 worker 由 `detect_crashed_workers` 检测并回收；任务的 `consecutive_failures` 递增，断路器触发时可能自动阻塞。
 - **运行级重试** — 任务重试时（post-block、post-crash、post-reclaim），worker 可在终止工具上使用 `expected_run_id` 参数，在自身运行已被取代时快速失败。
 - **每任务最大运行时间** — `task.max_runtime_seconds` 对每次运行的挂钟时间进行硬性限制，与 PID 存活状态无关。可捕获真正死锁的 worker——否则存活 PID 延期机制会让其持续运行。


### PR DESCRIPTION
## Summary\n- raise the default claim lease to 2 hours\n- keep the 1-hour heartbeat backstop independent and reset retry heartbeat state\n- cover default expiry, explicit CLI override, and retry behavior\n\n## Verification\n- 403 focused Kanban tests passed\n- py_compile passed\n- git diff --check passed