### PR TITLE
fix(state): inherit owner (user_id) on delegate/subagent children

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4057,12 +4057,17 @@ class SessionDB:
         (#64709), or lose its owning profile and be aggregated as "default" every
         time it rotated or branched (the cross-profile session-jump bug). This
         only fills NULLs — an explicit value on the child is never overwritten.
+        ``user_id`` (owner attribution) is inherited for EVERY lineage kind,
+        including delegate/subagent children, so delegated work is attributable
+        to whoever spawned it (#24321).
         For compression forks specifically
         (parent ended with ``end_reason='compression'``), the gateway origin
-        columns (``user_id``/``session_key``/``chat_id``/``chat_type``/
+        columns (``session_key``/``chat_id``/``chat_type``/
         ``thread_id``/``display_name``/``origin_json``) are inherited too, so a
         crash before the gateway re-records the peer can't strand the child
-        without a recoverable routing mapping (#59527).
+        without a recoverable routing mapping (#59527). Those stay fork-only
+        because they are routing keys — a live-parent child must never inherit
+        them or peer recovery could repoint gateway traffic into a subagent.
         """
         def _do(conn):
             conn.execute(
@@ -4120,6 +4125,28 @@ class SessionDB:
                      WHERE id = ? AND parent_session_id IS NOT NULL""",
                     (session_id,),
                 )
+                # Owner attribution (``user_id``) inherits from the parent for
+                # EVERY lineage kind — compression forks, branches, and
+                # delegate/subagent children alike. It records *whose* work a row
+                # represents, and a delegate child is doing its spawner's work.
+                # Leaving it NULL is why sub-agent rows land unattributed in
+                # ``state.db`` (issue #24321): ``tools/delegate_tool.py``
+                # constructs children without ``user_id``, so propagating the
+                # value at the AIAgent constructor cannot reach them — the
+                # parent row is the only place the owner is known. ``user_id`` is
+                # NOT a routing key: peer recovery
+                # (``find_latest_gateway_session_for_peer``) keys off
+                # ``session_key`` and returns early without it, so inheriting the
+                # owner cannot repoint gateway traffic. The routing columns below
+                # stay gated to compression forks.
+                conn.execute(
+                    """UPDATE sessions
+                       SET user_id = COALESCE(sessions.user_id,
+                                     (SELECT p.user_id FROM sessions p
+                                       WHERE p.id = sessions.parent_session_id))
+                     WHERE id = ? AND parent_session_id IS NOT NULL""",
+                    (session_id,),
+                )
                 # Belt-and-suspenders for gateway routing metadata (#59527):
                 # the gateway re-records the peer on the child after rotation
                 # (d5b4879d4), but a hard crash between child creation and that
@@ -4130,13 +4157,11 @@ class SessionDB:
                 # with end_reason='compression'). Delegate/subagent children
                 # are spawned while the parent is still live and must NOT
                 # inherit routing keys, or peer recovery could repoint gateway
-                # traffic into a subagent's session.
+                # traffic into a subagent's session. (``user_id`` is handled
+                # above for all lineage kinds — it is attribution, not routing.)
                 conn.execute(
                     """UPDATE sessions
-                       SET user_id = COALESCE(sessions.user_id,
-                                     (SELECT p.user_id FROM sessions p
-                                       WHERE p.id = sessions.parent_session_id)),
-                           session_key = COALESCE(sessions.session_key,
+                       SET session_key = COALESCE(sessions.session_key,
                                          (SELECT p.session_key FROM sessions p
                                            WHERE p.id = sessions.parent_session_id)),
                            chat_id = COALESCE(sessions.chat_id,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4566,12 +4566,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         (#64709), or lose its owning profile and be aggregated as "default" every
         time it rotated or branched (the cross-profile session-jump bug). This
         only fills NULLs — an explicit value on the child is never overwritten.
+        ``user_id`` (owner attribution) is inherited for EVERY lineage kind,
+        including delegate/subagent children, so delegated work is attributable
+        to whoever spawned it (#24321).
         For compression forks specifically
         (parent ended with ``end_reason='compression'``), the gateway origin
-        columns (``user_id``/``session_key``/``chat_id``/``chat_type``/
+        columns (``session_key``/``chat_id``/``chat_type``/
         ``thread_id``/``display_name``/``origin_json``) are inherited too, so a
         crash before the gateway re-records the peer can't strand the child
-        without a recoverable routing mapping (#59527).
+        without a recoverable routing mapping (#59527). Those stay fork-only
+        because they are routing keys — a live-parent child must never inherit
+        them or peer recovery could repoint gateway traffic into a subagent.
         """
         def _do(conn):
             system_prompt_hash = self._store_system_prompt(conn, system_prompt)
@@ -4664,6 +4669,28 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                      WHERE id = ? AND parent_session_id IS NOT NULL""",
                     (session_id,),
                 )
+                # Owner attribution (``user_id``) inherits from the parent for
+                # EVERY lineage kind — compression forks, branches, and
+                # delegate/subagent children alike. It records *whose* work a row
+                # represents, and a delegate child is doing its spawner's work.
+                # Leaving it NULL is why sub-agent rows land unattributed in
+                # ``state.db`` (issue #24321): ``tools/delegate_tool.py``
+                # constructs children without ``user_id``, so propagating the
+                # value at the AIAgent constructor cannot reach them — the
+                # parent row is the only place the owner is known. ``user_id`` is
+                # NOT a routing key: peer recovery
+                # (``find_latest_gateway_session_for_peer``) keys off
+                # ``session_key`` and returns early without it, so inheriting the
+                # owner cannot repoint gateway traffic. The routing columns below
+                # stay gated to compression forks.
+                conn.execute(
+                    """UPDATE sessions
+                       SET user_id = COALESCE(sessions.user_id,
+                                     (SELECT p.user_id FROM sessions p
+                                       WHERE p.id = sessions.parent_session_id))
+                     WHERE id = ? AND parent_session_id IS NOT NULL""",
+                    (session_id,),
+                )
                 # Belt-and-suspenders for gateway routing metadata (#59527):
                 # the gateway re-records the peer on the child after rotation
                 # (d5b4879d4), but a hard crash between child creation and that
@@ -4674,13 +4701,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # with end_reason='compression'). Delegate/subagent children
                 # are spawned while the parent is still live and must NOT
                 # inherit routing keys, or peer recovery could repoint gateway
-                # traffic into a subagent's session.
+                # traffic into a subagent's session. (``user_id`` is handled
+                # above for all lineage kinds — it is attribution, not routing.)
                 conn.execute(
                     """UPDATE sessions
-                       SET user_id = COALESCE(sessions.user_id,
-                                     (SELECT p.user_id FROM sessions p
-                                       WHERE p.id = sessions.parent_session_id)),
-                           session_key = COALESCE(sessions.session_key,
+                       SET session_key = COALESCE(sessions.session_key,
                                          (SELECT p.session_key FROM sessions p
                                            WHERE p.id = sessions.parent_session_id)),
                            chat_id = COALESCE(sessions.chat_id,

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -263,10 +263,11 @@ class TestSessionLifecycle:
         assert child["display_name"] == "Chat One"
         assert child["origin_json"] == '{"p":"telegram"}'
 
-    def test_live_parent_child_does_not_inherit_gateway_origin(self, db):
+    def test_live_parent_child_does_not_inherit_gateway_routing_keys(self, db):
         """Delegate/subagent children (parent still live) must NOT inherit
         routing keys — peer recovery could otherwise repoint gateway traffic
-        into a subagent's session."""
+        into a subagent's session. ``user_id`` is exempt: it is owner
+        attribution, not a routing key (see the owner test below)."""
         db.create_session(
             session_id="parent", source="telegram",
             user_id="u1", session_key="telegram:u1:c1",
@@ -280,13 +281,73 @@ class TestSessionLifecycle:
         sub = db.get_session("sub")
         assert sub["session_key"] is None
         assert sub["chat_id"] is None
-        assert sub["user_id"] is None
+        assert sub["chat_type"] is None
+        assert sub["thread_id"] is None
+        assert sub["display_name"] is None
+        assert sub["origin_json"] is None
         # Workspace metadata still inherits — that part is safe for any child.
         db.update_session_cwd("parent", "/work/repo", git_repo_root="/work/repo")
         db.create_session(
             session_id="sub2", source="telegram", parent_session_id="parent"
         )
         assert db.get_session("sub2")["cwd"] == "/work/repo"
+
+    def test_live_parent_child_inherits_owner(self, db):
+        """A delegate/subagent child inherits ``user_id`` from its live parent.
+
+        Owner attribution answers "whose work is this", and a subagent is doing
+        its spawner's work. ``tools/delegate_tool.py`` constructs children
+        without ``user_id``, so the parent row is the only place the owner is
+        known — without this, delegated sessions are unattributable and can only
+        be reached by walking ``parent_session_id`` (#24321).
+        """
+        db.create_session(
+            session_id="parent", source="acp", user_id="dev@example.com"
+        )
+        db.create_session(
+            session_id="sub", source="subagent", parent_session_id="parent"
+        )
+
+        assert db.get_session("sub")["user_id"] == "dev@example.com"
+        # Owner inheritance must not drag routing keys along with it.
+        assert db.get_session("sub")["session_key"] is None
+
+    def test_child_owner_inheritance_is_null_fill_only(self, db):
+        """An explicitly-owned child keeps its own owner; the parent's value
+        never overwrites it (COALESCE semantics)."""
+        db.create_session(
+            session_id="parent", source="acp", user_id="spawner@example.com"
+        )
+        db.create_session(
+            session_id="sub", source="subagent", parent_session_id="parent",
+            user_id="explicit@example.com",
+        )
+
+        assert db.get_session("sub")["user_id"] == "explicit@example.com"
+
+    def test_multi_generation_lineage_inherits_owner(self, db):
+        """Owner propagates down a chain of live-parent children."""
+        db.create_session(
+            session_id="root", source="acp", user_id="dev@example.com"
+        )
+        db.create_session(
+            session_id="gen1", source="subagent", parent_session_id="root"
+        )
+        db.create_session(
+            session_id="gen2", source="subagent", parent_session_id="gen1"
+        )
+
+        assert db.get_session("gen1")["user_id"] == "dev@example.com"
+        assert db.get_session("gen2")["user_id"] == "dev@example.com"
+
+    def test_untagged_parent_leaves_child_owner_null(self, db):
+        """A child of an unowned parent (CLI/cron delegation) stays untagged."""
+        db.create_session(session_id="parent", source="cli")
+        db.create_session(
+            session_id="sub", source="subagent", parent_session_id="parent"
+        )
+
+        assert db.get_session("sub")["user_id"] is None
 
     def test_update_session_cwd_empty_branch_does_not_clobber(self, db):
         """A failed branch probe (empty string) must not wipe a branch we

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -346,6 +346,82 @@ class TestSessionLifecycle:
         assert session["cwd"] == "/work/repo"
         assert session["git_branch"] == "pets-feature"
 
+    def test_live_parent_child_does_not_inherit_gateway_routing_keys(self, db):
+        """Owner inheritance must not copy gateway routing metadata."""
+        db.create_session(
+            session_id="parent",
+            source="telegram",
+            user_id="u1",
+            session_key="telegram:u1:c1",
+            chat_id="c1",
+            chat_type="private",
+            thread_id="t1",
+            display_name="Chat One",
+            origin_json='{"p":"telegram"}',
+        )
+
+        db.create_session(
+            session_id="sub", source="subagent", parent_session_id="parent"
+        )
+
+        sub = db.get_session("sub")
+        assert sub["session_key"] is None
+        assert sub["chat_id"] is None
+        assert sub["chat_type"] is None
+        assert sub["thread_id"] is None
+        assert sub["display_name"] is None
+        assert sub["origin_json"] is None
+
+    def test_live_parent_child_inherits_owner(self, db):
+        """A delegate/subagent child inherits ``user_id`` from its live parent."""
+        db.create_session(
+            session_id="parent", source="acp", user_id="dev@example.com"
+        )
+        db.create_session(
+            session_id="sub", source="subagent", parent_session_id="parent"
+        )
+
+        assert db.get_session("sub")["user_id"] == "dev@example.com"
+        assert db.get_session("sub")["session_key"] is None
+
+    def test_child_owner_inheritance_is_null_fill_only(self, db):
+        """An explicitly-owned child keeps its own owner."""
+        db.create_session(
+            session_id="parent", source="acp", user_id="spawner@example.com"
+        )
+        db.create_session(
+            session_id="sub",
+            source="subagent",
+            parent_session_id="parent",
+            user_id="explicit@example.com",
+        )
+
+        assert db.get_session("sub")["user_id"] == "explicit@example.com"
+
+    def test_multi_generation_lineage_inherits_owner(self, db):
+        """Owner propagates down a chain of live-parent children."""
+        db.create_session(
+            session_id="root", source="acp", user_id="dev@example.com"
+        )
+        db.create_session(
+            session_id="gen1", source="subagent", parent_session_id="root"
+        )
+        db.create_session(
+            session_id="gen2", source="subagent", parent_session_id="gen1"
+        )
+
+        assert db.get_session("gen1")["user_id"] == "dev@example.com"
+        assert db.get_session("gen2")["user_id"] == "dev@example.com"
+
+    def test_untagged_parent_leaves_child_owner_null(self, db):
+        """A child of an unowned parent stays untagged."""
+        db.create_session(session_id="parent", source="cli")
+        db.create_session(
+            session_id="sub", source="subagent", parent_session_id="parent"
+        )
+
+        assert db.get_session("sub")["user_id"] is None
+
 
 
 


### PR DESCRIPTION
## What / why

Sub-agent session rows land in `state.db` with `user_id` NULL, so delegated work is unattributable — it can only be reached by walking `parent_session_id`. In our profile that was 55 subagent rows on a single day (~28% of that day's token spend) with no owner.

`_insert_session_row` already inherits parent→child metadata, but `user_id` was bundled into the `UPDATE` gated behind `p.end_reason = 'compression'`, so only compression forks picked up an owner.

That gate exists for a good reason — a live-parent child must not inherit gateway **routing** keys (`session_key`/`chat_id`/`chat_type`/`thread_id`), or peer recovery could repoint gateway traffic into a subagent's session. But `user_id` is not a routing key: `find_latest_gateway_session_for_peer` keys off `session_key` and returns early without it (`if not session_key: return None`). `user_id` is attribution, and it got swept into a guard aimed at the four routing columns sitting beside it.

This splits `user_id` into its own `COALESCE` UPDATE with no `end_reason` predicate. The six routing/display columns keep the compression-fork gate exactly as before. NULL-fill only, so an explicitly-set owner is never overwritten.

### Relationship to the existing PRs on #24321

This is **complementary to, not competing with, #24333 and #24406.** Both propose forwarding the AIAgent user id at the `run_agent.py` session-row creation site. The hermes-sweeper review on #24333 already identified why that alone is insufficient:

> Delegate coverage is not real on current main: `tools/delegate_tool.py:1301-1331` constructs children without `user_id`, so the helper would still receive `None`.

That is exactly the gap this PR closes. `delegate_tool.py` never has the owner to pass — the parent row is the only place it is known — so the fix has to happen at the DB layer where the parent edge is visible. Fixing the constructor site covers gateway/background sessions; fixing inheritance covers delegate children. Both are needed for full coverage of #24321, and they do not touch the same lines.

I deliberately did **not** re-implement the constructor-side change here, to keep this reviewable independently and avoid a fourth overlapping diff on the same issue.

## How to test

```bash
uv sync --frozen --all-extras
scripts/run_tests.sh tests/test_hermes_state.py
scripts/run_tests.sh tests/tools/test_delegate.py \
  tests/tools/test_restored_delegation_ownership.py \
  tests/gateway/test_session.py \
  tests/run_agent/test_compression_persistence.py
python3 scripts/check-windows-footguns.py hermes_state.py tests/test_hermes_state.py
```

Results on this branch (base `74f8e59877`):

- `tests/test_hermes_state.py` — **484 passed, 0 failed** (456 discovered, 8 workers, 102.9s)
- delegate + gateway + compression-persistence — **330 passed, 0 failed**
- `check-windows-footguns.py` — **12 findings, identical to the pre-change baseline** (verified by `git stash` / re-run); all pre-existing bare `Path.read_text()`/`write_text()` calls, none introduced or touched by this diff

### Tests changed

`test_live_parent_child_does_not_inherit_gateway_origin` → `test_live_parent_child_does_not_inherit_gateway_routing_keys`: renamed to say what it now guards, widened from 2 to all 6 routing/display columns, and its `user_id is None` assertion removed (that assertion was pinning the bug).

Added four:

| Test | Asserts |
|---|---|
| `test_live_parent_child_inherits_owner` | child of a live owned parent gets `user_id`; `session_key` stays NULL |
| `test_child_owner_inheritance_is_null_fill_only` | explicit child owner is never overwritten by the parent's |
| `test_multi_generation_lineage_inherits_owner` | owner propagates root → gen1 → gen2 |
| `test_untagged_parent_leaves_child_owner_null` | child of an unowned CLI/cron parent stays NULL |

Also verified out-of-band against the real spawn ordering (ACP parent created with an owner, then children created with `user_id=None` exactly as `run_agent.py` does): owner propagates through two generations while all six routing columns stay NULL.

## Platforms tested

Linux (Ubuntu, 6.17 kernel), Python 3.12, SQLite session store. No platform-specific primitives touched — the change is two SQL `UPDATE` statements. Windows footgun check run and clean relative to baseline.

## Related issues

- Refs #24321 (umbrella: sub-agent sessions land with NULL `user_id`)
- Refs #35407 (`_ensure_db_session` hardcodes `user_id=None`)
- Complements #24333, #24406 (constructor-side propagation; neither reaches delegate children)
- Does not touch the `delegated_role` feature requests (#40189, #40816, #41554) — orthogonal
