### PR TITLE
feat(matrix): support thread-scoped processing reactions

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -948,6 +948,11 @@ platform_toolsets:
 # Platform-specific knobs live under `extra`.
 #
 # platforms:
+#   matrix:
+#     extra:
+#       # Keep processing reactions on each message (default), or set `thread`
+#       # to aggregate 👀/✅/❌ on the Matrix thread root event.
+#       processing_reaction_scope: "message"  # message | thread
 #   telegram:
 #     reply_to_mode: "first"  # off | first | all
 #     # guest_mode lets explicit @mentions from non-allowlisted groups through.

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -953,6 +953,8 @@ platform_toolsets:
 #       # Keep processing reactions on each message (default), or set `thread`
 #       # to aggregate 👀/✅/❌ on the Matrix thread root event.
 #       processing_reaction_scope: "message"  # message | thread
+#       # Maximum completed thread states retained in memory (default: 500).
+#       processing_reaction_state_limit: 500
 #   telegram:
 #     reply_to_mode: "first"  # off | first | all
 #     # guest_mode lets explicit @mentions from non-allowlisted groups through.

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -19,6 +19,9 @@ Environment variables:
     MATRIX_HOME_ROOM        Room ID for cron/notification delivery
     MATRIX_REACTIONS        Set "false" to disable processing lifecycle reactions
                             (eyes/checkmark/cross). Default: true
+                            `platforms.matrix.extra.processing_reaction_scope`
+                            accepts `message` (default) or `thread` to place
+                            the state on the Matrix thread root event.
     MATRIX_REQUIRE_MENTION      Require @mention in rooms (default: true)
     MATRIX_FREE_RESPONSE_ROOMS  Comma-separated room IDs exempt from mention requirement
                                 (alias of matrix.free_response_rooms)
@@ -437,6 +440,16 @@ class MatrixRoomIdentity:
     has_explicit_name: bool
     chat_type: str
     conflict: bool = False
+
+
+@dataclass
+class _MatrixProcessingReactionState:
+    """Hermes-owned processing reactions for one Matrix target event."""
+
+    generation: int = 0
+    eyes_event_id: str | None = None
+    terminal_event_id: str | None = None
+    terminal_emoji: str | None = None
 
 
 @dataclass
@@ -980,6 +993,7 @@ class MatrixAdapter(BasePlatformAdapter):
     # overrides both from _resolve_max_message_length().
     max_message_length = DEFAULT_MAX_MESSAGE_LENGTH
     _split_threshold = DEFAULT_MAX_MESSAGE_LENGTH - 100
+    _processing_reaction_scope = "message"
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.MATRIX)
@@ -1103,7 +1117,24 @@ class MatrixAdapter(BasePlatformAdapter):
         self._reactions_enabled: bool = os.getenv(
             "MATRIX_REACTIONS", "true"
         ).lower() not in {"false", "0", "no"}
+        raw_reaction_scope = config.extra.get("processing_reaction_scope", "message")
+        reaction_scope = (
+            raw_reaction_scope.strip().lower()
+            if isinstance(raw_reaction_scope, str)
+            else "message"
+        )
+        if reaction_scope not in {"message", "thread"}:
+            logger.warning(
+                "Matrix: unsupported processing_reaction_scope=%r; using message",
+                raw_reaction_scope,
+            )
+            reaction_scope = "message"
+        self._processing_reaction_scope = reaction_scope
         self._pending_reactions: dict[tuple[str, str], str] = {}
+        self._reaction_states: dict[
+            tuple[str, str], _MatrixProcessingReactionState
+        ] = {}
+        self._processing_event_generations: dict[tuple[str, str], int] = {}
         # Delay before redacting reactions so Matrix homeservers have time to
         # deliver the final message event without tripping "missing event"
         # errors in some clients.  5s is empirically safe; not user-tunable —
@@ -3512,44 +3543,211 @@ class MatrixAdapter(BasePlatformAdapter):
         self._reaction_redaction_tasks.add(task)
         task.add_done_callback(self._reaction_redaction_tasks.discard)
 
+    def _processing_reaction_target(
+        self,
+        event: MessageEvent,
+    ) -> tuple[str, str] | None:
+        """Return the Matrix event that owns this processing state.
+
+        Thread-scoped reactions point at ``SessionSource.thread_id`` (the
+        Matrix thread root).  Non-threaded events keep the legacy per-message
+        target so enabling the feature cannot make unrelated messages share a
+        status reaction.
+        """
+
+        source = getattr(event, "source", None)
+        room_id = getattr(source, "chat_id", None)
+        message_id = getattr(event, "message_id", None)
+        if not isinstance(room_id, str) or not room_id:
+            return None
+        if not isinstance(message_id, str) or not message_id:
+            return None
+
+        if getattr(self, "_processing_reaction_scope", "message") == "thread":
+            thread_id = getattr(source, "thread_id", None)
+            if isinstance(thread_id, str) and thread_id:
+                return room_id, thread_id
+        return room_id, message_id
+
+    def _get_processing_reaction_state(
+        self,
+        reaction_key: tuple[str, str],
+    ) -> _MatrixProcessingReactionState:
+        """Get state for a target, tolerating lightweight test instances."""
+
+        states = getattr(self, "_reaction_states", None)
+        if states is None:
+            states = {}
+            self._reaction_states = states
+        return states.setdefault(reaction_key, _MatrixProcessingReactionState())
+
+    async def _redact_tracked_reaction(
+        self,
+        room_id: str,
+        reaction_event_id: str | None,
+        reason: str,
+    ) -> None:
+        """Redact one Hermes-owned reaction without breaking message flow."""
+
+        if not reaction_event_id:
+            return
+        try:
+            if not await self._redact_reaction(room_id, reaction_event_id, reason):
+                logger.debug(
+                    "Matrix: failed to redact tracked reaction %s",
+                    reaction_event_id,
+                )
+        except Exception as exc:
+            logger.debug(
+                "Matrix: tracked reaction redaction failed for %s: %s",
+                reaction_event_id,
+                exc,
+            )
+
     async def on_processing_start(self, event: MessageEvent) -> None:
-        """Add eyes reaction when the agent starts processing a message."""
+        """Add eyes to the message or thread root when processing starts."""
         if not self._reactions_enabled:
             return
-        msg_id = event.message_id
-        room_id = event.source.chat_id
-        if msg_id and room_id:
-            reaction_event_id = await self._send_reaction(room_id, msg_id, "\U0001f440")
-            if reaction_event_id:
-                self._pending_reactions[(room_id, msg_id)] = reaction_event_id
+        target = self._processing_reaction_target(event)
+        if target is None:
+            return
+        room_id, target_event_id = target
+        reaction_key = (room_id, target_event_id)
+        state = self._get_processing_reaction_state(reaction_key)
+        state.generation += 1
+        generation = state.generation
+
+        event_message_id = event.message_id
+        event_generations = getattr(self, "_processing_event_generations", None)
+        if event_generations is None:
+            event_generations = {}
+            self._processing_event_generations = event_generations
+        event_generations[(room_id, event_message_id)] = generation
+
+        previous_eyes_event_id = state.eyes_event_id
+        previous_terminal_event_id = state.terminal_event_id
+        state.eyes_event_id = None
+        state.terminal_event_id = None
+        state.terminal_emoji = None
+        if (
+            getattr(self, "_pending_reactions", {}).get(reaction_key)
+            == previous_eyes_event_id
+        ):
+            self._pending_reactions.pop(reaction_key, None)
+
+        # A new turn reopens a completed thread.  Only event IDs returned by
+        # this adapter are redacted, so user-authored reactions remain intact.
+        await self._redact_tracked_reaction(
+            room_id,
+            previous_eyes_event_id,
+            "processing resumed",
+        )
+        await self._redact_tracked_reaction(
+            room_id,
+            previous_terminal_event_id,
+            "processing resumed",
+        )
+
+        reaction_event_id = await self._send_reaction(
+            room_id,
+            target_event_id,
+            "\U0001f440",
+        )
+        if state.generation != generation:
+            # Another start won while the network request was in flight.  Do
+            # not let this stale request become the current eyes marker.
+            await self._redact_tracked_reaction(
+                room_id,
+                reaction_event_id,
+                "stale processing start",
+            )
+            return
+        if reaction_event_id:
+            state.eyes_event_id = reaction_event_id
+            self._pending_reactions[reaction_key] = reaction_event_id
 
     async def on_processing_complete(
         self,
         event: MessageEvent,
         outcome: ProcessingOutcome,
     ) -> None:
-        """Replace eyes with checkmark (success) or cross (failure)."""
+        """Replace the active marker with a terminal processing state."""
         if not self._reactions_enabled:
             return
-        msg_id = event.message_id
-        room_id = event.source.chat_id
-        if not msg_id or not room_id:
+        target = self._processing_reaction_target(event)
+        if target is None:
             return
+        room_id, target_event_id = target
+        reaction_key = (room_id, target_event_id)
+        state = self._get_processing_reaction_state(reaction_key)
+
+        event_message_id = event.message_id
+        event_generations = getattr(self, "_processing_event_generations", {})
+        event_generation = event_generations.pop((room_id, event_message_id), None)
+        if event_generation is not None and event_generation != state.generation:
+            # A newer message in this thread owns the visible state.
+            return
+
         if outcome == ProcessingOutcome.CANCELLED:
+            if getattr(self, "_processing_reaction_scope", "message") == "thread":
+                eyes_event_id = state.eyes_event_id
+                if eyes_event_id is None:
+                    eyes_event_id = getattr(self, "_pending_reactions", {}).get(
+                        reaction_key
+                    )
+                state.eyes_event_id = None
+                if (
+                    getattr(self, "_pending_reactions", {}).get(reaction_key)
+                    == eyes_event_id
+                ):
+                    self._pending_reactions.pop(reaction_key, None)
+                await self._redact_tracked_reaction(
+                    room_id,
+                    eyes_event_id,
+                    "processing cancelled",
+                )
+            else:
+                self._reaction_states.pop(reaction_key, None)
+            # Preserve the legacy message-scoped cancellation behavior.
             return
-        reaction_key = (room_id, msg_id)
-        if reaction_key in self._pending_reactions:
-            eyes_event_id = self._pending_reactions.pop(reaction_key)
+
+        eyes_event_id = state.eyes_event_id
+        if eyes_event_id is None:
+            eyes_event_id = getattr(self, "_pending_reactions", {}).get(reaction_key)
+        state.eyes_event_id = None
+        if getattr(self, "_pending_reactions", {}).get(reaction_key) == eyes_event_id:
+            self._pending_reactions.pop(reaction_key, None)
+        if eyes_event_id:
             self._schedule_reaction_redaction(
                 room_id,
                 eyes_event_id,
                 "processing complete",
             )
-        await self._send_reaction(
+
+        # This mainly protects idempotent/recovered state.  A normal new turn
+        # already removes the previous terminal event in on_processing_start.
+        previous_terminal_event_id = state.terminal_event_id
+        state.terminal_event_id = None
+        state.terminal_emoji = None
+        await self._redact_tracked_reaction(
             room_id,
-            msg_id,
-            "\u2705" if outcome == ProcessingOutcome.SUCCESS else "\u274c",
+            previous_terminal_event_id,
+            "processing complete",
         )
+
+        terminal_emoji = "\u2705" if outcome == ProcessingOutcome.SUCCESS else "\u274c"
+        terminal_event_id = await self._send_reaction(
+            room_id,
+            target_event_id,
+            terminal_emoji,
+        )
+        if terminal_event_id:
+            state.terminal_event_id = terminal_event_id
+            state.terminal_emoji = terminal_emoji
+        if getattr(self, "_processing_reaction_scope", "message") != "thread":
+            # Message-scoped reactions do not need a reopening state after the
+            # terminal event is sent; avoid retaining one entry per message.
+            self._reaction_states.pop(reaction_key, None)
 
     async def _on_reaction(self, event: Any) -> None:
         """Handle incoming reaction events."""

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -22,6 +22,8 @@ Environment variables:
                             `platforms.matrix.extra.processing_reaction_scope`
                             accepts `message` (default) or `thread` to place
                             the state on the Matrix thread root event.
+                            `processing_reaction_state_limit` bounds completed
+                            thread state retained in memory (default: 500).
     MATRIX_REQUIRE_MENTION      Require @mention in rooms (default: true)
     MATRIX_FREE_RESPONSE_ROOMS  Comma-separated room IDs exempt from mention requirement
                                 (alias of matrix.free_response_rooms)
@@ -450,6 +452,7 @@ class _MatrixProcessingReactionState:
     eyes_event_id: str | None = None
     terminal_event_id: str | None = None
     terminal_emoji: str | None = None
+    active_message_ids: Set[str] = field(default_factory=set)
 
 
 @dataclass
@@ -994,6 +997,7 @@ class MatrixAdapter(BasePlatformAdapter):
     max_message_length = DEFAULT_MAX_MESSAGE_LENGTH
     _split_threshold = DEFAULT_MAX_MESSAGE_LENGTH - 100
     _processing_reaction_scope = "message"
+    _processing_reaction_state_limit = 500
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.MATRIX)
@@ -1130,6 +1134,11 @@ class MatrixAdapter(BasePlatformAdapter):
             )
             reaction_scope = "message"
         self._processing_reaction_scope = reaction_scope
+        raw_state_limit = config.extra.get("processing_reaction_state_limit", 500)
+        try:
+            self._processing_reaction_state_limit = max(1, int(raw_state_limit))
+        except (TypeError, ValueError):
+            self._processing_reaction_state_limit = 500
         self._pending_reactions: dict[tuple[str, str], str] = {}
         self._reaction_states: dict[
             tuple[str, str], _MatrixProcessingReactionState
@@ -3581,6 +3590,36 @@ class MatrixAdapter(BasePlatformAdapter):
             self._reaction_states = states
         return states.setdefault(reaction_key, _MatrixProcessingReactionState())
 
+    def _prune_completed_processing_reaction_states(
+        self,
+        protected_key: tuple[str, str] | None = None,
+    ) -> list[tuple[tuple[str, str], _MatrixProcessingReactionState]]:
+        """Drop old completed thread state while preserving active turns."""
+        states = getattr(self, "_reaction_states", None)
+        if not states:
+            return []
+        try:
+            limit = max(1, int(getattr(self, "_processing_reaction_state_limit", 500)))
+        except (TypeError, ValueError):
+            limit = 500
+        if len(states) <= limit:
+            return []
+
+        pending = getattr(self, "_pending_reactions", {})
+        removed: list[tuple[tuple[str, str], _MatrixProcessingReactionState]] = []
+        for key, state in list(states.items()):
+            if len(states) <= limit:
+                break
+            if key == protected_key:
+                continue
+            if getattr(state, "active_message_ids", set()):
+                continue
+            if state.eyes_event_id is not None or key in pending:
+                continue
+            states.pop(key, None)
+            removed.append((key, state))
+        return removed
+
     async def _redact_tracked_reaction(
         self,
         room_id: str,
@@ -3614,6 +3653,14 @@ class MatrixAdapter(BasePlatformAdapter):
         room_id, target_event_id = target
         reaction_key = (room_id, target_event_id)
         state = self._get_processing_reaction_state(reaction_key)
+        for expired_key, expired_state in self._prune_completed_processing_reaction_states(
+            protected_key=reaction_key
+        ):
+            await self._redact_tracked_reaction(
+                expired_key[0],
+                expired_state.terminal_event_id,
+                "processing state expired",
+            )
         state.generation += 1
         generation = state.generation
 
@@ -3623,6 +3670,8 @@ class MatrixAdapter(BasePlatformAdapter):
             event_generations = {}
             self._processing_event_generations = event_generations
         event_generations[(room_id, event_message_id)] = generation
+        if isinstance(event_message_id, str):
+            state.active_message_ids.add(event_message_id)
 
         previous_eyes_event_id = state.eyes_event_id
         previous_terminal_event_id = state.terminal_event_id
@@ -3684,6 +3733,7 @@ class MatrixAdapter(BasePlatformAdapter):
         event_message_id = event.message_id
         event_generations = getattr(self, "_processing_event_generations", {})
         event_generation = event_generations.pop((room_id, event_message_id), None)
+        state.active_message_ids.discard(event_message_id)
         if event_generation is not None and event_generation != state.generation:
             # A newer message in this thread owns the visible state.
             return

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -3073,6 +3073,156 @@ class TestMatrixReactions:
         self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", "\U0001f440")
         assert self.adapter._pending_reactions == {("!room:ex", "$msg1"): "$reaction_event_123"}
 
+    def test_processing_reaction_scope_reads_matrix_extra(self):
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        config = PlatformConfig(
+            enabled=True,
+            token="syt_test_token",
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+                "processing_reaction_scope": "thread",
+            },
+        )
+        adapter = MatrixAdapter(config)
+
+        assert adapter._processing_reaction_scope == "thread"
+
+    def test_thread_scope_without_thread_id_falls_back_to_message(self):
+        from gateway.platforms.base import MessageEvent, MessageType
+
+        self.adapter._processing_reaction_scope = "thread"
+        source = MagicMock()
+        source.chat_id = "!room:ex"
+        source.thread_id = None
+        event = MessageEvent(
+            text="plain message",
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message={},
+            message_id="$message",
+        )
+
+        assert self.adapter._processing_reaction_target(event) == (
+            "!room:ex",
+            "$message",
+        )
+
+    @pytest.mark.asyncio
+    async def test_thread_scope_reopens_parent_on_follow_up(self):
+        from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
+
+        self.adapter._reactions_enabled = True
+        self.adapter._processing_reaction_scope = "thread"
+        self.adapter._reaction_redaction_delay_seconds = 0
+        self.adapter._send_reaction = AsyncMock(
+            side_effect=["$eyes_root", "$check_root", "$eyes_reply"]
+        )
+        self.adapter._redact_reaction = AsyncMock(return_value=True)
+
+        root_source = MagicMock()
+        root_source.chat_id = "!room:ex"
+        root_source.thread_id = "$root"
+        root = MessageEvent(
+            text="root",
+            message_type=MessageType.TEXT,
+            source=root_source,
+            raw_message={},
+            message_id="$root",
+        )
+        await self.adapter.on_processing_start(root)
+        await self.adapter.on_processing_complete(root, ProcessingOutcome.SUCCESS)
+        await asyncio.sleep(0.01)
+
+        reply_source = MagicMock()
+        reply_source.chat_id = "!room:ex"
+        reply_source.thread_id = "$root"
+        reply = MessageEvent(
+            text="follow-up",
+            message_type=MessageType.TEXT,
+            source=reply_source,
+            raw_message={},
+            message_id="$reply",
+        )
+        await self.adapter.on_processing_start(reply)
+
+        self.adapter._redact_reaction.assert_any_await(
+            "!room:ex", "$check_root", "processing resumed"
+        )
+        assert self.adapter._send_reaction.call_args_list[-1].args == (
+            "!room:ex",
+            "$root",
+            "\U0001f440",
+        )
+        assert self.adapter._pending_reactions == {("!room:ex", "$root"): "$eyes_reply"}
+        state = self.adapter._reaction_states[("!room:ex", "$root")]
+        assert state.terminal_event_id is None
+        assert state.eyes_event_id == "$eyes_reply"
+
+    @pytest.mark.asyncio
+    async def test_thread_scope_stale_completion_does_not_overwrite_newer_state(self):
+        from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
+
+        self.adapter._reactions_enabled = True
+        self.adapter._processing_reaction_scope = "thread"
+        self.adapter._send_reaction = AsyncMock(
+            side_effect=["$eyes_first", "$eyes_second", "$check_second"]
+        )
+        self.adapter._redact_reaction = AsyncMock(return_value=True)
+
+        def make_event(message_id: str) -> MessageEvent:
+            source = MagicMock()
+            source.chat_id = "!room:ex"
+            source.thread_id = "$root"
+            return MessageEvent(
+                text=message_id,
+                message_type=MessageType.TEXT,
+                source=source,
+                raw_message={},
+                message_id=message_id,
+            )
+
+        first = make_event("$first")
+        second = make_event("$second")
+        await self.adapter.on_processing_start(first)
+        await self.adapter.on_processing_start(second)
+
+        await self.adapter.on_processing_complete(first, ProcessingOutcome.SUCCESS)
+        assert self.adapter._send_reaction.call_count == 2
+
+        await self.adapter.on_processing_complete(second, ProcessingOutcome.SUCCESS)
+        self.adapter._send_reaction.assert_called_with("!room:ex", "$root", "\u2705")
+
+    @pytest.mark.asyncio
+    async def test_thread_scope_cancelled_clears_parent_eyes(self):
+        from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
+
+        self.adapter._reactions_enabled = True
+        self.adapter._processing_reaction_scope = "thread"
+        self.adapter._send_reaction = AsyncMock(return_value="$eyes_root")
+        self.adapter._redact_reaction = AsyncMock(return_value=True)
+
+        source = MagicMock()
+        source.chat_id = "!room:ex"
+        source.thread_id = "$root"
+        event = MessageEvent(
+            text="cancel me",
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message={},
+            message_id="$message",
+        )
+        await self.adapter.on_processing_start(event)
+        await self.adapter.on_processing_complete(event, ProcessingOutcome.CANCELLED)
+
+        self.adapter._redact_reaction.assert_awaited_once_with(
+            "!room:ex",
+            "$eyes_root",
+            "processing cancelled",
+        )
+        assert self.adapter._pending_reactions == {}
+
     @pytest.mark.asyncio
     async def test_on_processing_complete_sends_check(self):
         from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -3088,6 +3088,24 @@ class TestMatrixReactions:
         adapter = MatrixAdapter(config)
 
         assert adapter._processing_reaction_scope == "thread"
+        assert adapter._processing_reaction_state_limit == 500
+
+    def test_processing_reaction_state_limit_is_configurable(self):
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        config = PlatformConfig(
+            enabled=True,
+            token="syt_test_token",
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+                "processing_reaction_scope": "thread",
+                "processing_reaction_state_limit": 2,
+            },
+        )
+        adapter = MatrixAdapter(config)
+
+        assert adapter._processing_reaction_state_limit == 2
 
     def test_thread_scope_without_thread_id_falls_back_to_message(self):
         from gateway.platforms.base import MessageEvent, MessageType
@@ -3222,6 +3240,45 @@ class TestMatrixReactions:
             "processing cancelled",
         )
         assert self.adapter._pending_reactions == {}
+
+    @pytest.mark.asyncio
+    async def test_thread_scope_prunes_completed_state_but_keeps_active_state(self):
+        from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
+
+        self.adapter._reactions_enabled = True
+        self.adapter._processing_reaction_scope = "thread"
+        self.adapter._processing_reaction_state_limit = 1
+        self.adapter._reaction_redaction_delay_seconds = 0
+        self.adapter._send_reaction = AsyncMock(
+            side_effect=["$eyes_old", "$check_old", "$eyes_active"]
+        )
+        self.adapter._redact_reaction = AsyncMock(return_value=True)
+
+        def make_event(thread_id: str, message_id: str) -> MessageEvent:
+            source = MagicMock()
+            source.chat_id = "!room:ex"
+            source.thread_id = thread_id
+            return MessageEvent(
+                text=message_id,
+                message_type=MessageType.TEXT,
+                source=source,
+                raw_message={},
+                message_id=message_id,
+            )
+
+        old = make_event("$old", "$old-message")
+        await self.adapter.on_processing_start(old)
+        await self.adapter.on_processing_complete(old, ProcessingOutcome.SUCCESS)
+        await asyncio.sleep(0.01)
+
+        active = make_event("$active", "$active-message")
+        await self.adapter.on_processing_start(active)
+
+        assert ("!room:ex", "$old") not in self.adapter._reaction_states
+        assert ("!room:ex", "$active") in self.adapter._reaction_states
+        self.adapter._redact_reaction.assert_awaited_with(
+            "!room:ex", "$check_old", "processing state expired"
+        )
 
     @pytest.mark.asyncio
     async def test_on_processing_complete_sends_check(self):

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -120,6 +120,19 @@ MATRIX_ALLOW_ROOM_MENTIONS=false
 `MATRIX_REACTIONS=false` turns off the processing-lifecycle emoji reactions (👀/✅/❌) the bot posts on inbound messages. Useful for rooms where reaction events are noisy or aren't supported by all participating clients.
 :::
 
+:::tip Thread-scoped processing reactions
+By default, processing reactions are attached to each inbound message. To keep one status marker on the Matrix thread root instead, opt in with:
+
+```yaml
+platforms:
+  matrix:
+    extra:
+      processing_reaction_scope: thread
+```
+
+With this setting, a follow-up message reopens the thread-root status (`✅`/`❌` → `👀`) and the latest completion updates that same root. Messages without a Matrix `thread_id` retain message-scoped behavior. Hermes only redacts reaction events it created during the current gateway process; existing reactions are not scanned or changed after a gateway restart.
+:::
+
 :::tip Room-wide mentions
 Hermes sends structured Matrix user mentions for explicit Matrix IDs such as `@alice:example.org`. Room-wide `@room` notifications are disabled by default; set `MATRIX_ALLOW_ROOM_MENTIONS=true` only in rooms where the bot is allowed to notify everyone.
 :::

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -128,9 +128,10 @@ platforms:
   matrix:
     extra:
       processing_reaction_scope: thread
+      processing_reaction_state_limit: 500
 ```
 
-With this setting, a follow-up message reopens the thread-root status (`✅`/`❌` → `👀`) and the latest completion updates that same root. Messages without a Matrix `thread_id` retain message-scoped behavior. Hermes only redacts reaction events it created during the current gateway process; existing reactions are not scanned or changed after a gateway restart.
+With this setting, a follow-up message reopens the thread-root status (`✅`/`❌` → `👀`) and the latest completion updates that same root. `processing_reaction_state_limit` bounds completed thread state retained in memory while preserving active turns. Messages without a Matrix `thread_id` retain message-scoped behavior. Hermes only redacts reaction events it created during the current gateway process; existing reactions are not scanned or changed after a gateway restart.
 :::
 
 :::tip Room-wide mentions


### PR DESCRIPTION
## Summary

- scope Matrix processing reactions to the originating thread
- preserve the thread relation for both the initial check and the completion cross/check
- document and test thread-scoped reaction behavior

This keeps processing markers attached to the conversation that triggered the work instead of leaking them to the room root or another thread.

## Verification

- `python3 -m pytest tests/gateway/test_matrix.py -k 'processing_reaction_scope or thread_scope' -q`
- `uvx --from ruff ruff check plugins/platforms/matrix/adapter.py tests/gateway/test_matrix.py`
- `python3 -m compileall -q plugins/platforms/matrix/adapter.py tests/gateway/test_matrix.py`
- `git diff --check`
