### PR TITLE
fix: replace assert with ImportError guard in Buzz adapter nostr_auth loader

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -104,7 +104,10 @@ def _load_nostr_auth():
 
         path = Path(__file__).with_name("nostr_auth.py")
         spec = importlib.util.spec_from_file_location("plugin_adapter_buzz_nostr_auth", path)
-        assert spec is not None and spec.loader is not None
+        if spec is None or spec.loader is None:
+            raise ImportError(
+                f"Cannot load nostr_auth module from {path}"
+            )
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
         return module


### PR DESCRIPTION
## Summary

Replace bare `assert` with explicit `ImportError` guard in the Buzz adapter's nostr_auth lazy loader.

## Problem

`plugins/platforms/buzz/adapter.py:107` uses `assert spec is not None and spec.loader is not None` after `importlib.util.spec_from_file_location()`. This has two issues:

1. **Stripped under `python -O`**: The assert is silently removed, and `spec.loader.exec_module(module)` on line 109 crashes with `AttributeError: 'NoneType' object has no attribute 'exec_module'` — a confusing error with no indication of root cause.
2. **Bare `AssertionError` in production**: Without `-O`, the assert crashes with a generic `AssertionError` instead of a descriptive error explaining which module failed to load.

## Fix

Replace the assert with an explicit `if` guard that raises `ImportError` with a descriptive message including the path that failed to load.

## Testing

- `python3 -m py_compile plugins/platforms/buzz/adapter.py` passes
- Follows the same pattern as existing assert→runtime-guard PRs (#56736, #56866, #61983, #62001, #62006, #62659, #64063, #64071, #64808, #64818, #73800)