### PR TITLE
fix(gateway): bound voice transcription stalls

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1133,6 +1133,9 @@ platform_toolsets:
 # Set the corresponding API key in .env: GROQ_API_KEY, OPENAI_API_KEY, or MISTRAL_API_KEY.
 stt:
   enabled: true
+  # Max seconds the messaging gateway waits for one transcription (including
+  # local fallback) before it releases the chat and surfaces the audio path.
+  gateway_timeout_seconds: 45
   # provider: "local"          # auto-detected if omitted
   local:
     model: "base"              # tiny | base | small | medium | large-v3 | turbo

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -101,6 +101,12 @@ def _coerce_float(value: Any, default: float) -> float:
         return default
 
 
+def _coerce_positive_float(value: Any, default: float) -> float:
+    """Coerce a positive float, falling back for zero/negative/invalid values."""
+    parsed = _coerce_float(value, default)
+    return parsed if parsed > 0 else default
+
+
 def _coerce_int(value: Any, default: int) -> int:
     """Coerce integer config values, falling back on malformed input."""
     if value is None:
@@ -913,6 +919,9 @@ class GatewayConfig:
     # STT settings
     stt_enabled: bool = True  # Whether to auto-transcribe inbound voice messages
     stt_echo_transcripts: bool = True  # Whether to echo raw STT transcripts back to the user
+    # Hard gateway deadline around the complete STT worker. Provider-level
+    # HTTP/process timeouts are insufficient when setup or cleanup itself hangs.
+    stt_timeout_seconds: float = 45.0
 
     # Session isolation in shared chats
     group_sessions_per_user: bool = True  # Isolate group/channel sessions per participant when user IDs are available
@@ -1066,6 +1075,7 @@ class GatewayConfig:
             "filter_silence_narration": self.filter_silence_narration,
             "stt_enabled": self.stt_enabled,
             "stt_echo_transcripts": self.stt_echo_transcripts,
+            "stt_timeout_seconds": self.stt_timeout_seconds,
             "group_sessions_per_user": self.group_sessions_per_user,
             "thread_sessions_per_user": self.thread_sessions_per_user,
             "max_concurrent_sessions": self.max_concurrent_sessions,
@@ -1129,6 +1139,14 @@ class GatewayConfig:
                 if isinstance(data.get("stt"), dict)
                 else None
             )
+        stt_timeout_raw = data.get("stt_timeout_seconds")
+        if stt_timeout_raw is None:
+            stt_timeout_raw = (
+                data.get("stt", {}).get("gateway_timeout_seconds")
+                if isinstance(data.get("stt"), dict)
+                else None
+            )
+        stt_timeout_seconds = _coerce_positive_float(stt_timeout_raw, 45.0)
 
         group_sessions_per_user = data.get("group_sessions_per_user")
         thread_sessions_per_user = data.get("thread_sessions_per_user")
@@ -1204,6 +1222,7 @@ class GatewayConfig:
             ),
             stt_enabled=_coerce_bool(stt_enabled, True),
             stt_echo_transcripts=_coerce_bool(stt_echo_transcripts, True),
+            stt_timeout_seconds=stt_timeout_seconds,
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18210,23 +18210,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return f"{unavailable_note}\n\n{user_text}", []
             return unavailable_note, []
 
+        async def _transcribe_with_local_fallback(path: str):
+            result = await asyncio.to_thread(transcribe_audio, path)
+            if not result.get("success"):
+                fallback = await asyncio.to_thread(
+                    transcribe_audio_local_fallback,
+                    path,
+                )
+                if fallback.get("success"):
+                    logger.info(
+                        "Configured STT failed for %s; recovered with local STT",
+                        path,
+                    )
+                    result = fallback
+            return result
+
         enriched_parts = []
         successful_transcripts: List[str] = []
+        stt_timeout_seconds = getattr(self.config, "stt_timeout_seconds", 45.0)
         for path in audio_paths:
             try:
                 logger.debug("Transcribing user voice: %s", path)
-                result = await asyncio.to_thread(transcribe_audio, path)
-                if not result.get("success"):
-                    fallback = await asyncio.to_thread(
-                        transcribe_audio_local_fallback,
-                        path,
-                    )
-                    if fallback.get("success"):
-                        logger.info(
-                            "Configured STT failed for %s; recovered with local STT",
-                            path,
-                        )
-                        result = fallback
+                result = await asyncio.wait_for(
+                    _transcribe_with_local_fallback(path),
+                    timeout=stt_timeout_seconds,
+                )
                 if result["success"]:
                     transcript = result["transcript"]
                     # Speech-to-text can return success=True with an empty or
@@ -18268,6 +18276,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "[voice message could not be transcribed automatically; "
                         f"the audio is available at: {agent_path}]"
                     )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Voice transcription timed out after %.1fs for %s; continuing fail-open",
+                    stt_timeout_seconds,
+                    path,
+                )
+                from tools.credential_files import to_agent_visible_cache_path
+
+                agent_path = to_agent_visible_cache_path(os.path.abspath(path))
+                enriched_parts.append(
+                    "[voice message could not be transcribed automatically; "
+                    f"the audio is available at: {agent_path}]"
+                )
             except Exception as e:
                 logger.error("Transcription error: %s", e)
                 from tools.credential_files import to_agent_visible_cache_path

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2321,6 +2321,9 @@ DEFAULT_CONFIG = {
         # the raw transcript is also echoed back to the user as a 🎙️ message.
         # Set false to keep STT for the agent while suppressing that user-facing echo.
         "echo_transcripts": True,
+        # Hard deadline for one gateway voice transcription, including local fallback.
+        # Prevents a stuck provider/setup path from holding the chat lock indefinitely.
+        "gateway_timeout_seconds": 45.0,
         "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe) | "elevenlabs" (Scribe) | "deepinfra"
         # Global language hint applied to EVERY provider unless a per-provider
         # language overrides it. Defaults to "en" — Whisper auto-detection

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -1,5 +1,7 @@
-"""Gateway STT config tests — honor stt.enabled: false from config.yaml."""
+"""Gateway STT config tests — config bridging and fail-open voice handling."""
 
+import asyncio
+import threading
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -11,16 +13,36 @@ from gateway.platforms.base import MessageEvent, MessageType
 from gateway.session import SessionSource
 
 
+async def _wait_for_thread_event(event: threading.Event) -> None:
+    """Wait without consuming another executor thread."""
+    for _ in range(200):
+        if event.is_set():
+            return
+        await asyncio.sleep(0.001)
+    raise AssertionError("worker thread did not start")
+
+
 def test_gateway_config_stt_disabled_from_dict_nested():
     config = GatewayConfig.from_dict({"stt": {"enabled": False}})
     assert config.stt_enabled is False
+
+
+def test_gateway_config_stt_timeout_defaults_and_accepts_nested_override():
+    assert GatewayConfig.from_dict({}).stt_timeout_seconds == 45.0
+    config = GatewayConfig.from_dict({"stt": {"gateway_timeout_seconds": 12.5}})
+    assert config.stt_timeout_seconds == 12.5
+
+
+def test_gateway_config_stt_timeout_rejects_invalid_values():
+    assert GatewayConfig.from_dict({"stt": {"gateway_timeout_seconds": 0}}).stt_timeout_seconds == 45.0
+    assert GatewayConfig.from_dict({"stt": {"gateway_timeout_seconds": "bad"}}).stt_timeout_seconds == 45.0
 
 
 def test_load_gateway_config_bridges_stt_enabled_from_config_yaml(tmp_path, monkeypatch):
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()
     (hermes_home / "config.yaml").write_text(
-        yaml.dump({"stt": {"enabled": False}}),
+        yaml.dump({"stt": {"enabled": False, "gateway_timeout_seconds": 7.5}}),
         encoding="utf-8",
     )
 
@@ -30,6 +52,7 @@ def test_load_gateway_config_bridges_stt_enabled_from_config_yaml(tmp_path, monk
     config = load_gateway_config()
 
     assert config.stt_enabled is False
+    assert config.stt_timeout_seconds == 7.5
 
 
 @pytest.mark.asyncio
@@ -134,6 +157,83 @@ async def test_enrich_message_with_transcription_falls_back_to_installed_local_s
     assert result == '"recovered locally"'
     assert transcripts == ["recovered locally"]
     local_fallback.assert_called_once_with("/tmp/voice.ogg")
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_transcription_times_out_fail_open():
+    """A stuck STT worker must not hold the gateway/chat lock indefinitely."""
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True, stt_timeout_seconds=0.2)
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+
+    def stuck_transcription(_path):
+        worker_started.set()
+        release_worker.wait(timeout=5)
+        return {"success": True, "transcript": "too late"}
+
+    try:
+        with patch(
+            "tools.transcription_tools.transcribe_audio",
+            side_effect=stuck_transcription,
+        ):
+            transcription_task = asyncio.create_task(
+                runner._enrich_message_with_transcription(
+                    "caption",
+                    ["/tmp/stuck-voice.ogg"],
+                )
+            )
+            await _wait_for_thread_event(worker_started)
+            result, transcripts = await transcription_task
+    finally:
+        release_worker.set()
+
+    assert "voice message could not be transcribed automatically" in result
+    assert "stuck-voice.ogg" in result
+    assert "caption" in result
+    assert transcripts == []
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_transcription_bounds_local_fallback_too():
+    """The same gateway deadline must cover a stuck local fallback."""
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True, stt_timeout_seconds=0.2)
+    fallback_started = threading.Event()
+    release_worker = threading.Event()
+
+    def stuck_local_fallback(_path):
+        fallback_started.set()
+        release_worker.wait(timeout=5)
+        return {"success": True, "transcript": "too late"}
+
+    try:
+        with patch(
+            "tools.transcription_tools.transcribe_audio",
+            return_value={"success": False, "error": "configured provider unavailable"},
+        ), patch(
+            "tools.transcription_tools.transcribe_audio_local_fallback",
+            side_effect=stuck_local_fallback,
+        ) as local_fallback:
+            transcription_task = asyncio.create_task(
+                runner._enrich_message_with_transcription(
+                    "",
+                    ["/tmp/stuck-fallback.ogg"],
+                )
+            )
+            await _wait_for_thread_event(fallback_started)
+            result, transcripts = await transcription_task
+            local_fallback.assert_called_once_with("/tmp/stuck-fallback.ogg")
+    finally:
+        release_worker.set()
+
+    assert "voice message could not be transcribed automatically" in result
+    assert "stuck-fallback.ogg" in result
+    assert transcripts == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Prevents a stalled gateway speech-to-text call from holding a messaging chat indefinitely.

Gateway voice transcription currently runs synchronous provider work through `asyncio.to_thread()`. Provider HTTP/process timeouts do not cover hangs in setup, local fallback, filesystem access, or cleanup, so one stuck call can block the chat lock and every later message in that conversation.

This change adds a configurable gateway-level deadline around the complete configured-provider + local-fallback sequence. On timeout, Hermes logs the failure, keeps the existing audio-path marker, and continues fail-open so the agent can respond instead of leaving the chat wedged.

## Related Issue

No existing matching issue found. Searched open/closed issues and PRs for gateway voice/STT hangs and transcription timeouts; existing timeout PRs are desktop-specific.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `stt.gateway_timeout_seconds` with a 45-second default and positive-value validation.
- Apply the deadline to the complete configured STT and local fallback path.
- Preserve existing fail-open audio-path behavior after timeout.
- Document the setting in `cli-config.yaml.example` and register it in `DEFAULT_CONFIG`.
- Add deterministic tests for configured-provider stalls, local-fallback stalls, invalid values, and real YAML loading.

## How to Test

1. Run `pytest tests/gateway/test_stt_config.py tests/gateway/test_telegram_audio_vs_voice.py tests/gateway/test_stt_transcript_echo_config.py tests/hermes_cli/test_set_config_value.py -q -o 'addopts='`.
2. Confirm both stuck-worker tests release the gateway within the configured deadline and retain the audio path in the user-visible marker.
3. Set `stt.gateway_timeout_seconds` in a temporary `config.yaml` and confirm `load_gateway_config()` returns the override.

## Verification

- `132 passed` — focused gateway/config suite.
- `150 passed, 3 deselected` — remaining transcription tool tests.
- The three deselected macOS faster-whisper tests fail identically on clean `origin/main`; they are unchanged baseline failures caused by platform device normalization.
- `git diff --check` passes.
- Python compile checks pass.
- Independent Codex review: **APPROVE**, no blocking findings.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — focused suites pass; three unrelated macOS baseline failures are documented above; CI will run the full Linux suite
- [x] I've added tests for my changes
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` for the new config key
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A
- [x] I've considered cross-platform impact; the change uses standard `asyncio` APIs
- [x] Tool descriptions/schemas are N/A

## Screenshots / Logs

Not applicable; this is a gateway reliability fix covered by deterministic regression tests.
