### PR TITLE
fix(buzz): don't cache transient _resolve_user_name CLI failures

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1155,24 +1155,31 @@ class BuzzAdapter(BasePlatformAdapter):
     async def _resolve_user_name(self, pubkey: str) -> str:
         """Resolve a pubkey to a display name (cached; falls back to npub prefix).
 
-        Failures are cached too (negative caching): without it, every message
-        from a profile-less pubkey re-runs ``users get`` each poll sweep,
-        which amplifies badly when several adapter instances poll in one
-        process.
+        A profile-less pubkey is negative-cached: without it, every message
+        from a member with no display name re-runs ``users get`` each poll
+        sweep, which amplifies badly when several adapter instances poll in
+        one process. That negative cache is only trustworthy when the CLI
+        call itself succeeded (``code == 0``) — a transient failure (relay
+        hiccup, or the 30s ``_exec_buzz`` timeout returning code 124) must
+        NOT be cached, or one bad poll sweep permanently pins that user to
+        their npub prefix for the rest of the gateway process's lifetime.
         """
         cached = self._user_names.get(pubkey)
         if cached is not None:
             return cached
-        name = ""
         code, out, _err = await self._run_cli(["users", "get", "--pubkey", pubkey])
+        name = ""
         if code == 0:
             profiles = _parse_json_list(out)
             if profiles:
                 name = str(profiles[0].get("display_name") or "").strip()
-        if not name:
-            name = (hex_to_npub(pubkey) or pubkey)[:16]
-        self._user_names[pubkey] = name
-        return name
+            if not name:
+                name = (hex_to_npub(pubkey) or pubkey)[:16]
+            self._user_names[pubkey] = name
+            return name
+        # Transient failure: fall back to the npub prefix for this call only,
+        # without caching, so the next poll sweep retries the lookup.
+        return (hex_to_npub(pubkey) or pubkey)[:16]
 
     @staticmethod
     def _trim_seen(state: dict) -> None:

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -197,6 +197,77 @@ class TestCliErrorContract:
         assert "exit code 3" in _cli_error_message("", 3)
 
 
+# ── Display-name resolution / negative caching (#73919) ───────────────────
+
+
+class TestResolveUserName:
+    """A transient CLI failure must not be cached as "no profile"."""
+
+    @pytest.mark.asyncio
+    async def test_success_is_cached(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("users", "get", [{"display_name": "Alice"}], code=0)
+        adapter._run_cli = cli
+
+        name = await adapter._resolve_user_name(OTHER_PUBKEY)
+        assert name == "Alice"
+        assert adapter._user_names[OTHER_PUBKEY] == "Alice"
+
+        # Second call must be served from cache, not re-invoke the CLI.
+        name2 = await adapter._resolve_user_name(OTHER_PUBKEY)
+        assert name2 == "Alice"
+        assert len(cli.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_profile_is_cached_as_npub_prefix(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("users", "get", [], code=0)  # empty profile list, success
+        adapter._run_cli = cli
+
+        name = await adapter._resolve_user_name(OTHER_PUBKEY)
+        expected = hex_to_npub(OTHER_PUBKEY)[:16]
+        assert name == expected
+        assert adapter._user_names[OTHER_PUBKEY] == expected
+
+        await adapter._resolve_user_name(OTHER_PUBKEY)
+        assert len(cli.calls) == 1  # cached, no second CLI call
+
+    @pytest.mark.asyncio
+    async def test_transient_cli_failure_is_not_cached(self):
+        """CLI error (e.g. relay hiccup) must retry on the next poll sweep."""
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        # Queue both responses upfront: _ScriptedCli pops in FIFO order once
+        # more than one response is queued for the same (group, cmd).
+        cli.script("users", "get", "", code=1, stderr='{"error":"relay_error","message":"boom"}')
+        cli.script("users", "get", [{"display_name": "Bob"}], code=0)
+        adapter._run_cli = cli
+
+        name = await adapter._resolve_user_name(OTHER_PUBKEY)
+        assert name == hex_to_npub(OTHER_PUBKEY)[:16]
+        assert OTHER_PUBKEY not in adapter._user_names  # must NOT be cached
+
+        # Next sweep succeeds: the CLI must be re-invoked, not served stale.
+        name2 = await adapter._resolve_user_name(OTHER_PUBKEY)
+        assert name2 == "Bob"
+        assert len(cli.calls) == 2
+        assert adapter._user_names[OTHER_PUBKEY] == "Bob"
+
+    @pytest.mark.asyncio
+    async def test_timeout_failure_is_not_cached(self):
+        """The 124-timeout return code from _exec_buzz must not be cached either."""
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("users", "get", "", code=124, stderr='{"error":"timeout","message":"buzz users timed out after 30.0s"}')
+        adapter._run_cli = cli
+
+        name = await adapter._resolve_user_name(OTHER_PUBKEY)
+        assert name == hex_to_npub(OTHER_PUBKEY)[:16]
+        assert OTHER_PUBKEY not in adapter._user_names
+
+
 # ── Seeding / high-water mark / de-dupe ───────────────────────────────────
 
 


### PR DESCRIPTION
Fixes #73919.

## Bug

`BuzzAdapter._resolve_user_name()` cached the resolved display name on every code path, including `code != 0` (CLI error, or the `124`-timeout return code from `_exec_buzz`). A single transient relay hiccup or CLI timeout while resolving a user's display name permanently pinned that user to their npub prefix for the rest of the gateway process's lifetime — every future message from them showed the truncated npub instead of their real name, until the gateway was restarted.

The negative-caching intent itself is correct and stays: a genuinely profile-less pubkey (CLI succeeds, returns an empty profile list) is still cached, to avoid re-running `users get` on every poll sweep.

## Fix

Only populate `self._user_names[pubkey]` when `code == 0`. A transient failure returns the npub-prefix fallback for that single call without writing to the cache, so the next poll sweep retries the lookup.

## Tests

Added `TestResolveUserName` (4 cases) to `tests/gateway/test_buzz_adapter.py`:
- `test_success_is_cached` — successful lookup is cached, second call doesn't re-invoke the CLI
- `test_no_profile_is_cached_as_npub_prefix` — CLI succeeds with an empty profile list; still cached (unchanged behavior)
- `test_transient_cli_failure_is_not_cached` — CLI returns a non-zero exit; result is NOT cached, and the next successful call is properly resolved and cached
- `test_timeout_failure_is_not_cached` — the `124` timeout path from `_exec_buzz` is likewise not cached

Verified RED on the unpatched handler: `test_transient_cli_failure_is_not_cached` and `test_timeout_failure_is_not_cached` both fail on current `main` (npub prefix incorrectly present in `_user_names` after a failed call). All 67 tests in `tests/gateway/test_buzz_adapter.py` pass with the fix (no regressions in the mention-gating / DM-classification / polling-dedupe suites that also touch this adapter).

```
67 passed in 0.28s
```
