### PR TITLE
fix(agent): reuse default container in backend probe instead of spawning a second redundant one

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1071,7 +1071,7 @@ def _probe_remote_backend(env_type: str) -> str | None:
             timeout=config.get("timeout", 180),
             ssh_config=ssh_config,
             container_config=container_config,
-            task_id="prompt-backend-probe",
+            task_id="default",
             host_cwd=config.get("host_cwd"),
         )
         # Single-line POSIX probe — works on any Unixy backend. Wrapped in


### PR DESCRIPTION
## Fix for #74053

### Problem
`_probe_remote_backend()` in `agent/prompt_builder.py` provisions a **second, redundant container** labeled `hermes-task-id=prompt-backend-probe` that runs alongside, and is never reused by, the agent's real work container (labeled `hermes-task-id=default`). This defeats the documented "ONE long-lived container shared across sessions" contract and silently doubles the running-container footprint on container backends (Docker, Singularity, Modal, Daytona).

### Root Cause
The probe used `task_id="prompt-backend-probe"` when calling `_create_environment()`, while the real terminal tool uses `task_id="default"` (the parameter default). When `docker_persist_across_processes: true` (default), `DockerEnvironment._find_reusable_container()` matches on labels — but the probe's container had the wrong label, so the real terminal tool never found it.

### Fix
Change the `task_id` from `"prompt-backend-probe"` to `"default"`. This means:
- If a "default" persistent container already exists (from a prior terminal call), the probe reuses it — no new container.
- If no container exists yet, the probe creates one with the correct `hermes-task-id=default` label, which the terminal tool will find and reuse via the existing `_find_reusable_container()` logic.

### Testing
- `test_prompt_builder.py`: 167 passed
- `test_docker_environment.py`: 76 passed