### PR TITLE
fix(acp): publish current context and compression depth

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -844,9 +844,9 @@ class HermesACPAgent(acp.Agent):
 
         Zed's circular context indicator is driven by ACP ``usage_update``
         session updates: ``size`` is the model context window and ``used`` is
-        the current request pressure.  Hermes estimates ``used`` from the same
-        buckets it sends to providers: system prompt, conversation history, and
-        tool schemas.
+        the current request pressure. Prefer the provider-reported prompt size
+        from the most recent model call; before any call has completed, fall
+        back to a rough estimate of the same request buckets.
         """
         agent = state.agent
         compressor = getattr(agent, "context_compressor", None)
@@ -855,21 +855,32 @@ class HermesACPAgent(acp.Agent):
             return None
 
         try:
-            from agent.model_metadata import estimate_request_tokens_rough
-
-            used = estimate_request_tokens_rough(
-                state.history,
-                system_prompt=getattr(agent, "_cached_system_prompt", "") or "",
-                tools=getattr(agent, "tools", None) or None,
-            )
-        except Exception:
-            logger.debug("Could not estimate ACP native context usage", exc_info=True)
             used = int(getattr(compressor, "last_prompt_tokens", 0) or 0)
+        except (TypeError, ValueError):
+            used = 0
+        if used <= 0:
+            try:
+                from agent.model_metadata import estimate_request_tokens_rough
+
+                used = estimate_request_tokens_rough(
+                    state.history,
+                    system_prompt=getattr(agent, "_cached_system_prompt", "") or "",
+                    tools=getattr(agent, "tools", None) or None,
+                )
+            except Exception:
+                logger.debug("Could not estimate ACP native context usage", exc_info=True)
+                used = 0
+
+        try:
+            compression_count = max(0, int(getattr(compressor, "compression_count", 0) or 0))
+        except (TypeError, ValueError):
+            compression_count = 0
 
         return UsageUpdate(
             session_update="usage_update",
             size=max(size, 0),
             used=max(used, 0),
+            field_meta={"hermes": {"compressionCount": compression_count}},
         )
 
     async def _send_usage_update(self, state: SessionState) -> None:
@@ -965,6 +976,24 @@ class HermesACPAgent(acp.Agent):
             return
         loop = asyncio.get_running_loop()
         loop.call_soon(asyncio.create_task, self._send_usage_update(state))
+
+    def _schedule_usage_update_from_thread(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        state: SessionState,
+    ) -> None:
+        """Publish current context pressure after a worker-thread model step."""
+
+        def _schedule_on_loop() -> None:
+            asyncio.create_task(self._send_usage_update(state))
+
+        try:
+            loop.call_soon_threadsafe(_schedule_on_loop)
+        except RuntimeError:
+            logger.debug(
+                "ACP event loop closed before usage update for %s",
+                state.session_id,
+            )
 
     async def _register_session_mcp_servers(
         self,
@@ -1491,7 +1520,13 @@ class HermesACPAgent(acp.Agent):
                 exc_info=True,
             )
         self._schedule_available_commands_update(session_id)
-        self._schedule_usage_update(state)
+        # Unlike session/new, session/load already has a client-side routing
+        # binding before the request starts so replay notifications can be
+        # consumed. Publish restored context/compression telemetry in the same
+        # request lifetime; deferring it until after return can lose the update
+        # during transport/task handoff and leaves a resumed client stale until
+        # its first prompt.
+        await self._send_usage_update(state)
         return LoadSessionResponse(
             models=self._build_model_state(state),
             modes=self._session_modes(state),
@@ -1527,7 +1562,11 @@ class HermesACPAgent(acp.Agent):
                 exc_info=True,
             )
         self._schedule_available_commands_update(state.session_id)
-        self._schedule_usage_update(state)
+        # `session/resume` has the same response-boundary contract as
+        # `session/load`: the client routing entry already exists, so restored
+        # context/compression telemetry must be delivered before this request
+        # returns rather than via a task that can lose the update on handoff.
+        await self._send_usage_update(state)
         return ResumeSessionResponse(
             models=self._build_model_state(state),
             modes=self._session_modes(state),
@@ -1791,8 +1830,14 @@ class HermesACPAgent(acp.Agent):
                 edit_approval_policy_getter=lambda: self._edit_approval_policy_for_state(state),
             )
             reasoning_cb = make_thinking_cb(conn, session_id, loop)
-            step_cb = make_step_cb(conn, session_id, loop, tool_call_ids, tool_call_meta)
+            base_step_cb = make_step_cb(conn, session_id, loop, tool_call_ids, tool_call_meta)
             message_cb = make_message_cb(conn, session_id, loop)
+
+            def _step_cb(api_call_count: int, prev_tools: Any = None) -> None:
+                base_step_cb(api_call_count, prev_tools)
+                self._schedule_usage_update_from_thread(loop, state)
+
+            step_cb = _step_cb
 
             def stream_delta_cb(text: str) -> None:
                 nonlocal streamed_message
@@ -2336,6 +2381,15 @@ class HermesACPAgent(acp.Agent):
             reset_session_state = getattr(state.agent, "reset_session_state", None)
             if callable(reset_session_state):
                 reset_session_state()
+            compressor = getattr(state.agent, "context_compressor", None)
+            persist_compression_count = getattr(
+                compressor, "_persist_compression_count", None
+            )
+            if callable(persist_compression_count):
+                # ACP /reset clears the existing stable session in place. Other
+                # hosts may call on_session_reset while switching to a new id,
+                # where persisting here would erase the old session's history.
+                persist_compression_count()
         except Exception:
             reset_failed = True
             logger.warning("ACP session state reset failed for %s", state.session_id, exc_info=True)

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1638,10 +1638,12 @@ class ContextCompressor(ContextEngine):
         self._fallback_compression_streak = 0
         self._ineffective_compression_count = 0
         self._prellm_skip_count = 0
+        self.compression_count = 0
         self._anti_thrash_recovery_deadline = 0.0
         self.get_active_compression_failure_cooldown()
         self._load_fallback_compression_streak()
         self._load_ineffective_compression_count()
+        self._load_compression_count()
 
     def on_session_start(self, session_id: str, **kwargs) -> None:
         """Bind session-scoped compression state for a new or resumed session."""
@@ -1651,6 +1653,7 @@ class ContextCompressor(ContextEngine):
         session_db = kwargs.get("session_db", getattr(self, "_session_db", None))
         previous_fallback_streak = self._fallback_compression_streak
         previous_ineffective_count = self._ineffective_compression_count
+        previous_compression_count = self.compression_count
         if boundary_reason == "compression" and old_session_id:
             getter = getattr(session_db, "get_compression_fallback_streak", None)
             if callable(getter):
@@ -1682,12 +1685,35 @@ class ContextCompressor(ContextEngine):
                         "compression parent ineffective count lookup failed (non-sqlite): %s",
                         exc,
                     )
+            compression_getter = getattr(session_db, "get_compression_count", None)
+            if callable(compression_getter):
+                try:
+                    stored_count = compression_getter(old_session_id)
+                    if isinstance(stored_count, (int, float, str)):
+                        previous_compression_count = max(
+                            previous_compression_count,
+                            max(0, int(stored_count)),
+                        )
+                except (TypeError, ValueError, sqlite3.Error) as exc:
+                    logger.debug("compression parent count lookup failed: %s", exc)
+                except Exception as exc:
+                    logger.debug("compression parent count lookup failed (non-sqlite): %s", exc)
         self.bind_session_state(session_db, session_id)
         if boundary_reason == "compression":
+            # A recovery path may re-adopt a child row that already has a
+            # newer durable count. Compression depth is monotonic within the
+            # logical conversation, so preserve the newest valid value from
+            # live state, the parent row, or the destination row.
+            previous_compression_count = max(
+                previous_compression_count,
+                self.compression_count,
+            )
             # Rotation creates a fresh child row before this callback. Preserve
             # the logical conversation's streak until boundary bookkeeping
             # persists the updated value onto the child row.
             self._fallback_compression_streak = previous_fallback_streak
+            self.compression_count = previous_compression_count
+            self._persist_compression_count()
             # Same for the anti-thrash strike counter — but unlike the streak,
             # no later boundary bookkeeping writes it, so persist the carried
             # value onto the (fresh) child row now. Otherwise a restart between
@@ -1715,6 +1741,38 @@ class ContextCompressor(ContextEngine):
             logger.debug("compression fallback streak lookup failed: %s", exc)
         except Exception as exc:
             logger.debug("compression fallback streak lookup failed (non-sqlite): %s", exc)
+
+    def _load_compression_count(self) -> None:
+        session_db = getattr(self, "_session_db", None)
+        session_id = getattr(self, "_session_id", "")
+        getter = getattr(session_db, "get_compression_count", None)
+        if not session_id or not callable(getter):
+            return
+        try:
+            stored_count = getter(session_id)
+            self.compression_count = max(
+                0,
+                int(stored_count)
+                if isinstance(stored_count, (int, float, str))
+                else 0,
+            )
+        except (TypeError, ValueError, sqlite3.Error) as exc:
+            logger.debug("compression count lookup failed: %s", exc)
+        except Exception as exc:
+            logger.debug("compression count lookup failed (non-sqlite): %s", exc)
+
+    def _persist_compression_count(self) -> None:
+        session_db = getattr(self, "_session_db", None)
+        session_id = getattr(self, "_session_id", "")
+        setter = getattr(session_db, "set_compression_count", None)
+        if not session_id or not callable(setter):
+            return
+        try:
+            setter(session_id, self.compression_count)
+        except sqlite3.Error as exc:
+            logger.debug("compression count persist failed: %s", exc)
+        except Exception as exc:
+            logger.debug("compression count persist failed (non-sqlite): %s", exc)
 
     def _persist_fallback_compression_streak(self) -> None:
         session_db = getattr(self, "_session_db", None)
@@ -1796,6 +1854,7 @@ class ContextCompressor(ContextEngine):
         breaker exists for, and its recovery probe bounds the block.
         """
         self._verify_compaction_cleared_threshold = True
+        self._persist_compression_count()
         if feasibility_skip:
             # A deliberate pre-LLM feasibility skip (#60451) is not a
             # summary-quality verdict: it must neither extend a fallback

--- a/contributors/emails/stefan@noble-pro.com
+++ b/contributors/emails/stefan@noble-pro.com
@@ -1,0 +1,2 @@
+stefanpieter
+# PR #74032: ACP current-context and compression telemetry

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3623,6 +3623,40 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         self._execute_write(_do)
 
+    def get_compression_count(self, session_id: str) -> int:
+        """Return the durable completed-compaction count for a session."""
+        if not session_id:
+            return 0
+        with self._lock:
+            conn = self._conn
+            if conn is None:
+                return 0
+            row = conn.execute(
+                "SELECT compression_count FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+        if row is None:
+            return 0
+        value = row["compression_count"] if isinstance(row, sqlite3.Row) else row[0]
+        try:
+            return max(0, int(value or 0))
+        except (TypeError, ValueError):
+            return 0
+
+    def set_compression_count(self, session_id: str, count: int) -> None:
+        """Persist the completed-compaction count for a session."""
+        if not session_id:
+            return
+        normalized = max(0, int(count))
+
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET compression_count = ? WHERE id = ?",
+                (normalized, session_id),
+            )
+
+        self._execute_write(_do)
+
     def get_compression_ineffective_count(self, session_id: str) -> int:
         """Return the persisted ineffective-compaction strike count.
 

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -180,6 +180,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     handoff_error TEXT,
     compression_failure_cooldown_until REAL,
     compression_failure_error TEXT,
+    compression_count INTEGER NOT NULL DEFAULT 0,
     compression_fallback_streak INTEGER NOT NULL DEFAULT 0,
     compression_ineffective_count INTEGER NOT NULL DEFAULT 0,
     profile_name TEXT,

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -42,6 +42,7 @@ from acp_adapter.server import (
     HERMES_VERSION,
 )
 from acp_adapter.session import SessionManager
+from agent.context_compressor import ContextCompressor
 from hermes_state import SessionDB
 
 
@@ -263,22 +264,102 @@ class TestSessionOps:
     def test_build_usage_update_for_zed_context_indicator(self, agent, mock_manager):
         state = mock_manager.create_session(cwd="/tmp")
         state.history = [{"role": "user", "content": "hello"}]
-        state.agent.context_compressor = MagicMock(context_length=100_000)
+        state.agent.context_compressor = MagicMock(
+            context_length=100_000,
+            last_prompt_tokens=24_000,
+            compression_count=2,
+        )
         state.agent._cached_system_prompt = "system"
         state.agent.tools = [{"type": "function", "function": {"name": "demo"}}]
 
         with patch(
             "agent.model_metadata.estimate_request_tokens_rough",
-            return_value=25_000,
+            return_value=18_000,
         ):
             update = agent._build_usage_update(state)
 
         assert isinstance(update, UsageUpdate)
         assert update.session_update == "usage_update"
         assert update.size == 100_000
+        assert update.used == 24_000
+        assert update.field_meta == {"hermes": {"compressionCount": 2}}
+
+    def test_build_usage_update_estimates_before_real_provider_usage(
+        self, agent, mock_manager
+    ):
+        state = mock_manager.create_session(cwd="/tmp")
+        state.agent.context_compressor = MagicMock(
+            context_length=100_000,
+            last_prompt_tokens=0,
+            compression_count=0,
+        )
+
+        with patch(
+            "agent.model_metadata.estimate_request_tokens_rough",
+            return_value=18_000,
+        ):
+            update = agent._build_usage_update(state)
+
+        assert update.used == 18_000
+
+    @pytest.mark.asyncio
+    async def test_send_usage_update_to_client(self, agent, mock_manager):
+        state = mock_manager.create_session(cwd="/tmp")
+        state.agent.context_compressor = MagicMock(
+            context_length=100_000,
+            last_prompt_tokens=0,
+            compression_count=0,
+        )
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        with patch(
+            "agent.model_metadata.estimate_request_tokens_rough",
+            return_value=25_000,
+        ):
+            await agent._send_usage_update(state)
+
+        mock_conn.session_update.assert_awaited_once()
+        call = mock_conn.session_update.await_args
+        assert call.kwargs["session_id"] == state.session_id
+        update = call.kwargs["update"]
+        assert isinstance(update, UsageUpdate)
+        assert update.size == 100_000
         assert update.used == 25_000
+        assert update.field_meta == {"hermes": {"compressionCount": 0}}
 
+    @pytest.mark.asyncio
+    async def test_prompt_schedules_live_usage_update_after_each_model_step(
+        self, agent, mock_manager
+    ):
+        state = mock_manager.create_session(cwd="/tmp")
+        state.agent.context_compressor = MagicMock(
+            context_length=100_000,
+            last_prompt_tokens=0,
+            compression_count=1,
+        )
 
+        def _run_conversation(*_args, **_kwargs):
+            state.agent.context_compressor.last_prompt_tokens = 31_000
+            state.agent.step_callback(1)
+            return {
+                "final_response": "done",
+                "messages": [{"role": "assistant", "content": "done"}],
+            }
+
+        state.agent.run_conversation = MagicMock(side_effect=_run_conversation)
+        agent._schedule_usage_update_from_thread = MagicMock()
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="hello")],
+            session_id=state.session_id,
+        )
+
+        assert agent._schedule_usage_update_from_thread.call_count == 1
 
 
     @pytest.mark.asyncio
@@ -286,10 +367,63 @@ class TestSessionOps:
         resp = await agent.load_session(cwd="/tmp", session_id="bogus")
         assert resp is None
 
+    @pytest.mark.asyncio
+    async def test_load_session_sends_restored_usage_before_returning(
+        self, agent, mock_manager
+    ):
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+        state = mock_manager.create_session(cwd="/tmp")
+        state.history = [{"role": "user", "content": "restored turn"}]
+        state.agent.context_compressor = MagicMock(
+            context_length=272_000,
+            last_prompt_tokens=182_079,
+            compression_count=2,
+        )
 
+        await agent.load_session(cwd="/tmp", session_id=state.session_id)
 
+        usage_updates = [
+            call.kwargs["update"]
+            for call in mock_conn.session_update.await_args_list
+            if isinstance(call.kwargs.get("update"), UsageUpdate)
+        ]
+        assert len(usage_updates) == 1
+        assert usage_updates[0].used == 182_079
+        assert usage_updates[0].size == 272_000
+        assert usage_updates[0].field_meta == {
+            "hermes": {"compressionCount": 2}
+        }
 
+    @pytest.mark.asyncio
+    async def test_resume_session_sends_restored_usage_before_returning(
+        self, agent, mock_manager
+    ):
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+        state = mock_manager.create_session(cwd="/tmp")
+        state.history = [{"role": "user", "content": "restored turn"}]
+        state.agent.context_compressor = MagicMock(
+            context_length=272_000,
+            last_prompt_tokens=182_079,
+            compression_count=2,
+        )
 
+        await agent.resume_session(cwd="/tmp", session_id=state.session_id)
+
+        usage_updates = [
+            call.kwargs["update"]
+            for call in mock_conn.session_update.await_args_list
+            if isinstance(call.kwargs.get("update"), UsageUpdate)
+        ]
+        assert len(usage_updates) == 1
+        assert usage_updates[0].used == 182_079
+        assert usage_updates[0].size == 272_000
+        assert usage_updates[0].field_meta == {
+            "hermes": {"compressionCount": 2}
+        }
 
     @pytest.mark.asyncio
     async def test_resume_session_replays_persisted_history_to_client(self, agent):
@@ -476,6 +610,36 @@ class TestSlashCommands:
         result = agent._handle_slash_command("/reset", state)
         assert "cleared" in result.lower()
         assert len(state.history) == 0
+
+    def test_reset_persists_cleared_compression_count(
+        self, agent, mock_manager, tmp_path, monkeypatch
+    ):
+        state = self._make_state(mock_manager)
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(state.session_id, source="acp")
+        db.set_compression_count(state.session_id, 2)
+        monkeypatch.setattr(
+            "agent.context_compressor.get_model_context_length",
+            lambda *_a, **_k: 100_000,
+        )
+        compressor = ContextCompressor(
+            model="fake-model",
+            threshold_percent=0.85,
+            protect_first_n=2,
+            protect_last_n=2,
+            quiet_mode=True,
+        )
+        compressor.bind_session_state(db, state.session_id)
+        state.agent.context_compressor = compressor
+        state.agent.reset_session_state = MagicMock(
+            side_effect=compressor.on_session_reset
+        )
+
+        result = agent._handle_slash_command("/reset", state)
+
+        assert "cleared" in result.lower()
+        assert compressor.compression_count == 0
+        assert db.get_compression_count(state.session_id) == 0
 
 
 

--- a/tests/agent/test_context_engine_host_contract.py
+++ b/tests/agent/test_context_engine_host_contract.py
@@ -90,6 +90,7 @@ def test_reset_session_state_rebinds_builtin_compressor_after_session_switch(tmp
     db.create_session("new-sid", source="cli")
     db.record_compression_failure_cooldown("old-sid", 4_000_000_000.0, "old-timeout")
     db.set_compression_fallback_streak("old-sid", 2)
+    db.set_compression_count("old-sid", 3)
 
     monkeypatch.setattr(
         "agent.context_compressor.get_model_context_length",
@@ -112,15 +113,104 @@ def test_reset_session_state_rebinds_builtin_compressor_after_session_switch(tmp
     agent.reset_session_state()
 
     assert compressor._session_id == "new-sid"
+    assert compressor.compression_count == 0
     assert compressor.get_active_compression_failure_cooldown() is None
     assert compressor._fallback_compression_streak == 0
     assert db.get_compression_failure_cooldown("old-sid") is not None
     assert db.get_compression_fallback_streak("old-sid") == 2
+    assert db.get_compression_count("old-sid") == 3
 
     compressor._record_compression_failure_cooldown(30.0, "new-timeout")
 
     assert db.get_compression_failure_cooldown("new-sid") is not None
     assert db.get_compression_failure_cooldown("old-sid")["error"] == "old-timeout"
+
+
+def test_builtin_compressor_restores_and_persists_compression_count(tmp_path, monkeypatch):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("sid", source="acp")
+    db.set_compression_count("sid", 2)
+    monkeypatch.setattr(
+        "agent.context_compressor.get_model_context_length",
+        lambda *_a, **_k: 100_000,
+    )
+    compressor = ContextCompressor(
+        model="fake-model",
+        threshold_percent=0.85,
+        protect_first_n=2,
+        protect_last_n=2,
+        quiet_mode=True,
+    )
+
+    compressor.bind_session_state(db, "sid")
+    assert compressor.compression_count == 2
+
+    compressor.compression_count += 1
+    compressor.record_completed_compaction()
+    assert db.get_compression_count("sid") == 3
+
+
+def test_builtin_compressor_carries_newest_count_across_rotation(tmp_path, monkeypatch):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("parent", source="acp")
+    db.set_compression_count("parent", 1)
+    db.create_session("child", source="acp", parent_session_id="parent")
+    monkeypatch.setattr(
+        "agent.context_compressor.get_model_context_length",
+        lambda *_a, **_k: 100_000,
+    )
+    compressor = ContextCompressor(
+        model="fake-model",
+        threshold_percent=0.85,
+        protect_first_n=2,
+        protect_last_n=2,
+        quiet_mode=True,
+    )
+    compressor.bind_session_state(db, "parent")
+    compressor.compression_count += 1
+
+    compressor.on_session_start(
+        "child",
+        session_db=db,
+        boundary_reason="compression",
+        old_session_id="parent",
+    )
+
+    assert compressor.compression_count == 2
+    assert db.get_compression_count("child") == 2
+
+
+def test_builtin_compressor_does_not_downgrade_newer_child_count_on_rotation(
+    tmp_path, monkeypatch,
+):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("parent", source="acp")
+    db.set_compression_count("parent", 1)
+    db.create_session("child", source="acp", parent_session_id="parent")
+    db.set_compression_count("child", 4)
+    monkeypatch.setattr(
+        "agent.context_compressor.get_model_context_length",
+        lambda *_a, **_k: 100_000,
+    )
+    compressor = ContextCompressor(
+        model="fake-model",
+        threshold_percent=0.85,
+        protect_first_n=2,
+        protect_last_n=2,
+        quiet_mode=True,
+    )
+    compressor.bind_session_state(db, "parent")
+    compressor.compression_count = 2
+
+    compressor.on_session_start(
+        "child",
+        session_db=db,
+        boundary_reason="compression",
+        old_session_id="parent",
+    )
+
+    assert compressor.compression_count == 4
+    assert db.get_compression_count("child") == 4
 
 
 def test_update_from_response_forwards_canonical_cache_buckets():

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3012,3 +3012,14 @@ class TestApplyDatabasePragmas:
             assert conn.execute("PRAGMA wal_autocheckpoint").fetchone()[0] == before
         finally:
             conn.close()
+
+
+def test_compression_count_round_trips(db):
+    db.create_session("s1", "cli")
+
+    assert db.get_compression_count("s1") == 0
+    db.set_compression_count("s1", 3)
+    assert db.get_compression_count("s1") == 3
+    db.set_compression_count("s1", -2)
+    assert db.get_compression_count("s1") == 0
+    assert db.get_compression_count("missing") == 0


### PR DESCRIPTION
## What does this PR do?

Make ACP context telemetry represent the current effective model window and durably expose completed compression depth.

ACP `usage_update.used` now prefers provider-reported `last_prompt_tokens` and uses the existing request estimator only before real model usage is available. Each completed worker-thread model step schedules a fresh update, including non-negative `_meta.hermes.compressionCount`.

Compression count round-trips through session storage, survives restore and compression-driven internal rotation, and is cleared durably by an explicit same-session ACP `/reset`.

Restored sessions replay existing history and then await the current usage/compression update before either `session/load` or `session/resume` returns, so a fresh client is current at the response boundary.

This complements #70267: that PR changes `PromptResponse.usage.inputTokens`; this PR fixes the authoritative ACP `usage_update` stream, compression metadata, and durable reset/rotation behavior.

## Related Issue
Related to #70204 and #70267.

## Changes made
- `acp_adapter/server.py`: publish current-window usage/compression depth after model steps and during load/resume restore; persist cleared count on ACP `/reset`
- `agent/context_compressor.py`: load, persist, rotate, and explicitly reset compression depth
- `hermes_state_common.py` and `hermes_state.py`: add the authoritative schema column plus bounded session accessors after current `main` moved `SCHEMA_SQL` into the common module
- regressions cover current-window usage, estimate fallback, mid-turn scheduling, metadata, load/resume response boundaries, rotation, explicit reset, and durable state
- contributor attribution remains mapped by the repository helper

## Review remediation
- replaced deferred resume telemetry scheduling with an awaited update after history replay, matching the existing load response-boundary contract
- added an exact resume regression that failed on the prior head because no `UsageUpdate` was visible when `resume_session()` returned
- reconciled current-main schema/test splits without resurrecting obsolete inline schema or removed test blocks

## Current exact-head verification
- head: `1e0784da1333b06370567fa77ca59fed86da4843`
- `scripts/run_tests.sh tests/acp/test_server.py tests/agent/test_context_engine_host_contract.py tests/test_hermes_state.py -q` — **180 passed**
- Ruff, compileall, `git diff --check`, and added-line security scan — passed
- independent exact-SHA review — PASS
- branch contains reviewed base `f3cda0ceb18d8ba7465a6d223098ef0e56c8fee1`; live `main` later advanced only in `tools/file_operations.py` and its test, with no dependency overlap and a clean `git merge-tree` proof
- upstream CI is awaiting external-fork workflow approval: https://github.com/NousResearch/hermes-agent/actions/runs/30619238988

## Type of change
- [x] Bug fix (non-breaking)
- [x] Tests

## Checklist
- [x] Contributing guide reviewed
- [x] Conventional commits
- [x] Focused regressions added
- [x] Tested on macOS
- [ ] Full repository suite not claimed; affected hermetic suites are reported above
