### PR TITLE
feat(mcp): generation-bound static lazy catalogs for zero-startup-cost MCP servers

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -26,6 +26,7 @@ import sys
 import threading
 import time
 import uuid
+from copy import deepcopy
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import parse_qs, urlparse, urlunparse
@@ -1390,12 +1391,32 @@ def init_agent(
         agent._tool_snapshot_generation = _snapshot_registry._generation
     except Exception:
         agent._tool_snapshot_generation = 0
-    agent.tools = _ra().get_tool_definitions(
+    raw_tool_defs = _ra().get_tool_definitions(
         enabled_toolsets=enabled_toolsets,
         disabled_toolsets=disabled_toolsets,
-        quiet_mode=agent.quiet_mode,
+        quiet_mode=True,
+        skip_tool_search_assembly=True,
     )
-    
+    agent._deferred_tool_defs_snapshot = deepcopy(raw_tool_defs or [])
+    raw_tool_names = [
+        tool["function"]["name"]
+        for tool in (raw_tool_defs or [])
+    ]
+    from tools.mcp_tool import (
+        get_static_lazy_tool_generations,
+        has_static_lazy_mcp_catalogs,
+    )
+
+    agent._deferred_tool_snapshot_locked = has_static_lazy_mcp_catalogs()
+    agent._deferred_tool_generations_snapshot = get_static_lazy_tool_generations(
+        raw_tool_names
+    )
+    from model_tools import assemble_tool_search_definitions
+
+    agent.tools = assemble_tool_search_definitions(
+        raw_tool_defs or [], quiet_mode=agent.quiet_mode
+    )
+
     # Show tool configuration and store valid tool names for validation
     agent.valid_tool_names = set()
     if agent.tools:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2694,6 +2694,12 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 skip_tool_request_middleware=True,
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                deferred_tool_defs=getattr(
+                    agent, "_deferred_tool_defs_snapshot", None
+                ),
+                deferred_tool_generations=getattr(
+                    agent, "_deferred_tool_generations_snapshot", None
+                ),
                 tool_request_middleware_trace=list(_tool_middleware_trace),
             )
             if skip_tool_execution_middleware:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -255,16 +255,25 @@ def _tool_search_scoped_names(agent) -> frozenset:
     set: the deferrable subset of the session's own enabled/disabled toolset
     scope.
 
-    Result is cached on the agent and refreshed when the tool registry's
-    generation changes (e.g. an MCP server reconnects), so the common case is
-    a dict lookup, not a full tool-defs rebuild on every tool call.
+    Current agents pin the pre-assembly definitions at initialization. Older
+    and external agent doubles without that attribute retain the live-registry
+    fallback for compatibility.
     """
     try:
         import model_tools
         from tools import tool_search as _ts
-        from tools.registry import registry as _registry
     except Exception:
         return frozenset()
+
+    snapshot = getattr(agent, "_deferred_tool_defs_snapshot", None)
+    if snapshot is not None:
+        cached = getattr(agent, "_deferred_tool_names_snapshot", None)
+        if cached is None:
+            cached = _ts.scoped_deferrable_names(snapshot)
+            agent._deferred_tool_names_snapshot = cached
+        return cached
+
+    from tools.registry import registry as _registry
 
     enabled = getattr(agent, "enabled_toolsets", None)
     disabled = getattr(agent, "disabled_toolsets", None)
@@ -711,7 +720,13 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         # Probe-validate before unwrapping (ironclaw#5149):
                         # missing required args return the parameter schema
                         # instead of dispatching into an opaque failure.
-                        _probe_err = _ts.validate_deferred_call_args(_underlying, _underlying_args)
+                        _probe_err = _ts.validate_deferred_call_args(
+                            _underlying,
+                            _underlying_args,
+                            current_tool_defs=getattr(
+                                agent, "_deferred_tool_defs_snapshot", None
+                            ),
+                        )
                         if _probe_err is not None:
                             _ts_scope_block = _probe_err
                         else:
@@ -1385,7 +1400,13 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                         # Probe-validate before unwrapping (ironclaw#5149):
                         # missing required args return the parameter schema
                         # instead of dispatching into an opaque failure.
-                        _probe_err = _ts.validate_deferred_call_args(_underlying, _underlying_args)
+                        _probe_err = _ts.validate_deferred_call_args(
+                            _underlying,
+                            _underlying_args,
+                            current_tool_defs=getattr(
+                                agent, "_deferred_tool_defs_snapshot", None
+                            ),
+                        )
                         if _probe_err is not None:
                             # This path wraps _block_msg in {"error": ...} —
                             # flatten the probe payload to one plain string.
@@ -1691,6 +1712,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                         tool_request_middleware_trace=list(middleware_trace),
                         enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                         disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                        deferred_tool_defs=getattr(
+                            agent, "_deferred_tool_defs_snapshot", None
+                        ),
+                        deferred_tool_generations=getattr(
+                            agent, "_deferred_tool_generations_snapshot", None
+                        ),
                     )
 
                 (
@@ -1761,6 +1788,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                         tool_request_middleware_trace=list(middleware_trace),
                         enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                         disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                        deferred_tool_defs=getattr(
+                            agent, "_deferred_tool_defs_snapshot", None
+                        ),
+                        deferred_tool_generations=getattr(
+                            agent, "_deferred_tool_generations_snapshot", None
+                        ),
                     )
 
                 (

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -1068,6 +1068,55 @@ def cmd_mcp_configure(args):
     _info("Start a new session for changes to take effect.")
 
 
+# ─── Static lazy-catalog snapshots ──────────────────────────────────────────
+
+def cmd_mcp_snapshot(args):
+    """Explicitly refresh generation-bound tool snapshots for lazy MCPs."""
+    from tools.mcp_tool import _parse_boolish, refresh_mcp_static_catalog
+
+    servers = _get_mcp_servers()
+    refresh_all = bool(getattr(args, "snapshot_all", False))
+    requested = str(getattr(args, "name", None) or "")
+    if not refresh_all and not requested:
+        _error("Specify a server name or pass --all")
+        raise SystemExit(2)
+
+    if refresh_all:
+        targets = [
+            (name, config)
+            for name, config in servers.items()
+            if _parse_boolish(config.get("enabled", True), default=True)
+        ]
+    else:
+        config = servers.get(requested)
+        if config is None:
+            _error(f"MCP server '{requested}' is not configured")
+            raise SystemExit(2)
+        targets = [(requested, config)]
+
+    if not targets:
+        _warning("No enabled MCP servers to snapshot")
+        return
+
+    failures = 0
+    for name, config in targets:
+        _info(f"Refreshing static MCP snapshot for '{name}'...")
+        try:
+            catalog = refresh_mcp_static_catalog(name, config)
+        except Exception as exc:
+            failures += 1
+            _error(f"{name}: {exc}")
+            continue
+        generation = catalog["generation"].removeprefix("sha256:")[:12]
+        _success(
+            f"{name}: {len(catalog['tools'])} tools, generation {generation}"
+        )
+
+    if failures:
+        raise SystemExit(1)
+    _info("Start a new session to use the refreshed snapshot.")
+
+
 # ─── Dispatcher ───────────────────────────────────────────────────────────────
 
 def mcp_command(args):
@@ -1108,6 +1157,7 @@ def mcp_command(args):
         "config": cmd_mcp_configure,
         "login": cmd_mcp_login,
         "reauth": cmd_mcp_reauth,
+        "snapshot": cmd_mcp_snapshot,
     }
 
     handler = handlers.get(action)
@@ -1132,4 +1182,5 @@ def mcp_command(args):
         _info("hermes mcp configure <name>                   Toggle tools")
         _info("hermes mcp login <name>                       Re-authenticate OAuth")
         _info("hermes mcp reauth <name> | --all              Re-auth one or all OAuth servers")
+        _info("hermes mcp snapshot <name> | --all            Refresh lazy tool snapshots")
         print()

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -104,6 +104,22 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
         help="Re-authenticate every OAuth server in config, one at a time",
     )
 
+    mcp_snapshot_p = mcp_sub.add_parser(
+        "snapshot",
+        help="Refresh static tool schemas for lazy MCP startup",
+    )
+    mcp_snapshot_p.add_argument(
+        "name",
+        nargs="?",
+        help="Configured MCP server name (omit with --all)",
+    )
+    mcp_snapshot_p.add_argument(
+        "--all",
+        action="store_true",
+        dest="snapshot_all",
+        help="Refresh snapshots for every enabled MCP server",
+    )
+
     # ── Catalog (Nous-approved MCPs shipped with the repo) ─────────────────
     mcp_sub.add_parser(
         "picker",

--- a/model_tools.py
+++ b/model_tools.py
@@ -548,23 +548,29 @@ def _compute_tool_definitions(
     except Exception as e:  # pragma: no cover — defensive
         logger.warning("Schema sanitization skipped: %s", e)
 
-    # ── Tool Search (progressive disclosure) ────────────────────────────
-    # Conditionally replace MCP + plugin (non-core) tools with three bridge
-    # tools (tool_search / tool_describe / tool_call) when the deferrable
-    # surface exceeds the configured threshold (default 10% of context
-    # window). Core Hermes tools (toolsets._HERMES_CORE_TOOLS) are NEVER
-    # deferred. See tools/tool_search.py for full design notes.
-    #
-    # This is deliberately the last step before returning — sanitization
-    # has already normalized schemas, and the assembly is idempotent in
-    # case some caller invokes get_tool_definitions twice.
+    if not skip_tool_search_assembly:
+        filtered_tools = assemble_tool_search_definitions(
+            filtered_tools,
+            quiet_mode=quiet_mode,
+        )
+
+    return filtered_tools
+
+
+def assemble_tool_search_definitions(
+    tool_defs: List[Dict[str, Any]],
+    *,
+    quiet_mode: bool = False,
+) -> List[Dict[str, Any]]:
+    """Apply progressive disclosure to an already-scoped raw tool snapshot."""
+    assembled_defs = tool_defs
     try:
         from tools.tool_search import assemble_tool_defs, load_config as _load_ts_config
         ts_cfg = _load_ts_config()
-        if not skip_tool_search_assembly and ts_cfg.enabled != "off":
+        if ts_cfg.enabled != "off":
             context_length = _resolve_active_context_length()
             assembly = assemble_tool_defs(
-                filtered_tools,
+                assembled_defs,
                 context_length=context_length,
                 config=ts_cfg,
             )
@@ -579,11 +585,10 @@ def _compute_tool_definitions(
                     f"MCP/plugin tools deferred (~{assembly.deferred_tokens} tokens) behind "
                     f"tool_search/describe/call — {_forms.get(assembly.listing_form, assembly.listing_form)}."
                 )
-            filtered_tools = assembly.tool_defs
+            assembled_defs = assembly.tool_defs
     except Exception as e:  # pragma: no cover — never break tool loading
         logger.warning("Tool search assembly skipped: %s", e)
-
-    return filtered_tools
+    return assembled_defs
 
 
 def _resolve_active_context_length() -> int:
@@ -702,7 +707,12 @@ def _sanitize_tool_error(error_msg: str) -> str:
 # Tool argument type coercion
 # =========================================================================
 
-def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
+def coerce_tool_args(
+    tool_name: str,
+    args: Dict[str, Any],
+    *,
+    schema_override: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """Coerce tool call arguments to match their JSON Schema types.
 
     LLMs frequently return numbers as strings (``"42"`` instead of ``42``)
@@ -723,7 +733,7 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
     if not args or not isinstance(args, dict):
         return args
 
-    schema = registry.get_schema(tool_name)
+    schema = schema_override or registry.get_schema(tool_name)
     if not schema:
         return args
 
@@ -1097,6 +1107,8 @@ def handle_function_call(
     tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
+    deferred_tool_defs: Optional[List[Dict[str, Any]]] = None,
+    deferred_tool_generations: Optional[Dict[str, str]] = None,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -1118,12 +1130,30 @@ def handle_function_call(
                        matching ``get_tool_definitions`` semantics.
         disabled_toolsets: The session's disabled toolsets, applied as a
                        subtraction when scoping the bridge catalog.
+        deferred_tool_defs: Optional immutable pre-assembly tool snapshot for
+                       this session. When supplied, deferred discovery and
+                       invocation authorization do not consult live registry
+                       mutations.
+        deferred_tool_generations: Hidden session mapping from static lazy MCP
+                       tool names to their pinned catalog generation.
 
     Returns:
         Function result as a JSON string.
     """
-    # Coerce string arguments to their schema-declared types (e.g. "42"→42)
-    function_args = coerce_tool_args(function_name, function_args)
+    # Coerce against the schema the session actually saw. Falling back to the
+    # live registry is retained for non-agent callers and legacy direct tools.
+    _coercion_schema = None
+    if deferred_tool_defs is not None:
+        for _tool_def in deferred_tool_defs:
+            _fn = _tool_def.get("function", _tool_def)
+            if isinstance(_fn, dict) and _fn.get("name") == function_name:
+                _coercion_schema = _fn
+                break
+    function_args = coerce_tool_args(
+        function_name,
+        function_args,
+        schema_override=_coercion_schema,
+    )
     if not isinstance(function_args, dict):
         function_args = {}
     _tool_middleware_trace = list(tool_request_middleware_trace or [])
@@ -1140,27 +1170,30 @@ def handle_function_call(
         _ts_mod = None
 
     if _ts_mod is not None and _ts_mod.is_bridge_tool(function_name):
-        try:
-            # Use skip_tool_search_assembly=True so we see the real catalog,
-            # not the already-collapsed bridge-only list (the bridge would
-            # otherwise be searching only itself).
-            #
-            # Scope the catalog to the session's toolsets so the bridge can
-            # only surface and invoke tools the session was actually granted.
-            # Without this, a restricted-toolset session (subagent, kanban
-            # worker, curated gateway session) would see and be able to call
-            # the entire process registry via the bridge. Passing the same
-            # enabled/disabled toolsets the session was assembled with keeps
-            # the deferred catalog identical to the deferrable subset of the
-            # session's own tool list, and avoids polluting the process-global
-            # _last_resolved_tool_names with out-of-scope tools.
-            current_defs = get_tool_definitions(
-                enabled_toolsets=enabled_toolsets,
-                disabled_toolsets=disabled_toolsets,
-                quiet_mode=True, skip_tool_search_assembly=True,
-            ) or []
-        except Exception:
-            current_defs = []
+        if deferred_tool_defs is not None:
+            current_defs = deferred_tool_defs
+        else:
+            try:
+                # Use skip_tool_search_assembly=True so we see the real catalog,
+                # not the already-collapsed bridge-only list (the bridge would
+                # otherwise be searching only itself).
+                #
+                # Scope the catalog to the session's toolsets so the bridge can
+                # only surface and invoke tools the session was actually granted.
+                # Without this, a restricted-toolset session (subagent, kanban
+                # worker, curated gateway session) would see and be able to call
+                # the entire process registry via the bridge. Passing the same
+                # enabled/disabled toolsets the session was assembled with keeps
+                # the deferred catalog identical to the deferrable subset of the
+                # session's own tool list, and avoids polluting the process-global
+                # _last_resolved_tool_names with out-of-scope tools.
+                current_defs = get_tool_definitions(
+                    enabled_toolsets=enabled_toolsets,
+                    disabled_toolsets=disabled_toolsets,
+                    quiet_mode=True, skip_tool_search_assembly=True,
+                ) or []
+            except Exception:
+                current_defs = []
         if function_name == _ts_mod.TOOL_SEARCH_NAME:
             return _ts_mod.dispatch_tool_search(function_args or {},
                                                 current_tool_defs=current_defs)
@@ -1189,7 +1222,11 @@ def handle_function_call(
             # Probe-validate against the deferred tool's schema (ironclaw#5149):
             # a blind call missing required arguments returns the parameter
             # schema instead of dispatching into an opaque downstream failure.
-            _probe_err = _ts_mod.validate_deferred_call_args(underlying_name, underlying_args)
+            _probe_err = _ts_mod.validate_deferred_call_args(
+                underlying_name,
+                underlying_args,
+                current_tool_defs=current_defs,
+            )
             if _probe_err is not None:
                 return _probe_err
             # Recurse with the underlying tool. All hooks fire against the
@@ -1208,6 +1245,8 @@ def handle_function_call(
                 tool_request_middleware_trace=list(_tool_middleware_trace),
                 enabled_toolsets=enabled_toolsets,
                 disabled_toolsets=disabled_toolsets,
+                deferred_tool_defs=deferred_tool_defs,
+                deferred_tool_generations=deferred_tool_generations,
             )
 
     _tool_original_args = dict(function_args)
@@ -1337,12 +1376,19 @@ def handle_function_call(
                     )
             else:
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
-                    return registry.dispatch(
-                        function_name, next_args,
-                        task_id=task_id,
-                        session_id=session_id,
-                        user_task=user_task,
+                    dispatch_kwargs = {
+                        "task_id": task_id,
+                        "session_id": session_id,
+                        "user_task": user_task,
+                    }
+                    expected_generation = (deferred_tool_generations or {}).get(
+                        function_name
                     )
+                    if expected_generation is not None:
+                        dispatch_kwargs["_deferred_catalog_generation"] = (
+                            expected_generation
+                        )
+                    return registry.dispatch(function_name, next_args, **dispatch_kwargs)
             if skip_tool_execution_middleware:
                 result = _dispatch(function_args)
             else:

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -1049,3 +1049,51 @@ class TestMcpReauth:
         cmd_mcp_reauth(_make_args(name="ghost", all=False))
         out = capsys.readouterr().out
         assert "not found" in out
+
+
+class TestMcpSnapshot:
+    def test_snapshot_one_server(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {
+            "docs": {"url": "https://docs.example.com/mcp", "lazy_connect": True},
+        })
+        from tools import mcp_tool
+
+        visited = []
+        monkeypatch.setattr(
+            mcp_tool,
+            "refresh_mcp_static_catalog",
+            lambda name, config: visited.append((name, config)) or {
+                "generation": "sha256:" + "a" * 64,
+                "tools": [{"registry_name": "mcp__docs__lookup"}],
+            },
+        )
+        from hermes_cli.mcp_config import cmd_mcp_snapshot
+
+        cmd_mcp_snapshot(_make_args(name="docs", snapshot_all=False))
+        out = capsys.readouterr().out
+
+        assert [name for name, _ in visited] == ["docs"]
+        assert "1 tools" in out
+        assert "aaaaaaaaaaaa" in out
+        assert "new session" in out
+
+    def test_snapshot_all_skips_disabled_servers(self, tmp_path, monkeypatch):
+        _seed_config(tmp_path, {
+            "enabled": {"url": "https://one.example.com/mcp"},
+            "disabled": {"url": "https://two.example.com/mcp", "enabled": False},
+        })
+        from tools import mcp_tool
+
+        visited = []
+        monkeypatch.setattr(
+            mcp_tool,
+            "refresh_mcp_static_catalog",
+            lambda name, config: visited.append(name) or {
+                "generation": "sha256:" + "b" * 64,
+                "tools": [],
+            },
+        )
+        from hermes_cli.mcp_config import cmd_mcp_snapshot
+
+        cmd_mcp_snapshot(_make_args(name=None, snapshot_all=True))
+        assert visited == ["enabled"]

--- a/tests/tools/test_mcp_dynamic_discovery.py
+++ b/tests/tools/test_mcp_dynamic_discovery.py
@@ -75,6 +75,54 @@ class TestRefreshTools:
             assert "mcp__live_srv__new_tool" in resolve_toolset("live_srv")
             assert server._registered_tool_names == ["mcp__live_srv__new_tool"]
 
+    @pytest.mark.asyncio
+    async def test_static_catalog_marks_stale_without_mutating_registry(self, mock_registry):
+        from tools.mcp_static_catalog import build_catalog
+
+        server = MCPServerTask("static_srv")
+        server._refresh_lock = asyncio.Lock()
+        server._config = {"tools": {"resources": False, "prompts": False}}
+        old_tool = _make_mcp_tool("old_tool", "old behavior")
+        server._tools = [old_tool]
+        expected = build_catalog(
+            "static_srv",
+            [
+                {
+                    "registry_name": "mcp__static_srv__old_tool",
+                    "remote_name": "old_tool",
+                    "kind": "tool",
+                    "schema": {
+                        "name": "mcp__static_srv__old_tool",
+                        "description": "old behavior",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+        )
+        server._static_catalog_generation = expected["generation"]
+
+        mock_registry.register(
+            name="mcp__static_srv__old_tool",
+            toolset="mcp-static_srv",
+            schema={},
+            handler=lambda x: x,
+        )
+        server._registered_tool_names = ["mcp__static_srv__old_tool"]
+        server.session = SimpleNamespace(
+            list_tools=AsyncMock(
+                return_value=SimpleNamespace(
+                    tools=[_make_mcp_tool("new_tool", "new behavior")]
+                )
+            )
+        )
+
+        with patch("tools.registry.registry", mock_registry):
+            await server._refresh_tools()
+
+        assert "mcp__static_srv__old_tool" in mock_registry.get_all_tool_names()
+        assert "mcp__static_srv__new_tool" not in mock_registry.get_all_tool_names()
+        assert server._static_catalog_stale is True
+
 
 class TestMessageHandler:
     """Tests for MCPServerTask._make_message_handler dispatch."""

--- a/tests/tools/test_mcp_lazy_catalog.py
+++ b/tests/tools/test_mcp_lazy_catalog.py
@@ -1,0 +1,457 @@
+import asyncio
+import json
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+
+SERVER = "lazy-catalog-test"
+REMOTE_TOOL = "lookup"
+REGISTRY_TOOL = "mcp__lazy_catalog_test__lookup"
+
+
+def _mcp_tool(
+    *,
+    description="Look up documentation",
+    output_schema=None,
+    annotations=None,
+):
+    return SimpleNamespace(
+        name=REMOTE_TOOL,
+        description=description,
+        inputSchema={
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+        outputSchema=output_schema,
+        annotations=annotations,
+    )
+
+
+def _catalog_entry(*, description="Look up documentation"):
+    return {
+        "registry_name": REGISTRY_TOOL,
+        "remote_name": REMOTE_TOOL,
+        "kind": "tool",
+        "schema": {
+            "name": REGISTRY_TOOL,
+            "description": description,
+            "parameters": _mcp_tool(description=description).inputSchema,
+        },
+    }
+
+
+def _config():
+    return {
+        "enabled": True,
+        "lazy_connect": True,
+        "url": "http://127.0.0.1:65530/mcp",
+        "tools": {"resources": False, "prompts": False},
+        "connect_timeout": 1,
+    }
+
+
+class _FakeServer:
+    def __init__(self, *, description="Look up documentation"):
+        self.name = SERVER
+        self._tools = [_mcp_tool(description=description)]
+        self.tool_timeout = 1
+        self.session = object()
+        self.initialize_result = None
+        self.shutdown_calls = 0
+
+    async def shutdown(self):
+        self.shutdown_calls += 1
+
+
+@pytest.fixture(autouse=True)
+def _clean_lazy_state():
+    from tools import mcp_tool
+    from tools.registry import registry
+
+    registry.deregister(REGISTRY_TOOL)
+    mcp_tool._lazy_server_configs.pop(SERVER, None)
+    mcp_tool._lazy_server_catalogs.pop(SERVER, None)
+    mcp_tool._lazy_registered_names.pop(SERVER, None)
+    mcp_tool._lazy_connect_failures.pop(SERVER, None)
+    mcp_tool._lazy_connect_locks.pop(SERVER, None)
+    with mcp_tool._lock:
+        mcp_tool._servers.pop(SERVER, None)
+    yield
+    registry.deregister(REGISTRY_TOOL)
+    mcp_tool._lazy_server_configs.pop(SERVER, None)
+    mcp_tool._lazy_server_catalogs.pop(SERVER, None)
+    mcp_tool._lazy_registered_names.pop(SERVER, None)
+    mcp_tool._lazy_connect_failures.pop(SERVER, None)
+    mcp_tool._lazy_connect_locks.pop(SERVER, None)
+    with mcp_tool._lock:
+        mcp_tool._servers.pop(SERVER, None)
+
+
+def _write_catalog():
+    from tools.mcp_static_catalog import build_catalog, write_catalog
+
+    catalog = build_catalog(SERVER, [_catalog_entry()])
+    write_catalog(catalog)
+    return catalog
+
+
+def test_lazy_registration_uses_static_catalog_without_connecting(monkeypatch):
+    from tools import mcp_tool
+    from tools.registry import registry
+
+    _write_catalog()
+    monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", True)
+
+    def _must_not_start_loop():
+        raise AssertionError("lazy registration started the MCP loop")
+
+    monkeypatch.setattr(mcp_tool, "_ensure_mcp_loop", _must_not_start_loop)
+    registered = mcp_tool.register_mcp_servers({SERVER: _config()})
+
+    assert REGISTRY_TOOL in registered
+    assert registry.get_toolset_for_tool(REGISTRY_TOOL) == f"mcp-{SERVER}"
+    assert SERVER not in mcp_tool._servers
+    assert SERVER in mcp_tool._lazy_server_configs
+
+
+def test_lazy_catalog_is_internal_but_not_model_visible(monkeypatch):
+    import model_tools
+    from tools import mcp_tool
+
+    _write_catalog()
+    monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", True)
+    mcp_tool.register_mcp_servers({SERVER: _config()})
+
+    raw = model_tools.get_tool_definitions(
+        enabled_toolsets=[f"mcp-{SERVER}"],
+        quiet_mode=True,
+        skip_tool_search_assembly=True,
+    )
+    visible = model_tools.get_tool_definitions(
+        enabled_toolsets=[f"mcp-{SERVER}"],
+        quiet_mode=True,
+    )
+    raw_names = {item["function"]["name"] for item in raw}
+    visible_names = {item["function"]["name"] for item in visible}
+
+    assert REGISTRY_TOOL in raw_names
+    assert REGISTRY_TOOL not in visible_names
+    assert {"tool_search", "tool_describe", "tool_call"} <= visible_names
+
+
+def test_shutdown_removes_lazy_placeholders_and_state(monkeypatch):
+    from tools import mcp_tool
+    from tools.registry import registry
+
+    _write_catalog()
+    monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", True)
+    mcp_tool.register_mcp_servers({SERVER: _config()})
+
+    mcp_tool.shutdown_mcp_servers()
+
+    assert REGISTRY_TOOL not in registry.get_all_tool_names()
+    assert SERVER not in mcp_tool._lazy_server_catalogs
+    assert SERVER not in mcp_tool._lazy_server_configs
+    assert SERVER not in mcp_tool._lazy_registered_names
+
+
+def test_transport_outage_preserves_static_catalog_placeholder(monkeypatch):
+    from tools import mcp_tool
+    from tools.registry import registry
+
+    _write_catalog()
+    monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", True)
+    mcp_tool.register_mcp_servers({SERVER: _config()})
+    task = mcp_tool.MCPServerTask(SERVER)
+    task._static_catalog_generation = "sha256:pinned"
+    task._registered_tool_names = [REGISTRY_TOOL]
+
+    task._deregister_tools()
+
+    assert REGISTRY_TOOL in registry.get_all_tool_names()
+    assert task._registered_tool_names == [REGISTRY_TOOL]
+
+
+def test_session_generation_rejects_replaced_registry_handler(monkeypatch):
+    import model_tools
+    from tools import mcp_tool
+    from tools.mcp_static_catalog import build_catalog, write_catalog
+
+    catalog_a = _write_catalog()
+    monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", True)
+    mcp_tool.register_mcp_servers({SERVER: _config()})
+    snapshot_a = model_tools.get_tool_definitions(
+        enabled_toolsets=[f"mcp-{SERVER}"],
+        quiet_mode=True,
+        skip_tool_search_assembly=True,
+    )
+
+    catalog_b = build_catalog(
+        SERVER,
+        [{
+            "registry_name": REGISTRY_TOOL,
+            "remote_name": REMOTE_TOOL,
+            "kind": "tool",
+            "schema": {
+                "name": REGISTRY_TOOL,
+                "description": "Generation B",
+                "parameters": _mcp_tool().inputSchema,
+            },
+        }],
+    )
+    write_catalog(catalog_b)
+    mcp_tool.register_mcp_servers({SERVER: _config()})
+
+    async def _must_not_connect(name, config):
+        raise AssertionError("stale session attempted to connect generation B")
+
+    monkeypatch.setattr(mcp_tool, "_connect_server", _must_not_connect)
+    result = json.loads(model_tools.handle_function_call(
+        function_name="tool_call",
+        function_args={"name": REGISTRY_TOOL, "arguments": {"query": "x"}},
+        enabled_toolsets=[f"mcp-{SERVER}"],
+        deferred_tool_defs=snapshot_a,
+        deferred_tool_generations={REGISTRY_TOOL: catalog_a["generation"]},
+    ))
+
+    assert result["error_type"] == "mcp_catalog_stale"
+    assert "new session" in result["error"].lower()
+
+
+def test_lazy_server_without_catalog_stays_disconnected_and_unregistered(monkeypatch):
+    from tools import mcp_tool
+    from tools.registry import registry
+
+    monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", True)
+    monkeypatch.setattr(
+        mcp_tool,
+        "_ensure_mcp_loop",
+        lambda: (_ for _ in ()).throw(AssertionError("MCP loop started")),
+    )
+
+    registered = mcp_tool.register_mcp_servers({SERVER: _config()})
+
+    assert REGISTRY_TOOL not in registered
+    assert registry.get_entry(REGISTRY_TOOL) is None
+    assert SERVER not in mcp_tool._servers
+
+
+def test_lazy_transport_secrets_are_resolved_only_at_connect(monkeypatch):
+    from tools import mcp_tool
+
+    secret_ref = "${HERMES_TEST_LAZY_SECRET}"
+    monkeypatch.setenv("HERMES_TEST_LAZY_SECRET", "startup-canary")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "mcp_servers": {
+                SERVER: {
+                    "url": "https://example.invalid/mcp",
+                    "headers": {"Authorization": f"Bearer {secret_ref}"},
+                    "lazy_connect": True,
+                }
+            }
+        },
+    )
+    loaded = mcp_tool._load_mcp_config()[SERVER]
+    assert loaded["headers"]["Authorization"] == f"Bearer {secret_ref}"
+
+    monkeypatch.setenv("HERMES_TEST_LAZY_SECRET", "first-call-canary")
+    captured = {}
+
+    class _Task:
+        def __init__(self, name):
+            self.name = name
+
+        async def start(self, config):
+            captured.update(config)
+
+    monkeypatch.setattr(mcp_tool, "MCPServerTask", _Task)
+    asyncio.run(mcp_tool._connect_server(SERVER, loaded))
+
+    assert captured["headers"]["Authorization"] == "Bearer first-call-canary"
+
+
+def test_concurrent_first_calls_connect_once_then_use_existing_handler(monkeypatch):
+    from tools import mcp_tool
+    from tools.registry import registry
+
+    _write_catalog()
+    monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", True)
+    calls = 0
+    calls_lock = threading.Lock()
+    server = _FakeServer()
+
+    async def _connect(name, config):
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+        await asyncio.sleep(0.05)
+        return server
+
+    monkeypatch.setattr(mcp_tool, "_connect_server", _connect)
+    monkeypatch.setattr(
+        mcp_tool,
+        "_make_tool_handler",
+        lambda server_name, remote_name, timeout: (
+            lambda args, **kwargs: json.dumps({"query": args["query"]})
+        ),
+    )
+    mcp_tool.register_mcp_servers({SERVER: _config()})
+
+    results = []
+
+    def _call(index):
+        results.append(json.loads(registry.dispatch(REGISTRY_TOOL, {"query": str(index)})))
+
+    threads = [threading.Thread(target=_call, args=(index,)) for index in range(6)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=3)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert calls == 1
+    assert len(results) == 6
+    assert SERVER in mcp_tool._servers
+
+
+def test_schema_drift_fails_closed_and_does_not_publish_server(monkeypatch):
+    from tools import mcp_tool
+    from tools.registry import registry
+
+    _write_catalog()
+    monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", True)
+    server = _FakeServer(description="Changed live schema")
+
+    async def _connect(name, config):
+        return server
+
+    monkeypatch.setattr(mcp_tool, "_connect_server", _connect)
+    mcp_tool.register_mcp_servers({SERVER: _config()})
+
+    result = json.loads(registry.dispatch(REGISTRY_TOOL, {"query": "x"}))
+
+    assert result["error_type"] == "mcp_catalog_stale"
+    assert "refresh" in result["error"].lower()
+    assert SERVER not in mcp_tool._servers
+    assert server.shutdown_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_reconnect_discovery_revalidates_static_generation():
+    from tools.mcp_tool import MCPServerTask
+
+    catalog = _write_catalog()
+    live_tool = _mcp_tool()
+
+    async def _list_tools():
+        return SimpleNamespace(tools=[live_tool], nextCursor=None)
+
+    task = MCPServerTask(SERVER)
+    task.session = SimpleNamespace(list_tools=_list_tools)
+    task.initialize_result = SimpleNamespace(
+        capabilities=SimpleNamespace(tools=object(), resources=None, prompts=None)
+    )
+    task._config = _config()
+    task._static_catalog_generation = catalog["generation"]
+    task._registered_tool_names = [REGISTRY_TOOL]
+
+    await task._discover_tools()
+    assert task._static_catalog_stale is False
+
+    live_tool = _mcp_tool(description="Changed after reconnect")
+    with pytest.raises(RuntimeError, match="no longer matches"):
+        await task._discover_tools()
+    assert task._static_catalog_stale is True
+
+
+@pytest.mark.asyncio
+async def test_reconnect_detects_output_schema_drift():
+    from tools import mcp_tool
+    from tools.mcp_static_catalog import build_catalog
+
+    initial_tool = _mcp_tool(output_schema={"type": "string"})
+    task = mcp_tool.MCPServerTask(SERVER)
+    task._config = _config()
+    task._tools = [initial_tool]
+    task._static_catalog_generation = build_catalog(
+        SERVER,
+        mcp_tool._catalog_entries_from_server(SERVER, task, _config()),
+    )["generation"]
+    task.initialize_result = SimpleNamespace(
+        capabilities=SimpleNamespace(tools=object(), resources=None, prompts=None)
+    )
+    task._registered_tool_names = [REGISTRY_TOOL]
+
+    async def _list_tools():
+        return SimpleNamespace(
+            tools=[_mcp_tool(output_schema={"type": "object"})],
+            nextCursor=None,
+        )
+
+    task.session = SimpleNamespace(list_tools=_list_tools)
+
+    with pytest.raises(RuntimeError, match="no longer matches"):
+        await task._discover_tools()
+    assert task._static_catalog_stale is True
+
+
+def test_failed_first_connect_is_cooled_down(monkeypatch):
+    from tools import mcp_tool
+    from tools.registry import registry
+
+    _write_catalog()
+    monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", True)
+    monkeypatch.setattr(mcp_tool, "_LAZY_CONNECT_FAILURE_COOLDOWN_S", 60)
+    calls = 0
+
+    async def _connect(name, config):
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("offline")
+
+    monkeypatch.setattr(mcp_tool, "_connect_server", _connect)
+    mcp_tool.register_mcp_servers({SERVER: _config()})
+
+    first = json.loads(registry.dispatch(REGISTRY_TOOL, {"query": "x"}))
+    second = json.loads(registry.dispatch(REGISTRY_TOOL, {"query": "y"}))
+
+    assert calls == 1
+    assert first["error_type"] == "mcp_lazy_connect_failed"
+    assert second["error_type"] == "mcp_lazy_connect_failed"
+    assert second == first
+
+    failed_at, error, generation = mcp_tool._lazy_connect_failures[SERVER]
+    mcp_tool._lazy_connect_failures[SERVER] = (
+        failed_at - 61, error, generation
+    )
+    third = json.loads(registry.dispatch(REGISTRY_TOOL, {"query": "z"}))
+    assert calls == 2
+    assert third["error_type"] == "mcp_lazy_connect_failed"
+
+
+def test_explicit_snapshot_refresh_connects_writes_and_closes(monkeypatch):
+    from tools import mcp_tool
+    from tools.mcp_static_catalog import load_catalog
+
+    monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", True)
+    server = _FakeServer()
+    calls = 0
+
+    async def _connect(name, config):
+        nonlocal calls
+        calls += 1
+        return server
+
+    monkeypatch.setattr(mcp_tool, "_connect_server", _connect)
+    catalog = mcp_tool.refresh_mcp_static_catalog(SERVER, _config())
+
+    assert calls == 1
+    assert server.shutdown_calls == 1
+    assert load_catalog(SERVER)["generation"] == catalog["generation"]
+    assert SERVER not in mcp_tool._servers

--- a/tests/tools/test_mcp_lazy_catalog_e2e.py
+++ b/tests/tools/test_mcp_lazy_catalog_e2e.py
@@ -1,0 +1,140 @@
+"""Fresh-process E2E coverage for generation-bound lazy MCP catalogs."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+import pytest
+import yaml
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_fresh_process_connects_static_mcp_only_on_first_call(tmp_path, monkeypatch):
+    pytest.importorskip("mcp.server.fastmcp")
+
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    marker = tmp_path / "server-started"
+    server_script = tmp_path / "lazy_server.py"
+    server_script.write_text(
+        textwrap.dedent(
+            """
+            import os
+            from pathlib import Path
+            from mcp.server.fastmcp import FastMCP
+
+            Path(os.environ["LAZY_MCP_MARKER"]).write_text(str(os.getpid()), encoding="utf-8")
+            mcp = FastMCP("lazy-e2e")
+
+            @mcp.tool()
+            def lazy_e2e_echo(value: str) -> str:
+                return f"lazy-e2e-ok:{value}"
+
+            if __name__ == "__main__":
+                mcp.run(transport="stdio")
+            """
+        ),
+        encoding="utf-8",
+    )
+    server_config = {
+        "enabled": True,
+        "lazy_connect": True,
+        "command": sys.executable,
+        "args": [str(server_script)],
+        "env": {"LAZY_MCP_MARKER": str(marker)},
+        "tools": {"resources": False, "prompts": False},
+    }
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"mcp_servers": {"lazy-e2e": server_config}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from tools.mcp_tool import refresh_mcp_static_catalog
+
+    catalog = refresh_mcp_static_catalog("lazy-e2e", server_config)
+    assert len(catalog["tools"]) == 1
+    assert marker.exists()
+    marker.unlink()
+
+    child = tmp_path / "fresh_child.py"
+    child.write_text(
+        textwrap.dedent(
+            """
+            import json
+            import os
+            from pathlib import Path
+            import sys
+            import yaml
+
+            repo_root, home, marker_arg = sys.argv[1:]
+            sys.path.insert(0, repo_root)
+            os.environ["HERMES_HOME"] = home
+            marker = Path(marker_arg)
+            config = yaml.safe_load((Path(home) / "config.yaml").read_text())["mcp_servers"]
+
+            from tools import mcp_tool
+            from tools.registry import registry
+            mcp_tool.register_mcp_servers(config)
+            startup_marker = marker.exists()
+            startup_connected = sorted(mcp_tool._servers)
+
+            import model_tools
+            raw = model_tools.get_tool_definitions(
+                enabled_toolsets=["mcp-lazy-e2e"],
+                quiet_mode=True,
+                skip_tool_search_assembly=True,
+            )
+            visible = model_tools.get_tool_definitions(
+                enabled_toolsets=["mcp-lazy-e2e"],
+                quiet_mode=True,
+            )
+            raw_names = [item["function"]["name"] for item in raw]
+            visible_names = [item["function"]["name"] for item in visible]
+            result = registry.dispatch(
+                "mcp__lazy_e2e__lazy_e2e_echo",
+                {"value": "probe"},
+            )
+            payload = {
+                "startup_marker": startup_marker,
+                "startup_connected": startup_connected,
+                "raw_names": raw_names,
+                "visible_names": visible_names,
+                "result": result,
+                "after_marker": marker.exists(),
+                "after_connected": sorted(mcp_tool._servers),
+            }
+            print(json.dumps(payload))
+            mcp_tool.shutdown_mcp_servers()
+            """
+        ),
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    env["PYTHONPATH"] = str(_REPO_ROOT)
+    completed = subprocess.run(
+        [sys.executable, str(child), str(_REPO_ROOT), str(hermes_home), str(marker)],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    payload = json.loads(completed.stdout.strip().splitlines()[-1])
+
+    assert payload["startup_marker"] is False
+    assert payload["startup_connected"] == []
+    assert "mcp__lazy_e2e__lazy_e2e_echo" in payload["raw_names"]
+    assert "mcp__lazy_e2e__lazy_e2e_echo" not in payload["visible_names"]
+    assert {"tool_search", "tool_describe", "tool_call"} <= set(payload["visible_names"])
+    assert "lazy-e2e-ok:probe" in payload["result"]
+    assert payload["after_marker"] is True
+    assert payload["after_connected"] == ["lazy-e2e"]

--- a/tests/tools/test_mcp_static_catalog.py
+++ b/tests/tools/test_mcp_static_catalog.py
@@ -1,0 +1,97 @@
+import json
+import stat
+
+import pytest
+
+
+def _entries():
+    return [
+        {
+            "registry_name": "mcp__docs__lookup",
+            "remote_name": "lookup",
+            "kind": "tool",
+            "schema": {
+                "name": "mcp__docs__lookup",
+                "description": "Look up documentation",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+            },
+        }
+    ]
+
+
+def test_catalog_round_trip_is_generation_bound_and_secret_free(tmp_path):
+    from tools.mcp_static_catalog import build_catalog, load_catalog, write_catalog
+
+    catalog = build_catalog("../docs server", _entries())
+    path = write_catalog(catalog, root=tmp_path)
+
+    assert path.parent == tmp_path
+    assert path.name.endswith(".json")
+    assert ".." not in path.name
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+    raw = path.read_text(encoding="utf-8")
+    assert "command" not in raw
+    assert "headers" not in raw
+    assert "env" not in raw
+    assert "token" not in raw.lower()
+
+    loaded = load_catalog("../docs server", root=tmp_path)
+    assert loaded == catalog
+    assert loaded["generation"].startswith("sha256:")
+
+
+def test_tampered_catalog_generation_is_rejected(tmp_path):
+    from tools.mcp_static_catalog import (
+        CatalogValidationError,
+        build_catalog,
+        catalog_path,
+        load_catalog,
+        write_catalog,
+    )
+
+    catalog = build_catalog("docs", _entries())
+    write_catalog(catalog, root=tmp_path)
+    path = catalog_path("docs", root=tmp_path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["tools"][0]["schema"]["description"] = "tampered"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(CatalogValidationError, match="generation"):
+        load_catalog("docs", root=tmp_path)
+
+
+def test_catalog_rejects_duplicate_names_and_unknown_fields():
+    from tools.mcp_static_catalog import CatalogValidationError, build_catalog
+
+    duplicate = _entries() + _entries()
+    with pytest.raises(CatalogValidationError, match="duplicate"):
+        build_catalog("docs", duplicate)
+
+    with_extra = _entries()
+    with_extra[0]["command"] = "steal-secret"
+    with pytest.raises(CatalogValidationError, match="unknown fields"):
+        build_catalog("docs", with_extra)
+
+
+def test_loading_wrong_server_catalog_is_rejected(tmp_path):
+    from tools.mcp_static_catalog import (
+        CatalogValidationError,
+        build_catalog,
+        catalog_path,
+        load_catalog,
+        write_catalog,
+    )
+
+    catalog = build_catalog("docs", _entries())
+    write_catalog(catalog, root=tmp_path)
+    source = catalog_path("docs", root=tmp_path)
+    target = catalog_path("other", root=tmp_path)
+    target.write_bytes(source.read_bytes())
+
+    with pytest.raises(CatalogValidationError, match="server"):
+        load_catalog("other", root=tmp_path)

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -61,6 +61,24 @@ def test_refresh_no_change_returns_empty_and_leaves_agent_untouched(monkeypatch)
     assert agent.tools is original_tools  # not replaced → no churn / no cache thrash
 
 
+def test_refresh_is_blocked_for_static_lazy_session(monkeypatch):
+    """A static-lazy session never swaps its model-visible tools array."""
+    agent = _agent(["read_file", "tool_search", "tool_describe", "tool_call"])
+    agent._deferred_tool_snapshot_locked = True
+    original_tools = agent.tools
+
+    import model_tools
+
+    monkeypatch.setattr(
+        model_tools,
+        "get_tool_definitions",
+        lambda **kw: (_ for _ in ()).throw(AssertionError("must not rebuild")),
+    )
+
+    assert mcp_tool.refresh_agent_mcp_tools(agent) == set()
+    assert agent.tools is original_tools
+
+
 def test_refresh_detects_equal_size_swap(monkeypatch):
     """Name-based diff catches an add+remove of equal count (count-compare can't)."""
     agent = _agent(["a", "old_mcp_tool"])  # 2 tools
@@ -77,6 +95,33 @@ def test_refresh_detects_equal_size_swap(monkeypatch):
     assert added == {"new_mcp_tool"}
     assert agent.valid_tool_names == {"a", "new_mcp_tool"}
     assert "old_mcp_tool" not in agent.valid_tool_names
+
+
+def test_refresh_publishes_matching_deferred_snapshot(monkeypatch):
+    agent = _agent(["read_file"])
+    agent._deferred_tool_defs_snapshot = [_tool("mcp_old")]
+    agent._deferred_tool_names_snapshot = {"mcp_old"}
+
+    import model_tools
+
+    monkeypatch.setattr(
+        model_tools,
+        "get_tool_definitions",
+        lambda **kw: [_tool("read_file"), _tool("mcp_fresh")],
+    )
+    monkeypatch.setattr(
+        model_tools,
+        "assemble_tool_search_definitions",
+        lambda defs, quiet_mode=False: defs,
+    )
+
+    assert mcp_tool.refresh_agent_mcp_tools(agent) == {"mcp_fresh"}
+    snapshot_names = {
+        tool["function"]["name"]
+        for tool in agent._deferred_tool_defs_snapshot
+    }
+    assert snapshot_names == {"read_file", "mcp_fresh"}
+    assert not hasattr(agent, "_deferred_tool_names_snapshot")
 
 
 def test_refresh_passes_agent_toolset_filters(monkeypatch):

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -629,6 +629,127 @@ class TestRegression_ToolsetScoping:
         assert "terminal" not in names
 
 
+class TestRegression_SessionCatalogSnapshot:
+    """Deferred discovery must stay fixed for the life of an agent session."""
+
+    @staticmethod
+    def _register(name, *, required=(), field_type="string"):
+        from tools.registry import registry
+
+        params = {
+            "type": "object",
+            "properties": {
+                field: {"type": field_type}
+                for field in required
+            },
+            "required": list(required),
+        }
+
+        def _handler(args, task_id=None, **kw):
+            return json.dumps({"ok": True, "tool": name, "args": args})
+
+        registry.register(
+            name=name,
+            handler=_handler,
+            schema={
+                "name": name,
+                "description": f"snapshot test {name}",
+                "parameters": params,
+            },
+            toolset="mcp-session-snapshot",
+        )
+
+    @staticmethod
+    def _snapshot():
+        import model_tools
+
+        return model_tools.get_tool_definitions(
+            enabled_toolsets=["mcp-session-snapshot"],
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+
+    def test_search_and_call_scope_ignore_tools_registered_after_snapshot(self):
+        import model_tools
+
+        self._register("mcp_session_snapshot_before")
+        snapshot = self._snapshot()
+        self._register("mcp_session_snapshot_after")
+
+        searched = json.loads(model_tools.handle_function_call(
+            function_name="tool_search",
+            function_args={"query": "session snapshot", "limit": 20},
+            enabled_toolsets=["mcp-session-snapshot"],
+            deferred_tool_defs=snapshot,
+        ))
+        hit_names = {entry["name"] for entry in searched["matches"]}
+        assert "mcp_session_snapshot_before" in hit_names
+        assert "mcp_session_snapshot_after" not in hit_names
+        assert searched["total_available"] == 1
+
+        rejected = json.loads(model_tools.handle_function_call(
+            function_name="tool_call",
+            function_args={
+                "name": "mcp_session_snapshot_after",
+                "arguments": {},
+            },
+            enabled_toolsets=["mcp-session-snapshot"],
+            deferred_tool_defs=snapshot,
+        ))
+        assert "not available in this session" in rejected["error"]
+
+    def test_argument_probe_uses_snapshot_schema_after_registry_changes(self):
+        import model_tools
+
+        name = "mcp_session_snapshot_schema"
+        self._register(name, required=("old_arg",))
+        snapshot = self._snapshot()
+        self._register(name, required=("new_arg",))
+
+        result = json.loads(model_tools.handle_function_call(
+            function_name="tool_call",
+            function_args={"name": name, "arguments": {}},
+            enabled_toolsets=["mcp-session-snapshot"],
+            deferred_tool_defs=snapshot,
+        ))
+        assert "old_arg" in result["error"]
+        assert "new_arg" not in result["error"]
+
+    def test_argument_coercion_uses_snapshot_schema_after_registry_changes(self):
+        import model_tools
+
+        name = "mcp_session_snapshot_coercion"
+        self._register(name, required=("count",), field_type="integer")
+        snapshot = self._snapshot()
+        self._register(name, required=("count",), field_type="string")
+
+        result = json.loads(model_tools.handle_function_call(
+            function_name="tool_call",
+            function_args={"name": name, "arguments": {"count": "42"}},
+            enabled_toolsets=["mcp-session-snapshot"],
+            deferred_tool_defs=snapshot,
+        ))
+        assert result["args"]["count"] == 42
+
+    def test_agent_executor_scope_uses_the_session_snapshot(self):
+        from agent.tool_executor import _tool_search_scoped_names
+
+        name = "mcp__snapshot_scope__original"
+        self._register(name)
+        snapshot = self._snapshot()
+
+        class Agent:
+            enabled_toolsets = None
+            disabled_toolsets = None
+            _deferred_tool_defs_snapshot = snapshot
+
+        agent = Agent()
+        names = _tool_search_scoped_names(agent)
+
+        assert name in names
+        assert not hasattr(agent, "_tool_search_scoped_cache")
+
+
 
 # ---------------------------------------------------------------------------
 # Catalog listing (skills-style progressive disclosure)

--- a/tools/mcp_static_catalog.py
+++ b/tools/mcp_static_catalog.py
@@ -229,7 +229,6 @@ def write_catalog(catalog: dict[str, Any], *, root: Path | None = None) -> Path:
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(temp_path, path)
-        os.chmod(path, 0o600)
         try:
             dir_fd = os.open(path.parent, os.O_RDONLY)
             try:

--- a/tools/mcp_static_catalog.py
+++ b/tools/mcp_static_catalog.py
@@ -1,0 +1,297 @@
+"""Generation-bound static manifests for truly lazy MCP servers.
+
+The manifest deliberately contains only tool routing metadata and schemas. MCP
+transport configuration (commands, URLs, headers, environment variables, and
+credentials) stays in config.yaml and is never serialized here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import stat
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from hermes_constants import get_hermes_home
+
+CATALOG_FORMAT_VERSION = 1
+MAX_CATALOG_BYTES = 4 * 1024 * 1024
+_TOP_LEVEL_FIELDS = frozenset({"format_version", "server", "generation", "created_at", "tools"})
+_TOOL_REQUIRED_FIELDS = frozenset({"registry_name", "remote_name", "kind", "schema"})
+_TOOL_FIELDS = _TOOL_REQUIRED_FIELDS | {"metadata"}
+_SCHEMA_FIELDS = frozenset({"name", "description", "parameters"})
+_METADATA_FIELDS = frozenset({"output_schema", "annotations"})
+_VALID_KINDS = frozenset({"tool", "utility"})
+
+
+class CatalogValidationError(ValueError):
+    """Raised when a static MCP catalog fails structural or digest checks."""
+
+
+class CatalogNotFoundError(FileNotFoundError):
+    """Raised when a lazy MCP server has no bootstrapped catalog."""
+
+
+def _canonical_json(value: Any) -> bytes:
+    try:
+        return json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise CatalogValidationError(f"catalog is not canonical JSON: {exc}") from exc
+
+
+def _generation(server: str, tools: list[dict[str, Any]]) -> str:
+    digest_payload = {
+        "format_version": CATALOG_FORMAT_VERSION,
+        "server": server,
+        "tools": tools,
+    }
+    return f"sha256:{hashlib.sha256(_canonical_json(digest_payload)).hexdigest()}"
+
+
+def _validated_tools(entries: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, raw_entry in enumerate(entries):
+        if not isinstance(raw_entry, dict):
+            raise CatalogValidationError(f"tool entry {index} must be an object")
+        unknown = set(raw_entry) - _TOOL_FIELDS
+        missing = _TOOL_REQUIRED_FIELDS - set(raw_entry)
+        if unknown:
+            raise CatalogValidationError(
+                f"tool entry {index} has unknown fields: {', '.join(sorted(unknown))}"
+            )
+        if missing:
+            raise CatalogValidationError(
+                f"tool entry {index} is missing fields: {', '.join(sorted(missing))}"
+            )
+
+        registry_name = raw_entry["registry_name"]
+        remote_name = raw_entry["remote_name"]
+        kind = raw_entry["kind"]
+        schema = raw_entry["schema"]
+        metadata = raw_entry.get("metadata", {})
+        if not isinstance(registry_name, str) or not registry_name:
+            raise CatalogValidationError(f"tool entry {index} has invalid registry_name")
+        if registry_name in seen:
+            raise CatalogValidationError(f"duplicate tool name in catalog: {registry_name}")
+        seen.add(registry_name)
+        if not isinstance(remote_name, str) or not remote_name:
+            raise CatalogValidationError(f"tool entry {index} has invalid remote_name")
+        if kind not in _VALID_KINDS:
+            raise CatalogValidationError(f"tool entry {index} has invalid kind: {kind!r}")
+        if not isinstance(schema, dict):
+            raise CatalogValidationError(f"tool entry {index} schema must be an object")
+        schema_unknown = set(schema) - _SCHEMA_FIELDS
+        schema_missing = _SCHEMA_FIELDS - set(schema)
+        if schema_unknown or schema_missing:
+            details = []
+            if schema_unknown:
+                details.append(f"unknown fields: {', '.join(sorted(schema_unknown))}")
+            if schema_missing:
+                details.append(f"missing fields: {', '.join(sorted(schema_missing))}")
+            raise CatalogValidationError(
+                f"tool entry {index} schema has {'; '.join(details)}"
+            )
+        if schema["name"] != registry_name:
+            raise CatalogValidationError(
+                f"tool entry {index} schema name does not match registry_name"
+            )
+        if not isinstance(schema["description"], str):
+            raise CatalogValidationError(f"tool entry {index} description must be a string")
+        if not isinstance(schema["parameters"], dict):
+            raise CatalogValidationError(f"tool entry {index} parameters must be an object")
+        if not isinstance(metadata, dict):
+            raise CatalogValidationError(f"tool entry {index} metadata must be an object")
+        metadata_unknown = set(metadata) - _METADATA_FIELDS
+        if metadata_unknown:
+            raise CatalogValidationError(
+                f"tool entry {index} metadata has unknown fields: "
+                f"{', '.join(sorted(metadata_unknown))}"
+            )
+        for field, value in metadata.items():
+            if not isinstance(value, dict):
+                raise CatalogValidationError(
+                    f"tool entry {index} metadata.{field} must be an object"
+                )
+
+        normalized.append(
+            {
+                "registry_name": registry_name,
+                "remote_name": remote_name,
+                "kind": kind,
+                "schema": {
+                    "name": registry_name,
+                    "description": schema["description"],
+                    "parameters": schema["parameters"],
+                },
+                "metadata": metadata,
+            }
+        )
+    normalized.sort(key=lambda item: item["registry_name"])
+    return normalized
+
+
+def build_catalog(server: str, entries: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    """Build and validate a static catalog without transport configuration."""
+    if not isinstance(server, str) or not server.strip():
+        raise CatalogValidationError("catalog server must be a non-empty string")
+    server = server.strip()
+    tools = _validated_tools(entries)
+    return {
+        "format_version": CATALOG_FORMAT_VERSION,
+        "server": server,
+        "generation": _generation(server, tools),
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "tools": tools,
+    }
+
+
+def validate_catalog(payload: Any, *, expected_server: str | None = None) -> dict[str, Any]:
+    """Validate an untrusted catalog payload and return canonical data."""
+    if not isinstance(payload, dict):
+        raise CatalogValidationError("catalog root must be an object")
+    unknown = set(payload) - _TOP_LEVEL_FIELDS
+    missing = _TOP_LEVEL_FIELDS - set(payload)
+    if unknown:
+        raise CatalogValidationError(f"catalog has unknown fields: {', '.join(sorted(unknown))}")
+    if missing:
+        raise CatalogValidationError(f"catalog is missing fields: {', '.join(sorted(missing))}")
+    if payload["format_version"] != CATALOG_FORMAT_VERSION:
+        raise CatalogValidationError(
+            f"unsupported catalog format_version: {payload['format_version']!r}"
+        )
+    server = payload["server"]
+    if not isinstance(server, str) or not server:
+        raise CatalogValidationError("catalog server must be a non-empty string")
+    if expected_server is not None and server != expected_server:
+        raise CatalogValidationError(
+            f"catalog server mismatch: expected {expected_server!r}, got {server!r}"
+        )
+    if not isinstance(payload["created_at"], str) or not payload["created_at"]:
+        raise CatalogValidationError("catalog created_at must be a non-empty string")
+    tools = _validated_tools(payload["tools"] if isinstance(payload["tools"], list) else [])
+    if not isinstance(payload["tools"], list):
+        raise CatalogValidationError("catalog tools must be an array")
+    expected_generation = _generation(server, tools)
+    if payload["generation"] != expected_generation:
+        raise CatalogValidationError(
+            "catalog generation mismatch; refresh the static MCP catalog"
+        )
+    return {
+        "format_version": CATALOG_FORMAT_VERSION,
+        "server": server,
+        "generation": expected_generation,
+        "created_at": payload["created_at"],
+        "tools": tools,
+    }
+
+
+def catalog_root() -> Path:
+    return get_hermes_home() / "mcp" / "tool_catalogs"
+
+
+def catalog_path(server: str, *, root: Path | None = None) -> Path:
+    """Return a traversal-safe path derived from the exact logical server name."""
+    base = Path(root) if root is not None else catalog_root()
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", server).strip(".-")[:48] or "server"
+    suffix = hashlib.sha256(server.encode("utf-8")).hexdigest()[:12]
+    return base / f"{slug}-{suffix}.json"
+
+
+def write_catalog(catalog: dict[str, Any], *, root: Path | None = None) -> Path:
+    """Atomically persist a validated catalog with owner-only permissions."""
+    validated = validate_catalog(catalog)
+    path = catalog_path(validated["server"], root=root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = _canonical_json(validated) + b"\n"
+    if len(data) > MAX_CATALOG_BYTES:
+        raise CatalogValidationError(
+            f"catalog exceeds {MAX_CATALOG_BYTES} byte limit"
+        )
+
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temp_path = Path(temp_name)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+        os.chmod(path, 0o600)
+        try:
+            dir_fd = os.open(path.parent, os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+        except OSError:
+            pass
+    except Exception:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        temp_path.unlink(missing_ok=True)
+        raise
+    return path
+
+
+def load_catalog(server: str, *, root: Path | None = None) -> dict[str, Any]:
+    """Load and validate a catalog without following a final-path symlink."""
+    path = catalog_path(server, root=root)
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(path, flags)
+    except FileNotFoundError as exc:
+        raise CatalogNotFoundError(
+            f"no static MCP catalog for {server!r}; refresh it explicitly"
+        ) from exc
+    try:
+        metadata = os.fstat(fd)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise CatalogValidationError("catalog path is not a regular file")
+        if metadata.st_size > MAX_CATALOG_BYTES:
+            raise CatalogValidationError(
+                f"catalog exceeds {MAX_CATALOG_BYTES} byte limit"
+            )
+        with os.fdopen(fd, "rb") as handle:
+            fd = -1
+            data = handle.read(MAX_CATALOG_BYTES + 1)
+        if len(data) > MAX_CATALOG_BYTES:
+            raise CatalogValidationError(
+                f"catalog exceeds {MAX_CATALOG_BYTES} byte limit"
+            )
+        try:
+            payload = json.loads(data.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise CatalogValidationError(f"invalid catalog JSON: {exc}") from exc
+        return validate_catalog(payload, expected_server=server)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+
+__all__ = [
+    "CATALOG_FORMAT_VERSION",
+    "MAX_CATALOG_BYTES",
+    "CatalogNotFoundError",
+    "CatalogValidationError",
+    "build_catalog",
+    "catalog_path",
+    "catalog_root",
+    "load_catalog",
+    "validate_catalog",
+    "write_catalog",
+]

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1833,6 +1833,7 @@ class MCPServerTask:
         "_idle_timeout_seconds", "_max_lifetime_seconds", "_recycled_reason",
         "initialize_result", "_ping_unsupported",
         "_reconnect_retries", "_session_proven", "_was_parked",
+        "_static_catalog_generation", "_static_catalog_stale",
     )
 
     def __init__(self, name: str):
@@ -1867,6 +1868,8 @@ class MCPServerTask:
         # until the session proves healthy again — used to log the
         # parked→revived transition exactly once.
         self._was_parked: bool = False
+        self._static_catalog_generation: Optional[str] = None
+        self._static_catalog_stale: bool = False
         self._auth_type: str = ""
         self._refresh_lock = asyncio.Lock()
         # MCP stdio sessions are a single JSON-RPC stream. Some servers emit
@@ -2097,6 +2100,23 @@ class MCPServerTask:
                 new_mcp_tools = await _paginate_full_list(
                     self.session.list_tools, "tools", self.name
                 )
+
+            if self._static_catalog_generation:
+                self._tools = new_mcp_tools
+                self._static_catalog_stale = not self._static_catalog_matches()
+                if self._static_catalog_stale:
+                    logger.warning(
+                        "MCP server '%s': tools changed; static snapshot is stale. "
+                        "Refusing calls until `hermes mcp snapshot %s` and a new session.",
+                        self.name,
+                        self.name,
+                    )
+                else:
+                    logger.info(
+                        "MCP server '%s': tools/list_changed matched static snapshot",
+                        self.name,
+                    )
+                return
 
             # 2. Re-register with fresh tool list. Avoid nuke-and-repave for
             # all names: live agent turns may already have tool-call IDs
@@ -2982,6 +3002,18 @@ class MCPServerTask:
                 reason = self._reconnect_or_reraise_group(_eg)
             return reason
 
+    def _static_catalog_matches(self) -> bool:
+        """Compare the current live tool surface with the pinned generation."""
+        if not self._static_catalog_generation:
+            return True
+        from tools.mcp_static_catalog import build_catalog
+
+        live = build_catalog(
+            self.name,
+            _catalog_entries_from_server(self.name, self, self._config),
+        )
+        return live["generation"] == self._static_catalog_generation
+
     async def _discover_tools(self):
         """Discover tools from the connected session.
 
@@ -3005,12 +3037,23 @@ class MCPServerTask:
                 self.name,
             )
             self._tools = []
+            if not self._static_catalog_matches():
+                self._static_catalog_stale = True
+                raise RuntimeError(
+                    f"MCP server '{self.name}' no longer matches its static snapshot"
+                )
             self._register_discovered_tools_if_needed()
             return
         async with self._rpc_lock:
             self._tools = await _paginate_full_list(
                 self.session.list_tools, "tools", self.name
             )
+        if not self._static_catalog_matches():
+            self._static_catalog_stale = True
+            raise RuntimeError(
+                f"MCP server '{self.name}' no longer matches its static snapshot"
+            )
+        self._static_catalog_stale = False
         self._register_discovered_tools_if_needed()
 
     def _register_discovered_tools_if_needed(self) -> None:
@@ -3427,6 +3470,11 @@ class MCPServerTask:
 
     async def start(self, config: dict):
         """Create the background Task and wait until ready (or failed)."""
+        generation = config.get("_static_catalog_generation")
+        self._static_catalog_generation = (
+            str(generation) if generation else None
+        )
+        self._static_catalog_stale = False
         self._task = asyncio.ensure_future(self.run(config))
         try:
             await self._ready.wait()
@@ -3481,8 +3529,13 @@ class MCPServerTask:
         stops advertising them to the model. Called on shutdown AND when the
         reconnect budget is exhausted, so a dead server never leaves phantom
         tool definitions bloating the prompt cache and producing "not
-        connected" errors on every turn.
+        connected" errors on every turn. Static-catalog placeholders are the
+        exception: they describe a disconnected-capable surface and must
+        survive transport outages. ``shutdown_mcp_servers()`` removes them via
+        the lazy catalog registration cleanup after the transport is stopped.
         """
+        if self._static_catalog_generation:
+            return
         from tools.registry import registry
 
         for tool_name in list(getattr(self, "_registered_tool_names", [])):
@@ -3516,6 +3569,16 @@ class MCPServerTask:
 _servers: Dict[str, MCPServerTask] = {}
 _server_connecting: set[str] = set()
 _server_connect_errors: Dict[str, str] = {}
+
+# Servers configured with ``lazy_connect`` are represented in the tool registry
+# by generation-bound static catalog entries. They do not own an MCP transport
+# until the first real tool invocation.
+_lazy_server_configs: Dict[str, dict] = {}
+_lazy_server_catalogs: Dict[str, dict] = {}
+_lazy_registered_names: Dict[str, set[str]] = {}
+_lazy_connect_locks: Dict[str, threading.Lock] = {}
+_lazy_connect_failures: Dict[str, tuple[float, str, str]] = {}
+_LAZY_CONNECT_FAILURE_COOLDOWN_S = 30.0
 
 # Connection-retry cooldown (per-server isolation against restart storms).
 #
@@ -4588,9 +4651,14 @@ def _load_mcp_config() -> Dict[str, dict]:
             pass
         safe_servers: Dict[str, dict] = {}
         for name, cfg in _filter_suspicious_mcp_servers(servers).items():
-            interpolated = _interpolate_env_vars(cfg)
-            if isinstance(interpolated, dict):
-                safe_servers[name] = interpolated
+            if _parse_boolish(cfg.get("lazy_connect"), False):
+                # Keep secret references unresolved until the first real
+                # connection. The static catalog never needs transport values.
+                safe_servers[name] = dict(cfg)
+            else:
+                interpolated = _interpolate_env_vars(cfg)
+                if isinstance(interpolated, dict):
+                    safe_servers[name] = interpolated
         return safe_servers
     except Exception as exc:
         logger.debug("Failed to load MCP config: %s", exc)
@@ -4612,8 +4680,11 @@ async def _connect_server(name: str, config: dict) -> MCPServerTask:
         ImportError: if HTTP transport is needed but not available.
         Exception: on connection or initialization failure.
     """
+    resolved_config = _interpolate_env_vars(config)
+    if not isinstance(resolved_config, dict):
+        raise ValueError(f"MCP server '{name}' config must resolve to an object")
     server = MCPServerTask(name)
-    await server.start(config)
+    await server.start(resolved_config)
     return server
 
 
@@ -5624,6 +5695,90 @@ def _existing_tool_names() -> List[str]:
     return names
 
 
+def _mcp_metadata_json(value: Any) -> Optional[dict]:
+    """Return canonical JSON metadata from an MCP SDK dict/model value."""
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return value
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        dumped = model_dump(mode="json", by_alias=True, exclude_none=True)
+        return dumped if isinstance(dumped, dict) else None
+    return None
+
+
+def _catalog_entries_from_server(
+    name: str,
+    server: MCPServerTask,
+    config: dict,
+) -> List[dict]:
+    """Build deterministic serializable entries for a server's live schema."""
+    tools_filter = config.get("tools") or {}
+    include_set = _normalize_name_filter(
+        tools_filter.get("include"), f"mcp_servers.{name}.tools.include"
+    )
+    exclude_set = _normalize_name_filter(
+        tools_filter.get("exclude"), f"mcp_servers.{name}.tools.exclude"
+    )
+
+    def _selected(tool_name: str) -> bool:
+        if include_set:
+            return matches_name_filter(tool_name, include_set)
+        if exclude_set:
+            return not matches_name_filter(tool_name, exclude_set)
+        return True
+
+    entries: List[dict] = []
+    for mcp_tool in server._tools:
+        if not _selected(mcp_tool.name):
+            continue
+        _scan_mcp_description(name, mcp_tool.name, mcp_tool.description or "")
+        schema = _convert_mcp_schema(name, mcp_tool)
+        metadata = {}
+        output_schema = _mcp_metadata_json(getattr(mcp_tool, "outputSchema", None))
+        annotations = _mcp_metadata_json(getattr(mcp_tool, "annotations", None))
+        if output_schema is not None:
+            metadata["output_schema"] = output_schema
+        if annotations is not None:
+            metadata["annotations"] = annotations
+        entries.append({
+            "registry_name": schema["name"],
+            "remote_name": mcp_tool.name,
+            "kind": "tool",
+            "schema": schema,
+            "metadata": metadata,
+        })
+
+    for utility in _select_utility_schemas(name, server, config):
+        schema = utility["schema"]
+        entries.append({
+            "registry_name": schema["name"],
+            "remote_name": utility["handler_key"],
+            "kind": "utility",
+            "schema": schema,
+            "metadata": {},
+        })
+
+    # Provider-safe normalization is lossy. Mirror eager registration's
+    # fail-closed collision policy rather than selecting an arbitrary target.
+    counts: Dict[str, int] = {}
+    for entry in entries:
+        registry_name = entry["registry_name"]
+        counts[registry_name] = counts.get(registry_name, 0) + 1
+    ambiguous = {registry_name for registry_name, count in counts.items() if count > 1}
+    if ambiguous:
+        logger.error(
+            "MCP server '%s': omitting ambiguous static catalog name(s): %s",
+            name,
+            ", ".join(sorted(ambiguous)),
+        )
+    return sorted(
+        (entry for entry in entries if entry["registry_name"] not in ambiguous),
+        key=lambda entry: entry["registry_name"],
+    )
+
+
 def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> List[str]:
     """Register tools from an already-connected server into the registry.
 
@@ -5838,9 +5993,304 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
     return registered_names
 
 
+def _lazy_handler_delegate(server_name: str, entry: dict, tool_timeout: float):
+    """Build the existing live handler represented by a catalog entry."""
+    if entry["kind"] == "tool":
+        return _make_tool_handler(server_name, entry["remote_name"], tool_timeout)
+    factories = {
+        "list_resources": _make_list_resources_handler,
+        "read_resource": _make_read_resource_handler,
+        "list_prompts": _make_list_prompts_handler,
+        "get_prompt": _make_get_prompt_handler,
+    }
+    factory = factories.get(entry["remote_name"])
+    if factory is None:
+        raise ValueError(f"Unknown MCP catalog utility: {entry['remote_name']}")
+    return factory(server_name, tool_timeout)
+
+
+def _make_lazy_catalog_handler(
+    server_name: str,
+    entry: dict,
+    tool_timeout: float,
+    config: dict,
+    catalog: dict,
+):
+    """Create a placeholder handler that connects before the first real call."""
+    delegate = _lazy_handler_delegate(server_name, entry, tool_timeout)
+    expected_generation = catalog["generation"]
+    expected_config = dict(config)
+
+    def _handler(args: dict, **kwargs) -> str:
+        requested_generation = kwargs.pop(
+            "_deferred_catalog_generation", expected_generation
+        )
+        if requested_generation != expected_generation:
+            return _lazy_connect_error(
+                "mcp_catalog_stale",
+                f"Static MCP catalog generation for '{server_name}' changed; "
+                "start a new session.",
+            )
+        error = _ensure_lazy_server_connected(
+            server_name,
+            config=expected_config,
+            expected=catalog,
+        )
+        if error is not None:
+            return error
+        return delegate(args, **kwargs)
+
+    return _handler
+
+
+def _lazy_connect_error(error_type: str, message: str) -> str:
+    return json.dumps(
+        {"error": message, "error_type": error_type},
+        ensure_ascii=False,
+    )
+
+
+def _ensure_lazy_server_connected(
+    server_name: str,
+    *,
+    config: Optional[dict] = None,
+    expected: Optional[dict] = None,
+) -> Optional[str]:
+    """Connect and verify one lazy server; return a JSON error on failure."""
+    from tools.mcp_static_catalog import build_catalog
+
+    with _lock:
+        config = config or _lazy_server_configs.get(server_name)
+        expected = expected or _lazy_server_catalogs.get(server_name)
+        connected = _servers.get(server_name)
+        if connected is not None:
+            if (
+                expected is None
+                or getattr(connected, "_static_catalog_generation", None)
+                != expected["generation"]
+                or getattr(connected, "_static_catalog_stale", False)
+            ):
+                return _lazy_connect_error(
+                    "mcp_catalog_stale",
+                    f"Static MCP catalog for '{server_name}' became stale; refresh it and start a new session.",
+                )
+            return None
+        connect_lock = _lazy_connect_locks.setdefault(server_name, threading.Lock())
+    if config is None or expected is None:
+        return _lazy_connect_error(
+            "mcp_catalog_unavailable",
+            f"Static MCP catalog for '{server_name}' is unavailable; refresh it first.",
+        )
+
+    with connect_lock:
+        with _lock:
+            connected = _servers.get(server_name)
+            if connected is not None:
+                if (
+                    getattr(connected, "_static_catalog_generation", None)
+                    != expected["generation"]
+                    or getattr(connected, "_static_catalog_stale", False)
+                ):
+                    return _lazy_connect_error(
+                        "mcp_catalog_stale",
+                        f"Static MCP catalog for '{server_name}' became stale; refresh it and start a new session.",
+                    )
+                return None
+            failed = _lazy_connect_failures.get(server_name)
+        if (
+            failed
+            and failed[2] == expected["generation"]
+            and time.monotonic() - failed[0] < _LAZY_CONNECT_FAILURE_COOLDOWN_S
+        ):
+            return failed[1]
+
+        server = None
+        try:
+            _ensure_mcp_loop()
+            connect_timeout = float(
+                config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+            )
+            with _lock:
+                _server_connecting.add(server_name)
+            connect_config = dict(config)
+            connect_config["_static_catalog_generation"] = expected["generation"]
+            server = _run_on_mcp_loop(
+                lambda: _connect_server(server_name, connect_config),
+                timeout=connect_timeout,
+            )
+            live_entries = _catalog_entries_from_server(server_name, server, config)
+            live_catalog = build_catalog(server_name, live_entries)
+            if live_catalog["generation"] != expected["generation"]:
+                stale_server = server
+                _run_on_mcp_loop(
+                    lambda: stale_server.shutdown(),
+                    timeout=min(connect_timeout, 15.0),
+                )
+                server = None
+                error = _lazy_connect_error(
+                    "mcp_catalog_stale",
+                    f"Static MCP catalog for '{server_name}' does not match the live server; refresh it before retrying.",
+                )
+                with _lock:
+                    _lazy_connect_failures[server_name] = (
+                        time.monotonic(), error, expected["generation"]
+                    )
+                return error
+
+            with _lock:
+                server._registered_tool_names = [
+                    entry["registry_name"] for entry in expected["tools"]
+                ]
+                _servers[server_name] = server
+                _server_connect_errors.pop(server_name, None)
+                _lazy_connect_failures.pop(server_name, None)
+            return None
+        except Exception as exc:
+            if server is not None:
+                try:
+                    _run_on_mcp_loop(lambda: server.shutdown(), timeout=5)
+                except Exception:
+                    logger.debug("Lazy MCP cleanup failed", exc_info=True)
+            message = _sanitize_error(
+                f"Lazy MCP server '{server_name}' failed to connect: {type(exc).__name__}: {_exc_str(exc)}"
+            )
+            error = _lazy_connect_error("mcp_lazy_connect_failed", message)
+            with _lock:
+                _server_connect_errors[server_name] = message
+                _lazy_connect_failures[server_name] = (
+                    time.monotonic(), error, expected["generation"]
+                )
+            return error
+        finally:
+            with _lock:
+                _server_connecting.discard(server_name)
+
+
+def _clear_lazy_server_catalog_registration(name: str) -> None:
+    """Remove one lazy server's placeholders and process-local state."""
+    from tools.registry import registry
+
+    with _lock:
+        registered = set(_lazy_registered_names.pop(name, set()))
+        _lazy_server_configs.pop(name, None)
+        _lazy_server_catalogs.pop(name, None)
+        _lazy_connect_locks.pop(name, None)
+        _lazy_connect_failures.pop(name, None)
+    toolset_name = f"mcp-{name}"
+    for tool_name in registered:
+        if registry.get_toolset_for_tool(tool_name) == toolset_name:
+            registry.deregister(tool_name)
+            _forget_mcp_tool_server(tool_name)
+
+
+def _register_lazy_server_catalog(name: str, config: dict) -> List[str]:
+    """Register static placeholders for one lazy server without connecting."""
+    from tools.mcp_static_catalog import (
+        CatalogNotFoundError,
+        CatalogValidationError,
+        load_catalog,
+    )
+    from tools.registry import registry
+
+    _clear_lazy_server_catalog_registration(name)
+    try:
+        catalog = load_catalog(name)
+    except (CatalogNotFoundError, CatalogValidationError) as exc:
+        logger.warning(
+            "MCP server '%s' is lazy but has no usable static catalog: %s. "
+            "Run an explicit catalog refresh before starting a session.",
+            name,
+            exc,
+        )
+        return []
+
+    toolset_name = f"mcp-{name}"
+    timeout = float(config.get("timeout", _DEFAULT_TOOL_TIMEOUT))
+    registered: List[str] = []
+    with _lock:
+        _lazy_server_configs[name] = dict(config)
+        _lazy_server_catalogs[name] = catalog
+        _lazy_connect_locks.setdefault(name, threading.Lock())
+
+    for entry in catalog["tools"]:
+        registry_name = entry["registry_name"]
+        existing_owner = registry.get_toolset_for_tool(registry_name)
+        if existing_owner is not None and existing_owner != toolset_name:
+            logger.error(
+                "MCP server '%s': static catalog tool '%s' collides with toolset '%s'; skipping",
+                name,
+                registry_name,
+                existing_owner,
+            )
+            continue
+        registry.register(
+            name=registry_name,
+            toolset=toolset_name,
+            schema=entry["schema"],
+            handler=_make_lazy_catalog_handler(name, entry, timeout, config, catalog),
+            check_fn=lambda: True,
+            is_async=False,
+        )
+        _track_mcp_tool_server(registry_name, name)
+        registered.append(registry_name)
+
+    if registered:
+        registry.register_toolset_alias(name, toolset_name)
+    with _lock:
+        _lazy_registered_names[name] = set(registered)
+    return registered
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
+
+def refresh_mcp_static_catalog(server_name: str, config: dict) -> dict:
+    """Explicitly connect once and atomically refresh a server's tool snapshot."""
+    from tools.mcp_static_catalog import build_catalog, write_catalog
+
+    if not _MCP_AVAILABLE:
+        raise RuntimeError("MCP SDK is not available")
+    filtered = _filter_suspicious_mcp_servers({server_name: config})
+    if server_name not in filtered:
+        raise ValueError(f"MCP server '{server_name}' failed security validation")
+
+    with _lock:
+        server = _servers.get(server_name)
+    owns_connection = server is None
+    connect_timeout = float(config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT))
+    try:
+        if server is None:
+            _ensure_mcp_loop()
+            server = _run_on_mcp_loop(
+                lambda: _connect_server(server_name, config),
+                timeout=connect_timeout,
+            )
+        entries = _catalog_entries_from_server(server_name, server, config)
+        catalog = build_catalog(server_name, entries)
+        write_catalog(catalog)
+        return catalog
+    except Exception as exc:
+        message = _sanitize_error(
+            f"MCP snapshot for '{server_name}' failed: {type(exc).__name__}: {_exc_str(exc)}"
+        )
+        raise RuntimeError(message) from None
+    finally:
+        if owns_connection and server is not None:
+            try:
+                snapshot_server = server
+                _run_on_mcp_loop(
+                    lambda: snapshot_server.shutdown(),
+                    timeout=min(connect_timeout, 15.0),
+                )
+            except Exception:
+                logger.warning(
+                    "MCP server '%s': snapshot connection cleanup failed",
+                    server_name,
+                    exc_info=True,
+                )
+
 
 def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     """Connect to explicit MCP servers and register their tools.
@@ -5863,6 +6313,19 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         logger.debug("No explicit MCP servers provided")
         return []
 
+    lazy_servers = {
+        name: config
+        for name, config in servers.items()
+        if _parse_boolish(config.get("enabled", True), default=True)
+        and _parse_boolish(config.get("lazy_connect", False), default=False)
+    }
+    lazy_registered: List[str] = []
+    for name, config in lazy_servers.items():
+        with _lock:
+            already_connected = name in _servers
+        if not already_connected:
+            lazy_registered.extend(_register_lazy_server_catalog(name, config))
+
     # Only attempt servers that aren't already connected and are enabled
     # (enabled: false skips the server entirely without removing its config)
     with _lock:
@@ -5871,6 +6334,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
             for k, v in servers.items()
             if k not in _servers
             and _parse_boolish(v.get("enabled", True), default=True)
+            and not _parse_boolish(v.get("lazy_connect", False), default=False)
             # Skip a server still serving its post-failure backoff. Without
             # this, a server that fails to connect (and is therefore never
             # recorded in ``_servers``) would be re-spawned on every worker
@@ -5903,7 +6367,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         _signal_reconnect(srv)
 
     if not new_servers:
-        return _existing_tool_names()
+        return list(dict.fromkeys([*_existing_tool_names(), *lazy_registered]))
 
     # Start the background event loop for MCP connections
     _ensure_mcp_loop()
@@ -5973,7 +6437,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
             summary += f" ({failed} failed)"
         logger.info(summary)
 
-    return _existing_tool_names()
+    return list(dict.fromkeys([*_existing_tool_names(), *lazy_registered]))
 
 
 def discover_mcp_tools() -> List[str]:
@@ -6253,6 +6717,30 @@ def get_registered_mcp_server_names() -> set:
         return set(_mcp_tool_server_names.values())
 
 
+def has_static_lazy_mcp_catalogs() -> bool:
+    """Return whether this process registered any static lazy MCP catalog."""
+    with _lock:
+        return bool(_lazy_server_catalogs)
+
+
+def get_static_lazy_tool_generations(
+    tool_names: Optional[List[str]] = None,
+) -> Dict[str, str]:
+    """Return the current generation bound to each registered lazy tool."""
+    allowed = set(tool_names) if tool_names is not None else None
+    result: Dict[str, str] = {}
+    with _lock:
+        for server_name, registered_names in _lazy_registered_names.items():
+            catalog = _lazy_server_catalogs.get(server_name)
+            if catalog is None:
+                continue
+            generation = catalog["generation"]
+            for tool_name in registered_names:
+                if allowed is None or tool_name in allowed:
+                    result[tool_name] = generation
+    return result
+
+
 
 def refresh_agent_mcp_tools(
     agent,
@@ -6295,7 +6783,12 @@ def refresh_agent_mcp_tools(
     explicit user consent; the late-binding and between-turns paths only rebuild
     at a turn boundary, before that turn's ``tools=`` prefix is assembled).
     """
-    from model_tools import get_tool_definitions
+    if getattr(agent, "_deferred_tool_snapshot_locked", False):
+        return set()
+
+    from copy import deepcopy
+
+    from model_tools import assemble_tool_search_definitions, get_tool_definitions
     from tools.registry import registry
 
     # Explicit reloads (/reload-mcp) pass freshly-resolved toolsets so a server
@@ -6323,13 +6816,17 @@ def refresh_agent_mcp_tools(
     # Computed OUTSIDE the lock (get_tool_definitions can be slow); the diff and
     # publish below happen together in ONE critical section so two concurrent
     # callers can't torn-publish or compute overlapping ``added`` sets.
-    new_defs = list(
+    raw_defs = list(
         get_tool_definitions(
             enabled_toolsets=enabled,
             disabled_toolsets=disabled,
-            quiet_mode=quiet_mode,
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
         )
         or []
+    )
+    new_defs = list(
+        assemble_tool_search_definitions(raw_defs, quiet_mode=quiet_mode)
     )
     new_names = {t["function"]["name"] for t in new_defs}
 
@@ -6367,6 +6864,12 @@ def refresh_agent_mcp_tools(
             return set()
         agent.tools = new_defs
         agent.valid_tool_names = new_names
+        agent._deferred_tool_defs_snapshot = deepcopy(raw_defs)
+        agent._deferred_tool_generations_snapshot = get_static_lazy_tool_generations(
+            [tool["function"]["name"] for tool in raw_defs]
+        )
+        if hasattr(agent, "_deferred_tool_names_snapshot"):
+            delattr(agent, "_deferred_tool_names_snapshot")
         # Publish context-engine routing names atomically with the snapshot.
         engine_names = getattr(agent, "_context_engine_tool_names", None)
         if isinstance(engine_names, set):
@@ -6454,6 +6957,7 @@ def shutdown_mcp_servers():
     """
     with _lock:
         servers_snapshot = list(_servers.values())
+        lazy_servers_snapshot = list(_lazy_registered_names)
 
     # Fast path: nothing to shut down. The connect-cooldown maps can still
     # be populated here — a server that failed to connect is never recorded
@@ -6462,6 +6966,8 @@ def shutdown_mcp_servers():
     # entries exist. Clear them so a post-shutdown restart re-attempts every
     # configured server immediately.
     if not servers_snapshot:
+        for server_name in lazy_servers_snapshot:
+            _clear_lazy_server_catalog_registration(server_name)
         with _lock:
             _server_connect_retry_after.clear()
             _server_connect_failures.clear()
@@ -6508,6 +7014,9 @@ def shutdown_mcp_servers():
     with _lock:
         _server_connect_retry_after.clear()
         _server_connect_failures.clear()
+
+    for server_name in lazy_servers_snapshot:
+        _clear_lazy_server_catalog_registration(server_name)
 
     _stop_mcp_loop()
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6083,7 +6083,23 @@ def _ensure_lazy_server_connected(
         )
 
     with connect_lock:
+        # Re-validate under the per-server lock: if _clear_lazy_server_catalog_registration
+        # ran between releasing _lock and acquiring connect_lock, our lock is now orphaned
+        # and config/catalog are gone. Bail out so the caller retries with fresh state.
         with _lock:
+            if _lazy_connect_locks.get(server_name) is not connect_lock:
+                return _lazy_connect_error(
+                    "mcp_catalog_unavailable",
+                    f"Static MCP catalog for '{server_name}' was cleared; retry.",
+                )
+            # Re-read config/expected in case they were replaced
+            config = _lazy_server_configs.get(server_name)
+            expected = _lazy_server_catalogs.get(server_name)
+            if config is None or expected is None:
+                return _lazy_connect_error(
+                    "mcp_catalog_unavailable",
+                    f"Static MCP catalog for '{server_name}' is unavailable; refresh it first.",
+                )
             connected = _servers.get(server_name)
             if connected is not None:
                 if (

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -934,7 +934,12 @@ def scoped_deferrable_names(tool_defs: List[Dict[str, Any]]) -> frozenset[str]:
     return frozenset(names)
 
 
-def validate_deferred_call_args(name: str, args: Dict[str, Any]) -> Optional[str]:
+def validate_deferred_call_args(
+    name: str,
+    args: Dict[str, Any],
+    *,
+    current_tool_defs: Optional[List[Dict[str, Any]]] = None,
+) -> Optional[str]:
     """Probe-validate ``tool_call`` arguments against the deferred tool's schema.
 
     A deferred tool's parameter schema is invisible to the model until it
@@ -957,11 +962,23 @@ def validate_deferred_call_args(name: str, args: Dict[str, Any]) -> Optional[str
     call should dispatch.
     """
     try:
-        from tools.registry import registry as _registry
-        schema = _registry.get_schema(name)
+        schema = None
+        if current_tool_defs is not None:
+            for tool_def in current_tool_defs:
+                function = tool_def.get("function") or {}
+                if function.get("name") == name:
+                    schema = tool_def
+                    break
+        else:
+            from tools.registry import registry as _registry
+            schema = _registry.get_schema(name)
         if not isinstance(schema, dict):
             return None
-        fn = schema.get("function") if schema.get("type") == "function" else schema
+        fn = schema
+        for _ in range(2):
+            if fn.get("type") != "function" or not isinstance(fn.get("function"), dict):
+                break
+            fn = fn["function"]
         if not isinstance(fn, dict):
             return None
         params = fn.get("parameters")

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1334,6 +1334,7 @@ Manage MCP (Model Context Protocol) server configurations and run Hermes as an M
 | `remove <name>` (alias: `rm`) | Remove an MCP server from config. |
 | `list` (alias: `ls`) | List configured MCP servers. |
 | `test <name>` | Test connection to an MCP server. |
+| `snapshot <name>` or `snapshot --all` | Refresh generation-bound tool schemas used by `lazy_connect` servers. |
 | `configure <name>` (alias: `config`) | Toggle tool selection for a server. |
 | `login <name>` | Force re-authentication for an OAuth-based MCP server. |
 

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -31,6 +31,7 @@ mcp_servers:
     # client_key: "/path/to/key.pem"  # optional, when key lives in a separate file
 
     enabled: true
+    lazy_connect: false
     timeout: 120
     connect_timeout: 60
     supports_parallel_tool_calls: false
@@ -54,6 +55,7 @@ mcp_servers:
 | `client_cert` | string or list | HTTP | mTLS client certificate. String = path to a PEM file containing cert + key. List `[cert, key]` = separate files. List `[cert, key, password]` = encrypted key |
 | `client_key` | string | HTTP | Path to the client private key, when `client_cert` is a string and the key is in a separate file |
 | `enabled` | bool | both | Skip the server entirely when false |
+| `lazy_connect` | bool | both | Load a generation-bound static tool snapshot at startup and defer the real MCP connection until the first tool call (default: `false`) |
 | `timeout` | number | both | Tool call timeout in seconds (default: `300`) |
 | `connect_timeout` | number | both | Initial connection timeout in seconds (default: `60`) |
 | `supports_parallel_tool_calls` | bool | both | Allow tools from this server to run concurrently |
@@ -154,6 +156,60 @@ Behavior:
 - no discovery
 - no tool registration
 - config remains in place for later reuse
+
+## True lazy startup with `lazy_connect`
+
+`lazy_connect: true` separates tool discovery from the live MCP transport. Hermes
+loads a previously verified static tool snapshot into its internal registry, but
+does not start a stdio child process or open an HTTP connection during startup.
+The first call to one of the server's tools establishes a single shared
+connection, fetches the live schemas, and compares their generation digest with
+the snapshot before dispatching.
+
+Create or refresh the snapshot explicitly:
+
+```bash
+hermes mcp snapshot github
+# or every enabled server
+hermes mcp snapshot --all
+```
+
+Then enable lazy startup:
+
+```yaml
+mcp_servers:
+  github:
+    command: "npx"
+    args: ["-y", "@modelcontextprotocol/server-github"]
+    lazy_connect: true
+```
+
+Important behavior:
+
+- Missing, malformed, or tampered snapshots **do not** trigger an eager fallback.
+  The server remains disconnected and unavailable until an explicit snapshot
+  refresh succeeds.
+- The first concurrent calls share one connection attempt. A failed attempt is
+  cached briefly so concurrent callers do not respawn a broken server.
+- Live schema drift fails closed. Run `hermes mcp snapshot <name>` and start a
+  new session; Hermes never changes the current session's tool catalog.
+- Snapshots contain schemas and routing names only—never MCP commands, URLs,
+  headers, environment values, or credentials. They are written atomically with
+  owner-only permissions under the active `HERMES_HOME/mcp/tool_catalogs`
+  state directory.
+
+For the smallest model-visible surface, combine lazy startup with bare Tool
+Search bridges:
+
+```yaml
+tools:
+  tool_search:
+    enabled: on
+    listing: off
+```
+
+This keeps the raw MCP schemas internal. The model sees only `tool_search`,
+`tool_describe`, and `tool_call` for deferred capabilities.
 
 ## Empty result behavior
 

--- a/website/docs/user-guide/features/tool-search.md
+++ b/website/docs/user-guide/features/tool-search.md
@@ -83,6 +83,10 @@ tools:
     listing_max_tokens: 20000
 ```
 
+For a bare bridge with no embedded tool-name manifest, set `listing: off`.
+This is useful with generation-bound lazy MCP snapshots when the session's
+stable behavior policy already instructs the model to search before calling.
+
 | Key | Default | Meaning |
 | --- | --- | --- |
 | `enabled` | `auto` | `auto`/`on` activate whenever at least one deferrable tool exists; `off` disables entirely (everything stays eager). |
@@ -141,10 +145,11 @@ to any progressive-disclosure design, not specific to this implementation:
   less well; the published Anthropic numbers (49% → 74% on Opus 4 with
   vs. without tool search) show the upside but also that ~26 points of
   accuracy is still retrieval failure.
-- **Toolset edits invalidate cache.** Adding or removing a tool mid-
-  session changes the bridge tools' descriptions (which include the
-  count of deferred tools) and the catalog, so the prompt cache is
-  invalidated. This is the same trade-off as any toolset edit.
+- **Toolset edits require a new static-lazy session.** Normal eager MCP sessions
+  can still accept explicit reloads at a turn boundary. A session containing a
+  static-lazy MCP catalog instead pins its tool definitions and allowlist at
+  agent initialization; refreshed snapshots become visible only to new
+  sessions, preserving the prompt-cache prefix.
 
 ## Implementation details
 
@@ -153,10 +158,12 @@ to any progressive-disclosure design, not specific to this implementation:
   BM25 returns no positive-score hits, which protects against
   zero-IDF degenerate cases (e.g. searching `"github"` against a
   catalog where every tool name contains "github").
-- **Catalog is stateless across turns.** It rebuilds from the current
-  tool-defs list every assembly — no session-keyed `Map`. This avoids
-  the class of bug where a stored catalog drifts out of sync with the
-  live tool registry.
+- **Catalog input is session-scoped.** Each agent snapshots its granted raw
+  tool definitions before progressive-disclosure assembly. Bridge search,
+  describe, argument validation, and call authorization all read that same
+  snapshot instead of the process-global live registry. Static-lazy sessions
+  also lock model-visible tool refreshes so a first connection or server
+  notification cannot mutate an active conversation.
 - **The catalog is scoped to the session's toolsets.** `tool_search`,
   `tool_describe`, and `tool_call` only ever see and invoke tools the
   session was actually granted. A subagent, kanban worker, or gateway


### PR DESCRIPTION
## Summary

Implements **true lazy MCP servers**: tools are registered from a generation-bound static catalog at startup, but the actual MCP transport (stdio child process or HTTP connection) is deferred until the first tool call. This eliminates startup cost for MCP servers that may never be used in a session.

## Architecture

### Static Catalog (`tools/mcp_static_catalog.py`)
- Generation-bound JSON manifests at `$HERMES_HOME/mcp/tool_catalogs/<slug>-<hash>.json`
- SHA-256 digest over `(format_version, server, tools)` ensures tamper detection
- Atomic write: `tempfile` + `fchmod(0o600)` + `fsync` + `os.replace`
- Symlink-safe load: `O_NOFOLLOW` + `fstat` + size limit
- Contains only routing metadata and schemas — never transport config or credentials

### Lazy Registration (`tools/mcp_tool.py`)
- `register_mcp_servers()` detects `lazy_connect: true` servers and registers placeholder handlers from the static catalog
- No MCP loop started, no subprocess spawned, no network connection opened
- First tool call triggers `_ensure_lazy_server_connected()`:
  - Single-flight via per-server `connect_lock` with orphan-detection
  - Connects, runs `tools/list`, validates generation matches catalog
  - On mismatch: `mcp_catalog_stale` error, server shut down
  - On success: server registered in `_servers`, subsequent calls use it directly
- Secret interpolation (`${VAR}`) deferred to connect time, not config load time

### Session Snapshot Isolation (`model_tools.py`, `agent/agent_init.py`)
- Each `AIAgent` captures `_deferred_tool_defs_snapshot` and `_deferred_tool_generations_snapshot` at init
- `tool_search`, `tool_call`, and `coerce_tool_args` use the session snapshot, not the live registry
- Generation mismatch between session snapshot and current catalog: `mcp_catalog_stale`
- `refresh_agent_mcp_tools()` is a no-op for locked sessions

### CLI
- `hermes mcp snapshot <name>` — connect once, write generation-bound catalog
- `hermes mcp snapshot --all` — refresh all enabled lazy servers

## Security Properties
- Catalog files: owner-only (0o600), no credentials serialized
- Symlink protection: `O_NOFOLLOW` on load
- Generation digest: SHA-256 over canonical JSON
- Secret late-binding: `${VAR}` resolved at connect time, not startup
- Suspicious server filtering: same gate as eager servers
- Orphaned-lock detection: re-validates lock identity under `connect_lock`

## Concurrency
- Single-flight connect: per-server `threading.Lock` with double-checked locking
- Orphan detection: if `_clear_lazy_server_catalog_registration` runs between lock capture and acquisition, the stale lock is detected and the caller bails out
- `shutdown_mcp_servers()` clears all lazy state after transport teardown

## Test Coverage
- 14 unit tests for lazy catalog lifecycle
- 1 real stdio E2E test (fake MCP server over JSONL)
- 11 dynamic discovery tests (non-lazy path unaffected)
- 16 refresh tests (locked sessions skip rebuild)
- 58 tool_search tests (snapshot isolation, coercion, probe-validation)
- 33 model_tools tests
- All existing MCP tests pass (234 in test_mcp_tool.py, 161 in hermes_cli/test_mcp*.py)

## Files Changed (19 files, +2093/-77)
- `tools/mcp_static_catalog.py` — new: catalog format, validation, atomic I/O
- `tools/mcp_tool.py` — lazy registration, single-flight connect, generation checks
- `tools/tool_search.py` — snapshot-aware deferred validation
- `model_tools.py` — extracted `assemble_tool_search_definitions`, session-scoped coercion
- `agent/agent_init.py` — capture deferred snapshot + generations at init
- `agent/tool_executor.py` — pass snapshot through to dispatch
- `agent/agent_runtime_helpers.py` — pass snapshot through to dispatch
- `hermes_cli/mcp_config.py` — `hermes mcp snapshot` subcommand
- `hermes_cli/subcommands/mcp.py` — CLI wiring
- `website/docs/` — config reference, CLI reference, tool-search guide
- Tests: 4 new files, 5 extended

## Backward Compatibility
- Non-lazy servers (`lazy_connect: false` or unset) behave identically to before
- `refresh_agent_mcp_tools()` still works for non-locked sessions
- Older agent doubles without `_deferred_tool_defs_snapshot` retain the live-registry fallback
