### PR TITLE
fix(desktop): widen probe-budget fix to sibling boot-path probes

### DIFF
--- a/apps/desktop/electron/backend-probes.ts
+++ b/apps/desktop/electron/backend-probes.ts
@@ -92,6 +92,7 @@ function execProbeSync(
   command: string,
   args: string[],
   options: {
+    cwd?: string
     env?: NodeJS.ProcessEnv
     stdio: 'ignore'
     timeout: number
@@ -211,6 +212,7 @@ function verifyHermesCli(hermesCommand: string, opts?: { shell?: boolean }) {
 export {
   canImportHermesCli,
   DEFAULT_PROBE_TIMEOUT_MS,
+  execProbeSync,
   hermesRuntimeImportProbe,
   PROBE_TIMEOUT_MS,
   resolveProbeTimeoutMs,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -37,7 +37,7 @@ import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { buildDesktopBackendEnv, normalizeHermesHomeRoot } from './backend-env'
 import { isReauthRequiredError, waitForHermesReady } from './backend-health'
-import { canImportHermesCli, shouldTrustHermesOverride, verifyHermesCli } from './backend-probes'
+import { canImportHermesCli, execProbeSync, PROBE_TIMEOUT_MS, shouldTrustHermesOverride, verifyHermesCli } from './backend-probes'
 import { waitForDashboardPortAnnouncement } from './backend-ready'
 import { shouldLatchBackendStartFailure, shouldLatchRemoteReauthFailure } from './backend-start-failure'
 import { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } from './bootstrap-platform'
@@ -1886,10 +1886,16 @@ function backendSupportsServe(backend) {
   if (supported === null) {
     try {
       const prefix = backend.args && backend.args[0] === '-m' ? backend.args.slice(0, 2) : []
-      execFileSync(backend.command, [...prefix, 'serve', '--help'], {
+      // Same cold-Windows Python-startup class as the runtime probes
+      // (#61764/#72632/#72707): `serve --help` imports at least as much as
+      // `hermes --version` (~10.5s measured cold), and a false negative here
+      // is cached for the process lifetime, silently routing a modern
+      // runtime through the legacy `dashboard` form. Share the probe budget
+      // and its timeout-only retry instead of a thinner local bound.
+      execProbeSync(backend.command, [...prefix, 'serve', '--help'], {
         cwd: backend.root || undefined,
         env: { ...process.env, HERMES_HOME, ...(backend.env || {}) },
-        timeout: 15000,
+        timeout: PROBE_TIMEOUT_MS,
         stdio: 'ignore',
         windowsHide: true
       })
@@ -3879,17 +3885,20 @@ function resolveHermesBackend(backendArgs) {
       // through to the install-script bootstrap if the optional probe times
       // out under load; the pinned backend is the only valid runtime there.
       if (shouldTrustHermesOverride(hermesOverride) || verifyHermesCli(hermesCommand, { shell: shellForProbe })) {
-        return (
-          unwrapWindowsVenvHermesCommand(hermesCommand, backendArgs) || {
-            label: `existing Hermes CLI at ${hermesCommand}`,
-            command: hermesCommand,
-            args: backendArgs,
-            bootstrap: false,
-            env: {},
-            kind: 'command',
-            shell: shellForProbe
-          }
-        )
+        // `unwrapped` above already answered "is this a Windows venv shim?" —
+        // it was null (not a shim, or its import probe failed). Do NOT re-run
+        // unwrapWindowsVenvHermesCommand here: the second call repeats the
+        // same un-memoized import probe, costing up to another full probe
+        // timeout on the boot path for an answer we already have.
+        return {
+          label: `existing Hermes CLI at ${hermesCommand}`,
+          command: hermesCommand,
+          args: backendArgs,
+          bootstrap: false,
+          env: {},
+          kind: 'command',
+          shell: shellForProbe
+        }
       }
 
       rememberLog(


### PR DESCRIPTION
## Summary

Widens #73907's probe-budget fix (15s default + `HERMES_PROBE_TIMEOUT_MS` override + timeout-only retry) to the two sibling boot-path probe sites it missed, closing out the #72707 bug class: a slow-but-healthy Windows runtime must never be misclassified by a thin synchronous probe.

## Changes

- `apps/desktop/electron/main.ts` — `backendSupportsServe`: the `serve --help` probe still used a bare `execFileSync` with its own `timeout: 15000` literal. Same cold-Windows Python-startup class (#72632 measured ~10.5s for `--version` cold), no retry, and a false negative is **cached for the process lifetime** (`_serveSupportCache`), silently routing a modern runtime through the legacy `dashboard --no-open` form. Now routes through the shared `execProbeSync` + `PROBE_TIMEOUT_MS` (honours the env override, gets the timeout-only retry).
- `apps/desktop/electron/main.ts` — `resolveHermesBackend` step 4 called `unwrapWindowsVenvHermesCommand` **twice** (once before `verifyHermesCli`, again inside the success return). The second call re-ran the same un-memoized `canImportHermesCli` probe — up to another full probe timeout on a hung interpreter, on the synchronous boot path, for an answer the first call already produced. Dropped the redundant re-probe.
- `apps/desktop/electron/backend-probes.ts` — export `execProbeSync` and accept `cwd` in its options so the serve probe can use it (no behavior change to existing callers).

## Validation

| | Result |
|---|---|
| `tsc -p tsconfig.electron.json --noEmit` | clean |
| `eslint electron/main.ts electron/backend-probes.ts` | clean |
| `vitest run electron/` | 830 passed, 2 skipped, 0 failed |

Part of #72707 (destructive bootstrap-recovery loop). Follow-up to #73907; supersedes the sibling-gap noted while reviewing #72713.
