### PR TITLE
fix(gateway): use the selected history snapshot for post stream media dedup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1516,6 +1516,15 @@ def _collect_history_media_paths(agent_history: List[Dict[str, Any]]) -> set:
     """
     paths: set = set()
     tool_name_by_call_id: Dict[str, str] = {}
+
+    def _add_text_media_paths(content: str) -> None:
+        for match in _TOOL_MEDIA_RE.finditer(content):
+            path = match.group(1).strip().rstrip('",}')
+            if path:
+                paths.add(path)
+        media_files, _ = BasePlatformAdapter.extract_media(content)
+        paths.update(path for path, _is_voice in media_files)
+
     for msg in agent_history:
         if msg.get("role") == "assistant":
             for call in msg.get("tool_calls") or []:
@@ -1529,19 +1538,13 @@ def _collect_history_media_paths(agent_history: List[Dict[str, Any]]) -> set:
         if role == "assistant":
             content = str(msg.get("content", "") or "")
             if "MEDIA:" in content:
-                for match in _TOOL_MEDIA_RE.finditer(content):
-                    p = match.group(1).strip().rstrip('",}')
-                    if p:
-                        paths.add(p)
+                _add_text_media_paths(content)
             continue
         if role not in {"tool", "function"}:
             continue
         content = str(msg.get("content", "") or "")
         if "MEDIA:" in content:
-            for match in _TOOL_MEDIA_RE.finditer(content):
-                p = match.group(1).strip().rstrip('",}')
-                if p:
-                    paths.add(p)
+            _add_text_media_paths(content)
             continue
         cid = str(msg.get("tool_call_id") or msg.get("call_id") or "")
         if tool_name_by_call_id.get(cid) == "image_generate":
@@ -3244,7 +3247,7 @@ def _preserve_queued_followup_history_offset(
     current_result: dict,
     followup_result: dict,
 ) -> dict:
-    """Carry the outer history offset through queued follow-up drains.
+    """Carry outer history state through queued follow-up drains.
 
     ``_process_message_background()`` persists transcript rows only once, after the
     entire in-band queued-follow-up chain returns.  Each recursive ``_run_agent()``
@@ -3254,6 +3257,10 @@ def _preserve_queued_followup_history_offset(
 
     Preserve the earliest (outermost) history offset so the final transcript slice
     still includes every queued turn that ran during the chain.
+
+    History media snapshots are cumulative across the same chain. A recursive
+    turn can receive compacted history that no longer contains an older media
+    path, so union its snapshot with the outer turn's snapshot.
     """
     if not isinstance(followup_result, dict):
         return followup_result
@@ -3262,13 +3269,34 @@ def _preserve_queued_followup_history_offset(
 
     current_offset = current_result.get("history_offset")
     followup_offset = followup_result.get("history_offset")
-    if not isinstance(current_offset, int):
-        return followup_result
-    if isinstance(followup_offset, int) and followup_offset <= current_offset:
+    preserve_offset = (
+        isinstance(current_offset, int)
+        and not (
+            isinstance(followup_offset, int)
+            and followup_offset <= current_offset
+        )
+    )
+    current_media_paths = current_result.get("history_media_paths")
+    followup_media_paths = followup_result.get("history_media_paths")
+    preserve_media_paths = (
+        isinstance(current_media_paths, set)
+        and (
+            not isinstance(followup_media_paths, set)
+            or bool(current_media_paths - followup_media_paths)
+        )
+    )
+    if not preserve_offset and not preserve_media_paths:
         return followup_result
 
     merged = dict(followup_result)
-    merged["history_offset"] = current_offset
+    if preserve_offset:
+        merged["history_offset"] = current_offset
+    if preserve_media_paths:
+        merged["history_media_paths"] = current_media_paths | (
+            followup_media_paths
+            if isinstance(followup_media_paths, set)
+            else set()
+        )
     return merged
 
 
@@ -15017,9 +15045,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if response:
                     _media_adapter = self._adapter_for_source(source)
                     if _media_adapter:
+                        _history_media_paths = agent_result.get(
+                            "history_media_paths"
+                        )
+                        if _history_media_paths is None:
+                            _history_media_paths = _collect_history_media_paths(
+                                history
+                            )
                         await self._deliver_media_from_response(
                             response, event, _media_adapter,
-                            history_media_paths=_collect_history_media_paths(history),
+                            history_media_paths=_history_media_paths,
                         )
                 # Streaming already delivered the body text, but the footer was
                 # intentionally held back (see the `not already_sent` gate above).
@@ -16156,10 +16191,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # the model may echo a previous turn's MEDIA: tag in a later
             # response; without this guard the same file is re-sent.
             if history_media_paths:
+                def _canonical_media_path(path: Any) -> str:
+                    try:
+                        return os.path.normcase(
+                            os.path.normpath(os.path.expanduser(str(path)))
+                        )
+                    except (OSError, RuntimeError, ValueError):
+                        return str(path)
+
+                _canonical_history_media_paths = {
+                    _canonical_media_path(path)
+                    for path in history_media_paths
+                }
                 media_files = [
                     (path, is_voice)
                     for path, is_voice in media_files
-                    if path not in history_media_paths
+                    if (
+                        _canonical_media_path(path)
+                        not in _canonical_history_media_paths
+                    )
                 ]
             # Strip image URLs from the cleaned text for parity with the
             # non-streaming chain, but do NOT run extract_local_files here:
@@ -23083,6 +23133,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "compression_deferred": result.get("compression_deferred", False),
                     "tools": tools_holder[0] or [],
                     "history_offset": _effective_history_offset,
+                    "history_media_paths": _history_media_paths,
                     "compacted_in_place": _compacted_in_place,
                     "session_id": effective_session_id,
                     "last_prompt_tokens": _last_prompt_toks,
@@ -23211,6 +23262,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 ),
                 "tools": tools_holder[0] or [],
                 "history_offset": _effective_history_offset,
+                "history_media_paths": _history_media_paths,
                 "compacted_in_place": _compacted_in_place,
                 "last_prompt_tokens": _last_prompt_toks,
                 "input_tokens": _input_toks,
@@ -23731,6 +23783,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             # Check if we were interrupted OR have a queued message (/queue).
             result = result_holder[0]
+            current_result = (
+                response
+                if isinstance(response, dict)
+                else (result or {"final_response": response, "messages": history})
+            )
             adapter = self._adapter_for_source(source)
 
             # Finalize the streaming-TTS consumer (#60671).
@@ -23871,7 +23928,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         merge_pending_message_event(adapter._pending_messages, session_key, pending_event)
                     elif adapter and hasattr(adapter, 'queue_message'):
                         adapter.queue_message(session_key, pending)
-                    return result_holder[0] or {"final_response": response, "messages": history}
+                    return current_result
 
                 was_interrupted = result.get("interrupted")
                 if not was_interrupted:
@@ -23895,7 +23952,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # finalized task result. The latter contains empty/failure
                     # normalization and any final response processing applied by
                     # _run_agent_task; sending the raw copy bypasses those steps.
-                    _delivery_result = response if isinstance(response, dict) else (result or {})
+                    _delivery_result = current_result
                     _previewed = bool(_delivery_result.get("response_previewed"))
                     first_response = _delivery_result.get("final_response", "")
                     _already_streamed = _stream_confirmed_final_delivery(
@@ -23982,7 +24039,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "Discarding stale goal continuation for session %s — goal is no longer active",
                             session_key or "?",
                         )
-                        return result
+                        return current_result
                     # Resolve the follow-up's session key BEFORE preparing the
                     # inbound text: _prepare_inbound_message_text buffers native
                     # image paths under the key it is given, and the recursive
@@ -24003,7 +24060,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         session_key=next_session_key,
                     )
                     if next_message is None:
-                        return result
+                        return current_result
                     next_message_id = self._reply_anchor_for_event(pending_event)
                     next_channel_prompt = getattr(pending_event, "channel_prompt", None)
                     next_message_type = getattr(pending_event, "message_type", None)
@@ -24063,7 +24120,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     channel_prompt=next_channel_prompt,
                     message_type=next_message_type,
                 )
-                return _preserve_queued_followup_history_offset(result, followup_result)
+                return _preserve_queued_followup_history_offset(
+                    current_result,
+                    followup_result,
+                )
         finally:
             # Stop progress sender, interrupt monitor, and notification task
             if progress_task:

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -216,20 +216,19 @@ async def test_not_new_messages_skip_db_when_agent_has_session_db(
 
 
 @pytest.mark.asyncio
-async def test_streamed_response_receives_prior_turn_media_paths(
+async def test_streamed_response_prefers_selected_agent_history_media_paths(
     monkeypatch, tmp_path
 ):
-    """An ordinary streamed reply completes the post-stream delivery branch.
+    """Post-stream delivery uses the history selected by the agent run.
 
-    The history-derived dedup set is part of that branch's contract, rather
-    than an optional best-effort hint: passing an undefined local crashes the
-    entire reply, while passing an empty set reintroduces duplicate MEDIA
-    attachments on later streamed responses.
+    The persisted transcript can lag the cached agent history after FTS
+    corruption. The result snapshot must win so media found only in the live
+    history is not delivered again.
     """
     runner = _bootstrap(monkeypatch, tmp_path)
     prior_path = "/tmp/already-delivered.png"
     runner.session_store.load_transcript.return_value = [
-        {"role": "assistant", "content": f"MEDIA:{prior_path}"},
+        {"role": "assistant", "content": "short persisted history"},
     ]
     runner.adapters = {Platform.TELEGRAM: MagicMock()}
     runner._deliver_media_from_response = AsyncMock()
@@ -241,6 +240,41 @@ async def test_streamed_response_receives_prior_turn_media_paths(
                 {"role": "user", "content": "what is my status?"},
                 {"role": "assistant", "content": "the streamed reply completed normally"},
             ],
+            "tools": [],
+            "history_offset": 0,
+            "history_media_paths": {prior_path},
+            "last_prompt_tokens": 0,
+            "already_sent": True,
+            "failed": False,
+        }
+    )
+
+    response = await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assert response is None
+    runner._deliver_media_from_response.assert_awaited_once()
+    assert runner._deliver_media_from_response.await_args.kwargs[
+        "history_media_paths"
+    ] == {prior_path}
+
+
+@pytest.mark.asyncio
+async def test_streamed_response_falls_back_to_persisted_history_media_paths(
+    monkeypatch, tmp_path
+):
+    runner = _bootstrap(monkeypatch, tmp_path)
+    prior_path = "/tmp/persisted-history.png"
+    runner.session_store.load_transcript.return_value = [
+        {"role": "assistant", "content": f"MEDIA:{prior_path}"},
+    ]
+    runner.adapters = {Platform.TELEGRAM: MagicMock()}
+    runner._deliver_media_from_response = AsyncMock()
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "streamed response",
+            "messages": [],
             "tools": [],
             "history_offset": 1,
             "last_prompt_tokens": 0,
@@ -254,7 +288,6 @@ async def test_streamed_response_receives_prior_turn_media_paths(
     )
 
     assert response is None
-    runner._deliver_media_from_response.assert_awaited_once()
     assert runner._deliver_media_from_response.await_args.kwargs[
         "history_media_paths"
     ] == {prior_path}

--- a/tests/gateway/test_history_media_snapshot.py
+++ b/tests/gateway/test_history_media_snapshot.py
@@ -1,0 +1,318 @@
+import sys
+import threading
+import types
+from types import SimpleNamespace
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import Platform, PlatformConfig, StreamingConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+from gateway.session import SessionSource
+
+
+class _Adapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content=None, **kwargs):
+        return SendResult(success=True, message_id="sent")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+class _CachedAgent:
+    def __init__(self, **kwargs):
+        self.session_id = kwargs["session_id"]
+        self.model = kwargs["model"]
+        self.provider = kwargs.get("provider")
+        self.tools = []
+        self._session_messages = []
+        self._last_compaction_in_place = False
+        self.context_compressor = SimpleNamespace(
+            last_prompt_tokens=0,
+            context_length=100_000,
+        )
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+
+    def run_conversation(
+        self,
+        user_message,
+        conversation_history=None,
+        task_id=None,
+        **kwargs,
+    ):
+        messages = list(conversation_history or [])
+        messages.extend(
+            [
+                {"role": "user", "content": user_message},
+                {"role": "assistant", "content": "done"},
+            ]
+        )
+        self._session_messages = messages
+        return {
+            "final_response": "done",
+            "messages": messages,
+            "api_calls": 1,
+        }
+
+    def interrupt(self, *_args, **_kwargs):
+        return None
+
+
+class _CompactingQueuedAgent(_CachedAgent):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.turn_count = 0
+
+    def run_conversation(
+        self,
+        user_message,
+        conversation_history=None,
+        task_id=None,
+        **kwargs,
+    ):
+        self.turn_count += 1
+        self._last_compaction_in_place = True
+        messages = [
+            {"role": "user", "content": user_message},
+            {"role": "assistant", "content": f"done {self.turn_count}"},
+        ]
+        self._session_messages = messages
+        result = {
+            "final_response": f"done {self.turn_count}",
+            "messages": messages,
+            "api_calls": 1,
+        }
+        if self.turn_count == 1:
+            result["pending_steer"] = "queued followup"
+        return result
+
+
+def _runner(adapter):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.config = SimpleNamespace(
+        multiplex_profiles=False,
+        streaming=StreamingConfig(enabled=False),
+        group_sessions_per_user=False,
+        thread_sessions_per_user=False,
+        stt_enabled=False,
+    )
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.session_store = SimpleNamespace(_entries={}, _save=lambda: None)
+    runner._session_db = None
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._session_run_generation = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._draining = False
+    runner._get_proxy_url = lambda: None
+    runner._resolve_session_agent_runtime = lambda **_kwargs: (
+        "test-model",
+        {
+            "provider": "test-provider",
+            "base_url": "https://example.invalid",
+            "api_key": "test",
+        },
+    )
+    runner._resolve_session_reasoning_config = lambda **_kwargs: None
+    runner._resolve_session_service_tier = lambda **_kwargs: None
+    runner._resolve_turn_agent_config = lambda message, model, runtime: {
+        "model": model,
+        "runtime": runtime,
+        "request_overrides": {},
+    }
+    runner._agent_config_signature = lambda *_args, **_kwargs: ("stable",)
+    runner._extract_cache_busting_config = lambda _config: ()
+    runner._get_system_prompt_for_channel = lambda *_args, **_kwargs: None
+    runner._refresh_fallback_model = lambda: None
+    runner._thread_metadata_for_source = lambda *_args, **_kwargs: {}
+    runner._release_running_agent_state = lambda *_args, **_kwargs: None
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_run_agent_returns_media_snapshot_from_selected_cached_history(
+    monkeypatch,
+):
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CachedAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda: "test-model")
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        lambda *_args, **_kwargs: {"core"},
+    )
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+    )
+    session_key = "agent:main:telegram:dm:12345"
+    session_id = "session-media-snapshot"
+    runner = _runner(_Adapter())
+
+    await runner._run_agent(
+        message="first turn",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id=session_id,
+        session_key=session_key,
+    )
+
+    cached_agent = runner._agent_cache[session_key][0]
+    prior_path = "/tmp/cached-only.png"
+    cached_agent._session_messages = [
+        {"role": "user", "content": "make an image"},
+        {"role": "assistant", "content": f"MEDIA:{prior_path}"},
+    ]
+
+    result = await runner._run_agent(
+        message="second turn",
+        context_prompt="",
+        history=[{"role": "user", "content": "stale persisted row"}],
+        source=source,
+        session_id=session_id,
+        session_key=session_key,
+    )
+
+    assert result["history_media_paths"] == {prior_path}
+
+
+@pytest.mark.asyncio
+async def test_queued_followup_keeps_snapshot_removed_by_compaction(
+    monkeypatch,
+):
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CompactingQueuedAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda: "test-model")
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        lambda *_args, **_kwargs: {"core"},
+    )
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+    )
+    runner = _runner(_Adapter())
+    prior_path = "/tmp/pre-compaction.png"
+
+    result = await runner._run_agent(
+        message="first turn",
+        context_prompt="",
+        history=[
+            {"role": "assistant", "content": f"MEDIA:{prior_path}"},
+        ],
+        source=source,
+        session_id="session-queued-snapshot",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["history_media_paths"] == {prior_path}
+
+
+@pytest.mark.asyncio
+async def test_queued_depth_cap_returns_finalized_media_snapshot(
+    monkeypatch,
+):
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CompactingQueuedAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda: "test-model")
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        lambda *_args, **_kwargs: {"core"},
+    )
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+    )
+    runner = _runner(_Adapter())
+    prior_path = "/tmp/depth-capped.png"
+
+    result = await runner._run_agent(
+        message="first turn",
+        context_prompt="",
+        history=[
+            {"role": "assistant", "content": f"MEDIA:{prior_path}"},
+        ],
+        source=source,
+        session_id="session-depth-capped",
+        session_key="agent:main:telegram:dm:12345",
+        _interrupt_depth=runner._MAX_INTERRUPT_DEPTH,
+    )
+
+    assert result["history_media_paths"] == {prior_path}
+
+
+@pytest.mark.asyncio
+async def test_stale_goal_discard_returns_finalized_media_snapshot(
+    monkeypatch,
+):
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CachedAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda: "test-model")
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        lambda *_args, **_kwargs: {"core"},
+    )
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+    )
+    session_key = "agent:main:telegram:dm:12345"
+    adapter = _Adapter()
+    adapter._pending_messages[session_key] = MessageEvent(
+        text="[Continuing toward your standing goal]\nGoal: finish",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    runner = _runner(adapter)
+    runner._goal_still_active_for_session = lambda _session_id: False
+    prior_path = "/tmp/stale-goal.png"
+
+    result = await runner._run_agent(
+        message="first turn",
+        context_prompt="",
+        history=[
+            {"role": "assistant", "content": f"MEDIA:{prior_path}"},
+        ],
+        source=source,
+        session_id="session-stale-goal",
+        session_key=session_key,
+    )
+
+    assert result["history_media_paths"] == {prior_path}

--- a/tests/gateway/test_media_spaced_paths_and_history_dedupe.py
+++ b/tests/gateway/test_media_spaced_paths_and_history_dedupe.py
@@ -124,5 +124,22 @@ class TestHistoryMediaDedupe:
         paths = _collect_history_media_paths(history)
         assert "/tmp/out.pdf" in paths
 
+    def test_quoted_spaced_home_path_is_collected_in_delivery_form(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        history = [
+            {
+                "role": "assistant",
+                "content": 'MEDIA:"~/audio cache/old.ogg"',
+            },
+        ]
+
+        paths = _collect_history_media_paths(history)
+
+        assert str(tmp_path / "audio cache" / "old.ogg") in paths
+
     def test_empty_history_empty_set(self):
         assert _collect_history_media_paths([]) == set()

--- a/tests/gateway/test_post_stream_media_delivery.py
+++ b/tests/gateway/test_post_stream_media_delivery.py
@@ -144,3 +144,29 @@ async def test_explicit_media_document_still_delivers_post_stream(tmp_path, monk
         file_path=str(media_file),
         metadata={},
     )
+
+
+@pytest.mark.asyncio
+async def test_history_dedup_expands_home_relative_media_paths(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    media_file = _allowed_media_path(
+        tmp_path,
+        monkeypatch,
+        "report.pdf",
+    )
+    adapter = _adapter()
+    history_path = "~/media-cache/report.pdf"
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({}),
+        f"Report attached.\nMEDIA:{history_path}",
+        _event(),
+        adapter,
+        history_media_paths={history_path},
+    )
+
+    assert str(media_file) == str(tmp_path / "media-cache" / "report.pdf")
+    adapter.send_document.assert_not_awaited()

--- a/tests/gateway/test_transcript_offset.py
+++ b/tests/gateway/test_transcript_offset.py
@@ -323,3 +323,40 @@ class TestTranscriptHistoryOffset:
         )
 
         assert merged["history_offset"] == 3
+
+    def test_recursive_queued_followup_unions_history_media_snapshots(self):
+        """A nested turn keeps media paths that compaction removed from history."""
+        current_result = {
+            "history_offset": 2,
+            "history_media_paths": {"/tmp/before-compaction.png"},
+        }
+        followup_result = {
+            "history_offset": 4,
+            "history_media_paths": {"/tmp/after-compaction.png"},
+        }
+
+        merged = _preserve_queued_followup_history_offset(
+            current_result,
+            followup_result,
+        )
+
+        assert merged["history_media_paths"] == {
+            "/tmp/before-compaction.png",
+            "/tmp/after-compaction.png",
+        }
+
+    def test_recursive_queued_followup_preserves_empty_media_snapshot(self):
+        current_result = {
+            "history_offset": 2,
+            "history_media_paths": set(),
+        }
+        followup_result = {
+            "history_offset": 4,
+        }
+
+        merged = _preserve_queued_followup_history_offset(
+            current_result,
+            followup_result,
+        )
+
+        assert merged["history_media_paths"] == set()


### PR DESCRIPTION
## What does this PR do?

`c2ee5039e` added history based media dedup so a file delivered in an earlier turn is not re-sent after a streamed reply. The dedup set is currently computed twice, from two different message lists, and the streamed delivery path uses the wrong one.

Inside the agent run path, `_history_media_paths` is built from the **selected** `agent_history`. That selection matters: when the persisted transcript is stale or truncated, Hermes deliberately substitutes the cached agent's longer `_session_messages` (the FTS corruption recovery path). The correct snapshot is used internally for auto append dedup, but it is never returned to the caller.

The streamed post stream delivery site then **recomputes** the set from the raw outer `history` with `history_media_paths=_collect_history_media_paths(history)`.

So when the cached history substitution fires, delivery excludes paths derived from the shorter persisted history. A media path that exists only in the cached history is missing from the exclusion set and can be delivered a second time. This is reachable whenever that substitution runs and the turn returns `history_offset=0`, which the gateway does deliberately after split or in place compaction.

This PR surfaces the already computed snapshot instead of adding a parallel mechanism. The agent result now carries `history_media_paths` alongside the existing `history_offset`, and the delivery site prefers it when present, falling back to the current recompute when it is absent. The fallback keeps proxy mode, other result shapes and existing callers working byte identically.

## Related Issue

No existing issue. Introduced by `c2ee5039e`, found while reviewing that commit's interaction with post stream delivery.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: return `history_media_paths` from the agent result at the sites where the selected snapshot is in scope, carry it through the queued followup merge helper, and consume it at the streamed delivery site with a fallback to the existing recompute.
- `tests/gateway/test_history_media_snapshot.py`: new, covers the snapshot surviving compaction, the queued depth cap, the stale goal discard path, and the empty snapshot case.
- `tests/gateway/test_transcript_offset.py`, `tests/gateway/test_post_stream_media_delivery.py`, `tests/gateway/test_42039_duplicate_user_message.py`, `tests/gateway/test_media_spaced_paths_and_history_dedupe.py`: extended to assert the snapshot is threaded through the real glue rather than only the helper.

## How to Test

1. `pytest tests/gateway/test_history_media_snapshot.py -q` passes on this branch.
2. Revert `gateway/run.py` to `origin/main` and re-run that file: 4 tests fail, which confirms the tests exercise the production change rather than only the helper.
3. `pytest tests/gateway/test_*media*.py tests/gateway/test_*delivery*.py -q` for the wider regression: 380 passed, 2 skipped.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian 12 (OpenVZ container)

### Documentation & Housekeeping

- [x] I've updated relevant documentation: N/A, no user facing surface changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys: N/A, no new config
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md`: N/A
- [x] I've considered cross-platform impact: N/A, no platform specific code
- [x] I've updated tool descriptions/schemas: N/A
