### PR TITLE
fix: route memory-provider dep installs through lazy_deps durable target (salvage #72335)

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -162,16 +162,22 @@ def _install_dependencies(provider_name: str, *, force: bool = False) -> None:
 
     print(f"\n  Installing dependencies: {', '.join(missing)}")
 
-    from hermes_cli.tools_config import _pip_install
+    # Environment-aware install: on immutable hosted images the agent venv
+    # is sealed read-only and installs must go to the durable target on the
+    # data volume (HERMES_LAZY_INSTALL_TARGET). install_specs handles the
+    # routing/gating; on normal installs it is venv-scoped as before (NS-605).
+    from tools.lazy_deps import install_specs
 
     manual_cmd = f"uv pip install {' '.join(missing)}"
     try:
-        result = _pip_install(["--quiet"] + missing, timeout=120)
-        if result.returncode == 0:
+        outcome = install_specs(missing, timeout=120)
+        if outcome.ok:
             print(f"  ✓ Installed {', '.join(missing)}")
+        elif outcome.blocked:
+            print(f"  ⚠ Cannot install {', '.join(missing)}: {outcome.reason}")
         else:
             print(f"  ⚠ Failed to install {', '.join(missing)}")
-            stderr = (result.stderr or "")[:200]
+            stderr = (outcome.stderr or "")[:200]
             if stderr:
                 print(f"    {stderr}")
             print(f"  Run manually: {manual_cmd}")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5967,24 +5967,38 @@ def _install_memory_provider_pip_dependencies(dependencies: List[str]) -> List[D
             _command_result(kind="pip", name=", ".join(dependencies), status="already_installed")
         ]
 
-    uv_path = shutil.which("uv")
-    if uv_path:
-        command: Any = [uv_path, "pip", "install", "--python", sys.executable, "--quiet", *missing]
-        display = f"uv pip install --python {sys.executable} {' '.join(missing)}"
-    else:
-        command = [sys.executable, "-m", "pip", "install", "--quiet", *missing]
-        display = f"{sys.executable} -m pip install {' '.join(missing)}"
-
+    # Route through the lazy-install pipeline (tools.lazy_deps.install_specs)
+    # instead of shelling out to pip against sys.executable directly. That
+    # pipeline is environment-aware: on hosted/immutable images the agent venv
+    # under /opt/hermes is sealed read-only, and installs must be redirected
+    # to the writable durable target on the data volume
+    # (HERMES_LAZY_INSTALL_TARGET, e.g. /opt/data/lazy-packages) — the same
+    # path every lazy backend already uses. A direct `pip install --python
+    # sys.executable` on those images fails with a permission error (NS-605).
+    # install_specs also activates the target on sys.path post-install so the
+    # availability recheck below sees the new packages without a restart.
     try:
-        completed = _run_setup_command(command, display=display, timeout=240)
+        from tools.lazy_deps import install_specs
+
+        outcome = install_specs(missing, timeout=240)
     except Exception as exc:
         return [
             _command_result(
                 kind="pip",
                 name=", ".join(missing),
                 status="failed",
-                command=display,
                 error=str(exc),
+            )
+        ]
+
+    if outcome.blocked:
+        return [
+            _command_result(
+                kind="pip",
+                name=", ".join(missing),
+                status="failed",
+                command=outcome.command,
+                error=outcome.reason,
             )
         ]
 
@@ -5992,9 +6006,14 @@ def _install_memory_provider_pip_dependencies(dependencies: List[str]) -> List[D
         _command_result(
             kind="pip",
             name=", ".join(missing),
-            status="installed" if completed.returncode == 0 else "failed",
-            command=display,
-            completed=completed,
+            status="installed" if outcome.ok else "failed",
+            command=outcome.command,
+            completed=subprocess.CompletedProcess(
+                args=outcome.command,
+                returncode=0 if outcome.ok else 1,
+                stdout=outcome.stdout,
+                stderr=outcome.stderr,
+            ),
         )
     ]
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -833,21 +833,18 @@ class HindsightMemoryProvider(MemoryProvider):
             provider_config["llm_provider"] = llm_provider
 
         print("\n  Checking dependencies...")
-        uv_path = shutil.which("uv")
-        if not uv_path:
-            print("  ⚠ uv not found — install it: curl -LsSf https://astral.sh/uv/install.sh | sh")
-            print(f"  Then run manually: uv pip install --python {sys.executable} {' '.join(deps_to_install)}")
+        # Environment-aware install: sealed hosted venvs redirect to the durable
+        # data-volume target instead of writing to /opt/hermes (NS-605).
+        from tools.lazy_deps import install_specs
+
+        outcome = install_specs(deps_to_install, timeout=120)
+        if outcome.ok:
+            print("  ✓ Dependencies up to date")
+        elif outcome.blocked:
+            print(f"  ⚠ Cannot install dependencies: {outcome.reason}")
         else:
-            try:
-                subprocess.run(
-                    [uv_path, "pip", "install", "--python", sys.executable, "--quiet", "--upgrade"] + deps_to_install,
-                    check=True, timeout=120, capture_output=True,
-                    stdin=subprocess.DEVNULL,
-                )
-                print("  ✓ Dependencies up to date")
-            except Exception as e:
-                print(f"  ⚠ Install failed: {e}")
-                print(f"  Run manually: uv pip install --python {sys.executable} {' '.join(deps_to_install)}")
+            print(f"  ⚠ Install failed:\n{(outcome.stderr or '').strip()}")
+            print(f"  Run manually: uv pip install --python {sys.executable} {' '.join(deps_to_install)}")
 
         # Step 3: Mode-specific config
         if mode == "cloud":
@@ -1234,24 +1231,18 @@ class HindsightMemoryProvider(MemoryProvider):
             if Version(installed) < Version(_MIN_CLIENT_VERSION):
                 logger.warning("hindsight-client %s is outdated (need >=%s), attempting upgrade...",
                                installed, _MIN_CLIENT_VERSION)
-                import shutil
-                import subprocess
-                import sys
-                uv_path = shutil.which("uv")
-                if uv_path:
-                    try:
-                        subprocess.run(
-                            [uv_path, "pip", "install", "--python", sys.executable,
-                             "--quiet", "--upgrade", f"hindsight-client>={_MIN_CLIENT_VERSION}"],
-                            check=True, timeout=120, capture_output=True,
-                            stdin=subprocess.DEVNULL,
-                        )
-                        logger.info("hindsight-client upgraded to >=%s", _MIN_CLIENT_VERSION)
-                    except Exception as e:
-                        logger.warning("Auto-upgrade failed: %s. Run: uv pip install 'hindsight-client>=%s'",
-                                       e, _MIN_CLIENT_VERSION)
+                # Environment-aware install: sealed hosted venvs redirect to the
+                # durable data-volume target instead of /opt/hermes (NS-605).
+                from tools.lazy_deps import install_specs
+                outcome = install_specs([f"hindsight-client>={_MIN_CLIENT_VERSION}"], timeout=120)
+                if outcome.ok:
+                    logger.info("hindsight-client upgraded to >=%s", _MIN_CLIENT_VERSION)
+                elif outcome.blocked:
+                    logger.warning("Auto-upgrade unavailable: %s. Run: uv pip install 'hindsight-client>=%s'",
+                                   outcome.reason, _MIN_CLIENT_VERSION)
                 else:
-                    logger.warning("uv not found. Run: pip install 'hindsight-client>=%s'", _MIN_CLIENT_VERSION)
+                    logger.warning("Auto-upgrade failed: %s. Run: uv pip install 'hindsight-client>=%s'",
+                                   (outcome.stderr or "").strip() or "install error", _MIN_CLIENT_VERSION)
         except Exception:
             pass  # packaging not available or other issue — proceed anyway
 

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -516,12 +516,17 @@ def _ensure_sdk_installed() -> bool:
         return False
 
     print("  Installing honcho-ai...", flush=True)
-    from hermes_cli.tools_config import _pip_install
+    # Environment-aware install: sealed hosted venvs redirect to the durable
+    # data-volume target instead of writing to /opt/hermes (NS-605).
+    from tools.lazy_deps import install_specs
 
-    result = _pip_install(["honcho-ai==2.2.0"])
-    if result.returncode == 0:
+    result = install_specs(["honcho-ai==2.2.0"])
+    if result.ok:
         print("  Installed.\n")
         return True
+    elif result.blocked:
+        print(f"  Cannot install: {result.reason}\n")
+        return False
     else:
         print(f"  Install failed:\n{(result.stderr or '').strip()}")
         print("  Run manually: uv pip install 'honcho-ai==2.2.0'\n")

--- a/plugins/memory/mem0/_setup.py
+++ b/plugins/memory/mem0/_setup.py
@@ -863,11 +863,17 @@ def _install_provider_deps(llm_id: str, embedder_id: str, vector_id: str) -> Non
     for dep in sorted(deps):
         try:
             print(f"  Installing {dep}...")
-            subprocess.run(
-                ["uv", "pip", "install", "--python", sys.executable, dep],
-                capture_output=True, timeout=60,
-            )
-            print(f"  ✓ Installed {dep}")
+            # Environment-aware install: sealed hosted venvs redirect to the
+            # durable data-volume target instead of /opt/hermes (NS-605).
+            from tools.lazy_deps import install_specs
+
+            outcome = install_specs([dep], timeout=60)
+            if outcome.ok:
+                print(f"  ✓ Installed {dep}")
+            elif outcome.blocked:
+                print(f"  Warning: cannot install {dep}: {outcome.reason}")
+            else:
+                print(f"  Warning: Could not install {dep}. Install manually: uv pip install {dep}")
         except Exception:
             print(f"  Warning: Could not install {dep}. Install manually: uv pip install {dep}")
     if deps:

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -293,13 +293,13 @@ def test_install_dependencies_force_reinstalls_versioned_specs(tmp_path, monkeyp
 
     installed = []
 
-    def fake_pip_install(args, timeout=120):
-        installed.append(args)
-        return SimpleNamespace(returncode=0, stderr="")
+    def fake_install_specs(specs, timeout=120):
+        installed.append(list(specs))
+        return SimpleNamespace(ok=True, blocked=False, reason="", stderr="")
 
-    monkeypatch.setattr("hermes_cli.tools_config._pip_install", fake_pip_install)
+    monkeypatch.setattr("tools.lazy_deps.install_specs", fake_install_specs)
 
     memory_setup._install_dependencies("mem0", force=True)
 
-    assert installed, "force=True must reach the pip install step"
-    assert any("mem0ai>=2.0.10,<3" in args for args in installed)
+    assert installed, "force=True must reach the install step"
+    assert any("mem0ai>=2.0.10,<3" in specs for specs in installed)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -833,6 +833,107 @@ class TestWebServerEndpoints:
         ]
         assert calls[-1][0] == ["brv", "--version"]
 
+    def test_post_memory_provider_setup_routes_pip_through_lazy_deps(self, monkeypatch):
+        """NS-605: dashboard pip installs must use the environment-aware
+        lazy_deps pipeline (durable-target redirect on immutable hosted
+        images), never a direct `pip install --python sys.executable`."""
+        import subprocess as _subprocess
+
+        import hermes_cli.web_server as web_server
+        from tools import lazy_deps as ld
+
+        # honcho declares pip_dependencies: [honcho-ai]; force it missing.
+        monkeypatch.setattr(web_server, "_dependency_importable", lambda dep: False)
+
+        installed = []
+
+        def fake_install_specs(specs, *, timeout=300):
+            installed.append(tuple(specs))
+            return ld.InstallSpecsResult(
+                ok=True, command="uv pip install --target /opt/data/lazy-packages honcho-ai",
+                stdout="ok", stderr="",
+            )
+
+        monkeypatch.setattr(ld, "install_specs", fake_install_specs)
+
+        # Any direct pip/uv subprocess from the memory-provider pip path is
+        # a regression; external-dep checks may still run subprocess, so only
+        # trip on pip-flavored commands.
+        real_run = _subprocess.run
+
+        def guarded_run(command, **kwargs):
+            flat = command if isinstance(command, str) else " ".join(map(str, command))
+            assert "pip install" not in flat, f"direct pip call leaked: {flat}"
+            return real_run(command, **kwargs)
+
+        monkeypatch.setattr(web_server.subprocess, "run", guarded_run)
+
+        resp = self.client.post("/api/memory/providers/honcho/setup", json={"values": {}})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        pip_rows = [row for row in data["results"] if row["kind"] == "pip"]
+        assert pip_rows and pip_rows[0]["status"] == "installed"
+        assert "--target /opt/data/lazy-packages" in pip_rows[0]["command"]
+        assert installed == [("honcho-ai",)]
+
+    def test_post_memory_provider_setup_reports_blocked_install_reason(self, monkeypatch):
+        """When installs are gated off (sealed venv, no durable target),
+        the dashboard surfaces the actionable reason instead of a raw
+        permission error."""
+        import hermes_cli.web_server as web_server
+        from tools import lazy_deps as ld
+
+        monkeypatch.setattr(web_server, "_dependency_importable", lambda dep: False)
+        monkeypatch.setattr(
+            ld, "install_specs",
+            lambda specs, *, timeout=300: ld.InstallSpecsResult(
+                ok=False, blocked=True,
+                reason=(
+                    "runtime installs are disabled on this deployment: the "
+                    "agent environment is immutable and no writable install "
+                    "target is configured (HERMES_LAZY_INSTALL_TARGET)"
+                ),
+            ),
+        )
+
+        resp = self.client.post("/api/memory/providers/honcho/setup", json={"values": {}})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is False
+        pip_rows = [row for row in data["results"] if row["kind"] == "pip"]
+        assert pip_rows and pip_rows[0]["status"] == "failed"
+        assert "immutable" in pip_rows[0]["stderr"]
+
+    def test_post_memory_provider_setup_recheck_clears_stale_missing_state(self, monkeypatch):
+        """After a successful install, the same response's status block must
+        reflect the new availability (no restart, no stale 'missing deps')."""
+        import hermes_cli.web_server as web_server
+        from tools import lazy_deps as ld
+
+        installed_now = {"flag": False}
+
+        def fake_importable(dep):
+            return installed_now["flag"]
+
+        monkeypatch.setattr(web_server, "_dependency_importable", fake_importable)
+
+        def fake_install_specs(specs, *, timeout=300):
+            installed_now["flag"] = True  # install makes the package importable
+            return ld.InstallSpecsResult(ok=True, command="uv pip install honcho-ai")
+
+        monkeypatch.setattr(ld, "install_specs", fake_install_specs)
+
+        resp = self.client.post("/api/memory/providers/honcho/setup", json={"values": {}})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        status = data["status"]
+        assert status is not None
+        assert status["setup"]["dependencies_installed"] is True
+
     def test_post_unknown_memory_provider_setup_returns_404(self):
         resp = self.client.post("/api/memory/providers/nope/setup", json={"values": {}})
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1842,12 +1842,16 @@ class TestPostSetupEnvEncoding:
     def _run_cloud_post_setup(self, tmp_path, monkeypatch):
         """Drive post_setup through the cloud path with piped stdin."""
         import io
-        import shutil as shutil_mod
 
         monkeypatch.setattr("hermes_cli.memory_setup._curses_select",
                             lambda *a, **kw: 0)  # cloud mode
         monkeypatch.setattr("hermes_cli.config.save_config", lambda c: None)
-        monkeypatch.setattr(shutil_mod, "which", lambda *_: None)  # skip uv install
+        # Skip the dependency install (now routed through lazy_deps, NS-605).
+        import tools.lazy_deps as lazy_deps_mod
+        monkeypatch.setattr(
+            lazy_deps_mod, "install_specs",
+            lambda *a, **kw: lazy_deps_mod.InstallSpecsResult(ok=True),
+        )
         # First line: API key prompt (readline). Second line: API URL (input).
         monkeypatch.setattr(sys, "stdin", io.StringIO("sk-new\n\n"))
 
@@ -1879,3 +1883,65 @@ class TestPostSetupEnvEncoding:
         content = env_path.read_text(encoding="utf-8")
         assert "PROXY_NOTE=café-zürich-完了" in content
         assert "HINDSIGHT_API_KEY=sk-new" in content
+
+
+class TestClientAutoUpgradeRoutesThroughLazyDeps:
+    """The initialize()-time hindsight-client auto-upgrade must go through
+    lazy_deps.install_specs() (environment-aware, durable-target on sealed
+    hosted venvs) — never a direct `uv pip install --python sys.executable`
+    subprocess, which fails with EROFS/EACCES on immutable images (NS-605)."""
+
+    def _init_with_outdated_client(self, tmp_path, monkeypatch, outcome):
+        import importlib.metadata as md
+        import subprocess as subprocess_mod
+        import tools.lazy_deps as lazy_deps_mod
+
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({"mode": "cloud"}))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+
+        # Simulate an installed-but-outdated client.
+        monkeypatch.setattr(md, "version", lambda name: "0.0.1")
+
+        calls = []
+        monkeypatch.setattr(
+            lazy_deps_mod, "install_specs",
+            lambda specs, **kw: calls.append(tuple(specs)) or outcome,
+        )
+
+        # Regression guard: no direct pip subprocess may run.
+        def _no_subprocess(*a, **kw):  # pragma: no cover - fails loudly
+            raise AssertionError(f"unexpected subprocess.run during auto-upgrade: {a}")
+        monkeypatch.setattr(subprocess_mod, "run", _no_subprocess)
+
+        provider = HindsightMemoryProvider()
+        provider.initialize(session_id="s", hermes_home=str(tmp_path), platform="cli")
+        return calls
+
+    def test_upgrade_uses_install_specs_not_subprocess(self, tmp_path, monkeypatch):
+        from plugins.memory.hindsight import _MIN_CLIENT_VERSION
+        from tools.lazy_deps import InstallSpecsResult
+
+        calls = self._init_with_outdated_client(
+            tmp_path, monkeypatch, InstallSpecsResult(ok=True)
+        )
+        assert calls == [(f"hindsight-client>={_MIN_CLIENT_VERSION}",)]
+
+    def test_blocked_upgrade_is_nonfatal_and_surfaces_reason(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        import logging
+        from tools.lazy_deps import InstallSpecsResult
+
+        with caplog.at_level(logging.WARNING):
+            calls = self._init_with_outdated_client(
+                tmp_path, monkeypatch,
+                InstallSpecsResult(ok=False, blocked=True,
+                                   reason="runtime installs are disabled on this deployment"),
+            )
+        assert len(calls) == 1  # attempted exactly once, init still completed
+        assert any("runtime installs are disabled" in r.getMessage()
+                   for r in caplog.records)

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -472,3 +472,158 @@ class TestRefreshActiveFeatures:
         result = ld.refresh_active_features()
         assert result["a.ok"] == "current"
         assert result["b.fail"].startswith("failed:")
+
+
+# ---------------------------------------------------------------------------
+# install_specs — manifest-driven installs (dashboard memory providers etc.)
+#
+# NS-605: the dashboard's memory-provider setup endpoint used to shell out
+# to `uv pip install --python sys.executable`, which fails with a permission
+# error on the sealed hosted venv. install_specs routes those installs
+# through the same environment-aware pipeline as ensure(): venv-scoped on
+# normal installs, redirected to the durable target on immutable images,
+# and cleanly refused (with a reason) when installs are gated off.
+# ---------------------------------------------------------------------------
+
+
+class TestInstallSpecs:
+    def test_empty_specs_is_trivially_ok(self, monkeypatch):
+        monkeypatch.setattr(
+            ld, "_venv_pip_install",
+            lambda *a, **kw: pytest.fail("pip should not be called"),
+        )
+        result = ld.install_specs([])
+        assert result.ok is True
+        assert result.blocked is False
+
+    def test_blank_specs_are_ignored(self, monkeypatch):
+        monkeypatch.setattr(
+            ld, "_venv_pip_install",
+            lambda *a, **kw: pytest.fail("pip should not be called"),
+        )
+        result = ld.install_specs(["", "   "])
+        assert result.ok is True
+
+    @pytest.mark.parametrize("bad", [
+        "pkg; rm -rf /",
+        "-e git+https://evil.example/repo.git",
+        "https://evil.example/pkg.tar.gz",
+        "../../etc/passwd",
+        "pkg @ file:///tmp/x",
+    ])
+    def test_unsafe_specs_are_blocked_before_any_install(self, monkeypatch, bad):
+        monkeypatch.setattr(
+            ld, "_venv_pip_install",
+            lambda *a, **kw: pytest.fail("pip should not be called"),
+        )
+        result = ld.install_specs([bad])
+        assert result.ok is False
+        assert result.blocked is True
+        assert "unsafe spec" in result.reason
+
+    def test_one_unsafe_spec_blocks_the_whole_batch(self, monkeypatch):
+        monkeypatch.setattr(
+            ld, "_venv_pip_install",
+            lambda *a, **kw: pytest.fail("pip should not be called"),
+        )
+        result = ld.install_specs(["honcho-ai==2.2.0", "pkg; rm -rf /"])
+        assert result.blocked is True
+
+    def test_sealed_venv_without_target_reports_immutable_reason(self, monkeypatch):
+        # HERMES_DISABLE_LAZY_INSTALLS=1 with no durable target: never touch
+        # pip, never surface EROFS — report an actionable reason instead.
+        monkeypatch.setenv("HERMES_DISABLE_LAZY_INSTALLS", "1")
+        monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda: {}, raising=False
+        )
+        monkeypatch.setattr(
+            ld, "_venv_pip_install",
+            lambda *a, **kw: pytest.fail("pip should not be called"),
+        )
+        result = ld.install_specs(["honcho-ai==2.2.0"])
+        assert result.ok is False
+        assert result.blocked is True
+        assert "immutable" in result.reason
+        assert "HERMES_LAZY_INSTALL_TARGET" in result.reason
+
+    def test_config_killswitch_reports_config_reason(self, monkeypatch):
+        monkeypatch.delenv("HERMES_DISABLE_LAZY_INSTALLS", raising=False)
+        monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"security": {"allow_lazy_installs": False}},
+            raising=False,
+        )
+        monkeypatch.setattr(
+            ld, "_venv_pip_install",
+            lambda *a, **kw: pytest.fail("pip should not be called"),
+        )
+        result = ld.install_specs(["honcho-ai==2.2.0"])
+        assert result.blocked is True
+        assert "allow_lazy_installs" in result.reason
+
+    def test_sealed_venv_with_target_installs(self, monkeypatch, tmp_path):
+        # The hosted-image configuration: sealed venv + durable target.
+        # install_specs must proceed (the redirect is the safe path).
+        monkeypatch.setenv("HERMES_DISABLE_LAZY_INSTALLS", "1")
+        monkeypatch.setenv(ld._LAZY_TARGET_ENV, str(tmp_path / "lazy"))
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda: {}, raising=False
+        )
+        calls = []
+        monkeypatch.setattr(
+            ld, "_venv_pip_install",
+            lambda specs, **kw: (calls.append(specs), ld._InstallResult(True, "ok", ""))[1],
+        )
+        result = ld.install_specs(["honcho-ai==2.2.0"])
+        assert result.ok is True
+        assert result.blocked is False
+        assert calls == [("honcho-ai==2.2.0",)]
+        # Command display names the durable target so the dashboard shows
+        # where the install actually went.
+        assert str(tmp_path / "lazy") in result.command
+
+    def test_default_env_installs_venv_scoped(self, monkeypatch):
+        monkeypatch.delenv("HERMES_DISABLE_LAZY_INSTALLS", raising=False)
+        monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda: {}, raising=False
+        )
+        monkeypatch.setattr(
+            ld, "_venv_pip_install",
+            lambda specs, **kw: ld._InstallResult(True, "installed", ""),
+        )
+        result = ld.install_specs(["mem0ai>=2.0.10,<3"])
+        assert result.ok is True
+        assert "--target" not in result.command
+
+    def test_install_failure_surfaces_stderr(self, monkeypatch):
+        monkeypatch.delenv("HERMES_DISABLE_LAZY_INSTALLS", raising=False)
+        monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda: {}, raising=False
+        )
+        monkeypatch.setattr(
+            ld, "_venv_pip_install",
+            lambda specs, **kw: ld._InstallResult(False, "", "ERROR: resolution impossible"),
+        )
+        result = ld.install_specs(["honcho-ai==2.2.0"])
+        assert result.ok is False
+        assert result.blocked is False
+        assert "resolution impossible" in result.stderr
+
+    def test_never_raises_on_unexpected_error(self, monkeypatch):
+        monkeypatch.delenv("HERMES_DISABLE_LAZY_INSTALLS", raising=False)
+        monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda: {}, raising=False
+        )
+        # Contract: install_specs never raises — even an unexpected installer
+        # crash comes back as a failed result the caller can render.
+        def boom(specs, **kw):
+            raise RuntimeError("disk on fire")
+        monkeypatch.setattr(ld, "_venv_pip_install", boom)
+        result = ld.install_specs(["honcho-ai==2.2.0"])
+        assert result.ok is False
+        assert "disk on fire" in result.stderr

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -911,6 +911,105 @@ def feature_install_command(feature: str) -> Optional[str]:
     return "uv pip install " + " ".join(repr(s) for s in specs)
 
 
+@dataclass
+class InstallSpecsResult:
+    """Outcome of :func:`install_specs` for one batch of pip specs.
+
+    ``ok``       — install succeeded (or nothing was missing).
+    ``blocked``  — installs are gated off (config kill switch, sealed venv
+                   without a durable target) or a spec failed validation;
+                   nothing was executed. ``reason`` explains why.
+    ``command``  — human-readable description of what ran (for UIs/logs).
+    """
+    ok: bool
+    blocked: bool = False
+    reason: str = ""
+    command: str = ""
+    stdout: str = ""
+    stderr: str = ""
+
+
+def install_specs(specs: list[str] | tuple[str, ...], *, timeout: int = 300) -> InstallSpecsResult:
+    """Install arbitrary (validated) pip specs through the lazy-install pipeline.
+
+    This is the environment-aware install path for callers whose package
+    lists come from data (e.g. memory-provider plugin manifests declaring
+    ``pip_dependencies``) rather than the static :data:`LAZY_DEPS` allowlist.
+    It applies the exact same environment routing as :func:`ensure`:
+
+    * **Venv-scoped by default** — installs into ``sys.executable``'s venv.
+    * **Durable-target on immutable images** — when the deployment seals the
+      agent venv (``HERMES_DISABLE_LAZY_INSTALLS=1``) and sets
+      ``HERMES_LAZY_INSTALL_TARGET``, installs are redirected to the writable
+      data-volume dir (``--target`` + core-venv constraints), then activated
+      on ``sys.path`` so the packages import in this process immediately.
+    * **Gated** — honors ``security.allow_lazy_installs`` and refuses to run
+      when the venv is sealed with no durable target (never attempts a write
+      to a read-only tree; reports *why* instead of surfacing EROFS/EACCES).
+
+    Every spec must pass :func:`_spec_is_safe` (no URLs, paths, or shell
+    metacharacters). Unlike :func:`ensure`, unknown packages are permitted —
+    the caller owns manifest trust; this function owns spec hygiene and
+    environment routing.
+
+    Never raises; inspect the returned :class:`InstallSpecsResult`.
+    """
+    cleaned = tuple(str(s).strip() for s in specs if str(s).strip())
+    if not cleaned:
+        return InstallSpecsResult(ok=True, command="")
+
+    for spec in cleaned:
+        if not _spec_is_safe(spec):
+            return InstallSpecsResult(
+                ok=False, blocked=True,
+                reason=f"refusing to install unsafe spec {spec!r}",
+            )
+
+    if not _allow_lazy_installs():
+        target = _lazy_install_target()
+        if os.environ.get("HERMES_DISABLE_LAZY_INSTALLS") == "1" and target is None:
+            reason = (
+                "runtime installs are disabled on this deployment: the agent "
+                "environment is immutable and no writable install target is "
+                "configured (HERMES_LAZY_INSTALL_TARGET)"
+            )
+        else:
+            reason = "runtime installs disabled (security.allow_lazy_installs=false)"
+        return InstallSpecsResult(ok=False, blocked=True, reason=reason)
+
+    target = _lazy_install_target()
+    display = "uv pip install " + (
+        f"--target {target} " if target is not None else ""
+    ) + " ".join(cleaned)
+
+    logger.info("Installing pip specs %s (target=%s)", " ".join(cleaned), target or "venv")
+    try:
+        result = _venv_pip_install(cleaned, timeout=timeout)
+    except Exception as exc:
+        logger.warning("install_specs failed unexpectedly: %s", exc)
+        return InstallSpecsResult(
+            ok=False, command=display, stderr=f"install failed: {exc}"
+        )
+
+    # Freshly-installed dists must be visible to importers and metadata
+    # checks in this same process (dashboard rechecks availability inline).
+    try:
+        import importlib
+        importlib.invalidate_caches()
+        import importlib.metadata as _md
+        if hasattr(_md, "_cache_clear"):
+            _md._cache_clear()  # type: ignore[attr-defined]
+    except Exception:
+        pass
+
+    return InstallSpecsResult(
+        ok=result.success,
+        command=display,
+        stdout=result.stdout,
+        stderr=result.stderr,
+    )
+
+
 def active_features() -> list[str]:
     """Return the list of features the user has ever lazy-installed.
 


### PR DESCRIPTION
Memory-provider dependency installs now route through the environment-aware `lazy_deps` pipeline, so provider setup and auto-upgrade work on immutable hosted images (sealed read-only venv) by installing to the durable data-volume target instead of failing with permission errors — and packages survive redeploys.

Salvages #72335 by @shannonsands — authorship preserved via cherry-pick.

## Changes

**Cherry-picked from #72335 (NS-605):**
- `tools/lazy_deps.py`: new public `install_specs()` — same environment routing as `ensure()` (venv-scoped by default; `--target` durable dir + core-venv constraints when the venv is sealed), spec-safety validation via `_spec_is_safe()`, uv→pip→ensurepip ladder, blocked installs return an actionable reason (never raw EROFS/EACCES), post-install import/metadata cache invalidation, never raises.
- `hermes_cli/web_server.py`: dashboard memory-provider setup endpoint routes pip deps through `install_specs()`; blocked reasons surface in setup results; response status reflects post-install availability.
- `hermes_cli/memory_setup.py`, `plugins/memory/honcho/cli.py`, `plugins/memory/mem0/_setup.py`: CLI setup wizards routed the same way.

**Follow-up (this PR, fix-the-class):**
- `plugins/memory/hindsight/__init__.py`: the two remaining direct `uv pip install --python sys.executable` sites converted to `install_specs()` with the same ok/blocked/failed handling — the post_setup dependency install and the `initialize()`-time `hindsight-client` auto-upgrade (blocked upgrades log the gate reason + manual command and init proceeds).
- Audited all other memory plugins (supermemory, byterover, holographic, openviking, retaindb) for direct pip/uv install subprocess calls: none found — their deps flow through `plugin.yaml` `pip_dependencies` or `lazy_deps.ensure()`.

## Validation

| Check | Result |
| --- | --- |
| `tests/tools/test_lazy_deps.py` (incl. new `TestInstallSpecs` gating matrix) | ✅ pass |
| `tests/plugins/memory/test_hindsight_provider.py` (incl. new `TestClientAutoUpgradeRoutesThroughLazyDeps`: exact spec through `install_specs`, no-subprocess regression guard, blocked upgrade non-fatal) | ✅ 122 passed |
| `tests/plugins/memory/test_memory_lazy_install.py` | ✅ pass |
| Combined lazy_deps + hindsight + memory-lazy-install run | ✅ 218 passed |
| `tests/hermes_cli/test_web_server.py -k "memory or install or lazy"` | ✅ 27 passed, 499 deselected |
| `ruff check` on touched files | ✅ clean |
| Cherry-pick onto current `origin/main` | ✅ clean, 0 behind at push |

Fixes NS-605 (Plain T-1111).

## Infographic

![salvage-72335-lazydeps-memory](https://v3b.fal.media/files/b/0aa4272f/FIEJPfPdFV0OpYevzyYEw_C6rKIEkC.png)
