### PR TITLE
feat(skills): add profile-aware skills.auto_load

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1502,8 +1502,13 @@ def init_agent(
     # Cross-session-stable prefix of the cached prompt. It remains separate
     # from the persisted string and is used only to place an early cache marker.
     agent._cached_system_prompt_static: Optional[str] = None
-    
-    # Filesystem checkpoint manager (transparent — not a tool)
+    # Auto-loaded skill content is resolved exactly once for this AIAgent.
+    # Cache invalidation/reconstruction must reuse these exact bytes rather
+    # than reread profile config or skill files.
+    agent._auto_load_skills_resolved = False
+    agent._auto_load_skills_result = ("", [], [])
+
+    # Filesystem checkpoint manager
     from tools.checkpoint_manager import CheckpointManager
     agent._checkpoint_mgr = CheckpointManager(
         enabled=checkpoints_enabled,

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -747,6 +747,7 @@ def build_stacked_skill_invocation_message(
 def build_preloaded_skills_prompt(
     skill_identifiers: list[str],
     task_id: str | None = None,
+    excluded_loaded_names: set[str] | None = None,
 ) -> tuple[str, list[str], list[str]]:
     """Load one or more skills for session-wide CLI/TUI preloading.
 
@@ -769,12 +770,13 @@ def build_preloaded_skills_prompt(
     except Exception:
         disabled_names = set()
 
-    seen: set[str] = set()
+    seen_identifiers: set[str] = set()
+    seen_loaded_names = set(excluded_loaded_names or ())
     for raw_identifier in skill_identifiers:
         identifier = (raw_identifier or "").strip()
-        if not identifier or identifier in seen:
+        if not identifier or identifier in seen_identifiers:
             continue
-        seen.add(identifier)
+        seen_identifiers.add(identifier)
 
         loaded = _load_skill_payload(identifier, task_id=task_id)
         if not loaded:
@@ -786,6 +788,12 @@ def build_preloaded_skills_prompt(
         if skill_name in disabled_names or identifier in disabled_names:
             missing.append(identifier)
             continue
+
+        # Deduplicate only after a successful, enabled load. The canonical
+        # name returned by skill_view() is shared by aliases and path forms.
+        if skill_name in seen_loaded_names:
+            continue
+        seen_loaded_names.add(skill_name)
 
         # Track active usage for Curator lifecycle management (#17782)
         try:
@@ -819,7 +827,7 @@ def resolve_auto_load_skills(user_config: dict | None = None) -> list[str]:
     """
     if user_config is None:
         try:
-            from hermes_cli.config import load_cli_config as _load_hermes_config
+            from hermes_cli.config import load_config as _load_hermes_config
             user_config = _load_hermes_config()
         except Exception:
             return []
@@ -876,12 +884,13 @@ def build_auto_load_prompt(
     prompt_parts: list[str] = []
     loaded_names: list[str] = []
     missing: list[str] = []
-    seen: set[str] = set()
+    seen_identifiers: set[str] = set()
+    seen_loaded_names: set[str] = set()
 
     for identifier in auto_skills:
-        if identifier in seen:
+        if identifier in seen_identifiers:
             continue
-        seen.add(identifier)
+        seen_identifiers.add(identifier)
 
         loaded = _load_skill_payload(identifier, task_id=task_id)
         if not loaded:
@@ -893,6 +902,10 @@ def build_auto_load_prompt(
         if skill_name in disabled_names or identifier in disabled_names:
             missing.append(identifier)
             continue
+
+        if skill_name in seen_loaded_names:
+            continue
+        seen_loaded_names.add(skill_name)
 
         # Track active usage for Curator lifecycle management (#17782)
         try:

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -810,3 +810,67 @@ def build_preloaded_skills_prompt(
         loaded_names.append(skill_name)
 
     return "\n\n".join(prompt_parts), loaded_names, missing
+
+def resolve_auto_load_skills(user_config: dict | None = None) -> list[str]:
+    """Read skills.auto_load from user config and return the deduplicated list.
+
+    If user_config is None, reads from the active config file.
+    Returns an empty list if the key is missing or empty.
+    """
+    if user_config is None:
+        try:
+            from hermes_cli.config import load_cli_config as _load_hermes_config
+            user_config = _load_hermes_config()
+        except Exception:
+            return []
+
+    skills_block = user_config.get("skills", {})
+    if not isinstance(skills_block, dict):
+        return []
+    auto_load = skills_block.get("auto_load")
+    if not auto_load or not isinstance(auto_load, list):
+        return []
+
+    seen: set[str] = set()
+    result: list[str] = []
+    for entry in auto_load:
+        if not isinstance(entry, str):
+            continue
+        name = entry.strip()
+        if name and name not in seen:
+            seen.add(name)
+            result.append(name)
+    return result
+
+
+def build_auto_load_prompt(
+    task_id: str | None = None,
+    user_config: dict | None = None,
+) -> tuple[str, list[str], list[str]]:
+    """Load auto_load skills and build their prompt block.
+
+    Reads skills.auto_load from config, loads each skill, and returns
+    (prompt_text, loaded_names, missing_names).  Missing skills are
+    listed in ``missing_names`` rather than raising an error — callers
+    should log a warning for them.
+    """
+    auto_skills = resolve_auto_load_skills(user_config)
+    if not auto_skills:
+        return "", [], []
+
+    prompt_text, loaded, missing = build_preloaded_skills_prompt(
+        auto_skills, task_id=task_id
+    )
+
+    # Rewrite the activation note to be origin-agnostic (not CLI-specific).
+    if prompt_text:
+        prompt_text = prompt_text.replace(
+            'The user launched this CLI session with the',
+            'The',
+        )
+        prompt_text = prompt_text.replace(
+            'preloaded. Treat its instructions as active guidance for the duration of this session unless the user overrides them.]',
+            'skill is auto-loaded from skills.auto_load config. Treat its instructions as active guidance for the duration of this session unless the user overrides them.]',
+        )
+
+    return prompt_text, loaded, missing

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -772,6 +772,7 @@ def build_preloaded_skills_prompt(
 
     seen_identifiers: set[str] = set()
     seen_loaded_names = set(excluded_loaded_names or ())
+    resolved_names: set[str] = set()
     for raw_identifier in skill_identifiers:
         identifier = (raw_identifier or "").strip()
         if not identifier or identifier in seen_identifiers:
@@ -789,11 +790,17 @@ def build_preloaded_skills_prompt(
             missing.append(identifier)
             continue
 
-        # Deduplicate only after a successful, enabled load. The canonical
-        # name returned by skill_view() is shared by aliases and path forms.
+        # Deduplicate prompt injection only after a successful, enabled load.
+        # The canonical name returned by skill_view() is shared by aliases and
+        # path forms. Already auto-loaded skills still count as successfully
+        # resolved explicit requests so a separate typo can degrade gracefully.
         if skill_name in seen_loaded_names:
+            if skill_name not in resolved_names:
+                loaded_names.append(skill_name)
+                resolved_names.add(skill_name)
             continue
         seen_loaded_names.add(skill_name)
+        resolved_names.add(skill_name)
 
         # Track active usage for Curator lifecycle management (#17782)
         try:

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -853,24 +853,67 @@ def build_auto_load_prompt(
     (prompt_text, loaded_names, missing_names).  Missing skills are
     listed in ``missing_names`` rather than raising an error — callers
     should log a warning for them.
+
+    Uses ``_load_skill_payload`` + the disabled-skill gate directly
+    (same primitives as ``build_preloaded_skills_prompt``) with a
+    purpose-built activation note, rather than reusing
+    ``build_preloaded_skills_prompt`` and string-replacing the note.
+    A string replace is fragile: if the upstream note wording changes,
+    the replace silently breaks and the CLI-specific note leaks into
+    all sessions.
     """
     auto_skills = resolve_auto_load_skills(user_config)
     if not auto_skills:
         return "", [], []
 
-    prompt_text, loaded, missing = build_preloaded_skills_prompt(
-        auto_skills, task_id=task_id
-    )
+    # Same disabled-skill gate as build_preloaded_skills_prompt (#59156).
+    try:
+        from agent.skill_utils import get_disabled_skill_names
+        disabled_names = get_disabled_skill_names()
+    except Exception:
+        disabled_names = set()
 
-    # Rewrite the activation note to be origin-agnostic (not CLI-specific).
-    if prompt_text:
-        prompt_text = prompt_text.replace(
-            'The user launched this CLI session with the',
-            'The',
-        )
-        prompt_text = prompt_text.replace(
-            'preloaded. Treat its instructions as active guidance for the duration of this session unless the user overrides them.]',
-            'skill is auto-loaded from skills.auto_load config. Treat its instructions as active guidance for the duration of this session unless the user overrides them.]',
-        )
+    prompt_parts: list[str] = []
+    loaded_names: list[str] = []
+    missing: list[str] = []
+    seen: set[str] = set()
 
-    return prompt_text, loaded, missing
+    for identifier in auto_skills:
+        if identifier in seen:
+            continue
+        seen.add(identifier)
+
+        loaded = _load_skill_payload(identifier, task_id=task_id)
+        if not loaded:
+            missing.append(identifier)
+            continue
+
+        loaded_skill, skill_dir, skill_name = loaded
+
+        if skill_name in disabled_names or identifier in disabled_names:
+            missing.append(identifier)
+            continue
+
+        # Track active usage for Curator lifecycle management (#17782)
+        try:
+            from tools.skill_usage import bump_use
+            bump_use(skill_name)
+        except Exception:
+            pass  # Non-critical
+
+        activation_note = (
+            f'[IMPORTANT: The "{skill_name}" skill is auto-loaded via config '
+            "(skills.auto_load). Treat its instructions as active guidance "
+            "for the duration of this session unless the user overrides them.]"
+        )
+        prompt_parts.append(
+            _build_skill_message(
+                loaded_skill,
+                skill_dir,
+                activation_note,
+                session_id=task_id,
+            )
+        )
+        loaded_names.append(skill_name)
+
+    return "\n\n".join(prompt_parts), loaded_names, missing

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -352,7 +352,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             if _auto_prompt:
                 stable_parts.append(_auto_prompt)
         except Exception:
-            pass  # Non-fatal — config read errors must not break session start
+            logger.debug("skills.auto_load: injection skipped", exc_info=True)  # Non-fatal — config read errors must not break session start
     # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
     # of the requested model. Inject explicit model identity into the system prompt
     # so the agent can correctly report which model it is (workaround for API bug).

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -330,29 +330,35 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
 
 
     # ── Auto-load skills from skills.auto_load config ──
-    # Covers programmatic AIAgent users who don't pass --skills or
-    # system_message.  Only injected on the FIRST system prompt build
-    # (new session); resumed sessions already have the auto_load block
-    # in their conversation history.
-    # Respects HERMES_IGNORE_RULES — users who opt out of auto-injection
-    # should not get auto-injected skills.
-    _is_new_session = getattr(agent, "_cached_system_prompt", None) is None
-    _ignore_rules = os.environ.get("HERMES_IGNORE_RULES") == "1"
-    if _is_new_session and not _ignore_rules:
-        from agent.skill_commands import build_auto_load_prompt as _build_auto
+    # Covers every AIAgent surface (CLI, gateway, TUI, cron, API). Resolve and
+    # render once per agent lifecycle, then reuse the exact bytes whenever a
+    # model switch, compression, or static-prefix restoration rebuilds this
+    # prompt. `_cached_system_prompt is None` is not a new-session signal.
+    # HERMES_IGNORE_RULES is captured on first resolution so the result itself
+    # remains stable for the lifetime of the agent.
+    if not getattr(agent, "_auto_load_skills_resolved", False):
+        agent._auto_load_skills_result = ("", [], [])
         try:
-            _auto_prompt, _auto_loaded, _auto_missing = _build_auto(
-                task_id=getattr(agent, "session_id", None),
-            )
+            if os.environ.get("HERMES_IGNORE_RULES") != "1":
+                from agent.skill_commands import build_auto_load_prompt as _build_auto
+
+                agent._auto_load_skills_result = _build_auto(
+                    task_id=getattr(agent, "session_id", None),
+                )
+            _auto_missing = agent._auto_load_skills_result[2]
             if _auto_missing:
-                from hermes_logging import get_logger
-                get_logger().warning(
+                logger.warning(
                     "Auto-load skill(s) not found: %s", ", ".join(_auto_missing)
                 )
-            if _auto_prompt:
-                stable_parts.append(_auto_prompt)
         except Exception:
-            logger.debug("skills.auto_load: injection skipped", exc_info=True)  # Non-fatal — config read errors must not break session start
+            # Non-fatal — config/skill errors must not break session start.
+            logger.debug("skills.auto_load: injection skipped", exc_info=True)
+        finally:
+            agent._auto_load_skills_resolved = True
+
+    _auto_prompt = agent._auto_load_skills_result[0]
+    if _auto_prompt:
+        stable_parts.append(_auto_prompt)
     # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
     # of the requested model. Inject explicit model identity into the system prompt
     # so the agent can correctly report which model it is (workaround for API bug).

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -348,7 +348,8 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             _auto_missing = agent._auto_load_skills_result[2]
             if _auto_missing:
                 logger.warning(
-                    "Auto-load skill(s) not found: %s", ", ".join(_auto_missing)
+                    "Auto-load skill(s) not found or disabled: %s",
+                    ", ".join(_auto_missing),
                 )
         except Exception:
             # Non-fatal — config/skill errors must not break session start.

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -328,6 +328,31 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if skills_prompt:
         stable_parts.append(skills_prompt)
 
+
+    # ── Auto-load skills from skills.auto_load config ──
+    # Covers programmatic AIAgent users who don't pass --skills or
+    # system_message.  Only injected on the FIRST system prompt build
+    # (new session); resumed sessions already have the auto_load block
+    # in their conversation history.
+    # Respects HERMES_IGNORE_RULES — users who opt out of auto-injection
+    # should not get auto-injected skills.
+    _is_new_session = getattr(agent, "_cached_system_prompt", None) is None
+    _ignore_rules = os.environ.get("HERMES_IGNORE_RULES") == "1"
+    if _is_new_session and not _ignore_rules:
+        from agent.skill_commands import build_auto_load_prompt as _build_auto
+        try:
+            _auto_prompt, _auto_loaded, _auto_missing = _build_auto(
+                task_id=getattr(agent, "session_id", None),
+            )
+            if _auto_missing:
+                from hermes_logging import get_logger
+                get_logger().warning(
+                    "Auto-load skill(s) not found: %s", ", ".join(_auto_missing)
+                )
+            if _auto_prompt:
+                stable_parts.append(_auto_prompt)
+        except Exception:
+            pass  # Non-fatal — config read errors must not break session start
     # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
     # of the requested model. Inject explicit model identity into the system prompt
     # so the agent can correctly report which model it is (workaround for API bug).

--- a/cli.py
+++ b/cli.py
@@ -17596,22 +17596,6 @@ def main(
             toolsets_list = sorted(_get_platform_tools(CLI_CONFIG, "cli"))
     
     parsed_skills = _parse_skills_argument(skills)
-
-    # Resolve and build skills.auto_load now so CLI dedup is based on successful
-    # canonical loads, not raw config text. The result is handed to the lazily
-    # created AIAgent, whose shared system-prompt path injects and reuses it.
-    # --ignore-rules suppresses all auto-injection (AGENTS.md, SOUL.md,
-    # memory, skills), including when enabled through HERMES_IGNORE_RULES.
-    from agent.skill_commands import build_auto_load_prompt
-
-    effective_ignore_rules = ignore_rules or os.environ.get("HERMES_IGNORE_RULES") == "1"
-    auto_load_result = (
-        ("", [], [])
-        if effective_ignore_rules
-        else build_auto_load_prompt(user_config=CLI_CONFIG)
-    )
-    _auto_prompt, auto_load_skills, auto_load_missing = auto_load_result
-    auto_load_set = set(auto_load_skills)
     loaded_skills: list[str] = []
 
     # Create CLI instance
@@ -17629,6 +17613,26 @@ def main(
         pass_session_id=pass_session_id,
         ignore_rules=ignore_rules,
     )
+
+    # Resolve auto-load templates only after the session exists so
+    # ${HERMES_SESSION_ID} substitutions receive the real CLI session ID. The
+    # exact rendered bytes are handed to lazily created replacement agents and
+    # remain stable across model switches for this CLI session.
+    from agent.skill_commands import build_auto_load_prompt
+
+    effective_ignore_rules = (
+        ignore_rules or os.environ.get("HERMES_IGNORE_RULES") == "1"
+    )
+    auto_load_result = (
+        ("", [], [])
+        if effective_ignore_rules
+        else build_auto_load_prompt(
+            task_id=cli.session_id,
+            user_config=CLI_CONFIG,
+        )
+    )
+    _auto_prompt, auto_load_skills, auto_load_missing = auto_load_result
+    auto_load_set = set(auto_load_skills)
     cli._auto_load_skills_result = auto_load_result
     if auto_load_missing:
         logger.warning(

--- a/cli.py
+++ b/cli.py
@@ -4676,6 +4676,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._attached_images: list[Path] = []
         self._image_counter = 0
         self.preloaded_skills: list[str] = []
+        self._auto_load_skills_result: tuple[str, list[str], list[str]] | None = None
         self._startup_skills_line_shown = False
         self._active_session_lease = None
 
@@ -17596,17 +17597,22 @@ def main(
     
     parsed_skills = _parse_skills_argument(skills)
 
-    # Resolve skills.auto_load for dedup. The actual injection of auto_load
-    # skills happens once in AIAgent._build_system_prompt_parts (gated on
-    # new-session). Here we only need the list so we can avoid injecting the
-    # same skill twice when --skills overlaps with auto_load, and so the
-    # "Activated skills" display reflects both sources.
+    # Resolve and build skills.auto_load now so CLI dedup is based on successful
+    # canonical loads, not raw config text. The result is handed to the lazily
+    # created AIAgent, whose shared system-prompt path injects and reuses it.
     # --ignore-rules suppresses all auto-injection (AGENTS.md, SOUL.md,
-    # memory, skills), so auto_load is skipped in that mode.
-    from agent.skill_commands import resolve_auto_load_skills
-    auto_load_skills = resolve_auto_load_skills(CLI_CONFIG) if not ignore_rules else []
+    # memory, skills), including when enabled through HERMES_IGNORE_RULES.
+    from agent.skill_commands import build_auto_load_prompt
+
+    effective_ignore_rules = ignore_rules or os.environ.get("HERMES_IGNORE_RULES") == "1"
+    auto_load_result = (
+        ("", [], [])
+        if effective_ignore_rules
+        else build_auto_load_prompt(user_config=CLI_CONFIG)
+    )
+    _auto_prompt, auto_load_skills, auto_load_missing = auto_load_result
     auto_load_set = set(auto_load_skills)
-    cli_only_skills = [s for s in parsed_skills if s not in auto_load_set]
+    loaded_skills: list[str] = []
 
     # Create CLI instance
     cli = HermesCLI(
@@ -17623,11 +17629,18 @@ def main(
         pass_session_id=pass_session_id,
         ignore_rules=ignore_rules,
     )
+    cli._auto_load_skills_result = auto_load_result
+    if auto_load_missing:
+        logger.warning(
+            "Auto-load skill(s) not found or disabled: %s",
+            ", ".join(auto_load_missing),
+        )
 
-    if cli_only_skills:
+    if parsed_skills:
         skills_prompt, loaded_skills, missing_skills = build_preloaded_skills_prompt(
-            cli_only_skills,
+            parsed_skills,
             task_id=cli.session_id,
+            excluded_loaded_names=auto_load_set,
         )
         if missing_skills:
             missing_display = ", ".join(missing_skills)
@@ -17651,12 +17664,10 @@ def main(
                 part for part in (cli.system_prompt, skills_prompt) if part
             ).strip()
 
-    # Display includes both CLI --skills and auto_load (deduped, auto_load first).
-    # Functional injection of auto_load happens in AIAgent; CLI just shows the
-    # combined activated set so users see what's loaded.
-    if auto_load_skills or parsed_skills:
+    # Display only canonical names that loaded successfully, auto_load first.
+    if auto_load_skills or loaded_skills:
         display = list(auto_load_skills)
-        for s in parsed_skills:
+        for s in loaded_skills:
             if s not in auto_load_set:
                 display.append(s)
         cli.preloaded_skills = display

--- a/cli.py
+++ b/cli.py
@@ -17596,6 +17596,18 @@ def main(
     
     parsed_skills = _parse_skills_argument(skills)
 
+    # Resolve skills.auto_load for dedup. The actual injection of auto_load
+    # skills happens once in AIAgent._build_system_prompt_parts (gated on
+    # new-session). Here we only need the list so we can avoid injecting the
+    # same skill twice when --skills overlaps with auto_load, and so the
+    # "Activated skills" display reflects both sources.
+    # --ignore-rules suppresses all auto-injection (AGENTS.md, SOUL.md,
+    # memory, skills), so auto_load is skipped in that mode.
+    from agent.skill_commands import resolve_auto_load_skills
+    auto_load_skills = resolve_auto_load_skills(CLI_CONFIG) if not ignore_rules else []
+    auto_load_set = set(auto_load_skills)
+    cli_only_skills = [s for s in parsed_skills if s not in auto_load_set]
+
     # Create CLI instance
     cli = HermesCLI(
         model=model,
@@ -17612,9 +17624,9 @@ def main(
         ignore_rules=ignore_rules,
     )
 
-    if parsed_skills:
+    if cli_only_skills:
         skills_prompt, loaded_skills, missing_skills = build_preloaded_skills_prompt(
-            parsed_skills,
+            cli_only_skills,
             task_id=cli.session_id,
         )
         if missing_skills:
@@ -17638,7 +17650,16 @@ def main(
             cli.system_prompt = "\n\n".join(
                 part for part in (cli.system_prompt, skills_prompt) if part
             ).strip()
-            cli.preloaded_skills = loaded_skills
+
+    # Display includes both CLI --skills and auto_load (deduped, auto_load first).
+    # Functional injection of auto_load happens in AIAgent; CLI just shows the
+    # combined activated set so users see what's loaded.
+    if auto_load_skills or parsed_skills:
+        display = list(auto_load_skills)
+        for s in parsed_skills:
+            if s not in auto_load_set:
+                display.append(s)
+        cli.preloaded_skills = display
 
     # Inject worktree context into agent's system prompt
     if wt_info:

--- a/contributors/emails/314574126@qq.com
+++ b/contributors/emails/314574126@qq.com
@@ -1,0 +1,2 @@
+ArcherQAQ
+# Cherry-picked from PR #26840

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -410,6 +410,13 @@ class CLIAgentSetupMixin:
                 notice_clear_callback=self._on_notice_clear,
                 reaction_callback=self._on_reaction,
             )
+            # main() may pre-resolve auto-load skills to deduplicate them
+            # against explicit --skills. Seed this AIAgent's lifecycle cache so
+            # the shared prompt path does not reread config or skill files.
+            _auto_load_result = getattr(self, "_auto_load_skills_result", None)
+            if _auto_load_result is not None:
+                self.agent._auto_load_skills_result = _auto_load_result
+                self.agent._auto_load_skills_resolved = True
             # Store reference for atexit memory provider shutdown.
             # NOTE: this MUST write to the ``cli`` module's global, not a
             # local module global. ``_run_cleanup`` (in cli.py) reads

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1685,6 +1685,12 @@ DEFAULT_CONFIG = {
         # content with the absolute skill directory and the active session id
         # before the agent sees it.  Lets skill authors reference bundled
         # scripts without the agent having to join paths.
+        # Skills to auto-load at the start of every new session. Each entry
+        # is a skill name (e.g. "my-workflow") or a glob pattern. Resolved
+        # at session build time, deduped against the agent's existing skill
+        # set, and injected into the system prompt as fully-loaded skill
+        # messages. Ignored when HERMES_IGNORE_RULES is set.
+        "auto_load": [],
         "template_vars": True,
         # Pre-execute inline shell snippets written as !`cmd` in SKILL.md
         # body.  Their stdout is inlined into the skill message before the

--- a/tests/agent/test_skills_auto_load.py
+++ b/tests/agent/test_skills_auto_load.py
@@ -1,0 +1,432 @@
+"""Tests for skills.auto_load config — persistent skill pre-loading at session start.
+
+Tests cover:
+- resolve_auto_load_skills() — config reading
+- build_auto_load_prompt() — prompt generation
+- CLI merge with --skills
+- Missing auto_load skill → warning (non-fatal)
+- AIAgent._build_system_prompt injects auto_load
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ── resolve_auto_load_skills ──
+
+def test_resolve_auto_load_skills_reads_from_config():
+    """resolve_auto_load_skills reads the auto_load list from user config."""
+    from agent.skill_commands import resolve_auto_load_skills
+
+    config = {
+        "skills": {
+            "auto_load": ["skill-a", "skill-b", "skill-c"],
+        }
+    }
+    result = resolve_auto_load_skills(config)
+    assert result == ["skill-a", "skill-b", "skill-c"]
+
+
+def test_resolve_auto_load_skills_empty_list():
+    """Returns empty list when auto_load is empty."""
+    from agent.skill_commands import resolve_auto_load_skills
+
+    config = {"skills": {"auto_load": []}}
+    result = resolve_auto_load_skills(config)
+    assert result == []
+
+
+def test_resolve_auto_load_skills_missing_key():
+    """Returns empty list when auto_load key is missing."""
+    from agent.skill_commands import resolve_auto_load_skills
+
+    config = {"skills": {}}
+    result = resolve_auto_load_skills(config)
+    assert result == []
+
+
+def test_resolve_auto_load_skills_no_config():
+    """Returns empty list when config is None."""
+    from agent.skill_commands import resolve_auto_load_skills
+
+    result = resolve_auto_load_skills(None)
+    assert result == []
+
+
+def test_resolve_auto_load_skills_deduplicates():
+    """Duplicate entries are deduplicated (first occurrence wins)."""
+    from agent.skill_commands import resolve_auto_load_skills
+
+    config = {"skills": {"auto_load": ["skill-a", "skill-b", "skill-a"]}}
+    result = resolve_auto_load_skills(config)
+    assert result == ["skill-a", "skill-b"]
+
+
+def test_resolve_auto_load_skills_filters_non_strings():
+    """Non-string entries are filtered out."""
+    from agent.skill_commands import resolve_auto_load_skills
+
+    config = {"skills": {"auto_load": ["skill-a", 123, None, "", "skill-b"]}}
+    result = resolve_auto_load_skills(config)
+    assert result == ["skill-a", "skill-b"]
+
+
+def test_resolve_auto_load_skills_strips_whitespace():
+    """Whitespace is stripped from skill names."""
+    from agent.skill_commands import resolve_auto_load_skills
+
+    config = {"skills": {"auto_load": ["  skill-a  ", "skill-b"]}}
+    result = resolve_auto_load_skills(config)
+    assert result == ["skill-a", "skill-b"]
+
+
+def test_resolve_auto_load_skills_not_a_list():
+    """Returns empty list when auto_load is not a list."""
+    from agent.skill_commands import resolve_auto_load_skills
+
+    config = {"skills": {"auto_load": "not-a-list"}}
+    result = resolve_auto_load_skills(config)
+    assert result == []
+
+
+# ── build_auto_load_prompt ──
+
+def test_build_auto_load_prompt_loads_skills(tmp_path):
+    """build_auto_load_prompt loads skills from config and builds prompt."""
+    from agent.skill_commands import build_auto_load_prompt
+
+    # Create a real skill
+    skill_dir = tmp_path / "test-auto"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: test-auto\ndescription: Auto-load test.\n---\n\n# Test Auto\n\nContent.\n"
+    )
+
+    config = {"skills": {"auto_load": ["test-auto"]}}
+
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        prompt, loaded, missing = build_auto_load_prompt(user_config=config)
+
+    assert missing == []
+    assert loaded == ["test-auto"]
+    assert "test-auto" in prompt
+    assert "auto-loaded from skills.auto_load config" in prompt
+
+
+def test_build_auto_load_prompt_activation_note_not_cli_specific(tmp_path):
+    """The activation note is origin-agnostic, not CLI-specific."""
+    from agent.skill_commands import build_auto_load_prompt
+
+    skill_dir = tmp_path / "test-auto"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: test-auto\ndescription: Test.\n---\n\n# Test\n\nContent.\n"
+    )
+
+    config = {"skills": {"auto_load": ["test-auto"]}}
+
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        prompt, _, _ = build_auto_load_prompt(user_config=config)
+
+    # Must NOT contain the CLI-specific phrase
+    assert "launched this CLI session" not in prompt
+    # Must contain the auto_load-specific phrase
+    assert "auto-loaded from skills.auto_load config" in prompt
+
+
+def test_build_auto_load_prompt_reports_missing_non_fatal(tmp_path):
+    """Missing auto_load skills are reported in missing, not raised."""
+    from agent.skill_commands import build_auto_load_prompt
+
+    config = {"skills": {"auto_load": ["missing-skill"]}}
+
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        prompt, loaded, missing = build_auto_load_prompt(user_config=config)
+
+    assert missing == ["missing-skill"]
+    assert loaded == []
+    assert prompt == ""
+
+
+def test_build_auto_load_prompt_empty_config():
+    """Returns empty when no auto_load skills configured."""
+    from agent.skill_commands import build_auto_load_prompt
+
+    config = {"skills": {"auto_load": []}}
+    prompt, loaded, missing = build_auto_load_prompt(user_config=config)
+
+    assert prompt == ""
+    assert loaded == []
+    assert missing == []
+
+
+# ── CLI merge with --skills ──
+
+def test_cli_merges_auto_load_with_cli_skills(monkeypatch):
+    """CLI main() displays auto_load skills alongside --skills in 'Activated skills'.
+
+    Functional injection of auto_load happens in AIAgent (new-session gated);
+    the CLI display should still reflect both sources.
+    """
+    import cli as cli_mod
+
+    created = {}
+
+    class _DummyCLI:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.session_id = "sess-001"
+            self.system_prompt = "base"
+            self.preloaded_skills = []
+            created["cli"] = self
+
+        def show_banner(self): pass
+        def show_tools(self): pass
+        def show_toolsets(self): pass
+        def run(self): pass
+
+    auto_load = ["auto-skill"]
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", lambda **kw: _DummyCLI(**kw))
+    monkeypatch.setattr(cli_mod, "CLI_CONFIG", {})
+
+    import agent.skill_commands as sc_mod
+    monkeypatch.setattr(sc_mod, "resolve_auto_load_skills", lambda config: list(auto_load))
+    monkeypatch.setattr(
+        cli_mod,
+        "build_preloaded_skills_prompt",
+        lambda skills, task_id=None: (
+            "prompt", sorted(skills), [],
+        ),
+    )
+
+    with pytest.raises(SystemExit):
+        cli_mod.main(skills="cli-skill", list_tools=True)
+
+    cli_obj = created["cli"]
+    assert "auto-skill" in cli_obj.preloaded_skills
+    assert "cli-skill" in cli_obj.preloaded_skills
+
+
+def test_cli_deduplicates_overlapping_skills(monkeypatch):
+    """When auto_load and --skills share a skill, it loads only once."""
+    import cli as cli_mod
+
+    created = {}
+
+    class _DummyCLI:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.session_id = "sess-002"
+            self.system_prompt = "base"
+            self.preloaded_skills = []
+            created["cli"] = self
+
+        def show_banner(self): pass
+        def show_tools(self): pass
+        def show_toolsets(self): pass
+        def run(self): pass
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", lambda **kw: _DummyCLI(**kw))
+    monkeypatch.setattr(cli_mod, "CLI_CONFIG", {})
+
+    import agent.skill_commands as sc_mod
+    monkeypatch.setattr(sc_mod, "resolve_auto_load_skills", lambda config: ["shared-skill"])
+    monkeypatch.setattr(
+        cli_mod,
+        "build_preloaded_skills_prompt",
+        lambda skills, task_id=None: (
+            "prompt", skills, [],
+        ),
+    )
+
+    with pytest.raises(SystemExit):
+        cli_mod.main(skills="shared-skill", list_tools=True)
+
+    cli_obj = created["cli"]
+    # shared-skill should appear only once
+    assert cli_obj.preloaded_skills.count("shared-skill") == 1
+
+
+def test_cli_does_not_error_on_missing_auto_load_skills(monkeypatch):
+    """CLI should not raise for missing auto_load skills.
+
+    Auto_load skills are injected later by AIAgent; missing ones are reported
+    as a warning by build_auto_load_prompt (covered by
+    test_build_auto_load_prompt_reports_missing_non_fatal). The CLI must only
+    validate skills it actually injects itself (--skills).
+    """
+    import cli as cli_mod
+
+    created = {}
+
+    class _DummyCLI:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.session_id = "sess-003"
+            self.system_prompt = "base"
+            self.preloaded_skills = []
+            created["cli"] = self
+
+        def show_banner(self): pass
+        def show_tools(self): pass
+        def show_toolsets(self): pass
+        def run(self): pass
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", lambda **kw: _DummyCLI(**kw))
+    monkeypatch.setattr(cli_mod, "CLI_CONFIG", {})
+
+    import agent.skill_commands as sc_mod
+    monkeypatch.setattr(sc_mod, "resolve_auto_load_skills", lambda config: ["missing-auto"])
+    # CLI should only build prompts for --skills entries, not auto_load.
+    monkeypatch.setattr(
+        cli_mod,
+        "build_preloaded_skills_prompt",
+        lambda skills, task_id=None: ("prompt", list(skills), []),
+    )
+
+    # Should NOT raise ValueError — missing auto_load is handled in AIAgent layer
+    with pytest.raises(SystemExit):
+        cli_mod.main(skills="valid-cli-skill", list_tools=True)
+
+    cli_obj = created["cli"]
+    # Both still appear in display
+    assert "missing-auto" in cli_obj.preloaded_skills
+    assert "valid-cli-skill" in cli_obj.preloaded_skills
+
+
+def test_cli_still_errors_for_missing_cli_skills(monkeypatch):
+    """Missing --skills still produce a ValueError (not auto_load)."""
+    import cli as cli_mod
+
+    class _DummyCLI:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.session_id = "sess-004"
+            self.system_prompt = "base"
+            self.preloaded_skills = []
+
+        def show_banner(self): pass
+        def show_tools(self): pass
+        def show_toolsets(self): pass
+        def run(self): pass
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", lambda **kw: _DummyCLI(**kw))
+    monkeypatch.setattr(cli_mod, "CLI_CONFIG", {})
+
+    import agent.skill_commands as sc_mod
+    monkeypatch.setattr(sc_mod, "resolve_auto_load_skills", lambda config: [])
+    monkeypatch.setattr(
+        cli_mod,
+        "build_preloaded_skills_prompt",
+        lambda skills, task_id=None: ("", [], ["missing-cli"]),
+    )
+
+    with pytest.raises(ValueError, match=r"Unknown skill\(s\): missing-cli"):
+        cli_mod.main(skills="missing-cli", list_tools=True)
+
+
+# ── AIAgent._build_system_prompt ──
+
+def test_aiagent_build_system_prompt_injects_auto_load(tmp_path):
+    """AIAgent._build_system_prompt() includes auto_load skills."""
+    from run_agent import AIAgent
+
+    # Create a real skill for auto_load
+    skill_dir = tmp_path / "buildsys-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: buildsys-skill\ndescription: Test.\n---\n\n# Buildsys\n\nContent.\n"
+    )
+
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path), \
+         patch("agent.skill_commands.resolve_auto_load_skills", return_value=["buildsys-skill"]), \
+         patch("run_agent.AIAgent._ensure_db_session"), \
+         patch("run_agent._install_safe_stdio"):
+
+        agent = AIAgent.__new__(AIAgent)
+        agent.valid_tool_names = {"skills_list", "skill_view", "skill_manage"}
+        agent.model = "test-model"
+        agent.provider = "test"
+        agent.pass_session_id = False
+        agent.skip_context_files = True  # avoid upstream context_parts init-order bug
+        agent.load_soul_identity = False
+        agent._memory_enabled = False
+        agent._user_profile_enabled = False
+        agent._memory_manager = None
+        agent._memory_store = None
+        agent.session_id = "test-session"
+        agent.platform = "cli"
+        agent._tool_use_enforcement = False
+        agent.ephemeral_system_prompt = None
+        agent._cached_system_prompt = None
+
+        prompt = agent._build_system_prompt()
+
+    assert "auto-loaded from skills.auto_load config" in prompt
+    assert "buildsys-skill" in prompt
+
+
+def test_aiagent_build_system_prompt_no_auto_load_when_empty(tmp_path):
+    """When auto_load is empty, no injection happens."""
+    from run_agent import AIAgent
+
+    with patch("agent.skill_commands.resolve_auto_load_skills", return_value=[]), \
+         patch("run_agent.AIAgent._ensure_db_session"), \
+         patch("run_agent._install_safe_stdio"):
+
+        agent = AIAgent.__new__(AIAgent)
+        agent.valid_tool_names = {"skills_list", "skill_view", "skill_manage"}
+        agent.model = "test-model"
+        agent.provider = "test"
+        agent.pass_session_id = False
+        agent.skip_context_files = True  # avoid upstream context_parts init-order bug
+        agent.load_soul_identity = False
+        agent._memory_enabled = False
+        agent._user_profile_enabled = False
+        agent._memory_manager = None
+        agent._memory_store = None
+        agent.session_id = "test-session"
+        agent.platform = "cli"
+        agent._tool_use_enforcement = False
+        agent.ephemeral_system_prompt = None
+        agent._cached_system_prompt = None
+
+        prompt = agent._build_system_prompt()
+
+    assert "auto-loaded from skills.auto_load config" not in prompt
+
+
+def test_aiagent_build_system_prompt_survives_config_errors(tmp_path):
+    """Config read errors in auto_load are non-fatal."""
+    from run_agent import AIAgent
+
+    with patch(
+        "agent.skill_commands.resolve_auto_load_skills",
+        side_effect=RuntimeError("config read failed"),
+    ), \
+         patch("run_agent.AIAgent._ensure_db_session"), \
+         patch("run_agent._install_safe_stdio"):
+
+        agent = AIAgent.__new__(AIAgent)
+        agent.valid_tool_names = {"skills_list", "skill_view", "skill_manage"}
+        agent.model = "test-model"
+        agent.provider = "test"
+        agent.pass_session_id = False
+        agent.skip_context_files = True  # avoid upstream context_parts init-order bug
+        agent.load_soul_identity = False
+        agent._memory_enabled = False
+        agent._user_profile_enabled = False
+        agent._memory_manager = None
+        agent._memory_store = None
+        agent.session_id = "test-session"
+        agent.platform = "cli"
+        agent._tool_use_enforcement = False
+        agent.ephemeral_system_prompt = None
+        agent._cached_system_prompt = None
+
+        # Should NOT raise
+        prompt = agent._build_system_prompt()
+
+    assert "auto-loaded" not in prompt

--- a/tests/agent/test_skills_auto_load.py
+++ b/tests/agent/test_skills_auto_load.py
@@ -21,6 +21,31 @@ import pytest
 
 # ── resolve_auto_load_skills ──
 
+def test_resolved_config_includes_auto_load_default(tmp_path):
+    """The canonical DEFAULT_CONFIG path exposes skills.auto_load."""
+    script = textwrap.dedent(
+        """
+        import json
+        from hermes_cli.config import load_config
+
+        print(json.dumps(load_config()["skills"]["auto_load"]))
+        """
+    )
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(tmp_path / "profile-home")
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout.strip().splitlines()[-1]) == []
+
+
 def test_resolve_auto_load_skills_reads_from_config():
     """resolve_auto_load_skills reads the auto_load list from user config."""
     from agent.skill_commands import resolve_auto_load_skills

--- a/tests/agent/test_skills_auto_load.py
+++ b/tests/agent/test_skills_auto_load.py
@@ -8,6 +8,12 @@ Tests cover:
 - AIAgent._build_system_prompt injects auto_load
 """
 
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -47,10 +53,11 @@ def test_resolve_auto_load_skills_missing_key():
 
 
 def test_resolve_auto_load_skills_no_config():
-    """Returns empty list when config is None."""
+    """Loads the active config and returns empty when auto_load is absent."""
     from agent.skill_commands import resolve_auto_load_skills
 
-    result = resolve_auto_load_skills(None)
+    with patch("hermes_cli.config.load_config", return_value={}):
+        result = resolve_auto_load_skills(None)
     assert result == []
 
 
@@ -192,11 +199,15 @@ def test_cli_merges_auto_load_with_cli_skills(monkeypatch):
     monkeypatch.setattr(cli_mod, "CLI_CONFIG", {})
 
     import agent.skill_commands as sc_mod
-    monkeypatch.setattr(sc_mod, "resolve_auto_load_skills", lambda config: list(auto_load))
+    monkeypatch.setattr(
+        sc_mod,
+        "build_auto_load_prompt",
+        lambda **kwargs: ("auto prompt", list(auto_load), []),
+    )
     monkeypatch.setattr(
         cli_mod,
         "build_preloaded_skills_prompt",
-        lambda skills, task_id=None: (
+        lambda skills, task_id=None, excluded_loaded_names=None: (
             "prompt", sorted(skills), [],
         ),
     )
@@ -232,12 +243,16 @@ def test_cli_deduplicates_overlapping_skills(monkeypatch):
     monkeypatch.setattr(cli_mod, "CLI_CONFIG", {})
 
     import agent.skill_commands as sc_mod
-    monkeypatch.setattr(sc_mod, "resolve_auto_load_skills", lambda config: ["shared-skill"])
+    monkeypatch.setattr(
+        sc_mod,
+        "build_auto_load_prompt",
+        lambda **kwargs: ("auto prompt", ["shared-skill"], []),
+    )
     monkeypatch.setattr(
         cli_mod,
         "build_preloaded_skills_prompt",
-        lambda skills, task_id=None: (
-            "prompt", skills, [],
+        lambda skills, task_id=None, excluded_loaded_names=None: (
+            "", [], [],
         ),
     )
 
@@ -278,12 +293,18 @@ def test_cli_does_not_error_on_missing_auto_load_skills(monkeypatch):
     monkeypatch.setattr(cli_mod, "CLI_CONFIG", {})
 
     import agent.skill_commands as sc_mod
-    monkeypatch.setattr(sc_mod, "resolve_auto_load_skills", lambda config: ["missing-auto"])
+    monkeypatch.setattr(
+        sc_mod,
+        "build_auto_load_prompt",
+        lambda **kwargs: ("", [], ["valid-cli-skill"]),
+    )
     # CLI should only build prompts for --skills entries, not auto_load.
     monkeypatch.setattr(
         cli_mod,
         "build_preloaded_skills_prompt",
-        lambda skills, task_id=None: ("prompt", list(skills), []),
+        lambda skills, task_id=None, excluded_loaded_names=None: (
+            "prompt", list(skills), []
+        ),
     )
 
     # Should NOT raise ValueError — missing auto_load is handled in AIAgent layer
@@ -291,8 +312,7 @@ def test_cli_does_not_error_on_missing_auto_load_skills(monkeypatch):
         cli_mod.main(skills="valid-cli-skill", list_tools=True)
 
     cli_obj = created["cli"]
-    # Both still appear in display
-    assert "missing-auto" in cli_obj.preloaded_skills
+    # Only successfully loaded canonical names appear in the display.
     assert "valid-cli-skill" in cli_obj.preloaded_skills
 
 
@@ -316,11 +336,15 @@ def test_cli_still_errors_for_missing_cli_skills(monkeypatch):
     monkeypatch.setattr(cli_mod, "CLI_CONFIG", {})
 
     import agent.skill_commands as sc_mod
-    monkeypatch.setattr(sc_mod, "resolve_auto_load_skills", lambda config: [])
+    monkeypatch.setattr(
+        sc_mod, "build_auto_load_prompt", lambda **kwargs: ("", [], [])
+    )
     monkeypatch.setattr(
         cli_mod,
         "build_preloaded_skills_prompt",
-        lambda skills, task_id=None: ("", [], ["missing-cli"]),
+        lambda skills, task_id=None, excluded_loaded_names=None: (
+            "", [], ["missing-cli"]
+        ),
     )
 
     with pytest.raises(ValueError, match=r"Unknown skill\(s\): missing-cli"):
@@ -430,3 +454,194 @@ def test_aiagent_build_system_prompt_survives_config_errors(tmp_path):
         prompt = agent._build_system_prompt()
 
     assert "auto-loaded" not in prompt
+
+
+def test_auto_load_disabled_skill_is_reported_not_loaded(tmp_path, monkeypatch):
+    """Disabled auto-load entries use the same gate as explicit preloads."""
+    from agent.skill_commands import build_auto_load_prompt
+    import agent.skill_utils as skill_utils
+
+    skill_dir = tmp_path / "disabled-auto"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: disabled-auto\ndescription: Disabled.\n---\n\nSECRET BODY\n"
+    )
+    monkeypatch.setattr(
+        skill_utils, "get_disabled_skill_names", lambda platform=None: {"disabled-auto"}
+    )
+
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        prompt, loaded, missing = build_auto_load_prompt(
+            user_config={"skills": {"auto_load": ["disabled-auto"]}}
+        )
+
+    assert (prompt, loaded, missing) == ("", [], ["disabled-auto"])
+
+
+def test_auto_load_deduplicates_successful_canonical_names(monkeypatch):
+    """Different lookup forms resolving to one skill produce one prompt block."""
+    from pathlib import Path
+    import agent.skill_commands as skill_commands
+    import agent.skill_utils as skill_utils
+
+    payload = {"success": True, "name": "canonical", "content": "BODY"}
+    monkeypatch.setattr(
+        skill_commands,
+        "_load_skill_payload",
+        lambda identifier, task_id=None: (payload, Path("/tmp/canonical"), "canonical"),
+    )
+    monkeypatch.setattr(
+        skill_utils, "get_disabled_skill_names", lambda platform=None: set()
+    )
+
+    prompt, loaded, missing = skill_commands.build_auto_load_prompt(
+        user_config={"skills": {"auto_load": ["alias", "/absolute/alias"]}}
+    )
+
+    assert loaded == ["canonical"]
+    assert missing == []
+    assert prompt.count('The "canonical" skill is auto-loaded') == 1
+
+
+def test_real_profile_config_and_shared_prompt_are_lifecycle_stable(tmp_path):
+    """Exercise canonical config + skill I/O through the gateway/TUI prompt path.
+
+    A subprocess gives imports a genuinely isolated HERMES_HOME, avoiding module
+    constant/config-cache monkeypatches that previously hid the broken loader.
+    """
+    script = textwrap.dedent(
+        r"""
+        import json
+        import os
+        from pathlib import Path
+        from run_agent import AIAgent
+
+        home = Path(os.environ["HERMES_HOME"])
+        skills = home / "skills"
+        skills.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text("skills:\n  auto_load:\n    - stable-skill\n")
+        skill_dir = skills / "stable-skill"
+        skill_dir.mkdir()
+        skill_file = skill_dir / "SKILL.md"
+        skill_file.write_text(
+            "---\nname: stable-skill\ndescription: Stable.\n---\n\nORIGINAL SKILL BYTES\n"
+        )
+
+        def make_agent(platform):
+            agent = AIAgent.__new__(AIAgent)
+            agent.valid_tool_names = {"skills_list", "skill_view", "skill_manage"}
+            agent.model = "before-model"
+            agent.provider = "test"
+            agent.pass_session_id = False
+            agent.skip_context_files = True
+            agent.load_soul_identity = False
+            agent._memory_enabled = False
+            agent._user_profile_enabled = False
+            agent._memory_manager = None
+            agent._memory_store = None
+            agent.session_id = "shared-" + platform
+            agent.platform = platform
+            agent._tool_use_enforcement = False
+            agent.ephemeral_system_prompt = None
+            agent._cached_system_prompt = None
+            agent._auto_load_skills_resolved = False
+            agent._auto_load_skills_result = ("", [], [])
+            return agent
+
+        outputs = {}
+        for platform in ("telegram", "tui"):
+            agent = make_agent(platform)
+            first = agent._build_system_prompt()
+            outputs[platform] = {
+                "loaded": agent._auto_load_skills_result[1],
+                "has_original": "ORIGINAL SKILL BYTES" in first,
+            }
+            if platform == "telegram":
+                # Simulate both file/config mutation and model-switch cache
+                # invalidation. Rebuild must retain the first resolved bytes.
+                cached_auto_prompt = agent._auto_load_skills_result[0]
+                skill_file.write_text(
+                    "---\nname: stable-skill\ndescription: Stable.\n---\n\nMUTATED BYTES\n"
+                )
+                (home / "config.yaml").write_text("skills:\n  auto_load: []\n")
+                agent.model = "after-model"
+                agent._cached_system_prompt = None
+                rebuilt = agent._build_system_prompt()
+                outputs[platform].update({
+                    "stable": (
+                        agent._auto_load_skills_result[0] == cached_auto_prompt
+                        and "ORIGINAL SKILL BYTES" in rebuilt
+                        and "MUTATED BYTES" not in rebuilt
+                    ),
+                    "resolved": agent._auto_load_skills_resolved,
+                })
+                # Restore disk for the separate TUI agent, proving each agent
+                # resolves independently through the same shared path.
+                (home / "config.yaml").write_text(
+                    "skills:\n  auto_load:\n    - stable-skill\n"
+                )
+                skill_file.write_text(
+                    "---\nname: stable-skill\ndescription: Stable.\n---\n\nORIGINAL SKILL BYTES\n"
+                )
+
+        print(json.dumps(outputs))
+        """
+    )
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(tmp_path / "profile-home")
+    env.pop("HERMES_IGNORE_RULES", None)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout.strip().splitlines()[-1])
+
+    assert data["telegram"] == {
+        "loaded": ["stable-skill"],
+        "has_original": True,
+        "stable": True,
+        "resolved": True,
+    }
+    assert data["tui"] == {
+        "loaded": ["stable-skill"],
+        "has_original": True,
+    }
+
+
+def test_ignore_rules_is_stable_for_agent_lifetime(monkeypatch):
+    """Ignoring rules resolves to an empty immutable lifecycle result."""
+    from run_agent import AIAgent
+
+    agent = AIAgent.__new__(AIAgent)
+    agent._auto_load_skills_resolved = False
+    agent._auto_load_skills_result = ("", [], [])
+    agent.valid_tool_names = set()
+    agent.model = "test"
+    agent.provider = "test"
+    agent.pass_session_id = False
+    agent.skip_context_files = True
+    agent.load_soul_identity = False
+    agent._memory_enabled = False
+    agent._user_profile_enabled = False
+    agent._memory_manager = None
+    agent._memory_store = None
+    agent.session_id = "ignore-rules"
+    agent.platform = "gateway"
+    agent._tool_use_enforcement = False
+    agent.ephemeral_system_prompt = None
+    agent._cached_system_prompt = None
+    monkeypatch.setenv("HERMES_IGNORE_RULES", "1")
+
+    first = agent._build_system_prompt()
+    monkeypatch.delenv("HERMES_IGNORE_RULES")
+    agent._cached_system_prompt = None
+    rebuilt = agent._build_system_prompt()
+
+    assert agent._auto_load_skills_resolved is True
+    assert agent._auto_load_skills_result == ("", [], [])
+    assert rebuilt == first

--- a/tests/agent/test_skills_auto_load.py
+++ b/tests/agent/test_skills_auto_load.py
@@ -111,7 +111,7 @@ def test_build_auto_load_prompt_loads_skills(tmp_path):
     assert missing == []
     assert loaded == ["test-auto"]
     assert "test-auto" in prompt
-    assert "auto-loaded from skills.auto_load config" in prompt
+    assert "auto-loaded via config (skills.auto_load)" in prompt
 
 
 def test_build_auto_load_prompt_activation_note_not_cli_specific(tmp_path):
@@ -132,7 +132,7 @@ def test_build_auto_load_prompt_activation_note_not_cli_specific(tmp_path):
     # Must NOT contain the CLI-specific phrase
     assert "launched this CLI session" not in prompt
     # Must contain the auto_load-specific phrase
-    assert "auto-loaded from skills.auto_load config" in prompt
+    assert "auto-loaded via config (skills.auto_load)" in prompt
 
 
 def test_build_auto_load_prompt_reports_missing_non_fatal(tmp_path):
@@ -343,7 +343,7 @@ def test_aiagent_build_system_prompt_injects_auto_load(tmp_path):
     with patch("tools.skills_tool.SKILLS_DIR", tmp_path), \
          patch("agent.skill_commands.resolve_auto_load_skills", return_value=["buildsys-skill"]), \
          patch("run_agent.AIAgent._ensure_db_session"), \
-         patch("run_agent._install_safe_stdio"):
+         patch("agent.process_bootstrap._install_safe_stdio"):
 
         agent = AIAgent.__new__(AIAgent)
         agent.valid_tool_names = {"skills_list", "skill_view", "skill_manage"}
@@ -364,7 +364,7 @@ def test_aiagent_build_system_prompt_injects_auto_load(tmp_path):
 
         prompt = agent._build_system_prompt()
 
-    assert "auto-loaded from skills.auto_load config" in prompt
+    assert "auto-loaded via config (skills.auto_load)" in prompt
     assert "buildsys-skill" in prompt
 
 
@@ -374,7 +374,7 @@ def test_aiagent_build_system_prompt_no_auto_load_when_empty(tmp_path):
 
     with patch("agent.skill_commands.resolve_auto_load_skills", return_value=[]), \
          patch("run_agent.AIAgent._ensure_db_session"), \
-         patch("run_agent._install_safe_stdio"):
+         patch("agent.process_bootstrap._install_safe_stdio"):
 
         agent = AIAgent.__new__(AIAgent)
         agent.valid_tool_names = {"skills_list", "skill_view", "skill_manage"}
@@ -395,7 +395,7 @@ def test_aiagent_build_system_prompt_no_auto_load_when_empty(tmp_path):
 
         prompt = agent._build_system_prompt()
 
-    assert "auto-loaded from skills.auto_load config" not in prompt
+    assert "auto-loaded via config (skills.auto_load)" not in prompt
 
 
 def test_aiagent_build_system_prompt_survives_config_errors(tmp_path):
@@ -407,7 +407,7 @@ def test_aiagent_build_system_prompt_survives_config_errors(tmp_path):
         side_effect=RuntimeError("config read failed"),
     ), \
          patch("run_agent.AIAgent._ensure_db_session"), \
-         patch("run_agent._install_safe_stdio"):
+         patch("agent.process_bootstrap._install_safe_stdio"):
 
         agent = AIAgent.__new__(AIAgent)
         agent.valid_tool_names = {"skills_list", "skill_view", "skill_manage"}

--- a/tests/agent/test_skills_auto_load.py
+++ b/tests/agent/test_skills_auto_load.py
@@ -121,6 +121,30 @@ def test_build_auto_load_prompt_loads_skills(tmp_path):
     assert "auto-loaded via config (skills.auto_load)" in prompt
 
 
+def test_build_auto_load_prompt_substitutes_session_id(tmp_path):
+    from agent.skill_commands import build_auto_load_prompt
+
+    skill_dir = tmp_path / "session-aware"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: session-aware\ndescription: Test.\n---\n\n"
+        "Session: ${HERMES_SESSION_ID}\n",
+        encoding="utf-8",
+    )
+    config = {"skills": {"auto_load": ["session-aware"]}}
+
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        prompt, loaded, missing = build_auto_load_prompt(
+            task_id="sess-real-123",
+            user_config=config,
+        )
+
+    assert loaded == ["session-aware"]
+    assert missing == []
+    assert "sess-real-123" in prompt
+    assert "${HERMES_SESSION_ID}" not in prompt
+
+
 def test_build_auto_load_prompt_activation_note_not_cli_specific(tmp_path):
     """The activation note is origin-agnostic, not CLI-specific."""
     from agent.skill_commands import build_auto_load_prompt
@@ -168,6 +192,28 @@ def test_build_auto_load_prompt_empty_config():
     assert missing == []
 
 
+def test_preloaded_overlap_counts_as_successful_resolution(tmp_path):
+    """An already auto-loaded canonical skill is resolved but not injected twice."""
+    from agent.skill_commands import build_preloaded_skills_prompt
+
+    loaded_payload = ({"content": "skill body"}, tmp_path, "shared-skill")
+    with (
+        patch(
+            "agent.skill_commands._load_skill_payload",
+            side_effect=[loaded_payload, None],
+        ),
+        patch("agent.skill_utils.get_disabled_skill_names", return_value=set()),
+    ):
+        prompt, loaded, missing = build_preloaded_skills_prompt(
+            ["shared-alias", "typo"],
+            excluded_loaded_names={"shared-skill"},
+        )
+
+    assert prompt == ""
+    assert loaded == ["shared-skill"]
+    assert missing == ["typo"]
+
+
 # ── CLI merge with --skills ──
 
 def test_cli_merges_auto_load_with_cli_skills(monkeypatch):
@@ -194,6 +240,11 @@ def test_cli_merges_auto_load_with_cli_skills(monkeypatch):
         def run(self): pass
 
     auto_load = ["auto-skill"]
+    auto_calls = []
+
+    def fake_auto_load(**kwargs):
+        auto_calls.append(kwargs)
+        return "auto prompt", list(auto_load), []
 
     monkeypatch.setattr(cli_mod, "HermesCLI", lambda **kw: _DummyCLI(**kw))
     monkeypatch.setattr(cli_mod, "CLI_CONFIG", {})
@@ -202,7 +253,7 @@ def test_cli_merges_auto_load_with_cli_skills(monkeypatch):
     monkeypatch.setattr(
         sc_mod,
         "build_auto_load_prompt",
-        lambda **kwargs: ("auto prompt", list(auto_load), []),
+        fake_auto_load,
     )
     monkeypatch.setattr(
         cli_mod,
@@ -218,6 +269,7 @@ def test_cli_merges_auto_load_with_cli_skills(monkeypatch):
     cli_obj = created["cli"]
     assert "auto-skill" in cli_obj.preloaded_skills
     assert "cli-skill" in cli_obj.preloaded_skills
+    assert auto_calls == [{"task_id": "sess-001", "user_config": {}}]
 
 
 def test_cli_deduplicates_overlapping_skills(monkeypatch):
@@ -252,12 +304,12 @@ def test_cli_deduplicates_overlapping_skills(monkeypatch):
         cli_mod,
         "build_preloaded_skills_prompt",
         lambda skills, task_id=None, excluded_loaded_names=None: (
-            "", [], [],
+            "", ["shared-skill"], ["typo"],
         ),
     )
 
     with pytest.raises(SystemExit):
-        cli_mod.main(skills="shared-skill", list_tools=True)
+        cli_mod.main(skills="shared-skill,typo", list_tools=True)
 
     cli_obj = created["cli"]
     # shared-skill should appear only once

--- a/tests/cli/test_cli_preloaded_skills.py
+++ b/tests/cli/test_cli_preloaded_skills.py
@@ -81,7 +81,11 @@ def test_main_applies_preloaded_skills_to_system_prompt(monkeypatch):
     monkeypatch.setattr(
         cli_mod,
         "build_preloaded_skills_prompt",
-        lambda skills, task_id=None: ("skill prompt", ["hermes-agent-dev", "github-auth"], []),
+        lambda skills, task_id=None, excluded_loaded_names=None: (
+            "skill prompt",
+            ["hermes-agent-dev", "github-auth"],
+            [],
+        ),
     )
 
     with pytest.raises(SystemExit):
@@ -99,7 +103,9 @@ def test_main_raises_for_unknown_preloaded_skill(monkeypatch):
     monkeypatch.setattr(
         cli_mod,
         "build_preloaded_skills_prompt",
-        lambda skills, task_id=None: ("", [], ["missing-skill"]),
+        lambda skills, task_id=None, excluded_loaded_names=None: (
+            "", [], ["missing-skill"]
+        ),
     )
 
     with pytest.raises(ValueError, match=r"Unknown skill\(s\): missing-skill"):

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -190,7 +190,16 @@ skills:
 
 Each entry is a skill name or glob pattern. At session build time Hermes resolves the list, deduplicates it against the session's existing skill set, and injects each matching skill as a fully-loaded skill message in the system prompt. This is the persistent equivalent of the `-s` launch flag, useful for workflows where you always need the same context.
 
-Auto-load respects `HERMES_IGNORE_RULES`: when that env var is set, auto-load injection is skipped (same as other skill/rules processing). The setting is **profile-scoped**. Each profile's `config.yaml` controls its own auto-load list, so you can have different preloaded skills per profile.
+Auto-load injection can be skipped for a troubleshooting run with the `--ignore-rules` flag:
+
+```bash
+hermes chat --ignore-rules
+hermes chat -s my-skill --ignore-rules   # explicit -s still loads, but auto-load is skipped
+```
+
+`--ignore-rules` disables auto-injection of AGENTS.md, SOUL.md, .cursorrules, memory, and preloaded (auto-load) skills. It works by setting the `HERMES_IGNORE_RULES` environment variable to `1`, so setting that variable directly has the same effect without a flag. For a fully isolated run, combine it with `--ignore-user-config`, or use `--safe-mode` which implies both.
+
+The `skills.auto_load` setting is **profile-scoped**. Each profile's `config.yaml` controls its own auto-load list, so you can have different preloaded skills per profile. Because `--ignore-rules` acts at the session level, it overrides auto-load for any profile when present.
 
 ## Skill Slash Commands
 

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -177,6 +177,21 @@ hermes chat -s github-pr-workflow -s github-auth
 
 Hermes loads each named skill into the session prompt before the first turn. The same flag works in interactive mode and single-query mode.
 
+### Persistent auto-load via config
+
+If you want the same set of skills loaded automatically at the start of **every** new session, set `skills.auto_load` in `config.yaml`:
+
+```yaml
+skills:
+  auto_load:
+    - hermes-agent-dev
+    - github-pr-workflow
+```
+
+Each entry is a skill name or glob pattern. At session build time Hermes resolves the list, deduplicates it against the session's existing skill set, and injects each matching skill as a fully-loaded skill message in the system prompt. This is the persistent equivalent of the `-s` launch flag, useful for workflows where you always need the same context.
+
+Auto-load respects `HERMES_IGNORE_RULES`: when that env var is set, auto-load injection is skipped (same as other skill/rules processing). The setting is **profile-scoped**. Each profile's `config.yaml` controls its own auto-load list, so you can have different preloaded skills per profile.
+
 ## Skill Slash Commands
 
 Every installed skill in `~/.hermes/skills/` is automatically registered as a slash command. The skill name becomes the command:


### PR DESCRIPTION
## Summary

Builds on #26840 by adding native, profile-aware `skills.auto_load` support to the shared Hermes system-prompt path while preserving the original contributor's authorship.

```yaml
skills:
  auto_load:
    - hermes-agent
    - github-auth
```

## Behaviour

- Reads configuration through the canonical profile-aware `hermes_cli.config.load_config` path.
- Resolves auto-load templates after the real CLI session ID exists, so `${HERMES_SESSION_ID}` is populated correctly.
- Reuses exact rendered prompt bytes after prompt-cache invalidation or model switches within the session lifecycle.
- Uses the shared system-prompt path used by CLI, TUI and gateway agents.
- Preserves `HERMES_IGNORE_RULES` and `--ignore-rules` semantics.
- Deduplicates explicit `--skills` only after an auto skill resolves successfully and by canonical loaded identity.
- An explicitly requested skill already present through auto-load counts as resolved but is not injected twice.
- Missing or disabled auto skills cannot suppress an explicitly requested skill.
- Missing or disabled auto skills warn without preventing startup.

## Authorship

The branch preserves ArcherQAQ's original feature commit as authored by ArcherQAQ, followed by Carl's integration and hardening commits.

## Tests

- 194 prompt-cache, system-prompt, skill-command, banner and CLI preload tests passed against current main.
- Includes real temporary-profile integration coverage, session-ID substitution, missing/disabled/overlap cases, canonical deduplication, cache invalidation and model-switch stability.
- Ruff passed on all touched implementation and test files.
- `git diff --check` passed.
