### PR TITLE
Add Harness engineering solidification assets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,12 @@ growing the core.
 Two properties shape almost every design decision and are the lens for
 reviewing any change:
 
+- **Non-trivial AI-assisted engineering runs through Harness discipline.** Use
+  [`docs/harness-agenting-engineering.md`](docs/harness-agenting-engineering.md)
+  for spec-first context routing, extension placement, evidence gates, and
+  retention decisions. The bundled plugin/skill live at
+  `plugins/harness_engineering/` and
+  `skills/software-development/harness-agenting-engineering/`.
 - **Per-conversation prompt caching is sacred.** A long-lived conversation
   reuses a cached prefix every turn. Anything that mutates past context,
   swaps toolsets, or rebuilds the system prompt mid-conversation invalidates

--- a/docs/harness-agenting-engineering.md
+++ b/docs/harness-agenting-engineering.md
@@ -91,9 +91,12 @@ Retention is what makes the next session better instead of forcing the same expl
 
 This section is the operator-facing usage guide for the current Hermes Harness / Agenting Engineering setup.
 
-### 1. Normal WebUI / chat usage
+### 1. Normal chat usage
 
-For non-trivial engineering work, just ask normally in WebUI, CLI, or connected gateway platforms:
+For non-trivial engineering work, just ask normally in Hermes. Current in-repo
+soft preflight integration is gateway-scoped; CLI and WebUI users can invoke the
+explicit `hermes harness classify`, `hermes harness new`, and `/intake` surfaces
+until those entrypoints grow their own model-facing bridge.
 
 ```text
 请修复这个 bug
@@ -101,7 +104,11 @@ For non-trivial engineering work, just ask normally in WebUI, CLI, or connected 
 请重构这段逻辑并保证不破坏现有行为
 ```
 
-When `HERMES_HARNESS_PREFLIGHT` is unset or set to `advisory`, Hermes will keep the visible user message unchanged, but will prepend a model-facing Harness reminder for engineering-like tasks. The reminder asks the assistant to define scope, acceptance criteria, risk surface, rollback, context routing, and verification evidence before implementation.
+When `harness_engineering.preflight_mode` is unset or set to `advisory`, gateway
+messages keep the visible/persisted user message unchanged, but the hook returns
+a model-facing Harness reminder for engineering-like tasks. The reminder asks
+the assistant to define scope, acceptance criteria, risk surface, rollback,
+context routing, and verification evidence before implementation.
 
 Plain questions should not trigger the harness:
 
@@ -129,12 +136,24 @@ hermes harness prompt /tmp/harness-intake.md --output /tmp/harness-prompt.txt --
 If `hermes harness ...` is unavailable in a particular shell, use the profile-local helper directly:
 
 ```bash
-~/.hermes/bin/hermes-harness new --title "My task" --workspace /path/to/repo --mode "Implement changes"
-~/.hermes/bin/hermes-harness check /path/to/intake.md
-~/.hermes/bin/hermes-harness prompt /path/to/intake.md
+${HERMES_HOME:-$HOME/.hermes}/bin/hermes-harness new --title "My task" --workspace /path/to/repo --mode "Implement changes"
+${HERMES_HOME:-$HOME/.hermes}/bin/hermes-harness check /path/to/intake.md
+${HERMES_HOME:-$HOME/.hermes}/bin/hermes-harness prompt /path/to/intake.md
 ```
 
 Blank generated forms are expected to fail `check` until the required fields are filled.
+
+For plugin-backed `/intake`, `hermes harness ...`, and gateway preflight hooks,
+enable the standalone plugin in the active profile:
+
+```bash
+mkdir -p "${HERMES_HOME:-$HOME/.hermes}/plugins"
+cp -R plugins/harness_engineering "${HERMES_HOME:-$HOME/.hermes}/plugins/harness_engineering"
+hermes plugins enable harness_engineering
+```
+
+`kind: standalone` plugins are opt-in via `plugins.enabled`; the harness plugin
+does not auto-load until enabled.
 
 ### 3. In-session helper
 
@@ -148,27 +167,24 @@ It prints the Harness / Agenting Engineering intake instructions. It is advisory
 
 ### 4. Preflight modes
 
-The soft preflight is controlled by `HERMES_HARNESS_PREFLIGHT`:
+The gateway soft preflight is controlled by `harness_engineering.preflight_mode`
+in `config.yaml`:
 
 | Mode | Behavior | Use when |
 |---|---|---|
-| unset / `advisory` | Soft rewrite for engineering-like requests | Default daily development |
+| unset / `advisory` | Soft gateway rewrite for engineering-like requests | Default daily development |
 | `strict` | Prepends an intake-required instruction | Risky work: auth, secrets, shell, filesystem, deploys, data deletion, cross-platform behavior |
 | `off` | No rewrite | Debugging false positives or temporarily disabling the harness |
 
 Examples:
 
 ```bash
-export HERMES_HARNESS_PREFLIGHT=advisory
-export HERMES_HARNESS_PREFLIGHT=strict
-export HERMES_HARNESS_PREFLIGHT=off
+hermes config set harness_engineering.preflight_mode advisory
+hermes config set harness_engineering.preflight_mode strict
+hermes config set harness_engineering.preflight_mode off
 ```
 
-Restart the relevant process after changing the variable:
-
-- WebUI/API server: restart the WebUI/API process.
-- Gateway/WeChat/Telegram/etc.: restart the gateway.
-- CLI: start a new `hermes` session.
+Restart the gateway after changing the setting.
 
 ### 5. Verification commands
 
@@ -188,8 +204,7 @@ scripts/run_tests.sh \
 venv/bin/python -m py_compile \
   hermes_cli/plugins.py \
   gateway/run.py \
-  hermes-webui/api/streaming.py \
-  ~/.hermes/plugins/harness_engineering/__init__.py
+  plugins/harness_engineering/__init__.py
 ```
 
 If pytest fails before collection with `unrecognized arguments: --timeout=30 --timeout-method=signal`, install `pytest-timeout` into the active venv or run a focused check with `-o addopts=''`.
@@ -200,9 +215,9 @@ Use these behavioral checks after changes:
 
 - Engineering request such as `请修复这个 bug` triggers `[Harness / Agenting Engineering preflight]`.
 - Plain explanation such as `解释一下什么是 MCP` is allowed unchanged.
-- `HERMES_HARNESS_PREFLIGHT=strict` emits the `intake required` variant.
-- `HERMES_HARNESS_PREFLIGHT=off` disables rewrites.
-- WebUI must not mutate the visible/persisted user message; only the model-facing current turn is rewritten.
+- `harness_engineering.preflight_mode: strict` emits the `intake required` variant.
+- `harness_engineering.preflight_mode: off` disables gateway rewrites.
+- WebUI/CLI coverage claims stay limited to explicit `hermes harness ...` commands until their entrypoints wire an equivalent model-facing bridge.
 - The current Harness plugin should use `allow` / `rewrite`, not `skip`, so it remains a soft guard rather than a hard blocker.
 
 ### 7. Notes and pitfalls

--- a/docs/harness-agenting-engineering.md
+++ b/docs/harness-agenting-engineering.md
@@ -1,0 +1,364 @@
+# Harness / Agenting Engineering for Hermes
+
+Status: initial project working agreement. This document translates the ideas from two WeChat articles about Agentic Engineering and Harness Engineering into Hermes-specific engineering rules.
+
+Source articles reviewed:
+
+- `https://mp.weixin.qq.com/s/FB2v0kQHJDNBF4EmqPkXIQ` — argues that Vibe Coding breaks down as projects grow, and that Spec-Driven Development, Context Engineering, token-budget discipline, and reusable skills turn AI coding from a craft into an engineering practice.
+- `https://mp.weixin.qq.com/s/dhN-zkSDNntG_U-0TQQQVA` — defines Harness Engineering as encoding engineering discipline into AI-assistant-executable behavior through Hooks, Subagents, Skills, Rules, MCP/LSP, Plugins, commands, monitors, and state/memory.
+
+This document is not a philosophy note. It is the common contract for Hermes contributors and AI coding assistants: **do not rely on “try until it runs.” Encode what “correct” means, route context explicitly, verify with evidence, and preserve reusable knowledge.**
+
+## Definition
+
+**Harness / Agenting Engineering** is the practice of turning engineering discipline into executable assistant behavior:
+
+- safety checks become hooks, gates, review checklists, and negative tests;
+- code conventions become short always-on rules;
+- complex workflows become skills or commands;
+- subsystem knowledge becomes contract docs and context indexes;
+- external systems become MCP/LSP/plugin tools with explicit budgets;
+- large tasks become delegated subagent work with review boundaries;
+- cross-session lessons become durable skills or narrowly scoped memory.
+
+The goal is to move Hermes from “a helpful CLI/WebUI agent that can code” to **a team-grade engineering substrate** whose quality practices can be reused in any project.
+
+## Core rule: Spec → Context → Implementation → Evidence → Retention
+
+Every non-trivial Hermes engineering task should follow this lifecycle.
+
+### 1. Spec before code
+
+Before editing, define the smallest useful specification:
+
+- problem statement and non-goals;
+- public contract or invariant being changed;
+- acceptance criteria;
+- failure modes and security/privacy boundaries;
+- verification evidence needed before claiming done.
+
+For small fixes this can be a short task note or PR body section. For larger work use an RFC, plan, issue, or markdown design. The important rule is that the assistant knows what counts as correct **before** it writes code.
+
+### 2. Context before edits
+
+Route context explicitly instead of trusting the model to infer the repository:
+
+- start from `AGENTS.md`, `CONTRIBUTING.md`, and the relevant contract/RFC docs;
+- inspect current code and tests for the touched subsystem;
+- load relevant Hermes skills before acting;
+- prefer targeted searches over broad context dumps;
+- keep active tool/MCP surfaces bounded and task-relevant.
+
+Context engineering is not “stuff the prompt.” It is choosing the minimum correct context that prevents local fixes from violating system contracts.
+
+### 3. Implementation inside the harness
+
+Implementation must stay inside the repository’s extension and contract model:
+
+- prefer existing public extension points over hardcoded special cases;
+- if a plugin needs a missing capability, extend the generic plugin surface instead of patching plugin-specific logic into core;
+- keep one logical change per PR;
+- avoid new dependencies, build tools, frameworks, or long-lived processes unless the benefit and rollback story are explicit;
+- update docs and tests with behavior changes.
+
+### 4. Evidence before “done”
+
+A coding assistant may not claim a fix is complete without evidence appropriate to the touched subsystem.
+
+At minimum, include:
+
+- commands run and results;
+- tests added/updated or reason not applicable;
+- manual verification for UI, setup, runtime-state, or integration behavior;
+- negative/security checks where the change touches auth, tokens, secrets, approvals, shell execution, filesystem writes, webhooks, plugins, or network calls;
+- screenshots or browser notes for UI/UX changes;
+- state-layer and invariant proof for streaming, sessions, replay, compression, cancellation, approval, sidebar, or workspace changes.
+
+Green CI is necessary but not always sufficient. The evidence must match the risk surface.
+
+### 5. Retention after completion
+
+After a difficult or repeated workflow:
+
+- patch or create a skill for reusable procedures;
+- update contract docs when the public rule changed;
+- save durable memory only for stable user/project preferences or environment facts;
+- never store credentials, raw tokens, full private paths, or stale task progress in memory or tracked docs.
+
+Retention is what makes the next session better instead of forcing the same explanation again.
+
+## How to use this harness in Hermes
+
+This section is the operator-facing usage guide for the current Hermes Harness / Agenting Engineering setup.
+
+### 1. Normal WebUI / chat usage
+
+For non-trivial engineering work, just ask normally in WebUI, CLI, or connected gateway platforms:
+
+```text
+请修复这个 bug
+请实现一个新功能并加测试
+请重构这段逻辑并保证不破坏现有行为
+```
+
+When `HERMES_HARNESS_PREFLIGHT` is unset or set to `advisory`, Hermes will keep the visible user message unchanged, but will prepend a model-facing Harness reminder for engineering-like tasks. The reminder asks the assistant to define scope, acceptance criteria, risk surface, rollback, context routing, and verification evidence before implementation.
+
+Plain questions should not trigger the harness:
+
+```text
+解释一下什么是 MCP
+总结一下这篇文章
+翻译这段文字
+```
+
+### 2. Explicit intake flow for larger tasks
+
+For larger, risky, or multi-session work, create an intake form before implementation:
+
+```bash
+hermes harness new \
+  --title "Fix gateway preflight regression" \
+  --workspace /path/to/repo \
+  --mode "Implement changes" \
+  --output /tmp/harness-intake.md
+
+hermes harness check /tmp/harness-intake.md
+hermes harness prompt /tmp/harness-intake.md --output /tmp/harness-prompt.txt --force
+```
+
+If `hermes harness ...` is unavailable in a particular shell, use the profile-local helper directly:
+
+```bash
+~/.hermes/bin/hermes-harness new --title "My task" --workspace /path/to/repo --mode "Implement changes"
+~/.hermes/bin/hermes-harness check /path/to/intake.md
+~/.hermes/bin/hermes-harness prompt /path/to/intake.md
+```
+
+Blank generated forms are expected to fail `check` until the required fields are filled.
+
+### 3. In-session helper
+
+Use this in Hermes sessions when you want the reminder without creating a file:
+
+```text
+/intake
+```
+
+It prints the Harness / Agenting Engineering intake instructions. It is advisory only.
+
+### 4. Preflight modes
+
+The soft preflight is controlled by `HERMES_HARNESS_PREFLIGHT`:
+
+| Mode | Behavior | Use when |
+|---|---|---|
+| unset / `advisory` | Soft rewrite for engineering-like requests | Default daily development |
+| `strict` | Prepends an intake-required instruction | Risky work: auth, secrets, shell, filesystem, deploys, data deletion, cross-platform behavior |
+| `off` | No rewrite | Debugging false positives or temporarily disabling the harness |
+
+Examples:
+
+```bash
+export HERMES_HARNESS_PREFLIGHT=advisory
+export HERMES_HARNESS_PREFLIGHT=strict
+export HERMES_HARNESS_PREFLIGHT=off
+```
+
+Restart the relevant process after changing the variable:
+
+- WebUI/API server: restart the WebUI/API process.
+- Gateway/WeChat/Telegram/etc.: restart the gateway.
+- CLI: start a new `hermes` session.
+
+### 5. Verification commands
+
+Run these from the Hermes Agent repository when changing this harness:
+
+```bash
+cd /home/kevin/tools/hermes/hermes-agent
+
+venv/bin/python -m pytest \
+  tests/gateway/test_pre_gateway_dispatch.py \
+  tests/hermes_cli/test_plugins.py -q
+
+scripts/run_tests.sh \
+  tests/gateway/test_pre_gateway_dispatch.py \
+  tests/hermes_cli/test_plugins.py
+
+venv/bin/python -m py_compile \
+  hermes_cli/plugins.py \
+  gateway/run.py \
+  hermes-webui/api/streaming.py \
+  ~/.hermes/plugins/harness_engineering/__init__.py
+```
+
+If pytest fails before collection with `unrecognized arguments: --timeout=30 --timeout-method=signal`, install `pytest-timeout` into the active venv or run a focused check with `-o addopts=''`.
+
+### 6. Acceptance checks for the current setup
+
+Use these behavioral checks after changes:
+
+- Engineering request such as `请修复这个 bug` triggers `[Harness / Agenting Engineering preflight]`.
+- Plain explanation such as `解释一下什么是 MCP` is allowed unchanged.
+- `HERMES_HARNESS_PREFLIGHT=strict` emits the `intake required` variant.
+- `HERMES_HARNESS_PREFLIGHT=off` disables rewrites.
+- WebUI must not mutate the visible/persisted user message; only the model-facing current turn is rewritten.
+- The current Harness plugin should use `allow` / `rewrite`, not `skip`, so it remains a soft guard rather than a hard blocker.
+
+### 7. Notes and pitfalls
+
+- The harness is not a replacement for tests. It is a mechanism to make the assistant ask for and produce the right evidence.
+- Do not put long procedures into always-on rules; keep long workflows in skills or docs.
+- Do not turn every advisory into a hard gate. Promote only low-noise checks after observing false positives.
+- Do not store task progress, PR numbers, secrets, tokens, cookies, or raw private config in memory or docs.
+- For WebUI changes, keep using `hermes-webui/scripts/harness_quality_gate.py` where applicable to generate changed-file routing and suggested checks.
+- For plugins/MCP/providers, prefer generic extension points over core special cases and document credentials as environment variables only.
+
+## Practices imported from “Vibe Coding died, Agentic Engineering arrived”
+
+The first source article is not imported as named-tool fan fiction. Its examples are translated into Hermes-native practices:
+
+| Article example / practice | Engineering meaning | Hermes adoption |
+|---|---|---|
+| OpenSpec / Spec-Driven Development | Tell the assistant what “correct” means before code exists | Non-trivial work must start with a lightweight spec: problem, acceptance criteria, non-goals, risk surface, and required evidence. Larger work should use a plan, RFC, issue, or design doc. |
+| Archon / harness builder | Make AI coding deterministic and repeatable with checks around generation | Use Harness Evidence, focused tests, negative checks, contract routing, and advisory/CI quality gates. WebUI already has `scripts/harness_quality_gate.py`; core Hermes should grow similar project commands. |
+| Context Engineering | AI fails when it lacks repository/subsystem context | Route context explicitly through `AGENTS.md`, `CONTRIBUTING.md`, contract docs, RFCs, touched tests, and relevant skills before editing. Prefer targeted searches over broad prompt stuffing. |
+| graphify-style code knowledge graph | Convert codebase structure into queryable context | Hermes should treat architecture docs, contract docs, tests, symbol-aware search, LSP/static analysis, and future code-index tools as context indexes. Do not rely on filename guesses for cross-subsystem edits. |
+| context7-style live documentation via MCP | Give the assistant current docs/API context instead of stale memory | Prefer task-scoped MCP/docs tools for external APIs and dependencies, with bounded tool counts and explicit security/config boundaries. |
+| caveman / token saving | Token budget is an engineering constraint, not an afterthought | Use skills, summaries, targeted reads, compressed handoffs, and narrow context routing. Avoid dumping whole repos, whole logs, or many MCP tools into context. |
+| agent-skills / production prompt templates | Reusable procedures should become versioned skills | Difficult or repeated workflows must patch/create skills with exact commands, pitfalls, and verification. Small always-on rules stay in `AGENTS.md`, not in bulky prompts. |
+| rsync-style AI PR failure cautionary tale | AI-generated code without human-spec security boundaries can introduce subtle defects | Any change touching auth, secrets, shell, filesystem, network, approvals, plugins, or data deletion needs negative/security verification before “done.” |
+
+These practices are intentionally expressed as Hermes rules and gates rather than instructions to install the referenced projects. If a referenced tool becomes useful later, add it through a plugin/MCP/command with bounded context and security review.
+
+## Mapping the nine extension mechanisms to Hermes
+
+| Mechanism | Hermes surface | Use it for | Do not use it for |
+|---|---|---|---|
+| Rules | `AGENTS.md`, `CONTRIBUTING.md`, contract docs, system/developer instructions | Short always-on constraints: secrets redaction, one logical PR, run evidence gates | Long workflows or rare procedures |
+| Skills | `skills/`, `optional-skills/`, user/profile skills | Complex task procedures that should load on demand | Tiny universal rules that should be in `AGENTS.md` |
+| Commands | CLI subcommands, scripts, project commands | Repeatable operator actions and review/gate helpers | One-off shell snippets hidden in chat history |
+| Hooks | plugin lifecycle hooks, gateway hooks, future CI/preflight hooks | Automatic checks at tool, LLM, session, approval, or dispatch boundaries | Business logic that belongs in core services |
+| Monitors | observability plugins, logs, cron/webhook monitors | Drift detection, cost/token alerts, runtime health, quality telemetry | Blocking policy without a clear escape hatch |
+| Subagents | Hermes subagents, Kanban worker/orchestrator, external coding agents | Parallel research/implementation/review with bounded context | Replacing final integration ownership |
+| MCP | native MCP / mcporter integrations | External APIs, databases, docs, code intelligence, search | Loading many irrelevant tools into context |
+| LSP / code intelligence | language servers, static analyzers, pyright/ruff/eslint-like gates | Symbol-aware edits, diagnostics, refactor safety | Guessing code structure from filenames only |
+| Plugins | `plugins/`, model-provider plugins, memory-provider plugins | Packaged extension surfaces and shareable team capabilities | Hardcoded provider/tool special cases in core |
+
+## Placement rules: Rule vs Skill vs Hook vs Plugin
+
+Use this decision table before adding new process.
+
+| Need | Put it in |
+|---|---|
+| Must apply every time, one sentence, low nuance | Rule in `AGENTS.md` / `CONTRIBUTING.md` |
+| Multi-step procedure, task-specific, too long for always-on context | Skill |
+| Must run automatically at a lifecycle point | Hook or CI/preflight script |
+| Adds a reusable tool, provider, platform, memory backend, command, or integration | Plugin / MCP server |
+| Captures public behavior, invariant, or review expectation | Contract doc / RFC / tests |
+| Captures stable local/user preference | Durable memory, narrowly scoped |
+| Captures temporary task progress | Session transcript / issue / PR, not memory |
+
+## Hermes quality gates by change type
+
+### Python core / CLI / gateway
+
+- Read the relevant architecture and plugin surface docs before editing.
+- Run focused tests first, then broader pytest where practical.
+- Run lint gates that catch runtime bugs, not style churn.
+- For tool, shell, approval, filesystem, credential, or platform changes, include at least one negative/abuse-path check.
+
+### WebUI
+
+- Start from `hermes-webui/AGENTS.md`, `hermes-webui/docs/CONTRACTS.md`, and touched RFC/design docs.
+- Use `python3 scripts/harness_quality_gate.py` to generate the advisory Harness Evidence block for changed files.
+- For frontend changes, run `npm run lint:runtime` and browser smoke/manual browser evidence where applicable.
+- For runtime state changes, name the mutated state layer and prove replay/recovery/sidebar/session invariant.
+
+### Plugins / MCP / providers
+
+- Prefer extension surfaces over core special cases.
+- Keep tool count and prompt footprint bounded; load only task-relevant tools.
+- Document installation, configuration, security boundaries, and failure behavior.
+- Never commit API keys, cookies, OAuth tokens, or full local config files.
+
+### Skills
+
+- Follow the skill authoring rules in `AGENTS.md` and the `hermes-agent-skill-authoring` skill.
+- Keep descriptions short and task-triggered.
+- Include exact commands, pitfalls, verification, and when not to use the skill.
+- Patch stale skills immediately when a real task proves them incomplete.
+
+### Docs / contracts
+
+- Docs that change public behavior must move with tests or explicit verification.
+- Contract-changing PRs need `Contract Routing`; intentional contract changes need `Contract Change`.
+- Do not let tests silently redefine product behavior without updating public docs.
+
+## Standard Harness Evidence block
+
+Use this block in PRs, review notes, or AI handoffs when a change is non-trivial.
+
+```markdown
+## Harness Evidence
+
+Spec:
+- Problem:
+- Acceptance criteria:
+- Non-goals:
+- Risk surface:
+
+Context Routing:
+- Read:
+- Skills loaded:
+- Relevant contracts/RFCs:
+
+Implementation:
+- Touched areas:
+- Extension point used:
+- Docs updated:
+
+Verification:
+- Automated:
+- Manual:
+- Negative/security:
+- UI/state evidence:
+
+Retention:
+- Skill/memory/doc updated:
+- Follow-ups:
+```
+
+Keep this lightweight for small fixes. The goal is to make engineering evidence explicit, not to create bureaucracy.
+
+## Operating principles transferable to any project
+
+1. **Define correctness before generation.** AI coding becomes reliable when specs, invariants, and tests precede code.
+2. **Engineer context as an artifact.** Context should be routed, indexed, and budgeted, not improvised in every session.
+3. **Automate judgment points.** Repeated review questions should become hooks, gates, commands, or checklists.
+4. **Delegate with boundaries.** Subagents are useful when their task, context, and review criteria are explicit.
+5. **Retain only reusable knowledge.** Skills and contract docs compound; stale task notes and secrets create risk.
+6. **Evidence beats assertion.** An assistant’s “done” means commands, tests, logs, screenshots, or invariant proof — not confidence.
+
+## Adoption path
+
+### Phase 1 — advisory, now
+
+- Link this document from AI entry points.
+- Require non-trivial work to include Harness Evidence.
+- Use existing WebUI `scripts/harness_quality_gate.py` for changed-file routing.
+- Create/patch skills after difficult workflows.
+
+### Phase 2 — semi-automated
+
+- Add lightweight project commands that generate evidence blocks for core Hermes, not only WebUI.
+- Add optional pre-PR checks for secrets, missing tests, and contract-routing drift.
+- Add review-agent prompts/subagents for security, runtime-state, docs, and UI evidence.
+
+### Phase 3 — enforceable harness
+
+- Promote low-noise checks to CI/hooks.
+- Add observability for token/tool budget, flaky tests, and repeated failure modes.
+- Package reusable quality gates as plugins or MCP tools that can be installed into other projects.
+
+The adoption sequence matters: start advisory, measure false positives, then enforce only the checks that reliably catch real defects.

--- a/plugins/harness_engineering/README.md
+++ b/plugins/harness_engineering/README.md
@@ -29,3 +29,16 @@ harness_engineering:
 experiments and tests.
 
 The plugin registers `/intake`, `hermes harness ...`, and `pre_gateway_dispatch`.
+
+## Task classification
+
+Phase 2 adds `hermes harness classify` as an advisory-only classifier. It returns
+stable routing fields for chat, WebUI, gateway, or future Kanban intake without
+starting work, writing state, or changing dispatch behavior.
+
+```bash
+hermes harness classify --text "Refactor auth token storage and add tests" --format json
+```
+
+High-risk, multi-agent, or scheduled/ops tasks are marked `intake_required`;
+small code changes, research, and plain chat remain advisory/direct routes.

--- a/plugins/harness_engineering/README.md
+++ b/plugins/harness_engineering/README.md
@@ -4,14 +4,14 @@ Hermes plugin for Harness / Agenting Engineering soft preflight and task intake.
 
 The bundled copy uses the repo skill helper at
 `skills/software-development/harness-agenting-engineering/scripts/harness_intake.py`.
-Existing profile installs that provide `~/.hermes/bin/hermes-harness` continue to
-work as a fallback.
+Existing profile installs that provide `bin/hermes-harness` under the active
+Hermes profile home continue to work as a fallback.
 
 ## Install into a Hermes profile
 
 ```bash
-mkdir -p ~/.hermes/plugins
-cp -R plugins/harness_engineering ~/.hermes/plugins/harness_engineering
+mkdir -p "${HERMES_HOME:-$HOME/.hermes}/plugins"
+cp -R plugins/harness_engineering "${HERMES_HOME:-$HOME/.hermes}/plugins/harness_engineering"
 ```
 
 Restart Hermes WebUI/gateway/CLI after installation.
@@ -25,8 +25,8 @@ harness_engineering:
   preflight_mode: advisory  # advisory | strict | off
 ```
 
-`HERMES_HARNESS_PREFLIGHT` is still supported as an operator override for local
-experiments and tests.
+Set this persistently with `hermes config set harness_engineering.preflight_mode
+advisory|strict|off`; the plugin does not read an environment variable override.
 
 The plugin registers `/intake`, `hermes harness ...`, and `pre_gateway_dispatch`.
 

--- a/plugins/harness_engineering/README.md
+++ b/plugins/harness_engineering/README.md
@@ -1,0 +1,31 @@
+# Harness Engineering Plugin
+
+Hermes plugin for Harness / Agenting Engineering soft preflight and task intake.
+
+The bundled copy uses the repo skill helper at
+`skills/software-development/harness-agenting-engineering/scripts/harness_intake.py`.
+Existing profile installs that provide `~/.hermes/bin/hermes-harness` continue to
+work as a fallback.
+
+## Install into a Hermes profile
+
+```bash
+mkdir -p ~/.hermes/plugins
+cp -R plugins/harness_engineering ~/.hermes/plugins/harness_engineering
+```
+
+Restart Hermes WebUI/gateway/CLI after installation.
+
+## Modes
+
+Preferred persistent config:
+
+```yaml
+harness_engineering:
+  preflight_mode: advisory  # advisory | strict | off
+```
+
+`HERMES_HARNESS_PREFLIGHT` is still supported as an operator override for local
+experiments and tests.
+
+The plugin registers `/intake`, `hermes harness ...`, and `pre_gateway_dispatch`.

--- a/plugins/harness_engineering/README.md
+++ b/plugins/harness_engineering/README.md
@@ -12,9 +12,13 @@ Hermes profile home continue to work as a fallback.
 ```bash
 mkdir -p "${HERMES_HOME:-$HOME/.hermes}/plugins"
 cp -R plugins/harness_engineering "${HERMES_HOME:-$HOME/.hermes}/plugins/harness_engineering"
+hermes plugins enable harness_engineering
 ```
 
 Restart Hermes WebUI/gateway/CLI after installation.
+
+Bundled `standalone` plugins are opt-in via `plugins.enabled`; this plugin does
+not auto-load until enabled.
 
 ## Modes
 

--- a/plugins/harness_engineering/__init__.py
+++ b/plugins/harness_engineering/__init__.py
@@ -26,6 +26,7 @@ CLI:
   hermes harness kanban create /path/to/intake.md --triage
   hermes harness evidence <task-id> --output evidence.md
   hermes harness gc-template --output weekly-harness-gc.md
+  hermes harness migration-pack --output-dir /path/to/repo
 
 Helper resolution:
   bundled skill script first, then ~/.hermes/bin/hermes-harness
@@ -160,6 +161,11 @@ def _setup_harness_cli(parser) -> None:
     gc_p.add_argument("--output", "-o", default="", help="Write template to this file instead of stdout")
     gc_p.add_argument("--board", default="hermes-engineering-loop", help="Target board slug to mention in the template")
 
+    migration_p = sub.add_parser("migration-pack", help="Generate cross-agent Harness migration files")
+    migration_p.add_argument("--output-dir", "-o", default=".", help="Repository/directory where pack files should be written")
+    migration_p.add_argument("--force", action="store_true", help="Overwrite existing migration-pack files")
+    migration_p.add_argument("--json", action="store_true", help="Print written file paths as JSON")
+
     parser.set_defaults(func=_handle_harness_cli)
 
 
@@ -175,6 +181,8 @@ def _handle_harness_cli(args) -> None:
         raise SystemExit(_handle_harness_evidence_cli(args))
     if action == "gc-template":
         raise SystemExit(_handle_harness_gc_template_cli(args))
+    if action == "migration-pack":
+        raise SystemExit(_handle_harness_migration_pack_cli(args))
 
     argv: list[str] = [action]
     if action == "classify":
@@ -459,6 +467,119 @@ For each drift finding, create a triage card with evidence, affected paths, risk
         print(target)
     else:
         print(content)
+    return 0
+
+
+MIGRATION_PACK_FILES = {
+    "CODEX.md": """# Codex Harness Rules
+
+Use the repository `AGENTS.md` plus this Harness migration pack before non-trivial coding tasks.
+
+## Required Loop
+
+1. Classify the task with `hermes harness classify --text \"<request>\" --format json` when Hermes CLI is available.
+2. For high-risk, multi-agent, scheduled, filesystem, auth, secret, approval, or cross-module work, create/fill an intake with `hermes harness new` and validate it with `hermes harness check`.
+3. Read applicable contracts before editing: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, subsystem RFC/docs, and tests for the touched area.
+4. Keep implementation and review separate. Use `hermes harness kanban decompose <task-id>` for worker/reviewer child-card commands when Kanban is available.
+5. Attach evidence with commands run, failures, manual checks, risk/rollback notes, and retention decisions before claiming done.
+
+## Safety Defaults
+
+- Do not bypass user approval for destructive shell, filesystem, credential, cron, gateway, release, or force-push operations.
+- Do not treat upstream PR/CI state as the local completion gate when a local Harness manifest/gate exists.
+- Prefer focused tests and local deterministic gates over broad claims.
+""",
+    "CLAUDE.md": """# Claude Harness Rules
+
+This repository uses Hermes Harness Engineering constraints. Follow them as project memory.
+
+## Context
+
+- `AGENTS.md` and `docs/CONTRACTS.md` are authoritative local entry points.
+- `hermes harness classify` routes tasks into direct answer, research, bounded engineering, advisory, or intake-required modes.
+- `hermes harness evidence` records completion proof.
+
+## Work Policy
+
+Before code changes, identify scope, acceptance criteria, non-goals, risk surface, rollback/recovery, and verification commands. For multi-agent work, keep implementer and reviewer responsibilities separate.
+
+Do not mutate secrets, cron jobs, credentials, memory, profile config, or destructive filesystem state without explicit human approval.
+""",
+    "OPENCODE.md": """# OpenCode Harness Rules
+
+Use this file as the OpenCode-compatible entry rule for Harness Engineering.
+
+- Load `AGENTS.md`, `CONTRIBUTING.md`, and `docs/CONTRACTS.md` before repository edits.
+- Run `hermes harness classify --text \"<task>\" --format json` for non-trivial work when available.
+- Use `hermes harness new/check/prompt` for high-risk or cross-module tasks.
+- Produce Harness Evidence before done: spec compliance, automated checks, manual/negative checks, rollback, retention.
+- Keep publication PRs separate from local completion gates.
+""",
+    ".cursor/rules/harness.mdc": """---
+description: Harness Engineering local constraints
+globs:
+  - \"**/*\"
+alwaysApply: true
+---
+
+Use AGENTS.md, docs/CONTRACTS.md, and Hermes Harness commands before non-trivial edits.
+
+For risky/cross-module work, require intake, explicit risk surface, verification evidence, and rollback notes. Do not perform destructive state changes without human approval.
+""",
+    ".windsurfrules": """# Harness Engineering Rules
+
+Read AGENTS.md and docs/CONTRACTS.md before editing. Use `hermes harness classify` for non-trivial work and `hermes harness evidence` before claiming done.
+
+High-risk changes require explicit scope, acceptance criteria, risk surface, negative checks, rollback/recovery, and human approval for destructive state.
+""",
+    "prompts/task-intake.md": """# Harness Task Intake Prompt
+
+Fill this before delegating non-trivial AI engineering work.
+
+- Problem:
+- Acceptance criteria:
+- Non-goals:
+- Workspace / affected paths:
+- Applicable contracts/docs:
+- Risk surface:
+- Rollback or recovery:
+- Required automated checks:
+- Required manual/negative checks:
+- Retention decision:
+
+After filling, run:
+
+```bash
+hermes harness check /path/to/intake.md
+hermes harness prompt /path/to/intake.md
+```
+""",
+}
+
+
+def _handle_harness_migration_pack_cli(args) -> int:
+    output_dir = Path(getattr(args, "output_dir", ".") or ".").expanduser().resolve()
+    force = bool(getattr(args, "force", False))
+    written: list[str] = []
+    skipped: list[str] = []
+    for rel, content in MIGRATION_PACK_FILES.items():
+        target = output_dir / rel
+        if target.exists() and not force:
+            skipped.append(str(target))
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+        written.append(str(target))
+    payload = {"output_dir": str(output_dir), "written": written, "skipped_existing": skipped}
+    if getattr(args, "json", False):
+        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        for path in written:
+            print(path)
+        for path in skipped:
+            print(f"SKIP existing: {path}")
+        if skipped:
+            print("Use --force to overwrite existing migration-pack files.")
     return 0
 
 ENGINEERING_KEYWORDS = re.compile(

--- a/plugins/harness_engineering/__init__.py
+++ b/plugins/harness_engineering/__init__.py
@@ -7,6 +7,7 @@ helper as a compatibility fallback for existing profiles.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import subprocess
@@ -17,6 +18,7 @@ HELP_TEXT = """Harness / Agenting Engineering intake
 
 CLI:
   hermes harness template
+  hermes harness classify --text "Fix this WebUI bug and add tests"
   hermes harness new --title "My task" --workspace /path/to/repo --mode "Implement changes"
   hermes harness check /path/to/intake.md
   hermes harness prompt /path/to/intake.md
@@ -29,6 +31,37 @@ Purpose:
   Harness / Agenting Engineering by requiring task scope, acceptance criteria,
   risk surface, and verification evidence before implementation.
 """.strip()
+
+
+class TaskClassification:
+    """Advisory task routing result for Harness preflight and CLI use."""
+
+    def __init__(
+        self,
+        *,
+        task_type: str,
+        harness_required: bool,
+        risk_level: str,
+        route: str,
+        signals: list[str] | None = None,
+        recommended_next_steps: list[str] | None = None,
+    ) -> None:
+        self.task_type = task_type
+        self.harness_required = harness_required
+        self.risk_level = risk_level
+        self.route = route
+        self.signals = signals or []
+        self.recommended_next_steps = recommended_next_steps or []
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_type": self.task_type,
+            "harness_required": self.harness_required,
+            "risk_level": self.risk_level,
+            "route": self.route,
+            "signals": self.signals,
+            "recommended_next_steps": self.recommended_next_steps,
+        }
 
 
 def _bundled_helper_path() -> Path:
@@ -73,6 +106,10 @@ def _setup_harness_cli(parser) -> None:
     template_p = sub.add_parser("template", help="Print or copy the Harness task intake template")
     template_p.add_argument("--output", "-o", default="", help="Copy template to this path instead of stdout")
 
+    classify_p = sub.add_parser("classify", help="Classify a task and print advisory Harness routing")
+    classify_p.add_argument("--text", "-t", default="", help="Task text to classify")
+    classify_p.add_argument("--format", choices=("markdown", "json"), default="markdown", help="Output format")
+
     new_p = sub.add_parser("new", help="Create a new Harness task intake form")
     new_p.add_argument("--title", default="", help="Task title")
     new_p.add_argument("--workspace", default="", help="Workspace / repo path")
@@ -99,6 +136,17 @@ def _handle_harness_cli(args) -> None:
         raise SystemExit(0)
 
     argv: list[str] = [action]
+    if action == "classify":
+        text = getattr(args, "text", "")
+        if not text:
+            print("Missing --text for harness classify.")
+            raise SystemExit(2)
+        classification = classify_task(text)
+        if getattr(args, "format", "markdown") == "json":
+            print(json.dumps(classification.to_dict(), ensure_ascii=False, indent=2, sort_keys=True))
+        else:
+            print(_render_classification_markdown(classification))
+        raise SystemExit(0)
     if action == "new":
         for flag in ("title", "workspace", "mode"):
             value = getattr(args, flag, "")
@@ -140,6 +188,30 @@ ENGINEERING_KEYWORDS = re.compile(
     r")",
     re.IGNORECASE,
 )
+RESEARCH_PATTERNS = re.compile(
+    r"(调研|研究|查资料|搜索|对比|总结资料|文献|论文|market|research|search|compare|survey|literature)",
+    re.IGNORECASE,
+)
+SMALL_CODE_PATTERNS = re.compile(
+    r"(小修|简单修|typo|文案|样式|one[- ]?line|small fix|minor|quick fix|加测试|单测)",
+    re.IGNORECASE,
+)
+LARGE_CODE_PATTERNS = re.compile(
+    r"(重构|架构|迁移|端到端|全流程|跨模块|系统性|大规模|多文件|refactor|architecture|migration|end[- ]?to[- ]?end|cross[- ]?module|systematic)",
+    re.IGNORECASE,
+)
+HIGH_RISK_PATTERNS = re.compile(
+    r"(认证|授权|权限|密钥|凭证|token|secret|password|cookie|支付|license|删除|清空|覆盖|force[- ]?push|deploy|release|auth|oauth|credential|filesystem|webhook|database|migration)",
+    re.IGNORECASE,
+)
+MULTI_AGENT_PATTERNS = re.compile(
+    r"(多代理|子代理|并行|分解|派工|kanban|codex|claude|opencode|multi[- ]?agent|subagent|parallel|delegate|orchestrate)",
+    re.IGNORECASE,
+)
+OPS_SCHEDULED_PATTERNS = re.compile(
+    r"(cron|定时|周期|监控|告警|任务队列|scheduler|scheduled|monitor|daemon|gateway)",
+    re.IGNORECASE,
+)
 LOW_RISK_PATTERNS = re.compile(
     r"^(怎么看|是什么|解释|总结|翻译|润色|写一段|生成文案|画|查一下|搜索|what is|explain|summarize|translate)\b",
     re.IGNORECASE,
@@ -152,6 +224,144 @@ HARNESS_ALREADY_PRESENT = re.compile(
 PREFLIGHT_NOTICE = """[Harness / Agenting Engineering preflight]\nThis appears to be a non-trivial engineering task. Before implementing, use the harness discipline:\n- define scope, acceptance criteria, risk surface, and rollback plan;\n- inspect the codebase before editing;\n- preserve tests / quality gates as evidence;\n- prefer reusable Skill/Rules/Plugin updates for repeated workflow.\nIf the task is underspecified, ask only for missing information that changes the implementation.\n\nOriginal user request:\n"""
 
 STRICT_NOTICE = """[Harness / Agenting Engineering preflight: intake required]\nThis appears to be a high-risk engineering task. Ask the user to create or fill a Harness intake before implementation:\n  hermes harness new --title \"<task>\" --workspace \"<repo>\" --mode \"Implement changes\" --out /tmp/task-intake.md\n  hermes harness check /tmp/task-intake.md\nProceed only after scope, acceptance criteria, risk surface, and verification evidence are explicit.\n\nOriginal user request:\n"""
+
+
+def _has(pattern: re.Pattern[str], text: str) -> bool:
+    return bool(pattern.search(text))
+
+
+def classify_task(text: str) -> TaskClassification:
+    """Classify task text into advisory Harness routing buckets."""
+    compact = (text or "").strip()
+    if not compact:
+        return TaskClassification(
+            task_type="simple_chat",
+            harness_required=False,
+            risk_level="low",
+            route="answer_directly",
+            signals=["empty_text"],
+            recommended_next_steps=["Ask for the task text before routing."],
+        )
+    if compact.startswith("/"):
+        return TaskClassification(
+            task_type="simple_chat",
+            harness_required=False,
+            risk_level="low",
+            route="slash_command",
+            signals=["slash_command"],
+            recommended_next_steps=["Handle as an in-session command."],
+        )
+
+    signals: list[str] = []
+    if _has(HARNESS_ALREADY_PRESENT, compact):
+        signals.append("harness_context_present")
+    if _has(ENGINEERING_KEYWORDS, compact):
+        signals.append("engineering_keywords")
+    if _has(RESEARCH_PATTERNS, compact):
+        signals.append("research_keywords")
+    if _has(SMALL_CODE_PATTERNS, compact):
+        signals.append("small_code_keywords")
+    if _has(LARGE_CODE_PATTERNS, compact):
+        signals.append("large_code_keywords")
+    if _has(HIGH_RISK_PATTERNS, compact):
+        signals.append("high_risk_keywords")
+    if _has(MULTI_AGENT_PATTERNS, compact):
+        signals.append("multi_agent_keywords")
+    if _has(OPS_SCHEDULED_PATTERNS, compact):
+        signals.append("ops_scheduled_keywords")
+
+    if _has(LOW_RISK_PATTERNS, compact) and len(compact) < 220 and "engineering_keywords" not in signals:
+        return TaskClassification(
+            task_type="simple_chat",
+            harness_required=False,
+            risk_level="low",
+            route="answer_directly",
+            signals=[*signals, "low_risk_prompt_shape"],
+            recommended_next_steps=["Answer directly; no Harness intake needed."],
+        )
+
+    if "multi_agent_keywords" in signals:
+        task_type = "multi_agent_project"
+    elif "high_risk_keywords" in signals:
+        task_type = "high_risk_change"
+    elif "ops_scheduled_keywords" in signals:
+        task_type = "ops_scheduled"
+    elif "large_code_keywords" in signals:
+        task_type = "large_code_change"
+    elif "engineering_keywords" in signals:
+        task_type = "small_code_change" if "small_code_keywords" in signals else "large_code_change"
+    elif "research_keywords" in signals:
+        task_type = "research"
+    else:
+        task_type = "simple_chat"
+
+    if task_type in {"high_risk_change", "multi_agent_project", "ops_scheduled"}:
+        return TaskClassification(
+            task_type=task_type,
+            harness_required=True,
+            risk_level="high",
+            route="intake_required",
+            signals=signals or ["no_special_signal"],
+            recommended_next_steps=[
+                "Create or fill a Harness intake before implementation.",
+                "Name risk surface, rollback plan, and verification evidence.",
+            ],
+        )
+    if task_type == "large_code_change":
+        return TaskClassification(
+            task_type=task_type,
+            harness_required=True,
+            risk_level="medium",
+            route="harness_advisory",
+            signals=signals or ["no_special_signal"],
+            recommended_next_steps=[
+                "Define scope, acceptance criteria, risk surface, and tests before editing.",
+                "Inspect project rules and touched subsystem contracts first.",
+            ],
+        )
+    if task_type == "small_code_change":
+        return TaskClassification(
+            task_type=task_type,
+            harness_required=False,
+            risk_level="medium",
+            route="bounded_engineering",
+            signals=signals or ["no_special_signal"],
+            recommended_next_steps=["Keep the change scoped and run focused tests before reporting done."],
+        )
+    if task_type == "research":
+        return TaskClassification(
+            task_type=task_type,
+            harness_required=False,
+            risk_level="low",
+            route="research_then_report",
+            signals=signals or ["no_special_signal"],
+            recommended_next_steps=["Gather source evidence and report assumptions or gaps explicitly."],
+        )
+    return TaskClassification(
+        task_type="simple_chat",
+        harness_required=False,
+        risk_level="low",
+        route="answer_directly",
+        signals=signals or ["no_special_signal"],
+        recommended_next_steps=["Answer directly; no Harness intake needed."],
+    )
+
+
+def _render_classification_markdown(classification: TaskClassification) -> str:
+    lines = [
+        "## Harness Task Classification",
+        "",
+        f"Task type: `{classification.task_type}`",
+        f"Risk level: `{classification.risk_level}`",
+        f"Route: `{classification.route}`",
+        f"Harness intake required: `{str(classification.harness_required).lower()}`",
+        "",
+        "Signals:",
+    ]
+    lines.extend(f"- `{signal}`" for signal in classification.signals)
+    lines.extend(["", "Recommended next steps:"])
+    lines.extend(f"- {step}" for step in classification.recommended_next_steps)
+    return "\n".join(lines)
 
 
 def _configured_preflight_mode() -> str:
@@ -172,16 +382,14 @@ def _preflight_mode() -> str:
 
 
 def _looks_like_engineering_task(text: str) -> bool:
-    compact = (text or "").strip()
-    if not compact:
-        return False
-    if compact.startswith("/"):
-        return False
-    if HARNESS_ALREADY_PRESENT.search(compact):
-        return False
-    if LOW_RISK_PATTERNS.search(compact) and len(compact) < 220:
-        return False
-    return bool(ENGINEERING_KEYWORDS.search(compact))
+    classification = classify_task(text)
+    return classification.task_type in {
+        "small_code_change",
+        "large_code_change",
+        "high_risk_change",
+        "multi_agent_project",
+        "ops_scheduled",
+    }
 
 
 def _handle_pre_gateway_dispatch(event: Any = None, **_: Any) -> dict[str, str] | None:
@@ -198,9 +406,20 @@ def _handle_pre_gateway_dispatch(event: Any = None, **_: Any) -> dict[str, str] 
     if mode in {"", "off", "0", "false", "no", "disabled"}:
         return {"action": "allow"}
     text = getattr(event, "text", "") if event is not None else ""
-    if not isinstance(text, str) or not _looks_like_engineering_task(text):
+    if not isinstance(text, str):
+        return {"action": "allow"}
+    classification = classify_task(text)
+    if classification.task_type not in {
+        "small_code_change",
+        "large_code_change",
+        "high_risk_change",
+        "multi_agent_project",
+        "ops_scheduled",
+    }:
         return {"action": "allow"}
     if mode in {"strict", "require", "required"}:
+        return {"action": "rewrite", "text": STRICT_NOTICE + text}
+    if classification.harness_required:
         return {"action": "rewrite", "text": STRICT_NOTICE + text}
     return {"action": "rewrite", "text": PREFLIGHT_NOTICE + text}
 

--- a/plugins/harness_engineering/__init__.py
+++ b/plugins/harness_engineering/__init__.py
@@ -7,6 +7,7 @@ helper as a compatibility fallback for existing profiles.
 
 from __future__ import annotations
 
+import datetime as _dt
 import json
 import os
 import re
@@ -22,6 +23,9 @@ CLI:
   hermes harness new --title "My task" --workspace /path/to/repo --mode "Implement changes"
   hermes harness check /path/to/intake.md
   hermes harness prompt /path/to/intake.md
+  hermes harness kanban create /path/to/intake.md --triage
+  hermes harness evidence <task-id> --output evidence.md
+  hermes harness gc-template --output weekly-harness-gc.md
 
 Helper resolution:
   bundled skill script first, then ~/.hermes/bin/hermes-harness
@@ -126,6 +130,36 @@ def _setup_harness_cli(parser) -> None:
     prompt_p.add_argument("--output", "-o", default="", help="Write prompt to this file instead of stdout")
     prompt_p.add_argument("--force", action="store_true", help="Overwrite output file if it exists")
 
+    kanban_p = sub.add_parser("kanban", help="Bridge Harness intake into Kanban lifecycle")
+    kanban_sub = kanban_p.add_subparsers(dest="harness_kanban_action")
+
+    kanban_create = kanban_sub.add_parser("create", help="Create a Kanban triage card from a filled intake form")
+    kanban_create.add_argument("file", help="Filled intake markdown file")
+    kanban_create.add_argument("--assignee", default="architect", help="Kanban assignee/profile (default: architect)")
+    kanban_create.add_argument("--workspace", default="", help="Override workspace; defaults to the intake form workspace")
+    kanban_create.add_argument("--triage", action="store_true", default=True, help="Park card in triage (default)")
+    kanban_create.add_argument("--no-triage", dest="triage", action="store_false", help="Create directly in todo/runnable state")
+    kanban_create.add_argument("--dry-run", action="store_true", help="Print the hermes kanban command instead of running it")
+    kanban_create.add_argument("--json", action="store_true", help="Emit JSON from hermes kanban create when running")
+
+    kanban_decompose = kanban_sub.add_parser("decompose", help="Create or print implementation/review child-card commands")
+    kanban_decompose.add_argument("task_id", help="Parent Kanban task id")
+    kanban_decompose.add_argument("--worker", default="loop-worker", help="Worker profile for implementation card")
+    kanban_decompose.add_argument("--reviewer", default="loop-reviewer", help="Reviewer profile for review card")
+    kanban_decompose.add_argument("--workspace", default="worktree", help="Workspace hint for implementation card")
+    kanban_decompose.add_argument("--branch", default="", help="Branch name for implementation worktree tasks")
+    kanban_decompose.add_argument("--execute", action="store_true", help="Actually create child cards; default is dry-run")
+    kanban_decompose.add_argument("--json", action="store_true", help="Emit JSON from hermes kanban create when executing")
+
+    evidence_p = sub.add_parser("evidence", help="Generate a Harness Evidence markdown report for a Kanban task or workspace")
+    evidence_p.add_argument("task_id", nargs="?", default="", help="Optional Kanban task id to include via hermes kanban show")
+    evidence_p.add_argument("--workspace", default="", help="Repo/workspace to inspect; defaults to cwd")
+    evidence_p.add_argument("--output", "-o", default="", help="Write evidence markdown to this file")
+
+    gc_p = sub.add_parser("gc-template", help="Write a weekly Harness GC / drift-review checklist template")
+    gc_p.add_argument("--output", "-o", default="", help="Write template to this file instead of stdout")
+    gc_p.add_argument("--board", default="hermes-engineering-loop", help="Target board slug to mention in the template")
+
     parser.set_defaults(func=_handle_harness_cli)
 
 
@@ -134,6 +168,13 @@ def _handle_harness_cli(args) -> None:
     if not action:
         print(HELP_TEXT)
         raise SystemExit(0)
+
+    if action == "kanban":
+        raise SystemExit(_handle_harness_kanban_cli(args))
+    if action == "evidence":
+        raise SystemExit(_handle_harness_evidence_cli(args))
+    if action == "gc-template":
+        raise SystemExit(_handle_harness_gc_template_cli(args))
 
     argv: list[str] = [action]
     if action == "classify":
@@ -178,6 +219,247 @@ def _handle_harness_cli(args) -> None:
         raise SystemExit(2)
     raise SystemExit(_run_helper(argv))
 
+
+
+INTAKE_TITLE = re.compile(r"^- Task title:[ \t]*(.*)$", re.MULTILINE)
+INTAKE_WORKSPACE = re.compile(r"^- Workspace / repo:[ \t]*(.*)$", re.MULTILINE)
+INTAKE_PROBLEM = re.compile(r"^- Problem / request:[ \t]*(.*)$", re.MULTILINE)
+INTAKE_ACCEPTANCE = re.compile(r"^\s*\d+\.[ \t]+(.+)$", re.MULTILINE)
+INTAKE_RISK = re.compile(r"^\s*- \[x\][ \t]+(.+)$", re.MULTILINE | re.IGNORECASE)
+
+
+def _read_text(path: str | Path) -> str:
+    return Path(path).expanduser().resolve().read_text(encoding="utf-8")
+
+
+def _first(pattern: re.Pattern[str], content: str, default: str = "") -> str:
+    match = pattern.search(content)
+    return match.group(1).strip() if match else default
+
+
+def _parse_intake_summary(path: str | Path) -> dict[str, Any]:
+    intake_path = Path(path).expanduser().resolve()
+    content = _read_text(intake_path)
+    title = _first(INTAKE_TITLE, content) or intake_path.stem
+    workspace = _first(INTAKE_WORKSPACE, content)
+    problem = _first(INTAKE_PROBLEM, content)
+    acceptance = [m.group(1).strip() for m in INTAKE_ACCEPTANCE.finditer(content) if m.group(1).strip()]
+    risks = [m.group(1).strip() for m in INTAKE_RISK.finditer(content) if m.group(1).strip()]
+    return {
+        "path": str(intake_path),
+        "title": title,
+        "workspace": workspace,
+        "problem": problem,
+        "acceptance": acceptance,
+        "risks": risks,
+    }
+
+
+def _run_capture(command: list[str], *, cwd: str | None = None) -> tuple[int, str, str]:
+    try:
+        proc = subprocess.run(command, cwd=cwd, text=True, capture_output=True, check=False)
+    except FileNotFoundError as exc:
+        return 127, "", str(exc)
+    return int(proc.returncode), proc.stdout.strip(), proc.stderr.strip()
+
+
+def _kanban_body_from_intake(summary: dict[str, Any]) -> str:
+    lines = [
+        "## Harness Intake",
+        "",
+        f"Source intake: `{summary['path']}`",
+        f"Workspace: `{summary.get('workspace') or '<unspecified>'}`",
+        "",
+        "### Problem",
+        summary.get("problem") or "<unspecified>",
+        "",
+        "### Acceptance criteria",
+    ]
+    acceptance = summary.get("acceptance") or []
+    lines.extend(f"- {item}" for item in acceptance) if acceptance else lines.append("- <unspecified>")
+    lines.extend(["", "### Risk surface"])
+    risks = summary.get("risks") or []
+    lines.extend(f"- {item}" for item in risks) if risks else lines.append("- <unspecified>")
+    lines.extend([
+        "",
+        "### Lifecycle policy",
+        "- Keep this card in triage until scope, affected paths, validation commands, rollback/recovery, and evidence are explicit.",
+        "- Do not dispatch implementation workers from this bridge unless a human explicitly promotes/decomposes the card.",
+        "- Attach Harness Evidence before marking done.",
+    ])
+    return "\n".join(lines)
+
+
+def _handle_harness_kanban_cli(args) -> int:
+    subaction = getattr(args, "harness_kanban_action", None)
+    if subaction == "create":
+        summary = _parse_intake_summary(getattr(args, "file"))
+        workspace = getattr(args, "workspace", "") or summary.get("workspace") or "scratch"
+        command = [
+            "hermes", "kanban", "create", summary["title"],
+            "--body", _kanban_body_from_intake(summary),
+            "--assignee", getattr(args, "assignee", "architect") or "architect",
+            "--workspace", workspace,
+            "--skill", "harness-agenting-engineering",
+            "--skill", "hermes-engineering-loop",
+            "--idempotency-key", f"harness-intake:{summary['path']}",
+        ]
+        if getattr(args, "triage", True):
+            command.append("--triage")
+        if getattr(args, "json", False):
+            command.append("--json")
+        if getattr(args, "dry_run", False):
+            print(json.dumps({"command": command, "intake": summary}, ensure_ascii=False, indent=2))
+            return 0
+        code, out, err = _run_capture(command)
+        if out:
+            print(out)
+        if err:
+            print(err)
+        return code
+    if subaction == "decompose":
+        parent = getattr(args, "task_id")
+        workspace = getattr(args, "workspace", "worktree") or "worktree"
+        branch = getattr(args, "branch", "")
+        worker_cmd = [
+            "hermes", "kanban", "create", f"Implement Harness task {parent}",
+            "--parent", parent,
+            "--assignee", getattr(args, "worker", "loop-worker") or "loop-worker",
+            "--workspace", workspace,
+            "--body", "Implement the parent Harness intake in an isolated worktree. Preserve scope and attach verification evidence before completion.",
+            "--skill", "harness-agenting-engineering",
+            "--skill", "hermes-engineering-loop",
+        ]
+        if branch:
+            worker_cmd.extend(["--branch", branch])
+        reviewer_cmd = [
+            "hermes", "kanban", "create", f"Review Harness task {parent}",
+            "--parent", parent,
+            "--assignee", getattr(args, "reviewer", "loop-reviewer") or "loop-reviewer",
+            "--workspace", "scratch",
+            "--body", "Review only. Check spec compliance, scope control, tests/evidence, Hermes invariants, and safety boundaries. Do not implement changes in this review card.",
+            "--skill", "harness-agenting-engineering",
+            "--skill", "hermes-engineering-loop",
+            "--initial-status", "blocked",
+        ]
+        if getattr(args, "json", False):
+            worker_cmd.append("--json")
+            reviewer_cmd.append("--json")
+        if not getattr(args, "execute", False):
+            print(json.dumps({"dry_run": True, "commands": [worker_cmd, reviewer_cmd]}, ensure_ascii=False, indent=2))
+            return 0
+        results = []
+        for command in (worker_cmd, reviewer_cmd):
+            code, out, err = _run_capture(command)
+            results.append({"command": command, "exit_code": code, "stdout": out, "stderr": err})
+            if out:
+                print(out)
+            if err:
+                print(err)
+            if code != 0:
+                return code
+        return 0
+    print("Usage: hermes harness kanban {create,decompose} ...")
+    return 2
+
+
+def _handle_harness_evidence_cli(args) -> int:
+    workspace = Path(getattr(args, "workspace", "") or os.getcwd()).expanduser().resolve()
+    task_id = getattr(args, "task_id", "") or ""
+    stamp = _dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    lines = [
+        "## Harness Evidence",
+        "",
+        f"Generated: {stamp}",
+        f"Workspace: `{workspace}`",
+    ]
+    if task_id:
+        code, out, err = _run_capture(["hermes", "kanban", "show", task_id, "--json"])
+        lines.extend(["", "### Kanban task", ""])
+        if code == 0 and out:
+            lines.append("```json")
+            lines.append(out)
+            lines.append("```")
+        else:
+            lines.append(f"Unable to read Kanban task `{task_id}` with `hermes kanban show --json`.")
+            if err:
+                lines.append(f"Error: `{err}`")
+    for heading, cmd in [
+        ("Git HEAD", ["git", "rev-parse", "--short", "HEAD"]),
+        ("Git status", ["git", "status", "--short"]),
+        ("Diff stat", ["git", "diff", "--stat"]),
+    ]:
+        code, out, err = _run_capture(cmd, cwd=str(workspace))
+        lines.extend(["", f"### {heading}", "", "```text"])
+        lines.append(out if out else ("<empty>" if code == 0 else err or f"exit {code}"))
+        lines.append("```")
+    lines.extend([
+        "",
+        "### Required completion notes",
+        "- Spec compliance:",
+        "- Automated verification:",
+        "- Manual/negative checks:",
+        "- Rollback or recovery:",
+        "- Retention decision:",
+    ])
+    content = "\n".join(lines) + "\n"
+    output = getattr(args, "output", "")
+    if output:
+        target = Path(output).expanduser().resolve()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+        print(target)
+    else:
+        print(content)
+    return 0
+
+
+def _handle_harness_gc_template_cli(args) -> int:
+    board = getattr(args, "board", "hermes-engineering-loop") or "hermes-engineering-loop"
+    stamp = _dt.datetime.now().strftime("%Y-%m-%d")
+    content = f"""## Weekly Harness GC / Drift Review
+
+Date: {stamp}
+Board: `{board}`
+Assignee: reviewer / architect
+
+### Scope
+
+Create/update Kanban triage cards for drift. Do not auto-repair, auto-restart services, delete state, modify credentials, or dispatch implementation workers from this GC pass.
+
+### Checks
+
+- [ ] Blocked Kanban tasks older than policy window have current evidence and owner.
+- [ ] Done Harness tasks include evidence, validation commands, and rollback/recovery notes.
+- [ ] Profile-local plugins or scripts that are relied on operationally are solidified into repo/skill tap or explicitly marked local-only.
+- [ ] `docs/CONTRACTS.md`, `AGENTS.md`, and Harness docs still point to valid commands and current contracts.
+- [ ] Skills patched repeatedly are consolidated and still load successfully.
+- [ ] Temporary scripts/reports are either archived, promoted, or deleted with human approval.
+- [ ] WebUI Harness gate was run for WebUI-facing changes.
+- [ ] PR/body handoffs include Contract Routing and Verification when publication is used.
+
+### Evidence commands
+
+```bash
+hermes kanban boards switch {board}
+hermes kanban list --status blocked
+hermes kanban list --archived
+hermes harness evidence --workspace /path/to/repo --output /tmp/harness-evidence.md
+```
+
+### Output
+
+For each drift finding, create a triage card with evidence, affected paths, risk level, and human-gated recommendation. Leave destructive actions blocked until explicitly approved.
+"""
+    output = getattr(args, "output", "")
+    if output:
+        target = Path(output).expanduser().resolve()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+        print(target)
+    else:
+        print(content)
+    return 0
 
 ENGINEERING_KEYWORDS = re.compile(
     r"("

--- a/plugins/harness_engineering/__init__.py
+++ b/plugins/harness_engineering/__init__.py
@@ -1,0 +1,232 @@
+"""Harness / Agenting Engineering Hermes plugin.
+
+The plugin delegates intake-form operations to the bundled skill helper when the
+repo ships it, while keeping the user-local ``~/.hermes/bin/hermes-harness``
+helper as a compatibility fallback for existing profiles.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Sequence
+
+HELP_TEXT = """Harness / Agenting Engineering intake
+
+CLI:
+  hermes harness template
+  hermes harness new --title "My task" --workspace /path/to/repo --mode "Implement changes"
+  hermes harness check /path/to/intake.md
+  hermes harness prompt /path/to/intake.md
+
+Helper resolution:
+  bundled skill script first, then ~/.hermes/bin/hermes-harness
+
+Purpose:
+  Move non-trivial AI-assisted coding tasks from vibe coding to sustainable
+  Harness / Agenting Engineering by requiring task scope, acceptance criteria,
+  risk surface, and verification evidence before implementation.
+""".strip()
+
+
+def _bundled_helper_path() -> Path:
+    return (
+        Path(__file__).resolve().parents[2]
+        / "skills"
+        / "software-development"
+        / "harness-agenting-engineering"
+        / "scripts"
+        / "harness_intake.py"
+    )
+
+
+def _user_helper_path() -> Path:
+    return Path.home() / ".hermes" / "bin" / "hermes-harness"
+
+
+def _helper_command() -> list[str] | None:
+    bundled = _bundled_helper_path()
+    if bundled.exists():
+        return [os.environ.get("PYTHON", "python3"), str(bundled)]
+    user_helper = _user_helper_path()
+    if user_helper.exists():
+        return [str(user_helper)]
+    return None
+
+
+def _run_helper(argv: Sequence[str]) -> int:
+    command = _helper_command()
+    if command is None:
+        print("Missing Harness intake helper.")
+        print(f"Expected bundled script: {_bundled_helper_path()}")
+        print(f"Or user-local helper: {_user_helper_path()}")
+        return 2
+    proc = subprocess.run([*command, *argv], check=False)
+    return int(proc.returncode)
+
+
+def _setup_harness_cli(parser) -> None:
+    sub = parser.add_subparsers(dest="harness_action")
+
+    template_p = sub.add_parser("template", help="Print or copy the Harness task intake template")
+    template_p.add_argument("--output", "-o", default="", help="Copy template to this path instead of stdout")
+
+    new_p = sub.add_parser("new", help="Create a new Harness task intake form")
+    new_p.add_argument("--title", default="", help="Task title")
+    new_p.add_argument("--workspace", default="", help="Workspace / repo path")
+    new_p.add_argument("--mode", default="", help="Desired mode / permission level")
+    new_p.add_argument("--out", default="", help="Output path or directory")
+    new_p.add_argument("--print-path", action="store_true", help="Print only the created file path")
+
+    check_p = sub.add_parser("check", help="Validate a filled Harness intake form")
+    check_p.add_argument("file", help="Intake markdown file")
+
+    prompt_p = sub.add_parser("prompt", help="Render a compact prompt from a filled intake form")
+    prompt_p.add_argument("file", help="Intake markdown file")
+    prompt_p.add_argument("--allow-incomplete", action="store_true", help="Render even if required fields are missing")
+    prompt_p.add_argument("--output", "-o", default="", help="Write prompt to this file instead of stdout")
+    prompt_p.add_argument("--force", action="store_true", help="Overwrite output file if it exists")
+
+    parser.set_defaults(func=_handle_harness_cli)
+
+
+def _handle_harness_cli(args) -> None:
+    action = getattr(args, "harness_action", None)
+    if not action:
+        print(HELP_TEXT)
+        raise SystemExit(0)
+
+    argv: list[str] = [action]
+    if action == "new":
+        for flag in ("title", "workspace", "mode"):
+            value = getattr(args, flag, "")
+            if value:
+                argv.extend([f"--{flag}", value])
+        out_value = getattr(args, "out", "")
+        if out_value:
+            argv.extend(["--output", out_value])
+        # The helper already prints the created path for `new`; keep
+        # --print-path as a plugin-side compatibility flag without passing it
+        # to the helper.
+    elif action == "check":
+        argv.append(getattr(args, "file"))
+    elif action == "prompt":
+        argv.append(getattr(args, "file"))
+        if getattr(args, "allow_incomplete", False):
+            argv.append("--allow-incomplete")
+        output_value = getattr(args, "output", "")
+        if output_value:
+            argv.extend(["--output", output_value])
+        if getattr(args, "force", False):
+            argv.append("--force")
+    elif action == "template":
+        output_value = getattr(args, "output", "")
+        if output_value:
+            argv.extend(["--output", output_value])
+    else:
+        print(HELP_TEXT)
+        raise SystemExit(2)
+    raise SystemExit(_run_helper(argv))
+
+
+ENGINEERING_KEYWORDS = re.compile(
+    r"("
+    r"修复|修 bug|bug|报错|异常|失败|不生效|调试|排查|"
+    r"实现|开发|改代码|重构|优化|接入|集成|迁移|发布|部署|"
+    r"测试|单测|pytest|CI|PR|代码审查|review|"
+    r"feature|fix|debug|refactor|implement|integrat|migrat|deploy|release|test|coverage"
+    r")",
+    re.IGNORECASE,
+)
+LOW_RISK_PATTERNS = re.compile(
+    r"^(怎么看|是什么|解释|总结|翻译|润色|写一段|生成文案|画|查一下|搜索|what is|explain|summarize|translate)\b",
+    re.IGNORECASE,
+)
+HARNESS_ALREADY_PRESENT = re.compile(
+    r"(Harness\s*/\s*Agenting|harness-agenting|hermes\s+harness|/intake|intake\s+form|验收标准|验证证据|risk surface)",
+    re.IGNORECASE,
+)
+
+PREFLIGHT_NOTICE = """[Harness / Agenting Engineering preflight]\nThis appears to be a non-trivial engineering task. Before implementing, use the harness discipline:\n- define scope, acceptance criteria, risk surface, and rollback plan;\n- inspect the codebase before editing;\n- preserve tests / quality gates as evidence;\n- prefer reusable Skill/Rules/Plugin updates for repeated workflow.\nIf the task is underspecified, ask only for missing information that changes the implementation.\n\nOriginal user request:\n"""
+
+STRICT_NOTICE = """[Harness / Agenting Engineering preflight: intake required]\nThis appears to be a high-risk engineering task. Ask the user to create or fill a Harness intake before implementation:\n  hermes harness new --title \"<task>\" --workspace \"<repo>\" --mode \"Implement changes\" --out /tmp/task-intake.md\n  hermes harness check /tmp/task-intake.md\nProceed only after scope, acceptance criteria, risk surface, and verification evidence are explicit.\n\nOriginal user request:\n"""
+
+
+def _configured_preflight_mode() -> str:
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        value = cfg_get(load_config(), "harness_engineering", "preflight_mode", default="advisory")
+    except Exception:
+        value = "advisory"
+    return str(value or "advisory").strip().lower()
+
+
+def _preflight_mode() -> str:
+    env_value = os.getenv("HERMES_HARNESS_PREFLIGHT")
+    if env_value is not None:
+        return env_value.strip().lower()
+    return _configured_preflight_mode()
+
+
+def _looks_like_engineering_task(text: str) -> bool:
+    compact = (text or "").strip()
+    if not compact:
+        return False
+    if compact.startswith("/"):
+        return False
+    if HARNESS_ALREADY_PRESENT.search(compact):
+        return False
+    if LOW_RISK_PATTERNS.search(compact) and len(compact) < 220:
+        return False
+    return bool(ENGINEERING_KEYWORDS.search(compact))
+
+
+def _handle_pre_gateway_dispatch(event: Any = None, **_: Any) -> dict[str, str] | None:
+    """Soft Level-4 preflight for gateway messages.
+
+    Modes via HERMES_HARNESS_PREFLIGHT:
+      off/0/false/no  -> disabled
+      advisory/warn/rewrite (default) -> prepend Harness discipline reminder
+      strict -> prepend an intake-required instruction
+
+    The hook returns only `allow` or `rewrite`; it never skips messages.
+    """
+    mode = _preflight_mode()
+    if mode in {"", "off", "0", "false", "no", "disabled"}:
+        return {"action": "allow"}
+    text = getattr(event, "text", "") if event is not None else ""
+    if not isinstance(text, str) or not _looks_like_engineering_task(text):
+        return {"action": "allow"}
+    if mode in {"strict", "require", "required"}:
+        return {"action": "rewrite", "text": STRICT_NOTICE + text}
+    return {"action": "rewrite", "text": PREFLIGHT_NOTICE + text}
+
+
+def _handle_intake_slash(raw_args: str = "") -> str:
+    raw = (raw_args or "").strip()
+    if raw:
+        return (
+            f"/intake currently provides entry instructions only. Received: {raw}\n\n"
+            f"{HELP_TEXT}"
+        )
+    return HELP_TEXT
+
+
+def register(ctx) -> None:
+    ctx.register_cli_command(
+        "harness",
+        help="Harness / Agenting Engineering task intake helper",
+        description=HELP_TEXT,
+        setup_fn=_setup_harness_cli,
+        handler_fn=_handle_harness_cli,
+    )
+    ctx.register_command(
+        "intake",
+        handler=_handle_intake_slash,
+        description="Show Harness / Agenting Engineering task intake instructions.",
+        args_hint="[optional note]",
+    )
+    ctx.register_hook("pre_gateway_dispatch", _handle_pre_gateway_dispatch)

--- a/plugins/harness_engineering/__init__.py
+++ b/plugins/harness_engineering/__init__.py
@@ -1,8 +1,8 @@
 """Harness / Agenting Engineering Hermes plugin.
 
 The plugin delegates intake-form operations to the bundled skill helper when the
-repo ships it, while keeping the user-local ``~/.hermes/bin/hermes-harness``
-helper as a compatibility fallback for existing profiles.
+repo ships it, while keeping an active-profile ``bin/hermes-harness`` helper as
+a compatibility fallback for existing profiles.
 """
 
 from __future__ import annotations
@@ -14,6 +14,8 @@ import re
 import subprocess
 from pathlib import Path
 from typing import Any, Sequence
+
+from hermes_constants import display_hermes_home, get_hermes_home
 
 HELP_TEXT = """Harness / Agenting Engineering intake
 
@@ -29,7 +31,7 @@ CLI:
   hermes harness migration-pack --output-dir /path/to/repo
 
 Helper resolution:
-  bundled skill script first, then ~/.hermes/bin/hermes-harness
+  bundled skill script first, then the active profile's hermes-harness helper
 
 Purpose:
   Move non-trivial AI-assisted coding tasks from vibe coding to sustainable
@@ -81,7 +83,7 @@ def _bundled_helper_path() -> Path:
 
 
 def _user_helper_path() -> Path:
-    return Path.home() / ".hermes" / "bin" / "hermes-harness"
+    return get_hermes_home() / "bin" / "hermes-harness"
 
 
 def _helper_command() -> list[str] | None:
@@ -99,42 +101,45 @@ def _run_helper(argv: Sequence[str]) -> int:
     if command is None:
         print("Missing Harness intake helper.")
         print(f"Expected bundled script: {_bundled_helper_path()}")
-        print(f"Or user-local helper: {_user_helper_path()}")
+        print(f"Or profile-local helper: {display_hermes_home()}/bin/hermes-harness")
         return 2
     proc = subprocess.run([*command, *argv], check=False)
     return int(proc.returncode)
 
 
 def _setup_harness_cli(parser) -> None:
+    # Keep the public flag surface exact: argparse's default abbreviation would
+    # otherwise continue accepting the removed `--out` spelling for `--output`.
+    parser.allow_abbrev = False
     sub = parser.add_subparsers(dest="harness_action")
 
-    template_p = sub.add_parser("template", help="Print or copy the Harness task intake template")
+    template_p = sub.add_parser("template", help="Print or copy the Harness task intake template", allow_abbrev=False)
     template_p.add_argument("--output", "-o", default="", help="Copy template to this path instead of stdout")
 
-    classify_p = sub.add_parser("classify", help="Classify a task and print advisory Harness routing")
+    classify_p = sub.add_parser("classify", help="Classify a task and print advisory Harness routing", allow_abbrev=False)
     classify_p.add_argument("--text", "-t", default="", help="Task text to classify")
     classify_p.add_argument("--format", choices=("markdown", "json"), default="markdown", help="Output format")
 
-    new_p = sub.add_parser("new", help="Create a new Harness task intake form")
+    new_p = sub.add_parser("new", help="Create a new Harness task intake form", allow_abbrev=False)
     new_p.add_argument("--title", default="", help="Task title")
     new_p.add_argument("--workspace", default="", help="Workspace / repo path")
     new_p.add_argument("--mode", default="", help="Desired mode / permission level")
-    new_p.add_argument("--out", default="", help="Output path or directory")
+    new_p.add_argument("--output", "-o", default="", help="Output path or directory")
     new_p.add_argument("--print-path", action="store_true", help="Print only the created file path")
 
-    check_p = sub.add_parser("check", help="Validate a filled Harness intake form")
+    check_p = sub.add_parser("check", help="Validate a filled Harness intake form", allow_abbrev=False)
     check_p.add_argument("file", help="Intake markdown file")
 
-    prompt_p = sub.add_parser("prompt", help="Render a compact prompt from a filled intake form")
+    prompt_p = sub.add_parser("prompt", help="Render a compact prompt from a filled intake form", allow_abbrev=False)
     prompt_p.add_argument("file", help="Intake markdown file")
     prompt_p.add_argument("--allow-incomplete", action="store_true", help="Render even if required fields are missing")
     prompt_p.add_argument("--output", "-o", default="", help="Write prompt to this file instead of stdout")
     prompt_p.add_argument("--force", action="store_true", help="Overwrite output file if it exists")
 
-    kanban_p = sub.add_parser("kanban", help="Bridge Harness intake into Kanban lifecycle")
+    kanban_p = sub.add_parser("kanban", help="Bridge Harness intake into Kanban lifecycle", allow_abbrev=False)
     kanban_sub = kanban_p.add_subparsers(dest="harness_kanban_action")
 
-    kanban_create = kanban_sub.add_parser("create", help="Create a Kanban triage card from a filled intake form")
+    kanban_create = kanban_sub.add_parser("create", help="Create a Kanban triage card from a filled intake form", allow_abbrev=False)
     kanban_create.add_argument("file", help="Filled intake markdown file")
     kanban_create.add_argument("--assignee", default="architect", help="Kanban assignee/profile (default: architect)")
     kanban_create.add_argument("--workspace", default="", help="Override workspace; defaults to the intake form workspace")
@@ -143,7 +148,7 @@ def _setup_harness_cli(parser) -> None:
     kanban_create.add_argument("--dry-run", action="store_true", help="Print the hermes kanban command instead of running it")
     kanban_create.add_argument("--json", action="store_true", help="Emit JSON from hermes kanban create when running")
 
-    kanban_decompose = kanban_sub.add_parser("decompose", help="Create or print implementation/review child-card commands")
+    kanban_decompose = kanban_sub.add_parser("decompose", help="Create or print implementation/review child-card commands", allow_abbrev=False)
     kanban_decompose.add_argument("task_id", help="Parent Kanban task id")
     kanban_decompose.add_argument("--worker", default="loop-worker", help="Worker profile for implementation card")
     kanban_decompose.add_argument("--reviewer", default="loop-reviewer", help="Reviewer profile for review card")
@@ -152,16 +157,16 @@ def _setup_harness_cli(parser) -> None:
     kanban_decompose.add_argument("--execute", action="store_true", help="Actually create child cards; default is dry-run")
     kanban_decompose.add_argument("--json", action="store_true", help="Emit JSON from hermes kanban create when executing")
 
-    evidence_p = sub.add_parser("evidence", help="Generate a Harness Evidence markdown report for a Kanban task or workspace")
+    evidence_p = sub.add_parser("evidence", help="Generate a Harness Evidence markdown report for a Kanban task or workspace", allow_abbrev=False)
     evidence_p.add_argument("task_id", nargs="?", default="", help="Optional Kanban task id to include via hermes kanban show")
     evidence_p.add_argument("--workspace", default="", help="Repo/workspace to inspect; defaults to cwd")
     evidence_p.add_argument("--output", "-o", default="", help="Write evidence markdown to this file")
 
-    gc_p = sub.add_parser("gc-template", help="Write a weekly Harness GC / drift-review checklist template")
+    gc_p = sub.add_parser("gc-template", help="Write a weekly Harness GC / drift-review checklist template", allow_abbrev=False)
     gc_p.add_argument("--output", "-o", default="", help="Write template to this file instead of stdout")
     gc_p.add_argument("--board", default="hermes-engineering-loop", help="Target board slug to mention in the template")
 
-    migration_p = sub.add_parser("migration-pack", help="Generate cross-agent Harness migration files")
+    migration_p = sub.add_parser("migration-pack", help="Generate cross-agent Harness migration files", allow_abbrev=False)
     migration_p.add_argument("--output-dir", "-o", default=".", help="Repository/directory where pack files should be written")
     migration_p.add_argument("--force", action="store_true", help="Overwrite existing migration-pack files")
     migration_p.add_argument("--json", action="store_true", help="Print written file paths as JSON")
@@ -201,7 +206,7 @@ def _handle_harness_cli(args) -> None:
             value = getattr(args, flag, "")
             if value:
                 argv.extend([f"--{flag}", value])
-        out_value = getattr(args, "out", "")
+        out_value = getattr(args, "output", "")
         if out_value:
             argv.extend(["--output", out_value])
         # The helper already prints the created path for `new`; keep
@@ -626,7 +631,7 @@ HARNESS_ALREADY_PRESENT = re.compile(
 
 PREFLIGHT_NOTICE = """[Harness / Agenting Engineering preflight]\nThis appears to be a non-trivial engineering task. Before implementing, use the harness discipline:\n- define scope, acceptance criteria, risk surface, and rollback plan;\n- inspect the codebase before editing;\n- preserve tests / quality gates as evidence;\n- prefer reusable Skill/Rules/Plugin updates for repeated workflow.\nIf the task is underspecified, ask only for missing information that changes the implementation.\n\nOriginal user request:\n"""
 
-STRICT_NOTICE = """[Harness / Agenting Engineering preflight: intake required]\nThis appears to be a high-risk engineering task. Ask the user to create or fill a Harness intake before implementation:\n  hermes harness new --title \"<task>\" --workspace \"<repo>\" --mode \"Implement changes\" --out /tmp/task-intake.md\n  hermes harness check /tmp/task-intake.md\nProceed only after scope, acceptance criteria, risk surface, and verification evidence are explicit.\n\nOriginal user request:\n"""
+STRICT_NOTICE = """[Harness / Agenting Engineering preflight: intake required]\nThis appears to be a high-risk engineering task. Ask the user to create or fill a Harness intake before implementation:\n  hermes harness new --title \"<task>\" --workspace \"<repo>\" --mode \"Implement changes\" --output /tmp/task-intake.md\n  hermes harness check /tmp/task-intake.md\nProceed only after scope, acceptance criteria, risk surface, and verification evidence are explicit.\n\nOriginal user request:\n"""
 
 
 def _has(pattern: re.Pattern[str], text: str) -> bool:
@@ -778,9 +783,6 @@ def _configured_preflight_mode() -> str:
 
 
 def _preflight_mode() -> str:
-    env_value = os.getenv("HERMES_HARNESS_PREFLIGHT")
-    if env_value is not None:
-        return env_value.strip().lower()
     return _configured_preflight_mode()
 
 
@@ -798,7 +800,7 @@ def _looks_like_engineering_task(text: str) -> bool:
 def _handle_pre_gateway_dispatch(event: Any = None, **_: Any) -> dict[str, str] | None:
     """Soft Level-4 preflight for gateway messages.
 
-    Modes via HERMES_HARNESS_PREFLIGHT:
+    Modes via config.yaml `harness_engineering.preflight_mode`:
       off/0/false/no  -> disabled
       advisory/warn/rewrite (default) -> prepend Harness discipline reminder
       strict -> prepend an intake-required instruction

--- a/plugins/harness_engineering/plugin.yaml
+++ b/plugins/harness_engineering/plugin.yaml
@@ -1,0 +1,11 @@
+name: harness_engineering
+version: 0.1.0
+description: Harness / Agenting Engineering intake commands and slash helper
+kind: standalone
+provides_cli:
+  - harness
+provides_commands:
+  - intake
+provides_hooks:
+  - pre_gateway_dispatch
+author: Hermes Agent

--- a/plugins/harness_engineering/plugin.yaml
+++ b/plugins/harness_engineering/plugin.yaml
@@ -8,4 +8,4 @@ provides_commands:
   - intake
 provides_hooks:
   - pre_gateway_dispatch
-author: Hermes Agent
+author: Kevin Lin (@wumujushi) + Hermes Agent

--- a/skills/software-development/harness-agenting-engineering/SKILL.md
+++ b/skills/software-development/harness-agenting-engineering/SKILL.md
@@ -2,7 +2,7 @@
 name: harness-agenting-engineering
 description: Spec-first AI engineering with evidence gates.
 version: 0.1.0
-author: Hermes Agent
+author: Kevin Lin (@wumujushi) + Hermes Agent
 license: MIT
 platforms:
   - linux
@@ -296,13 +296,18 @@ If the active profile's `bin` directory is on `PATH`, use `hermes-harness ...` d
 
 ## Hermes plugin entrypoints
 
-This profile also has a user-local plugin for Level 3 soft integration:
+This skill can be paired with the `harness_engineering` standalone plugin for
+Level 3 soft integration. Install or enable it in the active profile before
+expecting `/intake`, `hermes harness ...`, or gateway preflight hooks to load:
 
-```text
-~/.hermes/plugins/harness_engineering/
+```bash
+mkdir -p "${HERMES_HOME:-$HOME/.hermes}/plugins"
+cp -R plugins/harness_engineering "${HERMES_HOME:-$HOME/.hermes}/plugins/harness_engineering"
+hermes plugins enable harness_engineering
 ```
 
-It is enabled in the active `default` profile and registers:
+Bundled `standalone` plugins are opt-in via `plugins.enabled`; this plugin does
+not auto-load until enabled. Once enabled, it registers:
 
 ```bash
 # Hermes-native CLI wrapper around the same helper

--- a/skills/software-development/harness-agenting-engineering/SKILL.md
+++ b/skills/software-development/harness-agenting-engineering/SKILL.md
@@ -312,6 +312,7 @@ hermes harness kanban decompose <task-id> --workspace worktree --branch wt/<task
 hermes harness kanban decompose <task-id> --execute  # explicit only; default is dry-run
 hermes harness evidence <task-id> --workspace /path/to/repo --output /path/to/evidence.md
 hermes harness gc-template --output /path/to/weekly-harness-gc.md
+hermes harness migration-pack --output-dir /path/to/repo --json
 ```
 
 Lifecycle command safety boundaries:

--- a/skills/software-development/harness-agenting-engineering/SKILL.md
+++ b/skills/software-development/harness-agenting-engineering/SKILL.md
@@ -304,7 +304,23 @@ hermes harness new --title "My task" --workspace /path/to/repo --mode "Implement
 hermes harness check /path/to/intake.md
 hermes harness prompt /path/to/intake.md
 hermes harness prompt /path/to/intake.md --allow-incomplete --output /path/to/prompt.txt --force
+
+# Lifecycle bridge: intake -> Kanban triage -> worker/reviewer plan -> evidence -> GC
+hermes harness kanban create /path/to/intake.md --triage --json
+hermes harness kanban create /path/to/intake.md --dry-run --json
+hermes harness kanban decompose <task-id> --workspace worktree --branch wt/<task-id>
+hermes harness kanban decompose <task-id> --execute  # explicit only; default is dry-run
+hermes harness evidence <task-id> --workspace /path/to/repo --output /path/to/evidence.md
+hermes harness gc-template --output /path/to/weekly-harness-gc.md
 ```
+
+Lifecycle command safety boundaries:
+
+- `kanban create` turns a filled intake into a Kanban card and defaults to `--triage`, with an idempotency key derived from the intake path.
+- `kanban decompose` defaults to dry-run and prints implementation/review child-card commands; it only creates cards when `--execute` is explicit.
+- Review child cards are created blocked by default so a reviewer can check spec compliance and evidence without silently starting implementation.
+- `evidence` captures Kanban task JSON when available plus Git HEAD/status/diff-stat and completion note placeholders.
+- `gc-template` writes a weekly drift review checklist; it must not auto-repair, auto-restart services, delete state, modify credentials, or dispatch workers.
 
 It also registers the in-session plugin slash command:
 

--- a/skills/software-development/harness-agenting-engineering/SKILL.md
+++ b/skills/software-development/harness-agenting-engineering/SKILL.md
@@ -1,0 +1,367 @@
+---
+name: harness-agenting-engineering
+description: Spec-first AI engineering with evidence gates.
+version: 0.1.0
+author: Hermes Agent
+license: MIT
+platforms:
+  - linux
+  - macos
+metadata:
+  hermes:
+    category: software-development
+    tags:
+      - ai-engineering
+      - harness
+      - quality
+      - agents
+    related_skills:
+      - engineering-workflow
+      - test-driven-development
+      - systematic-debugging
+      - hermes-agent-skill-authoring
+---
+
+# Harness / Agenting Engineering
+
+Use this skill when a task asks for sustainable engineering quality, AI-assisted coding discipline, project rules, PR readiness, workflow standardization, hooks/plugins/subagents/skills/rules/MCP, or moving from “vibe coding” to evidence-backed engineering.
+
+## Principle
+
+Do not rely on “try until it runs.” Turn engineering discipline into assistant-executable behavior:
+
+1. **Spec** — define correctness before code.
+2. **Context** — route repository/subsystem context explicitly.
+3. **Implementation** — use the right extension surface and keep scope narrow.
+4. **Evidence** — verify before claiming done.
+5. **Retention** — preserve reusable lessons as skills, rules, contracts, or narrow durable memory.
+
+## Imported practices from “Vibe Coding died, Agentic Engineering arrived”
+
+| Article example / practice | Engineering meaning | Hermes behavior |
+|---|---|---|
+| OpenSpec / Spec-Driven Development | Define correctness before code | Start non-trivial work with problem, acceptance criteria, non-goals, risk surface, and required evidence. |
+| Archon / harness builder | Make AI coding deterministic and repeatable | Use Harness Evidence, focused tests, negative checks, contract routing, and quality gates. |
+| Context Engineering | Provide repository/subsystem context before edits | Read entry rules, contracts, touched code/tests, and relevant skills; use targeted search, not context dumps. |
+| graphify-style code knowledge graph | Convert code structure into queryable context | Prefer architecture docs, contracts, tests, symbol-aware search, LSP/static analysis, and future code indexes over filename guessing. |
+| context7-style live documentation via MCP | Use current external docs/API context | Add task-scoped MCP/docs tools with bounded tool counts and explicit security/config boundaries. |
+| caveman / token saving | Treat token budget as engineering constraint | Use skills, summaries, targeted reads, compressed handoffs, and narrow context routing. |
+| agent-skills / production templates | Reuse procedures as versioned skills | Patch/create skills for difficult or repeated workflows; keep small universal rules in `AGENTS.md`. |
+| rsync-style AI PR failure cautionary tale | Missing security spec creates subtle defects | Require negative/security verification for auth, secrets, shell, filesystem, network, approvals, plugins, or data deletion changes. |
+
+These are imported as Hermes-native rules and gates, not as a requirement to install those named projects.
+
+## Required workflow
+
+### 1. Spec before code
+
+For non-trivial work, write or identify:
+
+- problem statement;
+- acceptance criteria;
+- non-goals;
+- affected contract/invariant;
+- risk surface: secrets, auth, shell, filesystem, network, plugins, approvals, state, UI, data loss;
+- evidence needed before “done.”
+
+Keep it lightweight for small fixes, but never skip defining what correct means.
+
+### 2. Context routing
+
+Before editing:
+
+- read project entry rules such as `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, RFCs, design docs, or TESTING docs;
+- inspect current code and tests for the touched subsystem;
+- load relevant Hermes skills;
+- use targeted searches instead of dumping the entire repository;
+- keep MCP/tool surfaces task-relevant and bounded.
+
+### 3. Extension placement
+
+Choose the smallest correct mechanism:
+
+| Need | Put it in |
+|---|---|
+| Always-on short rule | `AGENTS.md`, `CONTRIBUTING.md`, rules docs |
+| Multi-step reusable workflow | Skill |
+| Automatic lifecycle enforcement | Hook, CI gate, preflight script |
+| External system/tool/data integration | MCP server or plugin |
+| Packaged reusable capability | Plugin |
+| Public invariant or review expectation | Contract doc/RFC/test |
+| Stable user/project preference | Durable memory |
+| Temporary task status | Issue/PR/session, not memory |
+
+### 4. Implementation discipline
+
+- One logical change per PR/task.
+- Prefer existing extension points over core special cases.
+- If a plugin needs a missing capability, extend the generic plugin surface rather than hardcoding plugin-specific logic into core.
+- Avoid new dependencies/frameworks/long-lived processes unless benefit and rollback are explicit.
+- Update docs and tests alongside behavior changes.
+
+### 5. Evidence gates
+
+Do not claim completion without evidence matched to the risk:
+
+- commands run and pass/fail results;
+- focused tests and, when practical, broader tests;
+- lint/static checks that catch runtime defects;
+- manual verification for UI/setup/runtime/integration behavior;
+- screenshots or browser notes for UI/UX;
+- state-layer and invariant proof for streaming/session/replay/compression/sidebar/workspace changes;
+- negative/security checks for secrets, auth, shell, approvals, plugins, filesystem, network, webhooks, or data deletion.
+
+### 6. Retention
+
+After a hard or repeated workflow:
+
+- patch or create a skill if the procedure is reusable;
+- update contract docs if the public rule changed;
+- save memory only for stable preferences/environment facts;
+- never store credentials, raw tokens, full private config, or stale task progress.
+
+## Harness Evidence template
+
+Use this in PRs, handoffs, or final reports for non-trivial work:
+
+```markdown
+## Harness Evidence
+
+Spec:
+- Problem:
+- Acceptance criteria:
+- Non-goals:
+- Risk surface:
+
+Context Routing:
+- Read:
+- Skills loaded:
+- Relevant contracts/RFCs:
+
+Implementation:
+- Touched areas:
+- Extension point used:
+- Docs updated:
+
+Verification:
+- Automated:
+- Manual:
+- Negative/security:
+- UI/state evidence:
+
+Retention:
+- Skill/memory/doc updated:
+- Follow-ups:
+```
+
+## Unified task intake template
+
+For non-trivial work, use `templates/task-intake-form.md` before sending the task to Hermes / an LLM / a coding agent. The form collects:
+
+- spec and acceptance criteria;
+- context routing;
+- risk surface and negative checks;
+- extension choice: Plugin / MCP / Command / Skill / Rule / Contract / built-in change;
+- verification evidence;
+- retention decision.
+
+The condensed final prompt at the bottom of the template can be pasted directly into Hermes after the form is filled.
+
+## How to use this harness
+
+### Normal WebUI / chat usage
+
+For non-trivial engineering work, ask normally in WebUI, CLI, or connected gateway platforms:
+
+```text
+请修复这个 bug
+请实现一个新功能并加测试
+请重构这段逻辑并保证不破坏现有行为
+```
+
+When `HERMES_HARNESS_PREFLIGHT` is unset or set to `advisory`, Hermes keeps the visible/persisted user message unchanged, but prepends a model-facing Harness reminder for engineering-like tasks. The reminder asks for scope, acceptance criteria, risk surface, rollback, context routing, and verification evidence before implementation.
+
+Plain explanation/summarization/translation requests should not trigger the harness.
+
+### Explicit intake for larger tasks
+
+```bash
+hermes harness new \
+  --title "Fix gateway preflight regression" \
+  --workspace /path/to/repo \
+  --mode "Implement changes" \
+  --output /tmp/harness-intake.md
+
+hermes harness check /tmp/harness-intake.md
+hermes harness prompt /tmp/harness-intake.md --output /tmp/harness-prompt.txt --force
+```
+
+Fallback helper:
+
+```bash
+~/.hermes/bin/hermes-harness new --title "My task" --workspace /path/to/repo --mode "Implement changes"
+~/.hermes/bin/hermes-harness check /path/to/intake.md
+~/.hermes/bin/hermes-harness prompt /path/to/intake.md
+```
+
+Blank generated forms are expected to fail `check` until problem, acceptance criteria, risk surface, and verification fields are filled.
+
+### In-session helper
+
+```text
+/intake
+```
+
+This prints the Harness / Agenting Engineering intake instructions. It is advisory only.
+
+### Preflight modes
+
+`HERMES_HARNESS_PREFLIGHT` controls the soft preflight:
+
+| Mode | Behavior | Use when |
+|---|---|---|
+| unset / `advisory` | Soft rewrite for engineering-like requests | Default daily development |
+| `strict` | Prepends an intake-required instruction | Risky work: auth, secrets, shell, filesystem, deploys, data deletion, cross-platform behavior |
+| `off` | No rewrite | Debugging false positives or temporarily disabling the harness |
+
+Examples:
+
+```bash
+export HERMES_HARNESS_PREFLIGHT=advisory
+export HERMES_HARNESS_PREFLIGHT=strict
+export HERMES_HARNESS_PREFLIGHT=off
+```
+
+Restart the relevant process after changing the variable: WebUI/API server, gateway, or CLI session.
+
+### Current acceptance checks
+
+- Engineering request such as `请修复这个 bug` triggers `[Harness / Agenting Engineering preflight]`.
+- Plain explanation such as `解释一下什么是 MCP` is allowed unchanged.
+- `HERMES_HARNESS_PREFLIGHT=strict` emits the `intake required` variant.
+- `HERMES_HARNESS_PREFLIGHT=off` disables rewrites.
+- WebUI must not mutate the visible/persisted user message; only the model-facing current turn is rewritten.
+- The current Harness plugin should use `allow` / `rewrite`, not `skip`, so it remains a soft guard rather than a hard blocker.
+
+## Local command helper
+
+This skill includes a local helper command for Level 2 soft enforcement:
+
+```bash
+# Create a new intake form, prefilled with title/workspace/mode
+~/.hermes/bin/hermes-harness new \
+  --title "My task" \
+  --workspace /path/to/repo \
+  --mode "Implement changes"
+
+# Validate required fields in a filled form
+~/.hermes/bin/hermes-harness check /path/to/intake.md
+
+# Render the condensed prompt to paste into Hermes / an LLM / a coding agent
+~/.hermes/bin/hermes-harness prompt /path/to/intake.md
+
+# Print the blank template
+~/.hermes/bin/hermes-harness template
+```
+
+The executable wrapper lives at `~/.hermes/bin/hermes-harness`; the source script lives at `scripts/harness_intake.py` inside this skill. It has no third-party dependencies and intentionally avoids importing Hermes internals, so it can run from CLI, WebUI terminals, WSL, cron scripts, or other agents.
+
+If `~/.hermes/bin` is on `PATH`, use `hermes-harness ...` directly.
+
+## Hermes plugin entrypoints
+
+This profile also has a user-local plugin for Level 3 soft integration:
+
+```text
+~/.hermes/plugins/harness_engineering/
+```
+
+It is enabled in the active `default` profile and registers:
+
+```bash
+# Hermes-native CLI wrapper around the same helper
+hermes harness template
+hermes harness template --output /path/to/template.md
+hermes harness new --title "My task" --workspace /path/to/repo --mode "Implement changes" --out /path/to/intake.md
+hermes harness check /path/to/intake.md
+hermes harness prompt /path/to/intake.md
+hermes harness prompt /path/to/intake.md --allow-incomplete --output /path/to/prompt.txt --force
+```
+
+It also registers the in-session plugin slash command:
+
+```text
+/intake
+```
+
+`/intake` is intentionally advisory: it returns the Harness / Agenting Engineering intake instructions and does not intercept every message. Use this before non-trivial engineering tasks when a full WebUI/gateway preflight gate is not yet enabled.
+
+Important implementation notes:
+
+- `hermes harness ...` delegates to `~/.hermes/bin/hermes-harness`; keep the helper and plugin argument surfaces in sync.
+- The plugin handler raises `SystemExit(code)` so failed `check` results propagate as non-zero process exit codes for scripts/CI.
+- Blank/generated forms are expected to fail `check` until problem, acceptance criteria, risk surface, and verification evidence are filled.
+
+## Plugin / MCP / Command integration choice
+
+Use this quick decision path:
+
+1. **MCP** — use when an external tool/server/API already exists, or the integration should remain outside Hermes core. Add via `hermes mcp add NAME --command ...` or `hermes mcp add NAME --url ...`, then `hermes mcp test NAME` and `hermes mcp configure NAME` to filter tools.
+2. **Plugin** — use when the capability should be a reusable Hermes extension: custom tools, hooks, slash commands, provider backends, memory/context/image/video/search providers, or bundled skills. Create `~/.hermes/plugins/<name>/plugin.yaml` plus schemas/handlers/hooks, or an in-repo plugin when it should ship with Hermes.
+3. **Command / script** — use when the capability is a repeatable operator action, quality gate, evidence generator, migration, or setup helper. Prefer a script or CLI subcommand over asking the model to remember shell snippets.
+4. **Skill** — use when the capability is a reusable multi-step procedure rather than executable code.
+5. **Rule / contract** — use when the behavior is an always-on constraint or public invariant.
+
+Security default: start with the smallest useful surface, whitelist tools where possible, document credentials as env vars, and never pass broad secrets or full filesystem access to an untrusted MCP/plugin.
+
+## Hermes repository notes
+
+For Hermes Agent work, also read the repository-level `docs/harness-agenting-engineering.md` when present. For WebUI work, run or reference `hermes-webui/scripts/harness_quality_gate.py` to produce advisory changed-file routing and recommended checks.
+
+## Level 4 soft preflight integration
+
+The user-local `harness_engineering` plugin registers a `pre_gateway_dispatch` hook for soft enforcement:
+
+- `HERMES_HARNESS_PREFLIGHT=advisory` (default): rewrite non-trivial engineering prompts by prepending a Harness / Agenting Engineering reminder.
+- `HERMES_HARNESS_PREFLIGHT=strict`: prepend an intake-required instruction for high-risk work.
+- `HERMES_HARNESS_PREFLIGHT=off`: disable the preflight.
+
+Gateway messages pass through `gateway/run.py` and can honor `skip`, `rewrite`, and `allow` hook actions. WebUI/browser-originated chats do not pass through gateway dispatch, so `hermes-webui/api/streaming.py` bridges only `rewrite` actions into the model-facing current turn; it must not mutate the visible/persisted user message and must not block requests.
+
+Verification commands used for this path:
+
+```bash
+# In the Hermes Agent repo; use venv if .venv is absent.
+venv/bin/python -m pytest -o addopts='' \
+  tests/gateway/test_pre_gateway_dispatch.py \
+  tests/hermes_cli/test_plugins.py -q
+
+PYTHONPATH=/path/to/hermes-agent:/path/to/hermes-agent/hermes-webui \
+venv/bin/python - <<'PY'
+import os
+from api.streaming import _apply_webui_pre_gateway_dispatch_preflight
+os.environ['HERMES_HARNESS_PREFLIGHT'] = 'advisory'
+rewritten = _apply_webui_pre_gateway_dispatch_preflight('请修复这个 bug', session_id='sid', workspace='/tmp/ws', profile='default')
+assert rewritten.startswith('[Harness / Agenting Engineering preflight]')
+assert 'acceptance criteria' in rewritten.lower()
+assert 'risk surface' in rewritten.lower()
+assert _apply_webui_pre_gateway_dispatch_preflight('解释一下什么是 MCP', session_id='sid', workspace='/tmp/ws', profile='default') == '解释一下什么是 MCP'
+os.environ['HERMES_HARNESS_PREFLIGHT'] = 'off'
+assert _apply_webui_pre_gateway_dispatch_preflight('请修复这个 bug', session_id='sid', workspace='/tmp/ws', profile='default') == '请修复这个 bug'
+PY
+
+venv/bin/python -m py_compile \
+  hermes_cli/plugins.py gateway/run.py hermes-webui/api/streaming.py \
+  ~/.hermes/plugins/harness_engineering/__init__.py
+```
+
+Pitfall: if the active test environment lacks `pytest-timeout`, project `pyproject.toml` addopts (`--timeout=30 --timeout-method=signal`) make pytest fail before collection. For focused validation, use `-o addopts=''` or install the dev extras into the active venv.
+
+## Pitfalls
+
+- Do not turn every rule into a skill; always-on constraints belong in rules.
+- Do not turn rare workflows into always-on prompt bloat; make them skills.
+- Do not load many MCP tools “just in case”; tool count consumes context.
+- Do not delegate to subagents without explicit scope, context, and review criteria.
+- Do not store task progress or PR numbers in memory.
+- Do not write secrets into docs, skills, examples, or logs; redact as `[REDACTED]`.

--- a/skills/software-development/harness-agenting-engineering/SKILL.md
+++ b/skills/software-development/harness-agenting-engineering/SKILL.md
@@ -169,9 +169,12 @@ The condensed final prompt at the bottom of the template can be pasted directly 
 
 ## How to use this harness
 
-### Normal WebUI / chat usage
+### Normal chat usage
 
-For non-trivial engineering work, ask normally in WebUI, CLI, or connected gateway platforms:
+For non-trivial engineering work, ask normally in Hermes. Current in-repo soft
+preflight integration is gateway-scoped; CLI and WebUI users can invoke the
+explicit `hermes harness classify`, `hermes harness new`, and `/intake` surfaces
+until those entrypoints grow their own model-facing bridge.
 
 ```text
 请修复这个 bug
@@ -179,7 +182,11 @@ For non-trivial engineering work, ask normally in WebUI, CLI, or connected gatew
 请重构这段逻辑并保证不破坏现有行为
 ```
 
-When `HERMES_HARNESS_PREFLIGHT` is unset or set to `advisory`, Hermes keeps the visible/persisted user message unchanged, but prepends a model-facing Harness reminder for engineering-like tasks. The reminder asks for scope, acceptance criteria, risk surface, rollback, context routing, and verification evidence before implementation.
+When `harness_engineering.preflight_mode` is unset or set to `advisory`, gateway
+messages keep the visible/persisted user message unchanged, but the hook returns
+a model-facing Harness reminder for engineering-like tasks. The reminder asks
+for scope, acceptance criteria, risk surface, rollback, context routing, and
+verification evidence before implementation.
 
 Plain explanation/summarization/translation requests should not trigger the harness.
 
@@ -217,9 +224,9 @@ hermes harness prompt /tmp/harness-intake.md --output /tmp/harness-prompt.txt --
 Fallback helper:
 
 ```bash
-~/.hermes/bin/hermes-harness new --title "My task" --workspace /path/to/repo --mode "Implement changes"
-~/.hermes/bin/hermes-harness check /path/to/intake.md
-~/.hermes/bin/hermes-harness prompt /path/to/intake.md
+${HERMES_HOME:-$HOME/.hermes}/bin/hermes-harness new --title "My task" --workspace /path/to/repo --mode "Implement changes"
+${HERMES_HOME:-$HOME/.hermes}/bin/hermes-harness check /path/to/intake.md
+${HERMES_HOME:-$HOME/.hermes}/bin/hermes-harness prompt /path/to/intake.md
 ```
 
 Blank generated forms are expected to fail `check` until problem, acceptance criteria, risk surface, and verification fields are filled.
@@ -234,31 +241,32 @@ This prints the Harness / Agenting Engineering intake instructions. It is adviso
 
 ### Preflight modes
 
-`HERMES_HARNESS_PREFLIGHT` controls the soft preflight:
+`harness_engineering.preflight_mode` in `config.yaml` controls the gateway soft
+preflight:
 
 | Mode | Behavior | Use when |
 |---|---|---|
-| unset / `advisory` | Soft rewrite for engineering-like requests | Default daily development |
+| unset / `advisory` | Soft gateway rewrite for engineering-like requests | Default daily development |
 | `strict` | Prepends an intake-required instruction | Risky work: auth, secrets, shell, filesystem, deploys, data deletion, cross-platform behavior |
 | `off` | No rewrite | Debugging false positives or temporarily disabling the harness |
 
 Examples:
 
 ```bash
-export HERMES_HARNESS_PREFLIGHT=advisory
-export HERMES_HARNESS_PREFLIGHT=strict
-export HERMES_HARNESS_PREFLIGHT=off
+hermes config set harness_engineering.preflight_mode advisory
+hermes config set harness_engineering.preflight_mode strict
+hermes config set harness_engineering.preflight_mode off
 ```
 
-Restart the relevant process after changing the variable: WebUI/API server, gateway, or CLI session.
+Restart the gateway after changing the setting.
 
 ### Current acceptance checks
 
 - Engineering request such as `请修复这个 bug` triggers `[Harness / Agenting Engineering preflight]`.
 - Plain explanation such as `解释一下什么是 MCP` is allowed unchanged.
-- `HERMES_HARNESS_PREFLIGHT=strict` emits the `intake required` variant.
-- `HERMES_HARNESS_PREFLIGHT=off` disables rewrites.
-- WebUI must not mutate the visible/persisted user message; only the model-facing current turn is rewritten.
+- `harness_engineering.preflight_mode: strict` emits the `intake required` variant.
+- `harness_engineering.preflight_mode: off` disables gateway rewrites.
+- WebUI/CLI coverage claims stay limited to explicit `hermes harness ...` commands until their entrypoints wire an equivalent model-facing bridge.
 - The current Harness plugin should use `allow` / `rewrite`, not `skip`, so it remains a soft guard rather than a hard blocker.
 
 ## Local command helper
@@ -267,24 +275,24 @@ This skill includes a local helper command for Level 2 soft enforcement:
 
 ```bash
 # Create a new intake form, prefilled with title/workspace/mode
-~/.hermes/bin/hermes-harness new \
+${HERMES_HOME:-$HOME/.hermes}/bin/hermes-harness new \
   --title "My task" \
   --workspace /path/to/repo \
   --mode "Implement changes"
 
 # Validate required fields in a filled form
-~/.hermes/bin/hermes-harness check /path/to/intake.md
+${HERMES_HOME:-$HOME/.hermes}/bin/hermes-harness check /path/to/intake.md
 
 # Render the condensed prompt to paste into Hermes / an LLM / a coding agent
-~/.hermes/bin/hermes-harness prompt /path/to/intake.md
+${HERMES_HOME:-$HOME/.hermes}/bin/hermes-harness prompt /path/to/intake.md
 
 # Print the blank template
-~/.hermes/bin/hermes-harness template
+${HERMES_HOME:-$HOME/.hermes}/bin/hermes-harness template
 ```
 
-The executable wrapper lives at `~/.hermes/bin/hermes-harness`; the source script lives at `scripts/harness_intake.py` inside this skill. It has no third-party dependencies and intentionally avoids importing Hermes internals, so it can run from CLI, WebUI terminals, WSL, cron scripts, or other agents.
+The executable wrapper lives at `bin/hermes-harness` under the active Hermes profile home; the source script lives at `scripts/harness_intake.py` inside this skill. It has no third-party dependencies and intentionally avoids importing Hermes internals, so it can run from CLI, WebUI terminals, WSL, cron scripts, or other agents.
 
-If `~/.hermes/bin` is on `PATH`, use `hermes-harness ...` directly.
+If the active profile's `bin` directory is on `PATH`, use `hermes-harness ...` directly.
 
 ## Hermes plugin entrypoints
 
@@ -300,7 +308,7 @@ It is enabled in the active `default` profile and registers:
 # Hermes-native CLI wrapper around the same helper
 hermes harness template
 hermes harness template --output /path/to/template.md
-hermes harness new --title "My task" --workspace /path/to/repo --mode "Implement changes" --out /path/to/intake.md
+hermes harness new --title "My task" --workspace /path/to/repo --mode "Implement changes" --output /path/to/intake.md
 hermes harness check /path/to/intake.md
 hermes harness prompt /path/to/intake.md
 hermes harness prompt /path/to/intake.md --allow-incomplete --output /path/to/prompt.txt --force
@@ -333,7 +341,7 @@ It also registers the in-session plugin slash command:
 
 Important implementation notes:
 
-- `hermes harness ...` delegates to `~/.hermes/bin/hermes-harness`; keep the helper and plugin argument surfaces in sync.
+- `hermes harness ...` delegates first to the bundled helper, then to the active profile's `bin/hermes-harness`; keep the helper and plugin argument surfaces in sync.
 - The plugin handler raises `SystemExit(code)` so failed `check` results propagate as non-zero process exit codes for scripts/CI.
 - Blank/generated forms are expected to fail `check` until problem, acceptance criteria, risk surface, and verification evidence are filled.
 
@@ -357,11 +365,11 @@ For Hermes Agent work, also read the repository-level `docs/harness-agenting-eng
 
 The user-local `harness_engineering` plugin registers a `pre_gateway_dispatch` hook for soft enforcement:
 
-- `HERMES_HARNESS_PREFLIGHT=advisory` (default): rewrite non-trivial engineering prompts by prepending a Harness / Agenting Engineering reminder.
-- `HERMES_HARNESS_PREFLIGHT=strict`: prepend an intake-required instruction for high-risk work.
-- `HERMES_HARNESS_PREFLIGHT=off`: disable the preflight.
+- `harness_engineering.preflight_mode: advisory` (default): rewrite non-trivial engineering prompts by prepending a Harness / Agenting Engineering reminder.
+- `harness_engineering.preflight_mode: strict`: prepend an intake-required instruction for high-risk work.
+- `harness_engineering.preflight_mode: off`: disable the preflight.
 
-Gateway messages pass through `gateway/run.py` and can honor `skip`, `rewrite`, and `allow` hook actions. WebUI/browser-originated chats do not pass through gateway dispatch, so `hermes-webui/api/streaming.py` bridges only `rewrite` actions into the model-facing current turn; it must not mutate the visible/persisted user message and must not block requests.
+Gateway messages pass through `gateway/run.py` and can honor `skip`, `rewrite`, and `allow` hook actions. Current main does not route CLI or WebUI/browser-originated chats through this hook; those surfaces are covered by explicit `hermes harness ...` and `/intake` commands only.
 
 Verification commands used for this path:
 
@@ -371,23 +379,8 @@ venv/bin/python -m pytest -o addopts='' \
   tests/gateway/test_pre_gateway_dispatch.py \
   tests/hermes_cli/test_plugins.py -q
 
-PYTHONPATH=/path/to/hermes-agent:/path/to/hermes-agent/hermes-webui \
-venv/bin/python - <<'PY'
-import os
-from api.streaming import _apply_webui_pre_gateway_dispatch_preflight
-os.environ['HERMES_HARNESS_PREFLIGHT'] = 'advisory'
-rewritten = _apply_webui_pre_gateway_dispatch_preflight('请修复这个 bug', session_id='sid', workspace='/tmp/ws', profile='default')
-assert rewritten.startswith('[Harness / Agenting Engineering preflight]')
-assert 'acceptance criteria' in rewritten.lower()
-assert 'risk surface' in rewritten.lower()
-assert _apply_webui_pre_gateway_dispatch_preflight('解释一下什么是 MCP', session_id='sid', workspace='/tmp/ws', profile='default') == '解释一下什么是 MCP'
-os.environ['HERMES_HARNESS_PREFLIGHT'] = 'off'
-assert _apply_webui_pre_gateway_dispatch_preflight('请修复这个 bug', session_id='sid', workspace='/tmp/ws', profile='default') == '请修复这个 bug'
-PY
-
 venv/bin/python -m py_compile \
-  hermes_cli/plugins.py gateway/run.py hermes-webui/api/streaming.py \
-  ~/.hermes/plugins/harness_engineering/__init__.py
+  hermes_cli/plugins.py gateway/run.py plugins/harness_engineering/__init__.py
 ```
 
 Pitfall: if the active test environment lacks `pytest-timeout`, project `pyproject.toml` addopts (`--timeout=30 --timeout-method=signal`) make pytest fail before collection. For focused validation, use `-o addopts=''` or install the dev extras into the active venv.

--- a/skills/software-development/harness-agenting-engineering/SKILL.md
+++ b/skills/software-development/harness-agenting-engineering/SKILL.md
@@ -185,6 +185,24 @@ Plain explanation/summarization/translation requests should not trigger the harn
 
 ### Explicit intake for larger tasks
 
+Use `classify` when a caller needs a stable advisory route before deciding
+whether to create a full intake. Classification does not dispatch work, write
+state, or replace the caller's own permission checks.
+
+```bash
+hermes harness classify --text "Refactor auth token storage and add tests" --format json
+```
+
+Core routes:
+
+| Route | Meaning |
+|---|---|
+| `answer_directly` | Plain chat; no Harness intake needed. |
+| `research_then_report` | Gather evidence and report assumptions/gaps. |
+| `bounded_engineering` | Small scoped code work with focused tests. |
+| `harness_advisory` | Larger engineering work; define scope and verification before editing. |
+| `intake_required` | High-risk, scheduled/ops, or multi-agent work; create/fill an intake before implementation. |
+
 ```bash
 hermes harness new \
   --title "Fix gateway preflight regression" \

--- a/skills/software-development/harness-agenting-engineering/scripts/harness_intake.py
+++ b/skills/software-development/harness-agenting-engineering/scripts/harness_intake.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Harness / Agenting Engineering task intake helper.
+
+Local command helper for the user-local `harness-agenting-engineering` skill.
+It intentionally avoids importing Hermes internals so it can run from CLI, WebUI
+terminals, WSL, cron scripts, or other agents.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import os
+import re
+import shutil
+import sys
+from pathlib import Path
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+TEMPLATE = SKILL_DIR / "templates" / "task-intake-form.md"
+DEFAULT_OUT_DIR = Path.home() / ".hermes" / "harness" / "intake"
+
+FIELD_PATTERNS = {
+    "task_title": re.compile(r"^- Task title:[ \t]*(.*)$", re.MULTILINE),
+    "workspace": re.compile(r"^- Workspace / repo:[ \t]*(.*)$", re.MULTILINE),
+    "problem": re.compile(r"^- Problem / request:[ \t]*(.*)$", re.MULTILINE),
+    "business_outcome": re.compile(r"^- Business or user outcome:[ \t]*(.*)$", re.MULTILINE),
+    "chosen_extension": re.compile(r"^Chosen extension surface:[ \t]*(.*)$", re.MULTILINE),
+    "reason": re.compile(r"^Reason:[ \t]*(.*)$", re.MULTILINE),
+}
+
+CHECKED_LINE = re.compile(r"^\s*- \[x\][ \t]+(.+)$", re.MULTILINE | re.IGNORECASE)
+ACCEPTANCE_ITEM = re.compile(r"^\s*\d+\.[ \t]+(.+)$", re.MULTILINE)
+REQUIRED_NEGATIVE = re.compile(r"^Required negative checks:\n(?P<body>(?:^-.*\n?)*)", re.MULTILINE)
+VERIFICATION_SECTION = re.compile(
+    r"## 6\. Verification evidence required before done\n(?P<body>.*?)(?:\n## 7\.|\Z)",
+    re.DOTALL,
+)
+RETENTION_SECTION = re.compile(r"## 7\. Retention decision\n(?P<body>.*?)(?:\n## 8\.|\Z)", re.DOTALL)
+
+
+def _slugify(text: str) -> str:
+    text = text.strip().lower()
+    text = re.sub(r"[^a-z0-9\u4e00-\u9fff]+", "-", text)
+    text = re.sub(r"-+", "-", text).strip("-")
+    return text[:80] or "task"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _write(path: Path, content: str, force: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists() and not force:
+        raise SystemExit(f"Refusing to overwrite existing file: {path}\nUse --force to overwrite.")
+    path.write_text(content, encoding="utf-8")
+
+
+def command_new(args: argparse.Namespace) -> int:
+    if not TEMPLATE.exists():
+        raise SystemExit(f"Template not found: {TEMPLATE}")
+    content = _read(TEMPLATE)
+    title = args.title.strip() if args.title else ""
+    workspace = args.workspace.strip() if args.workspace else os.getcwd()
+    if title:
+        content = content.replace("- Task title:", f"- Task title: {title}", 1)
+    if workspace:
+        content = content.replace("- Workspace / repo:", f"- Workspace / repo: {workspace}", 1)
+    if args.mode:
+        # Mark a matching Desired mode checkbox when the label is present.
+        mode = args.mode.strip().lower()
+        lines = []
+        for line in content.splitlines():
+            if line.strip().startswith("- [ ]") and line.strip()[6:].strip().lower() == mode:
+                line = line.replace("[ ]", "[x]", 1)
+            lines.append(line)
+        content = "\n".join(lines) + "\n"
+
+    out = Path(args.output) if args.output else None
+    if out is None:
+        stamp = _dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+        slug = _slugify(title) if title else "task"
+        out = DEFAULT_OUT_DIR / f"{stamp}-{slug}.md"
+    _write(out.expanduser().resolve(), content, force=args.force)
+    print(out.expanduser().resolve())
+    return 0
+
+
+def _field(content: str, key: str) -> str:
+    m = FIELD_PATTERNS[key].search(content)
+    return (m.group(1).strip() if m else "")
+
+
+def _checked_in_section(content: str, start_heading: str, next_heading: str | None = None) -> list[str]:
+    start = content.find(start_heading)
+    if start == -1:
+        return []
+    end = len(content)
+    if next_heading:
+        n = content.find(next_heading, start + len(start_heading))
+        if n != -1:
+            end = n
+    section = content[start:end]
+    return [m.group(1).strip() for m in CHECKED_LINE.finditer(section)]
+
+
+def parse_form(content: str) -> dict[str, object]:
+    acceptance = [m.group(1).strip() for m in ACCEPTANCE_ITEM.finditer(content) if m.group(1).strip()]
+    modes = _checked_in_section(content, "## 0. Submission mode", "## 1.")
+    risks = _checked_in_section(content, "## 3. Risk surface", "## 4.")
+    extension_choices = _checked_in_section(content, "## 4. Extension choice", "## 5.")
+
+    neg = ""
+    m = REQUIRED_NEGATIVE.search(content)
+    if m:
+        neg = m.group("body").strip()
+    verification = ""
+    m = VERIFICATION_SECTION.search(content)
+    if m:
+        verification = m.group("body").strip()
+    retention = ""
+    m = RETENTION_SECTION.search(content)
+    if m:
+        retention = m.group("body").strip()
+
+    return {
+        "task_title": _field(content, "task_title"),
+        "workspace": _field(content, "workspace"),
+        "problem": _field(content, "problem"),
+        "business_outcome": _field(content, "business_outcome"),
+        "acceptance": acceptance,
+        "modes": modes,
+        "risks": risks,
+        "chosen_extension": _field(content, "chosen_extension"),
+        "extension_reason": _field(content, "reason"),
+        "extension_choices": extension_choices,
+        "negative_checks": neg,
+        "verification": verification,
+        "retention": retention,
+    }
+
+
+def validate_form(data: dict[str, object]) -> list[str]:
+    missing: list[str] = []
+    for key, label in [
+        ("task_title", "Task title"),
+        ("workspace", "Workspace / repo"),
+        ("problem", "Problem / request"),
+    ]:
+        if not str(data.get(key) or "").strip():
+            missing.append(label)
+    if not data.get("modes"):
+        missing.append("At least one desired mode / permission checkbox")
+    if not data.get("acceptance"):
+        missing.append("Acceptance criteria")
+    if not data.get("risks"):
+        missing.append("Risk surface checkbox")
+    if not str(data.get("verification") or "").strip():
+        missing.append("Verification evidence required")
+    return missing
+
+
+def command_check(args: argparse.Namespace) -> int:
+    path = Path(args.form).expanduser().resolve()
+    content = _read(path)
+    data = parse_form(content)
+    missing = validate_form(data)
+    if missing:
+        print("Missing or incomplete fields:")
+        for item in missing:
+            print(f"- {item}")
+        return 2
+    print(f"OK: {path}")
+    return 0
+
+
+def command_prompt(args: argparse.Namespace) -> int:
+    path = Path(args.form).expanduser().resolve()
+    content = _read(path)
+    data = parse_form(content)
+    missing = validate_form(data)
+    if missing and not args.allow_incomplete:
+        print("Form is incomplete; use `check` to see details or pass --allow-incomplete.", file=sys.stderr)
+        for item in missing:
+            print(f"- {item}", file=sys.stderr)
+        return 2
+
+    prompt = f"""Please execute this task under Harness / Agenting Engineering discipline.
+
+Task: {data['task_title'] or '<title>'}
+Workspace/repo: {data['workspace'] or '<workspace>'}
+Mode and permissions: {', '.join(data['modes']) if data['modes'] else '<mode + permission level>'}
+Spec: Problem: {data['problem'] or '<problem>'}; Outcome: {data['business_outcome'] or '<outcome>'}; Acceptance criteria: {'; '.join(data['acceptance']) if data['acceptance'] else '<acceptance criteria>'}
+Context routing: inspect the form for docs/files/skills/MCP/tools before editing; do not skip AGENTS/CONTRIBUTING/contracts when present.
+Risk surface: {', '.join(data['risks']) if data['risks'] else '<checked risks>'}; Required negative checks: {data['negative_checks'] or '<negative checks>'}
+Extension choice: {data['chosen_extension'] or ', '.join(data['extension_choices']) or '<Plugin/MCP/Command/Skill/Rule/Contract/Built-in>'}; Reason: {data['extension_reason'] or '<reason>'}
+Implementation expectation: smallest useful change; keep scope narrow; update docs/tests alongside behavior changes.
+Verification required: {data['verification'] or '<tests, lint, manual evidence, security checks>'}
+Retention: {data['retention'] or '<skill/rule/contract/memory decision>'}
+
+Do not claim completion without evidence. If required context is missing and cannot be retrieved, ask a targeted clarification before implementation.
+"""
+    if args.output:
+        _write(Path(args.output).expanduser().resolve(), prompt, force=args.force)
+        print(Path(args.output).expanduser().resolve())
+    else:
+        print(prompt)
+    return 0
+
+
+def command_template(args: argparse.Namespace) -> int:
+    target = Path(args.output).expanduser().resolve() if args.output else None
+    if target:
+        shutil.copyfile(TEMPLATE, target)
+        print(target)
+    else:
+        print(_read(TEMPLATE))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="hermes-harness",
+        description="Harness / Agenting Engineering task intake helper",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_new = sub.add_parser("new", help="create a new task intake form")
+    p_new.add_argument("--title", "-t", default="", help="task title to prefill")
+    p_new.add_argument("--workspace", "-w", default="", help="workspace/repo to prefill; defaults to cwd")
+    p_new.add_argument("--mode", "-m", default="", help="desired mode label to check, e.g. 'Implement changes'")
+    p_new.add_argument("--output", "-o", default="", help="output markdown path")
+    p_new.add_argument("--force", action="store_true", help="overwrite output if it exists")
+    p_new.set_defaults(func=command_new)
+
+    p_check = sub.add_parser("check", help="validate required intake fields")
+    p_check.add_argument("form", help="filled intake form markdown")
+    p_check.set_defaults(func=command_check)
+
+    p_prompt = sub.add_parser("prompt", help="render condensed prompt from a filled form")
+    p_prompt.add_argument("form", help="filled intake form markdown")
+    p_prompt.add_argument("--allow-incomplete", action="store_true", help="render even if required fields are missing")
+    p_prompt.add_argument("--output", "-o", default="", help="write prompt to file instead of stdout")
+    p_prompt.add_argument("--force", action="store_true", help="overwrite output if it exists")
+    p_prompt.set_defaults(func=command_prompt)
+
+    p_template = sub.add_parser("template", help="print or copy the blank template")
+    p_template.add_argument("--output", "-o", default="", help="copy template to path instead of stdout")
+    p_template.set_defaults(func=command_template)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/software-development/harness-agenting-engineering/scripts/harness_intake.py
+++ b/skills/software-development/harness-agenting-engineering/scripts/harness_intake.py
@@ -17,7 +17,26 @@ from pathlib import Path
 
 SKILL_DIR = Path(__file__).resolve().parents[1]
 TEMPLATE = SKILL_DIR / "templates" / "task-intake-form.md"
-DEFAULT_OUT_DIR = Path.home() / ".hermes" / "harness" / "intake"
+
+
+def _fallback_hermes_home() -> Path:
+    if sys.platform == "win32":
+        local_appdata = os.environ.get("LOCALAPPDATA", "").strip()
+        base = Path(local_appdata) if local_appdata else Path.home() / "AppData" / "Local"
+        return base / "hermes"
+    return Path.home().joinpath(".hermes")
+
+
+def _default_out_dir() -> Path:
+    """Return the active-profile intake directory without importing Hermes.
+
+    Hermes profile launches set HERMES_HOME before plugin/helper execution. The
+    standalone helper still has a platform fallback so it can run outside Hermes
+    for migration or bootstrapping, but it honors HERMES_HOME whenever present.
+    """
+    hermes_home = os.environ.get("HERMES_HOME", "").strip()
+    root = Path(hermes_home).expanduser() if hermes_home else _fallback_hermes_home()
+    return root / "harness" / "intake"
 
 FIELD_PATTERNS = {
     "task_title": re.compile(r"^- Task title:[ \t]*(.*)$", re.MULTILINE),
@@ -80,7 +99,7 @@ def command_new(args: argparse.Namespace) -> int:
     if out is None:
         stamp = _dt.datetime.now().strftime("%Y%m%d-%H%M%S")
         slug = _slugify(title) if title else "task"
-        out = DEFAULT_OUT_DIR / f"{stamp}-{slug}.md"
+        out = _default_out_dir() / f"{stamp}-{slug}.md"
     _write(out.expanduser().resolve(), content, force=args.force)
     print(out.expanduser().resolve())
     return 0

--- a/skills/software-development/harness-agenting-engineering/templates/task-intake-form.md
+++ b/skills/software-development/harness-agenting-engineering/templates/task-intake-form.md
@@ -1,0 +1,144 @@
+# Harness Task Intake Form
+
+> Fill this before submitting a non-trivial task to Hermes / an LLM / a coding agent. Leave fields blank only when genuinely not applicable.
+
+## 0. Submission mode
+
+- Task title:
+- Workspace / repo:
+- Desired mode:
+  - [ ] Analysis only
+  - [ ] Plan only
+  - [ ] Implement changes
+  - [ ] Review existing changes
+  - [ ] Debug / root cause
+  - [ ] Integrate external tool via Plugin / MCP / Command
+- Permission level:
+  - [ ] Read-only
+  - [ ] May write files
+  - [ ] May run tests/builds
+  - [ ] May install dependencies
+  - [ ] May touch config
+  - [ ] May call external APIs
+  - [ ] Needs confirmation before side effects
+
+## 1. Spec — what counts as correct?
+
+- Problem / request:
+- Business or user outcome:
+- Acceptance criteria:
+  1.
+  2.
+  3.
+- Non-goals / out of scope:
+- Constraints:
+  - Time:
+  - Compatibility:
+  - Performance:
+  - Cost / token budget:
+  - Security / privacy:
+- Known examples / references:
+- What should not change:
+
+## 2. Context routing — what must the agent read first?
+
+- Relevant docs / rules:
+  - [ ] AGENTS.md
+  - [ ] CONTRIBUTING.md
+  - [ ] docs/CONTRACTS.md or equivalent
+  - [ ] RFC / design doc:
+  - [ ] TESTING.md / test docs:
+- Relevant files / modules:
+- Relevant prior sessions / memories / skills:
+- External docs or APIs needed:
+- MCP servers / tools that should be available:
+- Tools that should be disabled or avoided:
+
+## 3. Risk surface
+
+Check anything touched by the task:
+
+- [ ] Secrets / API keys / credentials
+- [ ] Auth / OAuth / license / payment
+- [ ] Shell commands / destructive filesystem ops
+- [ ] Network calls / webhooks / external APIs
+- [ ] Plugin / MCP / provider integration
+- [ ] Browser automation / cookies / sessions
+- [ ] Database / persistent state
+- [ ] User data / PII
+- [ ] UI / frontend state / replay / streaming
+- [ ] Build / packaging / release artifacts
+- [ ] No special risk identified
+
+Required negative checks:
+-
+
+## 4. Extension choice
+
+If this task adds a capability, choose one:
+
+- [ ] Built-in code change — because:
+- [ ] Plugin — because it is a reusable Hermes extension or provider/tool/hook package.
+- [ ] MCP — because an external server/tool already exists or should stay outside Hermes core.
+- [ ] Command / script — because this is a repeatable operator action or quality gate.
+- [ ] Skill — because this is a reusable multi-step workflow.
+- [ ] Rule / AGENTS.md — because this is a short always-on constraint.
+- [ ] Contract doc / tests — because this changes a public invariant.
+
+Chosen extension surface:
+Reason:
+Rollback plan:
+
+## 5. Implementation plan
+
+- Smallest useful change:
+- Files likely touched:
+- Tests likely touched:
+- Dependencies to add, if any:
+- Migration / compatibility concerns:
+- Expected output artifact:
+
+## 6. Verification evidence required before done
+
+- Automated tests:
+- Lint / static checks:
+- Manual verification:
+- UI evidence / screenshots / browser notes:
+- Security / negative tests:
+- Performance / token budget evidence:
+- Logs / diagnostics to include:
+
+## 7. Retention decision
+
+After completion, should Hermes update any of these?
+
+- [ ] Skill
+- [ ] AGENTS.md / rule
+- [ ] Contract doc
+- [ ] Test fixture / harness gate
+- [ ] MCP / plugin config docs
+- [ ] Durable memory, only if stable and non-secret
+- [ ] No retention needed
+
+Notes:
+
+## 8. Final prompt to submit
+
+Use this condensed prompt after filling the form:
+
+```text
+Please execute this task under Harness / Agenting Engineering discipline.
+
+Task: <title>
+Workspace/repo: <workspace>
+Mode and permissions: <mode + permission level>
+Spec: <problem, acceptance criteria, non-goals, constraints>
+Context routing: <docs/files/skills/MCP/tools to inspect first>
+Risk surface: <checked risks + required negative checks>
+Extension choice: <Plugin/MCP/Command/Skill/Rule/Contract/Built-in + reason>
+Implementation expectation: <smallest useful change + likely files>
+Verification required: <tests, lint, manual evidence, security checks>
+Retention: <skill/rule/contract/memory decision>
+
+Do not claim completion without evidence. If required context is missing and cannot be retrieved, ask a targeted clarification before implementation.
+```

--- a/tests/plugins/test_harness_engineering_plugin.py
+++ b/tests/plugins/test_harness_engineering_plugin.py
@@ -148,3 +148,125 @@ def test_register_exposes_harness_command_and_gateway_hook():
     assert ctx.register_command.call_args.args[0] == "intake"
     ctx.register_hook.assert_called_once()
     assert ctx.register_hook.call_args.args[0] == "pre_gateway_dispatch"
+
+
+
+def _filled_intake(tmp_path):
+    intake = tmp_path / "intake.md"
+    intake.write_text(
+        """# Harness / Agenting Engineering Task Intake
+
+- Task title: Close lifecycle loop
+- Workspace / repo: /repo/ws
+- Problem / request: Bridge intake to Kanban and evidence.
+
+## 0. Submission mode
+- [x] Implement changes
+
+## 2. Acceptance criteria
+1. Kanban card can be created from intake.
+2. Evidence report can be generated.
+
+## 3. Risk surface
+- [x] Plugins / hooks / tools
+
+## 6. Verification evidence required before done
+Run plugin unit tests.
+""",
+        encoding="utf-8",
+    )
+    return intake
+
+
+def test_harness_kanban_create_dry_run_from_intake(tmp_path, capsys):
+    plugin = _load_plugin()
+    intake = _filled_intake(tmp_path)
+
+    code = plugin._handle_harness_kanban_cli(
+        SimpleNamespace(
+            harness_kanban_action="create",
+            file=str(intake),
+            assignee="architect",
+            workspace="",
+            triage=True,
+            dry_run=True,
+            json=True,
+        )
+    )
+
+    assert code == 0
+    out = capsys.readouterr().out
+    assert '"hermes"' in out
+    assert '"kanban"' in out
+    assert '"create"' in out
+    assert '"Close lifecycle loop"' in out
+    assert '"--triage"' in out
+    assert "harness-intake:" in out
+
+
+def test_harness_kanban_decompose_defaults_to_dry_run(capsys):
+    plugin = _load_plugin()
+
+    code = plugin._handle_harness_kanban_cli(
+        SimpleNamespace(
+            harness_kanban_action="decompose",
+            task_id="t123",
+            worker="loop-worker",
+            reviewer="loop-reviewer",
+            workspace="worktree:/tmp/wt",
+            branch="wt/t123",
+            execute=False,
+            json=False,
+        )
+    )
+
+    assert code == 0
+    out = capsys.readouterr().out
+    assert '"dry_run": true' in out
+    assert '"--parent"' in out
+    assert '"t123"' in out
+    assert '"--initial-status"' in out
+    assert '"blocked"' in out
+
+
+def test_harness_evidence_writes_report(tmp_path, monkeypatch):
+    plugin = _load_plugin()
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    out = tmp_path / "evidence.md"
+
+    def fake_run(command, cwd=None):
+        if command[:2] == ["git", "rev-parse"]:
+            return 0, "abc1234", ""
+        if command[:2] == ["git", "status"]:
+            return 0, "", ""
+        if command[:2] == ["git", "diff"]:
+            return 0, " plugins/harness_engineering/__init__.py | 10 +", ""
+        return 0, "{}", ""
+
+    monkeypatch.setattr(plugin, "_run_capture", fake_run)
+
+    code = plugin._handle_harness_evidence_cli(
+        SimpleNamespace(task_id="t123", workspace=str(workspace), output=str(out))
+    )
+
+    assert code == 0
+    content = out.read_text(encoding="utf-8")
+    assert "## Harness Evidence" in content
+    assert "abc1234" in content
+    assert "Required completion notes" in content
+
+
+def test_harness_gc_template_documents_non_mutating_boundary(tmp_path):
+    plugin = _load_plugin()
+    out = tmp_path / "gc.md"
+
+    code = plugin._handle_harness_gc_template_cli(
+        SimpleNamespace(output=str(out), board="hermes-engineering-loop")
+    )
+
+    assert code == 0
+    content = out.read_text(encoding="utf-8")
+    assert "Weekly Harness GC" in content
+    assert "Do not auto-repair" in content
+    assert "hermes-engineering-loop" in content

--- a/tests/plugins/test_harness_engineering_plugin.py
+++ b/tests/plugins/test_harness_engineering_plugin.py
@@ -1,0 +1,97 @@
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def _load_plugin():
+    plugin_path = Path(__file__).resolve().parents[2] / "plugins" / "harness_engineering" / "__init__.py"
+    spec = importlib.util.spec_from_file_location("harness_engineering_under_test", plugin_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_preflight_allows_plain_explanation(monkeypatch):
+    plugin = _load_plugin()
+    monkeypatch.setenv("HERMES_HARNESS_PREFLIGHT", "advisory")
+
+    result = plugin._handle_pre_gateway_dispatch(SimpleNamespace(text="解释一下什么是 MCP"))
+
+    assert result == {"action": "allow"}
+
+
+def test_preflight_rewrites_engineering_task(monkeypatch):
+    plugin = _load_plugin()
+    monkeypatch.setenv("HERMES_HARNESS_PREFLIGHT", "advisory")
+
+    result = plugin._handle_pre_gateway_dispatch(SimpleNamespace(text="请修复这个 WebUI bug 并加测试"))
+
+    assert result["action"] == "rewrite"
+    assert "Harness / Agenting Engineering preflight" in result["text"]
+    assert result["text"].endswith("请修复这个 WebUI bug 并加测试")
+
+
+def test_preflight_strict_uses_intake_notice(monkeypatch):
+    plugin = _load_plugin()
+    monkeypatch.setenv("HERMES_HARNESS_PREFLIGHT", "strict")
+
+    result = plugin._handle_pre_gateway_dispatch(SimpleNamespace(text="重构 gateway 认证流程"))
+
+    assert result["action"] == "rewrite"
+    assert "intake required" in result["text"]
+
+
+def test_preflight_uses_config_when_env_unset(monkeypatch):
+    plugin = _load_plugin()
+    monkeypatch.delenv("HERMES_HARNESS_PREFLIGHT", raising=False)
+    monkeypatch.setattr(plugin, "_configured_preflight_mode", lambda: "off")
+
+    result = plugin._handle_pre_gateway_dispatch(SimpleNamespace(text="请修复这个 bug"))
+
+    assert result == {"action": "allow"}
+
+
+def test_helper_command_prefers_bundled_script(monkeypatch, tmp_path):
+    plugin = _load_plugin()
+    bundled = tmp_path / "repo" / "skills" / "software-development" / "harness-agenting-engineering" / "scripts" / "harness_intake.py"
+    bundled.parent.mkdir(parents=True)
+    bundled.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    user_helper = tmp_path / "home" / ".hermes" / "bin" / "hermes-harness"
+    user_helper.parent.mkdir(parents=True)
+    user_helper.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    monkeypatch.setenv("PYTHON", "python3.12")
+    monkeypatch.setattr(plugin, "_bundled_helper_path", lambda: bundled)
+    monkeypatch.setattr(plugin, "_user_helper_path", lambda: user_helper)
+
+    assert plugin._helper_command() == ["python3.12", str(bundled)]
+
+
+def test_helper_command_falls_back_to_user_helper(monkeypatch, tmp_path):
+    plugin = _load_plugin()
+    bundled = tmp_path / "missing" / "harness_intake.py"
+    user_helper = tmp_path / "home" / ".hermes" / "bin" / "hermes-harness"
+    user_helper.parent.mkdir(parents=True)
+    user_helper.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    monkeypatch.setattr(plugin, "_bundled_helper_path", lambda: bundled)
+    monkeypatch.setattr(plugin, "_user_helper_path", lambda: user_helper)
+
+    assert plugin._helper_command() == [str(user_helper)]
+
+
+def test_register_exposes_harness_command_and_gateway_hook():
+    plugin = _load_plugin()
+    ctx = MagicMock()
+
+    plugin.register(ctx)
+
+    cli_call = ctx.register_cli_command.call_args
+    assert cli_call.args[0] == "harness"
+    ctx.register_command.assert_called_once()
+    assert ctx.register_command.call_args.args[0] == "intake"
+    ctx.register_hook.assert_called_once()
+    assert ctx.register_hook.call_args.args[0] == "pre_gateway_dispatch"

--- a/tests/plugins/test_harness_engineering_plugin.py
+++ b/tests/plugins/test_harness_engineering_plugin.py
@@ -1,3 +1,4 @@
+import argparse
 import importlib.util
 from pathlib import Path
 from types import SimpleNamespace
@@ -14,9 +15,26 @@ def _load_plugin():
     return module
 
 
+def _load_intake_helper():
+    script = (
+        Path(__file__).resolve().parents[2]
+        / "skills"
+        / "software-development"
+        / "harness-agenting-engineering"
+        / "scripts"
+        / "harness_intake.py"
+    )
+    spec = importlib.util.spec_from_file_location("harness_intake_under_test", script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_preflight_allows_plain_explanation(monkeypatch):
     plugin = _load_plugin()
-    monkeypatch.setenv("HERMES_HARNESS_PREFLIGHT", "advisory")
+    monkeypatch.setattr(plugin, "_configured_preflight_mode", lambda: "advisory")
 
     result = plugin._handle_pre_gateway_dispatch(SimpleNamespace(text="解释一下什么是 MCP"))
 
@@ -25,7 +43,7 @@ def test_preflight_allows_plain_explanation(monkeypatch):
 
 def test_preflight_rewrites_engineering_task(monkeypatch):
     plugin = _load_plugin()
-    monkeypatch.setenv("HERMES_HARNESS_PREFLIGHT", "advisory")
+    monkeypatch.setattr(plugin, "_configured_preflight_mode", lambda: "advisory")
 
     result = plugin._handle_pre_gateway_dispatch(SimpleNamespace(text="请修复这个 WebUI bug 并加测试"))
 
@@ -36,7 +54,7 @@ def test_preflight_rewrites_engineering_task(monkeypatch):
 
 def test_preflight_strict_uses_intake_notice(monkeypatch):
     plugin = _load_plugin()
-    monkeypatch.setenv("HERMES_HARNESS_PREFLIGHT", "strict")
+    monkeypatch.setattr(plugin, "_configured_preflight_mode", lambda: "strict")
 
     result = plugin._handle_pre_gateway_dispatch(SimpleNamespace(text="重构 gateway 认证流程"))
 
@@ -46,7 +64,7 @@ def test_preflight_strict_uses_intake_notice(monkeypatch):
 
 def test_preflight_advisory_requires_intake_for_high_risk(monkeypatch):
     plugin = _load_plugin()
-    monkeypatch.setenv("HERMES_HARNESS_PREFLIGHT", "advisory")
+    monkeypatch.setattr(plugin, "_configured_preflight_mode", lambda: "advisory")
 
     result = plugin._handle_pre_gateway_dispatch(SimpleNamespace(text="请修改 OAuth token 存储并 force-push"))
 
@@ -97,14 +115,40 @@ def test_classify_cli_emits_json(capsys):
     assert '"route": "intake_required"' in out
 
 
-def test_preflight_uses_config_when_env_unset(monkeypatch):
+def test_preflight_uses_config_mode(monkeypatch):
     plugin = _load_plugin()
-    monkeypatch.delenv("HERMES_HARNESS_PREFLIGHT", raising=False)
     monkeypatch.setattr(plugin, "_configured_preflight_mode", lambda: "off")
 
     result = plugin._handle_pre_gateway_dispatch(SimpleNamespace(text="请修复这个 bug"))
 
     assert result == {"action": "allow"}
+
+
+def test_preflight_ignores_legacy_env_override(monkeypatch):
+    plugin = _load_plugin()
+    monkeypatch.setenv("HERMES_HARNESS_PREFLIGHT", "strict")
+    monkeypatch.setattr(plugin, "_configured_preflight_mode", lambda: "off")
+
+    result = plugin._handle_pre_gateway_dispatch(SimpleNamespace(text="请修改 OAuth token 存储"))
+
+    assert result == {"action": "allow"}
+
+
+def test_preflight_loads_mode_from_config_yaml(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "profile-home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "harness_engineering:\n  preflight_mode: strict\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    plugin = _load_plugin()
+
+    assert plugin._configured_preflight_mode() == "strict"
+    result = plugin._handle_pre_gateway_dispatch(SimpleNamespace(text="请修复这个 WebUI bug"))
+
+    assert result["action"] == "rewrite"
+    assert "intake required" in result["text"]
 
 
 def test_helper_command_prefers_bundled_script(monkeypatch, tmp_path):
@@ -123,17 +167,83 @@ def test_helper_command_prefers_bundled_script(monkeypatch, tmp_path):
     assert plugin._helper_command() == ["python3.12", str(bundled)]
 
 
-def test_helper_command_falls_back_to_user_helper(monkeypatch, tmp_path):
+def test_helper_command_falls_back_to_profile_helper(monkeypatch, tmp_path):
     plugin = _load_plugin()
     bundled = tmp_path / "missing" / "harness_intake.py"
-    user_helper = tmp_path / "home" / ".hermes" / "bin" / "hermes-harness"
-    user_helper.parent.mkdir(parents=True)
-    user_helper.write_text("#!/bin/sh\n", encoding="utf-8")
+    profile_helper = tmp_path / "profiles" / "coder" / "bin" / "hermes-harness"
+    profile_helper.parent.mkdir(parents=True)
+    profile_helper.write_text("#!/bin/sh\n", encoding="utf-8")
 
     monkeypatch.setattr(plugin, "_bundled_helper_path", lambda: bundled)
-    monkeypatch.setattr(plugin, "_user_helper_path", lambda: user_helper)
+    monkeypatch.setattr(plugin, "_user_helper_path", lambda: profile_helper)
 
-    assert plugin._helper_command() == [str(user_helper)]
+    assert plugin._helper_command() == [str(profile_helper)]
+
+
+def test_user_helper_path_uses_active_profile_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profiles" / "coder"))
+    plugin = _load_plugin()
+
+    assert plugin._user_helper_path() == tmp_path / "profiles" / "coder" / "bin" / "hermes-harness"
+
+
+def test_harness_new_accepts_documented_output_flag(monkeypatch, tmp_path):
+    plugin = _load_plugin()
+    calls = []
+
+    def fake_run(argv):
+        calls.append(argv)
+        return 0
+
+    monkeypatch.setattr(plugin, "_run_helper", fake_run)
+    try:
+        plugin._handle_harness_cli(
+            SimpleNamespace(
+                harness_action="new",
+                title="Task",
+                workspace="/repo",
+                mode="Implement changes",
+                output=str(tmp_path / "intake.md"),
+                print_path=False,
+            )
+        )
+    except SystemExit as exc:
+        assert exc.code == 0
+
+    assert calls == [[
+        "new",
+        "--title",
+        "Task",
+        "--workspace",
+        "/repo",
+        "--mode",
+        "Implement changes",
+        "--output",
+        str(tmp_path / "intake.md"),
+    ]]
+
+
+def test_harness_new_parser_rejects_legacy_out_flag(capsys):
+    plugin = _load_plugin()
+    parser = argparse.ArgumentParser(prog="hermes harness")
+    plugin._setup_harness_cli(parser)
+
+    try:
+        parser.parse_args(["new", "--out", "/tmp/intake.md"])
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("legacy --out flag should not parse")
+
+    assert "--out" in capsys.readouterr().err
+
+
+def test_helper_default_output_dir_honors_hermes_home(monkeypatch, tmp_path):
+    helper = _load_intake_helper()
+    profile_home = tmp_path / "profiles" / "writer"
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    assert helper._default_out_dir() == profile_home / "harness" / "intake"
 
 
 def test_register_exposes_harness_command_and_gateway_hook():
@@ -148,7 +258,6 @@ def test_register_exposes_harness_command_and_gateway_hook():
     assert ctx.register_command.call_args.args[0] == "intake"
     ctx.register_hook.assert_called_once()
     assert ctx.register_hook.call_args.args[0] == "pre_gateway_dispatch"
-
 
 
 def _filled_intake(tmp_path):

--- a/tests/plugins/test_harness_engineering_plugin.py
+++ b/tests/plugins/test_harness_engineering_plugin.py
@@ -44,6 +44,59 @@ def test_preflight_strict_uses_intake_notice(monkeypatch):
     assert "intake required" in result["text"]
 
 
+def test_preflight_advisory_requires_intake_for_high_risk(monkeypatch):
+    plugin = _load_plugin()
+    monkeypatch.setenv("HERMES_HARNESS_PREFLIGHT", "advisory")
+
+    result = plugin._handle_pre_gateway_dispatch(SimpleNamespace(text="请修改 OAuth token 存储并 force-push"))
+
+    assert result["action"] == "rewrite"
+    assert "intake required" in result["text"]
+
+
+def test_task_classifier_routes_research_without_harness():
+    plugin = _load_plugin()
+
+    result = plugin.classify_task("调研并对比三个 MCP server 方案")
+
+    assert result.task_type == "research"
+    assert result.harness_required is False
+    assert result.route == "research_then_report"
+
+
+def test_task_classifier_routes_multi_agent_as_intake_required():
+    plugin = _load_plugin()
+
+    result = plugin.classify_task("把这个功能拆成 Kanban 多代理并行执行")
+
+    assert result.task_type == "multi_agent_project"
+    assert result.harness_required is True
+    assert result.route == "intake_required"
+
+
+def test_task_classifier_routes_small_code_change():
+    plugin = _load_plugin()
+
+    result = plugin.classify_task("请做一个 small fix 并加测试")
+
+    assert result.task_type == "small_code_change"
+    assert result.harness_required is False
+    assert result.route == "bounded_engineering"
+
+
+def test_classify_cli_emits_json(capsys):
+    plugin = _load_plugin()
+
+    try:
+        plugin._handle_harness_cli(SimpleNamespace(harness_action="classify", text="重构认证流程", format="json"))
+    except SystemExit as exc:
+        assert exc.code == 0
+
+    out = capsys.readouterr().out
+    assert '"task_type": "high_risk_change"' in out
+    assert '"route": "intake_required"' in out
+
+
 def test_preflight_uses_config_when_env_unset(monkeypatch):
     plugin = _load_plugin()
     monkeypatch.delenv("HERMES_HARNESS_PREFLIGHT", raising=False)

--- a/tests/plugins/test_harness_engineering_plugin.py
+++ b/tests/plugins/test_harness_engineering_plugin.py
@@ -270,3 +270,42 @@ def test_harness_gc_template_documents_non_mutating_boundary(tmp_path):
     assert "Weekly Harness GC" in content
     assert "Do not auto-repair" in content
     assert "hermes-engineering-loop" in content
+
+
+def test_harness_migration_pack_generates_cross_agent_files(tmp_path, capsys):
+    plugin = _load_plugin()
+
+    code = plugin._handle_harness_migration_pack_cli(
+        SimpleNamespace(output_dir=str(tmp_path), force=False, json=False)
+    )
+
+    assert code == 0
+    out = capsys.readouterr().out
+    expected = [
+        "CODEX.md",
+        "CLAUDE.md",
+        "OPENCODE.md",
+        ".cursor/rules/harness.mdc",
+        ".windsurfrules",
+        "prompts/task-intake.md",
+    ]
+    for rel in expected:
+        target = tmp_path / rel
+        assert target.exists()
+        assert str(target.resolve()) in out
+    assert "hermes harness classify" in (tmp_path / "CODEX.md").read_text(encoding="utf-8")
+    assert "docs/CONTRACTS.md" in (tmp_path / ".cursor/rules/harness.mdc").read_text(encoding="utf-8")
+
+
+def test_harness_migration_pack_skips_existing_without_force(tmp_path, capsys):
+    plugin = _load_plugin()
+    target = tmp_path / "CODEX.md"
+    target.write_text("custom", encoding="utf-8")
+
+    code = plugin._handle_harness_migration_pack_cli(
+        SimpleNamespace(output_dir=str(tmp_path), force=False, json=False)
+    )
+
+    assert code == 0
+    assert target.read_text(encoding="utf-8") == "custom"
+    assert "SKIP existing" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- Adds an in-repo Harness Engineering method document, bundled skill, plugin, and helper script for spec-first AI-assisted engineering.
- Wires the root AGENTS.md to the Harness discipline without expanding the core model tool surface.
- Keeps the plugin profile-safe by preferring the bundled helper and falling back to a user-local `~/.hermes/bin/hermes-harness` only when present.

## Relationship to WebUI PR
This is the P0 solidification layer for the broader Harness optimization effort. The companion WebUI P1 advisory gate is tracked separately in nesquena/hermes-webui#6595.

## Test Plan
- `/home/kevin/.hermes/hermes-agent/venv/bin/python -m py_compile plugins/harness_engineering/__init__.py skills/software-development/harness-agenting-engineering/scripts/harness_intake.py`
- `/home/kevin/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/plugins/test_harness_engineering_plugin.py -o 'addopts='`
- `git diff --cached --check` before commit