### PR TITLE
fix(models): serve stale models.dev cache without blocking; keep gateway refreshes off the event loop (salvage #73621 + #35853)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -118,7 +118,7 @@ def _provider_default_routes(provider: str) -> set[str]:
         from hermes_cli.providers import HERMES_OVERLAYS, get_provider
 
         overlay = HERMES_OVERLAYS.get(provider)
-        provider_def = get_provider(provider)
+        provider_def = get_provider(provider, allow_network=False)
         for value in (
             getattr(overlay, "base_url_override", ""),
             getattr(provider_def, "base_url", ""),

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -41,6 +41,8 @@ _models_dev_cache: Dict[str, Any] = {}
 _models_dev_cache_time: float = 0
 _models_dev_retry_after: float = 0
 _models_dev_fetch_lock = threading.Lock()
+_models_dev_refresh_lock = threading.Lock()
+_models_dev_refresh_in_flight = False
 
 
 # ---------------------------------------------------------------------------
@@ -241,6 +243,73 @@ def _save_disk_cache(data: Dict[str, Any]) -> None:
         logger.debug("Failed to save models.dev disk cache: %s", e)
 
 
+def _fetch_models_dev_from_network() -> Dict[str, Any]:
+    """Fetch the live models.dev registry without touching local caches."""
+    response = requests.get(MODELS_DEV_URL, timeout=15)
+    response.raise_for_status()
+    data = response.json()
+    if isinstance(data, dict) and data:
+        return data
+    return {}
+
+
+def _mark_stale_cache_grace() -> None:
+    """Give stale cache data a short in-memory grace before retrying refresh."""
+    global _models_dev_cache_time
+    _models_dev_cache_time = (
+        time.time() - _MODELS_DEV_CACHE_TTL + _MODELS_DEV_RETRY_DELAY
+    )
+
+
+def _background_refresh_models_dev() -> None:
+    """Best-effort refresh after serving stale cache data."""
+    global _models_dev_cache, _models_dev_cache_time
+    global _models_dev_retry_after, _models_dev_refresh_in_flight
+    try:
+        data = _fetch_models_dev_from_network()
+        if not data:
+            raise ValueError("models.dev returned an empty or invalid registry")
+        _save_disk_cache(data)
+        _models_dev_cache = data
+        _models_dev_cache_time = time.time()
+        _models_dev_retry_after = 0
+        logger.debug(
+            "Refreshed models.dev registry in background: %d providers",
+            len(data),
+        )
+    except Exception as e:
+        _models_dev_retry_after = time.time() + _MODELS_DEV_RETRY_DELAY
+        logger.debug(
+            "Background models.dev refresh failed; retry suppressed for %ds: %s",
+            _MODELS_DEV_RETRY_DELAY,
+            e,
+        )
+    finally:
+        with _models_dev_refresh_lock:
+            _models_dev_refresh_in_flight = False
+
+
+def _start_background_refresh_models_dev() -> None:
+    """Start one daemon refresh worker if none is already running.
+
+    Honors the process-wide failure backoff: after a failed refresh,
+    no new background worker is spawned until ``_models_dev_retry_after``.
+    """
+    global _models_dev_refresh_in_flight
+    if time.time() < _models_dev_retry_after:
+        return
+    with _models_dev_refresh_lock:
+        if _models_dev_refresh_in_flight:
+            return
+        _models_dev_refresh_in_flight = True
+    thread = threading.Thread(
+        target=_background_refresh_models_dev,
+        name="models-dev-refresh",
+        daemon=True,
+    )
+    thread.start()
+
+
 def fetch_models_dev(
     force_refresh: bool = False, *, allow_network: bool = True
 ) -> Dict[str, Any]:
@@ -249,20 +318,25 @@ def fetch_models_dev(
     Returns the full registry dict keyed by provider ID, or empty dict on failure.
 
     Cache hierarchy (when ``force_refresh=False``):
-      1. In-memory cache, populated and < TTL old → return immediately.
-      2. **Disk cache file < TTL old by mtime → load, populate in-mem, return.**
-         No network call. Saves ~500 ms per cold-start agent construction;
-         ``models.dev`` only changes when providers add new models, so a
-         1 hour staleness window is acceptable (same TTL as in-mem cache).
-      3. Network fetch → on success, save to disk + in-mem and return.
-      4. Network fails → fall back to ANY available cache (even stale) and
-         suppress additional automatic refreshes for 5 minutes.
+      1. Fresh in-memory cache → return immediately.
+      2. Stale in-memory cache → return immediately and refresh in a single
+         background daemon thread. Callers never block on the network while
+         any cache exists; ``models.dev`` only changes when providers add
+         new models, so stale data is preferable to a foreground timeout.
+      3. Disk cache file (any age) → load, populate in-mem, return
+         immediately. Stale disk caches trigger the same background refresh.
+      4. No cache at all → singleflight foreground network fetch. On
+         success, save to disk + in-mem and return.
+      5. Any failed refresh (foreground or background) suppresses further
+         automatic refreshes for 5 minutes process-wide.
 
     When ``force_refresh=True`` (used by ``hermes config refresh``, the
-    \"refresh model catalog\" code path), stages 1 and 2 are skipped. The
-    function bypasses caches and failure backoff, then only falls back to
-    cached data if the network call fails. When ``allow_network=False``, any
-    memory or disk cache is returned regardless of age and no request is made.
+    \"refresh model catalog\" code path), cache fast paths and the failure
+    backoff are bypassed; the function hits the network and only falls back
+    to cached data if the call fails. When ``allow_network=False``, any
+    memory or disk cache is returned regardless of age and no request is
+    made — used by latency-sensitive paths (gateway route-identity checks)
+    that must never wait on the network.
     """
     global _models_dev_cache, _models_dev_cache_time, _models_dev_retry_after
 
@@ -287,55 +361,65 @@ def fetch_models_dev(
     ):
         return _models_dev_cache
 
-    # Stage 2: fresh-by-mtime disk cache short-circuits the network call.
-    # Only kicks in on cold-start processes (in-mem cache is empty or
-    # expired) and only when the user hasn't asked for a forced refresh.
-    # Skipped if the disk cache file is missing, unreadable, or older
-    # than _MODELS_DEV_CACHE_TTL.
+    # Stage 2: stale in-memory cache is still better than blocking provider
+    # resolution on a foreground network timeout. Refresh it in the background.
+    if not force_refresh and _models_dev_cache:
+        _mark_stale_cache_grace()
+        _start_background_refresh_models_dev()
+        logger.debug(
+            "Using stale in-memory models.dev cache; refreshing in background"
+        )
+        return _models_dev_cache
+
+    # Stage 3: disk cache short-circuits the network call.
+    # Only kicks in on cold-start processes (in-mem cache is empty) and only
+    # when the user hasn't asked for a forced refresh. A stale disk cache is
+    # deliberately usable: provider/model resolution should not hang just
+    # because models.dev is unreachable.
     if not force_refresh:
         disk_age = _disk_cache_age_seconds()
-        if disk_age is not None and disk_age < _MODELS_DEV_CACHE_TTL:
+        if disk_age is not None:
             disk_data = _load_disk_cache()
             if disk_data:
                 _models_dev_cache = disk_data
-                # Anchor in-mem TTL to the disk file's age so we don't
-                # extend an already-aging cache by another full hour.
-                _models_dev_cache_time = time.time() - disk_age
-                logger.debug(
-                    "Loaded models.dev from fresh disk cache "
-                    "(%d providers, age=%.0fs)", len(disk_data), disk_age,
-                )
+                if disk_age < _MODELS_DEV_CACHE_TTL:
+                    # Anchor in-mem TTL to the disk file's age so we don't
+                    # extend an already-aging cache by another full hour.
+                    _models_dev_cache_time = time.time() - disk_age
+                    logger.debug(
+                        "Loaded models.dev from fresh disk cache "
+                        "(%d providers, age=%.0fs)", len(disk_data), disk_age,
+                    )
+                else:
+                    _mark_stale_cache_grace()
+                    _start_background_refresh_models_dev()
+                    logger.debug(
+                        "Using stale models.dev disk cache (age=%.0fs); "
+                        "refreshing in background",
+                        disk_age,
+                    )
                 return _models_dev_cache
 
     # Failed automatic refreshes are process-wide. Avoid making every caller
-    # retry the same unreachable endpoint while stale data remains usable.
+    # retry the same unreachable endpoint while no usable cache exists.
     if not force_refresh and time.time() < _models_dev_retry_after:
-        if not _models_dev_cache:
-            _models_dev_cache = _load_disk_cache()
-            _models_dev_cache_time = 0
         return _models_dev_cache
 
-    # Stage 3: singleflight network fetch. Recheck state after acquiring the
-    # lock because another caller may have refreshed or established backoff.
+    # Stage 4: singleflight foreground network fetch — only reached when no
+    # memory or disk cache exists (or on force_refresh). Recheck state after
+    # acquiring the lock because another caller may have refreshed or
+    # established backoff while we waited.
     with _models_dev_fetch_lock:
         now = time.time()
         if not force_refresh:
-            if (
-                _models_dev_cache
-                and (now - _models_dev_cache_time) < _MODELS_DEV_CACHE_TTL
-            ):
+            if _models_dev_cache:
                 return _models_dev_cache
             if now < _models_dev_retry_after:
-                if not _models_dev_cache:
-                    _models_dev_cache = _load_disk_cache()
-                    _models_dev_cache_time = 0
                 return _models_dev_cache
 
         try:
-            response = requests.get(MODELS_DEV_URL, timeout=15)
-            response.raise_for_status()
-            data = response.json()
-            if not isinstance(data, dict) or not data:
+            data = _fetch_models_dev_from_network()
+            if not data:
                 raise ValueError("models.dev returned an empty or invalid registry")
 
             _save_disk_cache(data)
@@ -360,7 +444,7 @@ def fetch_models_dev(
                 e,
             )
 
-        # Stage 4: network failed — return any stale memory/disk cache. Cache
+        # Stage 5: network failed — return any stale memory/disk cache. Cache
         # freshness remains expired; the retry-after timestamp controls when
         # the next automatic request is allowed.
         if not _models_dev_cache:

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -8,11 +8,15 @@ of 4000+ models across 109+ providers.  Provides:
   (reasoning, tools, vision, PDF, audio), modalities, knowledge cutoff,
   open-weights flag, family grouping, deprecation status
 
-Data resolution order (like TypeScript OpenCode):
-  1. Bundled snapshot (ships with the package — offline-first)
-  2. Disk cache (~/.hermes/models_dev_cache.json)
-  3. Network fetch (https://models.dev/api.json)
-  4. Background refresh every 60 minutes
+Data resolution order:
+  1. In-memory cache (fresh, or stale served immediately while a single
+     background daemon thread refreshes)
+  2. Disk cache (~/.hermes/models_dev_cache.json — any age; stale data is
+     served rather than blocking callers on the network)
+  3. Network fetch (https://models.dev/api.json) — only when no cache
+     exists at all; failed refreshes back off for 5 minutes process-wide
+Latency-sensitive callers (gateway route-identity checks) pass
+``allow_network=False`` and never touch the network.
 
 Other modules should import the dataclasses and query functions from here
 rather than parsing the raw JSON themselves.
@@ -244,21 +248,29 @@ def _save_disk_cache(data: Dict[str, Any]) -> None:
 
 
 def _fetch_models_dev_from_network() -> Dict[str, Any]:
-    """Fetch the live models.dev registry without touching local caches."""
+    """Fetch the live models.dev registry without touching local caches.
+
+    Raises on network errors and on an empty/invalid registry payload.
+    """
     response = requests.get(MODELS_DEV_URL, timeout=15)
     response.raise_for_status()
     data = response.json()
-    if isinstance(data, dict) and data:
-        return data
-    return {}
+    if not isinstance(data, dict) or not data:
+        raise ValueError("models.dev returned an empty or invalid registry")
+    return data
 
 
 def _mark_stale_cache_grace() -> None:
-    """Give stale cache data a short in-memory grace before retrying refresh."""
+    """Give stale cache data a short in-memory grace before retrying refresh.
+
+    Only ever moves the timestamp forward: if a background refresh completed
+    between the caller's staleness check and this call, the fresh timestamp
+    is preserved instead of being rewound to a 5-minute grace.
+    """
     global _models_dev_cache_time
-    _models_dev_cache_time = (
-        time.time() - _MODELS_DEV_CACHE_TTL + _MODELS_DEV_RETRY_DELAY
-    )
+    grace_time = time.time() - _MODELS_DEV_CACHE_TTL + _MODELS_DEV_RETRY_DELAY
+    if grace_time > _models_dev_cache_time:
+        _models_dev_cache_time = grace_time
 
 
 def _background_refresh_models_dev() -> None:
@@ -267,8 +279,6 @@ def _background_refresh_models_dev() -> None:
     global _models_dev_retry_after, _models_dev_refresh_in_flight
     try:
         data = _fetch_models_dev_from_network()
-        if not data:
-            raise ValueError("models.dev returned an empty or invalid registry")
         _save_disk_cache(data)
         _models_dev_cache = data
         _models_dev_cache_time = time.time()
@@ -307,7 +317,14 @@ def _start_background_refresh_models_dev() -> None:
         name="models-dev-refresh",
         daemon=True,
     )
-    thread.start()
+    try:
+        thread.start()
+    except Exception as e:
+        # Thread/fd exhaustion: clear the flag so refresh isn't disabled
+        # for the rest of the process lifetime. Callers still get stale data.
+        with _models_dev_refresh_lock:
+            _models_dev_refresh_in_flight = False
+        logger.debug("Failed to start models.dev refresh thread: %s", e)
 
 
 def fetch_models_dev(
@@ -419,9 +436,6 @@ def fetch_models_dev(
 
         try:
             data = _fetch_models_dev_from_network()
-            if not data:
-                raise ValueError("models.dev returned an empty or invalid registry")
-
             _save_disk_cache(data)
             _models_dev_cache = data
             _models_dev_cache_time = time.time()
@@ -823,11 +837,7 @@ def get_provider_info(
     # Resolve Hermes ID → models.dev ID
     mdev_id = PROVIDER_TO_MODELS_DEV.get(provider_id, provider_id)
 
-    data = (
-        fetch_models_dev()
-        if allow_network
-        else fetch_models_dev(allow_network=False)
-    )
+    data = fetch_models_dev(allow_network=allow_network)
     raw = data.get(mdev_id)
     if not isinstance(raw, dict):
         return None

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -20,6 +20,7 @@ rather than parsing the raw JSON themselves.
 
 import json
 import logging
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -33,10 +34,13 @@ logger = logging.getLogger(__name__)
 
 MODELS_DEV_URL = "https://models.dev/api.json"
 _MODELS_DEV_CACHE_TTL = 3600  # 1 hour in-memory
+_MODELS_DEV_RETRY_DELAY = 300  # 5 minutes after a failed refresh
 
 # In-memory cache
 _models_dev_cache: Dict[str, Any] = {}
 _models_dev_cache_time: float = 0
+_models_dev_retry_after: float = 0
+_models_dev_fetch_lock = threading.Lock()
 
 
 # ---------------------------------------------------------------------------
@@ -237,7 +241,9 @@ def _save_disk_cache(data: Dict[str, Any]) -> None:
         logger.debug("Failed to save models.dev disk cache: %s", e)
 
 
-def fetch_models_dev(force_refresh: bool = False) -> Dict[str, Any]:
+def fetch_models_dev(
+    force_refresh: bool = False, *, allow_network: bool = True
+) -> Dict[str, Any]:
     """Fetch models.dev registry. Cache hierarchy: in-mem → disk → network.
 
     Returns the full registry dict keyed by provider ID, or empty dict on failure.
@@ -249,15 +255,28 @@ def fetch_models_dev(force_refresh: bool = False) -> Dict[str, Any]:
          ``models.dev`` only changes when providers add new models, so a
          1 hour staleness window is acceptable (same TTL as in-mem cache).
       3. Network fetch → on success, save to disk + in-mem and return.
-      4. Network fails → fall back to ANY available disk cache (even stale)
-         with a short 5 min in-mem grace period before retrying network.
+      4. Network fails → fall back to ANY available cache (even stale) and
+         suppress additional automatic refreshes for 5 minutes.
 
     When ``force_refresh=True`` (used by ``hermes config refresh``, the
     \"refresh model catalog\" code path), stages 1 and 2 are skipped. The
-    function always hits the network and only falls back to disk if the
-    network call fails.
+    function bypasses caches and failure backoff, then only falls back to
+    cached data if the network call fails. When ``allow_network=False``, any
+    memory or disk cache is returned regardless of age and no request is made.
     """
-    global _models_dev_cache, _models_dev_cache_time
+    global _models_dev_cache, _models_dev_cache_time, _models_dev_retry_after
+
+    if not allow_network:
+        if _models_dev_cache:
+            return _models_dev_cache
+        disk_data = _load_disk_cache()
+        if disk_data:
+            _models_dev_cache = disk_data
+            disk_age = _disk_cache_age_seconds()
+            _models_dev_cache_time = (
+                time.time() - disk_age if disk_age is not None else 0
+            )
+        return _models_dev_cache
 
     # Stage 1: fresh in-memory cache wins. This is the hot path on
     # long-lived processes — no I/O, no system calls.
@@ -288,34 +307,72 @@ def fetch_models_dev(force_refresh: bool = False) -> Dict[str, Any]:
                 )
                 return _models_dev_cache
 
-    # Stage 3: network fetch.
-    try:
-        response = requests.get(MODELS_DEV_URL, timeout=15)
-        response.raise_for_status()
-        data = response.json()
-        if isinstance(data, dict) and data:
+    # Failed automatic refreshes are process-wide. Avoid making every caller
+    # retry the same unreachable endpoint while stale data remains usable.
+    if not force_refresh and time.time() < _models_dev_retry_after:
+        if not _models_dev_cache:
+            _models_dev_cache = _load_disk_cache()
+            _models_dev_cache_time = 0
+        return _models_dev_cache
+
+    # Stage 3: singleflight network fetch. Recheck state after acquiring the
+    # lock because another caller may have refreshed or established backoff.
+    with _models_dev_fetch_lock:
+        now = time.time()
+        if not force_refresh:
+            if (
+                _models_dev_cache
+                and (now - _models_dev_cache_time) < _MODELS_DEV_CACHE_TTL
+            ):
+                return _models_dev_cache
+            if now < _models_dev_retry_after:
+                if not _models_dev_cache:
+                    _models_dev_cache = _load_disk_cache()
+                    _models_dev_cache_time = 0
+                return _models_dev_cache
+
+        try:
+            response = requests.get(MODELS_DEV_URL, timeout=15)
+            response.raise_for_status()
+            data = response.json()
+            if not isinstance(data, dict) or not data:
+                raise ValueError("models.dev returned an empty or invalid registry")
+
+            _save_disk_cache(data)
             _models_dev_cache = data
             _models_dev_cache_time = time.time()
-            _save_disk_cache(data)
+            _models_dev_retry_after = 0
             logger.debug(
                 "Fetched models.dev registry: %d providers, %d total models",
                 len(data),
-                sum(len(p.get("models", {})) for p in data.values() if isinstance(p, dict)),
+                sum(
+                    len(p.get("models", {}))
+                    for p in data.values()
+                    if isinstance(p, dict)
+                ),
             )
             return data
-    except Exception as e:
-        logger.debug("Failed to fetch models.dev: %s", e)
+        except Exception as e:
+            _models_dev_retry_after = time.time() + _MODELS_DEV_RETRY_DELAY
+            logger.debug(
+                "Failed to fetch models.dev; retry suppressed for %ds: %s",
+                _MODELS_DEV_RETRY_DELAY,
+                e,
+            )
 
-    # Stage 4: network failed — fall back to whatever disk cache exists,
-    # even if it's stale. Give it a short 5 min in-mem TTL so we retry
-    # the network soon instead of serving stale data for a full hour.
-    if not _models_dev_cache:
-        _models_dev_cache = _load_disk_cache()
-        if _models_dev_cache:
-            _models_dev_cache_time = time.time() - _MODELS_DEV_CACHE_TTL + 300
-            logger.debug("Loaded models.dev from disk cache (%d providers)", len(_models_dev_cache))
+        # Stage 4: network failed — return any stale memory/disk cache. Cache
+        # freshness remains expired; the retry-after timestamp controls when
+        # the next automatic request is allowed.
+        if not _models_dev_cache:
+            _models_dev_cache = _load_disk_cache()
+            _models_dev_cache_time = 0
+            if _models_dev_cache:
+                logger.debug(
+                    "Loaded stale models.dev disk cache (%d providers)",
+                    len(_models_dev_cache),
+                )
 
-    return _models_dev_cache
+        return _models_dev_cache
 
 
 def lookup_models_dev_context(provider: str, model: str) -> Optional[int]:
@@ -671,7 +728,9 @@ def _parse_provider_info(provider_id: str, raw: Dict[str, Any]) -> ProviderInfo:
 # Provider-level queries
 # ---------------------------------------------------------------------------
 
-def get_provider_info(provider_id: str) -> Optional[ProviderInfo]:
+def get_provider_info(
+    provider_id: str, *, allow_network: bool = True
+) -> Optional[ProviderInfo]:
     """Get full provider metadata from models.dev.
 
     Accepts either a Hermes provider ID (e.g. "kilocode") or a models.dev
@@ -680,7 +739,11 @@ def get_provider_info(provider_id: str) -> Optional[ProviderInfo]:
     # Resolve Hermes ID → models.dev ID
     mdev_id = PROVIDER_TO_MODELS_DEV.get(provider_id, provider_id)
 
-    data = fetch_models_dev()
+    data = (
+        fetch_models_dev()
+        if allow_network
+        else fetch_models_dev(allow_network=False)
+    )
     raw = data.get(mdev_id)
     if not isinstance(raw, dict):
         return None

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -837,7 +837,14 @@ def get_provider_info(
     # Resolve Hermes ID → models.dev ID
     mdev_id = PROVIDER_TO_MODELS_DEV.get(provider_id, provider_id)
 
-    data = fetch_models_dev(allow_network=allow_network)
+    # NOTE: keep the zero-argument call on the default path. Dozens of test
+    # sites monkeypatch fetch_models_dev with zero-arg lambdas; passing the
+    # kwarg unconditionally would break them all (they raise TypeError).
+    data = (
+        fetch_models_dev()
+        if allow_network
+        else fetch_models_dev(allow_network=False)
+    )
     raw = data.get(mdev_id)
     if not isinstance(raw, dict):
         return None

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -273,27 +273,52 @@ def _mark_stale_cache_grace() -> None:
         _models_dev_cache_time = grace_time
 
 
+def _commit_registry(data: Dict[str, Any], *, where: str) -> None:
+    """Persist a freshly fetched registry: disk + in-mem + clear backoff.
+
+    Callers must hold ``_models_dev_fetch_lock`` so a failing refresh on one
+    path can never stomp the state a succeeding refresh on the other path
+    just committed (e.g. a failing background worker re-arming the backoff
+    immediately after a successful ``force_refresh``).
+    """
+    global _models_dev_cache, _models_dev_cache_time, _models_dev_retry_after
+    _save_disk_cache(data)
+    _models_dev_cache = data
+    _models_dev_cache_time = time.time()
+    _models_dev_retry_after = 0
+    logger.debug(
+        "Refreshed models.dev registry (%s): %d providers, %d total models",
+        where,
+        len(data),
+        sum(len(p.get("models", {})) for p in data.values() if isinstance(p, dict)),
+    )
+
+
+def _note_refresh_failure(exc: Exception, *, where: str) -> None:
+    """Record a failed refresh: arm the process-wide 5-minute backoff.
+
+    Callers must hold ``_models_dev_fetch_lock`` (see ``_commit_registry``).
+    """
+    global _models_dev_retry_after
+    _models_dev_retry_after = time.time() + _MODELS_DEV_RETRY_DELAY
+    logger.debug(
+        "models.dev refresh failed (%s); retry suppressed for %ds: %s",
+        where,
+        _MODELS_DEV_RETRY_DELAY,
+        exc,
+    )
+
+
 def _background_refresh_models_dev() -> None:
     """Best-effort refresh after serving stale cache data."""
-    global _models_dev_cache, _models_dev_cache_time
-    global _models_dev_retry_after, _models_dev_refresh_in_flight
+    global _models_dev_refresh_in_flight
     try:
         data = _fetch_models_dev_from_network()
-        _save_disk_cache(data)
-        _models_dev_cache = data
-        _models_dev_cache_time = time.time()
-        _models_dev_retry_after = 0
-        logger.debug(
-            "Refreshed models.dev registry in background: %d providers",
-            len(data),
-        )
+        with _models_dev_fetch_lock:
+            _commit_registry(data, where="background")
     except Exception as e:
-        _models_dev_retry_after = time.time() + _MODELS_DEV_RETRY_DELAY
-        logger.debug(
-            "Background models.dev refresh failed; retry suppressed for %ds: %s",
-            _MODELS_DEV_RETRY_DELAY,
-            e,
-        )
+        with _models_dev_fetch_lock:
+            _note_refresh_failure(e, where="background")
     finally:
         with _models_dev_refresh_lock:
             _models_dev_refresh_in_flight = False
@@ -436,27 +461,10 @@ def fetch_models_dev(
 
         try:
             data = _fetch_models_dev_from_network()
-            _save_disk_cache(data)
-            _models_dev_cache = data
-            _models_dev_cache_time = time.time()
-            _models_dev_retry_after = 0
-            logger.debug(
-                "Fetched models.dev registry: %d providers, %d total models",
-                len(data),
-                sum(
-                    len(p.get("models", {}))
-                    for p in data.values()
-                    if isinstance(p, dict)
-                ),
-            )
+            _commit_registry(data, where="foreground")
             return data
         except Exception as e:
-            _models_dev_retry_after = time.time() + _MODELS_DEV_RETRY_DELAY
-            logger.debug(
-                "Failed to fetch models.dev; retry suppressed for %ds: %s",
-                _MODELS_DEV_RETRY_DELAY,
-                e,
-            )
+            _note_refresh_failure(e, where="foreground")
 
         # Stage 5: network failed — return any stale memory/disk cache. Cache
         # freshness remains expired; the retry-after timestamp controls when

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13110,7 +13110,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     try:
                         from hermes_cli.route_identity import should_clear_context_pin
 
-                        if should_clear_context_pin(
+                        if await asyncio.to_thread(
+                            should_clear_context_pin,
                             None,  # model match already checked above
                             None,
                             _msg_model_cfg.get("base_url"),
@@ -13705,7 +13706,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     try:
                         from hermes_cli.route_identity import should_clear_context_pin
 
-                        if should_clear_context_pin(
+                        if await asyncio.to_thread(
+                            should_clear_context_pin,
                             _hyg_configured_model,
                             _hyg_model,
                             _hyg_configured_base_url,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13108,10 +13108,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _msg_config_ctx = None
                 if _msg_config_ctx is not None and isinstance(_msg_model_cfg, dict):
                     try:
-                        from hermes_cli.route_identity import should_clear_context_pin
+                        from hermes_cli.route_identity import should_clear_context_pin_async
 
-                        if await asyncio.to_thread(
-                            should_clear_context_pin,
+                        if await should_clear_context_pin_async(
                             None,  # model match already checked above
                             None,
                             _msg_model_cfg.get("base_url"),
@@ -13704,10 +13703,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                 if _hyg_config_context_length is not None:
                     try:
-                        from hermes_cli.route_identity import should_clear_context_pin
+                        from hermes_cli.route_identity import should_clear_context_pin_async
 
-                        if await asyncio.to_thread(
-                            should_clear_context_pin,
+                        if await should_clear_context_pin_async(
                             _hyg_configured_model,
                             _hyg_model,
                             _hyg_configured_base_url,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2008,10 +2008,9 @@ class GatewaySlashCommandsMixin:
                                     _persist_model_cfg = {}
                                     _persist_cfg["model"] = _persist_model_cfg
                                 try:
-                                    from hermes_cli.route_identity import should_clear_context_pin
+                                    from hermes_cli.route_identity import should_clear_context_pin_async
 
-                                    if await asyncio.to_thread(
-                                        should_clear_context_pin,
+                                    if await should_clear_context_pin_async(
                                         _persist_model_cfg.get("default")
                                         or _persist_model_cfg.get("model"),
                                         result.new_model,
@@ -2337,10 +2336,9 @@ class GatewaySlashCommandsMixin:
                         model_cfg = {}
                         cfg["model"] = model_cfg
                     try:
-                        from hermes_cli.route_identity import should_clear_context_pin
+                        from hermes_cli.route_identity import should_clear_context_pin_async
 
-                        if await asyncio.to_thread(
-                            should_clear_context_pin,
+                        if await should_clear_context_pin_async(
                             model_cfg.get("default") or model_cfg.get("model"),
                             result.new_model,
                             model_cfg.get("base_url"),

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2010,7 +2010,8 @@ class GatewaySlashCommandsMixin:
                                 try:
                                     from hermes_cli.route_identity import should_clear_context_pin
 
-                                    if should_clear_context_pin(
+                                    if await asyncio.to_thread(
+                                        should_clear_context_pin,
                                         _persist_model_cfg.get("default")
                                         or _persist_model_cfg.get("model"),
                                         result.new_model,
@@ -2338,7 +2339,8 @@ class GatewaySlashCommandsMixin:
                     try:
                         from hermes_cli.route_identity import should_clear_context_pin
 
-                        if should_clear_context_pin(
+                        if await asyncio.to_thread(
+                            should_clear_context_pin,
                             model_cfg.get("default") or model_cfg.get("model"),
                             result.new_model,
                             model_cfg.get("base_url"),

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -450,7 +450,13 @@ def get_provider(name: str, *, allow_network: bool = True) -> Optional[ProviderD
     # Try to get models.dev data
     try:
         from agent.models_dev import get_provider_info as _mdev_provider
-        mdev_info = _mdev_provider(canonical, allow_network=allow_network)
+        # Keep the single-argument call on the default path: test sites
+        # monkeypatch get_provider_info with single-arg lambdas.
+        mdev_info = (
+            _mdev_provider(canonical)
+            if allow_network
+            else _mdev_provider(canonical, allow_network=False)
+        )
     except Exception:
         mdev_info = None
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -431,7 +431,7 @@ def normalize_provider(name: str) -> str:
     return ALIASES.get(key, key)
 
 
-def get_provider(name: str) -> Optional[ProviderDef]:
+def get_provider(name: str, *, allow_network: bool = True) -> Optional[ProviderDef]:
     """Look up a built-in provider by id or alias.
 
     Resolution order:
@@ -450,7 +450,11 @@ def get_provider(name: str) -> Optional[ProviderDef]:
     # Try to get models.dev data
     try:
         from agent.models_dev import get_provider_info as _mdev_provider
-        mdev_info = _mdev_provider(canonical)
+        mdev_info = (
+            _mdev_provider(canonical)
+            if allow_network
+            else _mdev_provider(canonical, allow_network=False)
+        )
     except Exception:
         mdev_info = None
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -450,11 +450,7 @@ def get_provider(name: str, *, allow_network: bool = True) -> Optional[ProviderD
     # Try to get models.dev data
     try:
         from agent.models_dev import get_provider_info as _mdev_provider
-        mdev_info = (
-            _mdev_provider(canonical)
-            if allow_network
-            else _mdev_provider(canonical, allow_network=False)
-        )
+        mdev_info = _mdev_provider(canonical, allow_network=allow_network)
     except Exception:
         mdev_info = None
 

--- a/hermes_cli/route_identity.py
+++ b/hermes_cli/route_identity.py
@@ -74,3 +74,31 @@ def should_clear_context_pin(
         )
     except Exception:
         return True
+
+
+async def should_clear_context_pin_async(
+    configured_model: Any,
+    active_model: Any,
+    configured_base_url: Any,
+    active_base_url: Any,
+    configured_provider: Any,
+    active_provider: Any,
+) -> bool:
+    """Async wrapper for ``should_clear_context_pin``.
+
+    Offloads the route comparison to a worker thread so async gateway
+    handlers never run it on the event loop — the resolution chain is
+    cache-only (``allow_network=False``) but can still do cold-start disk
+    I/O. Shares all logic with the sync version — no code duplication.
+    """
+    import asyncio
+
+    return await asyncio.to_thread(
+        should_clear_context_pin,
+        configured_model,
+        active_model,
+        configured_base_url,
+        active_base_url,
+        configured_provider,
+        active_provider,
+    )

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -344,11 +344,12 @@ class TestFetchModelsDev:
             return_value=md._MODELS_DEV_CACHE_TTL + 60,
         ), patch.object(md, "_load_disk_cache", return_value=SAMPLE_REGISTRY):
             first = fetch_models_dev()
-            # Wait for the background refresh worker to finish so its
-            # failure backoff is observable and requests.get stays patched.
-            deadline = time.time() + 5
-            while md._models_dev_refresh_in_flight and time.time() < deadline:
-                time.sleep(0.01)
+            # Join the background refresh worker so its failure backoff is
+            # observable and requests.get stays patched for its lifetime.
+            for worker in threading.enumerate():
+                if worker.name == "models-dev-refresh":
+                    worker.join(timeout=5)
+                    assert not worker.is_alive()
 
         assert first == SAMPLE_REGISTRY
         assert not md._models_dev_refresh_in_flight
@@ -363,6 +364,30 @@ class TestFetchModelsDev:
         assert second == SAMPLE_REGISTRY
         assert not md._models_dev_refresh_in_flight
         mock_get.assert_called_once()
+
+    @patch("agent.models_dev.requests.get")
+    def test_background_refresh_success_commits_registry(self, mock_get):
+        """The bg worker must save disk + swap mem cache + clear backoff."""
+        import agent.models_dev as md
+
+        response = MagicMock()
+        response.json.return_value = SAMPLE_REGISTRY
+        mock_get.return_value = response
+
+        md._models_dev_cache = {"stale": {}}
+        md._models_dev_cache_time = 0
+        md._models_dev_retry_after = time.time() - 1
+
+        with patch.object(md, "_save_disk_cache") as mock_save:
+            # Run the worker synchronously — deterministic, no thread.
+            md._models_dev_refresh_in_flight = True
+            md._background_refresh_models_dev()
+
+        mock_save.assert_called_once_with(SAMPLE_REGISTRY)
+        assert md._models_dev_cache == SAMPLE_REGISTRY
+        assert md._models_dev_cache_time > 0
+        assert md._models_dev_retry_after == 0
+        assert not md._models_dev_refresh_in_flight
 
     @patch("agent.models_dev.requests.get")
     def test_missing_cache_failure_enters_backoff(self, mock_get):

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -1,11 +1,17 @@
 """Tests for agent.models_dev — models.dev registry integration."""
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import patch, MagicMock
+
+import pytest
 
 from agent.models_dev import (
     PROVIDER_TO_MODELS_DEV,
     _extract_context,
     fetch_models_dev,
     get_model_capabilities,
+    get_provider_info,
     lookup_models_dev_context,
 )
 
@@ -164,6 +170,18 @@ class TestLookupModelsDevContext:
 
 
 class TestFetchModelsDev:
+    @pytest.fixture(autouse=True)
+    def _reset_fetch_state(self):
+        import agent.models_dev as md
+
+        md._models_dev_cache = {}
+        md._models_dev_cache_time = 0
+        md._models_dev_retry_after = 0
+        yield
+        md._models_dev_cache = {}
+        md._models_dev_cache_time = 0
+        md._models_dev_retry_after = 0
+
     @patch("agent.models_dev.requests.get")
     def test_fetch_success(self, mock_get):
         mock_resp = MagicMock()
@@ -302,6 +320,158 @@ class TestFetchModelsDev:
 
         mock_get.assert_called_once()
         assert "anthropic" in result
+
+    @patch("agent.models_dev.requests.get")
+    def test_stale_cache_failure_enters_backoff_and_suppresses_retry(self, mock_get):
+        import agent.models_dev as md
+
+        mock_get.side_effect = OSError("models.dev unreachable")
+        md._models_dev_cache = SAMPLE_REGISTRY
+        md._models_dev_cache_time = time.time() - md._MODELS_DEV_CACHE_TTL - 1
+
+        with patch.object(
+            md,
+            "_disk_cache_age_seconds",
+            return_value=md._MODELS_DEV_CACHE_TTL + 60,
+        ), patch.object(md, "_load_disk_cache", return_value=SAMPLE_REGISTRY):
+            first = fetch_models_dev()
+            second = fetch_models_dev()
+
+        assert first == SAMPLE_REGISTRY
+        assert second == SAMPLE_REGISTRY
+        assert md._models_dev_retry_after > time.time()
+        mock_get.assert_called_once()
+
+    @patch("agent.models_dev.requests.get")
+    def test_missing_cache_failure_enters_backoff(self, mock_get):
+        import agent.models_dev as md
+
+        mock_get.side_effect = OSError("models.dev unreachable")
+        with patch.object(md, "_disk_cache_age_seconds", return_value=None), patch.object(
+            md, "_load_disk_cache", return_value={}
+        ):
+            first = fetch_models_dev()
+            second = fetch_models_dev()
+
+        assert first == {}
+        assert second == {}
+        assert md._models_dev_retry_after > time.time()
+        mock_get.assert_called_once()
+
+    @patch("agent.models_dev.requests.get")
+    def test_concurrent_refreshes_share_one_network_request(self, mock_get):
+        import agent.models_dev as md
+
+        request_started = threading.Event()
+        release_request = threading.Event()
+        response = MagicMock()
+        response.json.return_value = SAMPLE_REGISTRY
+
+        def blocking_get(*_args, **_kwargs):
+            request_started.set()
+            assert release_request.wait(timeout=5)
+            return response
+
+        mock_get.side_effect = blocking_get
+        with patch.object(md, "_disk_cache_age_seconds", return_value=None), patch.object(
+            md, "_save_disk_cache"
+        ), ThreadPoolExecutor(max_workers=6) as pool:
+            futures = [pool.submit(fetch_models_dev) for _ in range(6)]
+            assert request_started.wait(timeout=2)
+            release_request.set()
+            results = [future.result(timeout=5) for future in futures]
+
+        assert results == [SAMPLE_REGISTRY] * 6
+        mock_get.assert_called_once()
+
+    @patch("agent.models_dev.requests.get")
+    def test_force_refresh_bypasses_failure_backoff(self, mock_get):
+        import agent.models_dev as md
+
+        response = MagicMock()
+        response.json.return_value = SAMPLE_REGISTRY
+        mock_get.side_effect = [OSError("models.dev unreachable"), response]
+
+        with patch.object(md, "_disk_cache_age_seconds", return_value=None), patch.object(
+            md, "_load_disk_cache", return_value={}
+        ), patch.object(md, "_save_disk_cache"):
+            assert fetch_models_dev() == {}
+            assert fetch_models_dev(force_refresh=True) == SAMPLE_REGISTRY
+
+        assert mock_get.call_count == 2
+        assert md._models_dev_retry_after == 0
+
+    @pytest.mark.parametrize(
+        ("cache", "cache_time", "disk_data", "expected"),
+        [
+            (SAMPLE_REGISTRY, lambda md: time.time(), {}, SAMPLE_REGISTRY),
+            (
+                SAMPLE_REGISTRY,
+                lambda md: time.time() - md._MODELS_DEV_CACHE_TTL - 1,
+                {},
+                SAMPLE_REGISTRY,
+            ),
+            ({}, lambda _md: 0, {}, {}),
+        ],
+        ids=["fresh-memory", "stale-memory", "missing"],
+    )
+    @patch("agent.models_dev.requests.get")
+    def test_network_disabled_never_fetches(
+        self, mock_get, cache, cache_time, disk_data, expected
+    ):
+        import agent.models_dev as md
+
+        md._models_dev_cache = cache
+        md._models_dev_cache_time = cache_time(md)
+        with patch.object(md, "_load_disk_cache", return_value=disk_data):
+            result = fetch_models_dev(allow_network=False)
+
+        assert result == expected
+        mock_get.assert_not_called()
+
+    @patch("agent.models_dev.requests.get")
+    def test_network_disabled_loads_stale_disk_cache(self, mock_get):
+        import agent.models_dev as md
+
+        with patch.object(md, "_load_disk_cache", return_value=SAMPLE_REGISTRY):
+            result = fetch_models_dev(allow_network=False)
+
+        assert result == SAMPLE_REGISTRY
+        mock_get.assert_not_called()
+
+    @patch("agent.models_dev.fetch_models_dev", return_value=SAMPLE_REGISTRY)
+    def test_provider_info_propagates_network_disabled(self, mock_fetch):
+        info = get_provider_info("anthropic", allow_network=False)
+
+        assert info is not None
+        mock_fetch.assert_called_once_with(allow_network=False)
+
+    @patch("agent.models_dev.fetch_models_dev", return_value=SAMPLE_REGISTRY)
+    def test_provider_info_default_preserves_zero_argument_fetch(self, mock_fetch):
+        info = get_provider_info("anthropic")
+
+        assert info is not None
+        mock_fetch.assert_called_once_with()
+
+    def test_provider_definition_propagates_network_disabled(self):
+        from hermes_cli.providers import get_provider
+
+        with patch(
+            "agent.models_dev.get_provider_info", return_value=None
+        ) as mock_provider_info:
+            get_provider("anthropic", allow_network=False)
+
+        mock_provider_info.assert_called_once_with(
+            "anthropic", allow_network=False
+        )
+
+    def test_default_route_lookup_is_cache_only(self):
+        from agent.agent_init import _provider_default_routes
+
+        with patch("hermes_cli.providers.get_provider", return_value=None) as mock_get:
+            _provider_default_routes("anthropic")
+
+        mock_get.assert_called_once_with("anthropic", allow_network=False)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -177,10 +177,12 @@ class TestFetchModelsDev:
         md._models_dev_cache = {}
         md._models_dev_cache_time = 0
         md._models_dev_retry_after = 0
+        md._models_dev_refresh_in_flight = False
         yield
         md._models_dev_cache = {}
         md._models_dev_cache_time = 0
         md._models_dev_retry_after = 0
+        md._models_dev_refresh_in_flight = False
 
     @patch("agent.models_dev.requests.get")
     def test_fetch_success(self, mock_get):
@@ -226,6 +228,20 @@ class TestFetchModelsDev:
         assert result == SAMPLE_REGISTRY
 
     @patch("agent.models_dev.requests.get")
+    def test_stale_in_memory_cache_returns_without_foreground_network(self, mock_get):
+        """Expired in-memory data should not block foreground resolution."""
+        import agent.models_dev as md
+        md._models_dev_cache = SAMPLE_REGISTRY
+        md._models_dev_cache_time = 0
+
+        with patch.object(md, "_start_background_refresh_models_dev") as mock_refresh:
+            result = fetch_models_dev()
+
+        mock_get.assert_not_called()
+        mock_refresh.assert_called_once()
+        assert result == SAMPLE_REGISTRY
+
+    @patch("agent.models_dev.requests.get")
     def test_fresh_disk_cache_skips_network(self, mock_get):
         """When in-mem cache is empty but disk cache exists and is fresh by
         mtime (< TTL), fetch_models_dev returns disk data without ever
@@ -252,27 +268,20 @@ class TestFetchModelsDev:
         assert md._models_dev_cache == SAMPLE_REGISTRY
 
     @patch("agent.models_dev.requests.get")
-    def test_stale_disk_cache_falls_through_to_network(self, mock_get):
-        """When the disk cache is OLDER than TTL, we must hit the network
-        (and only fall back to the stale disk data if network fails)."""
+    def test_stale_disk_cache_returns_without_foreground_network(self, mock_get):
+        """#35838: stale disk cache should not wait on models.dev timeout."""
         import agent.models_dev as md
         md._models_dev_cache = {}
         md._models_dev_cache_time = 0
 
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = SAMPLE_REGISTRY
-        mock_resp.raise_for_status = MagicMock()
-        mock_get.return_value = mock_resp
-
-        # Disk cache exists but is older than the TTL — must NOT short-circuit.
         with patch.object(md, "_disk_cache_age_seconds",
                           return_value=md._MODELS_DEV_CACHE_TTL + 60), \
              patch.object(md, "_load_disk_cache", return_value=SAMPLE_REGISTRY), \
-             patch.object(md, "_save_disk_cache"):
+             patch.object(md, "_start_background_refresh_models_dev") as mock_refresh:
             result = fetch_models_dev()
 
-        mock_get.assert_called_once()
+        mock_get.assert_not_called()
+        mock_refresh.assert_called_once()
         assert "anthropic" in result
 
     @patch("agent.models_dev.requests.get")
@@ -335,11 +344,24 @@ class TestFetchModelsDev:
             return_value=md._MODELS_DEV_CACHE_TTL + 60,
         ), patch.object(md, "_load_disk_cache", return_value=SAMPLE_REGISTRY):
             first = fetch_models_dev()
-            second = fetch_models_dev()
+            # Wait for the background refresh worker to finish so its
+            # failure backoff is observable and requests.get stays patched.
+            deadline = time.time() + 5
+            while md._models_dev_refresh_in_flight and time.time() < deadline:
+                time.sleep(0.01)
 
         assert first == SAMPLE_REGISTRY
-        assert second == SAMPLE_REGISTRY
+        assert not md._models_dev_refresh_in_flight
         assert md._models_dev_retry_after > time.time()
+        mock_get.assert_called_once()
+
+        # A subsequent stale-cache hit inside the backoff window must not
+        # spawn another refresh worker (in_flight is set synchronously
+        # before the worker thread starts, so False proves no spawn).
+        md._models_dev_cache_time = time.time() - md._MODELS_DEV_CACHE_TTL - 1
+        second = fetch_models_dev()
+        assert second == SAMPLE_REGISTRY
+        assert not md._models_dev_refresh_in_flight
         mock_get.assert_called_once()
 
     @patch("agent.models_dev.requests.get")

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -469,11 +469,13 @@ class TestFetchModelsDev:
         mock_fetch.assert_called_once_with(allow_network=False)
 
     @patch("agent.models_dev.fetch_models_dev", return_value=SAMPLE_REGISTRY)
-    def test_provider_info_default_allows_network(self, mock_fetch):
+    def test_provider_info_default_preserves_zero_argument_fetch(self, mock_fetch):
+        """Default path must stay a zero-arg call: many test sites monkeypatch
+        fetch_models_dev with zero-arg lambdas."""
         info = get_provider_info("anthropic")
 
         assert info is not None
-        mock_fetch.assert_called_once_with(allow_network=True)
+        mock_fetch.assert_called_once_with()
 
     def test_provider_definition_propagates_network_disabled(self):
         from hermes_cli.providers import get_provider

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -469,11 +469,11 @@ class TestFetchModelsDev:
         mock_fetch.assert_called_once_with(allow_network=False)
 
     @patch("agent.models_dev.fetch_models_dev", return_value=SAMPLE_REGISTRY)
-    def test_provider_info_default_preserves_zero_argument_fetch(self, mock_fetch):
+    def test_provider_info_default_allows_network(self, mock_fetch):
         info = get_provider_info("anthropic")
 
         assert info is not None
-        mock_fetch.assert_called_once_with()
+        mock_fetch.assert_called_once_with(allow_network=True)
 
     def test_provider_definition_propagates_network_disabled(self):
         from hermes_cli.providers import get_provider

--- a/tests/gateway/test_image_input_routing_runtime.py
+++ b/tests/gateway/test_image_input_routing_runtime.py
@@ -223,3 +223,91 @@ async def test_prepare_image_routing_runs_off_the_event_loop(monkeypatch):
         "the blocking image-routing decision must be offloaded off the gateway "
         "event loop, not run inline on it"
     )
+
+
+@pytest.mark.asyncio
+async def test_prepare_route_identity_check_keeps_event_loop_responsive(monkeypatch):
+    """A slow route-identity check must not block gateway heartbeats."""
+    import asyncio
+    import threading
+    from types import SimpleNamespace
+
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="inspect @AGENTS.md",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    started = threading.Event()
+    released_by_event_loop = threading.Event()
+    seen = {}
+    main_thread = threading.current_thread()
+
+    cfg = {
+        "model": {
+            "default": "test-model",
+            "provider": "test-provider",
+            "base_url": "https://example.invalid/v1",
+            "context_length": 128000,
+        }
+    }
+    monkeypatch.setattr("gateway.run._load_gateway_config", lambda: cfg)
+    monkeypatch.setattr(
+        runner,
+        "_resolve_session_agent_runtime",
+        lambda **_kwargs: (
+            "test-model",
+            {
+                "provider": "test-provider",
+                "base_url": "https://example.invalid/v1",
+                "api_key": "",
+            },
+        ),
+    )
+
+    def blocking_route_identity_check(*_args):
+        seen["thread"] = threading.current_thread()
+        started.set()
+        seen["event_loop_progressed"] = released_by_event_loop.wait(timeout=2)
+        return False
+
+    monkeypatch.setattr(
+        "hermes_cli.route_identity.should_clear_context_pin",
+        blocking_route_identity_check,
+    )
+
+    async def fake_context_length(*_args, **_kwargs):
+        return 128000
+
+    async def fake_preprocess(message, **_kwargs):
+        return SimpleNamespace(
+            blocked=False,
+            expanded=False,
+            message=message,
+            warnings=[],
+        )
+
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length_async", fake_context_length
+    )
+    monkeypatch.setattr(
+        "agent.context_references.preprocess_context_references_async",
+        fake_preprocess,
+    )
+
+    async def heartbeat_ticker():
+        while not started.is_set():
+            await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        released_by_event_loop.set()
+
+    heartbeat = asyncio.create_task(heartbeat_ticker())
+    result = await runner._prepare_inbound_message_text(
+        event=event, source=source, history=[]
+    )
+    await heartbeat
+
+    assert result == "inspect @AGENTS.md"
+    assert seen["event_loop_progressed"] is True
+    assert seen["thread"] is not main_thread


### PR DESCRIPTION
## Summary
Gateway event loops no longer block on models.dev catalog refreshes, and no caller anywhere in the process waits on the network while any cached catalog exists. Combines PR #73621 (@StellarisW) and PR #35853 (@zapabob) into one coherent design.

Root cause (#73621's report): when the 1-hour cache expired on a host that cannot reach models.dev, gateway route-identity checks ran a synchronous 15s `requests.get()` on the Discord asyncio event loop — heartbeats blocked, the WebSocket went ack_stale, and the systemd watchdog restarted the gateway, killing active sessions. A failed refresh also left the cache immediately eligible for another refresh, so every message re-entered the same blocking request.

## Changes
- `agent/models_dev.py`: rewritten `fetch_models_dev` cache hierarchy:
  - Stale cache (memory or disk, any age) is served immediately; ONE daemon background thread refreshes (from #35853 — callers never block while any cache exists)
  - Failed refreshes (foreground or background) set a 5-minute process-wide backoff (from #73621)
  - `allow_network=False` mode returns any cache with zero network I/O (from #73621)
  - Singleflight lock on the foreground fetch — only reachable when no cache exists at all; the background worker commits under the same lock (no cross-path races)
  - Shared `_commit_registry` / `_note_refresh_failure` helpers — one success path, one failure path
  - `force_refresh=True` bypasses caches and backoff (unchanged behavior)
- `hermes_cli/route_identity.py`: new `should_clear_context_pin_async` (matching the `get_model_context_length_async` precedent)
- `gateway/run.py`, `gateway/slash_commands.py`: the 4 async `should_clear_context_pin` call sites use the async wrapper; the 5th (sync `_format_session_info`) is already off-loop via its callers' `to_thread`
- `agent/agent_init.py`, `hermes_cli/providers.py`: route-identity default-route lookups are cache-only via `allow_network=False` (#73621). The default call paths deliberately keep zero-arg `fetch_models_dev()` / single-arg `get_provider_info()` call shapes — ~69 test sites monkeypatch them with zero/single-arg lambdas (documented inline)
- Tests: backoff, singleflight concurrency, force-refresh bypass, allow_network propagation, stale-serve semantics, background-refresh success commit (mutation-checked), gateway event-loop responsiveness

## Validation
| | Before | After |
|---|---|---|
| Gateway route check, cache expired, models.dev unreachable | 15s block on event loop per message | cache-only, ~0ms |
| Any caller, stale cache present | 15s foreground fetch | stale served instantly, bg refresh |
| Repeated failures | retry on every call | one attempt per 5 min |
| Targeted suites (models_dev, image-routing, switch-model, provider-listing) | — | 149 passed |

E2E (real imports, isolated HERMES_HOME): no-cache network-dead returns {} in <1ms with backoff set; `allow_network=False` zero network calls; stale-serve + background refresh updates memory and disk cache in ~22ms; `force_refresh` bypasses backoff; `_provider_default_routes` makes zero network requests. Mutation checks: backoff-arm and bg-commit mutations each fail their guard tests.

## Credit
- @StellarisW (#73621): event-loop offload, `allow_network=False` plumbing, failure backoff, singleflight, gateway/event-loop regression tests — commit cherry-picked with authorship preserved. Closes #73621
- @zapabob (#35853): stale-while-revalidate serve + single daemon background refresh — commit cherry-picked with authorship preserved. Closes #35853

Merge-resolution reconciles the two `fetch_models_dev` rewrites: #35853's serve-stale-refresh-in-background is the primary path, #73621's backoff gates both the background spawner and the foreground singleflight.
