### PR TITLE
feat(cron): audit model pinning and drift-guard state

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -499,6 +499,13 @@ def cron_command(args):
     if subcmd in {"remove", "rm", "delete"}:
         return _job_action("remove", args.job_id, "Removed")
 
+    if subcmd == "audit-models":
+        from hermes_cli.cron_audit import audit_cron_models
+
+        json_output = getattr(args, "json_output", False)
+        print(audit_cron_models(json_output=json_output))
+        return 0
+
     print(f"Unknown cron command: {subcmd}")
-    print("Usage: hermes cron [list|create|edit|pause|resume|run|remove|status|runs|tick]")
+    print("Usage: hermes cron [list|create|edit|pause|resume|run|remove|status|runs|audit-models|tick]")
     sys.exit(1)

--- a/hermes_cli/cron_audit.py
+++ b/hermes_cli/cron_audit.py
@@ -1,0 +1,110 @@
+"""Cron model/provider pinning audit.
+
+Identifies which cron jobs have pinned models (safe from provider drift),
+which inherit the global config (will drift if config changes), and which
+are script-only (no LLM call, unaffected).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+
+def audit_cron_models(json_output: bool = False) -> str:
+    """Audit all cron jobs for model/provider pinning status.
+
+    Identifies which jobs have pinned models (safe from provider drift),
+    which inherit the global config (will drift if config changes), and
+    which are script-only (no LLM call, unaffected).
+    """
+    from cron.jobs import load_jobs, _resolve_default_model_snapshot
+    from hermes_cli.config import load_config
+
+    jobs = load_jobs()
+    config = load_config()
+
+    # Resolve global defaults for context
+    global_model = _resolve_default_model_snapshot()
+    # Resolve global provider
+    model_cfg = config.get("model") or {}
+    if isinstance(model_cfg, dict):
+        global_provider = model_cfg.get("provider", "")
+    else:
+        global_provider = ""
+
+    results = []
+    for job in jobs:
+        model = job.get("model")
+        provider = job.get("provider")
+        no_agent = job.get("no_agent", False)
+        job_id = job.get("id", "")
+        name = job.get("name", "") or ""
+
+        if no_agent:
+            status = "script-only"
+            status_icon = "\u2713"  # checkmark
+        elif model is not None and provider is not None:
+            status = "pinned"
+            status_icon = "\u2713"
+        elif model is not None or provider is not None:
+            status = "partial"
+            status_icon = "\u26a0"  # warning
+        else:
+            status = "inherited"
+            status_icon = "\u26a0"
+
+        results.append({
+            "id": job_id,
+            "name": name,
+            "model": model or "(inherited)",
+            "provider": provider or "(inherited)",
+            "status": status,
+            "status_icon": status_icon,
+            "no_agent": no_agent,
+        })
+
+    if json_output:
+        return json.dumps({
+            "global_model": global_model or "(none)",
+            "global_provider": global_provider or "(none)",
+            "jobs": results,
+        }, indent=2)
+
+    # Format as table
+    lines = ["Cron Model Audit", "=" * 60, ""]
+    lines.append(f"Global model: {global_model or '(none)'}")
+    lines.append(f"Global provider: {global_provider or '(none)'}")
+    lines.append("")
+
+    # Table header
+    lines.append(f"{'ID':<14} {'Name':<24} {'Model':<18} {'Provider':<18} {'Status'}")
+    lines.append("\u2500" * 80)
+
+    for r in results:
+        lines.append(
+            f"{r['id'][:12]:<14} {r['name'][:22]:<24} {r['model'][:16]:<18} "
+            f"{r['provider'][:16]:<18} {r['status_icon']} {r['status']}"
+        )
+
+    # Summary
+    pinned = sum(1 for r in results if r["status"] == "pinned")
+    inherited = sum(1 for r in results if r["status"] == "inherited")
+    script_only = sum(1 for r in results if r["status"] == "script-only")
+    partial = sum(1 for r in results if r["status"] == "partial")
+
+    lines.append("")
+    lines.append(
+        f"Summary: {pinned} pinned, {inherited} inherited, {partial} partial, {script_only} script-only"
+    )
+
+    if inherited > 0 or partial > 0:
+        lines.append("")
+        lines.append(
+            "\u26a0  Inherited/partial jobs will silently fail if global model/provider changes."
+        )
+        lines.append(
+            "   Pin them with: hermes cron update <id> --model <model> --provider <provider>"
+        )
+
+    return "\n".join(lines)

--- a/hermes_cli/cron_audit.py
+++ b/hermes_cli/cron_audit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import Any
 
 
@@ -20,6 +21,7 @@ def _configured_defaults(config: dict[str, Any]) -> tuple[str, str, bool, bool]:
 
     cron_model = _text(cron_cfg.get("model"))
     cron_provider = _text(cron_cfg.get("model_provider"))
+    env_model = _text(os.environ.get("HERMES_MODEL"))
 
     model_default = ""
     model_provider = ""
@@ -30,7 +32,7 @@ def _configured_defaults(config: dict[str, Any]) -> tuple[str, str, bool, bool]:
         model_provider = _text(model_cfg.get("provider"))
 
     return (
-        cron_model or model_default,
+        cron_model or model_default or env_model,
         cron_provider or model_provider,
         bool(cron_model),
         bool(cron_provider),
@@ -81,6 +83,9 @@ def audit_cron_models(json_output: bool = False) -> str:
         model = _text(job.get("model"))
         provider = _text(job.get("provider"))
         no_agent = bool(job.get("no_agent", False))
+        enabled = bool(job.get("enabled", True))
+        state = _text(job.get("state")) or "active"
+        active = enabled and state != "paused"
 
         if no_agent:
             status = "script-only"
@@ -133,10 +138,13 @@ def audit_cron_models(json_output: bool = False) -> str:
                 "provider_snapshot": provider_snapshot or None,
                 "status": status,
                 "no_agent": no_agent,
+                "enabled": enabled,
+                "state": state,
+                "active": active,
                 "guarded_axes": guarded_axes,
                 "drifted_axes": drifted_axes,
                 "unprotected_axes": unprotected_axes,
-                "at_risk": bool(drifted_axes),
+                "at_risk": active and bool(drifted_axes),
             }
         )
 
@@ -164,7 +172,11 @@ def audit_cron_models(json_output: bool = False) -> str:
     lines.append("─" * 96)
 
     for result in results:
-        if result["at_risk"]:
+        if not result["active"] and result["drifted_axes"]:
+            risk = "paused; drift on resume: " + ",".join(result["drifted_axes"])
+        elif not result["active"]:
+            risk = "paused"
+        elif result["at_risk"]:
             risk = "SKIP: " + ",".join(result["drifted_axes"])
         elif result["unprotected_axes"]:
             risk = "unguarded: " + ",".join(result["unprotected_axes"])

--- a/hermes_cli/cron_audit.py
+++ b/hermes_cli/cron_audit.py
@@ -1,110 +1,214 @@
-"""Cron model/provider pinning audit.
-
-Identifies which cron jobs have pinned models (safe from provider drift),
-which inherit the global config (will drift if config changes), and which
-are script-only (no LLM call, unaffected).
-"""
+"""Cron model/provider pinning and drift-safety audit."""
 
 from __future__ import annotations
 
 import json
-from typing import Optional
+from typing import Any
+
+
+def _text(value: Any) -> str:
+    """Return a normalized optional text value."""
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _configured_defaults(config: dict[str, Any]) -> tuple[str, str, bool, bool]:
+    """Resolve cron's effective fleet defaults and whether each is explicit."""
+    cron_cfg = config.get("cron") or {}
+    if not isinstance(cron_cfg, dict):
+        cron_cfg = {}
+    model_cfg = config.get("model") or {}
+
+    cron_model = _text(cron_cfg.get("model"))
+    cron_provider = _text(cron_cfg.get("model_provider"))
+
+    model_default = ""
+    model_provider = ""
+    if isinstance(model_cfg, str):
+        model_default = model_cfg.strip()
+    elif isinstance(model_cfg, dict):
+        model_default = _text(model_cfg.get("default") or model_cfg.get("model"))
+        model_provider = _text(model_cfg.get("provider"))
+
+    return (
+        cron_model or model_default,
+        cron_provider or model_provider,
+        bool(cron_model),
+        bool(cron_provider),
+    )
 
 
 def audit_cron_models(json_output: bool = False) -> str:
-    """Audit all cron jobs for model/provider pinning status.
+    """Audit cron pinning and whether the drift guard would skip a job now.
 
-    Identifies which jobs have pinned models (safe from provider drift),
-    which inherit the global config (will drift if config changes), and
-    which are script-only (no LLM call, unaffected).
+    Pinning state and drift impact are deliberately separate. An inherited job
+    is not automatically broken: the scheduler only skips an unpinned axis
+    when the guard is enabled, a creation-time snapshot exists, no cron-fleet
+    default covers that axis, and current resolution differs from the snapshot.
     """
-    from cron.jobs import load_jobs, _resolve_default_model_snapshot
-    from hermes_cli.config import load_config
+    from cron.jobs import (
+        _compute_provider_model_snapshots,
+        _resolve_default_model_snapshot,
+        load_jobs,
+    )
+    from hermes_cli.config import cron_model_drift_guard_enabled, load_config
 
     jobs = load_jobs()
     config = load_config()
+    if not isinstance(config, dict):
+        config = {}
 
-    # Resolve global defaults for context
-    global_model = _resolve_default_model_snapshot()
-    # Resolve global provider
-    model_cfg = config.get("model") or {}
-    if isinstance(model_cfg, dict):
-        global_provider = model_cfg.get("provider", "")
-    else:
-        global_provider = ""
+    effective_model, effective_provider, fleet_model, fleet_provider = (
+        _configured_defaults(config)
+    )
+    # Use the same model resolver as job creation/scheduler as a backstop for
+    # managed overlays and legacy config forms.
+    effective_model = effective_model or (_resolve_default_model_snapshot() or "")
+    if not effective_provider:
+        # Best-effort provider resolution. Failure is represented as unknown,
+        # never as a false drift finding.
+        effective_provider, _ = _compute_provider_model_snapshots(
+            provider=None,
+            model=effective_model or None,
+            base_url=None,
+            no_agent=False,
+        )
+        effective_provider = effective_provider or ""
 
-    results = []
+    guard_enabled = cron_model_drift_guard_enabled(config)
+    results: list[dict[str, Any]] = []
+
     for job in jobs:
-        model = job.get("model")
-        provider = job.get("provider")
-        no_agent = job.get("no_agent", False)
-        job_id = job.get("id", "")
-        name = job.get("name", "") or ""
+        model = _text(job.get("model"))
+        provider = _text(job.get("provider"))
+        no_agent = bool(job.get("no_agent", False))
 
         if no_agent:
             status = "script-only"
-            status_icon = "\u2713"  # checkmark
-        elif model is not None and provider is not None:
+        elif model and provider:
             status = "pinned"
-            status_icon = "\u2713"
-        elif model is not None or provider is not None:
+        elif model or provider:
             status = "partial"
-            status_icon = "\u26a0"  # warning
         else:
             status = "inherited"
-            status_icon = "\u26a0"
 
-        results.append({
-            "id": job_id,
-            "name": name,
-            "model": model or "(inherited)",
-            "provider": provider or "(inherited)",
-            "status": status,
-            "status_icon": status_icon,
-            "no_agent": no_agent,
-        })
+        model_snapshot = _text(job.get("model_snapshot"))
+        provider_snapshot = _text(job.get("provider_snapshot"))
+        current_model = model or effective_model
+        current_provider = provider or effective_provider
 
-    if json_output:
-        return json.dumps({
-            "global_model": global_model or "(none)",
-            "global_provider": global_provider or "(none)",
-            "jobs": results,
-        }, indent=2)
+        guarded_axes: list[str] = []
+        drifted_axes: list[str] = []
+        unprotected_axes: list[str] = []
 
-    # Format as table
-    lines = ["Cron Model Audit", "=" * 60, ""]
-    lines.append(f"Global model: {global_model or '(none)'}")
-    lines.append(f"Global provider: {global_provider or '(none)'}")
-    lines.append("")
+        if not no_agent:
+            axes = (
+                ("model", model, model_snapshot, current_model, fleet_model),
+                (
+                    "provider",
+                    provider,
+                    provider_snapshot,
+                    current_provider,
+                    fleet_provider,
+                ),
+            )
+            for axis, pinned, snapshot, current, fleet_covered in axes:
+                if pinned or fleet_covered:
+                    continue
+                if guard_enabled and snapshot:
+                    guarded_axes.append(axis)
+                    if current and current.lower() != snapshot.lower():
+                        drifted_axes.append(axis)
+                else:
+                    unprotected_axes.append(axis)
 
-    # Table header
-    lines.append(f"{'ID':<14} {'Name':<24} {'Model':<18} {'Provider':<18} {'Status'}")
-    lines.append("\u2500" * 80)
-
-    for r in results:
-        lines.append(
-            f"{r['id'][:12]:<14} {r['name'][:22]:<24} {r['model'][:16]:<18} "
-            f"{r['provider'][:16]:<18} {r['status_icon']} {r['status']}"
+        results.append(
+            {
+                "id": _text(job.get("id")),
+                "name": _text(job.get("name")),
+                "model": model or "(inherited)",
+                "provider": provider or "(inherited)",
+                "effective_model": current_model or "(unknown)",
+                "effective_provider": current_provider or "(unknown)",
+                "model_snapshot": model_snapshot or None,
+                "provider_snapshot": provider_snapshot or None,
+                "status": status,
+                "no_agent": no_agent,
+                "guarded_axes": guarded_axes,
+                "drifted_axes": drifted_axes,
+                "unprotected_axes": unprotected_axes,
+                "at_risk": bool(drifted_axes),
+            }
         )
 
-    # Summary
-    pinned = sum(1 for r in results if r["status"] == "pinned")
-    inherited = sum(1 for r in results if r["status"] == "inherited")
-    script_only = sum(1 for r in results if r["status"] == "script-only")
-    partial = sum(1 for r in results if r["status"] == "partial")
+    payload = {
+        "effective_default_model": effective_model or "(none)",
+        "effective_default_provider": effective_provider or "(none)",
+        "cron_fleet_model_configured": fleet_model,
+        "cron_fleet_provider_configured": fleet_provider,
+        "drift_guard_enabled": guard_enabled,
+        "jobs": results,
+    }
+    if json_output:
+        return json.dumps(payload, indent=2)
 
+    lines = ["Cron Model Audit", "=" * 72, ""]
+    lines.append(
+        f"Effective default: {payload['effective_default_provider']} / "
+        f"{payload['effective_default_model']}"
+    )
+    lines.append(f"Drift guard: {'enabled' if guard_enabled else 'disabled'}")
     lines.append("")
     lines.append(
-        f"Summary: {pinned} pinned, {inherited} inherited, {partial} partial, {script_only} script-only"
+        f"{'ID':<14} {'Name':<22} {'Model':<17} {'Provider':<17} {'Pinning':<12} Risk"
     )
+    lines.append("─" * 96)
 
-    if inherited > 0 or partial > 0:
-        lines.append("")
+    for result in results:
+        if result["at_risk"]:
+            risk = "SKIP: " + ",".join(result["drifted_axes"])
+        elif result["unprotected_axes"]:
+            risk = "unguarded: " + ",".join(result["unprotected_axes"])
+        elif result["guarded_axes"]:
+            risk = "guarded"
+        else:
+            risk = "none"
         lines.append(
-            "\u26a0  Inherited/partial jobs will silently fail if global model/provider changes."
+            f"{result['id'][:12]:<14} {result['name'][:20]:<22} "
+            f"{result['model'][:15]:<17} {result['provider'][:15]:<17} "
+            f"{result['status']:<12} {risk}"
         )
-        lines.append(
-            "   Pin them with: hermes cron update <id> --model <model> --provider <provider>"
+
+    counts = {
+        status: sum(1 for result in results if result["status"] == status)
+        for status in ("pinned", "inherited", "partial", "script-only")
+    }
+    at_risk = [result for result in results if result["at_risk"]]
+    unprotected = [result for result in results if result["unprotected_axes"]]
+    lines.extend(
+        [
+            "",
+            "Summary: "
+            f"{counts['pinned']} pinned, {counts['inherited']} inherited, "
+            f"{counts['partial']} partial, {counts['script-only']} script-only; "
+            f"{len(at_risk)} would be skipped now",
+        ]
+    )
+    if at_risk:
+        lines.extend(
+            [
+                "",
+                "⚠  Drift guard would skip the jobs marked SKIP on their next run.",
+                "   Pin intended values with: hermes cron edit <id> "
+                "--model <model> --provider <provider>",
+            ]
+        )
+    if unprotected:
+        lines.extend(
+            [
+                "",
+                "Note: jobs marked unguarded have an unpinned axis without active "
+                "snapshot protection; they follow current configuration.",
+            ]
         )
 
     return "\n".join(lines)

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -188,6 +188,17 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     cron_runs.add_argument("job_id", nargs="?", help="Optional job ID filter")
     cron_runs.add_argument("--limit", type=int, default=20, help="Rows to show (1-500)")
 
+    # cron audit-models
+    cron_audit = cron_subparsers.add_parser(
+        "audit-models", help="Audit cron job model/provider pinning"
+    )
+    cron_audit.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Output as JSON",
+    )
+
     # cron tick (mostly for debugging)
     cron_tick = cron_subparsers.add_parser("tick", help="Run due jobs once and exit")
     add_accept_hooks_flag(cron_tick)

--- a/tests/hermes_cli/test_cron_audit.py
+++ b/tests/hermes_cli/test_cron_audit.py
@@ -22,8 +22,11 @@ def _job(
     provider_snapshot=None,
     no_agent=False,
     enabled=True,
+    state=None,
 ):
     result = {"id": job_id, "name": f"Job {job_id}", "enabled": enabled}
+    if state is not None:
+        result["state"] = state
     for key, value in (
         ("model", model),
         ("provider", provider),
@@ -37,7 +40,13 @@ def _job(
     return result
 
 
-def _audit(jobs, config, *, resolved_model="global-model", resolved_provider="global-provider"):
+def _audit(
+    jobs,
+    config,
+    *,
+    resolved_model: str | None = "global-model",
+    resolved_provider: str | None = "global-provider",
+):
     with (
         patch("cron.jobs.load_jobs", return_value=jobs),
         patch("hermes_cli.config.load_config", return_value=config),
@@ -85,6 +94,51 @@ def test_drifted_snapshot_is_reported_as_scheduler_skip_risk():
     )
     result = data["jobs"][0]
     assert result["drifted_axes"] == ["model", "provider"]
+    assert result["at_risk"] is True
+
+
+@pytest.mark.parametrize(
+    "job",
+    [
+        _job(
+            "disabled",
+            enabled=False,
+            model_snapshot="old-model",
+            provider_snapshot="old-provider",
+        ),
+        _job(
+            "paused",
+            state="paused",
+            model_snapshot="old-model",
+            provider_snapshot="old-provider",
+        ),
+    ],
+)
+def test_inactive_drift_is_not_counted_as_would_skip_now(job):
+    data = _audit(
+        [job],
+        {"model": {"default": "new-model", "provider": "new-provider"}},
+        resolved_model="new-model",
+        resolved_provider="new-provider",
+    )
+    result = data["jobs"][0]
+    assert result["active"] is False
+    assert result["drifted_axes"] == ["model", "provider"]
+    assert result["at_risk"] is False
+
+
+def test_hermes_model_is_used_when_config_has_no_model_default(monkeypatch):
+    monkeypatch.setenv("HERMES_MODEL", "env-model")
+    data = _audit(
+        [_job(model_snapshot="old-model")],
+        {"model": {"provider": "global-provider"}},
+        resolved_model=None,
+        resolved_provider="global-provider",
+    )
+    result = data["jobs"][0]
+    assert data["effective_default_model"] == "env-model"
+    assert result["effective_model"] == "env-model"
+    assert result["drifted_axes"] == ["model"]
     assert result["at_risk"] is True
 
 

--- a/tests/hermes_cli/test_cron_audit.py
+++ b/tests/hermes_cli/test_cron_audit.py
@@ -1,0 +1,214 @@
+"""Tests for ``hermes cron audit-models`` command."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.cron_audit import audit_cron_models
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_global_config():
+    """Mock the global config and model snapshot resolution."""
+    with patch("hermes_cli.config.load_config") as mock_load_config, \
+         patch("cron.jobs._resolve_default_model_snapshot") as mock_resolve:
+        mock_load_config.return_value = {
+            "model": {
+                "default": "gpt-4o",
+                "provider": "openai",
+            }
+        }
+        mock_resolve.return_value = "gpt-4o"
+        yield mock_load_config, mock_resolve
+
+
+def _make_job(
+    job_id: str = "test123",
+    name: str = "Test Job",
+    model=None,
+    provider=None,
+    no_agent=False,
+):
+    """Build a minimal job record matching the shape ``load_jobs`` returns."""
+    job = {
+        "id": job_id,
+        "name": name,
+        "enabled": True,
+    }
+    if model is not None:
+        job["model"] = model
+    if provider is not None:
+        job["provider"] = provider
+    if no_agent:
+        job["no_agent"] = True
+    return job
+
+
+# ---------------------------------------------------------------------------
+# Status classification tests
+# ---------------------------------------------------------------------------
+
+class TestAuditStatusClassification:
+    """Verify the audit correctly classifies each pinning state."""
+
+    def test_pinned_job(self, mock_global_config):
+        """Both model and provider set → status 'pinned'."""
+        jobs = [_make_job(model="claude-3", provider="anthropic")]
+        with patch("cron.jobs.load_jobs", return_value=jobs):
+            result = audit_cron_models(json_output=True)
+        data = json.loads(result)
+        assert data["jobs"][0]["status"] == "pinned"
+
+    def test_inherited_job(self, mock_global_config):
+        """Neither model nor provider set → status 'inherited'."""
+        jobs = [_make_job()]
+        with patch("cron.jobs.load_jobs", return_value=jobs):
+            result = audit_cron_models(json_output=True)
+        data = json.loads(result)
+        assert data["jobs"][0]["status"] == "inherited"
+        assert data["jobs"][0]["model"] == "(inherited)"
+        assert data["jobs"][0]["provider"] == "(inherited)"
+
+    def test_script_only_job(self, mock_global_config):
+        """no_agent=True → status 'script-only'."""
+        jobs = [_make_job(no_agent=True)]
+        with patch("cron.jobs.load_jobs", return_value=jobs):
+            result = audit_cron_models(json_output=True)
+        data = json.loads(result)
+        assert data["jobs"][0]["status"] == "script-only"
+        assert data["jobs"][0]["no_agent"] is True
+
+    def test_partial_job_model_only(self, mock_global_config):
+        """Model set but provider not → status 'partial'."""
+        jobs = [_make_job(model="claude-3")]
+        with patch("cron.jobs.load_jobs", return_value=jobs):
+            result = audit_cron_models(json_output=True)
+        data = json.loads(result)
+        assert data["jobs"][0]["status"] == "partial"
+
+    def test_partial_job_provider_only(self, mock_global_config):
+        """Provider set but model not → status 'partial'."""
+        jobs = [_make_job(provider="anthropic")]
+        with patch("cron.jobs.load_jobs", return_value=jobs):
+            result = audit_cron_models(json_output=True)
+        data = json.loads(result)
+        assert data["jobs"][0]["status"] == "partial"
+
+    def test_script_only_takes_precedence_over_model(self, mock_global_config):
+        """no_agent=True with model set → still 'script-only'."""
+        jobs = [_make_job(model="claude-3", provider="anthropic", no_agent=True)]
+        with patch("cron.jobs.load_jobs", return_value=jobs):
+            result = audit_cron_models(json_output=True)
+        data = json.loads(result)
+        assert data["jobs"][0]["status"] == "script-only"
+
+
+# ---------------------------------------------------------------------------
+# JSON output tests
+# ---------------------------------------------------------------------------
+
+class TestJsonOutput:
+    """Verify the JSON output structure."""
+
+    def test_json_is_valid(self, mock_global_config):
+        jobs = [_make_job(job_id="abc123", name="My Job", model="x", provider="y")]
+        with patch("cron.jobs.load_jobs", return_value=jobs):
+            result = audit_cron_models(json_output=True)
+        data = json.loads(result)  # should not raise
+        assert "global_model" in data
+        assert "global_provider" in data
+        assert "jobs" in data
+        assert isinstance(data["jobs"], list)
+
+    def test_json_global_model_and_provider(self, mock_global_config):
+        with patch("cron.jobs.load_jobs", return_value=[]):
+            result = audit_cron_models(json_output=True)
+        data = json.loads(result)
+        assert data["global_model"] == "gpt-4o"
+        assert data["global_provider"] == "openai"
+
+    def test_json_job_fields(self, mock_global_config):
+        jobs = [_make_job(job_id="j1", name="Job One", model="m1", provider="p1")]
+        with patch("cron.jobs.load_jobs", return_value=jobs):
+            result = audit_cron_models(json_output=True)
+        data = json.loads(result)
+        job = data["jobs"][0]
+        assert job["id"] == "j1"
+        assert job["name"] == "Job One"
+        assert job["model"] == "m1"
+        assert job["provider"] == "p1"
+        assert job["status"] == "pinned"
+        assert job["no_agent"] is False
+
+    def test_json_empty_jobs(self, mock_global_config):
+        with patch("cron.jobs.load_jobs", return_value=[]):
+            result = audit_cron_models(json_output=True)
+        data = json.loads(result)
+        assert data["jobs"] == []
+
+
+# ---------------------------------------------------------------------------
+# Table output tests
+# ---------------------------------------------------------------------------
+
+class TestTableOutput:
+    """Verify the human-readable table output."""
+
+    def test_table_contains_header(self, mock_global_config):
+        with patch("cron.jobs.load_jobs", return_value=[]):
+            result = audit_cron_models(json_output=False)
+        assert "Cron Model Audit" in result
+        assert "Global model:" in result
+        assert "Global provider:" in result
+
+    def test_table_contains_column_headers(self, mock_global_config):
+        with patch("cron.jobs.load_jobs", return_value=[]):
+            result = audit_cron_models(json_output=False)
+        assert "ID" in result
+        assert "Name" in result
+        assert "Model" in result
+        assert "Provider" in result
+        assert "Status" in result
+
+    def test_table_contains_summary(self, mock_global_config):
+        jobs = [
+            _make_job(job_id="a", name="A", model="m", provider="p"),
+            _make_job(job_id="b", name="B"),
+            _make_job(job_id="c", name="C", no_agent=True),
+        ]
+        with patch("cron.jobs.load_jobs", return_value=jobs):
+            result = audit_cron_models(json_output=False)
+        assert "Summary:" in result
+        assert "1 pinned" in result
+        assert "1 inherited" in result
+        assert "1 script-only" in result
+
+    def test_table_warning_for_inherited(self, mock_global_config):
+        jobs = [_make_job(job_id="x", name="Inherited Job")]
+        with patch("cron.jobs.load_jobs", return_value=jobs):
+            result = audit_cron_models(json_output=False)
+        assert "silently fail" in result
+        assert "hermes cron update" in result
+
+    def test_table_no_warning_when_all_pinned(self, mock_global_config):
+        jobs = [_make_job(job_id="x", name="Pinned", model="m", provider="p")]
+        with patch("cron.jobs.load_jobs", return_value=jobs):
+            result = audit_cron_models(json_output=False)
+        assert "silently fail" not in result
+
+    def test_table_shows_job_data(self, mock_global_config):
+        jobs = [_make_job(job_id="abc123def456", name="My Test Job", model="claude-3", provider="anthropic")]
+        with patch("cron.jobs.load_jobs", return_value=jobs):
+            result = audit_cron_models(json_output=False)
+        assert "abc123def456"[:12] in result
+        assert "My Test Job" in result
+        assert "claude-3" in result
+        assert "anthropic" in result
+        assert "pinned" in result

--- a/tests/hermes_cli/test_cron_audit.py
+++ b/tests/hermes_cli/test_cron_audit.py
@@ -1,214 +1,238 @@
-"""Tests for ``hermes cron audit-models`` command."""
+"""Tests for ``hermes cron audit-models``."""
 
 from __future__ import annotations
 
+import argparse
 import json
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+import yaml
 
 from hermes_cli.cron_audit import audit_cron_models
 
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-@pytest.fixture
-def mock_global_config():
-    """Mock the global config and model snapshot resolution."""
-    with patch("hermes_cli.config.load_config") as mock_load_config, \
-         patch("cron.jobs._resolve_default_model_snapshot") as mock_resolve:
-        mock_load_config.return_value = {
-            "model": {
-                "default": "gpt-4o",
-                "provider": "openai",
-            }
-        }
-        mock_resolve.return_value = "gpt-4o"
-        yield mock_load_config, mock_resolve
-
-
-def _make_job(
-    job_id: str = "test123",
-    name: str = "Test Job",
+def _job(
+    job_id="job-1",
+    *,
     model=None,
     provider=None,
+    model_snapshot=None,
+    provider_snapshot=None,
     no_agent=False,
+    enabled=True,
 ):
-    """Build a minimal job record matching the shape ``load_jobs`` returns."""
-    job = {
-        "id": job_id,
-        "name": name,
-        "enabled": True,
-    }
-    if model is not None:
-        job["model"] = model
-    if provider is not None:
-        job["provider"] = provider
+    result = {"id": job_id, "name": f"Job {job_id}", "enabled": enabled}
+    for key, value in (
+        ("model", model),
+        ("provider", provider),
+        ("model_snapshot", model_snapshot),
+        ("provider_snapshot", provider_snapshot),
+    ):
+        if value is not None:
+            result[key] = value
     if no_agent:
-        job["no_agent"] = True
-    return job
+        result["no_agent"] = True
+    return result
 
 
-# ---------------------------------------------------------------------------
-# Status classification tests
-# ---------------------------------------------------------------------------
-
-class TestAuditStatusClassification:
-    """Verify the audit correctly classifies each pinning state."""
-
-    def test_pinned_job(self, mock_global_config):
-        """Both model and provider set → status 'pinned'."""
-        jobs = [_make_job(model="claude-3", provider="anthropic")]
-        with patch("cron.jobs.load_jobs", return_value=jobs):
-            result = audit_cron_models(json_output=True)
-        data = json.loads(result)
-        assert data["jobs"][0]["status"] == "pinned"
-
-    def test_inherited_job(self, mock_global_config):
-        """Neither model nor provider set → status 'inherited'."""
-        jobs = [_make_job()]
-        with patch("cron.jobs.load_jobs", return_value=jobs):
-            result = audit_cron_models(json_output=True)
-        data = json.loads(result)
-        assert data["jobs"][0]["status"] == "inherited"
-        assert data["jobs"][0]["model"] == "(inherited)"
-        assert data["jobs"][0]["provider"] == "(inherited)"
-
-    def test_script_only_job(self, mock_global_config):
-        """no_agent=True → status 'script-only'."""
-        jobs = [_make_job(no_agent=True)]
-        with patch("cron.jobs.load_jobs", return_value=jobs):
-            result = audit_cron_models(json_output=True)
-        data = json.loads(result)
-        assert data["jobs"][0]["status"] == "script-only"
-        assert data["jobs"][0]["no_agent"] is True
-
-    def test_partial_job_model_only(self, mock_global_config):
-        """Model set but provider not → status 'partial'."""
-        jobs = [_make_job(model="claude-3")]
-        with patch("cron.jobs.load_jobs", return_value=jobs):
-            result = audit_cron_models(json_output=True)
-        data = json.loads(result)
-        assert data["jobs"][0]["status"] == "partial"
-
-    def test_partial_job_provider_only(self, mock_global_config):
-        """Provider set but model not → status 'partial'."""
-        jobs = [_make_job(provider="anthropic")]
-        with patch("cron.jobs.load_jobs", return_value=jobs):
-            result = audit_cron_models(json_output=True)
-        data = json.loads(result)
-        assert data["jobs"][0]["status"] == "partial"
-
-    def test_script_only_takes_precedence_over_model(self, mock_global_config):
-        """no_agent=True with model set → still 'script-only'."""
-        jobs = [_make_job(model="claude-3", provider="anthropic", no_agent=True)]
-        with patch("cron.jobs.load_jobs", return_value=jobs):
-            result = audit_cron_models(json_output=True)
-        data = json.loads(result)
-        assert data["jobs"][0]["status"] == "script-only"
+def _audit(jobs, config, *, resolved_model="global-model", resolved_provider="global-provider"):
+    with (
+        patch("cron.jobs.load_jobs", return_value=jobs),
+        patch("hermes_cli.config.load_config", return_value=config),
+        patch("cron.jobs._resolve_default_model_snapshot", return_value=resolved_model),
+        patch(
+            "cron.jobs._compute_provider_model_snapshots",
+            return_value=(resolved_provider, None),
+        ),
+    ):
+        return json.loads(audit_cron_models(json_output=True))
 
 
-# ---------------------------------------------------------------------------
-# JSON output tests
-# ---------------------------------------------------------------------------
-
-class TestJsonOutput:
-    """Verify the JSON output structure."""
-
-    def test_json_is_valid(self, mock_global_config):
-        jobs = [_make_job(job_id="abc123", name="My Job", model="x", provider="y")]
-        with patch("cron.jobs.load_jobs", return_value=jobs):
-            result = audit_cron_models(json_output=True)
-        data = json.loads(result)  # should not raise
-        assert "global_model" in data
-        assert "global_provider" in data
-        assert "jobs" in data
-        assert isinstance(data["jobs"], list)
-
-    def test_json_global_model_and_provider(self, mock_global_config):
-        with patch("cron.jobs.load_jobs", return_value=[]):
-            result = audit_cron_models(json_output=True)
-        data = json.loads(result)
-        assert data["global_model"] == "gpt-4o"
-        assert data["global_provider"] == "openai"
-
-    def test_json_job_fields(self, mock_global_config):
-        jobs = [_make_job(job_id="j1", name="Job One", model="m1", provider="p1")]
-        with patch("cron.jobs.load_jobs", return_value=jobs):
-            result = audit_cron_models(json_output=True)
-        data = json.loads(result)
-        job = data["jobs"][0]
-        assert job["id"] == "j1"
-        assert job["name"] == "Job One"
-        assert job["model"] == "m1"
-        assert job["provider"] == "p1"
-        assert job["status"] == "pinned"
-        assert job["no_agent"] is False
-
-    def test_json_empty_jobs(self, mock_global_config):
-        with patch("cron.jobs.load_jobs", return_value=[]):
-            result = audit_cron_models(json_output=True)
-        data = json.loads(result)
-        assert data["jobs"] == []
+@pytest.mark.parametrize(
+    ("job", "status"),
+    [
+        (_job(model="m", provider="p"), "pinned"),
+        (_job(model="m"), "partial"),
+        (_job(provider="p"), "partial"),
+        (_job(), "inherited"),
+        (_job(model="m", provider="p", no_agent=True), "script-only"),
+    ],
+)
+def test_pinning_status_is_separate_from_drift(job, status):
+    data = _audit([job], {"model": {"default": "global-model", "provider": "global-provider"}})
+    assert data["jobs"][0]["status"] == status
 
 
-# ---------------------------------------------------------------------------
-# Table output tests
-# ---------------------------------------------------------------------------
+def test_inherited_job_with_matching_snapshots_is_guarded_not_at_risk():
+    data = _audit(
+        [_job(model_snapshot="global-model", provider_snapshot="global-provider")],
+        {"model": {"default": "global-model", "provider": "global-provider"}},
+    )
+    result = data["jobs"][0]
+    assert result["guarded_axes"] == ["model", "provider"]
+    assert result["drifted_axes"] == []
+    assert result["at_risk"] is False
 
-class TestTableOutput:
-    """Verify the human-readable table output."""
 
-    def test_table_contains_header(self, mock_global_config):
-        with patch("cron.jobs.load_jobs", return_value=[]):
-            result = audit_cron_models(json_output=False)
-        assert "Cron Model Audit" in result
-        assert "Global model:" in result
-        assert "Global provider:" in result
+def test_drifted_snapshot_is_reported_as_scheduler_skip_risk():
+    data = _audit(
+        [_job(model_snapshot="old-model", provider_snapshot="old-provider")],
+        {"model": {"default": "new-model", "provider": "new-provider"}},
+        resolved_model="new-model",
+        resolved_provider="new-provider",
+    )
+    result = data["jobs"][0]
+    assert result["drifted_axes"] == ["model", "provider"]
+    assert result["at_risk"] is True
 
-    def test_table_contains_column_headers(self, mock_global_config):
-        with patch("cron.jobs.load_jobs", return_value=[]):
-            result = audit_cron_models(json_output=False)
-        assert "ID" in result
-        assert "Name" in result
-        assert "Model" in result
-        assert "Provider" in result
-        assert "Status" in result
 
-    def test_table_contains_summary(self, mock_global_config):
-        jobs = [
-            _make_job(job_id="a", name="A", model="m", provider="p"),
-            _make_job(job_id="b", name="B"),
-            _make_job(job_id="c", name="C", no_agent=True),
+def test_disabled_guard_does_not_claim_job_will_fail():
+    data = _audit(
+        [_job(model_snapshot="old-model", provider_snapshot="old-provider")],
+        {
+            "model": {"default": "new-model", "provider": "new-provider"},
+            "cron": {"model_drift_guard": False},
+        },
+        resolved_model="new-model",
+        resolved_provider="new-provider",
+    )
+    result = data["jobs"][0]
+    assert result["at_risk"] is False
+    assert result["unprotected_axes"] == ["model", "provider"]
+
+
+def test_pre_snapshot_job_is_unprotected_not_claimed_to_fail():
+    data = _audit(
+        [_job()],
+        {"model": {"default": "new-model", "provider": "new-provider"}},
+        resolved_model="new-model",
+        resolved_provider="new-provider",
+    )
+    result = data["jobs"][0]
+    assert result["at_risk"] is False
+    assert result["unprotected_axes"] == ["model", "provider"]
+
+
+def test_cron_fleet_defaults_cover_unpinned_axes_and_provider_precedence():
+    data = _audit(
+        [_job(model_snapshot="old-model", provider_snapshot="old-provider")],
+        {
+            "model": {"default": "chat-model", "provider": "chat-provider"},
+            "cron": {"model": "cron-model", "model_provider": "cron-provider"},
+        },
+    )
+    result = data["jobs"][0]
+    assert data["effective_default_model"] == "cron-model"
+    assert data["effective_default_provider"] == "cron-provider"
+    assert result["effective_model"] == "cron-model"
+    assert result["effective_provider"] == "cron-provider"
+    assert result["guarded_axes"] == []
+    assert result["at_risk"] is False
+
+
+def test_pinned_axis_is_not_evaluated_for_drift():
+    data = _audit(
+        [_job(model="pinned", model_snapshot="old", provider_snapshot="global-provider")],
+        {"model": {"default": "new", "provider": "global-provider"}},
+        resolved_model="new",
+    )
+    result = data["jobs"][0]
+    assert "model" not in result["guarded_axes"]
+    assert result["effective_model"] == "pinned"
+
+
+def test_json_has_machine_readable_safety_fields_without_icons():
+    data = _audit([_job()], {"model": {"default": "m", "provider": "p"}}, resolved_model="m", resolved_provider="p")
+    result = data["jobs"][0]
+    assert "status_icon" not in result
+    assert set(
+        [
+            "effective_model",
+            "effective_provider",
+            "model_snapshot",
+            "provider_snapshot",
+            "guarded_axes",
+            "drifted_axes",
+            "unprotected_axes",
+            "at_risk",
         ]
-        with patch("cron.jobs.load_jobs", return_value=jobs):
-            result = audit_cron_models(json_output=False)
-        assert "Summary:" in result
-        assert "1 pinned" in result
-        assert "1 inherited" in result
-        assert "1 script-only" in result
+    ).issubset(result)
 
-    def test_table_warning_for_inherited(self, mock_global_config):
-        jobs = [_make_job(job_id="x", name="Inherited Job")]
-        with patch("cron.jobs.load_jobs", return_value=jobs):
-            result = audit_cron_models(json_output=False)
-        assert "silently fail" in result
-        assert "hermes cron update" in result
 
-    def test_table_no_warning_when_all_pinned(self, mock_global_config):
-        jobs = [_make_job(job_id="x", name="Pinned", model="m", provider="p")]
-        with patch("cron.jobs.load_jobs", return_value=jobs):
-            result = audit_cron_models(json_output=False)
-        assert "silently fail" not in result
+def test_table_uses_real_edit_command_and_precise_warning():
+    with (
+        patch("cron.jobs.load_jobs", return_value=[_job(model_snapshot="old")]),
+        patch(
+            "hermes_cli.config.load_config",
+            return_value={"model": {"default": "new", "provider": "p"}},
+        ),
+        patch("cron.jobs._resolve_default_model_snapshot", return_value="new"),
+        patch(
+            "cron.jobs._compute_provider_model_snapshots",
+            return_value=("p", None),
+        ),
+    ):
+        text = audit_cron_models()
+    assert "would skip" in text.lower()
+    assert "hermes cron edit <id>" in text
+    assert "silently fail" not in text
+    assert "hermes cron update" not in text
 
-    def test_table_shows_job_data(self, mock_global_config):
-        jobs = [_make_job(job_id="abc123def456", name="My Test Job", model="claude-3", provider="anthropic")]
-        with patch("cron.jobs.load_jobs", return_value=jobs):
-            result = audit_cron_models(json_output=False)
-        assert "abc123def456"[:12] in result
-        assert "My Test Job" in result
-        assert "claude-3" in result
-        assert "anthropic" in result
-        assert "pinned" in result
+
+def test_real_profile_store_and_config_resolution(tmp_path, monkeypatch):
+    """Exercise actual config + jobs resolution from a temporary HERMES_HOME."""
+    home = tmp_path / "profile"
+    (home / "cron").mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "model": {"default": "chat-model", "provider": "chat-provider"},
+                "cron": {
+                    "model": "cron-model",
+                    "model_provider": "cron-provider",
+                    "model_drift_guard": True,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (home / "cron" / "jobs.json").write_text(
+        json.dumps(
+            [
+                _job(
+                    "real-job",
+                    model_snapshot="old-model",
+                    provider_snapshot="old-provider",
+                )
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    data = json.loads(audit_cron_models(json_output=True))
+    assert data["effective_default_model"] == "cron-model"
+    assert data["effective_default_provider"] == "cron-provider"
+    assert data["jobs"][0]["id"] == "real-job"
+    assert data["jobs"][0]["at_risk"] is False
+
+
+def test_parser_and_handler_dispatch(capsys):
+    from hermes_cli.cron import cron_command
+    from hermes_cli.subcommands.cron import build_cron_parser
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_cron_parser(subparsers, cmd_cron=lambda _args: None)
+    args = parser.parse_args(["cron", "audit-models", "--json"])
+    assert args.cron_command == "audit-models"
+    assert args.json_output is True
+
+    with patch(
+        "hermes_cli.cron_audit.audit_cron_models", return_value='{"jobs": []}'
+    ) as audit:
+        assert cron_command(args) == 0
+    assert json.loads(capsys.readouterr().out) == {"jobs": []}
+    audit.assert_called_once_with(json_output=True)

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -94,6 +94,96 @@ global defaults. A switch to a paid provider or model can therefore spend money
 on every scheduled run.
 :::
 
+## Auditing model pinning
+
+`hermes cron audit-models` inspects every cron job's model and provider
+pinning state and tells you which jobs the drift guard would skip on their next
+run. It is read-only: it never modifies jobs, config, or scheduler state.
+
+```bash
+hermes cron audit-models
+hermes cron audit-models --json   # machine-readable output
+```
+
+### What it reports
+
+Each job is classified by pinning status:
+
+| Status | Meaning |
+|-------|---------|
+| `pinned` | Both `--model` and `--provider` are set on the job. |
+| `partial` | Only one of model or provider is pinned. |
+| `inherited` | Neither is pinned; the job follows the effective default. |
+| `script-only` | `no_agent` job; no model resolution applies. |
+
+The risk column tells you what the drift guard would do right now:
+
+| Risk | Meaning |
+|------|---------|
+| `none` | Pinned or fully covered by a fleet default; no drift exposure. |
+| `guarded` | Unpinned axis has a creation-time snapshot and the guard is enabled, but current resolution still matches the snapshot. |
+| `unguarded: <axes>` | Unpinned axis has no snapshot (or the guard is disabled); the job follows current configuration without protection. |
+| `SKIP: <axes>` | The guard would skip this job on its next run because current resolution differs from the snapshot. |
+| `paused` | Job is not active; no skip regardless of drift. |
+| `paused; drift on resume: <axes>` | Job is paused but will skip when resumed if the drift is not resolved first. |
+
+The summary line counts pinned, inherited, partial, and script-only jobs and
+reports how many would be skipped now.
+
+### Remediation
+
+When jobs are marked `SKIP`, the audit output names the remediation command:
+
+```bash
+hermes cron edit <job_id> --model <model> --provider <provider>
+```
+
+This pins the job to explicit values so the drift guard no longer applies to
+those axes. Alternatively, set a cron-fleet default so all unpinned jobs share
+one model:
+
+```bash
+hermes config set cron.model <model>
+hermes config set cron.model_provider <provider>
+```
+
+A fleet default covers every unpinned axis, so the guard will not skip those
+jobs even if the global default later changes.
+
+### JSON output
+
+Pass `--json` for a structured payload suitable for scripts or monitoring:
+
+```json
+{
+  "effective_default_model": "global-model",
+  "effective_default_provider": "global-provider",
+  "cron_fleet_model_configured": true,
+  "cron_fleet_provider_configured": true,
+  "drift_guard_enabled": true,
+  "jobs": [
+    {
+      "id": "a1b2c3d4",
+      "name": "Morning feeds",
+      "model": "(inherited)",
+      "provider": "(inherited)",
+      "effective_model": "global-model",
+      "effective_provider": "global-provider",
+      "status": "inherited",
+      "active": true,
+      "guarded_axes": ["model", "provider"],
+      "drifted_axes": [],
+      "unprotected_axes": [],
+      "at_risk": false
+    }
+  ]
+}
+```
+
+Each job entry includes `model_snapshot` and `provider_snapshot` (the
+creation-time values the guard compares against), plus `enabled` and `state`
+so you can filter active vs paused jobs in automation.
+
 ## Skill-backed cron jobs
 
 A cron job can load one or more skills before it runs the prompt.


### PR DESCRIPTION
## Summary

Adds `hermes cron audit-models`, a read-only audit of cron model/provider pinning and the scheduler's model-drift guard state.

## What it reports

For each job, the command distinguishes:

- explicit model/provider pins,
- inherited effective defaults,
- stored model/provider snapshots,
- guarded and unguarded axes,
- actual drifted axes,
- whether the current scheduler would skip the job now.

Script-only jobs are reported separately because they do not invoke a model. Paused and disabled jobs remain visible, including drift that would matter on resume, but are not counted as jobs the scheduler would skip now.

The implementation follows the scheduler's effective model/provider and per-axis drift-guard semantics, including cron fleet defaults and the `HERMES_MODEL` fallback when no configured model default exists. Remediation uses the existing `hermes cron edit` command.

Use `--json` for machine-readable output.

## Verification

- 65 cron audit, CLI, parser, provider-pin and profile-isolation tests passed against current main.
- Includes regression coverage for paused/disabled jobs, environment fallback, fleet defaults, snapshots, guarded axes and script-only jobs.
- The audit was exercised against a real Hermes cron fleet.
- Ruff passed.
- `ty` passed for the new audit module.
- `git diff --check` passed.
