### PR TITLE
ci(docker): retry buildx setup on transient Docker Hub failures

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,7 +53,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # Retry once on transient Docker Hub / buildkit pull failures
+      # (connection reset, auth token timeout, rate limiting). The action
+      # generates a unique builder name per invocation so the retry doesn't
+      # collide with the failed first attempt. A genuine persistent failure
+      # still fails the job — only the first attempt has continue-on-error.
+      # Refs: docker/setup-buildx-action#510
       - name: Set up Docker Buildx
+        id: buildx
+        continue-on-error: true
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Set up Docker Buildx (retry)
+        if: steps.buildx.outcome == 'failure'
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       # Build once, load into the local daemon for testing.  Cached
@@ -146,7 +158,15 @@ jobs:
       - name: Checkout trusted source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # Retry once on transient Docker Hub / buildkit pull failures.
+      # See build job for rationale; same pattern.
       - name: Set up Docker Buildx
+        id: buildx
+        continue-on-error: true
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Set up Docker Buildx (retry)
+        if: steps.buildx.outcome == 'failure'
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
@@ -208,7 +228,15 @@ jobs:
           pattern: digest-*
           merge-multiple: true
 
+      # Retry once on transient Docker Hub / buildkit pull failures.
+      # See build job for rationale; same pattern.
       - name: Set up Docker Buildx
+        id: buildx
+        continue-on-error: true
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Set up Docker Buildx (retry)
+        if: steps.buildx.outcome == 'failure'
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub


### PR DESCRIPTION
## Problem

The Docker Build, Test, and Publish workflow (`docker.yml`) fails when `docker/setup-buildx-action` can't pull the `moby/buildkit:buildx-stable-1` image from Docker Hub. The failure happens during builder bootstrap at the Docker Hub auth token exchange — a transient network blip that self-resolves on re-run.

**Recent failure** — run [30449230291](https://github.com/NousResearch/hermes-agent/actions/runs/30449230291), merge job:

```
[internal] booting buildkit
pulling image moby/buildkit:buildx-stable-1
pulling image moby/buildkit:buildx-stable-1 0.2s done
ERROR: Error response from daemon: Head "https://registry-1.docker.io/v2/moby/buildkit/manifests/buildx-stable-1":
  Get "https://auth.docker.io/token?account=githubactions&scope=repository%3Amoby%2Fbuildkit%3Apull&service=registry.docker.io":
  read tcp 10.1.0.171:45666->104.18.43.178:443: read: connection reset by peer
```

This kills the entire job — build, publish, or merge — even though nothing is wrong with the code or the image. A manual `gh run rerun --failed` always fixes it.

## Fix

Wrap each of the 3 `Set up Docker Buildx` steps (build, publish, merge jobs) with `continue-on-error: true` + a conditional retry step:

```yaml
- name: Set up Docker Buildx
  id: buildx
  continue-on-error: true
  uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3

- name: Set up Docker Buildx (retry)
  if: steps.buildx.outcome == "failure"
  uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
```

**Why this approach:**

- **Keeps the maintained action intact** — driver flags, buildkitd-flags, binary caching, cleanup all preserved. No hand-rolled shell script replacing the action.
- **No builder collision** — `setup-buildx-action` generates a unique builder name per invocation, so the retry creates a fresh builder rather than reusing the failed one.
- **Genuine failures still fail** — only the first attempt has `continue-on-error`. The retry step runs with no escape hatch.
- **Matches existing patterns** — the merge job already retries `docker buildx imagetools create` for the same class of transient Docker Hub flake (eventual consistency on digest push). This extends that retry philosophy to the setup step.
- **Maintainer-endorsed layer** — the `docker/setup-buildx-action` maintainer has explicitly said retry belongs at the workflow level, not inside the action ([docker/setup-buildx-action#510](https://github.com/docker/setup-buildx-action/issues/510)). Other repos use this same `continue-on-error` pattern for this exact failure ([joshjhall/containers#688](https://github.com/joshjhall/containers/pull/688), [ethpandaops#391](https://github.com/ethpandaops/eth-client-docker-image-builder/commit/ca28d09d1e4c443226c3bba5f63a9463dd3d061c)).

## What I did NOT do

- **Did not replace the action with a shell script.** The AI-recommended fix that prompted this PR replaced `setup-buildx-action` with a hand-rolled `docker buildx create`/`inspect --bootstrap` loop that dropped the `--driver docker-container` and `--buildkitd-flags` configuration the action sets. That would silently change the builder configuration.
- **Did not add a sleep between attempts.** The second `uses:` step has enough startup latency to break the thundering-herd pattern that caused the connection reset.

## Testing

YAML validated. The change only affects the retry path — normal runs hit the first attempt and skip the retry step entirely (the `if` condition is false). No behavioral change on green runs.

## Checklist

- [x] Only touches `.github/workflows/docker.yml`
- [x] Same pinned action SHA (`8d2750c...`) — no version bump
- [x] All 3 buildx call sites treated identically
- [x] No new dependencies or actions