### PR TITLE
feat(telegram): durable outbox for text sends — survives SIGKILL/reboot

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8030,6 +8030,61 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 logger.debug("Failed to cancel gateway loop floor timer", exc_info=True)
 
+    def _schedule_telegram_outbox_drain(self) -> None:
+        """One-shot, deferred drain of the durable Telegram outbox.
+
+        Runs after the Telegram adapter reports connected (cold start and
+        outage reconnect) so text sends interrupted by SIGKILL/reboot are
+        re-attempted instead of staying pending forever. Deferred off the
+        connect path for the same reason as the adapter's post-connect
+        housekeeping (#46298): resends are Bot API calls and must not eat
+        into the gateway's connect timeout. Contract: at most one drain task
+        in flight per runner — a reconnect landing mid-drain does not start a
+        second one (later reconnects after it finishes may drain again; the
+        WAL's own grace window and fresh-read compaction keep that safe).
+        Bounded (max_items/deadline) so a large backlog cannot stall shutdown
+        for long. Deliberately NOT wired into the per-profile adapter paths
+        in this change: profile sends write outboxes under their own profile
+        homes, and draining those correctly requires running the resend under
+        the matching profile runtime/secret scope — left as an explicit
+        follow-up rather than resending through the wrong bot from here.
+        """
+        # Shutdown guard. Deliberately keyed on _shutdown_event, NOT
+        # self._running: start() only flips _running=True after the connect
+        # loop, so a _running check would silently skip the cold-start drain
+        # (the primary reboot-recovery case this exists for).
+        shutdown_event = getattr(self, "_shutdown_event", None)
+        if shutdown_event is not None and shutdown_event.is_set():
+            return
+        task = getattr(self, "_telegram_outbox_drain_task", None)
+        if task is not None and not task.done():
+            return
+
+        async def _drain() -> None:
+            try:
+                from tools.telegram_outbox import outbox_drain
+
+                summary = await asyncio.to_thread(
+                    outbox_drain, max_items=100, deadline_seconds=120.0
+                )
+                if summary.get("attempted") or summary.get("dropped_stale"):
+                    logger.info("telegram outbox drain: %s", summary)
+            except Exception:
+                logger.warning(
+                    "telegram outbox drain failed; entries stay pending for "
+                    "the next connect",
+                    exc_info=True,
+                )
+
+        task = asyncio.ensure_future(_drain())
+        self._telegram_outbox_drain_task = task
+        # Owned like every other runner task: cancelled by _stop_impl's
+        # background-task sweep instead of surviving into shutdown.
+        registry = getattr(self, "_background_tasks", None)
+        if registry is not None:
+            registry.add(task)
+            task.add_done_callback(registry.discard)
+
     async def start(self) -> bool:
         """
         Start the gateway and all configured platform adapters.
@@ -8482,6 +8537,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         error_message=None,
                     )
                     logger.info("✓ %s connected", platform.value)
+                    if platform == Platform.TELEGRAM:
+                        self._schedule_telegram_outbox_drain()
                 else:
                     logger.warning("✗ %s failed to connect", platform.value)
                     # Defensive cleanup: a failed connect() may have
@@ -9566,6 +9623,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         if hasattr(adapter, "_voice_input_callback"):
                             adapter._voice_input_callback = self._handle_voice_channel_input
                         self.delivery_router.adapters = self.adapters
+                        if platform == Platform.TELEGRAM:
+                            self._schedule_telegram_outbox_drain()
                         del self._failed_platforms[platform]
                         self._update_platform_runtime_status(
                             platform.value,

--- a/tests/gateway/test_telegram_outbox_drain.py
+++ b/tests/gateway/test_telegram_outbox_drain.py
@@ -1,0 +1,316 @@
+"""Integration tests for the startup Telegram outbox drain.
+
+Covers the review ask on the durable-outbox PR: a send interrupted before
+completion (recorded as pending in the outbox WAL) must actually be re-sent
+once the gateway starts and the Telegram adapter reports connected — not
+merely recorded. Pre-seeds an isolated HERMES_HOME, runs GatewayRunner.start()
+with a stubbed Telegram connect, and observes the resend.
+"""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.run import GatewayRunner
+
+
+@pytest.fixture(autouse=True)
+def _isolated_outbox_home(tmp_path, monkeypatch):
+    """Point HERMES_HOME at a scratch dir so tests never touch the real
+    ~/.hermes/state/telegram-outbox.jsonl (same pattern as
+    tests/tools/test_send_message_telegram_outbox.py)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield
+
+
+class StubAdapter(BasePlatformAdapter):
+    def __init__(self, *, platform=Platform.TELEGRAM):
+        super().__init__(PlatformConfig(enabled=True, token="test"), platform)
+
+    async def connect(self, *, is_reconnect: bool = False):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True, message_id="1")
+
+    async def send_typing(self, chat_id, metadata=None):
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+def _make_runner(tmp_path):
+    """Minimal GatewayRunner via object.__new__ (mirrors
+    tests/gateway/test_platform_reconnect.py)."""
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="test")},
+        sessions_dir=tmp_path,
+    )
+    runner._running = True
+    runner._shutdown_event = asyncio.Event()
+    runner._exit_reason = None
+    runner._exit_with_failure = False
+    runner._exit_cleanly = False
+    runner._failed_platforms = {}
+    runner.adapters = {}
+    runner.delivery_router = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._honcho_managers = {}
+    runner._honcho_configs = {}
+    runner._shutdown_all_gateway_honcho = lambda: None
+    runner._background_tasks = set()
+    runner.session_store = MagicMock()
+    runner.hooks = MagicMock()
+    runner.hooks.loaded_hooks = []
+    runner.hooks.emit = AsyncMock()
+    runner._suspend_stuck_loop_sessions = MagicMock(return_value=0)
+    runner._update_runtime_status = MagicMock()
+    runner._update_platform_runtime_status = MagicMock()
+    runner._sync_voice_mode_state_to_adapter = MagicMock()
+    runner._send_update_notification = AsyncMock(return_value=True)
+    runner._send_restart_notification = AsyncMock()
+    runner._create_adapter = MagicMock(
+        side_effect=lambda platform, _config: StubAdapter(platform=platform)
+    )
+    runner._connect_adapter_with_timeout = AsyncMock(return_value=True)
+    return runner
+
+
+def _start_patches():
+    """The environment patches GatewayRunner.start() needs in a unit context
+    (same set as tests/gateway/test_platform_reconnect.py)."""
+
+    def fake_create_task(coro):
+        coro.close()
+        return MagicMock()
+
+    return [
+        patch("gateway.status.write_runtime_status"),
+        patch("hermes_cli.plugins.discover_plugins"),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("agent.shell_hooks.register_from_config"),
+        patch(
+            "tools.process_registry.process_registry.recover_from_checkpoint",
+            return_value=0,
+        ),
+        patch(
+            "gateway.channel_directory.build_channel_directory",
+            new=AsyncMock(return_value={"platforms": {}}),
+        ),
+        patch("gateway.run.asyncio.create_task", side_effect=fake_create_task),
+    ]
+
+
+class TestStartupOutboxDrain:
+    @pytest.mark.asyncio
+    async def test_pending_entry_is_resent_after_start(self, tmp_path):
+        """Pre-seeded pending outbox entry is re-sent once telegram connects."""
+        from tools.telegram_outbox import (
+            _outbox_path,
+            outbox_append,
+            outbox_pending_entries,
+        )
+
+        outbox_append(chat_id="414606068", message="interrupted send", thread_id=None)
+        assert len(outbox_pending_entries()) == 1
+        # Backdate the entry past the drain's grace window (fresh entries are
+        # deliberately skipped as likely in-flight; this one simulates a send
+        # interrupted before a reboot, i.e. genuinely old).
+        path = _outbox_path()
+        entry = json.loads(path.read_text().strip())
+        entry["created_at"] -= 600
+        path.write_text(json.dumps(entry, ensure_ascii=False) + "\n")
+
+        sent_payloads = []
+
+        def fake_send_message_tool(payload):
+            sent_payloads.append(payload)
+            return json.dumps({"success": True, "message_id": "99"})
+
+        runner = _make_runner(tmp_path)
+        patches = _start_patches()
+        for p in patches:
+            p.start()
+        try:
+            with patch(
+                "tools.send_message_tool.send_message_tool",
+                side_effect=fake_send_message_tool,
+            ):
+                assert await runner.start() is True
+                drain_task = getattr(runner, "_telegram_outbox_drain_task", None)
+                assert drain_task is not None, "drain was not scheduled on connect"
+                await drain_task
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert len(sent_payloads) == 1
+        assert sent_payloads[0]["message"] == "interrupted send"
+        assert sent_payloads[0]["target"] == "telegram:414606068"
+        # The drain's own resend must not re-append (it sets _skip_outbox).
+        assert sent_payloads[0].get("_skip_outbox") is True
+        assert outbox_pending_entries() == []
+
+    @pytest.mark.asyncio
+    async def test_empty_outbox_start_is_clean(self, tmp_path):
+        """No pending entries: drain runs, sends nothing, start unaffected."""
+        sent_payloads = []
+
+        def fake_send_message_tool(payload):  # pragma: no cover - must not fire
+            sent_payloads.append(payload)
+            return json.dumps({"success": True})
+
+        runner = _make_runner(tmp_path)
+        patches = _start_patches()
+        for p in patches:
+            p.start()
+        try:
+            with patch(
+                "tools.send_message_tool.send_message_tool",
+                side_effect=fake_send_message_tool,
+            ):
+                assert await runner.start() is True
+                drain_task = getattr(runner, "_telegram_outbox_drain_task", None)
+                assert drain_task is not None
+                await drain_task
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert sent_payloads == []
+
+    @pytest.mark.asyncio
+    async def test_drain_is_not_doubled_while_running(self, tmp_path):
+        """A reconnect landing mid-drain must not start a second drain task."""
+        runner = _make_runner(tmp_path)
+        release = asyncio.Event()
+
+        async def _slow_drain():
+            await release.wait()
+
+        runner._telegram_outbox_drain_task = asyncio.ensure_future(_slow_drain())
+        first = runner._telegram_outbox_drain_task
+        runner._schedule_telegram_outbox_drain()
+        assert runner._telegram_outbox_drain_task is first
+        release.set()
+        await first
+
+    @pytest.mark.asyncio
+    async def test_drain_failure_does_not_break_start(self, tmp_path):
+        """outbox_drain raising must be swallowed (entries stay pending)."""
+        runner = _make_runner(tmp_path)
+        with patch(
+            "tools.telegram_outbox.outbox_drain",
+            side_effect=RuntimeError("boom"),
+        ):
+            runner._schedule_telegram_outbox_drain()
+            await runner._telegram_outbox_drain_task  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_not_scheduled_during_shutdown(self, tmp_path):
+        """A connect finishing during shutdown must not start a drain.
+
+        Keyed on _shutdown_event, not _running — start() only flips _running
+        after the connect loop, so a _running guard would have silently
+        disabled the cold-start drain (caught in review)."""
+        runner = _make_runner(tmp_path)
+        runner._shutdown_event.set()
+        runner._schedule_telegram_outbox_drain()
+        assert getattr(runner, "_telegram_outbox_drain_task", None) is None
+
+    @pytest.mark.asyncio
+    async def test_scheduled_on_cold_start_before_running_flag(self, tmp_path):
+        """Cold start schedules the drain even while _running is still False
+        (real start() ordering: connect loop runs before _running=True)."""
+        runner = _make_runner(tmp_path)
+        runner._running = False  # what start() actually looks like mid-loop
+        with patch(
+            "tools.telegram_outbox.outbox_drain",
+            return_value={"attempted": 0, "sent": 0, "dropped_stale": 0, "still_pending": 0},
+        ):
+            runner._schedule_telegram_outbox_drain()
+            task = getattr(runner, "_telegram_outbox_drain_task", None)
+            assert task is not None
+            await task
+
+    @pytest.mark.asyncio
+    async def test_task_is_owned_by_background_registry(self, tmp_path):
+        """The drain task joins _background_tasks (shutdown sweep) and leaves
+        it when done."""
+        runner = _make_runner(tmp_path)
+        with patch(
+            "tools.telegram_outbox.outbox_drain",
+            return_value={"attempted": 0, "sent": 0, "dropped_stale": 0, "still_pending": 0},
+        ):
+            runner._schedule_telegram_outbox_drain()
+            task = runner._telegram_outbox_drain_task
+            assert task in runner._background_tasks
+            await task
+            await asyncio.sleep(0)  # let the done_callback run
+            assert task not in runner._background_tasks
+
+
+class TestDrainWalSemantics:
+    """WAL-level behaviors the gateway wiring relies on (review High #1)."""
+
+    def test_concurrent_append_survives_compaction(self):
+        """An append landing while the drain is sending must survive the
+        compaction rewrite (fresh-read-under-lock, not snapshot replace)."""
+        from tools import telegram_outbox as ob
+
+        ob.outbox_append(chat_id="1", message="old entry")
+        path = ob._outbox_path()
+        entry = json.loads(path.read_text().strip())
+        entry["created_at"] -= 600
+        path.write_text(json.dumps(entry, ensure_ascii=False) + "\n")
+
+        def send_and_append_concurrently(chat_id, message, thread_id):
+            # Simulates a live sender appending mid-drain.
+            ob.outbox_append(chat_id="2", message="landed mid-drain")
+            return True
+
+        summary = ob.outbox_drain(send_fn=send_and_append_concurrently, grace_seconds=0.0)
+        # grace=0 means the mid-drain append is drain-eligible next pass but
+        # was appended after this drain's snapshot — it must NOT be lost.
+        assert summary["sent"] == 1
+        remaining = ob.outbox_pending_entries()
+        assert [e["message"] for e in remaining] == ["landed mid-drain"]
+
+    def test_grace_window_skips_fresh_entries(self):
+        from tools import telegram_outbox as ob
+
+        ob.outbox_append(chat_id="1", message="fresh in-flight send")
+        sends = []
+        summary = ob.outbox_drain(send_fn=lambda *a: sends.append(a) or True)
+        assert summary["attempted"] == 0
+        assert sends == []
+        # Still pending — a later drain (past the window) will pick it up.
+        assert len(ob.outbox_pending_entries()) == 1
+
+    def test_max_items_bounds_attempts(self):
+        from tools import telegram_outbox as ob
+
+        path = ob._outbox_path()
+        lines = []
+        for i in range(3):
+            ob.outbox_append(chat_id=str(i), message=f"m{i}")
+        entries = [json.loads(l) for l in path.read_text().splitlines()]
+        for e in entries:
+            e["created_at"] -= 600
+            lines.append(json.dumps(e, ensure_ascii=False))
+        path.write_text("\n".join(lines) + "\n")
+
+        summary = ob.outbox_drain(send_fn=lambda *a: True, grace_seconds=0, max_items=2)
+        assert summary["attempted"] == 2
+        assert len(ob.outbox_pending_entries()) == 1

--- a/tests/tools/test_send_message_telegram_outbox.py
+++ b/tests/tools/test_send_message_telegram_outbox.py
@@ -1,0 +1,213 @@
+"""Regression tests for the durable Telegram outbox (2026-07-22).
+
+send_message_tool's Telegram text-send path now records a pending outbox
+entry before attempting delivery and marks it sent afterward — so a send
+that dies mid-flight (SIGKILL, host reboot; anything a signal handler can't
+catch) leaves a durable record that outbox_drain() can retry later, instead
+of being silently lost.
+
+These tests exercise the wiring inside send_message_tool.py end-to-end
+(mocking _send_to_platform / load_gateway_config, same pattern as
+test_send_message_tool.py), not the outbox module's own unit tests (see
+tests/tools/test_telegram_outbox.py for those).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+def _run_async_immediately(coro):
+    return asyncio.run(coro)
+
+
+def _make_telegram_config():
+    from gateway.config import Platform
+
+    telegram_cfg = SimpleNamespace(enabled=True, token="***", extra={})
+    return SimpleNamespace(
+        platforms={Platform.TELEGRAM: telegram_cfg},
+        get_home_channel=lambda _platform: None,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_outbox_home(tmp_path, monkeypatch):
+    """Point HERMES_HOME at a scratch dir so tests never touch the real
+    ~/.hermes/state/telegram-outbox.jsonl."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield
+
+
+class TestTelegramOutboxWiring:
+    def test_successful_send_appends_then_marks_sent(self):
+        from tools.send_message_tool import send_message_tool
+        from tools.telegram_outbox import outbox_pending_entries
+
+        config = _make_telegram_config()
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool({
+                    "action": "send",
+                    "target": "telegram:12345",
+                    "message": "hello outbox",
+                })
+            )
+
+        assert result["success"] is True
+        # Entry was appended and then immediately marked sent on success —
+        # nothing should remain pending afterward.
+        assert outbox_pending_entries() == []
+
+    def test_failed_send_leaves_entry_pending(self):
+        from tools.send_message_tool import send_message_tool
+        from tools.telegram_outbox import outbox_pending_entries
+
+        config = _make_telegram_config()
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"error": "boom"})), \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            send_message_tool({
+                "action": "send",
+                "target": "telegram:12345",
+                "message": "will fail",
+            })
+
+        pending = outbox_pending_entries()
+        assert len(pending) == 1
+        assert pending[0]["message"] == "will fail"
+        assert pending[0]["chat_id"] == "12345"
+
+    def test_exception_during_send_leaves_entry_pending(self):
+        """A raised exception (not just a {"error": ...} result) must also
+        leave the outbox entry pending — this is the exact failure mode a
+        SIGKILL mid-send would produce (send never returns at all)."""
+        from tools.send_message_tool import send_message_tool
+        from tools.telegram_outbox import outbox_pending_entries
+
+        config = _make_telegram_config()
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(side_effect=RuntimeError("network died"))), \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool({
+                    "action": "send",
+                    "target": "telegram:12345",
+                    "message": "died mid-send",
+                })
+            )
+
+        assert "error" in result
+        pending = outbox_pending_entries()
+        assert len(pending) == 1
+        assert pending[0]["message"] == "died mid-send"
+
+    def test_media_send_does_not_use_outbox(self, tmp_path):
+        """Scoped to text-only for this pass — media re-send on drain would
+        need file paths that may no longer exist after a crash."""
+        from tools.send_message_tool import send_message_tool
+        from tools.telegram_outbox import outbox_pending_entries
+
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0fake-jpeg-bytes")
+
+        config = _make_telegram_config()
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"error": "boom"})), \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            send_message_tool({
+                "action": "send",
+                "target": "telegram:12345",
+                "message": f"[[media:{img}]] caption",
+            })
+
+        assert outbox_pending_entries() == []
+
+    def test_skip_outbox_flag_prevents_reentrant_append(self):
+        """outbox_drain()'s own resend path sets _skip_outbox=True so a
+        retry-of-a-retry doesn't keep appending fresh pending entries for
+        what is logically the same message."""
+        from tools.send_message_tool import send_message_tool
+        from tools.telegram_outbox import outbox_pending_entries
+
+        config = _make_telegram_config()
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"error": "still down"})), \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            send_message_tool({
+                "action": "send",
+                "target": "telegram:12345",
+                "message": "retried by drain",
+                "_skip_outbox": True,
+            })
+
+        assert outbox_pending_entries() == []
+
+    def test_non_telegram_platform_does_not_use_outbox(self):
+        from gateway.config import Platform
+        from tools.send_message_tool import send_message_tool
+        from tools.telegram_outbox import outbox_pending_entries
+
+        ntfy_cfg = SimpleNamespace(enabled=True, token=None, extra={"topic": "hermes-in"})
+        config = SimpleNamespace(
+            platforms={Platform("ntfy"): ntfy_cfg},
+            get_home_channel=lambda _platform: None,
+        )
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("gateway.channel_directory.resolve_channel_name", side_effect=AssertionError("should not resolve")), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"error": "boom"})), \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            send_message_tool({
+                "action": "send",
+                "target": "ntfy:alerts-channel",
+                "message": "not telegram",
+            })
+
+        assert outbox_pending_entries() == []
+
+    def test_outbox_append_failure_never_blocks_the_real_send(self, monkeypatch):
+        """If outbox bookkeeping itself is broken, the actual Telegram send
+        must still go through unaffected — durability is best-effort and
+        must never gate whether a real message can be delivered."""
+        from tools.send_message_tool import send_message_tool
+
+        def _broken_append(*a, **kw):
+            raise RuntimeError("disk full")
+
+        monkeypatch.setattr("tools.telegram_outbox.outbox_append", _broken_append)
+
+        config = _make_telegram_config()
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool({
+                    "action": "send",
+                    "target": "telegram:12345",
+                    "message": "outbox is broken but I still send",
+                })
+            )
+
+        assert result["success"] is True

--- a/tests/tools/test_telegram_outbox_unit.py
+++ b/tests/tools/test_telegram_outbox_unit.py
@@ -45,7 +45,8 @@ def test_drain_delivers_pending_and_compacts():
         return True  # pretend Telegram accepted it
 
     summary = ob.outbox_drain(send_fn=fake_send, grace_seconds=0)
-    assert summary == {"attempted": 2, "sent": 2, "dropped_stale": 0, "still_pending": 0}
+    assert summary == {"attempted": 2, "sent": 2, "dropped_stale": 0,
+                       "still_pending": 0, "ambiguous_replayed": 0}
     assert len(delivered) == 2
     assert ob.outbox_pending_entries() == []
 
@@ -116,3 +117,77 @@ def test_thread_id_round_trips_through_pending_entries():
     pending = ob.outbox_pending_entries()
     assert pending[0]["thread_id"] == "42"
     assert pending[0]["id"] == eid
+
+
+def test_ambiguous_entry_is_replayed_with_marker(tmp_path, monkeypatch):
+    """Crash between Bot-API acceptance and tombstone must NOT silently duplicate.
+
+    Review #74085: current main labels that state (delivery_ledger's
+    RECOVERED_MARKER) rather than resending blind. This asserts the outbox
+    honours the same contract — and that a *clean* pending entry is not
+    labeled (a marker on every replay would be crying wolf).
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import telegram_outbox as tox
+
+    clean_id = tox.outbox_append(111, "clean pending")
+    amb_id = tox.outbox_append(222, "ambiguous send")
+    tox.outbox_mark_attempting(amb_id)          # crashed right after this
+
+    seen = {}
+
+    def fake_send(chat_id, message, thread_id, ambiguous=False):
+        seen[chat_id] = ambiguous
+        return True
+
+    summary = tox.outbox_drain(send_fn=fake_send, grace_seconds=0)
+    assert summary["attempted"] == 2
+    assert summary["ambiguous_replayed"] == 1, summary
+    assert seen[222] is True, "attempting-without-tombstone must be labeled"
+    assert seen[111] is False, "clean pending must NOT be labeled"
+
+
+def test_legacy_send_fn_without_ambiguous_still_works(tmp_path, monkeypatch):
+    """Signature detection happens once; a 3-arg send_fn must not be called twice.
+
+    Probing with TypeError at call time double-sent whenever send_fn itself
+    raised TypeError internally.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import telegram_outbox as tox
+
+    tox.outbox_append(333, "legacy path")
+    calls = []
+
+    def legacy_send(chat_id, message, thread_id):
+        calls.append(chat_id)
+        return True
+
+    summary = tox.outbox_drain(send_fn=legacy_send, grace_seconds=0)
+    assert calls == [333], f"sent {len(calls)}x, expected exactly once"
+    assert summary["sent"] == 1
+
+
+def test_ambiguity_survives_compaction(tmp_path, monkeypatch):
+    """An unresolved 'attempting' entry must stay labeled after a compaction pass.
+
+    Otherwise the next drain sees a clean pending and silently duplicates.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import telegram_outbox as tox
+
+    amb_id = tox.outbox_append(444, "stays ambiguous")
+    tox.outbox_mark_attempting(amb_id)
+
+    # First drain: send fails, so the entry survives compaction still-pending.
+    tox.outbox_drain(send_fn=lambda c, m, t, ambiguous=False: False, grace_seconds=0)
+
+    seen = {}
+
+    def fake_send(chat_id, message, thread_id, ambiguous=False):
+        seen[chat_id] = ambiguous
+        return True
+
+    summary = tox.outbox_drain(send_fn=fake_send, grace_seconds=0)
+    assert seen.get(444) is True, "ambiguity was lost across compaction"
+    assert summary["ambiguous_replayed"] == 1

--- a/tests/tools/test_telegram_outbox_unit.py
+++ b/tests/tools/test_telegram_outbox_unit.py
@@ -44,7 +44,7 @@ def test_drain_delivers_pending_and_compacts():
         delivered.append((chat_id, message))
         return True  # pretend Telegram accepted it
 
-    summary = ob.outbox_drain(send_fn=fake_send)
+    summary = ob.outbox_drain(send_fn=fake_send, grace_seconds=0)
     assert summary == {"attempted": 2, "sent": 2, "dropped_stale": 0, "still_pending": 0}
     assert len(delivered) == 2
     assert ob.outbox_pending_entries() == []
@@ -56,7 +56,7 @@ def test_drain_leaves_failed_sends_pending():
     def fake_send_fail(chat_id, message, thread_id):
         return False  # simulate Telegram API down
 
-    summary = ob.outbox_drain(send_fn=fake_send_fail)
+    summary = ob.outbox_drain(send_fn=fake_send_fail, grace_seconds=0)
     assert summary["attempted"] == 1
     assert summary["sent"] == 0
     assert summary["still_pending"] == 1
@@ -80,7 +80,7 @@ def test_drain_drops_stale_entries_without_attempting_resend():
         called.append(1)
         return True
 
-    summary = ob.outbox_drain(send_fn=fake_send, max_age_seconds=3600)
+    summary = ob.outbox_drain(send_fn=fake_send, max_age_seconds=3600, grace_seconds=0)
     assert summary["dropped_stale"] == 1
     assert summary["attempted"] == 0
     assert called == [], "stale entry must not be attempted"

--- a/tests/tools/test_telegram_outbox_unit.py
+++ b/tests/tools/test_telegram_outbox_unit.py
@@ -1,0 +1,118 @@
+"""Unit tests for the standalone telegram_outbox module (2026-07-22).
+
+See tests/tools/test_send_message_telegram_outbox.py for the end-to-end
+wiring tests (via send_message_tool's Telegram send path). These tests
+exercise telegram_outbox.py in isolation — no gateway config, no mocked
+Telegram bot, just the append/mark_sent/drain bookkeeping on disk.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tools import telegram_outbox as ob
+
+
+@pytest.fixture(autouse=True)
+def _isolated_outbox_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield
+
+
+def test_append_and_pending():
+    eid = ob.outbox_append("12345", "hello world")
+    assert eid is not None, "append should return an id"
+    pending = ob.outbox_pending_entries()
+    assert len(pending) == 1
+    assert pending[0]["message"] == "hello world"
+
+
+def test_mark_sent_removes_from_pending():
+    eid = ob.outbox_append("12345", "will be sent")
+    ob.outbox_mark_sent(eid)
+    assert ob.outbox_pending_entries() == []
+
+
+def test_drain_delivers_pending_and_compacts():
+    ob.outbox_append("111", "msg one")
+    ob.outbox_append("222", "msg two")
+    delivered = []
+
+    def fake_send(chat_id, message, thread_id):
+        delivered.append((chat_id, message))
+        return True  # pretend Telegram accepted it
+
+    summary = ob.outbox_drain(send_fn=fake_send)
+    assert summary == {"attempted": 2, "sent": 2, "dropped_stale": 0, "still_pending": 0}
+    assert len(delivered) == 2
+    assert ob.outbox_pending_entries() == []
+
+
+def test_drain_leaves_failed_sends_pending():
+    ob.outbox_append("333", "will fail to send")
+
+    def fake_send_fail(chat_id, message, thread_id):
+        return False  # simulate Telegram API down
+
+    summary = ob.outbox_drain(send_fn=fake_send_fail)
+    assert summary["attempted"] == 1
+    assert summary["sent"] == 0
+    assert summary["still_pending"] == 1
+    pending = ob.outbox_pending_entries()
+    assert len(pending) == 1
+    assert pending[0]["message"] == "will fail to send"
+
+
+def test_drain_drops_stale_entries_without_attempting_resend():
+    ob.outbox_append("444", "ancient message")
+    # Backdate created_at to simulate an entry far older than max_age_seconds.
+    path = ob._outbox_path()
+    lines = path.read_text(encoding="utf-8").splitlines()
+    rec = json.loads(lines[0])
+    rec["created_at"] = 0  # epoch — infinitely old
+    path.write_text(json.dumps(rec) + "\n", encoding="utf-8")
+
+    called = []
+
+    def fake_send(chat_id, message, thread_id):
+        called.append(1)
+        return True
+
+    summary = ob.outbox_drain(send_fn=fake_send, max_age_seconds=3600)
+    assert summary["dropped_stale"] == 1
+    assert summary["attempted"] == 0
+    assert called == [], "stale entry must not be attempted"
+
+
+def test_pending_entries_skip_corrupt_lines():
+    path = ob._outbox_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "not json at all\n"
+        '{"id": "abc", "status": "pending", "chat_id": "1", "message": "ok", "created_at": 0}\n'
+        "\n",
+        encoding="utf-8",
+    )
+    pending = ob.outbox_pending_entries()
+    assert len(pending) == 1
+    assert pending[0]["id"] == "abc"
+
+
+def test_append_never_raises_even_if_state_dir_uncreatable(tmp_path, monkeypatch):
+    # Point HERMES_HOME at a dir where "state" already exists as a FILE, so
+    # state_dir.mkdir() inside _outbox_path() raises FileExistsError.
+    blocker = tmp_path / "state"
+    blocker.write_text("i am a file, not a directory", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    eid = ob.outbox_append("1", "test")
+    assert eid is None, "append should fail gracefully (return None), not raise"
+
+
+def test_thread_id_round_trips_through_pending_entries():
+    eid = ob.outbox_append("999", "topic message", thread_id="42")
+    pending = ob.outbox_pending_entries()
+    assert pending[0]["thread_id"] == "42"
+    assert pending[0]["id"] == eid

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -503,6 +503,18 @@ def _handle_send(args):
         except Exception:
             pass  # best-effort durability — never blocks the real send below
 
+    if _outbox_entry_id:
+        # Mark attempting immediately before handing the message to the Bot
+        # API. A crash between here and the tombstone is *ambiguous* — the
+        # platform may already have it — and the drain must label that replay
+        # rather than silently duplicate it (review #74085; same contract as
+        # delivery_ledger.mark_attempting).
+        try:
+            from tools.telegram_outbox import outbox_mark_attempting
+            outbox_mark_attempting(_outbox_entry_id)
+        except Exception:
+            pass  # best-effort bookkeeping — never blocks the real send
+
     try:
         from model_tools import _run_async
         result = _run_async(

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -487,6 +487,22 @@ def _handle_send(args):
                 return json.dumps(_resolve_err)
             chat_id = _resolved
 
+    # Durable outbox (2026-07-22): text-only Telegram sends are recorded to
+    # disk before the attempt, so a send that dies mid-flight (SIGKILL, host
+    # reboot — anything a signal handler can't catch) is not silently lost;
+    # outbox_drain() can re-attempt it later. Scoped to telegram+text-only to
+    # keep blast radius small (media re-send on drain would need file paths
+    # that may no longer exist after a crash — out of scope for this pass).
+    # `_skip_outbox` is set by outbox_drain()'s own resend path to avoid
+    # re-appending a new entry for every retry of the same logical message.
+    _outbox_entry_id = None
+    if platform_name == "telegram" and not media_files and not args.get("_skip_outbox"):
+        try:
+            from tools.telegram_outbox import outbox_append
+            _outbox_entry_id = outbox_append(chat_id, cleaned_message, thread_id=thread_id)
+        except Exception:
+            pass  # best-effort durability — never blocks the real send below
+
     try:
         from model_tools import _run_async
         result = _run_async(
@@ -500,6 +516,12 @@ def _handle_send(args):
                 force_document=force_document_attachments,
             )
         )
+        if _outbox_entry_id and isinstance(result, dict) and result.get("success"):
+            try:
+                from tools.telegram_outbox import outbox_mark_sent
+                outbox_mark_sent(_outbox_entry_id)
+            except Exception:
+                pass  # message was sent; only the outbox bookkeeping is stale
         if used_home_channel and isinstance(result, dict) and result.get("success"):
             result["note"] = f"Sent to {platform_name} home channel (chat_id: {chat_id})"
 

--- a/tools/telegram_outbox.py
+++ b/tools/telegram_outbox.py
@@ -116,12 +116,62 @@ def outbox_append(chat_id: str, message: str, thread_id: str | None = None) -> s
     try:
         path = _outbox_path()
         with _outbox_lock(path):
-            with open(path, "a", encoding="utf-8") as f:
-                f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+            _durable_append(path, entry)
         return entry_id
     except Exception as e:
         logger.warning("telegram_outbox: append failed (send proceeds anyway): %s", e)
         return None
+
+
+def _durable_append_fh(f, record: dict) -> None:
+    """Write one JSON line to an already-open handle and fsync it."""
+    f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    f.flush()
+    os.fsync(f.fileno())
+
+
+def _durable_append(path: Path, record: dict) -> None:
+    """Append one JSON line and make it survive a power loss / reboot.
+
+    Review #74085: the original append relied on Python buffering + normal
+    process exit, so the title's "survives SIGKILL/reboot" only held for
+    SIGKILL. flush()+fsync() covers the reboot case; the parent-directory
+    fsync covers first-ever creation (otherwise the file itself can be
+    missing from the directory after a crash even though its data landed).
+    """
+    existed = path.exists()
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        f.flush()
+        os.fsync(f.fileno())
+    if not existed:
+        try:
+            dfd = os.open(str(path.parent), os.O_RDONLY)
+            try:
+                os.fsync(dfd)
+            finally:
+                os.close(dfd)
+        except OSError:
+            pass      # best-effort: never block a send over directory fsync
+
+
+def outbox_mark_attempting(entry_id: str | None) -> None:
+    """Record that a send is about to be handed to the Bot API.
+
+    Mirrors ``delivery_ledger.mark_attempting()``. A crash after this point
+    but before the tombstone leaves an *ambiguous* entry: the platform may
+    already hold the message. The drain must not silently resend those —
+    see ``outbox_drain``.
+    """
+    if not entry_id:
+        return
+    try:
+        path = _outbox_path()
+        with _outbox_lock(path):
+            _durable_append(path, {"id": entry_id, "status": "attempting",
+                                   "attempting_at": time.time()})
+    except Exception as e:
+        logger.warning("telegram_outbox: mark_attempting failed: %s", e)
 
 
 def outbox_mark_sent(entry_id: str | None) -> None:
@@ -138,19 +188,25 @@ def outbox_mark_sent(entry_id: str | None) -> None:
         path = _outbox_path()
         with _outbox_lock(path):
             with open(path, "a", encoding="utf-8") as f:
-                f.write(json.dumps({"id": entry_id, "status": "sent", "sent_at": time.time()}, ensure_ascii=False) + "\n")
+                _durable_append_fh(f, {"id": entry_id, "status": "sent", "sent_at": time.time()})
     except Exception as e:
         logger.warning("telegram_outbox: mark_sent failed for %s (message was sent; only the outbox record is stale): %s", entry_id, e)
 
 
-def _load_resolved_ids(lines: list[str]) -> tuple[dict[str, dict], set[str]]:
-    """Parse outbox lines into (id -> pending entry, set of resolved ids).
+def _load_resolved_ids(lines: list[str]) -> tuple[dict[str, dict], set[str], set[str]]:
+    """Parse outbox lines into (id -> pending entry, resolved ids, ambiguous ids).
 
     Malformed lines are skipped (best-effort log parsing — a single corrupt
     line must never make the whole outbox unreadable).
+
+    ``ambiguous`` holds ids that reached ``attempting`` without a tombstone:
+    the Bot API may already have accepted them. Review #74085 required that
+    these be *labeled* on replay rather than silently duplicated, matching
+    ``delivery_ledger``'s contract (``RECOVERED_MARKER``).
     """
     pending: dict[str, dict] = {}
     resolved: set[str] = set()
+    ambiguous: set[str] = set()
     for line in lines:
         line = line.strip()
         if not line:
@@ -164,9 +220,13 @@ def _load_resolved_ids(lines: list[str]) -> tuple[dict[str, dict], set[str]]:
             continue
         if rec.get("status") == "sent":
             resolved.add(rid)
+        elif rec.get("status") == "attempting":
+            # 崩在 Bot API 已收下但 tombstone 未寫之間：平台可能已經有這則。
+            # 不移出 pending（還是要重送），但標記成模糊，重送時必須帶標記。
+            ambiguous.add(rid)
         elif rec.get("status") == "pending":
             pending[rid] = rec
-    return pending, resolved
+    return pending, resolved, ambiguous
 
 
 def outbox_pending_entries() -> list[dict]:
@@ -183,7 +243,7 @@ def outbox_pending_entries() -> list[dict]:
     except Exception as e:
         logger.warning("telegram_outbox: failed to read outbox for inspection: %s", e)
         return []
-    pending, resolved = _load_resolved_ids(lines)
+    pending, resolved, _amb = _load_resolved_ids(lines)
     return [e for rid, e in sorted(pending.items(), key=lambda kv: kv[1].get("created_at", 0)) if rid not in resolved]
 
 
@@ -220,7 +280,7 @@ def outbox_drain(
     that entry pending for the next drain call.
     """
     if send_fn is None:
-        def send_fn(chat_id, message, thread_id):
+        def send_fn(chat_id, message, thread_id, ambiguous=False):
             from tools.send_message_tool import send_message_tool
             # Telegram topic target format is "chat_id:thread_id" (see
             # _TELEGRAM_TOPIC_TARGET_RE in send_message_tool.py).
@@ -229,10 +289,23 @@ def outbox_drain(
             # without this flag _handle_send would outbox_append() again on
             # every retry, growing the file with duplicate pending entries
             # for what is logically the same message.
+            body = message
+            if ambiguous:
+                # Honest at-least-once: the platform may already hold this
+                # message, so label the replay instead of silently duplicating
+                # it — same contract as delivery_ledger (review #74085).
+                try:
+                    from gateway.delivery_ledger import RECOVERED_MARKER
+                except Exception:
+                    RECOVERED_MARKER = (
+                        "♻️ Recovered reply — the gateway restarted during "
+                        "delivery, so this may be a duplicate:\n\n"
+                    )
+                body = f"{RECOVERED_MARKER}{message}"
             result_str = send_message_tool({
                 "action": "send",
                 "target": target,
-                "message": message,
+                "message": body,
                 "_skip_outbox": True,
             })
             try:
@@ -241,9 +314,20 @@ def outbox_drain(
                 return False
             return bool(result.get("success"))
 
+    # Detect the send_fn signature ONCE, up front. Probing with TypeError at
+    # call time would re-invoke send_fn whenever send_fn itself raised
+    # TypeError internally — i.e. a double send. Older callers (tests, other
+    # integrations) that take only three positional args stay supported.
+    try:
+        import inspect
+        _send_fn_takes_ambiguous = "ambiguous" in inspect.signature(send_fn).parameters
+    except (TypeError, ValueError):
+        _send_fn_takes_ambiguous = False
+
     path = _outbox_path()
     if not path.exists():
-        return {"attempted": 0, "sent": 0, "dropped_stale": 0, "still_pending": 0}
+        return {"attempted": 0, "sent": 0, "dropped_stale": 0,
+                "still_pending": 0, "ambiguous_replayed": 0}
 
     try:
         with _outbox_lock(path):
@@ -251,9 +335,10 @@ def outbox_drain(
                 lines = f.readlines()
     except Exception as e:
         logger.warning("telegram_outbox: drain could not read outbox: %s", e)
-        return {"attempted": 0, "sent": 0, "dropped_stale": 0, "still_pending": 0}
+        return {"attempted": 0, "sent": 0, "dropped_stale": 0,
+                "still_pending": 0, "ambiguous_replayed": 0}
 
-    pending, resolved = _load_resolved_ids(lines)
+    pending, resolved, ambiguous = _load_resolved_ids(lines)
     now = time.time()
     started = time.monotonic()
     attempted = 0
@@ -278,8 +363,22 @@ def outbox_drain(
         if deadline_seconds is not None and time.monotonic() - started > deadline_seconds:
             break
         attempted += 1
+        is_ambiguous = rid in ambiguous
+        # Record the attempt *before* handing it to the Bot API, so a crash
+        # during this resend is itself recoverable-and-labeled next time
+        # (delivery_ledger.mark_attempting parity).
         try:
-            ok = bool(send_fn(entry.get("chat_id"), entry.get("message"), entry.get("thread_id")))
+            _durable_append(path, {"id": rid, "status": "attempting",
+                                   "attempting_at": time.time()})
+        except Exception:
+            pass          # best-effort: never block the resend over bookkeeping
+        try:
+            if _send_fn_takes_ambiguous:
+                ok = bool(send_fn(entry.get("chat_id"), entry.get("message"),
+                                  entry.get("thread_id"), ambiguous=is_ambiguous))
+            else:
+                ok = bool(send_fn(entry.get("chat_id"), entry.get("message"),
+                                  entry.get("thread_id")))
         except Exception as e:
             logger.warning("telegram_outbox: drain resend attempt raised for %s: %s", rid, e)
             ok = False
@@ -289,6 +388,7 @@ def outbox_drain(
 
     # Fallback summary count from the snapshot (used when compaction fails:
     # entries then remain on disk, so reporting 0 would be wrong).
+    ambiguous_replayed = len([rid for rid in sent_ids if rid in ambiguous])
     still_pending_count = len(
         [rid for rid in pending if rid not in resolved and rid not in sent_ids and rid not in stale_ids]
     )
@@ -302,14 +402,24 @@ def outbox_drain(
         with _outbox_lock(path):
             with open(path, "r", encoding="utf-8") as f:
                 fresh_lines = f.readlines()
-            fresh_pending, fresh_resolved = _load_resolved_ids(fresh_lines)
+            fresh_pending, fresh_resolved, fresh_ambiguous = _load_resolved_ids(fresh_lines)
             drop = fresh_resolved | sent_ids | stale_ids
             keep = {rid: e for rid, e in fresh_pending.items() if rid not in drop}
             still_pending_count = len(keep)
             tmp_path = path.with_suffix(path.suffix + ".tmp")
             with open(tmp_path, "w", encoding="utf-8") as f:
-                for entry in keep.values():
+                for rid, entry in keep.items():
                     f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+                    # Ambiguity must survive compaction: an entry that reached
+                    # 'attempting' but is still unresolved has to stay labeled,
+                    # otherwise the next drain would replay it as a clean
+                    # pending and silently duplicate (review #74085).
+                    if rid in fresh_ambiguous:
+                        f.write(json.dumps({"id": rid, "status": "attempting",
+                                            "attempting_at": time.time()},
+                                           ensure_ascii=False) + "\n")
+                f.flush()
+                os.fsync(f.fileno())
             os.replace(tmp_path, path)
     except Exception as e:
         logger.warning("telegram_outbox: drain compaction failed (outbox left as-is, will re-attempt next drain): %s", e)
@@ -319,4 +429,7 @@ def outbox_drain(
         "sent": sent,
         "dropped_stale": dropped_stale,
         "still_pending": still_pending_count,
+        # Ops visibility: how many of this pass's resends carried the
+        # recovered marker (i.e. were ambiguous rather than clean pending).
+        "ambiguous_replayed": ambiguous_replayed,
     }

--- a/tools/telegram_outbox.py
+++ b/tools/telegram_outbox.py
@@ -18,10 +18,10 @@ in-memory state or signal handler surviving the death of the process.
     except Exception:
         ...  # entry stays pending — picked up by the next outbox_drain()
 
-outbox_drain() is intentionally NOT wired into any signal handler or gateway
-startup hook in this change — it is a standalone, independently-callable
-function. Wiring it into a periodic driver (cron) is a separate decision
-(schedule changes are user-approval-gated) left for a follow-up.
+outbox_drain() is invoked by the gateway after the Telegram adapter reports
+connected (cold start and outage reconnect; see
+GatewayRunner._schedule_telegram_outbox_drain) with an item/deadline budget.
+It stays independently callable for tests and manual recovery.
 
 Every function here is best-effort: a failure in outbox bookkeeping must
 NEVER prevent or delay the real send it wraps. Callers should treat all
@@ -40,6 +40,50 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 _OUTBOX_FILENAME = "telegram-outbox.jsonl"
+
+
+class _outbox_lock:
+    """Advisory inter-process lock over the outbox file (sidecar .lock).
+
+    Serializes hot-path appends/tombstones against the drain's compaction
+    rewrite so an append landing mid-compaction can never be dropped by the
+    os.replace. Held only around file I/O — never across network sends.
+    Best-effort like everything here: if flock is unavailable (non-POSIX) or
+    fails, callers proceed unlocked rather than blocking the real send.
+    """
+
+    def __init__(self, path: Path):
+        self._lock_path = path.with_suffix(path.suffix + ".lock")
+        self._fh = None
+
+    def __enter__(self):
+        try:
+            import fcntl
+
+            self._fh = open(self._lock_path, "a+")
+            fcntl.flock(self._fh.fileno(), fcntl.LOCK_EX)
+        except Exception:
+            if self._fh is not None:
+                try:
+                    self._fh.close()
+                except Exception:
+                    pass
+                self._fh = None
+        return self
+
+    def __exit__(self, *exc):
+        if self._fh is not None:
+            try:
+                import fcntl
+
+                fcntl.flock(self._fh.fileno(), fcntl.LOCK_UN)
+            except Exception:
+                pass
+            try:
+                self._fh.close()
+            except Exception:
+                pass
+        return False
 
 
 def _outbox_path() -> Path:
@@ -71,8 +115,9 @@ def outbox_append(chat_id: str, message: str, thread_id: str | None = None) -> s
     }
     try:
         path = _outbox_path()
-        with open(path, "a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        with _outbox_lock(path):
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(entry, ensure_ascii=False) + "\n")
         return entry_id
     except Exception as e:
         logger.warning("telegram_outbox: append failed (send proceeds anyway): %s", e)
@@ -91,8 +136,9 @@ def outbox_mark_sent(entry_id: str | None) -> None:
         return
     try:
         path = _outbox_path()
-        with open(path, "a", encoding="utf-8") as f:
-            f.write(json.dumps({"id": entry_id, "status": "sent", "sent_at": time.time()}, ensure_ascii=False) + "\n")
+        with _outbox_lock(path):
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(json.dumps({"id": entry_id, "status": "sent", "sent_at": time.time()}, ensure_ascii=False) + "\n")
     except Exception as e:
         logger.warning("telegram_outbox: mark_sent failed for %s (message was sent; only the outbox record is stale): %s", entry_id, e)
 
@@ -141,8 +187,24 @@ def outbox_pending_entries() -> list[dict]:
     return [e for rid, e in sorted(pending.items(), key=lambda kv: kv[1].get("created_at", 0)) if rid not in resolved]
 
 
-def outbox_drain(send_fn=None, max_age_seconds: float = 7 * 24 * 3600) -> dict:
-    """Re-attempt delivery for every still-pending entry, then compact the file.
+def outbox_drain(
+    send_fn=None,
+    max_age_seconds: float = 7 * 24 * 3600,
+    max_items: int = 100,
+    deadline_seconds: float | None = None,
+    grace_seconds: float = 60.0,
+) -> dict:
+    """Re-attempt delivery for still-pending entries, then compact the file.
+
+    Bounded: at most ``max_items`` resend attempts per call, and no new
+    attempt starts after ``deadline_seconds`` (entries left over simply stay
+    pending for the next drain). The deadline bounds *starting* attempts —
+    a single already-running ``send_fn`` call (network stall, RetryAfter
+    sleep) can overshoot it; strict wall-clock kill of a synchronous sender
+    is deliberately out of scope here. Entries younger than ``grace_seconds`` are
+    skipped — an entry that fresh is very likely an in-flight send by a live
+    sender in this or another process, and resending it now would double-send;
+    it either gets tombstoned by its own sender or picked up by a later drain.
 
     Args:
         send_fn: callable(chat_id, message, thread_id) -> bool (True = delivered).
@@ -184,18 +246,21 @@ def outbox_drain(send_fn=None, max_age_seconds: float = 7 * 24 * 3600) -> dict:
         return {"attempted": 0, "sent": 0, "dropped_stale": 0, "still_pending": 0}
 
     try:
-        with open(path, "r", encoding="utf-8") as f:
-            lines = f.readlines()
+        with _outbox_lock(path):
+            with open(path, "r", encoding="utf-8") as f:
+                lines = f.readlines()
     except Exception as e:
         logger.warning("telegram_outbox: drain could not read outbox: %s", e)
         return {"attempted": 0, "sent": 0, "dropped_stale": 0, "still_pending": 0}
 
     pending, resolved = _load_resolved_ids(lines)
     now = time.time()
+    started = time.monotonic()
     attempted = 0
     sent = 0
     dropped_stale = 0
-    still_pending: dict[str, dict] = {}
+    sent_ids: set[str] = set()
+    stale_ids: set[str] = set()
 
     for rid, entry in pending.items():
         if rid in resolved:
@@ -203,7 +268,15 @@ def outbox_drain(send_fn=None, max_age_seconds: float = 7 * 24 * 3600) -> dict:
         age = now - entry.get("created_at", now)
         if age > max_age_seconds:
             dropped_stale += 1
+            stale_ids.add(rid)
             continue
+        if age < grace_seconds:
+            # Likely in-flight by a live sender — leave it alone this pass.
+            continue
+        if attempted >= max_items:
+            break
+        if deadline_seconds is not None and time.monotonic() - started > deadline_seconds:
+            break
         attempted += 1
         try:
             ok = bool(send_fn(entry.get("chat_id"), entry.get("message"), entry.get("thread_id")))
@@ -212,19 +285,32 @@ def outbox_drain(send_fn=None, max_age_seconds: float = 7 * 24 * 3600) -> dict:
             ok = False
         if ok:
             sent += 1
-        else:
-            still_pending[rid] = entry
+            sent_ids.add(rid)
 
-    # Compact: rewrite the file containing only entries still genuinely
-    # pending after this drain (drops sent/stale ones). Atomic replace via
-    # tmp file + os.replace so a crash mid-write never leaves a truncated
-    # outbox — worst case the old file (superset, safe to over-retry) survives.
+    # Fallback summary count from the snapshot (used when compaction fails:
+    # entries then remain on disk, so reporting 0 would be wrong).
+    still_pending_count = len(
+        [rid for rid in pending if rid not in resolved and rid not in sent_ids and rid not in stale_ids]
+    )
+    # Compact under the lock, against a FRESH read of the file — not the
+    # pre-send snapshot. Appends/tombstones that landed while this drain was
+    # sending (from live senders in this or another process) are therefore
+    # preserved, closing the lost-append window a snapshot-based os.replace
+    # would have. We drop only ids that are resolved in the fresh content,
+    # were sent by this drain, or aged out. Atomic tmp+os.replace as before.
     try:
-        tmp_path = path.with_suffix(path.suffix + ".tmp")
-        with open(tmp_path, "w", encoding="utf-8") as f:
-            for entry in still_pending.values():
-                f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-        os.replace(tmp_path, path)
+        with _outbox_lock(path):
+            with open(path, "r", encoding="utf-8") as f:
+                fresh_lines = f.readlines()
+            fresh_pending, fresh_resolved = _load_resolved_ids(fresh_lines)
+            drop = fresh_resolved | sent_ids | stale_ids
+            keep = {rid: e for rid, e in fresh_pending.items() if rid not in drop}
+            still_pending_count = len(keep)
+            tmp_path = path.with_suffix(path.suffix + ".tmp")
+            with open(tmp_path, "w", encoding="utf-8") as f:
+                for entry in keep.values():
+                    f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+            os.replace(tmp_path, path)
     except Exception as e:
         logger.warning("telegram_outbox: drain compaction failed (outbox left as-is, will re-attempt next drain): %s", e)
 
@@ -232,5 +318,5 @@ def outbox_drain(send_fn=None, max_age_seconds: float = 7 * 24 * 3600) -> dict:
         "attempted": attempted,
         "sent": sent,
         "dropped_stale": dropped_stale,
-        "still_pending": len(still_pending),
+        "still_pending": still_pending_count,
     }

--- a/tools/telegram_outbox.py
+++ b/tools/telegram_outbox.py
@@ -1,0 +1,236 @@
+"""Durable outbox for Telegram sends — survives SIGKILL / host reboot.
+
+Problem this solves: an in-flight Telegram send that dies mid-flight (process
+killed, host rebooted) before send_message_tool returns is silently lost —
+there is no record it was ever attempted. A SIGTERM handler can flush
+in-flight work on a *graceful* shutdown, but it can never catch SIGKILL or an
+unclean host reboot, which never deliver any signal at all.
+
+Design: append-before-send, delete-after-success. The record on disk is the
+single source of truth for "did this get sent" — no reliance on any
+in-memory state or signal handler surviving the death of the process.
+
+    entry_id = outbox_append(chat_id, message, thread_id=thread_id)
+    try:
+        result = await _send_to_platform(...)
+        if result.get("success"):
+            outbox_mark_sent(entry_id)
+    except Exception:
+        ...  # entry stays pending — picked up by the next outbox_drain()
+
+outbox_drain() is intentionally NOT wired into any signal handler or gateway
+startup hook in this change — it is a standalone, independently-callable
+function. Wiring it into a periodic driver (cron) is a separate decision
+(schedule changes are user-approval-gated) left for a follow-up.
+
+Every function here is best-effort: a failure in outbox bookkeeping must
+NEVER prevent or delay the real send it wraps. Callers should treat all
+outbox_* functions as advisory and continue past any exception.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import uuid
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_OUTBOX_FILENAME = "telegram-outbox.jsonl"
+
+
+def _outbox_path() -> Path:
+    """Resolve the outbox file path under the Hermes state directory.
+
+    Imports get_hermes_home() lazily so this module has no import-time
+    dependency on the rest of the agent — keeps it independently testable.
+    """
+    from hermes_constants import get_hermes_home
+
+    state_dir = get_hermes_home() / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    return state_dir / _OUTBOX_FILENAME
+
+
+def outbox_append(chat_id: str, message: str, thread_id: str | None = None) -> str | None:
+    """Record a pending send before attempting it. Returns the entry_id, or
+    None if the append itself failed (caller proceeds with the send regardless
+    — durability is best-effort, never a gate on whether a message can send).
+    """
+    entry_id = uuid.uuid4().hex
+    entry = {
+        "id": entry_id,
+        "chat_id": chat_id,
+        "message": message,
+        "thread_id": thread_id,
+        "created_at": time.time(),
+        "status": "pending",
+    }
+    try:
+        path = _outbox_path()
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        return entry_id
+    except Exception as e:
+        logger.warning("telegram_outbox: append failed (send proceeds anyway): %s", e)
+        return None
+
+
+def outbox_mark_sent(entry_id: str | None) -> None:
+    """Mark an entry as sent by appending a tombstone record with the same id.
+
+    Append-only by design (never rewrites/truncates the file in the hot
+    send path — that would risk corrupting the file if interrupted mid-write).
+    Compaction (dropping fully-resolved id pairs) happens in outbox_drain(),
+    which runs far less often and can afford a rewrite-the-whole-file pass.
+    """
+    if not entry_id:
+        return
+    try:
+        path = _outbox_path()
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(json.dumps({"id": entry_id, "status": "sent", "sent_at": time.time()}, ensure_ascii=False) + "\n")
+    except Exception as e:
+        logger.warning("telegram_outbox: mark_sent failed for %s (message was sent; only the outbox record is stale): %s", entry_id, e)
+
+
+def _load_resolved_ids(lines: list[str]) -> tuple[dict[str, dict], set[str]]:
+    """Parse outbox lines into (id -> pending entry, set of resolved ids).
+
+    Malformed lines are skipped (best-effort log parsing — a single corrupt
+    line must never make the whole outbox unreadable).
+    """
+    pending: dict[str, dict] = {}
+    resolved: set[str] = set()
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except Exception:
+            continue
+        rid = rec.get("id")
+        if not rid:
+            continue
+        if rec.get("status") == "sent":
+            resolved.add(rid)
+        elif rec.get("status") == "pending":
+            pending[rid] = rec
+    return pending, resolved
+
+
+def outbox_pending_entries() -> list[dict]:
+    """Return pending (not-yet-marked-sent) entries, oldest first.
+
+    Read-only — safe to call for inspection/monitoring without side effects.
+    """
+    path = _outbox_path()
+    if not path.exists():
+        return []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+    except Exception as e:
+        logger.warning("telegram_outbox: failed to read outbox for inspection: %s", e)
+        return []
+    pending, resolved = _load_resolved_ids(lines)
+    return [e for rid, e in sorted(pending.items(), key=lambda kv: kv[1].get("created_at", 0)) if rid not in resolved]
+
+
+def outbox_drain(send_fn=None, max_age_seconds: float = 7 * 24 * 3600) -> dict:
+    """Re-attempt delivery for every still-pending entry, then compact the file.
+
+    Args:
+        send_fn: callable(chat_id, message, thread_id) -> bool (True = delivered).
+            Defaults to a real Telegram send via send_message_tool when None
+            (kept as a parameter so this function is unit-testable without
+            hitting the network or requiring gateway config to be loaded).
+        max_age_seconds: entries older than this are dropped without a resend
+            attempt (default 7 days) — an alert this stale has lost its value
+            and resending it would be confusing, not helpful.
+
+    Returns a summary dict: {"attempted": N, "sent": N, "dropped_stale": N,
+    "still_pending": N}. Never raises — any per-entry failure just leaves
+    that entry pending for the next drain call.
+    """
+    if send_fn is None:
+        def send_fn(chat_id, message, thread_id):
+            from tools.send_message_tool import send_message_tool
+            # Telegram topic target format is "chat_id:thread_id" (see
+            # _TELEGRAM_TOPIC_TARGET_RE in send_message_tool.py).
+            target = f"telegram:{chat_id}:{thread_id}" if thread_id else f"telegram:{chat_id}"
+            # _skip_outbox=True: this call IS the drain's own resend attempt —
+            # without this flag _handle_send would outbox_append() again on
+            # every retry, growing the file with duplicate pending entries
+            # for what is logically the same message.
+            result_str = send_message_tool({
+                "action": "send",
+                "target": target,
+                "message": message,
+                "_skip_outbox": True,
+            })
+            try:
+                result = json.loads(result_str)
+            except Exception:
+                return False
+            return bool(result.get("success"))
+
+    path = _outbox_path()
+    if not path.exists():
+        return {"attempted": 0, "sent": 0, "dropped_stale": 0, "still_pending": 0}
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+    except Exception as e:
+        logger.warning("telegram_outbox: drain could not read outbox: %s", e)
+        return {"attempted": 0, "sent": 0, "dropped_stale": 0, "still_pending": 0}
+
+    pending, resolved = _load_resolved_ids(lines)
+    now = time.time()
+    attempted = 0
+    sent = 0
+    dropped_stale = 0
+    still_pending: dict[str, dict] = {}
+
+    for rid, entry in pending.items():
+        if rid in resolved:
+            continue
+        age = now - entry.get("created_at", now)
+        if age > max_age_seconds:
+            dropped_stale += 1
+            continue
+        attempted += 1
+        try:
+            ok = bool(send_fn(entry.get("chat_id"), entry.get("message"), entry.get("thread_id")))
+        except Exception as e:
+            logger.warning("telegram_outbox: drain resend attempt raised for %s: %s", rid, e)
+            ok = False
+        if ok:
+            sent += 1
+        else:
+            still_pending[rid] = entry
+
+    # Compact: rewrite the file containing only entries still genuinely
+    # pending after this drain (drops sent/stale ones). Atomic replace via
+    # tmp file + os.replace so a crash mid-write never leaves a truncated
+    # outbox — worst case the old file (superset, safe to over-retry) survives.
+    try:
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            for entry in still_pending.values():
+                f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        os.replace(tmp_path, path)
+    except Exception as e:
+        logger.warning("telegram_outbox: drain compaction failed (outbox left as-is, will re-attempt next drain): %s", e)
+
+    return {
+        "attempted": attempted,
+        "sent": sent,
+        "dropped_stale": dropped_stale,
+        "still_pending": len(still_pending),
+    }


### PR DESCRIPTION
## What does this PR do?

An in-flight Telegram send that dies mid-flight (process killed, host rebooted) before `send_message_tool` returns is silently lost — no record it was ever attempted. A SIGTERM handler can flush in-flight work on graceful shutdown, but can never catch SIGKILL or an unclean reboot.

This adds an append-before-send, mark-sent-after-success WAL file under `~/.hermes/state/telegram-outbox.jsonl`. The on-disk record is the single source of truth, independent of any in-memory state or signal handler surviving.

**Reliability contract:**
- Guarantee: append-before-send; pending entries are replayable after crash/restart
- Semantics: **at-least-once**, not exactly-once — a crash after send but before mark-sent can produce a duplicate on replay
- Deliberately does NOT touch `cli.py`'s SIGTERM/grace/interrupt paths

**Production evidence:** running on a live gateway (Telegram + 76 cron jobs) as a carried patch; motivated by real message loss during unclean restarts.

## Related Issue

No existing issue found — searched open+merged PRs and issues for "telegram outbox durable" / "message loss telegram send" per CONTRIBUTING before opening.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/telegram_outbox.py` — WAL implementation (append/mark-sent/replay)
- `tools/send_message_tool.py` — 22-line hook: append before send, mark after success
- `tests/tools/test_telegram_outbox_unit.py` — 8 unit tests
- `tests/tools/test_send_message_telegram_outbox.py` — 7 integration tests

All 15 tests pass on current `main` (41a07f5b8); cherry-picks cleanly.