### PR TITLE
feat(plugins): expose transient UI status callback

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -89,6 +89,32 @@ from hermes_logging import set_session_context
 from tools.skill_provenance import set_current_write_origin
 from utils import base_url_host_matches, env_var_enabled
 
+_PLUGIN_STATUS_UNSAFE = re.compile(r"[\x00-\x1f\x7f-\x9f\u202a-\u202e\u2066-\u2069]")
+_PLUGIN_STATUS_ANSI = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def _set_plugin_ui_status(agent: Any, text: Any) -> None:
+    """Project one plugin-owned status into the host's transient UI surface.
+
+    The callback is passed only to in-process lifecycle plugins. It never
+    appends conversation content, and malformed display text cannot interrupt
+    the model call.
+    """
+    if not isinstance(text, str):
+        return
+    cleaned = " ".join(
+        _PLUGIN_STATUS_UNSAFE.sub(" ", _PLUGIN_STATUS_ANSI.sub("", text)).split()
+    )[:180]
+    if not cleaned:
+        return
+    try:
+        agent._emit_wait_notice(cleaned)
+    except Exception:
+        logging.getLogger(__name__).debug(
+            "plugin status callback failed", exc_info=True
+        )
+
+
 logger = logging.getLogger(__name__)
 
 # Stable prefix of the local interrupt status string emitted when a turn is
@@ -2129,6 +2155,7 @@ def run_conversation(
                         _request_payload = agent._api_request_payload_for_hook(api_kwargs)
                         _invoke_hook(
                             "pre_api_request",
+                            set_ui_status=lambda text: _set_plugin_ui_status(agent, text),
                             task_id=effective_task_id,
                             turn_id=turn_id,
                             api_request_id=api_request_id,
@@ -5472,6 +5499,7 @@ def run_conversation(
                     _api_ended_at = api_start_time + api_duration
                     _invoke_hook(
                         "post_api_request",
+                        set_ui_status=lambda text: _set_plugin_ui_status(agent, text),
                         task_id=effective_task_id,
                         turn_id=turn_id,
                         api_request_id=api_request_id,

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -134,6 +134,9 @@ API hooks describe provider attempts inside the agent loop:
 
 `pre_api_request` includes:
 
+- `set_ui_status(text)`: a bounded, fail-open callback for rendering transient
+  plugin status in the active CLI/TUI. It does not write to the conversation.
+
 - identity: `session_id`, `task_id`, `turn_id`, `api_request_id`
 - runtime: `platform`, `model`, `provider`, `base_url`, `api_mode`
 - attempt metadata: `api_call_count`, `message_count`, `tool_count`,

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4670,8 +4670,15 @@ class TestRunConversation:
             patch.object(agent, "_persist_session"),
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_emit_wait_notice") as emit_wait_notice,
         ):
             result = agent.run_conversation("search something")
+            pre_status_callback = next(
+                kw["set_ui_status"]
+                for name, kw in hook_calls
+                if name == "pre_api_request"
+            )
+            pre_status_callback("◇ RFQ\x1b[31m   opening")
 
         assert result["final_response"] == "Done searching"
         pre_request_calls = [kw for name, kw in hook_calls if name == "pre_api_request"]
@@ -4691,6 +4698,8 @@ class TestRunConversation:
         assert any(msg.get("role") == "user" and msg.get("content") == "search something" for msg in pre_request_calls[0]["request_messages"])
         assert all("usage" in c and "response" in c for c in post_request_calls)
         assert all("assistant_message" in c["response"] for c in post_request_calls)
+        assert all(callable(c["set_ui_status"]) for c in pre_request_calls + post_request_calls)
+        emit_wait_notice.assert_called_once_with("◇ RFQ opening")
 
     def test_terminal_task_closes_logical_calls_before_metrics_scope(self, agent):
         from agent import relay_runtime


### PR DESCRIPTION
## What does this PR do?

Adds a generic, bounded `set_ui_status(text)` callback to the existing `pre_api_request` and `post_api_request` plugin hooks.

Standalone provider and observability plugins can use it to project short-lived request state into Hermes' native CLI/TUI without writing a message into the conversation. The host strips ANSI, control, and bidi characters, collapses whitespace, caps the label at 180 characters, and fails open if the renderer rejects it.

This deliberately widens the generic plugin surface rather than adding any third-party integration to Hermes core.

## Related Issue

N/A — no matching open or closed issue/PR was found for a transient plugin-owned UI status callback.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/conversation_loop.py`: supplies a fail-open, sanitized status callback to both request-scoped API hooks.
- `tests/run_agent/test_run_agent.py`: proves both hooks receive the callback and unsafe display text is normalized before rendering.
- `docs/observability/README.md`: documents the new hook argument and its conversation boundary.

## How to Test

1. Run `/tmp/hermes-plugin-status-ruff/bin/ruff check agent/conversation_loop.py tests/run_agent/test_run_agent.py`.
2. Run `python -m pytest tests/run_agent/test_run_agent.py -k request_scoped_api_hooks_fire_for_each_api_call -q`.
3. Register a standalone plugin API hook, call `set_ui_status("working")`, and confirm the active native CLI/TUI status changes without a new conversation message.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS, focused Python test and standalone-plugin integration path

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` update is N/A; no config keys were added
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A; the documented plugin surface was updated instead
- [x] I've considered cross-platform impact; implementation uses Python stdlib and the existing host renderer
- [x] Tool descriptions/schemas update is N/A; no tool behavior changed

## Screenshots / Logs

Focused validation:

```text
All checks passed!
1 passed, 460 deselected
```

AI-assisted: yes. I understand the hook lifetime, conversation boundary, sanitization, and fail-open behavior in this change.
