### PR TITLE
fix(gateway): expose agent exit metadata to hooks

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -30,6 +30,16 @@ Context dict passed to ``agent:start`` / ``agent:end`` handlers:
 
 ``agent:end`` adds:
   response     -- agent response text (truncated to 500 chars)
+  turn_exit_reason -- why the agent loop ended (truncated to 200 chars);
+                      finalizer text is collapsed to a single line,
+                      early user stops normalize to "interrupted_by_user",
+                      gateway system aborts remain distinct, and other missing
+                      or malformed reasons normalize to "unknown"
+  api_call_count -- non-negative API iterations consumed by the turn
+
+``turn_exit_reason`` is an open vocabulary: specific agent-finalizer reasons
+pass through, while gateway-owned classes use ``gateway_*`` and proxy classes
+use ``gateway_proxy_*`` prefixes.
 
 Handlers posting a follow-up into the same Telegram forum-topic should
 include ``message_thread_id=int(thread_id)`` when ``chat_type == "forum"``

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2653,25 +2653,97 @@ _INTERRUPT_REASON_TIMEOUT = "Execution timed out (inactivity)"
 _INTERRUPT_REASON_SSE_DISCONNECT = "SSE client disconnected"
 _INTERRUPT_REASON_GATEWAY_SHUTDOWN = "Gateway shutting down"
 _INTERRUPT_REASON_GATEWAY_RESTART = "Gateway restarting"
+_GATEWAY_AGENT_POLL_INTERVAL_SECONDS = 5.0
+
+def _normalize_interrupt_message(message: object) -> str:
+    """Normalize an interrupt marker without trusting its input type."""
+    try:
+        if not message:
+            return ""
+        return " ".join(str(message).strip().split()).lower()
+    except Exception:
+        return ""
+
 
 _CONTROL_INTERRUPT_MESSAGES = frozenset(
-    {
-        _INTERRUPT_REASON_STOP.lower(),
-        _INTERRUPT_REASON_RESET.lower(),
-        _INTERRUPT_REASON_TIMEOUT.lower(),
-        _INTERRUPT_REASON_SSE_DISCONNECT.lower(),
-        _INTERRUPT_REASON_GATEWAY_SHUTDOWN.lower(),
-        _INTERRUPT_REASON_GATEWAY_RESTART.lower(),
-    }
+    _normalize_interrupt_message(message)
+    for message in (
+        _INTERRUPT_REASON_STOP,
+        _INTERRUPT_REASON_RESET,
+        _INTERRUPT_REASON_TIMEOUT,
+        _INTERRUPT_REASON_SSE_DISCONNECT,
+        _INTERRUPT_REASON_GATEWAY_SHUTDOWN,
+        _INTERRUPT_REASON_GATEWAY_RESTART,
+    )
 )
 
 
 def _is_control_interrupt_message(message: Optional[str]) -> bool:
     """Return True when an interrupt message is internal control flow."""
-    if not message:
-        return False
-    normalized = " ".join(str(message).strip().split()).lower()
+    normalized = _normalize_interrupt_message(message)
     return normalized in _CONTROL_INTERRUPT_MESSAGES
+
+
+def _normalize_turn_exit_reason(reason: object) -> str:
+    """Collapse untrusted finalizer reason text to a single bounded-safe line."""
+    try:
+        if reason is None:
+            return ""
+        collapsed = " ".join(str(reason).strip().split())
+        return "".join(char for char in collapsed if char.isprintable())
+    except Exception:
+        return ""
+
+
+_SYSTEM_INTERRUPT_EXIT_REASONS = {
+    _normalize_interrupt_message(_INTERRUPT_REASON_TIMEOUT):
+        "gateway_inactivity_timeout",
+    _normalize_interrupt_message(_INTERRUPT_REASON_SSE_DISCONNECT):
+        "gateway_sse_disconnect",
+    _normalize_interrupt_message(_INTERRUPT_REASON_GATEWAY_SHUTDOWN):
+        "gateway_shutdown",
+    _normalize_interrupt_message(_INTERRUPT_REASON_GATEWAY_RESTART):
+        "gateway_restart",
+}
+_USER_INTERRUPT_MESSAGES = {
+    _normalize_interrupt_message(_INTERRUPT_REASON_STOP),
+    _normalize_interrupt_message(_INTERRUPT_REASON_RESET),
+}
+
+
+def _is_generic_agent_interrupt_exit_reason(reason: str) -> bool:
+    """Return True for agent-finalizer interruption classes and variants."""
+    return reason.casefold().startswith("interrupt")
+
+
+def _gateway_turn_exit_reason(agent_result: Dict[str, Any]) -> str:
+    """Return a stable reason for the ``agent:end`` hook.
+
+    Normal agent results carry the finalizer's explicit reason. Early
+    interrupts can bypass that finalizer, so classify their gateway control
+    marker instead of collapsing system aborts into user stops. Any other
+    missing or malformed reason is explicit ``unknown``.
+    """
+    reason = _normalize_turn_exit_reason(agent_result.get("turn_exit_reason"))
+    if reason and not _is_generic_agent_interrupt_exit_reason(reason):
+        return reason
+
+    try:
+        interrupted = bool(agent_result.get("interrupted"))
+    except Exception:
+        interrupted = False
+    if not interrupted:
+        return reason or "unknown"
+
+    normalized_message = _normalize_interrupt_message(
+        agent_result.get("interrupt_message")
+    )
+    system_reason = _SYSTEM_INTERRUPT_EXIT_REASONS.get(normalized_message)
+    if system_reason:
+        return system_reason
+    if normalized_message in _USER_INTERRUPT_MESSAGES:
+        return "interrupted_by_user"
+    return reason or "unknown"
 
 
 def _skill_slug_from_frontmatter(skill_md: Path) -> tuple[str | None, str | None]:
@@ -14696,10 +14768,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _footer_line and response and not agent_result.get("already_sent") and not _intentional_silence:
                 response = f"{response}\n\n{_footer_line}"
 
+            # Retry/error-backoff interrupts can bypass turn_finalizer. Preserve
+            # explicit agent reasons, distinguish gateway system aborts from
+            # user stops, and make every otherwise-missing class "unknown".
+            turn_exit_reason = _gateway_turn_exit_reason(agent_result)
+            try:
+                api_call_count = max(0, int(agent_result.get("api_calls") or 0))
+            except Exception:
+                api_call_count = 0
+
             # Emit agent:end hook
             await self.hooks.emit("agent:end", {
                 **hook_ctx,
                 "response": (response or "")[:500],
+                "turn_exit_reason": turn_exit_reason[:200],
+                "api_call_count": api_call_count,
             })
             
             # Check for pending process watchers (check_interval on background processes)
@@ -20357,6 +20440,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "messages": [],
                 "api_calls": 0,
                 "tools": [],
+                "partial": False,
+                "turn_exit_reason": "gateway_proxy_dependency_missing",
             }
 
         proxy_url = self._get_proxy_url()
@@ -20366,6 +20451,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "messages": [],
                 "api_calls": 0,
                 "tools": [],
+                "partial": False,
+                "turn_exit_reason": "gateway_proxy_not_configured",
             }
 
         proxy_key = os.getenv("GATEWAY_PROXY_KEY", "").strip()
@@ -20496,6 +20583,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Make the HTTP request with SSE streaming -----------------------
         full_response = ""
+        proxy_partial = False
         _start = time.time()
 
         try:
@@ -20517,6 +20605,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "messages": [],
                             "api_calls": 0,
                             "tools": [],
+                            "partial": False,
+                            "turn_exit_reason": "gateway_proxy_http_error",
                         }
 
                     # Parse SSE stream
@@ -20577,8 +20667,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "messages": [],
                     "api_calls": 0,
                     "tools": [],
+                    "partial": False,
+                    "turn_exit_reason": "gateway_proxy_connection_error",
                 }
             # Partial response — return what we got
+            proxy_partial = True
         finally:
             # Finalize stream consumer
             if _stream_consumer:
@@ -20621,6 +20714,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "history_offset": len(history),
             "session_id": session_id,
             "response_previewed": _stream_consumer is not None and bool(full_response),
+            "partial": proxy_partial,
+            "turn_exit_reason": (
+                "gateway_proxy_partial_response"
+                if proxy_partial
+                else (
+                    "gateway_proxy_response_complete"
+                    if full_response
+                    else "gateway_proxy_empty_response"
+                )
+            ),
         }
 
     # ------------------------------------------------------------------
@@ -21975,6 +22078,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "messages": [],
                     "api_calls": 0,
                     "tools": [],
+                    "turn_exit_reason": "gateway_agent_runtime_resolution_failed",
                 }
 
             pr = self._provider_routing
@@ -23114,6 +23218,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "final_response": final_response,
                     "messages": result.get("messages", []),
                     "api_calls": result.get("api_calls", 0),
+                    "turn_exit_reason": result.get("turn_exit_reason"),
                     "failed": result.get("failed", False),
                     # Sibling of the non-empty-response return below (#64686):
                     # the classifier's failure_reason must survive the
@@ -23241,6 +23346,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "last_reasoning": result.get("last_reasoning"),
                 "messages": result_holder[0].get("messages", []) if result_holder[0] else [],
                 "api_calls": result_holder[0].get("api_calls", 0) if result_holder[0] else 0,
+                "turn_exit_reason": (
+                    result_holder[0].get("turn_exit_reason")
+                    if result_holder[0] else None
+                ),
                 "failed": result_holder[0].get("failed", False) if result_holder[0] else False,
                 "failure_reason": (
                     result_holder[0].get("failure_reason") if result_holder[0] else None
@@ -23551,7 +23660,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
 
             _inactivity_timeout = False
-            _POLL_INTERVAL = 5.0
+            _POLL_INTERVAL = _GATEWAY_AGENT_POLL_INTERVAL_SECONDS
 
             if _agent_timeout is None:
                 # Unlimited — still poll periodically for backup interrupt
@@ -23739,6 +23848,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "tools": tools_holder[0] or [],
                     "history_offset": 0,
                     "failed": True,
+                    "turn_exit_reason": "gateway_inactivity_timeout",
                 }
 
             # Track fallback model state: if the agent switched to a

--- a/tests/gateway/test_agent_end_hook_metadata.py
+++ b/tests/gateway/test_agent_end_hook_metadata.py
@@ -1,0 +1,661 @@
+"""Gateway agent:end hook termination metadata."""
+
+import sys
+import threading
+import types
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource
+
+
+def _source():
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        user_id="12345",
+    )
+
+
+def _event():
+    return MessageEvent(
+        text="run a task",
+        source=_source(),
+        message_id="msg-42",
+    )
+
+
+def _runner(monkeypatch, tmp_path):
+    runner = gateway_run.GatewayRunner(GatewayConfig())
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._handle_active_session_busy_message = AsyncMock(return_value=False)
+    runner._session_db = MagicMock()
+    runner._recover_telegram_topic_thread_id = lambda _source: None
+    runner._cache_session_source = lambda _key, _source: None
+    runner._is_session_run_current = lambda _key, _gen: True
+    runner._reply_anchor_for_event = lambda _event: None
+    runner._get_guild_id = lambda _event: None
+    runner._should_send_voice_reply = lambda *_a, **_kw: False
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:group:-1001:12345",
+        session_id="sess-agent-end",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"}
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100_000,
+    )
+    return runner
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("turn_exit_reason", "api_calls", "interrupted"),
+    [
+        ("text_response(finish_reason=stop)", 1, False),
+        ("max_iterations_reached(90/90)", 90, False),
+        ("guardrail_halt", 3, False),
+        ("all_retries_exhausted_no_response", 3, False),
+        ("interrupted_by_user", 2, True),
+    ],
+)
+async def test_agent_end_hook_includes_termination_metadata(
+    monkeypatch,
+    tmp_path,
+    turn_exit_reason,
+    api_calls,
+    interrupted,
+):
+    runner = _runner(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "done",
+            "messages": [
+                {"role": "user", "content": "run a task"},
+                {"role": "assistant", "content": "done"},
+            ],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+            "api_calls": api_calls,
+            "turn_exit_reason": turn_exit_reason,
+            "failed": False,
+            "interrupted": interrupted,
+            "interrupt_message": (
+                gateway_run._INTERRUPT_REASON_STOP if interrupted else None
+            ),
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    agent_end_contexts = [
+        call.args[1]
+        for call in runner.hooks.emit.await_args_list
+        if call.args[0] == "agent:end"
+    ]
+    assert len(agent_end_contexts) == 1
+    assert agent_end_contexts[0]["turn_exit_reason"] == turn_exit_reason
+    assert agent_end_contexts[0]["api_call_count"] == api_calls
+    assert isinstance(agent_end_contexts[0]["turn_exit_reason"], str)
+    assert isinstance(agent_end_contexts[0]["api_call_count"], int)
+    assert agent_end_contexts[0]["session_id"] == "sess-agent-end"
+    assert agent_end_contexts[0]["user_id"] == "12345"
+
+
+@pytest.mark.asyncio
+async def test_agent_end_hook_normalizes_early_user_interrupt(monkeypatch, tmp_path):
+    runner = _runner(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "Operation interrupted during retry.",
+            "messages": [],
+            "tools": [],
+            "api_calls": 2,
+            "interrupted": True,
+            "interrupt_message": gateway_run._INTERRUPT_REASON_STOP,
+            "completed": False,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    agent_end = [
+        call.args[1]
+        for call in runner.hooks.emit.await_args_list
+        if call.args[0] == "agent:end"
+    ][0]
+    assert agent_end["turn_exit_reason"] == "interrupted_by_user"
+    assert agent_end["api_call_count"] == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("interrupt_message", "expected_reason"),
+    [
+        (gateway_run._INTERRUPT_REASON_STOP, "interrupted_by_user"),
+        (gateway_run._INTERRUPT_REASON_RESET, "interrupted_by_user"),
+        (
+            gateway_run._INTERRUPT_REASON_TIMEOUT,
+            "gateway_inactivity_timeout",
+        ),
+        (
+            gateway_run._INTERRUPT_REASON_SSE_DISCONNECT,
+            "gateway_sse_disconnect",
+        ),
+        (
+            gateway_run._INTERRUPT_REASON_GATEWAY_SHUTDOWN,
+            "gateway_shutdown",
+        ),
+        (
+            gateway_run._INTERRUPT_REASON_GATEWAY_RESTART,
+            "gateway_restart",
+        ),
+        (None, "unknown"),
+        ("future gateway interrupt", "unknown"),
+    ],
+)
+async def test_agent_end_hook_classifies_early_interrupt_actor(
+    monkeypatch,
+    tmp_path,
+    interrupt_message,
+    expected_reason,
+):
+    runner = _runner(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "Operation interrupted.",
+            "messages": [],
+            "tools": [],
+            "api_calls": 1,
+            "interrupted": True,
+            "interrupt_message": interrupt_message,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    agent_end = [
+        call.args[1]
+        for call in runner.hooks.emit.await_args_list
+        if call.args[0] == "agent:end"
+    ][0]
+    assert agent_end["turn_exit_reason"] == expected_reason
+
+
+def test_control_interrupt_markers_have_exhaustive_actor_classification():
+    classified = (
+        set(gateway_run._SYSTEM_INTERRUPT_EXIT_REASONS)
+        | gateway_run._USER_INTERRUPT_MESSAGES
+    )
+    assert classified == gateway_run._CONTROL_INTERRUPT_MESSAGES
+
+
+@pytest.mark.asyncio
+async def test_agent_end_hook_preserves_explicit_reason_over_interrupt_fallback(
+    monkeypatch,
+    tmp_path,
+):
+    runner = _runner(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "halted",
+            "messages": [],
+            "tools": [],
+            "api_calls": 1,
+            "interrupted": True,
+            "interrupt_message": gateway_run._INTERRUPT_REASON_TIMEOUT,
+            "turn_exit_reason": " guardrail_halt\x00\x1b[31m\n\twith context ",
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    agent_end = [
+        call.args[1]
+        for call in runner.hooks.emit.await_args_list
+        if call.args[0] == "agent:end"
+    ][0]
+    assert agent_end["turn_exit_reason"] == "guardrail_halt[31m with context"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("generic_reason", "system_marker", "expected_reason"),
+    [
+        (
+            "Interrupted_By_User(iteration=7)",
+            gateway_run._INTERRUPT_REASON_SSE_DISCONNECT,
+            "gateway_sse_disconnect",
+        ),
+        (
+            "interrupted_during_api_call",
+            gateway_run._INTERRUPT_REASON_GATEWAY_SHUTDOWN,
+            "gateway_shutdown",
+        ),
+    ],
+)
+async def test_agent_end_hook_system_marker_overrides_generic_agent_interrupt(
+    monkeypatch,
+    tmp_path,
+    generic_reason,
+    system_marker,
+    expected_reason,
+):
+    runner = _runner(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "interrupted",
+            "messages": [],
+            "tools": [],
+            "api_calls": 1,
+            "interrupted": True,
+            "interrupt_message": system_marker,
+            "turn_exit_reason": generic_reason,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    agent_end = [
+        call.args[1]
+        for call in runner.hooks.emit.await_args_list
+        if call.args[0] == "agent:end"
+    ][0]
+    assert agent_end["turn_exit_reason"] == expected_reason
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("agent_result", "expected_reason"),
+    [
+        (
+            {"turn_exit_reason": "interrupted_by_user"},
+            "interrupted_by_user",
+        ),
+        (
+            {
+                "turn_exit_reason": "interrupted_during_api_call",
+                "interrupted": True,
+                "interrupt_message": "future gateway interrupt",
+            },
+            "interrupted_during_api_call",
+        ),
+    ],
+)
+async def test_agent_end_hook_preserves_generic_reason_without_known_marker(
+    monkeypatch,
+    tmp_path,
+    agent_result,
+    expected_reason,
+):
+    runner = _runner(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "interrupted",
+            "messages": [],
+            "tools": [],
+            "api_calls": 1,
+            **agent_result,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    agent_end = [
+        call.args[1]
+        for call in runner.hooks.emit.await_args_list
+        if call.args[0] == "agent:end"
+    ][0]
+    assert agent_end["turn_exit_reason"] == expected_reason
+
+
+class _UnstringableReason:
+    def __bool__(self):
+        raise TypeError("malformed reason")
+
+    def __str__(self):
+        raise TypeError("malformed reason")
+
+
+class _ExplodingCount:
+    def __bool__(self):
+        raise RuntimeError("malformed count")
+
+
+@pytest.mark.asyncio
+async def test_agent_end_hook_bounds_reason_and_fails_safe_on_bad_count(
+    monkeypatch,
+    tmp_path,
+):
+    runner = _runner(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "failed",
+            "messages": [],
+            "tools": [],
+            "api_calls": object(),
+            "turn_exit_reason": "local_processing_error(" + ("x" * 500) + ")",
+            "failed": True,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    agent_end = [
+        call.args[1]
+        for call in runner.hooks.emit.await_args_list
+        if call.args[0] == "agent:end"
+    ][0]
+    assert len(agent_end["turn_exit_reason"]) == 200
+    assert agent_end["turn_exit_reason"].startswith("local_processing_error(")
+    assert agent_end["api_call_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_agent_end_hook_still_emits_when_count_protocol_raises(
+    monkeypatch,
+    tmp_path,
+):
+    runner = _runner(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "failed",
+            "messages": [],
+            "tools": [],
+            "api_calls": _ExplodingCount(),
+            "turn_exit_reason": "guardrail_halt",
+            "failed": True,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    agent_end = [
+        call.args[1]
+        for call in runner.hooks.emit.await_args_list
+        if call.args[0] == "agent:end"
+    ][0]
+    assert agent_end["turn_exit_reason"] == "guardrail_halt"
+    assert agent_end["api_call_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_agent_end_hook_fails_safe_on_malformed_reason(monkeypatch, tmp_path):
+    runner = _runner(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "failed",
+            "messages": [],
+            "tools": [],
+            "api_calls": 1,
+            "turn_exit_reason": _UnstringableReason(),
+            "failed": True,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    agent_end = [
+        call.args[1]
+        for call in runner.hooks.emit.await_args_list
+        if call.args[0] == "agent:end"
+    ][0]
+    assert agent_end["turn_exit_reason"] == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_agent_end_hook_clamps_negative_count(monkeypatch, tmp_path):
+    runner = _runner(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "done",
+            "messages": [],
+            "tools": [],
+            "api_calls": -3,
+            "turn_exit_reason": "text_response(finish_reason=stop)",
+            "failed": False,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    agent_end = [
+        call.args[1]
+        for call in runner.hooks.emit.await_args_list
+        if call.args[0] == "agent:end"
+    ][0]
+    assert agent_end["api_call_count"] == 0
+
+
+def _runtime_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._session_run_generation = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(
+        thread_sessions_per_user=False,
+        group_sessions_per_user=False,
+        stt_enabled=False,
+        streaming=None,
+    )
+    return runner
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("final_response", "turn_exit_reason", "completed", "failed"),
+    [
+        ("done", "text_response(finish_reason=stop)", True, False),
+        ("halted", "guardrail_halt", False, True),
+        (None, "all_retries_exhausted_no_response", False, True),
+    ],
+)
+async def test_run_agent_propagates_exit_reason_through_result_mapping(
+    monkeypatch,
+    tmp_path,
+    final_response,
+    turn_exit_reason,
+    completed,
+    failed,
+):
+    class _TerminationMetadataAgent:
+        def __init__(self, **_kwargs):
+            self.tools = []
+            self._interrupt_requested = False
+
+        @property
+        def is_interrupted(self):
+            return self._interrupt_requested
+
+        def run_conversation(
+            self,
+            _message,
+            conversation_history=None,
+            task_id=None,
+            **_kwargs,
+        ):
+            return {
+                "final_response": final_response,
+                "messages": [],
+                "api_calls": 3,
+                "completed": completed,
+                "failed": failed,
+                "error": "synthetic failure" if failed else None,
+                "turn_exit_reason": turn_exit_reason,
+            }
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _TerminationMetadataAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "fake"},
+    )
+
+    result = await _runtime_runner()._run_agent(
+        message="run a task",
+        context_prompt="",
+        history=[],
+        source=_source(),
+        session_id="sess-agent-end-runtime",
+        session_key="agent:main:telegram:group:-1001:12345",
+    )
+
+    assert result["turn_exit_reason"] == turn_exit_reason
+    assert result["api_calls"] == 3
+    assert result["completed"] is completed
+    assert result["failed"] is failed
+
+
+@pytest.mark.asyncio
+async def test_run_agent_classifies_runtime_resolution_failure(
+    monkeypatch,
+    tmp_path,
+):
+    runner = _runtime_runner()
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner._resolve_session_agent_runtime = MagicMock(
+        side_effect=RuntimeError("synthetic runtime resolution failure")
+    )
+
+    result = await runner._run_agent(
+        message="run a task",
+        context_prompt="",
+        history=[],
+        source=_source(),
+        session_id="sess-agent-end-auth-failure",
+        session_key="agent:main:telegram:group:-1001:12345",
+    )
+
+    assert "failed" not in result
+    assert result["turn_exit_reason"] == "gateway_agent_runtime_resolution_failed"
+
+
+@pytest.mark.asyncio
+async def test_run_agent_classifies_inactivity_timeout(monkeypatch, tmp_path):
+    interrupted = threading.Event()
+
+    class _InactiveAgent:
+        def __init__(self, **_kwargs):
+            self.tools = []
+            self._interrupt_requested = False
+
+        @property
+        def is_interrupted(self):
+            return self._interrupt_requested
+
+        def run_conversation(
+            self,
+            _message,
+            conversation_history=None,
+            task_id=None,
+            **_kwargs,
+        ):
+            interrupted.wait(timeout=2)
+            return {
+                "final_response": None,
+                "messages": [],
+                "api_calls": 1,
+                "completed": False,
+                "failed": True,
+            }
+
+        def get_activity_summary(self):
+            return {
+                "last_activity_desc": "synthetic stalled provider",
+                "seconds_since_activity": 60,
+                "current_tool": None,
+                "api_call_count": 1,
+                "max_iterations": 90,
+            }
+
+        def interrupt(self, _reason):
+            self._interrupt_requested = True
+            interrupted.set()
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _InactiveAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "fake"},
+    )
+    monkeypatch.setenv("HERMES_AGENT_TIMEOUT", "0.001")
+    monkeypatch.setenv("HERMES_AGENT_TIMEOUT_WARNING", "0")
+    monkeypatch.setattr(gateway_run, "_GATEWAY_AGENT_POLL_INTERVAL_SECONDS", 0.01)
+
+    result = await _runtime_runner()._run_agent(
+        message="run a task",
+        context_prompt="",
+        history=[],
+        source=_source(),
+        session_id="sess-agent-end-inactivity",
+        session_key="agent:main:telegram:group:-1001:12345",
+    )
+
+    assert result["failed"] is True
+    assert result["turn_exit_reason"] == "gateway_inactivity_timeout"
+    assert interrupted.is_set()

--- a/tests/gateway/test_proxy_mode.py
+++ b/tests/gateway/test_proxy_mode.py
@@ -1,5 +1,6 @@
 """Tests for gateway proxy mode — forwarding messages to a remote API server."""
 
+import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -39,10 +40,11 @@ def _make_source(platform=Platform.MATRIX):
 class _FakeSSEResponse:
     """Simulates an aiohttp response with SSE streaming."""
 
-    def __init__(self, status=200, sse_chunks=None, error_text=""):
+    def __init__(self, status=200, sse_chunks=None, error_text="", stream_error=None):
         self.status = status
         self._sse_chunks = sse_chunks or []
         self._error_text = error_text
+        self._stream_error = stream_error
         self.content = self
 
     async def text(self):
@@ -53,6 +55,8 @@ class _FakeSSEResponse:
             if isinstance(chunk, str):
                 chunk = chunk.encode("utf-8")
             yield chunk
+        if self._stream_error:
+            raise self._stream_error
 
     async def __aenter__(self):
         return self
@@ -228,6 +232,42 @@ class TestRunAgentViaProxy:
     """Test the actual proxy HTTP forwarding logic."""
 
     @pytest.mark.asyncio
+    async def test_reports_missing_aiohttp_dependency(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        runner = _make_runner()
+
+        with patch.dict(sys.modules, {"aiohttp": None}):
+            result = await runner._run_agent_via_proxy(
+                message="hi",
+                context_prompt="",
+                history=[],
+                source=_make_source(),
+                session_id="test",
+            )
+
+        assert "failed" not in result
+        assert result["partial"] is False
+        assert result["turn_exit_reason"] == "gateway_proxy_dependency_missing"
+
+    @pytest.mark.asyncio
+    async def test_reports_missing_proxy_configuration(self, monkeypatch):
+        monkeypatch.delenv("GATEWAY_PROXY_URL", raising=False)
+        runner = _make_runner()
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            result = await runner._run_agent_via_proxy(
+                message="hi",
+                context_prompt="",
+                history=[],
+                source=_make_source(),
+                session_id="test",
+            )
+
+        assert "failed" not in result
+        assert result["partial"] is False
+        assert result["turn_exit_reason"] == "gateway_proxy_not_configured"
+
+    @pytest.mark.asyncio
     async def test_builds_correct_request(self, monkeypatch):
         monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
         monkeypatch.setenv("GATEWAY_PROXY_KEY", "test-key-123")
@@ -303,6 +343,9 @@ class TestRunAgentViaProxy:
 
         assert "Proxy error (401)" in result["final_response"]
         assert result["api_calls"] == 0
+        assert "failed" not in result
+        assert result["partial"] is False
+        assert result["turn_exit_reason"] == "gateway_proxy_http_error"
 
     @pytest.mark.asyncio
     async def test_handles_connection_error(self, monkeypatch):
@@ -333,6 +376,9 @@ class TestRunAgentViaProxy:
                     )
 
         assert "Proxy connection error" in result["final_response"]
+        assert "failed" not in result
+        assert result["partial"] is False
+        assert result["turn_exit_reason"] == "gateway_proxy_connection_error"
 
     @pytest.mark.asyncio
     async def test_rejects_proxy_sse_without_line_boundary_after_buffer_cap(self, monkeypatch):
@@ -359,6 +405,66 @@ class TestRunAgentViaProxy:
         assert "Proxy connection error" in result["final_response"]
         assert "exceeded max buffer size" in result["final_response"]
         assert result["api_calls"] == 0
+        assert "failed" not in result
+        assert result["partial"] is False
+        assert result["turn_exit_reason"] == "gateway_proxy_connection_error"
+
+    @pytest.mark.asyncio
+    async def test_partial_stream_preserves_response_without_changing_failed_flow(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        monkeypatch.delenv("GATEWAY_PROXY_KEY", raising=False)
+        runner = _make_runner()
+        source = _make_source()
+        resp = _FakeSSEResponse(
+            status=200,
+            sse_chunks=[
+                b'data: {"choices":[{"delta":{"content":"partial"}}]}\n\n'
+            ],
+            stream_error=ConnectionError("stream interrupted"),
+        )
+        session = _FakeSession(resp)
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                with patch("aiohttp.ClientTimeout"):
+                    result = await runner._run_agent_via_proxy(
+                        message="hi",
+                        context_prompt="",
+                        history=[],
+                        source=source,
+                        session_id="test",
+                    )
+
+        assert result["final_response"] == "partial"
+        assert "failed" not in result
+        assert result["partial"] is True
+        assert result["turn_exit_reason"] == "gateway_proxy_partial_response"
+
+    @pytest.mark.asyncio
+    async def test_empty_stream_has_distinct_exit_reason(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        monkeypatch.delenv("GATEWAY_PROXY_KEY", raising=False)
+        runner = _make_runner()
+        source = _make_source()
+        session = _FakeSession(_FakeSSEResponse(status=200, sse_chunks=[]))
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                with patch("aiohttp.ClientTimeout"):
+                    result = await runner._run_agent_via_proxy(
+                        message="hi",
+                        context_prompt="",
+                        history=[],
+                        source=source,
+                        session_id="test",
+                    )
+
+        assert result["final_response"] == "(No response from remote agent)"
+        assert "failed" not in result
+        assert result["partial"] is False
+        assert result["turn_exit_reason"] == "gateway_proxy_empty_response"
 
     @pytest.mark.asyncio
     async def test_skips_tool_messages_in_history(self, monkeypatch):
@@ -428,6 +534,9 @@ class TestRunAgentViaProxy:
         assert "messages" in result
         assert "api_calls" in result
         assert "tools" in result
+        assert "failed" not in result
+        assert result["partial"] is False
+        assert result["turn_exit_reason"] == "gateway_proxy_response_complete"
         assert "history_offset" in result
         assert result["history_offset"] == 2  # len(history)
         assert "session_id" in result

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -81,10 +81,28 @@ async def handle(event_type: str, context: dict):
 | `session:compress` | Context compression completed for a session | `platform`, `session_id`, `old_session_id` (empty when compacted in place), `in_place` (bool — `true` = transcript compacted on the same id, `false` = rotated from `old_session_id`), `compression_count` |
 | `agent:start` | Agent begins processing a message | `platform`, `user_id`, `chat_id`, `thread_id` (forum-topic / thread root id; empty when not in a thread), `chat_type` (`"dm"` \| `"group"` \| `"forum"`; empty if unknown), `session_id`, `message` (truncated to 500 chars) |
 | `agent:step` | Each iteration of the tool-calling loop | `platform`, `user_id`, `session_id`, `iteration`, `tool_names` |
-| `agent:end` | Agent finishes processing | same keys as `agent:start`, plus `response` (truncated to 500 chars) |
+| `agent:end` | Agent finishes processing | same keys as `agent:start`, plus `response` (truncated to 500 chars), `turn_exit_reason`, `api_call_count` |
 | `reaction:added` | An emoji reaction was added to a message the bot can see (Slack adapter currently). Requires the `reactions:read` scope + the `reaction_added` bot event subscription; the bot must be a member of the channel. | `platform`, `reaction`, `user_id`, `item_user_id`, `item_type`, `channel_id`, `message_ts`, `team_id`, `event_ts`, `raw_event` |
 | `reaction:removed` | An emoji reaction was removed from a message the bot can see. Requires the `reaction_removed` bot event subscription. | same shape as `reaction:added` |
 | `command:*` | Any slash command executed | `platform`, `user_id`, `command`, `args` |
+
+`agent:end.turn_exit_reason` preserves the agent finalizer's reason, classifies
+early user stops as `interrupted_by_user`, and keeps gateway timeout, disconnect,
+shutdown, and restart aborts distinct. Missing or malformed reasons are
+`unknown`; consumers should treat that class as actionable until reconciled.
+Finalizer reason text is collapsed to a single line and truncated to 200
+characters before hook delivery.
+
+The value is an open vocabulary. Specific agent-finalizer reasons pass through.
+Gateway-owned classes are `interrupted_by_user`, `unknown`,
+`gateway_inactivity_timeout`, `gateway_sse_disconnect`, `gateway_shutdown`,
+`gateway_restart`, and `gateway_agent_runtime_resolution_failed`. Proxy mode
+uses `gateway_proxy_dependency_missing`, `gateway_proxy_not_configured`,
+`gateway_proxy_http_error`, `gateway_proxy_connection_error`,
+`gateway_proxy_partial_response`, `gateway_proxy_response_complete`, and
+`gateway_proxy_empty_response`. Consumers should recognize future
+`gateway_*` and `gateway_proxy_*` extensions without treating the vocabulary as
+closed.
 
 #### Wildcard Matching
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/hooks.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/hooks.md
@@ -80,8 +80,23 @@ async def handle(event_type: str, context: dict):
 | `session:reset` | 用户执行 `/new` 或 `/reset` | `platform`、`user_id`、`session_key` |
 | `agent:start` | Agent 开始处理消息 | `platform`、`user_id`、`session_id`、`message` |
 | `agent:step` | 工具调用循环的每次迭代 | `platform`、`user_id`、`session_id`、`iteration`、`tool_names` |
-| `agent:end` | Agent 完成处理 | `platform`、`user_id`、`session_id`、`message`、`response` |
+| `agent:end` | Agent 完成处理 | `platform`、`user_id`、`session_id`、`message`、`response`、`turn_exit_reason`、`api_call_count` |
 | `command:*` | 任意斜杠命令执行 | `platform`、`user_id`、`command`、`args` |
+
+`agent:end.turn_exit_reason` 会保留 Agent finalizer 给出的原因，将提前的用户停止分类为
+`interrupted_by_user`，并区分 Gateway 超时、断开连接、关闭和重启中止。缺失或格式错误的
+原因会归一化为 `unknown`；消费者在完成核对前应将此类视为可操作异常。
+Finalizer 原因文本在传递给 hook 前会折叠为单行并截断为 200 个字符。
+
+该字段采用开放词汇。具体的 Agent finalizer 原因会原样传递。Gateway 自有分类包括
+`interrupted_by_user`、`unknown`、`gateway_inactivity_timeout`、
+`gateway_sse_disconnect`、`gateway_shutdown`、`gateway_restart` 和
+`gateway_agent_runtime_resolution_failed`。Proxy 模式使用
+`gateway_proxy_dependency_missing`、`gateway_proxy_not_configured`、
+`gateway_proxy_http_error`、`gateway_proxy_connection_error`、
+`gateway_proxy_partial_response`、`gateway_proxy_response_complete` 和
+`gateway_proxy_empty_response`。消费者应兼容未来的 `gateway_*` 与
+`gateway_proxy_*` 扩展，不应把当前词汇表视为封闭枚举。
 
 #### 通配符匹配
 


### PR DESCRIPTION
## Summary

- propagate conversation-loop turn_exit_reason and real api_calls into agent:end
- distinguish immutable Gateway system markers from explicit STOP and RESET user interrupts
- keep unclassified exits fail-closed as unknown while preserving specific finalizer reasons
- classify proxy, runtime-resolution, timeout, disconnect, shutdown, and restart exits without changing existing failed control flow
- normalize untrusted reason text to one printable bounded line
- document the additive open-vocabulary hook contract in English and zh-Hans

Correlation ID: hermes-governed-autonomy-rel-01

Closes #73939.

## Exact source

- Validated base commit: 19055492aac32e26bf5c57c3ead376b0b084bd28
- Exact head: 2270fdf326ee226cbe03c60bdf328001cceabdc4
- Fork read-back: 2270fdf326ee226cbe03c60bdf328001cceabdc4
- Single commit: fix(gateway): expose agent exit metadata to hooks

The upstream main branch advanced again after validation; GitHub currently reports this PR MERGEABLE and BLOCKED, not conflicting.

## Validation

Exact-head validation:

- 11 focused Gateway, interrupt, hook, proxy, timeout, and Matrix files: 378 passed, 0 failed
- py_compile for all changed Python files: passed
- Ruff 0.15.22 for all changed Python files: passed
- Windows footgun diff scan: 4 changed Python files, 0 findings
- git diff check: passed
- clean exact-head worktree: passed
- independent Claude Code Opus 5 final review: NO ACTIONABLE FINDINGS

Broader source-equivalent validation completed during the review loop:

- full Gateway suite: 11,691 passed, 3 failed; all 3 failures were reproduced on the clean base and are existing macOS path, subprocess, and systemd-socket incompatibilities
- English and zh-Hans Docusaurus production builds: passed
- diagram lint: 383 documents, 0 errors

## CI and authority

- Exact-head CI: https://github.com/NousResearch/hermes-agent/actions/runs/30471568948
- Conclusion: action_required, zero jobs
- Review threads: 0 unresolved
- Current account has no upstream push, maintain, or admin permission
- No merge, deploy, restart, credential change, or live write was performed
