### PR TITLE
feat(cron): opt-in clarify support for cron agents via cron.allow_clarify

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -158,19 +158,26 @@ class CronPromptInjectionBlocked(Exception):
 
 
 def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
-    """Toolsets a cron-spawned agent must never receive.
+    """Toolsets a cron-spawned agent must not receive.
 
-    Three protected toolsets are always disabled in cron context:
+    Two protected toolsets are always disabled in cron context:
       - ``cronjob`` — would let a cron-spawned agent schedule more cron jobs
       - ``messaging`` — interactive, needs a live gateway session
-      - ``clarify`` — interactive, blocks waiting for user input
+
+    ``clarify`` is also disabled unless the operator opts in with
+    ``cron.allow_clarify: true``. Unattended jobs have nobody to answer a
+    clarify prompt, so the default stays fully autonomous; the opt-in wires a
+    callback over the job's live delivery adapter (see
+    ``_build_cron_clarify_callback``).
 
     User-level ``agent.disabled_toolsets`` from config.yaml is layered on top
     so per-job ``enabled_toolsets`` cannot bypass policy that applies to
     ordinary agent runs (#25752 — LLM-supplied enabled_toolsets was widening
     past config.yaml's denylist).
     """
-    disabled = ["cronjob", "messaging", "clarify"]
+    disabled = ["cronjob", "messaging"]
+    if not bool(((cfg or {}).get("cron") or {}).get("allow_clarify", False)):
+        disabled.append("clarify")
     agent_cfg = (cfg or {}).get("agent") or {}
     user_disabled = agent_cfg.get("disabled_toolsets") or []
     for name in user_disabled:
@@ -242,6 +249,122 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
             exc,
         )
         return None
+
+
+# Platform hint for cron sessions when cron.allow_clarify is enabled. Replaces
+# the default autonomous-execution hint (PLATFORM_HINTS["cron"], which tells
+# the model it cannot ask questions) so the hint and the available clarify
+# tool don't contradict each other. An explicit agent.platform_hints.cron
+# override in config.yaml always wins over this.
+_CRON_CLARIFY_PLATFORM_HINT = (
+    "You are running as a scheduled cron job with human-in-the-loop support "
+    "enabled. A user is reachable through the job's delivery channel: use the "
+    "clarify tool when a decision genuinely needs their input, but never block "
+    "on it for routine choices — if a clarify prompt times out or cannot be "
+    "delivered, proceed autonomously with a reasonable default. Your final "
+    "response is automatically delivered to the job's configured destination "
+    "— put the primary content directly in your response."
+)
+
+
+def _build_cron_clarify_callback(job: dict, adapters, loop, session_id):
+    """Build a clarify_callback for a cron-spawned agent.
+
+    Renders the clarify prompt through the live gateway adapter for the job's
+    first delivery target (e.g. Discord buttons in the delivery channel) and
+    blocks until the user answers or ``agent.clarify_timeout`` elapses.
+
+    Mirrors gateway/run.py's ``_clarify_callback_sync``; the cron-specific
+    difference is that the target chat comes from the job's delivery config,
+    not an inbound message event (a cron session has no attached chat). The
+    wait reuses clarify_gateway.wait_for_response, which polls in 1-second
+    slices and heartbeats the activity tracker, so the cron inactivity
+    watchdog (HERMES_CRON_TIMEOUT, default 600s) does not kill the run while
+    the user is deciding.
+
+    Returns None when no live adapter with ``send_clarify`` exists for the
+    job's delivery targets — the caller then leaves clarify_callback unset
+    and the tool reports its standard "not available in this execution
+    context" error.
+    """
+    from gateway.config import load_gateway_config, Platform
+    from gateway.delivery import resolve_delivery_transport
+
+    targets = _resolve_delivery_targets(job)
+    if not targets:
+        return None
+    try:
+        gw_config = load_gateway_config()
+    except Exception:
+        return None
+    if not loop.is_running():
+        return None
+
+    adapter = None
+    chat_id = None
+    thread_id = None
+    for target in targets:
+        try:
+            platform = Platform(str(target.get("platform", "")).lower())
+        except (ValueError, KeyError):
+            continue
+        transport = resolve_delivery_transport(platform, gw_config, adapters)
+        candidate = transport.adapter if transport is not None else None
+        if candidate is not None and callable(getattr(candidate, "send_clarify", None)):
+            adapter = candidate
+            chat_id = str(target.get("chat_id") or "")
+            thread_id = target.get("thread_id")
+            break
+    if adapter is None or not chat_id:
+        return None
+
+    job_id = job["id"]
+
+    def _cron_clarify_callback(question, choices, multi_select=False):
+        import asyncio
+        import uuid as _uuid
+
+        from tools import clarify_gateway as _clarify_mod
+
+        clarify_id = _uuid.uuid4().hex[:10]
+        sess_key = session_id or f"cron:{job_id}"
+        _clarify_mod.register(
+            clarify_id=clarify_id,
+            session_key=sess_key,
+            question=question,
+            choices=list(choices) if choices else None,
+            multi_select=bool(multi_select),
+        )
+
+        send_ok = False
+        try:
+            fut = asyncio.run_coroutine_threadsafe(
+                adapter.send_clarify(
+                    chat_id=chat_id,
+                    question=question,
+                    choices=list(choices) if choices else None,
+                    clarify_id=clarify_id,
+                    session_key=sess_key,
+                    metadata={"thread_id": thread_id} if thread_id else None,
+                ),
+                loop,
+            )
+            result = fut.result(timeout=15)
+            send_ok = bool(getattr(result, "success", False))
+        except Exception as exc:
+            logger.warning("Job '%s': clarify send failed: %s", job_id, exc)
+        if not send_ok:
+            _clarify_mod.clear_session(sess_key)
+            return "[clarify prompt could not be delivered]"
+
+        timeout = float(_clarify_mod.get_clarify_timeout())
+        response = _clarify_mod.wait_for_response(clarify_id, timeout=timeout)
+        if response is None or response == "":
+            return f"[user did not respond within {int(max(timeout, 0) / 60)}m]"
+        return response
+
+    return _cron_clarify_callback
+
 
 # Valid delivery platforms — used to validate user-supplied platform names
 # in cron delivery targets, preventing env var enumeration via crafted names.
@@ -2751,7 +2874,8 @@ def _guard_job_credential_exfil(job: dict) -> None:
 
 
 def run_job(
-    job: dict, *, defer_agent_teardown: Optional[list] = None
+    job: dict, *, defer_agent_teardown: Optional[list] = None,
+    adapters=None, loop=None,
 ) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
@@ -2765,6 +2889,12 @@ def run_job(
     torn-down async client (defense-in-depth alongside the interpreter-shutdown
     guard). When ``None`` (the default) teardown happens inline as before, so
     every existing caller is unchanged.
+
+    ``adapters`` / ``loop``: the gateway's live platform-adapter map and event
+    loop, present when the job is fired by the gateway ticker. They are only
+    used to wire a clarify callback when ``cron.allow_clarify`` is enabled.
+    Standalone ``hermes cron run`` fires pass neither, so clarify stays
+    unavailable there by design.
 
     Returns:
         Tuple of (success, full_output_doc, final_response, error_message)
@@ -3506,7 +3636,41 @@ def run_job(
             session_id=_cron_session_id,
             session_db=_session_db,
         )
-        
+
+        # cron.allow_clarify opt-in: when this run was fired by the gateway
+        # ticker (live adapters + loop present), attach a clarify callback
+        # over the job's delivery adapter and swap the autonomous-only cron
+        # platform hint for its human-in-the-loop variant. Standalone
+        # `hermes cron run` fires have no live adapter, so clarify keeps
+        # reporting "not available in this execution context" there.
+        try:
+            if (
+                bool((_cfg.get("cron") or {}).get("allow_clarify", False))
+                and adapters is not None and loop is not None
+            ):
+                _clarify_cb = _build_cron_clarify_callback(
+                    job, adapters, loop, _cron_session_id,
+                )
+                if _clarify_cb is not None:
+                    agent.clarify_callback = _clarify_cb
+                    _hint_overrides = getattr(agent, "_platform_hint_overrides", None)
+                    if not isinstance(_hint_overrides, dict):
+                        _hint_overrides = {}
+                    # An explicit operator platform-hint override always wins.
+                    if "cron" not in _hint_overrides:
+                        agent._platform_hint_overrides = {
+                            **_hint_overrides,
+                            "cron": {"replace": _CRON_CLARIFY_PLATFORM_HINT},
+                        }
+                    logger.info(
+                        "Job '%s': clarify enabled (live adapter attached)", job_id,
+                    )
+        except Exception as _clarify_exc:
+            logger.warning(
+                "Job '%s': clarify setup failed (non-fatal): %s",
+                job_id, _clarify_exc,
+            )
+
         # Run the agent with an *inactivity*-based timeout: the job can run
         # for hours if it's actively calling tools / receiving stream tokens,
         # but a hung API call or stuck tool with no activity for the configured
@@ -3943,7 +4107,8 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         _deferred_agents: list = []
         try:
             success, output, final_response, error = run_job(
-                job, defer_agent_teardown=_deferred_agents
+                job, defer_agent_teardown=_deferred_agents,
+                adapters=adapters, loop=loop,
             )
         except BaseException:
             # run_job's finally still hands back the agent when it raises; tear

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -267,7 +267,34 @@ _CRON_CLARIFY_PLATFORM_HINT = (
 )
 
 
-def _cron_clarify_reply_session_key(job: dict, target: dict, platform, gw_config):
+def _platform_dm_hint(platform_name: str, chat_id: str) -> Optional[bool]:
+    """Deterministic DM detection for platforms whose chat ids encode it.
+
+    Slack DM channel ids start with "D" (channels with "C"/"G"); Telegram
+    private-chat ids are positive integers (groups/supergroups negative) —
+    same rule as ``gateway.delivery.looks_like_telegram_private_chat_id``.
+    Returns None when the platform's ids don't encode the distinction
+    (Discord snowflakes) so the caller can fall back to the origin stamp or
+    the live adapter's ``get_chat_info``.
+    """
+    if platform_name == "slack":
+        return chat_id.startswith("D")
+    if platform_name == "telegram":
+        from gateway.delivery import looks_like_telegram_private_chat_id
+        return looks_like_telegram_private_chat_id(chat_id)
+    return None
+
+
+# Inbound ``chat_type`` for threaded surfaces, where it differs from the
+# container: Discord stamps thread messages ``"thread"`` (with
+# chat_id == thread_id), Telegram stamps forum topics ``"forum"``. Slack
+# threads key as the container (dm/group) + thread_id.
+_THREAD_CHAT_TYPES = {"discord": "thread", "telegram": "forum"}
+
+
+def _cron_clarify_reply_session_key(
+    job: dict, target: dict, platform, gw_config, *, chat_type_hint: Optional[str] = None
+):
     """Session key a text reply in the delivery chat will resolve to.
 
     The gateway intercepts typed clarify answers by the INBOUND chat's
@@ -275,51 +302,94 @@ def _cron_clarify_reply_session_key(job: dict, target: dict, platform, gw_config
     ``build_session_key``), so a cron clarify must register under the key the
     user's reply produces — the cron job's own session id never matches, and
     typed answers (open-ended clarifies, text fallback, the native-button
-    "Other" path) would hang until timeout. Key rules mirror
-    ``_seed_cron_channel_session`` / ``_seed_cron_thread_session``:
+    "Other" path) would hang until timeout.
 
-      * thread targets — participant-shared (``chat_type="thread"``), no user;
-      * DM targets     — key on chat_id alone (``chat_type="dm"``);
-      * group/channel  — user-isolated: bind to the job's origin user, only
-        when the delivery target IS the origin conversation (a fan-out target
-        cannot predict who will reply).
+    Chat-type resolution, most authoritative first:
+
+      * ``chat_type_hint`` — the live delivery adapter's ``get_chat_info``
+        for the actual target (resolved by the caller at fire time);
+      * the job's origin ``chat_type``/``scope_id`` stamp (written by
+        ``cronjob_tools._origin_from_env`` for chat-created jobs);
+      * deterministic platform id heuristics (``_platform_dm_hint``).
+
+    Key shapes mirror how each platform stamps inbound sources: DM targets
+    key on chat_id alone; thread surfaces are participant-shared (Discord
+    ``thread`` with chat_id remapped to the thread id — inbound thread
+    messages stamp chat_id = thread_id — Telegram ``forum``, Slack
+    container+thread_id); group/channel targets bind to the job's origin
+    user, only when the delivery target IS the origin conversation (a fan-out
+    target cannot predict who will reply). Slack ``scope_id`` is carried from
+    the origin stamp when present.
 
     Returns None when no deterministic key exists (fan-out group target with
-    per-user sessions): the caller falls back to the cron session id and
-    typed replies simply don't resolve — buttons and the timeout path are
-    unaffected.
+    per-user sessions, or ``thread_sessions_per_user`` isolation): the caller
+    falls back to the cron session id and typed replies simply don't resolve
+    — buttons and the timeout path are unaffected.
     """
     from gateway.session import SessionSource, build_session_key
 
     origin = _resolve_origin(job) or {}
+    platform_name = platform.value if hasattr(platform, "value") else str(platform)
     chat_id = str(target.get("chat_id") or "")
     thread_id = target.get("thread_id")
-    if thread_id:
+    scope_id = origin.get("scope_id") or None
+
+    target_is_origin = _target_matches_origin(
+        origin, platform_name, chat_id, thread_id,
+    )
+    origin_chat_type = (
+        str(origin.get("chat_type") or "").lower() if target_is_origin else ""
+    )
+
+    if thread_id and platform_name == "discord":
+        # Discord thread surfaces key as thread:<thread_id>:<thread_id> —
+        # inbound thread messages stamp chat_id = thread_id, so an explicit
+        # parent:thread target must remap to the thread id.
         chat_type = "thread"
+        chat_id = str(thread_id)
         user_id = None
+    elif thread_id:
+        chat_type = _THREAD_CHAT_TYPES.get(platform_name)
+        if chat_type is None:
+            # Slack-style: threads key as the container (dm/group) + thread_id.
+            hint = _platform_dm_hint(platform_name, chat_id)
+            if chat_type_hint in ("dm", "group"):
+                hint = chat_type_hint == "dm"
+            elif origin_chat_type in ("dm", "group"):
+                hint = origin_chat_type == "dm"
+            chat_type = "dm" if hint else "group"
+        user_id = None  # threads are participant-shared by default
     else:
-        target_is_origin = _target_matches_origin(
-            origin, str(target.get("platform", "")).lower(), chat_id, None,
-        )
-        origin_chat_type = (
-            str(origin.get("chat_type") or "").lower() if target_is_origin else ""
-        )
-        is_dm = origin_chat_type == "dm" or (
-            not origin_chat_type and chat_id.startswith("D")
-        )
+        if chat_type_hint in ("dm", "group"):
+            is_dm = chat_type_hint == "dm"
+        elif origin_chat_type in ("dm", "group"):
+            is_dm = origin_chat_type == "dm"
+        else:
+            is_dm = bool(_platform_dm_hint(platform_name, chat_id))
         chat_type = "dm" if is_dm else "group"
         user_id = None
         if not is_dm and target_is_origin and origin.get("user_id"):
             user_id = str(origin["user_id"])
+
     group_sessions = getattr(gw_config, "group_sessions_per_user", True)
-    if chat_type == "group" and group_sessions and not user_id:
+    if chat_type == "group" and group_sessions and not user_id and not thread_id:
         return None
+    if (
+        thread_id
+        and group_sessions
+        and getattr(gw_config, "thread_sessions_per_user", False)
+    ):
+        # Thread replies key per-user in this configuration — the replying
+        # user is unpredictable for a scheduled prompt.
+        return None
+
     source = SessionSource(
         platform=platform,
         chat_id=chat_id,
         chat_type=chat_type,
         user_id=user_id,
         thread_id=str(thread_id) if thread_id else None,
+        scope_id=scope_id,
     )
     return build_session_key(
         source,
@@ -399,7 +469,30 @@ def _build_cron_clarify_callback(job: dict, adapters, loop):
 
     job_id = job["id"]
 
-    reply_key = _cron_clarify_reply_session_key(job, chosen_target, platform, gw_config)
+    # Resolve the target chat's type from the live adapter when possible —
+    # the delivering adapter knows the chat (Discord DM vs guild channel is
+    # not derivable from a snowflake id). One bounded call per job fire;
+    # every failure degrades to the origin stamp / platform heuristics.
+    chat_type_hint = None
+    if not thread_id:
+        get_info = getattr(adapter, "get_chat_info", None)
+        if callable(get_info):
+            try:
+                import asyncio as _asyncio
+
+                _info_fut = _asyncio.run_coroutine_threadsafe(
+                    get_info(chat_id), loop,
+                )
+                info = _info_fut.result(timeout=5)
+                if isinstance(info, dict) and info.get("type"):
+                    _t = str(info["type"]).strip().lower()
+                    chat_type_hint = "dm" if _t == "dm" else "group"
+            except Exception:
+                chat_type_hint = None
+
+    reply_key = _cron_clarify_reply_session_key(
+        job, chosen_target, platform, gw_config, chat_type_hint=chat_type_hint,
+    )
     if reply_key is not None:
         logger.info(
             "Job '%s': clarify text replies bind to session key %s",
@@ -444,15 +537,23 @@ def _build_cron_clarify_callback(job: dict, adapters, loop):
             result = fut.result(timeout=15)
             send_ok = bool(getattr(result, "success", False))
         except Exception as exc:
+            fut.cancel()
             logger.warning("Job '%s': clarify send failed: %s", job_id, exc)
         if not send_ok:
-            _clarify_mod.clear_session(sess_key)
+            # Drop ONLY this entry — clear_session would also cancel an
+            # unrelated interactive clarify pending in the same chat.
+            _clarify_mod.discard(clarify_id)
             return "[clarify prompt could not be delivered]"
 
         timeout = float(_clarify_mod.get_clarify_timeout())
         response = _clarify_mod.wait_for_response(clarify_id, timeout=timeout)
         if response is None or response == "":
-            return f"[user did not respond within {int(max(timeout, 0) / 60)}m]"
+            _wait_desc = (
+                f"{int(timeout)}s"
+                if 0 < timeout < 60
+                else f"{max(1, int(max(timeout, 0) / 60))}m"
+            )
+            return f"[user did not respond within {_wait_desc}]"
         return response
 
     return _cron_clarify_callback

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -267,20 +267,93 @@ _CRON_CLARIFY_PLATFORM_HINT = (
 )
 
 
-def _build_cron_clarify_callback(job: dict, adapters, loop, session_id):
+def _cron_clarify_reply_session_key(job: dict, target: dict, platform, gw_config):
+    """Session key a text reply in the delivery chat will resolve to.
+
+    The gateway intercepts typed clarify answers by the INBOUND chat's
+    session key (``GatewayRunner._maybe_intercept_clarify_text`` →
+    ``build_session_key``), so a cron clarify must register under the key the
+    user's reply produces — the cron job's own session id never matches, and
+    typed answers (open-ended clarifies, text fallback, the native-button
+    "Other" path) would hang until timeout. Key rules mirror
+    ``_seed_cron_channel_session`` / ``_seed_cron_thread_session``:
+
+      * thread targets — participant-shared (``chat_type="thread"``), no user;
+      * DM targets     — key on chat_id alone (``chat_type="dm"``);
+      * group/channel  — user-isolated: bind to the job's origin user, only
+        when the delivery target IS the origin conversation (a fan-out target
+        cannot predict who will reply).
+
+    Returns None when no deterministic key exists (fan-out group target with
+    per-user sessions): the caller falls back to the cron session id and
+    typed replies simply don't resolve — buttons and the timeout path are
+    unaffected.
+    """
+    from gateway.session import SessionSource, build_session_key
+
+    origin = _resolve_origin(job) or {}
+    chat_id = str(target.get("chat_id") or "")
+    thread_id = target.get("thread_id")
+    if thread_id:
+        chat_type = "thread"
+        user_id = None
+    else:
+        target_is_origin = _target_matches_origin(
+            origin, str(target.get("platform", "")).lower(), chat_id, None,
+        )
+        origin_chat_type = (
+            str(origin.get("chat_type") or "").lower() if target_is_origin else ""
+        )
+        is_dm = origin_chat_type == "dm" or (
+            not origin_chat_type and chat_id.startswith("D")
+        )
+        chat_type = "dm" if is_dm else "group"
+        user_id = None
+        if not is_dm and target_is_origin and origin.get("user_id"):
+            user_id = str(origin["user_id"])
+    group_sessions = getattr(gw_config, "group_sessions_per_user", True)
+    if chat_type == "group" and group_sessions and not user_id:
+        return None
+    source = SessionSource(
+        platform=platform,
+        chat_id=chat_id,
+        chat_type=chat_type,
+        user_id=user_id,
+        thread_id=str(thread_id) if thread_id else None,
+    )
+    return build_session_key(
+        source,
+        group_sessions_per_user=group_sessions,
+        thread_sessions_per_user=getattr(gw_config, "thread_sessions_per_user", False),
+    )
+
+
+def _build_cron_clarify_callback(job: dict, adapters, loop):
     """Build a clarify_callback for a cron-spawned agent.
 
     Renders the clarify prompt through the live gateway adapter for the job's
     first delivery target (e.g. Discord buttons in the delivery channel) and
     blocks until the user answers or ``agent.clarify_timeout`` elapses.
 
-    Mirrors gateway/run.py's ``_clarify_callback_sync``; the cron-specific
-    difference is that the target chat comes from the job's delivery config,
-    not an inbound message event (a cron session has no attached chat). The
-    wait reuses clarify_gateway.wait_for_response, which polls in 1-second
-    slices and heartbeats the activity tracker, so the cron inactivity
-    watchdog (HERMES_CRON_TIMEOUT, default 600s) does not kill the run while
-    the user is deciding.
+    Mirrors gateway/run.py's ``_clarify_callback_sync`` with two cron-specific
+    differences:
+
+      * the target chat comes from the job's delivery config, not an inbound
+        message event (a cron session has no attached chat);
+      * the pending entry registers under the DELIVERY CHAT's gateway session
+        key (see ``_cron_clarify_reply_session_key``) so typed answers from
+        that chat — open-ended clarifies, text fallback, the native-button
+        "Other" path — resolve through the same inbound text intercept the
+        interactive path uses. Button clicks resolve by clarify_id either
+        way. When the target is a relay-fronted platform the send stamps the
+        logical platform via the ``_relay_logical_platform`` metadata escape
+        hatch (same convention as cron delivery), since a scheduled send has
+        no inbound event to populate the relay's per-chat platform map.
+
+    The wait reuses clarify_gateway.wait_for_response, which polls in
+    1-second slices and heartbeats the activity tracker, so the cron
+    inactivity watchdog (HERMES_CRON_TIMEOUT, default 600s) does not kill the
+    run while the user is deciding.
 
     Returns None when no live adapter with ``send_clarify`` exists for the
     job's delivery targets — the caller then leaves clarify_callback unset
@@ -301,24 +374,43 @@ def _build_cron_clarify_callback(job: dict, adapters, loop, session_id):
         return None
 
     adapter = None
+    platform = None
     chat_id = None
     thread_id = None
+    is_relay = False
+    chosen_target = None
     for target in targets:
         try:
-            platform = Platform(str(target.get("platform", "")).lower())
+            candidate_platform = Platform(str(target.get("platform", "")).lower())
         except (ValueError, KeyError):
             continue
-        transport = resolve_delivery_transport(platform, gw_config, adapters)
+        transport = resolve_delivery_transport(candidate_platform, gw_config, adapters)
         candidate = transport.adapter if transport is not None else None
         if candidate is not None and callable(getattr(candidate, "send_clarify", None)):
             adapter = candidate
+            platform = candidate_platform
             chat_id = str(target.get("chat_id") or "")
             thread_id = target.get("thread_id")
+            is_relay = bool(getattr(transport, "is_relay", False))
+            chosen_target = target
             break
     if adapter is None or not chat_id:
         return None
 
     job_id = job["id"]
+
+    reply_key = _cron_clarify_reply_session_key(job, chosen_target, platform, gw_config)
+    if reply_key is not None:
+        logger.info(
+            "Job '%s': clarify text replies bind to session key %s",
+            job_id, reply_key,
+        )
+
+    send_metadata = {}
+    if thread_id:
+        send_metadata["thread_id"] = thread_id
+    if is_relay:
+        send_metadata["_relay_logical_platform"] = platform.value
 
     def _cron_clarify_callback(question, choices, multi_select=False):
         import asyncio
@@ -327,7 +419,7 @@ def _build_cron_clarify_callback(job: dict, adapters, loop, session_id):
         from tools import clarify_gateway as _clarify_mod
 
         clarify_id = _uuid.uuid4().hex[:10]
-        sess_key = session_id or f"cron:{job_id}"
+        sess_key = reply_key or f"cron:{job_id}"
         _clarify_mod.register(
             clarify_id=clarify_id,
             session_key=sess_key,
@@ -345,7 +437,7 @@ def _build_cron_clarify_callback(job: dict, adapters, loop, session_id):
                     choices=list(choices) if choices else None,
                     clarify_id=clarify_id,
                     session_key=sess_key,
-                    metadata={"thread_id": thread_id} if thread_id else None,
+                    metadata=send_metadata or None,
                 ),
                 loop,
             )
@@ -3649,7 +3741,7 @@ def run_job(
                 and adapters is not None and loop is not None
             ):
                 _clarify_cb = _build_cron_clarify_callback(
-                    job, adapters, loop, _cron_session_id,
+                    job, adapters, loop,
                 )
                 if _clarify_cb is not None:
                     agent.clarify_callback = _clarify_cb

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -1637,7 +1637,15 @@ class RelayAdapter(BasePlatformAdapter):
         # in exactly one place — run.py's _resolve_progress_thread_id (flat mode
         # suppresses the synthetic self-anchor there; thread mode stamps the
         # turn's thread). Boundary pinned by test_run_py_suppresses_self_anchor*.
+        # Same escape hatch as send(): scheduled/persisted prompts (cron
+        # clarify, persisted-home deliveries) have no fresh inbound event to
+        # populate _platform_by_chat, so the caller stamps the logical
+        # platform explicitly. Stripped before the metadata goes out.
+        logical_platform = None
         prompt_metadata = metadata
+        if isinstance(prompt_metadata, dict) and "_relay_logical_platform" in prompt_metadata:
+            prompt_metadata = dict(prompt_metadata)
+            logical_platform = str(prompt_metadata.pop("_relay_logical_platform") or "") or None
         action: Dict[str, Any] = {
             "op": "prompt",
             "chat_id": chat_id,
@@ -1655,7 +1663,7 @@ class RelayAdapter(BasePlatformAdapter):
         try:
             result = await self._transport.send_outbound(
                 action,
-                platform=self._platform_by_chat.get(str(chat_id)),
+                platform=logical_platform or self._platform_by_chat.get(str(chat_id)),
             )
         except Exception:  # noqa: BLE001 - transport failure degrades to fallback
             logger.debug("relay prompt transport failure", exc_info=True)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2095,6 +2095,15 @@ DEFAULT_CONFIG = {
         # jobs from silently inheriting a paid default. Set to false only when
         # jobs should deliberately track changing global inference defaults.
         "model_drift_guard": True,
+        # Allow cron-spawned agents to use the clarify tool (human-in-the-loop
+        # questions/approvals from scheduled jobs). Default false: cron jobs
+        # run unattended, so clarify is hard-disabled and the platform hint
+        # instructs fully autonomous execution. When true AND the job fires
+        # from the gateway ticker with a live delivery adapter, clarify
+        # prompts render through the job's first delivery target (e.g.
+        # Discord buttons) and the agent waits up to agent.clarify_timeout
+        # for an answer before proceeding autonomously.
+        "allow_clarify": False,
         # Default inference model for cron jobs (Axis A — WHAT model an
         # agent job runs on). Resolution at fire time: per-job user pin >
         # cron.model > global model.default. When set, unpinned jobs follow

--- a/tests/cron/test_cron_clarify.py
+++ b/tests/cron/test_cron_clarify.py
@@ -6,23 +6,29 @@ execution. ``cron.allow_clarify: true`` opts a deployment into clarify
 prompts that render through the job's live delivery adapter (gateway-fired
 runs only) and block until the user answers or agent.clarify_timeout fires.
 
-Text-reply binding (review round 1): pending entries register under the
-DELIVERY CHAT's gateway session key — the same key the gateway's inbound
-text intercept resolves typed answers against — so open-ended clarifies,
-text fallback, and the native-button "Other" path work from the delivery
-chat. Fan-out group targets (no predictable replying user) fall back to the
-cron session key; button clicks resolve by clarify_id either way.
+Text-reply binding: pending entries register under the DELIVERY CHAT's
+gateway session key — the same key the gateway's inbound text intercept
+resolves typed answers against. Chat-type resolution is platform-aware
+(live-adapter get_chat_info hint → origin stamp → id heuristics), Slack
+scope_id is carried, Discord parent:thread targets remap to the thread id,
+and fan-out group targets fall back to the cron session key (buttons resolve
+by clarify_id either way).
 """
 import asyncio
 import threading
 import time
 import types
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 import cron.scheduler as s
 import gateway.config as gw_config
 import gateway.delivery as gw_delivery
+import gateway.session_context as session_context
+import tools.cronjob_tools as cronjob_tools
+from gateway.config import Platform
+from gateway.session import SessionSource
 from tools import clarify_gateway
 
 
@@ -49,6 +55,17 @@ class _FakeAdapter:
             "metadata": metadata,
         })
         return _SendResult(self.success)
+
+
+class _ChatInfoAdapter(_FakeAdapter):
+    """Fake adapter that also answers get_chat_info (the fire-time DM hint)."""
+
+    def __init__(self, chat_type, success=True):
+        super().__init__(success=success)
+        self._chat_type = chat_type
+
+    async def get_chat_info(self, chat_id):
+        return {"name": "chat", "type": self._chat_type}
 
 
 @pytest.fixture
@@ -85,9 +102,11 @@ def _patch_delivery(monkeypatch, adapter, *, targets=None, is_relay=False):
 
 
 def _run_callback(cb, *args):
-    """Invoke a clarify callback on a worker thread; returns (result dict, thread)."""
+    """Invoke a clarify callback on a daemon worker thread."""
     result = {}
-    caller = threading.Thread(target=lambda: result.setdefault("r", cb(*args)))
+    caller = threading.Thread(
+        target=lambda: result.setdefault("r", cb(*args)), daemon=True,
+    )
     caller.start()
     return result, caller
 
@@ -98,6 +117,34 @@ def _wait_sent(adapter):
             return adapter.sent[0]
         time.sleep(0.05)
     raise AssertionError("clarify prompt was never sent")
+
+
+def _origin_via_env(monkeypatch, *, platform, chat_id, user_id=None,
+                    thread_id=None, chat_name=None, source=None):
+    """Build a job origin through the REAL ``_origin_from_env`` path, so
+    tests see the exact shape production stamps (including the round-2
+    chat_type/scope_id fields from the bound session source)."""
+    env = {
+        "HERMES_SESSION_PLATFORM": platform,
+        "HERMES_SESSION_CHAT_ID": chat_id,
+        "HERMES_SESSION_CHAT_NAME": chat_name or "",
+        "HERMES_SESSION_THREAD_ID": thread_id or "",
+        "HERMES_SESSION_USER_ID": user_id or "",
+        "HERMES_SESSION_SOURCE": source,
+    }
+    monkeypatch.setattr(
+        session_context, "get_session_env",
+        lambda name, default="": env.get(name) or default,
+    )
+    return cronjob_tools._origin_from_env()
+
+
+class _GwCfg:
+    """Gateway-config stand-in with the session-key flags build_session_key reads."""
+
+    def __init__(self, *, group_sessions_per_user=True, thread_sessions_per_user=False):
+        self.group_sessions_per_user = group_sessions_per_user
+        self.thread_sessions_per_user = thread_sessions_per_user
 
 
 # -- toolset gate ----------------------------------------------------------
@@ -134,6 +181,106 @@ def test_user_disabled_toolsets_still_layer_on_top():
     assert "browser" in disabled
 
 
+# -- reply-key matrix (direct helper tests) ----------------------------------
+
+
+def test_key_discord_dm_via_origin_chat_type_stamp(monkeypatch):
+    """Chat-created Discord DM job: origin carries chat_type from the bound
+    session source (stamped by _origin_from_env), keying `…:dm:<chat>`."""
+    origin = _origin_via_env(
+        monkeypatch, platform="discord", chat_id="8801234567",
+        source=SessionSource(
+            platform=Platform.DISCORD, chat_id="8801234567", chat_type="dm",
+        ),
+    )
+    assert origin["chat_type"] == "dm"
+    job = {"id": "j", "origin": origin}
+    target = {"platform": "discord", "chat_id": "8801234567"}
+    key = s._cron_clarify_reply_session_key(job, target, Platform.DISCORD, _GwCfg())
+    assert key == "agent:main:discord:dm:8801234567"
+
+
+def test_key_discord_dm_numeric_id_via_adapter_hint():
+    """Old jobs carry no origin chat_type and Discord snowflake ids don't
+    encode DM-vs-channel — the live adapter's get_chat_info hint decides."""
+    job = {"id": "j", "origin": {"platform": "discord", "chat_id": "8801234567"}}
+    target = {"platform": "discord", "chat_id": "8801234567"}
+    key = s._cron_clarify_reply_session_key(
+        job, target, Platform.DISCORD, _GwCfg(), chat_type_hint="dm",
+    )
+    assert key == "agent:main:discord:dm:8801234567"
+    # A guild channel hint binds the group key shape instead (no user → None).
+    key_group = s._cron_clarify_reply_session_key(
+        job, target, Platform.DISCORD, _GwCfg(), chat_type_hint="group",
+    )
+    assert key_group is None
+
+
+def test_key_slack_scope_id_carried_from_origin():
+    job = {
+        "id": "j",
+        "origin": {
+            "platform": "slack", "chat_id": "D123", "chat_type": "dm",
+            "scope_id": "T123", "user_id": "U1",
+        },
+    }
+    target = {"platform": "slack", "chat_id": "D123"}
+    key = s._cron_clarify_reply_session_key(job, target, Platform.SLACK, _GwCfg())
+    assert key == "agent:main:slack:dm:T123:D123"
+
+
+def test_key_telegram_dm_and_group_from_id_shape():
+    dm_job = {"id": "j", "origin": {"platform": "telegram", "chat_id": "421337"}}
+    dm_target = {"platform": "telegram", "chat_id": "421337"}
+    assert s._cron_clarify_reply_session_key(
+        dm_job, dm_target, Platform.TELEGRAM, _GwCfg()
+    ) == "agent:main:telegram:dm:421337"
+    # Negative ids are groups — per-user sessions make the key unpredictable.
+    grp_job = {"id": "j", "origin": {"platform": "telegram", "chat_id": "-1009"}}
+    grp_target = {"platform": "telegram", "chat_id": "-1009"}
+    assert s._cron_clarify_reply_session_key(
+        grp_job, grp_target, Platform.TELEGRAM, _GwCfg()
+    ) is None
+
+
+def test_key_discord_parent_thread_target_remaps_to_thread_id():
+    """Explicit parent:thread target: inbound thread messages stamp
+    chat_id = thread_id, so the key must be thread:<T>:<T>."""
+    job = {"id": "j"}
+    target = {"platform": "discord", "chat_id": "P1", "thread_id": "T9"}
+    key = s._cron_clarify_reply_session_key(job, target, Platform.DISCORD, _GwCfg())
+    assert key == "agent:main:discord:thread:T9:T9"
+
+
+def test_key_telegram_forum_topic():
+    job = {"id": "j"}
+    target = {"platform": "telegram", "chat_id": "-1009", "thread_id": "55"}
+    key = s._cron_clarify_reply_session_key(job, target, Platform.TELEGRAM, _GwCfg())
+    assert key == "agent:main:telegram:forum:-1009:55"
+
+
+def test_key_slack_thread_keys_as_container_plus_thread_id():
+    job = {
+        "id": "j",
+        "origin": {"platform": "slack", "chat_id": "D123", "scope_id": "T123"},
+    }
+    target = {"platform": "slack", "chat_id": "D123", "thread_id": "1700.01"}
+    key = s._cron_clarify_reply_session_key(job, target, Platform.SLACK, _GwCfg())
+    assert key == "agent:main:slack:dm:T123:D123:1700.01"
+
+
+def test_key_none_when_thread_sessions_per_user_isolates():
+    """thread_sessions_per_user: true makes thread replies per-user — the
+    replying user is unpredictable for a scheduled prompt."""
+    job = {"id": "j"}
+    target = {"platform": "discord", "chat_id": "P1", "thread_id": "T9"}
+    key = s._cron_clarify_reply_session_key(
+        job, target, Platform.DISCORD,
+        _GwCfg(thread_sessions_per_user=True),
+    )
+    assert key is None
+
+
 # -- callback construction --------------------------------------------------
 
 
@@ -145,8 +292,12 @@ def test_callback_none_without_delivery_targets(monkeypatch, running_loop):
 
 def test_callback_none_when_loop_not_running(monkeypatch):
     _patch_delivery(monkeypatch, _FakeAdapter())
-    cb = s._build_cron_clarify_callback({"id": "j1"}, {}, asyncio.new_event_loop())
-    assert cb is None
+    loop = asyncio.new_event_loop()
+    try:
+        cb = s._build_cron_clarify_callback({"id": "j1"}, {}, loop)
+        assert cb is None
+    finally:
+        loop.close()
 
 
 def test_callback_none_without_capable_adapter(monkeypatch, running_loop):
@@ -176,38 +327,55 @@ def test_callback_delivers_prompt_and_returns_response(monkeypatch, running_loop
     assert result["r"] == "yes"
 
 
-def test_callback_send_failure_returns_sentinel(monkeypatch, running_loop):
+def test_callback_send_failure_returns_sentinel_and_discards_only_own_entry(
+    monkeypatch, running_loop
+):
+    """Send failure drops ONLY the cron entry — a concurrent interactive
+    clarify registered under the same session key must survive (round-2:
+    was clear_session, which cancelled everything in the chat)."""
     adapter = _FakeAdapter(success=False)
     _patch_delivery(monkeypatch, adapter)
     cb = s._build_cron_clarify_callback({"id": "j1"}, {}, running_loop)
 
+    # An unrelated interactive prompt pending in the same fallback session.
+    clarify_gateway.register(
+        clarify_id="interactive1", session_key="cron:j1",
+        question="unrelated", choices=None,
+    )
     assert cb("Pick one", ["a", "b"]) == "[clarify prompt could not be delivered]"
+    # The cron entry is gone; the interactive one is untouched.
+    assert clarify_gateway.get_pending_for_session("cron:j1") is not None
+    assert clarify_gateway.discard("interactive1")
 
 
-def test_callback_timeout_returns_sentinel(monkeypatch, running_loop):
+def test_callback_timeout_returns_sentinel_with_seconds(monkeypatch, running_loop):
     adapter = _FakeAdapter(success=True)
     _patch_delivery(monkeypatch, adapter)
     monkeypatch.setattr(clarify_gateway, "get_clarify_timeout", lambda: 1)
     cb = s._build_cron_clarify_callback({"id": "j1"}, {}, running_loop)
 
     response = cb("Anyone there?", None)
-    assert response.startswith("[user did not respond within")
+    # Sub-minute timeouts render seconds, never "0m".
+    assert response == "[user did not respond within 1s]"
 
 
-# -- text-reply binding (review round 1) -------------------------------------
+# -- text-reply binding ------------------------------------------------------
 
 
 def test_open_ended_text_reply_resolves_via_delivery_chat_key(monkeypatch, running_loop):
     """Open-ended clarify to a DM target: the entry registers under the
     delivery chat's gateway session key, so the gateway's inbound text
-    intercept resolves a typed answer (previously the entry was indexed by
-    the cron session id and typed answers could never match)."""
+    intercept resolves a typed answer. Origin built through the real
+    _origin_from_env path (production shape)."""
     adapter = _FakeAdapter(success=True)
     _patch_delivery(monkeypatch, adapter)
-    job = {
-        "id": "j-dm",
-        "origin": {"platform": "discord", "chat_id": "12345", "chat_type": "dm"},
-    }
+    origin = _origin_via_env(
+        monkeypatch, platform="discord", chat_id="12345",
+        source=SessionSource(
+            platform=Platform.DISCORD, chat_id="12345", chat_type="dm",
+        ),
+    )
+    job = {"id": "j-dm", "origin": origin}
     cb = s._build_cron_clarify_callback(job, {}, running_loop)
     assert cb is not None
 
@@ -221,17 +389,44 @@ def test_open_ended_text_reply_resolves_via_delivery_chat_key(monkeypatch, runni
     assert result["r"] == "ship it"
 
 
+def test_discord_dm_numeric_id_binds_via_live_adapter_get_chat_info(
+    monkeypatch, running_loop
+):
+    """End-to-end DM detection for old jobs (no origin chat_type) on
+    Discord: the builder's fire-time get_chat_info call classifies the
+    numeric target as a DM and typed answers bind `…:dm:<chat>`."""
+    adapter = _ChatInfoAdapter("dm", success=True)
+    _patch_delivery(
+        monkeypatch, adapter,
+        targets=[{"platform": "discord", "chat_id": "8801234567"}],
+    )
+    job = {"id": "j-ddm", "origin": {"platform": "discord", "chat_id": "8801234567"}}
+    cb = s._build_cron_clarify_callback(job, {}, running_loop)
+    assert cb is not None
+
+    result, caller = _run_callback(cb, "Q?", None)
+    sent = _wait_sent(adapter)
+    assert sent["session_key"] == "agent:main:discord:dm:8801234567"
+    assert clarify_gateway.resolve_text_response_for_session(
+        "agent:main:discord:dm:8801234567", "blue"
+    )
+    caller.join(timeout=10)
+    assert result["r"] == "blue"
+
+
 def test_other_path_text_reply_resolves_via_group_origin_user_key(monkeypatch, running_loop):
     """Group/channel target that IS the job's origin: the entry binds to the
-    origin member's per-user session key (mirrors _seed_cron_channel_session
-    key rules), so a typed custom answer after picking "Other" resolves —
-    and only from that member's key."""
+    origin member's per-user session key — a typed custom answer after
+    "Other" resolves only from that member's key."""
     adapter = _FakeAdapter(success=True)
     _patch_delivery(monkeypatch, adapter)
-    job = {
-        "id": "j-grp",
-        "origin": {"platform": "discord", "chat_id": "12345", "user_id": "u-owner"},
-    }
+    origin = _origin_via_env(
+        monkeypatch, platform="discord", chat_id="12345", user_id="u-owner",
+        source=SessionSource(
+            platform=Platform.DISCORD, chat_id="12345", chat_type="group",
+        ),
+    )
+    job = {"id": "j-grp", "origin": origin}
     cb = s._build_cron_clarify_callback(job, {}, running_loop)
     assert cb is not None
 
@@ -283,16 +478,16 @@ def test_thread_target_binds_participant_shared_key(monkeypatch, running_loop):
 
     result, caller = _run_callback(cb, "Q?", None)
     sent = _wait_sent(adapter)
-    assert sent["session_key"] == "agent:main:discord:thread:12345:T9"
+    assert sent["session_key"] == "agent:main:discord:thread:T9:T9"
     assert sent["metadata"] == {"thread_id": "T9"}
     assert clarify_gateway.resolve_text_response_for_session(
-        "agent:main:discord:thread:12345:T9", "thread answer"
+        "agent:main:discord:thread:T9:T9", "thread answer"
     )
     caller.join(timeout=10)
     assert result["r"] == "thread answer"
 
 
-# -- relay transport (review round 1) ----------------------------------------
+# -- relay transport ---------------------------------------------------------
 
 
 def test_relay_target_stamps_logical_platform(monkeypatch, running_loop):
@@ -332,3 +527,81 @@ def test_native_adapter_send_omits_relay_platform_key(monkeypatch, running_loop)
     assert clarify_gateway.resolve_gateway_clarify(sent["clarify_id"], "x")
     caller.join(timeout=10)
     assert result["r"] == "x"
+
+
+# -- run_job wiring (gate + attach + platform-hint swap) ----------------------
+
+
+def _run_job_for_wiring(tmp_path, *, allow_clarify, preset_hints=None, spy=None):
+    """Drive run_job with the standard test patch bundle plus the clarify
+    delivery seams; return the constructed agent mock."""
+    fake_db = MagicMock()
+    mock_agent = MagicMock()
+    mock_agent.run_conversation.return_value = {"final_response": "ok"}
+    if preset_hints is not None:
+        mock_agent._platform_hint_overrides = preset_hints
+    adapter = _FakeAdapter(success=True)
+    loop = MagicMock()
+    loop.is_running.return_value = True
+    job = {"id": "j-wire", "name": "t", "prompt": "hello"}
+    builder_patch = (
+        patch.object(s, "_build_cron_clarify_callback", spy) if spy is not None
+        else patch.object(gw_config, "load_gateway_config", lambda: object())
+    )
+    with (
+        patch("cron.scheduler._hermes_home", tmp_path),
+        patch("hermes_cli.env_loader.load_hermes_dotenv"),
+        patch("hermes_cli.env_loader.reset_secret_source_cache"),
+        patch("hermes_state.SessionDB", return_value=fake_db),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "api_key": "test-key",
+                "base_url": "https://example.invalid/v1",
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+            },
+        ),
+        patch("run_agent.AIAgent", return_value=mock_agent),
+        patch.object(s, "load_config",
+                     return_value={"cron": {"allow_clarify": allow_clarify}}),
+        patch.object(s, "_resolve_delivery_targets",
+                     return_value=[{"platform": "discord", "chat_id": "12345"}]),
+        patch.object(
+            gw_delivery, "resolve_delivery_transport",
+            lambda platform, config, adapters: types.SimpleNamespace(
+                adapter=adapter, config=None, is_relay=False,
+            ),
+        ),
+        builder_patch,
+    ):
+        s.run_job(job, adapters={"live": adapter}, loop=loop)
+    return mock_agent
+
+
+def test_run_job_attaches_clarify_callback_and_swaps_hint(tmp_path):
+    """The wiring block runs for gated gateway-fired jobs: callback attached
+    AND the autonomous cron platform hint swapped for the HITL variant."""
+    agent = _run_job_for_wiring(tmp_path, allow_clarify=True)
+    assert callable(agent.clarify_callback)
+    assert agent._platform_hint_overrides == {
+        "cron": {"replace": s._CRON_CLARIFY_PLATFORM_HINT}
+    }
+
+
+def test_run_job_operator_hint_override_wins(tmp_path):
+    """An explicit agent.platform_hints.cron override is never replaced."""
+    agent = _run_job_for_wiring(
+        tmp_path, allow_clarify=True,
+        preset_hints={"cron": {"replace": "custom-cron-hint"}},
+    )
+    assert callable(agent.clarify_callback)
+    assert agent._platform_hint_overrides == {"cron": {"replace": "custom-cron-hint"}}
+
+
+def test_run_job_gate_off_attaches_nothing(tmp_path):
+    """Default posture: no callback, no hint swap."""
+    spy = MagicMock()
+    agent = _run_job_for_wiring(tmp_path, allow_clarify=False, spy=spy)
+    spy.assert_not_called()
+    assert not isinstance(agent._platform_hint_overrides, dict)

--- a/tests/cron/test_cron_clarify.py
+++ b/tests/cron/test_cron_clarify.py
@@ -1,0 +1,182 @@
+"""Tests for the cron.allow_clarify human-in-the-loop opt-in.
+
+Default posture (4494c0b0): cron agents run unattended, so the clarify
+toolset is hard-disabled and the cron platform hint demands fully autonomous
+execution. ``cron.allow_clarify: true`` opts a deployment into clarify
+prompts that render through the job's live delivery adapter (gateway-fired
+runs only) and block until the user answers or agent.clarify_timeout fires.
+"""
+import asyncio
+import threading
+import time
+import types
+
+import pytest
+
+import cron.scheduler as s
+import gateway.config as gw_config
+import gateway.delivery as gw_delivery
+from tools import clarify_gateway
+
+
+class _SendResult:
+    def __init__(self, success):
+        self.success = success
+
+
+class _FakeAdapter:
+    """Stand-in for a live platform adapter with a send_clarify coroutine."""
+
+    def __init__(self, success=True):
+        self.success = success
+        self.sent = []
+
+    async def send_clarify(self, chat_id, question, choices, clarify_id,
+                           session_key, metadata=None):
+        self.sent.append({
+            "chat_id": chat_id,
+            "question": question,
+            "choices": choices,
+            "clarify_id": clarify_id,
+            "session_key": session_key,
+            "metadata": metadata,
+        })
+        return _SendResult(self.success)
+
+
+@pytest.fixture
+def running_loop():
+    """A real asyncio loop running on a background thread (the gateway loop
+    stand-in that run_coroutine_threadsafe schedules onto)."""
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    for _ in range(100):
+        if loop.is_running():
+            break
+        time.sleep(0.01)
+    try:
+        yield loop
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=5)
+        loop.close()
+
+
+def _patch_delivery(monkeypatch, adapter):
+    """Route the job's delivery-target resolution at a fake live adapter."""
+    monkeypatch.setattr(
+        s, "_resolve_delivery_targets",
+        lambda job: [{"platform": "discord", "chat_id": "12345"}],
+    )
+    monkeypatch.setattr(gw_config, "load_gateway_config", lambda: object())
+    monkeypatch.setattr(
+        gw_delivery, "resolve_delivery_transport",
+        lambda platform, config, adapters: types.SimpleNamespace(adapter=adapter),
+    )
+
+
+# -- toolset gate ----------------------------------------------------------
+
+
+def test_clarify_hard_disabled_by_default():
+    disabled = s._resolve_cron_disabled_toolsets({})
+    assert "clarify" in disabled
+    assert "cronjob" in disabled
+    assert "messaging" in disabled
+
+
+def test_clarify_hard_disabled_when_allow_clarify_false():
+    disabled = s._resolve_cron_disabled_toolsets({"cron": {"allow_clarify": False}})
+    assert "clarify" in disabled
+
+
+def test_clarify_allowed_when_allow_clarify_true():
+    disabled = s._resolve_cron_disabled_toolsets({"cron": {"allow_clarify": True}})
+    assert "clarify" not in disabled
+    # The other protected toolsets stay disabled.
+    assert "cronjob" in disabled
+    assert "messaging" in disabled
+
+
+def test_user_disabled_toolsets_still_layer_on_top():
+    cfg = {
+        "cron": {"allow_clarify": True},
+        "agent": {"disabled_toolsets": ["clarify", "browser"]},
+    }
+    disabled = s._resolve_cron_disabled_toolsets(cfg)
+    # An explicit operator denylist entry still wins over the opt-in.
+    assert "clarify" in disabled
+    assert "browser" in disabled
+
+
+# -- callback construction --------------------------------------------------
+
+
+def test_callback_none_without_delivery_targets(monkeypatch, running_loop):
+    monkeypatch.setattr(s, "_resolve_delivery_targets", lambda job: [])
+    cb = s._build_cron_clarify_callback({"id": "j1"}, {}, running_loop, "sess")
+    assert cb is None
+
+
+def test_callback_none_when_loop_not_running(monkeypatch):
+    _patch_delivery(monkeypatch, _FakeAdapter())
+    cb = s._build_cron_clarify_callback(
+        {"id": "j1"}, {}, asyncio.new_event_loop(), "sess",
+    )
+    assert cb is None
+
+
+def test_callback_none_without_capable_adapter(monkeypatch, running_loop):
+    _patch_delivery(monkeypatch, object())  # no send_clarify attribute
+    cb = s._build_cron_clarify_callback({"id": "j1"}, {}, running_loop, "sess")
+    assert cb is None
+
+
+# -- callback behavior ------------------------------------------------------
+
+
+def test_callback_delivers_prompt_and_returns_response(monkeypatch, running_loop):
+    adapter = _FakeAdapter(success=True)
+    _patch_delivery(monkeypatch, adapter)
+    cb = s._build_cron_clarify_callback({"id": "j1"}, {}, running_loop, "sess-j1")
+    assert cb is not None
+
+    result = {}
+
+    def _call():
+        result["response"] = cb("Deploy to prod?", ["yes", "no"])
+
+    caller = threading.Thread(target=_call)
+    caller.start()
+    # Wait for the prompt to go out, then resolve it as the user would.
+    for _ in range(100):
+        if adapter.sent:
+            break
+        time.sleep(0.05)
+    assert adapter.sent, "clarify prompt was never sent"
+    sent = adapter.sent[0]
+    assert sent["chat_id"] == "12345"
+    assert sent["question"] == "Deploy to prod?"
+    assert sent["session_key"] == "sess-j1"
+    assert clarify_gateway.resolve_gateway_clarify(sent["clarify_id"], "yes")
+    caller.join(timeout=10)
+    assert result["response"] == "yes"
+
+
+def test_callback_send_failure_returns_sentinel(monkeypatch, running_loop):
+    adapter = _FakeAdapter(success=False)
+    _patch_delivery(monkeypatch, adapter)
+    cb = s._build_cron_clarify_callback({"id": "j1"}, {}, running_loop, "sess-j2")
+
+    assert cb("Pick one", ["a", "b"]) == "[clarify prompt could not be delivered]"
+
+
+def test_callback_timeout_returns_sentinel(monkeypatch, running_loop):
+    adapter = _FakeAdapter(success=True)
+    _patch_delivery(monkeypatch, adapter)
+    monkeypatch.setattr(clarify_gateway, "get_clarify_timeout", lambda: 1)
+    cb = s._build_cron_clarify_callback({"id": "j1"}, {}, running_loop, "sess-j3")
+
+    response = cb("Anyone there?", None)
+    assert response.startswith("[user did not respond within")

--- a/tests/cron/test_cron_clarify.py
+++ b/tests/cron/test_cron_clarify.py
@@ -5,6 +5,13 @@ toolset is hard-disabled and the cron platform hint demands fully autonomous
 execution. ``cron.allow_clarify: true`` opts a deployment into clarify
 prompts that render through the job's live delivery adapter (gateway-fired
 runs only) and block until the user answers or agent.clarify_timeout fires.
+
+Text-reply binding (review round 1): pending entries register under the
+DELIVERY CHAT's gateway session key — the same key the gateway's inbound
+text intercept resolves typed answers against — so open-ended clarifies,
+text fallback, and the native-button "Other" path work from the delivery
+chat. Fan-out group targets (no predictable replying user) fall back to the
+cron session key; button clicks resolve by clarify_id either way.
 """
 import asyncio
 import threading
@@ -63,17 +70,34 @@ def running_loop():
         loop.close()
 
 
-def _patch_delivery(monkeypatch, adapter):
-    """Route the job's delivery-target resolution at a fake live adapter."""
-    monkeypatch.setattr(
-        s, "_resolve_delivery_targets",
-        lambda job: [{"platform": "discord", "chat_id": "12345"}],
-    )
+def _patch_delivery(monkeypatch, adapter, *, targets=None, is_relay=False):
+    """Route the job's delivery-target resolution at a fake live transport."""
+    if targets is None:
+        targets = [{"platform": "discord", "chat_id": "12345"}]
+    monkeypatch.setattr(s, "_resolve_delivery_targets", lambda job: targets)
     monkeypatch.setattr(gw_config, "load_gateway_config", lambda: object())
     monkeypatch.setattr(
         gw_delivery, "resolve_delivery_transport",
-        lambda platform, config, adapters: types.SimpleNamespace(adapter=adapter),
+        lambda platform, config, adapters: types.SimpleNamespace(
+            adapter=adapter, config=None, is_relay=is_relay,
+        ),
     )
+
+
+def _run_callback(cb, *args):
+    """Invoke a clarify callback on a worker thread; returns (result dict, thread)."""
+    result = {}
+    caller = threading.Thread(target=lambda: result.setdefault("r", cb(*args)))
+    caller.start()
+    return result, caller
+
+
+def _wait_sent(adapter):
+    for _ in range(100):
+        if adapter.sent:
+            return adapter.sent[0]
+        time.sleep(0.05)
+    raise AssertionError("clarify prompt was never sent")
 
 
 # -- toolset gate ----------------------------------------------------------
@@ -115,21 +139,19 @@ def test_user_disabled_toolsets_still_layer_on_top():
 
 def test_callback_none_without_delivery_targets(monkeypatch, running_loop):
     monkeypatch.setattr(s, "_resolve_delivery_targets", lambda job: [])
-    cb = s._build_cron_clarify_callback({"id": "j1"}, {}, running_loop, "sess")
+    cb = s._build_cron_clarify_callback({"id": "j1"}, {}, running_loop)
     assert cb is None
 
 
 def test_callback_none_when_loop_not_running(monkeypatch):
     _patch_delivery(monkeypatch, _FakeAdapter())
-    cb = s._build_cron_clarify_callback(
-        {"id": "j1"}, {}, asyncio.new_event_loop(), "sess",
-    )
+    cb = s._build_cron_clarify_callback({"id": "j1"}, {}, asyncio.new_event_loop())
     assert cb is None
 
 
 def test_callback_none_without_capable_adapter(monkeypatch, running_loop):
     _patch_delivery(monkeypatch, object())  # no send_clarify attribute
-    cb = s._build_cron_clarify_callback({"id": "j1"}, {}, running_loop, "sess")
+    cb = s._build_cron_clarify_callback({"id": "j1"}, {}, running_loop)
     assert cb is None
 
 
@@ -139,35 +161,25 @@ def test_callback_none_without_capable_adapter(monkeypatch, running_loop):
 def test_callback_delivers_prompt_and_returns_response(monkeypatch, running_loop):
     adapter = _FakeAdapter(success=True)
     _patch_delivery(monkeypatch, adapter)
-    cb = s._build_cron_clarify_callback({"id": "j1"}, {}, running_loop, "sess-j1")
+    cb = s._build_cron_clarify_callback({"id": "j1"}, {}, running_loop)
     assert cb is not None
 
-    result = {}
-
-    def _call():
-        result["response"] = cb("Deploy to prod?", ["yes", "no"])
-
-    caller = threading.Thread(target=_call)
-    caller.start()
-    # Wait for the prompt to go out, then resolve it as the user would.
-    for _ in range(100):
-        if adapter.sent:
-            break
-        time.sleep(0.05)
-    assert adapter.sent, "clarify prompt was never sent"
-    sent = adapter.sent[0]
+    result, caller = _run_callback(cb, "Deploy to prod?", ["yes", "no"])
+    sent = _wait_sent(adapter)
     assert sent["chat_id"] == "12345"
     assert sent["question"] == "Deploy to prod?"
-    assert sent["session_key"] == "sess-j1"
+    # Origin-less job (e.g. CLI-created) delivering to a group channel: no
+    # predictable replying user, so registration falls back to the cron key.
+    assert sent["session_key"] == "cron:j1"
     assert clarify_gateway.resolve_gateway_clarify(sent["clarify_id"], "yes")
     caller.join(timeout=10)
-    assert result["response"] == "yes"
+    assert result["r"] == "yes"
 
 
 def test_callback_send_failure_returns_sentinel(monkeypatch, running_loop):
     adapter = _FakeAdapter(success=False)
     _patch_delivery(monkeypatch, adapter)
-    cb = s._build_cron_clarify_callback({"id": "j1"}, {}, running_loop, "sess-j2")
+    cb = s._build_cron_clarify_callback({"id": "j1"}, {}, running_loop)
 
     assert cb("Pick one", ["a", "b"]) == "[clarify prompt could not be delivered]"
 
@@ -176,7 +188,147 @@ def test_callback_timeout_returns_sentinel(monkeypatch, running_loop):
     adapter = _FakeAdapter(success=True)
     _patch_delivery(monkeypatch, adapter)
     monkeypatch.setattr(clarify_gateway, "get_clarify_timeout", lambda: 1)
-    cb = s._build_cron_clarify_callback({"id": "j1"}, {}, running_loop, "sess-j3")
+    cb = s._build_cron_clarify_callback({"id": "j1"}, {}, running_loop)
 
     response = cb("Anyone there?", None)
     assert response.startswith("[user did not respond within")
+
+
+# -- text-reply binding (review round 1) -------------------------------------
+
+
+def test_open_ended_text_reply_resolves_via_delivery_chat_key(monkeypatch, running_loop):
+    """Open-ended clarify to a DM target: the entry registers under the
+    delivery chat's gateway session key, so the gateway's inbound text
+    intercept resolves a typed answer (previously the entry was indexed by
+    the cron session id and typed answers could never match)."""
+    adapter = _FakeAdapter(success=True)
+    _patch_delivery(monkeypatch, adapter)
+    job = {
+        "id": "j-dm",
+        "origin": {"platform": "discord", "chat_id": "12345", "chat_type": "dm"},
+    }
+    cb = s._build_cron_clarify_callback(job, {}, running_loop)
+    assert cb is not None
+
+    result, caller = _run_callback(cb, "What should I do?", None)
+    sent = _wait_sent(adapter)
+    assert sent["session_key"] == "agent:main:discord:dm:12345"
+    assert clarify_gateway.resolve_text_response_for_session(
+        "agent:main:discord:dm:12345", "ship it"
+    )
+    caller.join(timeout=10)
+    assert result["r"] == "ship it"
+
+
+def test_other_path_text_reply_resolves_via_group_origin_user_key(monkeypatch, running_loop):
+    """Group/channel target that IS the job's origin: the entry binds to the
+    origin member's per-user session key (mirrors _seed_cron_channel_session
+    key rules), so a typed custom answer after picking "Other" resolves —
+    and only from that member's key."""
+    adapter = _FakeAdapter(success=True)
+    _patch_delivery(monkeypatch, adapter)
+    job = {
+        "id": "j-grp",
+        "origin": {"platform": "discord", "chat_id": "12345", "user_id": "u-owner"},
+    }
+    cb = s._build_cron_clarify_callback(job, {}, running_loop)
+    assert cb is not None
+
+    result, caller = _run_callback(cb, "Pick one", ["a", "b"])
+    sent = _wait_sent(adapter)
+    assert sent["session_key"] == "agent:main:discord:group:12345:u-owner"
+    # The user picked "Other" — the adapter flips the entry to text-capture.
+    assert clarify_gateway.mark_awaiting_text(sent["clarify_id"])
+    # A different member's reply keys to a different session and cannot resolve.
+    assert not clarify_gateway.resolve_text_response_for_session(
+        "agent:main:discord:group:12345:u-other", "custom answer"
+    )
+    # The origin member's typed answer resolves.
+    assert clarify_gateway.resolve_text_response_for_session(
+        "agent:main:discord:group:12345:u-owner", "custom answer"
+    )
+    caller.join(timeout=10)
+    assert result["r"] == "custom answer"
+
+
+def test_fanout_group_target_falls_back_to_cron_session_key(monkeypatch, running_loop):
+    """A group/channel target with no origin (or a fan-out target) cannot
+    predict the replying user: registration falls back to the cron session
+    key — typed answers don't resolve, but button clicks (key-independent)
+    still do."""
+    adapter = _FakeAdapter(success=True)
+    _patch_delivery(monkeypatch, adapter)
+    cb = s._build_cron_clarify_callback({"id": "j-fanout"}, {}, running_loop)
+    assert cb is not None
+
+    result, caller = _run_callback(cb, "Q?", ["x", "y"])
+    sent = _wait_sent(adapter)
+    assert sent["session_key"] == "cron:j-fanout"
+    assert clarify_gateway.resolve_gateway_clarify(sent["clarify_id"], "x")
+    caller.join(timeout=10)
+    assert result["r"] == "x"
+
+
+def test_thread_target_binds_participant_shared_key(monkeypatch, running_loop):
+    """Thread targets key participant-shared (thread_id present), so typed
+    replies from any participant resolve."""
+    adapter = _FakeAdapter(success=True)
+    _patch_delivery(
+        monkeypatch, adapter,
+        targets=[{"platform": "discord", "chat_id": "12345", "thread_id": "T9"}],
+    )
+    cb = s._build_cron_clarify_callback({"id": "j-thread"}, {}, running_loop)
+    assert cb is not None
+
+    result, caller = _run_callback(cb, "Q?", None)
+    sent = _wait_sent(adapter)
+    assert sent["session_key"] == "agent:main:discord:thread:12345:T9"
+    assert sent["metadata"] == {"thread_id": "T9"}
+    assert clarify_gateway.resolve_text_response_for_session(
+        "agent:main:discord:thread:12345:T9", "thread answer"
+    )
+    caller.join(timeout=10)
+    assert result["r"] == "thread answer"
+
+
+# -- relay transport (review round 1) ----------------------------------------
+
+
+def test_relay_target_stamps_logical_platform(monkeypatch, running_loop):
+    """Relay-fronted delivery: the clarify send carries the job's logical
+    platform via the _relay_logical_platform escape hatch — a scheduled send
+    has no inbound event to populate the relay's _platform_by_chat map."""
+    adapter = _FakeAdapter(success=True)
+    _patch_delivery(
+        monkeypatch, adapter,
+        targets=[{"platform": "slack", "chat_id": "C1", "thread_id": "T1"}],
+        is_relay=True,
+    )
+    cb = s._build_cron_clarify_callback({"id": "j-relay"}, {}, running_loop)
+    assert cb is not None
+
+    result, caller = _run_callback(cb, "Q?", ["x"])
+    sent = _wait_sent(adapter)
+    assert sent["metadata"]["_relay_logical_platform"] == "slack"
+    assert sent["metadata"]["thread_id"] == "T1"
+    # Thread targets still bind participant-shared reply keys over relay.
+    assert sent["session_key"] == "agent:main:slack:thread:C1:T1"
+    assert clarify_gateway.resolve_gateway_clarify(sent["clarify_id"], "x")
+    caller.join(timeout=10)
+    assert result["r"] == "x"
+
+
+def test_native_adapter_send_omits_relay_platform_key(monkeypatch, running_loop):
+    """A native (non-relay) adapter gets no _relay_logical_platform stamp."""
+    adapter = _FakeAdapter(success=True)
+    _patch_delivery(monkeypatch, adapter, is_relay=False)
+    cb = s._build_cron_clarify_callback({"id": "j-native"}, {}, running_loop)
+    assert cb is not None
+
+    result, caller = _run_callback(cb, "Q?", ["x"])
+    sent = _wait_sent(adapter)
+    assert sent["metadata"] is None
+    assert clarify_gateway.resolve_gateway_clarify(sent["clarify_id"], "x")
+    caller.join(timeout=10)
+    assert result["r"] == "x"

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -215,7 +215,7 @@ def test_run_one_job_records_running_then_terminal(monkeypatch):
     monkeypatch.setattr(
         scheduler,
         "run_job",
-        lambda job, *, defer_agent_teardown=None: (True, "output", "response", None),
+        lambda job, *, defer_agent_teardown=None, adapters=None, loop=None: (True, "output", "response", None),
     )
     monkeypatch.setattr(scheduler, "save_job_output", lambda *_args: None)
     monkeypatch.setattr(scheduler, "_deliver_result", lambda *_args, **_kwargs: None)

--- a/tests/cron/test_parallel_pool.py
+++ b/tests/cron/test_parallel_pool.py
@@ -146,7 +146,7 @@ class TestSequentialPool:
 
         barrier = threading.Barrier(2, timeout=5)
 
-        def slow_run(j, *, defer_agent_teardown=None):
+        def slow_run(j, *, defer_agent_teardown=None, adapters=None, loop=None):
             barrier.wait()
             return True, "out", "resp", None
 

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -18,7 +18,7 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
     """Patch the job pipeline primitives and record the call order."""
     calls = []
 
-    def fake_run_job(job, *, defer_agent_teardown=None):
+    def fake_run_job(job, *, defer_agent_teardown=None, adapters=None, loop=None):
         calls.append(("run_job", job["id"]))
         fr = final if silent_marker_in is None else silent_marker_in
         return (success, output, fr, error)
@@ -83,7 +83,7 @@ def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path
 
     scope_during_run = {}
 
-    def fake_run_job(job, *, defer_agent_teardown=None):
+    def fake_run_job(job, *, defer_agent_teardown=None, adapters=None, loop=None):
         # This is where resolve_runtime_provider() would read a secret. Prove a
         # scope is installed and the profile's secret resolves without raising.
         scope_during_run["scope"] = ss.current_secret_scope()
@@ -109,3 +109,25 @@ def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path
     assert ss.current_secret_scope() is None
 
 
+
+
+def test_run_one_job_forwards_adapters_and_loop_to_run_job(monkeypatch):
+    """run_one_job plumbs the gateway's live adapters/loop into run_job so a
+    cron.allow_clarify run can wire a clarify callback over the live delivery
+    adapter. Standalone `hermes cron run` passes neither (None)."""
+    seen = {}
+
+    def fake_run_job(job, *, defer_agent_teardown=None, adapters=None, loop=None):
+        seen["adapters"] = adapters
+        seen["loop"] = loop
+        return (True, "out", "final response", None)
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(s, "_deliver_result", lambda *a, **k: None)
+    monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
+
+    ok = s.run_one_job({"id": "j11", "name": "t"}, adapters="ADAPTERS", loop="LOOP")
+
+    assert ok is True
+    assert seen == {"adapters": "ADAPTERS", "loop": "LOOP"}

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1217,7 +1217,7 @@ class TestParallelTick:
         barrier = threading.Barrier(2, timeout=5)
         call_order = []
 
-        def mock_run_job(job, *, defer_agent_teardown=None):
+        def mock_run_job(job, *, defer_agent_teardown=None, adapters=None, loop=None):
             """Each job hits a barrier — both must be active simultaneously."""
             call_order.append(("start", job["id"]))
             barrier.wait()  # blocks until both threads reach here
@@ -1251,7 +1251,7 @@ class TestParallelTick:
         from gateway.session_context import get_session_env
         seen = {}
 
-        def mock_run_job(job, *, defer_agent_teardown=None):
+        def mock_run_job(job, *, defer_agent_teardown=None, adapters=None, loop=None):
             origin = job.get("origin", {})
             # run_job sets ContextVars — verify each job sees its own
             from gateway.session_context import set_session_vars, clear_session_vars

--- a/tests/gateway/relay/test_relay_interactive.py
+++ b/tests/gateway/relay/test_relay_interactive.py
@@ -257,3 +257,23 @@ async def test_processing_lifecycle_reacts_eyes_then_check():
     assert all(r["message_id"] == "m42" and r["chat_id"] == "ch1" for r in reacts)
 
 
+
+
+@pytest.mark.asyncio
+async def test_send_prompt_honors_relay_logical_platform_override():
+    """Scheduled/persisted prompts (e.g. cron clarify) have no inbound event
+    to populate _platform_by_chat; the caller stamps the logical platform via
+    the _relay_logical_platform metadata escape hatch (same as send())."""
+    adapter, stub = _adapter()
+    result = await adapter.send_clarify(
+        "c1",
+        "Which?",
+        ["a", "b"],
+        "cl-relay-1",
+        "s",
+        metadata={"_relay_logical_platform": "discord"},
+    )
+    assert result.success is True
+    assert stub.sent_platforms[-1] == "discord"
+    # The private routing key must not leak into the outbound metadata.
+    assert "_relay_logical_platform" not in (stub.sent[-1].get("metadata") or {})

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -354,6 +354,28 @@ def has_pending(session_key: str) -> bool:
         return any(_entries.get(cid) is not None for cid in ids)
 
 
+def discard(clarify_id: str) -> bool:
+    """Drop a single pending entry without resolving it.
+
+    Unlike :func:`clear_session`, this never touches other entries sharing
+    the session key — e.g. an interactive session's clarify pending in the
+    same chat a cron job also delivered to (send-failure cleanup must not
+    cancel the user's interactive prompt).
+
+    Returns True if an entry was removed.
+    """
+    with _lock:
+        entry = _entries.pop(clarify_id, None)
+        if entry is None:
+            return False
+        ids = _session_index.get(entry.session_key)
+        if ids and clarify_id in ids:
+            ids.remove(clarify_id)
+            if not ids:
+                _session_index.pop(entry.session_key, None)
+        return True
+
+
 def clear_session(session_key: str) -> int:
     """Resolve and drop every pending clarify for a session.
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -305,10 +305,23 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
                 "Cron origin captured thread_id=%s for %s:%s",
                 thread_id, origin_platform, origin_chat_id,
             )
+        # The bound session source carries the chat's type and workspace
+        # scope (Discord DM vs guild channel, Slack team_id) — stamp both so
+        # scheduled-job delivery and cron clarify can resolve the exact
+        # session key a reply in that chat produces, without re-deriving
+        # platform specifics at fire time. Absent for CLI/TUI/API-created
+        # jobs (no bound source) — fire-time fallbacks cover those.
+        _src = get_session_env("HERMES_SESSION_SOURCE") or None
         return {
             "platform": origin_platform,
             "chat_id": origin_chat_id,
             "chat_name": get_session_env("HERMES_SESSION_CHAT_NAME") or None,
+            "chat_type": getattr(_src, "chat_type", None) or None,
+            "scope_id": (
+                getattr(_src, "scope_id", None)
+                or getattr(_src, "guild_id", None)
+                or None
+            ),
             "thread_id": thread_id,
             # Captured so an opt-in delivery mirror (cron.mirror_delivery /
             # attach_to_session) can resolve the exact participant's session in

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -123,6 +123,13 @@ Notes:
 
 - The job's `deliver` must target a gateway-connected messaging platform
   whose adapter supports interactive clarify prompts (Discord, Telegram, …).
+  Relay-fronted platforms work too — the send carries the job's logical
+  delivery platform explicitly.
+- Typed answers (open-ended questions, or picking "Other" and typing) resolve
+  when the delivery chat's session can be determined: always for threads and
+  DMs; for group/channel deliveries only when the job was created from that
+  chat (the clarify binds to the member who scheduled it). Otherwise answer
+  with the buttons.
 - Standalone `hermes cron run` fires have no live messaging adapter, so
   `clarify` keeps reporting that it is unavailable in that context.
 - The wait heartbeats the scheduler's activity tracker, so the cron

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -125,11 +125,28 @@ Notes:
   whose adapter supports interactive clarify prompts (Discord, Telegram, …).
   Relay-fronted platforms work too — the send carries the job's logical
   delivery platform explicitly.
-- Typed answers (open-ended questions, or picking "Other" and typing) resolve
-  when the delivery chat's session can be determined: always for threads and
-  DMs; for group/channel deliveries only when the job was created from that
-  chat (the clarify binds to the member who scheduled it). Otherwise answer
-  with the buttons.
+- Typed answers (open-ended questions, or picking "Other" and typing)
+  resolve when the delivery chat's session key is deterministic:
+
+  | Delivery target | Typed answers |
+  |---|---|
+  | DM (any platform) | ✓ resolve (DM detected via the live adapter, the job's origin stamp, or platform id rules) |
+  | Thread / forum topic | ✓ resolve (participant-shared session) |
+  | Group/channel the job was created from | ✓ resolve, bound to the member who scheduled the job |
+  | Group/channel fan-out (`deliver=all`, another chat, CLI-created job) | ✗ typed answers don't resolve — use the buttons |
+
+  Known limitations:
+
+  - A cron clarify and an interactive-session clarify pending in the same
+    chat share FIFO-oldest text resolution — a typed answer resolves the
+    oldest one, so cross-talk is possible while both are open.
+  - For fan-out group deliveries, any group member can click the buttons
+    (component resolution is not user-bound).
+  - Multiplex-profile gateways and `thread_sessions_per_user: true` make
+    typed-reply sessions per-user unpredictable; typed answers may not
+    resolve there (buttons still work).
+  - If the job pins `enabled_toolsets`, it must include `clarify` — the
+    per-job allowlist is applied on top of the global gate.
 - Standalone `hermes cron run` fires have no live messaging adapter, so
   `clarify` keeps reporting that it is unavailable in that context.
 - The wait heartbeats the scheduler's activity tracker, so the cron

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -94,6 +94,44 @@ global defaults. A switch to a paid provider or model can therefore spend money
 on every scheduled run.
 :::
 
+## Human-in-the-loop jobs (clarify)
+
+By default cron agents run fully autonomously: the `clarify` tool is disabled
+because unattended jobs have nobody to answer questions. If a job should be
+able to pause and ask for your input — for example an approval gate before a
+destructive action — opt in via `config.yaml`:
+
+```yaml
+cron:
+  allow_clarify: true
+```
+
+Or use the config command:
+
+```bash
+hermes config set cron.allow_clarify true
+```
+
+When enabled and the job fires from the gateway scheduler, a clarify prompt
+renders through the job's first live delivery target (e.g. as buttons in the
+Discord delivery channel) and the agent waits for your answer, up to
+`agent.clarify_timeout` (default 1 hour; `0` waits indefinitely). If you
+don't respond in time — or the prompt can't be delivered — the agent is told
+so and continues autonomously.
+
+Notes:
+
+- The job's `deliver` must target a gateway-connected messaging platform
+  whose adapter supports interactive clarify prompts (Discord, Telegram, …).
+- Standalone `hermes cron run` fires have no live messaging adapter, so
+  `clarify` keeps reporting that it is unavailable in that context.
+- The wait heartbeats the scheduler's activity tracker, so the cron
+  inactivity watchdog (`HERMES_CRON_TIMEOUT`, default 600s) does not kill the
+  run while you are deciding.
+- To customize the cron system-prompt wording when clarify is enabled, set an
+  `agent.platform_hints.cron` override — it takes precedence over the
+  built-in human-in-the-loop hint.
+
 ## Skill-backed cron jobs
 
 A cron job can load one or more skills before it runs the prompt.


### PR DESCRIPTION
## What does this PR do?

Cron agents currently cannot use the `clarify` tool at all: 4494c0b0 hard-disabled the `clarify` toolset in cron context because jobs run unattended — "there's nobody to ask questions to". That is the right default, but it also makes a legitimate use case impossible even as an opt-in: **scheduled jobs that need a human-in-the-loop decision** (e.g. a nightly job that asks "deploy this migration? yes/no" before acting, or a weekly audit that asks which finding to escalate). The job already has a delivery channel to the user — delivery just happens at the *end* of the run, while `clarify` needs it *mid-run*.

This PR adds an opt-in config gate, `cron.allow_clarify` (default `false`, preserving current behavior exactly). When enabled **and** the job is fired by the gateway ticker (live platform adapters + event loop present):

1. `_resolve_cron_disabled_toolsets` no longer hard-disables `clarify`.
2. `run_job` builds a clarify callback via the new `_build_cron_clarify_callback`: it resolves the job's first delivery target, finds the live adapter for that platform (via the existing `resolve_delivery_transport`), and renders the clarify prompt through it — e.g. as Discord buttons in the job's delivery channel. The design mirrors `gateway/run.py`'s `_clarify_callback_sync`; the only cron-specific difference is that the target chat comes from the job's delivery config instead of an inbound message event (a cron session has no attached chat).
3. The cron platform hint is swapped for a human-in-the-loop variant so the system prompt ("you cannot ask questions") doesn't contradict the newly available tool. An explicit `agent.platform_hints.cron` override in config.yaml still wins.

Key behaviors:

- **Graceful degradation without adapters**: standalone `hermes cron run` fires have no live adapter, so no callback is attached and `clarify` keeps reporting its standard "not available in this execution context" — unchanged from today. Same when the delivery platform's adapter lacks `send_clarify`, or gateway config fails to load.
- **Watchdog-safe wait**: the wait reuses `clarify_gateway.wait_for_response`, which polls in 1-second slices and heartbeats the activity tracker, so the cron inactivity watchdog (`HERMES_CRON_TIMEOUT`, default 600s) does not kill the run while the user is deciding.
- **Timeout behavior**: on `agent.clarify_timeout` (default 1h, `0` = unlimited) or a failed send, the tool returns a sentinel string (`[user did not respond within Nm]` / `[clarify prompt could not be delivered]`) so the agent proceeds autonomously instead of hanging — identical to the gateway path.
- **Setup is non-fatal**: any exception while wiring the callback logs a warning and the job continues without clarify.
- **Typed answers resolve from the delivery chat**: the pending entry registers under the delivery chat's own gateway session key — the same key the gateway's inbound text intercept resolves against — computed by `_cron_clarify_reply_session_key` with platform-aware chat-type resolution (live adapter `get_chat_info` → origin `chat_type`/`scope_id` stamp → Slack/Telegram id heuristics). Supported matrix: DM targets ✓, thread/forum targets ✓ (participant-shared; Discord `parent:thread` targets remap to the thread id), group/channel the job was created from ✓ (bound to the scheduling member), group/channel fan-out ✗ (typed replies only — button clicks resolve by clarify_id either way). Multiplex profiles and `thread_sessions_per_user: true` limit typed-reply binding; a cron clarify and an interactive clarify pending in the same chat share FIFO-oldest text resolution.
- **Relay-fronted platforms supported**: when the resolved `DeliveryTransport.is_relay`, the clarify send stamps the logical platform via the existing `_relay_logical_platform` metadata escape hatch (the same convention cron delivery uses), extended to the Relay prompt lane — a scheduled send has no inbound event to populate the relay's per-chat platform map.

## Related Issue

No existing issue or PR covers this. Searched open + closed issues and PRs for `clarify`/`cron` combinations; the nearest neighbors are #36731 (CLI wording of cron delivery error status — unrelated) and #61438 (clarify constrained-choice UX across surfaces + profile-scoped cron storage — its `cron/scheduler.py` change is limited to `context_from` output paths, no overlap). The hard-disable this PR gates was introduced in 4494c0b0.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `cron/scheduler.py`
  - `_resolve_cron_disabled_toolsets`: `clarify` only hard-disabled when `cron.allow_clarify` is not set (docstring updated to match).
  - New `_CRON_CLARIFY_PLATFORM_HINT` + `_build_cron_clarify_callback(job, adapters, loop)`: delivery-target resolution, live-adapter lookup, fire-time `get_chat_info` chat-type hint, gateway-style clarify registration **under the delivery chat's reply-resolution session key**, Relay-aware send metadata, targeted send-failure cleanup + future cancel, watchdog-safe wait, sentinel returns on send failure/timeout.
  - New `_cron_clarify_reply_session_key` + `_platform_dm_hint`: platform-aware reply-key computation (Discord/Telegram/Slack DM & thread shapes, Slack `scope_id`, Discord `parent:thread` remap, origin-user group binding, fan-out/`thread_sessions_per_user` null-outs).
  - `run_job`: new optional `adapters`/`loop` kwargs (default `None` — every existing caller unchanged; docstring updated); attaches the callback + hint swap after `AIAgent` construction, non-fatally.
  - `run_one_job`: plumbs its existing `adapters`/`loop` through to `run_job`.
- `tools/cronjob_tools.py`: `_origin_from_env` stamps `chat_type` + `scope_id` from the bound session source so chat-created jobs carry the chat's true type/scope (justification: without it, DM detection for Discord/Telegram origins is impossible at fire time).
- `tools/clarify_gateway.py`: new `discard(clarify_id)` targeted-removal API (justification: the only removal was `clear_session`, which cancels every pending clarify in a chat — including an unrelated interactive session's prompt).
- `gateway/relay/adapter.py`: `_send_prompt` learns the `_relay_logical_platform` metadata escape hatch (10 lines, mirrors `send()` exactly; interactive path unchanged — it never sets the key).
- `hermes_cli/config_defaults.py`: registers the `cron.allow_clarify: False` default with explanatory comment.
- `website/docs/user-guide/features/cron.md`: new "Human-in-the-loop jobs (clarify)" section (config, timeout semantics, the typed-reply supported matrix, known limitations, Relay note, platform-hint override note).
- `tests/cron/test_cron_clarify.py` (new): toolset-gate tests; reply-key matrix unit tests (origin-stamp/adapter-hint/id-heuristic DM detection, Slack scope, Telegram DM/forum/group shapes, Discord `parent:thread` remap, Slack thread, `thread_sessions_per_user` null-out); callback-construction degradation tests; deliver + button-resolve round-trip; targeted send-failure discard (interactive entry survives); seconds-rendering timeout sentinel; text-reply binding tests with origins built through the real `_origin_from_env`; Relay metadata stamping tests; `run_job` wiring tests (gate + attach + hint swap + operator override + gate-off).
- `tests/gateway/relay/test_relay_interactive.py`: `_send_prompt` honors `_relay_logical_platform` and strips it from outbound metadata.
- `tests/cron/test_run_one_job.py`, `tests/cron/test_scheduler.py`, `tests/cron/test_parallel_pool.py`, `tests/cron/test_execution_ledger.py`: existing `run_job` fakes/lambdas updated to accept the new kwargs; new test in `test_run_one_job.py` asserting `run_one_job` forwards `adapters`/`loop` to `run_job`.

## How to Test

1. `scripts/run_tests.sh tests/cron/ -q` — new + existing cron tests pass.
2. Manual (gateway): set `cron.allow_clarify: true` in `~/.hermes/config.yaml`, create a job whose prompt calls the clarify tool and whose `deliver` targets a Discord channel, and let the gateway ticker fire it. The clarify prompt renders as buttons in the delivery channel; clicking resolves the tool call and the job completes.
3. Timeout path: don't click — after `agent.clarify_timeout` the agent receives `[user did not respond within Nm]` and continues; the scheduler does not stall and the inactivity watchdog does not fire.
4. Default path: with the config unset, `_resolve_cron_disabled_toolsets` still returns `clarify` and behavior is identical to before.

Tested on Ubuntu 24.04 (x86_64), Python 3.11:

- `pytest tests/cron/ tests/gateway/ -q` → **4869 passed, 7 failed** — the 7 failures are pre-existing suite-order flakiness in `test_discord_send.py` / `test_send_multiple_images.py` / `test_session_store_prune.py` / `test_compression_concurrent_sessions.py`: the same files fail on pristine `main @ 470cf66b0` without this branch (the exact set wobbles run-to-run) and all pass in isolation.
- Live end-to-end on a production gateway install, run against this exact branch: a ticker-fired cron job with an origin-bound Discord delivery rendered the clarify prompt in-channel; logs confirmed the pending entry registered under the delivery chat's gateway session key (`clarify text replies bind to session key agent:main:discord:group:<chat>:<user>`), and the timeout path completed cleanly — the clarify tool returned after exactly `agent.clarify_timeout` (600s), the agent continued autonomously, the final response was delivered, and the scheduler ticker stayed healthy throughout. An earlier revision was additionally verified live with button rendering and a real user click resolving the clarify call (same `resolve_gateway_clarify` round-trip the interactive path uses).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(cron): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (see "Related Issue")
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — `tests/cron/` + `tests/gateway/` green apart from 7 pre-existing suite-order flakes that fail identically on pristine main (see "How to Test")
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.11 (live gateway + Discord adapter)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `website/docs/user-guide/features/cron.md` (English; i18n zh-Hans copy intentionally untouched)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A: the example file has no `cron:` section at all (cron keys live in `hermes_cli/config_defaults.py` defaults); the new key is registered there with a comment
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — pure-Python change, no OS-specific calls (no process/signal/path handling); the callback thread model matches the existing gateway clarify path
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A: the `clarify` tool schema/handler is unchanged; only its availability in cron context is gated

## Screenshots / Logs

```
$ pytest tests/cron/ tests/gateway/ -q
4869 passed, 7 failed, 23 skipped in 425.60s   # 7 failures = pre-existing flakes, fail identically on pristine main
```

Live verification log lines from a ticker-fired run of THIS branch with `cron.allow_clarify: true` (origin-bound Discord delivery, no config-level platform-hint override):

```
Job '76555094e3c9': clarify text replies bind to session key agent:main:discord:group:1531975661911277588:1019361483311829003
Job '76555094e3c9': clarify enabled (live adapter attached)
tool clarify completed (600.48s, 146 chars)            # full agent.clarify_timeout wait
Job '76555094e3c9': delivered to discord:1531975661911277588 via live adapter
```

The Discord delivery channel showed the clarify prompt and the pending entry registered under the delivery chat's own gateway session key (the key an inbound typed reply resolves against); when the prompt expired unanswered the agent reported the timeout and its final response was delivered as usual, with the next tick on schedule. An earlier revision of this change was additionally verified with rendered buttons and a real user click resolving the clarify call (same `resolve_gateway_clarify` round-trip).
