### PR TITLE
fix(tts): accept stream kwarg in xAI TTS test mocks

### DIFF
--- a/tests/tools/test_tts_xai_speech_tags.py
+++ b/tests/tools/test_tts_xai_speech_tags.py
@@ -143,7 +143,7 @@ def test_generate_xai_tts_uses_oauth_pinned_base_url(tmp_path, monkeypatch):
         def raise_for_status(self):
             pass
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["url"] = url
         captured["headers"] = headers
         return FakeResponse()
@@ -590,7 +590,7 @@ def test_generate_xai_tts_omits_text_normalization_by_default(tmp_path, monkeypa
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
         return fake_response
 
@@ -614,7 +614,7 @@ def test_generate_xai_tts_sends_text_normalization_when_enabled(tmp_path, monkey
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
         return fake_response
 
@@ -640,7 +640,7 @@ def test_generate_xai_tts_omits_text_normalization_when_explicit_false(
     fake_response.content = b"mp3"
     fake_response.raise_for_status.return_value = None
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout, stream=False):
         captured["json"] = json
         return fake_response
 


### PR DESCRIPTION
## Summary
Fixes 4 pre-existing CI failures in test slice 5/8 — commit a1bc12f19 added `stream=True` to `requests.post()` in `_generate_xai_tts`, but 4 `fake_post` mocks in `tests/tools/test_tts_xai_speech_tags.py` still used the old signature without the `stream` parameter, causing `TypeError: fake_post() got an unexpected keyword argument 'stream'`.

Blocking PR #73596 (unrelated shutdown flush hardening) which is otherwise green.

## Changes
- `tests/tools/test_tts_xai_speech_tags.py`: added `stream=False` to 4 `fake_post` signatures that were missing it

## Validation
30/30 tests in `test_tts_xai_speech_tags.py` pass locally (was 4 failures).