### PR TITLE
feat(tts): add configurable pronunciation substitutions

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -737,7 +737,6 @@ export const SECTIONS: DesktopConfigSection[] = [
       'tts.piper.voice',
       'tts.deepinfra.model',
       'tts.deepinfra.voice',
-      'tts.pronunciation.substitutions',
       'stt.local.model',
       'stt.local.language',
       'stt.openai.model',

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -737,6 +737,7 @@ export const SECTIONS: DesktopConfigSection[] = [
       'tts.piper.voice',
       'tts.deepinfra.model',
       'tts.deepinfra.voice',
+      'tts.pronunciation.substitutions',
       'stt.local.model',
       'stt.local.language',
       'stt.openai.model',

--- a/cli.py
+++ b/cli.py
@@ -12160,27 +12160,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             from tools.tts_tool import text_to_speech_tool
             from tools.voice_mode import play_audio_file
 
-            # Strip markdown and non-speech content for cleaner TTS via the
-            # shared cleaner (tools/tts_text_normalize): markdown, emoji,
-            # <think> blocks, verifier footer, units, newline flattening.
-            try:
-                from tools.tts_text_normalize import prepare_spoken_text
-                tts_text = prepare_spoken_text(text, max_chars=4000)
-            except Exception:
-                # Legacy fallback pipeline — keep voice replies best-effort.
-                tts_text = text[:4000] if len(text) > 4000 else text
-                tts_text = re.sub(r'```[\s\S]*?```', ' ', tts_text)   # fenced code blocks
-                tts_text = re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', tts_text)  # [text](url) -> text
-                tts_text = re.sub(r'https?://\S+', '', tts_text)      # URLs
-                tts_text = re.sub(r'\*\*(.+?)\*\*', r'\1', tts_text)  # bold
-                tts_text = re.sub(r'\*(.+?)\*', r'\1', tts_text)      # italic
-                tts_text = re.sub(r'`(.+?)`', r'\1', tts_text)        # inline code
-                tts_text = re.sub(r'^#+\s*', '', tts_text, flags=re.MULTILINE)  # headers
-                tts_text = re.sub(r'^\s*[-*]\s+', '', tts_text, flags=re.MULTILINE)  # list items
-                tts_text = re.sub(r'---+', '', tts_text)              # horizontal rules
-                tts_text = re.sub(r'\n{3,}', '\n\n', tts_text)        # excessive newlines
-                tts_text = tts_text.strip()
-            if not tts_text:
+            # Pass the complete raw response to the central TTS pipeline so a
+            # protected block crossing character 4,000 is removed before the
+            # historical final-spoken-text cap is applied.
+            tts_text = text
+            if not tts_text.strip():
                 return
 
             # Use MP3 output for CLI playback (afplay doesn't handle OGG well).
@@ -12191,7 +12175,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 f"tts_{time.strftime('%Y%m%d_%H%M%S')}.mp3",
             )
 
-            raw_result = text_to_speech_tool(text=tts_text, output_path=mp3_path)
+            raw_result = text_to_speech_tool(
+                text=tts_text, output_path=mp3_path, _max_chars=4000
+            )
             try:
                 tts_result = json.loads(raw_result) if isinstance(raw_result, str) else {}
             except Exception:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5946,9 +5946,10 @@ class BasePlatformAdapter(ABC):
                         from tools.tts_tool import text_to_speech_tool, check_tts_requirements
                         if check_tts_requirements():
                             import json as _json
-                            speech_text = self.prepare_tts_text(text_content)
-                            if not speech_text:
-                                raise ValueError("Empty text after markdown cleanup")
+                            # Preserve the complete raw response through central
+                            # cleanup so protected blocks crossing character 4,000
+                            # cannot leak. The cap applies to final spoken text.
+                            speech_text = text_content
                             # Pass an explicit platform-aware output path: the
                             # HERMES_SESSION_PLATFORM contextvar the tool would
                             # otherwise consult is already cleared by the time
@@ -5962,6 +5963,7 @@ class BasePlatformAdapter(ABC):
                                 text_to_speech_tool,
                                 text=speech_text,
                                 output_path=_tts_requested_path,
+                                _max_chars=4000,
                             )
                             tts_data = _json.loads(tts_result_str)
                             if tts_data.get("success", True):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18287,10 +18287,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         audio_path = None
         actual_path = None
         try:
-            from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
+            from tools.tts_tool import text_to_speech_tool
 
-            tts_text = _strip_markdown_for_tts(text[:4000])
-            if not tts_text:
+            # Keep the complete raw response intact through central cleanup so
+            # protected blocks crossing character 4,000 cannot leak. The
+            # historical cap applies to final provider-bound speech.
+            tts_text = text
+            if not tts_text or not tts_text.strip():
                 return
 
             # Platform-aware output path: platforms whose native voice
@@ -18301,7 +18304,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             audio_path = build_auto_tts_output_path(event.source.platform)
 
             result_json = await asyncio.to_thread(
-                text_to_speech_tool, text=tts_text, output_path=audio_path
+                text_to_speech_tool,
+                text=tts_text,
+                output_path=audio_path,
+                _max_chars=4000,
             )
             try:
                 result = json.loads(result_json)

--- a/gateway/streaming_tts_consumer.py
+++ b/gateway/streaming_tts_consumer.py
@@ -66,6 +66,7 @@ class StreamingTTSConsumer:
         audio_format: Optional[AudioFormat] = None,
     ) -> None:
         from tools.tts_streaming import SentenceChunker, resolve_streaming_provider
+        from tools.tts_tool import _get_provider, _resolve_max_text_length
 
         self._adapter = adapter
         self._chat_id = chat_id
@@ -79,7 +80,26 @@ class StreamingTTSConsumer:
         # Resolve the streaming provider once. If unavailable, the consumer is
         # inactive and the gateway falls back to whole-file TTS.
         self._streamer = resolve_streaming_provider(tts_config)
-        self._chunker = SentenceChunker()
+        stream_provider = (
+            getattr(self._streamer, "provider_name", "")
+            or _get_provider(tts_config)
+        )
+        if self._streamer is not None:
+            stream_model_id = getattr(self._streamer, "model_id", None)
+            self._stream_max_len = (
+                _resolve_max_text_length(
+                    stream_provider,
+                    tts_config,
+                    model_id=stream_model_id,
+                )
+                if stream_model_id
+                else _resolve_max_text_length(stream_provider, tts_config)
+            )
+        else:
+            self._stream_max_len = 0
+        self._chunker = SentenceChunker(
+            pronunciation_substitutions=self._pronunciation_substitutions,
+        )
 
         if self._streamer is not None:
             self._audio_format = AudioFormat(
@@ -104,9 +124,6 @@ class StreamingTTSConsumer:
         self._suppress_whole_file = False
         self._task: Optional[asyncio.Task] = None
         self._lock = threading.Lock()
-
-        # Pre-allocate the strip-markdown helper lazily to avoid import cycles.
-        self._strip_markdown = None
 
     # ------------------------------------------------------------------
     # Public properties
@@ -322,17 +339,20 @@ class StreamingTTSConsumer:
         if self._handle is None or self._handle.aborted:
             return
 
-        # Apply only the pronunciation rewrite here, before the existing
-        # per-clause cleanup.  Running the full spoken-text pipeline a second
-        # time would duplicate normalization and could alter chunk boundaries.
-        from tools.tts_text_normalize import apply_pronunciation_substitutions
-        clause = apply_pronunciation_substitutions(
+        # The chunker removed protected blocks and kept configured phrases
+        # intact across sentence boundaries. Apply pronunciation once, then
+        # finish shared Markdown/symbol cleanup.
+        from tools.tts_text_normalize import prepare_spoken_text
+        cleaned = prepare_spoken_text(
             clause,
-            self._pronunciation_substitutions,
+            max_chars=None,
+            pronunciation_substitutions=self._pronunciation_substitutions,
         )
-        cleaned = self._strip_markdown_for_tts(clause)
         if not cleaned or not cleaned.strip():
             return
+
+        if self._stream_max_len and len(cleaned) > self._stream_max_len:
+            cleaned = cleaned[:self._stream_max_len]
 
         if self._streamer is None:
             return
@@ -365,16 +385,6 @@ class StreamingTTSConsumer:
             return True, next(iterator)
         except StopIteration:
             return False, None
-
-    def _strip_markdown_for_tts(self, text: str) -> str:
-        """Lazy-import and apply the TTS markdown stripper."""
-        if self._strip_markdown is None:
-            try:
-                from tools.tts_tool import _strip_markdown_for_tts as _strip
-                self._strip_markdown = _strip
-            except ImportError:
-                self._strip_markdown = lambda t: t  # noqa: E731
-        return self._strip_markdown(text).strip()
 
     async def _safe_abort(self, reason: str) -> None:
         """Abort the adapter stream, swallowing errors (idempotent)."""

--- a/gateway/streaming_tts_consumer.py
+++ b/gateway/streaming_tts_consumer.py
@@ -73,6 +73,9 @@ class StreamingTTSConsumer:
         self._loop = loop
         self._metadata = metadata
 
+        from tools.tts_text_normalize import get_pronunciation_substitutions
+        self._pronunciation_substitutions = get_pronunciation_substitutions(tts_config)
+
         # Resolve the streaming provider once. If unavailable, the consumer is
         # inactive and the gateway falls back to whole-file TTS.
         self._streamer = resolve_streaming_provider(tts_config)
@@ -319,6 +322,14 @@ class StreamingTTSConsumer:
         if self._handle is None or self._handle.aborted:
             return
 
+        # Apply only the pronunciation rewrite here, before the existing
+        # per-clause cleanup.  Running the full spoken-text pipeline a second
+        # time would duplicate normalization and could alter chunk boundaries.
+        from tools.tts_text_normalize import apply_pronunciation_substitutions
+        clause = apply_pronunciation_substitutions(
+            clause,
+            self._pronunciation_substitutions,
+        )
         cleaned = self._strip_markdown_for_tts(clause)
         if not cleaned or not cleaned.strip():
             return

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1403,6 +1403,13 @@ DEFAULT_CONFIG = {
             "voice": "default",
             # "base_url": "",  # override DEEPINFRA_BASE_URL for TTS only
         },
+        "pronunciation": {
+            # Map of term -> phonetic replacement. Applied to TTS text before
+            # sending to any provider. Case-insensitive literal match when the
+            # term is not adjacent to a word character.
+            # Example: {"Tahlia": "Tarlia"}
+            "substitutions": {},
+        },
     },
 
     "stt": {

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -974,26 +974,10 @@ def speak_text(text: str, stop_event: Optional[threading.Event] = None) -> None:
         except Exception as e:
             _debug(f"speak_text: streaming dispatch unavailable ({e}); using sync path")
 
-        # Shared cleaner (tools/tts_text_normalize): markdown, emoji,
-        # <think> blocks, verifier footer, units, newline flattening.
-        try:
-            from tools.tts_text_normalize import prepare_spoken_text
-            tts_text = prepare_spoken_text(text, max_chars=4000)
-        except Exception:
-            # Legacy fallback pipeline — keep speak_text best-effort.
-            tts_text = text[:4000] if len(text) > 4000 else text
-            tts_text = re.sub(r'```[\s\S]*?```', ' ', tts_text)             # fenced code blocks
-            tts_text = re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', tts_text)    # [text](url) → text
-            tts_text = re.sub(r'https?://\S+', '', tts_text)                # bare URLs
-            tts_text = re.sub(r'\*\*(.+?)\*\*', r'\1', tts_text)            # bold
-            tts_text = re.sub(r'\*(.+?)\*', r'\1', tts_text)                # italic
-            tts_text = re.sub(r'`(.+?)`', r'\1', tts_text)                  # inline code
-            tts_text = re.sub(r'^#+\s*', '', tts_text, flags=re.MULTILINE)  # headers
-            tts_text = re.sub(r'^\s*[-*]\s+', '', tts_text, flags=re.MULTILINE)  # list bullets
-            tts_text = re.sub(r'---+', '', tts_text)                        # horizontal rules
-            tts_text = re.sub(r'\n{3,}', '\n\n', tts_text)                  # excess newlines
-            tts_text = tts_text.strip()
-        if not tts_text:
+        # Pass the complete raw response so protected blocks are removed before
+        # the historical 4,000-character final-spoken-text cap is applied.
+        tts_text = text
+        if not tts_text.strip():
             return
 
         # MP3 output path, pre-chosen so we can play the MP3 directly even
@@ -1007,7 +991,9 @@ def speak_text(text: str, stop_event: Optional[threading.Event] = None) -> None:
         )
 
         _debug(f"speak_text: synthesizing {len(tts_text)} chars -> {mp3_path}")
-        raw_result = text_to_speech_tool(text=tts_text, output_path=mp3_path)
+        raw_result = text_to_speech_tool(
+            text=tts_text, output_path=mp3_path, _max_chars=4000
+        )
         try:
             tts_result = json.loads(raw_result) if isinstance(raw_result, str) else {}
         except Exception:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4522,20 +4522,35 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
     loop = asyncio.get_running_loop()
 
     def _resolve():
+        from tools.tts_text_normalize import get_pronunciation_substitutions
         from tools.tts_streaming import resolve_streaming_provider
         from tools.tts_tool import _get_provider, _load_tts_config, _resolve_max_text_length
 
         with _config_profile_scope(profile):
             cfg = _load_tts_config()
             streamer = resolve_streaming_provider(cfg)
-            cap = _resolve_max_text_length(_get_provider(cfg), cfg) if streamer else 0
-        return streamer, cap
+            stream_provider = (
+                getattr(streamer, "provider_name", "") or _get_provider(cfg)
+                if streamer
+                else ""
+            )
+            stream_model_id = getattr(streamer, "model_id", None) if streamer else None
+            if streamer and stream_model_id:
+                cap = _resolve_max_text_length(
+                    stream_provider,
+                    cfg,
+                    model_id=stream_model_id,
+                )
+            else:
+                cap = _resolve_max_text_length(stream_provider, cfg) if streamer else 0
+            pronunciation = get_pronunciation_substitutions(cfg)
+        return streamer, cap, pronunciation
 
     try:
-        streamer, cap = await loop.run_in_executor(None, _resolve)
+        streamer, cap, pronunciation = await loop.run_in_executor(None, _resolve)
     except Exception:
         _log.exception("speak-stream provider resolution failed")
-        streamer, cap = None, 0
+        streamer, cap, pronunciation = None, 0, {}
     if streamer is None:
         with contextlib.suppress(Exception):
             await ws.send_json({"type": "fallback"})
@@ -4552,9 +4567,11 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
 
     def _produce():
         from tools.tts_streaming import SentenceChunker
-        from tools.tts_tool import _strip_markdown_for_tts
+        from tools.tts_text_normalize import prepare_spoken_text
 
-        chunker = SentenceChunker()
+        chunker = SentenceChunker(
+            pronunciation_substitutions=pronunciation,
+        )
 
         # The session stays open for a whole agent turn, and the client only
         # sends `done` when the turn ends. During tool execution no text
@@ -4575,10 +4592,14 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
                 except queue.Empty:
                     idle_polls += 1
                     buffered = chunker.buf.strip()
-                    if not buffered or ("<think" in chunker.buf and "</think>" not in chunker.buf):
+                    if (
+                        not buffered
+                        or chunker.holding_protected_text
+                        or chunker.holding_pronunciation_lookahead
+                    ):
                         continue
                     if buffered.endswith((".", "!", "?", "…", ":")) or idle_polls >= idle_polls_before_force_flush:
-                        yield from chunker.flush()
+                        yield from chunker.flush_for_idle()
                     continue
                 idle_polls = 0
                 if delta is None:
@@ -4588,7 +4609,11 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
 
         try:
             for sentence in _sentences():
-                cleaned = _strip_markdown_for_tts(sentence)
+                cleaned = prepare_spoken_text(
+                    sentence,
+                    max_chars=None,
+                    pronunciation_substitutions=pronunciation,
+                )
                 if not cleaned:
                     continue
                 for piece in _split_text_for_speak_stream(cleaned, cap):

--- a/tests/gateway/test_auto_voice_reply_format.py
+++ b/tests/gateway/test_auto_voice_reply_format.py
@@ -33,9 +33,13 @@ class TestAutoVoiceReplyFormat:
         runner.adapters[platform] = adapter
         event = _make_event(platform)
         requested_paths = []
+        requested_texts = []
+        requested_caps = []
 
-        def fake_tts(*, text, output_path):
+        def fake_tts(*, text, output_path, _max_chars=None):
+            requested_texts.append(text)
             requested_paths.append(output_path)
+            requested_caps.append(_max_chars)
             Path(output_path).parent.mkdir(parents=True, exist_ok=True)
             Path(output_path).write_bytes(b"fake ogg opus")
             return json.dumps({
@@ -45,9 +49,12 @@ class TestAutoVoiceReplyFormat:
                 "voice_compatible": True,
             })
 
+        raw_reply = "Our **R&D** team shipped." + ("x" * 5000)
         with patch("tools.tts_tool.text_to_speech_tool", side_effect=fake_tts):
-            await runner._send_voice_reply(event, "hello from auto tts")
+            await runner._send_voice_reply(event, raw_reply)
 
+        assert requested_texts == [raw_reply]
+        assert requested_caps == [4000]
         assert requested_paths and requested_paths[0].endswith(".ogg")
         adapter.send_voice.assert_awaited_once()
         assert adapter.send_voice.await_args.kwargs["audio_path"].endswith(".ogg")

--- a/tests/gateway/test_base_auto_tts_output_format.py
+++ b/tests/gateway/test_base_auto_tts_output_format.py
@@ -94,13 +94,15 @@ async def _run_auto_tts(adapter: _DummyAdapter, platform: Platform):
     adapter._keep_typing = _hold_typing()
     adapter._should_auto_tts_for_chat = lambda _chat_id: True
     adapter.play_tts = AsyncMock(return_value=SendResult(success=True, message_id="tts-1"))
-    long_reply = "x" * 2000  # avoid the telegram caption-collapse path
+    long_reply = "Our **R&D** team shipped." + ("x" * 5000)
     adapter.set_message_handler(lambda _event: asyncio.sleep(0, result=long_reply))
     event = _make_voice_event(platform)
     requested = []
 
-    def fake_tts(*, text, output_path=None):
-        requested.append(output_path)
+    def fake_tts(*, text, output_path=None, _max_chars=None):
+        requested.append(
+            {"text": text, "output_path": output_path, "max_chars": _max_chars}
+        )
         from pathlib import Path
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
         Path(output_path).write_bytes(b"fake audio")
@@ -116,6 +118,21 @@ async def _run_auto_tts(adapter: _DummyAdapter, platform: Platform):
 
 
 @pytest.mark.asyncio
+async def test_base_auto_tts_preserves_raw_symbols_and_4000_character_cap():
+    requested, adapter = await _run_auto_tts(
+        _DummyAdapter(Platform.TELEGRAM),
+        Platform.TELEGRAM,
+    )
+
+    assert len(requested) == 1
+    expected = "Our **R&D** team shipped." + ("x" * 5000)
+    assert requested[0]["text"] == expected
+    assert requested[0]["max_chars"] == 4000
+    assert requested[0]["output_path"].endswith(".ogg")
+    adapter.play_tts.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_base_auto_tts_skips_playback_when_tool_reports_failure():
     """A success=False tool result must not deliver a stale/partial file."""
     adapter = _DummyAdapter(Platform.TELEGRAM)
@@ -125,7 +142,7 @@ async def test_base_auto_tts_skips_playback_when_tool_reports_failure():
     adapter.set_message_handler(lambda _event: asyncio.sleep(0, result="reply text"))
     event = _make_voice_event(Platform.TELEGRAM)
 
-    def fake_tts(*, text, output_path=None):
+    def fake_tts(*, text, output_path=None, _max_chars=None):
         from pathlib import Path
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
         Path(output_path).write_bytes(b"partial")

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -3,7 +3,7 @@
 import asyncio
 import json
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -170,7 +170,7 @@ class TestTelegramAutoTtsCaptionDelivery:
         # below it. Caption eligibility must follow the ORIGINAL reply, so the
         # full formatted text is still delivered as its own message instead of
         # being swallowed into a lossy caption.
-        long_reply = "\n".join(
+        long_reply = "Our **R&D** team shipped.\n" + "\n".join(
             f"- **item {i}** [details](https://example.com/some/very/long/path/{i:04d})"
             for i in range(20)
         )
@@ -182,12 +182,16 @@ class TestTelegramAutoTtsCaptionDelivery:
         tts_path.write_text("audio", encoding="utf-8")
         event = self._make_voice_event()
 
+        tts_mock = MagicMock(
+            return_value=json.dumps({"file_path": str(tts_path)})
+        )
         with patch("tools.tts_tool.check_tts_requirements", return_value=True), patch(
             "tools.tts_tool.text_to_speech_tool",
-            return_value=json.dumps({"file_path": str(tts_path)}),
+            tts_mock,
         ):
             await adapter._process_message_background(event, build_session_key(event.source))
 
+        assert tts_mock.call_args.kwargs["text"] == long_reply
         adapter.play_tts.assert_awaited_once()
         assert adapter.play_tts.await_args.kwargs["caption"] is None
         assert adapter.sent == [

--- a/tests/gateway/test_streaming_tts_consumer.py
+++ b/tests/gateway/test_streaming_tts_consumer.py
@@ -351,6 +351,32 @@ class TestStreamerFormatAndLooping:
             tts_streaming.resolve_streaming_provider = original_resolve
             loop.close()
 
+    def test_pronunciation_config_reaches_streaming_provider_without_rechunking(self):
+        async def run(loop):
+            streamer = FakeStreamer(chunks_per_clause=1)
+            adapter = FakeVoiceAdapter()
+            import tools.tts_streaming as tts_streaming
+
+            original_resolve = tts_streaming.resolve_streaming_provider
+            tts_streaming.resolve_streaming_provider = lambda *_args, **_kwargs: streamer
+            try:
+                config = {
+                    "pronunciation": {
+                        "substitutions": {"C++": "C plus plus", "alpha": "beta"},
+                    },
+                }
+                consumer = StreamingTTSConsumer(adapter, "chat1", config, loop)
+                consumer.start()
+                consumer.on_delta("Use C++ first. Then alpha second. ")
+                consumer.finish()
+
+                assert await consumer.wait_complete(timeout=5.0) is True
+                assert streamer.spoken_texts == ["Use C plus plus first. Then beta second."]
+            finally:
+                tts_streaming.resolve_streaming_provider = original_resolve
+
+        _run_test(run)
+
 
 class TestGatewayIntegrationSeam:
     """The actual adapter seam is per-turn, not chat-only."""

--- a/tests/gateway/test_streaming_tts_consumer.py
+++ b/tests/gateway/test_streaming_tts_consumer.py
@@ -35,8 +35,10 @@ class FakeStreamer:
         self.channels = channels
         self.sample_width = sample_width
         self._clause_count = 0
+        self.spoken_texts: list[str] = []
 
     def stream(self, text: str):
+        self.spoken_texts.append(text)
         self._clause_count += 1
         if self.fail_on_clause and self._clause_count >= self.fail_on_clause:
             raise RuntimeError(f"fake streamer failure on clause {self._clause_count}")
@@ -172,6 +174,7 @@ def _make_consumer(adapter, chat_id, loop, streamer):
     consumer._adapter = adapter
     consumer._chat_id = chat_id
     consumer._tts_config = {}
+    consumer._pronunciation_substitutions = {}
     consumer._loop = loop
     consumer._metadata = None
     consumer._audio_format = AudioFormat(
@@ -180,6 +183,7 @@ def _make_consumer(adapter, chat_id, loop, streamer):
         sample_width=int(getattr(streamer, "sample_width", 2)) if streamer is not None else 2,
     )
     consumer._streamer = streamer  # type: ignore[assignment]
+    consumer._stream_max_len = 0
     consumer._chunker = SentenceChunker()
     consumer._queue = queue.Queue(maxsize=256)
     consumer._handle = None
@@ -192,7 +196,6 @@ def _make_consumer(adapter, chat_id, loop, streamer):
     consumer._suppress_whole_file = False
     consumer._task = None
     consumer._lock = threading.Lock()
-    consumer._strip_markdown = None
     return consumer
 
 
@@ -360,18 +363,130 @@ class TestStreamerFormatAndLooping:
             original_resolve = tts_streaming.resolve_streaming_provider
             tts_streaming.resolve_streaming_provider = lambda *_args, **_kwargs: streamer
             try:
+                protected = "```secret code```"
                 config = {
                     "pronunciation": {
-                        "substitutions": {"C++": "C plus plus", "alpha": "beta"},
+                        "substitutions": {
+                            "C++": "C plus plus",
+                            "alpha": "beta",
+                            protected: "LEAK",
+                        },
                     },
                 }
                 consumer = StreamingTTSConsumer(adapter, "chat1", config, loop)
                 consumer.start()
-                consumer.on_delta("Use C++ first. Then alpha second. ")
+                consumer.on_delta(f"{protected} Use C++ first. Then alpha second. ")
                 consumer.finish()
 
                 assert await consumer.wait_complete(timeout=5.0) is True
-                assert streamer.spoken_texts == ["Use C plus plus first. Then beta second."]
+                assert streamer.spoken_texts == [
+                    "Use C plus plus first.",
+                    "Then beta second.",
+                ]
+            finally:
+                tts_streaming.resolve_streaming_provider = original_resolve
+
+        _run_test(run)
+
+    def test_provider_cap_applies_after_pronunciation_expansion(self, monkeypatch):
+        import tools.tts_streaming as tts_streaming
+        import tools.tts_tool as tts_tool
+
+        streamer = FakeStreamer(chunks_per_clause=1)
+        streamer.provider_name = "openai"
+        resolved_providers = []
+        monkeypatch.setattr(
+            tts_streaming,
+            "resolve_streaming_provider",
+            lambda *_args, **_kwargs: streamer,
+        )
+        monkeypatch.setattr(
+            tts_tool,
+            "_resolve_max_text_length",
+            lambda provider, _cfg: resolved_providers.append(provider) or 64,
+        )
+
+        async def run(loop):
+            adapter = FakeVoiceAdapter()
+            config = {
+                "provider": "edge",
+                "streaming": {"provider": "openai"},
+                "pronunciation": {
+                    "substitutions": {"word": "expanded phrase"},
+                },
+            }
+            consumer = StreamingTTSConsumer(adapter, "chat1", config, loop)
+            consumer.start()
+            consumer.on_delta(("word " * 50) + ".")
+            consumer.finish()
+
+            assert await consumer.wait_complete(timeout=5.0) is True
+
+        _run_test(run)
+        assert resolved_providers == ["openai"]
+        assert len(streamer.spoken_texts) == 1
+        assert len(streamer.spoken_texts[0]) == 64
+
+    def test_elevenlabs_cap_uses_actual_streaming_model(self, monkeypatch):
+        import tools.tts_streaming as tts_streaming
+
+        streamer = FakeStreamer(chunks_per_clause=1)
+        streamer.provider_name = "elevenlabs"
+        streamer.model_id = "eleven_v3"
+        monkeypatch.setattr(
+            tts_streaming,
+            "resolve_streaming_provider",
+            lambda *_args, **_kwargs: streamer,
+        )
+
+        async def run(loop):
+            adapter = FakeVoiceAdapter()
+            config = {
+                "provider": "edge",
+                "streaming": {"provider": "elevenlabs"},
+                "elevenlabs": {
+                    "model_id": "eleven_flash_v2_5",
+                    "streaming_model_id": "eleven_v3",
+                },
+                "pronunciation": {
+                    "substitutions": {"word": "expandedword"},
+                },
+            }
+            consumer = StreamingTTSConsumer(adapter, "chat1", config, loop)
+            consumer.start()
+            consumer.on_delta(("word " * 1000) + ".")
+            consumer.finish()
+
+            assert await consumer.wait_complete(timeout=5.0) is True
+
+        _run_test(run)
+        assert len(streamer.spoken_texts) == 1
+        assert len(streamer.spoken_texts[0]) == 5000
+
+    def test_unicode_ignorecase_pronunciation_survives_gateway_delta_boundary(self):
+        async def run(loop):
+            streamer = FakeStreamer(chunks_per_clause=1)
+            adapter = FakeVoiceAdapter()
+            import tools.tts_streaming as tts_streaming
+
+            original_resolve = tts_streaming.resolve_streaming_provider
+            tts_streaming.resolve_streaming_provider = lambda *_args, **_kwargs: streamer
+            try:
+                config = {
+                    "pronunciation": {
+                        "substitutions": {"Dr. Ipek": "Doctor Ipek"},
+                    },
+                }
+                consumer = StreamingTTSConsumer(adapter, "chat1", config, loop)
+                consumer.start()
+                consumer.on_delta("Please book an appointment with Dr. ")
+                consumer.on_delta("ıpek tomorrow. ")
+                consumer.finish()
+
+                assert await consumer.wait_complete(timeout=5.0) is True
+                assert streamer.spoken_texts == [
+                    "Please book an appointment with Doctor Ipek tomorrow.",
+                ]
             finally:
                 tts_streaming.resolve_streaming_provider = original_resolve
 

--- a/tests/hermes_cli/test_voice_wrapper.py
+++ b/tests/hermes_cli/test_voice_wrapper.py
@@ -186,6 +186,29 @@ class TestSpeakTextGuards:
         assert voice.speak_text("Hello world") is None
         assert played == [returned_path]
 
+    def test_sync_path_passes_raw_text_to_central_tts_pipeline(self, monkeypatch):
+        import hermes_cli.voice as voice
+        from tools import tts_tool
+
+        requested = []
+        monkeypatch.setattr(
+            "tools.tts_streaming.resolve_streaming_provider",
+            lambda _cfg: None,
+        )
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {})
+        monkeypatch.setattr(
+            tts_tool,
+            "text_to_speech_tool",
+            lambda **kwargs: requested.append(kwargs) or "{}",
+        )
+        monkeypatch.setattr(voice.os, "makedirs", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(voice.os.path, "isfile", lambda _path: False)
+
+        raw = "Our **R&D** team shipped." + ("x" * 5000)
+        assert voice.speak_text(raw) is None
+        assert requested[0]["text"] == raw
+        assert requested[0]["_max_chars"] == 4000
+
     def test_speak_text_prefers_requested_mp3_over_returned_ogg(self, monkeypatch):
         import hermes_cli.voice as voice
         from tools import tts_tool

--- a/tests/hermes_cli/test_web_server_speak_stream.py
+++ b/tests/hermes_cli/test_web_server_speak_stream.py
@@ -49,11 +49,26 @@ class _FakeStreamer:
         yield from self.chunks
 
 
-def _patch_provider(monkeypatch, streamer, cap=4000):
+def _patch_provider(
+    monkeypatch,
+    streamer,
+    cap=4000,
+    config=None,
+    provider_name=None,
+    resolved_providers=None,
+):
+    if provider_name is not None:
+        streamer.provider_name = provider_name
     monkeypatch.setattr("tools.tts_streaming.resolve_streaming_provider", lambda cfg: streamer)
-    monkeypatch.setattr("tools.tts_tool._load_tts_config", lambda: {})
+    monkeypatch.setattr("tools.tts_tool._load_tts_config", lambda: config or {})
     monkeypatch.setattr("tools.tts_tool._get_provider", lambda cfg: "fake")
-    monkeypatch.setattr("tools.tts_tool._resolve_max_text_length", lambda provider, cfg: cap)
+
+    def _resolve_cap(provider, _cfg):
+        if resolved_providers is not None:
+            resolved_providers.append(provider)
+        return cap
+
+    monkeypatch.setattr("tools.tts_tool._resolve_max_text_length", _resolve_cap)
 
 
 
@@ -76,10 +91,194 @@ def test_streams_pcm_frames_then_end(stream_client, monkeypatch):
     assert streamer.requests == ["Hello there."]
 
 
+def test_pinned_streamer_uses_its_provider_cap(stream_client, monkeypatch):
+    streamer = _FakeStreamer([b"\x00\x00"])
+    resolved_providers = []
+    _patch_provider(
+        monkeypatch,
+        streamer,
+        cap=32,
+        config={"provider": "edge", "streaming": {"provider": "openai"}},
+        provider_name="openai",
+        resolved_providers=resolved_providers,
+    )
+
+    with stream_client.websocket_connect(_url()) as conn:
+        assert conn.receive_json()["type"] == "start"
+        conn.send_text(json.dumps({"text": ("x" * 80) + ".", "done": True}))
+        while True:
+            message = conn.receive()
+            if message.get("bytes") is None:
+                assert json.loads(message["text"]) == {"type": "end"}
+                break
+
+    assert resolved_providers == ["openai"]
+    assert streamer.requests
+    assert all(len(request) <= 32 for request in streamer.requests)
 
 
+def test_pronunciation_precedes_chunking_and_protected_text_stays_silent(
+    stream_client,
+    monkeypatch,
+):
+    streamer = _FakeStreamer([b"\x00\x00"])
+    protected = (
+        "```text\n"
+        "⚠️ File-mutation verifier: literal documentation sample. private. code\n"
+        "```"
+    )
+    _patch_provider(
+        monkeypatch,
+        streamer,
+        config={
+            "pronunciation": {
+                "substitutions": {
+                    "Dr. Ipek": "Doctor Ipek",
+                    protected: "LEAK",
+                },
+            },
+        },
+    )
+
+    with stream_client.websocket_connect(_url()) as conn:
+        assert conn.receive_json()["type"] == "start"
+        conn.send_text(json.dumps({"text": protected + "Please call Dr. "}))
+        # The punctuation after "Dr." must not trigger the 0.5s idle flush
+        # while a configured source phrase is still incomplete.
+        time.sleep(0.7)
+        conn.send_text(json.dumps({"text": "ıpek tomorrow.", "done": True}))
+        assert conn.receive_bytes() == b"\x00\x00"
+        assert conn.receive_json() == {"type": "end"}
+
+    assert streamer.requests == ["Please call Doctor Ipek tomorrow."]
 
 
+def test_desktop_idle_waits_for_pronunciation_right_word_boundary(
+    stream_client,
+    monkeypatch,
+):
+    streamer = _FakeStreamer([b"\x00\x00"])
+    _patch_provider(
+        monkeypatch,
+        streamer,
+        config={
+            "pronunciation": {
+                "substitutions": {"Dr. Ipek": "Doctor Ipek"},
+            },
+        },
+    )
+    prefix = ("Visible ordinary words " * 6) + "Dr. Ipek"
+
+    with stream_client.websocket_connect(_url()) as conn:
+        assert conn.receive_json()["type"] == "start"
+        conn.send_text(json.dumps({"text": prefix}))
+        time.sleep(2.2)
+        conn.send_text(json.dumps({"text": "son arrives.", "done": True}))
+        while True:
+            message = conn.receive()
+            if message.get("bytes") is None:
+                assert json.loads(message["text"]) == {"type": "end"}
+                break
+
+    spoken = " ".join(streamer.requests)
+    assert "Doctor Ipek" not in spoken
+    assert "Dr. Ipekson arrives." in spoken
+
+
+def test_desktop_idle_preserves_pronunciation_left_word_boundary(
+    stream_client,
+    monkeypatch,
+):
+    streamer = _FakeStreamer([b"\x00\x00"])
+    _patch_provider(
+        monkeypatch,
+        streamer,
+        config={
+            "pronunciation": {
+                "substitutions": {"Ipek": "EE-peck"},
+            },
+        },
+    )
+    prefix = ("Visible ordinary words " * 6) + "my"
+
+    with stream_client.websocket_connect(_url()) as conn:
+        assert conn.receive_json()["type"] == "start"
+        conn.send_text(json.dumps({"text": prefix}))
+        time.sleep(2.2)
+        conn.send_text(json.dumps({"text": "Ipek arrives.", "done": True}))
+        while True:
+            message = conn.receive()
+            if message.get("bytes") is None:
+                assert json.loads(message["text"]) == {"type": "end"}
+                break
+
+    spoken = " ".join(streamer.requests)
+    assert "EE-peck" not in spoken
+    assert "myIpek arrives." in spoken
+
+
+def test_desktop_idle_preserves_punctuation_source_right_word_boundary(
+    stream_client,
+    monkeypatch,
+):
+    streamer = _FakeStreamer([b"\x00\x00"])
+    _patch_provider(
+        monkeypatch,
+        streamer,
+        config={
+            "pronunciation": {
+                "substitutions": {"C++": "C plus plus"},
+            },
+        },
+    )
+    prefix = ("Visible ordinary words " * 6) + "C++s"
+
+    with stream_client.websocket_connect(_url()) as conn:
+        assert conn.receive_json()["type"] == "start"
+        conn.send_text(json.dumps({"text": prefix}))
+        time.sleep(2.2)
+        conn.send_text(json.dumps({"text": "on concludes.", "done": True}))
+        while True:
+            message = conn.receive()
+            if message.get("bytes") is None:
+                assert json.loads(message["text"]) == {"type": "end"}
+                break
+
+    spoken = " ".join(streamer.requests)
+    assert "C plus plus" not in spoken
+    assert "C++son concludes." in spoken
+
+
+@pytest.mark.parametrize(
+    ("partial", "continuation", "forbidden"),
+    [
+        ("Fıle-muta", "tion verifier: SECRET verifier.", "verifier"),
+        ("<thı", "nk>SECRET reasoning.</thınk>Final visible answer.", "<th"),
+    ],
+)
+def test_unicode_partial_protected_opener_survives_desktop_idle_interval(
+    stream_client,
+    monkeypatch,
+    partial,
+    continuation,
+    forbidden,
+):
+    streamer = _FakeStreamer([b"\x00\x00"])
+    _patch_provider(monkeypatch, streamer)
+    prefix = ("Visible ordinary words " * 6) + partial
+
+    with stream_client.websocket_connect(_url()) as conn:
+        assert conn.receive_json()["type"] == "start"
+        conn.send_text(json.dumps({"text": prefix}))
+        # A non-protected long buffer would be force-flushed after ~2 seconds.
+        time.sleep(2.2)
+        conn.send_text(json.dumps({"text": continuation, "done": True}))
+        assert conn.receive_bytes() == b"\x00\x00"
+        assert conn.receive_json() == {"type": "end"}
+
+    assert streamer.requests
+    assert all("SECRET" not in request for request in streamer.requests)
+    assert all(forbidden not in request.casefold() for request in streamer.requests)
 
 
 def test_long_text_is_split_across_provider_requests(stream_client, monkeypatch):
@@ -109,6 +308,54 @@ def test_long_text_is_split_across_provider_requests(stream_client, monkeypatch)
     joined = " ".join(streamer.requests)
     for fragment in ("First sentence here.", "Second sentence here.", "Third one."):
         assert fragment in joined
+
+
+def test_desktop_cap_uses_actual_elevenlabs_streaming_model(
+    stream_client,
+    monkeypatch,
+):
+    from tools import tts_streaming, tts_tool
+
+    streamer = _FakeStreamer([b"\x00\x00"])
+    streamer.provider_name = "elevenlabs"
+    streamer.model_id = "eleven_v3"
+    config = {
+        "provider": "edge",
+        "streaming": {"provider": "elevenlabs"},
+        "elevenlabs": {
+            "model_id": "eleven_flash_v2_5",
+            "streaming_model_id": "eleven_v3",
+        },
+    }
+    resolved = []
+    original_resolve_cap = tts_tool._resolve_max_text_length
+
+    def _resolve_cap(provider, cfg, *, model_id=None):
+        resolved.append((provider, model_id))
+        return original_resolve_cap(provider, cfg, model_id=model_id)
+
+    monkeypatch.setattr(
+        tts_streaming,
+        "resolve_streaming_provider",
+        lambda *_args, **_kwargs: streamer,
+    )
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: config)
+    monkeypatch.setattr(tts_tool, "_get_provider", lambda _cfg: "edge")
+    monkeypatch.setattr(tts_tool, "_resolve_max_text_length", _resolve_cap)
+
+    with stream_client.websocket_connect(_url()) as conn:
+        assert conn.receive_json()["type"] == "start"
+        conn.send_text(json.dumps({"text": ("x" * 6000) + ".", "done": True}))
+        while True:
+            message = conn.receive()
+            if message.get("bytes") is None:
+                assert json.loads(message["text"]) == {"type": "end"}
+                break
+
+    assert resolved == [("elevenlabs", "eleven_v3")]
+    request_lengths = [len(request) for request in streamer.requests]
+    assert request_lengths == [5000, 1001]
+    assert max(request_lengths) <= 5000
 
 
 def test_split_text_respects_cap_and_preserves_content():

--- a/tests/tools/test_tts_max_text_length.py
+++ b/tests/tools/test_tts_max_text_length.py
@@ -47,6 +47,40 @@ class TestResolveMaxTextLength:
 
     # --- ElevenLabs model-aware ---
 
+    def test_elevenlabs_streaming_model_overrides_sync_model_for_cap(self):
+        config = {
+            "elevenlabs": {
+                "model_id": "eleven_flash_v2_5",
+                "streaming_model_id": "eleven_v3",
+            },
+        }
+        assert _resolve_max_text_length("elevenlabs", config) == 40000
+        assert (
+            _resolve_max_text_length(
+                "elevenlabs",
+                config,
+                model_id="eleven_v3",
+            )
+            == 5000
+        )
+
+    def test_elevenlabs_explicit_cap_still_wins_over_active_model(self):
+        config = {
+            "elevenlabs": {
+                "model_id": "eleven_flash_v2_5",
+                "streaming_model_id": "eleven_v3",
+                "max_text_length": 1234,
+            },
+        }
+        assert (
+            _resolve_max_text_length(
+                "elevenlabs",
+                config,
+                model_id="eleven_v3",
+            )
+            == 1234
+        )
+
 
     # --- Sanity: the table covers every provider listed in the schema ---
 

--- a/tests/tools/test_tts_speed.py
+++ b/tests/tools/test_tts_speed.py
@@ -243,6 +243,25 @@ class TestToolLevelSpeed:
         config_passed = call_args[0][2]  # (text, output_path, tts_config)
         assert config_passed["speed"] == 0.7
 
+    def test_pronunciation_config_is_applied_before_provider_dispatch(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        config = {
+            "provider": "openai",
+            "openai": {},
+            "pronunciation": {"substitutions": {"C++": r"C:\voices\cpp"}},
+        }
+
+        with patch("tools.tts_tool._load_tts_config", return_value=config), \
+             patch("tools.tts_tool._get_provider", return_value="openai"), \
+             patch("tools.tts_tool._resolve_command_provider_config", return_value=None), \
+             patch("tools.tts_tool._resolve_max_text_length", return_value=4096), \
+             patch("tools.tts_tool._generate_openai_tts") as mock_gen, \
+             patch("gateway.session_context.get_session_env", return_value=""):
+            from tools.tts_tool import text_to_speech_tool
+            text_to_speech_tool("Use C++", str(tmp_path / "out.mp3"))
+
+        assert mock_gen.call_args[0][0] == r"Use C:\voices\cpp"
+
     def test_speed_clamped_range(self, tmp_path, monkeypatch):
         """Speed values outside 0.25-4.0 are clamped."""
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")

--- a/tests/tools/test_tts_speed.py
+++ b/tests/tools/test_tts_speed.py
@@ -262,6 +262,40 @@ class TestToolLevelSpeed:
 
         assert mock_gen.call_args[0][0] == r"Use C:\voices\cpp"
 
+    def test_final_spoken_cap_applies_after_cleanup_and_substitution(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        config = {
+            "provider": "openai",
+            "openai": {},
+            "pronunciation": {"substitutions": {"word": "expanded phrase"}},
+        }
+        raw = (
+            ("word " * 790)
+            + "```private secret crosses character 4000."
+            + ("x" * 200)
+            + "```Visible ending."
+        )
+
+        with patch("tools.tts_tool._load_tts_config", return_value=config), \
+             patch("tools.tts_tool._get_provider", return_value="openai"), \
+             patch("tools.tts_tool._resolve_command_provider_config", return_value=None), \
+             patch("tools.tts_tool._resolve_max_text_length", return_value=4096), \
+             patch("tools.tts_tool._generate_openai_tts") as mock_gen, \
+             patch("gateway.session_context.get_session_env", return_value=""):
+            from tools.tts_tool import text_to_speech_tool
+            text_to_speech_tool(
+                raw,
+                str(tmp_path / "out.mp3"),
+                _max_chars=4000,
+            )
+
+        provider_text = mock_gen.call_args[0][0]
+        assert len(provider_text) == 4000
+        assert "expanded phrase" in provider_text
+        assert "private secret" not in provider_text
+
     def test_speed_clamped_range(self, tmp_path, monkeypatch):
         """Speed values outside 0.25-4.0 are clamped."""
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -30,8 +30,128 @@ class TestSentenceChunker:
 
     def test_think_blocks_are_stripped_even_across_deltas(self):
         c = ts.SentenceChunker()
-        assert c.feed("<think>secret reason") == []
-        assert c.feed("ing</think>The actual spoken answer. ") == ["The actual spoken answer. "]
+        assert c.feed("<THINK>secret reason.") == []
+        assert c.feed(" More.</ThInK>The actual spoken answer. ") == [
+            "The actual spoken answer. "
+        ]
+
+    def test_partial_think_opener_is_held_across_deltas(self):
+        c = ts.SentenceChunker()
+        assert c.feed("This visible answer is long enough. <thi") == []
+        assert c.holding_protected_text is True
+        out = c.feed("nk>secret reason.</think>Another visible answer follows. ")
+        assert "secret" not in "".join(out)
+        assert "This visible answer is long enough." in "".join(out)
+        assert c.holding_protected_text is False
+
+    def test_fenced_code_is_held_across_deltas_and_not_used_as_boundary(self):
+        c = ts.SentenceChunker()
+        assert c.feed("```python\nsecret = 'do not speak'.") == []
+        assert c.feed("\n```The actual spoken answer. ") == [
+            "```python\nsecret = 'do not speak'.\n```The actual spoken answer. "
+        ]
+
+    def test_partial_fence_opener_is_held_across_deltas(self):
+        c = ts.SentenceChunker()
+        assert c.feed("This visible answer is long enough. ``") == []
+        assert c.holding_protected_text is True
+        out = c.feed("`python\nsecret.\n```Another visible answer follows. ")
+        assert "secret" in "".join(out)  # retained for display; stripped before speech
+        assert c.holding_protected_text is False
+
+    def test_verifier_footer_and_later_deltas_are_never_spoken(self):
+        c = ts.SentenceChunker()
+        assert c.feed(
+            "The public answer is ready. ⚠️ File-mutation verifier: hidden. "
+        ) == ["The public answer is ready. "]
+        assert c.feed("More private verifier instructions. ") == []
+        assert c.flush() == []
+
+    def test_verifier_literal_inside_fenced_code_does_not_discard_visible_tail(self):
+        c = ts.SentenceChunker()
+        raw = (
+            "```text\n"
+            "⚠️ File-mutation verifier: literal documentation sample.\n"
+            "```The actual visible answer follows."
+        )
+        assert c.feed(raw) == []
+        assert c.flush() == [raw]
+
+    @pytest.mark.parametrize(
+        "partial",
+        ["⚠️ File-mut", "⚠ File-mut", "File-muta", "Fıle-muta", "Fİle-muta"],
+    )
+    def test_partial_verifier_header_is_held_across_deltas(self, partial):
+        c = ts.SentenceChunker()
+        assert c.feed(f"This visible answer is long enough.\n{partial}") == []
+        assert c.holding_protected_text is True
+        continuation = (
+            "ation verifier: hidden. More hidden details. "
+            if partial.endswith("mut")
+            else "tion verifier: hidden. More hidden details. "
+        )
+        out = c.feed(continuation)
+        assert [item.strip() for item in out] == ["This visible answer is long enough."]
+        assert c.holding_protected_text is False
+
+    def test_pronunciation_phrase_can_span_sentence_boundary_and_unicode_case_delta(self):
+        c = ts.SentenceChunker(
+            pronunciation_substitutions={"Dr. Ipek": "Doctor Ipek"},
+        )
+        assert c.feed("Please book an appointment with Dr. ") == []
+        assert c.holding_pronunciation_lookahead is True
+        assert c.feed("ıpek tomorrow. ") == [
+            "Please book an appointment with Dr. ıpek tomorrow. "
+        ]
+        assert c.holding_pronunciation_lookahead is False
+
+    def test_pronunciation_tail_holds_until_right_word_boundary_is_known(self):
+        c = ts.SentenceChunker(
+            pronunciation_substitutions={"Dr. Ipek": "Doctor Ipek"},
+        )
+        prefix = "Visible ordinary words " * 6
+        assert c.feed(prefix + "Dr. Ipek") == []
+        assert c.holding_pronunciation_lookahead is True
+
+        output = c.feed("son arrives. ")
+        assert "".join(output + c.flush()) == prefix + "Dr. Ipekson arrives."
+        assert c.holding_pronunciation_lookahead is False
+
+    def test_idle_flush_retains_left_word_boundary_context(self):
+        c = ts.SentenceChunker(
+            pronunciation_substitutions={"Ipek": "EE-peck"},
+        )
+        prefix = "Visible ordinary words " * 6
+        assert c.feed(prefix + "my") == []
+        ready = c.flush_for_idle()
+        assert "".join(ready) + c.buf == prefix + "my"
+        assert c.buf == "my"
+
+        output = c.feed("Ipek arrives. ")
+        assert "".join(ready + output + c.flush()) == prefix + "myIpek arrives."
+
+    def test_idle_flush_retains_punctuation_source_before_trailing_word(self):
+        c = ts.SentenceChunker(
+            pronunciation_substitutions={"C++": "C plus plus"},
+        )
+        prefix = "Visible ordinary words " * 6
+        assert c.feed(prefix + "C++s") == []
+        ready = c.flush_for_idle()
+        assert "".join(ready) + c.buf == prefix + "C++s"
+        assert c.buf == "C++s"
+
+        output = c.feed("on concludes. ")
+        assert "".join(ready + output + c.flush()) == prefix + "C++son concludes."
+
+    def test_unicode_ignorecase_partial_think_opener_is_held(self):
+        c = ts.SentenceChunker()
+        prefix = "Visible ordinary words " * 6
+        assert c.feed(prefix + "<thı") == []
+        assert c.holding_protected_text is True
+        assert c.feed("nk>SECRET reasoning.</thınk>Final visible answer. ") == [
+            prefix + "Final visible answer. "
+        ]
+        assert c.holding_protected_text is False
 
 
     def test_paragraph_break_is_a_boundary(self):
@@ -162,6 +282,29 @@ def _drain_queue(sentences):
     return q
 
 
+_IDLE = object()
+
+
+class _IdleOnceQueue:
+    """Queue stub that inserts one producer-idle timeout between deltas."""
+
+    def __init__(self, items):
+        self._items = list(items)
+
+    def get(self, timeout=None):
+        if not self._items:
+            raise queue.Empty
+        item = self._items.pop(0)
+        if item is _IDLE:
+            raise queue.Empty
+        return item
+
+    def get_nowait(self):
+        if not self._items:
+            raise queue.Empty
+        return self._items.pop(0)
+
+
 def _sd_mock():
     sd = MagicMock()
     out = MagicMock()
@@ -173,6 +316,7 @@ def test_streamer_path_applies_symbol_bearing_pronunciation_before_normalization
     from tools import tts_tool
 
     seen = []
+    displayed = []
 
     class _Fake(ts.StreamingTTSProvider):
         sample_rate = 24000
@@ -187,7 +331,13 @@ def test_streamer_path_applies_symbol_bearing_pronunciation_before_normalization
             yield b"\x01\x00" * 10
 
     sd, _ = _sd_mock()
-    q = _drain_queue(["Our R&D team shipped."])
+    raw_reply = (
+        "```text\n"
+        "⚠️ File-mutation verifier: literal documentation sample.\n"
+        "<think>literal unclosed documentation example.\n"
+        "```Our R&D team shipped."
+    )
+    q = _drain_queue([raw_reply])
     stop, done = threading.Event(), threading.Event()
     config = {
         "provider": "openai",
@@ -208,9 +358,64 @@ def test_streamer_path_applies_symbol_bearing_pronunciation_before_normalization
         patch.object(tts_tool, "_import_sounddevice", return_value=sd),
         patch.object(tts_tool.platform, "system", return_value="Linux"),
     ):
-        tts_tool.stream_tts_to_speaker(q, stop, done)
+        tts_tool.stream_tts_to_speaker(
+            q,
+            stop,
+            done,
+            display_callback=displayed.append,
+        )
 
     assert seen == ["Our Research and Development team shipped."]
+    assert displayed == [raw_reply]
+    assert done.is_set()
+
+
+def test_streamer_pronunciation_collision_does_not_suppress_raw_display(monkeypatch):
+    from tools import tts_tool
+
+    spoken = []
+    displayed = []
+
+    class _Fake(ts.StreamingTTSProvider):
+        sample_rate = 24000
+        channels = 1
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            spoken.append(text)
+            yield b"\x01\x00" * 10
+
+    sd, _ = _sd_mock()
+    q = _drain_queue(["Alpha is definitely here. Beta is definitely here."])
+    stop, done = threading.Event(), threading.Event()
+    config = {
+        "provider": "openai",
+        "pronunciation": {
+            "substitutions": {"Alpha": "Same", "Beta": "Same"},
+        },
+    }
+
+    with (
+        patch.object(tts_tool, "_load_tts_config", return_value=config),
+        patch(
+            "tools.tts_streaming.resolve_streaming_provider",
+            return_value=_Fake({}, {}),
+        ),
+        patch.object(tts_tool, "_import_sounddevice", return_value=sd),
+        patch.object(tts_tool.platform, "system", return_value="Linux"),
+    ):
+        tts_tool.stream_tts_to_speaker(
+            q,
+            stop,
+            done,
+            display_callback=displayed.append,
+        )
+
+    assert spoken == ["Same is definitely here."]
+    assert displayed == ["Alpha is definitely here. ", "Beta is definitely here."]
     assert done.is_set()
 
 
@@ -246,6 +451,310 @@ def test_sync_fallback_preserves_symbols_for_single_pronunciation_pass(monkeypat
         tts_tool.stream_tts_to_speaker(q, stop, done)
 
     assert generated.call_args[0][0] == "Our Research and Development team shipped."
+    assert done.is_set()
+
+
+def test_sync_fallback_keeps_unicode_ignorecase_pronunciation_across_queue_deltas(monkeypatch):
+    from tools import tts_tool
+
+    config = {
+        "provider": "openai",
+        "openai": {},
+        "pronunciation": {
+            "substitutions": {"Dr. Ipek": "Doctor Ipek"},
+        },
+    }
+    generated = MagicMock()
+    q = _drain_queue([
+        "Please book an appointment with Dr. ",
+        "ıpek tomorrow.",
+    ])
+    stop, done = threading.Event(), threading.Event()
+
+    with (
+        patch.object(tts_tool, "_load_tts_config", return_value=config),
+        patch.object(tts_tool, "_get_provider", return_value="openai"),
+        patch.object(tts_tool, "_resolve_command_provider_config", return_value=None),
+        patch.object(tts_tool, "_resolve_max_text_length", return_value=4096),
+        patch.object(tts_tool, "_generate_openai_tts", generated),
+        patch("tools.tts_streaming.resolve_streaming_provider", return_value=None),
+        patch("gateway.session_context.get_session_env", return_value=""),
+    ):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    assert generated.call_args[0][0] == (
+        "Please book an appointment with Doctor Ipek tomorrow."
+    )
+    assert done.is_set()
+
+
+def test_sync_fallback_does_not_idle_flush_incomplete_pronunciation(monkeypatch):
+    from tools import tts_tool
+
+    config = {
+        "provider": "openai",
+        "openai": {},
+        "pronunciation": {
+            "substitutions": {"Dr. Smith": "Doctor Smith"},
+        },
+    }
+    generated = MagicMock()
+    prefix = "Please book " + ("a very important appointment " * 5) + "with Dr. "
+    q = _IdleOnceQueue([prefix, _IDLE, "Smith tomorrow.", None])
+    stop, done = threading.Event(), threading.Event()
+
+    with (
+        patch.object(tts_tool, "_load_tts_config", return_value=config),
+        patch.object(tts_tool, "_get_provider", return_value="openai"),
+        patch.object(tts_tool, "_resolve_command_provider_config", return_value=None),
+        patch.object(tts_tool, "_resolve_max_text_length", return_value=4096),
+        patch.object(tts_tool, "_generate_openai_tts", generated),
+        patch("tools.tts_streaming.resolve_streaming_provider", return_value=None),
+        patch("gateway.session_context.get_session_env", return_value=""),
+    ):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    generated.assert_called_once()
+    assert generated.call_args[0][0].endswith("with Doctor Smith tomorrow.")
+    assert done.is_set()
+
+
+def test_sync_idle_waits_for_pronunciation_right_word_boundary(monkeypatch):
+    from tools import tts_tool
+
+    config = {
+        "provider": "openai",
+        "openai": {},
+        "pronunciation": {
+            "substitutions": {"Dr. Ipek": "Doctor Ipek"},
+        },
+    }
+    generated = MagicMock()
+    prefix = ("Visible ordinary words " * 6) + "Dr. Ipek"
+    q = _IdleOnceQueue([prefix, _IDLE, "son arrives.", None])
+    stop, done = threading.Event(), threading.Event()
+
+    with (
+        patch.object(tts_tool, "_load_tts_config", return_value=config),
+        patch.object(tts_tool, "_get_provider", return_value="openai"),
+        patch.object(tts_tool, "_resolve_command_provider_config", return_value=None),
+        patch.object(tts_tool, "_resolve_max_text_length", return_value=4096),
+        patch.object(tts_tool, "_generate_openai_tts", generated),
+        patch("tools.tts_streaming.resolve_streaming_provider", return_value=None),
+        patch("gateway.session_context.get_session_env", return_value=""),
+    ):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    spoken = " ".join(call.args[0] for call in generated.call_args_list)
+    assert "Doctor Ipek" not in spoken
+    assert "Dr. Ipekson arrives." in spoken
+    assert done.is_set()
+
+
+def test_sync_idle_preserves_pronunciation_left_word_boundary(monkeypatch):
+    from tools import tts_tool
+
+    config = {
+        "provider": "openai",
+        "openai": {},
+        "pronunciation": {
+            "substitutions": {"Ipek": "EE-peck"},
+        },
+    }
+    generated = MagicMock()
+    prefix = ("Visible ordinary words " * 6) + "my"
+    q = _IdleOnceQueue([prefix, _IDLE, "Ipek arrives.", None])
+    stop, done = threading.Event(), threading.Event()
+
+    with (
+        patch.object(tts_tool, "_load_tts_config", return_value=config),
+        patch.object(tts_tool, "_get_provider", return_value="openai"),
+        patch.object(tts_tool, "_resolve_command_provider_config", return_value=None),
+        patch.object(tts_tool, "_resolve_max_text_length", return_value=4096),
+        patch.object(tts_tool, "_generate_openai_tts", generated),
+        patch("tools.tts_streaming.resolve_streaming_provider", return_value=None),
+        patch("gateway.session_context.get_session_env", return_value=""),
+    ):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    spoken = " ".join(call.args[0] for call in generated.call_args_list)
+    assert "EE-peck" not in spoken
+    assert "myIpek arrives." in spoken
+    assert done.is_set()
+
+
+def test_sync_idle_preserves_punctuation_source_right_word_boundary(monkeypatch):
+    from tools import tts_tool
+
+    config = {
+        "provider": "openai",
+        "openai": {},
+        "pronunciation": {
+            "substitutions": {"C++": "C plus plus"},
+        },
+    }
+    generated = MagicMock()
+    prefix = ("Visible ordinary words " * 6) + "C++s"
+    q = _IdleOnceQueue([prefix, _IDLE, "on concludes.", None])
+    stop, done = threading.Event(), threading.Event()
+
+    with (
+        patch.object(tts_tool, "_load_tts_config", return_value=config),
+        patch.object(tts_tool, "_get_provider", return_value="openai"),
+        patch.object(tts_tool, "_resolve_command_provider_config", return_value=None),
+        patch.object(tts_tool, "_resolve_max_text_length", return_value=4096),
+        patch.object(tts_tool, "_generate_openai_tts", generated),
+        patch("tools.tts_streaming.resolve_streaming_provider", return_value=None),
+        patch("gateway.session_context.get_session_env", return_value=""),
+    ):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    spoken = " ".join(call.args[0] for call in generated.call_args_list)
+    assert "C plus plus" not in spoken
+    assert "C++son concludes." in spoken
+    assert done.is_set()
+
+
+@pytest.mark.parametrize(
+    ("partial", "continuation", "expected_tail"),
+    [
+        ("<thi", "nk>SECRET reasoning.</think>Final visible answer.", "Final visible answer."),
+        ("<thı", "nk>SECRET reasoning.</thınk>Final visible answer.", "Final visible answer."),
+        ("``", "`SECRET code.\n```Final visible answer.", "Final visible answer."),
+        ("File-muta", "tion verifier: SECRET verifier.", "Visible ordinary words"),
+        ("Fıle-muta", "tion verifier: SECRET verifier.", "Visible ordinary words"),
+    ],
+)
+def test_sync_fallback_does_not_idle_flush_partial_protected_opener(
+    monkeypatch,
+    partial,
+    continuation,
+    expected_tail,
+):
+    from tools import tts_tool
+
+    config = {"provider": "openai", "openai": {}}
+    generated = MagicMock()
+    prefix = ("Visible ordinary words " * 6) + partial
+    q = _IdleOnceQueue([
+        prefix,
+        _IDLE,
+        continuation,
+        None,
+    ])
+    stop, done = threading.Event(), threading.Event()
+
+    with (
+        patch.object(tts_tool, "_load_tts_config", return_value=config),
+        patch.object(tts_tool, "_get_provider", return_value="openai"),
+        patch.object(tts_tool, "_resolve_command_provider_config", return_value=None),
+        patch.object(tts_tool, "_resolve_max_text_length", return_value=4096),
+        patch.object(tts_tool, "_generate_openai_tts", generated),
+        patch("tools.tts_streaming.resolve_streaming_provider", return_value=None),
+        patch("gateway.session_context.get_session_env", return_value=""),
+    ):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    generated.assert_called_once()
+    spoken = generated.call_args[0][0]
+    assert "SECRET" not in spoken
+    assert expected_tail in spoken
+    assert done.is_set()
+
+
+def test_true_streamer_uses_resolved_streamer_provider_cap(monkeypatch):
+    from tools import tts_tool
+
+    spoken = []
+
+    class _OpenAIStreamer(ts.StreamingTTSProvider):
+        provider_name = "openai"
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            spoken.append(text)
+            yield b"\x01\x00" * 10
+
+    sd, _ = _sd_mock()
+    config = {
+        "provider": "edge",
+        "streaming": {"provider": "openai"},
+    }
+    q = _drain_queue([("x" * 5000) + "."])
+    stop, done = threading.Event(), threading.Event()
+
+    with (
+        patch.object(tts_tool, "_load_tts_config", return_value=config),
+        patch.object(
+            tts_tool,
+            "_resolve_max_text_length",
+            side_effect=lambda provider, _cfg: 4096 if provider == "openai" else 5000,
+        ),
+        patch(
+            "tools.tts_streaming.resolve_streaming_provider",
+            return_value=_OpenAIStreamer(config, {}),
+        ),
+        patch.object(tts_tool, "_import_sounddevice", return_value=sd),
+        patch.object(tts_tool.platform, "system", return_value="Linux"),
+    ):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    assert len(spoken) == 1
+    assert len(spoken[0]) == 4096
+    assert done.is_set()
+
+
+def test_true_elevenlabs_streamer_uses_streaming_model_cap():
+    from tools import tts_tool
+
+    section = {
+        "model_id": "eleven_flash_v2_5",
+        "streaming_model_id": "eleven_v3",
+    }
+    assert ts.ElevenLabsStreamer({}, section).model_id == "eleven_v3"
+
+    spoken = []
+
+    class _ElevenLabsStreamer(ts.StreamingTTSProvider):
+        provider_name = "elevenlabs"
+        model_id = "eleven_v3"
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            spoken.append(text)
+            yield b"\x01\x00" * 10
+
+    sd, _ = _sd_mock()
+    config = {
+        "provider": "edge",
+        "streaming": {"provider": "elevenlabs"},
+        "elevenlabs": {
+            "model_id": "eleven_flash_v2_5",
+            "streaming_model_id": "eleven_v3",
+        },
+    }
+    q = _drain_queue([("x" * 6000) + "."])
+    stop, done = threading.Event(), threading.Event()
+
+    with (
+        patch.object(tts_tool, "_load_tts_config", return_value=config),
+        patch(
+            "tools.tts_streaming.resolve_streaming_provider",
+            return_value=_ElevenLabsStreamer(config, config["elevenlabs"]),
+        ),
+        patch.object(tts_tool, "_import_sounddevice", return_value=sd),
+        patch.object(tts_tool.platform, "system", return_value="Linux"),
+    ):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    assert len(spoken) == 1
+    assert len(spoken[0]) == 5000
     assert done.is_set()
 
 

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -169,7 +169,7 @@ def _sd_mock():
     return sd, out
 
 
-def test_streamer_path_applies_configured_pronunciation(monkeypatch):
+def test_streamer_path_applies_symbol_bearing_pronunciation_before_normalization(monkeypatch):
     from tools import tts_tool
 
     seen = []
@@ -187,11 +187,16 @@ def test_streamer_path_applies_configured_pronunciation(monkeypatch):
             yield b"\x01\x00" * 10
 
     sd, _ = _sd_mock()
-    q = _drain_queue(["Say Tahlia now."])
+    q = _drain_queue(["Our R&D team shipped."])
     stop, done = threading.Event(), threading.Event()
     config = {
         "provider": "openai",
-        "pronunciation": {"substitutions": {"Tahlia": "Tarlia"}},
+        "pronunciation": {
+            "substitutions": {
+                "R&D": "Research and Development",
+                "Research and Development": "WRONG",
+            },
+        },
     }
 
     with (
@@ -205,11 +210,43 @@ def test_streamer_path_applies_configured_pronunciation(monkeypatch):
     ):
         tts_tool.stream_tts_to_speaker(q, stop, done)
 
-    assert seen == ["Say Tarlia now."]
+    assert seen == ["Our Research and Development team shipped."]
     assert done.is_set()
 
 
 # ── Dispatch: universal per-sentence sync fallback ───────────────────────
+
+
+def test_sync_fallback_preserves_symbols_for_single_pronunciation_pass(monkeypatch):
+    from tools import tts_tool
+
+    config = {
+        "provider": "openai",
+        "openai": {},
+        "pronunciation": {
+            "substitutions": {
+                "R&D": "Research and Development",
+                "Research and Development": "WRONG",
+            },
+        },
+    }
+    generated = MagicMock()
+    q = _drain_queue(["Our R&D team shipped."])
+    stop, done = threading.Event(), threading.Event()
+
+    with (
+        patch.object(tts_tool, "_load_tts_config", return_value=config),
+        patch.object(tts_tool, "_get_provider", return_value="openai"),
+        patch.object(tts_tool, "_resolve_command_provider_config", return_value=None),
+        patch.object(tts_tool, "_resolve_max_text_length", return_value=4096),
+        patch.object(tts_tool, "_generate_openai_tts", generated),
+        patch("tools.tts_streaming.resolve_streaming_provider", return_value=None),
+        patch("gateway.session_context.get_session_env", return_value=""),
+    ):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    assert generated.call_args[0][0] == "Our Research and Development team shipped."
+    assert done.is_set()
 
 
 # ── tts.streaming.provider config knob (salvaged from PR #47588) ─────────

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -169,6 +169,46 @@ def _sd_mock():
     return sd, out
 
 
+def test_streamer_path_applies_configured_pronunciation(monkeypatch):
+    from tools import tts_tool
+
+    seen = []
+
+    class _Fake(ts.StreamingTTSProvider):
+        sample_rate = 24000
+        channels = 1
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            seen.append(text)
+            yield b"\x01\x00" * 10
+
+    sd, _ = _sd_mock()
+    q = _drain_queue(["Say Tahlia now."])
+    stop, done = threading.Event(), threading.Event()
+    config = {
+        "provider": "openai",
+        "pronunciation": {"substitutions": {"Tahlia": "Tarlia"}},
+    }
+
+    with (
+        patch.object(tts_tool, "_load_tts_config", return_value=config),
+        patch(
+            "tools.tts_streaming.resolve_streaming_provider",
+            return_value=_Fake({}, {}),
+        ),
+        patch.object(tts_tool, "_import_sounddevice", return_value=sd),
+        patch.object(tts_tool.platform, "system", return_value="Linux"),
+    ):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    assert seen == ["Say Tarlia now."]
+    assert done.is_set()
+
+
 # ── Dispatch: universal per-sentence sync fallback ───────────────────────
 
 

--- a/tests/tools/test_tts_text_normalize.py
+++ b/tests/tools/test_tts_text_normalize.py
@@ -1,3 +1,5 @@
+import pytest
+
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter
 from tools.tts_text_normalize import apply_pronunciation_substitutions, prepare_spoken_text
@@ -97,6 +99,41 @@ def test_pronunciation_special_regex_chars_escaped():
     # the literal "foo.bar" matches, not "fooxbar".
     result = apply_pronunciation_substitutions("foo.bar and fooxbar", {"foo.bar": "qux"})
     assert result == "qux and fooxbar"
+
+
+def test_pronunciation_replacement_is_literal():
+    """Backslashes and backreference-like text are inserted verbatim."""
+    replacement = r"say \1 from C:\voices"
+    assert apply_pronunciation_substitutions("Tahlia", {"Tahlia": replacement}) == replacement
+
+
+def test_pronunciation_non_word_boundaries_support_technical_terms():
+    """Terms ending or starting in punctuation still match as standalone literals."""
+    substitutions = {"C++": "C plus plus", ".NET": "dot net"}
+    result = apply_pronunciation_substitutions("C++ and .NET, not XC++ or .NETwork", substitutions)
+    assert result == "C plus plus and dot net, not XC++ or .NETwork"
+
+
+@pytest.mark.parametrize(
+    "substitutions",
+    ["Tahlia: Tarlia", ["Tahlia", "Tarlia"], {"Tahlia": 123}, {123: "Tarlia"}],
+)
+def test_pronunciation_invalid_config_is_a_noop(substitutions):
+    """Malformed user config must not break or partially alter spoken text."""
+    assert apply_pronunciation_substitutions("Hello Tahlia", substitutions) == "Hello Tahlia"
+    assert prepare_spoken_text(
+        "## Hello **Tahlia**",
+        pronunciation_substitutions=substitutions,
+    ) == "Hello Tahlia."
+
+
+def test_pronunciation_is_single_pass_and_order_independent():
+    """Replacement output is not fed back through another configured key."""
+    forward = {"alpha": "beta", "beta": "gamma"}
+    reverse = {"beta": "gamma", "alpha": "beta"}
+    expected = "beta gamma"
+    assert apply_pronunciation_substitutions("alpha beta", forward) == expected
+    assert apply_pronunciation_substitutions("alpha beta", reverse) == expected
 
 
 def test_pronunciation_preserves_replacement_casing():

--- a/tests/tools/test_tts_text_normalize.py
+++ b/tests/tools/test_tts_text_normalize.py
@@ -1,6 +1,6 @@
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter
-from tools.tts_text_normalize import prepare_spoken_text
+from tools.tts_text_normalize import apply_pronunciation_substitutions, prepare_spoken_text
 
 
 class _DummyAdapter(BasePlatformAdapter):
@@ -47,3 +47,76 @@ def test_prepare_spoken_text_polish_edge_cases():
     assert "and/or" in prepare_spoken_text("choose and/or option")
     assert "N/A" in prepare_spoken_text("status N/A here")
     assert "2026/06/02" in prepare_spoken_text("due 2026/06/02 ok")
+
+
+# ---------------------------------------------------------------------------
+# Pronunciation substitution tests
+# ---------------------------------------------------------------------------
+
+def test_pronunciation_basic_substitution():
+    """A word is replaced by its phonetic replacement."""
+    result = apply_pronunciation_substitutions("Hello Tahlia", {"Tahlia": "Tarlia"})
+    assert result == "Hello Tarlia"
+
+
+def test_pronunciation_case_insensitive():
+    """The match is case-insensitive — any casing of the key is replaced."""
+    assert apply_pronunciation_substitutions("hello tahlia", {"Tahlia": "Tarlia"}) == "hello Tarlia"
+    assert apply_pronunciation_substitutions("TAHLIA is here", {"Tahlia": "Tarlia"}) == "Tarlia is here"
+    assert apply_pronunciation_substitutions("tAhLiA", {"Tahlia": "Tarlia"}) == "Tarlia"
+
+
+def test_pronunciation_word_boundary_no_partial_match():
+    """Whole-word boundary: 'Tahlias' is NOT substituted."""
+    result = apply_pronunciation_substitutions("Tahlias and Tahlia", {"Tahlia": "Tarlia"})
+    assert result == "Tahlias and Tarlia"
+
+
+def test_pronunciation_empty_dict_noop():
+    """Empty substitutions dict returns text unchanged."""
+    assert apply_pronunciation_substitutions("Hello Tahlia", {}) == "Hello Tahlia"
+
+
+def test_pronunciation_none_noop():
+    """None substitutions returns text unchanged."""
+    assert apply_pronunciation_substitutions("Hello Tahlia", None) == "Hello Tahlia"
+
+
+def test_pronunciation_multiple_substitutions():
+    """Multiple substitutions are all applied."""
+    result = apply_pronunciation_substitutions(
+        "Hello Tahlia and Siobhan",
+        {"Tahlia": "Tarlia", "Siobhan": "Shi-vaun"},
+    )
+    assert result == "Hello Tarlia and Shi-vaun"
+
+
+def test_pronunciation_special_regex_chars_escaped():
+    """Special regex characters in the key are escaped, not interpreted."""
+    # The dot in "foo.bar" is a regex metachar; it must be escaped so only
+    # the literal "foo.bar" matches, not "fooxbar".
+    result = apply_pronunciation_substitutions("foo.bar and fooxbar", {"foo.bar": "qux"})
+    assert result == "qux and fooxbar"
+
+
+def test_pronunciation_preserves_replacement_casing():
+    """The replacement's exact casing is used regardless of the match casing."""
+    assert apply_pronunciation_substitutions("TAHLIA", {"Tahlia": "Tarlia"}) == "Tarlia"
+
+
+def test_prepare_spoken_text_with_pronunciation():
+    """prepare_spoken_text applies substitutions before markdown stripping."""
+    raw = "## Hello **Tahlia**"
+    spoken = prepare_spoken_text(raw, pronunciation_substitutions={"Tahlia": "Tarlia"})
+    assert "Tarlia" in spoken
+    assert "Tahlia" not in spoken
+    assert "**" not in spoken
+    assert "##" not in spoken
+
+
+def test_prepare_spoken_text_without_pronunciation():
+    """prepare_spoken_text with no substitutions works as before."""
+    raw = "## Hello **Tahlia**"
+    spoken = prepare_spoken_text(raw)
+    assert "Tahlia" in spoken
+    assert "**" not in spoken

--- a/tests/tools/test_tts_text_normalize.py
+++ b/tests/tools/test_tts_text_normalize.py
@@ -151,6 +151,17 @@ def test_prepare_spoken_text_with_pronunciation():
     assert "##" not in spoken
 
 
+def test_pronunciation_cannot_mutate_protected_nonspoken_markers():
+    """User substitutions run only after private/verifier blocks are removed."""
+    raw = "<think>secret reasoning</think>Hello"
+    spoken = prepare_spoken_text(
+        raw,
+        pronunciation_substitutions={"think": "thought"},
+    )
+    assert spoken == "Hello"
+    assert "secret" not in spoken
+
+
 def test_prepare_spoken_text_without_pronunciation():
     """prepare_spoken_text with no substitutions works as before."""
     raw = "## Hello **Tahlia**"

--- a/tests/tools/test_tts_text_normalize.py
+++ b/tests/tools/test_tts_text_normalize.py
@@ -116,7 +116,13 @@ def test_pronunciation_non_word_boundaries_support_technical_terms():
 
 @pytest.mark.parametrize(
     "substitutions",
-    ["Tahlia: Tarlia", ["Tahlia", "Tarlia"], {"Tahlia": 123}, {123: "Tarlia"}],
+    [
+        "Tahlia: Tarlia",
+        ["Tahlia", "Tarlia"],
+        {"Tahlia": 123},
+        {123: "Tarlia"},
+        {"": "INVALID", "Tahlia": "Tarlia"},
+    ],
 )
 def test_pronunciation_invalid_config_is_a_noop(substitutions):
     """Malformed user config must not break or partially alter spoken text."""
@@ -160,6 +166,54 @@ def test_pronunciation_cannot_mutate_protected_nonspoken_markers():
     )
     assert spoken == "Hello"
     assert "secret" not in spoken
+
+
+def test_pronunciation_cannot_replace_an_entire_protected_block():
+    """A source equal to protected content cannot rewrite it into spoken text."""
+    protected = "```secret code```"
+    spoken = prepare_spoken_text(
+        f"{protected} Hello",
+        pronunciation_substitutions={protected: "LEAK"},
+    )
+    assert spoken == "Hello"
+    assert "LEAK" not in spoken
+
+
+def test_unterminated_fenced_code_tail_is_never_spoken():
+    raw = "Visible answer. ```python\nSECRET = 'do not speak'"
+    spoken = prepare_spoken_text(
+        raw,
+        pronunciation_substitutions={"SECRET": "LEAK"},
+    )
+    assert spoken == "Visible answer."
+    assert "SECRET" not in spoken
+    assert "LEAK" not in spoken
+
+
+@pytest.mark.parametrize(
+    "literal",
+    [
+        "<think>literal documentation</think>",
+        "<think>literal unclosed documentation",
+    ],
+)
+def test_think_literal_inside_fenced_code_does_not_consume_visible_tail(literal):
+    raw = f"```text\n{literal}\n```Visible answer survives."
+    assert prepare_spoken_text(raw) == "Visible answer survives."
+
+
+def test_truncation_inside_fenced_code_does_not_expose_its_contents():
+    raw = "Visible answer. ```text\n" + ("SECRET " * 800) + "``` Later answer."
+    truncated = raw[:4000]
+    assert truncated.count("```") == 1
+
+    spoken = prepare_spoken_text(
+        truncated,
+        pronunciation_substitutions={"SECRET": "LEAK"},
+    )
+    assert spoken == "Visible answer."
+    assert "SECRET" not in spoken
+    assert "LEAK" not in spoken
 
 
 def test_prepare_spoken_text_without_pronunciation():

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -296,8 +296,11 @@ class TestVoiceSpeakResponseReal:
         mock_tts.side_effect = fake_tts
 
         cli = _make_voice_cli(_voice_tts=True)
-        cli._voice_speak_response("Hello world")
+        raw_reply = "Our **R&D** team shipped." + ("x" * 5000)
+        cli._voice_speak_response(raw_reply)
 
+        assert mock_tts.call_args.kwargs["text"] == raw_reply
+        assert mock_tts.call_args.kwargs["_max_chars"] == 4000
         requested_path = mock_tts.call_args.kwargs["output_path"]
         mock_play.assert_called_once_with(requested_path)
 

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -25,7 +25,7 @@ import logging
 import re
 import time
 from abc import ABC, abstractmethod
-from typing import Callable, Dict, Iterator, List, Optional
+from typing import Callable, Dict, Iterator, List, Optional, Tuple
 
 from tools.tool_backend_helpers import resolve_openai_audio_api_key
 from tools.tts_tool import _get_provider, _load_tts_config, get_env_value
@@ -83,33 +83,259 @@ def take_speech_interrupted() -> bool:
 
 # Sentence boundary: after .!? followed by whitespace, or a blank line.
 SENTENCE_BOUNDARY_RE = re.compile(r"(?<=[.!?])(?:\s|\n)|(?:\n\n)")
-_THINK_BLOCK_RE = re.compile(r"<think[\s>].*?</think>", flags=re.DOTALL)
+_THINK_BLOCK_RE = re.compile(
+    r"<think(?:\s[^>]*)?>.*?</think\s*>",
+    flags=re.DOTALL | re.IGNORECASE,
+)
+_THINK_OPEN_RE = re.compile(r"<think(?:\s[^>]*)?>", flags=re.IGNORECASE)
+_FENCED_CODE_BLOCK_RE = re.compile(r"```[\s\S]*?```")
+_VERIFIER_START_RE = re.compile(
+    r"(?:⚠️?\s*)?File-mutation verifier:",
+    flags=re.IGNORECASE,
+)
+_REGEX_ASCII_FOLD_TRANSLATION = str.maketrans(
+    {"İ": "i", "ı": "i", "ſ": "s", "K": "k"}
+)
+
+
+def _regex_ascii_casefold(text: str) -> str:
+    """Fold text like ``re.IGNORECASE`` does for ASCII literals."""
+    return text.translate(_REGEX_ASCII_FOLD_TRANSLATION).casefold()
+
+
+def _literal_ignorecase_matches(text: str, literal: str) -> bool:
+    """Return whether equal-length *text* matches *literal* under ``re.I``."""
+    return len(text) == len(literal) and re.fullmatch(
+        re.escape(literal), text, flags=re.IGNORECASE
+    ) is not None
+
+
+def _fenced_code_ranges(text: str) -> List[Tuple[int, int]]:
+    """Return complete and open triple-backtick ranges in *text*."""
+    ranges: List[Tuple[int, int]] = []
+    cursor = 0
+    while True:
+        start = text.find("```", cursor)
+        if start < 0:
+            break
+        end = text.find("```", start + 3)
+        if end < 0:
+            ranges.append((start, len(text)))
+            break
+        ranges.append((start, end + 3))
+        cursor = end + 3
+    return ranges
+
+
+def _position_in_ranges(position: int, ranges: List[Tuple[int, int]]) -> bool:
+    return any(start <= position < end for start, end in ranges)
+
+
+def _first_think_open_outside_fences(text: str) -> Optional[re.Match]:
+    fenced_ranges = _fenced_code_ranges(text)
+    return next(
+        (
+            match
+            for match in _THINK_OPEN_RE.finditer(text)
+            if not _position_in_ranges(match.start(), fenced_ranges)
+        ),
+        None,
+    )
 
 
 class SentenceChunker:
     """Incremental sentence cutter for LLM token deltas.
 
-    Shared by the speaker pipeline (`stream_tts_to_speaker`) and the
-    speak-stream WebSocket so every surface cuts speech identically. Strips
-    ``<think>`` blocks (even split across deltas) and merges fragments shorter
-    than *min_len* into the following sentence, so "Ha!" rides along with the
-    sentence after it instead of stalling as a tiny clip.
+    Shared by every streaming speech surface. Protected non-spoken blocks are
+    removed before sentence cutting, even when their delimiters span deltas.
+    Optional pronunciation substitutions inform boundary selection without
+    altering returned display text. A boundary inside a configured phrase is
+    held until the phrase can be matched, so terms such as ``Dr. Smith`` reach
+    the speech-only rewrite intact.
     """
 
-    def __init__(self, min_len: int = 20):
+    def __init__(self, min_len: int = 20, pronunciation_substitutions: object = None):
         self.min_len = min_len
         self.buf = ""
+        self._discard_rest = False
+        from tools.tts_text_normalize import get_pronunciation_substitutions
+
+        self._pronunciation_substitutions = get_pronunciation_substitutions({
+            "pronunciation": {"substitutions": pronunciation_substitutions},
+        })
+        self._pronunciation_sources = tuple(self._pronunciation_substitutions)
+
+    @property
+    def holding_protected_text(self) -> bool:
+        """Whether an open protected block is waiting for its closing marker."""
+        return (
+            self._has_open_protected_block()
+            or self._partial_protected_tail_start(self.buf) is not None
+        )
+
+    @property
+    def holding_pronunciation_lookahead(self) -> bool:
+        """Whether the buffer ends inside a configured source phrase."""
+        return self._substitution_may_cross_boundary(len(self.buf))
+
+    def _remove_complete_protected_blocks(self, text: str) -> str:
+        fenced_ranges = _fenced_code_ranges(text)
+        removable_think_blocks = [
+            match
+            for match in _THINK_BLOCK_RE.finditer(text)
+            if not _position_in_ranges(match.start(), fenced_ranges)
+        ]
+        if removable_think_blocks:
+            parts: List[str] = []
+            cursor = 0
+            for match in removable_think_blocks:
+                parts.append(text[cursor:match.start()])
+                cursor = match.end()
+            parts.append(text[cursor:])
+            text = "".join(parts)
+
+        fenced_ranges = _fenced_code_ranges(text)
+        open_think = _first_think_open_outside_fences(text)
+        for verifier in _VERIFIER_START_RE.finditer(text):
+            # Literal verifier examples inside fenced documentation or an open
+            # think block are protected content, not the start of the actual
+            # hidden verifier footer. Complete think blocks were removed above.
+            if _position_in_ranges(verifier.start(), fenced_ranges) or (
+                open_think is not None and open_think.start() < verifier.start()
+            ):
+                continue
+            text = text[:verifier.start()]
+            self._discard_rest = True
+            break
+        return text
+
+    def _has_open_protected_block(self) -> bool:
+        return bool(
+            _first_think_open_outside_fences(self.buf) is not None
+            or self.buf.count("```") % 2
+        )
+
+    @staticmethod
+    def _partial_protected_tail_start(text: str) -> Optional[int]:
+        """Return the start of an incomplete protected opening delimiter."""
+        starts: List[int] = []
+
+        last_angle = text.rfind("<")
+        if last_angle >= 0:
+            fragment = text[last_angle:]
+            keyword = "<think"
+            if (
+                len(fragment) <= len(keyword)
+                and _literal_ignorecase_matches(fragment, keyword[:len(fragment)])
+            ) or (
+                len(fragment) > len(keyword)
+                and _literal_ignorecase_matches(fragment[:len(keyword)], keyword)
+                and fragment[len(keyword)].isspace()
+                and ">" not in fragment[len(keyword):]
+            ):
+                starts.append(last_angle)
+
+        trailing_ticks = len(text) - len(text.rstrip("`"))
+        if trailing_ticks in (1, 2):
+            starts.append(len(text) - trailing_ticks)
+
+        folded = _regex_ascii_casefold(text)
+        verifier_openers = (
+            "file-mutation verifier:",
+            "⚠ file-mutation verifier:",
+            "⚠️ file-mutation verifier:",
+        )
+        for opener in verifier_openers:
+            max_prefix = min(len(folded), len(opener) - 1)
+            for prefix_len in range(max_prefix, 0, -1):
+                if folded.endswith(opener[:prefix_len]):
+                    starts.append(len(text) - prefix_len)
+                    break
+
+        return min(starts) if starts else None
+
+    def _strip_open_protected_tail(self, text: str) -> str:
+        starts = []
+        think = _first_think_open_outside_fences(text)
+        if think is not None:
+            starts.append(think.start())
+        if text.count("```") % 2:
+            fence = text.rfind("```")
+            if fence >= 0:
+                starts.append(fence)
+        partial = self._partial_protected_tail_start(text)
+        if partial is not None:
+            starts.append(partial)
+        return text[:min(starts)] if starts else text
+
+    def _boundary_is_inside_fenced_code(self, boundary_end: int) -> bool:
+        return any(
+            match.start() < boundary_end <= match.end()
+            for match in _FENCED_CODE_BLOCK_RE.finditer(self.buf)
+        )
+
+    @staticmethod
+    def _is_word_char(char: str) -> bool:
+        return bool(char and re.match(r"\w", char))
+
+    def _substitution_may_cross_boundary(self, split: int) -> bool:
+        """Return True when a configured source may span *split*.
+
+        This includes an incomplete source prefix at the end of the current
+        buffer, which delays only the candidate boundary until the next delta
+        confirms or rejects the match.
+        """
+        if not self._pronunciation_sources:
+            return False
+        for source in self._pronunciation_sources:
+            source_len = len(source)
+
+            # At an idle boundary, a source that ends exactly at the current
+            # buffer tail still has an unresolved ``(?!\w)`` right boundary.
+            # Hold it until another delta supplies that character, or until the
+            # explicit end-of-text flush confirms there is no character.
+            exact_start = split - source_len
+            if split == len(self.buf) and exact_start >= 0:
+                candidate = self.buf[exact_start:split]
+                if (
+                    _literal_ignorecase_matches(candidate, source)
+                    and (exact_start == 0 or not self._is_word_char(self.buf[exact_start - 1]))
+                ):
+                    return True
+
+            first_start = max(0, split - source_len + 1)
+            for start in range(first_start, split):
+                end = start + source_len
+                if not (start < split < end):
+                    continue
+                available_end = min(len(self.buf), end)
+                candidate = self.buf[start:available_end]
+                source_prefix = source[:available_end - start]
+                if not _literal_ignorecase_matches(candidate, source_prefix):
+                    continue
+                if start > 0 and self._is_word_char(self.buf[start - 1]):
+                    continue
+                if len(self.buf) >= end:
+                    if end < len(self.buf) and self._is_word_char(self.buf[end]):
+                        continue
+                return True
+        return False
 
     def feed(self, delta: str) -> List[str]:
         """Absorb *delta*; return every complete sentence now ready to speak."""
-        self.buf = _THINK_BLOCK_RE.sub("", self.buf + delta)
-        if "<think" in self.buf and "</think>" not in self.buf:
-            return []  # open think tag — the closing tag may arrive next delta
+        if self._discard_rest:
+            return []
+        self.buf = self._remove_complete_protected_blocks(self.buf + delta)
+        if self.holding_protected_text:
+            return []
         out: List[str] = []
         start = 0  # skip boundaries that would leave the head too short
         while m := SENTENCE_BOUNDARY_RE.search(self.buf, start):
-            head = self.buf[: m.end()]
-            if len(head.strip()) < self.min_len:
+            if self._boundary_is_inside_fenced_code(m.end()):
+                start = m.end()
+                continue
+            head = self.buf[:m.end()]
+            if len(head.strip()) < self.min_len or self._substitution_may_cross_boundary(m.end()):
                 start = m.end()
                 continue
             out.append(head)
@@ -117,10 +343,61 @@ class SentenceChunker:
             start = 0
         return out
 
+    def flush_for_idle(self) -> List[str]:
+        """Drain an idle-safe prefix while retaining pronunciation context.
+
+        Pronunciation substitutions use ``(?<!\\w)``.  If an idle flush clears
+        a trailing word, the next delta can incorrectly make a source appear to
+        start at a word boundary.  Retain that trailing word until the next
+        delta (or the explicit end-of-text flush) resolves the boundary.
+        """
+        if not self._pronunciation_sources:
+            return self.flush()
+
+        tail = self._remove_complete_protected_blocks(self.buf)
+        self.buf = tail
+        if self.holding_protected_text:
+            return []
+        match = re.search(r"\w+$", tail)
+        if match is None:
+            self.buf = ""
+            return [tail] if tail.strip() else []
+
+        retain_start = match.start()
+        # A punctuation-ending source may sit immediately before the trailing
+        # word (for example ``C++s``).  Emitting it would invent a false
+        # ``(?!\\w)`` boundary.  Pull every such valid source into the retained
+        # suffix; iterate for adjacent/overlapping configured sources.
+        while True:
+            earlier_start: Optional[int] = None
+            for source in self._pronunciation_sources:
+                source_start = retain_start - len(source)
+                if source_start < 0:
+                    continue
+                if not _literal_ignorecase_matches(
+                    tail[source_start:retain_start], source
+                ):
+                    continue
+                if source_start > 0 and self._is_word_char(
+                    tail[source_start - 1]
+                ):
+                    continue
+                if earlier_start is None or source_start < earlier_start:
+                    earlier_start = source_start
+            if earlier_start is None:
+                break
+            retain_start = earlier_start
+
+        ready = tail[:retain_start]
+        self.buf = tail[retain_start:]
+        return [ready] if ready.strip() else []
+
     def flush(self) -> List[str]:
         """Drain the tail (end-of-text or long-idle flush)."""
-        tail = _THINK_BLOCK_RE.sub("", self.buf).strip()
+        tail = self._remove_complete_protected_blocks(self.buf)
+        tail = self._strip_open_protected_tail(tail).strip()
         self.buf = ""
+        self._discard_rest = False
         return [tail] if tail else []
 
 
@@ -131,6 +408,8 @@ class SentenceChunker:
 class StreamingTTSProvider(ABC):
     """Yields raw int16, little-endian, mono PCM chunks at ``sample_rate``."""
 
+    provider_name: str = ""
+    model_id: Optional[str] = None
     sample_rate: int = 24000
     channels: int = 1
     sample_width: int = 2  # bytes/sample (int16)
@@ -154,6 +433,7 @@ _REGISTRY: Dict[str, type[StreamingTTSProvider]] = {}
 
 def register(name: str) -> Callable[[type[StreamingTTSProvider]], type[StreamingTTSProvider]]:
     def _wrap(cls: type[StreamingTTSProvider]) -> type[StreamingTTSProvider]:
+        cls.provider_name = name
         _REGISTRY[name] = cls
         return cls
 
@@ -223,13 +503,22 @@ class ElevenLabsStreamer(StreamingTTSProvider):
 
     sample_rate = 24000
 
+    def __init__(self, tts_config: Dict, section: Dict):
+        super().__init__(tts_config, section)
+        from tools.tts_tool import DEFAULT_ELEVENLABS_STREAMING_MODEL_ID
+
+        self.model_id = str(
+            section.get("streaming_model_id")
+            or section.get("model_id")
+            or DEFAULT_ELEVENLABS_STREAMING_MODEL_ID
+        )
+
     @staticmethod
     def available() -> bool:
         return bool(_resolve_key("ELEVENLABS_API_KEY", "elevenlabs"))
 
     def stream(self, text: str) -> Iterator[bytes]:
         from tools.tts_tool import (
-            DEFAULT_ELEVENLABS_STREAMING_MODEL_ID,
             DEFAULT_ELEVENLABS_VOICE_ID,
             _elevenlabs_environment_kwargs,
             _import_elevenlabs,
@@ -240,14 +529,10 @@ class ElevenLabsStreamer(StreamingTTSProvider):
             **_elevenlabs_environment_kwargs(self.section),
         )
         voice_id = self.section.get("voice_id", DEFAULT_ELEVENLABS_VOICE_ID)
-        model_id = self.section.get(
-            "streaming_model_id",
-            self.section.get("model_id", DEFAULT_ELEVENLABS_STREAMING_MODEL_ID),
-        )
         yield from client.text_to_speech.convert(
             text=text,
             voice_id=voice_id,
-            model_id=model_id,
+            model_id=self.model_id,
             output_format="pcm_24000",
         )
 

--- a/tools/tts_text_normalize.py
+++ b/tools/tts_text_normalize.py
@@ -18,7 +18,7 @@ import re
 # rather than leaving a bare "Weather." label that reads abruptly aloud.
 _HEAD = "\x00"
 
-_MD_CODE_BLOCK_RE = re.compile(r"```[\s\S]*?```")
+_MD_CODE_BLOCK_RE = re.compile(r"```[\s\S]*?(?:```|$)")
 _MD_LINK_RE = re.compile(r"\[([^\]]+)\]\((?:[^()]|\([^)]*\))*\)")
 _MD_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\((?:[^()]|\([^)]*\))*\)")
 _MD_INLINE_CODE_RE = re.compile(r"`([^`]+)`")
@@ -230,11 +230,15 @@ _VERIFIER_FOOTER_RE = re.compile(
 def strip_nonspoken_blocks(text: str) -> str:
     """Remove blocks that must never reach a speech provider.
 
-    Currently: ``<think>`` reasoning blocks and the end-of-turn
-    file-mutation verifier footer.
+    Currently: ``<think>`` reasoning blocks, fenced code blocks, and the
+    end-of-turn file-mutation verifier footer.
     """
     if not text:
         return ""
+    # Remove fenced examples first so literal ``<think>`` or verifier syntax
+    # inside documentation cannot be mistaken for an outer protected block and
+    # consume visible prose that follows the closing fence.
+    text = _MD_CODE_BLOCK_RE.sub(" ", text)
     text = _THINK_BLOCK_RE.sub(" ", text)
     text = _THINK_BLOCK_OPEN_RE.sub(" ", text)
     text = _VERIFIER_FOOTER_RE.sub(" ", text)
@@ -263,7 +267,8 @@ def get_pronunciation_substitutions(tts_config: object) -> dict[str, str]:
 
     A malformed map is rejected as a whole rather than partially applied, so a
     typo in user configuration cannot produce surprising partial substitutions.
-    Empty source strings are ignored because they cannot identify a term.
+    Empty source strings invalidate the whole map because they cannot identify
+    a term and partial application would hide a configuration error.
     """
     if not isinstance(tts_config, dict):
         return {}
@@ -280,11 +285,9 @@ def _validate_pronunciation_substitutions(substitutions: object) -> dict[str, st
     if not all(isinstance(source, str) and isinstance(replacement, str)
                for source, replacement in substitutions.items()):
         return {}
-    return {
-        source: replacement
-        for source, replacement in substitutions.items()
-        if isinstance(source, str) and isinstance(replacement, str) and source
-    }
+    if any(not source for source in substitutions):
+        return {}
+    return dict(substitutions)
 
 
 def apply_pronunciation_substitutions(text: str, substitutions: object) -> str:

--- a/tools/tts_text_normalize.py
+++ b/tools/tts_text_normalize.py
@@ -258,33 +258,66 @@ def flatten_newlines_for_payload(text: str) -> str:
     return text.strip()
 
 
-def apply_pronunciation_substitutions(text: str, substitutions: dict | None) -> str:
-    """Replace words in *text* using a case-insensitive whole-word match.
+def get_pronunciation_substitutions(tts_config: object) -> dict[str, str]:
+    """Return a validated pronunciation map from a TTS config object.
 
-    *substitutions* maps a source word to its phonetic replacement.  The
-    match is case-insensitive and anchored on word boundaries (``\\b``) so
-    partial matches inside larger words are skipped.  The replacement's
-    exact casing is preserved — the replacement string is inserted verbatim
-    regardless of how the source word appeared in the text.
-
-    Returns *text* unchanged when *substitutions* is empty or ``None``.
+    A malformed map is rejected as a whole rather than partially applied, so a
+    typo in user configuration cannot produce surprising partial substitutions.
+    Empty source strings are ignored because they cannot identify a term.
     """
-    if not text or not substitutions:
+    if not isinstance(tts_config, dict):
+        return {}
+    pronunciation = tts_config.get("pronunciation")
+    if not isinstance(pronunciation, dict):
+        return {}
+    substitutions = pronunciation.get("substitutions")
+    return _validate_pronunciation_substitutions(substitutions)
+
+
+def _validate_pronunciation_substitutions(substitutions: object) -> dict[str, str]:
+    if not isinstance(substitutions, dict):
+        return {}
+    if not all(isinstance(source, str) and isinstance(replacement, str)
+               for source, replacement in substitutions.items()):
+        return {}
+    return {source: replacement for source, replacement in substitutions.items() if source}
+
+
+def apply_pronunciation_substitutions(text: str, substitutions: object) -> str:
+    """Apply a validated pronunciation map in one case-insensitive pass.
+
+    Source terms are treated as literals and must not touch an adjacent word
+    character.  This supports punctuation-bearing terms such as ``C++`` and
+    ``.NET`` where ``\\b`` boundaries do not work.  A callback inserts the
+    configured replacement literally, including backslashes.  One alternation
+    handles all terms so replacement output is never matched again.
+    """
+    validated = _validate_pronunciation_substitutions(substitutions)
+    if not text or not validated:
         return text
 
-    result = text
-    for word, replacement in substitutions.items():
-        if not word:
-            continue
-        pattern = re.compile(r"\b" + re.escape(word) + r"\b", flags=re.IGNORECASE)
-        result = pattern.sub(replacement, result)
-    return result
+    # Longest terms win when one literal is a prefix of another.  The remaining
+    # sort keys make ambiguous case-insensitive duplicates deterministic and
+    # independent of mapping insertion order.
+    sources = sorted(validated, key=lambda source: (-len(source), source.casefold(), source))
+    replacements: dict[str, str] = {}
+    alternatives: list[str] = []
+    for index, source in enumerate(sources):
+        group_name = f"term_{index}"
+        alternatives.append(f"(?P<{group_name}>{re.escape(source)})")
+        replacements[group_name] = validated[source]
+
+    pattern = re.compile(
+        rf"(?<!\w)(?:{'|'.join(alternatives)})(?!\w)",
+        flags=re.IGNORECASE,
+    )
+    return pattern.sub(lambda match: replacements[match.lastgroup or ""], text)
 
 
 def prepare_spoken_text(
     text: str,
     max_chars: int | None = 4000,
-    pronunciation_substitutions: dict | None = None,
+    pronunciation_substitutions: object = None,
 ) -> str:
     """Return a TTS-friendly script from assistant text.
 
@@ -295,13 +328,12 @@ def prepare_spoken_text(
     the result to a single line so newline-sensitive providers (Kokoro) speak
     the whole script.
 
-    When *pronunciation_substitutions* is a non-empty dict, each key→value
-    pair is applied as a case-insensitive whole-word replacement **before**
-    markdown stripping, so substitutions operate on the raw text.
+    When *pronunciation_substitutions* is a valid non-empty ``dict[str, str]``,
+    each source→replacement pair is applied case-insensitively without matching
+    adjacent word characters **before** markdown stripping, so substitutions
+    operate on the raw text.
     """
-    spoken = text
-    if pronunciation_substitutions:
-        spoken = apply_pronunciation_substitutions(spoken, pronunciation_substitutions)
+    spoken = apply_pronunciation_substitutions(text, pronunciation_substitutions)
     spoken = strip_nonspoken_blocks(spoken)
     spoken = strip_markdown_for_tts(spoken)
     spoken = normalize_symbols_for_tts(spoken)

--- a/tools/tts_text_normalize.py
+++ b/tools/tts_text_normalize.py
@@ -258,7 +258,34 @@ def flatten_newlines_for_payload(text: str) -> str:
     return text.strip()
 
 
-def prepare_spoken_text(text: str, max_chars: int | None = 4000) -> str:
+def apply_pronunciation_substitutions(text: str, substitutions: dict | None) -> str:
+    """Replace words in *text* using a case-insensitive whole-word match.
+
+    *substitutions* maps a source word to its phonetic replacement.  The
+    match is case-insensitive and anchored on word boundaries (``\\b``) so
+    partial matches inside larger words are skipped.  The replacement's
+    exact casing is preserved — the replacement string is inserted verbatim
+    regardless of how the source word appeared in the text.
+
+    Returns *text* unchanged when *substitutions* is empty or ``None``.
+    """
+    if not text or not substitutions:
+        return text
+
+    result = text
+    for word, replacement in substitutions.items():
+        if not word:
+            continue
+        pattern = re.compile(r"\b" + re.escape(word) + r"\b", flags=re.IGNORECASE)
+        result = pattern.sub(replacement, result)
+    return result
+
+
+def prepare_spoken_text(
+    text: str,
+    max_chars: int | None = 4000,
+    pronunciation_substitutions: dict | None = None,
+) -> str:
     """Return a TTS-friendly script from assistant text.
 
     Deterministic cleanup, not a semantic rewrite: it removes ``<think>``
@@ -267,8 +294,15 @@ def prepare_spoken_text(text: str, max_chars: int | None = 4000) -> str:
     turns visual line formatting into speakable sentence pauses, and flattens
     the result to a single line so newline-sensitive providers (Kokoro) speak
     the whole script.
+
+    When *pronunciation_substitutions* is a non-empty dict, each key→value
+    pair is applied as a case-insensitive whole-word replacement **before**
+    markdown stripping, so substitutions operate on the raw text.
     """
-    spoken = strip_nonspoken_blocks(text)
+    spoken = text
+    if pronunciation_substitutions:
+        spoken = apply_pronunciation_substitutions(spoken, pronunciation_substitutions)
+    spoken = strip_nonspoken_blocks(spoken)
     spoken = strip_markdown_for_tts(spoken)
     spoken = normalize_symbols_for_tts(spoken)
     spoken = smooth_whitespace_for_tts(spoken)

--- a/tools/tts_text_normalize.py
+++ b/tools/tts_text_normalize.py
@@ -280,7 +280,11 @@ def _validate_pronunciation_substitutions(substitutions: object) -> dict[str, st
     if not all(isinstance(source, str) and isinstance(replacement, str)
                for source, replacement in substitutions.items()):
         return {}
-    return {source: replacement for source, replacement in substitutions.items() if source}
+    return {
+        source: replacement
+        for source, replacement in substitutions.items()
+        if isinstance(source, str) and isinstance(replacement, str) and source
+    }
 
 
 def apply_pronunciation_substitutions(text: str, substitutions: object) -> str:
@@ -329,12 +333,14 @@ def prepare_spoken_text(
     the whole script.
 
     When *pronunciation_substitutions* is a valid non-empty ``dict[str, str]``,
-    each source→replacement pair is applied case-insensitively without matching
-    adjacent word characters **before** markdown stripping, so substitutions
-    operate on the raw text.
+    protected non-spoken blocks are removed first. Each source→replacement pair
+    is then applied case-insensitively without matching adjacent word characters,
+    before Markdown stripping.
     """
-    spoken = apply_pronunciation_substitutions(text, pronunciation_substitutions)
-    spoken = strip_nonspoken_blocks(spoken)
+    spoken = strip_nonspoken_blocks(text)
+    spoken = apply_pronunciation_substitutions(
+        spoken, pronunciation_substitutions
+    )
     spoken = strip_markdown_for_tts(spoken)
     spoken = normalize_symbols_for_tts(spoken)
     spoken = smooth_whitespace_for_tts(spoken)

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -3383,8 +3383,8 @@ def stream_tts_to_speaker(
         output_stream = None
         tts_config = _load_tts_config()
         from tools.tts_text_normalize import (
-            apply_pronunciation_substitutions,
             get_pronunciation_substitutions,
+            prepare_spoken_text,
         )
 
         streaming_pronunciation = get_pronunciation_substitutions(tts_config)
@@ -3434,7 +3434,18 @@ def stream_tts_to_speaker(
             """Display sentence and optionally generate + play audio."""
             if stop_event.is_set():
                 return
-            cleaned = _strip_markdown_for_tts(sentence).strip()
+            # The direct streamer does not re-enter text_to_speech_tool(), so
+            # run its pronunciation rewrite while the original symbols are
+            # still present. The sync fallback does re-enter the tool and must
+            # receive the original sentence so the rewrite remains single-pass.
+            if streamer is None:
+                cleaned = _strip_markdown_for_tts(sentence).strip()
+            else:
+                cleaned = prepare_spoken_text(
+                    sentence,
+                    max_chars=None,
+                    pronunciation_substitutions=streaming_pronunciation,
+                ).strip()
             if not cleaned:
                 return
             # Skip duplicate/near-duplicate sentences (LLM repetition)
@@ -3448,15 +3459,8 @@ def stream_tts_to_speaker(
                 display_callback(sentence)
             # No chunked streamer → per-sentence sync synthesis (universal).
             if streamer is None:
-                _speak_via_sync(cleaned)
+                _speak_via_sync(sentence)
                 return
-            # Apply the same literal pronunciation map used by synchronous and
-            # gateway streaming TTS. The sync fallback below re-enters
-            # text_to_speech_tool(), so only apply it on this direct streamer path.
-            if streaming_pronunciation:
-                cleaned = apply_pronunciation_substitutions(
-                    cleaned, streaming_pronunciation
-                )
             # Truncate very long sentences to the provider's per-request cap.
             if stream_max_len and len(cleaned) > stream_max_len:
                 cleaned = cleaned[:stream_max_len]

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -409,6 +409,8 @@ MAX_TEXT_LENGTH = FALLBACK_MAX_TEXT_LENGTH
 def _resolve_max_text_length(
     provider: Optional[str],
     tts_config: Optional[Dict[str, Any]] = None,
+    *,
+    model_id: Optional[str] = None,
 ) -> int:
     """Return the input-character cap for *provider*.
 
@@ -416,7 +418,8 @@ def _resolve_max_text_length(
       1. ``tts.<provider>.max_text_length`` (user override in config.yaml)
       2. ``tts.providers.<provider>.max_text_length`` for user-declared
          command providers
-      3. ElevenLabs model-aware table (keyed on configured ``model_id``)
+      3. ElevenLabs model-aware table (keyed on the active model when supplied,
+         otherwise the configured ``model_id``)
       4. ``PROVIDER_MAX_TEXT_LENGTH`` default
       5. ``DEFAULT_COMMAND_TTS_MAX_TEXT_LENGTH`` when the provider is a
          command-type user provider without an explicit cap
@@ -440,8 +443,12 @@ def _resolve_max_text_length(
         return override
 
     if key == "elevenlabs":
-        model_id = (prov_cfg or {}).get("model_id") or DEFAULT_ELEVENLABS_MODEL_ID
-        mapped = ELEVENLABS_MODEL_MAX_TEXT_LENGTH.get(str(model_id).strip())
+        active_model_id = (
+            model_id
+            or (prov_cfg or {}).get("model_id")
+            or DEFAULT_ELEVENLABS_MODEL_ID
+        )
+        mapped = ELEVENLABS_MODEL_MAX_TEXT_LENGTH.get(str(active_model_id).strip())
         if mapped:
             return mapped
 
@@ -2784,6 +2791,7 @@ def text_to_speech_tool(
     speed: Optional[float] = None,
     instructions: Optional[str] = None,
     provider: Optional[str] = None,
+    _max_chars: Optional[int] = None,
 ) -> str:
     """
     Convert text to speech audio.
@@ -2811,6 +2819,10 @@ def text_to_speech_tool(
             from ``tts.providers.<name>``, or plugin-registered provider
             names.  When ``None`` (the default), the configured provider
             from ``tts.provider`` in config.yaml is used.
+        _max_chars: Internal per-call cap for the final provider-bound spoken
+            text, applied after protected-content removal, pronunciation
+            substitutions, and normalization. The provider's own lower limit
+            still takes precedence.
 
     Returns:
         str: JSON result with success, file_path, and optionally MEDIA tag.
@@ -2856,6 +2868,12 @@ def text_to_speech_tool(
     # Truncate very long text with a warning. The cap is per-provider
     # (OpenAI 4096, xAI 15k, MiniMax 10k, ElevenLabs model-aware, etc.).
     max_len = _resolve_max_text_length(provider, tts_config)
+    if _max_chars is not None:
+        try:
+            requested_max = max(1, int(_max_chars))
+        except (TypeError, ValueError):
+            return tool_error("_max_chars must be a positive integer", success=False)
+        max_len = min(max_len, requested_max)
     if len(text) > max_len:
         logger.warning(
             "TTS text too long for provider %s (%d chars), truncating to %d",
@@ -3397,9 +3415,23 @@ def stream_tts_to_speaker(
         stream_max_len = 0
         if streamer is not None:
             try:
-                stream_max_len = _resolve_max_text_length(
-                    provider or _get_provider(tts_config), tts_config
+                stream_provider = (
+                    getattr(streamer, "provider_name", "")
+                    or provider
+                    or _get_provider(tts_config)
                 )
+                stream_model_id = getattr(streamer, "model_id", None)
+                if stream_model_id:
+                    stream_max_len = _resolve_max_text_length(
+                        stream_provider,
+                        tts_config,
+                        model_id=stream_model_id,
+                    )
+                else:
+                    stream_max_len = _resolve_max_text_length(
+                        stream_provider,
+                        tts_config,
+                    )
             except Exception:
                 stream_max_len = 0
             # On macOS, skip the sounddevice OutputStream entirely: PortAudio/
@@ -3425,7 +3457,9 @@ def stream_tts_to_speaker(
                     logger.warning("sounddevice OutputStream failed: %s", exc)
                     output_stream = None
 
-        chunker = SentenceChunker()
+        chunker = SentenceChunker(
+            pronunciation_substitutions=streaming_pronunciation,
+        )
         long_flush_len = 100
         queue_timeout = 0.5
         _spoken_sentences: list[str] = []  # track spoken sentences to skip duplicates
@@ -3434,10 +3468,16 @@ def stream_tts_to_speaker(
             """Display sentence and optionally generate + play audio."""
             if stop_event.is_set():
                 return
-            # The direct streamer does not re-enter text_to_speech_tool(), so
-            # run its pronunciation rewrite while the original symbols are
-            # still present. The sync fallback does re-enter the tool and must
-            # receive the original sentence so the rewrite remains single-pass.
+            # Display the raw clause before speech-only cleanup and duplicate
+            # suppression. Distinct visible sentences may intentionally map to
+            # the same pronunciation, and fenced code may have no spoken form.
+            if display_callback is not None:
+                display_callback(sentence)
+            # The chunker keeps configured phrases intact across boundaries on
+            # the direct-streamer path. Apply pronunciation once during the
+            # speech-only cleanup, while display_callback still receives the
+            # original visible clause. The sync fallback deliberately keeps raw
+            # text for the central whole-file tool to process once.
             if streamer is None:
                 cleaned = _strip_markdown_for_tts(sentence).strip()
             else:
@@ -3454,9 +3494,6 @@ def stream_tts_to_speaker(
                 if prev.lower().rstrip(".!,") == cleaned_lower:
                     return
             _spoken_sentences.append(cleaned)
-            # Display raw sentence on screen before TTS processing
-            if display_callback is not None:
-                display_callback(sentence)
             # No chunked streamer → per-sentence sync synthesis (universal).
             if streamer is None:
                 _speak_via_sync(sentence)
@@ -3560,8 +3597,12 @@ def stream_tts_to_speaker(
                 delta = text_queue.get(timeout=queue_timeout)
             except queue.Empty:
                 # Idle producer: flush a long buffer instead of sitting on it
-                if len(chunker.buf) > long_flush_len:
-                    for sentence in chunker.flush():
+                if (
+                    len(chunker.buf) > long_flush_len
+                    and not chunker.holding_protected_text
+                    and not chunker.holding_pronunciation_lookahead
+                ):
+                    for sentence in chunker.flush_for_idle():
                         _speak_sentence(sentence)
                 continue
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2818,15 +2818,20 @@ def text_to_speech_tool(
     if not text or not text.strip():
         return tool_error("Text is required", success=False)
 
+    tts_config = _load_tts_config()
+
+    # Extract pronunciation substitutions from config and apply them during
+    # spoken-text preparation (before markdown stripping).
+    pronunciation = tts_config.get("pronunciation", {})
+    substitutions = pronunciation.get("substitutions", {}) if isinstance(pronunciation, dict) else {}
+
     try:
         from tools.tts_text_normalize import prepare_spoken_text
-        text = prepare_spoken_text(text, max_chars=None)
+        text = prepare_spoken_text(text, max_chars=None, pronunciation_substitutions=substitutions)
     except Exception:
         text = text.strip()
     if not text:
         return tool_error("Text is empty after TTS cleanup", success=False)
-
-    tts_config = _load_tts_config()
 
     # When the model supplies a speed parameter, inject it into the config
     # so all downstream provider functions pick it up uniformly.

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -3382,6 +3382,12 @@ def stream_tts_to_speaker(
     try:
         output_stream = None
         tts_config = _load_tts_config()
+        from tools.tts_text_normalize import (
+            apply_pronunciation_substitutions,
+            get_pronunciation_substitutions,
+        )
+
+        streaming_pronunciation = get_pronunciation_substitutions(tts_config)
 
         # Prefer a chunked streamer for low time-to-first-audio; fall back to
         # per-sentence sync synthesis (universal — edge + every non-streamer).
@@ -3444,6 +3450,13 @@ def stream_tts_to_speaker(
             if streamer is None:
                 _speak_via_sync(cleaned)
                 return
+            # Apply the same literal pronunciation map used by synchronous and
+            # gateway streaming TTS. The sync fallback below re-enters
+            # text_to_speech_tool(), so only apply it on this direct streamer path.
+            if streaming_pronunciation:
+                cleaned = apply_pronunciation_substitutions(
+                    cleaned, streaming_pronunciation
+                )
             # Truncate very long sentences to the provider's per-request cap.
             if stream_max_len and len(cleaned) > stream_max_len:
                 cleaned = cleaned[:stream_max_len]

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2820,13 +2820,14 @@ def text_to_speech_tool(
 
     tts_config = _load_tts_config()
 
-    # Extract pronunciation substitutions from config and apply them during
-    # spoken-text preparation (before markdown stripping).
-    pronunciation = tts_config.get("pronunciation", {})
-    substitutions = pronunciation.get("substitutions", {}) if isinstance(pronunciation, dict) else {}
-
+    # Extract and validate pronunciation substitutions before cleanup.  Invalid
+    # user config is a no-op rather than disabling all TTS normalization.
     try:
-        from tools.tts_text_normalize import prepare_spoken_text
+        from tools.tts_text_normalize import (
+            get_pronunciation_substitutions,
+            prepare_spoken_text,
+        )
+        substitutions = get_pronunciation_substitutions(tts_config)
         text = prepare_spoken_text(text, max_chars=None, pronunciation_substitutions=substitutions)
     except Exception:
         text = text.strip()

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -165,9 +165,7 @@ tts:
       Notre: No-tra
 ```
 
-Substitutions are applied to the raw text before markdown stripping, so they work on formatted text too. They work with all TTS providers since the replacement happens before provider dispatch.
-
-You can also configure substitutions from the Desktop app under **Settings → Voice → Pronunciation Substitutions** (JSON editor).
+Protected non-spoken blocks are removed before substitutions, so a configured term cannot alter private reasoning or verifier markers. Substitutions then run before Markdown stripping and provider dispatch, so they still work on formatted text across synchronous and streaming TTS paths.
 
 ### Input length limits
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -165,6 +165,8 @@ tts:
       Notre: No-tra
 ```
 
+Pronunciation substitutions are currently a YAML-only advanced setting because the generic desktop settings form does not yet provide a safe key/value map editor.
+
 Protected non-spoken blocks are removed before substitutions, so a configured term cannot alter private reasoning or verifier markers. Substitutions then run before Markdown stripping and provider dispatch, so they still work on formatted text across synchronous and streaming TTS paths.
 
 ### Input length limits

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -103,6 +103,8 @@ tts:
     # noise_w_scale: 0.8
     # volume: 1.0                               # 0.5 = half as loud
     # normalize_audio: true
+  pronunciation:
+    substitutions: {}  # Word -> phonetic replacement, e.g. {Tahlia: Tarlia}
 ```
 
 MiniMax TTS selects its region, endpoint, and credential together:
@@ -146,6 +148,26 @@ The rewrite uses `auxiliary.tts_audio_tags` and defaults to your main chat model
 
 **Language (OpenAI-compatible endpoints)**: `tts.openai.language` is forwarded to the endpoint as a `lang_code` request parameter. It is intended for OpenAI-compatible TTS servers that support `lang_code` — for example [Kokoro-FastAPI](https://github.com/remsky/Kokoro-FastAPI), where `language: "es"` selects the Spanish phonemizer instead of the English default. Leave it unset when using the official OpenAI API, which does not accept this parameter. When unset, nothing extra is sent.
 
+
+### Pronunciation Substitutions
+
+Hermes can replace specific words in TTS text before sending them to any provider. This is useful for names or terms that TTS engines mispronounce — for example, "Tahlia" should be spoken as "Tarlia".
+
+Substitutions use case-insensitive whole-word matching, so `Tahlia`, `tahlia`, and `TAHLIA` all get replaced, but `Tahlias` does not. The replacement's exact casing is preserved.
+
+```yaml
+# In ~/.hermes/config.yaml
+tts:
+  pronunciation:
+    substitutions:
+      Tahlia: Tarlia
+      Siobhan: Shi-vaun
+      Notre: No-tra
+```
+
+Substitutions are applied to the raw text before markdown stripping, so they work on formatted text too. They work with all TTS providers since the replacement happens before provider dispatch.
+
+You can also configure substitutions from the Desktop app under **Settings → Voice → Pronunciation Substitutions** (JSON editor).
 
 ### Input length limits
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -153,7 +153,7 @@ The rewrite uses `auxiliary.tts_audio_tags` and defaults to your main chat model
 
 Hermes can replace specific words in TTS text before sending them to any provider. This is useful for names or terms that TTS engines mispronounce — for example, "Tahlia" should be spoken as "Tarlia".
 
-Substitutions use case-insensitive whole-word matching, so `Tahlia`, `tahlia`, and `TAHLIA` all get replaced, but `Tahlias` does not. The replacement's exact casing is preserved.
+Substitutions use case-insensitive literal matching and only match terms that are not adjacent to a word character. Thus `Tahlia`, `tahlia`, and `TAHLIA` all get replaced, but `Tahlias` does not; punctuation-bearing terms such as `C++` and `.NET` are also supported. Replacement text is inserted literally, including backslashes.
 
 ```yaml
 # In ~/.hermes/config.yaml


### PR DESCRIPTION
## Summary

Adds configurable, literal pronunciation substitutions to synchronous, conversational streaming and gateway streaming TTS paths.

```yaml
tts:
  pronunciation:
    substitutions:
      "Hermes": "Her-meez"
      "C++": "C plus plus"
      ".NET": "dot net"
```

## Behaviour

- Protected non-spoken blocks are removed before user-configurable substitutions, preventing private/verifier markers from being mutated into speech.
- Matching is case-insensitive and respects non-word lookarounds, including technical terms such as `C++` and `.NET`.
- Replacements are literal, so backslashes and backreference-like text are preserved.
- All matches are applied in one longest-first pass, preventing cascading and configuration-order dependence.
- Invalid or non-string substitution maps are ignored safely.
- Synchronous, conversational streaming and gateway streaming dispatch all receive the same validated substitutions.
- Streaming paths do not rerun unrelated normalisation or change chunking.

The generic desktop settings renderer intentionally does not expose this nested map as a raw JSON field. A dedicated human-friendly editor can be added separately.

## Tests

- 474 TTS-related tests passed, 6 skipped under the project dev environment.
- Includes focused regression coverage for protected content, literal replacements, malformed maps, `C++`/`.NET`, non-cascading order independence, synchronous dispatch and both streaming paths.
- Ruff passed on all touched Python files.
- `git diff --check` passed.
