### PR TITLE
fix(mcp): stop counting app-level tool errors as server unreachability

### DIFF
--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -322,6 +322,91 @@ def test_half_open_dead_session_recovers_after_reconnect(monkeypatch, tmp_path):
         _cleanup(mcp_tool, "srv")
 
 
+def test_app_level_tool_errors_do_not_trip_breaker(monkeypatch, tmp_path):
+    """Application-level tool errors (``result.isError``, e.g. a "not
+    found" lookup) prove the server responded — they must NOT count as
+    consecutive failures. Under the old implementation three of them in
+    a row opened the breaker and every tool on the server fast-failed
+    as "unreachable" for the whole cooldown, despite the server being
+    healthy.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    call_count = {"n": 0}
+
+    async def _call_tool_app_error(*a, **kw):
+        call_count["n"] += 1
+        result = MagicMock()
+        result.isError = True
+        block = MagicMock()
+        block.text = "Prompt not found"
+        result.content = [block]
+        result.structuredContent = None
+        return result
+
+    _install_stub_server(mcp_tool, "srv", _call_tool_app_error)
+    mcp_tool._ensure_mcp_loop()
+
+    try:
+        handler = _make_tool_handler("srv", "tool1", 10.0)
+
+        for _ in range(mcp_tool._CIRCUIT_BREAKER_THRESHOLD + 1):
+            result = handler({})
+            parsed = json.loads(result)
+            assert parsed.get("error") == "Prompt not found", parsed
+
+        # Every call reached the session — none was short-circuited.
+        assert call_count["n"] == mcp_tool._CIRCUIT_BREAKER_THRESHOLD + 1
+
+        # And the breaker stayed fully closed.
+        assert mcp_tool._server_error_counts.get("srv", 0) == 0
+    finally:
+        _cleanup(mcp_tool, "srv")
+
+
+def test_app_level_tool_error_closes_partially_tripped_breaker(
+    monkeypatch, tmp_path
+):
+    """A responding server is a reachability success: an ``isError``
+    tool result must reset a below-threshold transport-failure count,
+    exactly like a successful result does.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    async def _call_tool_app_error(*a, **kw):
+        result = MagicMock()
+        result.isError = True
+        block = MagicMock()
+        block.text = "Prompt not found"
+        result.content = [block]
+        result.structuredContent = None
+        return result
+
+    _install_stub_server(mcp_tool, "srv", _call_tool_app_error)
+    mcp_tool._ensure_mcp_loop()
+
+    try:
+        # Two prior transport failures — one below threshold.
+        mcp_tool._server_error_counts["srv"] = (
+            mcp_tool._CIRCUIT_BREAKER_THRESHOLD - 1
+        )
+
+        handler = _make_tool_handler("srv", "tool1", 10.0)
+        result = handler({})
+        parsed = json.loads(result)
+        assert parsed.get("error") == "Prompt not found", parsed
+
+        assert mcp_tool._server_error_counts.get("srv", 0) == 0
+    finally:
+        _cleanup(mcp_tool, "srv")
+
+
 def test_circuit_breaker_cleared_on_reconnect(monkeypatch, tmp_path):
     """When the auth-recovery path successfully reconnects the server,
     the breaker should be cleared so subsequent calls aren't gated on a

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3881,14 +3881,12 @@ def _handle_auth_error_and_retry(
 
         try:
             result = retry_call()
-            try:
-                parsed = json.loads(result)
-                if "error" not in parsed:
-                    _reset_server_error(server_name)
-                    return result
-            except (json.JSONDecodeError, TypeError):
-                _reset_server_error(server_name)
-                return result
+            # A completed retry proves the reconnect and the transport
+            # both work — return it even when it carries an
+            # application-level error payload. Only a raising retry
+            # falls through to the needs_reauth path below.
+            _reset_server_error(server_name)
+            return result
         except Exception as retry_exc:
             logger.warning(
                 "MCP %s/%s retry after auth recovery failed: %s",
@@ -4077,14 +4075,10 @@ def _handle_session_expired_and_retry(
 
     try:
         result = retry_call()
-        try:
-            parsed = json.loads(result)
-            if "error" not in parsed:
-                _reset_server_error(server_name)
-                return result
-        except (json.JSONDecodeError, TypeError):
-            _reset_server_error(server_name)
-            return result
+        # A completed retry proves the rebuilt transport works — return
+        # it even when it carries an application-level error payload.
+        _reset_server_error(server_name)
+        return result
     except Exception as retry_exc:
         logger.warning(
             "MCP %s/%s retry after session reconnect failed: %s",
@@ -4853,15 +4847,14 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
 
         try:
             result = _call_once()
-            # Check if the MCP tool itself returned an error
-            try:
-                parsed = json.loads(result)
-                if "error" in parsed:
-                    _bump_server_error(server_name)
-                else:
-                    _reset_server_error(server_name)  # success — reset
-            except (json.JSONDecodeError, TypeError):
-                _reset_server_error(server_name)  # non-JSON = success
+            # The RPC round-trip completed, so the server is reachable —
+            # even when the payload is an application-level tool error
+            # (``result.isError``, e.g. a "not found" lookup). Only the
+            # transport-failure paths below count toward the breaker;
+            # sniffing the payload for an "error" key conflated the two
+            # and let a few bad-argument calls take a healthy server
+            # "offline" for the whole cooldown.
+            _reset_server_error(server_name)
             return result
         except InterruptedError:
             return _interrupted_call_result()


### PR DESCRIPTION
## Summary

The MCP circuit breaker (#10776, added for the retry burn loops in #10447) decides "server unreachable" by sniffing the tool result JSON for an `"error"` key:

```python
parsed = json.loads(result)
if "error" in parsed:
    _bump_server_error(server_name)
```

Application-level tool errors — MCP `result.isError` payloads such as a "not found" lookup — produce exactly that shape, so they count as consecutive failures identically to transport failures. Three bad-argument calls in a row open the breaker, and **every** tool on that server fast-fails as `MCP server '<name>' is unreachable after 3 consecutive failures` for the full 60s cooldown.

Observed in production: an agent probed a server with three stale IDs, got three sub-second "not found" responses (i.e. the server was healthy and answering), and the harness then reported the whole server as down to the model and the user.

## Fix

Classify by mechanism instead of payload shape:

- A completed RPC round-trip proves the server is reachable — reset the breaker regardless of what the tool returned (`_reset_server_error` on any non-raising `_call_once()`).
- Only the transport paths bump the count: the `except Exception` handler and the server-not-connected path, unchanged.

The auth-recovery and session-expired retry helpers had the same payload-sniffing flaw — a retry that *completed* but carried an app-level error payload fell through to `needs_reauth` / the generic error path instead of being returned. They now return the completed result as-is and reset the breaker; a raising retry still falls through exactly as before.

Genuine outages are unaffected: transport failures trip the breaker, the cooldown and half-open probe behave as before (existing tests unchanged and passing).

## Tests

Two regression tests in `tests/tools/test_mcp_circuit_breaker.py`:

- `test_app_level_tool_errors_do_not_trip_breaker` — threshold+1 consecutive `isError` results: every call reaches the session, the breaker stays closed.
- `test_app_level_tool_error_closes_partially_tripped_breaker` — an `isError` result resets a below-threshold transport-failure count, like any successful response.

Ran per-file: `test_mcp_circuit_breaker.py` (9), `test_mcp_tool.py` (234), `test_mcp_tool_401_handling.py` (7), `test_mcp_tool_session_expired.py` (32) — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xa5D4FJwo8A3R8skLiK2aq
