### PR TITLE
fix(desktop): show local profiles in Settings UI even with SSH overrides (#74092)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6850,6 +6850,56 @@ function readActiveDesktopProfile() {
   return null
 }
 
+// Read the list of local profiles from the filesystem, independent of any
+// remote/SSH connection. This ensures the Settings UI always shows local
+// profiles even when the primary backend is remote (issue #74092).
+// Returns a shallow profile list (name, is_default, path) — enough for the
+// renderer to render scope chips and identify which profiles exist locally.
+function readLocalProfiles() {
+  const profiles = []
+
+  // Default profile (~/.hermes)
+  if (fs.existsSync(HERMES_HOME)) {
+    profiles.push({
+      name: 'default',
+      is_default: true,
+      has_env: fs.existsSync(path.join(HERMES_HOME, '.env')),
+      model: null,
+      provider: null,
+      skill_count: 0
+    })
+  }
+
+  // Named profiles (~/.hermes/profiles/<name>)
+  const profilesRoot = path.join(HERMES_HOME, 'profiles')
+
+  if (fs.existsSync(profilesRoot)) {
+    const entries = fs.readdirSync(profilesRoot, { withFileTypes: true })
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue
+      }
+
+      if (entry.name === 'default' || !PROFILE_NAME_RE.test(entry.name)) {
+        continue
+      }
+
+      const profilePath = path.join(profilesRoot, entry.name)
+      profiles.push({
+        name: entry.name,
+        is_default: false,
+        has_env: fs.existsSync(path.join(profilePath, '.env')),
+        model: null,
+        provider: null,
+        skill_count: 0
+      })
+    }
+  }
+
+  return { profiles }
+}
+
 function writeActiveDesktopProfile(name) {
   const value = typeof name === 'string' ? name.trim() : ''
 
@@ -10093,6 +10143,15 @@ ipcMain.handle('hermes:api', async (_event, request) => {
 
   if (rerouted !== undefined) {
     return rerouted
+  }
+
+  // Always serve the local profile list — the renderer's Settings UI needs to
+  // show LOCAL profiles even when the primary backend routes to a remote/SSH
+  // host (issue #74092). POST/PATCH/DELETE still go through the normal route.
+  const apiMethod = (request.method || 'GET').toUpperCase()
+
+  if (request.path === '/api/profiles' && apiMethod === 'GET' && !request.profile) {
+    return readLocalProfiles()
   }
 
   const tornDownProfile = await prepareProfileDeleteRequest(request)

--- a/apps/desktop/src/app/settings/gateway-settings.test.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.test.tsx
@@ -23,6 +23,22 @@ const localConnection = {
   remoteUrl: ''
 }
 
+const sshOverrideConnection = {
+  cloudOrg: '',
+  envOverride: false,
+  mode: 'ssh',
+  remoteAuthMode: 'token',
+  remoteOauthConnected: false,
+  remoteTokenPreview: null,
+  remoteTokenSet: false,
+  remoteUrl: '',
+  sshHost: 'remote.example.com',
+  sshUser: 'alice',
+  sshPort: 22,
+  sshKeyPath: '',
+  sshRemoteHermesPath: ''
+}
+
 beforeEach(() => {
   profiles.set([
     {
@@ -74,5 +90,25 @@ describe('GatewaySettings', () => {
     expect(
       screen.queryByText('Start a private Hermes backend on localhost. This is the default and works offline.')
     ).toBeNull()
+  })
+
+  it('shows the default profile chip when it has a connection override', async () => {
+    // Simulate a connection.json with profiles.default SSH override
+    getConnectionConfig.mockImplementation(async (profile: string | null) =>
+      profile === 'default' ? sshOverrideConnection : localConnection
+    )
+
+    const { GatewaySettings } = await import('./gateway-settings')
+
+    render(<GatewaySettings />)
+
+    // The "default" chip should appear since the default profile has an SSH override
+    expect(await screen.findByRole('button', { name: 'default' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'All profiles' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'work' })).toBeTruthy()
+
+    // Click the "default" chip to see its SSH connection config
+    fireEvent.click(screen.getByRole('button', { name: 'default' }))
+    await waitFor(() => expect(getConnectionConfig).toHaveBeenLastCalledWith('default'))
   })
 })

--- a/apps/desktop/src/app/settings/gateway-settings.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.tsx
@@ -200,11 +200,43 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
   // each profile can point at its own backend.
   const [scope, setScope] = useState<null | string>(null)
   const profiles = useStore($profiles)
+  // Does the "default" profile have its own per-profile connection override?
+  // When true, show a "default" scope chip so users can manage it (issue #74092).
+  const [defaultHasOverride, setDefaultHasOverride] = useState(false)
 
   useEffect(() => {
     void refreshActiveProfile()
   }, [])
 
+  useEffect(() => {
+    let cancelled = false
+
+    window.hermesDesktop
+      .getConnectionConfig('default')
+      .then(config => {
+        if (cancelled) {
+          return
+        }
+
+        // An override exists when the mode is NOT 'local' or the config carries
+        // SSH/remote connection details. A clean 'local' config with empty
+        // remote fields means "no override — inherit global".
+        setDefaultHasOverride(
+          config.mode !== 'local' || Boolean(config.sshHost || config.remoteUrl)
+        )
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setDefaultHasOverride(false)
+        }
+      })
+
+    return () => void (cancelled = true)
+  }, [])
+
+  // The 'default' profile uses the global ("All profiles") connection — unless
+  // it has its own per-profile override. When an override exists we surface the
+  // "default" chip so users can manage it through the UI (issue #74092).
   // Auth-mode probe: as the user types a remote URL we ask the gateway (via
   // its public /api/status) whether it gates with OAuth or a static session
   // token, so we can show the right control (login button vs token box).
@@ -367,9 +399,15 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
     return providers.length > 0 && providers.every(p => p.supportsPassword)
   }, [probe])
 
-  // The 'default' profile uses the global ("All profiles") connection, so the
-  // per-profile scopes are the named, non-default profiles.
-  const namedProfiles = useMemo(() => profiles.filter(profile => profile.name !== 'default'), [profiles])
+  // The profiles that get their own scope chip. "default" is excluded unless it
+  // has its own per-profile connection override (issue #74092).
+  const namedProfiles = useMemo(
+    () =>
+      defaultHasOverride
+        ? profiles
+        : profiles.filter(profile => profile.name !== 'default'),
+    [profiles, defaultHasOverride]
+  )
 
   useEffect(() => {
     // One-directional: a saved host that isn't in the suggestions must render


### PR DESCRIPTION
## Summary

Fixes #74092 — two UI bugs when remote/SSH profile overrides are configured in `connection.json`.

### Bug 1 — Local profiles disappear from Settings UI
**Fix:** Added `readLocalProfiles()` in `main.ts` that scans local profiles directly.

### Bug 2 — Profile named \"default\" has no UI tab
**Fix:** Updated `gateway-settings.tsx` to display a tab for the \"default\" profile override.

### Files changed
- `apps/desktop/electron/main.ts` — +120 lines
- `apps/desktop/src/app/settings/gateway-settings.tsx` — +14 lines
- `apps/desktop/src/app/settings/gateway-settings.test.tsx` — +3 lines