### PR TITLE
fix(auth): stop JWT refreshes from status polling + widen to read-only status surfaces

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -6519,6 +6519,69 @@ def _compute_nous_auth_status() -> Dict[str, Any]:
     return _snapshot_nous_pool_status()
 
 
+def get_nous_auth_status_local() -> Dict[str, Any]:
+    """Refresh-free Nous auth snapshot for read-only display surfaces.
+
+    Unlike :func:`get_nous_auth_status`, this NEVER calls
+    ``resolve_nous_runtime_credentials()`` and therefore never performs an
+    OAuth refresh POST or consumes a single-use refresh token. It reports the
+    persisted auth-store state, classifying the access token with a local
+    invoke-JWT decode only.
+
+    Use this from status panels, doctor checks, and polled dashboard
+    endpoints. Explicit auth actions (login flows, portal operations that
+    need a live credential) should keep using ``get_nous_auth_status()``.
+
+    ``logged_in`` here means "a persisted login exists that the runtime can
+    use or refresh": a currently-usable invoke JWT, or a refresh token that
+    has not been terminally quarantined. It does not prove the refresh token
+    is still accepted server-side — only a live resolve can do that.
+    """
+    try:
+        state = get_provider_auth_state("nous")
+    except Exception:
+        state = None
+
+    if not state:
+        return _snapshot_nous_pool_status()
+
+    access_token = state.get("access_token")
+    jwt_reason = _nous_invoke_jwt_status(
+        access_token,
+        scope=state.get("scope"),
+        expires_at=state.get("expires_at"),
+    )
+    last_err = state.get("last_auth_error")
+    terminal = bool(
+        isinstance(last_err, dict)
+        and last_err.get("relogin_required")
+        and not (access_token or state.get("refresh_token"))
+    )
+    logged_in = (jwt_reason is None) or (
+        bool(state.get("refresh_token")) and not terminal
+    )
+
+    status: Dict[str, Any] = {
+        "logged_in": logged_in,
+        "portal_base_url": state.get("portal_base_url"),
+        "inference_base_url": state.get("inference_base_url"),
+        "access_token": access_token,
+        "access_expires_at": state.get("expires_at"),
+        "agent_key_expires_at": state.get("agent_key_expires_at"),
+        "has_refresh_token": bool(state.get("refresh_token")),
+        "inference_credential_present": bool(
+            access_token or state.get("agent_key")
+        ),
+        "credential_source": "auth_store",
+        "source": "auth_store_local",
+    }
+    if terminal and isinstance(last_err, dict):
+        status["relogin_required"] = True
+        status["error_code"] = last_err.get("code")
+        status["error"] = last_err.get("message") or "re-login required"
+    return status
+
+
 # Enum values reported on the dashboard /api/status as ``nous_session_valid``.
 # NAS's health sweep re-mints the bootstrap session ONLY on "terminal"; "valid"
 # and "unknown" are no-ops. Keep this set small and stable — NAS parses it with

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2328,7 +2328,7 @@ def _log_nous_invoke_jwt_selected(
     access_token: Any,
     sequence_id: Optional[str] = None,
 ) -> None:
-    logger.info("Nous inference auth: using NAS invoke JWT")
+    logger.debug("Nous inference auth: using NAS invoke JWT")
     _oauth_trace(
         "nous_invoke_jwt_selected",
         sequence_id=sequence_id,
@@ -6540,7 +6540,9 @@ def get_nous_session_validity() -> str:
         non-terminal error). Never triggers a re-mint.
 
     Determinable with NO working token — it reads local auth-store state only,
-    which is exactly the condition a dead hosted box is in.
+    which is exactly the condition a dead hosted box is in. This function is
+    called by the frequently-polled public ``/api/status`` endpoint, so it must
+    never resolve credentials or perform an OAuth refresh.
 
     ANTI-FLAP CONTRACT: only a *terminal* failure maps to "terminal". A normal
     mid-rotation blip, a transient network error, or a merely-expiring token
@@ -6557,34 +6559,29 @@ def get_nous_session_validity() -> str:
     try:
         state = get_provider_auth_state("nous")
     except Exception:
-        state = None
-
-    if state:
-        last_err = state.get("last_auth_error")
-        if isinstance(last_err, dict) and last_err.get("relogin_required"):
-            # Only terminal while there is no usable credential left. If a later
-            # successful login repopulated tokens, the stale marker must not
-            # keep reporting terminal.
-            if not (state.get("access_token") or state.get("refresh_token")):
-                return NOUS_SESSION_TERMINAL
-
-    try:
-        status = get_nous_auth_status()
-    except Exception:
-        # Status computation itself failed — indeterminate, not terminal.
         return NOUS_SESSION_UNKNOWN
 
-    if status.get("logged_in"):
+    if not state:
+        return NOUS_SESSION_UNKNOWN
+
+    last_err = state.get("last_auth_error")
+    if isinstance(last_err, dict) and last_err.get("relogin_required"):
+        # Only terminal while there is no usable credential left. If a later
+        # successful login repopulated tokens, the stale marker must not
+        # keep reporting terminal.
+        if not (state.get("access_token") or state.get("refresh_token")):
+            return NOUS_SESSION_TERMINAL
+
+    if _nous_invoke_jwt_status(
+        state.get("access_token"),
+        scope=state.get("scope"),
+        expires_at=state.get("expires_at"),
+    ) is None:
         return NOUS_SESSION_VALID
 
-    # Not logged in. Distinguish a terminal (relogin-required) failure from a
-    # transient / indeterminate one. Only the former is actionable by NAS.
-    if status.get("relogin_required"):
-        return NOUS_SESSION_TERMINAL
-
-    # No Nous provider state at all, or a non-terminal not-logged-in condition
-    # (e.g. a transient refresh error that did not set relogin_required). Treat
-    # as unknown so a healthy box mid-blip never triggers a re-mint.
+    # Missing, malformed, expired, or merely expiring credentials are not proof
+    # of a terminal session. Runtime inference/keepalive paths own refreshes;
+    # the health endpoint remains side-effect free and reports indeterminate.
     return NOUS_SESSION_UNKNOWN
 
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1356,12 +1356,14 @@ def run_doctor(args):
 
     try:
         from hermes_cli.auth import (
-            get_nous_auth_status,
+            get_nous_auth_status_local,
             get_codex_auth_status,
             get_minimax_oauth_auth_status,
         )
 
-        nous_status = get_nous_auth_status()
+        # Read-only display: refresh-free snapshot — doctor must never
+        # trigger an OAuth refresh as a side effect of a health check.
+        nous_status = get_nous_auth_status_local()
         if nous_status.get("logged_in"):
             check_ok("Nous Portal auth", "(logged in)")
         else:

--- a/hermes_cli/portal_cli.py
+++ b/hermes_cli/portal_cli.py
@@ -33,13 +33,14 @@ DOCS_URL = "https://hermes-agent.nousresearch.com/docs/user-guide/features/tool-
 
 def _cmd_status(args) -> int:
     """Show Portal auth + Tool Gateway routing summary."""
-    from hermes_cli.auth import get_nous_auth_status
+    from hermes_cli.auth import get_nous_auth_status_local
     from hermes_cli.nous_subscription import get_nous_subscription_features
 
     config = load_config() or {}
 
     try:
-        auth = get_nous_auth_status() or {}
+        # Read-only status display: refresh-free snapshot (no OAuth refresh).
+        auth = get_nous_auth_status_local() or {}
     except Exception:
         auth = {}
 

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -195,12 +195,14 @@ def show_status(args):
 
     try:
         from hermes_cli.auth import (
-            get_nous_auth_status,
+            get_nous_auth_status_local,
             get_codex_auth_status,
             get_qwen_auth_status,
             get_minimax_oauth_auth_status,
         )
-        nous_status = get_nous_auth_status()
+        # Read-only display: use the refresh-free snapshot so `hermes status`
+        # never performs an OAuth refresh or burns a single-use refresh token.
+        nous_status = get_nous_auth_status_local()
         codex_status = get_codex_auth_status()
         qwen_status = get_qwen_auth_status()
         minimax_status = get_minimax_oauth_auth_status()

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3696,9 +3696,11 @@ async def get_portal_status():
     cfg = load_config() or {}
     auth: Dict[str, Any] = {}
     try:
-        from hermes_cli.auth import get_nous_auth_status
+        from hermes_cli.auth import get_nous_auth_status_local
 
-        auth = get_nous_auth_status() or {}
+        # Read-only dashboard endpoint: refresh-free snapshot so polling
+        # never performs an OAuth refresh or burns a refresh token.
+        auth = get_nous_auth_status_local() or {}
     except Exception:
         auth = {}
 
@@ -10249,7 +10251,9 @@ def _resolve_provider_status(provider_id: str, status_fn) -> Dict[str, Any]:
     try:
         from hermes_cli import auth as hauth
         if provider_id == "nous":
-            raw = hauth.get_nous_auth_status()
+            # Read-only accounts-tab card: refresh-free snapshot so listing
+            # providers never performs an OAuth refresh.
+            raw = hauth.get_nous_auth_status_local()
             return {
                 "logged_in": bool(raw.get("logged_in")),
                 "source": "nous_portal",

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -613,13 +613,18 @@ def test_nous_inference_auth_logs_do_not_include_secret_values(
 
     monkeypatch.setattr(auth_mod, "_refresh_access_token", _fake_refresh_access_token)
 
-    caplog.set_level(logging.INFO, logger="hermes_cli.auth")
+    caplog.set_level(logging.DEBUG, logger="hermes_cli.auth")
     auth_mod.resolve_nous_runtime_credentials(
         force_refresh=True,
     )
 
     logged = caplog.text
     assert "using NAS invoke JWT" in logged
+    assert not any(
+        record.levelno >= logging.INFO
+        and "using NAS invoke JWT" in record.getMessage()
+        for record in caplog.records
+    )
     assert token not in logged
     assert refreshed_token not in logged
     assert refresh_token not in logged

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -354,7 +354,7 @@ class TestDoctorMemoryProviderSection:
         # Stub auth checks to avoid real API calls
         try:
             from hermes_cli import auth as _auth_mod
-            monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {})
             monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
             monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
         except Exception:
@@ -461,7 +461,7 @@ def test_run_doctor_accepts_named_provider_from_providers_section(monkeypatch, t
 
     try:
         from hermes_cli import auth as _auth_mod
-        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
     except Exception:
@@ -499,7 +499,7 @@ def test_run_doctor_accepts_bare_custom_provider(monkeypatch, tmp_path):
 
     try:
         from hermes_cli import auth as _auth_mod
-        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
     except Exception:
@@ -539,7 +539,7 @@ def test_run_doctor_flags_missing_credentials_for_active_openrouter_provider(mon
     try:
         from hermes_cli import auth as _auth_mod
 
-        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {})
     except Exception:
@@ -589,7 +589,7 @@ def test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases(
 
     try:
         from hermes_cli import auth as _auth_mod
-        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
     except Exception:
@@ -636,7 +636,7 @@ def test_run_doctor_accepts_vendor_slugs_for_named_custom_provider(monkeypatch, 
 
     try:
         from hermes_cli import auth as _auth_mod
-        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
     except Exception:
@@ -683,7 +683,7 @@ def test_run_doctor_accepts_kimi_coding_cn_provider(monkeypatch, tmp_path):
 
     try:
         from hermes_cli import auth as _auth_mod
-        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_auth_status", lambda provider: {"logged_in": True})
         monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
@@ -723,7 +723,7 @@ def test_run_doctor_termux_does_not_mark_browser_available_without_agent_browser
 
     try:
         from hermes_cli import auth as _auth_mod
-        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
     except Exception:
@@ -763,7 +763,7 @@ def test_run_doctor_kimi_cn_env_is_detected_and_probe_is_null_safe(monkeypatch, 
 
     try:
         from hermes_cli import auth as _auth_mod
-        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
     except Exception:
@@ -812,7 +812,7 @@ def test_run_doctor_dashscope_retries_china_endpoint_after_intl_unauthorized(mon
 
     try:
         from hermes_cli import auth as _auth_mod
-        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
     except ImportError:
@@ -871,7 +871,7 @@ def test_run_doctor_opencode_go_skips_invalid_models_probe(monkeypatch, tmp_path
 
     try:
         from hermes_cli import auth as _auth_mod
-        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
     except ImportError:
@@ -1031,7 +1031,7 @@ def _run_doctor_with_healthy_oauth_fallback(
 
     from hermes_cli import auth as _auth_mod
 
-    monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {"logged_in": True})
+    monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {"logged_in": True})
     monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
     monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: minimax_oauth_status)
     _xai_status = xai_oauth_status if xai_oauth_status is not None else {}
@@ -1162,7 +1162,7 @@ class TestDoctorXaiOAuthStatus:
         monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
 
         from hermes_cli import auth as _auth_mod
-        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {"logged_in": False})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {"logged_in": False})
         monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {"logged_in": False})
         monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", xai_auth_fn)
@@ -1236,7 +1236,7 @@ class TestDoctorXaiOAuthStatus:
         monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
 
         from hermes_cli import auth as _auth_mod
-        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {"logged_in": False})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {"logged_in": False})
         monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {"logged_in": False})
         monkeypatch.delattr(_auth_mod, "get_xai_oauth_auth_status", raising=False)
@@ -1267,7 +1267,7 @@ class TestDoctorXaiOAuthStatus:
         monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
 
         from hermes_cli import auth as _auth_mod
-        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {"logged_in": True})
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {"logged_in": True})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {"logged_in": False})
         monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {"logged_in": False})
         monkeypatch.delattr(_auth_mod, "get_xai_oauth_auth_status", raising=False)
@@ -1327,7 +1327,7 @@ class TestDoctorCodexCliHintPlacement:
         monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
 
         from hermes_cli import auth as _auth_mod
-        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {"logged_in": False})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {"logged_in": codex_logged_in})
         monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {"logged_in": False})
         monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {"logged_in": False})

--- a/tests/hermes_cli/test_nous_session_validity.py
+++ b/tests/hermes_cli/test_nous_session_validity.py
@@ -1,11 +1,8 @@
-"""Tests for get_nous_session_validity — the /api/status classifier NAS reads
-to decide whether to re-mint a hosted-agent bootstrap session.
+"""Tests for the local-only Nous session classifier exposed on /api/status."""
 
-The anti-flap contract is the load-bearing property: only a *terminal* auth
-failure may report "terminal" (a spurious "terminal" triggers an unnecessary
-NAS re-mint + machine restart on a healthy box). A mid-rotation blip, a
-transient error, or a merely-expiring token must NOT report "terminal".
-"""
+import base64
+import json
+import time
 
 import hermes_cli.auth as auth
 from hermes_cli.auth import (
@@ -16,89 +13,144 @@ from hermes_cli.auth import (
 )
 
 
-def _clear_cache():
-    auth.invalidate_nous_auth_status_cache()
+def _invoke_jwt(*, seconds: int = 3600) -> str:
+    def _encode(value: dict) -> str:
+        raw = json.dumps(value, separators=(",", ":")).encode()
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+    return ".".join(
+        (
+            _encode({"alg": "none", "typ": "JWT"}),
+            _encode(
+                {
+                    "sub": "test-user",
+                    "scope": auth.DEFAULT_NOUS_SCOPE,
+                    "exp": int(time.time() + seconds),
+                }
+            ),
+            "signature",
+        )
+    )
 
 
-def test_valid_when_logged_in(monkeypatch):
-    """A healthy login → 'valid'."""
-    monkeypatch.setattr(auth, "get_provider_auth_state", lambda p: {
-        "access_token": "at", "refresh_token": "rt",
-    })
-    monkeypatch.setattr(auth, "get_nous_auth_status", lambda: {"logged_in": True})
+def _fail_if_live_auth_is_used(*args, **kwargs):
+    raise AssertionError("session validity must not resolve or refresh credentials")
+
+
+def _block_live_auth(monkeypatch):
+    monkeypatch.setattr(auth, "get_nous_auth_status", _fail_if_live_auth_is_used)
+    monkeypatch.setattr(
+        auth,
+        "resolve_nous_runtime_credentials",
+        _fail_if_live_auth_is_used,
+    )
+
+
+def test_valid_when_local_invoke_jwt_is_usable(monkeypatch):
+    monkeypatch.setattr(
+        auth,
+        "get_provider_auth_state",
+        lambda provider: {
+            "access_token": _invoke_jwt(),
+            "refresh_token": "rt",
+            "scope": auth.DEFAULT_NOUS_SCOPE,
+        },
+    )
+    _block_live_auth(monkeypatch)
+
     assert get_nous_session_validity() == NOUS_SESSION_VALID
+
+
+def test_repeated_status_checks_never_use_live_auth_resolution(monkeypatch):
+    state = {
+        "access_token": _invoke_jwt(),
+        "refresh_token": "rt",
+        "scope": auth.DEFAULT_NOUS_SCOPE,
+    }
+    monkeypatch.setattr(auth, "get_provider_auth_state", lambda provider: state)
+    _block_live_auth(monkeypatch)
+
+    assert [get_nous_session_validity() for _ in range(10)] == [
+        NOUS_SESSION_VALID
+    ] * 10
 
 
 def test_terminal_on_persisted_quarantine_marker(monkeypatch):
-    """A persisted last_auth_error.relogin_required with tokens cleared →
-    'terminal'. This is the exact on-disk state the incident produced."""
-    monkeypatch.setattr(auth, "get_provider_auth_state", lambda p: {
-        # tokens cleared by the quarantine path
-        "last_auth_error": {"relogin_required": True, "code": "invalid_grant"},
-    })
-    # status would also say not-logged-in, but the marker short-circuits first
-    monkeypatch.setattr(auth, "get_nous_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(
+        auth,
+        "get_provider_auth_state",
+        lambda provider: {
+            "last_auth_error": {
+                "relogin_required": True,
+                "code": "invalid_grant",
+            },
+        },
+    )
+    _block_live_auth(monkeypatch)
+
     assert get_nous_session_validity() == NOUS_SESSION_TERMINAL
-
-
-def test_terminal_on_relogin_required_status(monkeypatch):
-    """Not logged in + relogin_required from the live status → 'terminal'."""
-    monkeypatch.setattr(auth, "get_provider_auth_state", lambda p: {
-        "refresh_token": "rt",  # present, but status resolution fails terminally
-    })
-    monkeypatch.setattr(auth, "get_nous_auth_status", lambda: {
-        "logged_in": False, "relogin_required": True, "error_code": "invalid_grant",
-    })
-    assert get_nous_session_validity() == NOUS_SESSION_TERMINAL
-
-
-def test_unknown_when_no_provider_state(monkeypatch):
-    """No Nous provider state at all → 'unknown' (never terminal)."""
-    monkeypatch.setattr(auth, "get_provider_auth_state", lambda p: None)
-    monkeypatch.setattr(auth, "get_nous_auth_status", lambda: {"logged_in": False})
-    assert get_nous_session_validity() == NOUS_SESSION_UNKNOWN
-
-
-def test_anti_flap_transient_not_logged_in_is_unknown(monkeypatch):
-    """ANTI-FLAP: not-logged-in WITHOUT relogin_required (a transient/network
-    blip) must be 'unknown', NOT 'terminal' — otherwise a healthy box mid-blip
-    triggers a spurious re-mint."""
-    monkeypatch.setattr(auth, "get_provider_auth_state", lambda p: {
-        "access_token": "at", "refresh_token": "rt",
-    })
-    monkeypatch.setattr(auth, "get_nous_auth_status", lambda: {
-        "logged_in": False, "error": "connection reset",  # no relogin_required
-    })
-    assert get_nous_session_validity() == NOUS_SESSION_UNKNOWN
 
 
 def test_stale_quarantine_marker_ignored_after_relogin(monkeypatch):
-    """ANTI-FLAP: a leftover last_auth_error marker must NOT report 'terminal'
-    once a subsequent login has repopulated tokens."""
-    monkeypatch.setattr(auth, "get_provider_auth_state", lambda p: {
-        "access_token": "new-at", "refresh_token": "new-rt",
-        "last_auth_error": {"relogin_required": True, "code": "invalid_grant"},
-    })
-    monkeypatch.setattr(auth, "get_nous_auth_status", lambda: {"logged_in": True})
+    monkeypatch.setattr(
+        auth,
+        "get_provider_auth_state",
+        lambda provider: {
+            "access_token": _invoke_jwt(),
+            "refresh_token": "new-rt",
+            "scope": auth.DEFAULT_NOUS_SCOPE,
+            "last_auth_error": {
+                "relogin_required": True,
+                "code": "invalid_grant",
+            },
+        },
+    )
+    _block_live_auth(monkeypatch)
+
     assert get_nous_session_validity() == NOUS_SESSION_VALID
 
 
-def test_status_exception_is_unknown_not_terminal(monkeypatch):
-    """If status computation itself throws, that's indeterminate → 'unknown'."""
-    monkeypatch.setattr(auth, "get_provider_auth_state", lambda p: {"refresh_token": "rt"})
+def test_expiring_token_is_unknown_without_refreshing(monkeypatch):
+    monkeypatch.setattr(
+        auth,
+        "get_provider_auth_state",
+        lambda provider: {
+            "access_token": _invoke_jwt(seconds=30),
+            "refresh_token": "rt",
+            "scope": auth.DEFAULT_NOUS_SCOPE,
+        },
+    )
+    _block_live_auth(monkeypatch)
 
-    def _boom():
-        raise RuntimeError("boom")
-
-    monkeypatch.setattr(auth, "get_nous_auth_status", _boom)
     assert get_nous_session_validity() == NOUS_SESSION_UNKNOWN
 
 
-def test_provider_state_exception_falls_through_to_status(monkeypatch):
-    """If reading provider state throws, fall through to status (don't crash)."""
-    def _boom(p):
+def test_invalid_token_is_unknown_without_refreshing(monkeypatch):
+    monkeypatch.setattr(
+        auth,
+        "get_provider_auth_state",
+        lambda provider: {
+            "access_token": "not-a-jwt",
+            "refresh_token": "rt",
+        },
+    )
+    _block_live_auth(monkeypatch)
+
+    assert get_nous_session_validity() == NOUS_SESSION_UNKNOWN
+
+
+def test_no_provider_state_is_unknown(monkeypatch):
+    monkeypatch.setattr(auth, "get_provider_auth_state", lambda provider: None)
+    _block_live_auth(monkeypatch)
+
+    assert get_nous_session_validity() == NOUS_SESSION_UNKNOWN
+
+
+def test_provider_state_exception_is_unknown(monkeypatch):
+    def _boom(provider):
         raise RuntimeError("disk error")
 
     monkeypatch.setattr(auth, "get_provider_auth_state", _boom)
-    monkeypatch.setattr(auth, "get_nous_auth_status", lambda: {"logged_in": True})
-    assert get_nous_session_validity() == NOUS_SESSION_VALID
+    _block_live_auth(monkeypatch)
+
+    assert get_nous_session_validity() == NOUS_SESSION_UNKNOWN

--- a/tests/hermes_cli/test_nous_session_validity.py
+++ b/tests/hermes_cli/test_nous_session_validity.py
@@ -154,3 +154,77 @@ def test_provider_state_exception_is_unknown(monkeypatch):
     _block_live_auth(monkeypatch)
 
     assert get_nous_session_validity() == NOUS_SESSION_UNKNOWN
+
+
+# ── get_nous_auth_status_local — refresh-free display snapshot ──
+
+
+def test_local_status_logged_in_with_usable_jwt_never_refreshes(monkeypatch):
+    monkeypatch.setattr(
+        auth,
+        "get_provider_auth_state",
+        lambda provider: {
+            "access_token": _invoke_jwt(),
+            "refresh_token": "rt",
+            "scope": auth.DEFAULT_NOUS_SCOPE,
+            "portal_base_url": "https://portal.example",
+        },
+    )
+    _block_live_auth(monkeypatch)
+
+    status = auth.get_nous_auth_status_local()
+    assert status["logged_in"] is True
+    assert status["source"] == "auth_store_local"
+    assert status["portal_base_url"] == "https://portal.example"
+
+
+def test_local_status_logged_in_via_refresh_token_when_jwt_expired(monkeypatch):
+    monkeypatch.setattr(
+        auth,
+        "get_provider_auth_state",
+        lambda provider: {
+            "access_token": _invoke_jwt(seconds=-60),
+            "refresh_token": "rt",
+            "scope": auth.DEFAULT_NOUS_SCOPE,
+        },
+    )
+    _block_live_auth(monkeypatch)
+
+    # Runtime can still refresh — display should not claim logged-out.
+    assert auth.get_nous_auth_status_local()["logged_in"] is True
+
+
+def test_local_status_not_logged_in_after_terminal_quarantine(monkeypatch):
+    monkeypatch.setattr(
+        auth,
+        "get_provider_auth_state",
+        lambda provider: {
+            "last_auth_error": {
+                "relogin_required": True,
+                "code": "invalid_grant",
+            },
+        },
+    )
+    _block_live_auth(monkeypatch)
+
+    status = auth.get_nous_auth_status_local()
+    assert status["logged_in"] is False
+    assert status["relogin_required"] is True
+    assert status["error_code"] == "invalid_grant"
+
+
+def test_local_status_repeated_polling_never_uses_live_auth(monkeypatch):
+    monkeypatch.setattr(
+        auth,
+        "get_provider_auth_state",
+        lambda provider: {
+            "access_token": _invoke_jwt(),
+            "refresh_token": "rt",
+            "scope": auth.DEFAULT_NOUS_SCOPE,
+        },
+    )
+    _block_live_auth(monkeypatch)
+
+    assert all(
+        auth.get_nous_auth_status_local()["logged_in"] for _ in range(10)
+    )

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -28,7 +28,7 @@ def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys,
     monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex", raising=False)
     monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex", raising=False)
     monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
-    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status_local", lambda: {}, raising=False)
     monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
     monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status", lambda: {}, raising=False)
     monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
@@ -59,7 +59,7 @@ def test_show_status_reports_nous_auth_error(monkeypatch, capsys, tmp_path):
     monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
     monkeypatch.setattr(
         auth_mod,
-        "get_nous_auth_status",
+        "get_nous_auth_status_local",
         lambda: {
             "logged_in": False,
             "portal_base_url": "https://portal.nousresearch.com",
@@ -98,7 +98,7 @@ def test_show_status_reports_nous_inference_key_without_portal_login(monkeypatch
     monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
     monkeypatch.setattr(
         auth_mod,
-        "get_nous_auth_status",
+        "get_nous_auth_status_local",
         lambda: {
             "logged_in": False,
             "inference_credential_present": True,
@@ -150,7 +150,7 @@ def _base_xai_mocks(monkeypatch, tmp_path):
     monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex", raising=False)
     monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex", raising=False)
     monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
-    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status_local", lambda: {}, raising=False)
     monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
     monkeypatch.setattr(auth_mod, "get_qwen_auth_status", lambda: {}, raising=False)
     monkeypatch.setattr(auth_mod, "get_minimax_oauth_auth_status", lambda: {}, raising=False)
@@ -315,7 +315,7 @@ class TestShowStatusXaiOAuth:
         """Nous/Codex/MiniMax rows must still appear when xAI import fails."""
         import hermes_cli.auth as auth_mod
         status_mod = _base_xai_mocks(monkeypatch, tmp_path)
-        monkeypatch.setattr(auth_mod, "get_nous_auth_status",
+        monkeypatch.setattr(auth_mod, "get_nous_auth_status_local",
                             lambda: {"logged_in": True}, raising=False)
         monkeypatch.delattr(auth_mod, "get_xai_oauth_auth_status", raising=False)
 

--- a/tests/hermes_cli/test_status_model_provider.py
+++ b/tests/hermes_cli/test_status_model_provider.py
@@ -19,6 +19,9 @@ def _patch_common_status_deps(monkeypatch, status_mod, tmp_path, *, openai_base_
 
     monkeypatch.setattr(status_mod, "get_env_value", _get_env_value, raising=False)
     monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(
+        auth_mod, "get_nous_auth_status_local", lambda: {}, raising=False
+    )
     monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
     monkeypatch.setattr(
         status_mod.subprocess,
@@ -135,7 +138,7 @@ def test_show_status_reports_exhausted_nous_credits(monkeypatch, capsys, tmp_pat
     _patch_common_status_deps(monkeypatch, status_mod, tmp_path)
     monkeypatch.setattr(
         auth_mod,
-        "get_nous_auth_status",
+        "get_nous_auth_status_local",
         lambda: {
             "logged_in": False,
             "access_token": "jwt",

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -867,7 +867,7 @@ def test_status_hardcoded_branch_wins_over_generic_fallback():
     import hermes_cli.web_server as ws
 
     with patch(
-        "hermes_cli.auth.get_nous_auth_status",
+        "hermes_cli.auth.get_nous_auth_status_local",
         return_value={"logged_in": True, "portal_base_url": "https://portal.test"},
     ):
         out = ws._resolve_provider_status("nous", None)


### PR DESCRIPTION
Stops the dashboard's frequently-polled `/api/status` endpoint (and other read-only status surfaces) from triggering live OAuth resolution, which could burn single-use Nous OAuth grants under 5–10s polling (NS-592).

## Changes
- **Cherry-pick (contributor commit):** rewrites `get_nous_session_validity()` to read only persisted auth-store state — local invoke-JWT decode via `_nous_invoke_jwt_status()` — instead of calling `get_nous_auth_status()` → `resolve_nous_runtime_credentials()` → live OAuth refresh POST. Missing/expired/malformed credentials classify as `unknown` (never a refresh, never a spurious `terminal`); the persisted quarantine marker still classifies `terminal`. Also demotes the "using NAS invoke JWT" log line to DEBUG.
- **Follow-up widening (ours):** adds `get_nous_auth_status_local()` — a refresh-free auth-store snapshot for read-only display surfaces — and converts the remaining read-only `get_nous_auth_status()` callers:
  - `hermes_cli/status.py` — `hermes status` Auth Providers panel
  - `hermes_cli/doctor.py` — `hermes doctor` Auth Providers checks
  - `hermes_cli/portal_cli.py` — `hermes portal status` display
  - `hermes_cli/web_server.py` — `/api/portal` endpoint and the accounts-tab provider card dispatcher (`_resolve_provider_status` nous branch)
- Action paths that genuinely need a live resolve (login flows, portal operations) are intentionally left on `get_nous_auth_status()`.
- New tests for `get_nous_auth_status_local()` (logged-in via usable JWT, logged-in via refresh token with expired JWT, terminal quarantine, repeated polling never touches live auth); existing status/doctor/web-oauth tests updated to stub the new classifier.

## Validation
| Check | Result |
|---|---|
| `tests/hermes_cli/test_nous_session_validity.py` + `test_auth_nous_provider.py` | 85 passed |
| Full targeted set (+ `test_doctor.py`, `test_status_model_provider.py`, `test_web_oauth_dispatch.py`) | 194 passed, 0 failed |
| `ruff check` on all touched files | clean |
| Stale-base gate (`rev-list` behind origin/main) | 0 |

Salvages #63559 by @shannonsands — authorship preserved via cherry-pick.

## Infographic

![jwt-status-polling](https://v3b.fal.media/files/b/0aa4273f/V6rjzu8ARyuQm1PrMAhdc_BsLiHALD.png)
