### PR TITLE
fix(desktop): re-sync transcript to server active history on /undo

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -3,7 +3,7 @@ import type { MutableRefObject } from 'react'
 import { useEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getSession } from '@/hermes'
+import { getSession, getSessionMessages } from '@/hermes'
 import { textPart } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
@@ -32,6 +32,7 @@ import { uploadComposerAttachment, usePromptActions } from '.'
 vi.mock('@/hermes', () => ({
   getProfiles: vi.fn(async () => ({ profiles: [] })),
   getSession: vi.fn(),
+  getSessionMessages: vi.fn(async () => ({ messages: [], session_id: '' })),
   PROMPT_SUBMIT_REQUEST_TIMEOUT_MS: 1_800_000,
   setApiRequestProfile: vi.fn(),
   transcribeAudio: vi.fn()
@@ -915,6 +916,139 @@ describe('usePromptActions /compress', () => {
     await waitFor(() => expect($notifications.get().some(item => item.message === 'compressing context...')).toBe(true))
     resolveCompress({ messages: [{ content: 'compressed transcript', role: 'system' }] })
     await submitted
+  })
+})
+
+describe('usePromptActions /undo', () => {
+  // The stored DB id is deliberately different from the runtime id: the
+  // messages endpoint is REST and resolves against the stored sessions table,
+  // so re-syncing with the runtime id would 404 (same mismatch as /title).
+  const UNDO_STORED_SESSION_ID = 'stored-db-undo-1'
+
+  beforeEach(() => {
+    setSessions(() => [sessionInfo({ id: UNDO_STORED_SESSION_ID, profile: 'ai-engineer' })])
+  })
+
+  afterEach(() => {
+    cleanup()
+    setComposerDraft('')
+    setMessages([])
+    vi.restoreAllMocks()
+  })
+
+  it('re-syncs the transcript to the server active history and prefills the composer', async () => {
+    // What the server has left after the undo: the surviving turn only. The
+    // undone user/assistant pair is soft-deleted (active=0) before it answers.
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      messages: [
+        { role: 'user', content: 'first turn that survives' },
+        { role: 'assistant', content: 'reply that survives' }
+      ],
+      session_id: UNDO_STORED_SESSION_ID
+    } as never)
+
+    const seeds: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'slash.exec') {
+        // /undo is a pending-input command, so the slash worker rejects it and
+        // the client falls through to command.dispatch.
+        throw new Error('pending-input command: use command.dispatch for /undo')
+      }
+
+      if (method === 'command.dispatch') {
+        return {
+          type: 'prefill',
+          message: 'the undone message',
+          notice: '↶ Undid 1 turn (2 message(s)). Edit and resubmit, or send a new message.'
+        } as never
+      }
+
+      throw new Error(`unexpected method: ${method}`)
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        seedMessages={[
+          { id: 'u1', role: 'user', parts: [textPart('first turn that survives')] },
+          { id: 'a1', role: 'assistant', parts: [textPart('reply that survives')] },
+          { id: 'u2', role: 'user', parts: [textPart('the undone message')] },
+          { id: 'a2', role: 'assistant', parts: [textPart('reply that gets undone')] }
+        ]}
+        storedSessionId={UNDO_STORED_SESSION_ID}
+      />
+    )
+
+    await handle!.submitText('/undo')
+
+    // Stored id, not the runtime one — and carrying the owning profile, or the
+    // gateway falls back to the launch-profile DB and repaints the transcript
+    // from the wrong profile's session (#67603).
+    expect(getSessionMessages).toHaveBeenCalledWith(UNDO_STORED_SESSION_ID, 'ai-engineer')
+
+    const finalMessages = (seeds[seeds.length - 1]?.messages ?? []) as Array<{
+      parts?: Array<{ text?: string }>
+      role?: string
+    }>
+
+    const renderedText = finalMessages.flatMap(message => (message.parts ?? []).map(part => part.text ?? '')).join('\n')
+
+    // The core complaint in #39019: the undone exchange has to leave the screen.
+    expect(renderedText).not.toContain('the undone message')
+    expect(renderedText).not.toContain('reply that gets undone')
+    expect(renderedText).toContain('first turn that survives')
+
+    // The notice surviving the wholesale replace is what proves the re-sync ran
+    // *before* it was rendered — render it first and the replace eats it.
+    expect(renderedText).toContain('Undid 1 turn')
+
+    // The backed-up text lands in the composer for editing, not the transcript.
+    expect($composerDraft.get()).toContain('the undone message')
+  })
+
+  it('still surfaces the notice and prefill when the history refresh fails', async () => {
+    vi.mocked(getSessionMessages).mockRejectedValue(new Error('sessions endpoint unreachable'))
+
+    const seeds: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'slash.exec') {
+        throw new Error('pending-input command: use command.dispatch for /undo')
+      }
+
+      if (method === 'command.dispatch') {
+        return { type: 'prefill', message: 'the undone message', notice: '↶ Undid 1 turn (2 message(s)).' } as never
+      }
+
+      throw new Error(`unexpected method: ${method}`)
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        storedSessionId={UNDO_STORED_SESSION_ID}
+      />
+    )
+
+    await handle!.submitText('/undo')
+
+    // A failed refresh is reported, but the undo itself already happened
+    // server-side — swallowing the notice and the prefill would lose the
+    // backed-up text entirely.
+    const texts = renderedSeedTexts(seeds)
+
+    expect(texts.some(text => text.includes('sessions endpoint unreachable'))).toBe(true)
+    expect(texts.some(text => text.includes('Undid 1 turn'))).toBe(true)
+    expect($composerDraft.get()).toContain('the undone message')
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -1,7 +1,7 @@
 import { skillInvocationText } from '@hermes/shared'
 import { type MutableRefObject, useCallback, useRef } from 'react'
 
-import { getProfiles } from '@/hermes'
+import { getProfiles, getSessionMessages } from '@/hermes'
 import type { Translations } from '@/i18n'
 import { type ChatMessage, toChatMessages } from '@/lib/chat-messages'
 import { parseCommandDispatch, parseSlashCommand, sessionTitle } from '@/lib/chat-runtime'
@@ -53,6 +53,7 @@ import type {
   SessionTitleResponse,
   SlashExecResponse
 } from '../../../types'
+import { resolveSessionProfile } from '../use-session-actions/utils'
 
 import { resolveTargetSessionId } from './resolve-target-session'
 import {
@@ -274,11 +275,14 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             return
           }
 
-          // send / prefill carry an optional `notice` (e.g. "⊙ Goal set …")
-          // that the backend wants shown as a system line before the message
-          // is acted on. Mirrors the TUI's createSlashHandler — without it a
-          // `/goal <text>` looked like it did nothing.
-          if ((dispatch.type === 'send' || dispatch.type === 'prefill') && dispatch.notice?.trim()) {
+          // send carries an optional `notice` (e.g. "⊙ Goal set …") that the
+          // backend wants shown as a system line before the message is acted
+          // on. Mirrors the TUI's createSlashHandler — without it a
+          // `/goal <text>` looked like it did nothing. `prefill` also carries a
+          // notice, but it renders its own below: the transcript re-sync there
+          // replaces the message list wholesale and would clobber a line
+          // rendered here.
+          if (dispatch.type === 'send' && dispatch.notice?.trim()) {
             renderSlashOutput(dispatch.notice.trim())
 
             // `/goal <text>` returns its "⊙ Goal set …" notice here and kicks
@@ -296,6 +300,42 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           // /undo returns a prefill directive: drop the backed-up message into
           // the composer for editing instead of submitting it immediately.
           if (dispatch.type === 'prefill') {
+            // The backend has already soft-deleted the undone turns (active=0)
+            // by the time it answers, so re-sync the transcript to the server's
+            // active history — without this the undone exchange stays on screen
+            // even though it is gone from the agent's context, which is the
+            // whole complaint in #39019. Same wholesale replace the compress
+            // path above does, and for the same reason: the removed bubbles
+            // have to actually disappear. It intentionally drops local-only
+            // rows; /undo is a discard and runs on an idle session.
+            if (storedSessionId) {
+              try {
+                // Read through the owning profile. Without it the gateway falls
+                // back to the launch-profile DB and we would repaint the
+                // transcript from the wrong profile's session (#67603).
+                const profile = await resolveSessionProfile(storedSessionId)
+                const refreshed = await getSessionMessages(storedSessionId, profile)
+
+                if (Array.isArray(refreshed?.messages)) {
+                  updateSessionState(
+                    sessionId,
+                    state => ({ ...state, messages: toChatMessages(refreshed.messages) }),
+                    storedSessionId
+                  )
+                }
+              } catch (err) {
+                renderSlashOutput(
+                  `/${name}: could not refresh history — ${err instanceof Error ? err.message : String(err)}`
+                )
+              }
+            }
+
+            // After the replace, never before it — see the note on the `send`
+            // notice branch above.
+            if (dispatch.notice?.trim()) {
+              renderSlashOutput(dispatch.notice.trim())
+            }
+
             if (message) {
               setComposerDraft(message)
             }


### PR DESCRIPTION
## Summary

Fixes #39019 (the remaining half). `/undo` cleared the agent's context but left the undone user/assistant exchange visible in the desktop transcript, so the command looked like it had done nothing to the conversation.

This is the narrow follow-up @GottZ asked for in [the #39019 triage](https://github.com/NousResearch/hermes-agent/issues/39019): my earlier PR #39218 was closed by me because #49073 rewrote the prefill plumbing it was built on, but the transcript re-sync it carried was never ported. The prefill directive itself is fully handled on `main` today — notice and composer prefill both land — but the visible history is still never refreshed.

## Root cause

`/undo` is a pending-input command, so `slash.exec` rejects it and the client falls through to `command.dispatch`, which returns a `{type: "prefill", message, notice}` directive **after** soft-deleting the backed-up turns server-side (`tui_gateway/server.py`, `active=0`).

`main`'s prefill branch in `use-prompt-actions/slash.ts` surfaces the notice and calls `setComposerDraft`, but never touches the rendered message list — so the soft-deleted exchange stays on screen until the next session load. That is the reporter's core complaint.

## Fix

In the `prefill` branch, re-sync the rendered transcript to the server's active history before prefilling the composer. This is the same wholesale replace the `/compress` path a few lines above already does, and for the same reason: the removed bubbles have to actually disappear. It intentionally drops local-only rows — `/undo` is a discard and runs on an idle session.

Two details worth flagging for review:

- **The read goes through the stored session id and its owning profile.** `getSessionMessages` hits `/api/sessions/<id>/messages`, which resolves against the stored sessions table — a runtime id 404s there (the same mismatch `/title` documents). And an unprofiled read lets the gateway fall back to the launch-profile DB, which would repaint the transcript from the wrong profile's session (#67603), so it routes through `resolveSessionProfile` like the tile delegate does. A failed refresh is reported inline and does **not** swallow the notice or the prefill — the undo already happened server-side, so losing the backed-up text would be worse.
- **The prefill notice moved into the prefill branch.** It used to render in the shared `send`/`prefill` condition above; the wholesale replace would clobber a line rendered before it. `prefill` is emitted only by `/undo` (single producer in `tui_gateway/server.py`) and always carries a notice, so `send` — and the `/goal` store seeding attached to it — is unaffected.

## Tests

Two new cases in `use-prompt-actions/index.test.tsx`:

- the happy path: asserts `getSessionMessages` is called with the **stored** id + owning profile, that the undone exchange leaves the transcript, and that the notice survives the replace (which is what pins the ordering — render it first and the replace eats it);
- the failure path: a rejected refresh still surfaces the notice and the composer prefill.

Both were confirmed **red without the fix** (`getSessionMessages` never called / notice missing) and green with it.

`apps/desktop`: `npm run typecheck` clean, `eslint` clean on both changed files (one pre-existing `exhaustive-deps` warning on the test harness, present on `main`), and the full `vitest --project ui` suite is **2936 passed / 0 failed**.

## Scope

- **Desktop client only.** No backend or `command.dispatch` changes; the prefill contract is untouched.
- The Ink TUI has the same gap — it handles `prefill` but doesn't re-sync its transcript either. Left out to keep this narrow; happy to follow up if you want parity.
