### PR TITLE
fix(tts): support non-24 kHz PCM from OpenAI-compatible endpoints

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1341,6 +1341,9 @@ DEFAULT_CONFIG = {
         "openai": {
             "model": "gpt-4o-mini-tts",
             "voice": "alloy",
+            # Playback rate for raw PCM streams. OpenAI uses 24 kHz; compatible
+            # endpoints that emit another rate must override this to avoid drift.
+            "pcm_sample_rate": 24000,
             # Voices: alloy, ash, ballad, cedar, coral, echo, fable, marin,
             # nova, onyx, sage, shimmer, verse (gpt-4o-mini-tts; the tts-1
             # era stopped at alloy/echo/fable/onyx/nova/shimmer)

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -156,9 +156,23 @@ def test_openai_streamer_defaults_to_official_pcm_sample_rate():
 
 
 @pytest.mark.parametrize("pcm_sample_rate", [0, -1, True, 48000.5, "invalid"])
-def test_openai_streamer_rejects_non_positive_integer_sample_rate(pcm_sample_rate):
-    with pytest.raises(ValueError, match="must be a positive integer"):
-        ts.OpenAIStreamer({}, {"pcm_sample_rate": pcm_sample_rate})
+def test_openai_resolver_falls_back_to_official_rate_for_invalid_sample_rate(
+    pcm_sample_rate, monkeypatch, caplog
+):
+    monkeypatch.setattr(ts.OpenAIStreamer, "available", staticmethod(lambda: True))
+
+    with caplog.at_level("WARNING", logger=ts.__name__):
+        streamer = ts.resolve_streaming_provider(
+            {
+                "provider": "openai",
+                "openai": {"pcm_sample_rate": pcm_sample_rate},
+            }
+        )
+
+    assert isinstance(streamer, ts.OpenAIStreamer)
+    assert streamer.sample_rate == 24000
+    assert "Invalid tts.openai.pcm_sample_rate" in caplog.text
+    assert "falling back to 24000 Hz" in caplog.text
 
 
 def test_openai_streamer_uses_configured_pcm_sample_rate_from_real_config(
@@ -195,6 +209,50 @@ def test_openai_streamer_uses_configured_pcm_sample_rate_from_real_config(
         channels=1,
         dtype="int16",
     )
+    assert done.is_set()
+
+
+def test_invalid_openai_pcm_sample_rate_keeps_streaming_at_official_rate(
+    tmp_path, monkeypatch, caplog
+):
+    from tools import tts_tool
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "tts:\n"
+        "  provider: openai\n"
+        "  openai:\n"
+        "    api_key: test-key\n"
+        "    pcm_sample_rate: invalid\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        ts.OpenAIStreamer,
+        "stream",
+        lambda self, text: iter((b"\x01\x00" * 50,)),
+    )
+    sync_tts = MagicMock()
+    monkeypatch.setattr(tts_tool, "text_to_speech_tool", sync_tts)
+
+    sd, _out = _sd_mock()
+    q = _drain_queue(["Hello there, this is a full sentence."])
+    stop, done = threading.Event(), threading.Event()
+
+    with (
+        caplog.at_level("WARNING", logger=ts.__name__),
+        patch.object(tts_tool, "_import_sounddevice", return_value=sd),
+    ):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    sd.OutputStream.assert_called_once_with(
+        samplerate=24000,
+        channels=1,
+        dtype="int16",
+    )
+    sync_tts.assert_not_called()
+    assert "falling back to 24000 Hz" in caplog.text
     assert done.is_set()
 
 

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -151,6 +151,53 @@ def test_openai_streamer_prefers_configured_api_key(monkeypatch):
     assert captured["client"]["api_key"] == "cfg-key"
 
 
+def test_openai_streamer_defaults_to_official_pcm_sample_rate():
+    assert ts.OpenAIStreamer({}, {}).sample_rate == 24000
+
+
+@pytest.mark.parametrize("pcm_sample_rate", [0, -1, True, 48000.5, "invalid"])
+def test_openai_streamer_rejects_non_positive_integer_sample_rate(pcm_sample_rate):
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        ts.OpenAIStreamer({}, {"pcm_sample_rate": pcm_sample_rate})
+
+
+def test_openai_streamer_uses_configured_pcm_sample_rate_from_real_config(
+    tmp_path, monkeypatch
+):
+    from tools import tts_tool
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "tts:\n"
+        "  provider: openai\n"
+        "  openai:\n"
+        "    api_key: test-key\n"
+        "    pcm_sample_rate: 48000\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        ts.OpenAIStreamer,
+        "stream",
+        lambda self, text: iter((b"\x01\x00" * 50,)),
+    )
+
+    sd, _out = _sd_mock()
+    q = _drain_queue(["Hello there, this is a full sentence."])
+    stop, done = threading.Event(), threading.Event()
+
+    with patch.object(tts_tool, "_import_sounddevice", return_value=sd):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    sd.OutputStream.assert_called_once_with(
+        samplerate=48000,
+        channels=1,
+        dtype="int16",
+    )
+    assert done.is_set()
+
+
 # ── Dispatch: chunked streamer path ──────────────────────────────────────
 
 

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -271,17 +271,22 @@ class OpenAIStreamer(StreamingTTSProvider):
         super().__init__(tts_config, section)
         configured_rate = section.get("pcm_sample_rate", self.sample_rate)
         try:
-            self.sample_rate = int(configured_rate)
+            parsed_rate = int(configured_rate)
         except (TypeError, ValueError):
-            raise ValueError(
-                "tts.openai.pcm_sample_rate must be a positive integer"
-            ) from None
+            parsed_rate = None
         if (
             isinstance(configured_rate, bool)
             or (isinstance(configured_rate, float) and not configured_rate.is_integer())
-            or self.sample_rate <= 0
+            or parsed_rate is None
+            or parsed_rate <= 0
         ):
-            raise ValueError("tts.openai.pcm_sample_rate must be a positive integer")
+            logger.warning(
+                "Invalid tts.openai.pcm_sample_rate %r; falling back to %d Hz",
+                configured_rate,
+                self.sample_rate,
+            )
+            return
+        self.sample_rate = parsed_rate
 
     @staticmethod
     def available() -> bool:

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -263,9 +263,25 @@ def _openai_config_api_key() -> str:
 
 @register("openai")
 class OpenAIStreamer(StreamingTTSProvider):
-    """OpenAI speech with ``response_format=pcm`` (24 kHz mono int16)."""
+    """OpenAI-compatible speech with raw mono int16 PCM output."""
 
     sample_rate = 24000
+
+    def __init__(self, tts_config: Dict, section: Dict):
+        super().__init__(tts_config, section)
+        configured_rate = section.get("pcm_sample_rate", self.sample_rate)
+        try:
+            self.sample_rate = int(configured_rate)
+        except (TypeError, ValueError):
+            raise ValueError(
+                "tts.openai.pcm_sample_rate must be a positive integer"
+            ) from None
+        if (
+            isinstance(configured_rate, bool)
+            or (isinstance(configured_rate, float) and not configured_rate.is_integer())
+            or self.sample_rate <= 0
+        ):
+            raise ValueError("tts.openai.pcm_sample_rate must be a positive integer")
 
     @staticmethod
     def available() -> bool:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1543,6 +1543,7 @@ tts:
     voice: "alloy"              # alloy, echo, fable, onyx, nova, shimmer
     speed: 1.0                  # Speed multiplier (clamped to 0.25–4.0 by the API)
     base_url: "https://api.openai.com/v1"  # Override for OpenAI-compatible TTS endpoints
+    pcm_sample_rate: 24000      # Raw PCM playback rate; match compatible endpoint output
   minimax:
     speed: 1.0                  # Speech speed multiplier
     # base_url: ""              # Optional: override for OpenAI-compatible TTS endpoints

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -147,7 +147,7 @@ The rewrite uses `auxiliary.tts_audio_tags` and defaults to your main chat model
 
 **Language (OpenAI-compatible endpoints)**: `tts.openai.language` is forwarded to the endpoint as a `lang_code` request parameter. It is intended for OpenAI-compatible TTS servers that support `lang_code` — for example [Kokoro-FastAPI](https://github.com/remsky/Kokoro-FastAPI), where `language: "es"` selects the Spanish phonemizer instead of the English default. Leave it unset when using the official OpenAI API, which does not accept this parameter. When unset, nothing extra is sent.
 
-**PCM playback rate (OpenAI-compatible endpoints)**: `tts.openai.pcm_sample_rate` tells Hermes how to play the headerless raw PCM returned by the endpoint. The official OpenAI API uses `24000`, while compatible servers may use a model-native rate—for example, [openedai-speech](https://github.com/matatonic/openedai-speech) emits `22050` Hz PCM for its Piper-backed `tts-1` model. Set this value to the endpoint's output rate or speech will play at the wrong speed and pitch.
+**PCM playback rate (OpenAI-compatible endpoints)**: `tts.openai.pcm_sample_rate` tells Hermes how to play the headerless raw PCM returned by the endpoint. The official OpenAI API uses `24000`, while compatible servers may use a model-native rate—for example, [openedai-speech](https://github.com/matatonic/openedai-speech) emits `22050` Hz PCM for its Piper-backed `tts-1` model. Set this value to the endpoint's output rate or speech will play at the wrong speed and pitch. The value must be a positive integer; invalid values emit a warning and fall back to `24000` Hz without disabling streaming.
 
 
 ### Input length limits

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -57,6 +57,7 @@ tts:
     voice: "alloy"              # alloy, echo, fable, onyx, nova, shimmer
     base_url: "https://api.openai.com/v1"  # Override for OpenAI-compatible TTS endpoints
     speed: 1.0                  # 0.25 - 4.0
+    pcm_sample_rate: 24000      # Raw PCM playback rate; match compatible endpoint output
     # language: "es"            # Sent as lang_code — only for OpenAI-compatible endpoints that support it (e.g. Kokoro)
   minimax:
     region: "global"           # "global" or "cn"; see selection rules below
@@ -145,6 +146,8 @@ tts:
 The rewrite uses `auxiliary.tts_audio_tags` and defaults to your main chat model. Override that auxiliary task if you want tag insertion handled by a cheaper or faster model.
 
 **Language (OpenAI-compatible endpoints)**: `tts.openai.language` is forwarded to the endpoint as a `lang_code` request parameter. It is intended for OpenAI-compatible TTS servers that support `lang_code` — for example [Kokoro-FastAPI](https://github.com/remsky/Kokoro-FastAPI), where `language: "es"` selects the Spanish phonemizer instead of the English default. Leave it unset when using the official OpenAI API, which does not accept this parameter. When unset, nothing extra is sent.
+
+**PCM playback rate (OpenAI-compatible endpoints)**: `tts.openai.pcm_sample_rate` tells Hermes how to play the headerless raw PCM returned by the endpoint. The official OpenAI API uses `24000`, while compatible servers may use a model-native rate—for example, [openedai-speech](https://github.com/matatonic/openedai-speech) emits `22050` Hz PCM for its Piper-backed `tts-1` model. Set this value to the endpoint's output rate or speech will play at the wrong speed and pitch.
 
 
 ### Input length limits

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -1157,6 +1157,7 @@ tts:
     voice: "alloy"              # alloy、echo、fable、onyx、nova、shimmer
     speed: 1.0                  # 速度倍数（API 限制为 0.25–4.0）
     base_url: "https://api.openai.com/v1"  # 覆盖 OpenAI 兼容 TTS 端点
+    pcm_sample_rate: 24000      # 原始 PCM 播放采样率；须与兼容端点输出一致
   minimax:
     speed: 1.0                  # 语音速度倍数
     # base_url: ""              # 可选：覆盖 OpenAI 兼容 TTS 端点

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/tts.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/tts.md
@@ -56,6 +56,7 @@ tts:
     voice: "alloy"              # alloy, echo, fable, onyx, nova, shimmer
     base_url: "https://api.openai.com/v1"  # Override for OpenAI-compatible TTS endpoints
     speed: 1.0                  # 0.25 - 4.0
+    pcm_sample_rate: 24000      # 原始 PCM 播放采样率；须与兼容端点输出一致
   minimax:
     model: "speech-2.8-hd"     # speech-2.8-hd (default), speech-2.8-turbo
     voice_id: "English_Graceful_Lady"  # See https://platform.minimax.io/faq/system-voice-id
@@ -96,6 +97,8 @@ tts:
 ```
 
 **速度控制**：全局 `tts.speed` 值默认应用于所有提供商。每个提供商可用自身的 `speed` 设置覆盖它（例如 `tts.openai.speed: 1.5`）。提供商级别的速度优先于全局值。默认值为 `1.0`（正常速度）。
+
+**PCM 播放采样率（OpenAI 兼容端点）**：`tts.openai.pcm_sample_rate` 告诉 Hermes 如何播放端点返回的无标头原始 PCM。OpenAI 官方 API 使用 `24000`，而兼容服务器可能使用模型的原生采样率；例如，[openedai-speech](https://github.com/matatonic/openedai-speech) 的 Piper `tts-1` 模型输出 `22050` Hz PCM。该值必须与端点输出一致，否则语音的速度和音调会不正确。
 
 
 ### 输入长度限制

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/tts.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/tts.md
@@ -98,7 +98,7 @@ tts:
 
 **速度控制**：全局 `tts.speed` 值默认应用于所有提供商。每个提供商可用自身的 `speed` 设置覆盖它（例如 `tts.openai.speed: 1.5`）。提供商级别的速度优先于全局值。默认值为 `1.0`（正常速度）。
 
-**PCM 播放采样率（OpenAI 兼容端点）**：`tts.openai.pcm_sample_rate` 告诉 Hermes 如何播放端点返回的无标头原始 PCM。OpenAI 官方 API 使用 `24000`，而兼容服务器可能使用模型的原生采样率；例如，[openedai-speech](https://github.com/matatonic/openedai-speech) 的 Piper `tts-1` 模型输出 `22050` Hz PCM。该值必须与端点输出一致，否则语音的速度和音调会不正确。
+**PCM 播放采样率（OpenAI 兼容端点）**：`tts.openai.pcm_sample_rate` 告诉 Hermes 如何播放端点返回的无标头原始 PCM。OpenAI 官方 API 使用 `24000`，而兼容服务器可能使用模型的原生采样率；例如，[openedai-speech](https://github.com/matatonic/openedai-speech) 的 Piper `tts-1` 模型输出 `22050` Hz PCM。该值必须与端点输出一致，否则语音的速度和音调会不正确。该值必须为正整数；无效值会发出警告并回退到 `24000` Hz，而不会禁用流式播放。
 
 
 ### 输入长度限制


### PR DESCRIPTION
## Summary

Allow the OpenAI streaming TTS provider to play raw PCM at a configurable sample rate.

The official OpenAI speech API emits 24 kHz PCM, but OpenAI-compatible endpoints may return PCM at a model-native rate. For example, [`openedai-speech`](https://github.com/matatonic/openedai-speech) returns 22.05 kHz PCM for its Piper-backed `tts-1` model.

Hermes previously opened the playback stream at a hard-coded 24 kHz. Audio from an endpoint using another rate was therefore played at the wrong speed and pitch.

## Changes

- Add `tts.openai.pcm_sample_rate`, defaulting to `24000`
- Use the configured rate for PCM playback and the temporary WAV fallback
- Reject non-positive or non-integer values
- Document the setting for OpenAI-compatible endpoints
- Add coverage for the default, invalid values, and config-to-playback propagation

## Backward compatibility

The default remains `24000`, so the official OpenAI API and existing configurations retain their current behavior.

This setting only controls how Hermes interprets and plays the headerless PCM response. It does not add or modify fields in the upstream API request.

## Design note

Raw PCM does not carry its sample rate in the audio data itself. Some compatible servers expose the rate through non-standard response headers, while others do not.

An explicit playback-rate setting keeps the change small and works consistently across compatible endpoints without adding endpoint-specific detection.

## Verification

- `scripts/run_tests.sh tests/tools/test_tts_streaming.py tests/hermes_cli/test_config.py -q` (226 tests passed)
- Ruff passed for the modified Python files
- `compileall` passed
- Dogfooded with an OpenAI-compatible endpoint returning 48 kHz PCM; playback used the configured 48 kHz rate
