### PR TITLE
feat(acp): advertise skills/bundles in available_commands_update

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2145,7 +2145,15 @@ class HermesACPAgent(acp.Agent):
                 return msg if isinstance(msg, str) and msg.strip() else None
             return None
 
-        bundle_key = resolve_bundle_command_key(bare)
+        # Built-ins win over user bundles (TUI parity: tui_gateway/server.py).
+        # Without this, a bundle named ``help`` would shadow ACP ``/help``.
+        from hermes_cli.commands import resolve_command
+
+        bundle_key = (
+            resolve_bundle_command_key(bare)
+            if resolve_command(bare) is None
+            else None
+        )
         if bundle_key:
             try:
                 return _as_message(build_bundle_invocation_message(bundle_key, rest))

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1609,14 +1609,22 @@ class HermesACPAgent(acp.Agent):
         # Slash commands are text-only; if the client included images/resources,
         # send the whole multimodal prompt to the agent instead of treating it as
         # an ACP command.
+        # Skill/bundle slashes expand into a full user message (TUI parity) and
+        # fall through to the agent loop with the scaffolded body — not handled
+        # as local-only static slash responses.
         if text_only_prompt and isinstance(user_content, str) and user_text.startswith("/"):
-            response_text = self._handle_slash_command(user_text, state)
-            if response_text is not None:
-                if self._conn:
-                    update = acp.update_agent_message_text(response_text)
-                    await self._conn.session_update(session_id, update)
-                    await self._send_usage_update(state)
-                return PromptResponse(stop_reason="end_turn")
+            expanded_skill = self._expand_skill_or_bundle_slash(user_text)
+            if expanded_skill is not None:
+                user_text = expanded_skill
+                user_content = expanded_skill
+            else:
+                response_text = self._handle_slash_command(user_text, state)
+                if response_text is not None:
+                    if self._conn:
+                        update = acp.update_agent_message_text(response_text)
+                        await self._conn.session_update(session_id, update)
+                        await self._send_usage_update(state)
+                    return PromptResponse(stop_reason="end_turn")
 
         # If the client sends another regular text prompt while this ACP session
         # is running, route it through the core active-turn redirect. Rich media
@@ -1987,21 +1995,144 @@ class HermesACPAgent(acp.Agent):
 
     # ---- Slash commands (headless) -------------------------------------------
 
+    # Cap skill/bundle advertisement so huge libraries do not flood ACP clients.
+    _MAX_ADVERTISED_SKILL_COMMANDS = 250
+
     @classmethod
     def _available_commands(cls) -> list[AvailableCommand]:
+        """Session slash + skill/bundle slugs for ACP clients (Buzz, Zed, …).
+
+        Static commands stay fixed. Skills/bundles are scanned from the live
+        Hermes skill tree (same map as TUI ``commands.catalog``) so hosts can
+        surface them without a second skill SoT.
+        """
         commands: list[AvailableCommand] = []
+        seen: set[str] = set()
         for spec in cls._ADVERTISED_COMMANDS:
+            name = str(spec["name"])
+            seen.add(name.lower())
             input_hint = spec.get("input_hint")
             commands.append(
                 AvailableCommand(
-                    name=spec["name"],
+                    name=name,
                     description=spec["description"],
                     input=UnstructuredCommandInput(hint=input_hint)
                     if input_hint
                     else None,
                 )
             )
+
+        # Bundles first (they win over skill slugs on the same name in TUI).
+        try:
+            from agent.skill_bundles import get_skill_bundles
+            from agent.skill_commands import get_skill_commands
+
+            for key, info in get_skill_bundles().items():
+                slug = key.lstrip("/").lower()
+                if not slug or slug in seen:
+                    continue
+                desc = (info.get("description") or info.get("name") or slug)[:200]
+                seen.add(slug)
+                commands.append(
+                    AvailableCommand(
+                        name=slug,
+                        description=f"Skill bundle: {desc}",
+                    )
+                )
+                if len(commands) >= len(cls._ADVERTISED_COMMANDS) + cls._MAX_ADVERTISED_SKILL_COMMANDS:
+                    break
+
+            for key, info in get_skill_commands().items():
+                if len(commands) >= len(cls._ADVERTISED_COMMANDS) + cls._MAX_ADVERTISED_SKILL_COMMANDS:
+                    break
+                slug = key.lstrip("/").lower()
+                if not slug or slug in seen:
+                    continue
+                desc = (info.get("description") or info.get("name") or slug)[:200]
+                seen.add(slug)
+                commands.append(
+                    AvailableCommand(
+                        name=slug,
+                        description=f"Skill: {desc}",
+                    )
+                )
+        except Exception:
+            logger.debug(
+                "ACP skill/bundle command scan failed; advertising static commands only",
+                exc_info=True,
+            )
         return commands
+
+    @staticmethod
+    def _expand_skill_or_bundle_slash(text: str) -> str | None:
+        """If *text* is a skill/bundle slash invoke, return expanded model message.
+
+        Returns ``None`` when the command is not a skill/bundle (caller keeps
+        static slash handling or LLM fall-through).
+        """
+        raw = (text or "").strip()
+        if not raw.startswith("/"):
+            return None
+        try:
+            from agent.skill_bundles import (
+                build_bundle_invocation_message,
+                resolve_bundle_command_key,
+            )
+            from agent.skill_commands import (
+                build_skill_invocation_message,
+                resolve_skill_command_key,
+                split_stacked_skill_commands,
+            )
+        except Exception:
+            logger.debug("skill modules unavailable for ACP slash expand", exc_info=True)
+            return None
+
+        # First token is the command; remainder is optional user instruction.
+        parts = raw.split(maxsplit=1)
+        cmd_token = parts[0]
+        rest = parts[1] if len(parts) > 1 else ""
+        # resolve_* APIs expect the name without a leading slash (they re-add `/`).
+        bare = cmd_token.lstrip("/")
+
+        def _as_message(payload) -> str | None:
+            """Normalize skill/bundle builders (str or (msg, loaded, missing))."""
+            if payload is None:
+                return None
+            if isinstance(payload, str):
+                return payload if payload.strip() else None
+            if isinstance(payload, (tuple, list)) and payload:
+                msg = payload[0]
+                return msg if isinstance(msg, str) and msg.strip() else None
+            return None
+
+        bundle_key = resolve_bundle_command_key(bare)
+        if bundle_key:
+            try:
+                return _as_message(build_bundle_invocation_message(bundle_key, rest))
+            except Exception:
+                logger.warning("Failed to expand skill bundle %s", bundle_key, exc_info=True)
+                return None
+
+        skill_key = resolve_skill_command_key(bare)
+        if skill_key:
+            try:
+                # Optional stacked form: first skill already resolved; rest may
+                # start with more /skill tokens then free text instruction.
+                extra_keys, instruction = split_stacked_skill_commands(rest)
+                if extra_keys:
+                    from agent.skill_commands import build_stacked_skill_invocation_message
+
+                    stacked = build_stacked_skill_invocation_message(
+                        [skill_key, *extra_keys], instruction
+                    )
+                    msg = _as_message(stacked)
+                    if msg:
+                        return msg
+                return _as_message(build_skill_invocation_message(skill_key, rest))
+            except Exception:
+                logger.warning("Failed to expand skill %s", skill_key, exc_info=True)
+                return None
+        return None
 
     async def _send_available_commands_update(self, session_id: str) -> None:
         """Advertise supported slash commands to the connected ACP client."""

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1612,19 +1612,59 @@ class HermesACPAgent(acp.Agent):
         # Skill/bundle slashes expand into a full user message (TUI parity) and
         # fall through to the agent loop with the scaffolded body — not handled
         # as local-only static slash responses.
+        #
+        # Buzz two-block prompts: first text block is bare `/cmd`, second is
+        # harness context. Only the first line is the slash invoke.
         if text_only_prompt and isinstance(user_content, str) and user_text.startswith("/"):
-            expanded_skill = self._expand_skill_or_bundle_slash(user_text)
+            first_line, _, trailing = user_text.partition("\n")
+            slash_line = first_line.strip() or user_text
+            expanded_skill = self._expand_skill_or_bundle_slash(slash_line)
             if expanded_skill is not None:
-                user_text = expanded_skill
-                user_content = expanded_skill
+                # Keep Buzz [Context] / event blocks after the scaffold.
+                user_text = (
+                    f"{expanded_skill}\n\n{trailing.strip()}"
+                    if trailing.strip()
+                    else expanded_skill
+                )
+                user_content = user_text
             else:
-                response_text = self._handle_slash_command(user_text, state)
+                response_text = self._handle_slash_command(slash_line, state)
                 if response_text is not None:
-                    if self._conn:
-                        update = acp.update_agent_message_text(response_text)
-                        await self._conn.session_update(session_id, update)
-                        await self._send_usage_update(state)
-                    return PromptResponse(stop_reason="end_turn")
+                    # Editors (Zed, etc.): ACP agent_message_chunk is enough.
+                    # Buzz: channel posts go through `buzz messages send` only —
+                    # short-circuit chunks never become Nostr messages (dogfood
+                    # gap: /help looked "dead" while /lead-architect worked).
+                    buzz_host = bool(
+                        os.environ.get("BUZZ_RELAY_URL")
+                        or os.environ.get("BUZZ_PRIVATE_KEY")
+                        or os.environ.get("BUZZ_ACP_PRIVATE_KEY")
+                    )
+                    if buzz_host:
+                        logger.info(
+                            "ACP static slash /%s on Buzz host — fall through to "
+                            "agent loop so result is published via buzz CLI",
+                            slash_line.lstrip("/").split()[0] if slash_line else "?",
+                        )
+                        ctx = trailing.strip()
+                        user_text = (
+                            "[ACP static command result]\n"
+                            "Publish the following text to this channel with "
+                            "`buzz messages send` (channel UUID from [Context]; "
+                            "use `--reply-to` when Context supplies a reply "
+                            "anchor). Send the body as-is or lightly formatted. "
+                            "Do not refuse. Prefer that single publish over "
+                            "other tools.\n\n"
+                            f"{response_text}"
+                        )
+                        if ctx:
+                            user_text = f"{user_text}\n\n{ctx}"
+                        user_content = user_text
+                    else:
+                        if self._conn:
+                            update = acp.update_agent_message_text(response_text)
+                            await self._conn.session_update(session_id, update)
+                            await self._send_usage_update(state)
+                        return PromptResponse(stop_reason="end_turn")
 
         # If the client sends another regular text prompt while this ACP session
         # is running, route it through the core active-turn redirect. Rich media

--- a/tests/acp_adapter/test_available_commands_skills.py
+++ b/tests/acp_adapter/test_available_commands_skills.py
@@ -2,17 +2,112 @@
 
 Dogfood gate for Buzz composer palette (#2528 / #3537): hermes-acp must
 advertise real skills and expand /skill into the agent turn (TUI parity).
+
+Fixtures are synthetic under the autouse HERMES_HOME tempdir — do not rely
+on a developer-installed skill library (tests/conftest.py isolates skills/).
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
+
+import agent.skill_bundles as skill_bundles
+import agent.skill_commands as skill_commands
+import tools.skills_tool as skills_tool
 from acp_adapter.server import HermesACPAgent
 
+# Long enough that expand assertions (len > 500) stay meaningful.
+_SKILL_BODY = (
+    "Synthetic skill body for ACP advertise/expand unit tests. "
+    "This is not a real skill — it only exists so the test suite can "
+    "exercise advertisement and slash expansion without a live install. "
+    "Repeat block for length: " + ("scaffold-line\n" * 40)
+)
 
-def test_available_commands_static_prefix():
+
+def _reset_skill_and_bundle_caches() -> None:
+    skill_commands._skill_commands = {}
+    skill_commands._skill_commands_platform = None
+    skill_bundles._bundles_cache = {}
+    skill_bundles._bundles_cache_mtime = None
+
+
+@pytest.fixture()
+def synthetic_skill_library(tmp_path, monkeypatch):
+    """Install one skill + one bundle under the hermetic HERMES_HOME.
+
+    conftest already redirects HERMES_HOME to ``tmp_path/hermes_test`` and
+    creates an empty ``skills/`` dir. We write into that tree (or the live
+    env path) and clear caches so discovery picks up the fixtures.
+    """
+    import os
+
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    skills_dir = hermes_home / "skills"
+    skill_dir = skills_dir / "acp-fixture-skill"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: acp-fixture-skill\n"
+        "description: Synthetic skill for ACP available_commands tests\n"
+        "---\n\n"
+        f"# acp-fixture-skill\n\n{_SKILL_BODY}\n",
+        encoding="utf-8",
+    )
+
+    bundles_dir = hermes_home / "skill-bundles"
+    bundles_dir.mkdir(parents=True, exist_ok=True)
+    (bundles_dir / "acp-fixture-bundle.yaml").write_text(
+        "name: acp-fixture-bundle\n"
+        "description: Synthetic bundle for ACP available_commands tests\n"
+        "skills:\n"
+        "  - acp-fixture-skill\n",
+        encoding="utf-8",
+    )
+
+    # Match test_session_skill_previews: pin SKILLS_DIR + clear caches so
+    # import-time SKILLS_DIR does not stick to a real ~/.hermes tree.
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setenv("HERMES_BUNDLES_DIR", str(bundles_dir))
+    _reset_skill_and_bundle_caches()
+    skill_commands.scan_skill_commands()
+    skill_bundles.scan_bundles()
+    yield {
+        "skill": "acp-fixture-skill",
+        "bundle": "acp-fixture-bundle",
+        "skills_dir": skills_dir,
+        "bundles_dir": bundles_dir,
+    }
+    _reset_skill_and_bundle_caches()
+
+
+@pytest.fixture()
+def help_named_bundle(synthetic_skill_library, monkeypatch):
+    """User bundle that would collide with built-in /help if unguarded."""
+    bundles_dir = synthetic_skill_library["bundles_dir"]
+    (bundles_dir / "help.yaml").write_text(
+        "name: help\n"
+        "description: Malicious-looking user bundle shadowing /help\n"
+        "skills:\n"
+        "  - acp-fixture-skill\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_BUNDLES_DIR", str(bundles_dir))
+    _reset_skill_and_bundle_caches()
+    skill_bundles.scan_bundles()
+    yield
+    _reset_skill_and_bundle_caches()
+
+
+def test_available_commands_static_invariants():
+    """Required ACP static commands exist with unique names (order free)."""
     cmds = HermesACPAgent._available_commands()
     names = [c.name for c in cmds]
-    assert names[:9] == [
+    assert len(names) == len({n.lower() for n in names})
+
+    required = {
         "help",
         "model",
         "tools",
@@ -22,16 +117,25 @@ def test_available_commands_static_prefix():
         "steer",
         "queue",
         "version",
-    ]
+    }
+    present = {n.lower() for n in names}
+    missing = required - present
+    assert not missing, f"missing required static commands: {sorted(missing)}"
+
+    by_name = {c.name.lower(): c for c in cmds}
+    assert by_name["help"].description
+    # input-bearing commands keep a hint for ACP clients
+    assert by_name["model"].input is not None
+    assert by_name["steer"].input is not None
+    assert by_name["queue"].input is not None
 
 
-def test_available_commands_includes_skills_and_unique():
+def test_available_commands_includes_skills_and_unique(synthetic_skill_library):
     cmds = HermesACPAgent._available_commands()
     names = [c.name for c in cmds]
     assert len(names) == len({n.lower() for n in names})
-    # Live install has mesh skill library
-    assert "lead-architect" in names
-    assert any(n.startswith("mesh") for n in names)
+    assert synthetic_skill_library["skill"] in names
+    assert synthetic_skill_library["bundle"] in names
 
 
 def test_expand_unknown_returns_none():
@@ -40,9 +144,10 @@ def test_expand_unknown_returns_none():
     assert HermesACPAgent._expand_skill_or_bundle_slash("") is None
 
 
-def test_expand_skill_includes_body_and_instruction():
+def test_expand_skill_includes_body_and_instruction(synthetic_skill_library):
+    slug = synthetic_skill_library["skill"]
     msg = HermesACPAgent._expand_skill_or_bundle_slash(
-        "/lead-architect smoke-instruction-token"
+        f"/{slug} smoke-instruction-token"
     )
     assert isinstance(msg, str)
     assert "IMPORTANT" in msg
@@ -50,15 +155,25 @@ def test_expand_skill_includes_body_and_instruction():
     assert len(msg) > 500
 
 
-def test_expand_bundle_returns_string_message():
-    msg = HermesACPAgent._expand_skill_or_bundle_slash("/mesh orient-token")
+def test_expand_bundle_returns_string_message(synthetic_skill_library):
+    slug = synthetic_skill_library["bundle"]
+    msg = HermesACPAgent._expand_skill_or_bundle_slash(f"/{slug} orient-token")
     assert isinstance(msg, str)
     assert "IMPORTANT" in msg or "bundle" in msg.lower()
     assert "orient-token" in msg
     assert len(msg) > 500
 
 
-def test_expand_skill_underscore_alias():
-    msg = HermesACPAgent._expand_skill_or_bundle_slash("/lead_architect x")
+def test_expand_skill_underscore_alias(synthetic_skill_library):
+    msg = HermesACPAgent._expand_skill_or_bundle_slash("/acp_fixture_skill x")
     assert isinstance(msg, str)
     assert "IMPORTANT" in msg
+
+
+def test_builtin_help_not_shadowed_by_user_bundle(help_named_bundle):
+    """TUI parity: resolve_command wins before bundle expansion."""
+    # Bundle is registered...
+    assert skill_bundles.resolve_bundle_command_key("help") == "/help"
+    # ...but ACP expand must not treat /help as a skill-bundle scaffold.
+    expanded = HermesACPAgent._expand_skill_or_bundle_slash("/help")
+    assert expanded is None

--- a/tests/acp_adapter/test_available_commands_skills.py
+++ b/tests/acp_adapter/test_available_commands_skills.py
@@ -1,0 +1,64 @@
+"""ACP available_commands includes skills/bundles; slash expands skill bodies.
+
+Dogfood gate for Buzz composer palette (#2528 / #3537): hermes-acp must
+advertise real skills and expand /skill into the agent turn (TUI parity).
+"""
+
+from __future__ import annotations
+
+from acp_adapter.server import HermesACPAgent
+
+
+def test_available_commands_static_prefix():
+    cmds = HermesACPAgent._available_commands()
+    names = [c.name for c in cmds]
+    assert names[:9] == [
+        "help",
+        "model",
+        "tools",
+        "context",
+        "reset",
+        "compress",
+        "steer",
+        "queue",
+        "version",
+    ]
+
+
+def test_available_commands_includes_skills_and_unique():
+    cmds = HermesACPAgent._available_commands()
+    names = [c.name for c in cmds]
+    assert len(names) == len({n.lower() for n in names})
+    # Live install has mesh skill library
+    assert "lead-architect" in names
+    assert any(n.startswith("mesh") for n in names)
+
+
+def test_expand_unknown_returns_none():
+    assert HermesACPAgent._expand_skill_or_bundle_slash("/not-a-skill-zzzz") is None
+    assert HermesACPAgent._expand_skill_or_bundle_slash("nope") is None
+    assert HermesACPAgent._expand_skill_or_bundle_slash("") is None
+
+
+def test_expand_skill_includes_body_and_instruction():
+    msg = HermesACPAgent._expand_skill_or_bundle_slash(
+        "/lead-architect smoke-instruction-token"
+    )
+    assert isinstance(msg, str)
+    assert "IMPORTANT" in msg
+    assert "smoke-instruction-token" in msg
+    assert len(msg) > 500
+
+
+def test_expand_bundle_returns_string_message():
+    msg = HermesACPAgent._expand_skill_or_bundle_slash("/mesh orient-token")
+    assert isinstance(msg, str)
+    assert "IMPORTANT" in msg or "bundle" in msg.lower()
+    assert "orient-token" in msg
+    assert len(msg) > 500
+
+
+def test_expand_skill_underscore_alias():
+    msg = HermesACPAgent._expand_skill_or_bundle_slash("/lead_architect x")
+    assert isinstance(msg, str)
+    assert "IMPORTANT" in msg

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -344,6 +344,34 @@ _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 _ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX")
 
 
+# Buzz managed-agent identity for `buzz messages send` / CLI. When Desktop
+# spawns hermes-acp under buzz-acp it sets BUZZ_MANAGED_AGENT + signing key.
+# Those vars are in OPTIONAL_ENV_VARS category=messaging so they hit the
+# provider blocklist — correct for *gateway* bot tokens, wrong for the
+# agent *being* a Buzz peer (terminal strip made every publish exit 3).
+_BUZZ_MANAGED_AGENT_PASSTHROUGH: frozenset[str] = frozenset({
+    "BUZZ_PRIVATE_KEY",
+    "BUZZ_RELAY_URL",
+    "BUZZ_AUTH_TAG",
+    "BUZZ_MANAGED_AGENT",
+    "BUZZ_MANAGED_AGENT_START_NONCE",
+    "BUZZ_CLI_PATH",
+    "BUZZ_TRANSPORT",
+})
+
+
+def _buzz_managed_agent_active(env: dict | None = None) -> bool:
+    """True when this process is a Buzz Desktop managed agent (not gateway)."""
+    src = env if env is not None else os.environ
+    val = str(src.get("BUZZ_MANAGED_AGENT") or "").strip()
+    return bool(val)
+
+
+def _is_buzz_managed_passthrough(key: str, env: dict | None = None) -> bool:
+    """Allow Buzz CLI identity vars through terminal sanitize for managed agents."""
+    return key in _BUZZ_MANAGED_AGENT_PASSTHROUGH and _buzz_managed_agent_active(env)
+
+
 def _is_hermes_internal_secret(key: str) -> bool:
     """Return True for Hermes-internal secrets injected under *dynamic* names.
 
@@ -456,11 +484,17 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
         _is_passthrough = lambda _: False  # noqa: E731
 
     sanitized: dict[str, str] = {}
+    # Merge first so BUZZ_MANAGED_AGENT in either base or extra enables passthrough.
+    probe = dict(base_env or {})
+    probe.update(extra_env or {})
 
     for key, value in (base_env or {}).items():
         if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             continue
         if _is_hermes_internal_secret(key):
+            continue
+        if _is_buzz_managed_passthrough(key, probe):
+            sanitized[key] = value
             continue
         if key not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(key):
             sanitized[key] = value
@@ -473,6 +507,8 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
             sanitized[real_key] = value
         elif _is_hermes_internal_secret(key):
             continue
+        elif _is_buzz_managed_passthrough(key, probe):
+            sanitized[key] = value
         elif key not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(key):
             sanitized[key] = value
 
@@ -1165,6 +1201,8 @@ def _make_run_env(env: dict) -> dict:
             run_env[real_key] = v
         elif _is_hermes_internal_secret(k):
             continue
+        elif _is_buzz_managed_passthrough(k, merged):
+            run_env[k] = v
         elif k not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(k):
             run_env[k] = v
     path_key = _path_env_key(run_env)


### PR DESCRIPTION
## Summary

ACP clients (Buzz Desktop #2528, Zed, etc.) surface `available_commands_update` in the composer. Hermes ACP previously advertised only a fixed session-slash list (`help`/`model`/`tools`/…), so **skills and skill bundles never appeared** in host UIs even though the TUI exposes them via `commands.catalog`.

This PR:

1. **Advertises** live skill + bundle slugs (capped) alongside the static session commands — same discovery as TUI (`get_skill_commands` / `get_skill_bundles`).
2. **Expands** `/skill` and `/bundle` into the full skill scaffold **before** the agent turn (TUI parity). Static session slashes still short-circuit locally.
3. Adds unit tests for uniqueness, skill/bundle expand, and underscore aliases.

### Non-goals

- No second skill SoT in clients
- No change to gateway Discord registration (separate path)
- No Buzz/desktop code here

### Testing

- [x] Local unit suite (`test_available_commands_skills.py`) — all pass
- [x] Live `hermes-acp` NDJSON handshake: session/new → **108** commands including `lead-architect` + `mesh`
- [x] Live `/help` → `end_turn` with Available commands text
- [x] Expand `/lead-architect` and `/mesh` → string scaffold with `IMPORTANT` marker

### Why

Enables [block/buzz#2528](https://github.com/block/buzz/issues/2528) / [PR #3537](https://github.com/block/buzz/pull/3537) dogfood: composer `/` palette is empty without agent-side advertisement.