### PR TITLE
fix(desktop): restore Back/Escape from preview HTML report images

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -83,6 +83,7 @@ import {
 } from './desktop-uninstall'
 import { describeDevCdpDecision, resolveDevCdpPort } from './dev-cdp'
 import { installEmbedReferer } from './embed-referer'
+import { installPreviewWebviewGuards, wirePreviewWebviewById } from './preview-webview'
 import { createEventDeduper } from './event-dedupe'
 import { findGitBash as _findGitBash } from './find-git-bash'
 import { installFoundInPageForwarder, performFind, stopFind } from './find-in-page'
@@ -10331,6 +10332,10 @@ ipcMain.handle('hermes:watchPreviewFile', (_event, url) => watchPreviewFile(Stri
 
 ipcMain.handle('hermes:watchDirectory', (_event, dir) => watchDirectory(String(dir || '')))
 
+ipcMain.handle('hermes:wirePreviewWebview', (_event, webContentsId) =>
+  wirePreviewWebviewById(Number(webContentsId))
+)
+
 ipcMain.handle('hermes:stopPreviewFileWatch', (_event, id) => stopPreviewFileWatch(String(id || '')))
 
 // Each renderer reports the turns it has in flight; the quit guard reads the
@@ -11559,6 +11564,10 @@ app.whenReady().then(() => {
   installMediaPermissions()
   registerMediaProtocol()
   installEmbedReferer()
+  // Preview <webview> guests: keep target=_blank attachment opens in-pane with
+  // history, and map Escape → goBack so HTML report image views are dismissible
+  // without closing the whole preview pane.
+  installPreviewWebviewGuards(app)
   registerDeepLinkProtocol()
   ensureWslWindowsFonts()
   configureSpellChecker()

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -121,6 +121,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   watchPreviewFile: url => ipcRenderer.invoke('hermes:watchPreviewFile', url),
   watchDirectory: dir => ipcRenderer.invoke('hermes:watchDirectory', dir),
   stopPreviewFileWatch: id => ipcRenderer.invoke('hermes:stopPreviewFileWatch', id),
+  wirePreviewWebview: webContentsId => ipcRenderer.invoke('hermes:wirePreviewWebview', webContentsId),
   setActiveWork: payload => ipcRenderer.send('hermes:active-work', payload),
   setTitleBarTheme: payload => ipcRenderer.send('hermes:titlebar-theme', payload),
   setNativeTheme: mode => ipcRenderer.send('hermes:native-theme', mode),

--- a/apps/desktop/electron/preview-webview.test.ts
+++ b/apps/desktop/electron/preview-webview.test.ts
@@ -3,10 +3,27 @@ import assert from 'node:assert/strict'
 import { describe, expect, it, vi } from 'vitest'
 
 import {
+  installPreviewWebviewGuards,
   previewWindowOpenDecision,
   shouldHandleEscapeAsPreviewBack,
+  wirePreviewWebviewById,
   wirePreviewWebviewContents
 } from './preview-webview'
+
+function mockGuest(session: object, id?: number) {
+  return {
+    id,
+    session,
+    canGoBack: () => false,
+    getType: () => 'webview',
+    goBack: vi.fn(),
+    isDestroyed: () => false,
+    loadURL: vi.fn(async () => undefined),
+    on: vi.fn(),
+    once: vi.fn(),
+    setWindowOpenHandler: vi.fn()
+  }
+}
 
 describe('previewWindowOpenDecision', () => {
   it('keeps attachment / target=_blank navigations inside the preview webview', () => {
@@ -32,9 +49,12 @@ describe('wirePreviewWebviewContents', () => {
   it('navigates in-place on window.open and goes back on Escape', async () => {
     const loads: string[] = []
     let openHandler: ((details: { url: string }) => { action: string }) | null = null
+
     let inputHandler: ((event: { preventDefault: () => void }, input: { type: string; key: string }) => void) | null =
       null
+
     let canGoBack = false
+
     const goBack = vi.fn(() => {
       // history is still non-empty for a second Esc until navigate completes
     })
@@ -76,6 +96,7 @@ describe('wirePreviewWebviewContents', () => {
 
   it('does not go back on Escape when history is empty', () => {
     const goBack = vi.fn()
+
     let inputHandler: ((event: { preventDefault: () => void }, input: { type: string; key: string }) => void) | null =
       null
 
@@ -97,5 +118,49 @@ describe('wirePreviewWebviewContents', () => {
 
     expect(preventDefault).not.toHaveBeenCalled()
     expect(goBack).not.toHaveBeenCalled()
+  })
+})
+
+describe('preview guest scoping', () => {
+  it('installs guards only for webviews in the preview partition', () => {
+    const previewSession = {}
+    const otherSession = {}
+    const sessionApi = { fromPartition: vi.fn(() => previewSession) }
+    let onWebContentsCreated: ((_event: unknown, contents: unknown) => void) | undefined
+
+    const electronApp = {
+      on: vi.fn((event: string, listener: (_event: unknown, contents: unknown) => void) => {
+        if (event === 'web-contents-created') {
+          onWebContentsCreated = listener
+        }
+      })
+    }
+
+    const previewGuest = mockGuest(previewSession)
+    const unrelatedGuest = mockGuest(otherSession)
+
+    installPreviewWebviewGuards(electronApp as never, sessionApi as never)
+    onWebContentsCreated?.({}, unrelatedGuest)
+    onWebContentsCreated?.({}, previewGuest)
+
+    expect(unrelatedGuest.setWindowOpenHandler).not.toHaveBeenCalled()
+    expect(unrelatedGuest.on).not.toHaveBeenCalled()
+    expect(previewGuest.setWindowOpenHandler).toHaveBeenCalledTimes(1)
+    expect(previewGuest.on).toHaveBeenCalledWith('before-input-event', expect.any(Function))
+  })
+
+  it('rejects explicit registration for a non-preview guest', () => {
+    const previewSession = {}
+    const unrelatedGuest = mockGuest({}, 42)
+
+    expect(
+      wirePreviewWebviewById(
+        42,
+        { fromId: vi.fn(() => unrelatedGuest) } as never,
+        { fromPartition: vi.fn(() => previewSession) } as never
+      )
+    ).toBe(false)
+    expect(unrelatedGuest.setWindowOpenHandler).not.toHaveBeenCalled()
+    expect(unrelatedGuest.on).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/electron/preview-webview.test.ts
+++ b/apps/desktop/electron/preview-webview.test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  previewWindowOpenDecision,
+  shouldHandleEscapeAsPreviewBack,
+  wirePreviewWebviewContents
+} from './preview-webview'
+
+describe('previewWindowOpenDecision', () => {
+  it('keeps attachment / target=_blank navigations inside the preview webview', () => {
+    assert.equal(previewWindowOpenDecision('file:///tmp/report/shot.png'), 'navigate-in-place')
+    assert.equal(previewWindowOpenDecision('blob:file:///uuid'), 'navigate-in-place')
+    assert.equal(previewWindowOpenDecision('https://example.com'), 'navigate-in-place')
+  })
+})
+
+describe('shouldHandleEscapeAsPreviewBack', () => {
+  it('handles Escape only when the guest can go back', () => {
+    expect(shouldHandleEscapeAsPreviewBack({ type: 'keyDown', key: 'Escape' }, true)).toBe(true)
+    expect(shouldHandleEscapeAsPreviewBack({ type: 'keyDown', key: 'Escape' }, false)).toBe(false)
+  })
+
+  it('ignores non-Escape keys and keyUp', () => {
+    expect(shouldHandleEscapeAsPreviewBack({ type: 'keyDown', key: 'Enter' }, true)).toBe(false)
+    expect(shouldHandleEscapeAsPreviewBack({ type: 'keyUp', key: 'Escape' }, true)).toBe(false)
+  })
+})
+
+describe('wirePreviewWebviewContents', () => {
+  it('navigates in-place on window.open and goes back on Escape', async () => {
+    const loads: string[] = []
+    let openHandler: ((details: { url: string }) => { action: string }) | null = null
+    let inputHandler: ((event: { preventDefault: () => void }, input: { type: string; key: string }) => void) | null =
+      null
+    let canGoBack = false
+    const goBack = vi.fn(() => {
+      // history is still non-empty for a second Esc until navigate completes
+    })
+
+    const contents = {
+      canGoBack: () => canGoBack,
+      goBack,
+      isDestroyed: () => false,
+      loadURL: async (url: string) => {
+        loads.push(url)
+        canGoBack = true
+      },
+      on: (event: string, listener: (...args: any[]) => void) => {
+        if (event === 'before-input-event') {
+          inputHandler = listener
+        }
+      },
+      setWindowOpenHandler: (handler: (details: { url: string }) => { action: string }) => {
+        openHandler = handler
+      }
+    }
+
+    wirePreviewWebviewContents(contents as never)
+
+    expect(openHandler).toBeTruthy()
+    expect(openHandler!({ url: 'file:///tmp/shot.png' })).toEqual({ action: 'deny' })
+
+    await vi.waitFor(() => {
+      expect(loads).toEqual(['file:///tmp/shot.png'])
+    })
+    expect(canGoBack).toBe(true)
+
+    const preventDefault = vi.fn()
+    inputHandler?.({ preventDefault }, { type: 'keyDown', key: 'Escape' })
+
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(goBack).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not go back on Escape when history is empty', () => {
+    const goBack = vi.fn()
+    let inputHandler: ((event: { preventDefault: () => void }, input: { type: string; key: string }) => void) | null =
+      null
+
+    wirePreviewWebviewContents({
+      canGoBack: () => false,
+      goBack,
+      isDestroyed: () => false,
+      loadURL: async () => undefined,
+      on: (event: string, listener: (...args: any[]) => void) => {
+        if (event === 'before-input-event') {
+          inputHandler = listener
+        }
+      },
+      setWindowOpenHandler: () => undefined
+    } as never)
+
+    const preventDefault = vi.fn()
+    inputHandler?.({ preventDefault }, { type: 'keyDown', key: 'Escape' })
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(goBack).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/electron/preview-webview.ts
+++ b/apps/desktop/electron/preview-webview.ts
@@ -9,8 +9,10 @@
 //   2. Escape goes back one history entry when the guest can go back
 // The renderer surfaces an explicit Back titlebar tool from canGoBack().
 
-import type { App, WebContents } from 'electron'
-import { webContents as electronWebContents } from 'electron'
+import type { App, Session, WebContents } from 'electron'
+import { session as electronSession, webContents as electronWebContents } from 'electron'
+
+const PREVIEW_WEBVIEW_PARTITION = 'persist:hermes-preview'
 
 type WindowOpenDetails = { url: string }
 
@@ -26,6 +28,12 @@ type GuestWebContents = Pick<WebContents, 'canGoBack' | 'goBack' | 'isDestroyed'
   setWindowOpenHandler: (handler: (details: WindowOpenDetails) => { action: 'allow' | 'deny' }) => void
 }
 
+type CandidateWebContents = GuestWebContents & Pick<WebContents, 'getType' | 'session'>
+
+type SessionApi = {
+  fromPartition: (partition: string) => Session
+}
+
 const wiredGuestIds = new Set<number>()
 
 /** In-place navigation keeps history so Back/Escape can restore the report. */
@@ -34,10 +42,7 @@ export function previewWindowOpenDecision(_url: string): 'navigate-in-place' {
 }
 
 /** Escape means "leave the attachment view", not "close the preview pane". */
-export function shouldHandleEscapeAsPreviewBack(
-  input: InputEventLike,
-  canGoBack: boolean
-): boolean {
+export function shouldHandleEscapeAsPreviewBack(input: InputEventLike, canGoBack: boolean): boolean {
   if (!canGoBack) {
     return false
   }
@@ -94,34 +99,38 @@ export function wirePreviewWebviewContents(contents: GuestWebContents): void {
 }
 
 /**
- * Install once at app ready. Every subsequent <webview> guest (preview pane
- * partition or otherwise) gets the same back-friendly window.open + Escape
- * behavior. The renderer also calls wirePreviewWebviewById after mount so we
- * still win if type detection on web-contents-created is delayed/odd.
+ * Install once at app ready. Only <webview> guests in the dedicated preview
+ * partition get the back-friendly window.open + Escape behavior. The renderer
+ * also calls wirePreviewWebviewById after mount so we still win if type
+ * detection on web-contents-created is delayed/odd.
  */
-export function installPreviewWebviewGuards(electronApp: Pick<App, 'on'>): void {
+export function installPreviewWebviewGuards(
+  electronApp: Pick<App, 'on'>,
+  sessionApi: SessionApi = electronSession
+): void {
+  const previewSession = sessionApi.fromPartition(PREVIEW_WEBVIEW_PARTITION)
+
   electronApp.on('web-contents-created', (_event, contents) => {
-    const type = (contents as WebContents).getType?.()
-    // Only <webview> guests. BrowserWindows already have their own open handlers.
-    if (type !== 'webview') {
+    const candidate = contents as CandidateWebContents
+
+    // BrowserWindows and unrelated embedded surfaces retain their own open and
+    // keyboard contracts.
+    if (candidate.getType?.() !== 'webview' || candidate.session !== previewSession) {
       return
     }
 
-    wirePreviewWebviewContents(contents as unknown as GuestWebContents)
+    wirePreviewWebviewContents(candidate)
   })
 }
 
 /** Explicit wire from the renderer after a preview <webview> mounts. */
 export function wirePreviewWebviewById(
   webContentsId: number,
-  webContentsApi: Pick<typeof electronWebContents, 'fromId'> = electronWebContents
+  webContentsApi: Pick<typeof electronWebContents, 'fromId'> = electronWebContents,
+  sessionApi: SessionApi = electronSession
 ): boolean {
   if (!Number.isFinite(webContentsId) || webContentsId <= 0) {
     return false
-  }
-
-  if (wiredGuestIds.has(webContentsId)) {
-    return true
   }
 
   const contents = webContentsApi.fromId(webContentsId)
@@ -130,7 +139,18 @@ export function wirePreviewWebviewById(
     return false
   }
 
-  wirePreviewWebviewContents(contents as unknown as GuestWebContents)
+  const candidate = contents as CandidateWebContents
+  const previewSession = sessionApi.fromPartition(PREVIEW_WEBVIEW_PARTITION)
 
-  return wiredGuestIds.has(webContentsId) || true
+  if (candidate.getType?.() !== 'webview' || candidate.session !== previewSession) {
+    return false
+  }
+
+  if (wiredGuestIds.has(webContentsId)) {
+    return true
+  }
+
+  wirePreviewWebviewContents(candidate)
+
+  return true
 }

--- a/apps/desktop/electron/preview-webview.ts
+++ b/apps/desktop/electron/preview-webview.ts
@@ -1,0 +1,136 @@
+// Preview-pane <webview> guest wiring.
+//
+// HTML reports (Playwright, coverage, etc.) open attachment screenshots via
+// target=_blank. Without a guest handler those navigations either spawn a dead
+// window or replace the report with Chromium's bare image viewer — and the
+// preview chrome has no Back control, so the only obvious X closes the whole
+// pane. Wire every preview webview so:
+//   1. window.open / target=_blank navigates in-place (history stays intact)
+//   2. Escape goes back one history entry when the guest can go back
+// The renderer surfaces an explicit Back titlebar tool from canGoBack().
+
+import type { App, WebContents } from 'electron'
+import { webContents as electronWebContents } from 'electron'
+
+type WindowOpenDetails = { url: string }
+
+type InputEventLike = {
+  key?: string
+  type?: string
+}
+
+type GuestWebContents = Pick<WebContents, 'canGoBack' | 'goBack' | 'isDestroyed' | 'loadURL'> & {
+  id?: number
+  on: (event: string, listener: (...args: any[]) => void) => void
+  once?: (event: string, listener: (...args: any[]) => void) => void
+  setWindowOpenHandler: (handler: (details: WindowOpenDetails) => { action: 'allow' | 'deny' }) => void
+}
+
+const wiredGuestIds = new Set<number>()
+
+/** In-place navigation keeps history so Back/Escape can restore the report. */
+export function previewWindowOpenDecision(_url: string): 'navigate-in-place' {
+  return 'navigate-in-place'
+}
+
+/** Escape means "leave the attachment view", not "close the preview pane". */
+export function shouldHandleEscapeAsPreviewBack(
+  input: InputEventLike,
+  canGoBack: boolean
+): boolean {
+  if (!canGoBack) {
+    return false
+  }
+
+  if (input.type && input.type !== 'keyDown') {
+    return false
+  }
+
+  return String(input.key || '') === 'Escape'
+}
+
+export function wirePreviewWebviewContents(contents: GuestWebContents): void {
+  const guestId = typeof contents.id === 'number' ? contents.id : null
+
+  if (guestId != null) {
+    if (wiredGuestIds.has(guestId)) {
+      return
+    }
+
+    wiredGuestIds.add(guestId)
+    contents.once?.('destroyed', () => {
+      wiredGuestIds.delete(guestId)
+    })
+  }
+
+  contents.setWindowOpenHandler(details => {
+    if (previewWindowOpenDecision(details.url) === 'navigate-in-place') {
+      // Defer so we don't navigate during the handler (Electron rejects that).
+      // setImmediate is more reliable than queueMicrotask for webContents.loadURL
+      // inside setWindowOpenHandler on Electron 40 guests.
+      setImmediate(() => {
+        if (contents.isDestroyed()) {
+          return
+        }
+
+        void contents.loadURL(details.url).catch((error: unknown) => {
+          const message = error instanceof Error ? error.message : String(error)
+          console.warn(`[preview-webview] in-place open failed: ${message} (${details.url})`)
+        })
+      })
+    }
+
+    return { action: 'deny' }
+  })
+
+  contents.on('before-input-event', (event: { preventDefault: () => void }, input: InputEventLike) => {
+    if (!shouldHandleEscapeAsPreviewBack(input, contents.canGoBack())) {
+      return
+    }
+
+    event.preventDefault()
+    contents.goBack()
+  })
+}
+
+/**
+ * Install once at app ready. Every subsequent <webview> guest (preview pane
+ * partition or otherwise) gets the same back-friendly window.open + Escape
+ * behavior. The renderer also calls wirePreviewWebviewById after mount so we
+ * still win if type detection on web-contents-created is delayed/odd.
+ */
+export function installPreviewWebviewGuards(electronApp: Pick<App, 'on'>): void {
+  electronApp.on('web-contents-created', (_event, contents) => {
+    const type = (contents as WebContents).getType?.()
+    // Only <webview> guests. BrowserWindows already have their own open handlers.
+    if (type !== 'webview') {
+      return
+    }
+
+    wirePreviewWebviewContents(contents as unknown as GuestWebContents)
+  })
+}
+
+/** Explicit wire from the renderer after a preview <webview> mounts. */
+export function wirePreviewWebviewById(
+  webContentsId: number,
+  webContentsApi: Pick<typeof electronWebContents, 'fromId'> = electronWebContents
+): boolean {
+  if (!Number.isFinite(webContentsId) || webContentsId <= 0) {
+    return false
+  }
+
+  if (wiredGuestIds.has(webContentsId)) {
+    return true
+  }
+
+  const contents = webContentsApi.fromId(webContentsId)
+
+  if (!contents || contents.isDestroyed()) {
+    return false
+  }
+
+  wirePreviewWebviewContents(contents as unknown as GuestWebContents)
+
+  return wiredGuestIds.has(webContentsId) || true
+}

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -87,6 +87,42 @@ describe('PreviewPane console state', () => {
     expect(setTitlebarToolGroup).toHaveBeenCalledTimes(initialCalls)
   })
 
+  it('does not treat guest console output as a navigation command', async () => {
+    let rendered!: ReturnType<typeof render>
+    await act(async () => {
+      rendered = render(
+        <PreviewPane
+          setTitlebarToolGroup={vi.fn()}
+          target={{
+            kind: 'url',
+            label: 'Preview',
+            source: 'http://localhost:5174',
+            url: 'http://localhost:5174'
+          }}
+        />
+      )
+    })
+
+    const webview = rendered.container.querySelector('webview') as HTMLElement & {
+      loadURL?: (url: string) => Promise<void>
+    }
+
+    const loadURL = vi.fn(async () => undefined)
+    webview.loadURL = loadURL
+
+    act(() => {
+      webview.dispatchEvent(
+        Object.assign(new Event('console-message'), {
+          level: 0,
+          message: '__hermes_preview_navigate__:https://example.com/guest-controlled',
+          sourceId: 'http://localhost:5174/report.html'
+        })
+      )
+    })
+
+    expect(loadURL).not.toHaveBeenCalled()
+  })
+
   it('surfaces a Back titlebar tool once the webview can go back', async () => {
     const setTitlebarToolGroup = vi.fn()
 

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -86,4 +86,50 @@ describe('PreviewPane console state', () => {
 
     expect(setTitlebarToolGroup).toHaveBeenCalledTimes(initialCalls)
   })
+
+  it('surfaces a Back titlebar tool once the webview can go back', async () => {
+    const setTitlebarToolGroup = vi.fn()
+
+    let rendered!: ReturnType<typeof render>
+    await act(async () => {
+      rendered = render(
+        <PreviewPane
+          setTitlebarToolGroup={setTitlebarToolGroup}
+          target={{
+            kind: 'url',
+            label: 'Preview',
+            source: 'http://localhost:5174',
+            url: 'http://localhost:5174'
+          }}
+        />
+      )
+    })
+
+    const webview = rendered.container.querySelector('webview') as HTMLElement & {
+      canGoBack?: () => boolean
+      goBack?: () => void
+    }
+
+    expect(webview).toBeInstanceOf(HTMLElement)
+
+    const goBack = vi.fn()
+    webview.canGoBack = () => true
+    webview.goBack = goBack
+
+    await act(async () => {
+      webview.dispatchEvent(Object.assign(new Event('did-navigate'), { url: 'http://localhost:5174/shot.png' }))
+      webview.dispatchEvent(new Event('did-stop-loading'))
+    })
+
+    const latestTools = setTitlebarToolGroup.mock.calls.at(-1)?.[1] as Array<{ id: string; onSelect: () => void }>
+    const backTool = latestTools.find(tool => tool.id === 'preview-back')
+
+    expect(backTool).toBeTruthy()
+
+    act(() => {
+      backTool?.onSelect()
+    })
+
+    expect(goBack).toHaveBeenCalledTimes(1)
+  })
 })

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -14,8 +14,8 @@ import {
   $previewCanGoBack,
   $previewServerRestart,
   failPreviewServerRestart,
-  setPreviewGoBackHandler,
-  type PreviewTarget
+  type PreviewTarget,
+  setPreviewGoBackHandler
 } from '@/store/preview'
 
 import { ArtifactPreview } from './preview-artifact'
@@ -33,7 +33,6 @@ import { LocalFilePreview, PreviewEmptyState } from './preview-file'
 type PreviewWebview = HTMLElement & {
   canGoBack?: () => boolean
   closeDevTools?: () => void
-  executeJavaScript?: (code: string) => Promise<unknown>
   getURL?: () => string
   getWebContentsId?: () => number
   goBack?: () => void
@@ -622,24 +621,6 @@ export function PreviewPane({
 
       const message = detail.message || ''
 
-      // Guest-injected capture for target=_blank anchors. Prefer host loadURL so
-      // the webview history stack always gets a real entry (guest location.assign
-      // from the initial src load often does not).
-      const navigatePrefix = '__hermes_preview_navigate__:'
-      if (message.startsWith(navigatePrefix)) {
-        const href = message.slice(navigatePrefix.length).trim()
-
-        if (href) {
-          void (webview as PreviewWebview & { loadURL?: (url: string) => Promise<void> })
-            .loadURL?.(href)
-            .catch(() => {
-              // Fall through to console logging only.
-            })
-        }
-
-        return
-      }
-
       appendConsoleEntry({
         level: detail.level ?? 0,
         line: detail.line,
@@ -694,6 +675,7 @@ export function PreviewPane({
     }
 
     const onStart = () => setLoading(true)
+
     const onStop = () => {
       setLoading(false)
       syncNavigationState(webview)
@@ -722,39 +704,7 @@ export function PreviewPane({
       }
     }
 
-    // Belt-and-braces for HTML reports whose attachments use target=_blank:
-    // ask the host to loadURL so history/Back work even if main-process
-    // setWindowOpenHandler is delayed or silent.
-    const injectBlankLinkCapture = () => {
-      void webview
-        .executeJavaScript?.(
-          `(() => {
-            if (window.__hermesPreviewBlankCapture) return true;
-            window.__hermesPreviewBlankCapture = true;
-            document.addEventListener('click', event => {
-              const path = typeof event.composedPath === 'function' ? event.composedPath() : [];
-              const anchor = path.find(node => node instanceof HTMLAnchorElement)
-                || (event.target instanceof Element ? event.target.closest('a') : null);
-              if (!(anchor instanceof HTMLAnchorElement)) return;
-              if ((anchor.getAttribute('target') || '').toLowerCase() !== '_blank') return;
-              const href = anchor.href;
-              if (!href) return;
-              event.preventDefault();
-              event.stopPropagation();
-              console.log('__hermes_preview_navigate__:' + href);
-            }, true);
-            return true;
-          })()`
-        )
-        .catch(() => {
-          // Guest may not be scriptable yet; ignore.
-        })
-    }
-
-    const onDomReady = () => {
-      wireGuest()
-      injectBlankLinkCapture()
-    }
+    const onDomReady = () => wireGuest()
 
     webview.addEventListener('dom-ready', onDomReady)
     // Prefer dom-ready; a delayed attempt covers guests that already fired it.

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -6,11 +6,17 @@ import type { SetTitlebarToolGroup, TitlebarTool } from '@/app/shell/titlebar-co
 import { Tip } from '@/components/ui/tooltip'
 import { type Translations, useI18n } from '@/i18n'
 import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
-import { Bug } from '@/lib/icons'
+import { Bug, ChevronLeft } from '@/lib/icons'
 import { rafCoalesce } from '@/lib/raf-coalesce'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
-import { $previewServerRestart, failPreviewServerRestart, type PreviewTarget } from '@/store/preview'
+import {
+  $previewCanGoBack,
+  $previewServerRestart,
+  failPreviewServerRestart,
+  setPreviewGoBackHandler,
+  type PreviewTarget
+} from '@/store/preview'
 
 import { ArtifactPreview } from './preview-artifact'
 import {
@@ -25,9 +31,14 @@ import { type ConsoleEntry, createPreviewConsoleState } from './preview-console-
 import { LocalFilePreview, PreviewEmptyState } from './preview-file'
 
 type PreviewWebview = HTMLElement & {
+  canGoBack?: () => boolean
   closeDevTools?: () => void
+  executeJavaScript?: (code: string) => Promise<unknown>
   getURL?: () => string
+  getWebContentsId?: () => number
+  goBack?: () => void
   isDevToolsOpened?: () => boolean
+  loadURL?: (url: string) => Promise<void>
   openDevTools?: () => void
   reload?: () => void
   reloadIgnoringCache?: () => void
@@ -35,6 +46,8 @@ type PreviewWebview = HTMLElement & {
 
 interface PreviewPaneProps {
   embedded?: boolean
+  onCanGoBackChange?: (canGoBack: boolean) => void
+  onGoBackReady?: (goBack: (() => void) | null) => void
   onRestartServer?: (url: string, context?: string) => Promise<string>
   reloadRequest?: number
   setTitlebarToolGroup?: SetTitlebarToolGroup
@@ -124,6 +137,8 @@ const TITLEBAR_GROUP_ID = 'preview'
 
 export function PreviewPane({
   embedded = false,
+  onCanGoBackChange,
+  onGoBackReady,
   onRestartServer,
   reloadRequest = 0,
   setTitlebarToolGroup,
@@ -142,6 +157,7 @@ export function PreviewPane({
   const previewServerRestart = useStore($previewServerRestart)
   const consoleHeight = useStore(consoleState.$height)
   const consoleOpen = useStore(consoleState.$open)
+  const [canGoBack, setCanGoBack] = useState(false)
   const [currentUrl, setCurrentUrl] = useState(target.url)
   const [devtoolsOpen, setDevtoolsOpen] = useState(false)
   const [loading, setLoading] = useState(true)
@@ -277,6 +293,45 @@ export function PreviewPane({
     }
   }, [appendConsoleEntry, consoleState, copy, currentUrl, onRestartServer])
 
+  const syncNavigationState = useCallback((webview: PreviewWebview | null = webviewRef.current) => {
+    setCanGoBack(Boolean(webview?.canGoBack?.()))
+  }, [])
+
+  const goBack = useCallback(() => {
+    const webview = webviewRef.current
+
+    if (!webview?.goBack) {
+      return
+    }
+
+    // Prefer the live webview history check, but still attempt goBack when the
+    // UI believes history exists — some guest navigations report canGoBack late.
+    if (!webview.canGoBack?.() && !$previewCanGoBack.get()) {
+      return
+    }
+
+    webview.goBack()
+    // canGoBack updates again on did-navigate / did-stop-loading; seed now so
+    // the Back control doesn't linger stale for a frame after a quick Esc.
+    window.requestAnimationFrame(() => syncNavigationState(webview))
+  }, [syncNavigationState])
+
+  useEffect(() => {
+    $previewCanGoBack.set(canGoBack)
+    onCanGoBackChange?.(canGoBack)
+  }, [canGoBack, onCanGoBackChange])
+
+  useEffect(() => {
+    setPreviewGoBackHandler(goBack)
+    onGoBackReady?.(goBack)
+
+    return () => {
+      setPreviewGoBackHandler(null)
+      onGoBackReady?.(null)
+      $previewCanGoBack.set(false)
+    }
+  }, [goBack, onGoBackReady])
+
   const toggleDevTools = useCallback(() => {
     const webview = webviewRef.current
 
@@ -303,6 +358,16 @@ export function PreviewPane({
     const tools: TitlebarTool[] = [
       ...(isWebPreview
         ? [
+            ...(canGoBack
+              ? [
+                  {
+                    icon: <ChevronLeft />,
+                    id: `${TITLEBAR_GROUP_ID}-back`,
+                    label: copy.goBack,
+                    onSelect: goBack
+                  }
+                ]
+              : []),
             {
               active: consoleOpen,
               icon: <PreviewConsoleTitlebarIcon consoleState={consoleState} />,
@@ -324,7 +389,17 @@ export function PreviewPane({
     setTitlebarToolGroup(TITLEBAR_GROUP_ID, tools)
 
     return () => setTitlebarToolGroup(TITLEBAR_GROUP_ID, [])
-  }, [consoleOpen, consoleState, copy, devtoolsOpen, isWebPreview, setTitlebarToolGroup, toggleDevTools])
+  }, [
+    canGoBack,
+    consoleOpen,
+    consoleState,
+    copy,
+    devtoolsOpen,
+    goBack,
+    isWebPreview,
+    setTitlebarToolGroup,
+    toggleDevTools
+  ])
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
@@ -519,6 +594,7 @@ export function PreviewPane({
     host.replaceChildren()
     webviewRef.current = null
     setCurrentUrl(target.url)
+    setCanGoBack(false)
     setDevtoolsOpen(false)
     setLoadError(null)
     consoleState.reset()
@@ -546,6 +622,24 @@ export function PreviewPane({
 
       const message = detail.message || ''
 
+      // Guest-injected capture for target=_blank anchors. Prefer host loadURL so
+      // the webview history stack always gets a real entry (guest location.assign
+      // from the initial src load often does not).
+      const navigatePrefix = '__hermes_preview_navigate__:'
+      if (message.startsWith(navigatePrefix)) {
+        const href = message.slice(navigatePrefix.length).trim()
+
+        if (href) {
+          void (webview as PreviewWebview & { loadURL?: (url: string) => Promise<void> })
+            .loadURL?.(href)
+            .catch(() => {
+              // Fall through to console logging only.
+            })
+        }
+
+        return
+      }
+
       appendConsoleEntry({
         level: detail.level ?? 0,
         line: detail.line,
@@ -569,6 +663,8 @@ export function PreviewPane({
         setLoadError(null)
         setCurrentUrl(detail.url)
       }
+
+      syncNavigationState(webview)
     }
 
     const onFail = (event: Event) => {
@@ -594,10 +690,14 @@ export function PreviewPane({
         url: detail.validatedURL || webview.getURL?.() || target.url
       })
       setLoading(false)
+      syncNavigationState(webview)
     }
 
     const onStart = () => setLoading(true)
-    const onStop = () => setLoading(false)
+    const onStop = () => {
+      setLoading(false)
+      syncNavigationState(webview)
+    }
 
     webview.addEventListener('console-message', onConsole)
     webview.addEventListener('did-fail-load', onFail)
@@ -608,6 +708,59 @@ export function PreviewPane({
     host.appendChild(webview)
     webviewRef.current = webview
 
+    // Explicitly wire guest window.open + Escape→back after the guest exists.
+    // getWebContentsId throws if called before the webview is attached/ready.
+    const wireGuest = () => {
+      try {
+        const id = webview.getWebContentsId?.()
+
+        if (typeof id === 'number' && id > 0) {
+          void window.hermesDesktop?.wirePreviewWebview?.(id)
+        }
+      } catch {
+        // Not ready yet; dom-ready will retry.
+      }
+    }
+
+    // Belt-and-braces for HTML reports whose attachments use target=_blank:
+    // ask the host to loadURL so history/Back work even if main-process
+    // setWindowOpenHandler is delayed or silent.
+    const injectBlankLinkCapture = () => {
+      void webview
+        .executeJavaScript?.(
+          `(() => {
+            if (window.__hermesPreviewBlankCapture) return true;
+            window.__hermesPreviewBlankCapture = true;
+            document.addEventListener('click', event => {
+              const path = typeof event.composedPath === 'function' ? event.composedPath() : [];
+              const anchor = path.find(node => node instanceof HTMLAnchorElement)
+                || (event.target instanceof Element ? event.target.closest('a') : null);
+              if (!(anchor instanceof HTMLAnchorElement)) return;
+              if ((anchor.getAttribute('target') || '').toLowerCase() !== '_blank') return;
+              const href = anchor.href;
+              if (!href) return;
+              event.preventDefault();
+              event.stopPropagation();
+              console.log('__hermes_preview_navigate__:' + href);
+            }, true);
+            return true;
+          })()`
+        )
+        .catch(() => {
+          // Guest may not be scriptable yet; ignore.
+        })
+    }
+
+    const onDomReady = () => {
+      wireGuest()
+      injectBlankLinkCapture()
+    }
+
+    webview.addEventListener('dom-ready', onDomReady)
+    // Prefer dom-ready; a delayed attempt covers guests that already fired it.
+    window.setTimeout(wireGuest, 0)
+    window.setTimeout(wireGuest, 250)
+
     return () => {
       webview.removeEventListener('console-message', onConsole)
       webview.removeEventListener('did-fail-load', onFail)
@@ -615,15 +768,28 @@ export function PreviewPane({
       webview.removeEventListener('did-navigate-in-page', onNavigate)
       webview.removeEventListener('did-start-loading', onStart)
       webview.removeEventListener('did-stop-loading', onStop)
+      webview.removeEventListener('dom-ready', onDomReady)
       webview.remove()
     }
-  }, [appendConsoleEntry, consoleState, copy, isWebPreview, target.url])
+  }, [appendConsoleEntry, consoleState, copy, isWebPreview, syncNavigationState, target.url])
 
   return (
     <aside className="relative flex h-full w-full min-w-0 flex-col overflow-hidden bg-transparent text-muted-foreground">
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {!embedded && (
           <div className="pointer-events-none flex min-h-(--titlebar-height) items-center gap-1.5 border-b border-border/60 bg-background px-2 py-1">
+            {canGoBack && (
+              <Tip label={copy.goBack}>
+                <button
+                  aria-label={copy.goBack}
+                  className="pointer-events-auto grid size-7 shrink-0 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                  onClick={goBack}
+                  type="button"
+                >
+                  <ChevronLeft className="size-4" />
+                </button>
+              </Tip>
+            )}
             <div className="min-w-0 flex-1">
               <Tip label={copy.openTarget(currentUrl)}>
                 <a

--- a/apps/desktop/src/app/chat/right-rail/preview.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview.tsx
@@ -14,15 +14,18 @@ import { PaneTab, PaneTabLabel } from '@/components/ui/pane-tab'
 import { Tip } from '@/components/ui/tooltip'
 import { translateNow, useI18n } from '@/i18n'
 import { formatCombo } from '@/lib/keybinds/combo'
+import { ChevronLeft } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { $panesFlipped, $rightRailActiveTabId, selectRightRailTab } from '@/store/layout'
 import {
+  $previewCanGoBack,
   $previewReloadRequest,
   $previewTabs,
   closeOtherRightRailTabs,
   closeRightRail,
   closeRightRailTab,
   closeRightRailTabsToRight,
+  previewGoBack,
   type PreviewTarget
 } from '@/store/preview'
 import { $dirtyPreviewUrls } from '@/store/preview-edit'
@@ -56,6 +59,7 @@ export function ChatPreviewRail({ onRestartServer, setTitlebarToolGroup }: ChatP
   const panesFlipped = useStore($panesFlipped)
   const previewTabs = useStore($previewTabs)
   const dirtyPreviewUrls = useStore($dirtyPreviewUrls)
+  const canGoBack = useStore($previewCanGoBack)
 
   const tabs = useMemo(
     () =>
@@ -95,6 +99,18 @@ export function ChatPreviewRail({ onRestartServer, setTitlebarToolGroup }: ChatP
       style={{ paddingTop: 'var(--right-rail-top-inset, 0px)' }}
     >
       <div className="group/rail-tabs flex h-(--titlebar-height) shrink-0 bg-(--ui-sidebar-surface-background)">
+        {canGoBack && (
+          <Tip label={t.preview.web.goBack}>
+            <button
+              aria-label={t.preview.web.goBack}
+              className="ml-1.5 grid size-6 shrink-0 self-center place-items-center rounded-md text-(--ui-text-tertiary) transition-colors hover:bg-(--ui-control-hover-background) hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring [-webkit-app-region:no-drag]"
+              onClick={() => previewGoBack()}
+              type="button"
+            >
+              <ChevronLeft className="size-4" />
+            </button>
+          </Tip>
+        )}
         <div
           className="flex min-w-0 flex-1 overflow-x-auto overflow-y-hidden overscroll-x-contain [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           role="tablist"

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -136,6 +136,7 @@ declare global {
        *  older Electron shells predate it and fall back to the readdir poll. */
       watchDirectory?: (dir: string) => Promise<HermesPreviewWatch>
       stopPreviewFileWatch: (id: string) => Promise<boolean>
+      wirePreviewWebview?: (webContentsId: number) => Promise<boolean>
       setActiveWork?: (payload: HermesActiveWork) => void
       setTitleBarTheme?: (payload: HermesTitleBarTheme) => void
       setNativeTheme?: (mode: 'dark' | 'light' | 'system') => void

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2200,6 +2200,7 @@ export const ar = defineLocale({
       showConsole: 'إظهار كونسول المعاينة',
       hideDevTools: 'إخفاء DevTools المعاينة',
       openDevTools: 'فتح DevTools المعاينة',
+      goBack: 'العودة إلى الصفحة السابقة',
       finishedRestarting: message => `أنهى Hermes إعادة تشغيل خادم المعاينة${message ? `: ${message}` : ''}`,
       failedRestarting: message => `فشلت إعادة تشغيل الخادم: ${message}`,
       unknownError: 'خطأ غير معروف',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2594,6 +2594,7 @@ export const en: Translations = {
       showConsole: 'Show preview console',
       hideDevTools: 'Hide preview DevTools',
       openDevTools: 'Open preview DevTools',
+      goBack: 'Back to previous page',
       finishedRestarting: message => `Hermes finished restarting the preview server${message ? `: ${message}` : ''}`,
       failedRestarting: message => `Server restart failed: ${message}`,
       unknownError: 'unknown error',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2444,6 +2444,7 @@ export const ja = defineLocale({
       showConsole: 'プレビューコンソールを表示',
       hideDevTools: 'プレビュー DevTools を非表示',
       openDevTools: 'プレビュー DevTools を開く',
+      goBack: '前のページに戻る',
       finishedRestarting: message =>
         `Hermes がプレビューサーバーの再起動を完了しました${message ? `: ${message}` : ''}`,
       failedRestarting: message => `サーバーの再起動に失敗しました: ${message}`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2198,6 +2198,7 @@ export interface Translations {
       showConsole: string
       hideDevTools: string
       openDevTools: string
+      goBack: string
       finishedRestarting: (message?: string) => string
       failedRestarting: (message: string) => string
       unknownError: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2367,6 +2367,7 @@ export const zhHant = defineLocale({
       showConsole: '顯示預覽主控台',
       hideDevTools: '隱藏預覽 DevTools',
       openDevTools: '開啟預覽 DevTools',
+      goBack: '返回上一頁',
       finishedRestarting: message => `Hermes 已完成預覽伺服器重新啟動${message ? `：${message}` : ''}`,
       failedRestarting: message => `伺服器重新啟動失敗：${message}`,
       unknownError: '未知錯誤',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2774,6 +2774,7 @@ export const zh: Translations = {
       showConsole: '显示预览控制台',
       hideDevTools: '隐藏预览 DevTools',
       openDevTools: '打开预览 DevTools',
+      goBack: '返回上一页',
       finishedRestarting: message => `Hermes 已完成预览服务器重启${message ? `: ${message}` : ''}`,
       failedRestarting: message => `服务器重启失败：${message}`,
       unknownError: '未知错误',

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -146,6 +146,21 @@ export const $previewOpenRequest = atom(0)
 export const $previewServerRestart = atom<PreviewServerRestart | null>(null)
 export const $previewServerRestartStatus = computed($previewServerRestart, restart => restart?.status ?? 'idle')
 
+/** Whether the active web preview can navigate back (attachment image → report). */
+export const $previewCanGoBack = atom(false)
+
+let previewGoBackHandler: (() => void) | null = null
+
+/** Register the active preview pane's goBack implementation (or clear on unmount). */
+export function setPreviewGoBackHandler(handler: (() => void) | null) {
+  previewGoBackHandler = handler
+}
+
+/** Invoke the active preview pane's goBack, if any. */
+export function previewGoBack() {
+  previewGoBackHandler?.()
+}
+
 export function previewTabId(target: PreviewTarget): RightRailTabId {
   return `${target.kind}:${target.url}`
 }


### PR DESCRIPTION
## Summary

Preview-pane HTML reports (Playwright, etc.) open screenshot attachments via `target="_blank"`. Without guest handling, that replaces the report with Chromium's bare image viewer and leaves no way back except closing the whole preview pane.

This change:

1. Wires preview `<webview>` guests so `window.open` / `target=_blank` can navigate in-place with history preserved
2. Maps **Escape → goBack()** when the guest can go back
3. Injects a belt-and-braces click capture for `target=_blank` anchors that routes through host `loadURL` (reliable history)
4. Surfaces an explicit **Back** control in the preview **tab strip** (left of the tab label) when `canGoBack`
5. Keeps pane close distinct from image/history dismiss

## Test plan

- [x] Unit tests for guest wiring (`electron/preview-webview.test.ts`)
- [x] Preview pane Back tool / navigation tests (`preview-pane.test.tsx`)
- [x] `tsc` electron + renderer
- [x] Manual sandbox: open HTML repro → click shot → Escape returns to report
- [x] Manual sandbox: Back chevron in tab strip returns to report
- [x] Manual: pane X still closes the whole preview

## Notes

- Does not change chat `ZoomableImage` lightbox behavior; this is the embedded HTML report / preview webview path
- HTML opened from the file browser as **source** is unchanged; use the rendered webview path for this flow

Fixes #73899
