### PR TITLE
fix(cron): don't report script-job failures as provider/fallback errors

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -102,8 +102,21 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     text = (error or "unknown error").strip()
     lower = text.lower()
 
+    # The provider-shaped branches below are substring heuristics written for
+    # agent runs. A ``no_agent`` job never touches a provider — the script IS
+    # the job — so there is no fallback chain to exhaust and no auth to fail.
+    # Its errors come from the script runner ("Script timed out after 12600s:
+    # /path/to/x.sh", "Script exited with code 1"), and those strings trip the
+    # timeout heuristic: operators were told a shell-script timeout was a
+    # "provider timeout" and went debugging fallback chains. Script-job errors
+    # skip straight to the generic cleaned-message path, which reports the real
+    # failure. Jobs with a ``script`` but no ``no_agent`` still run an agent
+    # (the script is pre-run data collection whose failure is injected into the
+    # prompt, never returned as the job error), so they keep the provider wording.
+    uses_provider = not job.get("no_agent")
+
     # Provider/API failures are the common noisy path. Keep these short.
-    if "429" in text or "rate limit" in lower or "usage limit" in lower:
+    if uses_provider and ("429" in text or "rate limit" in lower or "usage limit" in lower):
         reason = "rate limit"
         if "weekly usage limit" in lower:
             reason = "weekly usage limit"
@@ -115,7 +128,7 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
             "Full details saved in cron output."
         )
 
-    if "readtimeout" in lower or "timed out" in lower or "timeout" in lower:
+    if uses_provider and ("readtimeout" in lower or "timed out" in lower or "timeout" in lower):
         return (
             f"⚠️ Cron '{job_name}' failed: provider timeout. "
             "Fallback chain was exhausted or unavailable. "
@@ -125,7 +138,9 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     # Match authentication/authorization wording at a word boundary and the
     # 401/403 status codes as whole tokens, so "oauth", "4015" and similar do
     # not trip a misleading auth message.
-    if re.search(r"authenticat|authoriz", lower) or re.search(r"\b(401|403)\b", text):
+    if uses_provider and (
+        re.search(r"authenticat|authoriz", lower) or re.search(r"\b(401|403)\b", text)
+    ):
         return (
             f"⚠️ Cron '{job_name}' failed: provider authentication error. "
             "Full details saved in cron output."

--- a/tests/cron/test_cron_failure_summary.py
+++ b/tests/cron/test_cron_failure_summary.py
@@ -1,0 +1,149 @@
+"""Regression guard — script-job failures must not be reported as provider errors.
+
+``_summarize_cron_failure_for_delivery`` classifies a failed cron run into a
+one-line chat message using substring heuristics ("timed out", "429",
+"authenticat"). Those heuristics describe an agent run talking to an LLM
+provider, but they were applied to every job, including ``no_agent`` script
+jobs that never contact a provider at all.
+
+Real-world symptom: a nightly ``no_agent`` script hit its script timeout and
+the runner returned ``Script timed out after 12600s: /path/podcast-nightly.sh``.
+That string contains "timed out", so the operator was told:
+
+    ⚠️ Cron 'podcast-adcut-nightly' failed: provider timeout.
+    Fallback chain was exhausted or unavailable.
+
+— and went debugging LLM providers and fallback chains for a shell-script
+timeout. Script jobs now fall through to the generic cleaned-message path so
+the real error is shown; agent jobs keep the provider wording.
+"""
+
+import sys
+from pathlib import Path
+
+# Ensure project root is importable
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cron.scheduler import _summarize_cron_failure_for_delivery
+
+
+PROVIDER_WORDING = ("provider", "fallback chain")
+
+
+def _script_job(name="podcast-adcut-nightly"):
+    return {"id": "job-1", "name": name, "no_agent": True, "script": "/x.sh"}
+
+
+def _agent_job(name="daily-briefing"):
+    return {"id": "job-2", "name": name, "prompt": "summarize the news"}
+
+
+def _assert_no_provider_wording(msg):
+    lowered = msg.lower()
+    for phrase in PROVIDER_WORDING:
+        assert phrase not in lowered, f"{phrase!r} leaked into script-job message: {msg}"
+
+
+# --- script jobs: no provider, no fallback chain -------------------------
+
+def test_script_timeout_is_not_reported_as_provider_timeout():
+    """The #podcast-adcut-nightly symptom: "timed out" is the SCRIPT's."""
+    msg = _summarize_cron_failure_for_delivery(
+        _script_job(),
+        "Script timed out after 12600s: /Users/x/scripts/podcast-nightly.sh",
+    )
+    _assert_no_provider_wording(msg)
+    assert "Script timed out after 12600s" in msg
+    assert "podcast-nightly.sh" in msg
+    assert "podcast-adcut-nightly" in msg
+
+
+def test_script_nonzero_exit_surfaces_the_script_error():
+    msg = _summarize_cron_failure_for_delivery(
+        _script_job(), "Script exited with code 1\nstderr:\nboom",
+    )
+    _assert_no_provider_wording(msg)
+    assert "Script exited with code 1" in msg
+
+
+def test_script_job_rate_limit_wording_in_script_output_is_not_provider_framed():
+    """A script whose own output says "rate limit" is still a script failure."""
+    msg = _summarize_cron_failure_for_delivery(
+        _script_job(),
+        "Script exited with code 1\nstderr:\ncurl: API returned 429 rate limit",
+    )
+    _assert_no_provider_wording(msg)
+    assert "Script exited with code 1" in msg
+
+
+def test_script_job_auth_wording_in_script_output_is_not_provider_framed():
+    msg = _summarize_cron_failure_for_delivery(
+        _script_job(),
+        "Script exited with code 1\nstderr:\nrsync: authentication failed (403)",
+    )
+    _assert_no_provider_wording(msg)
+    assert "Script exited with code 1" in msg
+
+
+def test_script_job_without_script_field_still_avoids_provider_wording():
+    """``no_agent`` alone is enough to disqualify the provider branches."""
+    msg = _summarize_cron_failure_for_delivery(
+        {"id": "job-3", "name": "watchdog", "no_agent": True},
+        "no_agent=True but no script is set for this job",
+    )
+    _assert_no_provider_wording(msg)
+    assert "no script is set" in msg
+
+
+# --- agent jobs: provider wording must be preserved ----------------------
+
+def test_agent_job_provider_timeout_message_unchanged():
+    msg = _summarize_cron_failure_for_delivery(
+        _agent_job(), "httpx.ReadTimeout: request timed out after 600s",
+    )
+    assert msg == (
+        "⚠️ Cron 'daily-briefing' failed: provider timeout. "
+        "Fallback chain was exhausted or unavailable. "
+        "Full details saved in cron output."
+    )
+
+
+def test_agent_job_rate_limit_message_unchanged():
+    msg = _summarize_cron_failure_for_delivery(
+        _agent_job(), "Error code: 429 - rate limit exceeded",
+    )
+    assert msg == (
+        "⚠️ Cron 'daily-briefing' failed: provider rate limit. "
+        "Fallback chain was exhausted or unavailable. "
+        "Full details saved in cron output."
+    )
+
+
+def test_agent_job_weekly_usage_limit_message_unchanged():
+    msg = _summarize_cron_failure_for_delivery(
+        _agent_job(), "weekly usage limit reached for this account",
+    )
+    assert "provider weekly usage limit" in msg
+    assert "Fallback chain was exhausted or unavailable." in msg
+
+
+def test_agent_job_auth_message_unchanged():
+    msg = _summarize_cron_failure_for_delivery(
+        _agent_job(), "401 authentication_error: invalid x-api-key",
+    )
+    assert msg == (
+        "⚠️ Cron 'daily-briefing' failed: provider authentication error. "
+        "Full details saved in cron output."
+    )
+
+
+def test_agent_job_with_prerun_script_keeps_provider_wording():
+    """A ``script`` without ``no_agent`` is a data-collection pre-run step; the
+    job still calls a provider, so provider failures keep their message."""
+    job = {"id": "job-4", "name": "market-watch", "script": "/collect.sh",
+           "prompt": "analyze"}
+    msg = _summarize_cron_failure_for_delivery(
+        job, "httpx.ReadTimeout: request timed out",
+    )
+    assert "provider timeout" in msg
+    assert "Fallback chain was exhausted or unavailable." in msg


### PR DESCRIPTION
## What does this PR do?

`_summarize_cron_failure_for_delivery()` turns a failed cron job into the one-line message the operator receives in chat. It classifies the failure with substring heuristics — rate limit, timeout, auth — and each of those replies talks about a **provider** and a **fallback chain**.

Those heuristics were applied unconditionally, including to `no_agent` script jobs. A `no_agent` job never contacts a provider; the script *is* the job. So there is no fallback chain to exhaust and no provider auth to fail.

The script runner emits errors like `Script timed out after 12600s: /path/to/x.sh` (`cron/scheduler.py`) — which contains the substring `timed out`, so it hit the provider-timeout branch.

**Real-world impact.** A nightly `no_agent` shell job of mine was killed by cron's own `script_timeout_seconds`. What arrived in Telegram was:

> ⚠️ Cron 'podcast-adcut-nightly' failed: provider timeout. Fallback chain was exhausted or unavailable. Full details saved in cron output.

There was no provider involved anywhere in that job. The message sent me debugging model fallback chains and provider credentials for what was a shell-script timeout. The accurate error was sitting in the cron output directory the whole time.

After this change the same failure reports:

> ⚠️ Cron 'podcast-adcut-nightly' failed: Script timed out after 12600s: /Users/…/podcast-nightly.sh

### Why gate on `no_agent` and not on `script`

A job can carry a `script` *and* still run an agent — there the script is a pre-run data-collection step, and if it fails its output is injected into the prompt as a `## Script Error` block and the agent runs anyway (`cron/scheduler.py`). A script failure in that mode never becomes the job's `error`, so gating on `script` would only ever fire when such a job's *provider* genuinely failed — degrading a correct provider-timeout message into a raw exception dump.

`no_agent` is the exact "no provider is involved" signal, and it is validated at creation time to require a script (`cron/jobs.py`: `no_agent=True requires a script`).

## Related Issue

No existing issue — filing this alongside the fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py` — `_summarize_cron_failure_for_delivery()`: introduce `uses_provider = not job.get("no_agent")` and gate the rate-limit, timeout and auth branches on it. Script-job failures fall through to the existing generic cleaned-message path, which reports the real error. No other logic touched (+18/−3).
- `tests/cron/test_cron_failure_summary.py` — new, 10 tests.

## How to Test

Reproduce the bug on `main`:

```python
from cron.scheduler import _summarize_cron_failure_for_delivery as f
job = {"name": "nightly", "no_agent": True, "script": "x.sh"}
f(job, "Script timed out after 12600s: /path/to/x.sh")
# -> "⚠️ Cron 'nightly' failed: provider timeout. Fallback chain was exhausted or unavailable. ..."
```

With this PR the same call returns `⚠️ Cron 'nightly' failed: Script timed out after 12600s: /path/to/x.sh`.

Test suite:

```
$ pytest tests/cron/test_cron_failure_summary.py -q
..........                                                               [100%]
10 passed in 0.27s

$ pytest tests/cron/test_cron_script.py tests/cron/test_cron_no_agent.py tests/cron/test_shutdown_interrupt.py -q
75 passed in 3.46s
```

The new tests cover 5 script-job cases (script timeout, non-zero exit, script stderr containing `429`, script stderr containing an auth string, `no_agent` with a missing script) and 5 agent-job regression locks (provider timeout, rate limit, weekly usage limit, auth, and the script-plus-agent pre-run case).

Guard value verified: with the fix reverted and the new tests kept, 3 of them fail (script-timeout, script-429, script-auth).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **ran the cron test packages listed above (85 passed), not the full suite**: the whole suite self-aborts on this macOS machine for reasons unrelated to this change. Happy for CI to be the arbiter.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal helper; the explanatory comment lives with the code)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (pure string/dict logic, no platform-specific paths)
- [x] I've updated tool descriptions/schemas — N/A
