### PR TITLE
fix(cron): warn agent when scheduler is unavailable

### DIFF
--- a/cron/scheduler_readiness.py
+++ b/cron/scheduler_readiness.py
@@ -1,0 +1,41 @@
+"""Shared scheduler-readiness checks for cron management surfaces."""
+
+from typing import Optional
+
+
+_GATEWAY_NOT_RUNNING_WARNING = (
+    "Gateway is not running — this job will NOT fire automatically. "
+    "Start it with `hermes gateway install`; check with `hermes cron status`."
+)
+
+
+def active_cron_provider_name() -> str:
+    """Return the resolved cron provider name without network access."""
+    try:
+        from cron.scheduler_provider import resolve_cron_scheduler
+
+        return resolve_cron_scheduler().name or "builtin"
+    except Exception:
+        return "builtin"
+
+
+def scheduler_readiness_warning(provider_name: Optional[str] = None) -> Optional[str]:
+    """Return a warning when the built-in scheduler has no process driving it.
+
+    External providers such as Chronos do not depend on the local gateway ticker,
+    so an absent gateway is not evidence that those jobs will fail to fire.
+    Readiness detection is best-effort: indeterminate state stays silent rather
+    than producing a false warning.
+    """
+    try:
+        if (provider_name or active_cron_provider_name()) != "builtin":
+            return None
+
+        from hermes_cli.gateway import find_gateway_pids
+
+        if find_gateway_pids():
+            return None
+    except Exception:
+        return None
+
+    return _GATEWAY_NOT_RUNNING_WARNING

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -24,6 +24,10 @@ from hermes_cli.colors import Colors, color
 from cron.lifecycle_guard import (  # noqa: F401  (re-exported for terminal_tool)
     contains_gateway_lifecycle_command as _contains_gateway_lifecycle_command,
 )
+from cron.scheduler_readiness import (
+    active_cron_provider_name as _shared_active_cron_provider_name,
+    scheduler_readiness_warning,
+)
 
 
 def _normalize_skills(single_skill=None, skills: Optional[Iterable[str]] = None) -> Optional[List[str]]:
@@ -55,12 +59,7 @@ def _active_cron_provider_name() -> str:
     provider's ``is_available()`` contract forbids network). Returns 'builtin'
     on any failure so callers fall back to the historical ticker-based checks.
     """
-    try:
-        from cron.scheduler_provider import resolve_cron_scheduler
-
-        return resolve_cron_scheduler().name or "builtin"
-    except Exception:
-        return "builtin"
+    return _shared_active_cron_provider_name()
 
 
 def _warn_if_gateway_not_running() -> None:
@@ -78,22 +77,11 @@ def _warn_if_gateway_not_running() -> None:
     any non-builtin provider; the gateway-process heuristic only speaks to the
     built-in ticker's trigger.
     """
-    try:
-        if _active_cron_provider_name() != "builtin":
-            return
-
-        from hermes_cli.gateway import find_gateway_pids
-
-        if find_gateway_pids():
-            return
-    except Exception:
-        # If we can't determine gateway state, stay quiet rather than nag.
+    warning = scheduler_readiness_warning(_active_cron_provider_name())
+    if not warning:
         return
 
-    print(color("  ⚠  Gateway is not running — jobs won't fire automatically.", Colors.YELLOW))
-    print(color("     Start it with: hermes gateway install", Colors.DIM))
-    print(color("                    sudo hermes gateway install --system  # Linux servers", Colors.DIM))
-    print(color("     Check status:  hermes cron status", Colors.DIM))
+    print(color(f"  ⚠  {warning}", Colors.YELLOW))
 
 
 def cron_list(show_all: bool = False):

--- a/tests/cron/test_scheduler_readiness.py
+++ b/tests/cron/test_scheduler_readiness.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+
+
+def _scheduler_readiness_warning():
+    from cron.scheduler_readiness import scheduler_readiness_warning
+
+    return scheduler_readiness_warning()
+
+
+def test_builtin_scheduler_without_gateway_warns(monkeypatch):
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler",
+        lambda: SimpleNamespace(name="builtin"),
+    )
+    monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [])
+
+    warning = _scheduler_readiness_warning()
+
+    assert warning is not None
+    assert "will NOT fire automatically" in warning
+    assert "hermes gateway install" in warning
+    assert "hermes cron status" in warning
+
+
+def test_builtin_scheduler_with_gateway_is_ready(monkeypatch):
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler",
+        lambda: SimpleNamespace(name="builtin"),
+    )
+    monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [4242])
+
+    assert _scheduler_readiness_warning() is None
+
+
+def test_external_scheduler_does_not_require_local_gateway(monkeypatch):
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler",
+        lambda: SimpleNamespace(name="chronos"),
+    )
+    monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [])
+
+    assert _scheduler_readiness_warning() is None

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -264,6 +264,50 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
 
+    def test_create_surfaces_scheduler_readiness_warning(self, monkeypatch):
+        warning = (
+            "Gateway is not running — this job will NOT fire automatically. "
+            "Start it with `hermes gateway install`; check with `hermes cron status`."
+        )
+        monkeypatch.setattr(
+            "tools.cronjob_tools._scheduler_readiness_warning",
+            lambda: warning,
+        )
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check server status",
+                schedule="every 1h",
+                name="Server Check",
+                deliver="local",
+            )
+        )
+
+        assert created["success"] is True
+        assert created["scheduler_warning"] == warning
+        assert warning in created["message"]
+
+    def test_create_omits_scheduler_warning_when_ready(self, monkeypatch):
+        monkeypatch.setattr(
+            "tools.cronjob_tools._scheduler_readiness_warning",
+            lambda: None,
+        )
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check server status",
+                schedule="every 1h",
+                name="Server Check",
+                deliver="local",
+            )
+        )
+
+        assert created["success"] is True
+        assert "scheduler_warning" not in created
+        assert "will NOT fire automatically" not in created["message"]
+
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -33,6 +33,9 @@ from cron.jobs import (
     resume_job,
     update_job,
 )
+from cron.scheduler_readiness import (
+    scheduler_readiness_warning as _scheduler_readiness_warning,
+)
 
 
 def _notify_provider_jobs_changed_safe() -> None:
@@ -714,22 +717,25 @@ def cronjob(
             _local_notice = _local_delivery_notice(job, _normalize_deliver_param(deliver))
             if _local_notice:
                 _create_message = f"{_create_message} {_local_notice}"
-            return json.dumps(
-                {
-                    "success": True,
-                    "job_id": job["id"],
-                    "name": job["name"],
-                    "skill": job.get("skill"),
-                    "skills": job.get("skills", []),
-                    "schedule": job["schedule_display"],
-                    "repeat": _repeat_display(job),
-                    "deliver": job.get("deliver", "local"),
-                    "next_run_at": job["next_run_at"],
-                    "job": _format_job(job),
-                    "message": _create_message,
-                },
-                indent=2,
-            )
+            _scheduler_warning = _scheduler_readiness_warning()
+            if _scheduler_warning:
+                _create_message = f"{_create_message} {_scheduler_warning}"
+            _create_response = {
+                "success": True,
+                "job_id": job["id"],
+                "name": job["name"],
+                "skill": job.get("skill"),
+                "skills": job.get("skills", []),
+                "schedule": job["schedule_display"],
+                "repeat": _repeat_display(job),
+                "deliver": job.get("deliver", "local"),
+                "next_run_at": job["next_run_at"],
+                "job": _format_job(job),
+                "message": _create_message,
+            }
+            if _scheduler_warning:
+                _create_response["scheduler_warning"] = _scheduler_warning
+            return json.dumps(_create_response, indent=2)
 
         if normalized == "list":
             jobs = [_format_job(job) for job in list_jobs(include_disabled=include_disabled)]


### PR DESCRIPTION
## Problem

The agent-facing `cronjob(action="create")` tool persisted a built-in cron job and returned success even when no Hermes gateway/scheduler was running. The CLI already warned in this state, but the model tool did not, so an agent could promise a durable one-shot that would never fire.

## Fix

- factor provider-aware scheduler readiness into `cron/scheduler_readiness.py`;
- reuse it from the CLI warning path;
- append a machine-readable `scheduler_warning` and the same warning in the create response message when the built-in scheduler lacks a gateway;
- remain silent for a running gateway and external schedulers such as Chronos.

Job persistence, local delivery semantics, and successful creation are unchanged.

## Verification

- RED before implementation: 5 focused failures, 77 pre-existing focused tests passed.
- GREEN after implementation and after final upstream rebase: 98/98 focused tests passed via `scripts/run_tests.sh`.
- Independent Gemini 3.6 Flash/high review: PASS; no material defect.
- Full repository run on the candidate surfaced 124 failures across 28 unrelated files. Exact failure-subset comparison against untouched parent `ceaa7880` reproduced 121 failures across the same 27 persistent files; no cron or changed-surface failure was introduced. The upstream baseline is therefore not globally green in this local environment, and this PR does not claim otherwise.
