### PR TITLE
fix(buzz): cap _user_names cache to prevent unbounded growth

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -411,6 +411,7 @@ class BuzzAdapter(BasePlatformAdapter):
         # classification (see _may_reclassify_as_dm).
         self._channel_meta: Dict[str, dict] = {}
         self._user_names: Dict[str, str] = {}
+        self._USER_NAMES_MAX = 5000
         self._poll_count = 0
 
     @property
@@ -1158,7 +1159,10 @@ class BuzzAdapter(BasePlatformAdapter):
         Failures are cached too (negative caching): without it, every message
         from a profile-less pubkey re-runs ``users get`` each poll sweep,
         which amplifies badly when several adapter instances poll in one
-        process.
+        process. The cache is bounded (``_USER_NAMES_MAX``, mirroring the
+        Slack adapter's ``_user_name_cache`` cap) so a long-running gateway
+        on a busy relay doesn't grow this dict for every unique sender ever
+        seen — oldest half is evicted on overflow.
         """
         cached = self._user_names.get(pubkey)
         if cached is not None:
@@ -1172,6 +1176,10 @@ class BuzzAdapter(BasePlatformAdapter):
         if not name:
             name = (hex_to_npub(pubkey) or pubkey)[:16]
         self._user_names[pubkey] = name
+        if len(self._user_names) > self._USER_NAMES_MAX:
+            excess = len(self._user_names) - self._USER_NAMES_MAX // 2
+            for old_key in list(self._user_names)[:excess]:
+                del self._user_names[old_key]
         return name
 
     @staticmethod

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -197,6 +197,44 @@ class TestCliErrorContract:
         assert "exit code 3" in _cli_error_message("", 3)
 
 
+# ── Display-name cache bound (#73961) ──────────────────────────────────────
+
+
+class TestUserNamesCacheCap:
+    """``_user_names`` must not grow unbounded on a long-running gateway
+    (mirrors the Slack ``_user_name_cache`` cap: 91693f9d4 / b0358cf3c)."""
+
+    def test_cache_cap_holds_under_churn(self):
+        adapter = _make_adapter()
+        adapter._USER_NAMES_MAX = 10
+        # Simulate the post-resolution write + trim path directly.
+        for i in range(50):
+            pubkey = f"{i:064x}"
+            adapter._user_names[pubkey] = f"user{i}"
+            if len(adapter._user_names) > adapter._USER_NAMES_MAX:
+                excess = len(adapter._user_names) - adapter._USER_NAMES_MAX // 2
+                for old_key in list(adapter._user_names)[:excess]:
+                    del adapter._user_names[old_key]
+        assert len(adapter._user_names) <= adapter._USER_NAMES_MAX
+        # Newest entry survives; oldest was evicted.
+        assert f"{49:064x}" in adapter._user_names
+        assert f"{0:064x}" not in adapter._user_names
+
+    @pytest.mark.asyncio
+    async def test_cache_bounded_through_resolve(self):
+        """End-to-end: _resolve_user_name enforces the cap."""
+        adapter = _make_adapter()
+        adapter._USER_NAMES_MAX = 4
+        cli = _ScriptedCli()
+        adapter._run_cli = cli
+        for i in range(10):
+            pubkey = f"{i:064x}"
+            cli.script("users", "get", [{"display_name": f"name-{i}"}])
+            await adapter._resolve_user_name(pubkey)
+        assert len(adapter._user_names) <= adapter._USER_NAMES_MAX
+        assert f"{9:064x}" in adapter._user_names
+
+
 # ── Seeding / high-water mark / de-dupe ───────────────────────────────────
 
 


### PR DESCRIPTION
Fixes #73961.

## Bug

`BuzzAdapter._user_names` (a plain `Dict[str, str]`) is populated by `_resolve_user_name()` with no size cap and no eviction. Every unique pubkey that ever sends a message adds a permanent entry for the lifetime of the gateway process. On a long-running gateway watching a busy community relay, this grows unbounded — memory grows with total unique senders ever seen, not with active membership.

## Precedent

The Slack adapter had the identical shape of bug in `_user_name_cache`, fixed and merged: commits `91693f9d4` ("fix(slack): cap `_user_name_cache` to prevent unbounded growth") and `b0358cf3c` ("fix(slack): unify DM-resolution caches and bound wave-2 caches"). This PR applies the exact same fix shape to Buzz's equivalent cache, which predates that Slack hardening pass.

## Fix

Add `self._USER_NAMES_MAX = 5000` in `__init__` and evict the oldest half of `self._user_names` on overflow after each write in `_resolve_user_name()` — identical mechanics to the Slack fix.

## Tests

Added `TestUserNamesCacheCap` (2 cases) to `tests/gateway/test_buzz_adapter.py`, mirroring the existing Slack cache-cap tests (`test_user_name_cache_cap_holds_under_churn` / `test_user_name_cache_bounded_through_resolve` in `tests/gateway/test_slack.py`):

- `test_cache_cap_holds_under_churn` — simulates 50 writes with `_USER_NAMES_MAX = 10`; cache stays bounded, newest entry survives, oldest evicted
- `test_cache_bounded_through_resolve` — end-to-end through `_resolve_user_name()` with `_USER_NAMES_MAX = 4`; resolves 10 distinct pubkeys, asserts the cache never exceeds the cap

Verified RED on the unpatched adapter: `test_cache_bounded_through_resolve` fails on current `main` (`assert 10 <= 4` — the cache grows past the intended cap because there's no eviction code to enforce it). `test_cache_cap_holds_under_churn` was written test-first as a direct port of the eviction *algorithm* (not the target code), so it necessarily passes against any correct implementation of that snippet — the end-to-end test is what exercises the actual bug.

All 77 tests across `tests/gateway/test_buzz_adapter.py` + `tests/gateway/test_buzz_websocket.py` pass with the fix, no regressions.

```
77 passed in 5.56s
```
