### PR TITLE
fix(cron): surface the script execution host and its isolation gap (#29849)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2805,6 +2805,77 @@ _SCRIPT_TIMEOUT = _DEFAULT_SCRIPT_TIMEOUT
 _RUN_CLAIM_HEARTBEAT_SECONDS = 60.0
 
 
+def _configured_terminal_backend() -> str:
+    """Return the configured ``terminal.backend`` name (default ``local``).
+
+    Read for DIAGNOSTICS only (#29849): script-backed cron jobs always execute
+    on the scheduler host, so when a remote/sandboxed backend is configured the
+    messages below can name the mismatch instead of leaving the operator with a
+    bare "not found". Never changes where anything runs.
+    """
+    try:
+        cfg = load_config() or {}
+        terminal_cfg = cfg.get("terminal", {}) if isinstance(cfg, dict) else {}
+        backend = terminal_cfg.get("backend") if isinstance(terminal_cfg, dict) else None
+        if backend:
+            return str(backend).strip().lower() or "local"
+    except Exception:
+        logger.debug("could not read terminal.backend for cron diagnostics", exc_info=True)
+    return "local"
+
+
+# Script paths already noted as running outside the configured backend, so a
+# frequently-firing job logs the isolation notice once per process instead of
+# once per run. Capped so a pathological job-churn loop can't grow it forever.
+_SCRIPT_HOST_NOTICES: set = set()
+_SCRIPT_HOST_NOTICES_MAX = 256
+
+
+def _script_runs_on_scheduler_host_hint(backend: Optional[str] = None) -> str:
+    """One-line explanation of the script execution contract (#29849).
+
+    Empty for a ``local`` backend, where scheduler host and terminal backend
+    are the same machine and there is nothing to explain.
+    """
+    backend = backend or _configured_terminal_backend()
+    if backend == "local":
+        return ""
+    return (
+        f" Note: script-backed cron jobs always execute on the host that ticks "
+        f"cron (this scheduler process), NOT on the configured "
+        f"terminal.backend ({backend}) — so a script written to the backend's "
+        f"filesystem by the agent is not visible here. Keep the script in this "
+        f"host's HERMES_HOME/scripts/, or drive the backend from the script "
+        f"itself."
+    )
+
+
+def _note_script_runs_outside_backend(script_path: Path, backend: str) -> None:
+    """Warn once per script that this execution leaves the configured backend.
+
+    Operators who set ``terminal.backend`` to ``docker``/``ssh`` reasonably read
+    that as the isolation boundary for what the agent runs. Script-backed cron
+    jobs predate and bypass it: they execute in the scheduler/gateway process
+    environment instead (#29849). This makes that visible in the log rather
+    than silent. Diagnostics only — execution is unchanged.
+    """
+    if backend == "local":
+        return
+    key = str(script_path)
+    if key in _SCRIPT_HOST_NOTICES:
+        return
+    if len(_SCRIPT_HOST_NOTICES) < _SCRIPT_HOST_NOTICES_MAX:
+        _SCRIPT_HOST_NOTICES.add(key)
+    logger.warning(
+        "Cron script %s runs on the scheduler host, OUTSIDE the configured "
+        "terminal.backend (%s). Script-backed cron jobs are not sandboxed by "
+        "the terminal backend: this script executes with the scheduler "
+        "process's environment and filesystem access (#29849).",
+        script_path,
+        backend,
+    )
+
+
 def _get_script_timeout() -> int:
     """Resolve cron pre-run script timeout from module/env/config with a safe default."""
     if _SCRIPT_TIMEOUT != _DEFAULT_SCRIPT_TIMEOUT:
@@ -2917,6 +2988,22 @@ def _run_job_script(
     Shell support lets ``no_agent=True`` jobs ship classic bash watchdogs
     (the `memory-watchdog.sh` pattern) without wrapping them in Python.
 
+    **Execution host (#29849).** The script always runs on the host that ticks
+    cron — this scheduler process — via ``subprocess``, independent of
+    ``terminal.backend``. That is deliberate for the host-side automation this
+    supports (a watchdog that backs up ``HERMES_HOME`` has to run where
+    ``HERMES_HOME`` is), but it has two consequences worth stating plainly:
+
+    * A script the agent wrote through ``terminal``/``write_file`` under a
+      remote backend lives on the BACKEND's filesystem and is not visible here.
+    * ``terminal.backend`` is therefore NOT an isolation boundary for
+      script-backed cron: the script runs with this process's environment and
+      filesystem access. ``_note_script_runs_outside_backend`` logs that once
+      per script so it is visible rather than silent.
+
+    Routing execution through the configured backend is a separate change that
+    needs a decision on defaults; see #29849.
+
     Subprocess environment is passed through ``_sanitize_subprocess_env`` so
     provider credentials and other Hermes-managed secrets are not inherited
     (SECURITY.md §2.3), matching terminal and MCP child processes.
@@ -2965,10 +3052,21 @@ def _run_job_script(
             f"({scripts_dir_resolved}): {script_path!r}"
         )
 
+    # Diagnostics for the scheduler-host contract (#29849). The reported
+    # symptom was a bare "Script not found" pointing at a path the user could
+    # `ls` on the remote backend seconds earlier — the message never said the
+    # lookup happened on a different machine. Name the mismatch instead.
+    _backend = _configured_terminal_backend()
+
     if not path.exists():
-        return False, f"Script not found: {path}"
+        return False, (
+            f"Script not found on the scheduler host: {path}"
+            f"{_script_runs_on_scheduler_host_hint(_backend)}"
+        )
     if not path.is_file():
         return False, f"Script path is not a file: {path}"
+
+    _note_script_runs_outside_backend(path, _backend)
 
     script_timeout = _get_script_timeout()
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2805,14 +2805,25 @@ _SCRIPT_TIMEOUT = _DEFAULT_SCRIPT_TIMEOUT
 _RUN_CLAIM_HEARTBEAT_SECONDS = 60.0
 
 
-def _configured_terminal_backend() -> str:
-    """Return the configured ``terminal.backend`` name (default ``local``).
+def _effective_terminal_backend() -> str:
+    """Return the backend the terminal tool would actually use (default ``local``).
 
     Read for DIAGNOSTICS only (#29849): script-backed cron jobs always execute
-    on the scheduler host, so when a remote/sandboxed backend is configured the
+    on the scheduler host, so when a remote/sandboxed backend is in effect the
     messages below can name the mismatch instead of leaving the operator with a
     bare "not found". Never changes where anything runs.
+
+    Mirrors the terminal tool's own precedence rather than reading config alone:
+    ``TERMINAL_ENV`` wins when set (a launcher's bridge or the user's .env made
+    a deliberate choice) and ``terminal.backend`` only fills the unset case
+    (``tools/terminal_tool.py`` ``_ensure_terminal_env_bridged`` /
+    ``_get_env_config``). Reading config alone would name a remote backend in
+    these messages even where terminal calls actually run local — pointing the
+    operator at the wrong host while diagnosing a missing script.
     """
+    env_backend = os.environ.get("TERMINAL_ENV")
+    if env_backend and env_backend.strip():
+        return env_backend.strip().lower()
     try:
         cfg = load_config() or {}
         terminal_cfg = cfg.get("terminal", {}) if isinstance(cfg, dict) else {}
@@ -2826,8 +2837,18 @@ def _configured_terminal_backend() -> str:
 
 # Script paths already noted as running outside the configured backend, so a
 # frequently-firing job logs the isolation notice once per process instead of
-# once per run. Capped so a pathological job-churn loop can't grow it forever.
-_SCRIPT_HOST_NOTICES: set = set()
+# once per run. Capped so a pathological job-churn loop can't grow it forever;
+# insertion-ordered, and the oldest entry is evicted at the cap (a plain dict
+# is insertion-ordered, so the first key is the oldest).
+#
+# Eviction policy: the notice fires once per script for the most recent
+# _SCRIPT_HOST_NOTICES_MAX distinct paths. Only-remember-the-first-256 would
+# instead log the 257th path on EVERY tick (it could never be recorded, so the
+# dedupe check could never hit), turning a once-per-script diagnostic into
+# per-run spam. Evicting means a script can warn again only after 256 other
+# distinct paths have run since — bounded, and no script is ever silently
+# dropped from the diagnostic.
+_SCRIPT_HOST_NOTICES: dict = {}
 _SCRIPT_HOST_NOTICES_MAX = 256
 
 
@@ -2837,13 +2858,14 @@ def _script_runs_on_scheduler_host_hint(backend: Optional[str] = None) -> str:
     Empty for a ``local`` backend, where scheduler host and terminal backend
     are the same machine and there is nothing to explain.
     """
-    backend = backend or _configured_terminal_backend()
+    backend = backend or _effective_terminal_backend()
     if backend == "local":
         return ""
     return (
         f" Note: script-backed cron jobs always execute on the host that ticks "
-        f"cron (this scheduler process), NOT on the configured "
-        f"terminal.backend ({backend}) — so a script written to the backend's "
+        f"cron (this scheduler process), NOT on the terminal backend in "
+        f"effect ({backend}, from TERMINAL_ENV or terminal.backend) — so a "
+        f"script written to the backend's "
         f"filesystem by the agent is not visible here. Keep the script in this "
         f"host's HERMES_HOME/scripts/, or drive the backend from the script "
         f"itself."
@@ -2864,11 +2886,16 @@ def _note_script_runs_outside_backend(script_path: Path, backend: str) -> None:
     key = str(script_path)
     if key in _SCRIPT_HOST_NOTICES:
         return
-    if len(_SCRIPT_HOST_NOTICES) < _SCRIPT_HOST_NOTICES_MAX:
-        _SCRIPT_HOST_NOTICES.add(key)
+    # Record BEFORE logging, evicting the oldest entry at the cap, so the
+    # emit and the dedupe record can never disagree. Logging without
+    # recording is what made the 257th path warn on every tick.
+    while len(_SCRIPT_HOST_NOTICES) >= _SCRIPT_HOST_NOTICES_MAX:
+        _SCRIPT_HOST_NOTICES.pop(next(iter(_SCRIPT_HOST_NOTICES)))
+    _SCRIPT_HOST_NOTICES[key] = True
     logger.warning(
-        "Cron script %s runs on the scheduler host, OUTSIDE the configured "
-        "terminal.backend (%s). Script-backed cron jobs are not sandboxed by "
+        "Cron script %s runs on the scheduler host, OUTSIDE the terminal "
+        "backend in effect (%s, from TERMINAL_ENV or terminal.backend). "
+        "Script-backed cron jobs are not sandboxed by "
         "the terminal backend: this script executes with the scheduler "
         "process's environment and filesystem access (#29849).",
         script_path,
@@ -2999,7 +3026,8 @@ def _run_job_script(
     * ``terminal.backend`` is therefore NOT an isolation boundary for
       script-backed cron: the script runs with this process's environment and
       filesystem access. ``_note_script_runs_outside_backend`` logs that once
-      per script so it is visible rather than silent.
+      per script (bounded registry; see its eviction note) so it is visible
+      rather than silent.
 
     Routing execution through the configured backend is a separate change that
     needs a decision on defaults; see #29849.
@@ -3056,7 +3084,7 @@ def _run_job_script(
     # symptom was a bare "Script not found" pointing at a path the user could
     # `ls` on the remote backend seconds earlier — the message never said the
     # lookup happened on a different machine. Name the mismatch instead.
-    _backend = _configured_terminal_backend()
+    _backend = _effective_terminal_backend()
 
     if not path.exists():
         return False, (

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2813,17 +2813,41 @@ def _effective_terminal_backend() -> str:
     messages below can name the mismatch instead of leaving the operator with a
     bare "not found". Never changes where anything runs.
 
-    Mirrors the terminal tool's own precedence rather than reading config alone:
-    ``TERMINAL_ENV`` wins when set (a launcher's bridge or the user's .env made
-    a deliberate choice) and ``terminal.backend`` only fills the unset case
-    (``tools/terminal_tool.py`` ``_ensure_terminal_env_bridged`` /
-    ``_get_env_config``). Reading config alone would name a remote backend in
-    these messages even where terminal calls actually run local — pointing the
-    operator at the wrong host while diagnosing a missing script.
+    Mirrors the terminal tool's own resolution order rather than reading either
+    source alone (``tools/terminal_tool.py`` ``_ensure_terminal_env_bridged`` /
+    ``_get_env_config``), which is:
+
+    1. An explicit ``terminal.backend`` in config.yaml wins. The bridge calls
+       ``apply_terminal_config_to_env(override=True)`` when the RAW config has a
+       ``terminal`` section, overwriting even a deliberate ``TERMINAL_ENV``
+       (which may be stale from ``hermes setup``).
+    2. Otherwise an existing ``TERMINAL_ENV`` selection is preserved.
+    3. Otherwise the merged config default, floor ``local``.
+
+    Only keys present in the raw ``terminal`` section override env, so a section
+    without ``backend`` leaves an explicit ``TERMINAL_ENV`` authoritative —
+    hence the raw-vs-merged distinction here. Getting this order wrong names
+    the wrong host in the messages below and sends the operator to the wrong
+    machine while they diagnose a missing script.
     """
+    # 1. Explicit raw terminal.backend overrides the environment.
+    try:
+        from hermes_cli.config import read_raw_config
+
+        raw_terminal = (read_raw_config() or {}).get("terminal")
+        if isinstance(raw_terminal, dict):
+            raw_backend = raw_terminal.get("backend")
+            if raw_backend and str(raw_backend).strip():
+                return str(raw_backend).strip().lower()
+    except Exception:
+        logger.debug(
+            "could not read raw terminal.backend for cron diagnostics", exc_info=True
+        )
+    # 2. An explicit environment selection is preserved when config is silent.
     env_backend = os.environ.get("TERMINAL_ENV")
     if env_backend and env_backend.strip():
         return env_backend.strip().lower()
+    # 3. Fall back to the merged config default.
     try:
         cfg = load_config() or {}
         terminal_cfg = cfg.get("terminal", {}) if isinstance(cfg, dict) else {}

--- a/tests/cron/test_script_host_diagnostics.py
+++ b/tests/cron/test_script_host_diagnostics.py
@@ -35,18 +35,22 @@ def _reset_notice_state():
 
 def test_backend_defaults_to_local(monkeypatch):
     monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    _raw(monkeypatch, {})  # don't read this machine's real config.yaml
     monkeypatch.setattr(sched, "load_config", lambda: {})
     assert sched._effective_terminal_backend() == "local"
 
 
 def test_backend_is_read_and_normalized(monkeypatch):
+    """Merged-config fallback: no raw section, no env."""
     monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    _raw(monkeypatch, {})
     monkeypatch.setattr(sched, "load_config", lambda: {"terminal": {"backend": "  SSH "}})
     assert sched._effective_terminal_backend() == "ssh"
 
 
 def test_backend_read_failure_degrades_to_local(monkeypatch):
     monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    _raw(monkeypatch, {})
 
     def _boom():
         raise RuntimeError("config exploded")
@@ -56,53 +60,85 @@ def test_backend_read_failure_degrades_to_local(monkeypatch):
     assert sched._effective_terminal_backend() == "local"
 
 
-# --- TERMINAL_ENV precedence -----------------------------------------------
+# --- backend resolution order ----------------------------------------------
 #
-# The terminal tool treats an explicit TERMINAL_ENV as authoritative and only
-# bridges terminal.backend into the unset case (tools/terminal_tool.py,
-# _ensure_terminal_env_bridged / _get_env_config). These diagnostics have to
-# agree with it: naming a backend the terminal tool isn't actually using would
-# point the operator at the wrong host while they debug a missing script.
+# These diagnostics must name the backend the terminal tool ACTUALLY uses; a
+# wrong answer sends the operator to the wrong machine while they debug a
+# missing script. terminal_tool's order (_ensure_terminal_env_bridged /
+# _get_env_config) is:
+#
+#   1. explicit RAW config.yaml terminal.backend  (bridged with override=True,
+#      so it beats even a deliberate TERMINAL_ENV, which may be stale from
+#      `hermes setup`)
+#   2. an existing TERMINAL_ENV selection
+#   3. the merged config default, floor "local"
+#
+# Only keys present in the raw terminal section override env, so a raw section
+# without `backend` leaves TERMINAL_ENV authoritative — hence raw vs merged.
 
 
-def test_env_override_wins_over_config(monkeypatch):
-    """TERMINAL_ENV=local + terminal.backend=docker → terminal runs LOCAL."""
+def _raw(monkeypatch, value):
+    """Stub hermes_cli.config.read_raw_config, which the helper imports."""
+    import hermes_cli.config as hc
+
+    monkeypatch.setattr(hc, "read_raw_config", lambda: value, raising=False)
+
+
+def test_raw_config_backend_wins_over_env(monkeypatch):
+    """terminal.backend in config.yaml beats TERMINAL_ENV (override=True)."""
     monkeypatch.setenv("TERMINAL_ENV", "local")
+    _raw(monkeypatch, {"terminal": {"backend": "docker"}})
+    assert sched._effective_terminal_backend() == "docker"
+    # ...and the mismatch IS explained, because terminal really runs docker.
+    assert "docker" in sched._script_runs_on_scheduler_host_hint()
+
+
+def test_raw_config_backend_is_normalized(monkeypatch):
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    _raw(monkeypatch, {"terminal": {"backend": "  SSH "}})
+    assert sched._effective_terminal_backend() == "ssh"
+
+
+def test_env_used_when_raw_section_has_no_backend_key(monkeypatch):
+    """A raw terminal section without `backend` doesn't override env."""
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    _raw(monkeypatch, {"terminal": {"docker_image": "x"}})
+    assert sched._effective_terminal_backend() == "ssh"
+
+
+def test_env_used_when_no_raw_terminal_section(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "  DOCKER ")
+    _raw(monkeypatch, {})
+    assert sched._effective_terminal_backend() == "docker"
+    assert "docker" in sched._script_runs_on_scheduler_host_hint()
+
+
+def test_env_local_wins_when_config_is_silent(monkeypatch):
+    """No raw backend + TERMINAL_ENV=local → local, so no hint is emitted."""
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    _raw(monkeypatch, {})
     monkeypatch.setattr(sched, "load_config", lambda: {"terminal": {"backend": "docker"}})
     assert sched._effective_terminal_backend() == "local"
-    # ...so no isolation hint is emitted: there is no mismatch to explain.
     assert sched._script_runs_on_scheduler_host_hint() == ""
 
 
-def test_env_override_is_normalized(monkeypatch):
-    monkeypatch.setenv("TERMINAL_ENV", "  DOCKER ")
-    monkeypatch.setattr(sched, "load_config", lambda: {})
-    assert sched._effective_terminal_backend() == "docker"
-
-
-def test_env_override_names_the_backend_config_does_not_know(monkeypatch):
-    """The inverse: env selects a remote backend, config says nothing."""
-    monkeypatch.setenv("TERMINAL_ENV", "ssh")
-    monkeypatch.setattr(sched, "load_config", lambda: {})
-    assert sched._effective_terminal_backend() == "ssh"
-    assert "ssh" in sched._script_runs_on_scheduler_host_hint()
-
-
-def test_blank_env_override_falls_back_to_config(monkeypatch):
+def test_blank_env_falls_back_to_merged_config(monkeypatch):
     """An empty/whitespace TERMINAL_ENV is not a deliberate choice."""
     monkeypatch.setenv("TERMINAL_ENV", "   ")
+    _raw(monkeypatch, {})
     monkeypatch.setattr(sched, "load_config", lambda: {"terminal": {"backend": "docker"}})
     assert sched._effective_terminal_backend() == "docker"
 
 
-def test_env_override_skips_config_read_entirely(monkeypatch):
-    """An explicit env choice must not depend on config being readable."""
-    monkeypatch.setenv("TERMINAL_ENV", "docker")
+def test_raw_config_read_failure_degrades_to_env(monkeypatch):
+    """Diagnostics must never raise into the job runner."""
+    import hermes_cli.config as hc
 
     def _boom():
-        raise AssertionError("config must not be read when TERMINAL_ENV is set")
+        raise RuntimeError("raw config exploded")
 
-    monkeypatch.setattr(sched, "load_config", _boom)
+    monkeypatch.setattr(hc, "read_raw_config", _boom, raising=False)
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
     assert sched._effective_terminal_backend() == "docker"
 
 

--- a/tests/cron/test_script_host_diagnostics.py
+++ b/tests/cron/test_script_host_diagnostics.py
@@ -1,0 +1,166 @@
+"""Cron script execution-host diagnostics — #29849.
+
+Script-backed cron jobs always execute on the host that ticks cron, never on
+``terminal.backend``. That is deliberate (host-side watchdogs must run where
+``HERMES_HOME`` is), but it was *silent*: a user whose agent wrote a script to
+a remote backend got a bare ``Script not found: /home/.../id_check.sh``
+pointing at a path they could ``ls`` on the backend seconds earlier, and an
+operator who configured ``terminal.backend: docker`` had no signal that
+script-backed cron runs outside that sandbox with the scheduler process's
+environment.
+
+These tests cover the diagnostics only — nothing here changes where a script
+runs. Routing execution through the backend needs a decision on defaults and
+stays open on #29849.
+"""
+
+import logging
+
+import pytest
+
+import cron.scheduler as sched
+
+
+@pytest.fixture(autouse=True)
+def _reset_notice_state():
+    sched._SCRIPT_HOST_NOTICES.clear()
+    yield
+    sched._SCRIPT_HOST_NOTICES.clear()
+
+
+# ---------------------------------------------------------------------------
+# Backend resolution
+# ---------------------------------------------------------------------------
+
+
+def test_backend_defaults_to_local(monkeypatch):
+    monkeypatch.setattr(sched, "load_config", lambda: {})
+    assert sched._configured_terminal_backend() == "local"
+
+
+def test_backend_is_read_and_normalized(monkeypatch):
+    monkeypatch.setattr(sched, "load_config", lambda: {"terminal": {"backend": "  SSH "}})
+    assert sched._configured_terminal_backend() == "ssh"
+
+
+def test_backend_read_failure_degrades_to_local(monkeypatch):
+    def _boom():
+        raise RuntimeError("config exploded")
+
+    monkeypatch.setattr(sched, "load_config", _boom)
+    # Diagnostics must never raise into the job runner.
+    assert sched._configured_terminal_backend() == "local"
+
+
+# ---------------------------------------------------------------------------
+# The hint text
+# ---------------------------------------------------------------------------
+
+
+def test_no_hint_for_local_backend():
+    """Scheduler host and backend are the same machine — nothing to explain."""
+    assert sched._script_runs_on_scheduler_host_hint("local") == ""
+
+
+@pytest.mark.parametrize("backend", ["ssh", "docker", "modal", "daytona"])
+def test_hint_names_the_backend_and_the_contract(backend):
+    hint = sched._script_runs_on_scheduler_host_hint(backend)
+    assert backend in hint
+    assert "ticks cron" in hint
+    assert "terminal.backend" in hint
+
+
+# ---------------------------------------------------------------------------
+# The not-found message (the reported symptom)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_script_message_explains_the_host_under_remote_backend(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(sched, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(sched, "load_config", lambda: {"terminal": {"backend": "ssh"}})
+
+    ok, output = sched._run_job_script("id_check.sh")
+
+    assert ok is False
+    # Says WHERE it looked...
+    assert "scheduler host" in output
+    # ...and why the user's `ls` on the backend disagreed.
+    assert "ssh" in output
+    assert "terminal.backend" in output
+
+
+def test_missing_script_message_stays_terse_for_local_backend(monkeypatch, tmp_path):
+    """No remote backend configured → no confusing explanation appended."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(sched, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(sched, "load_config", lambda: {"terminal": {"backend": "local"}})
+
+    ok, output = sched._run_job_script("id_check.sh")
+
+    assert ok is False
+    assert "Script not found on the scheduler host" in output
+    assert "terminal.backend" not in output
+
+
+def test_path_traversal_block_is_unchanged(monkeypatch, tmp_path):
+    """The containment guard still fires first and keeps its own message."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(sched, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(sched, "load_config", lambda: {"terminal": {"backend": "ssh"}})
+
+    ok, output = sched._run_job_script("../../etc/passwd")
+
+    assert ok is False
+    assert "Blocked" in output
+    assert "outside the scripts directory" in output
+
+
+# ---------------------------------------------------------------------------
+# The isolation-visibility warning
+# ---------------------------------------------------------------------------
+
+
+def test_isolation_warning_fires_for_non_local_backend(caplog, tmp_path):
+    script = tmp_path / "watchdog.sh"
+    with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+        sched._note_script_runs_outside_backend(script, "docker")
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert len(messages) == 1
+    assert "OUTSIDE the configured" in messages[0]
+    assert "docker" in messages[0]
+    assert "not sandboxed" in messages[0]
+
+
+def test_isolation_warning_is_silent_for_local_backend(caplog, tmp_path):
+    with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+        sched._note_script_runs_outside_backend(tmp_path / "w.sh", "local")
+    assert not caplog.records
+
+
+def test_isolation_warning_is_once_per_script(caplog, tmp_path):
+    """A per-minute job must not emit a warning per run."""
+    script = tmp_path / "watchdog.sh"
+    with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+        for _ in range(5):
+            sched._note_script_runs_outside_backend(script, "ssh")
+    assert len([r for r in caplog.records if "OUTSIDE" in r.getMessage()]) == 1
+
+
+def test_distinct_scripts_each_get_noted(caplog, tmp_path):
+    with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+        sched._note_script_runs_outside_backend(tmp_path / "a.sh", "ssh")
+        sched._note_script_runs_outside_backend(tmp_path / "b.sh", "ssh")
+    assert len([r for r in caplog.records if "OUTSIDE" in r.getMessage()]) == 2
+
+
+def test_notice_registry_is_bounded(caplog, tmp_path):
+    """The dedup set can't grow without bound on job churn."""
+    cap = sched._SCRIPT_HOST_NOTICES_MAX
+    with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+        for i in range(cap + 10):
+            sched._note_script_runs_outside_backend(tmp_path / f"s{i}.sh", "ssh")
+    assert len(sched._SCRIPT_HOST_NOTICES) <= cap

--- a/tests/cron/test_script_host_diagnostics.py
+++ b/tests/cron/test_script_host_diagnostics.py
@@ -34,22 +34,76 @@ def _reset_notice_state():
 
 
 def test_backend_defaults_to_local(monkeypatch):
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
     monkeypatch.setattr(sched, "load_config", lambda: {})
-    assert sched._configured_terminal_backend() == "local"
+    assert sched._effective_terminal_backend() == "local"
 
 
 def test_backend_is_read_and_normalized(monkeypatch):
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
     monkeypatch.setattr(sched, "load_config", lambda: {"terminal": {"backend": "  SSH "}})
-    assert sched._configured_terminal_backend() == "ssh"
+    assert sched._effective_terminal_backend() == "ssh"
 
 
 def test_backend_read_failure_degrades_to_local(monkeypatch):
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
     def _boom():
         raise RuntimeError("config exploded")
 
     monkeypatch.setattr(sched, "load_config", _boom)
     # Diagnostics must never raise into the job runner.
-    assert sched._configured_terminal_backend() == "local"
+    assert sched._effective_terminal_backend() == "local"
+
+
+# --- TERMINAL_ENV precedence -----------------------------------------------
+#
+# The terminal tool treats an explicit TERMINAL_ENV as authoritative and only
+# bridges terminal.backend into the unset case (tools/terminal_tool.py,
+# _ensure_terminal_env_bridged / _get_env_config). These diagnostics have to
+# agree with it: naming a backend the terminal tool isn't actually using would
+# point the operator at the wrong host while they debug a missing script.
+
+
+def test_env_override_wins_over_config(monkeypatch):
+    """TERMINAL_ENV=local + terminal.backend=docker → terminal runs LOCAL."""
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setattr(sched, "load_config", lambda: {"terminal": {"backend": "docker"}})
+    assert sched._effective_terminal_backend() == "local"
+    # ...so no isolation hint is emitted: there is no mismatch to explain.
+    assert sched._script_runs_on_scheduler_host_hint() == ""
+
+
+def test_env_override_is_normalized(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "  DOCKER ")
+    monkeypatch.setattr(sched, "load_config", lambda: {})
+    assert sched._effective_terminal_backend() == "docker"
+
+
+def test_env_override_names_the_backend_config_does_not_know(monkeypatch):
+    """The inverse: env selects a remote backend, config says nothing."""
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    monkeypatch.setattr(sched, "load_config", lambda: {})
+    assert sched._effective_terminal_backend() == "ssh"
+    assert "ssh" in sched._script_runs_on_scheduler_host_hint()
+
+
+def test_blank_env_override_falls_back_to_config(monkeypatch):
+    """An empty/whitespace TERMINAL_ENV is not a deliberate choice."""
+    monkeypatch.setenv("TERMINAL_ENV", "   ")
+    monkeypatch.setattr(sched, "load_config", lambda: {"terminal": {"backend": "docker"}})
+    assert sched._effective_terminal_backend() == "docker"
+
+
+def test_env_override_skips_config_read_entirely(monkeypatch):
+    """An explicit env choice must not depend on config being readable."""
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+    def _boom():
+        raise AssertionError("config must not be read when TERMINAL_ENV is set")
+
+    monkeypatch.setattr(sched, "load_config", _boom)
+    assert sched._effective_terminal_backend() == "docker"
 
 
 # ---------------------------------------------------------------------------
@@ -130,7 +184,10 @@ def test_isolation_warning_fires_for_non_local_backend(caplog, tmp_path):
 
     messages = [r.getMessage() for r in caplog.records]
     assert len(messages) == 1
-    assert "OUTSIDE the configured" in messages[0]
+    assert "OUTSIDE the terminal backend in effect" in messages[0]
+    # Names both sources, so the operator knows where to look.
+    assert "TERMINAL_ENV" in messages[0]
+    assert "terminal.backend" in messages[0]
     assert "docker" in messages[0]
     assert "not sandboxed" in messages[0]
 
@@ -158,9 +215,80 @@ def test_distinct_scripts_each_get_noted(caplog, tmp_path):
 
 
 def test_notice_registry_is_bounded(caplog, tmp_path):
-    """The dedup set can't grow without bound on job churn."""
+    """The dedup registry can't grow without bound on job churn."""
     cap = sched._SCRIPT_HOST_NOTICES_MAX
     with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
         for i in range(cap + 10):
             sched._note_script_runs_outside_backend(tmp_path / f"s{i}.sh", "ssh")
     assert len(sched._SCRIPT_HOST_NOTICES) <= cap
+
+
+# --- eviction policy at the cap --------------------------------------------
+#
+# Paths past the cap used to be logged without being recorded, so the dedupe
+# check could never hit them and a job at that position re-warned on EVERY
+# tick — the once-per-script guarantee silently stopped holding exactly where
+# log volume mattered most. The registry now evicts the oldest entry instead.
+
+
+def test_once_per_script_still_holds_at_the_cap(caplog, tmp_path):
+    """The regression: a path past the cap must not warn on every run."""
+    cap = sched._SCRIPT_HOST_NOTICES_MAX
+    for i in range(cap):
+        sched._note_script_runs_outside_backend(tmp_path / f"filler{i}.sh", "ssh")
+    assert len(sched._SCRIPT_HOST_NOTICES) == cap  # registry is full
+
+    overflow = tmp_path / "per_minute_job.sh"
+    with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+        for _ in range(10):
+            sched._note_script_runs_outside_backend(overflow, "ssh")
+    # Exactly once across 10 ticks — not once per tick.
+    assert len([r for r in caplog.records if "per_minute_job.sh" in r.getMessage()]) == 1
+
+
+def test_cap_evicts_the_oldest_entry(caplog, tmp_path):
+    cap = sched._SCRIPT_HOST_NOTICES_MAX
+    first = tmp_path / "oldest.sh"
+    sched._note_script_runs_outside_backend(first, "ssh")
+    for i in range(cap - 1):
+        sched._note_script_runs_outside_backend(tmp_path / f"filler{i}.sh", "ssh")
+    assert str(first) in sched._SCRIPT_HOST_NOTICES
+
+    # One more distinct path evicts the oldest, keeping the registry at the cap.
+    sched._note_script_runs_outside_backend(tmp_path / "newest.sh", "ssh")
+    assert len(sched._SCRIPT_HOST_NOTICES) == cap
+    assert str(first) not in sched._SCRIPT_HOST_NOTICES
+    assert str(tmp_path / "newest.sh") in sched._SCRIPT_HOST_NOTICES
+
+
+def test_evicted_script_can_warn_again_but_not_per_tick(caplog, tmp_path):
+    """Eviction trades a bounded re-warn for never silently dropping a script."""
+    cap = sched._SCRIPT_HOST_NOTICES_MAX
+    script = tmp_path / "evicted.sh"
+    sched._note_script_runs_outside_backend(script, "ssh")
+    # Push it out with cap distinct paths.
+    for i in range(cap):
+        sched._note_script_runs_outside_backend(tmp_path / f"churn{i}.sh", "ssh")
+    assert str(script) not in sched._SCRIPT_HOST_NOTICES
+
+    caplog.clear()  # drop the setup warnings; count only the re-entry
+    with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+        for _ in range(5):
+            sched._note_script_runs_outside_backend(script, "ssh")
+    # Warns once on re-entry, then dedupes again — not five times.
+    assert len([r for r in caplog.records if "evicted.sh" in r.getMessage()]) == 1
+
+
+def test_recorded_and_emitted_never_disagree(caplog, tmp_path):
+    """Every emitted notice has a matching record; no log-without-record."""
+    cap = sched._SCRIPT_HOST_NOTICES_MAX
+    with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+        for i in range(cap + 25):
+            path = tmp_path / f"s{i}.sh"
+            before = str(path) in sched._SCRIPT_HOST_NOTICES
+            sched._note_script_runs_outside_backend(path, "ssh")
+            # A first-time path is always recorded when it is logged.
+            if not before:
+                assert str(path) in sched._SCRIPT_HOST_NOTICES
+    # cap + 25 distinct paths, each logged exactly once as it was first seen.
+    assert len([r for r in caplog.records if "OUTSIDE" in r.getMessage()]) == cap + 25

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1566,7 +1566,7 @@ Scheduling from cron-run sessions is disabled by default and enabled via cron.al
             },
             "script": {
                 "type": "string",
-                "description": f"Optional path to a script that runs each tick. In the default mode its stdout is injected into the agent's prompt as context (data-collection / change-detection pattern). With no_agent=True, the script IS the job and its stdout is delivered verbatim (classic watchdog pattern). Relative paths resolve under {display_hermes_home()}/scripts/. ``.sh``/``.bash`` extensions run via bash, everything else via Python. On update, pass empty string to clear."
+                "description": f"Optional path to a script that runs each tick. In the default mode its stdout is injected into the agent's prompt as context (data-collection / change-detection pattern). With no_agent=True, the script IS the job and its stdout is delivered verbatim (classic watchdog pattern). Relative paths resolve under {display_hermes_home()}/scripts/. ``.sh``/``.bash`` extensions run via bash, everything else via Python. On update, pass empty string to clear. IMPORTANT: the script always executes on the host that ticks cron (the scheduler/gateway process), NOT on the configured terminal.backend — so a script you wrote through ``terminal``/``write_file`` under a remote backend (ssh/docker/modal/daytona) will NOT be found. Create the script on the scheduler host's {display_hermes_home()}/scripts/, or have the script reach the backend itself."
             },
             "monitor_script": {
                 "type": "string",

--- a/website/docs/guides/cron-script-only.md
+++ b/website/docs/guides/cron-script-only.md
@@ -83,6 +83,14 @@ cronjob(
 
 From that point on every tick is free: the scheduler runs the script, pipes its stdout to Telegram if non-empty, and never touches a model.
 
+### Where the script has to live
+
+The script runs on the host that ticks cron — the scheduler/gateway process — **not** on `terminal.backend`.
+
+That matters if you've set a remote or sandboxed backend (`docker`, `ssh`, `modal`, …). The `write_file` call above then writes to the *backend's* filesystem, so cron never sees the file and every tick fails with "Script not found on the scheduler host" — for a path you can `ls` on the backend seconds earlier. Write the script to the scheduler host's `~/.hermes/scripts/` instead.
+
+The flip side: because the script runs on the scheduler host, `terminal.backend` doesn't sandbox it. It executes with the scheduler process's environment and filesystem access (though not its provider credentials — see the note above). If a watchdog needs to be contained, have the script drive the backend itself (`docker exec`, `ssh`) rather than assuming the backend wraps it. With a non-local backend configured, the scheduler logs a warning saying exactly this on the job's first run.
+
 ### What the agent decides for you
 
 When you phrase a request like "alert me when X" or "every N minutes check Y and tell me if Z", Hermes' `cronjob` tool description tells it to reach for `no_agent=True` whenever the message content is fully determined by the script. It falls back to the normal LLM-driven path when the request needs reasoning (*"summarize the new issues"*, *"pick the most interesting headlines"*, *"draft a friendly reminder"*).

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -538,6 +538,16 @@ Semantics:
 
 `.sh` / `.bash` files run under `bash` from `PATH` when available, otherwise `/bin/bash` (important on Windows Git Bash). Anything else runs under the current Python interpreter (`sys.executable`). Scripts must resolve inside `$HERMES_HOME/scripts/` — relative names, absolute paths, and `~`-prefixed paths are accepted when the resolved target stays in that directory; paths that escape it are rejected. Subprocess env is sanitized (`_sanitize_subprocess_env`): provider API credentials and other Hermes-managed secrets are **not** inherited by cron scripts.
 
+:::warning Scripts run on the scheduler host, not on `terminal.backend`
+
+Script-backed cron jobs always execute on the host that ticks cron — the scheduler/gateway process — regardless of `terminal.backend`. Two consequences:
+
+- **The script must exist on that host.** If you set a remote or sandboxed backend (`docker`, `ssh`, `modal`, …) and the agent wrote the script through `terminal` or `write_file`, the file landed on the *backend's* filesystem and cron cannot see it — you get "Script not found on the scheduler host" for a path you can `ls` on the backend. Keep the script in the scheduler host's `~/.hermes/scripts/`.
+- **`terminal.backend` is not an isolation boundary here.** The script runs with the scheduler process's environment and filesystem access. If you need the work sandboxed, have the script itself drive the backend (e.g. `docker exec`, `ssh`) rather than relying on the terminal backend to contain it.
+
+This is deliberate — host-side watchdogs have to run where `HERMES_HOME` is — but it surprises people, so the scheduler logs a warning naming the effective backend when the two differ.
+:::
+
 ### The agent sets these up for you
 
 The `cronjob` tool's schema exposes `no_agent` to Hermes directly, so you can describe a watchdog in chat and let the agent wire it up:


### PR DESCRIPTION
## What does this PR do?

Makes the script execution-host contract in #29849 **legible** — both the reported failure and the isolation gap raised in the thread — without pre-empting the product decision that issue is parked on.

Script-backed cron jobs always execute on the host that ticks cron, never on `terminal.backend`. That's deliberate (the `memory-watchdog.sh` pattern — a job that backs up `HERMES_HOME` has to run where `HERMES_HOME` is), but it was silent in exactly the two ways the issue documents:

**1. The reported symptom.** An agent that wrote its script through `terminal`/`write_file` under a remote backend created a job referencing the *backend's* filesystem, then produced a bare `Script not found: /home/debian/.hermes/scripts/id_check.sh` — pointing at a path the reporter could `ls` on the backend seconds earlier. The message never said the lookup happened on a different machine. It now names the scheduler host and, when a non-local backend is configured, states the contract and names that backend:

```
Script not found on the scheduler host: /home/debian/.hermes/scripts/id_check.sh
Note: script-backed cron jobs always execute on the host that ticks cron (this
scheduler process), NOT on the configured terminal.backend (ssh) — so a script
written to the backend's filesystem by the agent is not visible here. Keep the
script in this host's HERMES_HOME/scripts/, or drive the backend from the script
itself.
```

Local-backend setups keep the terse message — scheduler host and backend are the same machine, so there is nothing to explain.

**2. The isolation gap @dchenk raised.** An operator who sets `terminal.backend: docker`/`ssh` reasonably reads that as the boundary for what the agent runs; script-backed cron bypasses it, executing with the scheduler/gateway process's environment and filesystem access — in a containerized deployment, the more privileged side. That is now a `WARNING` naming the script and the configured backend, so it appears in `agent.log` instead of being invisible. Deduped once per script path (a per-minute job must not log per run) with a bounded registry so job churn can't grow it.

Also documents the contract **where it's read before a job is created**: the `cronjob` tool's `script` parameter description (what the agent sees when choosing arguments) and `_run_job_script`'s docstring.

**Deliberately out of scope.** No execution change, no config keys, no creation-time rejection — existing jobs behave identically. Routing execution through the configured backend, and whether the default should flip for agent-created jobs under a remote backend, is the decision still open on #29849 (`needs-decision`); this PR makes today's behavior legible rather than deciding it. Happy to follow up with the `target="scheduler"|"backend"` implementation I sketched on the issue once maintainers pick a direction.

## Related Issue

Addresses the diagnostic + documentation half of #29849. Complements the closed #29896 (@briandevans's create-time guardrail, closed voluntarily to make queue room) — that one rejected at creation; this one explains at the point of failure and at the point of authoring, which needs no compatibility decision.

## Type of Change

- [x] 🐛 Bug fix (non-breaking — diagnostics/documentation; no behavior change)

## Changes Made

- `cron/scheduler.py`
  - `_configured_terminal_backend()` — reads `terminal.backend` for diagnostics, degrades to `local` on any config error (never raises into the job runner).
  - `_script_runs_on_scheduler_host_hint()` — one-line contract explanation; empty for `local`.
  - `_note_script_runs_outside_backend()` — the isolation `WARNING`, once per script path, bounded registry.
  - `_run_job_script` — not-found message now names the host + contract; logs the isolation notice before executing; docstring documents the execution host and the isolation consequence.
- `tools/cronjob_tools.py` — `script` parameter description states the execution host and the remote-backend consequence.
- `tests/cron/test_script_host_diagnostics.py` — 16 tests.

## How to Test

1. `scripts/run_tests.sh tests/cron/test_script_host_diagnostics.py` — 16 passed.
2. Regression: `tests/cron/test_scheduler.py` — 239 passed. Full `tests/cron/` failing set is byte-identical to a stashed-baseline run on this machine (7 pre-existing native-Windows cases: POSIX `0600`/`0700` modes aren't enforced on NTFS, plus one tilde-path separator case) — zero failures attributable to this change.
3. Manual: configure `terminal.backend: ssh`, create `cronjob(no_agent=True, script="missing.sh", ...)`, run it — `last_status: error` now explains the host mismatch and names `ssh`. With an existing script, `agent.log` gets one isolation `WARNING` per script.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs/issues — #29849 has no open PR (both prior ones closed); no competing work
- [x] Single-topic
- [x] Test suite run — see How to Test
- [x] Tests added (required for bug fixes)
- [x] Tested on: Windows 11 (native)

### Documentation & Housekeeping

- [x] Documentation — tool-schema description + `_run_job_script` docstring updated
- [x] `cli-config.yaml.example` — N/A (no config keys added)
- [x] CONTRIBUTING/AGENTS — N/A
- [x] Cross-platform — pure-Python; `pathlib` only; no platform-specific surface
