### PR TITLE
fix(telegram): escape MarkdownV2 reserved parens in chunk indicators (#74004)

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1299,6 +1299,20 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             text_chunks = BasePlatformAdapter.truncate_message(
                 formatted, 4096, len_fn=utf16_len
             )
+
+            # Escape MarkdownV2 reserved characters in chunk indicators.
+            # BasePlatformAdapter.truncate_message() appends " (1/3)", " (2/3)"
+            # etc. to each chunk when the message spans multiple messages.
+            # These parentheses '(', ')' are reserved in Telegram MarkdownV2
+            # and will be rejected by the API, causing a fallback to plain
+            # text that silently strips all formatting (#74004).
+            if send_parse_mode == ParseMode.MARKDOWN_V2 and len(text_chunks) > 1:
+                import re as _re
+                text_chunks = [
+                    _re.sub(r' \((\d+)/(\d+)\)$', r' \\(\1/\2\\)', c)
+                    for c in text_chunks
+                ]
+
             for chunk in text_chunks:
                 try:
                     last_msg = await _send_telegram_message_with_retry(


### PR DESCRIPTION
## Problem
When a Telegram message is sent via the standalone `_send_telegram()` path and is long enough to be chunked (>4096 UTF-16 units), `BasePlatformAdapter.truncate_message()` appends chunk indicators like `(1/3)` to each chunk. These parentheses are reserved characters in Telegram's MarkdownV2 format and cause the API to reject the message, falling back to plain text — silently stripping all formatting.

## Fix
After chunking, escape the parentheses in chunk indicators when the parse mode is MarkdownV2. The pattern `r' (\d+)/(\d+)\)$'` targets only the `(N/M)` suffix appended by `truncate_message()` at the end of each chunk and wraps the parentheses with MarkdownV2 escapes (`\(`, `\)`).

## Testing
The fix was verified with a Python unit test:
- Input: `**bold** message (1/3)` → Output: `**bold** message \(1/3\)`
- Multiple chunks all get proper escaping
- Chunks without indicators are unaffected

Closes #74004