### PR TITLE
fix(desktop): prevent stale project scope yank in followActiveSessionCwd

### DIFF
--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -20,6 +20,7 @@ import {
   endSessionMutation,
   enterProject,
   exitProjectScope,
+  followActiveSessionCwd,
   openProjectCreate,
   pickProjectFolder,
   projectNameForCwd,
@@ -542,5 +543,110 @@ describe('tombstone pruning', () => {
     await refreshProjectTree()
 
     expect($removedSessionIds.get().has('sess-1')).toBe(false)
+  })
+})
+
+describe('followActiveSessionCwd', () => {
+  const treeNode = (
+    over: Partial<SidebarProjectTree> & Pick<SidebarProjectTree, 'id' | 'label'>
+  ): SidebarProjectTree => ({ path: null, repos: [], sessionCount: 0, ...over })
+
+  const payload = (projects: SidebarProjectTree[]) => ({ active_id: null, projects, scoped_session_ids: [] })
+
+  const openGatewayReturning = (result: unknown) => {
+    const gateway = { connectionState: 'open', request: vi.fn().mockResolvedValue(result) }
+
+    activeGateway.mockImplementation(() => gateway as never)
+    gatewayAtom.set(gateway as never)
+
+    return gateway
+  }
+
+  const deferredGateway = () => {
+    let resolve!: (value: unknown) => void
+    const promise = new Promise(r => { resolve = r })
+    const gateway = { connectionState: 'open', request: vi.fn().mockReturnValue(promise) }
+
+    activeGateway.mockImplementation(() => gateway as never)
+    gatewayAtom.set(gateway as never)
+
+    return { resolve }
+  }
+
+  beforeEach(() => {
+    $projectTree.set([])
+    $projectScope.set(ALL_PROJECTS)
+    $currentCwd.set('')
+    $selectedStoredSessionId.set(null)
+  })
+
+  it('always refreshes even when the project is already cached', async () => {
+    $projectTree.set([treeNode({ id: 'p_known', label: 'Known', path: '/repos/known' })])
+    $currentCwd.set('/repos/known')
+
+    const gateway = openGatewayReturning(payload([treeNode({ id: 'p_known', label: 'Known', path: '/repos/known' })]))
+
+    await followActiveSessionCwd('/repos/known')
+
+    const methods = gateway.request.mock.calls.map((c: unknown[]) => c[0])
+
+    expect(methods).toContain('projects.list')
+    expect(methods).toContain('projects.tree')
+    expect($projectScope.get()).toBe('p_known')
+  })
+
+  it('resolves a nested repository to the inner project after refresh', async () => {
+    $projectTree.set([treeNode({ id: 'p_outer', label: 'Outer', path: '/repos/outer' })])
+    $currentCwd.set('/repos/outer/nested')
+    openGatewayReturning(payload([
+      treeNode({ id: 'p_outer', label: 'Outer', path: '/repos/outer' }),
+      treeNode({ id: 'p_nested', label: 'Nested', path: '/repos/outer/nested' })
+    ]))
+
+    await followActiveSessionCwd('/repos/outer/nested')
+
+    expect($projectScope.get()).toBe('p_nested')
+  })
+
+  it('does not abort when auto-compression rotates the stored session id mid-flight', async () => {
+    $currentCwd.set('/repos/active')
+    $selectedStoredSessionId.set('sess-original')
+    const { resolve } = deferredGateway()
+
+    const follow = followActiveSessionCwd('/repos/active')
+
+    $selectedStoredSessionId.set('sess-compressed')
+    resolve(payload([treeNode({ id: 'p_active', label: 'Active', path: '/repos/active' })]))
+    await follow
+
+    expect($projectScope.get()).toBe('p_active')
+  })
+
+  it('does not yank sidebar scope when the live cwd moved away mid-flight', async () => {
+    $currentCwd.set('/repos/old')
+    const { resolve } = deferredGateway()
+
+    const follow = followActiveSessionCwd('/repos/old')
+
+    $currentCwd.set('/repos/new')
+    resolve(payload([treeNode({ id: 'p_old', label: 'Old', path: '/repos/old' })]))
+    await follow
+
+    expect($projectScope.get()).toBe(ALL_PROJECTS)
+  })
+
+  it('supersedes an older follow when a newer one starts mid-flight', async () => {
+    const { resolve } = deferredGateway()
+
+    $currentCwd.set('/repos/first')
+    const first = followActiveSessionCwd('/repos/first')
+
+    $currentCwd.set('/repos/second')
+    const second = followActiveSessionCwd('/repos/second')
+
+    resolve(payload([treeNode({ id: 'p_second', label: 'Second', path: '/repos/second' })]))
+    await Promise.all([first, second])
+
+    expect($projectScope.get()).toBe('p_second')
   })
 })

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -354,6 +354,10 @@ export function projectNameForCwd(cwd: string): null | string {
 // session row show live, then follow the view into the session's new project
 // (from the overview or a now-stale project alike). Caller gates this on a real
 // same-session cwd move, so a plain session switch never reaches here.
+// Monotonic counter so a newer follow supersedes an older one still awaiting
+// its refresh RPCs — mirrors the projectTreeRefreshGeneration idiom below.
+let followCwdGeneration = 0
+
 export async function followActiveSessionCwd(cwd: string): Promise<void> {
   const target = cwd.trim()
 
@@ -361,9 +365,23 @@ export async function followActiveSessionCwd(cwd: string): Promise<void> {
     return
   }
 
+  const generation = ++followCwdGeneration
+
+  // Always refresh: projectIdForCwd() uses ancestor-prefix matching, so a
+  // newly created nested repository would hit the old outer project and skip
+  // the structural refresh that the backend needs to surface the new repo.
+  // The two RPCs are cheap relative to the correctness risk of a stale tree.
   await Promise.all([refreshProjects(), refreshProjectTree()])
 
-  // Resolve only after the refresh, so a just-created/auto project is in the tree.
+  // Stale-follow guard: a newer follow superseded this one, or the agent
+  // cd'd again while the RPCs were in flight. Only $currentCwd is checked —
+  // $selectedStoredSessionId is NOT compared because auto-compression rotates
+  // it for the same runtime session.
+  if (generation !== followCwdGeneration || $currentCwd.get().trim() !== target) {
+    return
+  }
+
+  // Resolve after the refresh so a just-created/auto project is in the tree.
   const projectId = projectIdForCwd(target)
 
   if (projectId) {


### PR DESCRIPTION
## Problem

`followActiveSessionCwd` (`apps/desktop/src/store/projects.ts`) could apply a stale project-scope change after its refresh RPCs completed.

When the agent relocates (nested `git init`/clone + `cd`, or another same-session cwd move), the function refreshes `projects.list` + `projects.tree` and then calls `enterProject()`. If a newer follow starts, or the live cwd moves again while those RPCs are in flight, the older completion must not yank the sidebar to a project that is no longer current.

A second, related trap: treating `$selectedStoredSessionId` rotation as "session changed" is wrong. Auto-compression rotates the stored id for the *same* runtime session, so comparing stored ids aborts a still-valid follow permanently.

## Fix

- **Always refresh** before resolving. `projectIdForCwd()` matches by ancestor prefix, so a cache hit does *not* mean nothing structural changed under a known root (nested repo / new auto project). Skipping refresh on hit was unsafe.
- **Stale-follow guard** after the RPCs:
  - module-level `followCwdGeneration` (same idiom as `projectTreeRefreshGeneration`)
  - live `$currentCwd` must still equal the follow target
  - do **not** compare `$selectedStoredSessionId` (compression rotation)
- Then resolve `projectIdForCwd(target)` from the refreshed tree and enter that project.

## Tests

Regression coverage in `projects.test.ts`:

- always refreshes even when the project is already cached
- nested cwd resolves to the inner project after refresh
- stored-id rotation mid-flight does not abort
- live cwd moved mid-flight does not yank scope
- newer follow supersedes an older in-flight one

## Verification

- `vitest` `src/store/projects.test.ts` — pass
- `tsc --noEmit` — clean