### PR TITLE
fix(cron): reconcile the dispatch claim when a run is cancelled or killed

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4035,6 +4035,23 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         finish_execution(execution_id, success=False, error=str(e))
         return False
 
+    except BaseException as e:
+        # CancelledError / KeyboardInterrupt / SystemExit are NOT Exception
+        # subclasses, so they slipped past the handler above — and the inner
+        # teardown handler re-raises them by design. claim_dispatch() has
+        # already consumed ``repeat.completed`` at this point, so skipping the
+        # reconciliation leaves a one-shot job with completed == times and
+        # last_run_at still null: its run_claim blocks re-dispatch until the
+        # TTL expires, and the dispatch-limit guard then drops the job without
+        # ever producing output (#73973). Record the failed run, then re-raise
+        # — cancellation and shutdown semantics are unchanged.
+        _abort_reason = f"aborted: {type(e).__name__}"
+        logger.error("Job %s aborted: %s", job["id"], type(e).__name__)
+        if not _consume_interrupted_flag(job["id"]):
+            mark_job_run(job["id"], False, _abort_reason)
+        finish_execution(execution_id, success=False, error=_abort_reason)
+        raise
+
 
 def _notify_provider_jobs_changed() -> None:
     """Best-effort: tell the active scheduler provider the job set changed.

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -372,3 +372,68 @@ def test_run_one_job_tears_down_deferred_agent_when_save_raises(monkeypatch):
     assert ok is False
     assert "deliver" not in order
     assert order == ["save-raise", "agent.close", "cleanup_stale"], order
+
+
+# ---------------------------------------------------------------------------
+# BaseException reconciliation (#73973).
+#
+# claim_dispatch() consumes repeat.completed BEFORE the run, so every exit
+# path out of run_one_job() must reconcile the claim via mark_job_run().
+# CancelledError / KeyboardInterrupt / SystemExit are NOT Exception
+# subclasses, so `except Exception` misses them: a one-shot job is left with
+# completed==times and last_run_at==null, the run_claim blocks re-dispatch
+# until its TTL, and the dispatch-limit guard then removes the job with no
+# output at all.
+# ---------------------------------------------------------------------------
+
+
+import asyncio
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "exc", [asyncio.CancelledError, KeyboardInterrupt, SystemExit]
+)
+def test_run_one_job_base_exception_still_marks_failure(monkeypatch, exc):
+    """A cancelled / interrupted run must not leave the claim unreconciled."""
+    def boom(job, *, defer_agent_teardown=None):
+        raise exc()
+
+    monkeypatch.setattr(s, "run_job", boom)
+    marks = []
+    monkeypatch.setattr(
+        s, "mark_job_run",
+        lambda jid, ok, err=None, delivery_error=None: marks.append((jid, ok)),
+    )
+
+    # The abort still propagates — shutdown/cancel semantics are unchanged.
+    with pytest.raises(exc):
+        s.run_one_job({"id": "j7", "name": "t"})
+
+    assert marks == [("j7", False)], (
+        "claim_dispatch() already consumed repeat.completed; the run must be "
+        "marked failed so the job is not wedged and silently dropped"
+    )
+
+
+def test_run_one_job_base_exception_finishes_the_execution_record(monkeypatch):
+    """The execution ledger entry must be closed out too, not left running."""
+    def boom(job, *, defer_agent_teardown=None):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(s, "run_job", boom)
+    monkeypatch.setattr(
+        s, "mark_job_run",
+        lambda jid, ok, err=None, delivery_error=None: None,
+    )
+    finished = []
+    monkeypatch.setattr(
+        s, "finish_execution",
+        lambda eid, success=None, error=None: finished.append((eid, success)),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        s.run_one_job({"id": "j8", "name": "t", "execution_id": "e8"})
+
+    assert finished == [("e8", False)]


### PR DESCRIPTION
## What

`claim_dispatch()` consumes `repeat.completed` **before** the run (at-most-times semantics), so every exit path out of `run_one_job()` has to reconcile that claim through `mark_job_run()`.

The outer handler is `except Exception`. The inner teardown handler catches `BaseException` and re-raises by design — and `CancelledError` / `KeyboardInterrupt` / `SystemExit` are not `Exception` subclasses, so they sail straight past the reconciliation.

A one-shot job killed mid-run — the reported case is the desktop cron ticker restarting at the job's own fire time — is then left as:

```
"repeat":      {"times": 1, "completed": 1},   ← consumed
"last_run_at": null,                           ← never set
"state":       "scheduled"
```

Its `run_claim` blocks re-dispatch until the TTL expires, and the dispatch-limit guard then removes the job: no output, no error, no signal that the scheduled work never ran.

## Fix

Add an `except BaseException` handler after the existing one. It records the failed run, closes the execution-ledger entry, and then **re-raises**, so cancellation and shutdown semantics are unchanged. It mirrors the `Exception` handler exactly — including the `_consume_interrupted_flag()` check, so a deliberate shutdown interrupt still isn't counted as a failed run.

This is the issue's own **"Safe"** fix (approach 1). The claim-ordering change in approach 2 is left alone — the issue is marked `needs-decision` and that half is a semantics call for the maintainers.

## Tests

`tests/cron/test_run_one_job.py`, mirroring the existing `test_run_one_job_exception_marks_failure`:

- parametrized over `CancelledError` / `KeyboardInterrupt` / `SystemExit`: the run is marked failed **and** the abort still propagates;
- the execution-ledger entry is finished rather than left running.

All four fail on `main` (`assert [] == [('j7', False)]`) and pass with this change.

- `pytest tests/cron/test_run_one_job.py -q` → 16 passed.
- `pytest tests/cron/ -q` → 748 passed / 7 failed; the same 7 fail on the stashed baseline (744 passed) — POSIX file-mode tests unrelated to this change.

Refs #73973
