### PR TITLE
fix(cli): end session in SQLite on CLI exit (#73848)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1258,6 +1258,19 @@ def _run_cleanup(*, notify_session_finalize: bool = True):
     except Exception as e:
         logger.warning("CLI cleanup memory shutdown failed: %s", e, exc_info=True)
 
+    # End the session in SQLite so auto_prune can reclaim it (#73848).
+    # Pre-0.19 compression ended sessions by splitting; in-place compression
+    # removed that path, leaving CLI/worker sessions immortal.
+    try:
+        _agent = _active_agent_ref
+        if _agent is not None:
+            _sdb = getattr(_agent, "_session_db", None)
+            _sid = getattr(_agent, "session_id", None)
+            if _sdb and _sid:
+                _sdb.end_session(_sid, "cli_exit")
+    except Exception as e:
+        logger.debug("CLI cleanup end_session failed: %s", e)
+
 
 def _should_emit_cleanup_session_finalize(session_id: str | None) -> bool:
     if not _single_query_finalize_attempted_session_ids:


### PR DESCRIPTION
## Summary

Fixes #73848. CLI/worker sessions never reach `ended_at` after 0.19's in-place compression, making `sessions.auto_prune` a dead letter and letting `state.db` grow without bound.

## Root Cause

Pre-0.19, compression SPLIT sessions and ended the old row (`end_reason='compression'`). In-place compression removed that path. The CLI cleanup path (`_run_cleanup`) never called `SessionDB.end_session`, so cleanly exiting CLI/kanban worker sessions are immortal.

## Fix

Add `end_session(session_id, 'cli_exit')` in `_run_cleanup` after memory shutdown. Uses the existing `_active_agent_ref` weak reference to access the agent's `_session_db`.

`end_session` already no-ops on ended rows, and resume/branch paths already re-open ended sessions, so this is safe by construction.

## Impact

- `sessions.auto_prune` can reclaim stale CLI/worker sessions
- `state.db` stops growing unbounded in busy deployments
- Prevents WAL checkpoint starvation and "database is locked" errors

## Testing

- `python3 -m py_compile cli.py` — OK
- `python3 -m ruff check cli.py` — clean
