### PR TITLE
Fix uncaught RuntimeError in MCP shutdown cleanup (mcp_tool.py)

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2357,8 +2357,8 @@ class MCPServerTask:
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
-                    t.cancel()
                     try:
+                        t.cancel()
                         await t
                     except (asyncio.CancelledError, Exception):
                         pass


### PR DESCRIPTION
Problem: During TUI shutdown (Ctrl-D), when one or more MCP servers are parked in _wait_for_reconnect_or_shutdown, t.cancel() is called outside the surrounding try/except block. If the event loop has already been closed by the time cleanup runs (e.g. when shutdown_mcp_servers()'s 15s timeout is exceeded with several parked servers), the resulting RuntimeError('Event loop is closed') isn't caught, and surfaces as "Exception ignored in" for each affected server's run() coroutine.

Fix: Move t.cancel() inside the existing try/except (asyncio.CancelledError, Exception) block so it's covered by the same handler as await t.

Repro: TUI session with 5 parked/reconnecting MCP servers, exit via Ctrl-D → 5× identical traceback pointing at mcp_tool.py, _wait_for_reconnect_or_shutdown.
