### PR TITLE
fix(config): pass model extra body to agent requests

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1179,6 +1179,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             base_url=getattr(agent, "_anthropic_base_url", None),
             fast_mode=(agent.request_overrides or {}).get("speed") == "fast",
             drop_context_1m_beta=bool(getattr(agent, "_oauth_1m_beta_disabled", False)),
+            request_overrides=agent.request_overrides,
         )
         # Nous Portal reads ``tags`` and ``session_id`` as top-level body fields
         # on its Messages route the same way it does on /chat/completions, but

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1247,7 +1247,8 @@ def _build_anthropic_kwargs(agent, api_messages, tools_for_api, reasoning_config
         context_length=ctx_len.context_length if ctx_len else None,
         base_url=getattr(agent, "_anthropic_base_url", None),
         fast_mode=request_overrides.get("speed") == "fast",
-        drop_context_1m_beta=bool(getattr(agent, "_oauth_1m_beta_disabled", False)))
+        drop_context_1m_beta=bool(getattr(agent, "_oauth_1m_beta_disabled", False)),
+        request_overrides=request_overrides)
     # Portal reads ``tags`` / ``session_id`` on its Messages route too, but the profile hook
     # is only consulted by the OpenAI-wire transport — merge here to keep sticky routing.
     return _merge_nous_portal_messages_extra_body(agent, anthropic_kwargs)

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -10,6 +10,18 @@ from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse
 
 
+def _merge_extra_body(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge request-body mappings, with ``override`` winning."""
+    merged = dict(base)
+    for key, value in override.items():
+        existing = merged.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            merged[key] = _merge_extra_body(existing, value)
+        else:
+            merged[key] = value
+    return merged
+
+
 class AnthropicTransport(ProviderTransport):
     """Transport for api_mode='anthropic_messages'.
 
@@ -59,10 +71,11 @@ class AnthropicTransport(ProviderTransport):
             base_url: str | None
             fast_mode: bool
             drop_context_1m_beta: bool
+            request_overrides: dict | None — model-level extra_body fields
         """
         from agent.anthropic_adapter import build_anthropic_kwargs
 
-        return build_anthropic_kwargs(
+        kwargs = build_anthropic_kwargs(
             model=model,
             messages=messages,
             tools=tools,
@@ -76,6 +89,14 @@ class AnthropicTransport(ProviderTransport):
             fast_mode=params.get("fast_mode", False),
             drop_context_1m_beta=params.get("drop_context_1m_beta", False),
         )
+        overrides = params.get("request_overrides")
+        extra_body = overrides.get("extra_body") if isinstance(overrides, dict) else None
+        if isinstance(extra_body, dict):
+            kwargs["extra_body"] = _merge_extra_body(
+                kwargs.get("extra_body") if isinstance(kwargs.get("extra_body"), dict) else {},
+                extra_body,
+            )
+        return kwargs
 
     def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:
         """Normalize Anthropic response to NormalizedResponse.

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -9,6 +9,18 @@ _MCP_PREFIX = "mcp__"
 _THINKING_TYPES = ("thinking", "redacted_thinking")
 
 
+def _merge_extra_body(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge request-body mappings, with ``override`` winning."""
+    merged = dict(base)
+    for key, value in override.items():
+        existing = merged.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            merged[key] = _merge_extra_body(existing, value)
+        else:
+            merged[key] = value
+    return merged
+
+
 def _unprefix_oauth_tool_name(name: str) -> str:
     """Reverse the OAuth-wire ``mcp__`` prefix back to the registered tool name.
     Two originals map onto one wire name (``read_file`` / ``mcp_linear_get_issue``), so
@@ -27,6 +39,7 @@ def _unprefix_oauth_tool_name(name: str) -> str:
 _BUILD_KWARG_DEFAULTS = {
     "max_tokens": 16384, "reasoning_config": None, "tool_choice": None, "is_oauth": False, "preserve_dots": False,
     "context_length": None, "base_url": None, "fast_mode": False, "drop_context_1m_beta": False,
+    "request_overrides": None,
 }
 
 
@@ -57,10 +70,22 @@ class AnthropicTransport(ProviderTransport):
     ) -> Dict[str, Any]:
         """Build Anthropic messages.create() kwargs (converts messages and tools internally)."""
         from agent.anthropic_adapter import build_anthropic_kwargs
-        return build_anthropic_kwargs(
+        kwargs = build_anthropic_kwargs(
             model=model, messages=messages, tools=tools,
-            **{key: params.get(key, default) for key, default in _BUILD_KWARG_DEFAULTS.items()},
+            **{
+                key: params.get(key, default)
+                for key, default in _BUILD_KWARG_DEFAULTS.items()
+                if key != "request_overrides"
+            },
         )
+        overrides = params.get("request_overrides")
+        extra_body = overrides.get("extra_body") if isinstance(overrides, dict) else None
+        if isinstance(extra_body, dict):
+            kwargs["extra_body"] = _merge_extra_body(
+                kwargs.get("extra_body") if isinstance(kwargs.get("extra_body"), dict) else {},
+                extra_body,
+            )
+        return kwargs
 
     def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:
         """Parse content blocks (text/thinking/tool_use), map stop_reason, collect reasoning_details."""

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -76,6 +76,18 @@ def _add_prompt_cache_key(
         api_kwargs["prompt_cache_key"] = cache_key
 
 
+def _merge_extra_body(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge request-body mappings, with ``override`` winning."""
+    merged = dict(base)
+    for key, value in override.items():
+        existing = merged.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            merged[key] = _merge_extra_body(existing, value)
+        else:
+            merged[key] = value
+    return merged
+
+
 def _reasoning_config_for_model(model: str, reasoning_config: dict | None) -> dict | None:
     """Return the model's wire-compatible reasoning config."""
     if not isinstance(reasoning_config, dict):
@@ -574,16 +586,23 @@ class ChatCompletionsTransport(ProviderTransport):
 
         # Merge any pre-built extra_body additions
         additions = params.get("extra_body_additions")
-        if additions:
-            extra_body.update(additions)
+        if isinstance(additions, dict):
+            extra_body = _merge_extra_body(extra_body, additions)
+
+        # Request overrides are explicit user configuration. Merge their
+        # extra_body recursively so nested user options preserve provider
+        # generated siblings (for example Ollama options.num_ctx).
+        overrides = params.get("request_overrides")
+        if overrides:
+            override_body = overrides.get("extra_body")
+            if isinstance(override_body, dict):
+                extra_body = _merge_extra_body(extra_body, override_body)
+            api_kwargs.update(
+                {key: value for key, value in overrides.items() if key != "extra_body"}
+            )
 
         if extra_body:
             api_kwargs["extra_body"] = extra_body
-
-        # Request overrides last (service_tier etc.)
-        overrides = params.get("request_overrides")
-        if overrides:
-            api_kwargs.update(overrides)
 
         _add_prompt_cache_key(
             api_kwargs,
@@ -692,23 +711,23 @@ class ChatCompletionsTransport(ProviderTransport):
             openrouter_min_coding_score=params.get("openrouter_min_coding_score"),
         )
         if profile_body:
-            extra_body.update(profile_body)
+            extra_body = _merge_extra_body(extra_body, profile_body)
 
         # Profile's reasoning/thinking extra_body entries
         if extra_body_from_profile:
-            extra_body.update(extra_body_from_profile)
+            extra_body = _merge_extra_body(extra_body, extra_body_from_profile)
 
         # Merge any pre-built extra_body additions from the caller
         additions = params.get("extra_body_additions")
-        if additions:
-            extra_body.update(additions)
+        if isinstance(additions, dict):
+            extra_body = _merge_extra_body(extra_body, additions)
 
         # Request overrides (user config)
         overrides = params.get("request_overrides")
         if overrides:
             for k, v in overrides.items():
                 if k == "extra_body" and isinstance(v, dict):
-                    extra_body.update(v)
+                    extra_body = _merge_extra_body(extra_body, v)
                 else:
                     api_kwargs[k] = v
 

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -109,6 +109,18 @@ def _add_prompt_cache_key(
         api_kwargs["prompt_cache_key"] = cache_key
 
 
+def _merge_extra_body(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge request-body mappings, with ``override`` winning."""
+    merged = dict(base)
+    for key, value in override.items():
+        existing = merged.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            merged[key] = _merge_extra_body(existing, value)
+        else:
+            merged[key] = value
+    return merged
+
+
 def _reasoning_config_for_model(model: str, reasoning_config: dict | None) -> dict | None:
     """Clamp Hermes' extended effort set (``ultra``) to the OpenAI-compat wire vocabulary.
 
@@ -433,12 +445,19 @@ class ChatCompletionsTransport(ProviderTransport):
             elif raw_thinking_config:
                 extra_body["thinking_config"] = raw_thinking_config
 
-        if params.get("extra_body_additions"):
-            extra_body.update(params["extra_body_additions"])
+        additions = params.get("extra_body_additions")
+        if isinstance(additions, dict):
+            extra_body = _merge_extra_body(extra_body, additions)
+
+        overrides = params.get("request_overrides")
+        if overrides:
+            override_body = overrides.get("extra_body")
+            if isinstance(override_body, dict):
+                extra_body = _merge_extra_body(extra_body, override_body)
+            api_kwargs.update({key: value for key, value in overrides.items() if key != "extra_body"})
+
         if extra_body:
             api_kwargs["extra_body"] = extra_body
-        if params.get("request_overrides"):
-            api_kwargs.update(params["request_overrides"])
         return _finish_kwargs(
             api_kwargs, sanitized, params,
             supports_prompt_cache_key=bool(params.get("supports_prompt_cache_key")) or _is_openai_api_base_url(base_url),
@@ -468,11 +487,11 @@ class ChatCompletionsTransport(ProviderTransport):
             openrouter_min_coding_score=params.get("openrouter_min_coding_score"),
         )
         for part in (profile_body, extra_body_from_profile, params.get("extra_body_additions")):
-            if part:
-                extra_body.update(part)
+            if isinstance(part, dict):
+                extra_body = _merge_extra_body(extra_body, part)
         for k, v in (params.get("request_overrides") or {}).items():
             if k == "extra_body" and isinstance(v, dict):
-                extra_body.update(v)
+                extra_body = _merge_extra_body(extra_body, v)
             else:
                 api_kwargs[k] = v
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -254,6 +254,7 @@ _RUNTIME_AGENT_OVERRIDE_KEYS = (
     "args",
     "credential_pool",
     "max_tokens",
+    "request_overrides",
 )
 
 
@@ -365,6 +366,7 @@ def _resolve_request_runtime_agent_kwargs(provider: str, target_model: Optional[
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
         "max_tokens": max_tokens,
+        "request_overrides": dict(runtime.get("request_overrides") or {}),
     }
 
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -251,7 +251,9 @@ _REQUEST_OPTION_MISSING = object()
 # vocabulary clamping happens downstream in agent.reasoning_effort.
 _REASONING_EFFORTS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"})
 _RUNTIME_AGENT_OVERRIDE_KEYS = (
-    "api_key", "base_url", "provider", "api_mode", "command", "args", "credential_pool")
+    "api_key", "base_url", "provider", "api_mode", "command", "args", "credential_pool",
+    "request_overrides",
+)
 
 
 def _clean_request_string(value: Any) -> Optional[str]:
@@ -317,7 +319,9 @@ def _resolve_request_runtime_agent_kwargs(provider: str, target_model: Optional[
     return {
         **{k: runtime.get(k) for k in ("api_key", "base_url", "provider", "api_mode", "command")},
         "args": list(runtime.get("args") or []),
-        "credential_pool": runtime.get("credential_pool")}
+        "credential_pool": runtime.get("credential_pool"),
+        "request_overrides": dict(runtime.get("request_overrides") or {}),
+    }
 
 
 def _request_agent_overrides(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2521,6 +2521,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
         "max_tokens": max_tokens,
+        "request_overrides": dict(runtime.get("request_overrides") or {}),
     }
 
 
@@ -2543,6 +2544,7 @@ def _resolve_runtime_agent_kwargs_for_provider(provider: str) -> dict:
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
+        "request_overrides": dict(runtime.get("request_overrides") or {}),
     }
 
 
@@ -2602,6 +2604,7 @@ def _try_resolve_fallback_provider() -> dict | None:
                     "args": list(runtime.get("args") or []),
                     "credential_pool": runtime.get("credential_pool"),
                     "model": entry.get("model"),
+                    "request_overrides": dict(runtime.get("request_overrides") or {}),
                 }
             except Exception as fb_exc:
                 logger.debug("Fallback entry %s failed: %s", entry.get("provider"), fb_exc)
@@ -7078,16 +7081,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             ),
         }
 
+        request_overrides = dict(runtime_kwargs.get("request_overrides") or {})
         service_tier = getattr(self, "_service_tier", None)
         if not service_tier:
-            route["request_overrides"] = {}
+            route["request_overrides"] = request_overrides
             return route
 
         try:
             overrides = resolve_fast_mode_overrides(route["model"])
         except Exception:
             overrides = None
-        route["request_overrides"] = overrides or {}
+        if overrides:
+            request_overrides.update(overrides)
+        route["request_overrides"] = request_overrides
         return route
 
     def _sync_session_model_from_agent(self, session_id: str, agent: Any) -> None:
@@ -22438,6 +22444,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _CACHE_BUSTING_CONFIG_KEYS: tuple = (
         ("model", "context_length"),
         ("model", "max_tokens"),
+        ("model", "extra_body"),
         ("compression", "enabled"),
         ("compression", "progress_notices"),
         ("compression", "threshold"),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4154,7 +4154,7 @@ class GatewayRunner(
     # cached agent or a mid-gateway edit is silently ignored. Add new baked-in settings here.
     # _MAX_INTERRUPT_DEPTH = 3  # Cap recursive interrupt handling (#816)
     _CACHE_BUSTING_CONFIG_KEYS: tuple = (
-        ("model", "context_length"), ("compression", "enabled"),
+        ("model", "context_length"), ("model", "extra_body"), ("compression", "enabled"),
         ("compression", "progress_notices"), ("compression", "threshold"),
         ("compression", "model_thresholds"), ("compression", "threshold_tokens"),
         ("compression", "codex_gpt55_autoraise"), ("compression", "codex_app_server_auto"),

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -90,6 +90,7 @@ class CLIAgentSetupMixin:
         resolved_acp_command = runtime.get("command")
         resolved_acp_args = list(runtime.get("args") or [])
         resolved_credential_pool = runtime.get("credential_pool")
+        resolved_request_overrides = dict(runtime.get("request_overrides") or {})
         # A callable api_key is a bearer-token provider (Azure Foundry
         # Entra ID — ``azure_identity_adapter.build_token_provider``).
         # The OpenAI SDK accepts ``Callable[[], str]`` for ``api_key`` and
@@ -130,12 +131,14 @@ class CLIAgentSetupMixin:
             or resolved_api_mode != self.api_mode
             or resolved_acp_command != self.acp_command
             or resolved_acp_args != self.acp_args
+            or resolved_request_overrides != getattr(self, "_runtime_request_overrides", {})
         )
         self.provider = resolved_provider
         self.api_mode = resolved_api_mode
         self.acp_command = resolved_acp_command
         self.acp_args = resolved_acp_args
         self._credential_pool = resolved_credential_pool
+        self._runtime_request_overrides = resolved_request_overrides
         self._provider_source = runtime.get("source")
         self.api_key = api_key
         self.base_url = base_url
@@ -304,10 +307,16 @@ class CLIAgentSetupMixin:
             "args": list(self.acp_args or []),
             "credential_pool": getattr(self, "_credential_pool", None),
         }
+        request_overrides = dict(
+            getattr(self, "_runtime_request_overrides", {}) or {}
+        )
         route = {
             "model": self.model,
             "runtime": runtime,
-            "signature": (
+        }
+
+        def _set_signature() -> None:
+            route["signature"] = (
                 self.model,
                 runtime["provider"],
                 runtime["requested_provider"],
@@ -315,19 +324,23 @@ class CLIAgentSetupMixin:
                 runtime["api_mode"],
                 runtime["command"],
                 tuple(runtime["args"]),
-            ),
-        }
+                repr(route["request_overrides"] or {}),
+            )
 
         service_tier = getattr(self, "service_tier", None)
         if not service_tier:
-            route["request_overrides"] = None
+            route["request_overrides"] = request_overrides or None
+            _set_signature()
             return route
 
         try:
             overrides = resolve_fast_mode_overrides(route["model"])
         except Exception:
             overrides = None
-        route["request_overrides"] = overrides
+        if overrides:
+            request_overrides.update(overrides)
+        route["request_overrides"] = request_overrides or None
+        _set_signature()
         return route
 
     def _init_agent(self, *, model_override: str = None, runtime_override: dict = None, request_overrides: dict | None = None) -> bool:
@@ -463,6 +476,10 @@ class CLIAgentSetupMixin:
                 "args": list(self.acp_args or []),
                 "credential_pool": getattr(self, "_credential_pool", None),
             }
+            if request_overrides is None:
+                request_overrides = dict(
+                    getattr(self, "_runtime_request_overrides", {}) or {}
+                ) or None
             effective_model = model_override or self.model
             self.agent = AIAgent(
                 model=effective_model,
@@ -549,6 +566,7 @@ class CLIAgentSetupMixin:
                 runtime.get("api_mode"),
                 runtime.get("command"),
                 tuple(runtime.get("args") or ()),
+                repr(request_overrides or {}),
             )
 
             # Force-create DB row on /title intent, then apply title.

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -41,14 +41,18 @@ def _current_runtime(cli) -> dict:
         "api_mode": cli.api_mode,
         "command": cli.acp_command,
         "args": list(cli.acp_args or []),
-        "credential_pool": getattr(cli, "_credential_pool", None)}
+        "credential_pool": getattr(cli, "_credential_pool", None),
+        "request_overrides": dict(getattr(cli, "_runtime_request_overrides", {}) or {}),
+    }
 
 
 def _route_signature(model, runtime: dict) -> tuple:
     """Hashable identity of (model, routing) used to detect when the agent must be rebuilt."""
     return (
         model, runtime.get("provider"), runtime.get("requested_provider"), runtime.get("base_url"),
-        runtime.get("api_mode"), runtime.get("command"), tuple(runtime.get("args") or ()))
+        runtime.get("api_mode"), runtime.get("command"), tuple(runtime.get("args") or ()),
+        repr(runtime.get("request_overrides") or {}),
+    )
 
 
 def _keyless_custom_base(base_url) -> bool:
@@ -201,6 +205,7 @@ class CLIAgentSetupMixin:
         resolved_routing = (
             resolved_provider, runtime.get("api_mode", self.api_mode), runtime.get("command"),
             list(runtime.get("args") or []))
+        resolved_request_overrides = dict(runtime.get("request_overrides") or {})
         # A callable api_key is a bearer-token provider (Azure Entra ID): the OpenAI SDK
         # invokes it per request, so skip string validation / placeholder substitution.
         if not callable(api_key) and not (isinstance(api_key, str) and api_key):
@@ -225,9 +230,13 @@ class CLIAgentSetupMixin:
                   "Check your provider config or run: hermes setup")
             return False
         credentials_changed = api_key != self.api_key or base_url != self.base_url
-        routing_changed = resolved_routing != (self.provider, self.api_mode, self.acp_command, self.acp_args)
+        routing_changed = (
+            resolved_routing != (self.provider, self.api_mode, self.acp_command, self.acp_args)
+            or resolved_request_overrides != getattr(self, "_runtime_request_overrides", {})
+        )
         self.provider, self.api_mode, self.acp_command, self.acp_args = resolved_routing
         self._credential_pool = runtime.get("credential_pool")
+        self._runtime_request_overrides = resolved_request_overrides
         self._provider_source = runtime.get("source")
         self.api_key = api_key
         self.base_url = base_url
@@ -377,16 +386,23 @@ class CLIAgentSetupMixin:
         auto/cold tiers are applied per request by agent.fast_mode instead."""
         from hermes_cli.models import resolve_fast_mode_overrides
         runtime = _current_runtime(self)
-        route = {"model": self.model, "runtime": runtime, "signature": _route_signature(self.model, runtime)}
-        overrides = None
+        request_overrides = dict(runtime.get("request_overrides") or {})
         if getattr(self, "service_tier", None) == "priority":
             try:
-                overrides = resolve_fast_mode_overrides(
-                    route["model"], provider=runtime["provider"], base_url=runtime["base_url"])
+                fast_overrides = resolve_fast_mode_overrides(
+                    self.model, provider=runtime["provider"], base_url=runtime["base_url"])
             except Exception:
-                pass
-        route["request_overrides"] = overrides
-        return route
+                fast_overrides = None
+            if fast_overrides:
+                request_overrides.update(fast_overrides)
+        request_overrides = request_overrides or None
+        return {
+            "model": self.model,
+            "runtime": runtime,
+            "request_overrides": request_overrides,
+            "signature": _route_signature(
+                self.model, {**runtime, "request_overrides": request_overrides}),
+        }
 
     def _follow_compression_chain(self, session_meta, announce):
         """If the resumed id is an empty compression-chain head, announce and switch to
@@ -504,6 +520,8 @@ class CLIAgentSetupMixin:
             return False
         try:
             runtime = runtime_override or _current_runtime(self)
+            if request_overrides is None:
+                request_overrides = dict(runtime.get("request_overrides") or {}) or None
             effective_model = model_override or self.model
             # -q never builds the prompt_toolkit app, so the clarify modal can't be
             # answered — answer headless instead of polling until clarify_timeout.
@@ -567,7 +585,8 @@ class CLIAgentSetupMixin:
                 seed_credits_at_session_start(self.agent)
             except Exception:
                 pass
-            self._active_agent_route_signature = _route_signature(effective_model, runtime)
+            self._active_agent_route_signature = _route_signature(
+                effective_model, {**runtime, "request_overrides": request_overrides})
 
             # Force-create DB row on /title intent, then apply title.
             if self._pending_title and self._session_db:

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -398,6 +398,7 @@ def _run_agent(
             platform="cli",
             session_db=session_db,
             credential_pool=runtime.get("credential_pool"),
+            request_overrides=runtime.get("request_overrides"),
             fallback_model=get_fallback_chain(cfg) or None,
             ephemeral_system_prompt=skills_prompt,
             # The only interactive callback wired: no user sits at a terminal. Sudo prompts gate on

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -433,6 +433,7 @@ def _run_agent(
             platform="cli",
             session_db=session_db,
             credential_pool=runtime.get("credential_pool"),
+            request_overrides=runtime.get("request_overrides"),
             fallback_model=_fb or None,
             # Interactive callbacks are intentionally NOT wired beyond this
             # one.  In oneshot mode there's no user sitting at a terminal:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -810,8 +810,8 @@ def _opencode_free_runtime(provider, requested_provider, model_cfg, target_model
     return _tag(_models.opencode_zen_free_runtime(provider, model), requested_provider)
 
 
-def resolve_runtime_provider(*, requested: Optional[str] = None, explicit_api_key: Optional[str] = None,
-                             explicit_base_url: Optional[str] = None, target_model: Optional[str] = None) -> Dict[str, Any]:
+def _resolve_runtime_provider(*, requested: Optional[str] = None, explicit_api_key: Optional[str] = None,
+                              explicit_base_url: Optional[str] = None, target_model: Optional[str] = None) -> Dict[str, Any]:
     """Resolve runtime provider credentials for agent execution. Ladder (order is behavior — each
     rung returns or raises, else falls to the next):
       1. disabled-provider guard (``providers.<name>.enabled: false``)
@@ -863,6 +863,43 @@ def _ladder_rungs(requested_provider, explicit_api_key, explicit_base_url, targe
     if pconfig and pconfig.auth_type == "api_key":
         yield _api_key_provider_runtime(provider, pconfig, requested_provider, model_cfg, target_model)
     yield _openrouter_fallback(requested_provider, explicit_api_key, explicit_base_url)
+
+
+def _deep_merge_extra_body(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge request-body mappings recursively, with ``override`` winning."""
+    merged = dict(base)
+    for key, value in override.items():
+        existing = merged.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            merged[key] = _deep_merge_extra_body(existing, value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _apply_model_extra_body(runtime: Dict[str, Any]) -> Dict[str, Any]:
+    """Attach user-configured ``model.extra_body`` to a resolved runtime."""
+    model_cfg = _get_model_config()
+    extra_body = model_cfg.get("extra_body") if isinstance(model_cfg, dict) else None
+    if not isinstance(extra_body, dict) or not extra_body:
+        return runtime
+
+    resolved = dict(runtime)
+    overrides = dict(resolved.get("request_overrides") or {})
+    existing_extra_body = overrides.get("extra_body")
+    overrides["extra_body"] = _deep_merge_extra_body(
+        existing_extra_body if isinstance(existing_extra_body, dict) else {}, extra_body)
+    resolved["request_overrides"] = overrides
+    return resolved
+
+
+def resolve_runtime_provider(*, requested: Optional[str] = None, explicit_api_key: Optional[str] = None,
+                             explicit_base_url: Optional[str] = None, target_model: Optional[str] = None) -> Dict[str, Any]:
+    """Resolve a runtime and attach model-level request fields."""
+    return _apply_model_extra_body(_resolve_runtime_provider(
+        requested=requested, explicit_api_key=explicit_api_key,
+        explicit_base_url=explicit_base_url, target_model=target_model,
+    ))
 
 
 def format_runtime_provider_error(error: Exception) -> str:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1662,7 +1662,7 @@ def _resolve_explicit_runtime(
     return None
 
 
-def resolve_runtime_provider(
+def _resolve_runtime_provider(
     *,
     requested: Optional[str] = None,
     explicit_api_key: Optional[str] = None,
@@ -2290,6 +2290,59 @@ def resolve_runtime_provider(
     )
     runtime["requested_provider"] = requested_provider
     return runtime
+
+
+def _deep_merge_extra_body(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge request-body mappings recursively, with ``override`` winning."""
+    merged = dict(base)
+    for key, value in override.items():
+        existing = merged.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            merged[key] = _deep_merge_extra_body(existing, value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _apply_model_extra_body(runtime: Dict[str, Any]) -> Dict[str, Any]:
+    """Attach ``model.extra_body`` to every resolved main-agent runtime.
+
+    A model-level payload is the user's explicit request configuration, so it
+    wins over a named custom provider's defaults. Nested mappings are merged
+    so a targeted override (for example ``options.seed``) keeps provider and
+    Hermes-generated siblings such as ``options.num_ctx``.
+    """
+    model_cfg = _get_model_config()
+    extra_body = model_cfg.get("extra_body") if isinstance(model_cfg, dict) else None
+    if not isinstance(extra_body, dict) or not extra_body:
+        return runtime
+
+    resolved = dict(runtime)
+    overrides = dict(resolved.get("request_overrides") or {})
+    existing_extra_body = overrides.get("extra_body")
+    overrides["extra_body"] = _deep_merge_extra_body(
+        existing_extra_body if isinstance(existing_extra_body, dict) else {},
+        extra_body,
+    )
+    resolved["request_overrides"] = overrides
+    return resolved
+
+
+def resolve_runtime_provider(
+    *,
+    requested: Optional[str] = None,
+    explicit_api_key: Optional[str] = None,
+    explicit_base_url: Optional[str] = None,
+    target_model: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Resolve a main-agent runtime and attach model-level request fields."""
+    runtime = _resolve_runtime_provider(
+        requested=requested,
+        explicit_api_key=explicit_api_key,
+        explicit_base_url=explicit_base_url,
+        target_model=target_model,
+    )
+    return _apply_model_extra_body(runtime)
 
 
 def format_runtime_provider_error(error: Exception) -> str:

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -224,6 +224,26 @@ class TestChatCompletionsBuildKwargs:
         )
         assert kw["extra_body"]["options"]["num_ctx"] == 32768
 
+    def test_request_extra_body_deep_merges_ollama_options(self, transport):
+        """A configured nested option must not erase Hermes' context limit."""
+        from providers import get_provider_profile
+
+        kw = transport.build_kwargs(
+            model="llama3",
+            messages=[{"role": "user", "content": "Hi"}],
+            provider_profile=get_provider_profile("custom"),
+            ollama_num_ctx=32768,
+            request_overrides={
+                "extra_body": {"options": {"seed": 42, "num_batch": 512}}
+            },
+        )
+
+        assert kw["extra_body"]["options"] == {
+            "num_ctx": 32768,
+            "seed": 42,
+            "num_batch": 512,
+        }
+
     def test_custom_think_false(self, transport):
         from providers import get_provider_profile
         profile = get_provider_profile("custom")

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -346,6 +346,26 @@ class TestChatCompletionsBuildKwargs:
         )
         assert kw["extra_body"]["options"]["num_ctx"] == 32768
 
+    def test_request_extra_body_deep_merges_ollama_options(self, transport):
+        """A configured nested option must not erase Hermes' context limit."""
+        from providers import get_provider_profile
+
+        kw = transport.build_kwargs(
+            model="llama3",
+            messages=[{"role": "user", "content": "Hi"}],
+            provider_profile=get_provider_profile("custom"),
+            ollama_num_ctx=32768,
+            request_overrides={
+                "extra_body": {"options": {"seed": 42, "num_batch": 512}}
+            },
+        )
+
+        assert kw["extra_body"]["options"] == {
+            "num_ctx": 32768,
+            "seed": 42,
+            "num_batch": 512,
+        }
+
     def test_custom_think_false(self, transport):
         from providers import get_provider_profile
         profile = get_provider_profile("custom")

--- a/tests/agent/transports/test_transport.py
+++ b/tests/agent/transports/test_transport.py
@@ -100,6 +100,26 @@ class TestAnthropicTransport:
         assert result[0]["name"] == "test_tool"
         assert "input_schema" in result[0]
 
+    def test_request_extra_body_merges_with_anthropic_generated_fields(
+        self, transport, monkeypatch
+    ):
+        """Model config can add a nested body field without dropping fast mode."""
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.build_anthropic_kwargs",
+            lambda **_kwargs: {"extra_body": {"options": {"server": True}, "speed": "fast"}},
+        )
+
+        kwargs = transport.build_kwargs(
+            model="claude-opus-4-6",
+            messages=[],
+            request_overrides={"extra_body": {"options": {"seed": 42}}},
+        )
+
+        assert kwargs["extra_body"] == {
+            "options": {"server": True, "seed": 42},
+            "speed": "fast",
+        }
+
 
 
 

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -200,6 +200,29 @@ class TestFastModeRouting(unittest.TestCase):
         assert route["runtime"]["provider"] == "openrouter"
         assert route.get("request_overrides") is None
 
+    def test_turn_route_keeps_runtime_extra_body_without_fast_mode(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace(
+            model="llama3.1",
+            api_key="local-key",
+            base_url="http://localhost:11434/v1",
+            provider="custom",
+            api_mode="chat_completions",
+            acp_command=None,
+            acp_args=[],
+            _credential_pool=None,
+            _runtime_request_overrides={
+                "extra_body": {"options": {"seed": 42}}
+            },
+            service_tier=None,
+        )
+
+        route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "hi")
+
+        assert route["request_overrides"] == {
+            "extra_body": {"options": {"seed": 42}}
+        }
+
 
 class TestAnthropicFastMode(unittest.TestCase):
     """Verify Anthropic Fast Mode model support and override resolution."""

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -184,6 +184,29 @@ class TestFastModeRouting(unittest.TestCase):
         assert route["runtime"]["provider"] == "openrouter"
         assert route.get("request_overrides") is None
 
+    def test_turn_route_keeps_runtime_extra_body_without_fast_mode(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace(
+            model="llama3.1",
+            api_key="local-key",
+            base_url="http://localhost:11434/v1",
+            provider="custom",
+            api_mode="chat_completions",
+            acp_command=None,
+            acp_args=[],
+            _credential_pool=None,
+            _runtime_request_overrides={
+                "extra_body": {"options": {"seed": 42}}
+            },
+            service_tier=None,
+        )
+
+        route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "hi")
+
+        assert route["request_overrides"] == {
+            "extra_body": {"options": {"seed": 42}}
+        }
+
 
 class TestAnthropicFastMode(unittest.TestCase):
     """Verify Anthropic Fast Mode model support and override resolution."""

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -129,6 +129,29 @@ def test_turn_route_injects_priority_processing_without_changing_runtime():
     assert route["request_overrides"] == {}
 
 
+def test_turn_route_carries_runtime_request_overrides():
+    """Model-level request fields survive gateway route construction."""
+    runner = _make_runner()
+    runtime_kwargs = {
+        "api_key": "***",
+        "base_url": "http://localhost:11434/v1",
+        "provider": "custom",
+        "requested_provider": "custom:ollama",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+        "max_tokens": None,
+        "request_overrides": {"extra_body": {"options": {"seed": 42}}},
+    }
+
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+        runner, "hi", "llama3.1", runtime_kwargs
+    )
+
+    assert route["request_overrides"] == {"extra_body": {"options": {"seed": 42}}}
+
+
 @pytest.mark.asyncio
 async def test_handle_fast_command_global_flag_persists_config(monkeypatch, tmp_path):
     runner = _make_runner()
@@ -173,5 +196,4 @@ async def test_session_fast_override_beats_config_default(monkeypatch, tmp_path)
     assert runner._resolve_session_service_tier(session_key=session_key) is None
     # A different session still gets the config default.
     assert runner._resolve_session_service_tier(session_key="other-session") == "priority"
-
 

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -124,6 +124,29 @@ def test_turn_route_injects_priority_processing_without_changing_runtime():
     assert route["request_overrides"] == {"service_tier": "priority"}
 
 
+def test_turn_route_carries_runtime_request_overrides():
+    """Model-level request fields survive gateway route construction."""
+    runner = _make_runner()
+    runtime_kwargs = {
+        "api_key": "***",
+        "base_url": "http://localhost:11434/v1",
+        "provider": "custom",
+        "requested_provider": "custom:ollama",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+        "max_tokens": None,
+        "request_overrides": {"extra_body": {"options": {"seed": 42}}},
+    }
+
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+        runner, "hi", "llama3.1", runtime_kwargs
+    )
+
+    assert route["request_overrides"] == {"extra_body": {"options": {"seed": 42}}}
+
+
 @pytest.mark.asyncio
 async def test_handle_fast_command_global_flag_persists_config(monkeypatch, tmp_path):
     runner = _make_runner()
@@ -168,5 +191,4 @@ async def test_session_fast_override_beats_config_default(monkeypatch, tmp_path)
     assert runner._resolve_session_service_tier(session_key=session_key) is None
     # A different session still gets the config default.
     assert runner._resolve_session_service_tier(session_key="other-session") == "priority"
-
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1783,3 +1783,42 @@ def test_custom_provider_pool_target_model_wins(monkeypatch):
 
     assert resolved is not None
     assert resolved["model"] == "myproxy/gemini-flash"
+
+
+def test_model_extra_body_merges_into_resolved_runtime(monkeypatch):
+    """``model.extra_body`` is carried on the normal runtime override rail."""
+    monkeypatch.setattr(
+        rp,
+        "_resolve_runtime_provider",
+        lambda **_kwargs: {
+            "provider": "custom",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "no-key-required",
+            "request_overrides": {
+                "extra_body": {
+                    "options": {"num_ctx": 131072, "seed": 1},
+                    "provider_default": True,
+                }
+            },
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "extra_body": {
+                "options": {"seed": 42, "num_batch": 512},
+                "model_only": {"enabled": True},
+            }
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider()
+
+    assert resolved["request_overrides"] == {
+        "extra_body": {
+            "options": {"num_ctx": 131072, "seed": 42, "num_batch": 512},
+            "provider_default": True,
+            "model_only": {"enabled": True},
+        }
+    }

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1553,3 +1553,42 @@ def test_resolve_named_custom_runtime_pool_result_includes_extra_headers(monkeyp
     assert resolved["source"] == "pool:lmstudio-pool"
     assert resolved["provider"] == "custom"
     assert resolved["requested_provider"] == "custom:lmstudio"
+
+
+def test_model_extra_body_merges_into_resolved_runtime(monkeypatch):
+    """``model.extra_body`` is carried on the normal runtime override rail."""
+    monkeypatch.setattr(
+        rp,
+        "_resolve_runtime_provider",
+        lambda **_kwargs: {
+            "provider": "custom",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "no-key-required",
+            "request_overrides": {
+                "extra_body": {
+                    "options": {"num_ctx": 131072, "seed": 1},
+                    "provider_default": True,
+                }
+            },
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "extra_body": {
+                "options": {"seed": 42, "num_batch": 512},
+                "model_only": {"enabled": True},
+            }
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider()
+
+    assert resolved["request_overrides"] == {
+        "extra_body": {
+            "options": {"num_ctx": 131072, "seed": 42, "num_batch": 512},
+            "provider_default": True,
+            "model_only": {"enabled": True},
+        }
+    }

--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -21,6 +21,7 @@ def test_make_agent_passes_resolved_provider():
         "command": None,
         "args": None,
         "credential_pool": None,
+        "request_overrides": {"extra_body": {"response_format": {"type": "json"}}},
     }
 
     fake_cfg = {
@@ -58,6 +59,9 @@ def test_make_agent_passes_resolved_provider():
         assert call_kwargs.kwargs["base_url"] == "https://api.anthropic.com"
         assert call_kwargs.kwargs["api_key"] == "sk-test-key"
         assert call_kwargs.kwargs["api_mode"] == "anthropic_messages"
+        assert call_kwargs.kwargs["request_overrides"] == {
+            "extra_body": {"response_format": {"type": "json"}}
+        }
 
 
 def test_probe_config_health_flags_null_sections():

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6438,6 +6438,7 @@ def _make_agent(
         acp_command=runtime.get("command"),
         acp_args=runtime.get("args"),
         credential_pool=runtime.get("credential_pool"),
+        request_overrides=runtime.get("request_overrides"),
         quiet_mode=True,
         # verbose_logging controls DEBUG-level agent logging; it is intentionally
         # independent of tool_progress_mode (which only controls per-tool

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2269,7 +2269,7 @@ def _make_agent(
         model=model, max_iterations=_cfg_max_turns(cfg, 500), provider=runtime.get("provider"),
         base_url=runtime.get("base_url"), api_key=runtime.get("api_key"), api_mode=runtime.get("api_mode"),
         acp_command=runtime.get("command"), acp_args=runtime.get("args"),
-        credential_pool=runtime.get("credential_pool"), quiet_mode=True,
+        credential_pool=runtime.get("credential_pool"), request_overrides=runtime.get("request_overrides"), quiet_mode=True,
         verbose_logging=False,  # DEBUG agent logging; independent of tool_progress_mode
         reasoning_config=(
             reasoning_config_override if reasoning_config_override is not None else _load_reasoning_config(str(model or ""))),

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1289,6 +1289,26 @@ providers:
       reasoning_effort: high
 ```
 
+For a request setting that belongs to your active main model rather than a
+named endpoint, put the same map under `model.extra_body` instead. This is an
+advanced escape hatch for provider-specific fields that Hermes does not expose
+as a first-class setting:
+
+```yaml
+model:
+  provider: ollama
+  default: qwen3:32b
+  extra_body:
+    options:
+      num_ctx: 65536
+      seed: 42
+```
+
+Hermes recursively merges `model.extra_body` with provider-generated request
+fields and custom-provider `extra_body` defaults. Fields you set under
+`model.extra_body` win on a conflict, while unrelated nested fields are kept.
+Use the request shape documented by your endpoint.
+
 Use the shape your server documents. For example, vLLM Gemma deployments and some NVIDIA NIM endpoints expect `enable_thinking` under `chat_template_kwargs` instead of as a top-level `extra_body` field:
 
 ```yaml

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1366,6 +1366,26 @@ providers:
       reasoning_effort: high
 ```
 
+For a request setting that belongs to your active main model rather than a
+named endpoint, put the same map under `model.extra_body` instead. This is an
+advanced escape hatch for provider-specific fields that Hermes does not expose
+as a first-class setting:
+
+```yaml
+model:
+  provider: ollama
+  default: qwen3:32b
+  extra_body:
+    options:
+      num_ctx: 65536
+      seed: 42
+```
+
+Hermes recursively merges `model.extra_body` with provider-generated request
+fields and custom-provider `extra_body` defaults. Fields you set under
+`model.extra_body` win on a conflict, while unrelated nested fields are kept.
+Use the request shape documented by your endpoint.
+
 Use the shape your server documents. For example, vLLM Gemma deployments and some NVIDIA NIM endpoints expect `enable_thinking` under `chat_template_kwargs` instead of as a top-level `extra_body` field:
 
 ```yaml


### PR DESCRIPTION
## What changed and why

Per the reporter's 2026-07-29 clarification, this ports #7218's intended behavior to current runtime routing. `model.extra_body` now flows through runtime resolution into normal agent requests, with recursive merging so an explicit nested setting such as `options.seed` preserves unrelated Hermes/provider-generated fields such as `options.num_ctx`. Explicit `model.extra_body` leaves win on conflicts.

The plumbing covers interactive CLI, the messaging gateway (including cache invalidation after a live config edit), API-server requests, one-shot CLI, and the TUI/desktop backend. It also applies the merge to chat-completions and Anthropic-message transports, and documents the setting as an advanced provider-specific escape hatch.

## How to test

1. Add a provider-specific payload to `config.yaml`, for example:

   ```yaml
   model:
     extra_body:
       options:
         num_ctx: 65536
         seed: 42
   ```

2. Start a CLI or gateway conversation and confirm the provider receives the fields alongside its generated request options.

3. Run:

   ```sh
   pytest -q tests/gateway/test_fast_command.py tests/cli/test_fast_command.py tests/hermes_cli/test_runtime_provider_resolution.py tests/agent/transports/test_chat_completions.py tests/agent/transports/test_transport.py tests/tui_gateway/test_make_agent_provider.py
   ```

   Result: 327 passed.

The required full-suite command was also attempted, but collection is blocked in this checkout because the system Python's pytest lacks `fastapi`/`uvicorn`; the available shared virtual environment has those packages but no pytest.

## What platforms tested on

- macOS (automated Python tests)

Fixes #7209

<!-- autocontrib:worker-id=issue-followup-1c1654dc kind=pr-open -->