### PR TITLE
fix(desktop): session switch perf — skip stale follow-cwd RPC + redundant view sync

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -778,7 +778,17 @@ export function useSessionActions({
               busyRef.current = running
               setBusy(running)
               setAwaitingResponse(running)
-              syncSessionStateToView(cachedRuntimeId, activatedState)
+
+              // Skip the view sync when the activated transcript matches
+              // what the warm cache already painted (L690).  For idle
+              // sessions — the common switch case — the persisted REST
+              // transcript carries the same rows as the runtime cache,
+              // so the reconcile above produces a deep-equal array.
+              // The unconditional sync stages a second RAF that
+              // re-renders the full message list for no visible change.
+              if (!chatMessageArraysEquivalent($messages.get(), activatedState.messages)) {
+                syncSessionStateToView(cachedRuntimeId, activatedState)
+              }
 
               return
             }


### PR DESCRIPTION
## Problem

Two issues made session switching feel sluggish and occasionally moved sessions into the wrong project:

1. **Stale follow-cwd RPC race** (`store/projects.ts`): `followActiveSessionCwd` fired two gateway RPCs (`session.info` + `project.resolve`) on every session switch. When the user switched sessions quickly, the async response from the *previous* session could arrive after the new selection and call `enterProject()` with the old session's cwd — visually moving the session into the wrong project.

2. **Redundant second view sync** (`use-session-actions/index.ts`): On a warm-cache resume, the transcript is painted immediately from cache (L690), then `session.activate` + REST prefetch run, and the result is unconditionally synced to the view again via `syncSessionStateToView`. For idle sessions (the common case), the reconciled transcript is deep-equal to what's already painted — the second sync stages a full RAF re-render of the message list for zero visible change.

## Fix

### 1. Fast-path + staleness guard (`store/projects.ts`)

- **Fast-path**: if `projectIdForCwd(target)` resolves from the already-known project list, skip both RPCs entirely.
- **Staleness guard**: when RPCs do fire, re-check `$currentCwd` and `$selectedStoredSessionId` after the awaits. If the user has already moved to a different session, abandon the `enterProject()` call.

### 2. Skip no-op view sync (`use-session-actions/index.ts`)

Guard the post-activate `syncSessionStateToView` with `chatMessageArraysEquivalent` — the same pattern already used on the cold path (L933/L1007). The second paint only fires when the reconcile actually changed rows.

## Verification

- `npx vitest run` — **406 files / 3801 tests passed**
- `npx tsc --noEmit` — clean
- `npm run pack` — build + sign succeeded
- Manual: rebuilt app, session switches feel noticeably snappier; no cross-project session jumps observed