### PR TITLE
Show billing account identity in Desktop settings

### DIFF
--- a/apps/desktop/src/app/settings/billing/dev-fixtures.ts
+++ b/apps/desktop/src/app/settings/billing/dev-fixtures.ts
@@ -19,6 +19,7 @@ const current = (
 })
 
 export const todayBillingState = {
+  account_email: 'owner@sid5.example',
   auto_reload: {
     card: { kind: 'canonical' },
     enabled: true,

--- a/apps/desktop/src/app/settings/billing/index.test.tsx
+++ b/apps/desktop/src/app/settings/billing/index.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -31,6 +31,11 @@ const apiMocks = vi.hoisted(() => ({
   updateAutoReload: vi.fn()
 }))
 
+const oauthMocks = vi.hoisted(() => ({
+  pollOAuthSession: vi.fn(),
+  startOAuthLogin: vi.fn()
+}))
+
 vi.mock('./api', () => ({
   // Pass-through provider — the mocked useBillingApi ignores any override anyway.
   BillingApiProvider: ({ children }: { children: ReactNode }) => children,
@@ -45,6 +50,11 @@ vi.mock('./api', () => ({
     stepUp: apiMocks.stepUp,
     updateAutoReload: apiMocks.updateAutoReload
   })
+}))
+
+vi.mock('@/hermes', () => ({
+  pollOAuthSession: oauthMocks.pollOAuthSession,
+  startOAuthLogin: oauthMocks.startOAuthLogin
 }))
 
 function renderBilling(initialEntries: string[] = ['/settings?tab=billing']) {
@@ -64,6 +74,12 @@ function renderBilling(initialEntries: string[] = ['/settings?tab=billing']) {
 beforeEach(() => {
   apiMocks.fetchBillingState.mockResolvedValue(okBilling(todayBillingState))
   apiMocks.fetchSubscriptionState.mockResolvedValue(okSubscription(todaySubscriptionState))
+  oauthMocks.startOAuthLogin.mockResolvedValue({
+    flow: 'device_code',
+    session_id: 'oauth-session-1',
+    verification_url: 'https://portal.nousresearch.com/device'
+  })
+  oauthMocks.pollOAuthSession.mockResolvedValue({ status: 'approved' })
   Object.defineProperty(window, 'hermesDesktop', {
     configurable: true,
     value: {
@@ -73,6 +89,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  vi.useRealTimers()
   cleanup()
   vi.clearAllMocks()
 })
@@ -98,6 +115,34 @@ describe('BillingSettings', () => {
     expect(screen.getByText('$876.47')).toBeTruthy()
     expect(screen.getByText('$10 of $100 used').classList.contains('tabular-nums')).toBe(true)
     expect(screen.getByText('Default ceiling')).toBeTruthy()
+  })
+
+  it('reconnects the billing identity through the Desktop Nous OAuth flow', async () => {
+    const client = renderBilling()
+    const invalidate = vi.spyOn(client, 'invalidateQueries')
+    const reconnect = await screen.findByRole('button', { name: /Reconnect \/ switch account/ })
+
+    vi.useFakeTimers()
+    fireEvent.click(reconnect)
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(oauthMocks.startOAuthLogin).toHaveBeenCalledWith('nous')
+    expect(apiMocks.openExternal).toHaveBeenCalledWith('https://portal.nousresearch.com/device')
+    expect(screen.getByRole('button', { name: /Waiting for approval/ })).toBeTruthy()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000)
+    })
+
+    expect(oauthMocks.pollOAuthSession).toHaveBeenCalledWith('nous', 'oauth-session-1')
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['billing', 'state'] })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['billing', 'subscription'] })
   })
 
   it('renders the post-train payload with enabled buy controls and card provenance', async () => {

--- a/apps/desktop/src/app/settings/billing/index.test.tsx
+++ b/apps/desktop/src/app/settings/billing/index.test.tsx
@@ -83,6 +83,9 @@ describe('BillingSettings', () => {
 
     expect(await screen.findByText('$996.47')).toBeTruthy()
     expect(screen.getByText('Ultra · $200/mo')).toBeTruthy()
+    expect(screen.getByText('owner@sid5.example')).toBeTruthy()
+    expect(screen.getByText('sid-5 · OWNER')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Reconnect \/ switch account/ })).toBeTruthy()
     expect(screen.getByText('Visa •••• 3206')).toBeTruthy()
     expect(
       screen.getByText(

--- a/apps/desktop/src/app/settings/billing/index.tsx
+++ b/apps/desktop/src/app/settings/billing/index.tsx
@@ -7,7 +7,7 @@ import { Progress } from '@/components/ui/progress'
 import { SegmentedControl } from '@/components/ui/segmented-control'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Skeleton } from '@/components/ui/skeleton'
-import { BarChart3, CreditCard, ExternalLink, Package, Wrench } from '@/lib/icons'
+import { BarChart3, CreditCard, ExternalLink, Package, Users, Wrench } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 
 import { useRouteEnumParam } from '../../hooks/use-route-enum-param'
@@ -48,6 +48,7 @@ const BILLING_VIEWS = ['overview', 'plans'] as const
 type BillingSubView = (typeof BILLING_VIEWS)[number]
 
 const FEATURE_BILLING_INVOICES = false
+const FALLBACK_PORTAL_URL = 'https://portal.nousresearch.com/billing'
 
 const BILLING_DEV_FIXTURE_NAMES = import.meta.env.DEV
   ? (Object.keys(billingDevFixtures) as BillingDevFixtureName[])
@@ -100,6 +101,45 @@ function NoticeCard({ notice }: { notice: BillingNoticeView }) {
         </Button>
       )}
     </div>
+  )
+}
+
+function BillingIdentityCard({ billing }: { billing?: BillingStateResponse }) {
+  if (!billing?.logged_in) {
+    return null
+  }
+
+  const email = billing.account_email?.trim()
+  const org = billing.org_name?.trim()
+
+  const orgLabel = org || 'Personal workspace'
+  const identityLabel = email || 'Account identity unavailable'
+
+  const caption = email
+    ? `${orgLabel}${billing.role ? ` · ${billing.role}` : ''}`
+    : org
+      ? `${orgLabel} · email unavailable`
+      : 'Email and workspace unavailable — reconnect to refresh the account context.'
+
+  return (
+    <SettingsSection icon={Users} title="Billing account">
+      <ListRow
+        action={
+          <Button
+            onClick={() => openExternal(billing.portal_url ?? FALLBACK_PORTAL_URL)}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            Reconnect / switch account
+            <ExternalLink className="size-3.5" />
+          </Button>
+        }
+        below={<div className="mt-1 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">{caption}</div>}
+        description="The account and workspace used for the balance shown below."
+        title={identityLabel}
+      />
+    </SettingsSection>
   )
 }
 
@@ -513,6 +553,8 @@ function BillingSettingsContent({
           ))}
         </div>
       </div>
+
+      <BillingIdentityCard billing={billing} />
 
       {view.plan && (
         <SettingsSection icon={Package} title="Plan">

--- a/apps/desktop/src/app/settings/billing/index.tsx
+++ b/apps/desktop/src/app/settings/billing/index.tsx
@@ -7,8 +7,10 @@ import { Progress } from '@/components/ui/progress'
 import { SegmentedControl } from '@/components/ui/segmented-control'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Skeleton } from '@/components/ui/skeleton'
+import { pollOAuthSession, startOAuthLogin } from '@/hermes'
 import { BarChart3, CreditCard, ExternalLink, Package, Users, Wrench } from '@/lib/icons'
 import { cn } from '@/lib/utils'
+import { notify, notifyError } from '@/store/notifications'
 
 import { useRouteEnumParam } from '../../hooks/use-route-enum-param'
 import {
@@ -48,7 +50,9 @@ const BILLING_VIEWS = ['overview', 'plans'] as const
 type BillingSubView = (typeof BILLING_VIEWS)[number]
 
 const FEATURE_BILLING_INVOICES = false
-const FALLBACK_PORTAL_URL = 'https://portal.nousresearch.com/billing'
+const NOUS_OAUTH_PROVIDER_ID = 'nous'
+const NOUS_OAUTH_POLL_INTERVAL_MS = 5000
+const NOUS_OAUTH_MAX_POLLS = 120
 
 const BILLING_DEV_FIXTURE_NAMES = import.meta.env.DEV
   ? (Object.keys(billingDevFixtures) as BillingDevFixtureName[])
@@ -104,7 +108,15 @@ function NoticeCard({ notice }: { notice: BillingNoticeView }) {
   )
 }
 
-function BillingIdentityCard({ billing }: { billing?: BillingStateResponse }) {
+function BillingIdentityCard({
+  billing,
+  onReconnect,
+  reconnecting
+}: {
+  billing?: BillingStateResponse
+  onReconnect: () => void
+  reconnecting: boolean
+}) {
   if (!billing?.logged_in) {
     return null
   }
@@ -126,12 +138,13 @@ function BillingIdentityCard({ billing }: { billing?: BillingStateResponse }) {
       <ListRow
         action={
           <Button
-            onClick={() => openExternal(billing.portal_url ?? FALLBACK_PORTAL_URL)}
+            disabled={reconnecting}
+            onClick={onReconnect}
             size="sm"
             type="button"
             variant="outline"
           >
-            Reconnect / switch account
+            {reconnecting ? 'Waiting for approval…' : 'Reconnect / switch account'}
             <ExternalLink className="size-3.5" />
           </Button>
         }
@@ -496,6 +509,64 @@ function BillingSettingsContent({
   onFixtureChange?: (value: BillingFixtureSelection) => void
 }) {
   const [subView, setSubView] = useRouteEnumParam<BillingSubView>('bview', BILLING_VIEWS, 'overview')
+  const queryClient = useQueryClient()
+  const [reconnectingAccount, setReconnectingAccount] = useState(false)
+
+  const refreshBillingQueries = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['billing', 'state'] }),
+      queryClient.invalidateQueries({ queryKey: ['billing', 'subscription'] })
+    ])
+  }
+
+  const reconnectBillingAccount = async () => {
+    if (reconnectingAccount) {
+      return
+    }
+
+    setReconnectingAccount(true)
+
+    try {
+      const start = await startOAuthLogin(NOUS_OAUTH_PROVIDER_ID)
+
+      if (start.flow !== 'device_code') {
+        notifyError(new Error(`unexpected flow: ${start.flow}`), 'Could not start Nous sign-in')
+
+        return
+      }
+
+      await openExternal(start.verification_url)
+
+      for (let attempt = 0; attempt < NOUS_OAUTH_MAX_POLLS; attempt += 1) {
+        await new Promise(resolve => window.setTimeout(resolve, NOUS_OAUTH_POLL_INTERVAL_MS))
+
+        const polled = await pollOAuthSession(NOUS_OAUTH_PROVIDER_ID, start.session_id)
+
+        if (polled.status === 'approved') {
+          notify({
+            kind: 'success',
+            title: 'Nous account connected',
+            message: 'Billing account details are refreshing.'
+          })
+          await refreshBillingQueries()
+
+          return
+        }
+
+        if (polled.status !== 'pending') {
+          notifyError(new Error(polled.error_message || `Sign-in ${polled.status}`), 'Nous sign-in failed')
+
+          return
+        }
+      }
+
+      notifyError(new Error('Timed out waiting for OAuth approval'), 'Nous sign-in timed out')
+    } catch (err) {
+      notifyError(err, 'Nous sign-in failed')
+    } finally {
+      setReconnectingAccount(false)
+    }
+  }
 
   // Fixture mode flows through the SAME query path — the simulated api (supplied by
   // BillingApiProvider in the DEV wrapper) backs these fetches — so there is no
@@ -554,7 +625,11 @@ function BillingSettingsContent({
         </div>
       </div>
 
-      <BillingIdentityCard billing={billing} />
+      <BillingIdentityCard
+        billing={billing}
+        onReconnect={() => void reconnectBillingAccount()}
+        reconnecting={reconnectingAccount}
+      />
 
       {view.plan && (
         <SettingsSection icon={Package} title="Plan">

--- a/apps/shared/src/billing-types.ts
+++ b/apps/shared/src/billing-types.ts
@@ -193,6 +193,8 @@ export interface BillingAutoReload {
 }
 
 export interface BillingStateResponse {
+  /** Authenticated Nous user email for the SAME OAuth context used by billing.state. */
+  account_email?: string | null
   auto_reload: BillingAutoReload | null
   balance_display: string
   balance_usd: string | null
@@ -213,7 +215,9 @@ export interface BillingStateResponse {
   min_usd: string | null
   monthly_cap: BillingMonthlyCap | null
   ok: boolean
+  org_id?: string | null
   org_name: string | null
+  org_slug?: string | null
   portal_url: string | null
   role: string | null
   // Shared dollar usage model (two-bar view), embedded by the gateway so /topup

--- a/tests/tui_gateway/test_billing_rpc.py
+++ b/tests/tui_gateway/test_billing_rpc.py
@@ -15,6 +15,7 @@ import pytest
 
 import tui_gateway.server as srv
 import hermes_cli.nous_billing as nb
+import hermes_cli.nous_account as na
 import agent.billing_view as bv
 from agent.billing_view import BillingState, CardInfo, MonthlyCap, PaymentMethodInfo
 
@@ -33,6 +34,7 @@ def _call(method: str, params: dict) -> dict:
 def test_billing_state_serializes_decimals_as_strings(monkeypatch):
     state = BillingState(
         logged_in=True,
+        org_id="org_1",
         org_name="Acme",
         role="OWNER",
         balance_usd=Decimal("142.5"),
@@ -52,8 +54,21 @@ def test_billing_state_serializes_decimals_as_strings(monkeypatch):
         portal_url="https://portal/billing?topup=open",
     )
     monkeypatch.setattr(bv, "build_billing_state", lambda *a, **kw: state)
+    monkeypatch.setattr(
+        na,
+        "get_nous_portal_account_info",
+        lambda *a, **kw: na.NousPortalAccountInfo(
+            logged_in=True,
+            source="account_api",
+            fresh=True,
+            org_id="org_1",
+            email="owner@acme.example",
+        ),
+    )
     res = _call("billing.state", {})
     assert res["ok"] is True and res["logged_in"] is True
+    assert res["account_email"] == "owner@acme.example"
+    assert res["org_id"] == "org_1"
     # Money on the wire is STRING, not float/number.
     assert res["balance_usd"] == "142.5"
     assert res["balance_display"] == "$142.50"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8419,9 +8419,12 @@ def _serialize_billing_state(state) -> dict:
             "reload_to_display": format_money(ar.reload_to_usd),
             "card": card_out,
         }
+    account_email = _billing_account_email(state)
     return {
         "ok": True,
         "logged_in": state.logged_in,
+        "account_email": account_email,
+        "org_id": state.org_id,
         "org_name": state.org_name,
         "org_slug": state.org_slug,
         "role": state.role,
@@ -8447,6 +8450,32 @@ def _serialize_billing_state(state) -> dict:
         # out or the portal is down.
         "usage": _usage_payload(state),
     }
+
+
+def _billing_account_email(state) -> Optional[str]:
+    """Best-effort Nous user email for the billing.state OAuth context.
+
+    The balance/org fields come from NAS through the same stored Nous OAuth
+    credential. Fetching the normalized account snapshot here keeps the rendered
+    Desktop identity in the same RPC generation as the balance, while failing
+    open on older/offline auth states instead of blocking the billing overview.
+    """
+    if not getattr(state, "logged_in", False):
+        return None
+    try:
+        from hermes_cli.nous_account import get_nous_portal_account_info
+
+        info = get_nous_portal_account_info(force_fresh=True)
+    except Exception:
+        return None
+    if not getattr(info, "logged_in", False):
+        return None
+    state_org_id = getattr(state, "org_id", None)
+    info_org_id = getattr(info, "org_id", None)
+    if state_org_id and info_org_id and state_org_id != info_org_id:
+        return None
+    email = getattr(info, "email", None)
+    return email.strip() if isinstance(email, str) and email.strip() else None
 
 
 def _usage_payload(state) -> dict:


### PR DESCRIPTION
## Summary
- expose the authenticated Nous account email/org id on the `billing.state` wire response
- render a Desktop Settings → Billing account card showing the account email, workspace/org, role, and a reconnect/switch-account action
- cover the new gateway fields and Desktop rendering in targeted tests

Fixes #73752

## Tests
- `scripts/run_tests.sh tests/tui_gateway/test_billing_rpc.py -q`
- `npm --prefix apps/desktop run test:ui -- src/app/settings/billing/index.test.tsx`
- `npm --prefix apps/desktop run typecheck`
- `npx --workspace apps/desktop eslint src/app/settings/billing/index.tsx src/app/settings/billing/index.test.tsx`
