### PR TITLE
fix(gateway): preserve voice_only semantics for text input

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18239,11 +18239,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             (voice_mode == "all")
             or (voice_mode == "voice_only" and is_voice_input)
             # ``voice.auto_tts`` is synced into the adapter on gateway startup.
-            # Treat it as "voice accompanies text replies" unless a chat was
-            # explicitly turned off. The base adapter's own auto-TTS path only
-            # covers voice-input replies, so final text replies need the runner
-            # path here.
-            or (voice_mode != "off" and adapter_auto_tts)
+            # It is the fallback only when the chat has no explicit mode;
+            # otherwise the chat-level all/voice_only/off choice takes precedence.
+            or (voice_mode is None and adapter_auto_tts)
         )
         if not should:
             logger.debug(

--- a/tests/gateway/test_auto_voice_reply_format.py
+++ b/tests/gateway/test_auto_voice_reply_format.py
@@ -73,6 +73,25 @@ class TestAutoVoiceReplyFormat:
             voice_event, "hello", [], already_sent=True
         ) is True
 
+    def test_should_send_voice_reply_voice_only_still_requires_voice_input(self):
+        """Explicit voice_only must not widen to text input (#73508 regression).
+
+        Persisted voice_only mode is synced into the adapter as an explicit
+        auto-TTS opt-in, so adapter_auto_tts is True for this chat. The
+        chat-level mode stays authoritative: text input gets no voice reply,
+        voice input still does.
+        """
+        runner = _make_runner()
+        runner._voice_mode["telegram:123"] = "voice_only"
+        adapter = _make_adapter(Platform.TELEGRAM)
+        adapter._should_auto_tts_for_chat = MagicMock(return_value=True)
+        runner.adapters[Platform.TELEGRAM] = adapter
+        event = _make_event(Platform.TELEGRAM, chat_id="123")
+
+        assert runner._should_send_voice_reply(event, "hello", []) is False
+
+        voice_event = _make_event(Platform.TELEGRAM, chat_id="123", message_type=MessageType.VOICE)
+        assert runner._should_send_voice_reply(voice_event, "hello", [], already_sent=True) is True
 
 def _make_runner() -> GatewayRunner:
     with patch("gateway.run.GatewayRunner._load_voice_modes", return_value={}):


### PR DESCRIPTION
## Summary

- Keep explicit chat-level voice modes (`all`, `voice_only`, `off`) authoritative over the adapter/global auto-TTS fallback.
- Prevent `voice_only` chats from speaking normal text-input replies after the mode is synced into the adapter as an auto-TTS opt-in.
- Preserve global `voice.auto_tts` behavior for chats with no explicit voice mode.

## Root cause

The runner gate added in #73508 used `voice_mode != "off" and adapter_auto_tts` as a broad fallback. `/voice on` stores `voice_only` and also enables auto-TTS for that chat in the adapter, so `adapter_auto_tts` is `True` for both text and voice input. That widened `voice_only` into the equivalent of `all`.

The fallback should apply only when no explicit chat mode exists. An explicit `voice_only` mode should continue to require voice input.

## Regression test

The existing `voice_only` gate test now includes the real adapter state produced by mode synchronization (`_should_auto_tts_for_chat(...) == True`). It fails on current `main` for text input and passes with this fix, while still confirming streamed voice input is spoken.

## Validation

```text
235 passed, 5 pre-existing RuntimeWarnings
ruff: all checks passed
python compile: passed
git diff --check: passed
```

Focused suites:

- `tests/gateway/test_auto_voice_reply_format.py`
- `tests/gateway/test_voice_command.py`
- `tests/gateway/test_base_auto_tts_output_format.py`
- `tests/gateway/test_telegram_voice_v0_regressions.py`
