### PR TITLE
fix(desktop): resolve local plugin root independent of remote backend (#66899)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -10868,7 +10868,12 @@ ipcMain.handle('hermes:fs:openDir', async (_event, dirPath) => {
 // on-disk plugin door silently breaks (#66899). Electron owns this resolution
 // so it stays valid in every connection mode. Created on demand, like openDir.
 ipcMain.handle('hermes:fs:desktopPluginsRoot', async () => {
-  const dir = path.join(HERMES_HOME, 'desktop-plugins')
+  // Profile-aware: a named Desktop profile gets its own plugin root under
+  // profiles/<name>/, matching the profile-scoped hermes_home the backend
+  // reported before this resolver existed. 'default'/unset pins the global root.
+  const profile = readActiveDesktopProfile()
+  const base = profile && profile !== 'default' ? path.join(HERMES_HOME, 'profiles', profile) : HERMES_HOME
+  const dir = path.join(base, 'desktop-plugins')
 
   try {
     await fs.promises.mkdir(dir, { recursive: true })

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -10860,6 +10860,26 @@ ipcMain.handle('hermes:fs:openDir', async (_event, dirPath) => {
   }
 })
 
+// The LOCAL Desktop runtime-plugin root: `<HERMES_HOME>/desktop-plugins`,
+// resolved from the main-process HERMES_HOME (see resolveHermesHome) — NOT from
+// the connected backend. A remote backend reports its own `hermes_home` over
+// the gateway, which is a path on the REMOTE box; deriving the plugin dir from
+// it yields `undefined/desktop-plugins` (or a non-existent remote path) and the
+// on-disk plugin door silently breaks (#66899). Electron owns this resolution
+// so it stays valid in every connection mode. Created on demand, like openDir.
+ipcMain.handle('hermes:fs:desktopPluginsRoot', async () => {
+  const dir = path.join(HERMES_HOME, 'desktop-plugins')
+
+  try {
+    await fs.promises.mkdir(dir, { recursive: true })
+  } catch {
+    // Best-effort create; return the path regardless so the reveal action can
+    // still surface a real openPath error and the scanner can retry later.
+  }
+
+  return dir
+})
+
 // Rename a file/folder in place. The renderer passes the existing path + a new
 // base name; the destination is resolved in the SAME parent dir so a rename can
 // never move the item elsewhere or traverse out. Rejects on a name collision.

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -155,6 +155,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   gitRoot: startPath => ipcRenderer.invoke('hermes:fs:gitRoot', startPath),
   revealPath: targetPath => ipcRenderer.invoke('hermes:fs:reveal', targetPath),
   openDir: dirPath => ipcRenderer.invoke('hermes:fs:openDir', dirPath),
+  desktopPluginsRoot: () => ipcRenderer.invoke('hermes:fs:desktopPluginsRoot'),
   renamePath: (targetPath, newName) => ipcRenderer.invoke('hermes:fs:rename', targetPath, newName),
   writeTextFile: (filePath, content) => ipcRenderer.invoke('hermes:fs:writeText', filePath, content),
   trashPath: targetPath => ipcRenderer.invoke('hermes:fs:trash', targetPath),

--- a/apps/desktop/src/app/settings/plugins-settings.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.tsx
@@ -6,7 +6,6 @@ import { Switch } from '@/components/ui/switch'
 import { Tip } from '@/components/ui/tooltip'
 import { $pluginRecords, type PluginRecord, setPluginEnabled } from '@/contrib/plugins-store'
 import { discoverRuntimePlugins } from '@/contrib/runtime-loader'
-import { getStatus } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { Package } from '@/lib/icons'
@@ -22,10 +21,19 @@ function reveal(file: string) {
 
 async function revealPluginsDir() {
   try {
-    const { hermes_home } = await getStatus()
+    // Electron owns the local plugin root — deriving it from the backend's
+    // hermes_home breaks against a remote backend (#66899).
+    const dir = await window.hermesDesktop?.desktopPluginsRoot?.()
+
+    if (!dir) {
+      notifyError('Desktop plugins are unavailable', 'Could not resolve the plugins folder')
+
+      return
+    }
+
     // openDir (not reveal): the door often doesn't exist on first use, and
     // showItemInFolder on a missing path silently no-ops (esp. Windows).
-    const result = await window.hermesDesktop?.openDir?.(`${hermes_home}/desktop-plugins`)
+    const result = await window.hermesDesktop?.openDir?.(dir)
 
     if (result && !result.ok) {
       notifyError(result.error ?? 'unknown error', 'Could not open the plugins folder')

--- a/apps/desktop/src/contrib/runtime-loader.test.ts
+++ b/apps/desktop/src/contrib/runtime-loader.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesReadDirResult } from '@/global'
+import type * as HermesModule from '@/hermes'
+
+import { discoverRuntimePlugins } from './runtime-loader'
+
+// getStatus would supply the connected backend's hermes_home — a REMOTE path in
+// remote mode. The disk scanner must NOT derive the plugin root from it (#66899).
+const getStatus = vi.fn(async () => ({ hermes_home: '/remote/box/.hermes' }))
+
+vi.mock('@/hermes', async importActual => ({
+  ...(await importActual<typeof HermesModule>()),
+  getStatus: () => getStatus()
+}))
+
+const desktopPluginsRoot = vi.fn<() => Promise<string>>()
+const readDir = vi.fn<(path: string) => Promise<HermesReadDirResult>>()
+
+beforeEach(() => {
+  desktopPluginsRoot.mockReset()
+  readDir.mockReset()
+  getStatus.mockClear()
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = { desktopPluginsRoot, readDir }
+})
+
+afterEach(() => {
+  delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+describe('scanDiskPlugins (#66899)', () => {
+  it('scans the Electron-resolved local root, never the backend hermes_home', async () => {
+    desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
+    readDir.mockResolvedValue({ entries: [] })
+
+    await discoverRuntimePlugins()
+
+    expect(desktopPluginsRoot).toHaveBeenCalled()
+    expect(readDir).toHaveBeenCalledWith('/local/.hermes/desktop-plugins')
+    // The remote backend's hermes_home must never feed the local plugin scan.
+    expect(getStatus).not.toHaveBeenCalled()
+    expect(readDir).not.toHaveBeenCalledWith('/remote/box/.hermes/desktop-plugins')
+  })
+
+  it('no-ops when the resolver yields no local root', async () => {
+    desktopPluginsRoot.mockResolvedValue('')
+
+    await discoverRuntimePlugins()
+
+    expect(readDir).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/contrib/runtime-loader.test.ts
+++ b/apps/desktop/src/contrib/runtime-loader.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { HermesReadDirResult } from '@/global'
 import type * as HermesModule from '@/hermes'
 
-import { discoverRuntimePlugins } from './runtime-loader'
+import { discoverRuntimePlugins, watchRuntimePlugins } from './runtime-loader'
 
 // getStatus would supply the connected backend's hermes_home — a REMOTE path in
 // remote mode. The disk scanner must NOT derive the plugin root from it (#66899).
@@ -16,12 +16,21 @@ vi.mock('@/hermes', async importActual => ({
 
 const desktopPluginsRoot = vi.fn<() => Promise<string>>()
 const readDir = vi.fn<(path: string) => Promise<HermesReadDirResult>>()
+const watchDirectory = vi.fn<(path: string) => Promise<{ id: string }>>()
+const onPreviewFileChanged = vi.fn()
 
 beforeEach(() => {
   desktopPluginsRoot.mockReset()
   readDir.mockReset()
+  watchDirectory.mockReset()
+  onPreviewFileChanged.mockReset()
   getStatus.mockClear()
-  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = { desktopPluginsRoot, readDir }
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+    desktopPluginsRoot,
+    onPreviewFileChanged,
+    readDir,
+    watchDirectory
+  }
 })
 
 afterEach(() => {
@@ -48,5 +57,21 @@ describe('scanDiskPlugins (#66899)', () => {
     await discoverRuntimePlugins()
 
     expect(readDir).not.toHaveBeenCalled()
+  })
+})
+
+describe('watchRuntimePlugins dir watch (#66899)', () => {
+  it('watches the Electron-resolved local root, never the backend hermes_home', async () => {
+    desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
+    readDir.mockResolvedValue({ entries: [] })
+    watchDirectory.mockResolvedValue({ id: 'watch-1' })
+
+    watchRuntimePlugins()
+    // Drain the async scan + startDirWatch chains.
+    await vi.waitFor(() => expect(watchDirectory).toHaveBeenCalled())
+
+    expect(watchDirectory).toHaveBeenCalledWith('/local/.hermes/desktop-plugins')
+    expect(watchDirectory).not.toHaveBeenCalledWith('/remote/box/.hermes/desktop-plugins')
+    expect(getStatus).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -350,8 +350,15 @@ export function watchRuntimePlugins(): void {
     }
 
     try {
-      const { hermes_home } = await getStatus()
-      dirWatchId = (await desktop.watchDirectory(`${hermes_home}/desktop-plugins`)).id
+      // Same Electron-local root as the scanner — never the backend's
+      // hermes_home, which is a remote path in remote mode (#66899).
+      const root = await desktop.desktopPluginsRoot?.()
+
+      if (!root) {
+        return false
+      }
+
+      dirWatchId = (await desktop.watchDirectory(root)).id
 
       return true
     } catch {

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -27,7 +27,6 @@
  * trust seam.
  */
 
-import { getStatus } from '@/hermes'
 import { installPluginSdk, sdkImportMap } from '@/sdk/runtime'
 import { notifyError } from '@/store/notifications'
 
@@ -247,8 +246,16 @@ async function scanDiskPlugins(): Promise<void> {
   scanning = true
 
   try {
-    const { hermes_home } = await getStatus()
-    const { entries } = await desktop.readDir(`${hermes_home}/desktop-plugins`)
+    // The plugin root is a LOCAL Electron path, resolved independently of the
+    // connected backend — a remote backend's hermes_home is a remote path and
+    // yields `undefined/desktop-plugins` here (#66899).
+    const root = await desktop.desktopPluginsRoot?.()
+
+    if (!root) {
+      return
+    }
+
+    const { entries } = await desktop.readDir(root)
     const seen = new Set<string>()
 
     for (const dir of entries.filter(e => e.isDirectory)) {

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -164,6 +164,10 @@ declare global {
       revealPath?: (path: string) => Promise<boolean>
       // Open a DIRECTORY (created if missing) in the OS file manager.
       openDir?: (path: string) => Promise<{ ok: boolean; error?: string }>
+      // Local Desktop runtime-plugin root (<HERMES_HOME>/desktop-plugins),
+      // resolved by Electron independently of the connected backend (#66899).
+      // Created on demand; returns the normalized absolute path.
+      desktopPluginsRoot?: () => Promise<string>
       // Rename a file/folder in place (new base name, same parent dir).
       renamePath?: (path: string, newName: string) => Promise<{ path: string }>
       // Write a small UTF-8 text file (hardened path, parent must exist).


### PR DESCRIPTION
## Summary

Desktop runtime plugins now load in every connection mode: the local plugin root (`<HERMES_HOME>/desktop-plugins`) is resolved by Electron via a typed IPC capability instead of being derived from the connected backend's `hermes_home`, which is a remote (or `undefined`) path in remote-gateway/SSH/cloud modes. Fixes #66899.

Salvages #66911 by @PRATHAMESH75 onto current `main` (authorship preserved), plus two follow-ups.

## Changes

- `electron/main.ts`: new `hermes:fs:desktopPluginsRoot` IPC — resolves the local root, **profile-aware** (`profiles/<name>/desktop-plugins` for a named desktop profile via `readActiveDesktopProfile()`, global root for default/unset), mkdir-on-demand.
- `electron/preload.ts` + `src/global.d.ts`: expose the typed capability.
- `src/contrib/runtime-loader.ts`: disk scanner AND `startDirWatch` (a third sibling site added by the later fs-watch commit, missed by the original PR) both use the Electron-local root; `getStatus()` no longer feeds any local fs path.
- `src/app/settings/plugins-settings.tsx`: "Open plugins folder" uses the same resolver.
- `src/contrib/runtime-loader.test.ts`: regression tests asserting scanner and dir-watch never consult backend `hermes_home` (watcher test verified to fail against the old behavior via sabotage run).

## Validation

| Check | Result |
|---|---|
| `npx vitest run src/contrib/runtime-loader.test.ts` | 3/3 pass |
| Sabotage run (old watch path restored) | watcher test fails as expected |
| `npm run typecheck` (ui + electron + e2e) | pass |
| ESLint on changed files | pass |
| Stale-base gate (`rev-list count`) | 0 |

Credit: @langoshjerod-source submitted the same Electron-local design first in #66152; #66911 is the more complete variant and was salvaged here. Both contributors credited.

## Infographic

![Desktop plugins local root infographic](https://v3b.fal.media/files/b/0aa4293d/dptY5nGcjpy7Z0SGBXjdT_LQrKquzs.png)
