### PR TITLE
fix(desktop): use Hermes skin description in theme picker

### DIFF
--- a/apps/desktop/src/themes/skin.ts
+++ b/apps/desktop/src/themes/skin.ts
@@ -108,7 +108,7 @@ export function skinToDesktopTheme(skin: HermesSkin): DesktopTheme | null {
   return {
     name,
     label: titleCase(name),
-    description: 'Hermes skin',
+    description: skin.description?.trim() || 'Hermes skin',
     // Single palette in both slots: a skin is one-mode, so the light/dark toggle
     // shouldn't invert it. renderedModeFor still paints `.dark` from luminance.
     colors: palette,


### PR DESCRIPTION
## What

The desktop `skinToDesktopTheme` converter always set `description: 'Hermes skin'` for every user-authored Hermes skin, ignoring the `description` field already present in the `HermesSkin` payload sent by the backend.

## Fix

Use `skin.description` when present; fall back to `'Hermes skin'` only when the skin omits a description.

## Why

- Built-in themes already show rich descriptions in Appearance / `/skin list`.
- User-authored skins in `$HERMES_HOME/skins/*.yaml` should have the same affordance.
- This makes community theme packages discoverable and informative without touching Hermes core for each new theme.

## Scope

Single-line change in `apps/desktop/src/themes/skin.ts`. No CLI/TUI changes needed; the skin engine already sends the description.