### PR TITLE
fix(desktop): raise probe timeout + sync warmup import before lifespan yield (#72632)

### DIFF
--- a/apps/desktop/electron/backend-probes.test.ts
+++ b/apps/desktop/electron/backend-probes.test.ts
@@ -14,7 +14,10 @@ import { test } from 'vitest'
 
 import {
   canImportHermesCli,
+  DEFAULT_PROBE_TIMEOUT_MS,
   hermesRuntimeImportProbe,
+  PROBE_TIMEOUT_MS,
+  resolveProbeTimeoutMs,
   shouldTrustHermesOverride,
   verifyHermesCli
 } from './backend-probes'
@@ -100,9 +103,25 @@ test('verifyHermesCli returns true when --version exits 0', () => {
 })
 
 test('verifyHermesCli swallows timeouts (does not throw)', () => {
-  // We can't easily provoke a real 5s hang in CI without slowing the
+  // We can't easily provoke a real hang in CI without slowing the
   // suite, but we CAN confirm that an invocation that DOES throw
   // (because the binary is missing) returns false rather than
   // propagating. Same code path the timeout case takes.
   assert.equal(verifyHermesCli('/definitely/not/a/real/binary/anywhere'), false)
+})
+
+test('default probe timeout is 15s (not the old 5s death-loop value)', () => {
+  assert.equal(DEFAULT_PROBE_TIMEOUT_MS, 15_000)
+  // Module constant uses process.env at load time; with no override it
+  // matches the default (tests run without HERMES_PROBE_TIMEOUT_MS).
+  assert.equal(PROBE_TIMEOUT_MS, DEFAULT_PROBE_TIMEOUT_MS)
+})
+
+test('resolveProbeTimeoutMs honours HERMES_PROBE_TIMEOUT_MS', () => {
+  assert.equal(resolveProbeTimeoutMs({}), DEFAULT_PROBE_TIMEOUT_MS)
+  assert.equal(resolveProbeTimeoutMs({ HERMES_PROBE_TIMEOUT_MS: '30000' }), 30_000)
+  assert.equal(resolveProbeTimeoutMs({ HERMES_PROBE_TIMEOUT_MS: '0' }), DEFAULT_PROBE_TIMEOUT_MS)
+  assert.equal(resolveProbeTimeoutMs({ HERMES_PROBE_TIMEOUT_MS: 'nope' }), DEFAULT_PROBE_TIMEOUT_MS)
+  // Cap runaway values
+  assert.equal(resolveProbeTimeoutMs({ HERMES_PROBE_TIMEOUT_MS: '999999' }), 120_000)
 })

--- a/apps/desktop/electron/backend-probes.ts
+++ b/apps/desktop/electron/backend-probes.ts
@@ -20,8 +20,9 @@
  * actually works.
  *
  * Both probes are deliberately fast and forgiving:
- *   - 5s timeout (a hung interpreter beats forever, but we still give
- *     slow disks / cold caches room to breathe)
+ *   - default 15s timeout (5s was too short on cold Windows disks / AV;
+ *     issue #61764 death-loop) with HERMES_PROBE_TIMEOUT_MS override
+ *   - one automatic retry after a timeout before declaring the runtime dead
  *   - stdio ignored (we only care about exit code; stdout/stderr are
  *     not surfaced to the user, just to recentHermesLog for forensics
  *     via the caller's catch block if it chooses)
@@ -34,7 +35,71 @@
 
 import { execFileSync } from 'node:child_process'
 
-const PROBE_TIMEOUT_MS = 5000
+/** Default probe budget. 5s false-negativeed healthy Windows cold starts (#61764). */
+const DEFAULT_PROBE_TIMEOUT_MS = 15_000
+
+/**
+ * Resolve the backend probe timeout (ms).
+ * Honours HERMES_PROBE_TIMEOUT_MS when it parses as a positive integer.
+ */
+function resolveProbeTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.HERMES_PROBE_TIMEOUT_MS
+  if (raw == null || raw === '') {
+    return DEFAULT_PROBE_TIMEOUT_MS
+  }
+  const n = Number.parseInt(String(raw), 10)
+  if (!Number.isFinite(n) || n <= 0) {
+    return DEFAULT_PROBE_TIMEOUT_MS
+  }
+  // Clamp absurd values (ms) so a typo can't hang startup forever.
+  return Math.min(n, 120_000)
+}
+
+const PROBE_TIMEOUT_MS = resolveProbeTimeoutMs()
+
+function isTimeoutError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') {
+    return false
+  }
+  const e = err as { code?: string; killed?: boolean; signal?: string }
+  if (e.killed === true) {
+    return true
+  }
+  if (e.code === 'ETIMEDOUT') {
+    return true
+  }
+  // Node marks timed-out execFileSync with SIGTERM on some platforms.
+  if (e.signal === 'SIGTERM') {
+    return true
+  }
+  return false
+}
+
+/**
+ * Run execFileSync; on timeout only, retry once before failing.
+ * Non-timeout failures (ENOENT, non-zero exit) fail immediately.
+ */
+function execProbeSync(
+  command: string,
+  args: string[],
+  options: {
+    env?: NodeJS.ProcessEnv
+    stdio: 'ignore'
+    timeout: number
+    shell?: boolean
+    windowsHide?: boolean
+  }
+): void {
+  try {
+    execFileSync(command, args, options)
+  } catch (err) {
+    if (!isTimeoutError(err)) {
+      throw err
+    }
+    // One cold-cache / AV miss should not force hermes-setup --update (#61764).
+    execFileSync(command, args, options)
+  }
+}
 
 /**
  * Return the Python snippet used to verify Hermes can import far enough to
@@ -71,7 +136,7 @@ function canImportHermesCli(pythonPath: string, opts: { env?: Record<string, str
   }
 
   try {
-    execFileSync(pythonPath, ['-c', hermesRuntimeImportProbe()], {
+    execProbeSync(pythonPath, ['-c', hermesRuntimeImportProbe()], {
       env: { ...process.env, ...(opts.env || {}) },
       stdio: 'ignore',
       timeout: PROBE_TIMEOUT_MS,
@@ -120,7 +185,7 @@ function verifyHermesCli(hermesCommand: string, opts?: { shell?: boolean }) {
   }
 
   try {
-    execFileSync(hermesCommand, ['--version'], {
+    execProbeSync(hermesCommand, ['--version'], {
       stdio: 'ignore',
       timeout: PROBE_TIMEOUT_MS,
       shell: Boolean(opts?.shell),
@@ -133,4 +198,4 @@ function verifyHermesCli(hermesCommand: string, opts?: { shell?: boolean }) {
   }
 }
 
-export { canImportHermesCli, hermesRuntimeImportProbe, PROBE_TIMEOUT_MS, shouldTrustHermesOverride, verifyHermesCli }
+export { canImportHermesCli, hermesRuntimeImportProbe, PROBE_TIMEOUT_MS, DEFAULT_PROBE_TIMEOUT_MS, resolveProbeTimeoutMs, shouldTrustHermesOverride, verifyHermesCli }

--- a/apps/desktop/electron/backend-probes.ts
+++ b/apps/desktop/electron/backend-probes.ts
@@ -198,4 +198,4 @@ function verifyHermesCli(hermesCommand: string, opts?: { shell?: boolean }) {
   }
 }
 
-export { canImportHermesCli, hermesRuntimeImportProbe, PROBE_TIMEOUT_MS, DEFAULT_PROBE_TIMEOUT_MS, resolveProbeTimeoutMs, shouldTrustHermesOverride, verifyHermesCli }
+export { canImportHermesCli, DEFAULT_PROBE_TIMEOUT_MS, hermesRuntimeImportProbe, PROBE_TIMEOUT_MS, resolveProbeTimeoutMs, shouldTrustHermesOverride, verifyHermesCli }

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -195,13 +195,13 @@ async def _lifespan(app: "FastAPI"):
     # event loop during lifespan startup — see _get_event_state's docstring.
     app.state.chat_argv_lock = asyncio.Lock()
 
-    # Fire hermes_cli.gateway import into a background thread so the event
-    # loop is not blocked and HERMES_DASHBOARD_READY fires without delay.
-    # On a cold Windows install the module chain triggers .pyc compilation
-    # and Defender real-time scans that can stall the event loop for 15-30s.
-    # Running in an executor means the cost is paid in a worker thread while
-    # the server socket is already open and accepting probes.
-    asyncio.get_event_loop().run_in_executor(None, _warm_gateway_module)
+    # Import hermes_cli.gateway eagerly *before* the lifespan yield so the
+    # GIL-heavy .pyc compilation and Defender scan cost is absorbed during
+    # backend initialisation — before the server socket accepts probes.
+    # On Windows + Python 3.11 the import does not release the GIL, so
+    # run_in_executor still froze the event loop for 15-22 s, causing the
+    # Desktop's 10-second WebSocket ready-probe to time out (GH-73083).
+    _warm_gateway_module()
 
     # Desktop-spawned backends (HERMES_DESKTOP=1) fire cron jobs themselves,
     # since the app has no gateway running the scheduler. Server `hermes

--- a/tests/hermes_cli/test_web_server_boot_handshake.py
+++ b/tests/hermes_cli/test_web_server_boot_handshake.py
@@ -3,13 +3,16 @@ Integration tests for the desktop boot handshake fix (PR #50231 / issue #50209).
 
 Simulates a slow hermes_cli.gateway import (15-30 s on a fresh Windows install
 with Defender scanning every new .pyc) by patching the two helpers that touch
-the blocking import and measuring event-loop freedom + response latency.
+the blocking import and measuring response latency.
 
 Three scenarios are covered:
 
-1. _lifespan fire-and-forget: patched _warm_gateway_module sleeps N seconds in
-   a thread; TestClient startup must complete in << N seconds (event loop not
-   blocked, HERMES_DASHBOARD_READY would fire immediately).
+1. _lifespan synchronous warmup: patched _warm_gateway_module sleeps N seconds;
+   TestClient startup blocks for >= N seconds (intentional — see #73083/#73291:
+   the import doesn't release the GIL on Windows + Python 3.11, so
+   run_in_executor still froze the event loop. Absorbing the cost before the
+   lifespan yield ensures the server socket doesn't accept probes until the
+   import is complete).
 
 2. get_status run_in_executor: patched _resolve_restart_drain_timeout sleeps N
    seconds in a thread; a concurrent fast endpoint (/api/version) must respond
@@ -53,15 +56,16 @@ def _make_slow_drain(seconds: float):
 
 
 # ---------------------------------------------------------------------------
-# Test 1 — _lifespan fire-and-forget does not block the event loop
+# Test 1 — _lifespan synchronous warmup blocks startup (intentional)
 # ---------------------------------------------------------------------------
 
-def test_lifespan_warmup_is_nonblocking():
+def test_lifespan_warmup_is_synchronous():
     """
-    _warm_gateway_module runs in an executor (fire-and-forget).
-    Even if it sleeps for SLOW_SECONDS, TestClient startup must complete
-    in well under that time — proving the event loop was never blocked and
-    HERMES_DASHBOARD_READY would have fired without delay.
+    _warm_gateway_module runs synchronously before the lifespan yield (#73083).
+    Startup blocks for at least SLOW_SECONDS — this is intentional: on Windows
+    + Python 3.11 the import doesn't release the GIL, so run_in_executor still
+    froze the event loop. Absorbing the cost before the yield ensures probes
+    arrive after the import is complete.
     """
     from fastapi.testclient import TestClient
 
@@ -70,13 +74,13 @@ def test_lifespan_warmup_is_nonblocking():
         with TestClient(web_server_mod.app, raise_server_exceptions=False) as _client:
             startup_ms = (time.perf_counter() - t0) * 1000
 
-    # Startup must complete in under half of SLOW_SECONDS (generous margin).
-    # If the import were synchronous, startup would block for >= SLOW_SECONDS.
-    threshold_ms = (SLOW_SECONDS * 1000) / 2
-    assert startup_ms < threshold_ms, (
-        f"_lifespan blocked the event loop: startup took {startup_ms:.0f} ms "
+    # Startup must block for at least SLOW_SECONDS (the import runs synchronously).
+    # If startup were faster, the import would still be fire-and-forget (old behavior).
+    threshold_ms = (SLOW_SECONDS * 1000) * 0.8
+    assert startup_ms >= threshold_ms, (
+        f"_lifespan did not block for the warmup import: startup took {startup_ms:.0f} ms "
         f"but slow import is {SLOW_SECONDS * 1000:.0f} ms — "
-        f"fire-and-forget is not working."
+        f"warmup is not synchronous."
     )
 
 


### PR DESCRIPTION
## Summary

Fixes the two remaining open bugs from #72632: the 5s backend probe timeout that false-negatives healthy Windows cold starts, and the `run_in_executor` warmup that still froze the event loop because the import doesn't release the GIL on Python 3.11/Windows.

## Changes

- `apps/desktop/electron/backend-probes.ts`: Raise default probe timeout from 5s to 15s (salvages #69944 by @Bartok9). Adds `HERMES_PROBE_TIMEOUT_MS` env override (clamped at 120s) and one-shot retry on timeout only — ENOENT/non-zero exits fail immediately.
- `hermes_cli/web_server.py`: Move `_warm_gateway_module()` from `run_in_executor` to synchronous before lifespan yield (salvages #73291 by @JonthanaHanh). The import doesn't release the GIL on Windows + Python 3.11, so the executor still froze the loop for 15-22s; absorbing the cost before the yield ensures probes arrive after the import completes.
- `tests/hermes_cli/test_web_server_boot_handshake.py`: Update test to assert synchronous warmup (old test asserted fire-and-forget; now reversed).

## Validation

| | Before | After |
|---|---|---|
| Probe timeout | 5s (false-negatives cold Windows) | 15s default + env override + retry |
| Warmup import | run_in_executor (still froze loop) | Synchronous before yield |
| Boot handshake test | Asserted non-blocking | Asserts synchronous (correct) |
| vitest (backend-probes) | 10 tests | 12 tests pass |
| pytest (web_server) | 6 pass | 6 pass |
| pytest (boot_handshake) | 3 pass | 3 pass |
| ruff | clean | clean |

Closes #72632 (remaining probe timeout + GIL warmup items). Supersedes #72713 (less flexible — no retry/env override) and #69944/#73291 (salvaged with authorship preserved).
