### PR TITLE
fix(desktop): harden Linux updates and stale previews

### DIFF
--- a/apps/desktop/electron/hardening.test.ts
+++ b/apps/desktop/electron/hardening.test.ts
@@ -72,6 +72,27 @@ test('attachment data URL helper reads bytes above the preview default without c
   }
 })
 
+test('preview data URL helper treats a stale missing path as an empty result only when opted in', async () => {
+  const missingPath = path.join(os.tmpdir(), 'hermes-desktop-missing-preview.png')
+
+  await assert.rejects(
+    readFileDataUrlForIpc(missingPath, {
+      mimeType: 'image/png',
+      purpose: 'Attachment upload'
+    }),
+    /file does not exist/
+  )
+
+  assert.equal(
+    await readFileDataUrlForIpc(missingPath, {
+      mimeType: 'image/png',
+      missingAsEmpty: true,
+      purpose: 'File preview'
+    }),
+    ''
+  )
+})
+
 test('resolveTimeoutMs falls back to defaults and accepts overrides', () => {
   assert.equal(resolveTimeoutMs(undefined), DEFAULT_FETCH_TIMEOUT_MS)
   assert.equal(resolveTimeoutMs(0), DEFAULT_FETCH_TIMEOUT_MS)

--- a/apps/desktop/electron/hardening.ts
+++ b/apps/desktop/electron/hardening.ts
@@ -337,13 +337,29 @@ async function readFileDataUrlForIpc(
     blockSensitive?: boolean
     maxBytes?: number
     mimeType: string
+    missingAsEmpty?: boolean
   }
 ): Promise<string> {
   const fsImpl = options.fs || fs
-  const { resolvedPath } = await resolveReadableFileForIpc(filePath, options)
-  const data = await fsImpl.promises.readFile(resolvedPath)
 
-  return `data:${options.mimeType};base64,${data.toString('base64')}`
+  try {
+    const { resolvedPath } = await resolveReadableFileForIpc(filePath, options)
+    const data = await fsImpl.promises.readFile(resolvedPath)
+
+    return `data:${options.mimeType};base64,${data.toString('base64')}`
+  } catch (error) {
+    const code = error && typeof error === 'object' ? (error as any).code : ''
+
+    // Preview targets are ephemeral: generated/composer files can disappear
+    // between rendering a prior message and the next Desktop launch. Treat
+    // only that stale-path race as an empty preview. Attachments remain strict,
+    // and security/permission/size failures must still surface to the caller.
+    if (options.missingAsEmpty && (code === 'ENOENT' || code === 'ENOTDIR')) {
+      return ''
+    }
+
+    throw error
+  }
 }
 
 export {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -10238,6 +10238,7 @@ ipcMain.handle('hermes:readFileDataUrl', async (_event, filePath) => {
   return readFileDataUrlForIpc(filePath, {
     maxBytes: dataUrlReadMaxBytesFromMb(dataUrlReadMaxMb),
     mimeType: mimeTypeForPath(resolveRequestedPathForIpc(filePath, { purpose: 'File preview' })),
+    missingAsEmpty: true,
     purpose: 'File preview'
   })
 })

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -147,7 +147,7 @@
     "@typescript-eslint/parser": "^8.59.1",
     "@vitejs/plugin-react": "^6.0.1",
     "bippy": "0.5.43",
-    "concurrently": "^10.0.3",
+    "concurrently": "^10.0.4",
     "cross-env": "^10.1.0",
     "electron": "40.10.2",
     "electron-builder": "^26.8.1",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6719,16 +6719,44 @@ def _desktop_linux_sandbox_fixup(packaged_executable: Path) -> bool:
         return True
 
     sudo = shutil.which("sudo")
-    if not sudo:
-        print("✗ Hermes Desktop requires sudo to configure Electron's Linux sandbox helper.")
+    try:
+        has_interactive_terminal = bool(sys.stdin and sys.stdin.isatty())
+    except (AttributeError, OSError):
+        has_interactive_terminal = False
+
+    if sudo and has_interactive_terminal:
+        print("→ Configuring Electron Linux sandbox helper (sudo required)...")
+        for command in ([sudo, "chown", "root:root", str(sandbox)], [sudo, "chmod", "4755", str(sandbox)]):
+            if subprocess.run(command, check=False).returncode != 0:
+                print(f"✗ Failed to configure Electron's Linux sandbox helper: {sandbox}")
+                return False
+        return True
+
+    # Desktop-driven updates and .desktop launchers have no interactive stdin,
+    # so sudo cannot request a password.  PolicyKit is the correct graphical
+    # authorization path.  Pass the sandbox as $1 rather than interpolating it
+    # into shell code so paths cannot alter the privileged command.
+    pkexec = shutil.which("pkexec")
+    if pkexec:
+        print("→ Configuring Electron Linux sandbox helper (system authorization required)...")
+        command = [
+            pkexec,
+            "/bin/sh",
+            "-c",
+            'chown root:root "$1" && chmod 4755 "$1"',
+            "hermes-desktop-sandbox",
+            str(sandbox),
+        ]
+        if subprocess.run(command, check=False).returncode == 0:
+            return True
+        print(f"✗ Failed to configure Electron's Linux sandbox helper: {sandbox}")
         return False
 
-    print("→ Configuring Electron Linux sandbox helper (sudo required)...")
-    for command in ([sudo, "chown", "root:root", str(sandbox)], [sudo, "chmod", "4755", str(sandbox)]):
-        if subprocess.run(command, check=False).returncode != 0:
-            print(f"✗ Failed to configure Electron's Linux sandbox helper: {sandbox}")
-            return False
-    return True
+    if sudo:
+        print("✗ Hermes Desktop requires an interactive terminal for sudo, or pkexec for graphical authorization.")
+    else:
+        print("✗ Hermes Desktop requires sudo or pkexec to configure Electron's Linux sandbox helper.")
+    return False
 
 
 def _desktop_launch_options() -> tuple[list[str], str]:
@@ -6985,6 +7013,12 @@ def cmd_gui(args: argparse.Namespace):
         elif packaged_executable is None:
             print(f"✗ --build-only produced no launchable app at: {desktop_dir / 'release'}")
             print("  Expected an unpacked Electron app for the current OS.")
+            sys.exit(1)
+        elif not _desktop_linux_sandbox_fixup(packaged_executable):
+            # The update path relaunches the packaged executable directly, so it
+            # cannot rely on the normal `hermes desktop` launch-time repair.
+            # Never report a Linux rebuild as successful while Electron's SUID
+            # helper would make that direct relaunch abort immediately.
             sys.exit(1)
         else:
             print(f"✓ Desktop packaged app ready: {packaged_executable} (not launching; --build-only)")

--- a/package-lock.json
+++ b/package-lock.json
@@ -166,7 +166,7 @@
         "@typescript-eslint/parser": "^8.59.1",
         "@vitejs/plugin-react": "^6.0.1",
         "bippy": "0.5.43",
-        "concurrently": "^10.0.3",
+        "concurrently": "^10.0.4",
         "cross-env": "^10.1.0",
         "electron": "40.10.2",
         "electron-builder": "^26.8.1",
@@ -403,6 +403,31 @@
         "undici-types": "~6.21.0"
       }
     },
+    "apps/desktop/node_modules/concurrently": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.4.tgz",
+      "integrity": "sha512-trZql+7l/0+WRAsAnEdctr4+iiOS6ZrViI6H8QWcCF9MFS/LT0dKpe8vluB1to6it+OxSI4VospFTIFMW8DJRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.9.0",
+        "supports-color": "10.2.2",
+        "tree-kill": "1.2.2",
+        "yargs": "18.0.0"
+      },
+      "bin": {
+        "conc": "dist/bin/index.js",
+        "concurrently": "dist/bin/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
     "apps/desktop/node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -448,6 +473,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "apps/desktop/node_modules/shell-quote": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "apps/desktop/node_modules/undici-types": {
@@ -8429,31 +8467,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/concurrently": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.3.tgz",
-      "integrity": "sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "5.6.2",
-        "rxjs": "7.8.2",
-        "shell-quote": "1.8.4",
-        "supports-color": "10.2.2",
-        "tree-kill": "1.2.2",
-        "yargs": "18.0.0"
-      },
-      "bin": {
-        "conc": "dist/bin/index.js",
-        "concurrently": "dist/bin/index.js"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -9585,9 +9598,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -10965,9 +10978,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -15580,9 +15593,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
       "funding": [
         {
           "type": "opencollective",
@@ -15599,7 +15612,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -15621,9 +15634,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -17239,19 +17252,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/shiki": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.3.0.tgz",
@@ -17921,9 +17921,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.17",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.17.tgz",
-      "integrity": "sha512-wPEBwzapC+2PaTYPH6e2L+cNOEE227S47wUYFqlegcs8zlLLmeb9Fcff1HVZY4Fwku/1Eyv38n7GYwB2aaS71g==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -208,7 +208,8 @@ def test_gui_linux_configures_sandbox_before_launch(tmp_path, monkeypatch):
     sandbox.chmod(0o755)
     ok = subprocess.CompletedProcess([], 0)
 
-    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/sudo"), \
+    with patch("hermes_cli.main.sys.stdin.isatty", return_value=True), \
+         patch("hermes_cli.main.shutil.which", return_value="/usr/bin/sudo"), \
          patch("hermes_cli.main.subprocess.run", return_value=ok) as mock_run, \
          pytest.raises(SystemExit) as exc:
         cli_main.cmd_gui(_ns(skip_build=True))
@@ -217,6 +218,51 @@ def test_gui_linux_configures_sandbox_before_launch(tmp_path, monkeypatch):
     assert mock_run.call_args_list[0].args[0] == ["/usr/bin/sudo", "chown", "root:root", str(sandbox)]
     assert mock_run.call_args_list[1].args[0] == ["/usr/bin/sudo", "chmod", "4755", str(sandbox)]
     assert mock_run.call_args_list[2].args[0] == [str(packaged_exe)]
+
+
+def test_gui_linux_build_only_rejects_unlaunchable_sandbox(tmp_path, monkeypatch):
+    """Updater rebuilds must not report success with a broken SUID helper."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    _make_packaged_executable(root, monkeypatch, platform="linux")
+
+    with patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=False) as mock_fixup, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(skip_build=True, build_only=True))
+
+    assert exc.value.code == 1
+    mock_fixup.assert_called_once()
+
+
+def test_gui_linux_sandbox_uses_pkexec_without_interactive_terminal(tmp_path, monkeypatch):
+    """Desktop-driven updates need a graphical privilege prompt, not sudo."""
+    root = _make_desktop_tree(tmp_path)
+    packaged_exe = _make_packaged_executable(root, monkeypatch, platform="linux")
+    sandbox = packaged_exe.parent / "chrome-sandbox"
+    sandbox.write_text("", encoding="utf-8")
+    sandbox.chmod(0o755)
+    ok = subprocess.CompletedProcess([], 0)
+
+    def which(command):
+        return {
+            "sudo": "/usr/bin/sudo",
+            "pkexec": "/usr/bin/pkexec",
+        }.get(command)
+
+    with patch("hermes_cli.main.sys.stdin.isatty", return_value=False), \
+         patch("hermes_cli.main.shutil.which", side_effect=which), \
+         patch("hermes_cli.main.subprocess.run", return_value=ok) as mock_run:
+        assert cli_main._desktop_linux_sandbox_fixup(packaged_exe) is True
+
+    mock_run.assert_called_once()
+    assert mock_run.call_args.args[0] == [
+        "/usr/bin/pkexec",
+        "/bin/sh",
+        "-c",
+        'chown root:root "$1" && chmod 4755 "$1"',
+        "hermes-desktop-sandbox",
+        str(sandbox),
+    ]
 
 
 def test_gui_linux_rejects_symlink_sandbox(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Harden the Linux Desktop update path and remove two additional startup/security risks:

- repair and validate Electron's Linux `chrome-sandbox` after updater-driven `--build-only` packages (`root:root`, mode `4755`)
- treat stale missing preview files as an empty preview only for the preview IPC path, while keeping attachment, permission, sensitivity, and size failures strict
- update compatible vulnerable patch dependencies (`concurrently`, `dompurify`, `fast-uri`, `postcss`, `tar`) without `npm audit fix --force`

## Why

A clean Desktop update can recreate `chrome-sandbox` as an unprivileged `0755` file. Electron then exits at startup with code 133. The updater previously reported a successful build before validating the helper.

Separately, a stale generated/composer preview path could reject the IPC handler with `ENOENT` during the next launch even though the renderer treated that preview as recoverable.

## Safety

- Linux sandbox repair uses `sudo` only in an interactive terminal and `pkexec` for GUI-launched updates.
- `--build-only` now fails rather than reporting an unusable package when the sandbox cannot be repaired.
- Missing-file suppression is opt-in and limited to `ENOENT`/`ENOTDIR` for preview reads. Attachment uploads remain strict.
- Dependency updates stay within compatible ranges. No forced downgrade or major upgrade was applied.

## Verification

- RED/GREEN regression test for stale preview paths
- Desktop Vitest suite: 3,800 passed, 2 skipped
- Desktop typecheck: passed
- Desktop lint: 0 errors (67 pre-existing warnings)
- Python GUI command tests: 3 passed
- Hermes CLI relevant suite: 74 passed
- ARM64 packaged rebuild: passed
- packaged `chrome-sandbox`: `4755 root:root`
- packaged build stamp: clean commit `2ee4d1af532ae5bf1217b55c3bb564ec070905a4`
- real Electron launch: window `1920x1048`, backend ready, no stale-preview `ENOENT`
- npm audit reduced from 28 findings (including 1 critical) to 22 high findings; remaining findings require incompatible major/downgrade paths and were intentionally not force-fixed
- `npm audit --omit=dev` reports only React Router's RSC-mode CSRF advisory; the Desktop uses client-side `HashRouter` and contains no RSC APIs, so that mode-specific attack surface is not active
- the other 20 audit findings are confined to build/lint tooling (`electron-builder` and ESLint dependency chains), not packaged runtime behavior
