### PR TITLE
fix(desktop): send quick-entry:shown IPC on first window spawn

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8983,6 +8983,10 @@ function showQuickEntryWindow() {
       if (!quickEntryWindow?.isDestroyed()) {
         quickEntryWindow.show()
         quickEntryWindow.focus()
+        // First spawn: the renderer's onShown callback refocuses the input.
+        // Without this IPC the mount-time focus() runs before the window is
+        // visible and silently fails, so the input never gets focus.
+        quickEntryWindow.webContents.send('hermes:quick-entry:shown')
       }
     })
 


### PR DESCRIPTION
## Bug

The global Quick Entry shortcut (Cmd/Ctrl+Shift+Space) summons a mini composer window. On **first spawn** (window doesn't exist yet), the input field does not get keyboard focus. Subsequent summons work correctly.

## Root cause

In `showQuickEntryWindow()` there are two code paths:

1. **First spawn** (no window exists): creates the BrowserWindow with `show: false`, waits for `ready-to-show`, then calls `show()` + `focus()` — but never sends the `hermes:quick-entry:shown` IPC.

2. **Re-summon** (window exists): calls `show()` + `focus()` and sends `hermes:quick-entry:shown` IPC. ✅

The renderer's `onShown` callback is what actually focuses the input via `requestAnimationFrame(() => inputRef.current?.focus())`. The mount-time `focus()` runs during page load before the window is shown (BrowserWindow created with `show: false`), so it fails silently — a hidden window can't focus its elements.

## Fix

Add `webContents.send('hermes:quick-entry:shown')` to the first-spawn `ready-to-show` path, matching the re-summon path.

## Test plan

- [x] Existing `electron/quick-entry.test.ts` — 23/23 pass (no regression)
- [ ] Manual: press the shortcut on a fresh launch (no quick window exists yet) → input should be focused and ready to type