### PR TITLE
fix(tts): rewrite xAI streaming against the real WebSocket protocol

### DIFF
--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -1,9 +1,11 @@
 """Tests for the provider-agnostic streaming TTS backend (tools.tts_streaming)
 and its dispatch through tools.tts_tool.stream_tts_to_speaker.
 
-No live audio or network: the ElevenLabs/OpenAI SDKs, sounddevice, and the sync
-synth path are all mocked. Covers the registry/resolver, provider availability,
-the chunked-streamer playback path, and the universal per-sentence sync fallback.
+No live audio or external network: the ElevenLabs/OpenAI SDKs, sounddevice, and
+the sync synth path are all mocked, and the xAI wire protocol runs against a
+loopback fake WebSocket server. Covers the registry/resolver, provider
+availability, the chunked-streamer playback path, and the universal per-sentence
+sync fallback.
 """
 
 import queue
@@ -206,6 +208,216 @@ def test_xai_available_uses_oauth_credential_resolver(monkeypatch):
 
 
 # ── xAI WebSocket bridge ─────────────────────────────────────────────────
+
+
+def _fake_xai_server(handler):
+    """Serve ``handler`` on a loopback WS server; return (url, server)."""
+    from websockets.sync.server import serve
+
+    server = serve(handler, "127.0.0.1", 0)
+    port = server.socket.getsockname()[1]
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return f"ws://127.0.0.1:{port}/tts", server
+
+
+def _patch_xai_creds(monkeypatch):
+    import tools.xai_http
+
+    monkeypatch.setattr(
+        tools.xai_http,
+        "resolve_xai_http_credentials",
+        lambda *a, **k: {"api_key": "test-xai-key"},
+    )
+
+
+def test_xai_streamer_speaks_the_real_wire_protocol(monkeypatch):
+    """Pin the exact wire format verified against the live xAI API: audio
+    params in the URL query string, bearer auth header, text.delta +
+    text.done out, base64 audio.delta in, audio.done terminates."""
+    import base64
+    import json
+
+    pcm1, pcm2 = b"\x01\x00" * 30, b"\x02\x00" * 30
+    seen = {}
+
+    def handler(ws):
+        seen["path"] = ws.request.path
+        seen["auth"] = ws.request.headers.get("Authorization")
+        seen["messages"] = []
+        for raw in ws:
+            msg = json.loads(raw)
+            seen["messages"].append(msg)
+            if msg.get("type") == "text.done":
+                break
+        for chunk in (pcm1, pcm2):
+            ws.send(json.dumps({
+                "type": "audio.delta",
+                "delta": base64.b64encode(chunk).decode(),
+            }))
+        ws.send(json.dumps({"type": "audio.done"}))
+
+    url, server = _fake_xai_server(handler)
+    try:
+        _patch_xai_creds(monkeypatch)
+        streamer = ts.XAIStreamer({}, {"streaming_url": url})
+        assert list(streamer.stream("A sentence.")) == [pcm1, pcm2]
+    finally:
+        server.shutdown()
+
+    assert "voice=eve" in seen["path"]
+    assert "language=en" in seen["path"]
+    assert "codec=pcm" in seen["path"]
+    assert "sample_rate=24000" in seen["path"]
+    assert seen["auth"] == "Bearer test-xai-key"
+    assert [m["type"] for m in seen["messages"]] == ["text.delta", "text.done"]
+    assert seen["messages"][0]["delta"] == "A sentence."
+
+
+def test_xai_streamer_passes_auth_via_additional_headers(monkeypatch):
+    """websockets 15 removed the ``extra_headers`` kwarg: the connect call
+    must carry the bearer token in ``additional_headers`` or every stream()
+    raises TypeError before any network traffic (#73985). Pin the kwarg by
+    name so a future edit cannot reintroduce the old spelling."""
+    import base64
+    import json
+
+    import websockets
+
+    captured = {}
+    real_connect = websockets.connect
+
+    def spy_connect(url, **kwargs):
+        captured.update(kwargs)
+        return real_connect(url, **kwargs)
+
+    # tools/tts_streaming imports websockets locally inside the coroutine,
+    # so it resolves the patched package attribute at call time.
+    monkeypatch.setattr(websockets, "connect", spy_connect)
+
+    def handler(ws):
+        for raw in ws:
+            if json.loads(raw).get("type") == "text.done":
+                break
+        ws.send(json.dumps({
+            "type": "audio.delta",
+            "delta": base64.b64encode(b"\x01\x00").decode(),
+        }))
+        ws.send(json.dumps({"type": "audio.done"}))
+
+    url, server = _fake_xai_server(handler)
+    try:
+        _patch_xai_creds(monkeypatch)
+        streamer = ts.XAIStreamer({}, {"streaming_url": url})
+        assert list(streamer.stream("A sentence.")) == [b"\x01\x00"]
+    finally:
+        server.shutdown()
+
+    assert "extra_headers" not in captured
+    assert captured["additional_headers"] == {"Authorization": "Bearer test-xai-key"}
+
+
+def test_xai_streamer_yields_before_the_sentence_finishes(monkeypatch):
+    """The first chunk must reach the caller while the server still holds
+    the rest. The old shape drained the whole WS response into a list
+    before yielding anything; against that shape this test never sees the
+    second chunk."""
+    import base64
+    import json
+
+    pcm1, pcm2 = b"\x01\x00" * 30, b"\x02\x00" * 30
+    first_delivered = threading.Event()
+
+    def handler(ws):
+        for raw in ws:
+            if json.loads(raw).get("type") == "text.done":
+                break
+        ws.send(json.dumps({
+            "type": "audio.delta",
+            "delta": base64.b64encode(pcm1).decode(),
+        }))
+        if not first_delivered.wait(timeout=10):
+            return  # consumer never saw chunk one before the stream ended
+        ws.send(json.dumps({
+            "type": "audio.delta",
+            "delta": base64.b64encode(pcm2).decode(),
+        }))
+        ws.send(json.dumps({"type": "audio.done"}))
+
+    url, server = _fake_xai_server(handler)
+    try:
+        _patch_xai_creds(monkeypatch)
+        streamer = ts.XAIStreamer({}, {"streaming_url": url})
+        gen = streamer.stream("A sentence.")
+        assert next(gen) == pcm1
+        first_delivered.set()
+        assert list(gen) == [pcm2]
+    finally:
+        server.shutdown()
+
+
+def test_xai_streamer_raises_on_error_envelope(monkeypatch):
+    """Mid-stream failures raise (the ABC contract: raise, caller logs),
+    instead of playing a truncated sentence as if it were complete."""
+    import json
+
+    def handler(ws):
+        for raw in ws:
+            if json.loads(raw).get("type") == "text.done":
+                break
+        ws.send(json.dumps({"type": "error", "message": "boom"}))
+
+    url, server = _fake_xai_server(handler)
+    try:
+        _patch_xai_creds(monkeypatch)
+        streamer = ts.XAIStreamer({}, {"streaming_url": url})
+        with pytest.raises(RuntimeError, match="boom"):
+            list(streamer.stream("A sentence."))
+    finally:
+        server.shutdown()
+
+
+def test_xai_streamer_stops_consuming_past_the_byte_cap(monkeypatch):
+    """The byte budget is enforced in the pump BEFORE enqueueing: the
+    consumer-side _capped() runs only after q.get(), so without a pump-side
+    check a runaway upstream would pile decoded PCM into the queue. The
+    producer must close the socket and stop reading once over budget."""
+    import base64
+    import json
+
+    monkeypatch.setattr(ts, "_STREAM_SENTENCE_BYTE_CAP", 100)
+    frame = b"\x00" * 64
+    sent = 0
+    client_gone = threading.Event()
+
+    def handler(ws):
+        nonlocal sent
+        for raw in ws:
+            if json.loads(raw).get("type") == "text.done":
+                break
+        try:
+            while True:
+                ws.send(json.dumps({
+                    "type": "audio.delta",
+                    "delta": base64.b64encode(frame).decode(),
+                }))
+                sent += 1
+        except Exception:
+            # ConnectionClosed: the client closed mid-stream once over budget.
+            client_gone.set()
+
+    url, server = _fake_xai_server(handler)
+    try:
+        _patch_xai_creds(monkeypatch)
+        streamer = ts.XAIStreamer({}, {"streaming_url": url})
+        chunks = list(streamer.stream("A sentence."))
+        # 64 fits, 128 > 100: the consumer sees one frame, never the tail.
+        assert sum(len(c) for c in chunks) <= 100
+        # The pump closed the socket: the server's send loop broke instead of
+        # streaming frames forever.
+        assert client_gone.wait(timeout=10)
+        assert sent < 1000
+    finally:
+        server.shutdown()
 
 
 # ── 16 MiB per-sentence stream cap ───────────────────────────────────────

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -399,17 +399,23 @@ class GeminiStreamer(StreamingTTSProvider):
 
 @register("xai")
 class XAIStreamer(StreamingTTSProvider):
-    """xAI WebSocket TTS → binary PCM frames (24 kHz mono int16).
+    """xAI WebSocket TTS → base64 PCM ``audio.delta`` frames (24 kHz mono int16).
 
-    Salvaged from PR #47588 (@Cdddo): xAI's chunked TTS API is
-    WebSocket-only (``wss://api.x.ai/v1/tts``). Credentials route through
-    ``resolve_xai_http_credentials`` (OAuth or XAI_API_KEY), same as the
-    sync ``_generate_xai_tts`` path. The async WS loop is bridged to the
-    sync iterator contract via ``_collect_async`` — the seam unit tests
-    monkeypatch.
+    Salvaged from PR #47588 (@Cdddo) and rewritten against the real wire
+    protocol: voice/language/codec/sample_rate ride in the URL query string
+    (the server 400s the bare path at handshake), the client sends
+    ``text.delta`` + ``text.done``, and the server streams JSON
+    ``audio.delta`` envelopes (base64 PCM in ``delta``) until ``audio.done``.
+    Credentials route through ``resolve_xai_http_credentials`` (OAuth or
+    XAI_API_KEY), same as the sync ``_generate_xai_tts`` path. The async WS
+    loop runs on a background thread feeding a queue, so ``stream()`` yields
+    chunks as they arrive and works from sync CLI code and from gateway
+    adapters that already run an event loop.
     """
 
     sample_rate = 24000
+
+    _RECV_TIMEOUT_S = 60  # a sentence of TTS should never gap this long
 
     @staticmethod
     def available() -> bool:
@@ -422,27 +428,65 @@ class XAIStreamer(StreamingTTSProvider):
             return False
 
     def stream(self, text: str) -> Iterator[bytes]:
-        yield from _capped(iter(self._collect_async(text)), "xAI streaming TTS")
+        yield from _capped(self._queued_frames(text), "xAI streaming TTS")
 
-    # -- async→sync bridge (test seam) ------------------------------------
+    # -- async→sync bridge -------------------------------------------------
 
-    def _collect_async(self, text: str) -> List[bytes]:
+    def _queued_frames(self, text: str) -> Iterator[bytes]:
+        """Yield PCM chunks as the WS delivers them, on a pump thread.
+
+        The thread owns a fresh event loop, so ``asyncio.run`` never fights
+        a loop the caller is already running (gateway adapters are async).
+        Exceptions from the pump are re-raised on the consumer side so the
+        caller's "raise on failure" contract holds.
+
+        ``_capped()`` runs on the consumer side of the queue, after
+        ``q.get()`` — so the byte budget is ALSO enforced in the pump before
+        each enqueue (see ``_pump``), and a consumer that stops early flips
+        ``stop`` so the pump closes the socket instead of piling decoded PCM
+        into a queue nobody drains.
+        """
         import asyncio
+        import queue
+        import threading
 
-        return asyncio.run(self._drain_async(text))
+        q: "queue.Queue[object]" = queue.Queue()
+        done = object()
+        stop = threading.Event()
 
-    async def _drain_async(self, text: str) -> List[bytes]:
-        frames: List[bytes] = []
-        async for frame in self._async_frames(text):
-            frames.append(frame)
-        return frames
+        def _pump_thread() -> None:
+            try:
+                asyncio.run(self._pump(text, q, stop))
+            except BaseException as exc:  # hand failures to the consumer
+                q.put(exc)
+            finally:
+                q.put(done)
 
-    async def _async_frames(self, text: str):
+        threading.Thread(
+            target=_pump_thread, name="xai-tts-pump", daemon=True
+        ).start()
+        try:
+            while True:
+                item = q.get()
+                if item is done:
+                    return
+                if isinstance(item, BaseException):
+                    raise item
+                yield item
+        finally:
+            # Generator closed early (cap, playback failure, caller dropped
+            # it): stop the pump at its next frame.
+            stop.set()
+
+    async def _pump(self, text: str, q, stop) -> None:
+        import asyncio
+        import base64
         import json as _json
+        from urllib.parse import urlencode
 
         import websockets
 
-        from tools.tts_tool import DEFAULT_XAI_VOICE_ID
+        from tools.tts_tool import DEFAULT_XAI_LANGUAGE, DEFAULT_XAI_VOICE_ID
         from tools.xai_http import resolve_xai_http_credentials
 
         creds = resolve_xai_http_credentials()
@@ -450,39 +494,71 @@ class XAIStreamer(StreamingTTSProvider):
         if not api_key:
             raise RuntimeError("No xAI credentials for streaming TTS")
         voice = str(self.section.get("voice_id", DEFAULT_XAI_VOICE_ID)).strip() or DEFAULT_XAI_VOICE_ID
-        ws_url = str(
+        language = str(self.section.get("language", DEFAULT_XAI_LANGUAGE)).strip() or DEFAULT_XAI_LANGUAGE
+        base = str(
             self.section.get("streaming_url") or "wss://api.x.ai/v1/tts"
         ).strip()
+        params = urlencode({
+            "voice": voice,
+            "language": language,
+            "codec": "pcm",
+            "sample_rate": self.sample_rate,
+        })
+        sep = "&" if "?" in base else "?"
+        ws_url = f"{base}{sep}{params}"
 
         async with websockets.connect(
-            ws_url, extra_headers={"Authorization": f"Bearer {api_key}"}
+            ws_url, additional_headers={"Authorization": f"Bearer {api_key}"}
         ) as ws:
-            await ws.send(_json.dumps({
-                "text": text,
-                "voice_id": voice,
-                "response_format": "pcm",
-            }))
-            try:
-                while True:
-                    message = await ws.recv()
-                    if isinstance(message, (bytes, bytearray, memoryview)):
-                        yield bytes(message)
-                        continue
-                    try:
-                        envelope = _json.loads(message)
-                    except (ValueError, TypeError):
-                        if message == "done":
+            await ws.send(_json.dumps({"type": "text.delta", "delta": text}))
+            await ws.send(_json.dumps({"type": "text.done"}))
+            enqueued = 0
+            while True:
+                try:
+                    message = await asyncio.wait_for(
+                        ws.recv(), timeout=self._RECV_TIMEOUT_S
+                    )
+                except asyncio.TimeoutError:
+                    raise RuntimeError("xAI streaming TTS: no audio for 60s")
+                except websockets.exceptions.ConnectionClosedOK:
+                    return  # clean close, with or without audio.done
+                except websockets.exceptions.ConnectionClosedError as exc:
+                    raise RuntimeError(f"xAI WS closed mid-stream: {exc}") from exc
+                if isinstance(message, (bytes, bytearray, memoryview)):
+                    continue  # the server speaks JSON; binary is not expected
+                try:
+                    envelope = _json.loads(message)
+                except (ValueError, TypeError):
+                    continue
+                msg_type = envelope.get("type")
+                if msg_type == "audio.delta":
+                    b64 = envelope.get("delta") or ""
+                    if b64:
+                        pcm = base64.b64decode(b64)
+                        enqueued += len(pcm)
+                        if enqueued > _STREAM_SENTENCE_BYTE_CAP:
+                            # Enforce the per-sentence byte budget BEFORE
+                            # enqueueing: the consumer-side _capped() only
+                            # runs after q.get(), so without this a runaway
+                            # upstream piles decoded PCM into the queue.
+                            # Returning exits the context manager, which
+                            # closes the socket — we stop reading upstream.
+                            logger.warning(
+                                "xAI streaming TTS exceeded %d bytes for one "
+                                "sentence; closing upstream",
+                                _STREAM_SENTENCE_BYTE_CAP,
+                            )
                             return
-                        continue
-                    etype = envelope.get("type")
-                    if etype == "done":
-                        return
-                    if etype == "error":
-                        logger.warning("xAI WS error envelope: %s",
-                                       envelope.get("error") or envelope.get("message") or envelope)
-                        return
-            except Exception as exc:
-                if exc.__class__.__name__ == "ConnectionClosed":
+                        if stop.is_set():
+                            # Consumer went away (cap, playback failure):
+                            # close and stop reading rather than filling a
+                            # queue nobody drains.
+                            return
+                        q.put(pcm)
+                elif msg_type == "audio.done":
                     return
-                logger.warning("xAI WS receive failed: %s", exc)
-                return
+                elif msg_type == "error":
+                    detail = (
+                        envelope.get("message") or envelope.get("error") or envelope
+                    )
+                    raise RuntimeError(f"xAI streaming TTS error: {detail}")


### PR DESCRIPTION
xAI streaming TTS now uses query-string audio settings, additional_headers authentication, text.delta/text.done requests, and base64 audio.delta responses. The background pump yields audio incrementally, propagates failures, and enforces the byte cap before enqueueing. It copies the caller's ContextVars so named profiles keep their own credentials, and imports constants from their current defining module.

Fixes #73985

Validation: 35 targeted tests passed through scripts/run_tests.sh: tests/tools/test_tts_streaming.py and tests/tools/test_tts_output_dir_profile_scope.py. Loopback WebSocket tests use the real profile credential resolver for two profiles, verify incremental delivery and wire messages, and exercise errors and receive limits. The profile tests failed before the context fix. An existing prefetch assertion now permits equal Windows monotonic clock ticks.

Updated on the refactored main at 1ab32b212b, with the repair folded into one commit.
