### PR TITLE
fix(cli): fail closed on partial one-shot responses

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2583,6 +2583,7 @@ def run_conversation(
                     continue  # Retry the API call
 
                 agent._turn_received_provider_response = True
+                agent.session_api_calls += 1
 
                 # Check finish_reason before proceeding
                 if agent.api_mode == "codex_responses":
@@ -3157,7 +3158,6 @@ def run_conversation(
                     agent.session_prompt_tokens += prompt_tokens
                     agent.session_completion_tokens += completion_tokens
                     agent.session_total_tokens += total_tokens
-                    agent.session_api_calls += 1
                     agent.session_input_tokens += canonical_usage.input_tokens
                     agent.session_output_tokens += canonical_usage.output_tokens
                     agent.session_cache_read_tokens += canonical_usage.cache_read_tokens

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -151,6 +151,7 @@ def _write_usage_file(path: Optional[str], result: dict, failure: Optional[str] 
             "session_id": result.get("session_id"),
             "completed": result.get("completed"),
             "failed": bool(result.get("failed")) or failure is not None,
+            "partial": bool(result.get("partial")),
             # Billing-audit field: the service tier this run REQUESTED via
             # request_overrides.extra_body (e.g. OpenAI "flex"). None when
             # unset. Lets batch pipelines verify the tier they think they're
@@ -190,13 +191,6 @@ def run_oneshot(
 
     Returns the exit code.  The caller owns process termination.
     """
-    # Silence every stdlib logger for the duration.  AIAgent, tools, and
-    # provider adapters all log to stderr through the root logger; file
-    # handlers added by setup_logging() keep working (they're attached to
-    # the root logger's handler list, not affected by level), but no
-    # bytes reach the terminal.
-    logging.disable(logging.CRITICAL)
-
     # --provider without --model is ambiguous: carrying the user's configured
     # model across to a different provider is usually wrong (that provider may
     # not host it), and silently picking the provider's catalog default hides
@@ -276,6 +270,13 @@ def run_oneshot(
         return 1
 
     _write_usage_file(usage_file, result)
+
+    if result.get("partial"):
+        real_stderr.write(
+            "hermes -z: incomplete model response; treating the run as failed.\n"
+        )
+        real_stderr.flush()
+        return 2
 
     if response:
         real_stdout.write(response)

--- a/tests/hermes_cli/test_oneshot_usage_file.py
+++ b/tests/hermes_cli/test_oneshot_usage_file.py
@@ -22,6 +22,7 @@ def _result(**overrides):
         "session_id": "abc123",
         "completed": True,
         "failed": False,
+        "partial": False,
     }
     base.update(overrides)
     return base
@@ -63,7 +64,9 @@ class TestWriteUsageFile:
         # Root-owned path — the write must be swallowed, not raised.
         _write_usage_file("/proc/definitely/not/writable/usage.json", _result())
 
-    def test_result_failed_flag_carries_through(self, tmp_path):
+    def test_result_status_flags_carry_through(self, tmp_path):
         path = tmp_path / "usage.json"
-        _write_usage_file(str(path), _result(failed=True))
-        assert json.loads(path.read_text())["failed"] is True
+        _write_usage_file(str(path), _result(failed=True, partial=True))
+        report = json.loads(path.read_text())
+        assert report["failed"] is True
+        assert report["partial"] is True

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -1,4 +1,5 @@
 from argparse import Namespace
+import logging
 import os
 from pathlib import Path
 import subprocess
@@ -1411,6 +1412,47 @@ def test_oneshot_prints_nonempty_final_response(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert captured.out == "done\n"
     assert captured.err == ""
+
+
+def test_oneshot_partial_response_fails_closed(monkeypatch, capsys):
+    _stub_plugin_discovery(monkeypatch)
+    import hermes_cli.oneshot as oneshot_mod
+
+    monkeypatch.setattr(
+        oneshot_mod,
+        "_run_agent",
+        lambda *_args, **_kwargs: ("unfinished answer", {"partial": True}),
+    )
+
+    assert oneshot_mod.run_oneshot("hello") == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "incomplete model response" in captured.err
+
+
+def test_oneshot_keeps_file_logging_enabled(monkeypatch, tmp_path):
+    _stub_plugin_discovery(monkeypatch)
+    import hermes_cli.oneshot as oneshot_mod
+
+    log_path = tmp_path / "oneshot.log"
+    logger = logging.getLogger("test.oneshot.file")
+    handler = logging.FileHandler(log_path)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+    def fake_run(*_args, **_kwargs):
+        logger.info("provider request sent")
+        return "done", {}
+
+    monkeypatch.setattr(oneshot_mod, "_run_agent", fake_run)
+    try:
+        assert oneshot_mod.run_oneshot("hello") == 0
+    finally:
+        logger.removeHandler(handler)
+        handler.close()
+
+    assert "provider request sent" in log_path.read_text()
 
 
 def test_oneshot_fails_closed_on_agent_exception(monkeypatch, capsys):

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -383,6 +383,7 @@ class TestConversationLoopPartialStreamContinuation:
             "Partial-stream-stub must trigger a continuation API call, not "
             "exit the loop after one call."
         )
+        assert loop_agent.session_api_calls == 2
         # The continuation prompt the loop appended must be the network-error
         # variant, not the "output length limit" lie — otherwise the model
         # no-ops with "I wasn't truncated, I'm done."


### PR DESCRIPTION
## Summary

- make `hermes -z` suppress partial model text and exit non-zero instead of presenting it as a completed result
- preserve file logging during one-shot runs and expose `partial` in usage reports
- count received provider responses even when the provider omits token usage, so session API-call accounting no longer stays at zero

## Why

A truncated/partial one-shot response could contain text, be printed to stdout, and exit 0. Downstream automation then treated incomplete model output as a successful review. Responses without a usage payload also failed to increment session API-call accounting, obscuring the attempt in local audit data.

## Tests

- `scripts/run_tests.sh -j 3 tests/hermes_cli/test_tui_resume_flow.py tests/hermes_cli/test_oneshot_usage_file.py tests/run_agent/test_partial_stream_finish_reason.py -q` — 103 passed
- `scripts/run_tests.sh -j 1 tests/run_agent/test_run_agent.py -q` — 461 passed