### PR TITLE
fix(mcp): prevent OAuth retry self-collisions

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -26,7 +26,11 @@ from hermes_cli.config import (
 from hermes_cli.colors import Colors, color
 from hermes_constants import display_hermes_home
 from hermes_cli.mcp_security import validate_mcp_server_entry
-from tools.mcp_tool import _ENV_VAR_PATTERN, _env_ref_name
+from tools.mcp_tool import (
+    _ENV_VAR_PATTERN,
+    _env_ref_name,
+    _unwrap_exception_group as _unwrap_mcp_exception_group,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -402,8 +406,7 @@ def _unwrap_exception_group(exc: BaseException) -> Exception:
     messages opaque ("unhandled errors in a TaskGroup").  We unwrap
     to surface the real cause (e.g. "401 Unauthorized").
     """
-    while isinstance(exc, BaseExceptionGroup) and exc.exceptions:
-        exc = exc.exceptions[0]
+    exc = _unwrap_mcp_exception_group(exc)
     # Return a plain Exception so callers can catch normally
     if isinstance(exc, Exception):
         return exc

--- a/tests/tools/test_mcp_failure_classification.py
+++ b/tests/tools/test_mcp_failure_classification.py
@@ -37,6 +37,13 @@ class TestUnwrapExceptionGroup:
         inner = BrokenPipeError()
         assert _unwrap_exception_group(_group(inner)) is inner
 
+    def test_prefers_oauth_error_over_socket_teardown(self):
+        from mcp.client.auth import OAuthTokenError
+
+        auth_error = OAuthTokenError("invalid_client: bad secret")
+        group = _group(OSError("address already in use"), _group(auth_error))
+
+        assert _unwrap_exception_group(group) is auth_error
 
     def test_system_exit_reraises(self):
         with pytest.raises(SystemExit):

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -383,6 +383,56 @@ class TestCallbackPortReservation:
         assert code == "flowA"
         assert state == "sA"
 
+    def test_same_pinned_port_waiters_are_serialized(self, monkeypatch):
+        """A second active flow waits instead of binding an owned pinned port."""
+        import asyncio
+        import threading
+        import tools.mcp_oauth as mod
+
+        port = _find_free_port()
+        monkeypatch.setattr(mod, "_is_interactive", lambda: False)
+        monkeypatch.setattr(mod, "_raise_if_non_interactive", lambda lead: None)
+
+        async def drive():
+            real_http_server = mod.HTTPServer
+            first_active = asyncio.Event()
+            second_active = asyncio.Event()
+            activation_count = 0
+
+            class RecordingHTTPServer(real_http_server):
+                def server_activate(self):
+                    nonlocal activation_count
+                    super().server_activate()
+                    activation_count += 1
+                    (first_active if activation_count == 1 else second_active).set()
+
+            monkeypatch.setattr(mod, "HTTPServer", RecordingHTTPServer)
+
+            first = asyncio.create_task(mod._make_callback_waiter(port)())
+            await asyncio.wait_for(first_active.wait(), timeout=2)
+
+            second = asyncio.create_task(mod._make_callback_waiter(port)())
+            await asyncio.sleep(0)
+            assert not second.done()
+            assert activation_count == 1
+
+            threading.Thread(
+                target=_hit_callback_when_ready,
+                args=(f"http://127.0.0.1:{port}/callback?code=first&state=s1",),
+                daemon=True,
+            ).start()
+            assert await asyncio.wait_for(first, timeout=2) == ("first", "s1")
+
+            await asyncio.wait_for(second_active.wait(), timeout=2)
+            threading.Thread(
+                target=_hit_callback_when_ready,
+                args=(f"http://127.0.0.1:{port}/callback?code=second&state=s2",),
+                daemon=True,
+            ).start()
+            assert await asyncio.wait_for(second, timeout=2) == ("second", "s2")
+
+        asyncio.run(drive())
+
 
 # ---------------------------------------------------------------------------
 # remove_oauth_tokens
@@ -833,6 +883,7 @@ def test_wait_for_callback_port_in_use_reports_clear_error(monkeypatch):
     assert "54321" in msg
     assert "already in use" in msg
     assert "timed out" not in msg
+    assert 54321 not in mo._active_callback_ports
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import socket
 import stat
 import sys
 from io import BytesIO
@@ -675,6 +676,38 @@ class TestPasteCallbackReader:
 
 class TestWaitForCallbackPasteIntegration:
     """_wait_for_callback offers the paste prompt only when interactive."""
+
+    def test_paste_callback_stops_http_listener_and_releases_port(self, monkeypatch):
+        """The paste winner must not leave the loopback listener blocked in accept."""
+        import tools.mcp_oauth as mod
+
+        port = _find_free_port()
+        monkeypatch.setattr(mod, "_is_interactive", lambda: True)
+        monkeypatch.setattr(
+            mod.sys.stdin,
+            "readline",
+            lambda: "code=from_paste&state=paste_state\n",
+        )
+
+        real_thread = mod.threading.Thread
+        created_threads = []
+
+        def recording_thread(*args, **kwargs):
+            thread = real_thread(*args, **kwargs)
+            created_threads.append(thread)
+            return thread
+
+        monkeypatch.setattr(mod.threading, "Thread", recording_thread)
+
+        result = asyncio.run(mod._make_callback_waiter(port)())
+
+        assert result == ("from_paste", "paste_state")
+        listener_thread = created_threads[0]
+        listener_thread.join(timeout=1.0)
+        assert not listener_thread.is_alive()
+
+        with socket.socket() as rebound:
+            rebound.bind(("127.0.0.1", port))
 
     def test_paste_prompt_shown_on_tty(self, monkeypatch, capsys):
         import tools.mcp_oauth as mod

--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -243,6 +243,7 @@ def _fake_response(status, url, body):
     resp = MagicMock()
     resp.status_code = status
     resp.request = SimpleNamespace(url=url)
+    resp.text = body.decode("utf-8", errors="replace")
 
     async def _aread():
         return body
@@ -285,6 +286,46 @@ def test_invalid_client_at_token_endpoint_poisons(tmp_path, monkeypatch):
     assert (d / "srv.client.json.bak").exists()
     assert provider._initialized is False
     assert provider.context.client_info is None
+    assert provider._hermes_terminal_token_error is None
+
+
+def test_preregistered_invalid_client_is_latched_not_poisoned(tmp_path, monkeypatch):
+    """A config-supplied credential fails terminally; re-registration cannot help."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    provider = _provider_with_token_endpoint(
+        tmp_path, {"client_id": "from-config"}, "https://idp.example.com/oauth/token", monkeypatch
+    )
+    d = tmp_path / "mcp-tokens"
+    # _maybe_preregister_client wrote client.json from config during build.
+    assert (d / "srv.client.json").exists()
+    resp = _fake_response(
+        400, "https://idp.example.com/oauth/token", b'{"error":"invalid_client"}'
+    )
+
+    asyncio.run(provider._maybe_flag_poisoned_client(resp))
+
+    assert (d / "srv.client.json").exists()
+    assert provider._initialized is True
+    assert provider._hermes_terminal_token_error == (
+        'Token exchange failed (400): {"error":"invalid_client"}'
+    )
+
+
+def test_configured_client_secret_alone_makes_invalid_client_terminal(
+    tmp_path, monkeypatch
+):
+    """A user-supplied secret must not be mistaken for dynamic registration."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    token_ep = "https://idp.example.com/oauth/token"
+    provider = _provider_with_token_endpoint(
+        tmp_path, {"client_secret": "wrong"}, token_ep, monkeypatch
+    )
+    resp = _fake_response(400, token_ep, b'{"error":"invalid_client"}')
+
+    asyncio.run(provider._maybe_flag_poisoned_client(resp))
+
+    assert provider._hermes_terminal_token_error is not None
+    assert provider._initialized is True
 
 
 def test_invalid_client_metadata_does_not_trip(tmp_path, monkeypatch):
@@ -364,3 +405,116 @@ def test_bridge_forwards_requests_and_poisons_on_token_endpoint_400(
     assert not (d / "srv.client.json").exists()
     assert provider._initialized is False
     assert provider.context.client_info is None
+
+
+def test_preregistered_token_error_stops_subsequent_auth_flows(tmp_path, monkeypatch):
+    """Concurrent requests must preserve invalid_client instead of opening a new flow."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    token_ep = "https://idp.example.com/oauth/token"
+    provider = _provider_with_token_endpoint(
+        tmp_path,
+        {"client_id": "configured", "client_secret": "wrong"},
+        token_ep,
+        monkeypatch,
+    )
+
+    from mcp.client.auth import OAuthTokenError
+    from mcp.client.auth.oauth2 import OAuthClientProvider
+
+    flow_starts = 0
+
+    async def fake_base_flow(self, request):
+        nonlocal flow_starts
+        flow_starts += 1
+        response = yield request
+        raise OAuthTokenError(
+            f"Token exchange failed ({response.status_code}): {response.text}"
+        )
+
+    monkeypatch.setattr(OAuthClientProvider, "async_auth_flow", fake_base_flow)
+    body = b'{"error":"invalid_client","error_description":"bad secret"}'
+    response = _fake_response(400, token_ep, body)
+    expected = f"Token exchange failed (400): {body.decode()}"
+
+    async def drive():
+        first = provider.async_auth_flow(object())
+        await first.__anext__()
+        with pytest.raises(OAuthTokenError) as first_error:
+            await first.asend(response)
+
+        second = provider.async_auth_flow(object())
+        with pytest.raises(OAuthTokenError) as second_error:
+            await second.__anext__()
+
+        return str(first_error.value), str(second_error.value)
+
+    first_message, second_message = asyncio.run(drive())
+
+    assert first_message == expected
+    assert second_message == expected
+    assert flow_starts == 1
+
+
+def test_queued_auth_flow_checks_terminal_error_before_yield(tmp_path, monkeypatch):
+    """A flow already queued on the SDK lock must not emit another OAuth request."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    provider = _provider_with_token_endpoint(
+        tmp_path,
+        {"client_id": "configured", "client_secret": "wrong"},
+        "https://idp.example.com/oauth/token",
+        monkeypatch,
+    )
+
+    from mcp.client.auth import OAuthTokenError
+    from mcp.client.auth.oauth2 import OAuthClientProvider
+
+    async def fake_queued_flow(self, request):
+        self._hermes_terminal_token_error = "terminal credential failure"
+        yield request
+
+    monkeypatch.setattr(OAuthClientProvider, "async_auth_flow", fake_queued_flow)
+
+    async def drive():
+        flow = provider.async_auth_flow(object())
+        with pytest.raises(OAuthTokenError, match="terminal credential failure"):
+            await flow.__anext__()
+
+    asyncio.run(drive())
+
+
+def test_refresh_invalid_client_stops_before_browser_reauthorization(
+    tmp_path, monkeypatch
+):
+    """A rejected configured refresh must not advance into a browser flow."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    token_ep = "https://idp.example.com/oauth/token"
+    provider = _provider_with_token_endpoint(
+        tmp_path,
+        {"client_id": "configured", "client_secret": "wrong"},
+        token_ep,
+        monkeypatch,
+    )
+
+    from mcp.client.auth import OAuthTokenError
+    from mcp.client.auth.oauth2 import OAuthClientProvider
+
+    browser_request = object()
+
+    async def fake_refresh_flow(self, request):
+        yield object()  # refresh request
+        yield browser_request  # what the SDK would emit after refresh fails
+
+    monkeypatch.setattr(OAuthClientProvider, "async_auth_flow", fake_refresh_flow)
+    response = _fake_response(
+        400,
+        token_ep,
+        b'{"error":"invalid_client","error_description":"bad secret"}',
+    )
+
+    async def drive():
+        flow = provider.async_auth_flow(object())
+        await flow.__anext__()
+        with pytest.raises(OAuthTokenError, match="invalid_client"):
+            await flow.asend(response)
+
+    asyncio.run(drive())

--- a/tests/tools/test_mcp_oauth_metadata.py
+++ b/tests/tools/test_mcp_oauth_metadata.py
@@ -89,6 +89,7 @@ def _manager_provider_with_context(storage: HermesTokenStorage, **context_attrs)
         pytest.skip("MCP SDK auth not available")
     provider = _HERMES_PROVIDER_CLS.__new__(_HERMES_PROVIDER_CLS)
     provider._hermes_server_name = context_attrs.get("server_name", "srv")
+    provider._hermes_terminal_token_error = None
     context = MagicMock()
     context.storage = storage
     context.oauth_metadata = context_attrs.get("oauth_metadata")

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -214,6 +214,32 @@ def _find_free_port() -> int:
 _reserved_sockets: "dict[int, socket.socket]" = {}
 _MAX_RESERVED_SOCKETS = 8
 
+# In-process callback waiters may run on different event loops/threads, so an
+# asyncio.Lock cannot safely coordinate them. Track ownership under a short
+# threading lock and let waiters poll asynchronously before they bind. Port 0
+# is excluded because the OS assigns each such listener its own ephemeral port.
+_active_callback_ports: set[int] = set()
+_active_callback_ports_guard = threading.Lock()
+_CALLBACK_PORT_CLAIM_POLL_SECONDS = 0.05
+
+
+def _try_claim_callback_port(port: int) -> bool:
+    """Claim a fixed callback port for one in-process waiter."""
+    if port == 0:
+        return True
+    with _active_callback_ports_guard:
+        if port in _active_callback_ports:
+            return False
+        _active_callback_ports.add(port)
+        return True
+
+
+def _release_callback_port(port: int) -> None:
+    if port == 0:
+        return
+    with _active_callback_ports_guard:
+        _active_callback_ports.discard(port)
+
 
 def _reserve_callback_port() -> int:
     """Pick an ephemeral callback port and keep its socket bound.
@@ -831,30 +857,7 @@ def _make_callback_waiter(port: int):
             to complete the browser auth), or in non-interactive contexts.
     """
 
-    async def _wait() -> tuple[str, str | None]:
-        from tools.mcp_dashboard_oauth import get_dashboard_oauth_flow
-
-        dashboard_flow = get_dashboard_oauth_flow()
-        if dashboard_flow is not None:
-            return await dashboard_flow.wait_for_callback()
-
-        # Reject before binding the callback listener in non-interactive
-        # contexts. Reaching here means the SDK entered the authorization-code
-        # flow (a valid or refreshable token would never call the callback
-        # handler), so a cached token file is present but unusable. Binding the
-        # listener here would block for the full 300s timeout and — on the next
-        # connection retry — collide with the still-bound/TIME_WAIT port,
-        # surfacing as ``OSError: [Errno 98] Address already in use``. Failing
-        # fast keeps gateway startup independent of an unusable optional MCP
-        # server. This guard holds "regardless of whether a token file exists"
-        # — the point the build_oauth_auth token-file guard cannot cover.
-        # See #57836.
-        _raise_if_non_interactive(
-            "OAuth callback requires an interactive session but none is "
-            "available (non-interactive/background context); skipping browser "
-            "authorization without binding a callback listener."
-        )
-
+    async def _wait_with_claimed_port() -> tuple[str, str | None]:
         handler_cls, result = _make_callback_handler()
 
         # Start a temporary server on this flow's port, adopting the socket
@@ -948,6 +951,41 @@ def _make_callback_waiter(port: int):
             )
 
         return result["auth_code"], result["state"]
+
+    async def _wait() -> tuple[str, str | None]:
+        from tools.mcp_dashboard_oauth import get_dashboard_oauth_flow
+
+        dashboard_flow = get_dashboard_oauth_flow()
+        if dashboard_flow is not None:
+            return await dashboard_flow.wait_for_callback()
+
+        # Reject before binding the callback listener in non-interactive
+        # contexts. Reaching here means the SDK entered the authorization-code
+        # flow (a valid or refreshable token would never call the callback
+        # handler), so a cached token file is present but unusable. Binding the
+        # listener here would block for the full 300s timeout and — on the next
+        # connection retry — collide with the still-bound/TIME_WAIT port,
+        # surfacing as ``OSError: [Errno 98] Address already in use``. Failing
+        # fast keeps gateway startup independent of an unusable optional MCP
+        # server. This guard holds "regardless of whether a token file exists"
+        # — the point the build_oauth_auth token-file guard cannot cover.
+        # See #57836.
+        _raise_if_non_interactive(
+            "OAuth callback requires an interactive session but none is "
+            "available (non-interactive/background context); skipping browser "
+            "authorization without binding a callback listener."
+        )
+
+        port_claimed = False
+        try:
+            while not port_claimed:
+                port_claimed = _try_claim_callback_port(port)
+                if not port_claimed:
+                    await asyncio.sleep(_CALLBACK_PORT_CLAIM_POLL_SECONDS)
+            return await _wait_with_claimed_port()
+        finally:
+            if port_claimed:
+                _release_callback_port(port)
 
     return _wait
 

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -892,7 +892,12 @@ def _make_callback_waiter(port: int):
                 "in the server config, then retry."
             ) from exc
 
-        server_thread = threading.Thread(target=server.handle_request, daemon=True)
+        server_thread = threading.Thread(
+            target=server.serve_forever,
+            kwargs={"poll_interval": 0.1},
+            daemon=True,
+            name=f"mcp-oauth-callback-{port}",
+        )
         server_thread.start()
 
         # Optional paste-fallback thread: only on interactive TTYs. Reads one
@@ -923,7 +928,14 @@ def _make_callback_waiter(port: int):
                 await asyncio.sleep(poll_interval)
                 elapsed += poll_interval
         finally:
-            server.server_close()
+            # server_close() alone does not reliably wake a listener blocked in
+            # accept() on another thread. Stop serve_forever first and wait for
+            # the thread to exit so an immediate retry can reuse a pinned port.
+            try:
+                server.shutdown()
+                server_thread.join(timeout=1.0)
+            finally:
+                server.server_close()
 
         if result["error"] == _USER_SKIPPED_SENTINEL:
             raise OAuthNonInteractiveError("user_skipped")

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -35,6 +35,7 @@ Design reference:
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import re
 import threading
@@ -139,12 +140,13 @@ def _make_hermes_provider_class() -> Optional[type]:
             super().__init__(*args, **kwargs)
             self._hermes_server_name = server_name
             self._hermes_home = ""
-            # When the client_id comes from config.yaml (pre-registered), an
+            # When either client credential comes from config.yaml, an
             # invalid_client rejection means the *config* is wrong — deleting
-            # client.json would just be re-seeded from config and re-running
-            # registration can't help. Only auto-heal dynamically-registered
-            # clients. See _maybe_flag_poisoned_client.
+            # client.json or repeating browser authorization cannot help. Only
+            # auto-heal clients whose credentials are entirely dynamic. See
+            # _maybe_flag_poisoned_client.
             self._hermes_preregistered = preregistered
+            self._hermes_terminal_token_error: str | None = None
 
         async def _initialize(self) -> None:
             """Load stored tokens + client info AND seed token_expiry_time.
@@ -320,26 +322,26 @@ def _make_hermes_provider_class() -> Optional[type]:
                 storage.save_oauth_metadata(meta)
 
         async def _maybe_flag_poisoned_client(self, response: Any) -> None:
-            """Detect a dead client registration and force re-registration.
+            """Handle deterministic client errors from the token endpoint.
 
             When the IdP rejects our ``client_id`` with ``invalid_client`` on
             the token endpoint (token exchange or refresh), the cached client
-            registration is provably dead server-side. We delete ``client.json``
-            (+ stale metadata) so the SDK's next ``async_auth_flow`` takes the
-            ``if not client_info`` branch and re-runs RFC 7591 dynamic client
-            registration. This addresses the recurring manual-reset ritual in
-            GH#36767 for the auto-detectable subset (token-endpoint rejection);
-            the browser-side "Redirect URI Mismatch" case has no HTTP signal
-            and is handled by ``hermes mcp reauth``.
+            registration is either stale dynamic state or bad configured
+            credentials. Dynamic registrations delete ``client.json`` (+ stale
+            metadata) so the next flow re-runs RFC 7591 registration (GH#36767).
+            Configured credentials instead latch the error because neither
+            registration nor another browser round-trip can repair them.
 
             Conservative by construction — acts ONLY when all hold:
               * status is 400/401,
               * the request hit the discovered ``token_endpoint`` (the only
                 request carrying our ``client_id``), and
-              * the body carries the ``invalid_client`` error code
-                (word-boundary match, so RFC 7591's ``invalid_client_metadata``
-                registration error does not trip it).
-            Pre-registered (config-supplied) clients are never poisoned.
+              * the body carries ``invalid_client`` or ``unauthorized_client``
+                as its OAuth error code (with a word-boundary fallback for
+                non-JSON servers, so ``invalid_client_metadata`` does not trip).
+            Config-supplied clients are never poisoned. Their deterministic
+            error is latched instead so sibling transport requests cannot
+            start another browser flow after the first token exchange fails.
             Fully best-effort: any failure here is swallowed so a detection
             miss never breaks the live auth flow.
 
@@ -350,8 +352,6 @@ def _make_hermes_provider_class() -> Optional[type]:
             back to ``hermes mcp reauth``.
             """
             try:
-                if self._hermes_preregistered:
-                    return
                 status = getattr(response, "status_code", None)
                 if status not in (400, 401):
                     return
@@ -368,10 +368,33 @@ def _make_hermes_provider_class() -> Optional[type]:
                 if not _same_endpoint(req_url, token_endpoint):
                     return
                 body = await response.aread()
-                # Word-boundary match: matches `"error":"invalid_client"` but
-                # not the RFC 7591 registration error `invalid_client_metadata`
-                # (the trailing `_metadata` removes the right-hand boundary).
-                if not re.search(rb"\binvalid_client\b", body.lower()):
+                try:
+                    payload = json.loads(body)
+                    error_code = (
+                        str(payload.get("error", "")).lower()
+                        if isinstance(payload, dict)
+                        else ""
+                    )
+                except (TypeError, ValueError):
+                    # Keep compatibility with non-JSON OAuth servers while
+                    # retaining the old word-boundary protection against
+                    # invalid_client_metadata.
+                    match = re.search(
+                        rb"\b(invalid_client|unauthorized_client)\b", body.lower()
+                    )
+                    error_code = match.group(1).decode() if match else ""
+                if error_code not in {"invalid_client", "unauthorized_client"}:
+                    return
+
+                if self._hermes_preregistered or error_code == "unauthorized_client":
+                    # A configured credential cannot be repaired by repeating
+                    # browser authorization. Latch the SDK-equivalent error so
+                    # concurrent transport requests queued on context.lock do
+                    # not start a second flow with a new state value.
+                    body_text = body.decode("utf-8", errors="replace")
+                    self._hermes_terminal_token_error = (
+                        f"Token exchange failed ({status}): {body_text}"
+                    )
                     return
 
                 storage = self.context.storage
@@ -388,6 +411,11 @@ def _make_hermes_provider_class() -> Optional[type]:
                 )
 
         async def async_auth_flow(self, request):  # type: ignore[override]
+            from mcp.client.auth import OAuthTokenError
+
+            if self._hermes_terminal_token_error is not None:
+                raise OAuthTokenError(self._hermes_terminal_token_error)
+
             # Pre-flow hook: ask the manager to refresh from disk if needed.
             # Any failure here is non-fatal — we just log and proceed with
             # whatever state the SDK already has.
@@ -420,6 +448,13 @@ def _make_hermes_provider_class() -> Optional[type]:
             try:
                 outgoing = await inner.__anext__()
                 while True:
+                    if self._hermes_terminal_token_error is not None:
+                        # The flow may have queued behind the failing request,
+                        # or the SDK may be continuing from a rejected refresh.
+                        # Close it before yielding another request so neither
+                        # path can start a second browser authorization.
+                        await inner.aclose()
+                        raise OAuthTokenError(self._hermes_terminal_token_error)
                     incoming = yield outgoing
                     # Sniff the response for a dead-client-registration signal
                     # before handing it back to the SDK (best-effort, GH#36767).
@@ -578,7 +613,7 @@ class MCPOAuthManager:
 
         return _HERMES_PROVIDER_CLS(
             server_name=server_name,
-            preregistered=bool(cfg.get("client_id")),
+            preregistered=bool(cfg.get("client_id") or cfg.get("client_secret")),
             server_url=entry.server_url,
             client_metadata=client_metadata,
             storage=storage,

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -992,9 +992,12 @@ def _unwrap_exception_group(exc: BaseException) -> BaseException:
     - **Fatal leaves re-raise.** A ``KeyboardInterrupt`` / ``SystemExit``
       anywhere in the (possibly nested) group must propagate to the
       interpreter, never be flattened into a loggable error.
-    - **Prefer non-cancellation leaves.** When a group carries both a real
-      error and the ``CancelledError``s that anyio cancellation sprays across
-      sibling tasks, the real error is the root cause worth logging.
+    - **Prefer auth leaves.** A token error must not be masked by a sibling
+      socket/teardown failure from the same transport TaskGroup.
+    - **Prefer non-cancellation leaves.** When no auth error exists and a group
+      carries both a real error and the ``CancelledError``s that anyio
+      cancellation sprays across sibling tasks, the real error is the root
+      cause worth logging.
     """
     while isinstance(exc, BaseExceptionGroup) and exc.exceptions:
         fatal, _rest = exc.split((KeyboardInterrupt, SystemExit))
@@ -1004,6 +1007,9 @@ def _unwrap_exception_group(exc: BaseException) -> BaseException:
             while isinstance(leaf, BaseExceptionGroup) and leaf.exceptions:
                 leaf = leaf.exceptions[0]
             raise leaf
+        auth_leaf = _find_exception_leaf(exc, _is_auth_error)
+        if auth_leaf is not None:
+            return auth_leaf
         # Prefer a non-cancellation leaf when one exists: cancellation
         # noise from sibling tasks should not mask the real error.
         chosen = exc.exceptions[0]
@@ -1013,6 +1019,17 @@ def _unwrap_exception_group(exc: BaseException) -> BaseException:
                 break
         exc = chosen
     return exc
+
+
+def _find_exception_leaf(exc: BaseException, predicate) -> BaseException | None:
+    """Return the first depth-first leaf matching ``predicate``."""
+    if isinstance(exc, BaseExceptionGroup):
+        for sub in exc.exceptions:
+            match = _find_exception_leaf(sub, predicate)
+            if match is not None:
+                return match
+        return None
+    return exc if predicate(exc) else None
 
 
 def _contains_only_cancellation(exc: BaseException) -> bool:


### PR DESCRIPTION
## What does this PR do?

Fixes MCP OAuth logins that start a second authorization flow after a configured client credential is rejected by the token endpoint. That retry can generate a new `state`, collide with the first flow's pinned callback port, and replace the actionable `invalid_client` response with `EADDRINUSE`.

The fix handles both configurations raised during triage:

- a configured `client_id` and `client_secret`
- a configured `client_secret` whose client state comes from the existing OAuth flow

Configured credentials now latch deterministic `invalid_client` / `unauthorized_client` token errors for the lifetime of that provider. Concurrent requests queued inside the SDK see the same error before they can emit another authorization request. Dynamically registered clients keep the existing `invalid_client` recovery path that discards stale registration state and re-registers.

The callback listener also uses the supported `serve_forever()` / `shutdown()` lifecycle and joins its thread before closing the socket, so the paste fallback cannot leave a live listener blocked in `accept()`.

## Related Issue

Fixes #73997

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- stop and join the loopback OAuth callback listener before releasing its pinned port
- classify configured client credentials as terminal on `invalid_client` / `unauthorized_client`
- block already-queued and refresh-fallback flows before they emit another browser authorization request
- prefer OAuth exceptions over sibling socket/teardown errors in MCP `ExceptionGroup` trees
- preserve dynamic-client re-registration recovery
- add regression coverage for listener exit, immediate port reuse, secret-only configuration, queued flows, refresh failures, original error preservation, and exception selection

## How to Test

1. Configure an OAuth MCP server with a pinned `oauth.redirect_port` and invalid configured client credentials.
2. Complete the browser flow through the interactive paste fallback.
3. Verify the token endpoint's `invalid_client` error is surfaced without a second authorization URL or `EADDRINUSE`.
4. Run:

```bash
scripts/run_tests.sh tests/tools/test_mcp_oauth.py tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_oauth_bidirectional.py tests/tools/test_mcp_oauth_integration.py tests/tools/test_mcp_oauth_metadata.py tests/tools/test_mcp_oauth_cold_load_expiry.py tests/tools/test_mcp_failure_classification.py tests/hermes_cli/test_mcp_config.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched open and merged PRs for duplicate MCP OAuth fixes
- [x] My PR contains only changes related to this fix
- [ ] I've run the complete `pytest tests/ -q` suite
- [x] I've added tests for my changes
- [x] I've tested on macOS 26.5.2 with Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing configuration or workflow changed
- [x] `cli-config.yaml.example`: N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; listener behavior uses stdlib `HTTPServer` APIs and the Windows footgun check passes
- [x] Tool descriptions/schemas: N/A; no model-tool behavior changed

## Validation

Pre-fix regression signal:

```text
listener_thread.is_alive() == True after the paste callback completed
```

Post-fix checks:

```text
8 focused test files: 250 passed, 0 failed
ruff: passed
py_compile: passed
Windows footgun scan: passed (4 production files)
git diff --check: passed
```

The tests exercise a real loopback listener and the real Hermes OAuth provider wrapper. A live Dropbox exchange with deliberately invalid production credentials was not run.
