### PR TITLE
fix(desktop): preserve mid-turn message order

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -572,8 +572,9 @@ describe('preserveLocalPendingTurnMessages', () => {
 
 describe('appendLiveSessionProjection', () => {
   // Corrections typed while a turn ran are their own user bubbles on the same
-  // turn. Resume must rebuild the prompt AND every correction, in order.
-  it('projects mid-turn redirect corrections after the prompt that started the turn', () => {
+  // turn. The live renderer appends them after the in-place assistant stream,
+  // so resume must preserve that visible arrival order.
+  it('projects mid-turn corrections after assistant output that predates them', () => {
     const restored = appendLiveSessionProjection([], {
       session_id: 'runtime-1',
       inflight: {
@@ -586,9 +587,9 @@ describe('appendLiveSessionProjection', () => {
 
     expect(restored.map(message => message.parts.map(part => ('text' in part ? part.text : '')).join(''))).toEqual([
       'remove the session counts',
+      'Moving.',
       'hurry up',
-      'and the worktree ones',
-      'Moving.'
+      'and the worktree ones'
     ])
   })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -466,22 +466,6 @@ export function appendLiveSessionProjection(
     })
   }
 
-  // Corrections typed while the turn ran. Each is its own bubble, placed after
-  // the original prompt and before the reply they redirected — the same order
-  // the live transcript showed. Skip any the transcript already holds so a
-  // resume doesn't double them.
-  for (const [index, correction] of inflightCorrections.entries()) {
-    if (persistedInLatestRun(correction)) {
-      continue
-    }
-
-    projected.push({
-      id: `user-inflight-correction-${index}-${sessionId}`,
-      role: 'user',
-      parts: [textPart(correction)]
-    })
-  }
-
   // Keep a pending assistant boundary even before the first delta when a
   // queued user turn follows it. This preserves the two distinct turns.
   if (inflightAssistant || inflightStreaming || inflightError || (inflightUser && queuedUser)) {
@@ -491,6 +475,23 @@ export function appendLiveSessionProjection(
       parts: inflightAssistant ? [assistantTextPart(inflightAssistant)] : [],
       pending: inflightStreaming,
       ...(inflightError ? { error: inflightError } : {})
+    })
+  }
+
+  // Corrections are accepted while the assistant bubble is already streaming
+  // in place. Keep that arrival order when rebuilding a live projection so a
+  // resume does not move a newly typed message above assistant output the user
+  // had already seen. Skip any correction the transcript already holds so a
+  // resume does not duplicate it.
+  for (const [index, correction] of inflightCorrections.entries()) {
+    if (persistedInLatestRun(correction)) {
+      continue
+    }
+
+    projected.push({
+      id: `user-inflight-correction-${index}-${sessionId}`,
+      role: 'user',
+      parts: [textPart(correction)]
     })
   }
 


### PR DESCRIPTION
## What changed

Reordered the live-session projection so mid-turn correction messages are appended after the assistant output that was already streaming when the correction arrived.

## Why

The live renderer updates the assistant bubble in place, then appends a mid-turn user message. On resume or reload, `appendLiveSessionProjection()` rebuilt the same data as prompt, correction, assistant. That moved the correction above all partial assistant output, including content the user had already read.

The projection now matches the visible arrival order: prompt, current assistant stream, corrections, then any queued next-turn prompt. Existing persisted corrections are still deduplicated.

Closes #73793.

## Validation

- `npm run --workspace apps/desktop test:ui -- src/app/session/hooks/use-session-actions/utils.test.ts` (42 tests)
- `npm exec --workspace apps/desktop -- eslint src/app/session/hooks/use-session-actions/utils.ts src/app/session/hooks/use-session-actions/utils.test.ts`
- `npm run --workspace apps/desktop typecheck`
- `git diff --check`
