### PR TITLE
fix(execute_code): tolerate tool payloads with a trailing hint

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -140,6 +140,68 @@ class TestHermesToolsGeneration(unittest.TestCase):
         self.assertIn("with _seq_lock:", src)
 
 
+class TestGeneratedToolResultParsing(unittest.TestCase):
+    """Regression: tool payloads with a trailing human-readable hint.
+
+    Several tools (search_files when results are truncated, notably) emit a
+    JSON object followed by a blank line and a "[Hint: ...]" string. A strict
+    json.loads() on that raises JSONDecodeError("Extra data"), which used to
+    surface inside execute_code as a spurious parse failure even though the
+    underlying tool call succeeded.
+    """
+
+    def _parser_for(self, transport):
+        src = generate_hermes_tools_module(["search_files"], transport=transport)
+        ns = {}
+        exec(compile(src, "hermes_tools", "exec"), ns)
+        self.assertIn("_parse_tool_result", ns)
+        return ns["_parse_tool_result"]
+
+    def test_both_transports_define_the_parser(self):
+        for transport in ("uds", "file"):
+            src = generate_hermes_tools_module(["search_files"], transport=transport)
+            self.assertIn("def _parse_tool_result(raw):", src)
+            # Neither transport should hand the raw payload to a strict loads().
+            self.assertNotIn("result = json.loads(raw)", src)
+
+    def test_plain_json_object_roundtrips(self):
+        for transport in ("uds", "file"):
+            parse = self._parser_for(transport)
+            result = parse(json.dumps({"total_count": 2, "matches_text": "a\nb"}))
+            self.assertEqual(result["total_count"], 2)
+            self.assertNotIn("_hint", result)
+
+    def test_trailing_hint_is_preserved_not_raised(self):
+        hint = "[Hint: Results truncated. Use offset=50 to see more.]"
+        payload = json.dumps({"total_count": 50, "truncated": True}) + "\n\n" + hint
+        for transport in ("uds", "file"):
+            parse = self._parser_for(transport)
+            result = parse(payload)
+            self.assertEqual(result["total_count"], 50)
+            self.assertTrue(result["truncated"])
+            self.assertEqual(result["_hint"], hint)
+
+    def test_existing_hint_key_is_not_clobbered(self):
+        payload = json.dumps({"ok": True, "_hint": "from tool"}) + "\n\ntrailing"
+        parse = self._parser_for("uds")
+        self.assertEqual(parse(payload)["_hint"], "from tool")
+
+    def test_double_encoded_payload_still_unwraps(self):
+        payload = json.dumps(json.dumps({"output": "hi", "exit_code": 0}))
+        parse = self._parser_for("file")
+        self.assertEqual(parse(payload)["output"], "hi")
+
+    def test_non_json_trailing_on_json_list_does_not_raise(self):
+        payload = "[1, 2, 3]\n\n[Hint: more]"
+        parse = self._parser_for("uds")
+        self.assertEqual(parse(payload), [1, 2, 3])
+
+    def test_truly_malformed_payload_still_raises(self):
+        parse = self._parser_for("uds")
+        with self.assertRaises(json.JSONDecodeError):
+            parse("not json at all")
+
+
 class TestExecuteCodeRemoteTempDir(unittest.TestCase):
     def test_execute_remote_uses_backend_temp_dir_for_sandbox(self):
         class FakeEnv:

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -157,13 +157,6 @@ class TestGeneratedToolResultParsing(unittest.TestCase):
         self.assertIn("_parse_tool_result", ns)
         return ns["_parse_tool_result"]
 
-    def test_both_transports_define_the_parser(self):
-        for transport in ("uds", "file"):
-            src = generate_hermes_tools_module(["search_files"], transport=transport)
-            self.assertIn("def _parse_tool_result(raw):", src)
-            # Neither transport should hand the raw payload to a strict loads().
-            self.assertNotIn("result = json.loads(raw)", src)
-
     def test_plain_json_object_roundtrips(self):
         for transport in ("uds", "file"):
             parse = self._parser_for(transport)
@@ -183,23 +176,56 @@ class TestGeneratedToolResultParsing(unittest.TestCase):
 
     def test_existing_hint_key_is_not_clobbered(self):
         payload = json.dumps({"ok": True, "_hint": "from tool"}) + "\n\ntrailing"
-        parse = self._parser_for("uds")
-        self.assertEqual(parse(payload)["_hint"], "from tool")
+        for transport in ("uds", "file"):
+            parse = self._parser_for(transport)
+            self.assertEqual(parse(payload)["_hint"], "from tool")
 
     def test_double_encoded_payload_still_unwraps(self):
         payload = json.dumps(json.dumps({"output": "hi", "exit_code": 0}))
-        parse = self._parser_for("file")
-        self.assertEqual(parse(payload)["output"], "hi")
+        for transport in ("uds", "file"):
+            parse = self._parser_for(transport)
+            self.assertEqual(parse(payload)["output"], "hi")
+
+    def test_double_encoded_payload_keeps_outer_trailing_hint(self):
+        """The suffix survives the double-encoded unwrap.
+
+        The outer value is a JSON string holding the real payload, and the hint
+        sits after that outer string. Unwrapping must not discard it.
+        """
+        hint = "[Hint: Results truncated. Use offset=50 to see more.]"
+        payload = json.dumps(json.dumps({"ok": True})) + "\n\n" + hint
+        for transport in ("uds", "file"):
+            parse = self._parser_for(transport)
+            result = parse(payload)
+            self.assertTrue(result["ok"])
+            self.assertEqual(result["_hint"], hint)
+
+    def test_double_encoded_payload_keeps_inner_trailing_hint(self):
+        """A hint after the inner payload is preserved too."""
+        hint = "[Hint: inner]"
+        payload = json.dumps(json.dumps({"ok": True}) + "\n\n" + hint)
+        for transport in ("uds", "file"):
+            parse = self._parser_for(transport)
+            result = parse(payload)
+            self.assertTrue(result["ok"])
+            self.assertEqual(result["_hint"], hint)
 
     def test_non_json_trailing_on_json_list_does_not_raise(self):
         payload = "[1, 2, 3]\n\n[Hint: more]"
-        parse = self._parser_for("uds")
-        self.assertEqual(parse(payload), [1, 2, 3])
+        for transport in ("uds", "file"):
+            parse = self._parser_for(transport)
+            self.assertEqual(parse(payload), [1, 2, 3])
+
+    def test_plain_string_payload_returned_as_is(self):
+        for transport in ("uds", "file"):
+            parse = self._parser_for(transport)
+            self.assertEqual(parse(json.dumps("just a message")), "just a message")
 
     def test_truly_malformed_payload_still_raises(self):
-        parse = self._parser_for("uds")
-        with self.assertRaises(json.JSONDecodeError):
-            parse("not json at all")
+        for transport in ("uds", "file"):
+            parse = self._parser_for(transport)
+            with self.assertRaises(json.JSONDecodeError):
+                parse("not json at all")
 
 
 class TestExecuteCodeRemoteTempDir(unittest.TestCase):

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -416,6 +416,35 @@ def retry(fn, max_attempts=3, delay=2):
                 time.sleep(delay * (2 ** attempt))
     raise last_err
 
+
+def _parse_tool_result(raw):
+    """Parse an RPC tool-result payload into Python data.
+
+    Some Hermes tools append a human-readable hint AFTER the JSON payload --
+    e.g. search_files emits a JSON object, a blank line, then
+    "[Hint: Results truncated. Use offset=50 ...]" whenever results were
+    truncated. A strict json.loads() raises JSONDecodeError("Extra data") on
+    those, which used to surface inside execute_code as a spurious parse
+    failure even though the tool call itself succeeded. Decode the first JSON
+    value and keep any trailing text under the "_hint" key so nothing is lost.
+    """
+    text = raw.strip() if isinstance(raw, str) else raw
+    trailing = ""
+    try:
+        result = json.loads(text)
+    except json.JSONDecodeError:
+        result, end = json.JSONDecoder().raw_decode(text)
+        trailing = text[end:].strip()
+    if isinstance(result, str):
+        # Doubly-encoded payload: the outer JSON value is itself a JSON string.
+        try:
+            return _parse_tool_result(result)
+        except (json.JSONDecodeError, TypeError):
+            return result
+    if trailing and isinstance(result, dict) and "_hint" not in result:
+        result["_hint"] = trailing
+    return result
+
 '''
 
 # ---- UDS transport (local backend) ---------------------------------------
@@ -476,13 +505,7 @@ def _call(tool_name, args):
             if buf.endswith(b"\\n"):
                 break
     raw = buf.decode().strip()
-    result = json.loads(raw)
-    if isinstance(result, str):
-        try:
-            return json.loads(result)
-        except (json.JSONDecodeError, TypeError):
-            return result
-    return result
+    return _parse_tool_result(raw)
 
 '''
 
@@ -542,12 +565,7 @@ def _call(tool_name, args):
     except OSError:
         pass
 
-    result = json.loads(raw)
-    if isinstance(result, str):
-        try:
-            return json.loads(result)
-        except (json.JSONDecodeError, TypeError):
-            return result
+    result = _parse_tool_result(raw)
     return result
 
 '''

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -427,20 +427,32 @@ def _parse_tool_result(raw):
     those, which used to surface inside execute_code as a spurious parse
     failure even though the tool call itself succeeded. Decode the first JSON
     value and keep any trailing text under the "_hint" key so nothing is lost.
+
+    A payload can also be doubly encoded (the outer JSON value is itself a JSON
+    string), and the trailing text can sit after either the outer or the inner
+    payload. Unwrap iteratively and carry the suffix through the unwrap instead
+    of dropping it.
     """
+    def _decode(text):
+        """Decode the first JSON value in `text` -> (value, trailing_text)."""
+        try:
+            return json.loads(text), ""
+        except json.JSONDecodeError:
+            value, end = json.JSONDecoder().raw_decode(text)
+            return value, text[end:].strip()
+
     text = raw.strip() if isinstance(raw, str) else raw
-    trailing = ""
-    try:
-        result = json.loads(text)
-    except json.JSONDecodeError:
-        result, end = json.JSONDecoder().raw_decode(text)
-        trailing = text[end:].strip()
-    if isinstance(result, str):
+    result, trailing = _decode(text)
+    while isinstance(result, str):
         # Doubly-encoded payload: the outer JSON value is itself a JSON string.
         try:
-            return _parse_tool_result(result)
+            inner, inner_trailing = _decode(result.strip())
         except (json.JSONDecodeError, TypeError):
-            return result
+            break
+        result = inner
+        # A hint attached to the inner payload is the more specific one; keep
+        # the outer suffix when the inner level had none.
+        trailing = inner_trailing or trailing
     if trailing and isinstance(result, dict) and "_hint" not in result:
         result["_hint"] = trailing
     return result


### PR DESCRIPTION
## What & why

The `hermes_tools` shim generated for `execute_code` sandboxes parses every RPC tool result with a strict `json.loads()`:

```python
# tools/code_execution_tool.py:479 (uds transport) and :545 (file transport)
result = json.loads(raw)
```

Several tools append human-readable text **after** the JSON payload. `search_files` appends a truncation hint (`tools/file_tools.py:1928`):

```
{"total_count": 50, "matches_text": "...", "truncated": true}

[Hint: Results truncated. Use offset=50 to see more, or narrow with a more specific pattern or file_glob.]
```

`json.loads()` raises `JSONDecodeError: Extra data` on that, so the sandbox call fails **even though the tool call itself succeeded and the data is present**. From inside `execute_code` the failure looks like the wrapper choking on large output, which sends you looking in the wrong place — the trigger is the appended hint, not the size.

Both transports had it; only the UDS path is commonly hit today, so the file-transport (remote backend) case was latent.

### Reachability today, and why this gets worse soon

The hint currently only fires when `context > 0`. With `context=0` the `truncated` flag can never become `True`, because `fetch_limit` is `limit + offset` while the flag is computed as `total > offset + limit` (`tools/file_operations.py:2293`, `:2421`) — the extra row that would prove truncation is never fetched. Measured on current `main`:

| call | hint emitted | `json.loads()` |
|---|---|---|
| `limit=3, context=0` | no | ok |
| `limit=3, context=2` | **yes** | **`JSONDecodeError: Extra data`** |
| `limit=100, context=0` | no | ok |

**#41439** (open, approved) fixes that off-by-one with an n+1 sentinel so `truncated` reports correctly in the default `context=0` path. Once it merges, every truncated `search_files` inside `execute_code` starts raising — this fix removes that latent regression ahead of it.

## Fix

Add a shared `_parse_tool_result()` to the shim's `_COMMON_HELPERS` and use it from both transports. It `raw_decode()`s the first JSON value and preserves any trailing text under `_hint` rather than discarding it (`_hint` is only set when absent, so a tool's own key is never clobbered). The existing double-encoded-payload unwrap is kept, and genuinely malformed payloads still raise `JSONDecodeError`.

This is the same bug class and same fix shape as **#33930**, which handles the appended `[Tool loop warning: ...]` suffix in `tools/delegate_tool.py`. That PR fixes the delegate surface; this one fixes the sandbox shim. They touch different files and do not conflict.

## How to test

Automated (CI-parity wrapper):

```bash
scripts/run_tests.sh tests/tools/test_code_execution.py \
  tests/tools/test_code_execution_modes.py \
  tests/tools/test_code_execution_windows_env.py
```

150 passed. The 7 new tests in `TestGeneratedToolResultParsing` `exec()` the generated shim and call the parser for real, rather than asserting on substrings of the generated source: plain payloads round-trip, a trailing hint is preserved under `_hint` instead of raising, an existing `_hint` is not clobbered, double-encoded payloads still unwrap, JSON arrays with trailing text work, and malformed input still raises.

Manual reproduction of the underlying failure on unpatched `main`:

```bash
printf 'MATCH %d\n' $(seq 0 9) > /tmp/hits.txt
python - <<'PY'
import json
from tools.file_tools import search_tool
s = search_tool(pattern="MATCH", path="/tmp/hits.txt", target="content",
                output_mode="content", limit=3, context=2)
print(json.loads(s))   # JSONDecodeError: Extra data  <-- shim does exactly this
PY
```

End to end, through a real sandbox (`execute_code` running `search_files(..., limit=3, context=2)` against that file). Before:

```
File "/tmp/hermes_sandbox_*/hermes_tools.py", line 90, in _call
    result = json.loads(raw)
json.decoder.JSONDecodeError: Extra data: line 3 column 1 (char 233)
```

After:

```
RESULT_TYPE dict
TOTAL 10
HINT [Hint: Results truncated. Use offset=3 to see ...
```

Windows footguns (change touches file I/O paths in the generated stub):

```bash
python scripts/check-windows-footguns.py tools/code_execution_tool.py tests/tools/test_code_execution.py
# ✓ No Windows footguns found (2 file(s) scanned).
```

## Platforms tested

Linux (Ubuntu, Python 3.12) fully verified — full suite plus the manual repro above. Windows and macOS not manually tested; the change is pure stdlib `json` string parsing with no OS-dependent behaviour, and `check-windows-footguns.py` passes on both touched files.

## Related

- **#33930** — same `json.loads` → `raw_decode` bug class for the `[Tool loop warning: ...]` suffix in `delegate_tool.py`. Different file, complementary; no conflict.
- **#41439** — `search_files` truncation off-by-one. Independent, but merging it widens this bug's blast radius from a `context>0` edge case to the default path, so landing this first (or together) avoids a regression.
- **#722** — structured tool-result hints/CTAs. The broader design question of whether hints should ride *inside* the payload rather than be appended as trailing prose. This PR deliberately only makes the consumer tolerant; other producers (`web_tools.py`, `browser_tool.py`, `agent/subdirectory_hints.py`) append similar footers and would be addressed by that design change, not here.
