### PR TITLE
fix(matrix): suppress processing reactions for unauthorized events

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3512,9 +3512,40 @@ class MatrixAdapter(BasePlatformAdapter):
         self._reaction_redaction_tasks.add(task)
         task.add_done_callback(self._reaction_redaction_tasks.discard)
 
+    def _processing_reactions_allowed(self, event: MessageEvent) -> bool:
+        """Return whether lifecycle reactions may be emitted for ``event``.
+
+        The gateway registers this callback on connected adapters.  An
+        explicit ``False`` is the only denial signal; ``None`` preserves
+        standalone-adapter behavior when no gateway auth context exists.
+        """
+        source = event.source
+        sender_authorized = self._is_sender_authorized(
+            getattr(source, "user_id", None),
+            getattr(source, "chat_type", None),
+            getattr(source, "chat_id", None),
+        )
+        if sender_authorized is False:
+            logger.debug(
+                "Matrix: skipping processing reaction for unauthorized sender %s",
+                getattr(source, "user_id", None),
+            )
+            return False
+        return True
+
     async def on_processing_start(self, event: MessageEvent) -> None:
-        """Add eyes reaction when the agent starts processing a message."""
+        """Add eyes reaction when the agent starts processing a message.
+
+        The base adapter invokes this hook before the gateway's normal auth
+        dispatch.  When the gateway has registered its authorization callback,
+        avoid emitting a processing marker for a sender it has already
+        classified as unauthorized.  ``None`` means that no callback is
+        configured (or the sender identity is unavailable), so standalone
+        adapters and legacy integrations retain their existing behavior.
+        """
         if not self._reactions_enabled:
+            return
+        if not self._processing_reactions_allowed(event):
             return
         msg_id = event.message_id
         room_id = event.source.chat_id
@@ -3530,6 +3561,8 @@ class MatrixAdapter(BasePlatformAdapter):
     ) -> None:
         """Replace eyes with checkmark (success) or cross (failure)."""
         if not self._reactions_enabled:
+            return
+        if not self._processing_reactions_allowed(event):
             return
         msg_id = event.message_id
         room_id = event.source.chat_id

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -3074,6 +3074,92 @@ class TestMatrixReactions:
         assert self.adapter._pending_reactions == {("!room:ex", "$msg1"): "$reaction_event_123"}
 
     @pytest.mark.asyncio
+    async def test_on_processing_start_skips_unauthorized_sender(self):
+        """An explicit gateway auth denial must not emit a misleading marker."""
+        from gateway.platforms.base import MessageEvent, MessageType
+
+        self.adapter._reactions_enabled = True
+        self.adapter.set_authorization_check(
+            lambda user_id, chat_type=None, chat_id=None: False
+        )
+        self.adapter._send_reaction = AsyncMock(return_value="$reaction_event_123")
+
+        source = MagicMock()
+        source.chat_id = "!room:ex"
+        source.chat_type = "group"
+        source.user_id = "@intruder:ex"
+        event = MessageEvent(
+            text="hello",
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message={},
+            message_id="$msg1",
+        )
+        await self.adapter.on_processing_start(event)
+
+        self.adapter._send_reaction.assert_not_called()
+        assert self.adapter._pending_reactions == {}
+
+    @pytest.mark.asyncio
+    async def test_on_processing_complete_skips_unauthorized_sender(self):
+        """An auth-denied event must not receive a terminal check/cross."""
+        from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
+
+        self.adapter._reactions_enabled = True
+        self.adapter.set_authorization_check(
+            lambda user_id, chat_type=None, chat_id=None: False
+        )
+        self.adapter._send_reaction = AsyncMock(return_value="$check_reaction_456")
+        self.adapter._redact_reaction = AsyncMock()
+
+        source = MagicMock()
+        source.chat_id = "!room:ex"
+        source.chat_type = "group"
+        source.user_id = "@intruder:ex"
+        event = MessageEvent(
+            text="hello",
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message={},
+            message_id="$msg1",
+        )
+        await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+        self.adapter._send_reaction.assert_not_called()
+        self.adapter._redact_reaction.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_on_processing_start_allows_authorized_sender(self):
+        """An explicit gateway auth allow still emits the normal marker."""
+        from gateway.platforms.base import MessageEvent, MessageType
+
+        self.adapter._reactions_enabled = True
+        self.adapter.set_authorization_check(
+            lambda user_id, chat_type=None, chat_id=None: True
+        )
+        self.adapter._send_reaction = AsyncMock(return_value="$reaction_event_123")
+
+        source = MagicMock()
+        source.chat_id = "!room:ex"
+        source.chat_type = "group"
+        source.user_id = "@allowed:ex"
+        event = MessageEvent(
+            text="hello",
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message={},
+            message_id="$msg1",
+        )
+        await self.adapter.on_processing_start(event)
+
+        self.adapter._send_reaction.assert_called_once_with(
+            "!room:ex", "$msg1", "\U0001f440"
+        )
+        assert self.adapter._pending_reactions == {
+            ("!room:ex", "$msg1"): "$reaction_event_123"
+        }
+
+    @pytest.mark.asyncio
     async def test_on_processing_complete_sends_check(self):
         from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
 


### PR DESCRIPTION
## Summary

- suppress Matrix processing reactions for unauthorized senders
- keep the check/cross lifecycle behind the same authorization gate as message handling
- add regression coverage for unauthorized, authorized, and failure paths

This prevents a visible processing marker from implying that Hermes accepted an event that it will not answer.

## Verification

- `python3 -m pytest tests/gateway/test_matrix.py -k 'on_processing_start or on_processing_complete_sends_check or on_processing_complete_skips_unauthorized_sender' -q`
- `uvx --from ruff ruff check plugins/platforms/matrix/adapter.py tests/gateway/test_matrix.py`
- `python3 -m compileall -q plugins/platforms/matrix/adapter.py tests/gateway/test_matrix.py`
- `git diff --check`
