### PR TITLE
feat(mcp): add Snyk to the MCP catalog

### DIFF
--- a/optional-mcps/snyk/manifest.yaml
+++ b/optional-mcps/snyk/manifest.yaml
@@ -1,0 +1,96 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: snyk
+description: Scan code, dependencies, containers, and IaC with Snyk.
+source: https://docs.snyk.io/integrate-with-snyk/snyk-mcp-server
+
+# Snyk ships its MCP server INSIDE the Snyk CLI — `snyk mcp` is a first-party
+# subcommand, not a community wrapper. Nothing to clone or bootstrap: npx
+# fetches the pinned CLI and launches it over stdio, so there is no `install:`
+# block.
+#
+# `--profile full` exposes all 13 non-experimental tools. We deliberately do
+# NOT pass `--profile lite` (7 tools): lite drops the container, IaC, SBOM,
+# AIBOM, package-health, and breakability tools, which are the ones an agent
+# with a terminal can't already approximate. The tool-schema cost is bounded
+# by `tools.default_enabled` below instead of by the profile flag, so users
+# who want the wider surface can opt in from the install checklist without
+# reinstalling.
+transport:
+  type: stdio
+  command: npx
+  args:
+    - "-y"
+    # Pinned per catalog dependency policy: exact version (never @latest), and
+    # the pinned release is at least 2 weeks old at pin time. 1.1306.0 was
+    # published 2026-07-09. Bumping the pin is a PR to this manifest.
+    - "snyk@1.1306.0"
+    - "mcp"
+    - "-t"
+    - "stdio"
+    - "--profile"
+    - "full"
+    # Snyk CLI reports usage analytics by default. Hermes does not ship
+    # opt-out-by-default telemetry, so disable it at launch.
+    - "--DISABLE_ANALYTICS"
+  version: "1.1306.0"
+  # Belt-and-braces telemetry opt-out: the flag above covers the CLI's own
+  # analytics; this covers the env-var path the CLI also honors. Static
+  # non-secret env only — credentials never go here.
+  env:
+    SNYK_DISABLE_ANALYTICS: "1"
+
+# No credentials are prompted at install time. The server exposes a `snyk_auth`
+# tool that runs Snyk's browser OAuth flow on demand, so installing is a
+# genuinely empty modal in the dashboard.
+auth:
+  type: none
+
+# Tool selection at install time:
+# The eight scanning/intelligence tools are pre-checked. Three are pruned from
+# the default surface:
+#   - snyk_send_feedback  — reports issue-count deltas back to Snyk. That is
+#     outbound telemetry, which we do not enable by default.
+#   - snyk_logout         — destructive, rarely wanted mid-session.
+#   - snyk_version        — pure noise in a model's tool schema.
+# snyk_trust IS included: scans of an untrusted folder fail without it, and it
+# only acts when the agent is explicitly told to.
+# Users see the full 13-tool list in the install checklist and can opt into the
+# pruned ones per their own threat model.
+tools:
+  default_enabled:
+    - snyk_auth
+    - snyk_trust
+    - snyk_code_scan
+    - snyk_sca_scan
+    - snyk_container_scan
+    - snyk_iac_scan
+    - snyk_sbom_scan
+    - snyk_package_health_check
+
+post_install: |
+  Authenticate before your first scan by asking Hermes to run the `snyk_auth`
+  tool — it opens a browser and stores the token in the Snyk CLI's own config.
+  A free Snyk account is enough for the code and open-source scanners.
+
+  What each scanner covers:
+    snyk_code_scan            SAST over your source
+    snyk_sca_scan             open-source dependency vulnerabilities
+    snyk_container_scan       container image OS + app packages
+    snyk_iac_scan             Terraform, CloudFormation, Kubernetes, ARM
+    snyk_sbom_scan            an existing SBOM file
+    snyk_package_health_check package intel before you add a dependency
+
+  Scans need an ABSOLUTE path. Snyk also refuses to scan an untrusted folder —
+  if a scan reports a trust error, have Hermes run `snyk_trust` on that path.
+
+  Scanning uploads code metadata to Snyk's cloud for analysis. Usage analytics
+  are disabled by this manifest, but the scan itself is a network call — keep
+  that in mind for private repositories.
+
+  Start a new Hermes session to load the Snyk tools.
+
+  Re-run the tool checklist any time with:
+    hermes mcp configure snyk


### PR DESCRIPTION
## Summary
Snyk is now installable from the MCP catalog with `hermes mcp install snyk` — one click in the dashboard, no credentials at install time.

Snyk ships its MCP server *inside* the Snyk CLI (`snyk mcp` is a first-party subcommand), so this is a pinned `npx` stdio launch with **no install block and no packaging changes** — one new file.

## Changes
- `optional-mcps/snyk/manifest.yaml`: new catalog entry.
  - **Pin:** `snyk@1.1306.0`, published 2026-07-09 — 19 days old at pin time, satisfying the exact-version / ≥2-week catalog policy. `@latest` explicitly avoided.
  - **Auth:** `none`. The server exposes a `snyk_auth` tool that runs Snyk's browser login on demand, so the dashboard install modal is genuinely empty.
  - **Telemetry:** disabled at launch via `--DISABLE_ANALYTICS` *and* the `SNYK_DISABLE_ANALYTICS` env var. `snyk_send_feedback` — which reports issue-count deltas back to Snyk — is off by default.
  - **Tools:** 8 of 13 pre-checked (SAST, dependencies, containers, IaC, SBOM, package health, plus `auth`/`trust`). `snyk_logout` and `snyk_version` pruned as noise. Users opt into the rest from the install checklist.

## Why this server
It fits what Hermes already is: an agent that writes code and drives a terminal, now able to scan what it just wrote and vet a dependency before adding it. Vendor-official and shipped as part of the CLI, so it doesn't rot the way community wrappers do, and the free tier makes it useful to individual users rather than enterprise-only.

Alternatives were checked and rejected: **Semgrep**'s MCP repo was archived Oct 2025; **CrowdStrike falcon-mcp** needs an enterprise Falcon tenant; **Burp Suite** needs Burp Pro plus a BApp jar and an SSE proxy shim; **VirusTotal** has no official server; **Wiz** is customers-only preview.

## Validation
Verified against the pinned version by completing a real MCP stdio handshake — not from docs.

| | Result |
|---|---|
| `initialize` serverInfo | `Snyk MCP Server` **1.1306.0** |
| `tools/list` | **13 tools** |
| Exact manifest launch line (with telemetry flags) | connects, 13 tools |
| `profile lite` vs `full` | 7 vs 13 tools — `full` chosen, surface bounded by `default_enabled` instead |
| Loader E2E (`_parse_manifest` / `list_catalog` / `get_entry("official/snyk")` / `_build_server_config`) | pass |
| `tests/hermes_cli/test_mcp_catalog.py` + `tests/test_packaging_metadata.py` | **47 passed, 0 failed** |

Both shards were run — including the packaging shard that false-greens when only the catalog test is run.

## Infographic

![Snyk MCP catalog entry](https://v3b.fal.media/files/b/0aa42705/uUMrvd6wAA4Q0Ul-PizEn_XFSUFyGA.png)
