### PR TITLE
fix(gateway): add turn_exit_reason and api_call_count to agent:end hook (#73939)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14652,6 +14652,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             await self.hooks.emit("agent:end", {
                 **hook_ctx,
                 "response": (response or "")[:500],
+                "turn_exit_reason": agent_result.get("turn_exit_reason", "unknown"),
+                "api_call_count": int(agent_result.get("api_calls", 0) or 0),
             })
             
             # Check for pending process watchers (check_interval on background processes)


### PR DESCRIPTION
## Summary

Fixes #73939. Gateway agent:end lifecycle hook now includes turn termination metadata.

## Fix

Add `turn_exit_reason` and `api_call_count` from agent_result to the agent:end hook context. Both fields already exist in the conversation_loop result dict (populated by turn_finalizer). Additive change — existing consumers unaffected.

## Testing

- py_compile OK, ruff clean
