### PR TITLE
fix(discord): add the /thread invoker to the thread they created

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6494,6 +6494,18 @@ class DiscordAdapter(BasePlatformAdapter):
                 auto_archive_duration=auto_archive_duration,
                 reason=reason,
             )
+            # A slash command runs as the bot, so the bot is the new thread's
+            # only member and the invoker cannot see it — the link we return
+            # renders as #unknown for the person who asked for it.
+            try:
+                await thread.add_user(interaction.user)
+            except Exception as add_user_error:
+                logger.warning(
+                    "[Discord] Failed to add /thread invoker %s to thread %s: %s",
+                    getattr(getattr(interaction, "user", None), "id", "?"),
+                    getattr(thread, "id", "?"),
+                    add_user_error,
+                )
             if starter_message:
                 await thread.send(starter_message)
             return {


### PR DESCRIPTION
## Problem

`/thread` creates a thread the invoker cannot see.

A slash command is executed by the bot, not by the human who typed it, so the
bot is the only member of the newly created thread. `TextChannel.create_thread()`
defaults to `ChannelType.private_thread` when no `message` is passed (discord.py
2.x), so the thread is private and the invoker was never added. The thread link
returned in the command response then renders as `#unknown` for the very person
who asked for it, with no way to reach it.

## Fix

Add the invoker immediately after creation. Failure is logged rather than
raised — the thread itself was created successfully and remains usable, so a
transient `add_user` failure shouldn't turn a working call into an error.

12 lines, pure insertion, no behaviour change to thread visibility (they were
already private by discord.py's default).

## Notes

The existing seed-message fallback path (`seed_msg.create_thread()`) is
unaffected: a thread created from a message is public and visible in-channel,
so it does not have this problem.

Running in production on a self-hosted install with six gateways.