### PR TITLE
fix(cli): route a provider-qualified -m to that provider, not the default

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4287,6 +4287,24 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # through MoA instead of hitting the real provider with an unknown
         # model (#56828). A ``moa:`` prefix wins over an explicit ``--provider``.
         _moa_provider_override, self.model = _normalize_moa_model(self.model)
+        # A provider-qualified model string has to select that provider too —
+        # the same reason the ``moa:`` prefix is decoded here (#56828).
+        # ``custom:<name>:<model>`` is the documented way to pick an entry out
+        # of the ``providers:`` block; when only the model half survives, the
+        # request is built for the DEFAULT provider with the unsplit string as
+        # the model name, so the whole prompt is transmitted to that provider's
+        # endpoint before it 404s — even when the user selected a local server
+        # (#73943). An explicit ``--provider`` still wins, but the model is
+        # split either way so the wire never carries the qualified form. A
+        # plain model name parses to no provider and is left untouched.
+        _model_provider_override = ""
+        if self.model:
+            from hermes_cli.models import parse_model_input as _parse_model_input
+
+            _parsed_provider, _parsed_model = _parse_model_input(self.model, "")
+            if _parsed_provider and _parsed_model:
+                _model_provider_override = _parsed_provider
+                self.model = _parsed_model
         # Read max_tokens from config (env var override: HERMES_MAX_TOKENS)
         _env_mt = os.environ.get("HERMES_MAX_TOKENS")
         if _env_mt:
@@ -4324,6 +4342,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.requested_provider = (
             _moa_provider_override
             or provider
+            or _model_provider_override
             or CLI_CONFIG["model"].get("provider")
             or os.getenv("HERMES_INFERENCE_PROVIDER")
             or "auto"

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -822,3 +822,36 @@ class TestProviderResolution:
         cli = _make_cli()
         assert isinstance(cli.model, str)
         assert isinstance(cli.model, str) and '/' in cli.model
+
+
+class TestProviderQualifiedModelString:
+    """A provider-qualified ``-m`` value must set the provider, not just the model.
+
+    ``custom:<name>:<model>`` is the documented way to select a provider from
+    the ``providers:`` block. Leaving ``requested_provider`` on the configured
+    default means the request is built for the DEFAULT endpoint with the
+    unsplit string as the model name — the whole prompt is transmitted to the
+    default cloud provider before it 404s (#73943). The ``moa:`` prefix right
+    above is decoded here for exactly this reason (#56828).
+    """
+
+    def test_custom_triple_sets_provider_and_model(self):
+        cli = _make_cli(model="custom:jetson-vllm:nemotron-nano-30b")
+        assert cli.requested_provider == "custom:jetson-vllm"
+        assert cli.model == "nemotron-nano-30b"
+
+    def test_known_provider_prefix_sets_provider_and_model(self):
+        cli = _make_cli(model="nous:hermes-3")
+        assert cli.requested_provider == "nous"
+        assert cli.model == "hermes-3"
+
+    def test_explicit_provider_flag_still_wins(self):
+        """--provider is the user's explicit choice; only the model is split."""
+        cli = _make_cli(model="custom:jetson-vllm:nemotron-nano-30b",
+                        provider="anthropic")
+        assert cli.requested_provider == "anthropic"
+        assert cli.model == "nemotron-nano-30b"
+
+    def test_plain_model_string_is_untouched(self):
+        cli = _make_cli(model="anthropic/claude-sonnet-4.5")
+        assert cli.model == "anthropic/claude-sonnet-4.5"


### PR DESCRIPTION
## What

`custom:<name>:<model>` is the documented way to select an entry from the `providers:` block, and `parse_model_input()` already decodes it correctly. `HermesCLI.__init__` never called it: `self.model` kept the raw string and `requested_provider` stayed on the configured default, so `_ensure_runtime_credentials()` resolved the **default** provider and the request was built for that endpoint with the unsplit string as the model name.

The consequence is **egress**, not just a failed call. A user who selects a *local* endpoint has the full prompt — user message included — transmitted to the default cloud provider before it 404s on the qualified model name (the reporter measured 17,963 bytes reaching `api.anthropic.com`). The error names only the model, so nothing tells the user the request went somewhere else.

The runtime resolver was always capable — it just never received the parsed provider. Confirmed against `main`:

```
parse_model_input("custom:jetson-vllm:nemotron-nano-30b", "")
  -> ("custom:jetson-vllm", "nemotron-nano-30b")
resolve_runtime_provider(requested="custom:jetson-vllm")
  -> base_url  http://192.168.1.149:8000/v1        # the local endpoint
```

## Fix

Decode the model string in `__init__` **before** provider resolution and feed the parsed provider into `requested_provider` — exactly what the `moa:` prefix already does two lines above, for the same stated reason ("Do this before provider resolution so `-Q -m moa:<preset>` routes through MoA instead of hitting the real provider with an unknown model", #56828).

- an explicit `--provider` still wins;
- the model is split either way, so the wire never carries the qualified form even when the provider was chosen by flag;
- a plain model name parses to no provider and is left untouched.

Scope: this is the egress path only. Per @jackjin1997's verification on the issue, the named runtime resolver and the ACP catalogue already handle named custom providers, so the remaining gap was precisely this entry path. The `providers:`-aware `parse_model_input` extension (bare `name:model`) is a separate behaviour change and is not attempted here.

## Tests

`tests/cli/test_cli_init.py::TestProviderQualifiedModelString` — four cases: the `custom:<name>:<model>` triple sets both halves, a known-provider prefix does too, an explicit `--provider` still wins while the model is still split, and a plain model string is untouched.

- The first three fail on `main` (`assert 'custom:jetson-vllm:nemotron-nano-30b' == 'nemotron-nano-30b'`); the fourth passes before and after and is the regression guard.
- `pytest tests/cli/test_cli_init.py -q` → 57 passed.
- `pytest tests/cli/ -q -k "init or model or provider or oneshot or moa"` → 127 passed / 0 failed, versus 123 passed on the stashed baseline — the delta is exactly the four new tests.
- `pytest tests/cli/ -q` → 1225 passed / 13 failed; that failure set (worktree / symlink suites) is pre-existing on this machine and unrelated.


Refs #73943
