### PR TITLE
feat(skills): add auto_load config for persistent skill pre-loading

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -810,3 +810,98 @@ def build_preloaded_skills_prompt(
         loaded_names.append(skill_name)
 
     return "\n\n".join(prompt_parts), loaded_names, missing
+
+
+def build_auto_load_skills_prompt(
+    config: dict[str, Any] | None = None,
+    task_id: str | None = None,
+) -> tuple[str, list[str], list[str]]:
+    """Load skills listed in ``config.yaml``'s ``skills.auto_load`` and return
+    their content as a system-prompt section.
+
+    Returns ``(prompt_text, loaded_skill_names, missing_identifiers)`` — the
+    same signature pattern as ``build_preloaded_skills_prompt``.
+
+    This reuses the same ``_load_skill_payload`` + disabled-skill gate as
+    ``build_preloaded_skills_prompt``.  The only differences are:
+
+    - Source: reads from config (``skills.auto_load``), not a CLI/env list.
+    - Activation note: a neutral config-sourced note instead of the
+      "launched this CLI session with this skill preloaded" wording.
+
+    Missing/disabled skills are skipped (non-fatal) and reported in the
+    ``missing_identifiers`` list so the caller can log a warning.
+
+    Empty/``None`` ``auto_load`` returns an empty prompt (no-op), preserving
+    existing behaviour when the key is unset.
+    """
+    if config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        except Exception:
+            return "", [], []
+
+    skills_cfg = config.get("skills") if isinstance(config, dict) else None
+    if not isinstance(skills_cfg, dict):
+        return "", [], []
+
+    auto_load = skills_cfg.get("auto_load")
+    if not auto_load or not isinstance(auto_load, list):
+        return "", [], []
+
+    prompt_parts: list[str] = []
+    loaded_names: list[str] = []
+    missing: list[str] = []
+
+    # Same disabled-skill gate as build_preloaded_skills_prompt (#59156).
+    try:
+        from agent.skill_utils import get_disabled_skill_names
+
+        disabled_names = get_disabled_skill_names()
+    except Exception:
+        disabled_names = set()
+
+    seen: set[str] = set()
+    for raw_identifier in auto_load:
+        identifier = (raw_identifier or "").strip()
+        if not identifier or identifier in seen:
+            continue
+        seen.add(identifier)
+
+        loaded = _load_skill_payload(identifier, task_id=task_id)
+        if not loaded:
+            missing.append(identifier)
+            continue
+
+        loaded_skill, skill_dir, skill_name = loaded
+
+        if skill_name in disabled_names or identifier in disabled_names:
+            missing.append(identifier)
+            continue
+
+        # Track active usage for Curator lifecycle management (#17782)
+        try:
+            from tools.skill_usage import bump_use
+
+            bump_use(skill_name)
+        except Exception:
+            pass  # Non-critical
+
+        activation_note = (
+            f'[IMPORTANT: The "{skill_name}" skill is auto-loaded via config '
+            "(skills.auto_load). Treat its instructions as active guidance "
+            "for the duration of this session.]"
+        )
+        prompt_parts.append(
+            _build_skill_message(
+                loaded_skill,
+                skill_dir,
+                activation_note,
+                session_id=task_id,
+            )
+        )
+        loaded_names.append(skill_name)
+
+    return "\n\n".join(prompt_parts), loaded_names, missing

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -328,6 +328,28 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if skills_prompt:
         stable_parts.append(skills_prompt)
 
+    # Auto-loaded skills: inject skill CONTENT for skills listed in
+    # config.yaml skills.auto_load.  Runs in the stable tier before the
+    # prompt is cached — cache-safe (config doesn't change mid-session).
+    # Same _load_skill_payload + disabled-skill gate as --skills / TUI
+    # preloading, just sourced from config instead of CLI/env.  All surfaces
+    # that go through build_system_prompt_parts get this automatically.
+    try:
+        from agent.skill_commands import build_auto_load_skills_prompt
+
+        _auto_prompt, _auto_loaded, _auto_missing = build_auto_load_skills_prompt(
+            task_id=getattr(agent, "session_id", None),
+        )
+        if _auto_prompt:
+            stable_parts.append(_auto_prompt)
+        if _auto_missing:
+            logger.warning(
+                "skills.auto_load: skipped missing/disabled: %s",
+                ", ".join(_auto_missing),
+            )
+    except Exception:
+        logger.debug("skills.auto_load: injection skipped", exc_info=True)
+
     # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
     # of the requested model. Inject explicit model identity into the system prompt
     # so the agent can correctly report which model it is (workaround for API bug).

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2587,6 +2587,14 @@ DEFAULT_CONFIG = {
     # always goes to ~/.hermes/skills/.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        # Skills auto-loaded into every session's system prompt — their
+        # CONTENT is injected alongside the skill index at system prompt
+        # build time (stable tier, cache-safe).  Unlike ``--skills`` /
+        # ``HERMES_TUI_SKILLS`` (which preload per-session via CLI/env),
+        # ``auto_load`` is config-native and applies to ALL surfaces
+        # (CLI, gateway, cron, TUI, API server, …) automatically.
+        # Default ``[]`` = no auto-load (existing behaviour unchanged).
+        "auto_load": [],
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
         # content with the absolute skill directory and the active session id
         # before the agent sees it.  Lets skill authors reference bundled

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -8,6 +8,7 @@ import pytest
 
 import tools.skills_tool as skills_tool_module
 from agent.skill_commands import (
+    build_auto_load_skills_prompt,
     build_preloaded_skills_prompt,
     build_skill_invocation_message,
     resolve_skill_command_key,
@@ -563,6 +564,141 @@ class TestBuildPreloadedSkillsPrompt:
 
         assert missing == []
         assert loaded == ["first-skill", "second-skill"]
+
+
+class TestBuildAutoLoadSkillsPrompt:
+    """Unit tests for build_auto_load_skills_prompt — the config-native
+    variant of build_preloaded_skills_prompt (skills.auto_load)."""
+
+    def test_returns_nonempty_prompt_for_existing_skill(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "existing-skill")
+            prompt, loaded, missing = build_auto_load_skills_prompt(
+                {"skills": {"auto_load": ["existing-skill"]}}
+            )
+
+        assert missing == []
+        assert loaded == ["existing-skill"]
+        assert prompt
+        assert "existing-skill" in prompt
+        assert "auto-loaded via config" in prompt
+
+    def test_returns_empty_prompt_for_empty_config(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "some-skill")
+            prompt, loaded, missing = build_auto_load_skills_prompt({})
+
+        assert prompt == ""
+        assert loaded == []
+        assert missing == []
+
+    def test_returns_empty_prompt_for_empty_auto_load_list(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "some-skill")
+            prompt, loaded, missing = build_auto_load_skills_prompt(
+                {"skills": {"auto_load": []}}
+            )
+
+        assert prompt == ""
+        assert loaded == []
+        assert missing == []
+
+    def test_missing_skill_in_missing_list_not_in_prompt(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "present-skill")
+            prompt, loaded, missing = build_auto_load_skills_prompt(
+                {"skills": {"auto_load": ["present-skill", "nonexistent-skill"]}}
+            )
+
+        assert loaded == ["present-skill"]
+        assert "nonexistent-skill" in missing
+        assert "present-skill" in prompt
+        assert "nonexistent-skill" not in prompt
+
+    def test_multiple_skills_all_loaded(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "alpha-skill")
+            _make_skill(tmp_path, "beta-skill")
+            prompt, loaded, missing = build_auto_load_skills_prompt(
+                {"skills": {"auto_load": ["alpha-skill", "beta-skill"]}}
+            )
+
+        assert missing == []
+        assert loaded == ["alpha-skill", "beta-skill"]
+        assert "alpha-skill" in prompt
+        assert "beta-skill" in prompt
+
+    def test_none_config_returns_empty_prompt(self, tmp_path, monkeypatch):
+        """When config is None, the function lazy-loads via load_config().
+        Patch load_config to return an empty dict so the no-op path holds."""
+        from hermes_cli import config as config_module
+
+        monkeypatch.setattr(config_module, "load_config", lambda: {})
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "some-skill")
+            prompt, loaded, missing = build_auto_load_skills_prompt(config=None)
+
+        assert prompt == ""
+        assert loaded == []
+        assert missing == []
+
+    def test_skips_disabled_skill(self, tmp_path, monkeypatch):
+        """A globally-disabled skill must not be force-loaded via
+        skills.auto_load (same gate as --skills, #59156)."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "enabled-skill", body="Enabled content.")
+            _make_skill(tmp_path, "disabled-skill", body="SECRET DISABLED CONTENT.")
+
+            import agent.skill_utils as su_module
+
+            monkeypatch.setattr(
+                su_module,
+                "get_disabled_skill_names",
+                lambda platform=None: {"disabled-skill"},
+            )
+
+            prompt, loaded, missing = build_auto_load_skills_prompt(
+                {"skills": {"auto_load": ["enabled-skill", "disabled-skill"]}}
+            )
+
+        assert loaded == ["enabled-skill"]
+        assert "disabled-skill" in missing
+        assert "SECRET DISABLED CONTENT." not in prompt
+        assert "enabled-skill" in prompt
+
+    def test_skills_section_not_a_dict_returns_empty(self, tmp_path):
+        """Malformed skills config (not a dict) should be a safe no-op."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "some-skill")
+            prompt, loaded, missing = build_auto_load_skills_prompt(
+                {"skills": "not-a-dict"}
+            )
+
+        assert prompt == ""
+        assert loaded == []
+        assert missing == []
+
+    def test_auto_load_not_a_list_returns_empty(self, tmp_path):
+        """Malformed auto_load value (not a list) should be a safe no-op."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "some-skill")
+            prompt, loaded, missing = build_auto_load_skills_prompt(
+                {"skills": {"auto_load": "not-a-list"}}
+            )
+
+        assert prompt == ""
+        assert loaded == []
+        assert missing == []
+
+    def test_deduplicates_repeated_skill_names(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "dup-skill")
+            prompt, loaded, missing = build_auto_load_skills_prompt(
+                {"skills": {"auto_load": ["dup-skill", "dup-skill"]}}
+            )
+
+        assert missing == []
+        assert loaded == ["dup-skill"]
 
 
 class TestBuildSkillInvocationMessage:

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -508,6 +508,54 @@ in the pending JSON file). Memory writes have the same gate under
 > (dangerous-pattern heuristics), not an approval gate — the two are
 > independent. See [Guard on agent-created skill writes](/user-guide/configuration#guard-on-agent-created-skill-writes).
 
+## Auto-loading skills into every session (`skills.auto_load`)
+
+Some skills are useful as permanent context rather than on-demand recall —
+for example household standards, a daily-log convention, or a butler protocol
+you want the agent to always follow. `skills.auto_load` lets you list skill
+names whose **content** is injected into the system prompt at build time, on
+every session across every surface (CLI, gateway, cron, TUI, API server,
+desktop app).
+
+```yaml
+skills:
+  auto_load:
+    - butler-standards
+    - daily-log
+    - home-brain-kb
+```
+
+Each listed skill is resolved and loaded the same way `--skills` /
+`HERMES_TUI_SKILLS` loads a preloaded skill (same disabled-skill gate, same
+skill resolution path) — the only difference is the source: `auto_load` reads
+from `config.yaml` and applies to all surfaces automatically, while `--skills`
+and `HERMES_TUI_SKILLS` are per-session CLI/env mechanisms.
+
+### Cache safety
+
+Auto-loaded skill content is injected into the **stable tier** of the system
+prompt — the cross-session-stable prefix that is built once per session and
+cached for the conversation lifetime. Because `config.yaml` does not change
+mid-session, the same skills load every turn. This is cache-safe by design.
+
+### Behaviour notes
+
+- **Missing skills are non-fatal.** A skill listed in `auto_load` that can't
+  be found (or is disabled via `skills.disabled` / `skills.platform_disabled`)
+  is skipped with a warning — the rest still load.
+- **Coexists with `--skills` / `HERMES_TUI_SKILLS`.** If a skill appears in
+  both `auto_load` and a per-session preload list, it is loaded once via each
+  path; there is no conflict.
+- **`--ignore-rules` does not strip auto-loaded skills.** Consistent with
+  existing behaviour — `--ignore-rules` strips identity/memory, not skills.
+  Use `--skills none` or disable the `skills` toolset to suppress all skills.
+- **Subagents do not inherit auto-loaded skills.** Subagents use an ephemeral
+  system prompt that bypasses `build_system_prompt_parts`. This is a
+  deliberate first-PR limitation; a follow-up can add subagent support if
+  needed.
+
+Default: `[]` (no auto-load — existing behaviour is unchanged).
+
 ## Skills Hub
 
 Browse, search, install, and manage skills from online registries, `skills.sh`, direct well-known skill endpoints, and official optional skills.


### PR DESCRIPTION
## What

Add a `skills.auto_load` config key that auto-loads specified skill CONTENT into every session's system prompt — CLI, gateway, cron, TUI, API server, all surfaces.

## Why

Currently the only mechanism to preload skills is per-invocation: `--skills` flag on CLI, `skills=[...]` on cron jobs, topic bindings on Telegram. There's no global "always load these skills" config.

Users with autonomous/multi-agent deployments (and cron-heavy setups) must either list skills on every cron job manually, wrap invocations in aliases (fragile, doesn't apply to cron/gateway), or accept that skills are missing on some sessions.

Adding a new critical skill means updating every cron job individually.

Implements #26800. Related to #12353 (platform-level default skills).

## How it works

```yaml
# config.yaml
skills:
  auto_load:
    - systematic-debugging
    - requesting-code-review
```

- Each listed skill's CONTENT is injected into the system prompt's stable tier at build time
- Applies to ALL session types (CLI, gateway, cron, TUI, API server, desktop app) via the shared `build_system_prompt_parts` path
- Default `[]` = no auto-load (existing behaviour unchanged)
- Missing skill = warning logged, continues (non-fatal)
- Disabled skills are skipped (same gate as `--skills`)
- Coexists with `--skills` / `HERMES_TUI_SKILLS` (union, not conflict)
- `--ignore-rules` does NOT strip auto_load (consistent with existing skill index behaviour)

## Architecture

Single injection point in `agent/system_prompt.py::build_system_prompt_parts` — right after the skill INDEX is appended to the stable tier, before the prompt is cached. This means:

- **One change point**, not per-surface merge at 3+ call sites
- **Cache-safe** — skill content is in the stable tier, built once, cached for session lifetime
- **All surfaces covered automatically** — they all funnel through `build_system_prompt_parts`

### Known limitation

Subagents and background review forks use `ephemeral_system_prompt` which bypasses `build_system_prompt_parts`. They don't inherit auto_load skills — this is deliberate (isolated by design). A follow-up PR can add support if there's demand.

## Files changed

- `hermes_cli/config.py` — `auto_load: []` added to DEFAULT_CONFIG `skills` section
- `agent/skill_commands.py` — `build_auto_load_skills_prompt()` function (reuses `_load_skill_payload` + disabled-skill gate from existing `build_preloaded_skills_prompt`)
- `agent/system_prompt.py` — injection in `build_system_prompt_parts` after skill index
- `tests/agent/test_skill_commands.py` — 10 new tests
- `website/docs/user-guide/features/skills.md` — documentation

## Tests

```
69 passed in 1.86s (59 existing + 10 new, no regressions)
```

## Compatibility

- No breaking changes — `auto_load: []` is the default (no-op)
- Existing `--skills` / `HERMES_TUI_SKILLS` / cron `skills=[...]` behaviour unchanged
- Config in config.yaml, not .env