### PR TITLE
(feature): Add flag --skip-webui to hermes update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12753,7 +12753,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
         _refresh_active_memory_provider_dependencies()
 
         node_failures = _update_node_dependencies()
-        _build_web_ui(PROJECT_ROOT / "web")
+        if args.skip_webui:
+            print("→ Skipping web UI build...")
+        else:
+            _build_web_ui(PROJECT_ROOT / "web")
 
         # Rebuild the desktop app if the source tree changed since the last
         # build.  ``hermes desktop --build-only`` uses the content-hash stamp

--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -73,4 +73,10 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         default=False,
         help="Windows: mutate the venv even while other processes are running from its interpreter (desktop backend, gateway, terminals). Those processes keep native .pyd files locked, so the dependency sync will likely fail partway and strand the install half-updated. Use only if you know the detected holders are false positives.",
     )
+    update_parser.add_argument(
+        "--skip-webui",
+        action="store_true",
+        default=False,
+        help="Skip building the web UI",
+    )
     update_parser.set_defaults(func=cmd_update)

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
-title: "Updating & Uninstalling"
-description: "How to update Hermes Agent to the latest version or uninstall it"
+title: 'Updating & Uninstalling'
+description: 'How to update Hermes Agent to the latest version or uninstall it'
 ---
 
 # Updating & Uninstalling
@@ -51,7 +51,7 @@ When the update runs **without a terminal** — from the desktop/chat app's "Upd
 ```yaml
 # ~/.hermes/config.yaml
 updates:
-  non_interactive_local_changes: stash   # default: keep + auto-restore
+  non_interactive_local_changes: stash # default: keep + auto-restore
   # non_interactive_local_changes: discard  # throw local source edits away
 ```
 
@@ -81,6 +81,14 @@ updates:
 ```
 
 `updates.pre_update_backup` is a single knob with three modes: `quick` (default — the lightweight state snapshot described above), `full` (the quick snapshot plus a complete `HERMES_HOME` zip; can add minutes on large homes), and `off` (no pre-update backup at all — `--no-backup` does the same for a single run). Legacy boolean values still work: `true` means `full`, `false` means `off`.
+
+### Skip building the web UI: `--skip-webui`
+
+```bash
+hermes update --skip-webui
+```
+
+If you run hermes agent without the webui, use `--skip-webui` to avoid the build step.
 
 ### Windows: another `hermes.exe` is running
 
@@ -257,9 +265,11 @@ rm -rf ~/.hermes            # Optional — keep if you plan to reinstall
 
 :::info
 If you installed the gateway as a system service, stop and disable it first:
+
 ```bash
 hermes gateway stop
 # Linux: systemctl --user disable hermes-gateway
 # macOS: launchctl remove ai.hermes.gateway
 ```
+
 :::


### PR DESCRIPTION
## What does this PR do?

Add flags `--skip-webui` when running `hermes update`

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A