### PR TITLE
fix: make stale-stream detector content-aware to catch heartbeat-only providers (#73872)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3098,7 +3098,28 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # ownership of closing the underlying provider stream.
             _set_request_stream_handle(stream)
         for chunk in stream:
-            last_chunk_time["t"] = time.time()
+            # Only refresh the stale-stream timer for chunks with actual
+            # content.  Heartbeat / keep-alive SSE frames carry empty
+            # choices (or choices whose deltas have no payload) and must
+            # NOT reset the detector — otherwise a provider that sends
+            # pings but never delivers content will keep the stream
+            # alive indefinitely.  We still touch activity so the
+            # gateway knows the process is alive.
+            _has_content = False
+            if chunk.choices:
+                for _c in chunk.choices:
+                    _d = getattr(_c, "delta", None)
+                    if _d and (
+                        getattr(_d, "content", None)
+                        or getattr(_d, "tool_calls", None)
+                        or getattr(_d, "function_call", None)
+                        or getattr(_d, "reasoning_content", None)
+                        or getattr(_d, "reasoning", None)
+                    ):
+                        _has_content = True
+                        break
+            if _has_content:
+                last_chunk_time["t"] = time.time()
             agent._touch_activity("receiving stream response")
 
             # Update per-attempt diagnostic counters.  Best-effort —
@@ -3548,7 +3569,20 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         try:
             for event in stream:
                 saw_stream_event = True
-                last_chunk_time["t"] = time.time()
+                # Only refresh the stale-stream timer for content-bearing
+                # events.  Anthropic ``ping`` frames must not reset the
+                # detector — otherwise a provider that heartbeats without
+                # delivering content keeps the stream alive forever.
+                _evt_type = getattr(event, "type", None)
+                _is_content = _evt_type in (
+                    "content_block_start",
+                    "content_block_delta",
+                    "content_block_stop",
+                    "message_start",
+                    "message_delta",
+                )
+                if _is_content:
+                    last_chunk_time["t"] = time.time()
                 agent._touch_activity("receiving stream response")
                 try:
                     _diag["chunks"] = int(_diag.get("chunks", 0)) + 1


### PR DESCRIPTION
## Summary

The stale-stream detector (`HERMES_STREAM_STALE_TIMEOUT`, default 180s) resets its timer on every SSE chunk, including empty heartbeat/keep-alive frames. A provider that sends SSE pings but never delivers actual content (observed with iFlytek via OpenAI-compatible API) keeps the stream alive indefinitely — the agent hangs for 50+ minutes with status "receiving stream response".

## Root Cause

In `chat_completion_helpers.py`, two streaming loops unconditionally reset `last_chunk_time` on every chunk/event:

- **OpenAI-compatible path** (line ~3101): `for chunk in stream: last_chunk_time["t"] = time.time()`
- **Anthropic path** (line ~3551): `for event in stream: last_chunk_time["t"] = time.time()`

Heartbeat frames carry empty choices (OpenAI) or `ping` event types (Anthropic) and should not count as "content received".

## Fix

- **OpenAI-compatible path**: Only reset `last_chunk_time` when the chunk's delta carries actual content (`content`, `tool_calls`, `function_call`, `reasoning_content`, or `reasoning`). Heartbeat frames with empty choices or empty deltas no longer reset the timer.
- **Anthropic path**: Only reset `last_chunk_time` for content-bearing event types (`content_block_start`, `content_block_delta`, `content_block_stop`, `message_start`, `message_delta`). `ping` events no longer reset the timer.

Both paths still call `agent._touch_activity()` on every chunk so the gateway knows the process is alive — only the stale timer is gated.

## Test Plan

- [x] `tests/run_agent/test_stream_stale_breaker_reset.py` — 8/8 passed
- [x] `tests/run_agent/test_partial_stream_finish_reason.py` — 24/24 passed
- [x] Syntax check via `ast.parse()` — OK

Fixes #73872