### PR TITLE
fix(codex): apply reasoning floor to post-first-byte SSE idle watchdog

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -778,13 +778,13 @@ def interruptible_api_call(agent, api_kwargs: dict):
         _stale_timeout = min(_stale_timeout, _codex_hard_timeout)
 
     if _est_tokens_for_codex_watchdog > 100_000:
-        _codex_idle_timeout_default = 180.0
+        _codex_idle_timeout_default = 300.0
     elif _est_tokens_for_codex_watchdog > 50_000:
-        _codex_idle_timeout_default = 120.0
+        _codex_idle_timeout_default = 240.0
     elif _est_tokens_for_codex_watchdog > 10_000:
-        _codex_idle_timeout_default = 60.0
+        _codex_idle_timeout_default = 180.0
     else:
-        _codex_idle_timeout_default = 12.0
+        _codex_idle_timeout_default = 60.0
 
     # No-byte TTFB cutoff. The OpenAI SDK's own streaming read timeout is far
     # longer (openai 2.x DEFAULT_TIMEOUT.read = 600s), so a tight 12s default
@@ -831,10 +831,40 @@ def interruptible_api_call(agent, api_kwargs: dict):
             _ttfb_timeout = _ttfb_cap
 
     _codex_idle_enabled = _codex_watchdog_enabled
+    # Prefer explicit env when set; otherwise start from token-tier default.
+    _user_set_codex_idle = (
+        os.environ.get("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS") is not None
+    )
     _codex_idle_timeout = _env_float(
         "HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS",
         _codex_idle_timeout_default,
     )
+    # Reasoning models (Grok 4.5, o-series, etc.) can emit a first SSE frame
+    # then stay silent for minutes while thinking — no keepalive. The post-
+    # first-byte idle watchdog used to sit at 60–180s and kill healthy
+    # streams (user-visible: "API call failed after 3 retries: Codex stream
+    # produced no SSE events for 120s"). Apply the same reasoning floor used
+    # on the non-codex stream path, unless the operator set the env explicitly.
+    if not _user_set_codex_idle and _codex_idle_timeout > 0:
+        try:
+            from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+
+            _rf = get_reasoning_stale_timeout_floor(api_kwargs.get("model"))
+            if _rf is not None and _rf > _codex_idle_timeout:
+                logger.info(
+                    "Raising Codex post-first-byte SSE idle timeout from %.0fs to "
+                    "%.0fs for reasoning model %s (context=~%s tokens). "
+                    "Override with HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS.",
+                    _codex_idle_timeout,
+                    _rf,
+                    api_kwargs.get("model", "unknown"),
+                    f"{_est_tokens_for_codex_watchdog:,}",
+                )
+                _codex_idle_timeout = float(_rf)
+        except Exception:
+            logger.debug(
+                "reasoning floor for codex idle timeout failed", exc_info=True
+            )
     if _codex_idle_timeout <= 0:
         _codex_idle_enabled = False
 

--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -114,14 +114,13 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
     # at the default 180s (300s with context scaling), tripping the
     # cross-turn circuit breaker after 5 consecutive stale kills.
     ("claude-fable", 600),
-    # xAI Grok reasoning variants.  Explicit reasoning-only keys
-    # plus one for the ``non-reasoning`` variant so users picking
-    # the fast variant don't get the 300s floor.  Bare ``grok-3``,
-    # ``grok-4`` etc. don't match — only the explicit reasoning /
-    # non-reasoning pairs.
-    ("grok-4-fast-reasoning", 300),
-    ("grok-4.20-reasoning", 300),
-    ("grok-4.5", 300),
+    # xAI Grok reasoning variants. Explicit keys so non-reasoning fast
+    # variants stay lower. Bare grok-4.5 is a common Desktop default and
+    # routinely thinks >2–4 min with no SSE keepalive after the first
+    # frame — post-first-byte Codex idle must not sit at ~120s.
+    ("grok-4-fast-reasoning", 600),
+    ("grok-4.20-reasoning", 600),
+    ("grok-4.5", 600),
     ("grok-4-fast-non-reasoning", 180),
 )
 
@@ -206,7 +205,7 @@ def get_reasoning_stale_timeout_floor(model: object) -> Optional[float]:
     >>> get_reasoning_stale_timeout_floor("qwen/qwen3-235b-a22b-thinking")
     180.0
     >>> get_reasoning_stale_timeout_floor("x-ai/grok-4-fast-reasoning")
-    300.0
+    600.0
     >>> get_reasoning_stale_timeout_floor("anthropic/claude-opus-4-6")
     240.0
     >>> get_reasoning_stale_timeout_floor("anthropic/claude-fable-5")

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -802,3 +802,71 @@ def test_large_codex_request_hard_ceiling_caps_raised_stale_floor(tmp_path, monk
         assert "stale_call_kill" in closes, f"stale kill expected, got {closes}"
     finally:
         stop["flag"] = True
+
+
+def test_event_idle_applies_reasoning_floor_when_env_unset(tmp_path, monkeypatch):
+    """Reasoning models can stay silent after the first SSE frame while thinking.
+
+    The Codex post-first-byte idle watchdog must raise to the reasoning floor
+    when HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS is unset — otherwise Grok /
+    o-series streams die around the token-tier default (~60–120s) and fail
+    after 3 retries with "no SSE events for 120s after first byte".
+    """
+    from agent import chat_completion_helpers as h
+    import agent.reasoning_timeouts as rt
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    monkeypatch.delenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "30")
+    # Floor short enough for a unit test. Tier default is forced low via
+    # _env_float so we can prove the floor *raises* the idle timeout.
+    monkeypatch.setattr(rt, "get_reasoning_stale_timeout_floor", lambda m: 2.5)
+    _orig_env_float = h._env_float
+
+    def _env_float(name, default=0.0):
+        if name == "HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS":
+            # Env unset → return a low "token-tier default"; floor should raise.
+            return 1.0
+        return _orig_env_float(name, default)
+
+    monkeypatch.setattr(h, "_env_float", _env_float)
+
+    closes: list = []
+    dummy_client = SimpleNamespace()
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+    monkeypatch.setattr(
+        agent,
+        "_abort_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+    monkeypatch.setattr(
+        agent,
+        "_close_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+
+    stop = {"flag": False}
+
+    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+        agent._codex_stream_last_event_ts = time.time()
+        deadline = time.time() + 30
+        while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
+            time.sleep(0.02)
+        raise RuntimeError("connection closed")
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_stream)
+
+    t0 = time.time()
+    try:
+        with pytest.raises(TimeoutError) as excinfo:
+            h.interruptible_api_call(agent, {"model": "grok-4.5", "input": "hi"})
+        elapsed = time.time() - t0
+        msg = str(excinfo.value)
+        assert "after first byte" in msg
+        assert "codex_stream_idle_kill" in closes
+        # Floor 2.5s over a 1s tier default: kill ~2–3s, not the old 60–120s.
+        assert elapsed < 12.0, f"idle kill too slow (floor not applied?): {elapsed:.1f}s"
+        assert elapsed >= 2.0, f"idle kill too fast: {elapsed:.1f}s"
+        assert "threshold: 2s" in msg
+    finally:
+        stop["flag"] = True

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -79,9 +79,9 @@ import pytest
     ("claude-fable-5", 600.0),
     ("claude-fable", 600.0),
     # xAI Grok reasoning variants — explicit, not bare `grok`.
-    ("x-ai/grok-4-fast-reasoning", 300.0),
-    ("x-ai/grok-4.20-reasoning", 300.0),
-    ("x-ai/grok-4.5", 300.0),
+    ("x-ai/grok-4-fast-reasoning", 600.0),
+    ("x-ai/grok-4.20-reasoning", 600.0),
+    ("x-ai/grok-4.5", 600.0),
     ("x-ai/grok-4-fast-non-reasoning", 180.0),
 ])
 def test_reasoning_stale_timeout_floor_positive_cases(model, expected):


### PR DESCRIPTION
## Summary

Reasoning models on the `codex_responses` path (notably xAI Grok-4.5) can emit one SSE frame and then stay silent for minutes while thinking, with no keepalive. The Codex **post-first-byte event-idle** watchdog used token-tier defaults of ~60–180s and did **not** consult `get_reasoning_stale_timeout_floor` (already applied on the non-codex stream path). Healthy streams were killed at 120s, then failed after 3 identical retries:

```
API call failed after 3 retries
Codex stream produced no SSE events for 120s after first byte (threshold: 120s)
provider=xai-oauth model=grok-4.5
```

## Changes

- Apply `get_reasoning_stale_timeout_floor(model)` to Codex event-idle timeout when `HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS` is unset (floor only; never overrides explicit env)
- Raise token-tier event-idle defaults: 60 / 180 / 240 / 300 (was 12 / 60 / 120 / 180)
- Raise Grok reasoning floors to 600s (`grok-4.5`, `grok-4-fast-reasoning`, `grok-4.20-reasoning`)
- Regression tests: floor table values + idle watchdog applies reasoning floor

## Test plan

- [x] `pytest tests/agent/test_reasoning_stale_timeout_floor.py tests/agent/test_codex_ttfb_watchdog.py::test_event_idle_applies_reasoning_floor_when_env_unset tests/agent/test_codex_ttfb_watchdog.py::test_event_idle_kills_after_first_event_then_silence` (63 passed)
- [ ] Long Desktop/gateway turn on `grok-4.5` with large context no longer hard-fails at 120s×3
- [ ] Explicit `HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS` still wins over the floor