### PR TITLE
fix(tests): use the platform temp dir for the isolation-probe handoff

### DIFF
--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -24,6 +24,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import textwrap
 import time
 from pathlib import Path
@@ -32,9 +33,14 @@ import pytest
 
 
 # Both tests share the same handoff file: the leaker writes here, the
-# verifier reads here. We park it in $TMPDIR with a unique-per-run name
-# so concurrent invocations of the suite don't clobber each other.
-_HANDOFF_DIR = Path(os.environ.get("TMPDIR", "/tmp")) / "hermes-isolation-probe"
+# verifier reads here. We park it in the platform temp dir with a
+# unique-per-run name so concurrent invocations of the suite don't clobber
+# each other. gettempdir() still honours $TMPDIR first, so POSIX behaviour is
+# unchanged; on Windows TMPDIR is normally unset and the old "/tmp" fallback
+# resolved to a non-existent \tmp on the current drive, raising here at import
+# time — before the skipif below could be evaluated — which aborts collection
+# for the entire suite.
+_HANDOFF_DIR = Path(tempfile.gettempdir()) / "hermes-isolation-probe"
 _HANDOFF_DIR.mkdir(exist_ok=True)
 
 


### PR DESCRIPTION
## What does this PR do?

`tests/test_run_tests_parallel.py` builds its handoff directory from
`os.environ.get("TMPDIR", "/tmp")` and `mkdir()`s it at **module scope**. On Windows
`TMPDIR` is normally unset — the platform uses `TEMP`/`TMP` — so the fallback resolves to a
non-existent `\tmp` on the current drive and raises during collection:

```
tests\test_run_tests_parallel.py:38: in <module>
    _HANDOFF_DIR.mkdir(exist_ok=True)
E   FileNotFoundError: [WinError 3] The system cannot find the path specified:
    '\tmp\hermes-isolation-probe'
```

pytest aborts the whole run on a collection error, so this single line stops the entire
suite on native Windows.

## The module already declares the right intent

Its docstring says *"POSIX-only … Marked accordingly"* and the probe carries
`@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only probe")`. The marker never
gets a chance to apply, because the `mkdir` runs at import time — before pytest evaluates
any marker.

`tempfile.gettempdir()` is the cross-platform primitive for this, and it still honours
`$TMPDIR` first, so POSIX behaviour is byte-identical. Nothing else changes: `_HANDOFF_DIR`
is read only by `_handoff_path_for`, whose sole caller is the skipped POSIX probe.

## Scope change since the first review

This PR originally carried two collection-time fixes. The `import pty` half **landed
independently on `main`** as `05504bd9f` (*test(gateway): make test_gateway collectable on
Windows*, @iso2kx, 2026-07-30) while this was open — same approach, same call site. That
half is dropped here and the branch is **rebased onto current `main`**, addressing
@monerostar's note that the head was ~600 commits behind. What remains is the one blocker
still live on `main` today.

## How to test

From **PowerShell or cmd** (not Git Bash — MSYS sets `TMPDIR`, which masks this entirely):

```powershell
python -m pytest tests/test_run_tests_parallel.py --collect-only -q
```

**Before**, on current `main` (`710b02663`):
```
E   FileNotFoundError: [WinError 3] ... '\tmp\hermes-isolation-probe'
Interrupted: 1 error during collection
no tests collected, 1 error
```

**After:**
```
7 tests collected in 0.12s        # exit 0
```

Running the file: `3 passed, 1 skipped, 3 failed`. The three failures are pre-existing
Windows gaps in the runner itself (`No test files to run` from
`scripts/run_tests_parallel.py`) — none of them reference `_HANDOFF_DIR` or
`_handoff_path_for`, and before this change they could not run at all.

## Platforms tested

Native Windows 11 Home, build 26200 · Python 3.11.6 · PowerShell (`TMPDIR` unset).
No production code is touched; on POSIX `gettempdir()` returns `$TMPDIR` exactly as the old
expression did.

## Why CI never caught this

All CI jobs run on `ubuntu-latest` (the only other runner in the tree is
`ubuntu-24.04-arm`, in `docker.yml`). There is no Windows runner, and Git Bash — the shell
most Windows contributors reach for — sets `TMPDIR` and hides the failure.

## Related

- `05504bd9f` — landed the `import pty` half of the original diff.
- #42872 — open PR for the third collection error (`tests/tools/test_search_hidden_dirs.py`).
- #48986 — Windows-native baseline failures (separate, untouched here).