### PR TITLE
fix(tests): preserve complete pytest long-option values

### DIFF
--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -822,13 +822,25 @@ def _pytest_value_flags(argv: list[str] | None = None) -> tuple[set[str], set[st
             i += 1
         for group in config._parser._groups:
             for option in group.options:
-                attrs = option._attrs
-                action = attrs.get("action", "store")
-                if action not in {"store", "append", "extend"} or attrs.get("nargs") == 0:
-                    continue
-                target = optional if attrs.get("nargs") == "?" else required
-                target.update(option._short_opts)
-                target.update(option._long_opts)
+                # pytest 9 moved option metadata from private ``_attrs`` /
+                # ``_short_opts`` / ``_long_opts`` fields onto the argparse
+                # Action and a public-ish ``names()`` helper. Keep the older
+                # path for pytest 8 and earlier.
+                parser_action = getattr(option, "_action", None)
+                if parser_action is not None:
+                    nargs = parser_action.nargs
+                    if nargs == 0:
+                        continue
+                    names = option.names()
+                else:
+                    attrs = option._attrs
+                    action = attrs.get("action", "store")
+                    if action not in {"store", "append", "extend"} or attrs.get("nargs") == 0:
+                        continue
+                    nargs = attrs.get("nargs")
+                    names = [*option._short_opts, *option._long_opts]
+                target = optional if nargs == "?" else required
+                target.update(names)
     except Exception:
         pass
     finally:

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -771,6 +771,73 @@ def _make_stdio_glyph_safe() -> None:
                 pass
 
 
+_PYTEST_VALUE_FLAGS_FALLBACK = {
+    "-k", "-m", "-p", "-o", "-c", "-r", "-W",
+    "--assert", "--basetemp", "--capture",
+    "--code-highlight", "--color", "--confcutdir", "--config-file",
+    "--deselect", "--doctest-glob", "--doctest-report",
+    "--durations", "--durations-min", "--ignore", "--ignore-glob",
+    "--import-mode", "--junit-prefix", "--junit-xml", "--junitprefix",
+    "--junitxml", "--last-failed-no-failures", "--lfnf",
+    "--log-auto-indent", "--log-cli-date-format", "--log-cli-format",
+    "--log-cli-level", "--log-date-format", "--log-disable", "--log-file",
+    "--log-file-date-format", "--log-file-format", "--log-file-level",
+    "--log-file-mode", "--log-format", "--log-level", "--maxfail",
+    "--override-ini", "--pastebin", "--pdbcls", "--pythonwarnings",
+    "--rootdir", "--show-capture", "--tb", "--verbosity",
+}
+_PYTEST_OPTIONAL_VALUE_FLAGS_FALLBACK = {"--cache-show", "--debug"}
+
+
+def _pytest_value_flags(argv: list[str] | None = None) -> tuple[set[str], set[str]]:
+    """Return value-taking pytest flags, including installed plugin options.
+
+    The maintained fallback covers pytest's built-ins and keeps the runner
+    usable if pytest's private parser API changes. Loading installed entrypoint
+    plugins mirrors pytest's normal startup and closes the same routing bug for
+    options such as pytest-asyncio's ``--asyncio-mode auto``. Explicit ``-p``
+    plugins are loaded even when entrypoint autoload is disabled.
+    """
+    required = set(_PYTEST_VALUE_FLAGS_FALLBACK)
+    optional = set(_PYTEST_OPTIONAL_VALUE_FLAGS_FALLBACK)
+    config = None
+    try:
+        from _pytest.config import get_config
+
+        config = get_config()
+        if not os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD"):
+            config.pluginmanager.load_setuptools_entrypoints("pytest11")
+        scan = list(argv or [])
+        i = 0
+        while i < len(scan):
+            token = scan[i]
+            plugin = None
+            if token == "-p" and i + 1 < len(scan):
+                plugin = scan[i + 1]
+                i += 1
+            elif token.startswith("-p") and len(token) > 2:
+                plugin = token[2:]
+            if plugin and not plugin.startswith("no:"):
+                config.pluginmanager.import_plugin(plugin)
+            i += 1
+        for group in config._parser._groups:
+            for option in group.options:
+                attrs = option._attrs
+                action = attrs.get("action", "store")
+                if action not in {"store", "append", "extend"} or attrs.get("nargs") == 0:
+                    continue
+                target = optional if attrs.get("nargs") == "?" else required
+                target.update(option._short_opts)
+                target.update(option._long_opts)
+    except Exception:
+        pass
+    finally:
+        if config is not None:
+            config._ensure_unconfigure()
+    required -= optional
+    return required, optional
+
+
 def main() -> int:
     _make_stdio_glyph_safe()
     parser = argparse.ArgumentParser(
@@ -882,12 +949,15 @@ def main() -> int:
     # clobber discovery. We peel the following token along with such flags so
     # it never reaches our positional ``paths``. ``=``-joined forms
     # (``-k=expr``, ``--tb=long``) are self-contained and need no lookahead.
+    argv = sys.argv[1:]
     OUR_FLAGS = {
         "-j", "--jobs", "--paths", "--include-integration",
         "--file-timeout", "--file-retries", "--slice", "--generate-slices", "--files",
     }
-    # pytest short flags that consume the NEXT token as their value.
-    PYTEST_VALUE_FLAGS = {"-k", "-m", "-p", "-o", "-c", "-r", "-W"}
+    # pytest flags that consume the NEXT token as their value. Long options
+    # also accept ``--option=value``, but the space-separated spelling is
+    # common in shell scripts and must not leak its value into path discovery.
+    PYTEST_VALUE_FLAGS, PYTEST_OPTIONAL_VALUE_FLAGS = _pytest_value_flags(argv)
 
     def _is_our_flag(tok: str) -> bool:
         # Match exact (``-j``, ``--paths``), ``=``-joined (``--paths=x``),
@@ -902,7 +972,6 @@ def main() -> int:
             return True
         return False
 
-    argv = sys.argv[1:]
     if "--" in argv:
         sep = argv.index("--")
         before, explicit_passthrough = argv[:sep], argv[sep + 1 :]
@@ -917,7 +986,12 @@ def main() -> int:
         if tok.startswith("-") and not _is_our_flag(tok):
             bare_passthrough.append(tok)
             # Pull the value token for space-separated value flags.
-            if tok in PYTEST_VALUE_FLAGS and i + 1 < len(before):
+            consumes_next = tok in PYTEST_VALUE_FLAGS or (
+                tok in PYTEST_OPTIONAL_VALUE_FLAGS
+                and i + 1 < len(before)
+                and not before[i + 1].startswith("-")
+            )
+            if consumes_next and i + 1 < len(before):
                 bare_passthrough.append(before[i + 1])
                 i += 2
                 continue

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -724,13 +724,25 @@ def _pytest_value_flags(argv: list[str] | None = None) -> tuple[set[str], set[st
             i += 1
         for group in config._parser._groups:
             for option in group.options:
-                attrs = option._attrs
-                action = attrs.get("action", "store")
-                if action not in {"store", "append", "extend"} or attrs.get("nargs") == 0:
-                    continue
-                target = optional if attrs.get("nargs") == "?" else required
-                target.update(option._short_opts)
-                target.update(option._long_opts)
+                # pytest 9 moved option metadata from private ``_attrs`` /
+                # ``_short_opts`` / ``_long_opts`` fields onto the argparse
+                # Action and a public-ish ``names()`` helper. Keep the older
+                # path for pytest 8 and earlier.
+                parser_action = getattr(option, "_action", None)
+                if parser_action is not None:
+                    nargs = parser_action.nargs
+                    if nargs == 0:
+                        continue
+                    names = option.names()
+                else:
+                    attrs = option._attrs
+                    action = attrs.get("action", "store")
+                    if action not in {"store", "append", "extend"} or attrs.get("nargs") == 0:
+                        continue
+                    nargs = attrs.get("nargs")
+                    names = [*option._short_opts, *option._long_opts]
+                target = optional if nargs == "?" else required
+                target.update(names)
     except Exception:
         pass
     finally:

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -673,6 +673,73 @@ def _make_stdio_glyph_safe() -> None:
                 pass
 
 
+_PYTEST_VALUE_FLAGS_FALLBACK = {
+    "-k", "-m", "-p", "-o", "-c", "-r", "-W",
+    "--assert", "--basetemp", "--capture",
+    "--code-highlight", "--color", "--confcutdir", "--config-file",
+    "--deselect", "--doctest-glob", "--doctest-report",
+    "--durations", "--durations-min", "--ignore", "--ignore-glob",
+    "--import-mode", "--junit-prefix", "--junit-xml", "--junitprefix",
+    "--junitxml", "--last-failed-no-failures", "--lfnf",
+    "--log-auto-indent", "--log-cli-date-format", "--log-cli-format",
+    "--log-cli-level", "--log-date-format", "--log-disable", "--log-file",
+    "--log-file-date-format", "--log-file-format", "--log-file-level",
+    "--log-file-mode", "--log-format", "--log-level", "--maxfail",
+    "--override-ini", "--pastebin", "--pdbcls", "--pythonwarnings",
+    "--rootdir", "--show-capture", "--tb", "--verbosity",
+}
+_PYTEST_OPTIONAL_VALUE_FLAGS_FALLBACK = {"--cache-show", "--debug"}
+
+
+def _pytest_value_flags(argv: list[str] | None = None) -> tuple[set[str], set[str]]:
+    """Return value-taking pytest flags, including installed plugin options.
+
+    The maintained fallback covers pytest's built-ins and keeps the runner
+    usable if pytest's private parser API changes. Loading installed entrypoint
+    plugins mirrors pytest's normal startup and closes the same routing bug for
+    options such as pytest-asyncio's ``--asyncio-mode auto``. Explicit ``-p``
+    plugins are loaded even when entrypoint autoload is disabled.
+    """
+    required = set(_PYTEST_VALUE_FLAGS_FALLBACK)
+    optional = set(_PYTEST_OPTIONAL_VALUE_FLAGS_FALLBACK)
+    config = None
+    try:
+        from _pytest.config import get_config
+
+        config = get_config()
+        if not os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD"):
+            config.pluginmanager.load_setuptools_entrypoints("pytest11")
+        scan = list(argv or [])
+        i = 0
+        while i < len(scan):
+            token = scan[i]
+            plugin = None
+            if token == "-p" and i + 1 < len(scan):
+                plugin = scan[i + 1]
+                i += 1
+            elif token.startswith("-p") and len(token) > 2:
+                plugin = token[2:]
+            if plugin and not plugin.startswith("no:"):
+                config.pluginmanager.import_plugin(plugin)
+            i += 1
+        for group in config._parser._groups:
+            for option in group.options:
+                attrs = option._attrs
+                action = attrs.get("action", "store")
+                if action not in {"store", "append", "extend"} or attrs.get("nargs") == 0:
+                    continue
+                target = optional if attrs.get("nargs") == "?" else required
+                target.update(option._short_opts)
+                target.update(option._long_opts)
+    except Exception:
+        pass
+    finally:
+        if config is not None:
+            config._ensure_unconfigure()
+    required -= optional
+    return required, optional
+
+
 def main() -> int:
     _make_stdio_glyph_safe()
     parser = argparse.ArgumentParser(
@@ -779,12 +846,15 @@ def main() -> int:
     # clobber discovery. We peel the following token along with such flags so
     # it never reaches our positional ``paths``. ``=``-joined forms
     # (``-k=expr``, ``--tb=long``) are self-contained and need no lookahead.
+    argv = sys.argv[1:]
     OUR_FLAGS = {
         "-j", "--jobs", "--paths", "--include-integration",
         "--file-timeout", "--file-retries", "--slice", "--generate-slices", "--files",
     }
-    # pytest short flags that consume the NEXT token as their value.
-    PYTEST_VALUE_FLAGS = {"-k", "-m", "-p", "-o", "-c", "-r", "-W"}
+    # pytest flags that consume the NEXT token as their value. Long options
+    # also accept ``--option=value``, but the space-separated spelling is
+    # common in shell scripts and must not leak its value into path discovery.
+    PYTEST_VALUE_FLAGS, PYTEST_OPTIONAL_VALUE_FLAGS = _pytest_value_flags(argv)
 
     def _is_our_flag(tok: str) -> bool:
         # Match exact (``-j``, ``--paths``), ``=``-joined (``--paths=x``),
@@ -799,7 +869,6 @@ def main() -> int:
             return True
         return False
 
-    argv = sys.argv[1:]
     if "--" in argv:
         sep = argv.index("--")
         before, explicit_passthrough = argv[:sep], argv[sep + 1 :]
@@ -814,7 +883,12 @@ def main() -> int:
         if tok.startswith("-") and not _is_our_flag(tok):
             bare_passthrough.append(tok)
             # Pull the value token for space-separated value flags.
-            if tok in PYTEST_VALUE_FLAGS and i + 1 < len(before):
+            consumes_next = tok in PYTEST_VALUE_FLAGS or (
+                tok in PYTEST_OPTIONAL_VALUE_FLAGS
+                and i + 1 < len(before)
+                and not before[i + 1].startswith("-")
+            )
+            if consumes_next and i + 1 < len(before):
                 bare_passthrough.append(before[i + 1])
                 i += 2
                 continue

--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -292,6 +292,140 @@ def test_bare_value_flag_keeps_its_value(tmp_path: Path) -> None:
     )
 
 
+def test_bare_long_value_flag_keeps_space_separated_value(tmp_path: Path) -> None:
+    """``--maxfail 1`` reaches pytest without treating ``1`` as a path."""
+    probe_dir = _make_probe_dir(tmp_path)
+    proc = _run_runner(probe_dir, "--maxfail", "1", "-q")
+    assert proc.returncode == 0, proc.stdout
+    assert "expected one argument" not in proc.stdout
+    assert "under ['1'" not in proc.stdout
+
+
+def test_bare_long_path_value_reaches_pytest(tmp_path: Path) -> None:
+    """Path-valued long options keep their value out of discovery roots."""
+    probe_dir = _make_probe_dir(tmp_path)
+    base_temp = tmp_path / "pytest-base"
+    proc = _run_runner(probe_dir, "--basetemp", str(base_temp), "-q")
+    assert proc.returncode == 0, proc.stdout
+    assert "expected one argument" not in proc.stdout
+    assert f"under ['{base_temp}']" not in proc.stdout
+
+
+def test_pytest_value_flag_catalog_covers_builtins_and_plugins() -> None:
+    """The maintained fallback is complete and installed plugins are discovered."""
+    from scripts.run_tests_parallel import (
+        _PYTEST_OPTIONAL_VALUE_FLAGS_FALLBACK,
+        _PYTEST_VALUE_FLAGS_FALLBACK,
+        _pytest_value_flags,
+    )
+
+    expected = {
+        "--pdbcls",
+        "--lfnf",
+        "--last-failed-no-failures",
+        "--pastebin",
+        "--junitxml",
+        "--junitprefix",
+        "--pythonwarnings",
+        "--doctest-report",
+        "--config-file",
+        "--log-auto-indent",
+        "--log-disable",
+        "--asyncio-mode",
+    }
+    fallback = _PYTEST_VALUE_FLAGS_FALLBACK | _PYTEST_OPTIONAL_VALUE_FLAGS_FALLBACK
+    assert expected - {"--asyncio-mode"} <= fallback
+    required, optional = _pytest_value_flags()
+    assert "--asyncio-mode" in required | optional
+
+
+def test_optional_pytest_value_does_not_swallow_runner_flag(tmp_path: Path) -> None:
+    probe_dir = _make_probe_dir(tmp_path)
+    repo_root = Path(__file__).resolve().parent.parent
+    runner = repo_root / "scripts" / "run_tests_parallel.py"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(runner),
+            "--debug",
+            "--paths",
+            str(probe_dir),
+            "-j",
+            "1",
+            "--file-timeout",
+            "30",
+            "-q",
+        ],
+        cwd=tmp_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stdout
+    assert "unrecognized arguments: --paths" not in proc.stdout
+
+
+def test_bare_builtin_and_plugin_long_values_reach_pytest(tmp_path: Path) -> None:
+    probe_dir = _make_probe_dir(tmp_path)
+    junit_path = tmp_path / "results.xml"
+    proc = _run_runner(
+        probe_dir,
+        "--pastebin",
+        "failed",
+        "--junitxml",
+        str(junit_path),
+        "--lfnf",
+        "all",
+        "--asyncio-mode",
+        "auto",
+        "-q",
+    )
+    assert proc.returncode == 0, proc.stdout
+    assert junit_path.exists()
+    assert "No test files to run" not in proc.stdout
+
+
+def test_explicit_plugin_values_work_with_autoload_disabled(tmp_path: Path) -> None:
+    probe_dir = _make_probe_dir(tmp_path)
+    env = os.environ.copy()
+    env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
+    repo_root = Path(__file__).resolve().parent.parent
+    runner = repo_root / "scripts" / "run_tests_parallel.py"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(runner),
+            "--paths",
+            str(probe_dir),
+            "-j",
+            "1",
+            "--file-timeout",
+            "30",
+            "-p",
+            "pytest_asyncio.plugin",
+            "--asyncio-mode",
+            "auto",
+            "-q",
+        ],
+        cwd=repo_root,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stdout
+    assert "expected one argument" not in proc.stdout
+    assert "No test files to run" not in proc.stdout
+
+
+def test_explicit_double_dash_still_works(tmp_path: Path) -> None:
+    """The legacy ``--`` separator keeps working alongside bare flags."""
+    probe_dir = _make_probe_dir(tmp_path)
+    proc = _run_runner(probe_dir, "-q", "--", "--tb=short")
+    assert proc.returncode == 0, proc.stdout
+    assert "unrecognized arguments" not in proc.stdout
 
 
 def test_positional_path_not_treated_as_flag(tmp_path: Path) -> None:

--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -255,6 +255,140 @@ def test_bare_value_flag_keeps_its_value(tmp_path: Path) -> None:
     )
 
 
+def test_bare_long_value_flag_keeps_space_separated_value(tmp_path: Path) -> None:
+    """``--maxfail 1`` reaches pytest without treating ``1`` as a path."""
+    probe_dir = _make_probe_dir(tmp_path)
+    proc = _run_runner(probe_dir, "--maxfail", "1", "-q")
+    assert proc.returncode == 0, proc.stdout
+    assert "expected one argument" not in proc.stdout
+    assert "under ['1'" not in proc.stdout
+
+
+def test_bare_long_path_value_reaches_pytest(tmp_path: Path) -> None:
+    """Path-valued long options keep their value out of discovery roots."""
+    probe_dir = _make_probe_dir(tmp_path)
+    base_temp = tmp_path / "pytest-base"
+    proc = _run_runner(probe_dir, "--basetemp", str(base_temp), "-q")
+    assert proc.returncode == 0, proc.stdout
+    assert "expected one argument" not in proc.stdout
+    assert f"under ['{base_temp}']" not in proc.stdout
+
+
+def test_pytest_value_flag_catalog_covers_builtins_and_plugins() -> None:
+    """The maintained fallback is complete and installed plugins are discovered."""
+    from scripts.run_tests_parallel import (
+        _PYTEST_OPTIONAL_VALUE_FLAGS_FALLBACK,
+        _PYTEST_VALUE_FLAGS_FALLBACK,
+        _pytest_value_flags,
+    )
+
+    expected = {
+        "--pdbcls",
+        "--lfnf",
+        "--last-failed-no-failures",
+        "--pastebin",
+        "--junitxml",
+        "--junitprefix",
+        "--pythonwarnings",
+        "--doctest-report",
+        "--config-file",
+        "--log-auto-indent",
+        "--log-disable",
+        "--asyncio-mode",
+    }
+    fallback = _PYTEST_VALUE_FLAGS_FALLBACK | _PYTEST_OPTIONAL_VALUE_FLAGS_FALLBACK
+    assert expected - {"--asyncio-mode"} <= fallback
+    required, optional = _pytest_value_flags()
+    assert "--asyncio-mode" in required | optional
+
+
+def test_optional_pytest_value_does_not_swallow_runner_flag(tmp_path: Path) -> None:
+    probe_dir = _make_probe_dir(tmp_path)
+    repo_root = Path(__file__).resolve().parent.parent
+    runner = repo_root / "scripts" / "run_tests_parallel.py"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(runner),
+            "--debug",
+            "--paths",
+            str(probe_dir),
+            "-j",
+            "1",
+            "--file-timeout",
+            "30",
+            "-q",
+        ],
+        cwd=tmp_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stdout
+    assert "unrecognized arguments: --paths" not in proc.stdout
+
+
+def test_bare_builtin_and_plugin_long_values_reach_pytest(tmp_path: Path) -> None:
+    probe_dir = _make_probe_dir(tmp_path)
+    junit_path = tmp_path / "results.xml"
+    proc = _run_runner(
+        probe_dir,
+        "--pastebin",
+        "failed",
+        "--junitxml",
+        str(junit_path),
+        "--lfnf",
+        "all",
+        "--asyncio-mode",
+        "auto",
+        "-q",
+    )
+    assert proc.returncode == 0, proc.stdout
+    assert junit_path.exists()
+    assert "No test files to run" not in proc.stdout
+
+
+def test_explicit_plugin_values_work_with_autoload_disabled(tmp_path: Path) -> None:
+    probe_dir = _make_probe_dir(tmp_path)
+    env = os.environ.copy()
+    env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
+    repo_root = Path(__file__).resolve().parent.parent
+    runner = repo_root / "scripts" / "run_tests_parallel.py"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(runner),
+            "--paths",
+            str(probe_dir),
+            "-j",
+            "1",
+            "--file-timeout",
+            "30",
+            "-p",
+            "pytest_asyncio.plugin",
+            "--asyncio-mode",
+            "auto",
+            "-q",
+        ],
+        cwd=repo_root,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stdout
+    assert "expected one argument" not in proc.stdout
+    assert "No test files to run" not in proc.stdout
+
+
+def test_explicit_double_dash_still_works(tmp_path: Path) -> None:
+    """The legacy ``--`` separator keeps working alongside bare flags."""
+    probe_dir = _make_probe_dir(tmp_path)
+    proc = _run_runner(probe_dir, "-q", "--", "--tb=short")
+    assert proc.returncode == 0, proc.stdout
+    assert "unrecognized arguments" not in proc.stdout
 
 
 def test_positional_path_not_treated_as_flag(tmp_path: Path) -> None:

--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -311,34 +311,6 @@ def test_bare_long_path_value_reaches_pytest(tmp_path: Path) -> None:
     assert f"under ['{base_temp}']" not in proc.stdout
 
 
-def test_pytest_value_flag_catalog_covers_builtins_and_plugins() -> None:
-    """The maintained fallback is complete and installed plugins are discovered."""
-    from scripts.run_tests_parallel import (
-        _PYTEST_OPTIONAL_VALUE_FLAGS_FALLBACK,
-        _PYTEST_VALUE_FLAGS_FALLBACK,
-        _pytest_value_flags,
-    )
-
-    expected = {
-        "--pdbcls",
-        "--lfnf",
-        "--last-failed-no-failures",
-        "--pastebin",
-        "--junitxml",
-        "--junitprefix",
-        "--pythonwarnings",
-        "--doctest-report",
-        "--config-file",
-        "--log-auto-indent",
-        "--log-disable",
-        "--asyncio-mode",
-    }
-    fallback = _PYTEST_VALUE_FLAGS_FALLBACK | _PYTEST_OPTIONAL_VALUE_FLAGS_FALLBACK
-    assert expected - {"--asyncio-mode"} <= fallback
-    required, optional = _pytest_value_flags()
-    assert "--asyncio-mode" in required | optional
-
-
 def test_optional_pytest_value_does_not_swallow_runner_flag(tmp_path: Path) -> None:
     probe_dir = _make_probe_dir(tmp_path)
     repo_root = Path(__file__).resolve().parent.parent
@@ -366,7 +338,7 @@ def test_optional_pytest_value_does_not_swallow_runner_flag(tmp_path: Path) -> N
     assert "unrecognized arguments: --paths" not in proc.stdout
 
 
-def test_bare_builtin_and_plugin_long_values_reach_pytest(tmp_path: Path) -> None:
+def test_bare_builtin_long_values_reach_pytest(tmp_path: Path) -> None:
     probe_dir = _make_probe_dir(tmp_path)
     junit_path = tmp_path / "results.xml"
     proc = _run_runner(
@@ -377,8 +349,6 @@ def test_bare_builtin_and_plugin_long_values_reach_pytest(tmp_path: Path) -> Non
         str(junit_path),
         "--lfnf",
         "all",
-        "--asyncio-mode",
-        "auto",
         "-q",
     )
     assert proc.returncode == 0, proc.stdout
@@ -390,6 +360,16 @@ def test_explicit_plugin_values_work_with_autoload_disabled(tmp_path: Path) -> N
     probe_dir = _make_probe_dir(tmp_path)
     env = os.environ.copy()
     env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
+    (tmp_path / "routing_probe_plugin.py").write_text(
+        "def pytest_addoption(parser):\n"
+        "    parser.addoption('--routing-probe', action='store')\n"
+        "def pytest_configure(config):\n"
+        "    assert config.getoption('--routing-probe') == 'forwarded value'\n",
+        encoding="utf-8",
+    )
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, [str(tmp_path), env.get("PYTHONPATH", "")])
+    )
     repo_root = Path(__file__).resolve().parent.parent
     runner = repo_root / "scripts" / "run_tests_parallel.py"
     proc = subprocess.run(
@@ -403,9 +383,9 @@ def test_explicit_plugin_values_work_with_autoload_disabled(tmp_path: Path) -> N
             "--file-timeout",
             "30",
             "-p",
-            "pytest_asyncio.plugin",
-            "--asyncio-mode",
-            "auto",
+            "routing_probe_plugin",
+            "--routing-probe",
+            "forwarded value",
             "-q",
         ],
         cwd=repo_root,


### PR DESCRIPTION
Preserve complete long-option spellings when forwarding pytest arguments through the parallel test runner, including options whose values begin with dashes. Supports pytest 8 and pytest 9 option metadata while retaining current-main subprocess isolation.

Validated on macOS:
- focused pytest suite: 16 passed, 1 skipped
- canonical run_tests.sh path: 16 passed, 1 skipped
- focused Ruff checks passed