### PR TITLE
fix(models): use Gemini's live API for model discovery, correct fictional 3.x entries

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -288,10 +288,17 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemini-2.5-pro",
     ],
     "gemini": [
-        "gemini-3.1-pro-preview",
-        "gemini-3-pro-preview",
-        "gemini-3.6-flash",
-        "gemini-3.1-flash-lite-preview",
+        # Verified against Google's own /v1beta/openai/models endpoint
+        # (issue #73825) -- the previous entries here (gemini-3.1-pro-preview,
+        # gemini-3-pro-preview, gemini-3.6-flash, gemini-3.1-flash-lite-preview)
+        # only exist on OpenRouter, not on Google's direct API; selecting one
+        # 404'd silently. This is only the offline/no-credentials fallback --
+        # provider_model_ids() queries the live endpoint first and only
+        # falls back to this list if that's unreachable or unconfigured.
+        "gemini-2.5-pro",
+        "gemini-2.5-flash",
+        "gemini-2.0-flash",
+        "gemini-2.0-flash-lite",
     ],
     "zai": [
         "glm-5.2",
@@ -2531,8 +2538,6 @@ _MODELS_DEV_PREFERRED: frozenset[str] = frozenset({
     "nvidia",
     "huggingface",
     "zai",
-    "gemini",
-    "google",
 })
 
 
@@ -2660,6 +2665,36 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
                     return live
         except Exception:
             pass
+    if normalized == "gemini":
+        # Query Google's live API directly rather than trusting models.dev's
+        # third-party-aggregated "google" catalog (previously merged via
+        # _MODELS_DEV_PREFERRED) or the hand-curated static list -- both
+        # have listed 3.x model IDs that don't exist on Google's own API,
+        # silently 404ing at call time (issue #73825). Uses the
+        # OpenAI-compatible /v1beta/openai surface (Gemini's own documented
+        # compat layer) specifically because it returns the standard
+        # {"data": [{"id": ...}]} shape fetch_api_models() already parses --
+        # the native /v1beta/models endpoint uses a different response
+        # shape ({"models": [{"name": "models/<id>", ...}]}) that would
+        # need separate parsing. normalize_provider() already canonicalizes
+        # a raw "google" input to "gemini" before this function runs.
+        try:
+            from hermes_cli.auth import resolve_api_key_provider_credentials
+
+            creds = resolve_api_key_provider_credentials("gemini")
+            api_key = str(creds.get("api_key") or "").strip()
+            if api_key:
+                live = fetch_api_models(
+                    api_key, "https://generativelanguage.googleapis.com/v1beta/openai"
+                )
+                if live:
+                    return live
+        except Exception:
+            pass
+        # Live fetch failed or no credentials configured: fall back to the
+        # curated static list (verified against Google's own API, not
+        # models.dev) rather than merging models.dev data.
+        return list(_PROVIDER_MODELS.get("gemini", []))
     if normalized == "anthropic":
         model_cfg = _get_model_config_dict()
         cfg_provider = normalize_provider(str(model_cfg.get("provider", "") or ""))

--- a/tests/hermes_cli/test_gemini_model_catalog.py
+++ b/tests/hermes_cli/test_gemini_model_catalog.py
@@ -1,0 +1,116 @@
+"""Regression tests for Gemini/Google model catalog discovery (issue #73825).
+
+The Gemini provider model list previously included 3.x model IDs
+(gemini-3.1-pro-preview, gemini-3.6-flash, etc.) that don't exist on
+Google's direct API -- only on OpenRouter. Both the hand-curated static
+list AND the models.dev merge (_MODELS_DEV_PREFERRED included "gemini"/
+"google") contained these fictional entries, so selecting one silently
+404'd with no indication to the user.
+
+provider_model_ids("gemini") now queries Google's live
+/v1beta/openai/models endpoint (Gemini's documented OpenAI-compatible
+surface, which returns the same {"data": [{"id": ...}]} shape
+fetch_api_models() already parses) first, and only falls back to a
+corrected, verified static list -- never to models.dev's third-party
+"google" catalog.
+"""
+from __future__ import annotations
+
+from hermes_cli.models import _MODELS_DEV_PREFERRED, _PROVIDER_MODELS, provider_model_ids
+
+
+class TestGeminiLiveModelDiscovery:
+    def test_prefers_live_api_over_static_list(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            lambda provider_id: {
+                "provider": provider_id,
+                "api_key": "AIzaFakeKey",
+                "base_url": "",
+                "source": "GEMINI_API_KEY",
+            },
+        )
+
+        def _fake_fetch(api_key, base_url):
+            assert base_url == "https://generativelanguage.googleapis.com/v1beta/openai"
+            assert api_key == "AIzaFakeKey"
+            return ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"]
+
+        monkeypatch.setattr("hermes_cli.models.fetch_api_models", _fake_fetch)
+
+        assert provider_model_ids("gemini") == [
+            "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash",
+        ]
+
+    def test_falls_back_to_corrected_static_list_when_live_fetch_fails(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            lambda provider_id: {
+                "provider": provider_id,
+                "api_key": "AIzaFakeKey",
+                "base_url": "",
+                "source": "GEMINI_API_KEY",
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.fetch_api_models", lambda api_key, base_url: None
+        )
+
+        result = provider_model_ids("gemini")
+        assert result == list(_PROVIDER_MODELS["gemini"])
+
+    def test_falls_back_to_static_list_when_no_api_key(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            lambda provider_id: {"provider": provider_id, "api_key": "", "base_url": "", "source": ""},
+        )
+        result = provider_model_ids("gemini")
+        assert result == list(_PROVIDER_MODELS["gemini"])
+
+    def test_static_fallback_contains_no_fictional_3x_models(self):
+        """The curated fallback must only list models verified to exist on
+        Google's own API -- no 3.x IDs that only exist on OpenRouter."""
+        curated = _PROVIDER_MODELS["gemini"]
+        for model_id in curated:
+            assert not model_id.startswith("gemini-3"), (
+                f"{model_id!r} is a fictional/OpenRouter-only model that "
+                f"404s on Google's direct API"
+            )
+
+    def test_static_fallback_contains_real_verified_models(self):
+        """Sanity: the corrected list should contain the models the issue
+        reporter verified exist on Google's live API."""
+        curated = set(_PROVIDER_MODELS["gemini"])
+        for expected in ("gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"):
+            assert expected in curated
+
+    def test_gemini_not_in_models_dev_preferred(self):
+        """gemini/google must not be merged with models.dev's third-party
+        catalog anymore -- provider_model_ids() has its own dedicated
+        live-fetch + verified-fallback branch that always returns before
+        reaching that merge, so leaving these in the set would be
+        misleading dead code."""
+        assert "gemini" not in _MODELS_DEV_PREFERRED
+        assert "google" not in _MODELS_DEV_PREFERRED
+
+    def test_google_alias_normalizes_to_gemini_branch(self, monkeypatch):
+        """normalize_provider() canonicalizes 'google' to 'gemini' before
+        provider_model_ids() runs, so passing either must hit the same
+        live-fetch path, not the (now-removed) models.dev merge."""
+        monkeypatch.setattr(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            lambda provider_id: {"provider": provider_id, "api_key": "", "base_url": "", "source": ""},
+        )
+        result = provider_model_ids("google")
+        assert result == list(_PROVIDER_MODELS["gemini"])
+
+    def test_live_fetch_exception_falls_back_gracefully(self, monkeypatch):
+        """A credential-resolution or network exception during the live
+        fetch must not propagate -- must degrade to the static fallback."""
+        def _raise(*a, **k):
+            raise RuntimeError("network unreachable")
+
+        monkeypatch.setattr("hermes_cli.auth.resolve_api_key_provider_credentials", _raise)
+
+        result = provider_model_ids("gemini")  # must not raise
+        assert result == list(_PROVIDER_MODELS["gemini"])


### PR DESCRIPTION
## Context

Fixes #73825.

## Problem

The Gemini provider model dropdown listed 3.x model IDs (`gemini-3.1-pro-preview`, `gemini-3.6-flash`, etc.) that don't exist on Google's own API -- only on OpenRouter. Selecting one produced a silent 404 -> fallback, with no indication to the user.

## Root Cause

Both sources feeding `provider_model_ids("gemini")` had the same fictional entries: the hand-curated static fallback list itself only listed 3.x IDs, and `gemini`/`google` were also in `_MODELS_DEV_PREFERRED`, merging in models.dev's third-party "google" catalog (which tracks broad availability, not specifically Google's direct API).

## Fix

1. Added a dedicated live-fetch branch for gemini using Google's documented OpenAI-compatible surface (`/v1beta/openai/models`), which returns the standard shape `fetch_api_models()` already parses.
2. Corrected the static fallback list to the model IDs the issue reporter verified against Google's live API.
3. Removed `gemini`/`google` from `_MODELS_DEV_PREFERRED` since the new branch always returns before reaching that merge.

## Verification

8 new tests pass (live-fetch preference, fallback scenarios, corrected static list contents, models.dev removal, google-alias normalization); 88/88 in the full `tests/hermes_cli/test_models.py` file; 133/133 across three more dependent test files, plus 2/2 gemini-specific validation tests (no regression).