### PR TITLE
fix(install): fall back to pip when uv crashes on Windows

### DIFF
--- a/contributors/emails/2895359972@qq.com
+++ b/contributors/emails/2895359972@qq.com
@@ -1,0 +1,2 @@
+XRX193
+# PR #72518 (Windows uv illegal-instruction fallback)

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -499,6 +499,19 @@ function Invoke-NativeWithRelaxedErrorAction {
         $ErrorActionPreference = $prevEAP
     }
 }
+
+function Test-UvIllegalInstructionExitCode {
+    param($ExitCode)
+
+    if ($null -eq $ExitCode) { return $false }
+    try {
+        $numericExitCode = [long]$ExitCode
+        return $numericExitCode -eq -1073741795 -or $numericExitCode -eq 3221225501
+    } catch {
+        return $false
+    }
+}
+
 function Discard-LockfileChurn {
     param([string]$Repo = $InstallDir)
 
@@ -2746,6 +2759,7 @@ function Install-Dependencies {
     # previous venv is restored before the error propagates, and the parked
     # tree is deleted only after the imports prove the replacement usable.
     try {
+    $usePipFallback = $false
     if (Test-Path "uv.lock") {
         Write-Info "Trying tier: hash-verified (uv.lock) ..."
         # Critical flag choice: `--extra all`, NOT `--all-extras`.
@@ -2763,13 +2777,23 @@ function Install-Dependencies {
         # in the wrong directory and imports fail with ModuleNotFoundError.
         # (Mirrors the same flag in scripts/install.sh::install_deps.)
         $env:UV_PROJECT_ENVIRONMENT = "$InstallDir\venv"
-        Invoke-NativeWithRelaxedErrorAction { & $UvCmd sync --extra all --locked }
-        if ($LASTEXITCODE -eq 0) {
+        $script:DependencyExitCode = $null
+        Invoke-NativeWithRelaxedErrorAction {
+            & $UvCmd sync --extra all --locked
+            $script:DependencyExitCode = $LASTEXITCODE
+        }
+        $uvExitCode = $script:DependencyExitCode
+        if ($uvExitCode -eq 0) {
             Write-Success "Main package installed (hash-verified via uv.lock)"
             $script:InstalledTier = "hash-verified (uv.lock)"
             # Skip the rest of the tiered cascade -- we already have a
             # complete, hash-verified install.
             $skipPipFallback = $true
+        } elseif (Test-UvIllegalInstructionExitCode $uvExitCode) {
+            Write-Warn "uv.exe exited with EXCEPTION_ILLEGAL_INSTRUCTION (0xC000001D). Switching to pip fallback."
+            Write-Warn "The pip fallback resolves packages without uv.lock hash verification."
+            $usePipFallback = $true
+            $skipPipFallback = $false
         } else {
             Write-Warn "uv.lock sync failed (lockfile may be stale), falling back to PyPI resolve..."
             $skipPipFallback = $false
@@ -2835,21 +2859,76 @@ except Exception:
         @{ Name = "core only (no extras)"; Spec = "." }
     )
     $installed = $skipPipFallback
-    if (-not $skipPipFallback) {
+    if (-not $skipPipFallback -and -not $usePipFallback) {
         foreach ($tier in $installTiers) {
-        Write-Info "Trying tier: $($tier.Name) ..."
-        Invoke-NativeWithRelaxedErrorAction { & $UvCmd pip install -e $tier.Spec }
-        if ($LASTEXITCODE -eq 0) {
-            Write-Success "Main package installed ($($tier.Name))"
-            $script:InstalledTier = $tier.Name
-            $installed = $true
-            break
+            Write-Info "Trying tier: $($tier.Name) ..."
+            $script:DependencyExitCode = $null
+            Invoke-NativeWithRelaxedErrorAction {
+                & $UvCmd pip install -e $tier.Spec
+                $script:DependencyExitCode = $LASTEXITCODE
+            }
+            $uvExitCode = $script:DependencyExitCode
+            if ($uvExitCode -eq 0) {
+                Write-Success "Main package installed ($($tier.Name))"
+                $script:InstalledTier = $tier.Name
+                $installed = $true
+                break
+            }
+            if (Test-UvIllegalInstructionExitCode $uvExitCode) {
+                Write-Warn "uv.exe exited with EXCEPTION_ILLEGAL_INSTRUCTION (0xC000001D). Switching to pip fallback."
+                Write-Warn "The pip fallback resolves packages without uv.lock hash verification."
+                $usePipFallback = $true
+                break
+            }
+            Write-Warn "Tier '$($tier.Name)' failed (exit $uvExitCode). Trying next tier..."
         }
-        Write-Warn "Tier '$($tier.Name)' failed (exit $LASTEXITCODE). Trying next tier..."
+    }
+
+    if ($usePipFallback) {
+        if ($NoVenv) {
+            throw "uv.exe is incompatible with this CPU, and pip fallback requires the managed venv. Re-run without -NoVenv."
+        }
+
+        $pipPython = "$InstallDir\venv\Scripts\python.exe"
+        if (-not (Test-Path $pipPython)) {
+            throw "uv.exe is incompatible with this CPU, and pip fallback could not find $pipPython."
+        }
+
+        $script:DependencyExitCode = $null
+        Invoke-NativeWithRelaxedErrorAction {
+            & $pipPython -m pip --version
+            $script:DependencyExitCode = $LASTEXITCODE
+        }
+        if ($script:DependencyExitCode -ne 0) {
+            Write-Info "Bootstrapping pip into venv for uv recovery..."
+            $script:DependencyExitCode = $null
+            Invoke-NativeWithRelaxedErrorAction {
+                & $pipPython -m ensurepip --upgrade
+                $script:DependencyExitCode = $LASTEXITCODE
+            }
+            if ($script:DependencyExitCode -ne 0) {
+                throw "uv.exe is incompatible with this CPU and ensurepip failed (exit $($script:DependencyExitCode))."
+            }
+        }
+
+        foreach ($tier in $installTiers) {
+            Write-Info "Trying pip fallback tier: $($tier.Name) ..."
+            Invoke-NativeWithRelaxedErrorAction {
+                & $pipPython -m pip install --disable-pip-version-check --no-input -e $tier.Spec
+                $script:DependencyExitCode = $LASTEXITCODE
+            }
+            $pipExitCode = $script:DependencyExitCode
+            if ($pipExitCode -eq 0) {
+                Write-Success "Main package installed via pip fallback ($($tier.Name))"
+                $script:InstalledTier = "pip fallback ($($tier.Name))"
+                $installed = $true
+                break
+            }
+            Write-Warn "pip fallback tier '$($tier.Name)' failed (exit $pipExitCode). Trying next tier..."
         }
     }
     if (-not $installed) {
-        throw "Failed to install hermes-agent package even with no extras. Inspect the uv pip install output above."
+        throw "Failed to install hermes-agent package even with no extras. Inspect the dependency install output above."
     }
 
     # Baseline-import gate. Even if a tier reported success above, the
@@ -2924,8 +3003,18 @@ print(','.join(scripts))
                 if ($missing.Count -gt 0) {
                     Write-Warn "Console entry point(s) missing: $($missing -join ', ')"
                     Write-Info "Reinstalling entry points..."
-                    $env:UV_PROJECT_ENVIRONMENT = "$InstallDir\venv"
-                    Invoke-NativeWithRelaxedErrorAction { & $UvCmd pip install --reinstall -e . }
+                    if ($usePipFallback) {
+                        Invoke-NativeWithRelaxedErrorAction {
+                            & $pythonExe -m pip install --disable-pip-version-check --no-input --reinstall -e .
+                            $script:DependencyExitCode = $LASTEXITCODE
+                        }
+                    } else {
+                        $env:UV_PROJECT_ENVIRONMENT = "$InstallDir\venv"
+                        Invoke-NativeWithRelaxedErrorAction {
+                            & $UvCmd pip install --reinstall -e .
+                            $script:DependencyExitCode = $LASTEXITCODE
+                        }
+                    }
                     $stillMissing = @()
                     foreach ($name in $expected) {
                         $exe = Join-Path $scriptsDir "$name.exe"
@@ -2969,11 +3058,23 @@ print(','.join(scripts))
         if (-not $webOk) {
             Write-Warn "fastapi/uvicorn not importable -- `hermes dashboard` will not work."
             Write-Info "Attempting targeted install of [web] extra as last resort..."
-            & $UvCmd pip install -e ".[web]"
-            if ($LASTEXITCODE -eq 0) {
+            if ($usePipFallback) {
+                Invoke-NativeWithRelaxedErrorAction {
+                    & $pythonExe -m pip install --disable-pip-version-check --no-input -e ".[web]"
+                    $script:DependencyExitCode = $LASTEXITCODE
+                }
+                $webInstallExitCode = $script:DependencyExitCode
+            } else {
+                Invoke-NativeWithRelaxedErrorAction {
+                    & $UvCmd pip install -e ".[web]"
+                    $script:DependencyExitCode = $LASTEXITCODE
+                }
+                $webInstallExitCode = $script:DependencyExitCode
+            }
+            if ($webInstallExitCode -eq 0) {
                 Write-Success "[web] extra installed; `hermes dashboard` should now work."
             } else {
-                Write-Warn "Could not install [web] extra. Run manually: uv pip install --python `"$pythonExe`" `"fastapi>=0.104,<1`" `"uvicorn[standard]>=0.24,<1`""
+                Write-Warn "Could not install [web] extra. Run manually: `"$pythonExe`" -m pip install -e `".[web]`""
             }
         }
         if (-not $webServerSyntaxOk) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -245,6 +245,19 @@ function Invoke-NativeWithRelaxedErrorAction {
         $ErrorActionPreference = $prevEAP
     }
 }
+
+function Test-UvIllegalInstructionExitCode {
+    param($ExitCode)
+
+    if ($null -eq $ExitCode) { return $false }
+    try {
+        $numericExitCode = [long]$ExitCode
+        return $numericExitCode -eq -1073741795 -or $numericExitCode -eq 3221225501
+    } catch {
+        return $false
+    }
+}
+
 function Discard-LockfileChurn {
     param([string]$Repo = $InstallDir)
 
@@ -2020,6 +2033,7 @@ function Install-Dependencies {
     # without any hash verification -- they exist to keep installs working
     # when the lockfile is stale, missing, or out-of-sync with the
     # current extras spec, NOT because they're equivalent in posture.
+    $usePipFallback = $false
     if (Test-Path "uv.lock") {
         Write-Info "Trying tier: hash-verified (uv.lock) ..."
         # Critical flag choice: `--extra all`, NOT `--all-extras`.
@@ -2037,13 +2051,23 @@ function Install-Dependencies {
         # in the wrong directory and imports fail with ModuleNotFoundError.
         # (Mirrors the same flag in scripts/install.sh::install_deps.)
         $env:UV_PROJECT_ENVIRONMENT = "$InstallDir\venv"
-        Invoke-NativeWithRelaxedErrorAction { & $UvCmd sync --extra all --locked }
-        if ($LASTEXITCODE -eq 0) {
+        $script:DependencyExitCode = $null
+        Invoke-NativeWithRelaxedErrorAction {
+            & $UvCmd sync --extra all --locked
+            $script:DependencyExitCode = $LASTEXITCODE
+        }
+        $uvExitCode = $script:DependencyExitCode
+        if ($uvExitCode -eq 0) {
             Write-Success "Main package installed (hash-verified via uv.lock)"
             $script:InstalledTier = "hash-verified (uv.lock)"
             # Skip the rest of the tiered cascade -- we already have a
             # complete, hash-verified install.
             $skipPipFallback = $true
+        } elseif (Test-UvIllegalInstructionExitCode $uvExitCode) {
+            Write-Warn "uv.exe exited with EXCEPTION_ILLEGAL_INSTRUCTION (0xC000001D). Switching to pip fallback."
+            Write-Warn "The pip fallback resolves packages without uv.lock hash verification."
+            $usePipFallback = $true
+            $skipPipFallback = $false
         } else {
             Write-Warn "uv.lock sync failed (lockfile may be stale), falling back to PyPI resolve..."
             $skipPipFallback = $false
@@ -2109,21 +2133,76 @@ except Exception:
         @{ Name = "core only (no extras)"; Spec = "." }
     )
     $installed = $skipPipFallback
-    if (-not $skipPipFallback) {
+    if (-not $skipPipFallback -and -not $usePipFallback) {
         foreach ($tier in $installTiers) {
-        Write-Info "Trying tier: $($tier.Name) ..."
-        Invoke-NativeWithRelaxedErrorAction { & $UvCmd pip install -e $tier.Spec }
-        if ($LASTEXITCODE -eq 0) {
-            Write-Success "Main package installed ($($tier.Name))"
-            $script:InstalledTier = $tier.Name
-            $installed = $true
-            break
+            Write-Info "Trying tier: $($tier.Name) ..."
+            $script:DependencyExitCode = $null
+            Invoke-NativeWithRelaxedErrorAction {
+                & $UvCmd pip install -e $tier.Spec
+                $script:DependencyExitCode = $LASTEXITCODE
+            }
+            $uvExitCode = $script:DependencyExitCode
+            if ($uvExitCode -eq 0) {
+                Write-Success "Main package installed ($($tier.Name))"
+                $script:InstalledTier = $tier.Name
+                $installed = $true
+                break
+            }
+            if (Test-UvIllegalInstructionExitCode $uvExitCode) {
+                Write-Warn "uv.exe exited with EXCEPTION_ILLEGAL_INSTRUCTION (0xC000001D). Switching to pip fallback."
+                Write-Warn "The pip fallback resolves packages without uv.lock hash verification."
+                $usePipFallback = $true
+                break
+            }
+            Write-Warn "Tier '$($tier.Name)' failed (exit $uvExitCode). Trying next tier..."
         }
-        Write-Warn "Tier '$($tier.Name)' failed (exit $LASTEXITCODE). Trying next tier..."
+    }
+
+    if ($usePipFallback) {
+        if ($NoVenv) {
+            throw "uv.exe is incompatible with this CPU, and pip fallback requires the managed venv. Re-run without -NoVenv."
+        }
+
+        $pipPython = "$InstallDir\venv\Scripts\python.exe"
+        if (-not (Test-Path $pipPython)) {
+            throw "uv.exe is incompatible with this CPU, and pip fallback could not find $pipPython."
+        }
+
+        $script:DependencyExitCode = $null
+        Invoke-NativeWithRelaxedErrorAction {
+            & $pipPython -m pip --version
+            $script:DependencyExitCode = $LASTEXITCODE
+        }
+        if ($script:DependencyExitCode -ne 0) {
+            Write-Info "Bootstrapping pip into venv for uv recovery..."
+            $script:DependencyExitCode = $null
+            Invoke-NativeWithRelaxedErrorAction {
+                & $pipPython -m ensurepip --upgrade
+                $script:DependencyExitCode = $LASTEXITCODE
+            }
+            if ($script:DependencyExitCode -ne 0) {
+                throw "uv.exe is incompatible with this CPU and ensurepip failed (exit $($script:DependencyExitCode))."
+            }
+        }
+
+        foreach ($tier in $installTiers) {
+            Write-Info "Trying pip fallback tier: $($tier.Name) ..."
+            Invoke-NativeWithRelaxedErrorAction {
+                & $pipPython -m pip install --disable-pip-version-check --no-input -e $tier.Spec
+                $script:DependencyExitCode = $LASTEXITCODE
+            }
+            $pipExitCode = $script:DependencyExitCode
+            if ($pipExitCode -eq 0) {
+                Write-Success "Main package installed via pip fallback ($($tier.Name))"
+                $script:InstalledTier = "pip fallback ($($tier.Name))"
+                $installed = $true
+                break
+            }
+            Write-Warn "pip fallback tier '$($tier.Name)' failed (exit $pipExitCode). Trying next tier..."
         }
     }
     if (-not $installed) {
-        throw "Failed to install hermes-agent package even with no extras. Inspect the uv pip install output above."
+        throw "Failed to install hermes-agent package even with no extras. Inspect the dependency install output above."
     }
 
     # Baseline-import gate. Even if a tier reported success above, the
@@ -2185,8 +2264,18 @@ print(','.join(scripts))
                 if ($missing.Count -gt 0) {
                     Write-Warn "Console entry point(s) missing: $($missing -join ', ')"
                     Write-Info "Reinstalling entry points..."
-                    $env:UV_PROJECT_ENVIRONMENT = "$InstallDir\venv"
-                    Invoke-NativeWithRelaxedErrorAction { & $UvCmd pip install --reinstall -e . }
+                    if ($usePipFallback) {
+                        Invoke-NativeWithRelaxedErrorAction {
+                            & $pythonExe -m pip install --disable-pip-version-check --no-input --reinstall -e .
+                            $script:DependencyExitCode = $LASTEXITCODE
+                        }
+                    } else {
+                        $env:UV_PROJECT_ENVIRONMENT = "$InstallDir\venv"
+                        Invoke-NativeWithRelaxedErrorAction {
+                            & $UvCmd pip install --reinstall -e .
+                            $script:DependencyExitCode = $LASTEXITCODE
+                        }
+                    }
                     $stillMissing = @()
                     foreach ($name in $expected) {
                         $exe = Join-Path $scriptsDir "$name.exe"
@@ -2230,11 +2319,23 @@ print(','.join(scripts))
         if (-not $webOk) {
             Write-Warn "fastapi/uvicorn not importable -- `hermes dashboard` will not work."
             Write-Info "Attempting targeted install of [web] extra as last resort..."
-            & $UvCmd pip install -e ".[web]"
-            if ($LASTEXITCODE -eq 0) {
+            if ($usePipFallback) {
+                Invoke-NativeWithRelaxedErrorAction {
+                    & $pythonExe -m pip install --disable-pip-version-check --no-input -e ".[web]"
+                    $script:DependencyExitCode = $LASTEXITCODE
+                }
+                $webInstallExitCode = $script:DependencyExitCode
+            } else {
+                Invoke-NativeWithRelaxedErrorAction {
+                    & $UvCmd pip install -e ".[web]"
+                    $script:DependencyExitCode = $LASTEXITCODE
+                }
+                $webInstallExitCode = $script:DependencyExitCode
+            }
+            if ($webInstallExitCode -eq 0) {
                 Write-Success "[web] extra installed; `hermes dashboard` should now work."
             } else {
-                Write-Warn "Could not install [web] extra. Run manually: uv pip install --python `"$pythonExe`" `"fastapi>=0.104,<1`" `"uvicorn[standard]>=0.24,<1`""
+                Write-Warn "Could not install [web] extra. Run manually: `"$pythonExe`" -m pip install -e `".[web]`""
             }
         }
         if (-not $webServerSyntaxOk) {

--- a/tests/test_install_ps1_uv_illegal_instruction_fallback.py
+++ b/tests/test_install_ps1_uv_illegal_instruction_fallback.py
@@ -1,0 +1,193 @@
+"""Windows installer fallback when uv crashes with illegal instruction (#72518)."""
+
+from __future__ import annotations
+
+import ensurepip
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+POWERSHELL = next(
+    (candidate for candidate in ("pwsh", "powershell") if shutil.which(candidate)),
+    None,
+)
+
+
+def _compile_uv_stub(output: Path, exit_code: int) -> None:
+    """Build an executable stub with a controlled Windows exit status."""
+    source = (
+        "public static class Program { "
+        "public static int Main(string[] args) { "
+        f"return unchecked((int)0x{exit_code:08X}); }} }}"
+    )
+    command = (
+        f"$code = '{source}'; "
+        f"Add-Type -TypeDefinition $code -Language CSharp "
+        f"-OutputAssembly '{output}' -OutputType ConsoleApplication"
+    )
+    result = subprocess.run(
+        [POWERSHELL, "-NoProfile", "-Command", command],
+        env=os.environ | {
+            "TEMP": str(output.parent),
+            "TMP": str(output.parent),
+        },
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(
+    os.name != "nt" or POWERSHELL is None,
+    reason="requires native Windows and PowerShell",
+)
+@pytest.mark.parametrize(
+    ("uv_exit_code", "powershell_exit_code", "expects_fallback"),
+    [
+        pytest.param(0xC000001D, -1073741795, True, id="illegal-instruction"),
+        pytest.param(1, 1, False, id="ordinary-error"),
+    ],
+)
+def test_dependencies_only_fall_back_for_uv_illegal_instruction(
+    tmp_path: Path,
+    uv_exit_code: int,
+    powershell_exit_code: int,
+    expects_fallback: bool,
+) -> None:
+    install_dir = tmp_path / "hermes-agent"
+    hermes_home = tmp_path / "hermes-home"
+    managed_bin = hermes_home / "bin"
+    install_dir.mkdir()
+    managed_bin.mkdir(parents=True)
+
+    # The real installer creates the venv in an earlier stage. Leave pip out so
+    # this test also exercises the fallback's ensurepip bootstrap.
+    venv_dir = install_dir / "venv"
+    subprocess.run(
+        [sys.executable, "-m", "venv", "--without-pip", str(venv_dir)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    # A local editable fixture avoids network access. The modules satisfy the
+    # installer's real baseline-import gate after the core-only tier succeeds.
+    (install_dir / "setup.py").write_text(
+        "from setuptools import setup\n"
+        "setup(name='hermes-installer-fixture', version='0.0.0', "
+        "py_modules=['dotenv', 'openai', 'rich', 'prompt_toolkit', "
+        "'fastapi', 'uvicorn'])\n",
+        encoding="utf-8",
+    )
+    (install_dir / "pyproject.toml").write_text(
+        "[build-system]\n"
+        "requires = ['setuptools>=40.8.0']\n"
+        "build-backend = 'setuptools.build_meta'\n"
+        "\n"
+        "[project]\n"
+        "name = 'hermes-installer-fixture'\n"
+        "version = '0.0.0'\n"
+        "\n"
+        "[project.optional-dependencies]\n"
+        "all = []\n"
+        "\n"
+        "[project.scripts]\n",
+        encoding="utf-8",
+    )
+    for module in ("dotenv", "openai", "rich", "prompt_toolkit", "fastapi", "uvicorn"):
+        (install_dir / f"{module}.py").write_text("READY = True\n", encoding="utf-8")
+    web_source = install_dir / "hermes_cli" / "web_server.py"
+    web_source.parent.mkdir()
+    web_source.write_text("READY = True\n", encoding="utf-8")
+
+    # Force the hash-verified uv path first, matching the reported update flow.
+    (install_dir / "uv.lock").write_text("", encoding="utf-8")
+    _compile_uv_stub(managed_bin / "uv.exe", uv_exit_code)
+
+    env = os.environ | {
+        "PIP_NO_INDEX": "1",
+        "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+        "PIP_FIND_LINKS": str(Path(ensurepip.__file__).parent / "_bundled"),
+        "COMSPEC": r"C:\Windows\System32\cmd.exe",
+        "NUMBER_OF_PROCESSORS": "1",
+        "OS": "Windows_NT",
+        "PATHEXT": ".COM;.EXE;.BAT;.CMD",
+        "PROCESSOR_ARCHITECTURE": "AMD64",
+        "SYSTEMDRIVE": r"C:",
+        "SYSTEMROOT": os.environ.get("SYSTEMROOT", r"C:\Windows"),
+        "TEMP": str(tmp_path),
+        "TMP": str(tmp_path),
+        "WINDIR": r"C:\Windows",
+    }
+    uv_probe = subprocess.run(
+        [
+            POWERSHELL,
+            "-NoProfile",
+            "-Command",
+            f"& '{managed_bin / 'uv.exe'}'; "
+            "Write-Output ('UV_TEST_EXIT=' + $LASTEXITCODE)",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert f"UV_TEST_EXIT={powershell_exit_code}" in uv_probe.stdout, (
+        f"invalid crash fixture: stdout={uv_probe.stdout!r}, "
+        f"stderr={uv_probe.stderr!r}"
+    )
+
+    result = subprocess.run(
+        [
+            POWERSHELL,
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(INSTALL_PS1),
+            "-Stage",
+            "dependencies",
+            "-NonInteractive",
+            "-InstallDir",
+            str(install_dir),
+            "-HermesHome",
+            str(hermes_home),
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+    output = result.stdout + result.stderr
+    if not expects_fallback:
+        assert result.returncode != 0, output
+        assert "pip fallback" not in output
+        return
+
+    assert result.returncode == 0, output
+    assert "EXCEPTION_ILLEGAL_INSTRUCTION" in output
+    assert "pip fallback" in output
+
+    venv_python = venv_dir / "Scripts" / "python.exe"
+    probe = subprocess.run(
+        [
+            str(venv_python),
+            "-c",
+            "import dotenv, openai, rich, prompt_toolkit; "
+            "assert all(m.READY for m in (dotenv, openai, rich, prompt_toolkit))",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert probe.returncode == 0, probe.stderr

--- a/tests/test_install_ps1_uv_illegal_instruction_fallback.py
+++ b/tests/test_install_ps1_uv_illegal_instruction_fallback.py
@@ -49,10 +49,28 @@ def _compile_uv_stub(output: Path, exit_code: int) -> None:
     reason="requires native Windows and PowerShell",
 )
 @pytest.mark.parametrize(
-    ("uv_exit_code", "powershell_exit_code", "expects_fallback"),
+    (
+        "uv_exit_code",
+        "powershell_exit_code",
+        "expects_fallback",
+        "create_lockfile",
+    ),
     [
-        pytest.param(0xC000001D, -1073741795, True, id="illegal-instruction"),
-        pytest.param(1, 1, False, id="ordinary-error"),
+        pytest.param(
+            0xC000001D,
+            -1073741795,
+            True,
+            True,
+            id="illegal-instruction-from-locked-sync",
+        ),
+        pytest.param(1, 1, False, True, id="ordinary-error"),
+        pytest.param(
+            0xC000001D,
+            -1073741795,
+            True,
+            False,
+            id="illegal-instruction-from-lockless-pip-tier",
+        ),
     ],
 )
 def test_dependencies_only_fall_back_for_uv_illegal_instruction(
@@ -60,6 +78,7 @@ def test_dependencies_only_fall_back_for_uv_illegal_instruction(
     uv_exit_code: int,
     powershell_exit_code: int,
     expects_fallback: bool,
+    create_lockfile: bool,
 ) -> None:
     install_dir = tmp_path / "hermes-agent"
     hermes_home = tmp_path / "hermes-home"
@@ -107,8 +126,9 @@ def test_dependencies_only_fall_back_for_uv_illegal_instruction(
     web_source.parent.mkdir()
     web_source.write_text("READY = True\n", encoding="utf-8")
 
-    # Force the hash-verified uv path first, matching the reported update flow.
-    (install_dir / "uv.lock").write_text("", encoding="utf-8")
+    # Cover both the locked sync path and the lockless editable-install tier.
+    if create_lockfile:
+        (install_dir / "uv.lock").write_text("", encoding="utf-8")
     _compile_uv_stub(managed_bin / "uv.exe", uv_exit_code)
 
     env = os.environ | {
@@ -178,6 +198,10 @@ def test_dependencies_only_fall_back_for_uv_illegal_instruction(
     assert result.returncode == 0, output
     assert "EXCEPTION_ILLEGAL_INSTRUCTION" in output
     assert "pip fallback" in output
+    if not create_lockfile:
+        assert "uv.lock not found" in output
+        assert "Trying tier: all ..." in output
+        assert "Trying pip fallback tier: all ..." in output
 
     venv_python = venv_dir / "Scripts" / "python.exe"
     probe = subprocess.run(


### PR DESCRIPTION
## What does this PR do?

Gracefully recovers when the managed Windows `uv.exe` crashes with `EXCEPTION_ILLEGAL_INSTRUCTION` (`0xC000001D`) during dependency installation. The installer bootstraps pip in the existing managed venv and continues through the same dependency tiers. Other uv failures keep their existing behavior.

## Related Issue

Fixes #72518

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `scripts/install.ps1`: classify the signed and unsigned illegal-instruction exit codes and switch to `python -m pip` only for that crash.
- `scripts/install.ps1`: keep entry-point and dashboard recovery on pip after fallback, and warn that the fallback does not preserve `uv.lock` hash verification.
- `tests/test_install_ps1_uv_illegal_instruction_fallback.py`: exercise the real PowerShell dependencies stage with controlled Windows executable exit statuses.
- `contributors/emails/2895359972@qq.com`: map the commit author to `XRX193` for contributor attribution.

## How to Test

1. On Windows, run `scripts/run_tests.sh tests/test_install_ps1_uv_illegal_instruction_fallback.py -v`.
2. Verify `0xC000001D` bootstraps pip and completes the dependencies stage.
3. Verify an ordinary uv exit code (`1`) still fails without entering the pip fallback.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs and found no duplicate for #72518
- [x] My PR contains only changes related to this fix
- [ ] I've run the complete `pytest tests/ -q` suite (focused installer tests were run instead)
- [x] I've added tests for the bug fix
- [x] I've tested on Windows with Windows PowerShell 5.1

### Documentation & Housekeeping

- [x] Documentation update: N/A; installer diagnostics are self-explanatory
- [x] `cli-config.yaml.example`: N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no workflow or architecture change
- [x] Cross-platform impact considered: change is isolated to `install.ps1`
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

Focused verification on the updated branch: all three parametrized cases in `tests/test_install_ps1_uv_illegal_instruction_fallback.py` reported passed locally, including the lockless editable-install crash path requested in review. Earlier verification on the initial branch ran the broader `tests/test_install_ps1*.py` slice with all 19 tests passing. Ruff and diff checks passed after the follow-up; the PowerShell parser check passed on the initial change.