### PR TITLE
fix(desktop): flip zone collapse chevron to action direction

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/floating-panes.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/floating-panes.test.tsx
@@ -167,6 +167,10 @@ describe('FloatingPanes (live DOM)', () => {
 
     const before = card()!.style.left
     const toggle = card()!.querySelector('button')!
+    const chevron = () => toggle.querySelector('i')!
+
+    // Expanded: down chevron (fold). Collapsed: up chevron (restore).
+    expect(chevron().className).toContain('codicon-chevron-down')
 
     // The button is inside the drag handle — [data-floating-no-drag] must
     // stop it starting a drag.
@@ -182,6 +186,7 @@ describe('FloatingPanes (live DOM)', () => {
 
     expect(document.querySelector('[data-testid="hud-body"]')).toBeNull()
     expect(card()!.style.height).toBe('')
+    expect(chevron().className).toContain('codicon-chevron-up')
   })
 
   it('renders one card per floating contribution', () => {

--- a/apps/desktop/src/components/pane-shell/tree/renderer/floating-panes.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/floating-panes.tsx
@@ -172,7 +172,7 @@ function FloatingPane({ pane }: { pane: Contribution }) {
           onClick={toggleCollapsed}
           type="button"
         >
-          <Codicon name={collapsed ? 'chevron-down' : 'chevron-up'} size="0.75rem" />
+          <Codicon name={collapsed ? 'chevron-up' : 'chevron-down'} size="0.75rem" />
         </button>
       </header>
 

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx
@@ -1,0 +1,76 @@
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { registry } from '@/contrib/registry'
+
+import type { GroupNode } from '../model'
+
+import { TreeGroup } from './tree-group'
+
+let root: null | Root = null
+let container: HTMLDivElement | null = null
+let disposePane: (() => void) | null = null
+
+function render(ui: ReactNode) {
+  if (!container) {
+    container = globalThis.document.createElement('div')
+    globalThis.document.body.append(container)
+    root = createRoot(container)
+  }
+
+  act(() => {
+    root!.render(ui)
+  })
+}
+
+function terminalGroup(minimized: boolean): GroupNode {
+  return {
+    active: 'terminal',
+    headerHidden: false,
+    id: 'terminal-zone',
+    minimized,
+    panes: ['terminal'],
+    type: 'group'
+  }
+}
+
+const toggle = (label: string) =>
+  globalThis.document.querySelector<HTMLButtonElement>(
+    `[data-tree-group="terminal-zone"] button[aria-label="${label}"]`
+  )!
+
+afterEach(() => {
+  if (root) {
+    act(() => root!.unmount())
+  }
+
+  container?.remove()
+  disposePane?.()
+  root = null
+  container = null
+  disposePane = null
+  vi.unstubAllGlobals()
+})
+
+describe('TreeGroup', () => {
+  it('points the docked-zone chevron in the collapse or restore action direction', () => {
+    disposePane = registry.register({
+      area: 'panes',
+      data: { height: '12rem' },
+      id: 'terminal',
+      render: () => <div>Terminal</div>,
+      title: 'Terminal'
+    })
+    // jsdom does not implement CSS.escape, which the real tab-strip effect uses.
+    vi.stubGlobal('CSS', { escape: (value: string) => value })
+
+    render(<TreeGroup node={terminalGroup(false)} parentAxis="column" />)
+
+    expect(toggle('Minimize').querySelector('i')!.className).toContain('codicon-chevron-down')
+
+    render(<TreeGroup node={terminalGroup(true)} parentAxis="column" />)
+
+    expect(toggle('Restore').querySelector('i')!.className).toContain('codicon-chevron-up')
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -544,7 +544,7 @@ export function TreeGroup({
                 onPointerDown={e => e.stopPropagation()}
                 type="button"
               >
-                <Codicon name={node.minimized ? 'chevron-down' : 'chevron-up'} size="0.75rem" />
+                <Codicon name={node.minimized ? 'chevron-up' : 'chevron-down'} size="0.75rem" />
               </button>
             )}
             <StripDropCaret groupId={node.id} stripRef={stripRef} />


### PR DESCRIPTION
## Summary
- Point zone minimize/restore chevrons in the **action** direction: down when expanded, up when collapsed.
- Align floating-pane collapse chevrons with the same convention (and with master-detail detail headers).
- Extend the floating-panes collapse test to assert the chevron classes.

Fixes #74006

## Test plan
- [x] `NODE_OPTIONS='--localstorage-file=/tmp/hermes-vitest-ls.json' npm run test:ui -- src/components/pane-shell/tree/renderer/floating-panes.test.tsx` (8 passed)
- [x] Manual desktop sandbox: terminal collapse shows an up chevron; restore shows a down chevron
- [x] Manual spot check confirmed by the user
