### PR TITLE
docs: add two Metedata community stories

### DIFF
--- a/website/src/data/userStories.json
+++ b/website/src/data/userStories.json
@@ -2880,5 +2880,27 @@
     "headline": "Recursively built a Supabase-backed CRM dashboard where each build reuses prior components",
     "quote": "Used the Hermes Desktop App to recursively generate a CRM dashboard where each build reuses components from prior generations; it can also build full videos using official HyperFrame skills — HTML-native, full control over scenes, animations, and rendering.",
     "size": "sm"
+  },
+  {
+    "id": "metedata-hermes-obsidian",
+    "source": "blog",
+    "author": "Mete Polat (Substack)",
+    "url": "https://metedata.substack.com/p/013-my-hermes-and-obsidian-set-up",
+    "date": "2026-05-20",
+    "category": "personal-assistant",
+    "headline": "Hermes turns Telegram voice notes into an Obsidian operating system",
+    "quote": "I send messy voice notes to Hermes through Telegram, and it turns them into structured Obsidian notes on an always-on Mac mini. The same setup now captures and researches business ideas, runs my content engine, adapts weekly fitness plans from feedback, standardizes family recipes, and helps with small purchases - while keeping the underlying knowledge portable in local files.",
+    "size": "lg"
+  },
+  {
+    "id": "metedata-personal-software-home",
+    "source": "blog",
+    "author": "Mete Polat (Substack)",
+    "url": "https://metedata.substack.com/p/016-my-personal-software-journey",
+    "date": "2026-07-28",
+    "category": "dev-workflow",
+    "headline": "Hermes builds and operates my private app library on a Mac mini",
+    "quote": "My agent builds small personal apps for recurring needs, deploys each one in a Docker container on my Mac mini, adds it to a private launcher behind Cloudflare Access, verifies it, and commits the result to Git. The library includes fitness and language-learning canvases, a family calendar, a wishlist, local-event discovery, and Hermes telemetry - all accessible from any device.",
+    "size": "lg"
   }
 ]


### PR DESCRIPTION
## What does this PR do?

Adds two source-backed community stories from Mete Polat's Metedata newsletter:

- A daily Hermes + Telegram + Obsidian system for idea capture, content workflows, fitness planning, recipes, and small purchases.
- A private personal-software library where Hermes builds, deploys, verifies, and maintains small apps on a Mac mini.

The stories cover distinct uses and link to the complete firsthand write-ups. Both articles are authored by the contributor, so this is a transparent self-submission.

## Related Issue

None.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added the [Hermes + Obsidian setup](https://metedata.substack.com/p/013-my-hermes-and-obsidian-set-up) under `personal-assistant`.
- Added the [self-hosted personal software journey](https://metedata.substack.com/p/016-my-personal-software-journey) under `dev-workflow`.
- Used the existing `blog` source, Substack author, category, and card-size conventions in `website/src/data/userStories.json`.

## How to Test

1. Run `jq empty website/src/data/userStories.json`.
2. Confirm all story IDs remain unique and both new entries contain valid source, URL, date, category, and size values.
3. Open both source URLs and confirm they return HTTP 200.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this documentation update (no unrelated commits)
- [x] Full Python tests are N/A for this data-only documentation change; JSON and link validation passed
- [x] Additional tests are N/A because no behavior changed
- [x] I've tested on macOS 26.5.1

### Documentation & Housekeeping

- [x] Relevant documentation is the change itself
- [x] `cli-config.yaml.example` update is N/A
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A
- [x] Cross-platform impact is N/A for static JSON data
- [x] Tool description/schema updates are N/A

## Screenshots / Logs

Not applicable.
