### PR TITLE
fix(desktop): pass shell to serve probe; bound Windows discovery probes

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1897,6 +1897,11 @@ function backendSupportsServe(backend) {
         env: { ...process.env, HERMES_HOME, ...(backend.env || {}) },
         timeout: PROBE_TIMEOUT_MS,
         stdio: 'ignore',
+        // `.cmd`/`.bat` shim backends carry shell: true in their descriptor
+        // (see resolveHermesBackend step 4); execFileSync of a .cmd without
+        // shell throws EINVAL on modern Node, which the catch below would
+        // mis-cache as "serve unsupported" for the process lifetime.
+        shell: Boolean(backend.shell),
         windowsHide: true
       })
       supported = true
@@ -2053,7 +2058,10 @@ function findSystemPython() {
         const out = execFileSync(
           'reg',
           ['query', `${hive}\\SOFTWARE\\Python\\PythonCore\\${version}\\InstallPath`, '/ve', '/reg:64'],
-          hiddenWindowsChildOptions({ encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] })
+          // Registry reads are near-instant; the bound only exists so a
+          // pathologically wedged reg.exe can't hang the synchronous boot
+          // resolver forever (this ran unbounded before).
+          hiddenWindowsChildOptions({ encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 5_000 })
         )
 
         // Output format: "    (Default)    REG_SZ    C:\Path\To\Python\"
@@ -2108,7 +2116,12 @@ function findSystemPython() {
           [`-${version}`, '-c', 'import sys; print(sys.executable)'],
           hiddenWindowsChildOptions({
             encoding: 'utf8',
-            stdio: ['ignore', 'pipe', 'ignore']
+            stdio: ['ignore', 'pipe', 'ignore'],
+            // Bare interpreter startup — much lighter than the hermes-import
+            // probes, but still python.exe under cold cache / AV scan, so
+            // share the probe budget rather than running unbounded (this
+            // synchronous exec previously had no timeout at all).
+            timeout: PROBE_TIMEOUT_MS
           })
         )
 


### PR DESCRIPTION
## Summary

Closes the two residual gaps the #74050 review flagged in the #72707/#72632 probe-hardening series: a `.cmd`-shim backend can no longer be permanently mis-cached as "serve unsupported", and the Windows python-discovery probes are no longer unbounded synchronous execs on the boot path.

## Changes

- `backendSupportsServe` now forwards `backend.shell` to the `serve --help` probe. `.cmd`/`.bat` shim backends carry `shell: true` in their step-4 descriptor, but the probe never passed it — `execFileSync` of a `.cmd` without `shell` throws EINVAL on modern Node, the bare catch caches `supported=false` for the process lifetime, and that backend is permanently routed through the legacy `dashboard` form.
- Windows `findSystemPython` discovery probes get bounds: `reg query` at 5s (registry reads are near-instant; the bound only guards a wedged reg.exe), `py.exe -c "import sys; print(sys.executable)"` at the shared `PROBE_TIMEOUT_MS` budget (bare interpreter startup, lighter than the hermes-import class but still python.exe under cold cache / AV). Both previously ran with **no timeout at all** on the synchronous boot resolver.

## Validation

| | Result |
|---|---|
| `tsc -p tsconfig.electron.json --noEmit` | clean |
| `eslint electron/main.ts` | clean |
| `vitest run electron/` | 830 passed, 2 skipped, 0 failed |
| `execProbeSync` shell-option plumbing (real subprocess) | pass-through ok; failure under `shell:true` still throws |

Follow-up to #74050; part of the #72707 bug class.
