### PR TITLE
fix(desktop): isolate live artifact previews

### DIFF
--- a/apps/desktop/e2e/artifact-preview-isolation.spec.ts
+++ b/apps/desktop/e2e/artifact-preview-isolation.spec.ts
@@ -1,0 +1,124 @@
+import { buildAppEnv, createSandbox, launchDesktop, type Sandbox } from './fixtures'
+import { type ElectronApplication, expect, type Page, test } from './test'
+
+let app: ElectronApplication | null = null
+let page: Page | null = null
+let sandbox: Sandbox | null = null
+
+test.beforeAll(async () => {
+  sandbox = createSandbox('artifact-isolation')
+
+  const launched = await launchDesktop(
+    buildAppEnv(sandbox, {
+      HERMES_DESKTOP_BOOT_FAKE: '1',
+      HERMES_DESKTOP_BOOT_FAKE_STEP_MS: '20'
+    })
+  )
+
+  app = launched.app
+  page = launched.page
+  await page.waitForSelector('body', { state: 'attached' })
+})
+
+test.afterAll(async () => {
+  await app?.close().catch(() => undefined)
+  sandbox?.cleanup()
+  app = null
+  page = null
+  sandbox = null
+})
+
+test('artifact webview keeps a busy generated page out of the host renderer', async () => {
+  if (!app || !page) {
+    throw new Error('Desktop fixture did not launch')
+  }
+
+  const runningApp = app
+  const hostPage = page
+
+  await hostPage.evaluate(() => {
+    const state = window as unknown as {
+      __artifactHostTicks?: number
+      __artifactHostTimer?: number
+    }
+
+    state.__artifactHostTicks = 0
+    state.__artifactHostTimer = window.setInterval(() => {
+      state.__artifactHostTicks = (state.__artifactHostTicks ?? 0) + 1
+    }, 25)
+
+    const guest = document.createElement('webview')
+    guest.id = 'artifact-isolation-probe'
+    guest.setAttribute('partition', 'hermes-artifact-preview')
+    guest.setAttribute('webpreferences', 'contextIsolation=yes,nodeIntegration=no,sandbox=yes,webSecurity=yes')
+    guest.setAttribute(
+      'src',
+      `data:text/html;charset=utf-8,${encodeURIComponent(
+        '<!doctype html><title>Busy artifact</title><script>setTimeout(() => { while (true) {} }, 100)</script>'
+      )}`
+    )
+    document.body.appendChild(guest)
+  })
+
+  await expect
+    .poll(
+      () =>
+        runningApp.evaluate(({ session, webContents }) => {
+          const partition = session.fromPartition('hermes-artifact-preview')
+
+          return webContents.getAllWebContents().some(contents => contents.session === partition)
+        }),
+      { timeout: 15_000 }
+    )
+    .toBe(true)
+
+  const guestPreferences = await runningApp.evaluate(({ session, webContents }) => {
+    const partition = session.fromPartition('hermes-artifact-preview')
+
+    const guest = webContents
+      .getAllWebContents()
+      .find(contents => contents.session === partition)
+
+    const preferences = (
+      guest as unknown as {
+        getLastWebPreferences?(): {
+          contextIsolation?: boolean
+          nodeIntegration?: boolean
+          sandbox?: boolean
+          webSecurity?: boolean
+        }
+      }
+    )?.getLastWebPreferences?.()
+
+    return {
+      contextIsolation: preferences?.contextIsolation,
+      nodeIntegration: preferences?.nodeIntegration,
+      sandbox: preferences?.sandbox,
+      type: guest?.getType(),
+      webSecurity: preferences?.webSecurity
+    }
+  })
+
+  expect(guestPreferences).toEqual({
+    contextIsolation: true,
+    nodeIntegration: false,
+    sandbox: true,
+    type: 'webview',
+    webSecurity: true
+  })
+
+  await hostPage.waitForTimeout(750)
+  expect(
+    await hostPage.evaluate(() => (window as unknown as { __artifactHostTicks?: number }).__artifactHostTicks ?? 0)
+  ).toBeGreaterThan(5)
+
+  await hostPage.evaluate(() => {
+    const state = window as unknown as { __artifactHostTimer?: number }
+
+    if (state.__artifactHostTimer) {
+      window.clearInterval(state.__artifactHostTimer)
+    }
+
+    document.getElementById('artifact-isolation-probe')?.remove()
+  })
+})

--- a/apps/desktop/electron/artifact-preview-guest.test.ts
+++ b/apps/desktop/electron/artifact-preview-guest.test.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  ARTIFACT_PREVIEW_PARTITION,
+  hardenArtifactPreviewWebPreferences,
+  installArtifactPreviewGuestIsolation
+} from './artifact-preview-guest'
+
+function makeHost() {
+  const handlers = new Map<string, (...args: any[]) => void>()
+
+  return {
+    handlers,
+    host: {
+      on(event: string, handler: (...args: any[]) => void) {
+        handlers.set(event, handler)
+      }
+    }
+  }
+}
+
+test('hardenArtifactPreviewWebPreferences removes preload access and pins isolation', () => {
+  const preferences: Record<string, unknown> = {
+    nodeIntegration: true,
+    preload: '/tmp/unsafe.cjs',
+    preloadURL: 'file:///tmp/unsafe.cjs',
+    sandbox: false
+  }
+
+  hardenArtifactPreviewWebPreferences(preferences)
+
+  assert.equal(preferences.preload, undefined)
+  assert.equal(preferences.preloadURL, undefined)
+  assert.equal(preferences.contextIsolation, true)
+  assert.equal(preferences.nodeIntegration, false)
+  assert.equal(preferences.sandbox, true)
+  assert.equal(preferences.webSecurity, true)
+})
+
+test('installArtifactPreviewGuestIsolation rejects non-data artifact guests', () => {
+  const { handlers, host } = makeHost()
+  installArtifactPreviewGuestIsolation(host as never)
+  let prevented = false
+
+  handlers.get('will-attach-webview')?.(
+    { preventDefault: () => (prevented = true) },
+    {},
+    { partition: ARTIFACT_PREVIEW_PARTITION, src: 'https://example.com' }
+  )
+
+  assert.equal(prevented, true)
+})
+
+test('installArtifactPreviewGuestIsolation hardens and locks an attached artifact guest', () => {
+  const { handlers, host } = makeHost()
+  installArtifactPreviewGuestIsolation(host as never)
+  const preferences: Record<string, unknown> = { nodeIntegration: true }
+  let attachPrevented = false
+
+  handlers.get('will-attach-webview')?.(
+    { preventDefault: () => (attachPrevented = true) },
+    preferences,
+    {
+      partition: ARTIFACT_PREVIEW_PARTITION,
+      src: 'data:text/html;charset=utf-8,%3Ch1%3Epreview%3C%2Fh1%3E'
+    }
+  )
+
+  assert.equal(attachPrevented, false)
+  assert.equal(preferences.nodeIntegration, false)
+  assert.equal(preferences.sandbox, true)
+
+  let navigationHandler: ((event: { preventDefault(): void }, url: string) => void) | null = null
+  let openHandler: (() => { action: 'deny' }) | null = null
+  let permissionCheck: (() => boolean) | null = null
+
+  let permissionRequest: ((webContents: unknown, permission: unknown, callback: (allowed: boolean) => void) => void) | null =
+    null
+
+  const guest = {
+    getURL: () => 'data:text/html;charset=utf-8,preview',
+    on: (_event: string, handler: typeof navigationHandler) => {
+      navigationHandler = handler
+    },
+    session: {
+      getPartition: () => ARTIFACT_PREVIEW_PARTITION,
+      setPermissionCheckHandler: (handler: () => boolean) => {
+        permissionCheck = handler
+      },
+      setPermissionRequestHandler: (handler: typeof permissionRequest) => {
+        permissionRequest = handler
+      }
+    },
+    setWindowOpenHandler: (handler: typeof openHandler) => {
+      openHandler = handler
+    }
+  }
+
+  handlers.get('did-attach-webview')?.({}, guest)
+
+  assert.deepEqual(openHandler?.(), { action: 'deny' })
+  assert.equal(permissionCheck?.(), false)
+
+  let permissionAllowed: boolean | null = null
+  permissionRequest?.(null, 'camera', allowed => {
+    permissionAllowed = allowed
+  })
+  assert.equal(permissionAllowed, false)
+
+  let navigationPrevented = false
+  navigationHandler?.({ preventDefault: () => (navigationPrevented = true) }, 'https://example.com')
+  assert.equal(navigationPrevented, true)
+})

--- a/apps/desktop/electron/artifact-preview-guest.ts
+++ b/apps/desktop/electron/artifact-preview-guest.ts
@@ -1,0 +1,80 @@
+export const ARTIFACT_PREVIEW_PARTITION = 'hermes-artifact-preview'
+
+const ARTIFACT_DATA_URL_PREFIX = 'data:text/html;charset=utf-8,'
+
+interface AttachEvent {
+  preventDefault(): void
+}
+
+interface AttachParams {
+  partition?: string
+  src?: string
+}
+
+interface GuestSession {
+  getPartition?(): string
+  setPermissionCheckHandler?(handler: () => boolean): void
+  setPermissionRequestHandler?(handler: (...args: unknown[]) => void): void
+}
+
+interface GuestWebContents {
+  getURL?(): string
+  on(event: 'will-navigate', handler: (event: AttachEvent, url: string) => void): void
+  session?: GuestSession
+  setWindowOpenHandler?(handler: () => { action: 'deny' }): void
+}
+
+interface HostWebContents {
+  on(
+    event: 'will-attach-webview',
+    handler: (event: AttachEvent, webPreferences: Record<string, unknown>, params: AttachParams) => void
+  ): void
+  on(event: 'did-attach-webview', handler: (event: unknown, guest: GuestWebContents) => void): void
+}
+
+export function hardenArtifactPreviewWebPreferences(webPreferences: Record<string, unknown>): void {
+  delete webPreferences.preload
+  delete webPreferences.preloadURL
+  Object.assign(webPreferences, {
+    allowRunningInsecureContent: false,
+    contextIsolation: true,
+    nodeIntegration: false,
+    sandbox: true,
+    webSecurity: true
+  })
+}
+
+export function installArtifactPreviewGuestIsolation(host: HostWebContents): void {
+  host.on('will-attach-webview', (event, webPreferences, params) => {
+    if (params.partition !== ARTIFACT_PREVIEW_PARTITION) {
+      return
+    }
+
+    if (!params.src?.startsWith(ARTIFACT_DATA_URL_PREFIX)) {
+      event.preventDefault()
+
+      return
+    }
+
+    hardenArtifactPreviewWebPreferences(webPreferences)
+  })
+
+  host.on('did-attach-webview', (_event, guest) => {
+    if (guest.session?.getPartition?.() !== ARTIFACT_PREVIEW_PARTITION) {
+      return
+    }
+
+    guest.setWindowOpenHandler?.(() => ({ action: 'deny' }))
+    guest.on('will-navigate', (event, url) => {
+      if (url !== guest.getURL?.()) {
+        event.preventDefault()
+      }
+    })
+    guest.session.setPermissionCheckHandler?.(() => false)
+    guest.session.setPermissionRequestHandler?.((_webContents, _permission, callback) => {
+      if (typeof callback === 'function') {
+        callback(false)
+      }
+    })
+  })
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -32,6 +32,7 @@ import {
 import nodePty from 'node-pty'
 
 import { classifyActiveRuntime } from './active-runtime-state'
+import { installArtifactPreviewGuestIsolation } from './artifact-preview-guest'
 import { stopBackendChild as stopBackendChildImpl } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
@@ -8606,6 +8607,7 @@ async function startHermes() {
 function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {}) {
   installPreviewShortcut(win)
   installDevToolsShortcut(win)
+  installArtifactPreviewGuestIsolation(win.webContents)
 
   if (zoom) {
     installZoomShortcuts(win)

--- a/apps/desktop/src/app/chat/right-rail/preview-artifact.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-artifact.test.tsx
@@ -30,16 +30,18 @@ describe('ArtifactPreview', () => {
     $artifactVersionSelection.set({})
   })
 
-  it('renders html in a scripts-only sandboxed frame the parent app is unreachable from', async () => {
+  it('renders html in an isolated guest process instead of the app renderer', async () => {
     const { artifactId } = register('Dashboard', 'html', '<h1>Hi</h1>')
     await renderArtifact(artifactId)
 
-    const frame = screen.getByTitle('Dashboard') as HTMLIFrameElement
+    const guest = screen.getByTitle('Dashboard')
 
-    expect(frame.getAttribute('sandbox')).toBe('allow-scripts')
-    expect(frame.srcdoc).toContain('<h1>Hi</h1>')
-    // No allow-same-origin: scripts inside cannot reach the renderer's origin.
-    expect(frame.getAttribute('sandbox')).not.toContain('same-origin')
+    expect(guest.tagName).toBe('WEBVIEW')
+    expect(guest.getAttribute('partition')).toBe('hermes-artifact-preview')
+    expect(guest.getAttribute('webpreferences')).toContain('nodeIntegration=no')
+    expect(guest.getAttribute('src')).toMatch(/^data:text\/html;charset=utf-8,/)
+    expect(window.document.querySelector('iframe')).toBeNull()
+    expect(decodeURIComponent(guest.getAttribute('src')!.split(',')[1]!)).toContain('<h1>Hi</h1>')
   })
 
   it('strips scripts out of svg before it renders inline', async () => {
@@ -51,8 +53,8 @@ describe('ArtifactPreview', () => {
 
     await renderArtifact(artifactId)
 
-    expect(document.querySelector('svg')).not.toBeNull()
-    expect(document.querySelector('svg script')).toBeNull()
+    expect(window.document.querySelector('svg')).not.toBeNull()
+    expect(window.document.querySelector('svg script')).toBeNull()
   })
 
   it('offers only the source view for code, which has nothing to render', async () => {
@@ -68,14 +70,14 @@ describe('ArtifactPreview', () => {
     await renderArtifact(artifactId)
 
     expect(screen.getByText('v2 of 2')).toBeTruthy()
-    expect((screen.getByTitle('Dashboard') as HTMLIFrameElement).srcdoc).toContain('v2')
+    expect(decodeURIComponent(screen.getByTitle('Dashboard').getAttribute('src')!.split(',')[1]!)).toContain('v2')
 
     await act(async () => {
       $artifactVersionSelection.set({ [artifactId]: 0 })
     })
 
     expect(screen.getByText('v1 of 2')).toBeTruthy()
-    expect((screen.getByTitle('Dashboard') as HTMLIFrameElement).srcdoc).toContain('v1')
+    expect(decodeURIComponent(screen.getByTitle('Dashboard').getAttribute('src')!.split(',')[1]!)).toContain('v1')
   })
 
   it('hides the stepper for a single-version artifact', async () => {
@@ -93,7 +95,7 @@ describe('ArtifactPreview', () => {
       register('Dashboard', 'html', '<h1>v2</h1>')
     })
 
-    expect((screen.getByTitle('Dashboard') as HTMLIFrameElement).srcdoc).toContain('v2')
+    expect(decodeURIComponent(screen.getByTitle('Dashboard').getAttribute('src')!.split(',')[1]!)).toContain('v2')
   })
 
   it('falls back to an empty state when the registry no longer has the artifact', async () => {

--- a/apps/desktop/src/app/chat/right-rail/preview-artifact.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-artifact.tsx
@@ -1,6 +1,6 @@
 import { useStore } from '@nanostores/react'
 import DOMPurify from 'dompurify'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { CopyButton } from '@/components/ui/copy-button'
 import { Tip } from '@/components/ui/tooltip'
@@ -8,7 +8,7 @@ import { useI18n } from '@/i18n'
 import { artifactDownloadName, type ArtifactKind } from '@/lib/artifact-detect'
 import { downloadTextFile } from '@/lib/download-text'
 import { ChevronLeft, ChevronRight, Download, ExternalLink } from '@/lib/icons'
-import { $artifactRegistry, $artifactVersionSelection, findArtifact, selectArtifactVersion } from '@/store/artifacts'
+import { $artifactRecord, $artifactSelectedVersion, selectArtifactVersion } from '@/store/artifacts'
 import { notifyError } from '@/store/notifications'
 import type { PreviewTarget } from '@/store/preview'
 
@@ -43,6 +43,19 @@ function composeArtifactHtml(content: string): string {
   ].join('\n')
 }
 
+type ArtifactPreviewWebview = HTMLElement & {
+  src?: string
+}
+
+function artifactGuestUrl(content: string): string {
+  // A data: document has a unique opaque origin. That preserves the old
+  // srcDoc sandbox's local-file boundary while the <webview> adds the process
+  // boundary the iframe lacked. Percent encoding is Unicode-safe and avoids
+  // writing generated code to disk (and the cleanup/orphan lifecycle that
+  // would come with temporary file:// previews).
+  return `data:text/html;charset=utf-8,${encodeURIComponent(composeArtifactHtml(content))}`
+}
+
 /** Write the composed document to a real temp file through the existing
  *  buffer-save IPC, then hand it to the OS browser. A blob/data URL can't
  *  cross into the OS default browser, so a file on disk is the honest path. */
@@ -74,10 +87,12 @@ async function openHtmlInBrowser(content: string): Promise<void> {
 /**
  * Live view for renderable artifact content.
  *
- * HTML runs in an `<iframe sandbox="allow-scripts">` — scripts execute in an
- * opaque origin with no same-origin access, no top navigation, no popups, no
- * form submission out of the frame. The parent app is unreachable. SVG is
- * DOMPurify-sanitized with the same profile as the inline ```svg embed.
+ * HTML runs in an Electron `<webview>` guest process. This is a process
+ * boundary, not merely an origin boundary: a generated page with expensive JS
+ * or an accidental infinite loop can hang its own preview without taking the
+ * chat, composer, and pane layout down with it. Node stays disabled and the
+ * guest is sandboxed. SVG is DOMPurify-sanitized with the same profile as the
+ * inline ```svg embed.
  */
 function ArtifactLiveView({ content, kind, title }: { content: string; kind: ArtifactKind; title: string }) {
   const svgClean = useMemo(
@@ -93,18 +108,36 @@ function ArtifactLiveView({ content, kind, title }: { content: string; kind: Art
     )
   }
 
-  return (
-    <iframe
-      className="block size-full border-0 bg-white"
-      sandbox="allow-scripts"
-      srcDoc={composeArtifactHtml(content)}
-      // Deliberately raw white + forced light scheme: the frame hosts foreign
-      // generated HTML that assumes a light canvas, so it renders deterministically
-      // light in both app themes instead of inheriting theme tokens it can't see.
-      style={{ colorScheme: 'light' }}
-      title={title}
-    />
-  )
+  return <ArtifactHtmlGuestView content={content} title={title} />
+}
+
+function ArtifactHtmlGuestView({ content, title }: { content: string; title: string }) {
+  const hostRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const host = hostRef.current
+
+    if (!host) {
+      return
+    }
+
+    const webview = document.createElement('webview') as ArtifactPreviewWebview
+
+    webview.className = 'block size-full border-0 bg-white'
+    webview.setAttribute('aria-label', title)
+    webview.setAttribute('partition', 'hermes-artifact-preview')
+    webview.setAttribute('title', title)
+    webview.setAttribute('webpreferences', 'contextIsolation=yes,nodeIntegration=no,sandbox=yes,webSecurity=yes')
+    webview.setAttribute('src', artifactGuestUrl(content))
+    webview.style.colorScheme = 'light'
+    host.replaceChildren(webview)
+
+    return () => {
+      webview.remove()
+    }
+  }, [content, title])
+
+  return <div className="size-full bg-white" ref={hostRef} />
 }
 
 function VersionStepper({
@@ -176,16 +209,14 @@ export function ArtifactPreview({ target }: { target: PreviewTarget }) {
   const { t } = useI18n()
   const copy = t.artifactPreview
   const artifactId = target.url
-  const registry = useStore($artifactRegistry)
-  const versionSelection = useStore($artifactVersionSelection)
+  const record = useStore(useMemo(() => $artifactRecord(artifactId), [artifactId]))
+  const selectedVersion = useStore(useMemo(() => $artifactSelectedVersion(artifactId), [artifactId]))
   const [userMode, setUserMode] = useState<PreviewViewMode | null>(null)
 
   // Reset the explicit mode when the pane is reused for another artifact.
   useEffect(() => {
     setUserMode(null)
   }, [artifactId])
-
-  const record = useMemo(() => findArtifact(registry, artifactId), [artifactId, registry])
 
   if (!record) {
     return <PreviewEmptyState body={copy.missingBody} title={copy.missingTitle} />
@@ -194,7 +225,7 @@ export function ArtifactPreview({ target }: { target: PreviewTarget }) {
   const renderable = record.kind === 'html' || record.kind === 'svg'
   const modes: PreviewViewMode[] = renderable ? ['rendered', 'source'] : ['source']
   const mode = userMode && modes.includes(userMode) ? userMode : modes[0]!
-  const versionIndex = Math.min(versionSelection[artifactId] ?? record.versions.length - 1, record.versions.length - 1)
+  const versionIndex = Math.min(selectedVersion ?? record.versions.length - 1, record.versions.length - 1)
   const version = record.versions[versionIndex]!
 
   return (

--- a/apps/desktop/src/store/artifacts.test.ts
+++ b/apps/desktop/src/store/artifacts.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { ArtifactDetection } from '@/lib/artifact-detect'
 
 import {
+  $artifactRecord,
+  $artifactSelectedVersion,
   $artifactVersionSelection,
   artifactsForSession,
   clearArtifactRegistry,
@@ -80,6 +82,23 @@ describe('artifacts store', () => {
     expect(artifactsForSession('session-2')).toHaveLength(1)
   })
 
+  it('does not notify one artifact preview when an unrelated artifact changes', () => {
+    const first = upsertArtifact('session-1', HTML_DETECTION, '<html>a</html>')!
+    const selected = $artifactRecord(first.artifactId)
+    const changes: unknown[] = []
+    const unsubscribe = selected.subscribe(value => changes.push(value))
+
+    upsertArtifact(
+      'session-2',
+      { ...HTML_DETECTION, title: 'Unrelated Dashboard' },
+      '<html>unrelated</html>'
+    )
+
+    expect(changes).toHaveLength(1)
+    expect(changes[0]).toBe(first.record)
+    unsubscribe()
+  })
+
   it('rejects empty sessions and empty content', () => {
     expect(upsertArtifact('', HTML_DETECTION, '<html>x</html>')).toBeNull()
     expect(upsertArtifact('session-1', HTML_DETECTION, '   ')).toBeNull()
@@ -128,6 +147,7 @@ describe('artifacts store', () => {
     selectArtifactVersion(result.artifactId, 0)
 
     expect($artifactVersionSelection.get()[result.artifactId]).toBe(0)
+    expect($artifactSelectedVersion(result.artifactId).get()).toBe(0)
 
     // Selecting the newest version clears the pin (absent = newest).
     selectArtifactVersion(result.artifactId, 2)
@@ -156,11 +176,15 @@ describe('artifacts store', () => {
 
   it('clearing the registry closes the tabs pointing into it', () => {
     const result = upsertArtifact('session-1', HTML_DETECTION, '<html>v1</html>')!
+    const recordStore = $artifactRecord(result.artifactId)
+    const selectionStore = $artifactSelectedVersion(result.artifactId)
 
     openArtifact(result.artifactId)
     clearArtifactRegistry()
 
     expect($previewTabs.get()).toEqual([])
     expect(artifactsForSession('session-1')).toEqual([])
+    expect($artifactRecord(result.artifactId)).not.toBe(recordStore)
+    expect($artifactSelectedVersion(result.artifactId)).not.toBe(selectionStore)
   })
 })

--- a/apps/desktop/src/store/artifacts.test.ts
+++ b/apps/desktop/src/store/artifacts.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ArtifactDetection } from '@/lib/artifact-detect'
 
@@ -97,6 +97,34 @@ describe('artifacts store', () => {
     expect(changes).toHaveLength(1)
     expect(changes[0]).toBe(first.record)
     unsubscribe()
+  })
+
+  it('evicts derived stores and version pins when bounded pruning removes an artifact', () => {
+    const now = vi.spyOn(Date, 'now')
+    let timestamp = 0
+    now.mockImplementation(() => ++timestamp)
+
+    const first = upsertArtifact('session-1', HTML_DETECTION, '<html>v1</html>')!
+    upsertArtifact('session-1', HTML_DETECTION, '<html>v2</html>')
+    selectArtifactVersion(first.artifactId, 0)
+
+    const recordStore = $artifactRecord(first.artifactId)
+    const selectionStore = $artifactSelectedVersion(first.artifactId)
+
+    for (let index = 0; index < 24; index += 1) {
+      upsertArtifact(
+        'session-1',
+        { ...HTML_DETECTION, title: `Newer artifact ${index}` },
+        `<html>${index}</html>`
+      )
+    }
+
+    expect(getArtifact(first.artifactId)).toBeNull()
+    expect(first.artifactId in $artifactVersionSelection.get()).toBe(false)
+    expect($artifactRecord(first.artifactId)).not.toBe(recordStore)
+    expect($artifactSelectedVersion(first.artifactId)).not.toBe(selectionStore)
+
+    now.mockRestore()
   })
 
   it('rejects empty sessions and empty content', () => {

--- a/apps/desktop/src/store/artifacts.ts
+++ b/apps/desktop/src/store/artifacts.ts
@@ -79,6 +79,38 @@ export const $artifactVersionSelection = atom<Record<string, number>>({})
 const artifactRecordCache = new Map<string, ReadableAtom<ArtifactRecord | null>>()
 const artifactVersionSelectionCache = new Map<string, ReadableAtom<number | undefined>>()
 
+function evictPrunedArtifactState(registry: ArtifactRegistry): void {
+  const retained = new Set(Object.values(registry).flatMap(records => records.map(record => record.id)))
+
+  for (const artifactId of artifactRecordCache.keys()) {
+    if (!retained.has(artifactId)) {
+      artifactRecordCache.delete(artifactId)
+    }
+  }
+
+  for (const artifactId of artifactVersionSelectionCache.keys()) {
+    if (!retained.has(artifactId)) {
+      artifactVersionSelectionCache.delete(artifactId)
+    }
+  }
+
+  const selection = $artifactVersionSelection.get()
+
+  const nextSelection = Object.fromEntries(
+    Object.entries(selection).filter(([artifactId]) => retained.has(artifactId))
+  )
+
+  if (Object.keys(nextSelection).length !== Object.keys(selection).length) {
+    $artifactVersionSelection.set(nextSelection)
+  }
+}
+
+function setPrunedRegistry(registry: ArtifactRegistry): void {
+  const pruned = pruneRegistry(registry)
+  $artifactRegistry.set(pruned)
+  evictPrunedArtifactState(pruned)
+}
+
 /** Lookup against a registry value, for components that already subscribe to
  *  the atom and need the record to change identity when it does. */
 export function findArtifact(registry: ArtifactRegistry, artifactId: string): ArtifactRecord | null {
@@ -180,12 +212,10 @@ export function upsertArtifact(
       versions
     }
 
-    $artifactRegistry.set(
-      pruneRegistry({
-        ...registry,
-        [id]: records.map(record => (record.id === existing.id ? next : record))
-      })
-    )
+    setPrunedRegistry({
+      ...registry,
+      [id]: records.map(record => (record.id === existing.id ? next : record))
+    })
 
     return { artifactId: existing.id, record: next, versionAdded: true }
   }
@@ -202,7 +232,7 @@ export function upsertArtifact(
     versions: [{ content: trimmed, createdAt: now, hash }]
   }
 
-  $artifactRegistry.set(pruneRegistry({ ...registry, [id]: [...records, record] }))
+  setPrunedRegistry({ ...registry, [id]: [...records, record] })
 
   return { artifactId: record.id, record, versionAdded: true }
 }

--- a/apps/desktop/src/store/artifacts.ts
+++ b/apps/desktop/src/store/artifacts.ts
@@ -1,4 +1,4 @@
-import { atom } from 'nanostores'
+import { atom, computed, type ReadableAtom } from 'nanostores'
 
 import { artifactContentHash, type ArtifactDetection, type ArtifactKind, artifactSlug } from '@/lib/artifact-detect'
 
@@ -72,6 +72,13 @@ export const $artifactRegistry = atom<ArtifactRegistry>({})
 /** Per-artifact selected version index; absent = newest. */
 export const $artifactVersionSelection = atom<Record<string, number>>({})
 
+// A mounted preview cares about one artifact, not the whole cross-session
+// registry. Cached derived atoms preserve the selected record's identity on an
+// unrelated artifact update, so a streaming message cannot rebuild a live
+// preview (or its guest renderer) merely because another artifact registered.
+const artifactRecordCache = new Map<string, ReadableAtom<ArtifactRecord | null>>()
+const artifactVersionSelectionCache = new Map<string, ReadableAtom<number | undefined>>()
+
 /** Lookup against a registry value, for components that already subscribe to
  *  the atom and need the record to change identity when it does. */
 export function findArtifact(registry: ArtifactRegistry, artifactId: string): ArtifactRecord | null {
@@ -88,6 +95,28 @@ export function findArtifact(registry: ArtifactRegistry, artifactId: string): Ar
 
 export function getArtifact(artifactId: string): ArtifactRecord | null {
   return findArtifact($artifactRegistry.get(), artifactId)
+}
+
+export function $artifactRecord(artifactId: string): ReadableAtom<ArtifactRecord | null> {
+  let cached = artifactRecordCache.get(artifactId)
+
+  if (!cached) {
+    cached = computed($artifactRegistry, registry => findArtifact(registry, artifactId))
+    artifactRecordCache.set(artifactId, cached)
+  }
+
+  return cached
+}
+
+export function $artifactSelectedVersion(artifactId: string): ReadableAtom<number | undefined> {
+  let cached = artifactVersionSelectionCache.get(artifactId)
+
+  if (!cached) {
+    cached = computed($artifactVersionSelection, selection => selection[artifactId])
+    artifactVersionSelectionCache.set(artifactId, cached)
+  }
+
+  return cached
 }
 
 export function artifactsForSession(sessionId: string | null | undefined): ArtifactRecord[] {
@@ -223,5 +252,7 @@ export function selectArtifactVersion(artifactId: string, versionIndex: number) 
 export function clearArtifactRegistry() {
   $artifactRegistry.set({})
   $artifactVersionSelection.set({})
+  artifactRecordCache.clear()
+  artifactVersionSelectionCache.clear()
   closeArtifactPreviewTabs()
 }


### PR DESCRIPTION
## What does this PR do?

Renderable HTML artifacts currently execute in a sandboxed iframe. The sandbox protects app origin/capabilities, but the iframe still shares the renderer process/main thread with chat, the composer, pane layout, and terminal overlays. Generated HTML with expensive JavaScript or an accidental infinite loop can therefore freeze the entire Desktop window even though it cannot escape the iframe.

This moves live HTML artifacts into Electron's already-enabled `<webview>` guest process. The guest receives a Unicode-safe opaque `data:` URL, keeps Node integration disabled, enables context isolation/sandbox/web security, and uses a dedicated in-memory partition. A bad preview can stall its guest without taking down the conversation UI.

The renderer attributes are defense in depth rather than the trust boundary: the Electron main process intercepts artifact guest attachment, rejects non-`data:` sources, removes preload access, forces hardened web preferences, denies permissions/new windows, and blocks guest navigation.

The PR also narrows preview subscriptions: an open artifact reads derived atoms for its own record and selected version instead of subscribing to the whole cross-session artifact registry. Streaming or registering an unrelated artifact no longer rebuilds the live preview guest. Normal bounded registry pruning now evicts derived atom caches and stale version selections too, so closed/pruned artifacts cannot retain large content through module-level caches.

SVG remains DOMPurify-sanitized and inline; source mode, versions, copy/download, and open-in-browser behavior are unchanged.

## Related Issue

Related to the right-side context/performance report in #73890; no existing upstream PR isolates generated HTML execution.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security/containment hardening without disabling live previews
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Render HTML artifacts in a sandboxed Electron guest process instead of an iframe in the app renderer.
- Keep an opaque-origin `data:` document and disable Node integration.
- Enforce artifact guest preferences and navigation/permission policy from the Electron main process.
- Add per-artifact/per-version derived atom caches.
- Prevent unrelated registry updates from remounting an open preview.
- Evict caches and stale version pins during normal bounded registry pruning as well as full clear.
- Add a real Electron E2E that runs a busy loop in the guest and verifies the host renderer remains responsive.

## How to Test

1. Open a generated HTML artifact with animation or continuous JavaScript work.
2. Confirm chat scrolling, composer input, Files, and Terminal remain responsive.
3. Register/update an unrelated artifact in another Session and confirm the open preview node is not replaced.
4. Switch the selected version of the current artifact and confirm that preview updates normally.
5. Generate enough artifacts to cross the bounded registry limit and confirm pruned artifact stores/version selections are released.
6. Verify SVG, source mode, copy, download, and open-in-browser still work.

Rebased onto `main` at `8defb9fd6` and validated on macOS with Node 22.23.2:

- `npx vitest run src/store/artifacts.test.ts src/app/chat/right-rail/preview-artifact.test.tsx` — 2 files, 21 tests passed.
- `npx vitest run electron/artifact-preview-guest.test.ts` — 1 file, 3 tests passed.
- `npm run typecheck` — passed.
- targeted ESLint on renderer, Electron, and E2E changes — passed.
- `npm test` — 429 files passed, 1 skipped; 3997 tests passed, 2 skipped.
- `npm run build` — passed.
- `npx playwright test e2e/artifact-preview-isolation.spec.ts --reporter=list` — 1 real Electron test passed; the guest busy-looped while the host renderer heartbeat continued.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing issues/PRs and found no duplicate
- [x] This PR contains only artifact preview containment/subscription work
- [ ] Full Python `pytest tests/ -q` (Desktop-only TypeScript change; Desktop checks above passed)
- [x] Tests were added
- [x] Tested on macOS

### Documentation & Housekeeping

- [x] Documentation update — N/A; user-facing behavior is unchanged except responsiveness
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered; all chat windows already enable `webviewTag`
- [x] Tool descriptions/schemas — N/A