### PR TITLE
fix(simplex): use composite chat_id for numeric/display name duality

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -516,7 +516,7 @@ class SimplexAdapter(BasePlatformAdapter):
             sender_name = contact.get("localDisplayName", "") or contact.get(
                 "profile", {}
             ).get("displayName", "")
-            chat_id = sender_id
+            chat_id = f"{sender_id}|{sender_name}" if sender_name else sender_id
         elif chat_type == "group":
             group_info = chat_info.get("groupInfo", {}) or {}
             group_id = str(group_info.get("groupId", ""))
@@ -838,7 +838,9 @@ class SimplexAdapter(BasePlatformAdapter):
                 )
                 cmd_str = f"/_send #{chat_id[6:]} json {composed}"
             else:
-                cmd_str = f"@{chat_id} {content}"
+                # chat_id format: "5|人可通_1" — use display name for @ command
+                display_name = chat_id.split("|")[-1] if "|" in chat_id else chat_id
+                cmd_str = f"@{display_name} {content}"
 
             await self._send_ws({"corrId": corr_id, "cmd": cmd_str})
 
@@ -972,7 +974,8 @@ class SimplexAdapter(BasePlatformAdapter):
             group_id = chat_id[6:]
             command = f"/_send #{group_id} json {composed}"
         else:
-            command = f"/_send @{chat_id} json {composed}"
+            numeric_id = chat_id.split("|")[0] if "|" in chat_id else chat_id
+            command = f"/_send @{numeric_id} json {composed}"
 
         result = await self._send_command(command)
         if result is not None:
@@ -1028,7 +1031,8 @@ class SimplexAdapter(BasePlatformAdapter):
             group_id = chat_id[6:]
             command = f"/_send #{group_id} json {composed}"
         else:
-            command = f"/_send @{chat_id} json {composed}"
+            numeric_id = chat_id.split("|")[0] if "|" in chat_id else chat_id
+            command = f"/_send @{numeric_id} json {composed}"
 
         result = await self._send_command(command)
         if result is not None:
@@ -1071,7 +1075,8 @@ class SimplexAdapter(BasePlatformAdapter):
             group_id = chat_id[6:]
             command = f"/_send #{group_id} json {composed}"
         else:
-            command = f"/_send @{chat_id} json {composed}"
+            numeric_id = chat_id.split("|")[0] if "|" in chat_id else chat_id
+            command = f"/_send @{numeric_id} json {composed}"
 
         result = await self._send_command(command)
         if result is not None:


### PR DESCRIPTION
## Problem

simplex-chat v6.5.6.1 has diverging requirements for different command types:

- `@` text commands require **display names** (e.g. `@人可通_1 hello`)
- `/_send` file commands require **numeric contactIds** (e.g. `/_send @5 json ...`)

The current adapter stores only the numeric `contactId` as `chat_id`, which causes text sends to fail with `chatCmdError` on simplex-chat v6.5+.

## Solution

Store both IDs as a composite `chat_id` in the format `contactId|displayName`:

- Text sending extracts the display name for `@` commands
- Image/file/voice sending extracts the numeric ID for `/_send` commands
- Falls back to raw `chat_id` when no `|` separator is present (backward-compatible)

## Changes

- `_handle_chat_item`: `chat_id` now carries both IDs
- `send_message`: parse display name for `@` command
- `send_image`, `send_document`, `send_voice`: parse numeric ID for `/_send`

## Testing

Tested end-to-end with simplex-chat v6.5.6.1 CLI + Hermes gateway + iPhone SimpleX app:
- Text messages (both directions) ✓
- Image delivery via `/_send` ✓  
- File delivery ✓
- Backward compatibility (single-format `chat_id` without `|`) ✓