### PR TITLE
fix(gateway): define media history for streamed delivery

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14406,6 +14406,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             }
             await self.hooks.emit("agent:start", hook_ctx)
 
+            # Snapshot media already present before this turn. The post-stream
+            # delivery path runs in this handler after _run_agent returns, so it
+            # must use a dedup set defined in this scope (not the private local
+            # created inside _run_agent).
+            _history_media_paths = _collect_history_media_paths(history)
+
             # Run the agent. Capture the session id that this run was launched
             # against so post-run compression publication can be identity-guarded
             # below; a /new or another lifecycle transition may move


### PR DESCRIPTION
## Summary

The post-stream delivery path in the gateway handler references `_history_media_paths` after `_run_agent` returns, but that dedup set was only defined as a private local inside `_run_agent`. On turns that combine streamed output (e.g. reasoning deltas delivered to the platform) with media in the session history, the handler dies on the undefined name and the final response is silently never delivered — no log line, no delivery-ledger record, no error surfaced to the user. The turn just goes quiet after the streamed messages.

This snapshots the media already present before the turn in the handler scope, so the post-stream delivery path has its own dedup set.

Observed in production: a Telegram turn delivered its streamed reasoning message (provider ACK with message_id) and then hung/died before the final text + TTS voice reply was sent.

## Testing

- `tests/gateway/test_post_stream_media_delivery.py` and the stream consumer suites pass (338 tests across the stream/ledger files on the deployment where this was hit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)