### PR TITLE
fix(desktop): keep composer stable across compression

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -57,6 +57,7 @@ import type { ChatBarState } from './composer/types'
 import { type DroppedFile, partitionDroppedFiles } from './hooks/use-composer-actions'
 import { type DragKind, useFileDropZone } from './hooks/use-file-drop-zone'
 import { ProfileTag } from './profile-tag'
+import { isRouteSessionMismatch } from './route-session-state'
 import { useRuntimeMessageRepository } from './runtime-repository'
 import { ScrollToBottomButton } from './scroll-to-bottom-button'
 import { useSessionView } from './session-view'
@@ -354,7 +355,9 @@ export function ChatView({
   // direct nav). Derived in render so the swap reads instantly: the same frame
   // the id changes we drop the old transcript and show the loader, instead of
   // waiting for the resume effect (which paints a frame later) to clear them.
-  const routeSessionMismatch = isRoutedSessionView && routedSessionId !== selectedSessionId
+  const routeSessionMismatch = isPrimary
+    ? isRouteSessionMismatch(routedSessionId, selectedSessionId, sessions)
+    : false
 
   // The compact new-session pop-out skips the wordmark/tagline intro — it's a
   // scratch window, not the full-height empty state.

--- a/apps/desktop/src/app/chat/route-session-state.test.ts
+++ b/apps/desktop/src/app/chat/route-session-state.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { isRouteSessionMismatch } from './route-session-state'
+
+describe('isRouteSessionMismatch', () => {
+  it('keeps the composer mounted when auto-compression rotates root to tip', () => {
+    const sessions = [{ id: 'tip-2', _lineage_root_id: 'root-1' }]
+
+    expect(isRouteSessionMismatch('root-1', 'tip-2', sessions)).toBe(false)
+    expect(isRouteSessionMismatch('tip-2', 'root-1', sessions)).toBe(false)
+  })
+
+  it('still suppresses the previous chat while a genuinely different route loads', () => {
+    const sessions = [{ id: 'selected', _lineage_root_id: null }]
+
+    expect(isRouteSessionMismatch('next-session', 'selected', sessions)).toBe(true)
+    expect(isRouteSessionMismatch('next-session', null, sessions)).toBe(true)
+  })
+
+  it('does not require a session row when the selected and routed ids already agree', () => {
+    expect(isRouteSessionMismatch('same', 'same', [])).toBe(false)
+    expect(isRouteSessionMismatch(null, 'same', [])).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/chat/route-session-state.ts
+++ b/apps/desktop/src/app/chat/route-session-state.ts
@@ -1,0 +1,31 @@
+import { sessionMatchesStoredId } from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
+
+/**
+ * Whether the route points at a different conversation than the selected view.
+ *
+ * Auto-compression rotates a conversation from its root id to a continuation
+ * tip while the durable URL intentionally stays on the root. Those ids are
+ * different strings but still the same conversation, so a loaded lineage row
+ * must win over the raw comparison. An unknown route remains a mismatch: that
+ * is the real navigation case where the old transcript/composer must hide
+ * until resume finishes.
+ */
+export function isRouteSessionMismatch(
+  routedSessionId: null | string,
+  selectedSessionId: null | string,
+  sessions: readonly Pick<SessionInfo, '_lineage_root_id' | 'id'>[]
+): boolean {
+  if (!routedSessionId || routedSessionId === selectedSessionId) {
+    return false
+  }
+
+  if (!selectedSessionId) {
+    return true
+  }
+
+  return !sessions.some(
+    session =>
+      sessionMatchesStoredId(session, routedSessionId) && sessionMatchesStoredId(session, selectedSessionId)
+  )
+}


### PR DESCRIPTION
## What does this PR do?

Desktop keeps a conversation URL on its durable lineage-root Session id, while automatic context compression can rotate the loaded Session to a continuation tip id. `ChatView` currently compares those two ids as raw strings. Immediately after rotation it treats the already-loaded conversation as a different routed Session, enters the loading state, and hides the composer until the surrounding Session state catches up.

This makes route mismatch lineage-aware. Root and continuation ids that resolve to the same loaded Session row are treated as the same conversation; an actually unknown/different route still suppresses the old transcript and composer while resume runs.

This covers both compression forms discussed in the Desktop UX: in-place compression remains unchanged, while tip-id rotation no longer produces a false navigation/loading transition.

## Related Issue

Reported and reproduced in the Desktop app; no existing upstream issue or PR matched this route/lineage bug.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add a small pure `isRouteSessionMismatch` helper.
- Reuse the existing `sessionMatchesStoredId` lineage semantics.
- Keep true route switches loading-safe while preventing root→tip compression from hiding the composer.
- Cover exact-id, different-id, and same-lineage root/tip cases.

## How to Test

1. Open a routed Desktop conversation whose URL uses the lineage root id.
2. Trigger automatic compression that returns a continuation tip id.
3. Confirm the transcript remains attached and the composer does not disappear.
4. Navigate to a genuinely different unloaded Session and confirm the loading guard still hides stale content until resume completes.

Validated after rebasing onto current upstream `main` (`8defb9fd6`), using the repository CI runtime (Node 22):

- `npx vitest run --project ui src/app/chat/route-session-state.test.ts` — 3/3 passed
- `npm run typecheck` — passed
- targeted ESLint on the three changed files — passed
- full Desktop UI suite — 355 files, 3,128 tests passed

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing issues/PRs and found no duplicate
- [x] This PR contains only the route/lineage fix
- [ ] Full Python `pytest tests/ -q` (Desktop-only TypeScript change; Desktop checks above passed)
- [x] Tests were added
- [x] Tested on macOS

### Documentation & Housekeeping

- [x] Documentation update — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered; the change is pure renderer state logic
- [x] Tool descriptions/schemas — N/A