### PR TITLE
fix(photon): avoid restarting healthy quiet streams

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -679,13 +679,12 @@ class PhotonAdapter(BasePlatformAdapter):
         # Presence watchdog. spectrum-ts only reconnects when its inbound
         # iterator throws or ends; a half-open ("zombie") gRPC socket makes the
         # iterator hang forever (no error, no end), so inbound silently dies
-        # until the sidecar is restarted. The sidecar owns primary zombie
-        # detection (stream-staleness + upstream probe -> degraded -> exit 75;
-        # surfaced here via /healthz in _monitor_sidecar_health). This adapter-
-        # side watchdog is a conservative second layer that only respawns the
-        # sidecar when the sidecar's own HTTP loop stops responding (probe
-        # HTTP call hangs) — an "inconclusive" probe (sidecar answered but
-        # could not prove upstream liveness) NEVER counts toward a respawn:
+        # until the sidecar is restarted. This watchdog periodically asks the
+        # sidecar to drive a unary call over the same gRPC channel. A successful
+        # call is a keepalive, but never evidence that a quiet event stream is
+        # dead: healthy shared lines can be silent for hours. Only repeated
+        # probe hangs respawn the sidecar. An "inconclusive" probe (the sidecar
+        # answered but could not prove upstream liveness) NEVER counts:
         # the network may simply be down, and restarting cannot fix that.
         # Thresholds are deliberately conservative (10 min interval) — shared
         # lines can be legitimately quiet for hours, so we never restart on
@@ -1048,22 +1047,6 @@ class PhotonAdapter(BasePlatformAdapter):
             stream = data.get("stream") if isinstance(data, dict) else None
             if not isinstance(stream, dict):
                 continue
-
-            # Surface the sidecar's zombie-stream staleness state early: a
-            # suspected half-open stream (silence past threshold + probe-proven
-            # connectivity) is worth a loud log line even before the sidecar's
-            # degraded->exit-75 path fires.
-            staleness = stream.get("staleness")
-            if (
-                isinstance(staleness, dict)
-                and staleness.get("zombieSuspected") is True
-            ):
-                logger.warning(
-                    "[photon] sidecar reports suspected zombie stream"
-                    " (silentForMs=%s, lastProbeOutcome=%s)",
-                    staleness.get("silentForMs"),
-                    staleness.get("lastProbeOutcome"),
-                )
 
             if stream.get("ok") is not False:
                 continue
@@ -1755,13 +1738,13 @@ class PhotonAdapter(BasePlatformAdapter):
 
         - ``"alive"``        — the sidecar completed a real upstream gRPC
           round-trip (HTTP 200). Only this counts as proof of liveness.
-        - ``"hung"``         — the probe HTTP call itself timed out: the
-          sidecar's event loop is unresponsive. Counts toward respawn.
-        - ``"inconclusive"`` — anything else (503 from the sidecar's strict
-          probe, connection refused, transport error). NEVER counts as alive
-          and NEVER counts toward a respawn: a rejected upstream probe may
-          just mean the network is down, and a dead sidecar process is the
-          supervisor's job, not ours.
+        - ``"hung"``         — the adapter HTTP call timed out, or the sidecar
+          reported that its upstream unary call timed out. Counts toward
+          respawn.
+        - ``"inconclusive"`` — anything else (non-hung 503, connection refused,
+          transport error). NEVER counts as alive and NEVER counts toward a
+          respawn: a rejected upstream probe may just mean the network is down,
+          and a dead sidecar process is the supervisor's job, not ours.
         """
         client = self._http_client
         if client is None:
@@ -1781,7 +1764,15 @@ class PhotonAdapter(BasePlatformAdapter):
                 return "hung"
             logger.debug("[photon] probe transport error (inconclusive): %s", e)
             return "inconclusive"
-        return "alive" if resp.status_code == 200 else "inconclusive"
+        if resp.status_code == 200:
+            return "alive"
+        try:
+            payload = resp.json()
+        except (AttributeError, TypeError, ValueError):
+            return "inconclusive"
+        if isinstance(payload, dict) and payload.get("outcome") == "hung":
+            return "hung"
+        return "inconclusive"
 
     async def _respawn_sidecar(self, reason: str) -> None:
         """Tear down and restart the sidecar to recover a dead gRPC stream.
@@ -1821,13 +1812,12 @@ class PhotonAdapter(BasePlatformAdapter):
     async def _presence_watchdog(self) -> None:
         """Periodically confirm the sidecar (and its stream) is responsive.
 
-        The sidecar owns primary zombie-stream detection (silence tracking +
-        upstream probe -> degraded /healthz -> exit 75). This loop is the
-        adapter's conservative second layer: it probes on a long interval,
-        skips the probe when natural inbound traffic already proved liveness,
-        and only counts a *hung* probe (the sidecar HTTP call itself timing
-        out) toward a respawn. Inconclusive probes — the sidecar answered but
-        couldn't prove upstream liveness — reset nothing and trigger nothing:
+        The loop probes on a long interval, skips the probe when natural
+        inbound traffic already proved liveness, and only counts a *hung*
+        upstream probe toward a respawn. The hang can surface either as an
+        adapter HTTP timeout or as the sidecar's explicit ``outcome=hung``
+        response. Inconclusive probes — the sidecar answered but couldn't
+        prove upstream liveness — reset nothing and trigger nothing:
         the network may just be down, and restarting can't fix that. After
         ``_probe_max_failures`` consecutive hung probes we respawn the sidecar
         to force a fresh stream.

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -67,11 +67,7 @@ import crypto from "node:crypto";
 import { once } from "node:events";
 import { patchSpectrumTs } from "./patch-spectrum-mixed-attachments.mjs";
 import { chooseSendFormat } from "./send-format.mjs";
-import {
-  classifyProbeRejection,
-  shouldProbe,
-  isZombieSuspect,
-} from "./stream-staleness.mjs";
+import { classifyProbeRejection } from "./stream-staleness.mjs";
 
 const projectId = process.env.PHOTON_PROJECT_ID;
 const projectSecret = process.env.PHOTON_PROJECT_SECRET;
@@ -98,22 +94,8 @@ const STREAM_DEGRADED_RESTART_MS =
   Number(process.env.PHOTON_STREAM_DEGRADED_RESTART_MS) || 90 * 1000;
 const STREAM_INTERRUPTED_DEGRADE_COUNT =
   Number(process.env.PHOTON_STREAM_INTERRUPTED_DEGRADE_COUNT) || 3;
-// Zombie-stream (half-open gRPC) watchdog. The inbound iterator can hang
-// forever without erroring; we track when it last yielded and, once it has
-// been silent past this threshold, drive a cheap authenticated probe. Silence
-// alone NEVER degrades the stream (shared lines can be quiet for hours) and a
-// rejected probe is INCONCLUSIVE, never proof either way — degradation
-// requires silence past the threshold plus a probe-proven live channel.
-// A non-positive threshold disables the watchdog.
-const STREAM_SILENCE_PROBE_MS = (() => {
-  const raw = Number(process.env.PHOTON_STREAM_SILENCE_PROBE_MS);
-  return Number.isFinite(raw) ? raw : 10 * 60 * 1000;
-})();
-const STREAM_PROBE_COOLDOWN_MS =
-  Number(process.env.PHOTON_STREAM_PROBE_COOLDOWN_MS) || 2 * 60 * 1000;
 const STREAM_PROBE_TIMEOUT_MS =
   Number(process.env.PHOTON_STREAM_PROBE_TIMEOUT_MS) || 10 * 1000;
-const STREAM_WATCHDOG_TICK_MS = 30 * 1000;
 
 const streamHealth = {
   state: "starting",
@@ -124,33 +106,6 @@ const streamHealth = {
   issueCount: 0,
 };
 let streamRestartTimer = null;
-
-// Zombie-watchdog runtime state (see stream-staleness.mjs for the rules).
-const staleness = {
-  lastInboundAt: Date.now(),
-  lastProbeAt: 0,
-  lastProbeOutcome: null, // "alive" | "inconclusive" | null
-  zombieSuspected: false,
-};
-
-function noteInboundYield() {
-  staleness.lastInboundAt = Date.now();
-  staleness.zombieSuspected = false;
-}
-
-function stalenessSnapshot(now) {
-  return {
-    lastInboundAt: new Date(staleness.lastInboundAt).toISOString(),
-    silentForMs: now - staleness.lastInboundAt,
-    silenceThresholdMs: STREAM_SILENCE_PROBE_MS,
-    lastProbeAt:
-      staleness.lastProbeAt > 0
-        ? new Date(staleness.lastProbeAt).toISOString()
-        : null,
-    lastProbeOutcome: staleness.lastProbeOutcome,
-    zombieSuspected: staleness.zombieSuspected,
-  };
-}
 
 function streamHealthSnapshot() {
   const now = Date.now();
@@ -165,7 +120,6 @@ function streamHealthSnapshot() {
     lastIssueAt: streamHealth.lastIssueAt,
     lastIssue: streamHealth.lastIssue,
     issueCount: streamHealth.issueCount,
-    staleness: stalenessSnapshot(now),
   };
 }
 
@@ -648,8 +602,6 @@ function inboundStreamErrorMessage(e) {
       for await (const [space, message] of app.messages) {
         backoff = 1000; // healthy traffic — reset
         markStreamHealthy();
-        // Every yield — any direction — proves the inbound stream is live.
-        noteInboundYield();
         // Only forward inbound messages (ignore our own outbound echoes).
         if (message && message.direction && message.direction !== "inbound") {
           continue;
@@ -673,23 +625,6 @@ function inboundStreamErrorMessage(e) {
     backoff = Math.min(backoff * 2, 30000);
   }
 })();
-
-// ---------------------------------------------------------------------------
-// Zombie-stream watchdog: detect a half-open gRPC stream the SDK can't see.
-//
-// The inbound iterator above can hang forever on a half-open socket — no
-// error, no end — so the re-subscribe loop never fires and classifyStreamLog
-// never sees a "[spectrum.stream]" line. We track the iterator's last yield
-// (noteInboundYield) and, once it has been silent past
-// STREAM_SILENCE_PROBE_MS, drive a cheap unary read (space.getMessage on a
-// synthetic id) over the same authenticated channel. Decision rules (see
-// stream-staleness.mjs):
-//   probe proves connectivity while the stream is silent -> the stream itself
-//     is the dead part -> markStreamDegraded -> existing exit-75 restart path.
-//   probe inconclusive (rejected/hung) -> do NOTHING: the network may just be
-//     down, and in that case the iterator eventually throws and the
-//     re-subscribe loop recovers on its own. Never restart on silence alone —
-//     shared lines can be legitimately quiet for hours.
 
 async function probeUpstream() {
   if (typeof app?.stop !== "function") {
@@ -720,51 +655,7 @@ async function probeUpstream() {
   })();
   const outcome = await Promise.race([attempt, timeout]);
   if (timer) clearTimeout(timer);
-  staleness.lastProbeAt = Date.now();
-  staleness.lastProbeOutcome = outcome.alive ? "alive" : "inconclusive";
   return outcome;
-}
-
-let watchdogProbeInFlight = false;
-async function zombieWatchdogTick() {
-  if (watchdogProbeInFlight) return;
-  const now = Date.now();
-  const silentForMs = now - staleness.lastInboundAt;
-  if (
-    !shouldProbe(
-      silentForMs,
-      STREAM_SILENCE_PROBE_MS,
-      now - staleness.lastProbeAt,
-      STREAM_PROBE_COOLDOWN_MS
-    )
-  ) {
-    return;
-  }
-  watchdogProbeInFlight = true;
-  try {
-    const outcome = await probeUpstream();
-    if (isZombieSuspect(silentForMs, STREAM_SILENCE_PROBE_MS, outcome)) {
-      staleness.zombieSuspected = true;
-      const reason =
-        `inbound stream silent for ${silentForMs}ms while an upstream probe ` +
-        "succeeded — half-open (zombie) gRPC stream suspected";
-      console.error("photon-sidecar: " + reason);
-      markStreamDegraded(reason);
-    }
-    // Inconclusive: deliberately no action (see block comment above).
-  } catch (e) {
-    console.error(
-      "photon-sidecar: zombie watchdog tick failed: " +
-        (e && e.message ? e.message : String(e))
-    );
-  } finally {
-    watchdogProbeInFlight = false;
-  }
-}
-
-if (STREAM_SILENCE_PROBE_MS > 0) {
-  const watchdogTimer = setInterval(zombieWatchdogTick, STREAM_WATCHDOG_TICK_MS);
-  watchdogTimer.unref();
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/platforms/photon/sidecar/stream-staleness.mjs
+++ b/plugins/platforms/photon/sidecar/stream-staleness.mjs
@@ -1,11 +1,10 @@
-// Pure decision helpers for the zombie-stream (half-open gRPC) watchdog.
+// Strict classification for the zombie-stream (half-open gRPC) liveness probe.
 //
 // spectrum-ts only reconnects when its inbound async iterator throws or ends.
 // A half-open ("zombie") socket makes the iterator hang forever — no error,
 // no end — so inbound silently dies while /healthz still looks fine. The
-// watchdog in index.mjs tracks the last time the inbound iterator yielded and,
-// once the stream has been silent past a conservative threshold, drives a
-// cheap authenticated unary read over the same channel. STRICT semantics:
+// adapter periodically drives a cheap authenticated unary read over the same
+// channel. STRICT semantics:
 //
 //   - probe resolves, or rejects with a not-found-shaped error for our
 //     synthetic id            -> ALIVE (the wire round-tripped)
@@ -13,14 +12,12 @@
 //     down, ...)              -> INCONCLUSIVE — never treated as alive, and
 //                                never treated as zombie-proof either
 //
-// A zombie is only declared when the stream is silent past the threshold AND
-// a probe proves connectivity (the wire works but the stream is deaf). Silence
-// alone NEVER degrades the stream: shared lines can be legitimately quiet for
-// hours. Inconclusive probes NEVER degrade it either: the network may simply
-// be down, and in that case the iterator will eventually throw and the
-// existing re-subscribe loop recovers on its own.
+// A successful unary call proves only that the channel can round-trip. It does
+// NOT prove that a quiet event stream is dead: healthy shared lines can emit no
+// messages for hours. The Python adapter therefore treats success as healthy
+// and only restarts after repeated probe hangs.
 //
-// These helpers are pure (no SDK, no timers) so tests can execute them under
+// This helper is pure (no SDK, no timers) so tests can execute it under
 // node — see tests/plugins/platforms/photon/test_zombie_stream_watchdog.py.
 
 // gRPC NOT_FOUND is code 5; SDKs also surface it as "not found" / "NotFound"
@@ -47,34 +44,4 @@ export function classifyProbeRejection(err) {
   // Anything else (UNAVAILABLE, DEADLINE_EXCEEDED, TLS, auth, ...) does NOT
   // prove liveness — and doesn't prove a zombie either.
   return { alive: false, inconclusive: true, reason: message };
-}
-
-/**
- * Should the watchdog probe at all this tick?
- *
- * @param {number} silentForMs   ms since the inbound iterator last yielded
- * @param {number} thresholdMs   silence threshold (<= 0 disables the watchdog)
- * @param {number} sinceLastProbeMs ms since the previous probe attempt
- * @param {number} probeCooldownMs  min spacing between probe attempts
- * @returns {boolean}
- */
-export function shouldProbe(silentForMs, thresholdMs, sinceLastProbeMs, probeCooldownMs) {
-  if (!(thresholdMs > 0)) return false;
-  if (silentForMs < thresholdMs) return false;
-  return sinceLastProbeMs >= probeCooldownMs;
-}
-
-/**
- * Final classification: zombie only on silence past threshold + probe-proven
- * connectivity. Never on silence alone, never on an inconclusive probe.
- *
- * @param {number} silentForMs ms since the inbound iterator last yielded
- * @param {number} thresholdMs silence threshold (<= 0 disables the watchdog)
- * @param {{alive: boolean}} probeOutcome
- * @returns {boolean}
- */
-export function isZombieSuspect(silentForMs, thresholdMs, probeOutcome) {
-  if (!(thresholdMs > 0)) return false;
-  if (silentForMs < thresholdMs) return false;
-  return probeOutcome != null && probeOutcome.alive === true;
 }

--- a/tests/plugins/platforms/photon/test_presence_watchdog.py
+++ b/tests/plugins/platforms/photon/test_presence_watchdog.py
@@ -104,6 +104,29 @@ async def test_probe_once_inconclusive_on_error_status(
 
 
 @pytest.mark.asyncio
+async def test_probe_once_hung_on_explicit_sidecar_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sidecar applies its own upstream timeout before replying. Preserve
+    that specific verdict so recovery does not depend on a race between two
+    equal HTTP timeout clocks."""
+    a = _make_adapter(monkeypatch)
+
+    class _Resp:
+        status_code = 503
+
+        def json(self) -> Any:
+            return {"ok": False, "alive": False, "outcome": "hung"}
+
+    class _Client:
+        async def post(self, *args: Any, **kwargs: Any) -> Any:
+            return _Resp()
+
+    a._http_client = _Client()  # type: ignore[assignment]
+    assert await a._probe_once() == "hung"
+
+
+@pytest.mark.asyncio
 async def test_probe_once_hung_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     a = _make_adapter(monkeypatch)
 

--- a/tests/plugins/platforms/photon/test_spectrum_patch.py
+++ b/tests/plugins/platforms/photon/test_spectrum_patch.py
@@ -84,7 +84,20 @@ def _write_sidecar_fixture(tmp_path: Path, *, sdk_available: bool) -> Path:
         encoding="utf-8",
     )
     (package / "providers" / "imessage.js").write_text(
-        "export function imessage() { return {}; }\nimessage.config = () => ({});\n",
+        textwrap.dedent(
+            """
+            export function imessage() {
+              return {
+                space: {
+                  get: async () => ({
+                    getMessage: async () => undefined,
+                  }),
+                },
+              };
+            }
+            imessage.config = () => ({});
+            """
+        ).lstrip(),
         encoding="utf-8",
     )
     return sidecar
@@ -127,6 +140,56 @@ def test_sidecar_patch_failure_still_reaches_health_endpoint(tmp_path: Path) -> 
         _, stderr = proc.communicate(timeout=5)
 
     assert "forced patch failure" in stderr
+
+
+def test_successful_probe_keeps_a_quiet_stream_healthy(tmp_path: Path) -> None:
+    """A unary round-trip proves channel liveness, not event-stream failure.
+
+    Spectrum's message iterator emits real events rather than heartbeats, so a
+    healthy shared line can stay quiet indefinitely. A successful synthetic
+    getMessage probe must therefore leave stream health unchanged.
+    """
+    sidecar = _write_sidecar_fixture(tmp_path, sdk_available=True)
+    port = _free_port()
+    proc = subprocess.Popen(
+        ["node", "index.mjs"],
+        cwd=sidecar,
+        env=_sidecar_env(port),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    def _post(path: str) -> dict[str, object]:
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{port}{path}",
+            data=b"{}",
+            headers={"X-Hermes-Sidecar-Token": "test-token"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=1) as response:
+            return json.load(response)
+
+    try:
+        deadline = time.monotonic() + 5
+        while True:
+            try:
+                health = _post("/healthz")
+                break
+            except OSError:
+                if proc.poll() is not None or time.monotonic() >= deadline:
+                    raise
+                time.sleep(0.05)
+
+        probe = _post("/probe")
+        health = _post("/healthz")
+
+        assert probe["alive"] is True
+        assert health["stream"]["ok"] is True  # type: ignore[index]
+        assert proc.poll() is None
+    finally:
+        proc.terminate()
+        proc.communicate(timeout=5)
 
 
 def test_sidecar_missing_sdk_remains_fatal_after_patch_failure(tmp_path: Path) -> None:

--- a/tests/plugins/platforms/photon/test_zombie_stream_watchdog.py
+++ b/tests/plugins/platforms/photon/test_zombie_stream_watchdog.py
@@ -4,22 +4,14 @@ spectrum-ts only reconnects when its inbound iterator throws or ends; a
 half-open ("zombie") socket makes the iterator hang forever — no error, no
 end — so inbound silently dies while the sidecar process looks healthy.
 
-The salvaged design has two layers:
+The sidecar exposes a strict unary liveness probe and the Python adapter
+drives it on a conservative interval. A completed unary call is a keepalive,
+not evidence that a quiet event stream is dead. Only repeated probe hangs
+trigger a sidecar respawn.
 
-1. Sidecar (node): ``stream-staleness.mjs`` decision rules + a watchdog in
-   ``index.mjs`` that tracks the iterator's last yield, probes only after a
-   conservative silence threshold, and classifies degraded ONLY when a probe
-   proves connectivity while the stream is silent (never on silence alone,
-   never on an inconclusive probe). Degraded feeds the existing exit-75
-   restart path and the ``staleness`` block on ``/healthz``.
-2. Adapter (python): ``_monitor_sidecar_health`` surfaces the new staleness
-   fields; ``_probe_once`` has strict tri-state semantics (alive / hung /
-   inconclusive).
-
-These tests execute the real node decision module and drive the adapter
-against mocked ``/healthz`` responses — style follows
-test_overflow_recovery.py / test_spectrum_patch.py. No ports are bound and no
-gRPC traffic occurs.
+These tests execute the real node classification module and drive the
+adapter against mocked responses. No ports are bound and no gRPC traffic
+occurs.
 """
 from __future__ import annotations
 
@@ -48,7 +40,7 @@ def _make_adapter(monkeypatch: pytest.MonkeyPatch) -> PhotonAdapter:
 
 def _run_staleness_harness(script: str) -> Dict[str, Any]:
     harness = (
-        "import { classifyProbeRejection, shouldProbe, isZombieSuspect } "
+        "import { classifyProbeRejection } "
         f"from {json.dumps(_MODULE.as_uri())};\n"
         + script
     )
@@ -91,121 +83,12 @@ def test_probe_rejection_classification_is_strict() -> None:
         assert out[name]["inconclusive"] is True, name
 
 
-def test_should_probe_requires_silence_past_threshold_and_cooldown() -> None:
-    out = _run_staleness_harness(
-        """
-        const MIN10 = 10 * 60 * 1000;
-        const results = {
-          quietButUnderThreshold: shouldProbe(MIN10 - 1, MIN10, MIN10, 120000),
-          pastThreshold: shouldProbe(MIN10 + 1, MIN10, MIN10, 120000),
-          pastThresholdButCoolingDown: shouldProbe(MIN10 + 1, MIN10, 1000, 120000),
-          watchdogDisabled: shouldProbe(MIN10 * 100, 0, MIN10, 120000),
-          watchdogDisabledNegative: shouldProbe(MIN10 * 100, -1, MIN10, 120000),
-        };
-        process.stdout.write(JSON.stringify(results));
-        """
-    )
-    assert out["quietButUnderThreshold"] is False
-    assert out["pastThreshold"] is True
-    assert out["pastThresholdButCoolingDown"] is False
-    assert out["watchdogDisabled"] is False
-    assert out["watchdogDisabledNegative"] is False
-
-
-def test_zombie_requires_probe_proven_connectivity_never_silence_alone() -> None:
-    """The core conservatism rule: shared lines can be quiet for hours, so a
-    zombie is declared only when the stream is silent past threshold AND a
-    probe PROVED the wire works (stream dead, channel alive)."""
-    out = _run_staleness_harness(
-        """
-        const MIN10 = 10 * 60 * 1000;
-        const alive = { alive: true };
-        const inconclusive = { alive: false };
-        const results = {
-          silentAndProbeAlive: isZombieSuspect(MIN10 * 2, MIN10, alive),
-          silentButProbeInconclusive: isZombieSuspect(MIN10 * 2, MIN10, inconclusive),
-          silentNoProbe: isZombieSuspect(MIN10 * 2, MIN10, null),
-          hoursOfSilenceInconclusive: isZombieSuspect(MIN10 * 36, MIN10, inconclusive),
-          notSilentEnough: isZombieSuspect(MIN10 - 1, MIN10, alive),
-          disabled: isZombieSuspect(MIN10 * 2, 0, alive),
-        };
-        process.stdout.write(JSON.stringify(results));
-        """
-    )
-    assert out["silentAndProbeAlive"] is True
-    # Silence alone — even 6 hours of it — is NEVER a zombie verdict.
-    assert out["silentButProbeInconclusive"] is False
-    assert out["silentNoProbe"] is False
-    assert out["hoursOfSilenceInconclusive"] is False
-    assert out["notSilentEnough"] is False
-    assert out["disabled"] is False
-
-
-# -- Adapter surfacing of the new /healthz staleness fields ------------------
-
-def _healthz_payload(**staleness: Any) -> Dict[str, Any]:
-    return {
-        "ok": True,
-        "stream": {
-            "ok": True,
-            "state": "healthy",
-            "degradedForMs": 0,
-            "staleness": {
-                "lastInboundAt": "2026-07-28T00:00:00.000Z",
-                "silentForMs": 0,
-                "silenceThresholdMs": 600000,
-                "lastProbeAt": None,
-                "lastProbeOutcome": None,
-                "zombieSuspected": False,
-                **staleness,
-            },
-        },
-    }
-
-
 @pytest.mark.asyncio
-async def test_monitor_surfaces_zombie_suspected_without_fatal(
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """zombieSuspected on /healthz is surfaced as a warning while the stream
-    is still 'ok' — the fatal path stays owned by the degraded state (the
-    sidecar escalates to degraded -> exit 75 itself)."""
-    adapter = _make_adapter(monkeypatch)
-    adapter._inbound_running = True
-    adapter._sidecar_health_interval = 0.0
-
-    polls = 0
-
-    async def _fake_call(path: str, payload: Dict[str, Any]) -> Any:
-        nonlocal polls
-        assert path == "/healthz"
-        polls += 1
-        if polls >= 2:
-            adapter._inbound_running = False
-        return _healthz_payload(
-            silentForMs=1_200_000,
-            lastProbeOutcome="alive",
-            zombieSuspected=True,
-        )
-
-    monkeypatch.setattr(adapter, "_sidecar_call", _fake_call)
-
-    with caplog.at_level("WARNING"):
-        await adapter._monitor_sidecar_health()
-
-    assert adapter.has_fatal_error is False
-    assert any(
-        "suspected zombie stream" in rec.message for rec in caplog.records
-    )
-
-
-@pytest.mark.asyncio
-async def test_monitor_still_raises_fatal_when_zombie_degrades_stream(
+async def test_monitor_still_raises_fatal_for_degraded_stream(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Once the sidecar's watchdog escalates the zombie to degraded, the
-    existing UPSTREAM_STREAM_DEGRADED reconnect path fires unchanged."""
+    """Existing Spectrum telemetry degradation still uses the unchanged
+    UPSTREAM_STREAM_DEGRADED reconnect path."""
     adapter = _make_adapter(monkeypatch)
     adapter._inbound_running = True
     adapter._sidecar_health_interval = 0.0
@@ -218,15 +101,7 @@ async def test_monitor_still_raises_fatal_when_zombie_degrades_stream(
                 "ok": False,
                 "state": "degraded",
                 "degradedForMs": 95000,
-                "lastIssue": (
-                    "inbound stream silent for 1200000ms while an upstream "
-                    "probe succeeded — half-open (zombie) gRPC stream suspected"
-                ),
-                "staleness": {
-                    "silentForMs": 1_200_000,
-                    "lastProbeOutcome": "alive",
-                    "zombieSuspected": True,
-                },
+                "lastIssue": "stream persistently failing",
             },
         }
 
@@ -255,11 +130,11 @@ async def test_monitor_still_raises_fatal_when_zombie_degrades_stream(
 
 
 @pytest.mark.asyncio
-async def test_monitor_ignores_healthz_without_staleness_block(
+async def test_monitor_accepts_healthy_stream(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Old sidecars (no staleness field) keep working: the monitor must not
-    crash or raise fatals on the legacy /healthz shape."""
+    """A healthy quiet stream remains healthy until Spectrum reports an actual
+    failure; absence of event traffic is not a degradation signal."""
     adapter = _make_adapter(monkeypatch)
     adapter._inbound_running = True
     adapter._sidecar_health_interval = 0.0


### PR DESCRIPTION
## Summary

Follow-up to #73615. Prevent the new Photon zombie-stream watchdog from classifying a healthy but quiet shared line as dead.

## Root cause

`spectrum-ts` 8's `app.messages` iterator yields real events, not periodic heartbeats. A healthy shared line can therefore be silent for hours. The merged classifier treated `silence past threshold + successful unary probe` as proof of a zombie stream, but a healthy quiet stream satisfies those same conditions. The sidecar would mark it degraded and enter the restart path every 10 minutes.

The adapter also collapsed the sidecar's explicit `{"outcome":"hung"}` 503 into `inconclusive`, making actual recovery depend on a race between the sidecar and HTTP client timeout clocks.

## Fix

- Remove the silence-plus-success sidecar classifier and duplicate probe timer.
- Keep successful unary probes as liveness keepalives only.
- Preserve explicit sidecar `hung` outcomes in the adapter.
- Continue ignoring strict non-hung 503 and transport errors as inconclusive.
- Add a real Node sidecar regression proving that a successful probe leaves a quiet stream healthy.

## Test plan

- [x] `node --check` on all three changed/imported `.mjs` modules
- [x] Ruff on the changed Python implementation and tests
- [x] Ty on `plugins/platforms/photon/adapter.py`
- [x] Canonical Photon suite: **21 files, 242 tests passed, 0 failed**

Contributed by **Vaibhav Sharma** (X: [@vabbyshabby](https://x.com/vabbyshabby)).
