### PR TITLE
fix(desktop): restore minimized layout state on boot

### DIFF
--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -13,11 +13,11 @@ import { LayoutTreeRoot } from '@/components/pane-shell/tree/renderer'
 import type { DoubleTapContext } from '@/components/pane-shell/tree/renderer/drag-session'
 import {
   $layoutTree,
+  bindPaneCollapse,
   bindTreeSideVisibility,
   declareDefaultTree,
   dismissTreePane,
   dockPaneBeside,
-  markCollapsePane,
   mirrorLayoutTree,
   paneRootSide,
   registerLayoutResetHandler,
@@ -25,7 +25,6 @@ import {
   registerPaneOpener,
   resetLayoutTree,
   revealTreePane,
-  setPaneCollapsed,
   setTreePaneHidden,
   setTreeSideCollapsed,
   treeSideOfPane,
@@ -493,23 +492,6 @@ function bindPaneVisibility(
   if (open) {
     registerPaneOpener(paneId, open)
   }
-}
-
-// TOOL PANELS (terminal, logs): like bindPaneVisibility but the toggle COLLAPSES
-// the zone to a persistent rail (tab stays) instead of hiding it — the
-// IntelliJ/VS-Code tool-window model. Restore routes back through `open` (rail
-// click / chevron) so ⌃`/the button stay truthful; the tab's ✕ removes it.
-function bindPaneCollapse(
-  paneId: string,
-  $open: { get(): boolean; listen(fn: (open: boolean) => void): void },
-  close: () => void,
-  open: () => void
-) {
-  markCollapsePane(paneId)
-  setPaneCollapsed(paneId, !$open.get())
-  $open.listen(isOpen => setPaneCollapsed(paneId, !isOpen))
-  registerPaneCloser(paneId, close)
-  registerPaneOpener(paneId, open)
 }
 
 // SIDES have one source of truth: the TREE. The legacy $panesFlipped flag is

--- a/apps/desktop/src/components/pane-shell/tree/collapse-persistence.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/collapse-persistence.test.ts
@@ -1,0 +1,114 @@
+import { atom } from 'nanostores'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const STORAGE_KEY = 'hermes.desktop.layoutTree.v2'
+
+async function loadToolZone(
+  minimized?: boolean,
+  terminalInitiallyOpen = true,
+  logsInitiallyOpen = true,
+  active: 'logs' | 'terminal' = 'terminal'
+) {
+  const model = await import('./model')
+
+  const persisted = model.split(
+    'column',
+    [
+      model.group(['workspace'], { id: 'grp-main' }),
+      model.group(['terminal', 'logs'], {
+        active,
+        id: 'grp-tools',
+        minimized
+      })
+    ],
+    [3, 1],
+    'spl-root'
+  )
+
+  const defaultTree = model.split(
+    'column',
+    [
+      model.group(['workspace'], { id: 'grp-main' }),
+      model.group(['terminal', 'logs'], {
+        active: 'terminal',
+        id: 'grp-tools',
+        minimized: false
+      })
+    ],
+    [3, 1],
+    'spl-root'
+  )
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(persisted))
+
+  const tree = await import('./store')
+  const terminalOpen = atom(terminalInitiallyOpen)
+  const logsOpen = atom(logsInitiallyOpen)
+
+  tree.declareDefaultTree(defaultTree)
+
+  for (const [paneId, open] of [
+    ['terminal', terminalOpen],
+    ['logs', logsOpen]
+  ] as const) {
+    tree.bindPaneCollapse(
+      paneId,
+      open,
+      () => open.set(false),
+      () => open.set(true)
+    )
+  }
+
+  return { logsOpen, model, terminalOpen, tree }
+}
+
+describe('tool-zone collapse persistence', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  it('keeps a persisted minimized tool zone collapsed during boot binding', async () => {
+    const { logsOpen, model, terminalOpen, tree } = await loadToolZone(true)
+
+    expect(model.findGroup(tree.$layoutTree.get()!, 'grp-tools')?.minimized).toBe(true)
+    expect(terminalOpen.get()).toBe(false)
+    expect(logsOpen.get()).toBe(false)
+  })
+
+  it('reopens only the active pane when the persisted tool zone is expanded', async () => {
+    const { logsOpen, model, terminalOpen, tree } = await loadToolZone(false, false, false, 'logs')
+
+    expect(model.findGroup(tree.$layoutTree.get()!, 'grp-tools')?.minimized).toBe(false)
+    expect(terminalOpen.get()).toBe(false)
+    expect(logsOpen.get()).toBe(true)
+  })
+
+  it('keeps legacy toggle migration when the tree has no minimized value', async () => {
+    const { logsOpen, model, terminalOpen, tree } = await loadToolZone(undefined, false, true)
+
+    expect(model.findGroup(tree.$layoutTree.get()!, 'grp-tools')?.minimized).toBe(false)
+    expect(model.findGroup(tree.$layoutTree.get()!, 'grp-tools')?.active).toBe('logs')
+  })
+
+  it('keeps post-boot toggle changes synchronized with the restored tree', async () => {
+    const { model, terminalOpen, tree } = await loadToolZone(true)
+
+    terminalOpen.set(true)
+    expect(model.findGroup(tree.$layoutTree.get()!, 'grp-tools')?.minimized).toBe(false)
+
+    terminalOpen.set(false)
+    expect(model.findGroup(tree.$layoutTree.get()!, 'grp-tools')?.minimized).toBe(true)
+  })
+
+  it('reconciles toggle stores when layout reset replaces the persisted tree', async () => {
+    const { logsOpen, model, terminalOpen, tree } = await loadToolZone(true)
+
+    tree.resetLayoutTree()
+
+    expect(model.findGroup(tree.$layoutTree.get()!, 'grp-tools')?.minimized).toBe(false)
+    expect(model.findGroup(tree.$layoutTree.get()!, 'grp-tools')?.active).toBe('terminal')
+    expect(terminalOpen.get()).toBe(true)
+    expect(logsOpen.get()).toBe(false)
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -219,8 +219,9 @@ export function registerPaneOpener(paneId: string, open: () => void) {
 // TOOL PANELS (terminal, logs, …): their toggle COLLAPSES the zone to a rail
 // (tab stays) instead of hiding it, and the tab's ✕ REMOVES it (vs a session
 // tile, whose ✕ closes the session). Membership tells the renderer which
-// semantics a tab gets. See bindPaneCollapse in the controller.
+// semantics a tab gets.
 const collapsePanes = new Set<string>()
+const initialGroupMinimized = new Map<string, boolean | undefined>()
 
 export function markCollapsePane(paneId: string) {
   collapsePanes.add(paneId)
@@ -228,6 +229,66 @@ export function markCollapsePane(paneId: string) {
 
 export function isCollapsePane(paneId: string): boolean {
   return collapsePanes.has(paneId)
+}
+
+/**
+ * Bind a tool pane's open toggle to its layout zone.
+ *
+ * An explicit v2 tree value is the persisted presentation authority. Capture
+ * it once per group because terminal and logs can share a zone, and binding
+ * the first pane may mutate the live tree before the second pane binds.
+ * Trees without an explicit value retain the legacy toggle-store migration.
+ */
+export function bindPaneCollapse(
+  paneId: string,
+  $open: { get(): boolean; listen(fn: (open: boolean) => void): void },
+  close: () => void,
+  open: () => void
+) {
+  markCollapsePane(paneId)
+  const group = paneGroup(paneId)
+  let minimized = group?.id ? initialGroupMinimized.get(group.id) : undefined
+
+  if (group?.id && !initialGroupMinimized.has(group.id)) {
+    minimized = group.minimized
+    initialGroupMinimized.set(group.id, minimized)
+  }
+
+  if (minimized === true) {
+    if ($open.get()) {
+      close()
+    }
+  } else if (minimized === false) {
+    if (group?.active === paneId && !$open.get()) {
+      open()
+    }
+  } else {
+    setPaneCollapsed(paneId, !$open.get())
+  }
+
+  $open.listen(isOpen => setPaneCollapsed(paneId, !isOpen))
+  registerPaneCloser(paneId, close)
+  registerPaneOpener(paneId, open)
+}
+
+function reconcileCollapsePaneStores() {
+  const tree = $layoutTree.get()
+
+  if (!tree) {
+    return
+  }
+
+  for (const paneId of collapsePanes) {
+    const group = findGroupOfPane(tree, paneId)
+
+    if (!group) {
+      continue
+    }
+
+    const action = !group.minimized && group.active === paneId ? paneOpeners[paneId] : paneClosers[paneId]
+
+    action?.()
+  }
 }
 
 const resetHandlers = new Set<() => void>()
@@ -1350,6 +1411,10 @@ export function resetLayoutTree() {
   resetHandlers.forEach(fn => fn())
   // Everything still missing (plugin panes) adopts by placement.
   adoptContributedPanes()
+  // Boot restoration may have closed a collapse pane's legacy toggle store.
+  // The reset tree is authoritative again, so mirror its active/minimized
+  // presentation back into those stores before controls render the next state.
+  reconcileCollapsePaneStores()
 
   // "Restore everything" includes collapsed SIDES: reopen every bound side
   // (through its store, so $sidebarOpen / the toggles stay truthful). Without


### PR DESCRIPTION
## Summary

- preserve explicit `minimized` state loaded from the v2 Desktop layout tree
- synchronize terminal/logs toggle stores without letting shared-group binding overwrite persisted intent
- retain legacy toggle-store migration when `minimized` is absent
- reconcile collapse-pane stores after layout reset

## Root cause

`bindPaneCollapse()` immediately mirrored each legacy toggle store into the layout tree during module boot. That overwrote the already-loaded v2 `minimized` value. Terminal and logs can share a group, so the second binding could also reinterpret the first binding mutation as persisted state.

The binding now snapshots the initial value once per group and treats explicit `true` and `false` as authoritative. Layouts without the field keep the previous migration behavior.

## Validation

- `vitest` focused collapse-persistence tests: 5 passed
- complete pane-tree test directory: 49 passed
- adjacent persistence suite: 12 passed
- Desktop renderer, Electron, and E2E TypeScript configs: clean
- ESLint on all changed files: clean
- independent read-only Codex review: pass, zero findings

Fixes #73929