### PR TITLE
fix(cron): kill the whole process group when a cron script times out

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2225,7 +2225,7 @@ def _kill_script_process_tree(proc: subprocess.Popen) -> None:
     pid = proc.pid
     if sys.platform == "win32":
         try:
-            subprocess.run(
+            result = subprocess.run(
                 ["taskkill", "/PID", str(pid), "/T", "/F"],
                 capture_output=True,
                 text=True, encoding="utf-8", errors="replace",
@@ -2233,7 +2233,13 @@ def _kill_script_process_tree(proc: subprocess.Popen) -> None:
                 creationflags=windows_hide_flags(),
                 stdin=subprocess.DEVNULL,
             )
-            return
+            if result.returncode == 0:
+                return
+            details = (result.stderr or result.stdout or "").strip()
+            logger.debug(
+                "taskkill tree-kill of cron script pid %s exited %s: %s",
+                pid, result.returncode, details,
+            )
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
             logger.debug("taskkill tree-kill of cron script pid %s failed: %s", pid, exc)
     else:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -17,6 +17,7 @@ import logging
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import threading
@@ -2097,6 +2098,12 @@ _DEFAULT_SCRIPT_TIMEOUT = 3600  # seconds (1 hour)
 # Backward-compatible module override used by tests and emergency monkeypatches.
 _SCRIPT_TIMEOUT = _DEFAULT_SCRIPT_TIMEOUT
 _RUN_CLAIM_HEARTBEAT_SECONDS = 60.0
+# How long to wait for stdout/stderr to drain after a timed-out script has been
+# tree-killed.  A descendant that survived the kill (or is wedged in
+# uninterruptible IO) can still hold the inherited pipes open, and an unbounded
+# drain would hang the scheduler thread forever — the very failure the timeout
+# exists to prevent.
+_SCRIPT_KILL_DRAIN_SECONDS = 10.0
 
 
 def _get_script_timeout() -> int:
@@ -2188,6 +2195,113 @@ def _windows_cron_python_invocation(python_exe: str) -> tuple[str, dict[str, str
             env_overlay["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
 
     return str(interpreter), env_overlay
+
+
+def _kill_script_process_tree(proc: subprocess.Popen) -> None:
+    """Hard-kill a timed-out cron script *and everything it spawned*.
+
+    ``subprocess.run(timeout=...)`` only kills the direct child.  A script that
+    backgrounds work (``worker.py &``, a transcode, a model run) therefore left
+    its grandchildren behind: reparented to init, still burning CPU/GPU, and
+    still holding the inherited stdout/stderr pipes open.  With the default
+    one-hour (or longer) cron script timeout that runaway lives forever and the
+    next scheduled run collides with it.
+
+    ``_run_job_script`` spawns the script into its own process group / session
+    (POSIX ``start_new_session=True``, Windows ``CREATE_NEW_PROCESS_GROUP``) so
+    the whole tree can be addressed at once:
+
+    * POSIX — ``os.killpg(pgid, SIGKILL)``.  SIGKILL rather than SIGTERM
+      because this is already the timeout path: the script has had its entire
+      budget and we need a guaranteed stop, not a request.
+    * Windows — ``taskkill /PID <pid> /T /F``, the same tree-kill primitive
+      used by ``tools/process_registry.py`` and ``gateway.status.terminate_pid``.
+      Windows has no cascading process-group signal, and ``Popen.kill()`` is
+      ``TerminateProcess()`` on the single handle only.
+
+    Best-effort by design: every failure path falls back to ``proc.kill()`` so
+    the direct child dies even when the group kill is unavailable or refused.
+    """
+    pid = proc.pid
+    if sys.platform == "win32":
+        try:
+            subprocess.run(
+                ["taskkill", "/PID", str(pid), "/T", "/F"],
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+                timeout=10,
+                creationflags=windows_hide_flags(),
+                stdin=subprocess.DEVNULL,
+            )
+            return
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+            logger.debug("taskkill tree-kill of cron script pid %s failed: %s", pid, exc)
+    else:
+        try:
+            pgid = os.getpgid(pid)  # windows-footgun: ok — POSIX-only branch
+            # Paranoia guard for unattended scheduler code: if start_new_session
+            # somehow did not take effect the child shares *our* process group,
+            # and killpg would take down the gateway itself.  Fall back to
+            # killing just the child in that case.
+            if pgid != os.getpgid(0):  # windows-footgun: ok — POSIX-only branch
+                os.killpg(pgid, getattr(signal, "SIGKILL", signal.SIGTERM))  # windows-footgun: ok — POSIX-only branch
+                return
+            logger.warning(
+                "Cron script pid %s shares the scheduler's process group; "
+                "killing only the direct child to avoid signalling the gateway.",
+                pid,
+            )
+        except (ProcessLookupError, PermissionError, OSError) as exc:
+            logger.debug("killpg of cron script pid %s failed: %s", pid, exc)
+
+    try:
+        proc.kill()
+    except Exception as exc:
+        logger.debug("Fallback kill of cron script pid %s failed: %s", pid, exc)
+
+
+def _kill_and_reap_script(proc: subprocess.Popen, path: Path) -> None:
+    """Tree-kill a cron script, then bound the cleanup of its pipes.
+
+    Shared by the timeout path and the catch-all bailout in
+    ``_run_job_script``.  Together those two call sites restore the guarantee
+    that ``subprocess.run``'s internal ``with Popen(...) as process:`` used to
+    give us for free: whatever goes wrong, we never return (or propagate) with
+    the script still running and our pipes still open.
+
+    Every step is best-effort and individually bounded — this only ever runs on
+    an already-failing path, so it must not introduce a *new* way to hang the
+    scheduler thread.  ``BaseException`` is caught deliberately: the catch-all
+    caller can be unwinding a ``KeyboardInterrupt``/``SystemExit`` during
+    gateway shutdown, and cleanup must still finish before that propagates.
+    """
+    _kill_script_process_tree(proc)
+    # Bounded drain.  A descendant that survived the kill can keep the
+    # inherited pipes open, and an unbounded communicate() would block the
+    # scheduler thread indefinitely.
+    try:
+        proc.communicate(timeout=_SCRIPT_KILL_DRAIN_SECONDS)
+        return
+    except BaseException as drain_exc:
+        if isinstance(drain_exc, subprocess.TimeoutExpired):
+            logger.warning(
+                "Cron script %s: output pipes still open %ss after the "
+                "timeout kill; abandoning the drain.",
+                path, _SCRIPT_KILL_DRAIN_SECONDS,
+            )
+        else:
+            logger.debug("Cron script %s: post-kill drain failed: %s", path, drain_exc)
+
+    for stream in (proc.stdout, proc.stderr):
+        try:
+            if stream is not None:
+                stream.close()
+        except Exception:
+            pass
+    try:
+        proc.wait(timeout=1)
+    except Exception:
+        pass
 
 
 def _run_job_script(
@@ -2300,17 +2414,46 @@ def _run_job_script(
         # NEVER mutate the Python process cwd — that would leak into
         # concurrent gateway sessions (#69396).
         _script_cwd = workdir or str(path.parent)
-        result = subprocess.run(
+        # Give the script its own process group / session so a timeout can kill
+        # the entire tree it spawned, not just the direct child (see
+        # _kill_script_process_tree).  subprocess.run(timeout=...) cannot do
+        # this, which is why this is an explicit Popen + communicate().
+        if sys.platform == "win32":
+            popen_kwargs["creationflags"] = (
+                popen_kwargs.get("creationflags", 0)
+                | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+            )
+        else:
+            popen_kwargs["start_new_session"] = True
+
+        proc = subprocess.Popen(
             argv,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
-            timeout=script_timeout,
             cwd=_script_cwd,
             env=env,
             **popen_kwargs,
         )
-        stdout = (result.stdout or "").strip()
-        stderr = (result.stderr or "").strip()
+        try:
+            raw_stdout, raw_stderr = proc.communicate(timeout=script_timeout)
+        except subprocess.TimeoutExpired as timeout_exc:
+            _kill_and_reap_script(proc, path)
+            # Re-raise the *original* timeout so the message below stays exact.
+            raise timeout_exc
+        except BaseException:
+            # Parity with the ``with Popen(...)`` context manager inside
+            # subprocess.run that this call replaced: on *any* other failure
+            # — a pipe-read OSError, MemoryError, or a KeyboardInterrupt /
+            # SystemExit during gateway shutdown — never leave the script
+            # running with our pipes still open.  Bare re-raise so the outer
+            # handlers (and the caller) behave exactly as before.
+            _kill_and_reap_script(proc, path)
+            raise
+
+        stdout = (raw_stdout or "").strip()
+        stderr = (raw_stderr or "").strip()
+        returncode = proc.returncode
 
         # Redact secrets from both stdout and stderr before any return path.
         try:
@@ -2322,8 +2465,8 @@ def _run_job_script(
             stdout = "[REDACTED - redaction failed]"
             stderr = "[REDACTED - redaction failed]"
 
-        if result.returncode != 0:
-            parts = [f"Script exited with code {result.returncode}"]
+        if returncode != 0:
+            parts = [f"Script exited with code {returncode}"]
             if stderr:
                 parts.append(f"stderr:\n{stderr}")
             if stdout:

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -4,13 +4,16 @@ Tests cover:
 - Script field in job creation / storage / update
 - Script execution and output injection into prompts
 - Error handling (missing script, timeout, non-zero exit)
+- Timeout kills the whole process group (no orphaned grandchildren)
 - Path resolution (absolute, relative to HERMES_HOME/scripts/)
 """
 
 import json
 import os
+import signal
 import sys
 import textwrap
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -19,6 +22,43 @@ import pytest
 
 # Ensure project root is importable
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+class _FakePopen:
+    """Minimal subprocess.Popen stand-in for spawn-argument assertions.
+
+    ``_run_job_script`` uses Popen + communicate() (rather than
+    subprocess.run) so it can tree-kill on timeout, so the spawn-shape tests
+    patch Popen instead.
+    """
+
+    def __init__(self, stdout="", stderr="", returncode=0):
+        self._stdout = stdout
+        self._stderr = stderr
+        self.returncode = returncode
+        self.pid = 4242
+        self.stdout = None
+        self.stderr = None
+
+    def communicate(self, timeout=None):
+        return self._stdout, self._stderr
+
+    def kill(self):
+        pass
+
+    def wait(self, timeout=None):
+        return self.returncode
+
+
+def _pid_alive(pid: int) -> bool:
+    """True if *pid* still exists (POSIX only; used by the orphan tests)."""
+    try:
+        os.kill(pid, 0)  # windows-footgun: ok — POSIX-only helper
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
 
 
 @pytest.fixture
@@ -152,26 +192,34 @@ class TestRunJobScript:
 
         captured = {}
 
-        def fake_run(argv, **kwargs):
+        def fake_popen(argv, **kwargs):
             captured["argv"] = argv
             captured["kwargs"] = kwargs
-            return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+            return _FakePopen(stdout="ok\n", stderr="")
 
         monkeypatch.setattr(sched_mod.sys, "platform", "win32")
         monkeypatch.setattr(sched_mod.sys, "executable", str(venv_python))
         monkeypatch.setattr(sched_mod, "windows_hide_flags", lambda: 0x08000000)
-        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(sched_mod.subprocess, "Popen", fake_popen)
+        # Present on Windows only; define it so this simulated-Windows test
+        # exercises the real creationflags path on POSIX CI too.
+        monkeypatch.setattr(
+            sched_mod.subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200, raising=False
+        )
 
         success, output = _run_job_script("probe.py")
 
         assert success is True
         assert output == "ok"
         assert captured["argv"] == [str(base_python), str(script.resolve())]
-        assert captured["kwargs"]["creationflags"] == 0x08000000
+        # Hide flags preserved, plus CREATE_NEW_PROCESS_GROUP so taskkill /T
+        # can reach the whole tree on timeout.
+        assert captured["kwargs"]["creationflags"] & 0x08000000
+        assert captured["kwargs"]["creationflags"] & 0x00000200
+        assert "start_new_session" not in captured["kwargs"]
         env = captured["kwargs"]["env"]
         assert env["VIRTUAL_ENV"] == str(venv)
         assert str(site_packages) in env["PYTHONPATH"]
-
 
     def test_non_windows_script_preserves_default_text_decoding(self, cron_env, monkeypatch):
         from cron import scheduler as sched_mod
@@ -182,13 +230,13 @@ class TestRunJobScript:
 
         captured = {}
 
-        def fake_run(argv, **kwargs):
+        def fake_popen(argv, **kwargs):
             captured["argv"] = argv
             captured["kwargs"] = kwargs
-            return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+            return _FakePopen(stdout="ok\n", stderr="")
 
         monkeypatch.setattr(sched_mod.sys, "platform", "linux")
-        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(sched_mod.subprocess, "Popen", fake_popen)
 
         success, output = _run_job_script("probe.py")
 
@@ -196,6 +244,8 @@ class TestRunJobScript:
         assert output == "ok"
         assert captured["argv"] == [sys.executable, str(script.resolve())]
         assert captured["kwargs"]["text"] is True
+        # Own session so a timeout can killpg the whole tree.
+        assert captured["kwargs"]["start_new_session"] is True
         assert "creationflags" not in captured["kwargs"]
         assert "encoding" not in captured["kwargs"]
         assert "errors" not in captured["kwargs"]
@@ -429,3 +479,239 @@ class TestRunJobEnvVarCleanup:
         assert os.environ.get("HERMES_SESSION_PLATFORM") is None
         assert os.environ.get("HERMES_SESSION_CHAT_ID") is None
         assert os.environ.get("HERMES_SESSION_CHAT_NAME") is None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group semantics")
+class TestScriptTimeoutKillsProcessGroup:
+    """Regression: a script timeout must kill the whole tree, not just bash.
+
+    ``subprocess.run(timeout=...)`` kills only the direct child.  Anything the
+    script backgrounded survived, reparented to init (PPID 1), still running
+    and still holding the inherited stdout/stderr pipes — so a multi-hour cron
+    timeout left a runaway workload alive forever and the next scheduled run
+    collided with it.
+    """
+
+    @staticmethod
+    def _wait_gone(pid: int, timeout: float = 5.0) -> bool:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if not _pid_alive(pid):
+                return True
+            time.sleep(0.05)
+        return not _pid_alive(pid)
+
+    @staticmethod
+    def _reap(pid: int) -> None:
+        """Best-effort cleanup so a failing assertion can't leak the sleeper.
+
+        Broad except: on the *failing* path the sleeper has been reparented to
+        init, which puts it outside the test subtree and trips conftest's
+        live-system guard (a RuntimeError, not an OSError).
+        """
+        if not _pid_alive(pid):
+            return
+        try:
+            os.kill(pid, signal.SIGKILL)  # windows-footgun: ok — POSIX-only test
+        except Exception:
+            pass
+
+    def test_backgrounded_grandchild_is_killed_on_timeout(self, cron_env, monkeypatch):
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        monkeypatch.setattr(sched_mod, "_SCRIPT_TIMEOUT", 2)
+
+        pidfile = cron_env / "grandchild.pid"
+        script = cron_env / "scripts" / "spawner.sh"
+        script.write_text(textwrap.dedent(f"""\
+            #!/bin/bash
+            {sys.executable} -c 'import time; time.sleep(300)' &
+            echo $! > {pidfile}
+            sleep 300
+        """), encoding="utf-8")
+
+        started = time.monotonic()
+        success, output = _run_job_script(str(script))
+        elapsed = time.monotonic() - started
+
+        assert success is False
+        assert "timed out" in output.lower()
+        # The bounded post-kill drain must not hang the scheduler.  2s timeout
+        # + 10s drain cap is the worst case; a healthy kill returns immediately.
+        assert elapsed < 12, f"timeout path took {elapsed:.1f}s"
+
+        grandchild = int(pidfile.read_text(encoding="utf-8").strip())
+        try:
+            assert self._wait_gone(grandchild), (
+                f"grandchild pid {grandchild} survived the script timeout "
+                "(orphaned, reparented to init)"
+            )
+        finally:
+            self._reap(grandchild)
+
+    def test_grandchild_holding_pipes_does_not_wedge_the_drain(self, cron_env, monkeypatch):
+        """The orphan also inherits stdout/stderr, so the drain must be bounded.
+
+        ``communicate()`` waits for EOF on the pipes.  A surviving descendant
+        keeps them open, which is the second way the old code could hang.
+        """
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        monkeypatch.setattr(sched_mod, "_SCRIPT_TIMEOUT", 2)
+
+        pidfile = cron_env / "holder.pid"
+        script = cron_env / "scripts" / "pipe_holder.sh"
+        # The background child inherits the script's stdout/stderr and never
+        # writes or exits, holding both pipes open.
+        script.write_text(textwrap.dedent(f"""\
+            #!/bin/bash
+            echo before-timeout
+            {sys.executable} -c 'import time; time.sleep(300)' &
+            echo $! > {pidfile}
+            sleep 300
+        """), encoding="utf-8")
+
+        started = time.monotonic()
+        success, output = _run_job_script(str(script))
+        elapsed = time.monotonic() - started
+
+        assert success is False
+        assert "timed out" in output.lower()
+        assert elapsed < 12, f"drain was not bounded: {elapsed:.1f}s"
+
+        holder = int(pidfile.read_text(encoding="utf-8").strip())
+        try:
+            assert self._wait_gone(holder), (
+                f"pipe-holding pid {holder} survived the script timeout"
+            )
+        finally:
+            self._reap(holder)
+
+    def test_non_timeout_failure_still_kills_the_tree(self, cron_env, monkeypatch):
+        """A pipe-read OSError must not leak the script or its descendants.
+
+        ``subprocess.run`` used ``with Popen(...) as process:`` internally, so
+        *any* exception in the body closed the pipes and reaped the child.  The
+        explicit Popen has no such context manager, so the catch-all bailout has
+        to provide the same guarantee — otherwise a long-lived gateway leaks a
+        running process plus its fds on every non-timeout failure.
+        """
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        pidfile = cron_env / "orphan.pid"
+        script = cron_env / "scripts" / "boom.sh"
+        script.write_text(textwrap.dedent(f"""\
+            #!/bin/bash
+            {sys.executable} -c 'import time; time.sleep(300)' &
+            echo $! > {pidfile}
+            sleep 300
+        """), encoding="utf-8")
+
+        real_popen = sched_mod.subprocess.Popen
+        spawned = {}
+
+        def popen_with_broken_communicate(*args, **kwargs):
+            proc = real_popen(*args, **kwargs)
+            spawned["pid"] = proc.pid
+            real_communicate = proc.communicate
+            calls = {"n": 0}
+
+            def failing_communicate(*a, **kw):
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    # Wait until the script has actually spawned its child, so
+                    # the test exercises the leak rather than racing it.
+                    deadline = time.monotonic() + 5
+                    while time.monotonic() < deadline and not pidfile.exists():
+                        time.sleep(0.05)
+                    raise OSError("simulated pipe read failure")
+                # The cleanup drain must still work normally.
+                return real_communicate(*a, **kw)
+
+            proc.communicate = failing_communicate
+            return proc
+
+        monkeypatch.setattr(
+            sched_mod.subprocess, "Popen", popen_with_broken_communicate
+        )
+
+        success, output = _run_job_script(str(script))
+
+        assert success is False
+        assert "simulated pipe read failure" in output
+
+        child = spawned["pid"]
+        grandchild = int(pidfile.read_text(encoding="utf-8").strip())
+        try:
+            assert self._wait_gone(child), (
+                f"script pid {child} survived a non-timeout failure"
+            )
+            assert self._wait_gone(grandchild), (
+                f"grandchild pid {grandchild} survived a non-timeout failure"
+            )
+        finally:
+            self._reap(child)
+            self._reap(grandchild)
+
+    def test_script_runs_in_its_own_session(self, cron_env):
+        """start_new_session=True is what makes the group kill possible."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "pgid_probe.py"
+        script.write_text(textwrap.dedent("""\
+            import os
+            print(os.getpid() == os.getpgid(0))
+        """), encoding="utf-8")
+
+        success, output = _run_job_script(str(script))
+        assert success is True
+        assert output == "True", "script is not a process-group leader"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="simulates Windows from POSIX")
+class TestKillScriptProcessTree:
+    """Unit coverage for the tree-kill helper's two platform paths."""
+
+    def test_windows_uses_taskkill_tree_kill(self, monkeypatch):
+        from cron import scheduler as sched_mod
+
+        captured = {}
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = argv
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(sched_mod.sys, "platform", "win32")
+        monkeypatch.setattr(sched_mod, "windows_hide_flags", lambda: 0x08000000)
+        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
+
+        proc = _FakePopen()
+        killed = []
+        proc.kill = lambda: killed.append(True)
+
+        sched_mod._kill_script_process_tree(proc)
+
+        assert captured["argv"] == ["taskkill", "/PID", "4242", "/T", "/F"]
+        assert killed == [], "taskkill succeeded; no fallback kill expected"
+
+    def test_refuses_to_killpg_the_schedulers_own_group(self, monkeypatch):
+        """If start_new_session ever failed, killpg would signal the gateway."""
+        from cron import scheduler as sched_mod
+
+        monkeypatch.setattr(sched_mod.os, "getpgid", lambda pid: 777)
+
+        def boom(pgid, sig):  # pragma: no cover - must never run
+            raise AssertionError("killpg called on the scheduler's own group")
+
+        monkeypatch.setattr(sched_mod.os, "killpg", boom)
+
+        proc = _FakePopen()
+        killed = []
+        proc.kill = lambda: killed.append(True)
+
+        sched_mod._kill_script_process_tree(proc)
+
+        assert killed == [True], "expected fallback to a direct child kill"

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -697,6 +697,26 @@ class TestKillScriptProcessTree:
         assert captured["argv"] == ["taskkill", "/PID", "4242", "/T", "/F"]
         assert killed == [], "taskkill succeeded; no fallback kill expected"
 
+    def test_windows_nonzero_taskkill_falls_back_to_direct_kill(self, monkeypatch):
+        """taskkill can *run* and still fail (access denied, stale PID);
+        a non-zero exit must not be treated as a completed tree kill."""
+        from cron import scheduler as sched_mod
+
+        def fake_run(argv, **kwargs):
+            return SimpleNamespace(returncode=1, stdout="", stderr="Access is denied.")
+
+        monkeypatch.setattr(sched_mod.sys, "platform", "win32")
+        monkeypatch.setattr(sched_mod, "windows_hide_flags", lambda: 0x08000000)
+        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
+
+        proc = _FakePopen()
+        killed = []
+        proc.kill = lambda: killed.append(True)
+
+        sched_mod._kill_script_process_tree(proc)
+
+        assert killed == [True], "non-zero taskkill must fall back to proc.kill()"
+
     def test_refuses_to_killpg_the_schedulers_own_group(self, monkeypatch):
         """If start_new_session ever failed, killpg would signal the gateway."""
         from cron import scheduler as sched_mod


### PR DESCRIPTION
## What does this PR do?

Cron script jobs are run with `subprocess.run(argv, capture_output=True, timeout=script_timeout, ...)` in `cron/scheduler.py`.

`subprocess.run(timeout=...)` kills **only the direct child**. When a cron script times out, anything it spawned — a background worker, a transcode, a model run — is left alive, reparented to init, still burning CPU/GPU, and still holding the inherited stdout/stderr pipes open. With the default one-hour (or longer) script timeout, that runaway lives indefinitely and the next scheduled run collides with it.

There is a second hazard on the same path: `capture_output=True` means the drain waits for EOF on those pipes. A surviving descendant that inherited them can keep them open, so the post-timeout drain can block the scheduler thread too.

**How I hit this.** A nightly `no_agent` script job of mine was killed by cron's `script_timeout_seconds`. `bash` died; its descendants (a Python pipeline process and a GPU-heavy `mlx_whisper` transcription) kept running with PPID 1 and had to be killed by hand.

Minimal reproduction against unpatched `main` — this is exactly the call shape `_run_job_script` uses today:

```python
# repro.sh:  sleep 600 & ; echo "grandchild pid: $!" ; sleep 600
import subprocess, os, re
try:
    subprocess.run(["/bin/bash", "repro.sh"], capture_output=True, text=True, timeout=3)
except subprocess.TimeoutExpired as e:
    gpid = int(re.search(r"grandchild pid: (\d+)", e.output).group(1))
    os.kill(gpid, 0)   # does NOT raise -> the grandchild outlived the timeout
```
```
RESULT: grandchild pid 3455 SURVIVED the timeout (orphaned, reparented)
```

## Related Issue

No existing issue — filing this alongside the fix. Related in spirit to #73480 (orphans from the `--replace` restart-watcher chain), but a different code path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`
  - `_run_job_script()` — replaces `subprocess.run(timeout=...)` with an explicit `Popen` + `communicate(timeout=...)` so the kill path is controllable. The script is spawned into its own process group / session: POSIX `start_new_session=True`; Windows `CREATE_NEW_PROCESS_GROUP` OR-ed into the existing `windows_hide_flags()`.
  - New `_kill_script_process_tree()` — POSIX `os.killpg(pgid, SIGKILL)`; Windows `taskkill /PID <pid> /T /F`, matching the tree-kill primitive already used by `tools/process_registry.py` and `gateway.status.terminate_pid`. Every failure path falls back to `proc.kill()` so the direct child still dies.
  - New `_SCRIPT_KILL_DRAIN_SECONDS` (10.0) — bounds the post-kill drain, then explicitly closes the pipes and does a bounded `wait()`. An unbounded drain would hang the scheduler on exactly the wedged descendant this change exists to kill.
  - New `_kill_and_reap_script()` — shared by the timeout path and a catch-all `except BaseException` bailout, so the two can't drift. This restores what `subprocess.run`'s internal `with Popen(...) as process:` gave for free: on a pipe-read `OSError`, a `MemoryError`, or a `KeyboardInterrupt`/`SystemExit` during gateway shutdown, we never propagate with the script still running and our pipes still open. The catch-all re-raises bare, so the outer handlers behave exactly as before.
- `tests/cron/test_cron_script.py` — regression tests.

**Contract preserved.** The original `TimeoutExpired` is re-raised so the existing handler still emits `Script timed out after {script_timeout}s: {path}` verbatim. The success path is unchanged: same capture, `text=True`, cwd, sanitized env, redaction, and returncode handling.

### Safety guard worth calling out

`_kill_script_process_tree` compares the child's pgid against the scheduler's own (`os.getpgid(0)`) before calling `killpg`. If `start_new_session` ever failed to take effect, the child would share the gateway's process group and `killpg` would SIGKILL the gateway itself — `tools/mcp_tool.py` describes that scenario as "catastrophic". On a match it logs a warning and kills only the direct child. One extra syscall to close a gateway-suicide path in unattended code.

### Behavior change worth noting

The script no longer shares the gateway's controlling terminal, so a Ctrl-C to the gateway will no longer propagate to a running cron script. That is mostly the intent of the change, but it is a real difference.

## How to Test

1. Run the reproduction above against `main` — the grandchild survives. With this PR it does not.
2. The added tests in `tests/cron/test_cron_script.py` assert a backgrounded grandchild is gone after the timeout path runs, that the drain stays bounded when a descendant holds the pipes, that a non-timeout exception also cleans up, and that `killpg` is never reached when the child shares the scheduler's process group.

Each new test was verified to fail before its corresponding fix was applied:

```
E  AssertionError: grandchild pid 2227 survived the script timeout (orphaned, reparented to init)
E  AssertionError: script pid 3751 survived a non-timeout failure
```

Results:

```
$ pytest tests/cron/test_cron_script.py -q
47 passed in 6.42s

$ pytest tests/cron/test_script_claim_heartbeat.py tests/cron/test_cron_no_agent.py -q
21 passed in 0.74s

$ pytest tests/cron/test_scheduler.py -q
239 passed, 2 warnings in 5.91s
```

The combined set was run 3× to check the new process-spawning tests aren't flaky (286 passed each time). The 2 warnings on `test_scheduler.py` are pre-existing — confirmed by stashing this change and re-running the baseline (an `audioop` deprecation from `discord/player.py`).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **ran the cron test packages (see above), not the full suite**: it self-aborts on this macOS machine for reasons unrelated to this change. Happy for CI to be the arbiter.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behavior documented in the new function's docstring)
- [x] I've updated `cli-config.yaml.example` — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — **yes, explicitly**: Windows uses `taskkill /T /F` (no cascading process-group signal exists there, and `Popen.kill()` is `TerminateProcess()` on a single handle), following the pattern already established in `tools/process_registry.py`. POSIX-only calls carry `# windows-footgun: ok` markers and `scripts/check-windows-footguns.py` reports the diff clean.
- [x] I've updated tool descriptions/schemas — N/A

### Note for reviewers

Three existing tests (`test_windows_uv_venv_python_script_bypasses_launcher`, `test_windows_pythonw_script_uses_sibling_python_for_captured_output`, `test_non_windows_script_preserves_default_text_decoding`) patched `subprocess.run`; they now patch `Popen` through a small `_FakePopen` helper. That is unavoidable given the call-shape change, but you will notice it in the diff.
