### PR TITLE
fix(desktop): correct checkbox state glyphs

### DIFF
--- a/apps/desktop/DESIGN.md
+++ b/apps/desktop/DESIGN.md
@@ -161,6 +161,9 @@ Notes:
   (color mode, tool-call display, usage period). Replaces radio piles and
   pill rows.
 - **`Switch`** (`size="xs"`) — bare, with `aria-label`. No bordered text wrapper.
+- **`Checkbox`** — unchecked, checked, and indeterminate states use the shared
+  primitive. Glyph visibility follows the primitive's own indicator state, not
+  ancestor group state.
 
 ## Layout
 

--- a/apps/desktop/src/components/ui/checkbox.test.tsx
+++ b/apps/desktop/src/components/ui/checkbox.test.tsx
@@ -1,0 +1,33 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { Checkbox } from './checkbox'
+
+afterEach(cleanup)
+
+describe('Checkbox', () => {
+  it('drives glyph visibility from the indicator state', () => {
+    render(<Checkbox aria-label="checked" checked />)
+
+    const checkbox = screen.getByRole('checkbox', { name: 'checked' })
+    const indicator = checkbox.querySelector('[data-slot="checkbox-indicator"]')
+
+    expect(checkbox.getAttribute('data-state')).toBe('checked')
+    expect(indicator?.getAttribute('data-state')).toBe('checked')
+    expect(indicator?.className).toContain('[&>.codicon]:hidden!')
+    expect(indicator?.className).toContain('data-[state=checked]:[&>.codicon-check]:block!')
+    expect(indicator?.className).toContain('data-[state=indeterminate]:[&>.codicon-dash]:block!')
+    expect(checkbox.className.split(' ')).not.toContain('group')
+  })
+
+  it('exposes the indeterminate state to the mixed-state glyph selector', () => {
+    render(<Checkbox aria-label="indeterminate" checked="indeterminate" />)
+
+    const checkbox = screen.getByRole('checkbox', { name: 'indeterminate' })
+    const indicator = checkbox.querySelector('[data-slot="checkbox-indicator"]')
+
+    expect(checkbox.getAttribute('aria-checked')).toBe('mixed')
+    expect(checkbox.getAttribute('data-state')).toBe('indeterminate')
+    expect(indicator?.getAttribute('data-state')).toBe('indeterminate')
+  })
+})

--- a/apps/desktop/src/components/ui/checkbox.tsx
+++ b/apps/desktop/src/components/ui/checkbox.tsx
@@ -8,18 +8,18 @@ function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxP
   return (
     <CheckboxPrimitive.Root
       className={cn(
-        'group peer size-4 shrink-0 rounded-sm border border-input shadow-xs outline-none transition-shadow focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=indeterminate]:border-primary data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',
+        'peer size-4 shrink-0 rounded-sm border border-input shadow-xs outline-none transition-shadow focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=indeterminate]:border-primary data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',
         className
       )}
       data-slot="checkbox"
       {...props}
     >
       <CheckboxPrimitive.Indicator
-        className="flex items-center justify-center text-current"
+        className="flex items-center justify-center text-current [&>.codicon]:hidden! data-[state=checked]:[&>.codicon-check]:block! data-[state=indeterminate]:[&>.codicon-dash]:block!"
         data-slot="checkbox-indicator"
       >
-        <Codicon className="hidden group-data-[state=checked]:block" name="check" size="0.875rem" />
-        <Codicon className="hidden group-data-[state=indeterminate]:block" name="dash" size="0.875rem" />
+        <Codicon name="check" size="0.875rem" />
+        <Codicon name="dash" size="0.875rem" />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   )


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop checkbox state glyphs so checked and indeterminate states render only their intended icon.

The shared checkbox previously put `hidden` on each Codicon and used ancestor `group-data` selectors to reveal the active glyph. Codicon's unlayered `display: inline-block` rule outranked Tailwind's layered visibility utilities, leaving both the check and dash visible. This change scopes important visibility rules to the Radix indicator's own `data-state`, which preserves the shared component API and fixes every checkbox call site.

## Related Issue

Fixes #74024

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Scope check and dash glyph visibility to the checkbox indicator state in `apps/desktop/src/components/ui/checkbox.tsx`.
- Add checked and indeterminate regression coverage in `apps/desktop/src/components/ui/checkbox.test.tsx`.
- Document the shared Checkbox state contract in `apps/desktop/DESIGN.md`.

## How to Test

1. Open Desktop Settings and choose **Edit Models**.
2. Enable every model for one provider and only some models for another.
3. Confirm the fully enabled provider shows only a check, the partially enabled provider shows only a dash, and a disabled provider is empty.
4. Run `npx --yes -p node@22 node ../../node_modules/vitest/vitest.mjs run --project ui` from `apps/desktop`.
5. Run `npm run check:lint` from `apps/desktop`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not run: Desktop-only TypeScript/CSS change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2, Node.js 22.23.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (shared Checkbox contract in `apps/desktop/DESIGN.md`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — CSS-only shared primitive change, verified in Chromium
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Verified in Chromium with the real shared Checkbox and Desktop stylesheet:

- checked: check glyph displayed, dash hidden
- indeterminate: check hidden, dash glyph displayed
- unchecked: no indicator glyph

Validation:

- Desktop UI suite on CI's Node 22: 333 files passed, 2,936 tests passed
- Desktop TypeScript checks: passed
- Desktop ESLint: passed with pre-existing warnings only
