### PR TITLE
fix(providers): honor named custom timeout settings

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -649,6 +649,12 @@ class SessionManager:
             kwargs.update(
                 {
                     "provider": runtime.get("provider"),
+                    "requested_provider": (
+                        runtime.get("requested_provider")
+                        or requested_provider
+                        or config_provider
+                        or ""
+                    ),
                     "api_mode": api_mode or runtime.get("api_mode"),
                     "base_url": base_url or runtime.get("base_url"),
                     "api_key": runtime.get("api_key"),

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -637,6 +637,12 @@ class SessionManager:
             kwargs.update(
                 {
                     "provider": runtime.get("provider"),
+                    "requested_provider": (
+                        runtime.get("requested_provider")
+                        or requested_provider
+                        or config_provider
+                        or ""
+                    ),
                     "api_mode": api_mode or runtime.get("api_mode"),
                     "base_url": base_url or runtime.get("base_url"),
                     "api_key": runtime.get("api_key"),

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -981,7 +981,11 @@ def init_agent(
     # every client construction path below (Anthropic native, OpenAI-wire,
     # router-based implicit auth) can apply it consistently.  Bedrock
     # Claude uses its own timeout path and is not covered here.
-    _provider_timeout = get_provider_request_timeout(agent.provider, agent.model)
+    _provider_timeout = get_provider_request_timeout(
+        agent.provider,
+        agent.model,
+        requested_provider_id=getattr(agent, "requested_provider", None),
+    )
 
     if agent.api_mode == "anthropic_messages":
         from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1156,7 +1156,11 @@ def init_agent(
     # every client construction path below (Anthropic native, OpenAI-wire,
     # router-based implicit auth) can apply it consistently.  Bedrock
     # Claude uses its own timeout path and is not covered here.
-    _provider_timeout = get_provider_request_timeout(agent.provider, agent.model)
+    _provider_timeout = get_provider_request_timeout(
+        agent.provider,
+        agent.model,
+        requested_provider_id=getattr(agent, "requested_provider", None),
+    )
 
     if agent.api_mode == "anthropic_messages":
         from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1302,7 +1302,11 @@ def try_recover_primary_transport(
             agent._anthropic_base_url = rt["anthropic_base_url"]
             agent._anthropic_client = build_anthropic_client(
                 rt["anthropic_api_key"], rt["anthropic_base_url"],
-                timeout=get_provider_request_timeout(agent.provider, agent.model),
+                timeout=get_provider_request_timeout(
+                    agent.provider,
+                    agent.model,
+                    requested_provider_id=getattr(agent, "requested_provider", None),
+                ),
             )
             agent._is_anthropic_oauth = rt["is_anthropic_oauth"]
             agent.client = None
@@ -1494,7 +1498,11 @@ def restore_primary_runtime(agent) -> bool:
             agent._anthropic_base_url = rt["anthropic_base_url"]
             agent._anthropic_client = build_anthropic_client(
                 rt["anthropic_api_key"], rt["anthropic_base_url"],
-                timeout=get_provider_request_timeout(agent.provider, agent.model),
+                timeout=get_provider_request_timeout(
+                    agent.provider,
+                    agent.model,
+                    requested_provider_id=getattr(agent, "requested_provider", None),
+                ),
             )
             agent._is_anthropic_oauth = rt["is_anthropic_oauth"]
             agent.client = None
@@ -2300,7 +2308,11 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             agent._anthropic_base_url = base_url or getattr(agent, "_anthropic_base_url", None)
             agent._anthropic_client = build_anthropic_client(
                 effective_key, agent._anthropic_base_url,
-                timeout=get_provider_request_timeout(agent.provider, agent.model),
+                timeout=get_provider_request_timeout(
+                    agent.provider,
+                    agent.model,
+                    requested_provider_id=getattr(agent, "requested_provider", None),
+                ),
             )
             agent._is_anthropic_oauth = _is_oauth_token(effective_key) if (_is_native_anthropic and isinstance(effective_key, str)) else False
             agent.client = None
@@ -2330,7 +2342,11 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
                 )
             except Exception:
                 logger.debug("custom-provider TLS resolution skipped on switch_model", exc_info=True)
-            _sm_timeout = get_provider_request_timeout(agent.provider, agent.model)
+            _sm_timeout = get_provider_request_timeout(
+                agent.provider,
+                agent.model,
+                requested_provider_id=getattr(agent, "requested_provider", None),
+            )
             if _sm_timeout is not None:
                 agent._client_kwargs["timeout"] = _sm_timeout
             # Reapply provider-specific headers (e.g. OpenRouter HTTP-Referer,

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1493,7 +1493,11 @@ def try_recover_primary_transport(
             agent._anthropic_base_url = rt["anthropic_base_url"]
             agent._anthropic_client = build_anthropic_client(
                 rt["anthropic_api_key"], rt["anthropic_base_url"],
-                timeout=get_provider_request_timeout(agent.provider, agent.model),
+                timeout=get_provider_request_timeout(
+                    agent.provider,
+                    agent.model,
+                    requested_provider_id=getattr(agent, "requested_provider", None),
+                ),
             )
             agent._is_anthropic_oauth = rt["is_anthropic_oauth"]
             agent.client = None
@@ -1781,7 +1785,11 @@ def restore_primary_runtime(agent) -> bool:
             agent._anthropic_base_url = rt["anthropic_base_url"]
             agent._anthropic_client = build_anthropic_client(
                 rt["anthropic_api_key"], rt["anthropic_base_url"],
-                timeout=get_provider_request_timeout(agent.provider, agent.model),
+                timeout=get_provider_request_timeout(
+                    agent.provider,
+                    agent.model,
+                    requested_provider_id=getattr(agent, "requested_provider", None),
+                ),
             )
             agent._is_anthropic_oauth = rt["is_anthropic_oauth"]
             agent.client = None
@@ -3060,7 +3068,11 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             agent._anthropic_base_url = base_url or getattr(agent, "_anthropic_base_url", None)
             agent._anthropic_client = build_anthropic_client(
                 effective_key, agent._anthropic_base_url,
-                timeout=get_provider_request_timeout(agent.provider, agent.model),
+                timeout=get_provider_request_timeout(
+                    agent.provider,
+                    agent.model,
+                    requested_provider_id=getattr(agent, "requested_provider", None),
+                ),
             )
             agent._is_anthropic_oauth = _is_oauth_token(effective_key) if (_is_native_anthropic and isinstance(effective_key, str)) else False
             agent.client = None
@@ -3090,7 +3102,11 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
                 )
             except Exception:
                 logger.debug("custom-provider TLS resolution skipped on switch_model", exc_info=True)
-            _sm_timeout = get_provider_request_timeout(agent.provider, agent.model)
+            _sm_timeout = get_provider_request_timeout(
+                agent.provider,
+                agent.model,
+                requested_provider_id=getattr(agent, "requested_provider", None),
+            )
             if _sm_timeout is not None:
                 agent._client_kwargs["timeout"] = _sm_timeout
             # Reapply provider-specific headers (e.g. OpenRouter HTTP-Referer,

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -58,6 +58,7 @@ def _resolve_review_runtime(agent: Any) -> Dict[str, Any]:
         parent_api_mode = "codex_responses"
     parent = {
         "provider": agent.provider,
+        "requested_provider": getattr(agent, "requested_provider", agent.provider),
         "model": agent.model,
         "api_key": parent_runtime.get("api_key") or None,
         "base_url": parent_runtime.get("base_url") or None,
@@ -94,6 +95,7 @@ def _resolve_review_runtime(agent: Any) -> Dict[str, Any]:
         )
         return {
             "provider": rp.get("provider") or task_provider,
+            "requested_provider": rp.get("requested_provider") or task_provider,
             "model": rp.get("model") or task_model,
             "api_key": rp.get("api_key"),
             "base_url": rp.get("base_url"),
@@ -733,6 +735,12 @@ def _run_review_in_thread(
                 quiet_mode=True,
                 platform=agent.platform,
                 provider=_rt.get("provider") or agent.provider,
+                requested_provider=(
+                    _rt.get("requested_provider")
+                    or _rt.get("provider")
+                    or agent.provider
+                    or ""
+                ),
                 api_mode=_rt.get("api_mode"),
                 base_url=_rt.get("base_url") or None,
                 api_key=_rt.get("api_key") or None,

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -336,6 +336,7 @@ def _resolve_review_runtime(
         parent_api_mode = "codex_responses"
     parent = {
         "provider": agent.provider,
+        "requested_provider": getattr(agent, "requested_provider", agent.provider),
         "model": agent.model,
         "api_key": parent_runtime.get("api_key") or None,
         "base_url": parent_runtime.get("base_url") or None,
@@ -366,6 +367,7 @@ def _resolve_review_runtime(
         )
         return {
             "provider": rp.get("provider") or task_provider,
+            "requested_provider": rp.get("requested_provider") or task_provider,
             "model": rp.get("model") or task_model,
             "api_key": rp.get("api_key"),
             "base_url": rp.get("base_url"),
@@ -1223,6 +1225,12 @@ def build_cache_parity_fork(
         quiet_mode=True,
         platform=agent.platform,
         provider=_rt.get("provider") or agent.provider,
+        requested_provider=(
+            _rt.get("requested_provider")
+            or _rt.get("provider")
+            or agent.provider
+            or ""
+        ),
         api_mode=_rt.get("api_mode"),
         base_url=_rt.get("base_url") or None,
         api_key=_rt.get("api_key") or None,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -355,7 +355,11 @@ def _derive_stream_stale_timeout(agent, api_kwargs: dict) -> float:
     watchdog shares the exact same patience budget as the OpenAI/Anthropic
     stale-stream detector below.
     """
-    _cfg_stale = get_provider_stale_timeout(agent.provider, agent.model)
+    _cfg_stale = get_provider_stale_timeout(
+        agent.provider,
+        agent.model,
+        requested_provider_id=getattr(agent, "requested_provider", None),
+    )
     if _cfg_stale is not None:
         _base = _cfg_stale
     else:
@@ -2967,7 +2971,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         import httpx as _httpx
         # Per-provider / per-model request_timeout_seconds (from config.yaml)
         # wins over the HERMES_API_TIMEOUT env default if the user set it.
-        _provider_timeout_cfg = get_provider_request_timeout(agent.provider, agent.model)
+        _provider_timeout_cfg = get_provider_request_timeout(
+            agent.provider,
+            agent.model,
+            requested_provider_id=getattr(agent, "requested_provider", None),
+        )
         _base_timeout = (
             _provider_timeout_cfg
             if _provider_timeout_cfg is not None
@@ -4009,7 +4017,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             )
 
     # Provider-configured stale timeout takes priority over env default.
-    _cfg_stale = get_provider_stale_timeout(agent.provider, agent.model)
+    _cfg_stale = get_provider_stale_timeout(
+        agent.provider,
+        agent.model,
+        requested_provider_id=getattr(agent, "requested_provider", None),
+    )
     if _cfg_stale is not None:
         _stream_stale_timeout_base = _cfg_stale
     else:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -824,7 +824,11 @@ def _derive_stream_stale_timeout(agent, api_kwargs: dict) -> float:
     watchdog shares the exact same patience budget as the OpenAI/Anthropic
     stale-stream detector below.
     """
-    _cfg_stale = get_provider_stale_timeout(agent.provider, agent.model)
+    _cfg_stale = get_provider_stale_timeout(
+        agent.provider,
+        agent.model,
+        requested_provider_id=getattr(agent, "requested_provider", None),
+    )
     if _cfg_stale is not None:
         _base = _cfg_stale
     else:
@@ -3902,7 +3906,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         import httpx as _httpx
         # Per-provider / per-model request_timeout_seconds (from config.yaml)
         # wins over the HERMES_API_TIMEOUT env default if the user set it.
-        _provider_timeout_cfg = get_provider_request_timeout(agent.provider, agent.model)
+        _provider_timeout_cfg = get_provider_request_timeout(
+            agent.provider,
+            agent.model,
+            requested_provider_id=getattr(agent, "requested_provider", None),
+        )
         _base_timeout = (
             _provider_timeout_cfg
             if _provider_timeout_cfg is not None
@@ -5093,7 +5101,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             )
 
     # Provider-configured stale timeout takes priority over env default.
-    _cfg_stale = get_provider_stale_timeout(agent.provider, agent.model)
+    _cfg_stale = get_provider_stale_timeout(
+        agent.provider,
+        agent.model,
+        requested_provider_id=getattr(agent, "requested_provider", None),
+    )
     if _cfg_stale is not None:
         _stream_stale_timeout_base = _cfg_stale
     else:

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1868,6 +1868,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
     _base_url = None
     _api_mode = None
     _resolved_provider = None
+    _requested_provider = None
     _credential_pool = None
     _request_overrides: Dict[str, Any] = {}
     _max_tokens = None
@@ -1890,6 +1891,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         _base_url = _rp.get("base_url")
         _api_mode = _rp.get("api_mode")
         _resolved_provider = _rp.get("provider") or _provider
+        _requested_provider = _rp.get("requested_provider") or _provider
         _credential_pool = _rp.get("credential_pool")
         _request_overrides = _merge_request_overrides(
             _rp.get("request_overrides"),
@@ -1917,6 +1919,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         review_agent = AIAgent(
             model=_model_name,
             provider=_resolved_provider,
+            requested_provider=_requested_provider or _resolved_provider or "",
             api_key=_api_key,
             base_url=_base_url,
             api_mode=_api_mode,

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1890,6 +1890,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
     _base_url = None
     _api_mode = None
     _resolved_provider = None
+    _requested_provider = None
     _credential_pool = None
     _request_overrides: Dict[str, Any] = {}
     _max_tokens = None
@@ -1912,6 +1913,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         _base_url = _rp.get("base_url")
         _api_mode = _rp.get("api_mode")
         _resolved_provider = _rp.get("provider") or _provider
+        _requested_provider = _rp.get("requested_provider") or _provider
         _credential_pool = _rp.get("credential_pool")
         _request_overrides = _merge_request_overrides(
             _rp.get("request_overrides"),
@@ -1939,6 +1941,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         review_agent = AIAgent(
             model=_model_name,
             provider=_resolved_provider,
+            requested_provider=_requested_provider or _resolved_provider or "",
             api_key=_api_key,
             base_url=_base_url,
             api_mode=_api_mode,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -174,6 +174,7 @@ _RUNTIME_AGENT_OVERRIDE_KEYS = (
     "api_key",
     "base_url",
     "provider",
+    "requested_provider",
     "api_mode",
     "command",
     "args",
@@ -285,6 +286,7 @@ def _resolve_request_runtime_agent_kwargs(provider: str, target_model: Optional[
         "api_key": runtime.get("api_key"),
         "base_url": runtime.get("base_url"),
         "provider": runtime.get("provider"),
+        "requested_provider": runtime.get("requested_provider") or provider,
         "api_mode": runtime.get("api_mode"),
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
@@ -2561,6 +2563,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 _apply_runtime_agent_overrides(runtime_kwargs, provider_runtime)
             elif effective_provider and effective_provider != current_provider:
                 runtime_kwargs["provider"] = effective_provider
+                runtime_kwargs["requested_provider"] = effective_provider
             model = effective_model
             # Per-route explicit transport secrets/base URLs win within the
             # route contract after provider resolution.

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -367,6 +367,7 @@ _RUNTIME_AGENT_OVERRIDE_KEYS = (
     "api_key",
     "base_url",
     "provider",
+    "requested_provider",
     "api_mode",
     "command",
     "args",
@@ -478,6 +479,7 @@ def _resolve_request_runtime_agent_kwargs(provider: str, target_model: Optional[
         "api_key": runtime.get("api_key"),
         "base_url": runtime.get("base_url"),
         "provider": runtime.get("provider"),
+        "requested_provider": runtime.get("requested_provider") or provider,
         "api_mode": runtime.get("api_mode"),
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
@@ -3024,6 +3026,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 _apply_runtime_agent_overrides(runtime_kwargs, provider_runtime)
             elif effective_provider and effective_provider != current_provider:
                 runtime_kwargs["provider"] = effective_provider
+                runtime_kwargs["requested_provider"] = effective_provider
             model = effective_model
             # Per-route explicit transport secrets/base URLs win within the
             # route contract after provider resolution.

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1901,6 +1901,11 @@ class CLICommandsMixin:
                     api_key=turn_route["runtime"].get("api_key"),
                     base_url=turn_route["runtime"].get("base_url"),
                     provider=turn_route["runtime"].get("provider"),
+                    requested_provider=(
+                        turn_route["runtime"].get("requested_provider")
+                        or turn_route["runtime"].get("provider")
+                        or ""
+                    ),
                     api_mode=turn_route["runtime"].get("api_mode"),
                     acp_command=turn_route["runtime"].get("command"),
                     acp_args=turn_route["runtime"].get("args"),

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2305,6 +2305,11 @@ class CLICommandsMixin:
                     api_key=turn_route["runtime"].get("api_key"),
                     base_url=turn_route["runtime"].get("base_url"),
                     provider=turn_route["runtime"].get("provider"),
+                    requested_provider=(
+                        turn_route["runtime"].get("requested_provider")
+                        or turn_route["runtime"].get("provider")
+                        or ""
+                    ),
                     api_mode=turn_route["runtime"].get("api_mode"),
                     acp_command=turn_route["runtime"].get("command"),
                     acp_args=turn_route["runtime"].get("args"),

--- a/hermes_cli/timeouts.py
+++ b/hermes_cli/timeouts.py
@@ -11,62 +11,120 @@ def _coerce_timeout(raw: object) -> float | None:
     return timeout
 
 
-def get_provider_request_timeout(
-    provider_id: str, model: str | None = None
+def _provider_timeout_candidates(
+    provider_id: str,
+    requested_provider_id: str | None,
+) -> tuple[str, ...]:
+    """Return config provider IDs from most to least route-specific."""
+    runtime_id = (provider_id or "").strip().lower()
+    requested_id = (requested_provider_id or "").strip().lower()
+    candidates: list[str] = []
+
+    # Named custom routes intentionally canonicalize to ``custom`` at runtime.
+    # Preserve the requested identity for config lookup, while retaining bare
+    # ``providers.custom`` as a backward-compatible fallback.
+    if runtime_id == "custom" and requested_id and requested_id != "custom":
+        candidates.append(requested_id)
+        if requested_id.startswith("custom:"):
+            candidates.append(requested_id.removeprefix("custom:"))
+        else:
+            candidates.append(f"custom:{requested_id}")
+
+    candidates.append(runtime_id)
+    return tuple(dict.fromkeys(candidate for candidate in candidates if candidate))
+
+
+def _provider_config_for_candidate(
+    providers: dict[object, object], candidate: str
+) -> object:
+    """Resolve a provider block using runtime custom-provider aliases."""
+    provider_config = providers.get(candidate)
+    if provider_config is not None:
+        return provider_config
+
+    for key, value in providers.items():
+        route_ids: set[str] = set()
+        for raw_name in (key, value.get("name") if isinstance(value, dict) else None):
+            if raw_name is None:
+                continue
+            raw_id = str(raw_name).strip().lower()
+            normalized_id = raw_id.replace(" ", "-")
+            route_ids.update((raw_id, normalized_id, f"custom:{normalized_id}"))
+        if candidate in route_ids:
+            return value
+    return None
+
+
+def _get_provider_timeout(
+    provider_id: str,
+    model: str | None,
+    *,
+    requested_provider_id: str | None,
+    model_field: str,
+    provider_field: str,
 ) -> float | None:
-    """Return a configured provider request timeout in seconds, if any."""
     if not provider_id:
         return None
 
     try:
         from hermes_cli.config import load_config_readonly
+
         config = load_config_readonly()
     except Exception:
         return None
 
     providers = config.get("providers", {}) if isinstance(config, dict) else {}
-    provider_config = (
-        providers.get(provider_id, {}) if isinstance(providers, dict) else {}
-    )
-    if not isinstance(provider_config, dict):
+    if not isinstance(providers, dict):
         return None
 
-    model_config = _get_model_config(provider_config, model)
-    if model_config is not None:
-        timeout = _coerce_timeout(model_config.get("timeout_seconds"))
+    for candidate in _provider_timeout_candidates(provider_id, requested_provider_id):
+        provider_config = _provider_config_for_candidate(providers, candidate)
+        if not isinstance(provider_config, dict):
+            continue
+
+        model_config = _get_model_config(provider_config, model)
+        if model_config is not None:
+            timeout = _coerce_timeout(model_config.get(model_field))
+            if timeout is not None:
+                return timeout
+
+        timeout = _coerce_timeout(provider_config.get(provider_field))
         if timeout is not None:
             return timeout
 
-    return _coerce_timeout(provider_config.get("request_timeout_seconds"))
+    return None
+
+
+def get_provider_request_timeout(
+    provider_id: str,
+    model: str | None = None,
+    *,
+    requested_provider_id: str | None = None,
+) -> float | None:
+    """Return a configured provider request timeout in seconds, if any."""
+    return _get_provider_timeout(
+        provider_id,
+        model,
+        requested_provider_id=requested_provider_id,
+        model_field="timeout_seconds",
+        provider_field="request_timeout_seconds",
+    )
 
 
 def get_provider_stale_timeout(
-    provider_id: str, model: str | None = None
+    provider_id: str,
+    model: str | None = None,
+    *,
+    requested_provider_id: str | None = None,
 ) -> float | None:
     """Return a configured non-stream stale timeout in seconds, if any."""
-    if not provider_id:
-        return None
-
-    try:
-        from hermes_cli.config import load_config_readonly
-        config = load_config_readonly()
-    except Exception:
-        return None
-
-    providers = config.get("providers", {}) if isinstance(config, dict) else {}
-    provider_config = (
-        providers.get(provider_id, {}) if isinstance(providers, dict) else {}
+    return _get_provider_timeout(
+        provider_id,
+        model,
+        requested_provider_id=requested_provider_id,
+        model_field="stale_timeout_seconds",
+        provider_field="stale_timeout_seconds",
     )
-    if not isinstance(provider_config, dict):
-        return None
-
-    model_config = _get_model_config(provider_config, model)
-    if model_config is not None:
-        timeout = _coerce_timeout(model_config.get("stale_timeout_seconds"))
-        if timeout is not None:
-            return timeout
-
-    return _coerce_timeout(provider_config.get("stale_timeout_seconds"))
 
 
 def _get_model_config(

--- a/plugins/platforms/feishu/feishu_comment.py
+++ b/plugins/platforms/feishu/feishu_comment.py
@@ -1076,6 +1076,11 @@ def _run_comment_agent(prompt: str, client: Any, session_key: str = "") -> str:
             base_url=runtime_kwargs.get("base_url"),
             api_key=runtime_kwargs.get("api_key"),
             provider=runtime_kwargs.get("provider"),
+            requested_provider=(
+                runtime_kwargs.get("requested_provider")
+                or runtime_kwargs.get("provider")
+                or ""
+            ),
             api_mode=runtime_kwargs.get("api_mode"),
             credential_pool=runtime_kwargs.get("credential_pool"),
             quiet_mode=True,

--- a/run_agent.py
+++ b/run_agent.py
@@ -1355,7 +1355,11 @@ class AIAgent:
         passed as a per-call ``timeout=`` kwarg, overriding the client-level
         timeout the AIAgent.__init__ path configured.
         """
-        cfg = get_provider_request_timeout(self.provider, self.model)
+        cfg = get_provider_request_timeout(
+            self.provider,
+            self.model,
+            requested_provider_id=self.requested_provider,
+        )
         if cfg is not None:
             return cfg
         return env_float("HERMES_API_TIMEOUT", 1800.0)
@@ -1378,7 +1382,11 @@ class AIAgent:
         explicitly configured a stale timeout, such as auto-disabling the
         detector for local endpoints.
         """
-        cfg = get_provider_stale_timeout(self.provider, self.model)
+        cfg = get_provider_stale_timeout(
+            self.provider,
+            self.model,
+            requested_provider_id=self.requested_provider,
+        )
         if cfg is not None:
             return cfg, False
 
@@ -4891,7 +4899,11 @@ class AIAgent:
             client = build_anthropic_client(
                 self._anthropic_api_key,
                 getattr(self, "_anthropic_base_url", None),
-                timeout=get_provider_request_timeout(self.provider, self.model),
+                timeout=get_provider_request_timeout(
+                    self.provider,
+                    self.model,
+                    requested_provider_id=self.requested_provider,
+                ),
                 drop_context_1m_beta=_drop_1m,
             )
         logger.debug(
@@ -5211,7 +5223,11 @@ class AIAgent:
             self._anthropic_client = build_anthropic_client(
                 new_token,
                 getattr(self, "_anthropic_base_url", None),
-                timeout=get_provider_request_timeout(self.provider, self.model),
+                timeout=get_provider_request_timeout(
+                    self.provider,
+                    self.model,
+                    requested_provider_id=self.requested_provider,
+                ),
             )
         except Exception as exc:
             logger.warning("Failed to rebuild Anthropic client after credential refresh: %s", exc)
@@ -5349,7 +5365,11 @@ class AIAgent:
             self._anthropic_base_url = runtime_base.rstrip("/") if isinstance(runtime_base, str) else runtime_base
             self._anthropic_client = build_anthropic_client(
                 runtime_key, self._anthropic_base_url,
-                timeout=get_provider_request_timeout(self.provider, self.model),
+                timeout=get_provider_request_timeout(
+                    self.provider,
+                    self.model,
+                    requested_provider_id=self.requested_provider,
+                ),
             )
             self._is_anthropic_oauth = _is_oauth_token(runtime_key) if self.provider == "anthropic" else False
             self.api_key = runtime_key
@@ -5447,7 +5467,11 @@ class AIAgent:
             self._anthropic_client = build_anthropic_client(
                 self._anthropic_api_key,
                 getattr(self, "_anthropic_base_url", None),
-                timeout=get_provider_request_timeout(self.provider, self.model),
+                timeout=get_provider_request_timeout(
+                    self.provider,
+                    self.model,
+                    requested_provider_id=self.requested_provider,
+                ),
                 drop_context_1m_beta=_drop_1m,
             )
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1444,7 +1444,11 @@ class AIAgent:
         passed as a per-call ``timeout=`` kwarg, overriding the client-level
         timeout the AIAgent.__init__ path configured.
         """
-        cfg = get_provider_request_timeout(self.provider, self.model)
+        cfg = get_provider_request_timeout(
+            self.provider,
+            self.model,
+            requested_provider_id=getattr(self, "requested_provider", None),
+        )
         if cfg is not None:
             return cfg
         return env_float("HERMES_API_TIMEOUT", 1800.0)
@@ -1467,7 +1471,11 @@ class AIAgent:
         explicitly configured a stale timeout, such as auto-disabling the
         detector for local endpoints.
         """
-        cfg = get_provider_stale_timeout(self.provider, self.model)
+        cfg = get_provider_stale_timeout(
+            self.provider,
+            self.model,
+            requested_provider_id=getattr(self, "requested_provider", None),
+        )
         if cfg is not None:
             return cfg, False
 
@@ -5581,7 +5589,11 @@ class AIAgent:
             "direct",
             self._anthropic_api_key,
             getattr(self, "_anthropic_base_url", None),
-            get_provider_request_timeout(self.provider, self.model),
+            get_provider_request_timeout(
+                self.provider,
+                self.model,
+                requested_provider_id=getattr(self, "requested_provider", None),
+            ),
             bool(getattr(self, "_oauth_1m_beta_disabled", False)),
         )
 
@@ -5646,7 +5658,11 @@ class AIAgent:
             client = build_anthropic_client(
                 self._anthropic_api_key,
                 getattr(self, "_anthropic_base_url", None),
-                timeout=get_provider_request_timeout(self.provider, self.model),
+                timeout=get_provider_request_timeout(
+                    self.provider,
+                    self.model,
+                    requested_provider_id=getattr(self, "requested_provider", None),
+                ),
                 drop_context_1m_beta=key[4],
             )
         logger.debug(
@@ -6315,7 +6331,11 @@ class AIAgent:
             self._anthropic_client = build_anthropic_client(
                 new_token,
                 getattr(self, "_anthropic_base_url", None),
-                timeout=get_provider_request_timeout(self.provider, self.model),
+                timeout=get_provider_request_timeout(
+                    self.provider,
+                    self.model,
+                    requested_provider_id=getattr(self, "requested_provider", None),
+                ),
             )
         except Exception as exc:
             logger.warning("Failed to rebuild Anthropic client after credential refresh: %s", exc)
@@ -6457,7 +6477,11 @@ class AIAgent:
             self._anthropic_base_url = runtime_base.rstrip("/") if isinstance(runtime_base, str) else runtime_base
             self._anthropic_client = build_anthropic_client(
                 runtime_key, self._anthropic_base_url,
-                timeout=get_provider_request_timeout(self.provider, self.model),
+                timeout=get_provider_request_timeout(
+                    self.provider,
+                    self.model,
+                    requested_provider_id=getattr(self, "requested_provider", None),
+                ),
             )
             self._is_anthropic_oauth = _is_oauth_token(runtime_key) if self.provider == "anthropic" else False
             self.api_key = runtime_key
@@ -6568,7 +6592,11 @@ class AIAgent:
             self._anthropic_client = build_anthropic_client(
                 self._anthropic_api_key,
                 getattr(self, "_anthropic_base_url", None),
-                timeout=get_provider_request_timeout(self.provider, self.model),
+                timeout=get_provider_request_timeout(
+                    self.provider,
+                    self.model,
+                    requested_provider_id=getattr(self, "requested_provider", None),
+                ),
                 drop_context_1m_beta=_drop_1m,
             )
 

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -102,6 +102,7 @@ def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):
             "hermes_cli.runtime_provider",
             resolve_runtime_provider=lambda **_kwargs: {
                 "provider": "p",
+                "requested_provider": "custom:p",
                 "api_mode": "chat_completions",
                 "base_url": "u",
                 "api_key": "k",
@@ -118,6 +119,7 @@ def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):
     assert captured["session_db"] is sentinel_db
     assert captured["platform"] == "acp"
     assert captured["session_id"] == "acp-session"
+    assert captured["requested_provider"] == "custom:p"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -35,6 +35,7 @@ from gateway.platforms.api_server import (
     _hermes_version,
     _redact_api_error_text,
     _request_agent_overrides,
+    _resolve_request_runtime_agent_kwargs,
     check_api_server_requirements,
     cors_middleware,
     security_headers_middleware,
@@ -356,6 +357,23 @@ def auth_adapter():
 
 
 class TestAgentExecution:
+    def test_request_runtime_keeps_named_provider_identity(self, monkeypatch):
+        import hermes_cli.runtime_provider as runtime_provider
+
+        monkeypatch.setattr(
+            runtime_provider,
+            "resolve_runtime_provider",
+            lambda **_kwargs: {"provider": "custom"},
+        )
+        monkeypatch.setattr(runtime_provider, "_get_model_config", lambda: {})
+
+        runtime = _resolve_request_runtime_agent_kwargs(
+            "custom:sub2api", target_model="gpt-5.6-sol"
+        )
+
+        assert runtime["provider"] == "custom"
+        assert runtime["requested_provider"] == "custom:sub2api"
+
     @pytest.mark.asyncio
     async def test_run_agent_uses_session_id_as_task_id(self, adapter):
         mock_agent = MagicMock()

--- a/tests/hermes_cli/test_timeouts.py
+++ b/tests/hermes_cli/test_timeouts.py
@@ -12,6 +12,67 @@ def _write_config(tmp_path, body: str) -> None:
     (tmp_path / "config.yaml").write_text(textwrap.dedent(body), encoding="utf-8")
 
 
+def test_named_custom_timeout_survives_runtime_canonicalization(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        providers:
+          custom:
+            request_timeout_seconds: 300
+            stale_timeout_seconds: 200
+          Custom:Sub2API:
+            request_timeout_seconds: 900
+            stale_timeout_seconds: 600
+            models:
+              gpt-5.6-sol:
+                timeout_seconds: 1200
+                stale_timeout_seconds: 700
+        """,
+    )
+
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        model="gpt-5.6-sol",
+        provider="custom",
+        requested_provider="custom:sub2api",
+        api_key="sk-dummy",
+        base_url="https://example.invalid/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="cli",
+    )
+
+    assert agent._resolved_api_call_timeout() == 1200.0
+    assert agent._resolved_api_call_stale_timeout_base() == (700.0, False)
+    agent._anthropic_api_key = "sk-dummy"
+    agent._anthropic_base_url = "https://example.invalid"
+    assert agent._request_anthropic_client_key()[3] == 1200.0
+
+
+def test_named_custom_timeout_matches_display_name(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        providers:
+          proxy-route:
+            name: Sub2 API
+            request_timeout_seconds: 902
+            stale_timeout_seconds: 602
+        """,
+    )
+
+    assert get_provider_request_timeout(
+        "custom", "gpt-5.6-sol", requested_provider_id="custom:sub2-api"
+    ) == 902.0
+    assert get_provider_stale_timeout(
+        "custom", "gpt-5.6-sol", requested_provider_id="custom:sub2-api"
+    ) == 602.0
+
+
 
 
 

--- a/tests/hermes_cli/test_timeouts.py
+++ b/tests/hermes_cli/test_timeouts.py
@@ -12,6 +12,64 @@ def _write_config(tmp_path, body: str) -> None:
     (tmp_path / "config.yaml").write_text(textwrap.dedent(body), encoding="utf-8")
 
 
+def test_named_custom_timeout_survives_runtime_canonicalization(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        providers:
+          custom:
+            request_timeout_seconds: 300
+            stale_timeout_seconds: 200
+          Custom:Sub2API:
+            request_timeout_seconds: 900
+            stale_timeout_seconds: 600
+            models:
+              gpt-5.6-sol:
+                timeout_seconds: 1200
+                stale_timeout_seconds: 700
+        """,
+    )
+
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        model="gpt-5.6-sol",
+        provider="custom",
+        requested_provider="custom:sub2api",
+        api_key="sk-dummy",
+        base_url="https://example.invalid/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="cli",
+    )
+
+    assert agent._resolved_api_call_timeout() == 1200.0
+    assert agent._resolved_api_call_stale_timeout_base() == (700.0, False)
+
+
+def test_named_custom_timeout_matches_display_name(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        providers:
+          proxy-route:
+            name: Sub2 API
+            request_timeout_seconds: 902
+            stale_timeout_seconds: 602
+        """,
+    )
+
+    assert get_provider_request_timeout(
+        "custom", "gpt-5.6-sol", requested_provider_id="custom:sub2-api"
+    ) == 902.0
+    assert get_provider_stale_timeout(
+        "custom", "gpt-5.6-sol", requested_provider_id="custom:sub2-api"
+    ) == 602.0
+
+
 
 
 

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -206,6 +206,8 @@ def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):
     monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
 
     agent = _bare_agent()
+    setattr(agent, "provider", "custom")
+    setattr(agent, "requested_provider", "custom:anthropic-proxy")
 
     AIAgent._spawn_background_review(
         agent,
@@ -219,6 +221,8 @@ def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):
         "shutdown_memory_provider",
         "close",
     ]
+    assert events[0][1]["provider"] == "custom"
+    assert events[0][1]["requested_provider"] == "custom:anthropic-proxy"
 
 
 def test_background_review_fork_opts_out_of_session_finalization(monkeypatch):

--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -6,6 +6,7 @@ provider/base_url/api_key empty in AIAgent, causing HTTP 404.
 """
 
 import os
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 
@@ -14,7 +15,8 @@ def test_make_agent_passes_resolved_provider():
     resolve_runtime_provider to AIAgent."""
 
     fake_runtime = {
-        "provider": "anthropic",
+        "provider": "custom",
+        "requested_provider": "custom:anthropic-proxy",
         "base_url": "https://api.anthropic.com",
         "api_key": "sk-test-key",
         "api_mode": "anthropic_messages",
@@ -54,10 +56,33 @@ def test_make_agent_passes_resolved_provider():
         assert mock_resolve.call_args.kwargs.get("requested") is None
 
         call_kwargs = mock_agent.call_args
-        assert call_kwargs.kwargs["provider"] == "anthropic"
+        assert call_kwargs.kwargs["provider"] == "custom"
+        assert call_kwargs.kwargs["requested_provider"] == "custom:anthropic-proxy"
         assert call_kwargs.kwargs["base_url"] == "https://api.anthropic.com"
         assert call_kwargs.kwargs["api_key"] == "sk-test-key"
         assert call_kwargs.kwargs["api_mode"] == "anthropic_messages"
+
+
+def test_background_agent_keeps_requested_provider():
+    parent = SimpleNamespace(
+        provider="custom",
+        requested_provider="custom:anthropic-proxy",
+        model="claude-opus-4-6",
+    )
+
+    with (
+        patch("tui_gateway.server._load_cfg", return_value={}),
+        patch("tui_gateway.server._get_db", return_value=MagicMock()),
+        patch("tui_gateway.server._load_reasoning_config", return_value=None),
+        patch("tui_gateway.server._load_service_tier", return_value=None),
+        patch("tui_gateway.server._load_enabled_toolsets", return_value=None),
+    ):
+        from tui_gateway.server import _background_agent_kwargs
+
+        kwargs = _background_agent_kwargs(parent, "task-1")
+
+    assert kwargs["provider"] == "custom"
+    assert kwargs["requested_provider"] == "custom:anthropic-proxy"
 
 
 def test_probe_config_health_flags_null_sections():

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1432,6 +1432,15 @@ def _build_child_agent(
         effective_provider = "copilot-acp"
         effective_api_mode = "chat_completions"
 
+    effective_requested_provider = (
+        "copilot-acp"
+        if override_acp_command
+        else override_provider
+        or getattr(parent_agent, "requested_provider", effective_provider)
+        or effective_provider
+        or ""
+    )
+
     # Resolve reasoning config: delegation override > parent inherit
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)
     child_reasoning = parent_reasoning
@@ -1506,6 +1515,7 @@ def _build_child_agent(
             api_key=effective_api_key,
             model=effective_model,
             provider=effective_provider,
+            requested_provider=effective_requested_provider,
             api_mode=effective_api_mode,
             acp_command=effective_acp_command,
             acp_args=effective_acp_args,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1847,6 +1847,15 @@ def _build_child_agent(
         effective_provider = "copilot-acp"
         effective_api_mode = "chat_completions"
 
+    effective_requested_provider = (
+        "copilot-acp"
+        if override_acp_command
+        else override_provider
+        or getattr(parent_agent, "requested_provider", effective_provider)
+        or effective_provider
+        or ""
+    )
+
     # Resolve reasoning config: delegation override > parent inherit
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)
     child_reasoning = parent_reasoning
@@ -1967,6 +1976,7 @@ def _build_child_agent(
                 api_key=effective_api_key,
                 model=effective_model,
                 provider=effective_provider,
+                requested_provider=effective_requested_provider,
                 api_mode=effective_api_mode,
                 acp_command=effective_acp_command,
                 acp_args=effective_acp_args,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5615,6 +5615,11 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "base_url": getattr(agent, "base_url", None) or None,
         "api_key": getattr(agent, "api_key", None) or None,
         "provider": getattr(agent, "provider", None) or None,
+        "requested_provider": (
+            getattr(agent, "requested_provider", None)
+            or getattr(agent, "provider", None)
+            or ""
+        ),
         "api_mode": getattr(agent, "api_mode", None) or None,
         "acp_command": getattr(agent, "acp_command", None) or None,
         "acp_args": getattr(agent, "acp_args", None) or None,
@@ -6091,6 +6096,9 @@ def _make_agent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 500),
         provider=runtime.get("provider"),
+        requested_provider=(
+            runtime.get("requested_provider") or requested_provider or ""
+        ),
         base_url=runtime.get("base_url"),
         api_key=runtime.get("api_key"),
         api_mode=runtime.get("api_mode"),

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8298,6 +8298,11 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "base_url": getattr(agent, "base_url", None) or None,
         "api_key": getattr(agent, "api_key", None) or None,
         "provider": getattr(agent, "provider", None) or None,
+        "requested_provider": (
+            getattr(agent, "requested_provider", None)
+            or getattr(agent, "provider", None)
+            or ""
+        ),
         "api_mode": getattr(agent, "api_mode", None) or None,
         "acp_command": getattr(agent, "acp_command", None) or None,
         "acp_args": getattr(agent, "acp_args", None) or None,
@@ -8782,6 +8787,9 @@ def _make_agent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 500),
         provider=runtime.get("provider"),
+        requested_provider=(
+            runtime.get("requested_provider") or requested_provider or ""
+        ),
         base_url=runtime.get("base_url"),
         api_key=runtime.get("api_key"),
         api_mode=runtime.get("api_mode"),


### PR DESCRIPTION
## Summary

- preserve the requested provider identity when a named custom provider canonicalizes to the runtime `custom` transport
- resolve request and stale timeouts from the named route first, with case-insensitive provider IDs and normalized display-name aliases and `providers.custom` retained as a fallback
- apply the same identity across initialization, streaming/non-streaming calls, model switching, credential refresh, primary recovery, API/ACP, TUI/background, delegation, curator, and platform fork entry points

## Root cause

Named custom providers intentionally resolve to `provider="custom"` at runtime. Timeout lookup used only that canonical runtime ID, so settings under `providers.<named-route>` were skipped and the generic stale watchdog default was used instead. Several secondary `AIAgent` construction paths also dropped the already-resolved `requested_provider` identity.

## Tests

- added an integration regression covering `AIAgent(provider="custom", requested_provider="custom:sub2api")`
- added identity-propagation assertions for TUI/background, ACP, and API Server agent construction
- 266 targeted tests passed across 12 current test files after rebasing onto the pruned main suite covering timeout resolution, stale watchdogs, custom-provider switching, fallback, rollback, credential-pool recovery, background review, curator, TUI, ACP, API Server, delegation, and Feishu comment agents
- full AST/manual audit covers explicit and `**kwargs` `AIAgent` construction paths
- Ruff, bytecode compilation, and `git diff --check` passed
