### PR TITLE
fix(gateway): make shutdown diagnostics portable on macOS

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -220,25 +220,37 @@ def spawn_async_diagnostic(
     except OSError:
         return None
 
-    # Inline shell so we don't have to ship a helper script.  bash -c is
+    # Inline shell so we don't have to ship a helper script.  bash is
     # available on every POSIX target we support; on Windows we just skip
     # the snapshot (the platform doesn't ship ps anyway).
     if sys.platform == "win32":
         return None
 
-    script = (
+    common = (
         f"echo '=== shutdown diagnostic @ {signal_name} ==='; "
         "echo '--- date ---'; date -u +%Y-%m-%dT%H:%M:%SZ; "
-        "echo '--- ps auxf (top 60 by cpu) ---'; "
-        "ps auxf --sort=-pcpu 2>/dev/null | head -60; "
-        "echo '--- pstree of self ---'; "
-        f"pstree -plau {os.getpid()} 2>/dev/null | head -40 || true; "
-        "echo '--- /proc/loadavg ---'; "
-        "cat /proc/loadavg 2>/dev/null || true; "
-        "echo '--- recent dmesg (oom/killed) ---'; "
-        "dmesg -T 2>/dev/null | tail -20 || journalctl --user -n 20 --no-pager 2>/dev/null | tail -20 || true; "
-        "echo '=== end ==='"
     )
+    if sys.platform == "darwin":
+        script = common + (
+            "echo '--- processes (top 60 by cpu) ---'; "
+            "ps -Ao pid,ppid,state,pcpu,pmem,command -r 2>/dev/null | head -60; "
+            "echo '--- gateway process ---'; "
+            f"ps -o pid,ppid,state,command -p {os.getpid()} 2>/dev/null || true; "
+            "echo '--- load ---'; uptime 2>/dev/null || true; "
+            "echo '=== end ==='"
+        )
+    else:
+        script = common + (
+            "echo '--- ps auxf (top 60 by cpu) ---'; "
+            "ps auxf --sort=-pcpu 2>/dev/null | head -60; "
+            "echo '--- pstree of self ---'; "
+            f"pstree -plau {os.getpid()} 2>/dev/null | head -40 || true; "
+            "echo '--- /proc/loadavg ---'; "
+            "cat /proc/loadavg 2>/dev/null || true; "
+            "echo '--- recent dmesg (oom/killed) ---'; "
+            "dmesg -T 2>/dev/null | tail -20 || journalctl --user -n 20 --no-pager 2>/dev/null | tail -20 || true; "
+            "echo '=== end ==='"
+        )
 
     try:
         # Open the log file in append mode and let the subprocess inherit.
@@ -248,6 +260,22 @@ def spawn_async_diagnostic(
     except OSError:
         return None
 
+    # Use Hermes' Python rather than the GNU-only `timeout` executable (absent
+    # on stock macOS).  The helper owns the shell's process group and kills the
+    # entire group at the deadline, preserving the original bounded contract.
+    helper = (
+        "import os, signal, subprocess, sys\n"
+        "p = subprocess.Popen(['bash', '-c', sys.argv[1]], start_new_session=True)\n"
+        "try:\n"
+        "    p.wait(timeout=float(sys.argv[2]))\n"
+        "except subprocess.TimeoutExpired:\n"
+        "    try:\n"
+        "        os.killpg(p.pid, signal.SIGKILL)\n"  # windows-footgun: ok -- helper only runs after the Windows early return
+        "    except ProcessLookupError:\n"
+        "        pass\n"
+        "    p.wait()\n"
+    )
+
     try:
         # Detach from our process group so the subprocess survives even
         # if systemd kills our cgroup with KillMode=control-group (which
@@ -255,7 +283,7 @@ def spawn_async_diagnostic(
         # start_new_session, a SIGKILL on our cgroup takes the diag down
         # before it can flush.
         proc = subprocess.Popen(
-            ["timeout", f"{timeout_seconds:.0f}", "bash", "-c", script],
+            [sys.executable, "-c", helper, script, str(timeout_seconds)],
             stdout=fd,
             stderr=subprocess.STDOUT,
             stdin=subprocess.DEVNULL,

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -132,23 +132,48 @@ def spawn_async_diagnostic(log_path: Path, signal_name: str, *,
         return None
     if sys.platform == "win32":
         return None
-    script = (
+    common = (
         f"echo '=== shutdown diagnostic @ {signal_name} ==='; "
         "echo '--- date ---'; date -u +%Y-%m-%dT%H:%M:%SZ; "
-        "echo '--- ps auxf (top 60 by cpu) ---'; ps auxf --sort=-pcpu 2>/dev/null | head -60; "
-        f"echo '--- pstree of self ---'; pstree -plau {os.getpid()} 2>/dev/null | head -40 || true; "
-        "echo '--- /proc/loadavg ---'; cat /proc/loadavg 2>/dev/null || true; "
-        "echo '--- recent dmesg (oom/killed) ---'; "
-        "dmesg -T 2>/dev/null | tail -20 || journalctl --user -n 20 --no-pager 2>/dev/null | tail -20 || true; "
-        "echo '=== end ==='"
     )
+    if sys.platform == "darwin":
+        script = common + (
+            "echo '--- processes (top 60 by cpu) ---'; "
+            "ps -Ao pid,ppid,state,pcpu,pmem,command -r 2>/dev/null | head -60; "
+            "echo '--- gateway process ---'; "
+            f"ps -o pid,ppid,state,command -p {os.getpid()} 2>/dev/null || true; "
+            "echo '--- load ---'; uptime 2>/dev/null || true; "
+            "echo '=== end ==='"
+        )
+    else:
+        script = common + (
+            "echo '--- ps auxf (top 60 by cpu) ---'; ps auxf --sort=-pcpu 2>/dev/null | head -60; "
+            f"echo '--- pstree of self ---'; pstree -plau {os.getpid()} 2>/dev/null | head -40 || true; "
+            "echo '--- /proc/loadavg ---'; cat /proc/loadavg 2>/dev/null || true; "
+            "echo '--- recent dmesg (oom/killed) ---'; "
+            "dmesg -T 2>/dev/null | tail -20 || journalctl --user -n 20 --no-pager 2>/dev/null | tail -20 || true; "
+            "echo '=== end ==='"
+        )
     try:  # O_APPEND so concurrent diagnostics from rapid signals don't trample each other
         fd = os.open(str(log_path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
     except OSError:
         return None
+    # Python wait-timeout instead of GNU `timeout` (absent on stock macOS).
+    helper = (
+        "import os, signal, subprocess, sys\n"
+        "p = subprocess.Popen(['bash', '-c', sys.argv[1]], start_new_session=True)\n"
+        "try:\n"
+        "    p.wait(timeout=float(sys.argv[2]))\n"
+        "except subprocess.TimeoutExpired:\n"
+        "    try:\n"
+        "        os.killpg(p.pid, signal.SIGKILL)\n"  # windows-footgun: ok -- helper only after Windows early return
+        "    except ProcessLookupError:\n"
+        "        pass\n"
+        "    p.wait()\n"
+    )
     try:  # start_new_session: outlive systemd killing our cgroup (KillMode=control-group) to flush
         return subprocess.Popen(
-            ["timeout", f"{timeout_seconds:.0f}", "bash", "-c", script], stdout=fd,
+            [sys.executable, "-c", helper, script, str(timeout_seconds)], stdout=fd,
             stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL, start_new_session=True,
             close_fds=True).pid
     except OSError:

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import json
 import os
 import signal
+import subprocess
 import sys
 import time
-from pathlib import Path
 
 import pytest
 
@@ -115,6 +115,58 @@ class TestSpawnAsyncDiagnostic:
         assert "shutdown diagnostic" in contents
         assert "SIGTERM" in contents
 
+    def test_darwin_uses_portable_process_commands(self, tmp_path, monkeypatch):
+        captured = {}
+
+        class FakeProcess:
+            pid = 4242
+
+        def fake_popen(args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return FakeProcess()
+
+        monkeypatch.setattr(sf.sys, "platform", "darwin")
+        monkeypatch.setattr(sf.subprocess, "Popen", fake_popen)
+
+        assert sf.spawn_async_diagnostic(tmp_path / "diag.log", "SIGTERM") == 4242
+        script = captured["args"][3]
+        assert "ps -Ao pid,ppid,state,pcpu,pmem,command -r" in script
+        assert "uptime" in script
+        assert "ps auxf --sort=-pcpu" not in script
+        assert "pstree" not in script
+        assert captured["kwargs"]["start_new_session"] is True
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups required")
+    def test_timeout_helper_kills_wedged_process_group(self, tmp_path, monkeypatch):
+        captured = {}
+
+        class FakeProcess:
+            pid = 4242
+
+        def fake_popen(args, **kwargs):
+            captured["args"] = args
+            return FakeProcess()
+
+        # Capture the exact helper passed to Hermes' Python without launching it.
+        with monkeypatch.context() as patcher:
+            patcher.setattr(sf.subprocess, "Popen", fake_popen)
+            assert sf.spawn_async_diagnostic(
+                tmp_path / "diag.log", "SIGTERM", timeout_seconds=0.1
+            ) == 4242
+
+        helper = captured["args"][2]
+        start = time.monotonic()
+        result = subprocess.run(
+            [sys.executable, "-c", helper, "sleep 30", "0.1"],
+            capture_output=True,
+            text=True,
+            timeout=3.0,
+            check=False,
+        )
+        elapsed = time.monotonic() - start
+        assert result.returncode == 0, result.stderr
+        assert elapsed < 2.0, f"timeout helper failed to terminate promptly: {elapsed:.2f}s"
 
 # ---------------------------------------------------------------------------
 # _parse_systemd_duration_to_us

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import json
 import os
 import signal
+import subprocess
+import sys
 import time
-from pathlib import Path
 
 import pytest
 
@@ -119,6 +120,58 @@ class TestSpawnAsyncDiagnostic:
         assert "shutdown diagnostic" in contents
         assert "SIGTERM" in contents
 
+    def test_darwin_uses_portable_process_commands(self, tmp_path, monkeypatch):
+        captured = {}
+
+        class FakeProcess:
+            pid = 4242
+
+        def fake_popen(args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return FakeProcess()
+
+        monkeypatch.setattr(sf.sys, "platform", "darwin")
+        monkeypatch.setattr(sf.subprocess, "Popen", fake_popen)
+
+        assert sf.spawn_async_diagnostic(tmp_path / "diag.log", "SIGTERM") == 4242
+        script = captured["args"][3]
+        assert "ps -Ao pid,ppid,state,pcpu,pmem,command -r" in script
+        assert "uptime" in script
+        assert "ps auxf --sort=-pcpu" not in script
+        assert "pstree" not in script
+        assert captured["kwargs"]["start_new_session"] is True
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups required")
+    def test_timeout_helper_kills_wedged_process_group(self, tmp_path, monkeypatch):
+        captured = {}
+
+        class FakeProcess:
+            pid = 4242
+
+        def fake_popen(args, **kwargs):
+            captured["args"] = args
+            return FakeProcess()
+
+        # Capture the exact helper passed to Hermes' Python without launching it.
+        with monkeypatch.context() as patcher:
+            patcher.setattr(sf.subprocess, "Popen", fake_popen)
+            assert sf.spawn_async_diagnostic(
+                tmp_path / "diag.log", "SIGTERM", timeout_seconds=0.1
+            ) == 4242
+
+        helper = captured["args"][2]
+        start = time.monotonic()
+        result = subprocess.run(
+            [sys.executable, "-c", helper, "sleep 30", "0.1"],
+            capture_output=True,
+            text=True,
+            timeout=3.0,
+            check=False,
+        )
+        elapsed = time.monotonic() - start
+        assert result.returncode == 0, result.stderr
+        assert elapsed < 2.0, f"timeout helper failed to terminate promptly: {elapsed:.2f}s"
 
 # ---------------------------------------------------------------------------
 # parse_systemd_duration_to_us

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -120,28 +120,6 @@ class TestSpawnAsyncDiagnostic:
         assert "shutdown diagnostic" in contents
         assert "SIGTERM" in contents
 
-    def test_darwin_uses_portable_process_commands(self, tmp_path, monkeypatch):
-        captured = {}
-
-        class FakeProcess:
-            pid = 4242
-
-        def fake_popen(args, **kwargs):
-            captured["args"] = args
-            captured["kwargs"] = kwargs
-            return FakeProcess()
-
-        monkeypatch.setattr(sf.sys, "platform", "darwin")
-        monkeypatch.setattr(sf.subprocess, "Popen", fake_popen)
-
-        assert sf.spawn_async_diagnostic(tmp_path / "diag.log", "SIGTERM") == 4242
-        script = captured["args"][3]
-        assert "ps -Ao pid,ppid,state,pcpu,pmem,command -r" in script
-        assert "uptime" in script
-        assert "ps auxf --sort=-pcpu" not in script
-        assert "pstree" not in script
-        assert captured["kwargs"]["start_new_session"] is True
-
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups required")
     def test_timeout_helper_kills_wedged_process_group(self, tmp_path, monkeypatch):
         captured = {}

--- a/tests/gateway/test_shutdown_native.py
+++ b/tests/gateway/test_shutdown_native.py
@@ -1,0 +1,29 @@
+"""Native macOS shutdown diagnostic contract."""
+import os
+import time
+
+import pytest
+
+from gateway.shutdown_forensics import spawn_async_diagnostic
+
+
+@pytest.mark.macos_only
+def test_native_diagnostic_without_coreutils(tmp_path, monkeypatch):
+    monkeypatch.setenv("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+    path = tmp_path / "diagnostic.log"
+    started = time.monotonic()
+    pid = spawn_async_diagnostic(path, "SIGTERM", timeout_seconds=2)
+    assert pid is not None, "stock macOS must not require GNU timeout"
+    assert time.monotonic() - started < 2
+    deadline = time.monotonic() + 5
+    contents = ""
+    while time.monotonic() < deadline:
+        contents = path.read_text(encoding="utf-8")
+        if "=== end ===" in contents:
+            break
+        time.sleep(0.05)
+    os.waitpid(pid, 0)
+    assert "=== end ===" in contents
+    assert "SIGTERM" in contents
+    assert str(os.getpid()) in contents
+    assert "load averages:" in contents


### PR DESCRIPTION
Run asynchronous shutdown diagnostics through a portable Python timeout wrapper and terminate the diagnostic process group when the deadline expires. Use ps output that works on Linux and macOS, with focused coverage for command construction, output, and timeout behavior.

Validated on macOS:
- shutdown-forensics suite: 12 passed
- focused Ruff checks passed
- live diagnostic smoke test completed and captured macOS process data