### PR TITLE
feat(discord): configure auto-thread archive duration

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -48,6 +48,7 @@ class _Snowflake:
         self.id = id
 
 VALID_THREAD_AUTO_ARCHIVE_MINUTES = {60, 1440, 4320, 10080}
+_DEFAULT_AUTO_THREAD_ARCHIVE_MINUTES = 1440
 _DISCORD_COMMAND_SYNC_POLICIES = {"safe", "bulk", "off"}
 _DISCORD_COMMAND_SYNC_STATE_SUBDIR = "gateway"
 _DISCORD_COMMAND_SYNC_STATE_FILENAME = "discord_command_sync_state.json"
@@ -850,6 +851,19 @@ def _env_bool(name: str, default: bool = False) -> bool:
     if not raw:
         return default
     return raw in {"true", "1", "yes", "on"}
+
+
+def _auto_thread_archive_minutes() -> int:
+    """Return the configured Discord auto-thread archive duration."""
+    try:
+        value = int(os.getenv("DISCORD_AUTO_THREAD_ARCHIVE_MINUTES", ""))
+    except (TypeError, ValueError):
+        return _DEFAULT_AUTO_THREAD_ARCHIVE_MINUTES
+    return (
+        value
+        if value in VALID_THREAD_AUTO_ARCHIVE_MINUTES
+        else _DEFAULT_AUTO_THREAD_ARCHIVE_MINUTES
+    )
 
 
 def _read_discord_prompt_timeout() -> int:
@@ -6557,6 +6571,7 @@ class DiscordAdapter(BasePlatformAdapter):
         burn through to the caller's failure path (#20243).
         """
         thread_name = self._derive_auto_thread_name(message.content or "")
+        auto_archive_duration = _auto_thread_archive_minutes()
         display_name = getattr(getattr(message, "author", None), "display_name", None) or "unknown user"
         reason = f"Auto-threaded from mention by {display_name}"
 
@@ -6565,7 +6580,10 @@ class DiscordAdapter(BasePlatformAdapter):
 
         for attempt in range(2):
             try:
-                thread = await message.create_thread(name=thread_name, auto_archive_duration=1440)
+                thread = await message.create_thread(
+                    name=thread_name,
+                    auto_archive_duration=auto_archive_duration,
+                )
                 try:
                     setattr(thread, "_hermes_auto_thread_initial_name", thread_name)
                 except Exception:
@@ -6579,7 +6597,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     )
                     thread = await seed_msg.create_thread(
                         name=thread_name,
-                        auto_archive_duration=1440,
+                        auto_archive_duration=auto_archive_duration,
                         reason=reason,
                     )
                     try:
@@ -9686,6 +9704,13 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
     if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
         os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
+    if (
+        "auto_thread_archive_minutes" in discord_cfg
+        and not os.getenv("DISCORD_AUTO_THREAD_ARCHIVE_MINUTES")
+    ):
+        os.environ["DISCORD_AUTO_THREAD_ARCHIVE_MINUTES"] = str(
+            discord_cfg["auto_thread_archive_minutes"]
+        )
     if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
         os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
     seeded_extra = {}

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -574,7 +574,8 @@ def test_build_slash_event_uses_group_context_for_channels(adapter):
 
 
 @pytest.mark.asyncio
-async def test_auto_create_thread_uses_message_content_as_name(adapter):
+async def test_auto_create_thread_uses_message_content_as_name(adapter, monkeypatch):
+    monkeypatch.delenv("DISCORD_AUTO_THREAD_ARCHIVE_MINUTES", raising=False)
     thread = SimpleNamespace(id=999, name="Hello world")
     message = SimpleNamespace(
         content="Hello world, how are you?",
@@ -591,6 +592,38 @@ async def test_auto_create_thread_uses_message_content_as_name(adapter):
     assert call_kwargs["name"] == "Hello world, how are you?"
     assert call_kwargs["auto_archive_duration"] == 1440
     assert thread._hermes_auto_thread_initial_name == "Hello world, how are you?"
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_uses_configured_archive_duration(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_AUTO_THREAD_ARCHIVE_MINUTES", "4320")
+    thread = SimpleNamespace(id=999, name="Hello")
+    message = SimpleNamespace(
+        content="Hello",
+        create_thread=AsyncMock(return_value=thread),
+        channel=SimpleNamespace(send=AsyncMock()),
+        author=SimpleNamespace(display_name="Jezza"),
+    )
+
+    await adapter._auto_create_thread(message)
+
+    assert message.create_thread.await_args.kwargs["auto_archive_duration"] == 4320
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_rejects_invalid_archive_duration(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_AUTO_THREAD_ARCHIVE_MINUTES", "999")
+    thread = SimpleNamespace(id=999, name="Hello")
+    message = SimpleNamespace(
+        content="Hello",
+        create_thread=AsyncMock(return_value=thread),
+        channel=SimpleNamespace(send=AsyncMock()),
+        author=SimpleNamespace(display_name="Jezza"),
+    )
+
+    await adapter._auto_create_thread(message)
+
+    assert message.create_thread.await_args.kwargs["auto_archive_duration"] == 1440
 
 
 @pytest.mark.asyncio
@@ -930,10 +963,14 @@ def test_discord_auto_thread_config_bridge(monkeypatch, tmp_path):
     hermes_dir.mkdir()
     config_path = hermes_dir / "config.yaml"
     config_path.write_text(yaml.dump({
-        "discord": {"auto_thread": True},
+        "discord": {
+            "auto_thread": True,
+            "auto_thread_archive_minutes": 4320,
+        },
     }))
 
     monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.delenv("DISCORD_AUTO_THREAD_ARCHIVE_MINUTES", raising=False)
     monkeypatch.setenv("HERMES_HOME", str(hermes_dir))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
@@ -942,6 +979,7 @@ def test_discord_auto_thread_config_bridge(monkeypatch, tmp_path):
 
     import os
     assert os.getenv("DISCORD_AUTO_THREAD") == "true"
+    assert os.getenv("DISCORD_AUTO_THREAD_ARCHIVE_MINUTES") == "4320"
 
 
 # ------------------------------------------------------------------

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -303,6 +303,7 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `DISCORD_REQUIRE_MENTION` | Require an @mention before responding in server channels |
 | `DISCORD_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where mention is not required |
 | `DISCORD_AUTO_THREAD` | Auto-thread long replies when supported |
+| `DISCORD_AUTO_THREAD_ARCHIVE_MINUTES` | Auto-archive duration for automatically created threads: `60`, `1440`, `4320`, or `10080` (default: `1440`) |
 | `DISCORD_ALLOW_ANY_ATTACHMENT` | When `true`, accept attachments of any file type (not just the built-in PDF/text/zip/office allowlist). Unknown types are cached and surfaced to the agent as a local path so it can inspect them via `terminal` / `read_file` / `ffprobe`. Default `false`. |
 | `DISCORD_MAX_ATTACHMENT_BYTES` | Maximum bytes per attachment the gateway will cache. Default `33554432` (32 MiB). Set to `0` for no cap (attachments are held in memory while being written). |
 | `DISCORD_REACTIONS` | Enable emoji reactions on messages during processing (default: `true`) |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2006,11 +2006,13 @@ discord:
   require_mention: true          # Require @mention to respond in server channels
   free_response_channels: ""     # Comma-separated channel IDs where bot responds without @mention
   auto_thread: true              # Auto-create threads on @mention in channels
+  auto_thread_archive_minutes: 1440  # 60, 1440, 4320, or 10080
 ```
 
 - `require_mention` — when `true` (default), the bot only responds in server channels when mentioned with `@BotName`. DMs always work without mention.
 - `free_response_channels` — comma-separated list of channel IDs where the bot responds to every message without requiring a mention.
 - `auto_thread` — when `true` (default), mentions in channels automatically create a thread for the conversation, keeping channels clean (similar to Slack threading).
+- `auto_thread_archive_minutes` — auto-archive duration for automatically created threads. Discord accepts `60`, `1440`, `4320`, or `10080`; invalid values fall back to `1440`.
 
 ## Security
 


### PR DESCRIPTION
## Summary

- add `discord.auto_thread_archive_minutes` for automatically created Discord threads
- preserve Discord’s existing 24-hour default
- accept only Discord-supported archive durations, with a safe fallback
- document the YAML and environment-variable configuration

## Tests

- `python -m pytest tests/gateway/test_discord_slash_commands.py tests/gateway/test_discord_connect.py -q -o "addopts="` (65 passed)