### PR TITLE
fix(gateway): dual-stack webhook bind defaults across LINE + 5 sibling adapters (salvage #70532, NS-603)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2323,7 +2323,10 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "agent_id": getenv("WECOM_CALLBACK_AGENT_ID", ""),
             "token": getenv("WECOM_CALLBACK_TOKEN", ""),
             "encoding_aes_key": getenv("WECOM_CALLBACK_ENCODING_AES_KEY", ""),
-            "host": getenv("WECOM_CALLBACK_HOST", "0.0.0.0"),
+            # No default here: an unset WECOM_CALLBACK_HOST leaves extra.host
+            # falsy so the adapter's dual-stack DEFAULT_HOST=None applies
+            # (binds IPv4 + IPv6; "0.0.0.0" was IPv4-only, NS-603).
+            "host": getenv("WECOM_CALLBACK_HOST", ""),
             "port": getenv_int("WECOM_CALLBACK_PORT", 8645),
         })
 

--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -30,7 +30,13 @@ from gateway.platforms.base import (
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_HOST = "0.0.0.0"
+# ``None`` → aiohttp/asyncio ``create_server`` binds one listening socket per
+# address family (IPv4 + IPv6). The old "0.0.0.0" default bound IPv4 ONLY and
+# was unreachable over IPv6-only private networks (e.g. Fly.io 6PN) — same
+# bug as the LINE adapter (NS-603) and gateway/platforms/webhook.py
+# (d542894ad). Pin a host via extra.host. The all-interfaces default still
+# requires extra.allowed_source_cidrs (see _source_allowlist_required_but_missing).
+DEFAULT_HOST = None
 DEFAULT_PORT = 8646
 DEFAULT_WEBHOOK_PATH = "/msgraph/webhook"
 DEFAULT_MAX_SEEN_RECEIPTS = 5000
@@ -49,7 +55,9 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.MSGRAPH_WEBHOOK)
         extra = config.extra or {}
-        self._host: str = str(extra.get("host", DEFAULT_HOST))
+        # Falsy host (None/"") collapses to the dual-stack default.
+        _raw_host = extra.get("host", DEFAULT_HOST) or DEFAULT_HOST
+        self._host: Optional[str] = str(_raw_host) if _raw_host else None
         self._port: int = int(extra.get("port", DEFAULT_PORT))
         self._webhook_path: str = self._normalize_path(
             extra.get("webhook_path", DEFAULT_WEBHOOK_PATH)
@@ -138,7 +146,9 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         self._notification_scheduler = scheduler
 
     def _source_allowlist_required_but_missing(self) -> bool:
-        return is_network_accessible(self._host) and not self._allowed_source_networks
+        # host=None binds all interfaces (both families) — network-accessible.
+        host_is_public = self._host is None or is_network_accessible(self._host)
+        return host_is_public and not self._allowed_source_networks
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         if self._client_state is None:

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -33,7 +33,7 @@ Optional / Phase-3+:
 - WHATSAPP_CLOUD_APP_SECRET       (HMAC key for X-Hub-Signature-256)
 - WHATSAPP_CLOUD_WABA_ID          (analytics / future use)
 - WHATSAPP_CLOUD_VERIFY_TOKEN     (hub.verify_token shared secret)
-- WHATSAPP_CLOUD_WEBHOOK_HOST     (default 0.0.0.0)
+- WHATSAPP_CLOUD_WEBHOOK_HOST     (default: unset → dual-stack, all interfaces IPv4+IPv6)
 - WHATSAPP_CLOUD_WEBHOOK_PORT     (default 8090)
 - WHATSAPP_CLOUD_WEBHOOK_PATH     (default /whatsapp/webhook)
 - WHATSAPP_CLOUD_API_VERSION      (default v20.0)
@@ -86,7 +86,12 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_API_VERSION = "v20.0"
-DEFAULT_WEBHOOK_HOST = "0.0.0.0"
+# ``None`` → aiohttp/asyncio ``create_server`` binds one listening socket per
+# address family (IPv4 + IPv6). The old "0.0.0.0" default bound IPv4 ONLY and
+# was unreachable over IPv6-only private networks (e.g. Fly.io 6PN) — same
+# bug as the LINE adapter (NS-603) and gateway/platforms/webhook.py
+# (d542894ad). Pin a host via WHATSAPP_CLOUD_WEBHOOK_HOST or extra.webhook_host.
+DEFAULT_WEBHOOK_HOST = None
 DEFAULT_WEBHOOK_PORT = 8090
 DEFAULT_WEBHOOK_PATH = "/whatsapp/webhook"
 GRAPH_API_BASE = "https://graph.facebook.com"
@@ -217,7 +222,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._verify_token: str = str(extra.get("verify_token", "")).strip()
 
         # Webhook server config
-        self._webhook_host: str = str(extra.get("webhook_host", DEFAULT_WEBHOOK_HOST))
+        # Falsy host (None/"") collapses to the dual-stack default.
+        _raw_webhook_host = extra.get("webhook_host", DEFAULT_WEBHOOK_HOST) or DEFAULT_WEBHOOK_HOST
+        self._webhook_host: Optional[str] = (
+            str(_raw_webhook_host) if _raw_webhook_host else None
+        )
         self._webhook_port: int = int(extra.get("webhook_port", DEFAULT_WEBHOOK_PORT))
         self._webhook_path: str = self._normalize_path(
             extra.get("webhook_path", DEFAULT_WEBHOOK_PATH)

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -30,8 +30,8 @@ binary uploads — images, audio, and video must be reachable HTTPS URLs.
 We register registered tempfiles under ``/line/media/<token>/<filename>``
 served by the same aiohttp app, with an allowed-roots traversal guard.
 ``LINE_PUBLIC_URL`` (e.g. ``https://my-tunnel.example.com``) overrides
-the host:port construction so URLs are reachable when bind is 0.0.0.0
-or behind a reverse proxy.
+the host:port construction so URLs are reachable when the bind is a
+wildcard/dual-stack listener or behind a reverse proxy.
 
 **5-message batching.** LINE accepts at most 5 message objects per
 Reply/Push call; longer responses are smart-chunked at 4500 chars
@@ -71,6 +71,7 @@ import mimetypes
 import os
 import re
 import secrets
+import sys
 import tempfile
 import time
 import uuid
@@ -121,6 +122,29 @@ WEBHOOK_BODY_MAX_BYTES = 1_048_576  # 1 MiB — webhooks are tiny JSON
 DEFAULT_WEBHOOK_PORT = 8646
 DEFAULT_WEBHOOK_PATH = "/line/webhook"
 DEFAULT_MEDIA_PATH_PREFIX = "/line/media"
+
+# Default bind host. ``None`` tells aiohttp/asyncio's ``create_server`` to
+# bind BOTH address families (IPv4 + IPv6) — the portable dual-stack default.
+# Mirrors gateway/platforms/webhook.py DEFAULT_HOST (commit d542894ad).
+#
+# Why not "0.0.0.0" (the old default) or "::"?
+#   - "0.0.0.0" binds IPv4 ONLY. On IPv6-only private networks — notably
+#     Fly.io 6PN, where the hosted edge router reverse-proxies LINE ingest to
+#     ``<app>.internal:8646`` over an ``fdaa:…`` IPv6 address — an IPv4-only
+#     listener is unreachable: dial refused → customer-visible 502 (NS-603).
+#   - "::" is NOT a safe fix: on hosts where the kernel sets IPV6_V6ONLY=1
+#     (verified on Fly machines), binding "::" yields an IPv6-ONLY socket,
+#     breaking IPv4 loopback health probes.
+#   - ``None`` asks the event loop to create a listening socket per resolved
+#     family, so both 127.0.0.1 (v4) and the 6PN fdaa (v6) are served
+#     regardless of the bindv6only sysctl. Users can still pin a host via
+#     ``LINE_HOST`` or ``platforms.line.extra.host``.
+DEFAULT_HOST = None
+
+# Hosts that mean "listening on every interface" — i.e. the bind address is
+# not a name LINE's servers could ever fetch media from, so a public base URL
+# is required for outbound media.
+_WILDCARD_HOSTS = frozenset({"0.0.0.0", "::", ""})
 
 # Slow-LLM postback button defaults
 DEFAULT_SLOW_RESPONSE_THRESHOLD = 45.0  # seconds; 0 disables
@@ -662,8 +686,12 @@ class LineAdapter(BasePlatformAdapter):
             or extra.get("channel_secret", "")
         )
 
-        # Webhook server
-        self.webhook_host = os.getenv("LINE_HOST") or extra.get("host", "0.0.0.0")
+        # Webhook server. Host default is ``None`` → dual-stack bind (both
+        # IPv4 and IPv6); see DEFAULT_HOST above. ``LINE_HOST``/extra.host pin
+        # a specific address when needed; empty string collapses to None.
+        self.webhook_host = (
+            os.getenv("LINE_HOST") or extra.get("host", DEFAULT_HOST) or DEFAULT_HOST
+        )
         try:
             self.webhook_port = int(
                 os.getenv("LINE_PORT") or extra.get("port", DEFAULT_WEBHOOK_PORT)
@@ -806,12 +834,26 @@ class LineAdapter(BasePlatformAdapter):
         self._runner = web.AppRunner(self._app)
         try:
             await self._runner.setup()
-            self._site = web.TCPSite(self._runner, self.webhook_host, self.webhook_port)
+            # SO_REUSEADDR is platform-dependent (mirrors the generic webhook
+            # adapter, commits d542894ad/9420ad946):
+            #   - macOS (BSD semantics): two wildcard/specific sockets with
+            #     SO_REUSEADDR can silently split traffic — disable it there.
+            #   - Linux: SO_REUSEADDR only permits rebinding past TIME_WAIT;
+            #     disabling it would make a quick gateway restart fail to
+            #     bind for up to ~60s — keep the default (enabled).
+            self._site = web.TCPSite(
+                self._runner,
+                self.webhook_host,
+                self.webhook_port,
+                reuse_address=False if sys.platform == "darwin" else None,
+            )
             await self._site.start()
         except OSError as exc:
             self._set_fatal_error(
                 "bind_failed",
-                f"Could not bind LINE webhook on {self.webhook_host}:{self.webhook_port}: {exc}",
+                "Could not bind LINE webhook on "
+                f"{self.webhook_host or 'all IPv4+IPv6 interfaces'}:"
+                f"{self.webhook_port}: {exc}",
                 retryable=True,
             )
             return False
@@ -819,7 +861,7 @@ class LineAdapter(BasePlatformAdapter):
         self._mark_connected()
         logger.info(
             "LINE: webhook listening on %s:%s%s%s",
-            self.webhook_host,
+            self.webhook_host or "* (all interfaces, IPv4+IPv6)",
             self.webhook_port,
             self.webhook_path,
             f" (public: {self.public_base_url})" if self.public_base_url else "",
@@ -1288,7 +1330,12 @@ class LineAdapter(BasePlatformAdapter):
         if self.public_base_url:
             base = self.public_base_url
         else:
+            # A wildcard/dual-stack bind has no fetchable hostname; the
+            # _missing_public_url guard should have caught this earlier.
+            # Fall back to localhost so the URL is at least well-formed.
             host = self.webhook_host
+            if host is None or host in _WILDCARD_HOSTS:
+                host = "127.0.0.1"
             port = self.webhook_port
             if port == 443:
                 base = f"https://{host}"
@@ -1296,6 +1343,14 @@ class LineAdapter(BasePlatformAdapter):
                 base = f"https://{host}:{port}"
         safe_name = _urlquote(filename, safe="")
         return f"{base}{DEFAULT_MEDIA_PATH_PREFIX}/{token}/{safe_name}"
+
+    def _missing_public_url(self) -> bool:
+        """True when outbound media cannot work: no LINE_PUBLIC_URL and the
+        bind host is a wildcard (or the dual-stack ``None`` default), i.e.
+        not an address LINE's fetchers could ever reach."""
+        if self.public_base_url:
+            return False
+        return self.webhook_host is None or self.webhook_host in _WILDCARD_HOSTS
 
     async def _handle_media(self, request) -> Any:
         """Serve a registered local file over HTTPS for LINE's media URLs.
@@ -1358,7 +1413,7 @@ class LineAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="image exceeds 10 MB LINE limit")
         if not self._client:
             return SendResult(success=False, error="LINE adapter not connected")
-        if not self.public_base_url and self.webhook_host == "0.0.0.0":
+        if self._missing_public_url():
             return SendResult(
                 success=False,
                 error="LINE_PUBLIC_URL must be set to send images "
@@ -1388,7 +1443,7 @@ class LineAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="audio exceeds 200 MB LINE limit")
         if not self._client:
             return SendResult(success=False, error="LINE adapter not connected")
-        if not self.public_base_url and self.webhook_host == "0.0.0.0":
+        if self._missing_public_url():
             return SendResult(
                 success=False,
                 error="LINE_PUBLIC_URL must be set to send audio",
@@ -1412,7 +1467,7 @@ class LineAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="video exceeds 200 MB LINE limit")
         if not self._client:
             return SendResult(success=False, error="LINE adapter not connected")
-        if not self.public_base_url and self.webhook_host == "0.0.0.0":
+        if self._missing_public_url():
             return SendResult(
                 success=False,
                 error="LINE_PUBLIC_URL must be set to send video",

--- a/plugins/platforms/line/plugin.yaml
+++ b/plugins/platforms/line/plugin.yaml
@@ -32,7 +32,7 @@ optional_env:
     prompt: "Webhook port"
     password: false
   - name: LINE_HOST
-    description: "Webhook bind host (default: 0.0.0.0)"
+    description: "Webhook bind host (default: unset → dual-stack, all interfaces IPv4+IPv6)"
     prompt: "Webhook host"
     password: false
   - name: LINE_PUBLIC_URL

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -105,6 +105,12 @@ _DEFAULT_PORT = 3978
 # Bot Framework activities are JSON payloads well under 1 MiB; an explicit
 # aiohttp client_max_size keeps oversized/chunked request bodies bounded.
 _MAX_BODY_BYTES = 1_048_576
+# ``None`` → aiohttp/asyncio ``create_server`` binds one listening socket per
+# address family (IPv4 + IPv6). The old hardcoded "0.0.0.0" bound IPv4 ONLY
+# and was unreachable over IPv6-only private networks (e.g. Fly.io 6PN) —
+# same bug as the LINE adapter (NS-603) and gateway/platforms/webhook.py
+# (d542894ad). Pin a host via TEAMS_HOST or extra.host.
+_DEFAULT_HOST = None
 _WEBHOOK_PATH = "/api/messages"
 
 
@@ -705,6 +711,9 @@ class TeamsAdapter(BasePlatformAdapter):
         self._port = _coerce_port(
             extra.get("port") or os.getenv("TEAMS_PORT", str(_DEFAULT_PORT))
         )
+        # Falsy host (unset/"") collapses to the dual-stack default (None).
+        _raw_host = extra.get("host") or os.getenv("TEAMS_HOST", "") or _DEFAULT_HOST
+        self._host: Optional[str] = str(_raw_host) if _raw_host else None
         self._app: Optional["App"] = None
         self._runner: Optional["web.AppRunner"] = None
         self._dedup = MessageDeduplicator(max_size=1000)
@@ -774,13 +783,14 @@ class TeamsAdapter(BasePlatformAdapter):
 
             self._runner = web.AppRunner(aiohttp_app)
             await self._runner.setup()
-            site = web.TCPSite(self._runner, "0.0.0.0", self._port)
+            site = web.TCPSite(self._runner, self._host, self._port)
             await site.start()
 
             self._running = True
             self._mark_connected()
             logger.info(
-                "[teams] Webhook server listening on 0.0.0.0:%d%s",
+                "[teams] Webhook server listening on %s:%d%s",
+                self._host or "* (all interfaces, IPv4+IPv6)",
                 self._port,
                 _WEBHOOK_PATH,
             )

--- a/plugins/platforms/teams/plugin.yaml
+++ b/plugins/platforms/teams/plugin.yaml
@@ -30,6 +30,10 @@ optional_env:
     description: "Webhook listen port (Bot Framework default: 3978)"
     prompt: "Webhook port"
     password: false
+  - name: TEAMS_HOST
+    description: "Webhook bind host (default: unset → dual-stack, all interfaces IPv4+IPv6)"
+    prompt: "Webhook host"
+    password: false
   - name: TEAMS_ALLOWED_USERS
     description: "Comma-separated Teams user IDs / UPNs allowed to talk to the bot"
     prompt: "Allowed users (comma-separated)"

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3592,6 +3592,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
             TELEGRAM_WEBHOOK_URL    Public HTTPS URL (e.g. https://app.fly.dev/telegram)
             TELEGRAM_WEBHOOK_PORT   Local listen port (default 8443)
+            TELEGRAM_WEBHOOK_HOST   Bind host (default: unset → dual-stack,
+                                    all interfaces IPv4+IPv6)
             TELEGRAM_WEBHOOK_SECRET Secret token for update verification
         """
         # Explicit connect() is the only operation allowed to reopen polling
@@ -3944,6 +3946,16 @@ class TelegramAdapter(BasePlatformAdapter):
                 # start rather than silently run in fail-open mode.
                 # See GHSA-3vpc-7q5r-276h.
                 webhook_port = env_int("TELEGRAM_WEBHOOK_PORT", 8443)
+                # Bind host. Default "" → tornado bind_sockets opens one
+                # listening socket per address family (IPv4 + IPv6). The old
+                # hardcoded "0.0.0.0" bound IPv4 ONLY and was unreachable
+                # over IPv6-only private networks (e.g. Fly.io 6PN) — same
+                # bug as the LINE adapter (NS-603). Pin via
+                # TELEGRAM_WEBHOOK_HOST or platforms.telegram.extra.webhook_host.
+                webhook_host = (
+                    os.getenv("TELEGRAM_WEBHOOK_HOST", "").strip()
+                    or str((self.config.extra or {}).get("webhook_host") or "").strip()
+                )
                 webhook_secret = os.getenv("TELEGRAM_WEBHOOK_SECRET", "").strip()
                 if not webhook_secret:
                     raise RuntimeError(
@@ -3962,7 +3974,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 webhook_path = urlparse(webhook_url).path or "/telegram"
 
                 await self._app.updater.start_webhook(
-                    listen="0.0.0.0",
+                    listen=webhook_host,
                     port=webhook_port,
                     url_path=webhook_path,
                     webhook_url=webhook_url,
@@ -3978,8 +3990,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._polling_progress_accepting = False
                 self._send_path_degraded = False
                 logger.info(
-                    "[%s] Webhook server listening on 0.0.0.0:%d%s",
-                    self.name, webhook_port, webhook_path,
+                    "[%s] Webhook server listening on %s:%d%s",
+                    self.name,
+                    webhook_host or "* (all interfaces, IPv4+IPv6)",
+                    webhook_port,
+                    webhook_path,
                 )
             else:
                 # ── Polling mode (default) ───────────────────────────

--- a/plugins/platforms/wecom/callback_adapter.py
+++ b/plugins/platforms/wecom/callback_adapter.py
@@ -51,7 +51,12 @@ from plugins.platforms.wecom.wecom_crypto import WXBizMsgCrypt, WeComCryptoError
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_HOST = "0.0.0.0"
+# ``None`` → aiohttp/asyncio ``create_server`` binds one listening socket per
+# address family (IPv4 + IPv6). The old "0.0.0.0" default bound IPv4 ONLY and
+# was unreachable over IPv6-only private networks (e.g. Fly.io 6PN) — same
+# bug as the LINE adapter (NS-603) and gateway/platforms/webhook.py
+# (d542894ad). Pin a host via WECOM_CALLBACK_HOST or extra.host.
+DEFAULT_HOST = None
 DEFAULT_PORT = 8645
 DEFAULT_PATH = "/wecom/callback"
 # Cap pre-auth request bodies. WeCom callbacks are small encrypted XML
@@ -71,7 +76,9 @@ class WecomCallbackAdapter(BasePlatformAdapter):
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.WECOM_CALLBACK)
         extra = config.extra or {}
-        self._host = str(extra.get("host") or DEFAULT_HOST)
+        # Falsy host (None/"") collapses to the dual-stack default.
+        _raw_host = extra.get("host") or DEFAULT_HOST
+        self._host = str(_raw_host) if _raw_host else None
         self._port = int(extra.get("port") or DEFAULT_PORT)
         self._path = str(extra.get("path") or DEFAULT_PATH)
         self._apps: List[Dict[str, Any]] = self._normalize_apps(extra)

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -752,3 +752,129 @@ class TestMessageTypeMapping:
     def test_unknown_type_falls_back_to_text(self):
         MessageType = _line.MessageType
         assert _line._LINE_MESSAGE_TYPES.get("flex", MessageType.TEXT) == MessageType.TEXT
+
+
+# ---------------------------------------------------------------------------
+# 10. Dual-stack bind default (NS-603)
+# ---------------------------------------------------------------------------
+
+class TestDualStackBind:
+    """The LINE webhook server's default bind must serve BOTH IPv4 and IPv6.
+
+    Regression guard for the hosted LINE 502 (NS-603): Fly.io 6PN — the
+    private network the edge router reverse-proxies LINE ingest over — is
+    IPv6-only (``<app>.internal`` resolves to an ``fdaa:…`` address). The
+    adapter used to default to ``host="0.0.0.0"`` (IPv4 only), so the
+    router's dial to ``<app>.internal:8646`` hit an address nothing was
+    listening on → connection refused → 502 on webhook verification.
+
+    Mirrors gateway/platforms/webhook.py's fix (commit d542894ad):
+    ``DEFAULT_HOST = None`` → asyncio binds one socket per address family.
+    ``"::"`` is NOT a valid substitute (bindv6only=1 on Fly machines makes
+    it IPv6-only, breaking IPv4 loopback health probes).
+    """
+
+    def _cfg(self, **extra):
+        from gateway.config import PlatformConfig
+        base = {"channel_access_token": "tok", "channel_secret": "sec"}
+        base.update(extra)
+        return PlatformConfig(enabled=True, extra=base)
+
+    def test_default_host_is_none_for_dual_stack(self, monkeypatch):
+        monkeypatch.delenv("LINE_HOST", raising=False)
+        assert _line.DEFAULT_HOST is None
+        ad = LineAdapter(self._cfg())
+        assert ad.webhook_host is None
+
+    def test_empty_host_normalises_to_none(self, monkeypatch):
+        monkeypatch.delenv("LINE_HOST", raising=False)
+        ad = LineAdapter(self._cfg(host=""))
+        assert ad.webhook_host is None
+
+    def test_pinned_host_is_preserved(self, monkeypatch):
+        monkeypatch.delenv("LINE_HOST", raising=False)
+        ad = LineAdapter(self._cfg(host="127.0.0.1"))
+        assert ad.webhook_host == "127.0.0.1"
+
+    def test_line_host_env_overrides(self, monkeypatch):
+        monkeypatch.setenv("LINE_HOST", "10.0.0.5")
+        ad = LineAdapter(self._cfg())
+        assert ad.webhook_host == "10.0.0.5"
+
+    @pytest.mark.asyncio
+    async def test_default_bind_serves_both_families(self, monkeypatch):
+        """Behavioural proof: host=None opens v4 AND v6 listening sockets."""
+        monkeypatch.delenv("LINE_HOST", raising=False)
+        ad = LineAdapter(self._cfg(port=0))
+        ad._client = MagicMock()
+        ad._client.get_bot_user_id = AsyncMock(return_value="Ubot")
+
+        # Skip credential/network preamble — drive the aiohttp bind directly
+        # the same way connect() does.
+        from aiohttp import web
+        ad._app = web.Application()
+        ad._runner = web.AppRunner(ad._app)
+        await ad._runner.setup()
+        site = web.TCPSite(ad._runner, ad.webhook_host, 0)
+        try:
+            await site.start()
+            addrs = list(ad._runner.addresses)
+            has_v6 = any(len(a) == 4 for a in addrs)
+            has_v4 = any(len(a) == 2 for a in addrs)
+            assert has_v4, f"IPv4 bind missing — got {addrs}"
+            assert has_v6, (
+                f"IPv6 bind missing (the 6PN reachability bug, NS-603) — got {addrs}"
+            )
+        finally:
+            await ad._runner.cleanup()
+
+
+class TestMediaPublicUrlGuard:
+    """Outbound media requires LINE_PUBLIC_URL whenever the bind host is not
+    a publicly fetchable address — including the new dual-stack ``None``
+    default and the legacy wildcard strings."""
+
+    def _adapter(self, monkeypatch, **extra):
+        from gateway.config import PlatformConfig
+        monkeypatch.delenv("LINE_HOST", raising=False)
+        monkeypatch.delenv("LINE_PUBLIC_URL", raising=False)
+        base = {"channel_access_token": "tok", "channel_secret": "sec"}
+        base.update(extra)
+        return LineAdapter(PlatformConfig(enabled=True, extra=base))
+
+    def test_missing_public_url_true_for_default_none(self, monkeypatch):
+        ad = self._adapter(monkeypatch)
+        assert ad.webhook_host is None
+        assert ad._missing_public_url() is True
+
+    @pytest.mark.parametrize("wildcard", ["0.0.0.0", "::"])
+    def test_missing_public_url_true_for_wildcards(self, monkeypatch, wildcard):
+        ad = self._adapter(monkeypatch, host=wildcard)
+        assert ad._missing_public_url() is True
+
+    def test_missing_public_url_false_with_public_base(self, monkeypatch):
+        ad = self._adapter(monkeypatch, public_url="https://tunnel.example.com")
+        if not ad.public_base_url:
+            # Adapter reads env var name LINE_PUBLIC_URL / extra key —
+            # set directly if the extra key differs.
+            ad.public_base_url = "https://tunnel.example.com"
+        assert ad._missing_public_url() is False
+
+    def test_missing_public_url_false_with_pinned_host(self, monkeypatch):
+        ad = self._adapter(monkeypatch, host="203.0.113.7")
+        assert ad._missing_public_url() is False
+
+    def test_send_image_blocked_without_public_url(self, monkeypatch, tmp_path):
+        ad = self._adapter(monkeypatch)
+        ad._client = MagicMock()
+        img = tmp_path / "x.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n123")
+        result = asyncio.run(ad.send_image_file("Uchat", str(img)))
+        assert not result.success
+        assert "LINE_PUBLIC_URL" in (result.error or "")
+
+    def test_media_url_never_contains_none(self, monkeypatch):
+        ad = self._adapter(monkeypatch)
+        url = ad._media_url("tok123", "cat.jpg")
+        assert "None" not in url
+        assert url.startswith("https://")

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -804,6 +804,21 @@ class TestDualStackBind:
     @pytest.mark.asyncio
     async def test_default_bind_serves_both_families(self, monkeypatch):
         """Behavioural proof: host=None opens v4 AND v6 listening sockets."""
+        # Guard: on IPv4-only hosts (CI runners with IPv6 disabled) the
+        # dual-stack bind legitimately yields no v6 socket — that's the
+        # environment, not a regression. Probe an actual ::1 bind rather
+        # than trusting socket.has_ipv6 (compile-time constant).
+        import socket as _socket
+        if not _socket.has_ipv6:
+            pytest.skip("IPv6 not supported by this Python build")
+        try:
+            _probe = _socket.socket(_socket.AF_INET6, _socket.SOCK_STREAM)
+            try:
+                _probe.bind(("::1", 0))
+            finally:
+                _probe.close()
+        except OSError:
+            pytest.skip("IPv6 stack unavailable on this host (cannot bind ::1)")
         monkeypatch.delenv("LINE_HOST", raising=False)
         ad = LineAdapter(self._cfg(port=0))
         ad._client = MagicMock()

--- a/website/docs/user-guide/messaging/line.md
+++ b/website/docs/user-guide/messaging/line.md
@@ -106,7 +106,7 @@ hermes gateway
 The agent log shows:
 
 ```
-LINE: webhook listening on 0.0.0.0:8646/line/webhook (public: https://my-tunnel.example.com)
+LINE: webhook listening on * (all interfaces, IPv4+IPv6):8646/line/webhook (public: https://my-tunnel.example.com)
 ```
 
 Add the bot as a friend from the LINE app (scan the QR in the channel's **Messaging API** tab) and send it a message.
@@ -162,7 +162,7 @@ Cron jobs with `deliver: line` route to `LINE_HOME_CHANNEL`. The adapter ships a
 |---|---|---|---|
 | `LINE_CHANNEL_ACCESS_TOKEN` | yes | — | Long-lived channel access token |
 | `LINE_CHANNEL_SECRET` | yes | — | Channel secret (HMAC-SHA256 webhook verification) |
-| `LINE_HOST` | no | `0.0.0.0` | Webhook bind host |
+| `LINE_HOST` | no | unset (dual-stack: all interfaces, IPv4+IPv6) | Webhook bind host |
 | `LINE_PORT` | no | `8646` | Webhook bind port |
 | `LINE_PUBLIC_URL` | for media | — | Public HTTPS base URL; required for image/voice/video sends |
 | `LINE_ALLOWED_USERS` | one of | — | Comma-separated user IDs (U-prefixed) |

--- a/website/docs/user-guide/messaging/msgraph-webhook.md
+++ b/website/docs/user-guide/messaging/msgraph-webhook.md
@@ -61,7 +61,7 @@ All settings go under `platforms.msgraph_webhook.extra`:
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `host` | `0.0.0.0` | Bind address for the HTTP listener. Non-loopback binds require `allowed_source_cidrs`; loopback (`127.0.0.1` / `::1`) is the easiest dev-tunnel / reverse-proxy setup. |
+| `host` | unset (dual-stack: all interfaces, IPv4+IPv6) | Bind address for the HTTP listener. Non-loopback binds require `allowed_source_cidrs`; loopback (`127.0.0.1` / `::1`) is the easiest dev-tunnel / reverse-proxy setup. |
 | `port` | `8646` | Bind port. |
 | `webhook_path` | `/msgraph/webhook` | URL path Graph POSTs to. |
 | `health_path` | `/health` | Readiness endpoint. |

--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -117,7 +117,7 @@ docker logs -f hermes
 
 Look for:
 ```
-[teams] Webhook server listening on 0.0.0.0:3978/api/messages
+[teams] Webhook server listening on * (all interfaces, IPv4+IPv6):3978/api/messages
 ```
 
 ---

--- a/website/docs/user-guide/messaging/wecom-callback.md
+++ b/website/docs/user-guide/messaging/wecom-callback.md
@@ -56,7 +56,7 @@ WECOM_CALLBACK_TOKEN=your-callback-token
 WECOM_CALLBACK_ENCODING_AES_KEY=your-43-char-aes-key
 
 # Optional
-WECOM_CALLBACK_HOST=0.0.0.0
+# WECOM_CALLBACK_HOST=  # optional pin; unset = dual-stack (all interfaces, IPv4+IPv6)
 WECOM_CALLBACK_PORT=8645
 WECOM_CALLBACK_ALLOWED_USERS=user1,user2
 ```
@@ -82,7 +82,7 @@ Set these in `config.yaml` under `platforms.wecom_callback.extra`, or use enviro
 | `agent_id` | — | Agent ID of the self-built app (required) |
 | `token` | — | Callback verification token (required) |
 | `encoding_aes_key` | — | 43-character AES key for callback encryption (required) |
-| `host` | `0.0.0.0` | Bind address for the HTTP callback server |
+| `host` | unset (dual-stack: all interfaces, IPv4+IPv6) | Bind address for the HTTP callback server |
 | `port` | `8645` | Port for the HTTP callback server |
 | `path` | `/wecom/callback` | URL path for the callback endpoint |
 
@@ -173,6 +173,7 @@ WeCom hits the public URL you registered. Confirm:
 **Port not reachable / listener not bound.**
 Check `hermes gateway run` logs for the bound host/port. If the adapter bound to
 `127.0.0.1` you must front it with a reverse proxy or tunnel — WeCom's servers
-can't reach loopback. Set `extra.host: 0.0.0.0` in `config.yaml` (plus
+can't reach loopback. Leave `extra.host` unset so the default dual-stack
+bind (all interfaces, IPv4+IPv6) applies, or pin an interface in `config.yaml` (plus
 `allowed_source_cidrs` if exposing directly) or keep loopback and use a tunnel
 such as Cloudflare Tunnel / nginx.

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -225,7 +225,7 @@ All settings live in `~/.hermes/.env`.  Required values are in **bold**.
 | `WHATSAPP_CLOUD_ALLOW_ALL_USERS` | `false` | Set to `true` to bypass the allowlist. |
 | `WHATSAPP_CLOUD_APP_ID` | — | Optional, for future analytics integration. |
 | `WHATSAPP_CLOUD_WABA_ID` | — | Optional, for future analytics integration. |
-| `WHATSAPP_CLOUD_WEBHOOK_HOST` | `0.0.0.0` | Interface the webhook server binds to. |
+| `WHATSAPP_CLOUD_WEBHOOK_HOST` | unset (dual-stack: all interfaces, IPv4+IPv6) | Interface the webhook server binds to. |
 | `WHATSAPP_CLOUD_WEBHOOK_PORT` | `8090` | Port the webhook server binds to.  Must match the port your tunnel forwards. |
 | `WHATSAPP_CLOUD_WEBHOOK_PATH` | `/whatsapp/webhook` | URL path Meta posts to. |
 | `WHATSAPP_CLOUD_API_VERSION` | `v20.0` | Meta Graph API version. Only override if a newer version is recommended in Meta's docs. |


### PR DESCRIPTION
Hermes webhook servers now default to a dual-stack bind (one listening socket per address family) instead of IPv4-only `0.0.0.0`, so hosted deployments on IPv6-only private networks (e.g. Fly.io 6PN) can actually reach them.

Salvages #70532 by @shannonsands — authorship preserved via cherry-pick.

## Changes

- **Cherry-pick (`fix(line)`, NS-603):** LINE adapter `DEFAULT_HOST = None` → asyncio/aiohttp `create_server` binds both IPv4 and IPv6 regardless of the `bindv6only` sysctl (`::` is not a safe substitute on `bindv6only=1` hosts). `LINE_HOST`/`extra.host` overrides preserved; the three outbound-media `webhook_host == "0.0.0.0"` guards extracted into `_missing_public_url()` covering `None`/`0.0.0.0`/`::`/`""`; macOS-only `reuse_address=False`. Behavioural both-families bind test + decision-table + media-guard matrix tests.
- **Flaky-test guard (ours):** `test_default_bind_serves_both_families` asserts an IPv6 socket exists — on IPv4-only CI runners that's the environment, not a regression. Added a skip guard that checks `socket.has_ipv6` **and** probes an actual `::1` bind, skipping cleanly when the host has no usable IPv6 stack.
- **Fix-the-class (ours):** the same IPv4-only default existed in five sibling adapters; all now use the LINE pattern with existing overrides preserved:
  - `plugins/platforms/wecom/callback_adapter.py` — `DEFAULT_HOST = None`; `gateway/config.py` env seed no longer forces `0.0.0.0` when `WECOM_CALLBACK_HOST` is unset.
  - `gateway/platforms/msgraph_webhook.py` — `DEFAULT_HOST = None`; `host=None` is treated as network-accessible so the `allowed_source_cidrs` startup requirement still fires for the all-interfaces default.
  - `gateway/platforms/whatsapp_cloud.py` — `DEFAULT_WEBHOOK_HOST = None`.
  - `plugins/platforms/teams/adapter.py` — hardcoded `TCPSite(..., "0.0.0.0", ...)` → `_DEFAULT_HOST = None` with new `TEAMS_HOST`/`extra.host` override (plugin.yaml entry added).
  - `plugins/platforms/telegram/adapter.py` — hardcoded `listen="0.0.0.0"` → default `""` (tornado `bind_sockets` opens one socket per family — verified against the venv's PTB 22.6/tornado) with new `TELEGRAM_WEBHOOK_HOST`/`extra.webhook_host` override.
- **Doc drift (ours):** LINE `plugin.yaml` still documented `default: 0.0.0.0`; updated, along with the line/wecom-callback/msgraph-webhook/whatsapp-cloud/teams user-guide pages and the whatsapp_cloud module docstring. Non-bind `0.0.0.0` occurrences (dashboards, netstat fixtures, CIDR examples) untouched.

## Validation

| Check | Result |
|---|---|
| `tests/gateway/test_line_plugin.py` + wecom (callback/plugin_setup) + msgraph_webhook + whatsapp_cloud + teams | 311 passed |
| `tests/gateway/test_telegram_webhook_secret.py` + `test_teams_pipeline_runtime_wiring.py` | 12 passed |
| `tests/gateway/test_config.py` (wecom/whatsapp env seeding) | 151 passed |
| `ruff check` on all touched Python files | clean |
| Dual-stack bind proof (`tornado.netutil.bind_sockets(0, address=None/"")`) | AF_INET + AF_INET6; `"0.0.0.0"` → AF_INET only |
| Stale-base gate (`rev-list merge-base..origin/main`) | 0 |

Contributor mapping for shannon.sands.1979@gmail.com → shannonsands already present in `contributors/emails/`.

Do not merge #70532 separately; this branch supersedes it.

## Infographic

![dual-stack-webhook-bind](https://v3b.fal.media/files/b/0aa42746/8EKRbmyh-YTUGZH96ZxFp_0THGzkqm.png)
