### PR TITLE
fix(whatsapp): update body-parser security patch

### DIFF
--- a/scripts/whatsapp-bridge/package-lock.json
+++ b/scripts/whatsapp-bridge/package-lock.json
@@ -831,9 +831,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",

--- a/scripts/whatsapp-bridge/package.json
+++ b/scripts/whatsapp-bridge/package.json
@@ -14,6 +14,7 @@
     "pino": "^9.0.0"
   },
   "overrides": {
+    "body-parser": "1.20.6",
     "protobufjs": "^7.5.5"
   }
 }


### PR DESCRIPTION
## Summary
- pin the WhatsApp bridge transitive body-parser dependency to 1.20.6
- refresh the standalone bridge lockfile
- clear GHSA-v422-hmwv-36x6 from the bridge audit

## Verification
- npm ci --ignore-scripts --prefix scripts/whatsapp-bridge
- npm audit --json --prefix scripts/whatsapp-bridge (0 vulnerabilities)
- node --check scripts/whatsapp-bridge/bridge.js
- git diff --check

This PR intentionally does not address the separate web/ui-tui build-tool advisories, whose npm-proposed remediations require major/downgrade changes.