### PR TITLE
fix(desktop): widen searchable timezone dropdown

### DIFF
--- a/apps/desktop/src/app/settings/searchable-select.test.tsx
+++ b/apps/desktop/src/app/settings/searchable-select.test.tsx
@@ -95,6 +95,28 @@ describe('SearchableSelect', () => {
 
     expect(screen.getByRole('combobox').textContent).toContain('Search…')
   })
+
+  it('opens at a readable width instead of inheriting a narrow trigger width', () => {
+    const { baseElement } = render(<SearchableSelect onChange={vi.fn()} options={options} placeholder="Search…" value="" />)
+
+    fireEvent.click(screen.getByRole('combobox'))
+
+    const content = baseElement.querySelector('[data-slot="popover-content"]')
+
+    expect(content?.className).toContain('w-80')
+    expect(content?.className).toContain('sm:w-96')
+    expect(content?.className).not.toContain('w-[var(--radix-popover-trigger-width)]')
+  })
+
+  it('keeps timezone labels on one line inside the dropdown', () => {
+    render(<SearchableSelect onChange={vi.fn()} options={options} placeholder="Search…" value="" />)
+
+    fireEvent.click(screen.getByRole('combobox'))
+
+    const item = screen.getByText('America/New_York').closest('[data-slot="command-item"]')
+
+    expect(item?.className).toContain('whitespace-nowrap')
+  })
 })
 
 describe('ConfigField searchable routing', () => {

--- a/apps/desktop/src/app/settings/searchable-select.tsx
+++ b/apps/desktop/src/app/settings/searchable-select.tsx
@@ -88,22 +88,22 @@ export function SearchableSelect({
           <Codicon className="shrink-0 opacity-60" name={open ? 'chevron-up' : 'chevron-down'} size="1rem" />
         </button>
       </PopoverTrigger>
-      <PopoverContent align="start" className="w-[var(--radix-popover-trigger-width)] p-0">
+      <PopoverContent align="start" className="w-80 max-w-[calc(100vw-2rem)] p-0 sm:w-96">
         <Command filter={rankSearchOption}>
           <CommandInput autoFocus placeholder={placeholder} />
           <CommandList>
             <CommandEmpty>{emptyMessage}</CommandEmpty>
             <CommandGroup>
               {clearLabel && (
-                <CommandItem onSelect={() => handleSelect('')} value={clearLabel}>
+                <CommandItem className="whitespace-nowrap" onSelect={() => handleSelect('')} value={clearLabel}>
                   <Codicon className={cn('mr-2 size-4', value === '' ? 'opacity-100' : 'opacity-0')} name="check" />
-                  {clearLabel}
+                  <span className="min-w-0 truncate">{clearLabel}</span>
                 </CommandItem>
               )}
               {options.map(option => (
-                <CommandItem key={option} onSelect={() => handleSelect(option)} value={option}>
+                <CommandItem className="whitespace-nowrap" key={option} onSelect={() => handleSelect(option)} value={option}>
                   <Codicon className={cn('mr-2 size-4', option === value ? 'opacity-100' : 'opacity-0')} name="check" />
-                  {option}
+                  <span className="min-w-0 truncate">{option}</span>
                 </CommandItem>
               ))}
             </CommandGroup>


### PR DESCRIPTION
## Summary
- widen the searchable settings dropdown so the Time Zone list no longer inherits a narrow trigger width
- keep timezone option labels on one line with truncation instead of wrapping into stacked characters
- add focused UI coverage for the readable popover width and nowrap option labels

Fixes #74034

## Tests
- `npm --prefix apps/desktop run test:ui -- src/app/settings/searchable-select.test.tsx`
- `npm --prefix apps/desktop run typecheck`
- `npx --workspace apps/desktop eslint src/app/settings/searchable-select.tsx src/app/settings/searchable-select.test.tsx`
- `git diff --check`
