### PR TITLE
feat(stt): fully configurable STT — hermes tools category, GUI toggle/matrix, dashboard dropdowns, setup status

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -547,6 +547,34 @@ def _print_setup_summary(config: dict, hermes_home):
     else:
         tool_status.append(("Text-to-Speech (Edge TTS)", True, None))
 
+    # STT — show configured provider
+    stt_provider = cfg_get(config, "stt", "provider", default="local") or "local"
+    if getattr(subscription_features, "stt", None) and subscription_features.stt.managed_by_nous:
+        tool_status.append(("Speech-to-Text (OpenAI via Nous subscription)", True, None))
+    elif stt_provider == "openai" and (
+        get_env_value("VOICE_TOOLS_OPENAI_KEY") or get_env_value("OPENAI_API_KEY")
+    ):
+        tool_status.append(("Speech-to-Text (OpenAI)", True, None))
+    elif stt_provider == "groq" and get_env_value("GROQ_API_KEY"):
+        tool_status.append(("Speech-to-Text (Groq Whisper)", True, None))
+    elif stt_provider == "elevenlabs" and get_env_value("ELEVENLABS_API_KEY"):
+        tool_status.append(("Speech-to-Text (ElevenLabs Scribe)", True, None))
+    elif stt_provider == "xai":
+        tool_status.append(("Speech-to-Text (xAI)", True, None))
+    elif stt_provider == "deepinfra" and get_env_value("DEEPINFRA_API_KEY"):
+        tool_status.append(("Speech-to-Text (DeepInfra)", True, None))
+    else:
+        try:
+            fw_ok = importlib.util.find_spec("faster_whisper") is not None
+        except Exception:
+            fw_ok = False
+        if fw_ok:
+            tool_status.append(("Speech-to-Text (Local Whisper)", True, None))
+        else:
+            tool_status.append(
+                ("Speech-to-Text (Local Whisper — not installed)", False, "run 'hermes tools' → Speech-to-Text")
+            )
+
     if subscription_features.modal.managed_by_nous:
         tool_status.append(("Modal Execution (Nous subscription)", True, None))
     elif cfg_get(config, "terminal", "backend") == "modal":

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -549,7 +549,8 @@ def _print_setup_summary(config: dict, hermes_home):
 
     # STT — show configured provider
     stt_provider = cfg_get(config, "stt", "provider", default="local") or "local"
-    if getattr(subscription_features, "stt", None) and subscription_features.stt.managed_by_nous:
+    _stt_feature = subscription_features.features.get("stt")
+    if _stt_feature is not None and _stt_feature.managed_by_nous:
         tool_status.append(("Speech-to-Text (OpenAI via Nous subscription)", True, None))
     elif stt_provider == "openai" and (
         get_env_value("VOICE_TOOLS_OPENAI_KEY") or get_env_value("OPENAI_API_KEY")

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -104,6 +104,7 @@ CONFIGURABLE_TOOLSETS = [
     ("video_gen",       "🎬 Video Generation",          "video_generate (text/image/reference)"),
     ("x_search",        "🐦 X (Twitter) Search",        "x_search (requires xAI OAuth or XAI_API_KEY)"),
     ("tts",             "🔊 Text-to-Speech",            "text_to_speech"),
+    ("stt",             "🎙️ Speech-to-Text",           "voice transcription (gateway voice messages + voice mode)"),
     ("skills",          "📚 Skills",                    "list, view, manage"),
     ("todo",            "📋 Task Planning",             "todo"),
     ("memory",          "💾 Memory",                    "persistent memory across sessions"),
@@ -151,6 +152,15 @@ def gui_toolset_label(label: str) -> str:
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
 _DEFAULT_OFF_TOOLSETS = {"homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+
+
+# Config-only capabilities: they appear in `hermes tools` for provider/API-key
+# configuration (TOOL_CATEGORIES) but are NOT model toolsets — they ship zero
+# tool schemas and their on/off switch lives in their own config section
+# (e.g. ``stt.enabled``), not ``platform_toolsets``. Excluded from the
+# per-platform enable/disable checklist; configured via the "Reconfigure an
+# existing tool" flow and the GUI provider matrix instead.
+_CONFIG_ONLY_TOOLSETS = {"stt"}
 
 
 def _xai_credentials_present() -> bool:
@@ -273,6 +283,7 @@ def _checklist_toolset_keys(platform: str) -> Set[str]:
         ts_key
         for ts_key, _, _ in _get_effective_configurable_toolsets()
         if _toolset_allowed_for_platform(ts_key, platform)
+        and ts_key not in _CONFIG_ONLY_TOOLSETS
     }
 
 # Platform display config — derived from the canonical registry so every
@@ -381,6 +392,76 @@ TOOL_CATEGORIES = {
                     {"key": "DEEPINFRA_API_KEY", "prompt": "DeepInfra API key", "url": "https://deepinfra.com/dash/api_keys"},
                 ],
                 "tts_provider": "deepinfra",
+            },
+        ],
+    },
+    "stt": {
+        "name": "Speech-to-Text",
+        "icon": "🎙️",
+        "providers": [
+            {
+                "name": "Local Whisper",
+                "badge": "★ recommended · free",
+                "tag": "faster-whisper on-device, no API key",
+                "env_vars": [],
+                "stt_provider": "local",
+                "post_setup": "faster_whisper",
+            },
+            {
+                "name": "Nous Subscription",
+                "badge": "subscription",
+                "tag": "Managed OpenAI transcription billed to your subscription",
+                "env_vars": [],
+                "stt_provider": "openai",
+                "requires_nous_auth": True,
+                "managed_nous_feature": "stt",
+                "override_env_vars": ["VOICE_TOOLS_OPENAI_KEY", "OPENAI_API_KEY"],
+            },
+            {
+                "name": "OpenAI",
+                "badge": "paid",
+                "tag": "whisper-1, gpt-4o-transcribe, gpt-transcribe",
+                "env_vars": [
+                    {"key": "VOICE_TOOLS_OPENAI_KEY", "prompt": "OpenAI API key", "url": "https://platform.openai.com/api-keys"},
+                ],
+                "stt_provider": "openai",
+            },
+            {
+                "name": "Groq",
+                "badge": "free tier",
+                "tag": "Whisper large-v3 family — very fast",
+                "env_vars": [
+                    {"key": "GROQ_API_KEY", "prompt": "Groq API key", "url": "https://console.groq.com/keys"},
+                ],
+                "stt_provider": "groq",
+            },
+            {
+                "name": "xAI",
+                "tag": "grok-stt — uses xAI Grok OAuth or XAI_API_KEY",
+                "env_vars": [],
+                "stt_provider": "xai",
+                "post_setup": "xai_grok",
+            },
+            {
+                "name": "ElevenLabs Scribe",
+                "badge": "paid",
+                "tag": "scribe_v2 — diarization + audio-event tagging",
+                "env_vars": [
+                    {"key": "ELEVENLABS_API_KEY", "prompt": "ElevenLabs API key", "url": "https://elevenlabs.io/app/settings/api-keys"},
+                ],
+                "stt_provider": "elevenlabs",
+            },
+            # Mistral Voxtral STT intentionally omitted — mistralai PyPI
+            # package quarantined (malicious 2.4.6 release, 2026-05-12).
+            # Restore alongside the dashboard stt.provider option.
+            {
+                "name": "DeepInfra",
+                "badge": "paid",
+                "tag": "Live STT catalog from api.deepinfra.com",
+                "env_vars": [
+                    {"key": "DEEPINFRA_API_KEY", "prompt": "DeepInfra API key", "url": "https://deepinfra.com/dash/api_keys"},
+                ],
+                "stt_provider": "deepinfra",
             },
         ],
     },
@@ -1534,6 +1615,29 @@ def _run_post_setup(post_setup_key: str):
     elif post_setup_key == "cua_driver":
         install_cua_driver(upgrade=False)
 
+    elif post_setup_key == "faster_whisper":
+        import subprocess
+        try:
+            __import__("faster_whisper")
+            _print_success("    faster-whisper is already installed")
+            return
+        except ImportError:
+            pass
+        _print_info("    Installing faster-whisper (model ~150MB downloads on first use)...")
+        try:
+            result = _pip_install(["-U", "faster-whisper", "--quiet"], timeout=300)
+            if result.returncode == 0:
+                _print_success("    faster-whisper installed")
+                _print_info("    Model sizes: tiny, base (default), small, medium, large-v3")
+                _print_info("    Change via stt.local.model in ~/.hermes/config.yaml")
+            else:
+                _print_warning("    faster-whisper install failed:")
+                _print_info(f"      {(result.stderr or '').strip()[:300]}")
+                _print_info("    Run manually: uv pip install -U faster-whisper")
+        except subprocess.TimeoutExpired:
+            _print_warning("    faster-whisper install timed out (>5min)")
+            _print_info("    Run manually: uv pip install -U faster-whisper")
+
     elif post_setup_key == "kittentts":
         try:
             __import__("kittentts")
@@ -2285,7 +2389,7 @@ def _toolset_has_keys(
         except Exception:
             return False
 
-    if ts_key in {"web", "image_gen", "video_gen", "tts", "browser"}:
+    if ts_key in {"web", "image_gen", "video_gen", "tts", "stt", "browser"}:
         features = get_nous_subscription_features(config, force_fresh=force_fresh)
         feature = features.features.get(ts_key)
         if feature and (feature.available or feature.managed_by_nous):
@@ -2380,10 +2484,12 @@ def _prompt_toolset_checklist(
     tool_tokens = _estimate_tool_tokens()
 
     effective_all = _get_effective_configurable_toolsets()
-    # Drop platform-scoped toolsets that don't apply to this platform.
+    # Drop platform-scoped toolsets that don't apply to this platform, and
+    # config-only capabilities (stt) that have no per-platform toggle.
     effective = [
         (k, l, d) for (k, l, d) in effective_all
         if _toolset_allowed_for_platform(k, platform)
+        and k not in _CONFIG_ONLY_TOOLSETS
     ]
 
     labels = []
@@ -2892,6 +2998,7 @@ def _camofox_installed() -> bool:
 _POST_SETUP_READY: dict = {
     "kittentts": lambda: _module_installed("kittentts"),
     "piper": lambda: _module_installed("piper"),
+    "faster_whisper": lambda: _module_installed("faster_whisper"),
     "ddgs": lambda: _module_installed("ddgs"),
     "langfuse": lambda: _module_installed("langfuse"),
     "agent_browser": lambda: _agent_browser_installed(),
@@ -3220,6 +3327,11 @@ def _is_provider_active(
                 feature.managed_by_nous
                 and cfg_get(config, "tts", "provider") == provider["tts_provider"]
             )
+        if provider.get("stt_provider"):
+            return (
+                feature.managed_by_nous
+                and cfg_get(config, "stt", "provider") == provider["stt_provider"]
+            )
         if "browser_provider" in provider:
             current = cfg_get(config, "browser", "cloud_provider")
             return feature.managed_by_nous and provider["browser_provider"] == current
@@ -3230,6 +3342,10 @@ def _is_provider_active(
 
     if provider.get("tts_provider"):
         return cfg_get(config, "tts", "provider") == provider["tts_provider"]
+    if provider.get("stt_provider"):
+        # Default stt.provider is "local" — an unset key means Local Whisper.
+        current = cfg_get(config, "stt", "provider") or "local"
+        return current == provider["stt_provider"]
     if "browser_provider" in provider:
         current = cfg_get(config, "browser", "cloud_provider")
         return provider["browser_provider"] == current
@@ -3593,6 +3709,49 @@ def _configure_videogen_model_for_plugin(plugin_name: str, config: dict) -> None
     _print_success(f"  Model set to: {chosen}")
 
 
+# Per-provider STT model catalogs for the interactive picker. Keys are
+# ``stt.<provider>`` config sections; the first entry is the default.
+# Kept in sync with the dashboard selects (hermes_cli/web_server.py
+# _CONFIG_FIELD_META) and the desktop settings enums
+# (apps/desktop/src/app/settings/constants.ts).
+STT_MODEL_CATALOG = {
+    "local": ["base", "tiny", "small", "medium", "large-v3"],
+    "groq": ["whisper-large-v3-turbo", "whisper-large-v3", "distil-whisper-large-v3-en"],
+    "openai": ["whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe", "gpt-transcribe"],
+    "elevenlabs": ["scribe_v2", "scribe_v1"],
+}
+
+# ElevenLabs historically uses ``model_id`` instead of ``model``.
+_STT_MODEL_CONFIG_KEY = {"elevenlabs": "model_id"}
+
+
+def _configure_stt_model(stt_provider: str, config: dict) -> None:
+    """Prompt for the STT model after a provider pick (when a catalog exists).
+
+    Providers without a static catalog (xai, deepinfra) skip the prompt —
+    xAI has a single model and DeepInfra resolves from its live catalog.
+    """
+    catalog = STT_MODEL_CATALOG.get(stt_provider)
+    if not catalog:
+        return
+    stt_cfg = config.setdefault("stt", {})
+    if not isinstance(stt_cfg, dict):
+        stt_cfg = {}
+        config["stt"] = stt_cfg
+    prov_cfg = stt_cfg.setdefault(stt_provider, {})
+    if not isinstance(prov_cfg, dict):
+        prov_cfg = {}
+        stt_cfg[stt_provider] = prov_cfg
+    model_key = _STT_MODEL_CONFIG_KEY.get(stt_provider, "model")
+    current = str(prov_cfg.get(model_key) or "").strip()
+    ordered = list(catalog)
+    default_idx = ordered.index(current) if current in ordered else 0
+    idx = _prompt_choice("  Select STT model:", ordered, default_idx)
+    chosen = ordered[idx]
+    prov_cfg[model_key] = chosen
+    _print_success(f"  STT model set to: {chosen}")
+
+
 def _select_plugin_video_gen_provider(plugin_name: str, config: dict, *, use_gateway: bool = False) -> None:
     """Persist a plugin-backed video generation provider selection."""
     vid_cfg = config.setdefault("video_gen", {})
@@ -3623,6 +3782,12 @@ def _write_provider_config(provider: dict, config: dict, *, managed_feature) -> 
         tts_cfg["provider"] = provider["tts_provider"]
         tts_cfg["use_gateway"] = bool(managed_feature)
 
+    # Set STT provider in config if applicable
+    if provider.get("stt_provider"):
+        stt_cfg = config.setdefault("stt", {})
+        stt_cfg["provider"] = provider["stt_provider"]
+        stt_cfg["use_gateway"] = bool(managed_feature)
+
     # Set browser cloud provider in config if applicable
     if "browser_provider" in provider:
         bp = provider["browser_provider"]
@@ -3639,7 +3804,7 @@ def _write_provider_config(provider: dict, config: dict, *, managed_feature) -> 
 
     # For tools without a specific config key (e.g. image_gen), still
     # track use_gateway so the runtime knows the user's intent.
-    if managed_feature and managed_feature not in {"web", "tts", "browser"}:
+    if managed_feature and managed_feature not in {"web", "tts", "stt", "browser"}:
         config.setdefault(managed_feature, {})["use_gateway"] = True
     elif not managed_feature:
         # User picked a non-gateway provider — find which category this
@@ -3762,6 +3927,10 @@ def _configure_provider(
         tts_cfg["provider"] = provider["tts_provider"]
         tts_cfg["use_gateway"] = bool(managed_feature)
 
+    # Set STT provider in config if applicable
+    if provider.get("stt_provider"):
+        _print_success(f"  STT provider set to: {provider['stt_provider']}")
+
     # Set browser cloud provider in config if applicable
     if "browser_provider" in provider:
         bp = provider["browser_provider"]
@@ -3807,6 +3976,10 @@ def _configure_provider(
             img_cfg = config.setdefault("image_gen", {})
             if isinstance(img_cfg, dict) and img_cfg.get("provider") not in {None, "", "fal"}:
                 img_cfg["provider"] = "fal"
+        # STT providers prompt for model selection after provider pick
+        # (skipped for managed rows — the gateway pins the model).
+        if provider.get("stt_provider") and not managed_feature:
+            _configure_stt_model(provider["stt_provider"], config)
         return
 
     # Prompt for each required env var
@@ -3883,6 +4056,9 @@ def _configure_provider(
             img_cfg = config.setdefault("image_gen", {})
             if isinstance(img_cfg, dict) and img_cfg.get("provider") not in {None, "", "fal"}:
                 img_cfg["provider"] = "fal"
+        # STT providers prompt for model selection after env vars are in.
+        if provider.get("stt_provider") and not managed_feature:
+            _configure_stt_model(provider["stt_provider"], config)
 
 
 def _configure_vision_backend() -> None:
@@ -4260,6 +4436,12 @@ def _reconfigure_provider(
         tts_cfg["use_gateway"] = bool(managed_feature)
         _print_success(f"  TTS provider set to: {provider['tts_provider']}")
 
+    if provider.get("stt_provider"):
+        stt_cfg = config.setdefault("stt", {})
+        stt_cfg["provider"] = provider["stt_provider"]
+        stt_cfg["use_gateway"] = bool(managed_feature)
+        _print_success(f"  STT provider set to: {provider['stt_provider']}")
+
     if "browser_provider" in provider:
         bp = provider["browser_provider"]
         browser_cfg = config.setdefault("browser", {})
@@ -4278,7 +4460,7 @@ def _reconfigure_provider(
         web_cfg["use_gateway"] = bool(managed_feature)
         _print_success(f"  Web backend set to: {provider['web_backend']}")
 
-    if managed_feature and managed_feature not in {"web", "tts", "browser"}:
+    if managed_feature and managed_feature not in {"web", "tts", "stt", "browser"}:
         section = config.setdefault(managed_feature, {})
         if not isinstance(section, dict):
             section = {}
@@ -4316,6 +4498,9 @@ def _reconfigure_provider(
                 if isinstance(img_cfg, dict):
                     img_cfg["provider"] = "fal"
                     img_cfg["use_gateway"] = False
+        # STT providers prompt for model selection on reconfig too.
+        if provider.get("stt_provider") and not managed_feature:
+            _configure_stt_model(provider["stt_provider"], config)
         return
 
     for var in env_vars:
@@ -4356,6 +4541,10 @@ def _reconfigure_provider(
             if isinstance(img_cfg, dict):
                 img_cfg["provider"] = "fal"
                 img_cfg["use_gateway"] = False
+
+    # STT providers prompt for model selection on reconfig too.
+    if provider.get("stt_provider") and not managed_feature:
+        _configure_stt_model(provider["stt_provider"], config)
 
 
 def _reconfigure_simple_requirements(ts_key: str):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15962,6 +15962,7 @@ async def update_skill_content(body: SkillContentUpdate):
 @app.get("/api/tools/toolsets")
 async def get_toolsets(profile: Optional[str] = None):
     from hermes_cli.tools_config import (
+        _CONFIG_ONLY_TOOLSETS,
         _get_effective_configurable_toolsets,
         _get_platform_tools,
         _toolset_configuration_platform,
@@ -15992,7 +15993,16 @@ async def get_toolsets(profile: Optional[str] = None):
         except Exception:
             tools = []
         target_platform = _toolset_configuration_platform(name)
-        is_enabled = name in enabled_by_platform[target_platform]
+        if name in _CONFIG_ONLY_TOOLSETS:
+            # Config-only capabilities (stt) have no per-platform toolset —
+            # their switch is their own config section (e.g. stt.enabled).
+            from utils import is_truthy_value
+
+            section = config.get(name)
+            section = section if isinstance(section, dict) else {}
+            is_enabled = is_truthy_value(section.get("enabled", True), default=True)
+        else:
+            is_enabled = name in enabled_by_platform[target_platform]
         result.append({
             "name": name,
             "label": gui_toolset_label(label),
@@ -16025,6 +16035,7 @@ async def toggle_toolset(name: str, body: ToolsetToggle, profile: Optional[str] 
     to ``body.profile`` when provided. Returns 400 for unknown toolset keys.
     """
     from hermes_cli.tools_config import (
+        _CONFIG_ONLY_TOOLSETS,
         _get_effective_configurable_toolsets,
         _get_platform_tools,
         _save_platform_tools,
@@ -16036,6 +16047,23 @@ async def toggle_toolset(name: str, body: ToolsetToggle, profile: Optional[str] 
         raise HTTPException(status_code=400, detail=f"Unknown toolset: {name}")
 
     target_platform = _toolset_configuration_platform(name)
+    if name in _CONFIG_ONLY_TOOLSETS:
+        # Config-only capabilities (stt) toggle their own config section's
+        # ``enabled`` flag — there is no platform_toolsets entry to write.
+        with _profile_scope(body.profile or profile):
+            config = load_config()
+            section = config.setdefault(name, {})
+            if not isinstance(section, dict):
+                section = {}
+                config[name] = section
+            section["enabled"] = bool(body.enabled)
+            save_config(config)
+        return {
+            "ok": True,
+            "name": name,
+            "platform": target_platform,
+            "enabled": body.enabled,
+        }
     with _profile_scope(body.profile or profile):
         config = load_config()
         enabled = set(

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -879,6 +879,21 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         # (malicious 2.4.6 release on 2026-05-12). Restore once available.
         "options": ["local", "groq", "openai", "xai", "elevenlabs"],
     },
+    "stt.local.model": {
+        "type": "select",
+        "description": "Local faster-whisper model size",
+        "options": ["tiny", "base", "small", "medium", "large-v3"],
+    },
+    "stt.groq.model": {
+        "type": "select",
+        "description": "Groq Whisper model",
+        "options": ["whisper-large-v3-turbo", "whisper-large-v3", "distil-whisper-large-v3-en"],
+    },
+    "stt.openai.model": {
+        "type": "select",
+        "description": "OpenAI transcription model",
+        "options": ["whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe", "gpt-transcribe"],
+    },
     "stt.elevenlabs.model_id": {
         "type": "select",
         "description": "ElevenLabs Scribe model",

--- a/tests/hermes_cli/test_stt_picker.py
+++ b/tests/hermes_cli/test_stt_picker.py
@@ -1,0 +1,171 @@
+"""Tests for the Speech-to-Text category in `hermes tools` (tools_config).
+
+Covers the STT provider picker rows, config writes (stt.provider /
+use_gateway), the model picker catalog, config-only checklist exclusion,
+and the faster_whisper post-setup readiness hook.
+"""
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from hermes_cli.tools_config import (  # noqa: E402
+    _CONFIG_ONLY_TOOLSETS,
+    CONFIGURABLE_TOOLSETS,
+    STT_MODEL_CATALOG,
+    TOOL_CATEGORIES,
+    _checklist_toolset_keys,
+    _configure_stt_model,
+    _is_provider_active,
+    _write_provider_config,
+    apply_provider_selection,
+)
+
+
+def _stt_cat():
+    return TOOL_CATEGORIES["stt"]
+
+
+def _stt_provider_named(name):
+    return next(p for p in _stt_cat()["providers"] if p["name"] == name)
+
+
+class TestSttCategory:
+    def test_stt_category_exists(self):
+        cat = _stt_cat()
+        assert cat["name"] == "Speech-to-Text"
+        assert len(cat["providers"]) >= 5
+
+    def test_stt_in_configurable_toolsets(self):
+        keys = {k for k, _, _ in CONFIGURABLE_TOOLSETS}
+        assert "stt" in keys
+
+    def test_every_row_writes_stt_provider(self):
+        for prov in _stt_cat()["providers"]:
+            assert prov.get("stt_provider"), f"row {prov['name']} missing stt_provider"
+
+    def test_provider_keys_cover_runtime_dispatch(self):
+        """Every picker row's stt_provider must be a runtime built-in."""
+        from agent.transcription_registry import _BUILTIN_NAMES
+
+        for prov in _stt_cat()["providers"]:
+            assert prov["stt_provider"] in _BUILTIN_NAMES
+
+    def test_managed_row_shares_tts_coverage_category(self):
+        from hermes_cli.nous_subscription import MANAGED_FEATURE_COVERAGE_CATEGORY
+
+        managed = [p for p in _stt_cat()["providers"] if p.get("managed_nous_feature")]
+        assert managed, "expected a Nous Subscription row"
+        for p in managed:
+            assert p["managed_nous_feature"] == "stt"
+        assert MANAGED_FEATURE_COVERAGE_CATEGORY["stt"] == "openai-audio"
+
+
+class TestConfigWrites:
+    def test_write_provider_config_sets_stt_provider(self):
+        config = {}
+        prov = _stt_provider_named("Groq")
+        _write_provider_config(prov, config, managed_feature=None)
+        assert config["stt"]["provider"] == "groq"
+        assert config["stt"]["use_gateway"] is False
+
+    def test_write_provider_config_managed_sets_gateway(self):
+        config = {}
+        prov = _stt_provider_named("Nous Subscription")
+        _write_provider_config(prov, config, managed_feature="stt")
+        assert config["stt"]["provider"] == "openai"
+        assert config["stt"]["use_gateway"] is True
+        # Managed stt must not create a bogus top-level section via the
+        # generic use_gateway fallback (it's in the exclusion set).
+        assert set(config.keys()) == {"stt"}
+
+    def test_apply_provider_selection_stt(self):
+        config = {}
+        with patch(
+            "hermes_cli.tools_config.get_nous_subscription_features"
+        ) as feats:
+            feats.return_value = MagicMock(
+                nous_auth_present=False, account_info=None
+            )
+            apply_provider_selection("stt", "OpenAI", config)
+        assert config["stt"]["provider"] == "openai"
+
+    def test_byok_pick_clears_stale_gateway_flag(self):
+        config = {"stt": {"provider": "openai", "use_gateway": True}}
+        prov = _stt_provider_named("Groq")
+        _write_provider_config(prov, config, managed_feature=None)
+        assert config["stt"]["use_gateway"] is False
+
+
+class TestActiveDetection:
+    def test_active_matches_config(self):
+        config = {"stt": {"provider": "groq"}}
+        assert _is_provider_active(_stt_provider_named("Groq"), config)
+        assert not _is_provider_active(_stt_provider_named("OpenAI"), config)
+
+    def test_unset_provider_defaults_to_local(self):
+        assert _is_provider_active(_stt_provider_named("Local Whisper"), {})
+
+
+class TestModelPicker:
+    def test_catalog_includes_gpt_transcribe(self):
+        assert "gpt-transcribe" in STT_MODEL_CATALOG["openai"]
+
+    def test_catalog_matches_runtime_model_sets(self):
+        from tools.transcription_tools import GROQ_MODELS, OPENAI_MODELS
+
+        assert set(STT_MODEL_CATALOG["openai"]) == OPENAI_MODELS
+        assert set(STT_MODEL_CATALOG["groq"]) == GROQ_MODELS
+
+    def test_configure_stt_model_writes_model(self):
+        config = {}
+        with patch("hermes_cli.tools_config._prompt_choice", return_value=3):
+            _configure_stt_model("openai", config)
+        assert config["stt"]["openai"]["model"] == STT_MODEL_CATALOG["openai"][3]
+
+    def test_configure_stt_model_elevenlabs_uses_model_id(self):
+        config = {}
+        with patch("hermes_cli.tools_config._prompt_choice", return_value=0):
+            _configure_stt_model("elevenlabs", config)
+        assert config["stt"]["elevenlabs"]["model_id"] == "scribe_v2"
+        assert "model" not in config["stt"]["elevenlabs"]
+
+    def test_configure_stt_model_skips_uncataloged_provider(self):
+        config = {}
+        with patch("hermes_cli.tools_config._prompt_choice") as pc:
+            _configure_stt_model("xai", config)
+            _configure_stt_model("deepinfra", config)
+        pc.assert_not_called()
+        assert config == {}
+
+    def test_configure_stt_model_defaults_to_current(self):
+        config = {"stt": {"openai": {"model": "gpt-transcribe"}}}
+        with patch(
+            "hermes_cli.tools_config._prompt_choice", return_value=0
+        ) as pc:
+            _configure_stt_model("openai", config)
+        # default index should point at the currently configured model
+        args = pc.call_args[0]
+        assert args[2] == STT_MODEL_CATALOG["openai"].index("gpt-transcribe")
+
+
+class TestConfigOnlyExclusion:
+    def test_stt_is_config_only(self):
+        assert "stt" in _CONFIG_ONLY_TOOLSETS
+
+    def test_stt_excluded_from_checklist_universe(self):
+        assert "stt" not in _checklist_toolset_keys("cli")
+        # sanity: tts (a real toolset) stays in
+        assert "tts" in _checklist_toolset_keys("cli")
+
+
+class TestPostSetup:
+    def test_faster_whisper_in_post_setup_ready(self):
+        from hermes_cli.tools_config import _POST_SETUP_READY
+
+        assert "faster_whisper" in _POST_SETUP_READY


### PR DESCRIPTION
## Summary
Speech-to-Text is now fully configurable from every surface — a new `hermes tools` category, GUI capabilities-tab provider matrix + toggle, dashboard model dropdowns, and a `hermes setup` status line. Previously STT could only be configured by hand-editing `config.yaml`.

Follow-up to #73853 (gpt-transcribe model support).

## Changes
- `hermes_cli/tools_config.py`:
  - New `TOOL_CATEGORIES["stt"]` with 7 provider rows — Local Whisper (recommended, free), Nous Subscription (managed `openai-audio` gateway), OpenAI, Groq (free tier), xAI (Grok OAuth), ElevenLabs Scribe, DeepInfra — each with key prompts/badges/post-setup
  - `stt_provider` marker wired through `_write_provider_config` / `_configure_provider` / `_reconfigure_provider` / `_is_provider_active`, so CLI and GUI share the single `apply_provider_selection` write path (`stt.provider` + `stt.use_gateway`)
  - STT model picker after provider selection (`STT_MODEL_CATALOG`): local sizes, Groq whisper family, OpenAI `whisper-1`/`gpt-4o-mini-transcribe`/`gpt-4o-transcribe`/`gpt-transcribe`, ElevenLabs scribe (`model_id`)
  - `faster_whisper` post-setup hook auto-installs the local backend (+ `_POST_SETUP_READY` readiness)
  - `_CONFIG_ONLY_TOOLSETS`: stt ships zero tool schemas, so it is excluded from the per-platform enable checklist — no `platform_toolsets` pollution
- `hermes_cli/web_server.py`:
  - GUI toolset list/toggle handle config-only capabilities: the stt toggle reads/writes `stt.enabled` instead of `platform_toolsets`
  - Dashboard config page: `stt.local.model`, `stt.groq.model`, `stt.openai.model` registered as dropdowns (previously free text)
- `hermes_cli/setup.py`: Speech-to-Text status line per provider (managed / OpenAI / Groq / ElevenLabs / xAI / DeepInfra / Local Whisper with install hint)
- Mistral row intentionally omitted (mistralai PyPI quarantine), mirroring the existing dashboard `stt.provider` options

## Validation
| | Result |
|---|---|
| `tests/hermes_cli/test_stt_picker.py` (new) | 20 passed |
| tts_picker + tools_config | 141 passed |
| web_server + nous_subscription + setup_menu | 568 passed |
| E2E (temp HERMES_HOME): provider select → config write → platform-tools isolation → checklist exclusion → model pick round-trip | all pass |
| E2E GUI endpoints: `get_toolsets` row, `stt.enabled` toggle round-trip, provider matrix | all pass |

## Infographic

![STT fully configurable](https://v3b.fal.media/files/b/0aa42926/I_JRhtlc9HXKwVQoT_23J_3BMhO9d6.png)
