### PR TITLE
fix(cli): discover keyless local LM Studio in pickers

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11302,6 +11302,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     ctx,
                     probe_custom_providers=force_refresh,
                     probe_current_custom_provider=not force_refresh,
+                    for_picker=True,
                 )["providers"]
             except Exception:
                 providers = []

--- a/cli.py
+++ b/cli.py
@@ -9398,6 +9398,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     ctx,
                     probe_custom_providers=force_refresh,
                     probe_current_custom_provider=not force_refresh,
+                    for_picker=True,
                 )["providers"]
             except Exception:
                 providers = []

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -311,6 +311,7 @@ def build_model_options_payload(
         refresh=refresh,
         probe_custom_providers=refresh,
         probe_current_custom_provider=not refresh,
+        for_picker=True,
     )
 
 
@@ -667,6 +668,9 @@ def _filter_explicit_provider_rows(rows: list[dict], ctx: ConfigContext) -> list
     ``list_authenticated_providers`` intentionally discovers ambient / auto-
     seeded credentials (for example GitHub CLI -> Copilot). Desktop chat model
     pickers want the narrower subset the user explicitly configured for Hermes.
+    A responsive default LM Studio server is the exception: it is discovered
+    only during an interactive picker request and is directly callable without
+    a credential.
     """
     from hermes_cli.auth import is_provider_explicitly_configured
 
@@ -677,6 +681,9 @@ def _filter_explicit_provider_rows(rows: list[dict], ctx: ConfigContext) -> list
         if not slug:
             continue
         if row.get("is_user_defined"):
+            kept.append(row)
+            continue
+        if row.get("is_locally_discovered"):
             kept.append(row)
             continue
         if current_slug and slug == current_slug:

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -310,6 +310,7 @@ def build_model_options_payload(
         refresh=refresh,
         probe_custom_providers=refresh,
         probe_current_custom_provider=not refresh,
+        for_picker=True,
     )
 
 
@@ -584,6 +585,9 @@ def _filter_explicit_provider_rows(rows: list[dict], ctx: ConfigContext) -> list
     ``list_authenticated_providers`` intentionally discovers ambient / auto-
     seeded credentials (for example GitHub CLI -> Copilot). Desktop chat model
     pickers want the narrower subset the user explicitly configured for Hermes.
+    A responsive default LM Studio server is the exception: it is discovered
+    only during an interactive picker request and is directly callable without
+    a credential.
     """
     from hermes_cli.auth import is_provider_explicitly_configured
 
@@ -594,6 +598,9 @@ def _filter_explicit_provider_rows(rows: list[dict], ctx: ConfigContext) -> list
         if not slug:
             continue
         if row.get("is_user_defined"):
+            kept.append(row)
+            continue
+        if row.get("is_locally_discovered"):
             kept.append(row)
             continue
         if current_slug and slug == current_slug:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2618,6 +2618,10 @@ def list_authenticated_providers(
     opens: probe only the currently-selected custom endpoint so its model list
     matches the active provider without blocking on every saved/offline custom
     endpoint.
+
+    ``for_picker`` permits a short probe of LM Studio's default loopback
+    endpoint. A successful no-auth response is enough to make the local
+    provider selectable; non-picker callers retain the no-probe behaviour.
     """
     import os
     from agent.models_dev import (
@@ -2749,7 +2753,10 @@ def list_authenticated_providers(
     # On auth rejection or unreachable server, fall back to the caller-supplied
     # current model so the picker still shows something when offline / mis-keyed.
     if "lmstudio" not in curated and (
-        os.environ.get("LM_API_KEY") or os.environ.get("LM_BASE_URL") or current_provider.strip().lower() == "lmstudio"
+        for_picker
+        or os.environ.get("LM_API_KEY")
+        or os.environ.get("LM_BASE_URL")
+        or current_provider.strip().lower() == "lmstudio"
     ):
         from hermes_cli.models import fetch_lmstudio_models
         from hermes_cli.auth import AuthError
@@ -2946,15 +2953,34 @@ def list_authenticated_providers(
         if pid.lower() in _excluded or hermes_slug.lower() in _excluded:
             continue
 
-        # Check if credentials exist
-        has_creds = False
-        if getattr(overlay, "keyless", False):
+        # A responding default LM Studio server is an intentional local
+        # no-auth configuration. Only interactive pickers make this probe;
+        # background/provider-resolution callers still require an explicit
+        # configuration signal before touching localhost.
+        is_keyless_lmstudio = (
+            for_picker
+            and hermes_slug == "lmstudio"
+            and bool(curated.get("lmstudio"))
+        )
+
+        # Existing LM Studio environment/config selection is already explicit;
+        # flag only the zero-configuration default-endpoint case so Desktop's
+        # configured-provider filter can retain that newly discovered row.
+        is_locally_discovered = is_keyless_lmstudio and not (
+            os.environ.get("LM_API_KEY")
+            or os.environ.get("LM_BASE_URL")
+            or current_provider.strip().lower() == "lmstudio"
+        )
+
+        # Check if credentials exist.
+        has_creds = is_keyless_lmstudio
+        if not has_creds and getattr(overlay, "keyless", False):
             # Keyless providers (opencode-free) are served anonymously —
             # there is no credential to check, so everyone is authenticated.
             has_creds = True
-        elif overlay.auth_type == "aws_sdk":
+        elif not has_creds and overlay.auth_type == "aws_sdk":
             has_creds = _has_aws_sdk_creds_for_listing(hermes_slug)
-        elif overlay.auth_type == "vertex":
+        elif not has_creds and overlay.auth_type == "vertex":
             # Vertex authenticates via OAuth2 (service-account JSON / ADC),
             # not an API key — mirror the aws_sdk gate above, otherwise the
             # provider is silently hidden from the /model picker even when
@@ -2964,7 +2990,7 @@ def list_authenticated_providers(
                 has_creds = has_vertex_credentials()
             except Exception as exc:
                 logger.debug("Vertex credential check failed: %s", exc)
-        elif overlay.extra_env_vars:
+        elif not has_creds and overlay.extra_env_vars:
             has_creds = any(os.environ.get(ev) for ev in overlay.extra_env_vars)
         # Also check api_key_env_vars from PROVIDER_REGISTRY for api_key auth_type
         if not has_creds and overlay.auth_type == "api_key":
@@ -3103,15 +3129,18 @@ def list_authenticated_providers(
         else:
             top = model_ids[:max_models] if max_models is not None else model_ids
 
-        results.append({
+        row = {
             "slug": hermes_slug,
             "name": get_label(hermes_slug),
             "is_current": hermes_slug == current_provider or pid == current_provider,
             "is_user_defined": False,
             "models": top,
             "total_models": total,
-            "source": "hermes",
-        })
+            "source": "local-discovery" if is_locally_discovered else "hermes",
+        }
+        if is_locally_discovered:
+            row["is_locally_discovered"] = True
+        results.append(row)
         seen_slugs.add(pid.lower())
         seen_slugs.add(hermes_slug.lower())
         _record_builtin_endpoint(hermes_slug)

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1990,6 +1990,10 @@ def list_authenticated_providers(
     opens: probe only the currently-selected custom endpoint so its model list
     matches the active provider without blocking on every saved/offline custom
     endpoint.
+
+    ``for_picker`` permits a short probe of LM Studio's default loopback
+    endpoint. A successful no-auth response is enough to make the local
+    provider selectable; non-picker callers retain the no-probe behaviour.
     """
     import os
     from agent.models_dev import (
@@ -2122,7 +2126,10 @@ def list_authenticated_providers(
     # On auth rejection or unreachable server, fall back to the caller-supplied
     # current model so the picker still shows something when offline / mis-keyed.
     if "lmstudio" not in curated and (
-        os.environ.get("LM_API_KEY") or os.environ.get("LM_BASE_URL") or current_provider.strip().lower() == "lmstudio"
+        for_picker
+        or os.environ.get("LM_API_KEY")
+        or os.environ.get("LM_BASE_URL")
+        or current_provider.strip().lower() == "lmstudio"
     ):
         from hermes_cli.models import fetch_lmstudio_models
         from hermes_cli.auth import AuthError
@@ -2296,11 +2303,30 @@ def list_authenticated_providers(
         if pid.lower() in _excluded or hermes_slug.lower() in _excluded:
             continue
 
-        # Check if credentials exist
-        has_creds = False
-        if overlay.auth_type == "aws_sdk":
+        # A responding default LM Studio server is an intentional local
+        # no-auth configuration. Only interactive pickers make this probe;
+        # background/provider-resolution callers still require an explicit
+        # configuration signal before touching localhost.
+        is_keyless_lmstudio = (
+            for_picker
+            and hermes_slug == "lmstudio"
+            and bool(curated.get("lmstudio"))
+        )
+
+        # Existing LM Studio environment/config selection is already explicit;
+        # flag only the zero-configuration default-endpoint case so Desktop's
+        # configured-provider filter can retain that newly discovered row.
+        is_locally_discovered = is_keyless_lmstudio and not (
+            os.environ.get("LM_API_KEY")
+            or os.environ.get("LM_BASE_URL")
+            or current_provider.strip().lower() == "lmstudio"
+        )
+
+        # Check if credentials exist.
+        has_creds = is_keyless_lmstudio
+        if not has_creds and overlay.auth_type == "aws_sdk":
             has_creds = _has_aws_sdk_creds_for_listing(hermes_slug)
-        elif overlay.auth_type == "vertex":
+        elif not has_creds and overlay.auth_type == "vertex":
             # Vertex authenticates via OAuth2 (service-account JSON / ADC),
             # not an API key — mirror the aws_sdk gate above, otherwise the
             # provider is silently hidden from the /model picker even when
@@ -2310,7 +2336,7 @@ def list_authenticated_providers(
                 has_creds = has_vertex_credentials()
             except Exception as exc:
                 logger.debug("Vertex credential check failed: %s", exc)
-        elif overlay.extra_env_vars:
+        elif not has_creds and overlay.extra_env_vars:
             has_creds = any(os.environ.get(ev) for ev in overlay.extra_env_vars)
         # Also check api_key_env_vars from PROVIDER_REGISTRY for api_key auth_type
         if not has_creds and overlay.auth_type == "api_key":
@@ -2449,15 +2475,18 @@ def list_authenticated_providers(
         else:
             top = model_ids[:max_models] if max_models is not None else model_ids
 
-        results.append({
+        row = {
             "slug": hermes_slug,
             "name": get_label(hermes_slug),
             "is_current": hermes_slug == current_provider or pid == current_provider,
             "is_user_defined": False,
             "models": top,
             "total_models": total,
-            "source": "hermes",
-        })
+            "source": "local-discovery" if is_locally_discovered else "hermes",
+        }
+        if is_locally_discovered:
+            row["is_locally_discovered"] = True
+        results.append(row)
         seen_slugs.add(pid.lower())
         seen_slugs.add(hermes_slug.lower())
         _record_builtin_endpoint(hermes_slug)

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -24,6 +24,7 @@ from unittest.mock import patch
 
 from hermes_cli.inventory import (
     ConfigContext,
+    build_model_options_payload,
     build_models_payload,
     load_picker_context,
 )
@@ -84,6 +85,17 @@ def _nous_row(model: str = "openai/gpt-5.5") -> dict:
     }
 
 
+
+
+def test_model_options_payload_requests_interactive_provider_discovery():
+    ctx = _empty_ctx()
+    with patch(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        return_value=[],
+    ) as mock_list:
+        build_model_options_payload(ctx)
+
+    assert mock_list.call_args.kwargs["for_picker"] is True
 
 
 def test_cli_model_picker_forwards_force_refresh_to_probe_flags():
@@ -207,6 +219,31 @@ def test_explicit_only_filters_ambient_credentials_but_keeps_current_and_custom_
         "custom:lab",
     ]
 
+
+
+def test_explicit_only_keeps_reachable_local_discovery():
+    """A live no-auth local server is callable without an env-var signal."""
+    rows = [
+        {
+            "slug": "lmstudio",
+            "name": "LM Studio",
+            "models": ["qwen/qwen3-coder-30b"],
+            "total_models": 1,
+            "is_current": False,
+            "is_user_defined": False,
+            "is_locally_discovered": True,
+            "source": "local-discovery",
+        }
+    ]
+    ctx = _empty_ctx(provider="openrouter")
+
+    with (
+        _list_auth_returning(rows),
+        patch("hermes_cli.auth.is_provider_explicitly_configured", return_value=False),
+    ):
+        payload = build_models_payload(ctx, explicit_only=True)
+
+    assert any(row["slug"] == "lmstudio" for row in payload["providers"])
 
 
 # ─── picker_hints ──────────────────────────────────────────────────────
@@ -541,7 +578,4 @@ def _apply_featured_with_dates(rows, dates: dict[str, str]):
 
     with patch("agent.models_dev.get_model_info", side_effect=_fake_get_model_info):
         inventory._apply_featured(rows)
-
-
-
 

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -24,6 +24,7 @@ from unittest.mock import patch
 
 from hermes_cli.inventory import (
     ConfigContext,
+    build_model_options_payload,
     build_models_payload,
     load_picker_context,
 )
@@ -84,6 +85,17 @@ def _nous_row(model: str = "openai/gpt-5.5") -> dict:
     }
 
 
+
+
+def test_model_options_payload_requests_interactive_provider_discovery():
+    ctx = _empty_ctx()
+    with patch(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        return_value=[],
+    ) as mock_list:
+        build_model_options_payload(ctx)
+
+    assert mock_list.call_args.kwargs["for_picker"] is True
 
 
 def test_cli_model_picker_forwards_force_refresh_to_probe_flags():
@@ -207,6 +219,31 @@ def test_explicit_only_filters_ambient_credentials_but_keeps_current_and_custom_
         "custom:lab",
     ]
 
+
+
+def test_explicit_only_keeps_reachable_local_discovery():
+    """A live no-auth local server is callable without an env-var signal."""
+    rows = [
+        {
+            "slug": "lmstudio",
+            "name": "LM Studio",
+            "models": ["qwen/qwen3-coder-30b"],
+            "total_models": 1,
+            "is_current": False,
+            "is_user_defined": False,
+            "is_locally_discovered": True,
+            "source": "local-discovery",
+        }
+    ]
+    ctx = _empty_ctx(provider="openrouter")
+
+    with (
+        _list_auth_returning(rows),
+        patch("hermes_cli.auth.is_provider_explicitly_configured", return_value=False),
+    ):
+        payload = build_models_payload(ctx, explicit_only=True)
+
+    assert any(row["slug"] == "lmstudio" for row in payload["providers"])
 
 
 # ─── picker_hints ──────────────────────────────────────────────────────
@@ -509,7 +546,4 @@ def _apply_featured_with_dates(rows, dates: dict[str, str]):
 
     with patch("agent.models_dev.get_model_info", side_effect=_fake_get_model_info):
         inventory._apply_featured(rows)
-
-
-
 

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -401,6 +401,65 @@ def test_switch_model_does_not_send_ollama_headers_to_unrelated_custom_endpoint(
 
 
 
+def test_lmstudio_picker_discovers_default_noauth_server(monkeypatch):
+    """A responsive default LM Studio server is selectable without env vars."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(
+        providers_mod,
+        "HERMES_OVERLAYS",
+        {"lmstudio": providers_mod.HERMES_OVERLAYS["lmstudio"]},
+    )
+    monkeypatch.delenv("LM_BASE_URL", raising=False)
+    monkeypatch.delenv("LM_API_KEY", raising=False)
+    monkeypatch.setattr("hermes_cli.models.cached_provider_model_ids", lambda *_a, **_kw: [])
+
+    captured: dict = {}
+
+    def _fake_fetch(api_key=None, base_url=None, timeout=5.0):
+        captured.update(api_key=api_key, base_url=base_url, timeout=timeout)
+        return ["qwen/qwen3-coder-30b"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_lmstudio_models", _fake_fetch)
+
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        current_base_url="https://openrouter.ai/api/v1",
+        for_picker=True,
+    )
+
+    assert captured == {
+        "api_key": "",
+        "base_url": "http://127.0.0.1:1234/v1",
+        "timeout": 1.5,
+    }
+    lmstudio = next(p for p in providers if p["slug"] == "lmstudio")
+    assert lmstudio["models"] == ["qwen/qwen3-coder-30b"]
+    assert lmstudio["is_locally_discovered"] is True
+
+
+def test_lmstudio_non_picker_skips_probe_when_not_configured(monkeypatch):
+    """Non-picker callers must not probe an unconfigured local server."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.delenv("LM_BASE_URL", raising=False)
+    monkeypatch.delenv("LM_API_KEY", raising=False)
+
+    captured: dict = {}
+
+    def _fake_fetch(api_key=None, base_url=None, timeout=5.0):
+        captured.update(api_key=api_key, base_url=base_url, timeout=timeout)
+        return []
+
+    monkeypatch.setattr("hermes_cli.models.fetch_lmstudio_models", _fake_fetch)
+
+    list_authenticated_providers(
+        current_provider="openrouter",
+        current_base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert "base_url" not in captured
+
+
 def test_is_routing_aggregator_excludes_flat_namespace_resellers():
     """opencode-go / opencode-zen stay ``is_aggregator=True`` (model-switch
     relies on it to search their flat bare-name catalog), but they are NOT
@@ -1629,7 +1688,6 @@ def test_excluded_providers_hides_builtin_row(monkeypatch):
         "excluded_providers=['openrouter'] must hide the openrouter row"
     )
 
-
 def test_custom_provider_context_length_models_dict_still_probes(monkeypatch):
     """Dict-shaped ``models:`` from ``_save_custom_provider`` is metadata.
 
@@ -2081,7 +2139,7 @@ def test_auto_saved_catalog_round_trips_without_pinning(tmp_path, monkeypatch):
 
     _save_discovered_models_to_config(_LOCAL_ENDPOINT, list(_LOCAL_CATALOG))
 
-    saved = yaml.safe_load(cfg_path.read_text())["custom_providers"][0]
+    saved = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))["custom_providers"][0]
     assert saved["models_discovered"] is True
     assert list(saved["models"]) == _LOCAL_CATALOG
     assert not any(m.startswith("__") for m in saved["models"]), (
@@ -2163,7 +2221,7 @@ def test_legacy_sentinel_catalog_still_resolves_and_migrates(tmp_path, monkeypat
 
     _save_discovered_models_to_config(_LOCAL_ENDPOINT, list(_LOCAL_CATALOG))
 
-    saved = yaml.safe_load(cfg_path.read_text())["custom_providers"][0]
+    saved = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))["custom_providers"][0]
     assert saved["models_discovered"] is True
     assert list(saved["models"]) == _LOCAL_CATALOG
     assert "__discovered_model_catalog__" not in saved["models"]

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -238,6 +238,65 @@ def test_is_aggregator_leaves_unknown_provider_non_aggregator():
     assert providers_mod.is_aggregator("not-a-provider") is False
 
 
+def test_lmstudio_picker_discovers_default_noauth_server(monkeypatch):
+    """A responsive default LM Studio server is selectable without env vars."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(
+        providers_mod,
+        "HERMES_OVERLAYS",
+        {"lmstudio": providers_mod.HERMES_OVERLAYS["lmstudio"]},
+    )
+    monkeypatch.delenv("LM_BASE_URL", raising=False)
+    monkeypatch.delenv("LM_API_KEY", raising=False)
+    monkeypatch.setattr("hermes_cli.models.cached_provider_model_ids", lambda *_a, **_kw: [])
+
+    captured: dict = {}
+
+    def _fake_fetch(api_key=None, base_url=None, timeout=5.0):
+        captured.update(api_key=api_key, base_url=base_url, timeout=timeout)
+        return ["qwen/qwen3-coder-30b"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_lmstudio_models", _fake_fetch)
+
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        current_base_url="https://openrouter.ai/api/v1",
+        for_picker=True,
+    )
+
+    assert captured == {
+        "api_key": "",
+        "base_url": "http://127.0.0.1:1234/v1",
+        "timeout": 1.5,
+    }
+    lmstudio = next(p for p in providers if p["slug"] == "lmstudio")
+    assert lmstudio["models"] == ["qwen/qwen3-coder-30b"]
+    assert lmstudio["is_locally_discovered"] is True
+
+
+def test_lmstudio_non_picker_skips_probe_when_not_configured(monkeypatch):
+    """Non-picker callers must not probe an unconfigured local server."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.delenv("LM_BASE_URL", raising=False)
+    monkeypatch.delenv("LM_API_KEY", raising=False)
+
+    captured: dict = {}
+
+    def _fake_fetch(api_key=None, base_url=None, timeout=5.0):
+        captured.update(api_key=api_key, base_url=base_url, timeout=timeout)
+        return []
+
+    monkeypatch.setattr("hermes_cli.models.fetch_lmstudio_models", _fake_fetch)
+
+    list_authenticated_providers(
+        current_provider="openrouter",
+        current_base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert "base_url" not in captured
+
+
 def test_is_routing_aggregator_excludes_flat_namespace_resellers():
     """opencode-go / opencode-zen stay ``is_aggregator=True`` (model-switch
     relies on it to search their flat bare-name catalog), but they are NOT
@@ -895,7 +954,6 @@ def test_excluded_providers_hides_builtin_row(monkeypatch):
     assert not any(p["slug"] == "openrouter" for p in filtered), (
         "excluded_providers=['openrouter'] must hide the openrouter row"
     )
-
 
 def test_custom_provider_context_length_models_dict_still_probes(monkeypatch):
     """Dict-shaped ``models:`` from ``_save_custom_provider`` is metadata.


### PR DESCRIPTION
## What changed and why

Per the thread's current-main reproduction, a default LM Studio server with authentication disabled was callable at runtime but hidden from picker surfaces until an unrelated `LM_API_KEY` or `LM_BASE_URL` signal was set. Interactive picker paths now probe the default loopback endpoint, treat a non-empty no-auth model response as a selectable local provider, and retain that explicitly marked discovery in the Desktop configured-provider view. Non-picker discovery still does not probe an unconfigured localhost server.

## Addressing maintainer feedback

- #41419 is closed and covered keyless runtime credential resolution, but it did not surface an unselected default LM Studio server in picker inventories. This change supplies that missing picker behavior.
- #41367 was identified in the reporter's reproduction as picker-focused work; this narrow follow-up covers the default-address discovery gap without modifying that PR's branch.
- #43052 is related generic-local-provider work; this PR intentionally stays within the existing LM Studio provider and picker infrastructure.

## How to test

1. Clear `LM_API_KEY` and `LM_BASE_URL`, configure a different active provider, and run LM Studio's server at `http://127.0.0.1:1234` with a loaded chat model and auth disabled.
2. Open a model picker in the CLI, TUI, Desktop, or gateway. Confirm LM Studio appears with the loaded model and can be selected.
3. With no local LM Studio server, confirm non-picker provider listing does not attempt the default localhost probe.
4. Run `pytest tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_inventory.py -q -x --timeout=60`.

## What platforms tested on

- macOS (local development environment)

Fixes #41370

<!-- autocontrib:worker-id=issue-followup-dee4f721 kind=pr-open -->