### PR TITLE
fix(honcho): enforce saveMessages across automatic persistence

### DIFF
--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -215,7 +215,7 @@ Pick **[e]** at the prompt to set the three keys directly instead of going throu
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `writeFrequency` | string/int | `"async"` | `"async"` (background), `"turn"` (sync per turn), `"session"` (batch on end), or integer N (every N turns) |
-| `saveMessages` | bool | `true` | Persist messages to Honcho API |
+| `saveMessages` | bool | `true` | Allow automatic turn persistence, built-in profile-write mirroring, and startup migration of `MEMORY.md` / `USER.md` / `SOUL.md`. When `false`, those automatic paths send no content; explicit tool writes such as `honcho_conclude` remain available |
 
 ### Session Resolution
 

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -488,12 +488,18 @@ class HonchoMemoryProvider(MemoryProvider):
         # not treat that partially initialized state as usable.
         session = self._manager.get_or_create(self._session_key)
 
-        # Skip under per-session strategy: every Hermes run creates a fresh
-        # Honcho session by design, so uploading MEMORY.md/USER.md/SOUL.md to
-        # each one would flood the backend with short-lived duplicates instead
-        # of performing a one-time migration.
+        # saveMessages=false is the privacy boundary for every automatic
+        # content write, including startup migration. Also skip under the
+        # per-session strategy: every Hermes run creates a fresh Honcho session,
+        # so uploading MEMORY.md/USER.md/SOUL.md to each one would flood the
+        # backend with short-lived duplicates instead of migrating once.
         try:
-            if not session.messages and cfg.session_strategy != "per-session":
+            if not self._automatic_persistence_enabled():
+                logger.debug(
+                    "Honcho memory file migration skipped: saveMessages is disabled (%s)",
+                    self._session_key,
+                )
+            elif not session.messages and cfg.session_strategy != "per-session":
                 from hermes_constants import get_hermes_home
                 mem_dir = str(get_hermes_home() / "memories")
                 self._manager.migrate_memory_files(self._session_key, mem_dir)
@@ -593,6 +599,16 @@ class HonchoMemoryProvider(MemoryProvider):
         if self._session_initialized:
             return True
         return not (self._init_thread and self._init_thread.is_alive())
+
+    def _automatic_persistence_enabled(self) -> bool:
+        """Return whether automatic message and startup-file writes are allowed.
+
+        ``saveMessages`` controls automatic persistence only. Explicit tool
+        writes such as ``honcho_conclude`` intentionally bypass this check.
+        ``getattr`` preserves the historical enabled-by-default behavior for
+        legacy/test config objects that predate the setting.
+        """
+        return bool(getattr(self._config, "save_messages", True))
 
     def _format_first_turn_context(self, ctx: dict) -> str:
         """Format the prefetch context dict into a readable system prompt block."""
@@ -1333,6 +1349,8 @@ class HonchoMemoryProvider(MemoryProvider):
         """
         if self._cron_skipped:
             return
+        if not self._automatic_persistence_enabled():
+            return
         if self._recall_mode == "tools" and not self._session_ready():
             return
         if not self._session_ready():
@@ -1379,6 +1397,8 @@ class HonchoMemoryProvider(MemoryProvider):
             return
         if self._cron_skipped:
             return
+        if not self._automatic_persistence_enabled():
+            return
         if self._recall_mode == "tools" and not self._session_ready():
             return
         if not self._session_ready():
@@ -1397,6 +1417,8 @@ class HonchoMemoryProvider(MemoryProvider):
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Flush all pending messages to Honcho on session end."""
         if self._cron_skipped:
+            return
+        if not self._automatic_persistence_enabled():
             return
         if not self._manager:
             return
@@ -1541,7 +1563,15 @@ class HonchoMemoryProvider(MemoryProvider):
             if t and t.is_alive():
                 t.join(timeout=5.0)
         # Flush any remaining messages
-        if self._manager and not (self._init_thread and self._init_thread.is_alive() and not self._session_initialized):
+        if (
+            self._automatic_persistence_enabled()
+            and self._manager
+            and not (
+                self._init_thread
+                and self._init_thread.is_alive()
+                and not self._session_initialized
+            )
+        ):
             try:
                 self._manager.flush_all()
             except Exception:

--- a/plugins/memory/honcho/config_schema.py
+++ b/plugins/memory/honcho/config_schema.py
@@ -178,7 +178,7 @@ CONFIG_SCHEMA = ProviderConfigSchema(
             label="Save messages",
             kind=KIND_BOOL,
             default="true",
-            description="Persist conversation messages to Honcho.",
+            description="Allow automatic turn persistence, profile-write mirroring, and startup memory-file migration. Explicit Honcho tool writes remain available.",
             group="Message writing",
         ),
         ProviderField(

--- a/tests/honcho_plugin/test_save_messages.py
+++ b/tests/honcho_plugin/test_save_messages.py
@@ -1,0 +1,199 @@
+"""Behavioral tests for Honcho's saveMessages persistence boundary."""
+
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from plugins.memory.honcho import HonchoMemoryProvider
+from plugins.memory.honcho.client import HonchoClientConfig
+
+
+def _initialize_provider(monkeypatch, tmp_path, *, save_messages: bool):
+    config = HonchoClientConfig(
+        api_key="test-key",
+        enabled=True,
+        recall_mode="tools",
+        init_on_session_start=True,
+        save_messages=save_messages,
+        session_strategy="per-directory",
+    )
+    remote_session = MagicMock(name="remote-session")
+    manager = MagicMock(name="manager")
+    manager.get_or_create.return_value = SimpleNamespace(messages=[])
+
+    def migrate_memory_files(*_args, **_kwargs):
+        remote_session.upload_file(file=("consolidated_memory.md", b"memory", "text/plain"))
+        return True
+
+    manager.migrate_memory_files.side_effect = migrate_memory_files
+
+    monkeypatch.setattr(
+        "plugins.memory.honcho.client.HonchoClientConfig.from_global_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "plugins.memory.honcho.client.get_honcho_client",
+        lambda _config: MagicMock(name="honcho-client"),
+    )
+    monkeypatch.setattr(
+        "plugins.memory.honcho.session.HonchoSessionManager",
+        lambda **_kwargs: manager,
+    )
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+    provider = HonchoMemoryProvider()
+    provider.initialize("test-session")
+    return provider, manager, remote_session
+
+
+def _ready_provider(*, save_messages: bool):
+    provider = HonchoMemoryProvider()
+    provider._config = HonchoClientConfig(
+        save_messages=save_messages,
+        message_max_chars=25000,
+    )
+    provider._session_key = "test-session"
+    provider._session_initialized = True
+
+    remote_session = MagicMock(name="remote-session")
+    local_session = MagicMock(name="local-session")
+    manager = MagicMock(name="manager")
+    manager.get_or_create.return_value = local_session
+    manager._flush_session.side_effect = lambda _session: remote_session.add_messages(
+        ["persisted-turn"]
+    )
+    manager.flush_all.side_effect = lambda: remote_session.add_messages(
+        ["persisted-session"]
+    )
+    provider._manager = manager
+    return provider, manager, local_session, remote_session
+
+
+def test_save_messages_false_skips_startup_memory_file_migration(
+    monkeypatch, tmp_path
+):
+    provider, manager, remote_session = _initialize_provider(
+        monkeypatch, tmp_path, save_messages=False
+    )
+
+    assert provider._session_initialized is True
+    manager.get_or_create.assert_called_once_with(provider._session_key)
+    manager.migrate_memory_files.assert_not_called()
+    remote_session.upload_file.assert_not_called()
+    remote_session.add_messages.assert_not_called()
+
+
+def test_save_messages_true_preserves_startup_memory_file_migration(
+    monkeypatch, tmp_path
+):
+    provider, manager, remote_session = _initialize_provider(
+        monkeypatch, tmp_path, save_messages=True
+    )
+
+    assert provider._session_initialized is True
+    manager.migrate_memory_files.assert_called_once()
+    remote_session.upload_file.assert_called_once()
+
+
+def test_save_messages_false_skips_turn_persistence():
+    provider, manager, local_session, remote_session = _ready_provider(
+        save_messages=False
+    )
+
+    provider.sync_turn("private user message", "private assistant response")
+
+    assert provider._sync_thread is None
+    manager.get_or_create.assert_not_called()
+    local_session.add_message.assert_not_called()
+    manager._flush_session.assert_not_called()
+    remote_session.add_messages.assert_not_called()
+
+
+def test_save_messages_true_preserves_turn_persistence():
+    provider, manager, local_session, remote_session = _ready_provider(
+        save_messages=True
+    )
+
+    provider.sync_turn("user message", "assistant response")
+    sync_thread = provider._sync_thread
+    assert sync_thread is not None
+    sync_thread.join(timeout=1)
+
+    assert not sync_thread.is_alive()
+    assert local_session.add_message.call_args_list[0].args == ("user", "user message")
+    assert local_session.add_message.call_args_list[1].args == (
+        "assistant",
+        "assistant response",
+    )
+    manager._flush_session.assert_called_once_with(local_session)
+    remote_session.add_messages.assert_called_once_with(["persisted-turn"])
+
+
+def test_save_messages_false_skips_automatic_memory_mirroring():
+    provider, manager, _local_session, remote_session = _ready_provider(
+        save_messages=False
+    )
+
+    provider.on_memory_write("add", "user", "private profile fact")
+
+    manager.create_conclusion.assert_not_called()
+    remote_session.add_messages.assert_not_called()
+    remote_session.upload_file.assert_not_called()
+
+
+def test_save_messages_true_preserves_automatic_memory_mirroring():
+    provider, manager, _local_session, _remote_session = _ready_provider(
+        save_messages=True
+    )
+
+    provider.on_memory_write("add", "user", "profile fact")
+
+    deadline = time.time() + 1
+    while time.time() < deadline and not manager.create_conclusion.called:
+        time.sleep(0.01)
+    manager.create_conclusion.assert_called_once_with("test-session", "profile fact")
+
+
+def test_save_messages_false_skips_session_end_and_shutdown_flushes():
+    provider, manager, _local_session, remote_session = _ready_provider(
+        save_messages=False
+    )
+
+    provider.on_session_end([])
+    provider.shutdown()
+
+    manager.flush_all.assert_not_called()
+    remote_session.add_messages.assert_not_called()
+    remote_session.upload_file.assert_not_called()
+
+
+def test_save_messages_true_preserves_session_end_flush():
+    provider, manager, _local_session, remote_session = _ready_provider(
+        save_messages=True
+    )
+
+    provider.on_session_end([])
+
+    manager.flush_all.assert_called_once_with()
+    remote_session.add_messages.assert_called_once_with(["persisted-session"])
+
+
+def test_save_messages_false_does_not_disable_explicit_conclusions():
+    provider, manager, _local_session, remote_session = _ready_provider(
+        save_messages=False
+    )
+    manager.create_conclusion.return_value = True
+
+    result = provider.handle_tool_call(
+        "honcho_conclude",
+        {"conclusion": "User explicitly approved this durable fact"},
+    )
+
+    assert "Conclusion saved" in result
+    manager.create_conclusion.assert_called_once_with(
+        "test-session",
+        "User explicitly approved this durable fact",
+        peer="user",
+    )
+    remote_session.add_messages.assert_not_called()
+    remote_session.upload_file.assert_not_called()

--- a/website/docs/user-guide/features/honcho.md
+++ b/website/docs/user-guide/features/honcho.md
@@ -124,7 +124,7 @@ When pointing Hermes at a self-hosted Honcho server, `hermes honcho setup` (and 
 | `dialecticMaxChars` | `600` | Max chars of dialectic result injected into system prompt |
 | `recallMode` | `'hybrid'` | `hybrid` (auto-inject + tools), `context` (inject only), `tools` (tools only) |
 | `writeFrequency` | `'async'` | When to flush messages: `async` (background thread), `turn` (sync), `session` (batch on end), or integer N |
-| `saveMessages` | `true` | Whether to persist messages to Honcho API |
+| `saveMessages` | `true` | Allow automatic turn persistence, built-in profile-write mirroring, and startup migration of `MEMORY.md` / `USER.md` / `SOUL.md`. When `false`, those automatic paths send no content; explicit tool writes such as `honcho_conclude` remain available |
 | `observationMode` | `'directional'` | `directional` (all on) or `unified` (shared pool). Override with `observation` object for granular control |
 | `messageMaxChars` | `25000` | Max chars per message sent via `add_messages()`. Chunked if exceeded |
 | `dialecticMaxInputChars` | `10000` | Max chars for dialectic query input to `peer.chat()` |

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -94,7 +94,7 @@ The legacy `hermes honcho setup` command still works (it now redirects to `herme
 | `dialecticMaxChars` | `600` | Max chars of dialectic result injected into system prompt |
 | `recallMode` | `'hybrid'` | `hybrid` (auto-inject + tools), `context` (inject only), `tools` (tools only) |
 | `writeFrequency` | `'async'` | When to flush messages: `async` (background thread), `turn` (sync), `session` (batch on end), or integer N |
-| `saveMessages` | `true` | Whether to persist messages to Honcho API |
+| `saveMessages` | `true` | Allow automatic turn persistence, built-in profile-write mirroring, and startup migration of `MEMORY.md` / `USER.md` / `SOUL.md`. When `false`, those automatic paths send no content; explicit tool writes such as `honcho_conclude` remain available |
 | `observationMode` | `'directional'` | `directional` (all on) or `unified` (shared pool). Override with `observation` object |
 | `messageMaxChars` | `25000` | Max chars per message (chunked if exceeded) |
 | `dialecticMaxInputChars` | `10000` | Max chars for dialectic query input to `peer.chat()` |


### PR DESCRIPTION
## What does this PR do?

Makes Honcho's existing `saveMessages` setting an actual boundary for **all automatic persistence**, while preserving explicit Honcho tool writes.

When `saveMessages: false`, the provider now skips:

- startup migration/upload of `MEMORY.md`, `USER.md`, and `SOUL.md`;
- automatic user/assistant turn persistence;
- automatic mirroring of built-in profile writes as conclusions;
- session-end and shutdown flushes.

Explicit calls such as `honcho_conclude` continue to work. The guard defaults to enabled when config is absent, preserving legacy behavior.

This is broader than #35210 (turn persistence only) and #67559 (turn/memory/session-end paths): it also covers startup file migration and shutdown flushes, documents the full contract, and tests that explicit writes stay available. #72708 additionally changes `writeFrequency` and lifecycle behavior; this PR intentionally stays focused on the `saveMessages` contract.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/honcho/__init__.py`: centralize the automatic-persistence gate and apply it to startup migration, turns, profile-write mirroring, session-end, and shutdown.
- `plugins/memory/honcho/config_schema.py`: clarify the setting's behavioral contract.
- `tests/honcho_plugin/test_save_messages.py`: add 9 behavioral tests covering disabled/enabled automatic paths and explicit conclusions.
- Honcho README and website docs: document the boundary and explicit-write exception.

## How to Test

1. `python -m pytest tests/honcho_plugin/test_save_messages.py -o 'addopts=' -q`
2. `python -m pytest tests/honcho_plugin -o 'addopts=' -q -k 'not cache_busting_signature_reflects'`
3. `python -m py_compile plugins/memory/honcho/__init__.py plugins/memory/honcho/config_schema.py tests/honcho_plugin/test_save_messages.py`

Observed results:

- canonical `scripts/run_tests.sh tests/honcho_plugin/test_save_messages.py -j 1 -q`: **9 passed**;
- focused regression file via direct pytest: **9 passed**;
- Honcho plugin suite: **445 passed, 4 deselected**;
- compile and `git diff --check`: passed.

A full `tests/` run collected 50,638 tests and was stopped after three unrelated existing failures: two ACP approval tests that pass in isolation on both this branch and pristine `origin/main`, and `tests/agent/lsp/test_broken_set.py::test_mark_broken_handles_no_workspace_silently`, which reproduces on pristine `origin/main`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) and documented the overlap/differences above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full run attempted; unrelated failures documented above
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` update is N/A (no new config key)
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A
- [x] I've considered cross-platform impact; the change is platform-neutral Python/config behavior
- [x] Tool descriptions/schemas are unchanged; the provider config description is updated

## Screenshots / Logs

Not applicable; verification is covered by the regression tests above.
