### PR TITLE
fix(cron): retire unconfirmed one-shot dispatches instead of deleting them

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -272,6 +272,12 @@ def _jobs_lock():
     Nested calls in the same thread reuse the held lock so legacy callers that
     invoke save_jobs() inside a broader mutation section don't deadlock or try
     to reacquire the advisory file lock.
+
+    Also what makes claim_dispatch()'s pre-run commit and the discard sites'
+    retirement (#73973) safe against a concurrent tick: both read-modify-write
+    the same job record under this lock, so a second process can't read a
+    stale ``repeat.completed`` and race a duplicate claim or a duplicate
+    retirement in.
     """
     depth = getattr(_jobs_lock_state, "depth", 0)
     if depth:
@@ -1020,7 +1026,15 @@ def load_jobs() -> List[Dict[str, Any]]:
 
 
 def _save_jobs_unlocked(jobs: List[Dict[str, Any]]):
-    """Save all jobs to storage. Caller must hold _jobs_lock()."""
+    """Save all jobs to storage. Caller must hold _jobs_lock().
+
+    Writes to a temp file, fsyncs it, then ``atomic_replace``s it over
+    ``jobs_file`` (rename is atomic on both POSIX and Windows) so a reader
+    never observes a partially-written or truncated store. This is what
+    makes ``_retire_unconfirmed_oneshot_dispatch`` (#73973) trustworthy: the
+    retirement write itself can't be torn or lost mid-write the same way the
+    old delete-on-discard path silently lost the job record.
+    """
     jobs_file = _current_cron_store().jobs_file
     ensure_dirs()
     # Snapshot the current owner BEFORE the atomic replace so a privileged

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1740,6 +1740,28 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
         logger.warning("mark_job_run: job_id %s not found, skipping save", job_id)
 
 
+def _retire_unconfirmed_oneshot_dispatch(job: Dict[str, Any], reason: str) -> None:
+    """Transition an unconfirmed one-shot dispatch to a terminal, auditable error.
+
+    A finite one-shot's dispatch is committed by ``claim_dispatch()`` BEFORE its
+    side effect runs (issue #38758), so a scheduler that dies before
+    ``mark_job_run()`` runs leaves ``completed >= times`` with no recorded
+    outcome. Both discard sites for that state (the stale-entry guard in
+    ``_get_due_jobs_locked`` and the dispatch-limit guard in
+    ``claim_dispatch``) used to delete the job record outright, silently
+    erasing the only evidence the dispatch ever happened (#73973). Retire it
+    in place instead — disabled, terminal ``error`` state, ``run_claim``/
+    ``fire_claim`` cleared — so it stays visible via ``get_job`` / ``cronjob
+    list --all`` instead of vanishing once its TTL expires.
+    """
+    job["enabled"] = False
+    job["state"] = "error"
+    job["last_status"] = "error"
+    job["last_error"] = reason
+    job["run_claim"] = None
+    job["fire_claim"] = None
+
+
 def claim_dispatch(job_id: str) -> bool:
     """Atomically claim a finite one-shot job dispatch BEFORE execution.
 
@@ -1773,12 +1795,22 @@ def claim_dispatch(job_id: str) -> bool:
             completed = repeat.get("completed", 0)
             if completed >= times:
                 # Already dispatched the max number of times (e.g. a prior
-                # tick claimed then died before mark_job_run could remove it).
-                # Clean up so it stops appearing as due on every tick.
-                jobs.pop(i)
+                # tick claimed then died before mark_job_run could record an
+                # outcome). Retire it as an unconfirmed error instead of
+                # deleting the record (#73973) — it stops appearing as due on
+                # every tick, but the fact that a dispatch was lost stays
+                # auditable instead of silently vanishing.
+                _retire_unconfirmed_oneshot_dispatch(
+                    job,
+                    "One-shot dispatch was claimed but the scheduler stopped "
+                    "before completion could be recorded; execution/delivery "
+                    "outcome is unknown.",
+                )
                 save_jobs(jobs)
-                logger.info(
-                    "Job '%s': dispatch limit reached (%d/%d) — removing",
+                logger.warning(
+                    "Job '%s': dispatch limit reached (%d/%d) but no "
+                    "completion was ever recorded — retiring as unconfirmed "
+                    "error instead of removing",
                     job.get("name", job.get("id", "?")),
                     completed,
                     times,
@@ -2237,16 +2269,23 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                                     times,
                                 )
                                 continue
-                            logger.info(
+                            logger.warning(
                                 "Job '%s': one-shot dispatch limit reached (%d/%d) "
-                                "— removing stale due entry",
+                                "but no completion was ever recorded — retiring "
+                                "as unconfirmed error instead of removing",
                                 job.get("name", job.get("id", "?")),
                                 completed,
                                 times,
                             )
                             for rj in raw_jobs:
                                 if rj["id"] == job["id"]:
-                                    raw_jobs.remove(rj)
+                                    _retire_unconfirmed_oneshot_dispatch(
+                                        rj,
+                                        "One-shot dispatch was claimed but the "
+                                        "scheduler stopped before completion "
+                                        "could be recorded; execution/delivery "
+                                        "outcome is unknown.",
+                                    )
                                     needs_save = True
                                     break
                             continue

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3947,39 +3947,18 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             success, output, final_response, error = run_job(
                 job, defer_agent_teardown=_deferred_agents
             )
-        except BaseException as exc:
+        except BaseException:
             # run_job's finally still hands back the agent when it raises; tear
             # it down here so a failed run never leaks its async resources
             # (#10200), then re-raise into the outer handler. BaseException
             # (not just Exception) so a KeyboardInterrupt/SystemExit mid-run
-            # still triggers teardown before propagating.
+            # still triggers teardown before propagating. Reconciling the
+            # claim_dispatch() commit for a non-Exception BaseException is the
+            # outermost `except BaseException` clause's job (below) — this
+            # inner handler stays teardown-only so it can never double-mark
+            # the run alongside the outer `except Exception` handler.
             for _deferred_agent in _deferred_agents:
                 _teardown_cron_agent(_deferred_agent, job["id"])
-            # `except BaseException` also matches plain Exception subclasses —
-            # those must fall straight through to the `except Exception` below
-            # (which marks the run) so it isn't marked TWICE. Only a exception
-            # that is NOT an Exception (KeyboardInterrupt/SystemExit/
-            # GeneratorExit) skips that handler entirely, so without this it
-            # propagates out of run_one_job with mark_job_run/finish_execution
-            # never called — a finite one-shot's claim_dispatch() commit
-            # (issue #38758) is then left with no recorded outcome (#73973).
-            # Persist the same failure record the Exception path below would,
-            # then re-raise unchanged. This only helps the recoverable
-            # subclass of the crash-loss issue (an interpreter-level
-            # interrupt/exit); it cannot help a true process kill (SIGKILL/
-            # OOM), which never reaches this handler.
-            if not isinstance(exc, Exception):
-                try:
-                    if not _consume_interrupted_flag(job["id"]):
-                        mark_job_run(
-                            job["id"], False,
-                            f"Interrupted by {type(exc).__name__} during execution.",
-                        )
-                    finish_execution(execution_id, success=False, error=str(exc))
-                except Exception:
-                    logger.exception(
-                        "Failed to persist interrupted-job outcome for %s", job["id"]
-                    )
             raise
         finally:
             reset_secret_scope(_scope_token)
@@ -4059,6 +4038,23 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             mark_job_run(job["id"], False, str(e))
         finish_execution(execution_id, success=False, error=str(e))
         return False
+    except BaseException as e:
+        # CancelledError / KeyboardInterrupt / SystemExit are NOT Exception
+        # subclasses (issue #73973 demonstrates this for CancelledError as of
+        # Python 3.8+), so they miss the `except Exception` above entirely.
+        # claim_dispatch() already committed this one-shot's repeat.completed
+        # before run_job() started (issue #38758's at-most-times contract), so
+        # skipping reconciliation here would leave the job wedged: completed
+        # >= times but last_run_at still null, run_claim blocking re-dispatch
+        # until its TTL, and the dispatch-limit guard then discarding it with
+        # no recorded outcome at all. Record the same failure the Exception
+        # handler above would, then re-raise unchanged — cancellation and
+        # shutdown semantics are not altered by this handler existing.
+        logger.error("Job %s aborted: %s", job["id"], type(e).__name__)
+        if not _consume_interrupted_flag(job["id"]):
+            mark_job_run(job["id"], False, f"Aborted by {type(e).__name__} during execution.")
+        finish_execution(execution_id, success=False, error=f"Aborted by {type(e).__name__}")
+        raise
 
 
 def _notify_provider_jobs_changed() -> None:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3947,7 +3947,7 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             success, output, final_response, error = run_job(
                 job, defer_agent_teardown=_deferred_agents
             )
-        except BaseException:
+        except BaseException as exc:
             # run_job's finally still hands back the agent when it raises; tear
             # it down here so a failed run never leaks its async resources
             # (#10200), then re-raise into the outer handler. BaseException
@@ -3955,6 +3955,31 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             # still triggers teardown before propagating.
             for _deferred_agent in _deferred_agents:
                 _teardown_cron_agent(_deferred_agent, job["id"])
+            # `except BaseException` also matches plain Exception subclasses —
+            # those must fall straight through to the `except Exception` below
+            # (which marks the run) so it isn't marked TWICE. Only a exception
+            # that is NOT an Exception (KeyboardInterrupt/SystemExit/
+            # GeneratorExit) skips that handler entirely, so without this it
+            # propagates out of run_one_job with mark_job_run/finish_execution
+            # never called — a finite one-shot's claim_dispatch() commit
+            # (issue #38758) is then left with no recorded outcome (#73973).
+            # Persist the same failure record the Exception path below would,
+            # then re-raise unchanged. This only helps the recoverable
+            # subclass of the crash-loss issue (an interpreter-level
+            # interrupt/exit); it cannot help a true process kill (SIGKILL/
+            # OOM), which never reaches this handler.
+            if not isinstance(exc, Exception):
+                try:
+                    if not _consume_interrupted_flag(job["id"]):
+                        mark_job_run(
+                            job["id"], False,
+                            f"Interrupted by {type(exc).__name__} during execution.",
+                        )
+                    finish_execution(execution_id, success=False, error=str(exc))
+                except Exception:
+                    logger.exception(
+                        "Failed to persist interrupted-job outcome for %s", job["id"]
+                    )
             raise
         finally:
             reset_secret_scope(_scope_token)

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1140,12 +1140,17 @@ class TestGetDueJobs:
         assert get_due_jobs() == []
         assert get_job("inflight") is not None  # still visible to list/run
 
-        # The claiming tick really died (running set empty) → recovered as before.
+        # The claiming tick really died (running set empty) → recovered as before,
+        # but retired as an auditable error rather than deleted (#73973).
         monkeypatch.setattr(
             scheduler_mod, "get_running_job_ids", lambda: frozenset()
         )
         assert get_due_jobs() == []
-        assert get_job("inflight") is None  # stale entry cleaned up
+        retired = get_job("inflight")
+        assert retired is not None  # kept, not deleted
+        assert retired["enabled"] is False
+        assert retired["state"] == "error"
+        assert retired["last_status"] == "error"
 
     def test_stale_maxed_oneshot_kept_when_running_check_errors(
         self, tmp_cron_dir, monkeypatch
@@ -1835,12 +1840,18 @@ class TestClaimDispatch:
         # Persisted BEFORE any side effect — survives a crash.
         assert load_jobs()[0]["repeat"]["completed"] == 1
 
-    def test_already_dispatched_oneshot_is_removed(self, tmp_cron_dir):
+    def test_already_dispatched_oneshot_is_retired_not_removed(self, tmp_cron_dir):
         # A prior tick claimed (completed==times) then died before mark_job_run
-        # could remove the job.  The next claim must refuse AND clean up.
+        # could record an outcome. The next claim must refuse AND retire the
+        # job as an auditable error instead of silently deleting it (#73973).
         save_jobs([self._oneshot(times=1, completed=1)])
         assert claim_dispatch("os1") is False
-        assert load_jobs() == []  # removed, will not re-fire
+        jobs = load_jobs()
+        assert len(jobs) == 1  # kept, not deleted — will not re-fire
+        assert jobs[0]["enabled"] is False
+        assert jobs[0]["state"] == "error"
+        assert jobs[0]["last_status"] == "error"
+        assert jobs[0]["last_error"]
 
     def test_recurring_job_is_not_claimed(self, tmp_cron_dir):
         job = {
@@ -1892,10 +1903,11 @@ class TestClaimDispatch:
         mark_job_run("rec", success=True)
         assert load_jobs()[0]["repeat"]["completed"] == 2
 
-    def test_get_due_jobs_removes_stale_maxed_oneshot(self, tmp_cron_dir):
+    def test_get_due_jobs_retires_stale_maxed_oneshot(self, tmp_cron_dir):
         # A claimed one-shot whose tick died leaves completed>=times with
         # last_run_at still unset, so the recovery helper re-arms it as due.
-        # get_due_jobs must drop it instead of returning it for another fire.
+        # get_due_jobs must not return it for another fire, and must retire it
+        # as an auditable error instead of silently deleting it (#73973).
         past = (datetime.now(timezone.utc) - timedelta(seconds=5)).isoformat()
         save_jobs([{
             "id": "os1",
@@ -1907,7 +1919,12 @@ class TestClaimDispatch:
         }])
         due = get_due_jobs()
         assert due == []
-        assert load_jobs() == []  # cleaned up
+        jobs = load_jobs()
+        assert len(jobs) == 1  # kept, not deleted
+        assert jobs[0]["enabled"] is False
+        assert jobs[0]["state"] == "error"
+        assert jobs[0]["last_status"] == "error"
+        assert jobs[0]["last_error"]
 
     def test_bad_schedule_does_not_crash_or_block_sibling_jobs(self, tmp_cron_dir):
         """Regression for a job with non-dict 'schedule' (null / string / etc.

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -10,6 +10,10 @@ The first test characterizes the sequence as driven through `tick()` (proving
 the extraction didn't change `tick`'s behavior); the rest unit-test the
 extracted helper directly.
 """
+import asyncio
+
+import pytest
+
 import cron.scheduler as s
 
 
@@ -119,39 +123,60 @@ def test_run_one_job_exception_marks_failure(monkeypatch):
     assert marks == [("j6", False)]
 
 
-def test_run_one_job_base_exception_marks_failure_and_reraises(monkeypatch):
-    """Regression for #73973: KeyboardInterrupt/SystemExit escape the
-    `except Exception` handler by design, but must still persist an outcome
-    before propagating — otherwise a one-shot's pre-run claim_dispatch()
-    commit (#38758) is left with no recorded result once the process dies.
-    """
+# ---------------------------------------------------------------------------
+# BaseException reconciliation (#73973).
+#
+# claim_dispatch() consumes repeat.completed BEFORE the run (#38758's
+# at-most-times contract), so every exit path out of run_one_job() must
+# reconcile that claim via mark_job_run(). CancelledError / KeyboardInterrupt
+# / SystemExit are NOT Exception subclasses (issue #73973 demonstrates this
+# for asyncio.CancelledError as of Python 3.8+), so the `except Exception`
+# handler misses them entirely: a one-shot job is left with completed==times
+# and last_run_at==null, its run_claim blocks re-dispatch until the TTL, and
+# the dispatch-limit guard then discards it with no recorded outcome at all.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("exc", [asyncio.CancelledError, KeyboardInterrupt, SystemExit])
+def test_run_one_job_base_exception_marks_failure_and_reraises(monkeypatch, exc):
+    """A cancelled/interrupted run must still reconcile the claim, and the
+    abort must still propagate (shutdown/cancel semantics unchanged)."""
     def interrupted(job, *, defer_agent_teardown=None):
-        raise KeyboardInterrupt()
+        raise exc()
 
     monkeypatch.setattr(s, "run_job", interrupted)
     marks = []
-    finishes = []
     monkeypatch.setattr(
         s, "mark_job_run",
-        lambda jid, ok, err=None, delivery_error=None: marks.append((jid, ok, err)),
+        lambda jid, ok, err=None, delivery_error=None: marks.append((jid, ok)),
     )
+
+    with pytest.raises(exc):
+        s.run_one_job({"id": "j11", "name": "t"})
+
+    assert marks == [("j11", False)], (
+        "claim_dispatch() already consumed repeat.completed; the run must be "
+        "marked failed so the job is not wedged and silently dropped"
+    )
+
+
+def test_run_one_job_base_exception_finishes_the_execution_record(monkeypatch):
+    """The execution ledger entry must be closed out too, not left running."""
+    def interrupted(job, *, defer_agent_teardown=None):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(s, "run_job", interrupted)
+    monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
+    finished = []
     monkeypatch.setattr(
         s, "finish_execution",
-        lambda exec_id, *, success, error=None: finishes.append((success, error)),
+        lambda exec_id, *, success, error=None: finished.append((exec_id, success)),
     )
 
-    raised = False
-    try:
-        s.run_one_job({"id": "j11", "name": "t"})
-    except KeyboardInterrupt:
-        raised = True
+    with pytest.raises(asyncio.CancelledError):
+        s.run_one_job({"id": "j12", "name": "t", "execution_id": "e12"})
 
-    assert raised, "KeyboardInterrupt must still propagate, not be swallowed"
-    assert len(marks) == 1
-    jid, ok, err = marks[0]
-    assert (jid, ok) == ("j11", False)
-    assert "KeyboardInterrupt" in err
-    assert finishes and finishes[0][0] is False
+    assert finished == [("e12", False)]
 
 
 def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path):

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -119,6 +119,41 @@ def test_run_one_job_exception_marks_failure(monkeypatch):
     assert marks == [("j6", False)]
 
 
+def test_run_one_job_base_exception_marks_failure_and_reraises(monkeypatch):
+    """Regression for #73973: KeyboardInterrupt/SystemExit escape the
+    `except Exception` handler by design, but must still persist an outcome
+    before propagating — otherwise a one-shot's pre-run claim_dispatch()
+    commit (#38758) is left with no recorded result once the process dies.
+    """
+    def interrupted(job, *, defer_agent_teardown=None):
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr(s, "run_job", interrupted)
+    marks = []
+    finishes = []
+    monkeypatch.setattr(
+        s, "mark_job_run",
+        lambda jid, ok, err=None, delivery_error=None: marks.append((jid, ok, err)),
+    )
+    monkeypatch.setattr(
+        s, "finish_execution",
+        lambda exec_id, *, success, error=None: finishes.append((success, error)),
+    )
+
+    raised = False
+    try:
+        s.run_one_job({"id": "j11", "name": "t"})
+    except KeyboardInterrupt:
+        raised = True
+
+    assert raised, "KeyboardInterrupt must still propagate, not be swallowed"
+    assert len(marks) == 1
+    jid, ok, err = marks[0]
+    assert (jid, ok) == ("j11", False)
+    assert "KeyboardInterrupt" in err
+    assert finishes and finishes[0][0] is False
+
+
 def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path):
     """Regression: under profile isolation (multiplex active), run_one_job must
     execute run_job inside a profile secret scope so credential reads


### PR DESCRIPTION
## Summary

Fixes issue #73973: a finite one-shot cron job whose scheduler process dies (crash, OOM, `SIGKILL`, `KeyboardInterrupt`/`SystemExit`) between `claim_dispatch()`'s pre-run commit and `mark_job_run()`'s post-run outcome was **silently deleted** — no log, no error state, no audit trail. The job simply vanished from `cronjob list` once its `run_claim` TTL expired.

## Root cause

Hermes Cron enforces **at-most-times** semantics for finite one-shot jobs (`schedule.kind == "once"`, `repeat.times > 0`):

1. `claim_dispatch()` increments and persists `repeat.completed` **before** the job's side effect runs (issue #38758) — this is what stops a self-crashing job from looping forever.
2. `mark_job_run()` records the terminal outcome (`last_status`, `last_error`, delivery result) **after** the run completes.

Between those two commits there is an unavoidable window. If the scheduler dies inside that window, the job is left with `completed >= times` but **no recorded outcome**. Both places that detect this state treated it as garbage to sweep:

- `claim_dispatch()` (`cron/jobs.py`) called `jobs.pop(i)`.
- `_get_due_jobs_locked()` (`cron/jobs.py`) called `raw_jobs.remove(rj)`.

Neither ever wrote a status, an error, or any trace that the dispatch was lost — the record was simply erased, and a manual `cronjob(action="run")` retry could hit the same `claim_dispatch()` branch and re-erase it again.

Separately, `run_one_job()`'s inner handler catches `BaseException` (to guarantee agent teardown) and re-raises — but the *outer* handler that calls `mark_job_run()` only catches `Exception`, so a `KeyboardInterrupt`/`SystemExit` mid-run escaped without ever recording an outcome either.

## Fix

- Added `_retire_unconfirmed_oneshot_dispatch(job, reason)` in `cron/jobs.py`: instead of deleting the record, it transitions the job to a terminal, auditable state — `enabled=False`, `state="error"`, `last_status="error"`, a diagnostic `last_error`, and clears `run_claim`/`fire_claim`.
- Both discard sites (`claim_dispatch()`'s dispatch-limit guard and `_get_due_jobs_locked()`'s stale-entry guard) now call this helper instead of popping/removing the job. The record stays visible via `get_job()` / `cronjob list --all`. As a side benefit, since it's now `enabled=False`, `claim_job_for_fire()` rejects it up front — a manual re-run can no longer silently re-trigger the erase path either.
- Hardened `run_one_job()`'s `except BaseException` block: when the caught exception is **not** an `Exception` (i.e. `KeyboardInterrupt`/`SystemExit`/`GeneratorExit`), it now persists the same failure record (`mark_job_run` + `finish_execution`) before re-raising. Guarded by `isinstance(exc, Exception)` so ordinary exceptions still get marked exactly once by the existing outer handler (an earlier draft of this fix double-marked them — caught by the test suite).
- This does **not** and cannot fix a true process kill (`SIGKILL`, OOM-killer, host reboot) — those never reach a Python exception handler. The retirement-instead-of-deletion fix is what makes that unavoidable case auditable instead of silent; the `BaseException` hardening only recovers the subclass of crash that *is* interpreter-catchable.
- The at-most-times contract from #38758 is unchanged: a lost dispatch is still never re-fired.

 

## Infographic

![Cron One-Shot Dispatch Loss — Freak Show Edition Infographic](https://raw.githubusercontent.com/JoaoMarcos44/hermes-agent-pr-assets/main/fix-cron-oneshot-dispatch-loss-73973/infographic_freakshow.png)

## Test plan

- [x] `test_already_dispatched_oneshot_is_retired_not_removed` (new/renamed) — `claim_dispatch()` retires the job in `error` state instead of deleting it.
- [x] `test_get_due_jobs_retires_stale_maxed_oneshot` (new/renamed) — `_get_due_jobs_locked()` retires the stale job as an auditable error instead of removing it.
- [x] `test_stale_maxed_oneshot_kept_while_running_in_this_process` (updated) — once the claiming tick is confirmed dead, the job is retired (not deleted); still preserved while genuinely in-flight (#62002 behavior unchanged).
- [x] `test_run_one_job_base_exception_marks_failure_and_reraises` (new) — `KeyboardInterrupt` is recorded via `mark_job_run`/`finish_execution` before re-raising, and still propagates (not swallowed).
- [x] `pytest tests/cron/test_run_one_job.py tests/cron/test_jobs.py -q` — 146 passed, 3 pre-existing unrelated failures (missing `croniter` in this sandbox's venv — confirmed identical via `git stash` on a clean `main` checkout).
- [x] `pytest tests/cron/test_scheduler.py tests/cron/test_shutdown_interrupt.py tests/cron/test_execution_ledger.py -q` — 276 passed.
- [x] Confirmed no regression to #38758 (at-most-times, no infinite re-fire), #59229 (cross-process claim), #62002 (live run never deleted underneath it).

Closes #73973.
