### PR TITLE
docs: add field diagnostics for cron and long sessions

### DIFF
--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -494,6 +494,30 @@ You can verify the plist has the correct PATH:
 - Check your network latency to the provider
 - For local models, ensure you have enough GPU VRAM
 
+If Hermes starts fast and then slows down over the life of a long session, check
+whether context size and compression are the actual bottleneck before changing
+models:
+
+```bash
+grep -E "Preflight compression|Compression summary failed|context=~|latency=" \
+  ~/.hermes/logs/agent.log ~/.hermes/logs/desktop.log 2>/dev/null | tail -40
+```
+
+Field signal to watch for:
+
+- `Preflight compression` before ordinary turns means Hermes is spending time
+  compacting the session before it can answer.
+- `Compression summary failed` means compaction itself hit a provider/network
+  failure and Hermes had to continue with a fallback marker.
+- `context=~... tokens` in the tens or hundreds of thousands usually means the
+  current conversation, tool outputs, or active tool schemas are dominating the
+  request.
+
+When those appear, the highest-leverage fix is usually a fresh session with a
+short handoff summary, plus only the toolsets needed for the next task. Treat
+`/compress` as a recovery step, not a reason to keep one conversation alive
+forever.
+
 #### High token usage
 
 **Cause:** Long conversations, verbose system prompts, or many tool calls accumulating context.

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -305,6 +305,38 @@ When scheduling jobs, you specify where the output goes:
 
 The agent's final response is automatically delivered to the configured `deliver:` target — the agent does not send messages itself, so there is nothing to call in the cron prompt.
 
+### Diagnosing "the job ran, but I did not get a message"
+
+First separate scheduling, execution, and delivery. A job can run successfully
+and still produce no chat notification if it was created from the CLI with the
+default `local` delivery, if `[SILENT]` suppressed the final message, or if the
+target platform has no configured home channel.
+
+Use this checklist before recreating the job:
+
+```bash
+hermes cron status
+hermes cron list
+hermes cron runs <job-id-or-name> --limit 5
+ls -lt ~/.hermes/cron/output/<job-id>/ | head
+```
+
+- If `next_run_at` passed but `last_run_at` did not change, check that the
+  gateway daemon is running; the scheduler ticks from the gateway process, not
+  from an open chat window.
+- If the execution ledger shows `failed`, inspect the latest local output file
+  and `~/.hermes/logs/gateway.log` before editing the schedule.
+- If `last_status` is successful but there is no chat message, confirm the
+  job's `deliver` target. CLI-created jobs default to `local`, which saves the
+  response under `~/.hermes/cron/output/` only.
+- If the output contains `[SILENT]`, the result was intentionally saved locally
+  without delivery. Failed jobs bypass this suppression and still deliver.
+
+For scheduled desktop or browser automation, make the script print a small
+status block (`STATUS`, `STATE`, `ACTIONS`, and `ERROR` when relevant). That
+turns "nothing happened" into an auditable execution record and makes it clear
+whether the scheduler, the script, or the delivery target needs attention.
+
 ### Routing intent (`all`)
 
 `all` lets you ship one cron job to every messaging channel you have configured, without having to enumerate them by name. It is **resolved at fire time**, so a job created before you wired up Telegram will pick up Telegram on the next tick after you set `TELEGRAM_HOME_CHANNEL`.


### PR DESCRIPTION
## Summary

- Add a cron troubleshooting checklist for the common case where a scheduled job ran but no chat message appeared.
- Clarify that CLI-created cron jobs default to local output under `~/.hermes/cron/output/`.
- Add field diagnostics for long-session slowness: `Preflight compression`, `Compression summary failed`, and large `context=~... tokens` log signals.

## Context

These docs updates are based on real macOS Hermes usage where two issues looked ambiguous from the UI alone:

1. A cron/no-agent automation had run successfully, but the observable result was local output rather than an active terminal/desktop notification.
2. Long sessions slowed down because ordinary turns were preceded by context compression and very large request contexts.

No private job names, chat IDs, meeting URLs, API keys, or raw personal logs are included; the PR keeps only generalized commands and public-safe diagnostic patterns.

## Validation

- `git diff --check` passed.
- `npm --prefix website run build` completed successfully.
  - The build still prints existing broken-link / broken-anchor warnings unrelated to these two edited docs files.
  - Local prebuild also warned that `pyyaml` is missing and wrote empty generated skills/blueprint indexes, but Docusaurus build completed.
- `npm --prefix website run typecheck` is currently blocked by existing TypeScript config behavior: `TS5101: Option 'baseUrl' is deprecated...`.
- `npm --prefix website run lint:diagrams` is currently blocked locally because `ascii-guard` is not on PATH.