### PR TITLE
docs: session filter tabs + photon immutable-tree fallback (July 29 wave follow-up)

### DIFF
--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -232,6 +232,7 @@ Advanced/rarely-used keys are hidden by default behind a toggle.
 
 Browse and inspect all agent sessions. Each row shows the session title, source platform icon (CLI, Telegram, Discord, Slack, cron), model name, message count, tool call count, and how long ago it was active. Live sessions are marked with a pulsing badge.
 
+- **Filter** — **Chats / Automation / All** tabs scope the list: *Chats* (the default) shows human conversations and hides automation noise (cron, tool, API, ACP sessions); *Automation* shows only those; *All* shows everything. An exact-source dropdown narrows further to a single channel (e.g. only Telegram). Search respects the active filter.
 - **Search** — full-text search across all message content using FTS5. Results show highlighted snippets and auto-scroll to the first matching message when expanded.
 - **Stats** — a summary bar shows total sessions, how many are active in the store, archived count, total messages, and a per-source breakdown.
 - **Expand** — click a session to load its full message history. Messages are color-coded by role (user, assistant, system, tool) and rendered as Markdown with syntax highlighting.

--- a/website/docs/user-guide/messaging/photon.md
+++ b/website/docs/user-guide/messaging/photon.md
@@ -73,7 +73,11 @@ The setup, in order:
    user with that number already exists, so re-running is safe.
 5. **Prints your assigned iMessage line** — the number you text to reach
    your agent.
-6. **Runs `npm install`** inside the plugin's sidecar directory.
+6. **Runs `npm install`** inside the plugin's sidecar directory. On
+   read-only / immutable install trees (hosted Docker images, Podman,
+   Nix) the sidecar automatically falls back to a writable mirror under
+   `~/.hermes/photon/sidecar`; set `PHOTON_SIDECAR_DIR` to pin an
+   explicit location.
 
 Runtime credentials are written to `~/.hermes/.env`
 (`PHOTON_PROJECT_ID` = the Spectrum project id, `PHOTON_PROJECT_SECRET`),


### PR DESCRIPTION
## Summary
Documents the two user-visible behaviors from the July 29 salvage wave that had no docs coverage: the dashboard Sessions filter tabs (#73865) and the photon sidecar's immutable-install-tree fallback (#73864).

## Changes
- `website/docs/user-guide/features/web-dashboard.md`: new **Filter** bullet under Sessions — Chats/Automation/All tabs, exact-source dropdown, search respecting the active filter.
- `website/docs/user-guide/messaging/photon.md`: setup step 6 now notes the automatic `~/.hermes/photon/sidecar` mirror on read-only install trees and the `PHOTON_SIDECAR_DIR` override.

## Validation
| | Before | After |
|---|---|---|
| Session filter tabs | undocumented | documented under Dashboard → Sessions |
| Photon immutable-tree fallback | undocumented | documented in photon setup steps |

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa4285c/MSYkgmCFFK-9F6cm6FMQx_38TCmSF9.png)
