### PR TITLE
fix(tts): keep Gemini API keys out of request URLs

### DIFF
--- a/tests/tools/test_tts_dotenv_fallback.py
+++ b/tests/tools/test_tts_dotenv_fallback.py
@@ -88,6 +88,7 @@ class TestDotenvFallbackPerProvider:
 
         def fake_post(url, **kwargs):
             captured["params"] = kwargs.get("params", {})
+            captured["headers"] = kwargs.get("headers", {})
             response = MagicMock()
             response.status_code = 200
             response.json.return_value = {
@@ -125,7 +126,8 @@ class TestDotenvFallbackPerProvider:
             tts_tool._generate_gemini_tts("hi", str(tmp_path / "out.wav"), {})
 
         assert "GEMINI_API_KEY" in seen_lookups
-        assert captured["params"]["key"] == "gemini-dotenv-key"
+        assert captured["headers"]["x-goog-api-key"] == "gemini-dotenv-key"
+        assert "key" not in captured["params"]
 
 
 class TestRegressionGuard:

--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -95,9 +95,26 @@ class TestGenerateGeminiTts:
         with patch("requests.post", return_value=mock_gemini_response) as mock_post:
             _generate_gemini_tts("Hi", output_path, {})
 
-        # Confirm it used the GOOGLE_API_KEY as the query parameter
+        # Confirm it used the GOOGLE_API_KEY, sent via the auth header
         _, kwargs = mock_post.call_args
-        assert kwargs["params"]["key"] == "from-google-env"
+        assert kwargs["headers"]["x-goog-api-key"] == "from-google-env"
+
+    def test_api_key_rides_in_header_not_url(self, tmp_path, monkeypatch, mock_gemini_response):
+        """The key must not be a query parameter: ``requests`` echoes the
+        full prepared URL (query string included) into HTTPError messages,
+        so a ``key=`` param would land in logs on any 4xx/5xx."""
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        output_path = str(tmp_path / "test.wav")
+
+        with patch("requests.post", return_value=mock_gemini_response) as mock_post:
+            _generate_gemini_tts("Hi", output_path, {})
+
+        _, kwargs = mock_post.call_args
+        assert kwargs["headers"]["x-goog-api-key"] == "test-key"
+        assert "key" not in (kwargs.get("params") or {})
+        assert "test-key" not in mock_post.call_args[0][0]
 
     def test_wav_output_fast_path(self, tmp_path, monkeypatch, mock_gemini_response, fake_pcm_bytes):
         from tools.tts_tool import _generate_gemini_tts

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -205,6 +205,62 @@ def test_xai_available_uses_oauth_credential_resolver(monkeypatch):
 # ── Gemini SSE parsing ────────────────────────────────────────────────────
 
 
+def test_gemini_streamer_decodes_sse_pcm_chunks(monkeypatch):
+    import base64
+    import json as _json
+    import sys
+    import types
+
+    pcm1, pcm2 = b"\x01\x00" * 40, b"\x02\x00" * 40
+
+    def _event(pcm):
+        return "data: " + _json.dumps({
+            "candidates": [{"content": {"parts": [
+                {"inlineData": {"data": base64.b64encode(pcm).decode()}}
+            ]}}]
+        })
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def raise_for_status(self):
+            pass
+
+        def iter_lines(self, decode_unicode=True):
+            yield _event(pcm1)
+            yield ""  # SSE separator
+            yield ": heartbeat"  # comment line
+            yield _event(pcm2)
+
+    captured = {}
+
+    def _post(url, **kwargs):
+        captured["url"] = url
+        captured["params"] = kwargs.get("params")
+        captured["headers"] = kwargs.get("headers")
+        captured["stream"] = kwargs.get("stream")
+        return _Resp()
+
+    fake_requests = types.ModuleType("requests")
+    fake_requests.post = _post
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+    monkeypatch.setattr(ts, "_resolve_key", lambda env, pid: "g-key")
+
+    streamer = ts.GeminiStreamer({}, {"voice": "Kore"})
+    assert list(streamer.stream("Hello there.")) == [pcm1, pcm2]
+    assert captured["params"]["alt"] == "sse"
+    # The key must ride in the header: ``requests`` echoes the full URL
+    # (query string included) into HTTPError messages, so a ``key=`` param
+    # would land in logs on any 4xx/5xx.
+    assert "key" not in captured["params"]
+    assert captured["headers"]["x-goog-api-key"] == "g-key"
+    assert captured["stream"] is True, "Gemini SSE must use a bounded streamed body"
+
+
 # ── xAI WebSocket bridge ─────────────────────────────────────────────────
 
 

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -365,12 +365,16 @@ class GeminiStreamer(StreamingTTSProvider):
         }
         # ``?alt=sse`` flips the response from a single JSON blob to an SSE
         # feed of base64 PCM chunks — the whole point of this provider.
+        # The key rides in the ``x-goog-api-key`` header, not the query
+        # string: ``requests`` puts the full URL into HTTPError messages,
+        # so a ``key=`` param would land in logs on any 4xx/5xx.
         url = f"{base_url}/models/{model}:streamGenerateContent"
 
         def _sse_chunks() -> Iterator[bytes]:
             with requests.post(
                 url,
-                params={"alt": "sse", "key": api_key},
+                params={"alt": "sse"},
+                headers={"x-goog-api-key": api_key},
                 json=payload,
                 timeout=60,
                 stream=True,

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2312,6 +2312,11 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     }
 
     headers = {"Content-Type": "application/json"}
+    # The key rides in the ``x-goog-api-key`` header, not the query string:
+    # ``requests`` puts the full URL into HTTPError messages, so a ``key=``
+    # param would land in logs on any 4xx/5xx (and the caller logs unexpected
+    # exception text).
+    headers["x-goog-api-key"] = api_key
     if urlparse(base_url).hostname == "generativelanguage.googleapis.com":
         try:
             import hermes_cli as _hermes_cli
@@ -2327,7 +2332,6 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     endpoint = f"{base_url}/models/{model}:generateContent"
     response = requests.post(
         endpoint,
-        params={"key": api_key},
         headers=headers,
         json=payload,
         timeout=60,


### PR DESCRIPTION
Send Gemini TTS credentials in x-goog-api-key headers for both synchronous and streaming requests. Keep only the non-secret alt=sse parameter in streaming URLs, preserving chunk decoding and response limits.

Fixes #73962

Validation: All 46 Gemini, dotenv-fallback and streaming TTS tests passed through scripts/run_tests.sh. Coverage verifies both credential headers and SSE PCM decoding without API keys in URL parameters.

Updated on the refactored main at 1ab32b212b, with the repair folded into one commit.
