### PR TITLE
fix(doctor): detect agent-browser in Hermes-managed node bin (salvage #53205)

### DIFF
--- a/contributors/emails/azureuser@Main.n1l05aasmpie5onxhehb5y5gra.lx.internal.cloudapp.net
+++ b/contributors/emails/azureuser@Main.n1l05aasmpie5onxhehb5y5gra.lx.internal.cloudapp.net
@@ -1,0 +1,1 @@
+AgenticSpark

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1813,10 +1813,22 @@ def run_doctor(args):
         agent_browser_path = PROJECT_ROOT / "node_modules" / "agent-browser"
         agent_browser_ok = False
         _which_ab = shutil.which("agent-browser")
+        # `hermes acp --setup-browser` installs agent-browser into the
+        # Hermes-managed node prefix, which isn't necessarily on PATH. Mirror
+        # dep_ensure._has_hermes_agent_browser() so doctor and dep_ensure agree
+        # on what "installed" means; otherwise doctor false-negatives (#53192).
+        _managed_ab = HERMES_HOME / "node" / "bin" / "agent-browser"
+        _legacy_ab = HERMES_HOME / "node_modules" / ".bin" / "agent-browser"
         if agent_browser_path.exists():
             check_ok("agent-browser (Node.js)", "(browser automation)")
             agent_browser_ok = True
         elif _which_ab and agent_browser_runnable(_which_ab):
+            check_ok("agent-browser", "(browser automation)")
+            agent_browser_ok = True
+        elif _managed_ab.is_file() and agent_browser_runnable(str(_managed_ab)):
+            check_ok("agent-browser", "(browser automation)")
+            agent_browser_ok = True
+        elif _legacy_ab.is_file() and agent_browser_runnable(str(_legacy_ab)):
             check_ok("agent-browser", "(browser automation)")
             agent_browser_ok = True
         elif _which_ab:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1817,18 +1817,32 @@ def run_doctor(args):
         # Hermes-managed node prefix, which isn't necessarily on PATH. Mirror
         # dep_ensure._has_hermes_agent_browser() so doctor and dep_ensure agree
         # on what "installed" means; otherwise doctor false-negatives (#53192).
-        _managed_ab = HERMES_HOME / "node" / "bin" / "agent-browser"
-        _legacy_ab = HERMES_HOME / "node_modules" / ".bin" / "agent-browser"
+        # Resolve with PATHEXT-aware ``shutil.which`` (not a bare is_file())
+        # so Windows picks the executable ``.cmd`` shim — the same class of
+        # miss fixed for _has_agent_browser() in #73932.
+        def _which_in(directory) -> str | None:
+            try:
+                if not directory.is_dir():
+                    return None
+                return shutil.which("agent-browser", path=str(directory))
+            except Exception:
+                return None
+
+        _managed_ab = (
+            _which_in(HERMES_HOME / "node" / "bin")
+            or _which_in(HERMES_HOME / "node")
+        )
+        _legacy_ab = _which_in(HERMES_HOME / "node_modules" / ".bin")
         if agent_browser_path.exists():
             check_ok("agent-browser (Node.js)", "(browser automation)")
             agent_browser_ok = True
         elif _which_ab and agent_browser_runnable(_which_ab):
             check_ok("agent-browser", "(browser automation)")
             agent_browser_ok = True
-        elif _managed_ab.is_file() and agent_browser_runnable(str(_managed_ab)):
+        elif _managed_ab and agent_browser_runnable(_managed_ab):
             check_ok("agent-browser", "(browser automation)")
             agent_browser_ok = True
-        elif _legacy_ab.is_file() and agent_browser_runnable(str(_legacy_ab)):
+        elif _legacy_ab and agent_browser_runnable(_legacy_ab):
             check_ok("agent-browser", "(browser automation)")
             agent_browser_ok = True
         elif _which_ab:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -751,6 +751,7 @@ def _run_doctor_with_managed_agent_browser(monkeypatch, tmp_path, runnable):
     (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
     managed_ab = home / "node" / "bin" / "agent-browser"
     managed_ab.write_text("#!/bin/sh\n", encoding="utf-8")
+    managed_ab.chmod(0o755)
     project = tmp_path / "project"
     project.mkdir(exist_ok=True)  # no node_modules/agent-browser here
 
@@ -759,12 +760,18 @@ def _run_doctor_with_managed_agent_browser(monkeypatch, tmp_path, runnable):
     monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
     monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
     monkeypatch.setattr(doctor_mod, "_DHH", str(home))
-    # node on PATH, agent-browser is NOT on PATH (only in the managed bin)
-    monkeypatch.setattr(
-        doctor_mod.shutil,
-        "which",
-        lambda cmd: "/usr/bin/node" if cmd in {"node", "npm"} else None,
-    )
+
+    # node on PATH, agent-browser is NOT on PATH (only in the managed bin).
+    # The managed-dir rung resolves via shutil.which(..., path=<dir>) so
+    # Windows picks the .cmd shim — mirror that shape here.
+    def _fake_which(cmd, path=None):
+        if path is not None:
+            if cmd == "agent-browser" and str(managed_ab.parent) == str(path):
+                return str(managed_ab)
+            return None
+        return "/usr/bin/node" if cmd in {"node", "npm"} else None
+
+    monkeypatch.setattr(doctor_mod.shutil, "which", _fake_which)
     # agent_browser_runnable is imported into doctor's namespace
     monkeypatch.setattr(
         doctor_mod,

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -742,6 +742,73 @@ def test_run_doctor_termux_does_not_mark_browser_available_without_agent_browser
     assert "npm install -g agent-browser && agent-browser install" in out
 
 
+def _run_doctor_with_managed_agent_browser(monkeypatch, tmp_path, runnable):
+    """Set up run_doctor with node present, agent-browser only in the
+    Hermes-managed node bin (~/.hermes/node/bin), not on PATH or in
+    PROJECT_ROOT/node_modules. Returns the captured stdout."""
+    home = tmp_path / ".hermes"
+    (home / "node" / "bin").mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    managed_ab = home / "node" / "bin" / "agent-browser"
+    managed_ab.write_text("#!/bin/sh\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)  # no node_modules/agent-browser here
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.delenv("PREFIX", raising=False)
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    # node on PATH, agent-browser is NOT on PATH (only in the managed bin)
+    monkeypatch.setattr(
+        doctor_mod.shutil,
+        "which",
+        lambda cmd: "/usr/bin/node" if cmd in {"node", "npm"} else None,
+    )
+    # agent_browser_runnable is imported into doctor's namespace
+    monkeypatch.setattr(
+        doctor_mod,
+        "agent_browser_runnable",
+        lambda path: runnable and str(path) == str(managed_ab),
+    )
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    return buf.getvalue()
+
+
+def test_run_doctor_detects_agent_browser_in_managed_node_bin(monkeypatch, tmp_path):
+    # Regression for #53192: `hermes acp --setup-browser` installs into
+    # ~/.hermes/node/bin/agent-browser, which isn't on PATH; doctor must still
+    # report it installed instead of "agent-browser not installed".
+    out = _run_doctor_with_managed_agent_browser(monkeypatch, tmp_path, runnable=True)
+    assert "agent-browser not installed" not in out
+    assert "agent-browser found but not runnable" not in out
+    assert "✓ agent-browser" in out
+
+
+def test_run_doctor_managed_agent_browser_not_runnable_still_warns(monkeypatch, tmp_path):
+    # A present-but-unrunnable managed binary must fall through to the existing
+    # warning, not be reported as OK.
+    out = _run_doctor_with_managed_agent_browser(monkeypatch, tmp_path, runnable=False)
+    assert "agent-browser not installed" in out
+
+
 def test_run_doctor_kimi_cn_env_is_detected_and_probe_is_null_safe(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
`hermes doctor` now detects agent-browser installed in the Hermes-managed Node prefix (`~/.hermes/node[/bin]`) and the legacy `node_modules/.bin` location — previously it reported "agent-browser not installed" after a successful `hermes acp --setup-browser` install because it only checked PATH and the repo `node_modules`.

Salvage of #53205 by @AgenticSpark (cherry-picked, authorship preserved), widened with the #73932 class fix: the managed/legacy dirs are resolved via PATHEXT-aware `shutil.which(..., path=dir)` instead of bare `is_file()` probes, so Windows picks the executable `.cmd` shim rather than the extensionless POSIX script, and the Windows managed layout (binary directly in `node/`) is covered.

## Changes
- `hermes_cli/doctor.py`: two new resolution rungs (managed Node dir, legacy `.bin`) between the PATH hit and the dangling-symlink warning, resolved via `shutil.which` per-directory.
- `tests/hermes_cli/test_doctor.py`: contributor's regression tests, updated to the `which(path=...)` resolution shape; not-runnable managed binary still warns.
- `contributors/emails/`: mapping for @AgenticSpark's commit email.

## Validation
| | Before | After |
|---|---|---|
| agent-browser only in `~/.hermes/node/bin` | "agent-browser not installed" | `✓ agent-browser (browser automation)` |
| Managed binary present but not runnable | — | still warns (no false OK) |
| Windows `.cmd` shim in managed dir | missed by `is_file("agent-browser")` | resolved via PATHEXT |

`test_doctor.py`: 81/81 green via `scripts/run_tests.sh`. Sabotage-verified: the new regression test fails against main's `doctor.py` and passes with the fix.

## Infographic

![hermes doctor managed agent-browser detection](https://v3b.fal.media/files/b/0aa42a32/zuHvjJfo3tHV4cJfm6PPU_mOufSww3.png)
