### PR TITLE
fix(compression): align compute-host RPC timeout

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7215,6 +7215,31 @@ def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float
     return default
 
 
+def resolve_auxiliary_task_timeout(
+    task: str,
+    *,
+    task_config: Optional[Dict[str, Any]] = None,
+    default: float = _DEFAULT_AUX_TIMEOUT,
+) -> float:
+    """Resolve a config-derived auxiliary timeout, including task-specific floors.
+
+    ``task_config`` lets profile-aware runtimes supply the exact config block
+    they already resolved instead of reloading the process-global config.
+    """
+    if task_config is None:
+        effective = _get_task_timeout(task, default)
+    else:
+        raw = task_config.get("timeout") if isinstance(task_config, dict) else None
+        try:
+            effective = float(raw) if raw is not None else default
+        except (TypeError, ValueError):
+            effective = default
+
+    if task == "compression":
+        effective = max(effective, _COMPRESSION_TIMEOUT_FLOOR_SECONDS)
+    return effective
+
+
 def _effective_aux_timeout(task: str, timeout: Optional[float]) -> float:
     """Resolve the effective timeout for an auxiliary LLM call.
 
@@ -7226,10 +7251,9 @@ def _effective_aux_timeout(task: str, timeout: Optional[float]) -> float:
     explicit ``timeout=`` — explicit per-call deadlines are always honoured —
     and it is a minimum (``max``), so a config value already above it is kept.
     """
-    effective = timeout if timeout is not None else _get_task_timeout(task)
-    if timeout is None and task == "compression":
-        effective = max(effective, _COMPRESSION_TIMEOUT_FLOOR_SECONDS)
-    return effective
+    if timeout is not None:
+        return timeout
+    return resolve_auxiliary_task_timeout(task)
 
 
 def _get_task_extra_body(task: str) -> Dict[str, Any]:

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -405,7 +405,7 @@ def test_slash_exec_compress_flag_on_applies_host_control_mirror(monkeypatch):
             self.controls = []
 
         def control(self, sid, *, route_name, payload=None, wait=True, timeout=30.0):
-            self.controls.append((sid, route_name, dict(payload or {}), wait))
+            self.controls.append((sid, route_name, dict(payload or {}), wait, timeout))
             return {
                 "type": "control.ack",
                 "sid": sid,
@@ -426,6 +426,11 @@ def test_slash_exec_compress_flag_on_applies_host_control_mirror(monkeypatch):
     session = _session(agent=None, agent_ready=threading.Event(), _compute_host_active=True)
     server._sessions["sid"] = session
     monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
+    monkeypatch.setattr(
+        server,
+        "_compression_rpc_timeout",
+        lambda affected: 3600.0 if affected is session else pytest.fail("wrong session"),
+    )
     monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: fake)
     monkeypatch.setattr(server, "_SlashWorker", _ExplodingWorker)
     monkeypatch.setattr(server, "_compress_session_history", lambda *a, **k: (_ for _ in ()).throw(AssertionError("parent compressed")))
@@ -445,6 +450,7 @@ def test_slash_exec_compress_flag_on_applies_host_control_mirror(monkeypatch):
     assert resp["result"]["output"] == "Compressed 4 → 2 messages"
     assert fake.controls[0][1] == "slash.compress"
     assert fake.controls[0][2]["command"] == "/compress focus"
+    assert fake.controls[0][4] == 3600.0
     assert session["session_key"] == "host-rotated-key"
     assert session["history_version"] == 9
     assert server._session_info(None, session)["model"] == "host-model"
@@ -7260,7 +7266,56 @@ def test_session_compress_returns_compute_host_history(monkeypatch):
     }
 
 
-def test_session_compress_forwards_120_second_budget_to_compute_host(monkeypatch):
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        (120, 300.0),
+        (3600, 3600.0),
+        ("invalid", 300.0),
+    ],
+)
+def test_compression_rpc_timeout_matches_effective_model_budget(
+    monkeypatch, configured, expected
+):
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"auxiliary": {"compression": {"timeout": configured}}},
+    )
+
+    assert server._compression_rpc_timeout({}) == expected
+
+
+def test_compression_rpc_timeout_uses_affected_session_profile(
+    monkeypatch, tmp_path
+):
+    launch_home = tmp_path / "launch"
+    remote_home = tmp_path / "profiles" / "remote"
+    launch_home.mkdir()
+    remote_home.mkdir(parents=True)
+    (launch_home / "config.yaml").write_text(
+        "auxiliary:\n  compression:\n    timeout: 600\n",
+        encoding="utf-8",
+    )
+    (remote_home / "config.yaml").write_text(
+        "auxiliary:\n  compression:\n    timeout: 3600\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
+    server._cfg_cache = None
+    server._cfg_mtime = None
+    server._cfg_path = None
+
+    assert (
+        server._compression_rpc_timeout({"profile_home": str(remote_home)})
+        == 3600.0
+    )
+    # The session-scoped override is reset after the read; subsequent launch
+    # profile requests still resolve against the gateway's own profile.
+    assert server._compression_rpc_timeout({}) == 600.0
+
+
+def test_session_compress_forwards_configured_budget_to_compute_host(monkeypatch):
     session = _session(agent=None, _compute_host_active=True)
     server._sessions["sid"] = session
     calls = []
@@ -7279,6 +7334,11 @@ def test_session_compress_forwards_120_second_budget_to_compute_host(monkeypatch
 
     monkeypatch.setattr(server, "_session_uses_compute_host", lambda _session: True)
     monkeypatch.setattr(server, "_send_compute_host_control", send_control)
+    monkeypatch.setattr(
+        server,
+        "_compression_rpc_timeout",
+        lambda affected: 3600.0 if affected is session else pytest.fail("wrong session"),
+    )
 
     try:
         resp = server.handle_request(
@@ -7295,7 +7355,7 @@ def test_session_compress_forwards_120_second_budget_to_compute_host(monkeypatch
                 "route_name": "session.compress",
                 "command": "/compress",
                 "wait": True,
-                "timeout": 120.0,
+                "timeout": 3600.0,
             },
         )
     ]
@@ -9897,6 +9957,38 @@ def test_mirror_slash_side_effects_allowed_when_idle(monkeypatch):
     # Should NOT contain "session busy" — the switch went through.
     assert "session busy" not in warning
     assert applied["model"]
+
+
+def test_mirror_slash_compress_forwards_configured_budget_to_compute_host(monkeypatch):
+    calls = []
+
+    def send_control(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {"type": "control.ack", "output": "compressed"}
+
+    monkeypatch.setattr(server, "_send_compute_host_control", send_control)
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda _session: True)
+    session = _session(agent=None, running=False, _compute_host_active=True)
+    monkeypatch.setattr(
+        server,
+        "_compression_rpc_timeout",
+        lambda affected: 3600.0 if affected is session else pytest.fail("wrong session"),
+    )
+
+    output = server._mirror_slash_side_effects("sid", session, "/compress")
+
+    assert output == "compressed"
+    assert calls == [
+        (
+            ("sid",),
+            {
+                "route_name": "slash.compress",
+                "command": "/compress",
+                "wait": True,
+                "timeout": 3600.0,
+            },
+        )
+    ]
 
 
 def test_mirror_slash_compress_does_not_prelock_history(monkeypatch):

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2331,7 +2331,7 @@ def _(rid, params: dict) -> dict:
                 route_name="session.compress",
                 command=command,
                 wait=True,
-                timeout=120.0,
+                timeout=_compression_rpc_timeout(session),
             )
         except Exception as exc:
             return _err(rid, 5019, f"compute-host compress failed: {exc}")

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -970,6 +970,7 @@ def _(rid, params: dict) -> dict:
                     route_name="slash.compress",
                     command=command,
                     wait=True,
+                    timeout=_compression_rpc_timeout(session),
                 )
             except Exception as exc:
                 return _err(rid, 5019, f"compute-host slash.compress failed: {exc}")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1652,6 +1652,28 @@ def _send_compute_host_control(
     )
 
 
+def _compression_rpc_timeout(session: dict) -> float:
+    """Match a compute-host wait to the affected session's compression budget."""
+    profile_home = session.get("profile_home") if isinstance(session, dict) else None
+    home_token = (
+        set_hermes_home_override(str(profile_home)) if profile_home else None
+    )
+    try:
+        cfg = _load_cfg()
+    finally:
+        if home_token is not None:
+            reset_hermes_home_override(home_token)
+
+    auxiliary = cfg.get("auxiliary") if isinstance(cfg, dict) else {}
+    compression = auxiliary.get("compression") if isinstance(auxiliary, dict) else {}
+    from agent.auxiliary_client import resolve_auxiliary_task_timeout
+
+    return resolve_auxiliary_task_timeout(
+        "compression",
+        task_config=compression if isinstance(compression, dict) else {},
+    )
+
+
 def _emit_approval_request(sid: str, data: dict | None) -> None:
     """Emit an ``approval.request`` event to the TUI client with the command
     redacted. The approval payload is built from the RAW command string, so a
@@ -12277,11 +12299,17 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
     if _session_uses_compute_host(session) and name in _MUTATES_WHILE_RUNNING:
         route_name = f"slash.{name}"
         try:
+            timeout_kwargs = (
+                {"timeout": _compression_rpc_timeout(session)}
+                if name == "compress"
+                else {}
+            )
             ack = _send_compute_host_control(
                 sid,
                 route_name=route_name,
                 command=command,
                 wait=True,
+                **timeout_kwargs,
             )
         except Exception as exc:
             return f"compute-host {route_name} failed: {exc}"


### PR DESCRIPTION
## Summary

Fixes #73468.

Compression already has a model-side effective timeout: it reads the profile-aware `auxiliary_models.compression.timeout` value and applies the existing 300-second minimum. The compute-host RPC boundary did not use that same budget:

- `session.compress` waited a hard-coded 120 seconds;
- slash-command compression and mirrored compression inherited the generic 30-second control timeout.

A valid long-running compression could therefore continue on the model side after the gateway had already reported an RPC timeout.

This change exposes the existing effective auxiliary-task timeout calculation as a shared resolver and uses it for all three compression RPC routes. It deliberately does not add a second `rpc_timeout` setting that could drift from the model-side budget. Non-compression compute-host controls retain their existing 30-second default.

The issue's referenced line numbers predate the compute-host refactor; the affected behavior now lives in `tui_gateway/server.py`.

## Behavior covered

- configured compression timeout `3600` propagates through session, slash-command, and mirrored compression;
- the existing default/raw `120` value resolves to the established 300-second compression floor;
- invalid values fall back safely to that same floor;
- unrelated compute-host controls keep their default timeout.

## Validation

Rebased cleanly onto current `main` (`158e9a997`) and validated there:

- focused gateway timeout regressions: **3 passed**
- auxiliary compression timeout-floor suite: **7 passed**
- compression lock/skip suite: **7 passed**
- compute-host session-compress regression: **1 passed**
- Ruff on all three changed files: **passed**
- `git diff --check`: **passed**

The canonical Bash wrapper is unavailable in this native Windows environment, so the same repository test runner was invoked directly with the project's Python 3.11 environment.