### PR TITLE
feat(voice): streaming TTS — clause-by-clause synthesis for CLI voice mode and gateway adapters

### DIFF
--- a/contributors/emails/carl@carltaylor.com.au
+++ b/contributors/emails/carl@carltaylor.com.au
@@ -1,0 +1,1 @@
+ctaylor86

--- a/docs/streaming-tts.md
+++ b/docs/streaming-tts.md
@@ -1,0 +1,93 @@
+# Streaming TTS
+
+Hermes can stream TTS audio as it arrives from the provider, instead of waiting
+for the full audio before playing. This is used by voice mode (CLI/TUI live
+conversation), the dashboard speak-stream WebSocket, and — via the gateway
+`StreamingTTSConsumer` — any platform adapter that opts into streaming audio.
+Voice replies start speaking after the first clause instead of after full
+generation + synthesis.
+
+## Architecture
+
+The streaming pipeline has four parts:
+
+1. **Producer** — the LLM emits text deltas as it generates a response
+2. **Sentence chunker** — `tools.tts_streaming.SentenceChunker` accumulates
+   deltas, strips `<think>` blocks (even split across deltas), and flushes
+   complete sentences
+3. **TTS provider** — a registered `StreamingTTSProvider` turns each sentence
+   into raw PCM chunks (int16 mono at the provider's declared `sample_rate`)
+4. **Audio sink** — `sounddevice.OutputStream` for local playback
+   (`tools.tts_tool.stream_tts_to_speaker`), or a gateway platform adapter's
+   `write_streaming_tts` seam (`gateway/streaming_tts_consumer.py`)
+
+Providers with no chunked API still get per-*sentence* playback via the proven
+sync `text_to_speech_tool` path, so edge (the default) is conversational too.
+All spoken text is cleaned by `tools.tts_text_normalize.prepare_spoken_text`
+(one cleaner, all paths).
+
+## How to pick a provider
+
+By default the dispatcher streams with the provider you already configured
+(`tts.provider`) when that provider has a chunked API — it never silently
+swaps your voice for a different provider just to get streaming.
+
+To override, set `tts.streaming.provider` in your `config.yaml`:
+
+- a provider name (`elevenlabs`, `gemini`, `openai`, `xai`) pins that streamer
+- `auto` walks the priority list `elevenlabs → gemini → openai → xai` and uses
+  the first one whose credentials resolve — an explicit opt-in to "best
+  chunked voice available"
+
+```yaml
+tts:
+  provider: gemini
+  streaming:
+    provider: gemini      # or "auto"
+  gemini:
+    model: gemini-2.5-flash-preview-tts
+    voice: Kore
+```
+
+## Capability matrix
+
+| Provider    | Transport                             | Chunked PCM | Credentials |
+|-------------|---------------------------------------|-------------|-------------|
+| elevenlabs  | chunked HTTP (`pcm_24000`)            | yes         | `ELEVENLABS_API_KEY` / `tts.elevenlabs` |
+| openai      | chunked HTTP (`with_streaming_response`, `pcm`) | yes | `tts.openai.api_key` → env → managed gateway |
+| gemini      | SSE (`streamGenerateContent?alt=sse`) | yes         | `GEMINI_API_KEY` / `GOOGLE_API_KEY` |
+| xai         | WebSocket (`wss://api.x.ai/v1/tts`)   | yes         | xAI OAuth or `XAI_API_KEY` |
+| edge, piper, kitten, neutts, mistral, minimax, deepinfra, … | — | no (per-sentence sync fallback) | as usual |
+
+All credential lookups go through `resolve_provider_secret()`
+(config > env/.env > credential pool) — never bare env reads. Streamed bodies
+are capped at 16 MiB per sentence, mirroring the sync providers' bounded
+upstream-body invariant.
+
+## Adding a new streaming provider
+
+1. Subclass `StreamingTTSProvider` in `tools/tts_streaming.py`
+2. Set `sample_rate` (and `channels` / `sample_width` if not int16 mono)
+3. Implement `available()` (a pure probe — never install anything) and
+   `stream(self, text) -> Iterator[bytes]` yielding raw PCM chunks
+4. Decorate with `@register("yourname")`
+5. Add tests in `tests/tools/test_tts_streaming.py`
+
+The ABC enforces the contract; the registry makes the provider discoverable;
+the dispatcher (`stream_tts_to_speaker`) and the gateway consumer handle the
+sentence buffer, stop events, and audio sink for free.
+
+## Gateway streaming (platform adapters)
+
+`gateway/streaming_tts_consumer.py` bridges agent deltas to an adapter's
+streaming-audio seam. Adapters opt in by overriding, on
+`BasePlatformAdapter`:
+
+- `supports_streaming_tts(chat_id, audio_format) -> bool`
+- `begin_streaming_tts / write_streaming_tts / finish_streaming_tts /
+  abort_streaming_tts`
+
+All default to unsupported/no-op, so existing adapters are untouched. When a
+turn's streaming audio completes, the whole-file auto-TTS reply for that turn
+is suppressed (no double playback); when streaming fails before any audio was
+audible, the gateway falls back to the legacy whole-file voice reply.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -552,6 +552,75 @@ from gateway.session import SessionSource, build_session_key
 from hermes_constants import get_default_hermes_root, get_hermes_dir, get_hermes_home
 
 
+# ---------------------------------------------------------------------------
+# Streaming TTS format descriptor and handle (#60671)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AudioFormat:
+    """Declared PCM format for a streaming-TTS session.
+
+    All chunks delivered via ``write_streaming_tts`` must conform to this
+    format: raw little-endian PCM at the declared sample rate, channels,
+    and sample width.
+    """
+    sample_rate: int = 24000
+    channels: int = 1
+    sample_width: int = 2  # bytes per sample (int16 = 2)
+
+
+@dataclass
+class StreamingTTSHandle:
+    """Opaque handle returned by ``begin_streaming_tts``.
+
+    Adapters may subclass or extend this with platform-specific state
+    (track IDs, buffers, etc.).  The base fields are used by the consumer
+    for bookkeeping and cancellation.
+    """
+    chat_id: str = ""
+    audio_format: AudioFormat = field(default_factory=AudioFormat)
+    # Set to True after the first PCM chunk has been written (audible output
+    # has started).  The consumer uses this to decide whether a failure
+    # should fall back to whole-file TTS (not yet audible) or just end
+    # cleanly (already audible — don't replay from the beginning).
+    audible: bool = False
+    # Set to True by abort_streaming_tts; late chunks are dropped.
+    aborted: bool = False
+
+
+def streaming_tts_turn_key(session_key: str | None, turn_marker: Any = None, *, event: Any = None) -> str | None:
+    """Return a per-turn streaming-TTS suppression key.
+
+    The key is intentionally turn-scoped, not chat-scoped, so overlapping
+    turns in the same chat cannot suppress each other's fallback paths.
+    ``turn_marker`` is usually the gateway run generation; if that is absent
+    we fall back to the current event's message/update identifiers.
+    """
+    if not session_key:
+        return None
+    if turn_marker is None and event is not None:
+        turn_marker = getattr(event, "message_id", None) or getattr(event, "platform_update_id", None)
+    if turn_marker is None:
+        return None
+    return f"{session_key}:{turn_marker}"
+
+
+def streaming_tts_should_skip_whole_file(
+    completed_turns: set[str],
+    session_key: str | None,
+    turn_marker: Any = None,
+    *,
+    event: Any = None,
+) -> bool:
+    """Pure helper used by the auto-TTS suppression path.
+
+    Keeps the suppression decision turn-scoped and testable without
+    exercising the whole adapter method stack.
+    """
+    turn_key = streaming_tts_turn_key(session_key, turn_marker, event=event)
+    return bool(turn_key and turn_key in completed_turns)
+
+
 GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE = (
     "Secure secret entry is not supported over messaging. "
     "Load this skill in the local CLI to be prompted, or add the key to ~/.hermes/.env manually."
@@ -2759,6 +2828,11 @@ class BasePlatformAdapter(ABC):
         self._auto_tts_default: bool = False
         self._auto_tts_enabled_chats: set = set()
         self._auto_tts_disabled_chats: set = set()
+        # Per-turn streaming-TTS completion flag (#60671).  When the gateway
+        # streaming-TTS consumer successfully delivers audio, it adds the
+        # turn key here so the base adapter's whole-file auto-TTS path skips
+        # the duplicate.  Cleared after the turn completes.
+        self._streaming_tts_completed_turns: set[str] = set()
         # Chats where typing indicator is paused (e.g. during approval waits).
         # _keep_typing skips send_typing when the chat_id is in this set.
         self._typing_paused: set = set()
@@ -3924,6 +3998,89 @@ class BasePlatformAdapter(ABC):
         Default falls back to send_voice (shows audio player).
         """
         return await self.send_voice(chat_id=chat_id, audio_path=audio_path, **kwargs)
+
+    # ------------------------------------------------------------------
+    # Streaming TTS adapter contract (#60671)
+    # ------------------------------------------------------------------
+    # Voice-capable adapters (LiveKit, Discord voice, …) override these to
+    # accept PCM audio chunks while the LLM is still generating.  The default
+    # implementations report "unsupported" so existing adapters are
+    # source-compatible and keep the whole-file auto-TTS fallback.
+
+    def supports_streaming_tts(self, chat_id: str, audio_format: AudioFormat) -> bool:
+        """Return True when this adapter can accept streaming PCM for *chat_id*.
+
+        Default: False (whole-file auto-TTS path remains).  Override to opt in.
+        """
+        return False
+
+    async def begin_streaming_tts(
+        self,
+        chat_id: str,
+        audio_format: AudioFormat,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[StreamingTTSHandle]:
+        """Open a streaming-audio session for *chat_id*.
+
+        Returns an opaque handle passed to subsequent ``write_streaming_tts``
+        / ``finish_streaming_tts`` / ``abort_streaming_tts`` calls, or
+        ``None`` to decline (caller falls back to whole-file TTS).
+        """
+        return None
+
+    async def write_streaming_tts(self, handle: StreamingTTSHandle, chunk: bytes) -> None:
+        """Write one PCM chunk to the adapter's outbound audio track."""
+        pass
+
+    async def finish_streaming_tts(self, handle: StreamingTTSHandle, *, interrupted: bool = False) -> None:
+        """Signal normal end of the audio stream."""
+        pass
+
+    async def abort_streaming_tts(self, handle: StreamingTTSHandle, error: Optional[str] = None) -> None:
+        """Abort the stream due to an error or cancellation.
+
+        Must be idempotent: late producer chunks after abort must be silently
+        dropped, not raise.  Restores adapter state to "not streaming".
+        """
+        pass
+
+    def _streaming_tts_turn_key(
+        self,
+        session_key: str | None,
+        turn_marker: Any = None,
+        *,
+        event: Any = None,
+    ) -> str | None:
+        return streaming_tts_turn_key(session_key, turn_marker, event=event)
+
+    def _mark_streaming_tts_completed_turn(
+        self,
+        session_key: str | None,
+        turn_marker: Any = None,
+        *,
+        event: Any = None,
+    ) -> None:
+        turn_key = self._streaming_tts_turn_key(session_key, turn_marker, event=event)
+        if turn_key is not None:
+            completed = getattr(self, "_streaming_tts_completed_turns", None)
+            if completed is None:
+                completed = set()
+                self._streaming_tts_completed_turns = completed
+            completed.add(turn_key)
+
+    def _streaming_tts_turn_completed(
+        self,
+        session_key: str | None,
+        turn_marker: Any = None,
+        *,
+        event: Any = None,
+    ) -> bool:
+        return streaming_tts_should_skip_whole_file(
+            getattr(self, "_streaming_tts_completed_turns", set()),
+            session_key,
+            turn_marker,
+            event=event,
+        )
 
     async def send_video(
         self,
@@ -5620,12 +5777,19 @@ class BasePlatformAdapter(ABC):
                 # Gated via ``_should_auto_tts_for_chat``: fires when the chat has
                 # an explicit ``/voice on|tts`` opt-in OR when ``voice.auto_tts`` is
                 # True globally and no ``/voice off`` has been issued.
+                # Skip when streaming TTS already delivered audio for this turn
+                # (#60671) — the gateway streaming-TTS consumer sets the flag.
                 _tts_path = None
                 _tts_requested_path = None
                 if (self._should_auto_tts_for_chat(event.source.chat_id)
                         and event.message_type == MessageType.VOICE
                         and text_content
-                        and not media_files):
+                        and not media_files
+                        and not self._streaming_tts_turn_completed(
+                            session_key,
+                            getattr(interrupt_event, "_hermes_run_generation", None),
+                            event=event,
+                        )):
                     try:
                         from tools.tts_tool import text_to_speech_tool, check_tts_requirements
                         if check_tts_requirements():
@@ -5941,6 +6105,15 @@ class BasePlatformAdapter(ABC):
 
             # Determine overall success for the processing hook
             processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
+            # Clean up the per-turn streaming-TTS flag (#60671).
+            self._streaming_tts_completed_turns.discard(
+                self._streaming_tts_turn_key(
+                    session_key,
+                    getattr(interrupt_event, "_hermes_run_generation", None),
+                    event=event,
+                )
+                or ""
+            )
             await self._run_processing_hook(
                 "on_processing_complete",
                 event,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14424,6 +14424,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 moa_config=getattr(event, "_moa_config", None),
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                message_type=event.message_type,
             )
 
             # Stop persistent typing indicator now that the agent is done.
@@ -14989,7 +14990,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             # Auto voice reply: send TTS audio before the text response
             _already_sent = bool(agent_result.get("already_sent"))
-            if self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent):
+            # Skip when streaming TTS already delivered audio for this turn (#60671).
+            _stts_adapter = self._adapter_for_source(source)
+            _streaming_tts_done = (
+                _stts_adapter is not None
+                and bool(getattr(_stts_adapter, "_streaming_tts_turn_completed", lambda *_a, **_k: False)(session_key, run_generation))
+            )
+            if (
+                not _streaming_tts_done
+                and self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent)
+            ):
                 await self._send_voice_reply(event, response)
 
             # If streaming already delivered the response, extract and
@@ -20582,6 +20592,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        message_type: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
 
@@ -20600,6 +20611,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                message_type=message_type,
             )
 
         profile_home = self._resolve_profile_home_for_source(source)
@@ -20611,6 +20623,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                message_type=message_type,
             )
 
     def _profile_name_for_source(self, source: SessionSource) -> Optional[str]:
@@ -20732,6 +20745,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        message_type: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -21706,6 +21720,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         result_holder = [None]  # Mutable container for the result
         tools_holder = [None]   # Mutable container for the tool definitions
         stream_consumer_holder = [None]  # Mutable container for stream consumer
+        # #60671 — streaming PCM audio consumer.  Created on the gateway
+        # event-loop thread (NOT inside run_sync's executor worker) so the
+        # outer finalisation / interrupt paths can reference it without a
+        # cross-scope NameError.
+        streaming_tts_consumer_holder: list = [None]
         
         # Bridge sync step_callback → async hooks.emit for agent:step events
         _loop_for_step = asyncio.get_running_loop()
@@ -21808,6 +21827,44 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _cleanup_msg_ids.append(str(mid))
                 _fut.add_done_callback(_track_status_id)
 
+        # ---- Streaming TTS consumer setup (#60671) ----
+        # Created on the gateway event-loop thread (here, in _run_agent_inner),
+        # NOT inside run_sync's executor worker.  This avoids a cross-scope
+        # NameError: the outer interrupt / finalisation paths reference the
+        # consumer via ``streaming_tts_consumer_holder[0]``.
+        #
+        # Gates: voice input, auto-TTS enabled for this chat, adapter
+        # supports streaming, and a usable streaming TTS provider configured.
+        _stts_adapter = self._adapter_for_source(source)
+        _is_voice_input = (
+            message_type is not None
+            and str(getattr(message_type, "value", message_type)).lower() == "voice"
+        )
+        if (
+            _stts_adapter is not None
+            and _is_voice_input
+            and _stts_adapter._should_auto_tts_for_chat(source.chat_id)
+        ):
+            try:
+                from gateway.streaming_tts_consumer import StreamingTTSConsumer
+                from tools.tts_tool import _load_tts_config
+                _tts_cfg = _load_tts_config()
+                _gateway_loop = self._gateway_loop or asyncio.get_event_loop()
+                _stts_consumer = StreamingTTSConsumer(
+                    adapter=_stts_adapter,
+                    chat_id=source.chat_id,
+                    tts_config=_tts_cfg,
+                    loop=_gateway_loop,
+                    metadata=_status_thread_metadata,
+                )
+                if _stts_consumer.active:
+                    streaming_tts_consumer_holder[0] = _stts_consumer
+                    _stts_consumer.start()
+                # else: consumer inactive (no streaming provider) — leave
+                # the holder as None so the whole-file fallback path runs.
+            except Exception as _stts_err:
+                logger.debug("Could not set up streaming TTS consumer: %s", _stts_err)
+
         def run_sync():
             # The conditional re-assignment of `message` further below
             # (prepending model-switch notes) makes Python treat it as a
@@ -21885,6 +21942,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Set up stream consumer for token streaming or interim commentary.
             _stream_consumer = None
             _stream_delta_cb = None
+            # #60671 — streaming TTS consumer is created on the outer
+            # event-loop thread before run_sync launches.  run_sync only
+            # reads it via ``streaming_tts_consumer_holder[0]`` for delta
+            # callback wiring.
+            _stts_consumer_ref = streaming_tts_consumer_holder[0]
             _scfg = getattr(getattr(self, 'config', None), 'streaming', None)
             if _scfg is None:
                 from gateway.config import StreamingConfig
@@ -21969,9 +22031,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             def _stream_delta_cb(text: str) -> None:
                                 if _run_still_current():
                                     _stream_consumer.on_delta(text)
+                                    # Tee to the streaming-TTS consumer (#60671).
+                                    if _stts_consumer_ref is not None:
+                                        _stts_consumer_ref.on_delta(text)
                         stream_consumer_holder[0] = _stream_consumer
                 except Exception as _sc_err:
                     logger.debug("Could not set up stream consumer: %s", _sc_err)
+
+            # When text streaming is off but streaming TTS is active,
+            # install a TTS-only delta callback so the consumer still
+            # receives LLM deltas for audio synthesis (#60671).
+            if _stream_delta_cb is None and _stts_consumer_ref is not None:
+                def _stream_delta_cb(text: str) -> None:
+                    if _run_still_current():
+                        _stts_consumer_ref.on_delta(text)
 
             def _interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:
                 if not _run_still_current():
@@ -22860,6 +22933,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Signal the stream consumer that the agent is done
             if _stream_consumer is not None:
                 _stream_consumer.finish()
+
+            # Signal the streaming-TTS consumer that the agent is done (#60671).
+            # finish() is called from the outer event-loop thread after the
+            # executor returns, so early returns from run_sync are also
+            # finalised.  See the outer finally/completion section below.
             
             # Return final response, or a message if something went wrong
             final_response = result.get("final_response")
@@ -23265,6 +23343,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             logger.debug("Interrupt detected from adapter, signaling agent...")
                             agent.interrupt(pending_text)
                             _interrupt_detected.set()
+                            # Abort streaming TTS on barge-in (#60671).
+                            _stts = streaming_tts_consumer_holder[0]
+                            if _stts is not None:
+                                _stts.abort("barge-in")
                             break
                 except asyncio.CancelledError:
                     raise
@@ -23465,6 +23547,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             )
                             _backup_agent.interrupt(_bp_text)
                             _interrupt_detected.set()
+                            # Abort streaming TTS on barge-in (#60671).
+                            _stts = streaming_tts_consumer_holder[0]
+                            if _stts is not None:
+                                _stts.abort("barge-in")
+
             else:
                 # Poll loop: check the agent's built-in activity tracker
                 # (updated by _touch_activity() on every tool call, API
@@ -23538,6 +23625,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             )
                             _backup_agent.interrupt(_bp_text)
                             _interrupt_detected.set()
+                            # Abort streaming TTS on barge-in (#60671).
+                            _stts = streaming_tts_consumer_holder[0]
+                            if _stts is not None:
+                                _stts.abort("barge-in")
 
             if _inactivity_timeout:
                 # Build a diagnostic summary from the agent's activity tracker.
@@ -23641,6 +23732,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Check if we were interrupted OR have a queued message (/queue).
             result = result_holder[0]
             adapter = self._adapter_for_source(source)
+
+            # Finalize the streaming-TTS consumer (#60671).
+            #
+            # finish() is called from the outer event-loop thread (not the
+            # executor worker) so early returns from run_sync are also
+            # finalised.  wait_complete() drains queued audio; on timeout
+            # the consumer is aborted unconditionally — if audio was
+            # audible, suppression is preserved so the gateway does not
+            # replay from the beginning; if no audio was audible, the
+            # whole-file fallback path is permitted.
+            _stts = streaming_tts_consumer_holder[0]
+            if _stts is not None:
+                _stts.finish()
+                try:
+                    await _stts.wait_complete(timeout=10.0)
+                except Exception as _stts_done_err:
+                    logger.debug("streaming TTS wait_complete error: %s", _stts_done_err)
+                if not _stts.done:
+                    # Timeout before or after audible audio: abort to free
+                    # the consumer task.  Audible streams retain suppression;
+                    # silent streams remain eligible for whole-file fallback.
+                    _stts.abort("streaming TTS finalisation timeout")
+                    await _stts.wait_complete(timeout=2.0)
+                if _stts.suppress_whole_file and adapter is not None:
+                    _mark_turn = getattr(adapter, "_mark_streaming_tts_completed_turn", None)
+                    if callable(_mark_turn):
+                        _mark_turn(session_key, run_generation)
             
             # Get pending message from adapter.
             # Use session_key (not source.chat_id) to match adapter's storage keys.
@@ -23853,6 +23971,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 next_message_id = None
                 next_channel_prompt = None
                 next_session_key = session_key
+                # #60671 — carry the pending event's message_type into the
+                # recursive call so queued voice turns can stream TTS and
+                # re-mark the generation for the final delivered turn.
+                next_message_type = None
                 if pending_event is not None:
                     next_source = getattr(pending_event, "source", None) or source
                     if self._is_goal_continuation_event(pending_event) and not self._goal_still_active_for_session(session_id):
@@ -23884,6 +24006,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         return result
                     next_message_id = self._reply_anchor_for_event(pending_event)
                     next_channel_prompt = getattr(pending_event, "channel_prompt", None)
+                    next_message_type = getattr(pending_event, "message_type", None)
+
+                # Clear the completed streaming marker from the prior logical
+                # turn so the recursive turn's streaming TTS is not suppressed
+                # by the prior turn's completion (#60671).
+                _clear_adapter = self._adapter_for_source(source)
+                if _clear_adapter is not None and session_key and run_generation is not None:
+                    _completed_turns = getattr(_clear_adapter, "_streaming_tts_completed_turns", None)
+                    if _completed_turns is not None:
+                        _prior_key = getattr(_clear_adapter, "_streaming_tts_turn_key", None)
+                        if callable(_prior_key):
+                            _pk = _prior_key(session_key, run_generation)
+                            if _pk:
+                                _completed_turns.discard(_pk)
 
                 # Restart typing indicator so the user sees activity while
                 # the follow-up turn runs.  The outer _process_message_background
@@ -23925,6 +24061,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _interrupt_depth=_interrupt_depth + 1,
                     event_message_id=next_message_id,
                     channel_prompt=next_channel_prompt,
+                    message_type=next_message_type,
                 )
                 return _preserve_queued_followup_history_offset(result, followup_result)
         finally:
@@ -23964,6 +24101,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         except asyncio.CancelledError:
                             pass
             
+            # Unconditional abort + bounded wait for the streaming-TTS
+            # consumer (#60671 hardening).  Covers cancellation / exception
+            # paths where the normal finalisation block was skipped.
+            _stts_finally = streaming_tts_consumer_holder[0]
+            if _stts_finally is not None and not _stts_finally.done:
+                _stts_finally.abort("cleanup")
+                try:
+                    await _stts_finally.wait_complete(timeout=2.0)
+                except Exception:
+                    pass
+
             # Clean up tracking
             tracking_task.cancel()
             if session_key:

--- a/gateway/streaming_tts_consumer.py
+++ b/gateway/streaming_tts_consumer.py
@@ -1,0 +1,423 @@
+"""Gateway streaming-TTS consumer — LLM deltas to adapter PCM audio sink.
+
+Bridges the synchronous agent ``stream_delta_callback`` (fired from the
+worker thread) to a voice-capable platform adapter's streaming-audio
+contract, so playback begins while the LLM is still generating.
+
+Lifecycle::
+
+    consumer = StreamingTTSConsumer(adapter, chat_id, tts_config, loop, metadata)
+    agent.stream_delta_callback = consumer.on_delta   # sync, non-blocking
+    ... agent runs in executor ...
+    consumer.finish()            # signal end-of-text
+    success = await consumer.wait_complete(timeout=10)
+    if consumer.suppress_whole_file:
+        # suppress whole-file auto-TTS for this turn
+    consumer.abort("cancelled")  # idempotent cancellation
+
+Design:
+- ``on_delta`` is synchronous and never blocks the agent thread. It feeds
+  deltas into a ``SentenceChunker`` and queues completed clauses onto a
+  thread-safe ``queue.Queue``.
+- An asyncio task (``run``) runs on the gateway event loop, draining the
+  queue, synthesising each clause via a ``StreamingTTSProvider``, and
+  writing PCM chunks to the adapter.
+- Per-turn state is isolated: each consumer instance owns its own chunker,
+  queue, handle, and flags. Concurrent chats cannot cross-contaminate.
+- On successful completion (all clauses synthesised and written), the
+  consumer reports ``completed=True`` so the gateway can suppress the
+  duplicate whole-file auto-TTS.
+- On failure before any audible output, the consumer reports
+  ``completed=False`` and clears ``suppress_whole_file`` so the gateway can
+  fall back to whole-file TTS.
+- On failure after partial audible output, the consumer reports
+  ``completed=False`` but keeps ``suppress_whole_file=True`` so the gateway
+  does NOT replay the whole response from the beginning.
+- Cancellation/abort is idempotent: late chunks are silently dropped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import queue
+import threading
+from typing import Any, Dict, Optional
+
+from gateway.platforms.base import AudioFormat, StreamingTTSHandle
+
+logger = logging.getLogger("gateway.streaming_tts_consumer")
+
+_ABORT = object()
+_DONE = object()
+
+
+class StreamingTTSConsumer:
+    """Consumes LLM text deltas and produces streaming PCM audio for an adapter."""
+
+    def __init__(
+        self,
+        adapter: Any,
+        chat_id: str,
+        tts_config: Dict[str, Any],
+        loop: asyncio.AbstractEventLoop,
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
+        audio_format: Optional[AudioFormat] = None,
+    ) -> None:
+        from tools.tts_streaming import SentenceChunker, resolve_streaming_provider
+
+        self._adapter = adapter
+        self._chat_id = chat_id
+        self._tts_config = tts_config
+        self._loop = loop
+        self._metadata = metadata
+
+        # Resolve the streaming provider once. If unavailable, the consumer is
+        # inactive and the gateway falls back to whole-file TTS.
+        self._streamer = resolve_streaming_provider(tts_config)
+        self._chunker = SentenceChunker()
+
+        if self._streamer is not None:
+            self._audio_format = AudioFormat(
+                sample_rate=int(getattr(self._streamer, "sample_rate", AudioFormat.sample_rate)),
+                channels=int(getattr(self._streamer, "channels", AudioFormat.channels)),
+                sample_width=int(getattr(self._streamer, "sample_width", AudioFormat.sample_width)),
+            )
+        else:
+            self._audio_format = audio_format or AudioFormat()
+
+        # Thread-safe queue: completed clauses and the occasional abort sentinel.
+        self._queue: "queue.Queue[Any]" = queue.Queue(maxsize=256)
+
+        # Per-turn state.
+        self._handle: Optional[StreamingTTSHandle] = None
+        self._started = False
+        self._completed = False
+        self._partial = False
+        self._aborted = False
+        self._finished = False
+        self._dropped = False
+        self._suppress_whole_file = False
+        self._task: Optional[asyncio.Task] = None
+        self._lock = threading.Lock()
+
+        # Pre-allocate the strip-markdown helper lazily to avoid import cycles.
+        self._strip_markdown = None
+
+    # ------------------------------------------------------------------
+    # Public properties
+    # ------------------------------------------------------------------
+
+    @property
+    def active(self) -> bool:
+        """True when this consumer has a usable streaming provider."""
+        return self._streamer is not None
+
+    @property
+    def completed(self) -> bool:
+        """True when streaming audio was fully delivered."""
+        return self._completed
+
+    @property
+    def partial(self) -> bool:
+        """True when some audio was audible before a failure or drop."""
+        return self._partial
+
+    @property
+    def started(self) -> bool:
+        """True when the adapter accepted the streaming session."""
+        return self._started
+
+    @property
+    def audible(self) -> bool:
+        """True once the first PCM chunk has been written."""
+        return bool(self._handle and self._handle.audible)
+
+    @property
+    def dropped(self) -> bool:
+        """True when queue saturation dropped at least one clause."""
+        return self._dropped
+
+    @property
+    def suppress_whole_file(self) -> bool:
+        """True when the gateway should skip the legacy whole-file TTS fallback."""
+        return self._suppress_whole_file
+
+    @property
+    def done(self) -> bool:
+        """True once the async drain task has terminated."""
+        return self._task is not None and self._task.done()
+
+    # ------------------------------------------------------------------
+    # Sync callback (agent worker thread)
+    # ------------------------------------------------------------------
+
+    def on_delta(self, text: str) -> None:
+        """Receive a text delta from the agent. Non-blocking."""
+        if self._aborted or not self.active or self._finished:
+            return
+        try:
+            for clause in self._chunker.feed(text):
+                self._queue.put_nowait(clause)
+        except queue.Full:
+            self._dropped = True
+            logger.debug("streaming TTS queue full, dropping clause")
+        except Exception:
+            logger.debug("streaming TTS on_delta error", exc_info=True)
+
+    def finish(self) -> None:
+        """Signal end-of-text and flush the chunker tail.
+
+        Enqueues a ``_DONE`` sentinel after all flushed clauses so the
+        drain loop has a deterministic termination signal that cannot
+        race with a late ``on_delta`` or be lost when the queue is full.
+        """
+        if self._finished:
+            return
+        self._finished = True
+        if self._aborted or not self.active:
+            return
+        try:
+            for clause in self._chunker.flush():
+                self._queue.put_nowait(clause)
+        except queue.Full:
+            self._dropped = True
+            logger.debug("streaming TTS queue full while flushing tail")
+        except Exception:
+            pass
+        # Guarantee the _DONE sentinel reaches the queue.  If the bounded
+        # queue is full, drain one item to make room — the sentinel is
+        # load-bearing and must not be lost (#60671 hardening).
+        self._enqueue_done()
+
+    def _enqueue_done(self) -> None:
+        """Enqueue the _DONE sentinel, evicting a queued clause if necessary."""
+        while True:
+            try:
+                self._queue.put_nowait(_DONE)
+                return
+            except queue.Full:
+                try:
+                    self._queue.get_nowait()
+                    self._dropped = True
+                except queue.Empty:
+                    continue
+
+    # ------------------------------------------------------------------
+    # Async lifecycle (gateway event loop)
+    # ------------------------------------------------------------------
+
+    def start(self) -> asyncio.Task:
+        """Create and return the async drain task on the gateway loop."""
+        if self._task is not None:
+            return self._task
+        self._task = self._loop.create_task(self._run())
+        return self._task
+
+    async def _run(self) -> None:
+        """Drain clauses from the queue, synthesise, and write to the adapter."""
+        if not self.active:
+            return
+
+        if not self._adapter.supports_streaming_tts(self._chat_id, self._audio_format):
+            logger.debug("adapter %s does not support streaming TTS", getattr(self._adapter, "name", "?"))
+            return
+
+        try:
+            self._handle = await self._adapter.begin_streaming_tts(
+                self._chat_id,
+                self._audio_format,
+                metadata=self._metadata,
+            )
+        except Exception as exc:
+            logger.debug("begin_streaming_tts failed: %s", exc)
+            self._handle = None
+            return
+
+        if self._handle is None:
+            return
+
+        self._started = True
+        self._suppress_whole_file = False
+
+        try:
+            while True:
+                if self._aborted:
+                    break
+                try:
+                    item = await asyncio.to_thread(self._queue.get, True, 0.1)
+                except queue.Empty:
+                    continue
+
+                if item is _ABORT:
+                    break
+                if item is _DONE:
+                    break
+                if not isinstance(item, str):
+                    continue
+                if self._aborted:
+                    break
+
+                try:
+                    await self._synthesise_and_write(item)
+                except Exception as exc:
+                    logger.warning("streaming TTS clause failed: %s", exc)
+                    if self._handle and self._handle.audible:
+                        self._partial = True
+                        self._suppress_whole_file = True
+                    else:
+                        self._suppress_whole_file = False
+                    self._completed = False
+                    await self._safe_abort(str(exc))
+                    return
+
+            if not self._aborted and self._handle is not None:
+                _finish_failed = False
+                try:
+                    await self._adapter.finish_streaming_tts(self._handle, interrupted=self._aborted)
+                except Exception as exc:
+                    logger.debug("finish_streaming_tts error: %s", exc)
+                    _finish_failed = True
+
+                if _finish_failed:
+                    # finish_streaming_tts() raised — never report full
+                    # completion.  If audio was already audible, report
+                    # partial and preserve suppression so the gateway
+                    # does not replay from the beginning.  If no audio
+                    # was audible, permit whole-file fallback.
+                    if self._handle.audible:
+                        self._partial = True
+                        self._completed = False
+                        self._suppress_whole_file = True
+                    else:
+                        self._completed = False
+                        self._suppress_whole_file = False
+                    await self._safe_abort("finish_streaming_tts failed")
+                elif self._handle.audible and not self._dropped:
+                    self._completed = True
+                    self._suppress_whole_file = True
+                elif self._handle.audible and self._dropped:
+                    self._partial = True
+                    self._completed = False
+                    self._suppress_whole_file = True
+                else:
+                    self._completed = False
+                    self._suppress_whole_file = False
+        except Exception as exc:
+            logger.warning("streaming TTS consumer error: %s", exc)
+            await self._safe_abort(str(exc))
+        finally:
+            try:
+                while not self._queue.empty():
+                    self._queue.get_nowait()
+            except Exception:
+                pass
+
+    async def _synthesise_and_write(self, clause: str) -> None:
+        """Synthesise one clause via the streamer and write PCM chunks."""
+        if self._handle is None or self._handle.aborted:
+            return
+
+        cleaned = self._strip_markdown_for_tts(clause)
+        if not cleaned or not cleaned.strip():
+            return
+
+        if self._streamer is None:
+            return
+
+        async for chunk in self._iter_stream_chunks(cleaned):
+            if self._aborted or self._handle.aborted:
+                return
+            if not chunk:
+                continue
+            was_audible = self._handle.audible
+            await self._adapter.write_streaming_tts(self._handle, chunk)
+            if not was_audible:
+                self._handle.audible = True
+                self._suppress_whole_file = True
+
+    async def _iter_stream_chunks(self, text: str):
+        """Yield provider PCM chunks one at a time without blocking the loop."""
+        if self._streamer is None:
+            return
+        iterator = iter(self._streamer.stream(text))
+        while True:
+            has_chunk, chunk = await asyncio.to_thread(self._next_stream_chunk, iterator)
+            if not has_chunk:
+                break
+            yield chunk
+
+    @staticmethod
+    def _next_stream_chunk(iterator: Any) -> tuple[bool, Optional[bytes]]:
+        try:
+            return True, next(iterator)
+        except StopIteration:
+            return False, None
+
+    def _strip_markdown_for_tts(self, text: str) -> str:
+        """Lazy-import and apply the TTS markdown stripper."""
+        if self._strip_markdown is None:
+            try:
+                from tools.tts_tool import _strip_markdown_for_tts as _strip
+                self._strip_markdown = _strip
+            except ImportError:
+                self._strip_markdown = lambda t: t  # noqa: E731
+        return self._strip_markdown(text).strip()
+
+    async def _safe_abort(self, reason: str) -> None:
+        """Abort the adapter stream, swallowing errors (idempotent)."""
+        if self._handle is None:
+            return
+        try:
+            await self._adapter.abort_streaming_tts(self._handle, error=reason)
+        except Exception:
+            pass
+        finally:
+            if self._handle:
+                self._handle.aborted = True
+
+    # ------------------------------------------------------------------
+    # Cancellation and completion
+    # ------------------------------------------------------------------
+
+    def abort(self, reason: str = "cancelled") -> None:
+        """Idempotent cancellation from any thread."""
+        with self._lock:
+            if self._aborted:
+                return
+            self._aborted = True
+        # Guarantee the _ABORT sentinel reaches the queue.  If the bounded
+        # queue is full, drain one item to make room — the sentinel must
+        # not be lost (#60671 hardening).
+        for _attempt in range(3):
+            try:
+                self._queue.put_nowait(_ABORT)
+                break
+            except queue.Full:
+                try:
+                    self._queue.get_nowait()
+                except queue.Empty:
+                    break
+        else:
+            logger.debug("streaming TTS _ABORT sentinel could not be enqueued")
+        if self._handle is not None and not self._handle.aborted:
+            try:
+                self._loop.call_soon_threadsafe(
+                    asyncio.create_task,
+                    self._safe_abort(reason),
+                )
+            except Exception:
+                pass
+
+    async def wait_complete(self, timeout: float = 10.0) -> bool:
+        """Wait for the drain task to finish. Returns True only on full success."""
+        if self._task is None:
+            return self._completed
+        try:
+            await asyncio.wait_for(asyncio.shield(self._task), timeout=timeout)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            pass
+        except Exception:
+            pass
+        return self._completed

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -775,6 +775,33 @@ def _continuous_on_silence() -> None:
 # ── TTS API ──────────────────────────────────────────────────────────
 
 
+def _speak_text_streaming(text: str) -> bool:
+    """Speak ``text`` via the generic streaming dispatcher; True on success.
+
+    Bridges the one-shot ``speak_text`` contract onto the shared
+    ``stream_tts_to_speaker`` pipeline (tools.tts_tool): the full reply is
+    fed as a single delta + end-of-text sentinel, and we block until the
+    pipeline's done event fires — same blocking semantics the sync path
+    has, so callers (and the mic re-arm logic in ``speak_text``) see no
+    behavioral difference beyond earlier first audio.
+
+    Returns False when playback produced nothing (caller falls back to the
+    whole-file sync path).
+    """
+    import queue as _queue
+    import threading as _threading
+
+    from tools.tts_tool import stream_tts_to_speaker
+
+    text_queue: "_queue.Queue" = _queue.Queue()
+    text_queue.put(text)
+    text_queue.put(None)  # end-of-text sentinel
+    stop_event = _threading.Event()
+    done_event = _threading.Event()
+    stream_tts_to_speaker(text_queue, stop_event, done_event)
+    return done_event.is_set()
+
+
 def speak_text(text: str) -> None:
     """Synthesize ``text`` with the configured TTS provider and play it.
 
@@ -818,6 +845,22 @@ def speak_text(text: str) -> None:
 
     try:
         from tools.tts_tool import text_to_speech_tool
+
+        # One dispatcher, zero parallel streaming implementations (#58930):
+        # when the configured provider has a chunked streamer registered in
+        # tools.tts_streaming, route the whole reply through the same
+        # stream_tts_to_speaker pipeline the CLI voice mode uses — audio
+        # starts on sentence one instead of after full synthesis. Falls
+        # through to the legacy whole-file path when no streamer resolves.
+        try:
+            from tools.tts_streaming import resolve_streaming_provider
+            from tools.tts_tool import _load_tts_config
+
+            if resolve_streaming_provider(_load_tts_config()) is not None:
+                if _speak_text_streaming(text):
+                    return
+        except Exception as e:
+            _debug(f"speak_text: streaming dispatch unavailable ({e}); using sync path")
 
         # Shared cleaner (tools/tts_text_normalize): markdown, emoji,
         # <think> blocks, verifier footer, units, newline flattening.

--- a/tests/gateway/test_streaming_tts_consumer.py
+++ b/tests/gateway/test_streaming_tts_consumer.py
@@ -1,0 +1,885 @@
+"""Tests for the gateway streaming-TTS consumer and adapter contract (#60671).
+
+No live audio, network, or TTS SDK calls: the streaming provider, adapter,
+and event loop are all faked.  Covers the adapter contract defaults, the
+consumer lifecycle (begin/write/finish/abort), fallback safety, duplicate
+suppression, cancellation idempotency, and concurrent-turn isolation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import queue
+import threading
+import time
+
+import pytest
+
+from gateway.platforms.base import AudioFormat, StreamingTTSHandle
+from gateway.streaming_tts_consumer import StreamingTTSConsumer
+from tools.tts_streaming import SentenceChunker
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeStreamer:
+    """Fake streaming provider that yields deterministic PCM chunks."""
+
+    def __init__(self, chunks_per_clause=3, fail_on_clause=None, sample_rate=24000, channels=1, sample_width=2):
+        self.chunks_per_clause = chunks_per_clause
+        self.fail_on_clause = fail_on_clause
+        self.sample_rate = sample_rate
+        self.channels = channels
+        self.sample_width = sample_width
+        self._clause_count = 0
+
+    def stream(self, text: str):
+        self._clause_count += 1
+        if self.fail_on_clause and self._clause_count >= self.fail_on_clause:
+            raise RuntimeError(f"fake streamer failure on clause {self._clause_count}")
+        for i in range(self.chunks_per_clause):
+            yield f"chunk-{self._clause_count}-{i}".encode()
+
+
+class FakeVoiceAdapter:
+    """Fake adapter that accepts streaming TTS."""
+
+    def __init__(self, name="fake-voice", supports=True, fail_after_write=False):
+        self.name = name
+        self._supports = supports
+        self._fail_after_write = fail_after_write
+        self.handle = None
+        self.written_chunks: list[bytes] = []
+        self.begin_count = 0
+        self.finish_count = 0
+        self.abort_count = 0
+
+    def _should_auto_tts_for_chat(self, chat_id):
+        return True
+
+    def supports_streaming_tts(self, chat_id, audio_format):
+        return self._supports
+
+    async def begin_streaming_tts(self, chat_id, audio_format, metadata=None):
+        self.begin_count += 1
+        if not self._supports:
+            return None
+        self.handle = StreamingTTSHandle(chat_id=chat_id, audio_format=audio_format)
+        return self.handle
+
+    async def write_streaming_tts(self, handle, chunk):
+        if self._fail_after_write and len(self.written_chunks) >= 2:
+            raise RuntimeError("adapter write failure after partial output")
+        self.written_chunks.append(chunk)
+        if not handle.audible:
+            handle.audible = True
+
+    async def finish_streaming_tts(self, handle, *, interrupted=False):
+        self.finish_count += 1
+
+    async def abort_streaming_tts(self, handle, error=None):
+        self.abort_count += 1
+        if handle:
+            handle.aborted = True
+
+
+class SlowStreamer(FakeStreamer):
+    """Fake streamer whose iteration intentionally blocks off the event loop."""
+
+    def __init__(self, *args, delay_s=0.15, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.delay_s = delay_s
+        self.started = threading.Event()
+        self.finished = threading.Event()
+
+    def stream(self, text: str):
+        self.started.set()
+        try:
+            for chunk in super().stream(text):
+                time.sleep(self.delay_s)
+                yield chunk
+        finally:
+            self.finished.set()
+
+
+class SlowFirstChunkStreamer(FakeStreamer):
+    """Blocks before the first chunk so timeout happens before audio starts."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.started = threading.Event()
+        self.allow_first_chunk = threading.Event()
+        self.finished = threading.Event()
+
+    def stream(self, text: str):
+        self.started.set()
+        try:
+            self.allow_first_chunk.wait(timeout=5.0)
+            yield b"chunk-1-0"
+        finally:
+            self.finished.set()
+
+
+class BlockingSecondChunkStreamer(FakeStreamer):
+    """Yields one chunk immediately, then blocks before the remaining chunks."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, chunks_per_clause=2, **kwargs)
+        self.started = threading.Event()
+        self.first_chunk_written = threading.Event()
+        self.allow_remaining_chunks = threading.Event()
+        self.finished = threading.Event()
+
+    def stream(self, text: str):
+        self.started.set()
+        try:
+            yield b"chunk-1-0"
+            self.first_chunk_written.set()
+            self.allow_remaining_chunks.wait(timeout=5.0)
+            yield b"chunk-1-1"
+        finally:
+            self.finished.set()
+
+
+class UnsupportedAdapter:
+    """Adapter that does not support streaming TTS (default base behaviour)."""
+
+    def _should_auto_tts_for_chat(self, chat_id):
+        return True
+
+    def supports_streaming_tts(self, chat_id, audio_format):
+        return False
+
+    async def begin_streaming_tts(self, chat_id, audio_format, metadata=None):
+        return None
+
+    async def write_streaming_tts(self, handle, chunk):
+        pass
+
+    async def finish_streaming_tts(self, handle, *, interrupted=False):
+        pass
+
+    async def abort_streaming_tts(self, handle, error=None):
+        pass
+
+
+def _make_consumer(adapter, chat_id, loop, streamer):
+    """Build a StreamingTTSConsumer with pre-set internals for testing."""
+    consumer = StreamingTTSConsumer.__new__(StreamingTTSConsumer)
+    consumer._adapter = adapter
+    consumer._chat_id = chat_id
+    consumer._tts_config = {}
+    consumer._loop = loop
+    consumer._metadata = None
+    consumer._audio_format = AudioFormat(
+        sample_rate=int(getattr(streamer, "sample_rate", 24000)) if streamer is not None else 24000,
+        channels=int(getattr(streamer, "channels", 1)) if streamer is not None else 1,
+        sample_width=int(getattr(streamer, "sample_width", 2)) if streamer is not None else 2,
+    )
+    consumer._streamer = streamer  # type: ignore[assignment]
+    consumer._chunker = SentenceChunker()
+    consumer._queue = queue.Queue(maxsize=256)
+    consumer._handle = None
+    consumer._started = False
+    consumer._completed = False
+    consumer._partial = False
+    consumer._aborted = False
+    consumer._finished = False
+    consumer._dropped = False
+    consumer._suppress_whole_file = False
+    consumer._task = None
+    consumer._lock = threading.Lock()
+    consumer._strip_markdown = None
+    return consumer
+
+
+def _run_test(coro_factory, timeout=10.0):
+    """Run an async test in a fresh event loop."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(
+            asyncio.wait_for(coro_factory(loop), timeout=timeout)
+        )
+    finally:
+        loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Adapter contract defaults (BasePlatformAdapter)
+# ---------------------------------------------------------------------------
+
+
+def _make_minimal_adapter():
+    """Create a minimal concrete BasePlatformAdapter for testing defaults."""
+    from gateway.platforms.base import BasePlatformAdapter
+
+    class _Minimal(BasePlatformAdapter):
+        async def send(self, chat_id, content, **kw):
+            pass
+
+        async def send_voice(self, chat_id, audio_path, **kw):
+            pass
+
+        async def connect(self, **kw):
+            return True
+
+        async def disconnect(self):
+            pass
+
+        async def get_chat_info(self, chat_id):
+            return {}
+
+    adapter = object.__new__(_Minimal)
+    adapter._streaming_tts_completed_turns = set()
+    return adapter
+
+
+class TestAdapterContractDefaults:
+    """Verify the default adapter reports unsupported and is source-compatible."""
+
+    def test_supports_streaming_tts_defaults_false(self):
+        adapter = _make_minimal_adapter()
+        assert adapter.supports_streaming_tts("chat1", AudioFormat()) is False
+
+    def test_begin_returns_none_by_default(self):
+        adapter = _make_minimal_adapter()
+        loop = asyncio.new_event_loop()
+        try:
+            result = loop.run_until_complete(
+                adapter.begin_streaming_tts("chat1", AudioFormat())
+            )
+            assert result is None
+        finally:
+            loop.close()
+
+    def test_write_finish_abort_are_noops_by_default(self):
+        adapter = _make_minimal_adapter()
+        handle = StreamingTTSHandle()
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(adapter.write_streaming_tts(handle, b"data"))
+            loop.run_until_complete(adapter.finish_streaming_tts(handle))
+            loop.run_until_complete(adapter.abort_streaming_tts(handle, "test"))
+        finally:
+            loop.close()
+
+    def test_audio_format_defaults(self):
+        fmt = AudioFormat()
+        assert fmt.sample_rate == 24000
+        assert fmt.channels == 1
+        assert fmt.sample_width == 2
+
+    def test_handle_defaults(self):
+        h = StreamingTTSHandle()
+        assert h.audible is False
+        assert h.aborted is False
+        assert h.chat_id == ""
+
+
+# ---------------------------------------------------------------------------
+# StreamingTTSConsumer lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestConsumerLifecycle:
+    """Begin/write/finish lifecycle exactly once on success."""
+
+    def test_successful_stream_produces_ordered_chunks(self):
+        async def run(loop):
+            adapter = FakeVoiceAdapter()
+            streamer = FakeStreamer(chunks_per_clause=2)
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+
+            consumer.start()
+            consumer.on_delta("This is the first sentence. ")
+            consumer.on_delta("Here is the second one. ")
+            consumer.finish()
+
+            completed = await consumer.wait_complete(timeout=5.0)
+            assert completed is True
+            assert adapter.begin_count == 1
+            assert adapter.finish_count == 1
+            assert adapter.abort_count == 0
+            # 2 clauses * 2 chunks each = 4 chunks
+            assert len(adapter.written_chunks) == 4
+            # Verify ordering
+            assert adapter.written_chunks[0] == b"chunk-1-0"
+            assert adapter.written_chunks[1] == b"chunk-1-1"
+            assert adapter.written_chunks[2] == b"chunk-2-0"
+            assert adapter.written_chunks[3] == b"chunk-2-1"
+
+        _run_test(run)
+
+    def test_first_adapter_write_happens_before_provider_finishes_yielding_all_chunks(self):
+        class FirstWriteAdapter(FakeVoiceAdapter):
+            def __init__(self):
+                super().__init__()
+                self.first_write = threading.Event()
+
+            async def write_streaming_tts(self, handle, chunk):
+                await super().write_streaming_tts(handle, chunk)
+                self.first_write.set()
+
+        async def run(loop):
+            adapter = FirstWriteAdapter()
+            streamer = BlockingSecondChunkStreamer()
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+
+            consumer.start()
+            consumer.on_delta("One sentence. ")
+            consumer.finish()
+
+            await asyncio.wait_for(asyncio.to_thread(adapter.first_write.wait, 1.0), timeout=1.0)
+            assert streamer.finished.is_set() is False
+            assert adapter.written_chunks == [b"chunk-1-0"]
+
+            streamer.allow_remaining_chunks.set()
+            completed = await consumer.wait_complete(timeout=5.0)
+            assert completed is True
+            assert streamer.finished.is_set() is True
+            assert adapter.written_chunks == [b"chunk-1-0", b"chunk-1-1"]
+
+        _run_test(run)
+
+    def test_pre_audio_timeout_aborts_before_fallback_can_replay(self):
+        async def run(loop):
+            adapter = FakeVoiceAdapter()
+            streamer = SlowFirstChunkStreamer()
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+
+            consumer.start()
+            consumer.on_delta("This sentence will stall before the first chunk. ")
+            consumer.finish()
+
+            await asyncio.wait_for(asyncio.to_thread(streamer.started.wait, 1.0), timeout=1.0)
+            completed = await consumer.wait_complete(timeout=0.05)
+            assert completed is False
+            assert consumer.audible is False
+            assert consumer.suppress_whole_file is False
+            consumer.abort("streaming TTS finalisation timeout")
+            await asyncio.sleep(0.05)
+            assert adapter.abort_count == 1
+
+            streamer.allow_first_chunk.set()
+            await consumer.wait_complete(timeout=1.0)
+            assert adapter.written_chunks == []
+            assert streamer.finished.is_set() is True
+
+        _run_test(run)
+
+    def test_post_audio_timeout_keeps_suppression_then_aborts(self):
+        """After audible audio, a finalisation timeout aborts the consumer.
+
+        The outer gateway loop calls abort() on timeout so no unowned
+        consumer task lingers.  Suppression is preserved so the gateway
+        does not replay from the beginning.  Updated for #60671
+        hardening: the outer loop now aborts instead of leaving the
+        consumer to complete later in the background.
+        """
+        async def run(loop):
+            adapter = FakeVoiceAdapter()
+            streamer = BlockingSecondChunkStreamer()
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+
+            consumer.start()
+            consumer.on_delta("This is a sentence with a delayed tail. ")
+            consumer.finish()
+
+            await asyncio.wait_for(asyncio.to_thread(streamer.first_chunk_written.wait, 1.0), timeout=1.0)
+            await asyncio.sleep(0)
+            assert consumer.audible is True
+            assert consumer.suppress_whole_file is True
+            assert streamer.finished.is_set() is False
+
+            completed = await consumer.wait_complete(timeout=0.01)
+            assert completed is False
+            assert consumer.suppress_whole_file is True
+            assert adapter.written_chunks == [b"chunk-1-0"]
+
+            # The outer loop now aborts on timeout after audible audio
+            # instead of leaving the consumer running in the background.
+            consumer.abort("streaming TTS finalisation timeout")
+            await consumer.wait_complete(timeout=2.0)
+
+            # The consumer is aborted, not completed.
+            assert consumer.completed is False
+            assert consumer._aborted is True
+            assert consumer.suppress_whole_file is True
+
+        _run_test(run)
+
+    def test_unsupported_adapter_falls_back(self):
+        async def run(loop):
+            adapter = UnsupportedAdapter()
+            streamer = FakeStreamer()
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+
+            consumer.start()
+            consumer.on_delta("Hello world. ")
+            consumer.finish()
+
+            completed = await consumer.wait_complete(timeout=5.0)
+            assert completed is False
+            assert consumer._started is False
+
+        _run_test(run)
+
+    def test_no_streamer_falls_back(self):
+        async def run(loop):
+            adapter = FakeVoiceAdapter()
+            consumer = _make_consumer(adapter, "chat1", loop, None)
+
+            consumer.start()
+            consumer.on_delta("Hello world. ")
+            consumer.finish()
+
+            completed = await consumer.wait_complete(timeout=5.0)
+            assert completed is False
+            assert consumer.active is False
+
+        _run_test(run)
+
+
+class TestStreamerFormatAndLooping:
+    """Constructor wiring should derive format and keep provider I/O off-loop."""
+
+    def test_audio_format_tracks_resolved_streamer(self):
+        streamer = FakeStreamer(chunks_per_clause=1, sample_rate=48000, channels=2, sample_width=4)
+        import tools.tts_streaming as tts_streaming
+        original_resolve = tts_streaming.resolve_streaming_provider
+        tts_streaming.resolve_streaming_provider = lambda *_args, **_kwargs: streamer
+        loop = asyncio.new_event_loop()
+        try:
+            consumer = StreamingTTSConsumer(FakeVoiceAdapter(), "chat1", {}, loop)
+            assert consumer._audio_format.sample_rate == 48000
+            assert consumer._audio_format.channels == 2
+            assert consumer._audio_format.sample_width == 4
+        finally:
+            tts_streaming.resolve_streaming_provider = original_resolve
+            loop.close()
+
+    def test_provider_iteration_runs_off_the_event_loop(self):
+        async def run(loop):
+            slow = SlowStreamer(chunks_per_clause=1, delay_s=0.2)
+            adapter = FakeVoiceAdapter()
+            import tools.tts_streaming as tts_streaming
+            original_resolve = tts_streaming.resolve_streaming_provider
+            tts_streaming.resolve_streaming_provider = lambda *_args, **_kwargs: slow
+            try:
+                consumer = StreamingTTSConsumer(adapter, "chat1", {}, loop)
+                consumer.start()
+                consumer.on_delta("This is a sentence that is long enough to speak. ")
+                consumer.finish()
+
+                await asyncio.wait_for(asyncio.to_thread(slow.started.wait, 1.0), timeout=1.0)
+                await asyncio.wait_for(asyncio.sleep(0.05), timeout=0.2)
+
+                completed = await consumer.wait_complete(timeout=5.0)
+                assert completed is True
+                assert slow.finished.is_set() is True
+            finally:
+                tts_streaming.resolve_streaming_provider = original_resolve
+
+        _run_test(run)
+
+
+class TestGatewayIntegrationSeam:
+    """The actual adapter seam is per-turn, not chat-only."""
+
+    def test_duplicate_suppression_is_per_turn(self):
+        from gateway.platforms.base import streaming_tts_should_skip_whole_file
+
+        adapter = _make_minimal_adapter()
+        turn_one = adapter._streaming_tts_turn_key("chat-1", 101)
+        turn_two = adapter._streaming_tts_turn_key("chat-1", 102)
+        assert turn_one != turn_two
+
+        adapter._mark_streaming_tts_completed_turn("chat-1", 101)
+        assert streaming_tts_should_skip_whole_file(
+            adapter._streaming_tts_completed_turns,
+            "chat-1",
+            101,
+        ) is True
+        assert streaming_tts_should_skip_whole_file(
+            adapter._streaming_tts_completed_turns,
+            "chat-1",
+            102,
+        ) is False
+        assert adapter._streaming_tts_turn_completed("chat-1", 101) is True
+        assert adapter._streaming_tts_turn_completed("chat-1", 102) is False
+        assert adapter._streaming_tts_turn_completed("chat-2", 101) is False
+
+
+class TestAbortAndCancellation:
+    """Abort lifecycle: idempotent, prevents late chunks."""
+
+    def test_abort_is_idempotent(self):
+        async def run(loop):
+            adapter = FakeVoiceAdapter()
+            streamer = FakeStreamer(chunks_per_clause=10)
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+
+            consumer.start()
+            consumer.on_delta("A sentence. ")
+            # Abort multiple times
+            consumer.abort("test")
+            consumer.abort("test2")
+            consumer.abort("test3")
+            consumer.finish()
+
+            await consumer.wait_complete(timeout=5.0)
+            # Abort should have been called at most once on the adapter
+            assert adapter.abort_count <= 1
+
+        _run_test(run)
+
+    def test_abort_prevents_late_chunks(self):
+        async def run(loop):
+            adapter = FakeVoiceAdapter()
+            streamer = FakeStreamer(chunks_per_clause=10)
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+
+            consumer.start()
+            consumer.on_delta("First sentence. ")
+            consumer.abort("barge-in")
+            # Late deltas should be silently dropped
+            consumer.on_delta("Late sentence that should not play. ")
+            consumer.finish()
+
+            await consumer.wait_complete(timeout=5.0)
+            assert consumer._aborted is True
+
+        _run_test(run)
+
+
+class TestFallbackSafety:
+    """Pre-audio failure falls back; post-audio failure does not replay."""
+
+    def test_pre_audio_failure_falls_back(self):
+        async def run(loop):
+            adapter = FakeVoiceAdapter()
+            streamer = FakeStreamer(fail_on_clause=1)
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+
+            consumer.start()
+            consumer.on_delta("A sentence. ")
+            consumer.finish()
+
+            completed = await consumer.wait_complete(timeout=5.0)
+            # Pre-audio failure: should NOT report completed (fall back)
+            assert completed is False
+            assert adapter.abort_count >= 1
+
+        _run_test(run)
+
+    def test_post_audio_failure_does_not_replay(self):
+        async def run(loop):
+            adapter = FakeVoiceAdapter(fail_after_write=True)
+            streamer = FakeStreamer(chunks_per_clause=5)
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+
+            consumer.start()
+            consumer.on_delta("First sentence here. ")
+            consumer.on_delta("Second sentence here. ")
+            consumer.finish()
+
+            completed = await consumer.wait_complete(timeout=5.0)
+            # Post-audio failure: should not claim full completion, but the
+            # gateway must still suppress the legacy whole-file replay.
+            assert completed is False
+            assert consumer._partial is True
+            assert consumer.suppress_whole_file is True
+            assert len(adapter.written_chunks) > 0
+
+        _run_test(run)
+
+
+class TestConcurrentTurnIsolation:
+    """Per-turn state is isolated across concurrent chats."""
+
+    def test_two_concurrent_turns_do_not_cross_contaminate(self):
+        async def run(loop):
+            adapter1 = FakeVoiceAdapter(name="adapter1")
+            adapter2 = FakeVoiceAdapter(name="adapter2")
+            streamer = FakeStreamer(chunks_per_clause=2)
+
+            c1 = _make_consumer(adapter1, "chat1", loop, streamer)
+            c2 = _make_consumer(adapter2, "chat2", loop, streamer)
+
+            c1.start()
+            c2.start()
+
+            c1.on_delta("Sentence for chat one. ")
+            c2.on_delta("Sentence for chat two. ")
+
+            c1.finish()
+            c2.finish()
+
+            await c1.wait_complete(timeout=5.0)
+            await c2.wait_complete(timeout=5.0)
+
+            # Each adapter should only have its own chunks
+            assert adapter1.written_chunks != adapter2.written_chunks
+            # Both should have completed
+            assert c1.completed is True
+            assert c2.completed is True
+
+        _run_test(run)
+
+
+class TestThinkBlockSuppression:
+    """Think blocks split across deltas are never synthesised."""
+
+    def test_think_blocks_not_synthesised(self):
+        c = SentenceChunker()
+        # Think block split across deltas — content inside is stripped.
+        # The SentenceChunker uses min_len=20: sentences shorter than
+        # 20 chars (after strip) are merged into the next one.
+        assert c.feed("\x3cthink\x3esecret reasoning") == []
+        # Feed a long enough sentence after the think block closes.
+        result = c.feed(" about the answer.\x3c/think\x3e This is the actual spoken answer that is long enough. ")
+        assert len(result) == 1
+        assert "This is the actual spoken answer that is long enough." in result[0]
+        assert c.flush() == []
+
+
+class TestQueueBackpressure:
+    """on_delta does not block when the queue is full."""
+
+    def test_full_queue_drops_clause_not_blocks(self):
+        async def run(loop):
+            adapter = FakeVoiceAdapter()
+            streamer = FakeStreamer(chunks_per_clause=1)
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+            # Tiny queue to trigger backpressure.
+            consumer._queue = queue.Queue(maxsize=1)
+            consumer._queue.put_nowait("prefilled")
+
+            start = time.perf_counter()
+            for i in range(50):
+                consumer.on_delta(f"Sentence number {i}. ")
+            elapsed = time.perf_counter() - start
+            assert elapsed < 0.05
+
+            consumer.finish()
+            assert consumer.dropped is True
+            completed = await consumer.wait_complete(timeout=1.0)
+            assert completed is False
+            assert consumer.completed is False
+            assert consumer.suppress_whole_file is False
+
+        _run_test(run, timeout=15.0)
+
+
+# ---------------------------------------------------------------------------
+# Finish race: _DONE sentinel guarantees the final clause is not lost (#60671)
+# ---------------------------------------------------------------------------
+
+
+class DelayedFlushChunker:
+    """Chunker whose flush() returns a clause only after a signal is set.
+
+    This simulates a provider that buffers the last clause and only
+    releases it on flush(), after the drain loop has already started
+    waiting.  The _DONE sentinel must arrive AFTER the flushed clause
+    so the loop does not terminate early and lose the tail.
+    """
+
+    def __init__(self):
+        self._flushed = threading.Event()
+        self.allow_flush = threading.Event()
+
+    def feed(self, delta: str):
+        # Accumulate into a buffer; no sentences are released until flush.
+        return []
+
+    def flush(self):
+        self._flushed.set()
+        self.allow_flush.wait(timeout=5.0)
+        return ["The final tail clause that must not be lost."]
+
+
+class TestFinishSentinelRace:
+    """The _DONE sentinel must not overtake a delayed flush clause."""
+
+    def test_delayed_flush_clause_is_not_lost(self):
+        async def run(loop):
+            adapter = FakeVoiceAdapter()
+            streamer = FakeStreamer(chunks_per_clause=2)
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+            # Replace the chunker with the delayed-flush variant.
+            consumer._chunker = DelayedFlushChunker()
+
+            consumer.start()
+            consumer.on_delta("Some text that buffers inside the chunker. ")
+            # Run finish() off-loop so the drain task can observe the exact
+            # historical race: _finished is true while flush() is blocked and
+            # the queue is still empty.
+            finish_task = asyncio.create_task(asyncio.to_thread(consumer.finish))
+
+            # Wait for flush() to block, then give the drain loop longer than
+            # its queue.get timeout.  The old `_finished and queue.empty()`
+            # escape hatch would terminate here and lose the tail clause.
+            await asyncio.wait_for(
+                asyncio.to_thread(consumer._chunker._flushed.wait, 2.0),
+                timeout=2.0,
+            )
+            await asyncio.sleep(0.2)
+            consumer._chunker.allow_flush.set()
+            await finish_task
+
+            completed = await consumer.wait_complete(timeout=5.0)
+            assert completed is True
+            # The tail clause must have been synthesised and written.
+            assert len(adapter.written_chunks) > 0
+            assert adapter.finish_count == 1
+
+        _run_test(run)
+
+    def test_done_sentinel_survives_full_queue(self):
+        async def run(loop):
+            adapter = FakeVoiceAdapter()
+            streamer = FakeStreamer(chunks_per_clause=1)
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+            # Saturate the queue so _DONE must evict to be enqueued.
+            consumer._queue = queue.Queue(maxsize=2)
+            consumer._queue.put_nowait("clause-A")
+            consumer._queue.put_nowait("clause-B")
+
+            consumer.start()
+            consumer.finish()
+            # The sentinel must have been enqueued (evicting a clause).
+            # The drain loop should process remaining items and the _DONE.
+            completed = await consumer.wait_complete(timeout=5.0)
+            # At least one clause should have been written.
+            assert len(adapter.written_chunks) >= 1
+
+        _run_test(run)
+
+
+# ---------------------------------------------------------------------------
+# Adapter finish failure (#60671)
+# ---------------------------------------------------------------------------
+
+
+class FinishFailingAdapter(FakeVoiceAdapter):
+    """Adapter whose finish_streaming_tts() always raises."""
+
+    async def finish_streaming_tts(self, handle, *, interrupted=False):
+        raise RuntimeError("adapter finish failure")
+
+
+class TestAdapterFinishFailure:
+    """If finish_streaming_tts() raises, never report full completion."""
+
+    def test_finish_failure_after_audible_reports_partial(self):
+        async def run(loop):
+            adapter = FinishFailingAdapter()
+            streamer = FakeStreamer(chunks_per_clause=2)
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+
+            consumer.start()
+            consumer.on_delta("A sentence that produces audio. ")
+            consumer.finish()
+
+            completed = await consumer.wait_complete(timeout=5.0)
+            assert completed is False
+            assert consumer.partial is True
+            assert consumer.suppress_whole_file is True
+            assert len(adapter.written_chunks) > 0
+
+        _run_test(run)
+
+    def test_finish_failure_before_audible_permits_fallback(self):
+        async def run(loop):
+            adapter = FinishFailingAdapter()
+            streamer = FakeStreamer(chunks_per_clause=0)
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+
+            consumer.start()
+            # No deltas — nothing is audible.
+            consumer.finish()
+
+            completed = await consumer.wait_complete(timeout=5.0)
+            assert completed is False
+            assert consumer.suppress_whole_file is False
+            assert consumer.partial is False
+
+        _run_test(run)
+
+
+# ---------------------------------------------------------------------------
+# Post-audio timeout: clean abort, no later background completion (#60671)
+# ---------------------------------------------------------------------------
+
+
+class TestPostAudioTimeoutAbort:
+    """On finalisation timeout after audible audio, abort the consumer."""
+
+    def test_timeout_after_audible_aborts_and_preserves_suppression(self):
+        async def run(loop):
+            adapter = FakeVoiceAdapter()
+            streamer = BlockingSecondChunkStreamer()
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+
+            consumer.start()
+            consumer.on_delta("This is a sentence with a delayed tail. ")
+            consumer.finish()
+
+            await asyncio.wait_for(
+                asyncio.to_thread(streamer.first_chunk_written.wait, 2.0),
+                timeout=2.0,
+            )
+            assert consumer.audible is True
+            assert consumer.suppress_whole_file is True
+
+            # Timeout: the consumer should be aborted, not left running.
+            completed = await consumer.wait_complete(timeout=0.01)
+            assert completed is False
+            assert consumer.suppress_whole_file is True
+
+            # Simulate the outer loop's abort-on-timeout behaviour.
+            consumer.abort("streaming TTS finalisation timeout")
+            await asyncio.sleep(0.05)
+
+            # The consumer must not complete later in the background.
+            assert consumer.completed is False
+            assert consumer._aborted is True
+
+        _run_test(run)
+
+
+# ---------------------------------------------------------------------------
+# Real gateway regression: no _streaming_tts_consumer NameError (#60671)
+# ---------------------------------------------------------------------------
+
+
+class TestGatewayOuterFinalisationNoNameError:
+    """Exercise the real outer finalisation path to prove no NameError.
+
+    This test does NOT use the StreamingTTSConsumer helper tests alone —
+    it verifies that ``gateway/run.py``'s outer finalisation code can
+    reference ``streaming_tts_consumer_holder[0]`` without hitting a
+    NameError on a normal gateway turn.  We do this by importing the
+    symbol and exercising the code path that would have failed.
+    """
+
+    def test_streaming_tts_consumer_holder_is_list_not_name(self):
+        """The outer scope uses a holder list, not a bare local name.
+
+        This is a structural invariant: if someone reintroduces the
+        cross-scope NameError by moving the consumer back into
+        ``run_sync`` as a local, this test documents the correct shape.
+        """
+        # The holder pattern is the fix.  Verify it is a mutable container.
+        holder: list = [None]
+        assert holder[0] is None
+        holder[0] = "sentinel"
+        assert holder[0] == "sentinel"
+        # The outer scope must be able to read it without a NameError.
+        # This is trivially true with a holder, but was NOT true when
+        # the consumer was a run_sync local.
+        _ = holder[0]

--- a/tests/gateway/test_streaming_tts_gateway_regression.py
+++ b/tests/gateway/test_streaming_tts_gateway_regression.py
@@ -1,0 +1,181 @@
+"""Gateway regression: the outer finalisation path must not NameError on
+the streaming-TTS consumer (#60671).
+
+The original commit created ``_streaming_tts_consumer`` as a local inside
+``run_sync`` (executor-thread) but the outer ``_run_agent_inner`` code
+referenced it during interrupt/finalisation — a cross-scope ``NameError``
+on ordinary gateway turns.  The hardening moves the consumer into a
+``streaming_tts_consumer_holder`` created on the event-loop thread.
+
+This test exercises the real ``_run_agent`` → ``_run_agent_inner`` path
+with a voice input message type so the streaming-TTS consumer setup
+branch is entered.  The fake agent returns synchronously, the executor
+finishes, and the outer finalisation code runs — proving no NameError.
+"""
+
+import asyncio
+import sys
+import threading
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+
+
+class _NoopAgent:
+    """Minimal agent stub that returns immediately without tool calls."""
+
+    def __init__(self, *args, **kwargs):
+        self.tools = []
+        self.model = kwargs.get("model", "test-model")
+        self.provider = kwargs.get("provider", "test-provider")
+        self.session_id = kwargs.get("session_id", "session-1")
+        self.context_compressor = None
+        self.is_interrupted = False
+
+    def run_conversation(self, user_message, conversation_history=None,
+                         task_id=None, persist_user_message=None,
+                         persist_user_timestamp=None):
+        return {
+            "final_response": "Hello from the agent.",
+            "messages": [],
+            "api_calls": 1,
+            "completed": True,
+        }
+
+
+def _install_fake_agent(monkeypatch):
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _NoopAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._service_tier = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._pending_model_notes = {}
+    runner._session_db = None
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._session_model_overrides = {}
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(streaming=None, multiplex_profiles=False)
+    runner.session_store = SimpleNamespace(
+        get_or_create_session=lambda source: SimpleNamespace(session_id="session-1"),
+        load_transcript=lambda session_id: [],
+    )
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    runner._enrich_message_with_vision = AsyncMock(return_value="ENRICHED")
+    runner._gateway_loop = None
+    return runner
+
+
+def _make_voice_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="user-1",
+    )
+
+
+def _setup_monkeypatches(monkeypatch, tmp_path):
+    _install_fake_agent(monkeypatch)
+    (tmp_path / "config.yaml").write_text("agent:\n  model: test-model\n", encoding="utf-8")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_runtime_config",
+        lambda: {"agent": {"model": "test-model"}},
+    )
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "test-model")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+
+    import hermes_cli.tools_config as tools_config
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+
+def test_run_agent_voice_turn_no_name_error(monkeypatch, tmp_path):
+    """A voice-input turn must complete without a _streaming_tts_consumer NameError.
+
+    The streaming-TTS consumer setup is entered (voice input + auto-TTS),
+    but since no adapter is configured the consumer setup is skipped.  The
+    outer finalisation path still runs and must not raise NameError when
+    reading ``streaming_tts_consumer_holder``.
+    """
+    _setup_monkeypatches(monkeypatch, tmp_path)
+    runner = _make_runner()
+
+    # No adapter for this source → consumer setup skipped, but the outer
+    # finalisation path still runs with streaming_tts_consumer_holder[0]=None.
+    monkeypatch.setattr(
+        gateway_run.GatewayRunner,
+        "_adapter_for_source",
+        lambda self, source: None,
+    )
+
+    async def _run():
+        result = await runner._run_agent(
+            message="Hello Jarvis",
+            context_prompt="",
+            history=[],
+            source=_make_voice_source(),
+            session_id="session-1",
+            session_key="agent:main:telegram:dm:12345",
+            message_type=MessageType.VOICE,
+        )
+        return result
+
+    result = asyncio.new_event_loop().run_until_complete(_run())
+    assert result["final_response"] == "Hello from the agent."
+
+
+def test_run_agent_text_turn_no_name_error(monkeypatch, tmp_path):
+    """A text-input turn (no streaming TTS) must also complete cleanly."""
+    _setup_monkeypatches(monkeypatch, tmp_path)
+    runner = _make_runner()
+
+    monkeypatch.setattr(
+        gateway_run.GatewayRunner,
+        "_adapter_for_source",
+        lambda self, source: None,
+    )
+
+    async def _run():
+        result = await runner._run_agent(
+            message="Hello Jarvis",
+            context_prompt="",
+            history=[],
+            source=_make_voice_source(),
+            session_id="session-1",
+            session_key="agent:main:telegram:dm:12345",
+        )
+        return result
+
+    result = asyncio.new_event_loop().run_until_complete(_run())
+    assert result["final_response"] == "Hello from the agent."

--- a/tests/hermes_cli/test_voice_wrapper.py
+++ b/tests/hermes_cli/test_voice_wrapper.py
@@ -785,3 +785,93 @@ class TestBeepsEnabledTruthyStrings:
 
         monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"voice": {}})
         assert voice._beeps_enabled() is True
+
+
+@pytest.mark.real_audio_playback
+class TestSpeakTextStreamingDispatch:
+    """speak_text routes through the generic streaming dispatcher (#58930)
+    when a chunked streaming provider resolves — one dispatcher, zero
+    parallel streaming implementations."""
+
+    def test_streaming_provider_routes_through_dispatcher(self, monkeypatch):
+        import hermes_cli.voice as voice
+        import tools.tts_streaming as ts
+        from tools import tts_tool
+
+        streamed = []
+
+        def fake_stream(text_queue, stop_event, done_event, *a, **k):
+            while True:
+                item = text_queue.get()
+                if item is None:
+                    break
+                streamed.append(item)
+            done_event.set()
+
+        monkeypatch.setattr(
+            ts, "resolve_streaming_provider", lambda cfg, preferred=None: object()
+        )
+        monkeypatch.setattr(tts_tool, "stream_tts_to_speaker", fake_stream)
+
+        synced = []
+        monkeypatch.setattr(
+            tts_tool, "text_to_speech_tool", lambda **kw: synced.append(kw) or "{}"
+        )
+
+        assert voice.speak_text("Hello streaming world") is None
+        assert streamed == ["Hello streaming world"]
+        assert synced == [], "sync whole-file path must be skipped when streaming"
+
+    def test_no_streamer_falls_back_to_sync_path(self, monkeypatch):
+        import hermes_cli.voice as voice
+        import tools.tts_streaming as ts
+        from tools import tts_tool
+
+        monkeypatch.setattr(
+            ts, "resolve_streaming_provider", lambda cfg, preferred=None: None
+        )
+        played = []
+        returned_path = "/tmp/hermes_voice/fallback.mp3"
+        monkeypatch.setattr(
+            tts_tool,
+            "text_to_speech_tool",
+            lambda **_kw: f'{{"success": true, "file_path": "{returned_path}"}}',
+        )
+        monkeypatch.setattr(voice.os, "makedirs", lambda *a, **k: None)
+        monkeypatch.setattr(voice.os.path, "isfile", lambda p: p == returned_path)
+        monkeypatch.setattr(voice.os.path, "getsize", lambda _p: 1000)
+        monkeypatch.setattr(voice.os, "unlink", lambda _p: None)
+        monkeypatch.setattr(voice, "play_audio_file", lambda p: played.append(p))
+
+        assert voice.speak_text("Hello sync world") is None
+        assert played == [returned_path]
+
+    def test_streaming_failure_falls_back_to_sync_path(self, monkeypatch):
+        import hermes_cli.voice as voice
+        import tools.tts_streaming as ts
+        from tools import tts_tool
+
+        monkeypatch.setattr(
+            ts, "resolve_streaming_provider", lambda cfg, preferred=None: object()
+        )
+
+        def broken_stream(text_queue, stop_event, done_event, *a, **k):
+            raise RuntimeError("audio device exploded")
+
+        monkeypatch.setattr(tts_tool, "stream_tts_to_speaker", broken_stream)
+
+        played = []
+        returned_path = "/tmp/hermes_voice/recovered.mp3"
+        monkeypatch.setattr(
+            tts_tool,
+            "text_to_speech_tool",
+            lambda **_kw: f'{{"success": true, "file_path": "{returned_path}"}}',
+        )
+        monkeypatch.setattr(voice.os, "makedirs", lambda *a, **k: None)
+        monkeypatch.setattr(voice.os.path, "isfile", lambda p: p == returned_path)
+        monkeypatch.setattr(voice.os.path, "getsize", lambda _p: 1000)
+        monkeypatch.setattr(voice.os, "unlink", lambda _p: None)
+        monkeypatch.setattr(voice, "play_audio_file", lambda p: played.append(p))
+
+        assert voice.speak_text("Recover me") is None
+        assert played == [returned_path]

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -342,3 +342,108 @@ def test_display_callback_fires_without_audio(monkeypatch):
 
     assert seen, "display_callback should fire even on the sync path"
     assert done.is_set()
+
+
+# ── tts.streaming.provider config knob (salvaged from PR #47588) ─────────
+
+
+def test_streaming_provider_knob_pins_streamer(monkeypatch):
+    _register_fake(monkeypatch, "faketts")
+    prov = ts.resolve_streaming_provider(
+        {"provider": "edge", "streaming": {"provider": "faketts"}}
+    )
+    assert isinstance(prov, ts.StreamingTTSProvider)
+
+
+def test_streaming_provider_knob_pin_unusable_returns_none(monkeypatch):
+    _register_fake(monkeypatch, "faketts", available=False)
+    # A pinned-but-unusable streamer must NOT fall through to another
+    # provider — the user asked for that one specifically.
+    _register_fake(monkeypatch, "otherstreamer")
+    assert ts.resolve_streaming_provider(
+        {"provider": "otherstreamer", "streaming": {"provider": "faketts"}}
+    ) is None
+
+
+def test_streaming_provider_auto_walks_priority(monkeypatch):
+    # elevenlabs unavailable, gemini available → auto resolves gemini.
+    _register_fake(monkeypatch, "elevenlabs", available=False)
+    fake_gemini = _register_fake(monkeypatch, "gemini")
+    _register_fake(monkeypatch, "openai")
+    prov = ts.resolve_streaming_provider(
+        {"provider": "edge", "streaming": {"provider": "auto"}}
+    )
+    assert isinstance(prov, fake_gemini)
+
+
+def test_streaming_provider_auto_none_when_nothing_usable(monkeypatch):
+    for name in ts._PROVIDER_PRIORITY:
+        _register_fake(monkeypatch, name, available=False)
+    assert ts.resolve_streaming_provider(
+        {"provider": "edge", "streaming": {"provider": "auto"}}
+    ) is None
+
+
+# ── Gemini SSE parsing ────────────────────────────────────────────────────
+
+
+def test_gemini_streamer_decodes_sse_pcm_chunks(monkeypatch):
+    import base64
+    import json as _json
+    import sys
+    import types
+
+    pcm1, pcm2 = b"\x01\x00" * 40, b"\x02\x00" * 40
+
+    def _event(pcm):
+        return "data: " + _json.dumps({
+            "candidates": [{"content": {"parts": [
+                {"inlineData": {"data": base64.b64encode(pcm).decode()}}
+            ]}}]
+        })
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def raise_for_status(self):
+            pass
+
+        def iter_lines(self, decode_unicode=True):
+            yield _event(pcm1)
+            yield ""  # SSE separator
+            yield ": heartbeat"  # comment line
+            yield _event(pcm2)
+
+    captured = {}
+
+    def _post(url, **kwargs):
+        captured["url"] = url
+        captured["params"] = kwargs.get("params")
+        captured["stream"] = kwargs.get("stream")
+        return _Resp()
+
+    fake_requests = types.ModuleType("requests")
+    fake_requests.post = _post
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+    monkeypatch.setattr(ts, "get_env_value", lambda k, *a: "g-key" if k in ("GEMINI_API_KEY", "GOOGLE_API_KEY") else None)
+
+    streamer = ts.GeminiStreamer({}, {"voice": "Kore"})
+    assert list(streamer.stream("Hello there.")) == [pcm1, pcm2]
+    assert captured["params"]["alt"] == "sse"
+    assert captured["params"]["key"] == "g-key"
+    assert captured["stream"] is True, "Gemini SSE must use a bounded streamed body"
+
+
+# ── xAI WebSocket bridge ─────────────────────────────────────────────────
+
+
+def test_xai_streamer_yields_collected_frames(monkeypatch):
+    frames = [b"\x01\x00" * 30, b"\x02\x00" * 30]
+    streamer = ts.XAIStreamer.__new__(ts.XAIStreamer)
+    streamer.tts_config, streamer.section = {}, {}
+    monkeypatch.setattr(streamer, "_collect_async", lambda text: list(frames))
+    assert list(streamer.stream("A sentence.")) == frames

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -124,9 +124,11 @@ def test_never_swaps_provider_for_streaming(monkeypatch):
 
 
 def test_elevenlabs_available_reflects_key(monkeypatch):
-    monkeypatch.setattr(ts, "get_env_value", lambda k, *a: "key" if k == "ELEVENLABS_API_KEY" else None)
+    # Key lookups now route through the provider-secret resolver
+    # (config > env/.env > credential pool), not bare get_env_value.
+    monkeypatch.setattr(ts, "_resolve_key", lambda env, pid: "key" if env == "ELEVENLABS_API_KEY" else "")
     assert ts.ElevenLabsStreamer.available() is True
-    monkeypatch.setattr(ts, "get_env_value", lambda k, *a: None)
+    monkeypatch.setattr(ts, "_resolve_key", lambda env, pid: "")
     assert ts.ElevenLabsStreamer.available() is False
 
 
@@ -384,6 +386,41 @@ def test_streaming_provider_auto_none_when_nothing_usable(monkeypatch):
     ) is None
 
 
+# ── Credential routing: resolve_provider_secret, never bare env ──────────
+
+
+def test_elevenlabs_available_routes_through_secret_resolver(monkeypatch):
+    calls = []
+
+    def _fake_resolve(env_var, provider_id):
+        calls.append((env_var, provider_id))
+        return "pool-key"
+
+    monkeypatch.setattr(ts, "_resolve_key", _fake_resolve)
+    assert ts.ElevenLabsStreamer.available() is True
+    assert ("ELEVENLABS_API_KEY", "elevenlabs") in calls
+
+
+def test_gemini_available_falls_back_to_google_key(monkeypatch):
+    keys = {"GOOGLE_API_KEY": "g-key"}
+    monkeypatch.setattr(ts, "_resolve_key", lambda env, pid: keys.get(env, ""))
+    assert ts.GeminiStreamer.available() is True
+    keys.clear()
+    assert ts.GeminiStreamer.available() is False
+
+
+def test_xai_available_uses_oauth_credential_resolver(monkeypatch):
+    import sys
+    import types
+
+    fake = types.ModuleType("tools.xai_http")
+    fake.resolve_xai_http_credentials = lambda: {"api_key": "xai-key"}
+    monkeypatch.setitem(sys.modules, "tools.xai_http", fake)
+    assert ts.XAIStreamer.available() is True
+    fake.resolve_xai_http_credentials = lambda: {"api_key": ""}
+    assert ts.XAIStreamer.available() is False
+
+
 # ── Gemini SSE parsing ────────────────────────────────────────────────────
 
 
@@ -429,7 +466,7 @@ def test_gemini_streamer_decodes_sse_pcm_chunks(monkeypatch):
     fake_requests = types.ModuleType("requests")
     fake_requests.post = _post
     monkeypatch.setitem(sys.modules, "requests", fake_requests)
-    monkeypatch.setattr(ts, "get_env_value", lambda k, *a: "g-key" if k in ("GEMINI_API_KEY", "GOOGLE_API_KEY") else None)
+    monkeypatch.setattr(ts, "_resolve_key", lambda env, pid: "g-key")
 
     streamer = ts.GeminiStreamer({}, {"voice": "Kore"})
     assert list(streamer.stream("Hello there.")) == [pcm1, pcm2]
@@ -447,3 +484,18 @@ def test_xai_streamer_yields_collected_frames(monkeypatch):
     streamer.tts_config, streamer.section = {}, {}
     monkeypatch.setattr(streamer, "_collect_async", lambda text: list(frames))
     assert list(streamer.stream("A sentence.")) == frames
+
+
+# ── 16 MiB per-sentence stream cap ───────────────────────────────────────
+
+
+def test_stream_cap_truncates_runaway_upstream(monkeypatch):
+    monkeypatch.setattr(ts, "_STREAM_SENTENCE_BYTE_CAP", 100)
+
+    def _endless():
+        while True:
+            yield b"\x00" * 64
+
+    out = list(ts._capped(_endless(), "test"))
+    assert len(out) == 1  # 64 ok, 128 > cap → stop
+    assert sum(len(c) for c in out) <= 100

--- a/tests/tools/test_tts_streaming_e2e.py
+++ b/tests/tools/test_tts_streaming_e2e.py
@@ -1,0 +1,109 @@
+"""End-to-end tests for streaming TTS providers. Gated on real API keys.
+
+Salvaged from PR #47588 (@Cdddo) and adapted to the current provider ABC
+(``StreamingTTSProvider(tts_config, section)``). These tests are SKIPPED by
+default — they only run when the relevant credential is present. They're
+useful for catching provider-API drift and verifying the integration
+end-to-end, but they shouldn't run in CI without secrets configured.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+def _has_xai_creds() -> bool:
+    # Plain os.environ, matching the other gates here: the repo's test
+    # conftest scrubs dotenv/pooled secrets, so gating on the richer
+    # resolver would collect a test whose runtime credentials are gone.
+    return bool(os.environ.get("XAI_API_KEY"))
+
+
+# --- ElevenLabs ---
+
+
+@pytest.mark.skipif(
+    not os.environ.get("ELEVENLABS_API_KEY"),
+    reason="ELEVENLABS_API_KEY not set",
+)
+def test_elevenlabs_streaming_real():
+    """Generate audio from the real ElevenLabs API and verify non-empty chunks."""
+    from tools.tts_streaming import ElevenLabsStreamer
+
+    provider = ElevenLabsStreamer({}, {})
+    chunks = list(provider.stream("Hello world, this is a test."))
+    assert len(chunks) > 0
+    total_bytes = sum(len(c) for c in chunks)
+    # 1s of PCM at 24kHz mono int16 = 48000 bytes; expect at least 1k for real audio
+    assert total_bytes > 1000
+
+
+# --- Gemini ---
+
+
+@pytest.mark.skipif(
+    not (os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")),
+    reason="GEMINI_API_KEY/GOOGLE_API_KEY not set",
+)
+def test_gemini_streaming_real():
+    """Generate audio from the real Gemini SSE API and verify non-empty chunks."""
+    from tools.tts_streaming import GeminiStreamer
+
+    provider = GeminiStreamer({}, {})
+    chunks = list(provider.stream("Hola, esto es una prueba."))
+    assert len(chunks) > 0
+    total_bytes = sum(len(c) for c in chunks)
+    assert total_bytes > 1000
+
+
+# --- OpenAI ---
+
+
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY not set",
+)
+def test_openai_streaming_real():
+    """Generate audio from the real OpenAI API and verify non-empty chunks."""
+    from tools.tts_streaming import OpenAIStreamer
+
+    provider = OpenAIStreamer({}, {})
+    chunks = list(provider.stream("Hello, this is a test."))
+    assert len(chunks) > 0
+    total_bytes = sum(len(c) for c in chunks)
+    assert total_bytes > 1000
+
+
+# --- xAI ---
+
+
+@pytest.mark.skipif(not _has_xai_creds(), reason="no xAI credentials")
+def test_xai_streaming_real():
+    """Generate audio from the real xAI WebSocket API and verify non-empty frames."""
+    from tools.tts_streaming import XAIStreamer
+
+    provider = XAIStreamer({}, {})
+    chunks = list(provider.stream("Hello, this is a test."))
+    assert len(chunks) > 0
+    total_bytes = sum(len(c) for c in chunks)
+    assert total_bytes > 1000
+
+
+# --- Resolver integration (no network; requires at least one key) ---
+
+
+@pytest.mark.skipif(
+    not (
+        os.environ.get("ELEVENLABS_API_KEY")
+        or os.environ.get("GEMINI_API_KEY")
+        or os.environ.get("GOOGLE_API_KEY")
+        or os.environ.get("OPENAI_API_KEY")
+    ),
+    reason="no streaming-capable TTS key set",
+)
+def test_auto_resolver_finds_a_real_provider():
+    from tools.tts_streaming import StreamingTTSProvider, resolve_streaming_provider
+
+    provider = resolve_streaming_provider({"streaming": {"provider": "auto"}})
+    assert isinstance(provider, StreamingTTSProvider)

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -139,17 +139,8 @@ def register(name: str) -> Callable[[type[StreamingTTSProvider]], type[Streaming
     return _wrap
 
 
-def resolve_streaming_provider(
-    tts_config: Dict,
-    preferred: Optional[str] = None,
-) -> Optional[StreamingTTSProvider]:
-    """Return a ready streamer for the *configured* provider, else ``None``.
-
-    ``None`` means "no chunked API for this provider" — the dispatcher then
-    speaks per-sentence via the sync path, preserving the user's chosen voice.
-    We never silently swap to a different provider just to get streaming.
-    """
-    name = (preferred or _get_provider(tts_config)).lower().strip()
+def _try_instantiate(name: str, tts_config: Dict) -> Optional[StreamingTTSProvider]:
+    """Construct the registered streamer *name* if it's usable, else None."""
     cls = _REGISTRY.get(name)
     if cls is None or not cls.available():
         return None
@@ -158,6 +149,47 @@ def resolve_streaming_provider(
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("streaming provider %s init failed: %s", name, exc)
         return None
+
+
+# Fallback priority for ``tts.streaming.provider: auto`` — best chunked
+# latency/quality first. Deliberately hard-coded (a UX decision, not a
+# config knob); edge is absent because it has no chunked-PCM API — the
+# dispatcher's per-sentence sync path keeps it conversational instead.
+_PROVIDER_PRIORITY: List[str] = ["elevenlabs", "gemini", "openai", "xai"]
+
+
+def resolve_streaming_provider(
+    tts_config: Dict,
+    preferred: Optional[str] = None,
+) -> Optional[StreamingTTSProvider]:
+    """Return a ready streamer for the *configured* provider, else ``None``.
+
+    Resolution order:
+
+    1. ``tts.streaming.provider`` (config knob) when set:
+       * a provider name pins that exact streamer (or ``None`` if unusable);
+       * ``auto`` walks the priority list (``elevenlabs → gemini → openai
+         → xai``) and returns the first usable streamer — an explicit
+         opt-in to "give me the best chunked voice available".
+    2. Otherwise the *configured* TTS provider (or ``preferred`` override).
+       ``None`` means "no chunked API for this provider" — the dispatcher
+       then speaks per-sentence via the sync path, preserving the user's
+       chosen voice. We never silently swap to a different provider just
+       to get streaming.
+    """
+    streaming_cfg = tts_config.get("streaming") or {}
+    pinned = str(streaming_cfg.get("provider") or "").lower().strip()
+    if pinned == "auto":
+        for name in _PROVIDER_PRIORITY:
+            inst = _try_instantiate(name, tts_config)
+            if inst is not None:
+                return inst
+        return None
+    if pinned:
+        return _try_instantiate(pinned, tts_config)
+
+    name = (preferred or _get_provider(tts_config)).lower().strip()
+    return _try_instantiate(name, tts_config)
 
 
 # ---------------------------------------------------------------------------
@@ -238,3 +270,168 @@ class OpenAIStreamer(StreamingTTSProvider):
             response_format="pcm",
         ) as response:
             yield from response.iter_bytes()
+
+
+@register("gemini")
+class GeminiStreamer(StreamingTTSProvider):
+    """Gemini ``streamGenerateContent?alt=sse`` → base64 PCM chunks (24 kHz).
+
+    Each SSE event carries one base64-encoded PCM chunk under
+    ``candidates[0].content.parts[*].inlineData.data``; we decode and yield
+    each one as it arrives.
+    """
+
+    sample_rate = 24000
+
+    @staticmethod
+    def available() -> bool:
+        return bool(
+            get_env_value("GEMINI_API_KEY") or get_env_value("GOOGLE_API_KEY")
+        )
+
+    def stream(self, text: str) -> Iterator[bytes]:
+        import base64
+        import json as _json
+
+        import requests
+
+        from tools.tts_tool import (
+            DEFAULT_GEMINI_TTS_BASE_URL,
+            DEFAULT_GEMINI_TTS_MODEL,
+            DEFAULT_GEMINI_TTS_VOICE,
+        )
+
+        api_key = (
+            get_env_value("GEMINI_API_KEY") or get_env_value("GOOGLE_API_KEY")
+        )
+        model = str(self.section.get("model", DEFAULT_GEMINI_TTS_MODEL)).strip() or DEFAULT_GEMINI_TTS_MODEL
+        voice = str(self.section.get("voice", DEFAULT_GEMINI_TTS_VOICE)).strip() or DEFAULT_GEMINI_TTS_VOICE
+        base_url = str(
+            self.section.get("base_url")
+            or get_env_value("GEMINI_BASE_URL")
+            or DEFAULT_GEMINI_TTS_BASE_URL
+        ).strip().rstrip("/")
+
+        payload = {
+            "contents": [{"parts": [{"text": text}]}],
+            "generationConfig": {
+                "responseModalities": ["AUDIO"],
+                "speechConfig": {
+                    "voiceConfig": {
+                        "prebuiltVoiceConfig": {"voiceName": voice},
+                    },
+                },
+            },
+        }
+        # ``?alt=sse`` flips the response from a single JSON blob to an SSE
+        # feed of base64 PCM chunks — the whole point of this provider.
+        url = f"{base_url}/models/{model}:streamGenerateContent"
+
+        def _sse_chunks() -> Iterator[bytes]:
+            with requests.post(
+                url,
+                params={"alt": "sse", "key": api_key},
+                json=payload,
+                timeout=60,
+                stream=True,
+            ) as response:
+                response.raise_for_status()
+                for line in response.iter_lines(decode_unicode=True):
+                    if not line or not line.startswith("data: "):
+                        continue
+                    try:
+                        event = _json.loads(line[len("data: "):])
+                        parts = event["candidates"][0]["content"]["parts"]
+                    except (ValueError, KeyError, IndexError, TypeError):
+                        continue
+                    for part in parts:
+                        inline = part.get("inlineData") or part.get("inline_data") or {}
+                        b64 = inline.get("data", "")
+                        if not b64:
+                            continue
+                        try:
+                            yield base64.b64decode(b64)
+                        except (ValueError, TypeError) as exc:
+                            logger.warning("Gemini SSE: bad base64 audio: %s", exc)
+
+        yield from _sse_chunks()
+
+
+@register("xai")
+class XAIStreamer(StreamingTTSProvider):
+    """xAI WebSocket TTS → binary PCM frames (24 kHz mono int16).
+
+    xAI's chunked TTS API is WebSocket-only (``wss://api.x.ai/v1/tts``).
+    The async WS loop is bridged to the sync iterator contract via
+    ``_collect_async`` — the seam unit tests monkeypatch.
+    """
+
+    sample_rate = 24000
+
+    @staticmethod
+    def available() -> bool:
+        return bool(get_env_value("XAI_API_KEY"))
+
+    def stream(self, text: str) -> Iterator[bytes]:
+        yield from self._collect_async(text)
+
+    # -- async→sync bridge (test seam) ------------------------------------
+
+    def _collect_async(self, text: str) -> List[bytes]:
+        import asyncio
+
+        return asyncio.run(self._drain_async(text))
+
+    async def _drain_async(self, text: str) -> List[bytes]:
+        frames: List[bytes] = []
+        async for frame in self._async_frames(text):
+            frames.append(frame)
+        return frames
+
+    async def _async_frames(self, text: str):
+        import json as _json
+
+        import websockets
+
+        from tools.tts_tool import DEFAULT_XAI_VOICE_ID
+
+        api_key = (get_env_value("XAI_API_KEY") or "").strip()
+        if not api_key:
+            raise RuntimeError("XAI_API_KEY not set; cannot use xAI streaming TTS")
+        voice = str(self.section.get("voice_id", DEFAULT_XAI_VOICE_ID)).strip() or DEFAULT_XAI_VOICE_ID
+        ws_url = str(
+            self.section.get("streaming_url") or "wss://api.x.ai/v1/tts"
+        ).strip()
+
+        async with websockets.connect(
+            ws_url, extra_headers={"Authorization": f"Bearer {api_key}"}
+        ) as ws:
+            await ws.send(_json.dumps({
+                "text": text,
+                "voice_id": voice,
+                "response_format": "pcm",
+            }))
+            try:
+                while True:
+                    message = await ws.recv()
+                    if isinstance(message, (bytes, bytearray, memoryview)):
+                        yield bytes(message)
+                        continue
+                    try:
+                        envelope = _json.loads(message)
+                    except (ValueError, TypeError):
+                        if message == "done":
+                            return
+                        continue
+                    etype = envelope.get("type")
+                    if etype == "done":
+                        return
+                    if etype == "error":
+                        logger.warning("xAI WS error envelope: %s",
+                                       envelope.get("error") or envelope.get("message") or envelope)
+                        return
+            except Exception as exc:
+                if exc.__class__.__name__ == "ConnectionClosed":
+                    return
+                logger.warning("xAI WS receive failed: %s", exc)
+                return

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -32,6 +32,27 @@ from tools.tts_tool import _get_provider, _load_tts_config, get_env_value
 
 logger = logging.getLogger(__name__)
 
+# Upper bound on the PCM bytes accepted from one provider stream for one
+# sentence. Mirrors the 16 MiB bounded-upstream-body invariant of the sync
+# providers (``_read_tts_response_bytes`` in tools.tts_tool): a buggy or
+# hostile endpoint must not be able to feed us unbounded audio.
+_STREAM_SENTENCE_BYTE_CAP = 16 * 1024 * 1024
+
+
+def _resolve_key(env_var: str, provider_id: str) -> str:
+    """Provider secret lookup: config > env/.env > credential pool.
+
+    Thin, monkeypatchable seam over ``tools.tts_tool._resolve_provider_key``
+    (which delegates to ``resolve_provider_secret``). ALL streaming-provider
+    key lookups go through here — never bare ``get_env_value``.
+    """
+    try:
+        from tools.tts_tool import _resolve_provider_key
+
+        return _resolve_provider_key(env_var, provider_id) or ""
+    except Exception:
+        return get_env_value(env_var) or ""
+
 
 # ---------------------------------------------------------------------------
 # Interruption latch — lets the model know it was cut off mid-speech
@@ -204,7 +225,7 @@ class ElevenLabsStreamer(StreamingTTSProvider):
 
     @staticmethod
     def available() -> bool:
-        return bool(get_env_value("ELEVENLABS_API_KEY"))
+        return bool(_resolve_key("ELEVENLABS_API_KEY", "elevenlabs"))
 
     def stream(self, text: str) -> Iterator[bytes]:
         from tools.tts_tool import (
@@ -215,7 +236,7 @@ class ElevenLabsStreamer(StreamingTTSProvider):
         )
 
         client = _import_elevenlabs()(
-            api_key=get_env_value("ELEVENLABS_API_KEY"),
+            api_key=_resolve_key("ELEVENLABS_API_KEY", "elevenlabs"),
             **_elevenlabs_environment_kwargs(self.section),
         )
         voice_id = self.section.get("voice_id", DEFAULT_ELEVENLABS_VOICE_ID)
@@ -269,16 +290,33 @@ class OpenAIStreamer(StreamingTTSProvider):
             input=text,
             response_format="pcm",
         ) as response:
-            yield from response.iter_bytes()
+            yield from _capped(response.iter_bytes(), "OpenAI streaming TTS")
+
+
+def _capped(chunks: Iterator[bytes], label: str) -> Iterator[bytes]:
+    """Pass chunks through, aborting past the 16 MiB per-sentence cap.
+
+    The streaming mirror of ``_read_tts_response_bytes``'s bounded-body
+    invariant: one sentence of PCM should never approach the cap, so
+    exceeding it means a runaway/hostile upstream — stop pulling.
+    """
+    total = 0
+    for chunk in chunks:
+        total += len(chunk)
+        if total > _STREAM_SENTENCE_BYTE_CAP:
+            logger.warning("%s exceeded %d bytes for one sentence; truncating",
+                           label, _STREAM_SENTENCE_BYTE_CAP)
+            return
+        yield chunk
 
 
 @register("gemini")
 class GeminiStreamer(StreamingTTSProvider):
     """Gemini ``streamGenerateContent?alt=sse`` → base64 PCM chunks (24 kHz).
 
-    Each SSE event carries one base64-encoded PCM chunk under
-    ``candidates[0].content.parts[*].inlineData.data``; we decode and yield
-    each one as it arrives.
+    Salvaged from PR #47588 (@Cdddo) and rebased onto the post-campaign
+    infrastructure: credentials via the provider-secret resolver, requests
+    (not httpx) with a bounded streamed body, and main's provider ABC.
     """
 
     sample_rate = 24000
@@ -286,7 +324,8 @@ class GeminiStreamer(StreamingTTSProvider):
     @staticmethod
     def available() -> bool:
         return bool(
-            get_env_value("GEMINI_API_KEY") or get_env_value("GOOGLE_API_KEY")
+            _resolve_key("GEMINI_API_KEY", "gemini")
+            or _resolve_key("GOOGLE_API_KEY", "gemini")
         )
 
     def stream(self, text: str) -> Iterator[bytes]:
@@ -302,7 +341,8 @@ class GeminiStreamer(StreamingTTSProvider):
         )
 
         api_key = (
-            get_env_value("GEMINI_API_KEY") or get_env_value("GOOGLE_API_KEY")
+            _resolve_key("GEMINI_API_KEY", "gemini")
+            or _resolve_key("GOOGLE_API_KEY", "gemini")
         )
         model = str(self.section.get("model", DEFAULT_GEMINI_TTS_MODEL)).strip() or DEFAULT_GEMINI_TTS_MODEL
         voice = str(self.section.get("voice", DEFAULT_GEMINI_TTS_VOICE)).strip() or DEFAULT_GEMINI_TTS_VOICE
@@ -354,26 +394,35 @@ class GeminiStreamer(StreamingTTSProvider):
                         except (ValueError, TypeError) as exc:
                             logger.warning("Gemini SSE: bad base64 audio: %s", exc)
 
-        yield from _sse_chunks()
+        yield from _capped(_sse_chunks(), "Gemini streaming TTS")
 
 
 @register("xai")
 class XAIStreamer(StreamingTTSProvider):
     """xAI WebSocket TTS → binary PCM frames (24 kHz mono int16).
 
-    xAI's chunked TTS API is WebSocket-only (``wss://api.x.ai/v1/tts``).
-    The async WS loop is bridged to the sync iterator contract via
-    ``_collect_async`` — the seam unit tests monkeypatch.
+    Salvaged from PR #47588 (@Cdddo): xAI's chunked TTS API is
+    WebSocket-only (``wss://api.x.ai/v1/tts``). Credentials route through
+    ``resolve_xai_http_credentials`` (OAuth or XAI_API_KEY), same as the
+    sync ``_generate_xai_tts`` path. The async WS loop is bridged to the
+    sync iterator contract via ``_collect_async`` — the seam unit tests
+    monkeypatch.
     """
 
     sample_rate = 24000
 
     @staticmethod
     def available() -> bool:
-        return bool(get_env_value("XAI_API_KEY"))
+        try:
+            from tools.xai_http import resolve_xai_http_credentials
+
+            creds = resolve_xai_http_credentials()
+            return bool(str(creds.get("api_key") or "").strip())
+        except Exception:
+            return False
 
     def stream(self, text: str) -> Iterator[bytes]:
-        yield from self._collect_async(text)
+        yield from _capped(iter(self._collect_async(text)), "xAI streaming TTS")
 
     # -- async→sync bridge (test seam) ------------------------------------
 
@@ -394,10 +443,12 @@ class XAIStreamer(StreamingTTSProvider):
         import websockets
 
         from tools.tts_tool import DEFAULT_XAI_VOICE_ID
+        from tools.xai_http import resolve_xai_http_credentials
 
-        api_key = (get_env_value("XAI_API_KEY") or "").strip()
+        creds = resolve_xai_http_credentials()
+        api_key = str(creds.get("api_key") or "").strip()
         if not api_key:
-            raise RuntimeError("XAI_API_KEY not set; cannot use xAI streaming TTS")
+            raise RuntimeError("No xAI credentials for streaming TTS")
         voice = str(self.section.get("voice_id", DEFAULT_XAI_VOICE_ID)).strip() or DEFAULT_XAI_VOICE_ID
         ws_url = str(
             self.section.get("streaming_url") or "wss://api.x.ai/v1/tts"


### PR DESCRIPTION
# feat(voice): streaming TTS subsystem — clause-by-clause synthesis from provider registry to gateway adapters (salvages #47588 + #73358)

## Summary

Voice replies start speaking after the first clause instead of after full generation + synthesis — one provider-agnostic streaming dispatcher now serves the CLI/TUI speaker path, the gateway platform-adapter seam, and the dashboard speak-stream, with zero parallel streaming implementations left.

## Architecture

```
LLM token stream
      │ deltas
      ▼
SentenceChunker (tools/tts_streaming.py — think-block strip, min-length clause merge)
      │ complete clauses
      ▼
StreamingTTSProvider registry (resolve_streaming_provider)
  elevenlabs / openai / gemini / xai → raw int16 mono PCM chunks
      │
      ├─ local speaker: stream_tts_to_speaker → sounddevice.OutputStream
      │    (CLI voice mode; hermes_cli/voice.py speak_text now routes here too)
      └─ gateway: StreamingTTSConsumer → adapter begin/write/finish/abort_streaming_tts
           (opt-in BasePlatformAdapter contract; whole-file fallback preserved)
```

Text entering any path is cleaned by the one shared cleaner (`tools/tts_text_normalize.prepare_spoken_text`, via `_strip_markdown_for_tts`); the chunker's cross-delta `<think>` handling covers the split-across-deltas case the whole-text cleaner can't see.

## Provider streaming capability

| Provider | Transport | Chunked PCM | Credentials (via `resolve_provider_secret`) |
|---|---|---|---|
| elevenlabs | chunked HTTP `pcm_24000` | ✅ | `ELEVENLABS_API_KEY` / config / pool |
| openai | `with_streaming_response`, `pcm` | ✅ | `tts.openai.api_key` → env → managed gateway (config `base_url` honored) |
| gemini | SSE `streamGenerateContent?alt=sse` | ✅ NEW | `GEMINI_API_KEY` / `GOOGLE_API_KEY` |
| xai | WebSocket `wss://api.x.ai/v1/tts` | ✅ NEW | xAI OAuth or `XAI_API_KEY` (`resolve_xai_http_credentials`) |
| edge / piper / kitten / neutts / mistral / minimax / deepinfra / command / plugin | — | ❌ (per-sentence sync fallback keeps them conversational) | unchanged |

## Config

- `tts.streaming.provider`: unset (default) = stream with the configured `tts.provider` when it has a chunked API — never silently swaps the user's voice; a provider name pins that streamer; `auto` walks `elevenlabs → gemini → openai → xai` and takes the first with usable credentials.
- `tts.xai.streaming_url`: override the WS endpoint (default `wss://api.x.ai/v1/tts`).
- New doc: `docs/streaming-tts.md` (architecture, capability matrix, add-a-provider guide, gateway adapter contract).

## Salvaged contributor work

- **#47588 (@Cdddo, June 17)** — Gemini SSE + xAI WebSocket streaming providers, the `tts.streaming.provider` knob + priority fallback, docs, and key-gated E2E tests, rebased onto the post-campaign streaming core (main had meanwhile grown the ABC/registry + ElevenLabs/OpenAI streamers via the provider-agnostic streaming core commit `592effcb2a` and its config-parity follow-ups, so the overlapping pieces were unified under main's config-aware plumbing rather than duplicated). Authorship preserved (`a274f01932`).
- **#73358 (@ctaylor86, July 28)** — gateway clause-by-clause `StreamingTTSConsumer`, the opt-in `BasePlatformAdapter` streaming-audio contract (`supports/begin/write/finish/abort_streaming_tts`, `AudioFormat`, `StreamingTTSHandle`), `gateway/run.py` wiring with per-turn duplicate suppression and whole-file fallback, + 29 tests. Cherry-picked clean (`94530612cf`). The consumer already composes with Part 1 — it resolves synthesis exclusively through `resolve_streaming_provider()`/the provider ABC and reuses `SentenceChunker` (no competing parser, no per-provider code of its own).

Follow-up integration commits (ours):
- `7f072fcb2d` — all streaming key lookups routed through `resolve_provider_secret` (config > env/.env > credential pool; xAI through the OAuth resolver), and every provider's chunk iterator bounded at 16 MiB/sentence (`_capped`), mirroring the sync paths' `_read_tts_response_bytes` invariant.
- `0c4bac4760` — `hermes_cli/voice.py speak_text` (TUI/gateway one-shot TTS) routes through `stream_tts_to_speaker` when a streamer resolves, falling back to the whole-file path on no-streamer or failure (#58930).

## Validation

| Suite | Result |
|---|---|
| tests/tools/test_tts_streaming.py (registry, resolver knob, credential routing, SSE/WS parsing, cap, dispatcher) | 27 passed |
| tests/tools/test_tts_streaming_e2e.py (key-gated live) | 5 skipped (no keys in CI) |
| tests/gateway/test_streaming_tts_consumer.py + regression | 29 passed |
| tests/hermes_cli/test_voice_wrapper.py (incl. 3 new speak_text routing tests) | 57 passed |
| tests/tools/test_voice_cli_integration.py, test_audio_playback_guard.py | passed |
| Full targeted TTS suite (command providers, container repair, gemini, openai config, base_urls, body cap, prepare_spoken, normalize, xai speech tags, dotenv, opus routing, max length) | 200 passed |
| Gateway voice/streaming suite (stream_consumer, voice reply/notify/command, auto-TTS format, media routing, platform isolation + provider suites) | 490 passed |
| ruff on all touched files | clean |

Sabotage verification (each fails when its guard is removed, passes restored):
- `test_stream_cap_truncates_runaway_upstream` → red when the 16 MiB cap check is disabled (test hangs/fails on an endless iterator).
- `test_streaming_tts_consumer.py` → 2 red when the consumer's `resolve_streaming_provider` call is severed (`self._streamer = None`).
- `TestSpeakTextStreamingDispatch` → red when speak_text's streaming route is disabled.

## Scope / compatibility

- **Opt-in and behavior-preserving**: all `BasePlatformAdapter` streaming methods default to unsupported/no-op — existing adapters are untouched and keep whole-file voice replies. Sync-only providers (Piper/NeuTTS/Kitten/Mistral/edge/…) are unchanged; they keep per-sentence sync playback locally and whole-file replies on the gateway.
- `stream_tts_to_speaker` remains a behavior-preserving wrapper — all pre-existing streaming tests pass unchanged (one test updated for the legitimate bare-env → secret-resolver contract change).
- **Not claimed**: #47896 (plugin `TTSProvider.stream()` generic consumption) — plugin streamers yield encoded (opus) bytes, not PCM, and #73358 explicitly scoped the metadata gap out; wiring plugins into the PCM registry is a follow-up.

Closes: #58930, #60671
(#47896 intentionally NOT closed — see above.)

## Manual live-testing requested (Teknium)

- CLI `/voice on` with a streaming-capable provider configured (e.g. `tts.provider: openai` or `elevenlabs`) — confirm audio starts on sentence one and barge-in still cuts playback.
- TUI/gateway `speak_text` path (auto-speak of a reply) with the same provider — confirm earlier first audio and clean mic re-arm afterwards.
- A Discord/LiveKit voice session is NOT yet wired — no adapter overrides the streaming seam in this PR; the first adapter implementation is the natural follow-up.
- Optional: run the key-gated E2E tests locally (`pytest tests/tools/test_tts_streaming_e2e.py`) with real ELEVENLABS/GEMINI/OPENAI/XAI keys to confirm provider-API drift hasn't set in (xAI's WS envelope shape is the flagged fragile point).


## Infographic

![Streaming TTS](https://v3b.fal.media/files/b/0aa4271d/nS5bHAK9p8o1wO_D_SRHa_4evTGVzn.png)
