### PR TITLE
fix(desktop): preserve stream part order across flushes

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -50,9 +50,11 @@ interface MessageStreamOptions {
   ) => ClientSessionState
 }
 
-interface QueuedStreamDeltas {
-  assistant: string
-  reasoning: string
+type StreamDeltaChannel = 'assistant' | 'reasoning'
+
+interface QueuedStreamDeltaRun {
+  channel: StreamDeltaChannel
+  text: string
 }
 
 // Date.now() alone can collide when an interim seal and the next segment's
@@ -181,7 +183,7 @@ export function useMessageStream({
     []
   )
 
-  const queuedDeltasRef = useRef<Map<string, QueuedStreamDeltas>>(new Map())
+  const queuedDeltasRef = useRef<Map<string, QueuedStreamDeltaRun[]>>(new Map())
   const flushHandleRef = useRef<number | null>(null)
   const lastFlushAtRef = useRef<number>(0)
   // What the previous flush cost on the main thread — drives the adaptive
@@ -208,21 +210,31 @@ export function useMessageStream({
 
         queue.delete(id)
 
-        if (queued.assistant) {
-          mutateStream(
-            id,
-            parts => dedupeGeneratedImageEchoesInParts(appendAssistantTextPart(parts, queued.assistant)),
-            () => [assistantTextPart(queued.assistant)]
-          )
+        // Preserve the gateway's cross-channel run order. The previous pair of
+        // `{ assistant, reasoning }` strings always applied assistant first,
+        // so reasoning→text rendered text→reasoning whenever both landed in
+        // the same timer batch. Recording only each channel's first occurrence
+        // is also insufficient for A→R→A, so the queue coalesces ADJACENT runs
+        // and folds the whole ordered sequence into one state/cache publish.
+        //
+        // appendStreamPart still deliberately makes the opposite channel
+        // transparent within a tool-bounded segment (GLM/Kimi-style token
+        // interleave): preserving the run sequence here means batching cannot
+        // change that data-layer decision or its first-channel order.
+        const applyRuns = (parts: ChatMessagePart[]) => {
+          let next = parts
+
+          for (const run of queued) {
+            next =
+              run.channel === 'assistant'
+                ? dedupeGeneratedImageEchoesInParts(appendAssistantTextPart(next, run.text))
+                : appendReasoningPart(next, run.text)
+          }
+
+          return next
         }
 
-        if (queued.reasoning) {
-          mutateStream(
-            id,
-            parts => appendReasoningPart(parts, queued.reasoning),
-            () => [reasoningPart(queued.reasoning)]
-          )
-        }
+        mutateStream(id, applyRuns, () => applyRuns([]))
       }
     },
     [mutateStream]
@@ -289,13 +301,20 @@ export function useMessageStream({
   }, [flushQueuedDeltas])
 
   const queueDelta = useCallback(
-    (sessionId: string, key: keyof QueuedStreamDeltas, delta: string) => {
+    (sessionId: string, key: StreamDeltaChannel, delta: string) => {
       if (!delta) {
         return
       }
 
-      const queued = queuedDeltasRef.current.get(sessionId) ?? { assistant: '', reasoning: '' }
-      queued[key] += delta
+      const queued = queuedDeltasRef.current.get(sessionId) ?? []
+      const tail = queued.at(-1)
+
+      if (tail?.channel === key) {
+        tail.text += delta
+      } else {
+        queued.push({ channel: key, text: delta })
+      }
+
       queuedDeltasRef.current.set(sessionId, queued)
       scheduleDeltaFlush()
     },

--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
@@ -233,6 +233,52 @@ describe('useMessageStream interim text sealing', () => {
     expect(texts).toHaveLength(2)
   })
 
+  it('keeps reasoning, interim text, tool activity, and final text in stable turn order', async () => {
+    await mountStream()
+    await start()
+
+    // This is the smallest deterministic replay of the structure in the
+    // reported long-running turn. The two stream channels land in one batch,
+    // then an interim boundary seals the pre-tool commentary.
+    await act(() =>
+      handleEvent!({ payload: { text: 'checking the request' }, session_id: SID, type: 'reasoning.delta' })
+    )
+    await delta('I will retry the image request.')
+    await interim('I will retry the image request.')
+
+    const sealed = getState().messages.at(-1)
+    expect(sealed?.parts.map(part => part.type)).toEqual(['reasoning', 'text'])
+    expect(sealed?.interim).toBe(true)
+
+    await act(() =>
+      handleEvent!({
+        payload: { args: { command: 'generate-image' }, name: 'terminal', tool_id: 'tool-1' },
+        session_id: SID,
+        type: 'tool.start'
+      })
+    )
+
+    const liveToolMessageId = getState().messages.at(-1)?.id
+
+    await act(() =>
+      handleEvent!({
+        payload: { name: 'terminal', result: { exit_code: 0 }, tool_id: 'tool-1' },
+        session_id: SID,
+        type: 'tool.complete'
+      })
+    )
+    await delta('The image is ready.')
+    await complete('The image is ready.')
+
+    const assistants = getState().messages.filter(message => message.role === 'assistant' && !message.hidden)
+
+    expect(assistants).toHaveLength(2)
+    expect(assistants.map(message => message.id)).toEqual([sealed?.id, liveToolMessageId])
+    expect(assistants[0]?.parts.map(part => part.type)).toEqual(['reasoning', 'text'])
+    expect(assistants[1]?.parts.map(part => part.type)).toEqual(['tool-call', 'text'])
+    expect(assistantMessages()).toEqual(['I will retry the image request.', 'The image is ready.'])
+  })
+
   it('settles an identical final completion onto the interim when response_previewed', async () => {
     await mountStream()
     await start()

--- a/apps/desktop/src/app/session/hooks/use-message-stream/stream-flush.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/stream-flush.test.tsx
@@ -90,4 +90,78 @@ describe('stream delta delivery', () => {
     // The flush must not have depended on a frame at all.
     expect(rafSpy).not.toHaveBeenCalled()
   })
+
+  it('preserves reasoning-before-text order when both channels share one flush batch', async () => {
+    vi.useFakeTimers()
+
+    render(<Harness />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    act(() => {
+      handleEvent?.({ payload: { text: 'first thought' }, session_id: SID, type: 'reasoning.delta' })
+      handleEvent?.({ payload: { text: 'then the answer' }, session_id: SID, type: 'message.delta' })
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(STREAM_DELTA_FLUSH_MS)
+    })
+
+    expect(states.get(SID)?.messages.at(-1)?.parts).toEqual([
+      { type: 'reasoning', text: 'first thought' },
+      { type: 'text', text: 'then the answer' }
+    ])
+  })
+
+  it('preserves text-before-reasoning order when that is the gateway order', async () => {
+    vi.useFakeTimers()
+
+    render(<Harness />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    act(() => {
+      handleEvent?.({ payload: { text: 'narration first' }, session_id: SID, type: 'message.delta' })
+      handleEvent?.({ payload: { text: 'reasoning second' }, session_id: SID, type: 'reasoning.delta' })
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(STREAM_DELTA_FLUSH_MS)
+    })
+
+    expect(states.get(SID)?.messages.at(-1)?.parts).toEqual([
+      { type: 'text', text: 'narration first' },
+      { type: 'reasoning', text: 'reasoning second' }
+    ])
+  })
+
+  it('preserves an assistant-reasoning-assistant run sequence without timing-dependent fragmentation', async () => {
+    vi.useFakeTimers()
+
+    render(<Harness />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    act(() => {
+      handleEvent?.({ payload: { text: 'Let me ' }, session_id: SID, type: 'message.delta' })
+      handleEvent?.({ payload: { text: 'checking internally' }, session_id: SID, type: 'reasoning.delta' })
+      handleEvent?.({ payload: { text: 'retry that.' }, session_id: SID, type: 'message.delta' })
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(STREAM_DELTA_FLUSH_MS)
+    })
+
+    // The queue retains all three adjacent-channel runs. The message model's
+    // separate, deliberate GLM/Kimi interleave rule then coalesces the two
+    // narration fragments inside this tool-bounded segment, without letting
+    // timer batching choose a different first block.
+    expect(states.get(SID)?.messages.at(-1)?.parts).toEqual([
+      { type: 'text', text: 'Let me retry that.' },
+      { type: 'reasoning', text: 'checking internally' }
+    ])
+  })
 })


### PR DESCRIPTION
## What does this PR do?

Desktop batches assistant-text and reasoning deltas before publishing them to React. The queue currently stores one concatenated string per channel and always flushes assistant text first, then reasoning. If the gateway emits reasoning before text within the same timer batch, the rendered order is reversed. Alternating runs such as text → reasoning → text also lose their arrival order.

This replaces the two-channel object with an ordered list of adjacent channel runs. A flush folds the complete sequence into the message in one state update, preserving gateway order without giving up batching or the existing GLM/Kimi interleave behavior.

It also covers the reported live-turn shape: reasoning, interim narration, tool activity, then final text must remain in stable order rather than jumping around while the model is working.

## Related Issue

Reported and deterministically reproduced in Desktop streaming; no existing upstream issue or PR matched this batching bug.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Preserve cross-channel delta run order inside `useMessageStream`.
- Coalesce only adjacent runs from the same channel.
- Apply one ordered fold per flush, retaining the current render cadence.
- Add reasoning→text, text→reasoning, text→reasoning→text, and interim/tool/final regression coverage.

## How to Test

1. Stream a response that emits reasoning immediately before assistant narration.
2. Confirm the visible reasoning and narration keep the gateway order after the timer flush.
3. Continue through an interim response, tool calls, and final text; confirm existing message blocks stay in place.

Automated checks run on macOS:

- `NODE_OPTIONS=--no-experimental-webstorage npx vitest run --project ui src/app/session/hooks/use-message-stream/stream-flush.test.tsx src/app/session/hooks/use-message-stream/interim-sealing.test.tsx`
- `npm run typecheck`
- targeted ESLint on the three changed files

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing issues/PRs and found no duplicate
- [x] This PR contains only the stream-order fix
- [ ] Full Python `pytest tests/ -q` (Desktop-only TypeScript change; Desktop checks above passed)
- [x] Tests were added
- [x] Tested on macOS

### Documentation & Housekeeping

- [x] Documentation update — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered; the change is renderer state handling only
- [x] Tool descriptions/schemas — N/A