### PR TITLE
fix(desktop): quote Windows shell command paths

### DIFF
--- a/apps/desktop/electron/backend-probes.ts
+++ b/apps/desktop/electron/backend-probes.ts
@@ -35,6 +35,8 @@
 
 import { execFileSync } from 'node:child_process'
 
+import { windowsShellCommand } from './windows-child-options'
+
 /** Default probe budget. 5s false-negativeed healthy Windows cold starts (#61764). */
 const DEFAULT_PROBE_TIMEOUT_MS = 15_000
 
@@ -196,7 +198,7 @@ function verifyHermesCli(hermesCommand: string, opts?: { shell?: boolean }) {
   }
 
   try {
-    execProbeSync(hermesCommand, ['--version'], {
+    execProbeSync(windowsShellCommand(hermesCommand, Boolean(opts?.shell)), ['--version'], {
       stdio: 'ignore',
       timeout: PROBE_TIMEOUT_MS,
       shell: Boolean(opts?.shell),

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -208,7 +208,7 @@ import {
   MIN_HEIGHT as WINDOW_MIN_HEIGHT,
   MIN_WIDTH as WINDOW_MIN_WIDTH
 } from './window-state'
-import { hiddenWindowsChildOptions } from './windows-child-options'
+import { hiddenWindowsChildOptions, windowsShellCommand } from './windows-child-options'
 import {
   buildPathExtCandidates,
   chooseUpdaterArgs,
@@ -1898,7 +1898,7 @@ function backendSupportsServe(backend) {
       // is cached for the process lifetime, silently routing a modern
       // runtime through the legacy `dashboard` form. Share the probe budget
       // and its timeout-only retry instead of a thinner local bound.
-      execProbeSync(backend.command, [...prefix, 'serve', '--help'], {
+      execProbeSync(windowsShellCommand(backend.command, Boolean(backend.shell)), [...prefix, 'serve', '--help'], {
         cwd: backend.root || undefined,
         env: { ...process.env, HERMES_HOME, ...(backend.env || {}) },
         timeout: PROBE_TIMEOUT_MS,
@@ -8089,7 +8089,7 @@ async function spawnPoolBackend(profile, entry) {
   rememberLog(`Starting Hermes backend for profile "${profile}" via ${backend.label}`)
 
   const child = spawn(
-    backend.command,
+    windowsShellCommand(backend.command, Boolean(backend.shell)),
     backend.args,
     hiddenWindowsChildOptions({
       cwd: hermesCwd,
@@ -8377,7 +8377,7 @@ async function startHermes() {
     rememberLog(`Starting Hermes backend via ${backend.label}`)
 
     const hermesProcess = spawn(
-      backend.command,
+      windowsShellCommand(backend.command, Boolean(backend.shell)),
       backend.args,
       hiddenWindowsChildOptions({
         cwd: hermesCwd,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -233,7 +233,7 @@ import {
   MIN_HEIGHT as WINDOW_MIN_HEIGHT,
   MIN_WIDTH as WINDOW_MIN_WIDTH
 } from './window-state'
-import { hiddenWindowsChildOptions } from './windows-child-options'
+import { hiddenWindowsChildOptions, windowsShellCommand } from './windows-child-options'
 import {
   buildPathExtCandidates,
   chooseUpdaterArgs,
@@ -1990,7 +1990,7 @@ function backendSupportsServe(backend) {
       // is cached for the process lifetime, silently routing a modern
       // runtime through the legacy `dashboard` form. Share the probe budget
       // and its timeout-only retry instead of a thinner local bound.
-      execProbeSync(backend.command, [...prefix, 'serve', '--help'], {
+      execProbeSync(windowsShellCommand(backend.command, Boolean(backend.shell)), [...prefix, 'serve', '--help'], {
         cwd: backend.root || undefined,
         env: { ...process.env, HERMES_HOME, ...(backend.env || {}) },
         timeout: PROBE_TIMEOUT_MS,
@@ -8156,7 +8156,7 @@ async function spawnPoolBackend(profile, entry) {
   rememberLog(`Starting Hermes backend for profile "${profile}" via ${backend.label}`)
 
   const child = spawn(
-    backend.command,
+    windowsShellCommand(backend.command, Boolean(backend.shell)),
     backend.args,
     hiddenWindowsChildOptions({
       cwd: hermesCwd,
@@ -8449,7 +8449,7 @@ async function startHermes() {
     rememberLog(`Starting Hermes backend via ${backend.label}`)
 
     const hermesProcess = spawn(
-      backend.command,
+      windowsShellCommand(backend.command, Boolean(backend.shell)),
       backend.args,
       hiddenWindowsChildOptions({
         cwd: hermesCwd,

--- a/apps/desktop/electron/windows-child-options.test.ts
+++ b/apps/desktop/electron/windows-child-options.test.ts
@@ -3,7 +3,20 @@ import assert from 'node:assert/strict'
 import { test } from 'vitest'
 
 import { stopBackendChild } from './backend-child'
-import { hiddenWindowsChildOptions } from './windows-child-options'
+import { hiddenWindowsChildOptions, windowsShellCommand } from './windows-child-options'
+
+test('windowsShellCommand quotes Windows shell commands with spaces', () => {
+  const command = String.raw`C:\Users\First Last\AppData\Local\hermes\hermes.cmd`
+
+  assert.equal(windowsShellCommand(command, true, true), `"${command}"`)
+})
+
+test('windowsShellCommand leaves direct execution and non-Windows commands unchanged', () => {
+  const command = String.raw`C:\Users\First Last\AppData\Local\hermes\hermes.cmd`
+
+  assert.equal(windowsShellCommand(command, false, true), command)
+  assert.equal(windowsShellCommand(command, true, false), command)
+})
 
 test('hiddenWindowsChildOptions adds windowsHide:true on Windows when unset', () => {
   assert.deepEqual(hiddenWindowsChildOptions({}, true), { windowsHide: true })

--- a/apps/desktop/electron/windows-child-options.test.ts
+++ b/apps/desktop/electron/windows-child-options.test.ts
@@ -3,7 +3,20 @@ import assert from 'node:assert/strict'
 import { test } from 'vitest'
 
 import { stopBackendChild, stopBackendTreesForUpdate } from './backend-child'
-import { hiddenWindowsChildOptions } from './windows-child-options'
+import { hiddenWindowsChildOptions, windowsShellCommand } from './windows-child-options'
+
+test('windowsShellCommand quotes Windows shell commands with spaces', () => {
+  const command = String.raw`C:\Users\First Last\AppData\Local\hermes\hermes.cmd`
+
+  assert.equal(windowsShellCommand(command, true, true), `"${command}"`)
+})
+
+test('windowsShellCommand leaves direct execution and non-Windows commands unchanged', () => {
+  const command = String.raw`C:\Users\First Last\AppData\Local\hermes\hermes.cmd`
+
+  assert.equal(windowsShellCommand(command, false, true), command)
+  assert.equal(windowsShellCommand(command, true, false), command)
+})
 
 test('hiddenWindowsChildOptions adds windowsHide:true on Windows when unset', () => {
   assert.deepEqual(hiddenWindowsChildOptions({}, true), { windowsHide: true })

--- a/apps/desktop/electron/windows-child-options.ts
+++ b/apps/desktop/electron/windows-child-options.ts
@@ -16,6 +16,20 @@
 import type { ExecFileSyncOptionsWithStringEncoding } from 'node:child_process'
 
 /**
+ * Quote an executable token when Windows delegates execution to cmd.exe.
+ * Without the outer quotes, cmd.exe truncates paths at the first space.
+ * `command` must contain only the executable path; keep arguments in the
+ * separate argument array passed to spawn/execFileSync.
+ */
+export function windowsShellCommand(
+  command: string,
+  shell: boolean,
+  isWindows: boolean = process.platform === 'win32'
+): string {
+  return isWindows && shell ? `"${command}"` : command
+}
+
+/**
  * Merge `windowsHide: true` into `options` when running on Windows, unless
  * the caller already specified a `windowsHide` value (which is preserved
  * as-is, including an explicit `false` for cases that intentionally want a


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop enables `shell: true` for Windows `.cmd` and `.bat` backend shims, but passed the executable path to `cmd.exe` without surrounding quotes. When Hermes was installed under a path containing spaces, `cmd.exe` truncated the command at the first space, causing both runtime probes and backend startup to fail.

This adds one shared helper that quotes only the executable token when Windows shell execution is active. Arguments remain in their existing separate arrays, and non-Windows or direct execution remains unchanged.

## Related Issue

Fixes #74064

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `windowsShellCommand()` to the dependency-free Windows child-process helpers.
- Apply it to the CLI liveness probe and `serve --help` capability probe.
- Apply it to both primary and per-profile backend spawn paths.
- Add regression coverage for a `.cmd` path containing spaces and preservation coverage for non-Windows and `shell: false` execution.

## How to Test

1. Run `npm --workspace apps/desktop run test:desktop:platforms -- electron/windows-child-options.test.ts electron/backend-probes.test.ts`.
2. Run `npm --workspace apps/desktop run typecheck`.
3. Run `npm --workspace apps/desktop test` for the complete desktop suite.

Local results:

- Focused tests: 26 passed.
- Electron suite: 869 passed, 2 skipped.
- Complete desktop suite: 3,803 passed, 2 skipped.
- TypeScript, ESLint, Prettier, and `git diff --check`: passed.

The change was tested on Ubuntu 26.04 using the platform-injected Windows unit-test paths. It was not executed on a physical Windows machine.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (N/A: desktop TypeScript-only change; the complete desktop test suite passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 26.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the helper invariant is documented in its JSDoc
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable. This changes backend process invocation and adds automated regression coverage.
