### PR TITLE
fix(cli): keep compact banners out of output history

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6978,7 +6978,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         use_compact = self.compact or term_width < 80
         
         if use_compact:
-            self._console_print(_build_compact_banner())
+            with _suspend_output_history():
+                self._console_print(_build_compact_banner())
             self._show_status()
         else:
             # Get tools for display
@@ -9550,7 +9551,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 cc = ChatConsole()
                 term_w = shutil.get_terminal_size().columns
                 if self.compact or term_w < 80:
-                    cc.print(_build_compact_banner())
+                    with _suspend_output_history():
+                        cc.print(_build_compact_banner())
                 else:
                     tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
                     cwd = os.getenv("TERMINAL_CWD", os.getcwd())

--- a/cli.py
+++ b/cli.py
@@ -11872,7 +11872,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 cc = ChatConsole()
                 term_w = shutil.get_terminal_size().columns
                 if self.compact or term_w < 80:
-                    cc.print(_build_compact_banner())
+                    with _suspend_output_history():
+                        cc.print(_build_compact_banner())
                 else:
                     tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
                     cwd = os.getenv("TERMINAL_CWD", os.getcwd())

--- a/cli.py
+++ b/cli.py
@@ -6978,8 +6978,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         use_compact = self.compact or term_width < 80
         
         if use_compact:
-            with _suspend_output_history():
-                self._console_print(_build_compact_banner())
+            self._console_print(_build_compact_banner())
             self._show_status()
         else:
             # Get tools for display

--- a/tests/cli/test_cli_output_history_compact_banner.py
+++ b/tests/cli/test_cli_output_history_compact_banner.py
@@ -1,12 +1,15 @@
 from collections import deque
 import os
 from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
 
 import cli as cli_mod
 from cli import HermesCLI
 
 
-class _NullConsole:
+class _HistoryConsole:
     def clear(self):
         pass
 
@@ -26,23 +29,43 @@ class _NullOutput:
         pass
 
 
+@pytest.fixture(autouse=True)
+def restore_output_history(monkeypatch):
+    original = {
+        "_OUTPUT_HISTORY_ENABLED": cli_mod._OUTPUT_HISTORY_ENABLED,
+        "_OUTPUT_HISTORY_REPLAYING": cli_mod._OUTPUT_HISTORY_REPLAYING,
+        "_OUTPUT_HISTORY_SUPPRESSED": cli_mod._OUTPUT_HISTORY_SUPPRESSED,
+        "_OUTPUT_HISTORY_MAX_LINES": cli_mod._OUTPUT_HISTORY_MAX_LINES,
+        "_OUTPUT_HISTORY": cli_mod._OUTPUT_HISTORY,
+    }
+    monkeypatch.setattr(cli_mod, "_OUTPUT_HISTORY_ENABLED", True)
+    monkeypatch.setattr(cli_mod, "_OUTPUT_HISTORY_REPLAYING", False)
+    monkeypatch.setattr(cli_mod, "_OUTPUT_HISTORY_SUPPRESSED", False)
+    monkeypatch.setattr(cli_mod, "_OUTPUT_HISTORY_MAX_LINES", 200)
+    monkeypatch.setattr(cli_mod, "_OUTPUT_HISTORY", deque(maxlen=200))
+    monkeypatch.setattr(cli_mod, "_pt_print", lambda *args, **kwargs: None)
+    yield
+    for name, value in original.items():
+        setattr(cli_mod, name, value)
+
+
 def _history_text() -> str:
-    rendered = []
+    rendered: list[str] = []
     for entry in cli_mod._OUTPUT_HISTORY:
         if callable(entry):
             value = entry()
             if isinstance(value, str):
-                rendered.append(value)
+                rendered.extend(value.splitlines())
             else:
-                rendered.extend(str(line) for line in value)
+                rendered.extend(str(line) for line in cast(Any, value))
         else:
             rendered.append(str(entry))
     return "\n".join(rendered)
 
 
-def _make_cli(*, app=False):
-    cli_obj = HermesCLI.__new__(HermesCLI)
-    cli_obj.console = _NullConsole()
+def _make_cli(*, app_active: bool = False) -> HermesCLI:
+    cli_obj = cast(Any, HermesCLI.__new__(HermesCLI))
+    cli_obj.console = _HistoryConsole()
     cli_obj.compact = True
     cli_obj.agent = None
     cli_obj.enabled_toolsets = []
@@ -50,7 +73,7 @@ def _make_cli(*, app=False):
     cli_obj.model = "test-model"
     cli_obj.provider = "test-provider"
     cli_obj.base_url = ""
-    cli_obj._app = SimpleNamespace(output=_NullOutput()) if app else None
+    cli_obj._app = SimpleNamespace(output=_NullOutput()) if app_active else None
     cli_obj._pending_resume_sessions = None
     cli_obj._confirm_destructive_slash = lambda *args, **kwargs: True
     cli_obj.new_session = lambda *args, **kwargs: None
@@ -59,23 +82,17 @@ def _make_cli(*, app=False):
     return cli_obj
 
 
-def _reset_output_history(monkeypatch):
-    monkeypatch.setattr(cli_mod, "_OUTPUT_HISTORY_ENABLED", True)
-    monkeypatch.setattr(cli_mod, "_OUTPUT_HISTORY_REPLAYING", False)
-    monkeypatch.setattr(cli_mod, "_OUTPUT_HISTORY_SUPPRESSED", False)
-    monkeypatch.setattr(cli_mod, "_OUTPUT_HISTORY_MAX_LINES", 200)
-    monkeypatch.setattr(cli_mod, "_OUTPUT_HISTORY", deque(maxlen=200))
-    monkeypatch.setattr(cli_mod, "_pt_print", lambda *args, **kwargs: None)
-
-
-def test_show_banner_compact_does_not_record_banner_but_keeps_later_output(monkeypatch):
-    _reset_output_history(monkeypatch)
+def test_show_banner_compact_skips_output_history_but_later_output_records(monkeypatch):
     marker = "COMPACT_SHOW_BANNER_HISTORY_MARKER"
     ordinary = "ordinary output after compact show banner"
-    cli_obj = _make_cli(app=True)
+    cli_obj = _make_cli()
 
     monkeypatch.setattr(cli_mod, "_build_compact_banner", lambda: marker)
-    monkeypatch.setattr(cli_mod.shutil, "get_terminal_size", lambda *args, **kwargs: os.terminal_size((120, 24)))
+    monkeypatch.setattr(
+        cli_mod.shutil,
+        "get_terminal_size",
+        lambda *args, **kwargs: os.terminal_size((120, 24)),
+    )
 
     cli_obj.show_banner()
 
@@ -88,15 +105,18 @@ def test_show_banner_compact_does_not_record_banner_but_keeps_later_output(monke
     assert ordinary in history
 
 
-def test_clear_tui_compact_does_not_record_banner_after_clearing_history(monkeypatch):
-    _reset_output_history(monkeypatch)
+def test_clear_tui_compact_clears_history_and_skips_banner_but_later_output_records(monkeypatch):
     marker = "COMPACT_CLEAR_TUI_HISTORY_MARKER"
     ordinary = "ordinary output after compact tui clear"
-    cli_obj = _make_cli(app=True)
+    cli_obj = _make_cli(app_active=True)
     cli_mod._record_output_history("old history entry")
 
     monkeypatch.setattr(cli_mod, "_build_compact_banner", lambda: marker)
-    monkeypatch.setattr(cli_mod.shutil, "get_terminal_size", lambda *args, **kwargs: os.terminal_size((120, 24)))
+    monkeypatch.setattr(
+        cli_mod.shutil,
+        "get_terminal_size",
+        lambda *args, **kwargs: os.terminal_size((120, 24)),
+    )
     monkeypatch.setattr(cli_mod, "get_random_tip", lambda: "test tip", raising=False)
 
     cli_obj.process_command("/clear")

--- a/tests/cli/test_cli_output_history_compact_banner.py
+++ b/tests/cli/test_cli_output_history_compact_banner.py
@@ -1,0 +1,113 @@
+from collections import deque
+import os
+from types import SimpleNamespace
+
+import cli as cli_mod
+from cli import HermesCLI
+
+
+class _NullConsole:
+    def clear(self):
+        pass
+
+    def print(self, *args, **kwargs):
+        text = " ".join(str(arg) for arg in args)
+        cli_mod._cprint(text)
+
+
+class _NullOutput:
+    def erase_screen(self):
+        pass
+
+    def cursor_goto(self, *_args):
+        pass
+
+    def flush(self):
+        pass
+
+
+def _history_text() -> str:
+    rendered = []
+    for entry in cli_mod._OUTPUT_HISTORY:
+        if callable(entry):
+            value = entry()
+            if isinstance(value, str):
+                rendered.append(value)
+            else:
+                rendered.extend(str(line) for line in value)
+        else:
+            rendered.append(str(entry))
+    return "\n".join(rendered)
+
+
+def _make_cli(*, app=False):
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.console = _NullConsole()
+    cli_obj.compact = True
+    cli_obj.agent = None
+    cli_obj.enabled_toolsets = []
+    cli_obj.session_id = "test-session"
+    cli_obj.model = "test-model"
+    cli_obj.provider = "test-provider"
+    cli_obj.base_url = ""
+    cli_obj._app = SimpleNamespace(output=_NullOutput()) if app else None
+    cli_obj._pending_resume_sessions = None
+    cli_obj._confirm_destructive_slash = lambda *args, **kwargs: True
+    cli_obj.new_session = lambda *args, **kwargs: None
+    cli_obj._show_status = lambda: None
+    cli_obj._show_tool_availability_warnings = lambda: None
+    return cli_obj
+
+
+def _reset_output_history(monkeypatch):
+    monkeypatch.setattr(cli_mod, "_OUTPUT_HISTORY_ENABLED", True)
+    monkeypatch.setattr(cli_mod, "_OUTPUT_HISTORY_REPLAYING", False)
+    monkeypatch.setattr(cli_mod, "_OUTPUT_HISTORY_SUPPRESSED", False)
+    monkeypatch.setattr(cli_mod, "_OUTPUT_HISTORY_MAX_LINES", 200)
+    monkeypatch.setattr(cli_mod, "_OUTPUT_HISTORY", deque(maxlen=200))
+    monkeypatch.setattr(cli_mod, "_pt_print", lambda *args, **kwargs: None)
+
+
+def test_show_banner_compact_does_not_record_banner_but_keeps_later_output(monkeypatch):
+    _reset_output_history(monkeypatch)
+    marker = "COMPACT_SHOW_BANNER_HISTORY_MARKER"
+    ordinary = "ordinary output after compact show banner"
+    cli_obj = _make_cli(app=True)
+
+    monkeypatch.setattr(cli_mod, "_build_compact_banner", lambda: marker)
+    monkeypatch.setattr(cli_mod.shutil, "get_terminal_size", lambda *args, **kwargs: os.terminal_size((120, 24)))
+
+    cli_obj.show_banner()
+
+    assert marker not in _history_text()
+
+    cli_obj._console_print(ordinary)
+
+    history = _history_text()
+    assert marker not in history
+    assert ordinary in history
+
+
+def test_clear_tui_compact_does_not_record_banner_after_clearing_history(monkeypatch):
+    _reset_output_history(monkeypatch)
+    marker = "COMPACT_CLEAR_TUI_HISTORY_MARKER"
+    ordinary = "ordinary output after compact tui clear"
+    cli_obj = _make_cli(app=True)
+    cli_mod._record_output_history("old history entry")
+
+    monkeypatch.setattr(cli_mod, "_build_compact_banner", lambda: marker)
+    monkeypatch.setattr(cli_mod.shutil, "get_terminal_size", lambda *args, **kwargs: os.terminal_size((120, 24)))
+    monkeypatch.setattr(cli_mod, "get_random_tip", lambda: "test tip", raising=False)
+
+    cli_obj.process_command("/clear")
+
+    history_after_clear = _history_text()
+    assert "old history entry" not in history_after_clear
+    assert marker not in history_after_clear
+
+    cli_mod._cprint(ordinary)
+
+    history = _history_text()
+    assert "old history entry" not in history
+    assert marker not in history
+    assert ordinary in history

--- a/tests/cli/test_cli_output_history_compact_banner.py
+++ b/tests/cli/test_cli_output_history_compact_banner.py
@@ -1,0 +1,131 @@
+from collections import deque
+import os
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+import cli as cli_mod
+from cli import HermesCLI
+
+
+class _NullOutput:
+    def erase_screen(self):
+        pass
+
+    def cursor_goto(self, *_args):
+        pass
+
+    def flush(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def restore_output_history(monkeypatch):
+    original = {
+        "_OUTPUT_HISTORY_ENABLED": cli_mod._OUTPUT_HISTORY_ENABLED,
+        "_OUTPUT_HISTORY_REPLAYING": cli_mod._OUTPUT_HISTORY_REPLAYING,
+        "_OUTPUT_HISTORY_SUPPRESSED": cli_mod._OUTPUT_HISTORY_SUPPRESSED,
+        "_OUTPUT_HISTORY_MAX_LINES": cli_mod._OUTPUT_HISTORY_MAX_LINES,
+        "_OUTPUT_HISTORY": cli_mod._OUTPUT_HISTORY,
+    }
+    monkeypatch.setattr(cli_mod, "_OUTPUT_HISTORY_ENABLED", True)
+    monkeypatch.setattr(cli_mod, "_OUTPUT_HISTORY_REPLAYING", False)
+    monkeypatch.setattr(cli_mod, "_OUTPUT_HISTORY_SUPPRESSED", False)
+    monkeypatch.setattr(cli_mod, "_OUTPUT_HISTORY_MAX_LINES", 200)
+    monkeypatch.setattr(cli_mod, "_OUTPUT_HISTORY", deque(maxlen=200))
+    monkeypatch.setattr(cli_mod, "_pt_print", lambda *args, **kwargs: None)
+    yield
+    for name, value in original.items():
+        setattr(cli_mod, name, value)
+
+
+def _history_text() -> str:
+    rendered: list[str] = []
+    for entry in cli_mod._OUTPUT_HISTORY:
+        if callable(entry):
+            value = entry()
+            if isinstance(value, str):
+                rendered.extend(value.splitlines())
+            else:
+                rendered.extend(str(line) for line in cast(Any, value))
+        else:
+            rendered.append(str(entry))
+    return "\n".join(rendered)
+
+
+def _make_cli(*, compact: bool) -> HermesCLI:
+    cli_obj = cast(Any, HermesCLI.__new__(HermesCLI))
+    cli_obj.console = cli_mod.Console()
+    cli_obj.compact = compact
+    cli_obj.agent = None
+    cli_obj.enabled_toolsets = []
+    cli_obj.session_id = "test-session"
+    cli_obj.model = "test-model"
+    cli_obj.provider = "test-provider"
+    cli_obj.base_url = ""
+    cli_obj._app = SimpleNamespace(output=_NullOutput())
+    cli_obj._pending_resume_sessions = None
+    cli_obj._confirm_destructive_slash = lambda *args, **kwargs: True
+    cli_obj.new_session = lambda *args, **kwargs: None
+    return cli_obj
+
+
+def test_clear_tui_compact_clears_history_and_skips_banner_but_later_output_records(monkeypatch):
+    marker = "COMPACT_CLEAR_TUI_HISTORY_MARKER"
+    ordinary = "ordinary output after compact tui clear"
+    cli_obj = _make_cli(compact=True)
+    cli_mod._record_output_history("old history entry")
+
+    monkeypatch.setattr(cli_mod, "_build_compact_banner", lambda: marker)
+    monkeypatch.setattr(
+        cli_mod.shutil,
+        "get_terminal_size",
+        lambda *args, **kwargs: os.terminal_size((120, 24)),
+    )
+    monkeypatch.setattr(cli_mod, "get_random_tip", lambda: "test tip", raising=False)
+
+    cli_obj.process_command("/clear")
+
+    history_after_clear = _history_text()
+    assert "old history entry" not in history_after_clear
+    assert marker not in history_after_clear
+
+    # Subsequent ordinary TUI output must flow through ChatConsole (because
+    # self._app is live) and therefore land back in _OUTPUT_HISTORY.  Using
+    # the CLI's own _console_print exercises the production routing without
+    # bypassing it with a hand-rolled helper.
+    cli_obj._console_print(ordinary)
+
+    history = _history_text()
+    assert "old history entry" not in history
+    assert marker not in history
+    assert ordinary in history
+
+
+def test_clear_tui_non_compact_keeps_full_banner_history_behavior(monkeypatch):
+    full_banner_marker = "FULL_CLEAR_TUI_HISTORY_MARKER"
+    compact_marker = "COMPACT_CLEAR_TUI_HISTORY_MARKER"
+    cli_obj = _make_cli(compact=False)
+    cli_mod._record_output_history("old history entry")
+
+    monkeypatch.setattr(cli_mod, "_build_compact_banner", lambda: compact_marker)
+    monkeypatch.setattr(
+        cli_mod.shutil,
+        "get_terminal_size",
+        lambda *args, **kwargs: os.terminal_size((120, 24)),
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "build_welcome_banner",
+        lambda *, console, **kwargs: console.print(full_banner_marker),
+    )
+    monkeypatch.setattr(cli_mod, "get_tool_definitions", lambda **kwargs: [])
+    monkeypatch.setattr(cli_mod, "get_random_tip", lambda: "test tip", raising=False)
+
+    cli_obj.process_command("/clear")
+
+    history = _history_text()
+    assert "old history entry" not in history
+    assert compact_marker not in history
+    assert full_banner_marker in history

--- a/tests/cli/test_cli_output_history_compact_banner.py
+++ b/tests/cli/test_cli_output_history_compact_banner.py
@@ -9,15 +9,6 @@ import cli as cli_mod
 from cli import HermesCLI
 
 
-class _HistoryConsole:
-    def clear(self):
-        pass
-
-    def print(self, *args, **kwargs):
-        text = " ".join(str(arg) for arg in args)
-        cli_mod._cprint(text)
-
-
 class _NullOutput:
     def erase_screen(self):
         pass
@@ -63,52 +54,27 @@ def _history_text() -> str:
     return "\n".join(rendered)
 
 
-def _make_cli(*, app_active: bool = False) -> HermesCLI:
+def _make_cli(*, compact: bool) -> HermesCLI:
     cli_obj = cast(Any, HermesCLI.__new__(HermesCLI))
-    cli_obj.console = _HistoryConsole()
-    cli_obj.compact = True
+    cli_obj.console = cli_mod.Console()
+    cli_obj.compact = compact
     cli_obj.agent = None
     cli_obj.enabled_toolsets = []
     cli_obj.session_id = "test-session"
     cli_obj.model = "test-model"
     cli_obj.provider = "test-provider"
     cli_obj.base_url = ""
-    cli_obj._app = SimpleNamespace(output=_NullOutput()) if app_active else None
+    cli_obj._app = SimpleNamespace(output=_NullOutput())
     cli_obj._pending_resume_sessions = None
     cli_obj._confirm_destructive_slash = lambda *args, **kwargs: True
     cli_obj.new_session = lambda *args, **kwargs: None
-    cli_obj._show_status = lambda: None
-    cli_obj._show_tool_availability_warnings = lambda: None
     return cli_obj
-
-
-def test_show_banner_compact_skips_output_history_but_later_output_records(monkeypatch):
-    marker = "COMPACT_SHOW_BANNER_HISTORY_MARKER"
-    ordinary = "ordinary output after compact show banner"
-    cli_obj = _make_cli()
-
-    monkeypatch.setattr(cli_mod, "_build_compact_banner", lambda: marker)
-    monkeypatch.setattr(
-        cli_mod.shutil,
-        "get_terminal_size",
-        lambda *args, **kwargs: os.terminal_size((120, 24)),
-    )
-
-    cli_obj.show_banner()
-
-    assert marker not in _history_text()
-
-    cli_obj._console_print(ordinary)
-
-    history = _history_text()
-    assert marker not in history
-    assert ordinary in history
 
 
 def test_clear_tui_compact_clears_history_and_skips_banner_but_later_output_records(monkeypatch):
     marker = "COMPACT_CLEAR_TUI_HISTORY_MARKER"
     ordinary = "ordinary output after compact tui clear"
-    cli_obj = _make_cli(app_active=True)
+    cli_obj = _make_cli(compact=True)
     cli_mod._record_output_history("old history entry")
 
     monkeypatch.setattr(cli_mod, "_build_compact_banner", lambda: marker)
@@ -125,9 +91,41 @@ def test_clear_tui_compact_clears_history_and_skips_banner_but_later_output_reco
     assert "old history entry" not in history_after_clear
     assert marker not in history_after_clear
 
-    cli_mod._cprint(ordinary)
+    # Subsequent ordinary TUI output must flow through ChatConsole (because
+    # self._app is live) and therefore land back in _OUTPUT_HISTORY.  Using
+    # the CLI's own _console_print exercises the production routing without
+    # bypassing it with a hand-rolled helper.
+    cli_obj._console_print(ordinary)
 
     history = _history_text()
     assert "old history entry" not in history
     assert marker not in history
     assert ordinary in history
+
+
+def test_clear_tui_non_compact_keeps_full_banner_history_behavior(monkeypatch):
+    full_banner_marker = "FULL_CLEAR_TUI_HISTORY_MARKER"
+    compact_marker = "COMPACT_CLEAR_TUI_HISTORY_MARKER"
+    cli_obj = _make_cli(compact=False)
+    cli_mod._record_output_history("old history entry")
+
+    monkeypatch.setattr(cli_mod, "_build_compact_banner", lambda: compact_marker)
+    monkeypatch.setattr(
+        cli_mod.shutil,
+        "get_terminal_size",
+        lambda *args, **kwargs: os.terminal_size((120, 24)),
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "build_welcome_banner",
+        lambda *, console, **kwargs: console.print(full_banner_marker),
+    )
+    monkeypatch.setattr(cli_mod, "get_tool_definitions", lambda **kwargs: [])
+    monkeypatch.setattr(cli_mod, "get_random_tip", lambda: "test tip", raising=False)
+
+    cli_obj.process_command("/clear")
+
+    history = _history_text()
+    assert "old history entry" not in history
+    assert compact_marker not in history
+    assert full_banner_marker in history


### PR DESCRIPTION
## Summary

- Prevent the compact TUI banner emitted after `/clear` from being recorded in output history.
- Preserve `/clear` semantics by removing prior history before rendering the new banner.
- Preserve normal output-history recording immediately after `/clear`.
- Preserve the existing full-banner history behavior in non-compact mode.

Normal startup is intentionally unchanged. During startup, `run()` calls
`show_banner()` before assigning `self._app`, so `_output_console()` uses the
raw console rather than `ChatConsole` and does not route the startup banner
through `_cprint()`.

## Implementation

The verified compact `/clear` path is:

```text
process_command("/clear")
  -> ChatConsole.print()
  -> _cprint()
  -> _record_output_history()
```

The compact banner print is therefore wrapped with
`_suspend_output_history()` only on that productive path.

## Tests

- Behavioral compact `/clear` test:
  - prior history is removed;
  - the compact banner is not recorded;
  - ordinary subsequent TUI output is recorded.
- Non-compact `/clear` test:
  - prior history is removed;
  - the full banner retains its existing history behavior.
- No test calls `_cprint()` directly to manufacture a startup history path.

## Validation

- Focused and neighboring CLI tests: **36 passed**.
- `python -m py_compile`: passed.
- `git diff --check`: passed.
- Broad `tests/cli/` comparison:
  - branch: `1 failed, 1008 passed`;
  - PR merge-base `015718066ab8e9499c3caea3cda9f7ea469036fc`:
    `1 failed, 1006 passed`;
  - both fail first at the same preexisting test:
    `TestResumeQuietStderr::test_session_not_found_goes_to_stdout_in_full_mode`;
  - that test passes in isolation on both the branch and merge-base.

## Scope

Only these files are changed:

- `cli.py`
- `tests/cli/test_cli_output_history_compact_banner.py`
