### PR TITLE
fix(memory/holographic): improve Korean recall via NFC normalization and Hangul FTS5 prefix operator (#73868)

### DIFF
--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -7,6 +7,8 @@ Jaccard similarity reranking and trust-weighted scoring.
 from __future__ import annotations
 
 import math
+import re
+import unicodedata
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -549,10 +551,14 @@ class FactRetriever:
     def _tokenize(text: str) -> set[str]:
         """Simple whitespace tokenization with lowercasing.
 
-        Strips common punctuation. No stemming/lemmatization (Phase 1).
+        Strips common punctuation. NFC-normalizes to handle macOS NFD
+        Hangul. No stemming/lemmatization (Phase 1).
         """
         if not text:
             return set()
+        # NFC-normalize so that macOS NFD Hangul tokens (e.g. 알림을
+        # pasted as NFD) match the NFC form used during indexing.
+        text = unicodedata.normalize("NFC", text)
         # Split on whitespace, lowercase, strip punctuation
         tokens = set()
         for word in text.lower().split():
@@ -582,15 +588,30 @@ class FactRetriever:
         "you", "your", "yours", "yourself", "yourselves",
     })
 
+    # Hangul syllable ranges for detecting Korean text in FTS5 queries.
+    # Covers Hangul Jamo, Hangul Syllables, and Extended-A/B blocks.
+    _HANGUL_RE = re.compile(
+        "["
+        "\u1100-\u11ff"   # Hangul Jamo
+        "\uac00-\ud7af"   # Hangul Syllables
+        "\ua960-\ua97f"    # Hangul Jamo Extended-A
+        "\ud7b0-\ud7ff"    # Hangul Jamo Extended-B
+        "]"
+    )
+
     @classmethod
     def _sanitize_fts_query(cls, query: str) -> str:
         """Convert a natural-language query to an FTS5-safe OR expression.
 
         FTS5 treats a multi-word MATCH argument as AND-joined by default,
         which tanks recall on prose queries. This helper:
+          - NFC-normalizes the query (handles macOS NFD Hangul)
           - tokenizes the query
           - drops stopwords and short (<2 char) tokens
           - strips FTS5 special characters from each token
+          - appends the FTS5 prefix operator (*) to Hangul-containing
+            tokens so that a bare noun matches its particle-suffixed
+            indexed form (e.g. 알림 matches 알림을)
           - OR-joins the survivors
 
         If nothing remains (pathological query), falls back to the raw
@@ -598,6 +619,9 @@ class FactRetriever:
         """
         if not query:
             return ""
+        # NFC-normalize so that Hangul queries from macOS (which pastes
+        # as NFD) are comparable with NFC-indexed content.
+        query = unicodedata.normalize("NFC", query)
         # Strip FTS5 operator characters from EACH token to avoid
         # accidentally creating a malformed query.
         _FTS_SPECIAL = '"()*^:-+'
@@ -610,9 +634,13 @@ class FactRetriever:
                 continue
             if cleaned in cls._FTS_STOPWORDS:
                 continue
-            # FTS5 phrase-literal each token to ensure no special chars
-            # sneak through as operators.
-            tokens.append(f'"{cleaned}"')
+            # FTS5 phrase-literal each token. For Hangul-containing
+            # tokens, also append the prefix operator so queries for
+            # the bare noun match particle-suffixed indexed forms.
+            if cls._HANGUL_RE.search(cleaned):
+                tokens.append(f'"{cleaned}"*')
+            else:
+                tokens.append(f'"{cleaned}"')
         if not tokens:
             # Fallback: raw query (likely returns 0, but never crashes)
             return query


### PR DESCRIPTION
## Problem

Korean-language facts in the holographic memory provider are effectively write-only. FTS5's default `unicode61` tokenizer treats each space-delimited 어절 (noun + attached grammatical particle) as one indivisible token. A query for the bare noun `알림` never matches the indexed form `알림을`. Similarly, Latin identifiers like `Hermes` within Korean prose get indexed as `Hermes는` and become unsearchable.

Measured on the issue's 12 representative queries, only 3/12 recall correctly (vs 1/1 for the English control).

## Changes

All changes are in `plugins/memory/holographic/retrieval.py`:

1. **NFC normalization** in both `_sanitize_fts_query` and `_tokenize` — macOS pastes Hangul as NFD, making the same word mismatch across forms. NFC normalization aligns them with the NFC content in the index.

2. **Hangul FTS5 prefix operator** in `_sanitize_fts_query` — tokens containing Hangul syllables now emit as `"알림"*` instead of `"알림"`, enabling FTS5 prefix matching so a bare-noun query matches particle-suffixed forms.

## Improvement

| Query | Before | After |
|---|---|---|
| `알림` (stored as `알림을`) | ✗ | ✓ |
| `회의록` (stored as `회의록을`) | ✗ | ✓ |
| `배포` (mixed `배포`/`배포는`) | partial | ✓ |
| `파이썬` (stored as `파이썬으로`) | ✗ | ✓ |
| `화요일` (stored as `화요일에`) | ✗ | ✓ |
| `선호` (stored as `선호한다`) | ✗ | ✓ |
| `다크 모드` (multi-word) | ✓ | ✓ |
| `원한다` (exact surface form) | ✓ | ✓ |
| `weekday` (English control) | ✓ | ✓ |
| `Notion` (Latin + `에` particle) | ✗ | ✗* |
| `Hermes` (Latin + `는` particle) | ✗ | ✗* |
| `원해요` (verb, polite ending) | ✗ | ✗* |

\* These remaining gaps require index-side changes or a Korean morphological analyzer (kiwipiepy).

## Verification

- 14 existing holographic store tests pass
- Python syntax and import checks pass
- FTS5 query generation verified with all 12 queries from the issue
- NFC/NFD equivalence verified
