### PR TITLE
fix(security): scrub credentials from clipboard and thumbnail OS helpers

### DIFF
--- a/hermes_cli/clipboard.py
+++ b/hermes_cli/clipboard.py
@@ -21,6 +21,21 @@ from pathlib import Path
 
 from hermes_constants import is_wsl as _is_wsl
 
+
+def _scrubbed_env() -> dict:
+    """Environment for clipboard helpers — never Hermes credentials.
+
+    ``pngpaste`` / ``osascript`` / ``xclip`` / ``wl-paste`` / PowerShell are
+    OS utilities Hermes shells out to on the image-paste path. They have no
+    business seeing provider API keys, bot tokens or ``SUDO_PASSWORD`` — the
+    same rule already applied to the voice TTS/STT, playback and
+    ffmpeg/ffprobe helpers.
+    """
+    from tools.environments.local import hermes_subprocess_env
+
+    return hermes_subprocess_env(inherit_credentials=False)
+
+
 logger = logging.getLogger(__name__)
 _PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
@@ -68,6 +83,7 @@ def _macos_has_image() -> bool:
         info = subprocess.run(
             ["osascript", "-e", "clipboard info"],
             capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=3,
+            env=_scrubbed_env(),
         )
         return "«class PNGf»" in info.stdout or "«class TIFF»" in info.stdout
     except Exception:
@@ -80,6 +96,7 @@ def _macos_pngpaste(dest: Path) -> bool:
         r = subprocess.run(
             ["pngpaste", str(dest)],
             capture_output=True, timeout=3,
+            env=_scrubbed_env(),
         )
         if r.returncode == 0 and dest.exists() and dest.stat().st_size > 0:
             return True
@@ -110,6 +127,7 @@ def _macos_osascript(dest: Path) -> bool:
         r = subprocess.run(
             ["osascript", "-e", script],
             capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=5,
+            env=_scrubbed_env(),
         )
         if r.returncode == 0 and "fail" not in r.stdout and dest.exists() and dest.stat().st_size > 0:
             return True
@@ -201,6 +219,7 @@ def _run_powershell(exe: str, script: str, timeout: int) -> subprocess.Completed
     return subprocess.run(
         [exe, "-NoProfile", "-NonInteractive", "-Command", script],
         capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout,
+        env=_scrubbed_env(),
     )
 
 
@@ -259,6 +278,7 @@ def _find_powershell() -> str | None:
             r = subprocess.run(
                 [name, "-NoProfile", "-NonInteractive", "-Command", "echo ok"],
                 capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=5,
+                env=_scrubbed_env(),
             )
             if r.returncode == 0 and "ok" in r.stdout:
                 return name
@@ -334,6 +354,7 @@ def _wayland_has_image() -> bool:
         r = subprocess.run(
             ["wl-paste", "--list-types"],
             capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=3,
+            env=_scrubbed_env(),
         )
         return r.returncode == 0 and any(
             t.startswith("image/") for t in r.stdout.splitlines()
@@ -352,6 +373,7 @@ def _wayland_save(dest: Path) -> bool:
         types_r = subprocess.run(
             ["wl-paste", "--list-types"],
             capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=3,
+            env=_scrubbed_env(),
         )
         if types_r.returncode != 0:
             return False
@@ -373,6 +395,7 @@ def _wayland_save(dest: Path) -> bool:
             subprocess.run(
                 ["wl-paste", "--type", mime],
                 stdout=f, stderr=subprocess.DEVNULL, timeout=5, check=True,
+                env=_scrubbed_env(),
             )
 
         if not dest.exists() or dest.stat().st_size == 0:
@@ -417,6 +440,7 @@ def _convert_to_png(path: Path) -> bool:
         r = subprocess.run(
             ["convert", str(tmp), "png:" + str(path)],
             capture_output=True, timeout=5,
+            env=_scrubbed_env(),
         )
         if r.returncode == 0 and path.exists() and path.stat().st_size > 0:
             tmp.unlink(missing_ok=True)
@@ -454,6 +478,7 @@ def _xclip_has_image() -> bool:
         r = subprocess.run(
             ["xclip", "-selection", "clipboard", "-t", "TARGETS", "-o"],
             capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=3,
+            env=_scrubbed_env(),
         )
         return r.returncode == 0 and "image/png" in r.stdout
     except FileNotFoundError:
@@ -470,6 +495,7 @@ def _xclip_save(dest: Path) -> bool:
         targets = subprocess.run(
             ["xclip", "-selection", "clipboard", "-t", "TARGETS", "-o"],
             capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=3,
+            env=_scrubbed_env(),
         )
         if "image/png" not in targets.stdout:
             return False
@@ -485,6 +511,7 @@ def _xclip_save(dest: Path) -> bool:
             subprocess.run(
                 ["xclip", "-selection", "clipboard", "-t", "image/png", "-o"],
                 stdout=f, stderr=subprocess.DEVNULL, timeout=5, check=True,
+                env=_scrubbed_env(),
             )
         if dest.exists() and dest.stat().st_size > 0:
             return True

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -69,6 +69,18 @@ from gateway.platforms.base import (
 
 logger = logging.getLogger(__name__)
 
+def _scrubbed_media_env() -> dict:
+    """Environment for the ImageMagick thumbnailer — never Hermes credentials.
+
+    ``convert`` is an OS media helper on the attachment path; it has no
+    business seeing provider API keys, bot tokens or ``SUDO_PASSWORD`` (same
+    rule as the voice TTS/STT, playback and ffmpeg/ffprobe helpers).
+    """
+    from tools.environments.local import hermes_subprocess_env
+
+    return hermes_subprocess_env(inherit_credentials=False)
+
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -900,6 +912,7 @@ class SimplexAdapter(BasePlatformAdapter):
                         check=True,
                         capture_output=True,
                         timeout=30,
+                        env=_scrubbed_media_env(),
                     )
                 with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp:
                     tmp_path = tmp.name
@@ -916,6 +929,7 @@ class SimplexAdapter(BasePlatformAdapter):
                     check=True,
                     capture_output=True,
                     timeout=30,
+                    env=_scrubbed_media_env(),
                 )
                 with open(tmp_path, "rb") as f:
                     thumb_uri = (

--- a/tests/hermes_cli/test_clipboard_env_scrub.py
+++ b/tests/hermes_cli/test_clipboard_env_scrub.py
@@ -1,0 +1,102 @@
+"""Clipboard + thumbnail OS helpers must not inherit Hermes credentials.
+
+Same rule as the voice TTS/STT scrub (#56332 / #70342), the voice-mode
+playback scrub and the ffmpeg/ffprobe media helpers: a third-party binary
+Hermes shells out to has no business seeing provider API keys, bot tokens or
+``SUDO_PASSWORD``.
+
+``pngpaste`` / ``osascript`` / ``xclip`` / ``wl-paste`` / PowerShell run on the
+image-paste path, and ImageMagick ``convert`` runs on the attachment path.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+_SECRETS = {
+    "OPENAI_API_KEY": "sk-test",
+    "ANTHROPIC_API_KEY": "sk-ant-test",
+    "TELEGRAM_BOT_TOKEN": "secret-token",
+    "SUDO_PASSWORD": "hunter2",
+}
+
+
+def _seed_secrets(monkeypatch):
+    for key, value in _SECRETS.items():
+        monkeypatch.setenv(key, value)
+
+
+def _assert_scrubbed(env, what):
+    assert env is not None, f"{what} inherited the full process environment"
+    for key in _SECRETS:
+        assert key not in env, f"{key} leaked into {what}"
+
+
+def test_macos_clipboard_probe_scrubs_credentials(monkeypatch):
+    """`osascript` evaluates AppleScript — it must not carry credentials."""
+    _seed_secrets(monkeypatch)
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["env"] = kwargs.get("env")
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        return result
+
+    from hermes_cli import clipboard
+
+    with patch.object(clipboard.subprocess, "run", side_effect=fake_run):
+        clipboard._macos_has_image()
+
+    _assert_scrubbed(captured.get("env"), "osascript")
+
+
+def test_pngpaste_scrubs_credentials(tmp_path, monkeypatch):
+    _seed_secrets(monkeypatch)
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["env"] = kwargs.get("env")
+        result = MagicMock()
+        result.returncode = 1
+        return result
+
+    from hermes_cli import clipboard
+
+    with patch.object(clipboard.subprocess, "run", side_effect=fake_run):
+        clipboard._macos_pngpaste(tmp_path / "clip.png")
+
+    _assert_scrubbed(captured.get("env"), "pngpaste")
+
+
+def test_powershell_clipboard_scrubs_credentials(monkeypatch):
+    """The Windows clipboard path shells out to PowerShell."""
+    _seed_secrets(monkeypatch)
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["env"] = kwargs.get("env")
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        return result
+
+    from hermes_cli import clipboard
+
+    with patch.object(clipboard.subprocess, "run", side_effect=fake_run):
+        clipboard._run_powershell("powershell.exe", "echo ok", 5)
+
+    _assert_scrubbed(captured.get("env"), "PowerShell")
+
+
+def test_simplex_thumbnail_convert_scrubs_credentials(monkeypatch):
+    """ImageMagick `convert` on the attachment thumbnail path.
+
+    ``subprocess`` is imported inside the helper, so drive the real spawn
+    through the module-level scrub helper the call sites now pass.
+    """
+    _seed_secrets(monkeypatch)
+
+    from plugins.platforms.simplex import adapter as sx
+
+    _assert_scrubbed(sx._scrubbed_media_env(), "ImageMagick convert")


### PR DESCRIPTION
## What

Next sibling of the rule established by the TTS/STT command scrub (#56332 / #70342), the voice-mode playback scrub and the ffmpeg/ffprobe media helpers (#73879): **a third-party binary Hermes shells out to must not see provider API keys, bot tokens or `SUDO_PASSWORD`.**

Two surfaces still handed the child the full process environment:

| file | helpers | when it runs |
|---|---|---|
| `hermes_cli/clipboard.py` | `pngpaste`, `osascript`, `xclip`, `wl-paste`, PowerShell fallback — 12 spawn sites | every image paste into the CLI/TUI |
| `plugins/platforms/simplex/adapter.py` | ImageMagick `convert` | attachment thumbnailing |

`osascript` is worth calling out: it is an AppleScript interpreter, and it was being started with the full credential environment.

Both run on ordinary user actions, so the exposure is routine rather than exceptional.

## Fix

Route each spawn through `hermes_subprocess_env(inherit_credentials=False)` via a small module-local helper, matching the sibling call sites. No behavioural change otherwise — these helpers never needed anything from the Hermes environment.

Checked and deliberately left alone: `web_server.py`'s `open-terminal` endpoint spawns the **user's own terminal** to run a Hermes setup command — that one is supposed to inherit the environment.

## Tests

`tests/hermes_cli/test_clipboard_env_scrub.py` — seeds `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `TELEGRAM_BOT_TOKEN` / `SUDO_PASSWORD`, captures the spawn kwargs and asserts none reach the child. Mirrors `test_voice_mode_playback_env_scrub.py`.

- All four fail on `main` and pass with this change.
- `pytest tests/ -q -k "clipboard or simplex"` → 146 passed, 0 failed. With the source change stashed the same selection is 142 passed / 4 failed — the delta is exactly the new tests. (`tests/hermes_cli/test_gateway.py` excluded: it fails to collect on this machine — `termios` — independently of this change.)

