### PR TITLE
fix(cron): align ticker to wall-clock boundaries

### DIFF
--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -20,8 +20,16 @@ selected via the `cron.provider` config key (empty = built-in).
 from __future__ import annotations
 
 import threading
+import time
 from abc import ABC, abstractmethod
 from typing import Any
+
+
+def _seconds_until_next_tick(interval: float) -> float:
+    """Return the delay to the next wall-clock interval boundary."""
+    if interval <= 0:
+        return 0
+    return interval - (time.time() % interval)
 
 
 class CronScheduler(ABC):
@@ -258,7 +266,7 @@ class InProcessCronScheduler(CronScheduler):
             record_ticker_heartbeat(success=ok)
             if ok:
                 clear_ticker_error()
-            stop_event.wait(interval)
+            stop_event.wait(_seconds_until_next_tick(interval))
 
     def _start_multiplex(
         self,
@@ -354,4 +362,4 @@ class InProcessCronScheduler(CronScheduler):
                             record_ticker_error(_tick_error)
                 finally:
                     reset_hermes_home_override(home_token)
-            stop_event.wait(interval)
+            stop_event.wait(_seconds_until_next_tick(interval))

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -172,6 +172,47 @@ def test_inprocess_provider_ticks_and_stops():
     assert calls[0].get("sync") is False
 
 
+def test_inprocess_provider_waits_for_next_wall_clock_boundary(tmp_path, monkeypatch):
+    """Tick work must not accumulate into the next minute.
+
+    A cycle ending 0.25s before the next 60s boundary waits 0.25s, not another
+    full 60s.  The same timing contract applies to single-profile and
+    multiplex schedulers.
+    """
+    import cron.scheduler_provider as sp
+
+    class RecordingStop:
+        def __init__(self):
+            self.waits = []
+
+        def is_set(self):
+            return bool(self.waits)
+
+        def wait(self, timeout):
+            self.waits.append(timeout)
+            return True
+
+    class FakeTime:
+        @staticmethod
+        def time():
+            return 119.75
+
+    profile_home = tmp_path / "profile"
+    (profile_home / "cron").mkdir(parents=True)
+    monkeypatch.setattr(sp, "time", FakeTime, raising=False)
+
+    for profile_homes in (None, [("default", profile_home)]):
+        stop = RecordingStop()
+        provider = sp.InProcessCronScheduler()
+        with patch.object(provider, "recover_interrupted", return_value=0), \
+             patch("cron.scheduler.tick", return_value=0), \
+             patch("cron.jobs.record_ticker_heartbeat"), \
+             patch("cron.jobs.clear_ticker_error"):
+            provider.start(stop, interval=60, profile_homes=profile_homes)
+
+        assert stop.waits == [0.25]
+
+
 def test_inprocess_provider_skips_dispatch_while_draining():
     """A drain pause keeps due work pending until dispatch is re-enabled."""
     from cron.scheduler_provider import InProcessCronScheduler


### PR DESCRIPTION
## What does this PR do?

The built-in cron scheduler currently waits the full configured interval only after each tick cycle finishes. Its effective cadence is therefore `tick duration + interval`, so even short bookkeeping work accumulates phase drift.

For a `*/1 * * * *` job, that drift can move a tick just before a minute boundary. If the job finishes just after the boundary, `mark_job_run()` computes the next cron occurrence from that completion time. The following drifting tick can then arrive just before the new `next_run_at` and skip the minute entirely.

This change aligns post-tick waits to the next wall-clock interval boundary instead. It applies the same timing contract to both the single-profile and multiplex schedulers, while preserving the immediate first tick and the existing zero/non-positive interval behavior.

## Related Issue

No exact issue currently tracks this root cause. Related reports cover different failure modes:

- #51038: gateway not running, so no ticker was active
- #37312 and #27485: long-running jobs blocked the ticker
- #37179: ticker thread death / older sequential-job behavior

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `_seconds_until_next_tick()` in `cron/scheduler_provider.py`.
- Use the aligned delay in both single-profile and multiplex ticker loops.
- Add a behavioral regression test that exercises both paths at `time.time() == 119.75`: old behavior waits `60s`; corrected behavior waits `0.25s`.

## How to Test

1. On current `main`, run `scripts/run_tests.sh tests/cron/test_scheduler_provider.py::test_inprocess_provider_waits_for_next_wall_clock_boundary -q` and observe `[60] != [0.25]`.
2. Apply this patch and rerun the same test; it passes.
3. Run `scripts/run_tests.sh tests/cron -q`; result: `774 passed, 0 failed` across 34 files.
4. Manual macOS gateway verification: a real one-minute no-agent job fired continuously at `16:20:00.234`, `16:21:00.080`, through `16:28:00.135`, with no missing minute.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing issues and PRs for duplicates
- [x] My PR contains only changes related to this fix
- [ ] I've run the entire `tests/` suite locally (the complete `tests/cron` suite passes: 774/0)
- [x] I've added tests for my changes
- [x] I've tested on macOS 26.5.2 with Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation update: N/A (internal scheduler cadence fix)
- [x] `cli-config.yaml.example`: N/A (no config changes)
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A (no architecture or workflow changes)
- [x] Cross-platform impact considered: implementation uses existing stdlib `time` and `threading.Event` behavior
- [x] Tool descriptions/schemas: N/A

## Sanitized runtime evidence

Before the fix, one-minute execution timestamps drifted through the boundary and then skipped slots:

```text
11:20:58.620
11:21:58.787
11:22:58.985
11:23:59.168
11:24:59.370
11:25:59.594
11:27:59.892  # no 11:26 execution
11:29:00.065  # no 11:28 execution
```

After the fix, the ticker remains aligned to each minute boundary instead of accumulating cycle cost.