### PR TITLE
fix(mcp): report stdio credential authentication

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -31,6 +31,12 @@ from tools.mcp_tool import _ENV_VAR_PATTERN, _env_ref_name
 logger = logging.getLogger(__name__)
 
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_CREDENTIAL_ENV_KEY_RE = re.compile(
+    r"(?:^|_)(?:API[_-]?KEY|APIKEY|TOKEN|SECRET|PASSWORD|PASSWD|"
+    r"CREDENTIALS?|AUTH|AUTHORIZATION|PRIVATE[_-]?KEY|ACCESS[_-]?KEY)"
+    r"(?:_|$)",
+    re.IGNORECASE,
+)
 
 
 _MCP_PRESETS: Dict[str, Dict[str, Any]] = {
@@ -746,6 +752,11 @@ def cmd_mcp_test(args):
     # Show auth info (masked)
     auth_type = cfg.get("auth", "")
     headers = cfg.get("headers", {})
+    credential_env_keys = sorted(
+        key
+        for key in (cfg.get("env") or {})
+        if isinstance(key, str) and _CREDENTIAL_ENV_KEY_RE.search(key)
+    )
     if auth_type == "oauth":
         _info("Auth: OAuth 2.1 PKCE")
     elif headers:
@@ -758,6 +769,8 @@ def cmd_mcp_test(args):
                 else:
                     masked = "***"
                 print(f"    {k}: {masked}")
+    elif credential_env_keys:
+        _info(f"Auth: stdio env ({', '.join(credential_env_keys)})")
     else:
         _info("Auth: none")
 

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -446,6 +446,67 @@ class TestMcpTest:
         assert "Connected" in out
         assert "Tools discovered: 2" in out
 
+    def test_test_reports_stdio_env_credential_without_value(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        _seed_config(tmp_path, {
+            "github": {
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-github"],
+                "env": {
+                    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}",
+                },
+            },
+        })
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", lambda *a, **kw: []
+        )
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        cmd_mcp_test(_make_args(name="github"))
+        out = capsys.readouterr().out
+
+        assert "Auth: stdio env (GITHUB_PERSONAL_ACCESS_TOKEN)" in out
+        assert "${GITHUB_TOKEN}" not in out
+
+    def test_test_does_not_treat_noncredential_stdio_env_as_auth(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        _seed_config(tmp_path, {
+            "local": {
+                "command": "uvx",
+                "args": ["local-mcp"],
+                "env": {"LOG_LEVEL": "debug"},
+            },
+        })
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", lambda *a, **kw: []
+        )
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        cmd_mcp_test(_make_args(name="local"))
+        out = capsys.readouterr().out
+
+        assert "Auth: none" in out
+
+    def test_test_tolerates_null_stdio_env(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {
+            "local": {
+                "command": "uvx",
+                "args": ["local-mcp"],
+                "env": None,
+            },
+        })
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", lambda *a, **kw: []
+        )
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        cmd_mcp_test(_make_args(name="local"))
+        out = capsys.readouterr().out
+
+        assert "Auth: none" in out
+
     def test_probe_uses_configured_connect_timeout(self, monkeypatch):
         """OAuth-capable probes must not hard-code a short 30s timeout."""
         import asyncio


### PR DESCRIPTION
## Summary

- report credential-backed stdio environment authentication in `hermes mcp test`
- show credential environment variable names only; never print configured or resolved values
- preserve `Auth: none` for stdio servers whose environment contains only noncredential settings
- tolerate an explicitly null `env` block without crashing the diagnostic

## Problem

`cmd_mcp_test` only recognized OAuth and HTTP-header authentication. A correctly configured stdio GitHub MCP server using `GITHUB_PERSONAL_ACCESS_TOKEN` therefore printed `Auth: none`, even though the token was resolved and passed to the subprocess.

## Verification

- regression tests were written first and failed against both the previous `Auth: none` behavior and the null-env crash
- focused stdio-auth tests: 3 passed
- `scripts/run_tests.sh tests/hermes_cli/test_mcp_config.py -v --tb=short`: 62 passed, 0 failed
- live configured GitHub MCP probe reports `Auth: stdio env (GITHUB_PERSONAL_ACCESS_TOKEN)`, connects, and discovers 26 tools
- `git diff --check`: passed
