### PR TITLE
fix(kanban): drop assignee-disabled skills at card creation

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -382,26 +382,35 @@ def _raw_config_cache_clear() -> None:
     _RAW_CONFIG_CACHE.clear()
 
 
-def _load_raw_config() -> Dict[str, Any]:
+def _load_raw_config(config_path: Optional[Path] = None) -> Dict[str, Any]:
     """Read config.yaml with a shared mtime+size keyed cache.
 
     This module intentionally avoids importing ``hermes_cli.config`` on the
     skill prompt/build path. A tiny local cache gives the same repeated-read
     win without pulling the heavier CLI config stack into startup.
+
+    ``config_path`` overrides the HERMES_HOME lookup so a caller can inspect
+    another profile's config. Overridden reads deliberately bypass the cache:
+    it holds a single entry for the running profile's config, and letting
+    cross-profile lookups evict it would thrash the prompt-build hot path.
     """
-    config_path = get_config_path()
+    use_cache = config_path is None
+    if config_path is None:
+        config_path = get_config_path()
     if not config_path.exists():
         return {}
-    try:
-        stat = config_path.stat()
-        cache_key = (str(config_path), stat.st_mtime_ns, stat.st_size)
-    except OSError:
-        cache_key = None
+    cache_key = None
+    if use_cache:
+        try:
+            stat = config_path.stat()
+            cache_key = (str(config_path), stat.st_mtime_ns, stat.st_size)
+        except OSError:
+            cache_key = None
 
-    if cache_key is not None:
-        cached = _RAW_CONFIG_CACHE.get(cache_key)
-        if cached is not None:
-            return cached
+        if cache_key is not None:
+            cached = _RAW_CONFIG_CACHE.get(cache_key)
+            if cached is not None:
+                return cached
 
     try:
         parsed = yaml_load(config_path.read_text(encoding="utf-8"))
@@ -453,6 +462,22 @@ def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
         if platform_disabled is not None:
             return global_disabled | _normalize_string_set(platform_disabled)
     return global_disabled
+
+
+def get_globally_disabled_skill_names(hermes_home: Path) -> Set[str]:
+    """Return ``skills.disabled`` for the profile rooted at *hermes_home*.
+
+    For callers inspecting a profile they are **not** running as, where the
+    platform the target process will use is unknown. ``platform_disabled`` is
+    deliberately excluded for that reason; a globally-disabled skill is
+    disabled on every platform, so this is the subset guaranteed to be
+    unloadable there no matter how the profile is launched.
+    """
+    parsed = _load_raw_config(hermes_home / "config.yaml")
+    skills_cfg = parsed.get("skills")
+    if not isinstance(skills_cfg, dict):
+        return set()
+    return _normalize_string_set(skills_cfg.get("disabled"))
 
 
 def _normalize_string_set(values) -> Set[str]:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2817,6 +2817,41 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     return normalize_profile_name(assignee)
 
 
+def _drop_disabled_skills(skills: list[str], assignee: str) -> list[str]:
+    """Strip skills the assignee profile has disabled.
+
+    A worker treats a disabled skill as missing — ``build_preloaded_skills_prompt``
+    bypasses the scan-time filter on purpose so a pinned name cannot force-load
+    something an operator disabled (#59156) — and hard-fails when *every*
+    requested skill is missing. A card pinning only disabled skills therefore
+    kills its worker before it does any work, and the task auto-blocks once
+    retries run out.
+
+    Dropping those names at creation keeps the card dispatchable. A card left
+    with nothing simply behaves like one that pinned no skills at all.
+    """
+    try:
+        from agent.skill_utils import get_globally_disabled_skill_names
+        from hermes_cli.profiles import get_profile_dir
+
+        disabled = get_globally_disabled_skill_names(get_profile_dir(assignee))
+    except Exception:
+        return skills  # profile config unreadable — leave the card untouched
+    if not disabled:
+        return skills
+    dropped = [s for s in skills if s in disabled]
+    if not dropped:
+        return skills
+    kept = [s for s in skills if s not in disabled]
+    _log.warning(
+        "kanban create: dropping skill(s) %s — disabled in profile %r; keeping %s",
+        ", ".join(dropped),
+        assignee,
+        ", ".join(kept) or "(none)",
+    )
+    return kept
+
+
 def create_task(
     conn: sqlite3.Connection,
     *,
@@ -3035,6 +3070,11 @@ def create_task(
                 "capabilities (e.g. `web`, `browser`, `terminal`)."
             )
         skills_list = cleaned
+        if skills_list and assignee:
+            # ``or None`` so a card whose every skill was dropped is stored
+            # exactly like one that pinned no skills, rather than as an empty
+            # list the dispatcher would have to special-case.
+            skills_list = _drop_disabled_skills(skills_list, assignee) or None
 
     # Idempotency check — return the existing task instead of creating a
     # duplicate. Done BEFORE entering write_txn to keep the fast path fast

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2827,8 +2827,8 @@ def _drop_disabled_skills(skills: list[str], assignee: str) -> list[str]:
     kills its worker before it does any work, and the task auto-blocks once
     retries run out.
 
-    Dropping those names at creation keeps the card dispatchable. A card left
-    with nothing simply behaves like one that pinned no skills at all.
+    Dropping those names keeps the card dispatchable. A card left with nothing
+    simply behaves like one that pinned no skills at all.
     """
     try:
         from agent.skill_utils import get_globally_disabled_skill_names
@@ -2844,12 +2844,53 @@ def _drop_disabled_skills(skills: list[str], assignee: str) -> list[str]:
         return skills
     kept = [s for s in skills if s not in disabled]
     _log.warning(
-        "kanban create: dropping skill(s) %s — disabled in profile %r; keeping %s",
+        "kanban: dropping skill(s) %s — disabled in profile %r; keeping %s",
         ", ".join(dropped),
         assignee,
         ", ".join(kept) or "(none)",
     )
     return kept
+
+
+def _reconcile_skills_for_assignee(conn: sqlite3.Connection, task_id: str) -> None:
+    """Re-run the disabled-skill filter against a card's *current* owner.
+
+    ``create_task`` can only filter against the assignee a card is born with,
+    so an existing card can still acquire a fatal skill set later: an explicit
+    :func:`assign_task`, or the dispatcher applying ``kanban.default_assignee``
+    to a card that had no assignee to inspect at creation. Both end with the
+    same all-missing worker failure the creation-time filter exists to prevent,
+    so both re-run it here.
+
+    Deliberately reads the assignee back out of the row instead of taking it as
+    an argument: the filter then can never be applied on behalf of a profile
+    that did not actually win the assignment. Call inside the caller's
+    ``write_txn``.
+    """
+    row = conn.execute(
+        "SELECT assignee, skills FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    if row is None or not row["assignee"] or not row["skills"]:
+        return
+    try:
+        stored = json.loads(row["skills"])
+    except (TypeError, ValueError):
+        return
+    if not isinstance(stored, list):
+        return
+    skills = [s for s in stored if isinstance(s, str) and s]
+    if not skills:
+        return
+    kept = _drop_disabled_skills(skills, row["assignee"])
+    if kept == skills:
+        return
+    # ``or None`` to match create_task: a card whose every skill was dropped is
+    # stored exactly like one that pinned no skills. Dropping is one-way — a
+    # later reassignment does not resurrect a name, same as at creation.
+    conn.execute(
+        "UPDATE tasks SET skills = ? WHERE id = ?",
+        (json.dumps(kept) if kept else None, task_id),
+    )
 
 
 def create_task(
@@ -3392,6 +3433,7 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
             )
         else:
             conn.execute("UPDATE tasks SET assignee = ? WHERE id = ?", (profile, task_id))
+        _reconcile_skills_for_assignee(conn, task_id)
         _append_event(conn, task_id, "assigned", {"assignee": profile})
         return True
 
@@ -8333,6 +8375,9 @@ def _dispatch_once_locked(
                                 "AND (assignee IS NULL OR assignee = '')",
                                 (_default_assignee, row["id"]),
                             )
+                            # The card had no assignee for create_task to
+                            # filter its pinned skills against; it has one now.
+                            _reconcile_skills_for_assignee(conn, row["id"])
                             _append_event(
                                 conn, row["id"], "assigned",
                                 {

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -855,6 +855,71 @@ def test_create_task_ignores_platform_disabled_skills(kanban_home):
         conn.close()
 
 
+def test_assign_task_drops_skills_disabled_for_the_new_assignee(kanban_home):
+    """Reassignment re-runs the filter — creation only ever saw the old owner.
+
+    Otherwise a perfectly valid card can be handed to a profile that disables
+    a pinned skill, which is the state the creation-time filter exists to keep
+    off the board.
+    """
+    _write_profile_skills_config(kanban_home, "researcher", ["arxiv"])
+    conn = kb.connect()
+    try:
+        # "linguist" has no config, so nothing is dropped at creation.
+        tid = kb.create_task(
+            conn,
+            title="reassigned card",
+            assignee="linguist",
+            skills=["arxiv", "translation"],
+        )
+        assert kb.get_task(conn, tid).skills == ["arxiv", "translation"]
+
+        assert kb.assign_task(conn, tid, "researcher") is True
+        assert kb.get_task(conn, tid).skills == ["translation"]
+    finally:
+        conn.close()
+
+
+def test_assign_task_pins_none_when_new_assignee_disables_every_skill(kanban_home):
+    """The all-missing worker failure, reached by reassignment instead.
+
+    ``build_preloaded_skills_prompt`` raises when every requested skill is
+    missing, so the card would kill its worker before doing any work and
+    auto-block once retries ran out.
+    """
+    _write_profile_skills_config(kanban_home, "researcher", ["arxiv", "translation"])
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="reassigned card",
+            assignee="linguist",
+            skills=["arxiv", "translation"],
+        )
+        assert kb.assign_task(conn, tid, "researcher") is True
+        task = kb.get_task(conn, tid)
+        assert task.assignee == "researcher"
+        assert task.skills is None
+    finally:
+        conn.close()
+
+
+def test_assign_task_keeps_skills_the_new_assignee_allows(kanban_home):
+    """Regression: an ordinary reassignment must not touch the skill set."""
+    _write_profile_skills_config(kanban_home, "researcher", ["kanban-orchestrator"])
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="reassigned card",
+            assignee="linguist",
+            skills=["arxiv", "translation"],
+        )
+        assert kb.assign_task(conn, tid, "researcher") is True
+        assert kb.get_task(conn, tid).skills == ["arxiv", "translation"]
+    finally:
+        conn.close()
+
 def test_legacy_db_without_skills_column_migrates(tmp_path):
     """_migrate_add_optional_columns is idempotent and adds skills
     when absent. Run it twice on a pared-down schema to confirm."""

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -751,6 +751,108 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
 
 
 
+# ---------------------------------------------------------------------------
+# Skills disabled by the assignee profile
+# ---------------------------------------------------------------------------
+
+def _write_profile_skills_config(kanban_home, profile: str, disabled: list[str]):
+    """Give *profile* a config.yaml that disables *disabled*."""
+    profile_dir = kanban_home / "profiles" / profile
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    body = "skills:\n  disabled:\n" + "".join(f"    - {n}\n" for n in disabled)
+    (profile_dir / "config.yaml").write_text(body, encoding="utf-8")
+
+
+def test_create_task_drops_skills_disabled_for_assignee(kanban_home):
+    """A skill the assignee profile disabled is stripped; the rest survive.
+
+    The worker treats a disabled skill as missing, so carrying it on the card
+    buys nothing and risks the all-missing hard failure below.
+    """
+    _write_profile_skills_config(kanban_home, "linguist", ["kanban-orchestrator"])
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="mixed skills",
+            assignee="linguist",
+            skills=["kanban-orchestrator", "translation"],
+        )
+        task = kb.get_task(conn, tid)
+        assert task.skills == ["translation"]
+    finally:
+        conn.close()
+
+
+def test_create_task_with_all_skills_disabled_pins_none(kanban_home):
+    """Every pinned skill disabled -> the card pins nothing, not an empty list.
+
+    Regression guard: such a card used to reach the worker intact, where
+    ``build_preloaded_skills_prompt`` reported every name missing and the
+    launch raised ``ValueError`` before any work happened — the task then
+    auto-blocked once retries ran out. Storing ``None`` makes it behave like
+    a card that pinned no skills at all.
+    """
+    _write_profile_skills_config(
+        kanban_home, "researcher", ["kanban-orchestrator", "arxiv"]
+    )
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="fully disabled skills",
+            assignee="researcher",
+            skills=["kanban-orchestrator", "arxiv"],
+        )
+        task = kb.get_task(conn, tid)
+        assert task.skills is None
+    finally:
+        conn.close()
+
+
+def test_create_task_keeps_skills_when_profile_has_no_config(kanban_home):
+    """No profile config -> nothing is known to be disabled, nothing is dropped."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="unknown profile",
+            assignee="no-such-profile",
+            skills=["translation", "github-code-review"],
+        )
+        task = kb.get_task(conn, tid)
+        assert task.skills == ["translation", "github-code-review"]
+    finally:
+        conn.close()
+
+
+def test_create_task_ignores_platform_disabled_skills(kanban_home):
+    """``platform_disabled`` is not consulted at creation time.
+
+    Which platform the worker will run as is unknown here, so only the global
+    ``skills.disabled`` list — disabled on every platform — is safe to act on.
+    """
+    profile_dir = kanban_home / "profiles" / "linguist"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / "config.yaml").write_text(
+        "skills:\n"
+        "  platform_disabled:\n"
+        "    cli:\n"
+        "      - translation\n",
+        encoding="utf-8",
+    )
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="platform disabled only",
+            assignee="linguist",
+            skills=["translation"],
+        )
+        task = kb.get_task(conn, tid)
+        assert task.skills == ["translation"]
+    finally:
+        conn.close()
 
 
 def test_legacy_db_without_skills_column_migrates(tmp_path):

--- a/tests/hermes_cli/test_kanban_default_assignee.py
+++ b/tests/hermes_cli/test_kanban_default_assignee.py
@@ -10,6 +10,7 @@ import json
 import os
 import sys
 import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -71,6 +72,65 @@ def test_unassigned_task_auto_assigned_with_default_assignee(isolated_kanban_hom
     assert payload["assignee"] == "default"
     assert payload["source"] == "kanban.default_assignee"
 
+
+def test_default_assignee_drops_skills_that_profile_disables(isolated_kanban_home):
+    """The fallback profile's disabled skills are stripped as it is applied.
+
+    An unassigned card gave ``create_task`` no assignee to filter its pinned
+    skills against, so the check lands here instead — otherwise the dispatcher
+    spawns a worker whose every pinned skill is missing, which raises before
+    any work happens.
+    """
+    kb, home = isolated_kanban_home
+    profile_dir = Path(home) / "profiles" / "researcher"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / "config.yaml").write_text(
+        "skills:\n  disabled:\n    - arxiv\n", encoding="utf-8"
+    )
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        task_id = kb.create_task(
+            conn, title="t1", assignee=None, skills=["arxiv", "translation"]
+        )
+        # Nothing was known to be disabled at creation: there was no assignee.
+        assert kb.get_task(conn, task_id).skills == ["arxiv", "translation"]
+
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False,
+            default_assignee="researcher",
+        )
+    assert res.auto_assigned_default == [task_id]
+
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+    assert task.assignee == "researcher"
+    assert task.skills == ["translation"]
+
+
+def test_dry_run_default_assignee_leaves_skills_alone(isolated_kanban_home):
+    """Dry-run reports the routing without stripping anything from the card."""
+    kb, home = isolated_kanban_home
+    profile_dir = Path(home) / "profiles" / "researcher"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / "config.yaml").write_text(
+        "skills:\n  disabled:\n    - arxiv\n", encoding="utf-8"
+    )
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        task_id = kb.create_task(
+            conn, title="t1", assignee=None, skills=["arxiv", "translation"]
+        )
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=True,
+            default_assignee="researcher",
+        )
+    assert res.auto_assigned_default == [task_id]
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+    assert task.assignee is None
+    assert task.skills == ["arxiv", "translation"]
 
 
 


### PR DESCRIPTION
## What does this PR do?

A Kanban card can pin skills that the **assignee profile has disabled**. The worker treats a disabled skill as missing — `build_preloaded_skills_prompt` bypasses the scan-time disabled filter on purpose, so a pinned name cannot force-load a skill an operator disabled (#59156) — and hard-fails when *every* requested skill is missing:

```python
# cli.py
if loaded_skills:
    logger.warning("Unknown skill(s) requested, skipping: %s. ...")
else:
    raise ValueError(f"Unknown skill(s): {missing_display}")
```

So a card whose pinned skills are *all* disabled for its assignee kills the worker before it does any work, and the task auto-blocks once retries run out. Nothing in the pipeline catches this earlier: the dispatcher does not inject a fallback skill (`test_default_spawn_does_not_auto_load_any_skill`), so there is no floor to degrade to.

This is easy to hit on a multi-profile deployment where worker profiles disable large parts of the skill catalog: whoever creates the card sees a valid skill name, and the profile that has to load it is a different one.

**Approach.** Fix it at creation, not at load. The disabled-as-missing behavior is a deliberate security gate and should stay — so instead, `create_task` strips names the assignee profile is known to have disabled, and the card never leaves with a guaranteed-fatal skill set. A card left with nothing is stored as `None`, exactly like one that pinned no skills.

Only the profile's **global** `skills.disabled` is consulted. Which platform the worker will run as is not known at creation time, and a globally-disabled skill is disabled on every platform anyway — so this is the subset that is guaranteed unloadable regardless of how the profile is launched. `platform_disabled` is deliberately left alone (covered by a test).

## Related Issue

Fixes #74125

I searched open and closed PRs and issues before filing it (`skills disabled`, `platform_disabled`, `pinned skill`, `skill load failure`) and found nothing covering the Kanban creation path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/skill_utils.py` — `_load_raw_config()` takes an optional config path so a caller can inspect **another** profile's config. Overridden reads deliberately bypass the shared cache: it holds a single entry for the running profile's config, and letting cross-profile lookups evict it would thrash the prompt-build hot path. New `get_globally_disabled_skill_names(hermes_home)` wraps it. Existing callers and the cached default path are unchanged.
- `hermes_cli/kanban_db.py` — new `_drop_disabled_skills()`, called from `create_task()` right after the existing skills normalization. Unreadable/missing profile config is a no-op, so behavior is unchanged for anyone without a profile config.
- `tests/hermes_cli/test_kanban_core_functionality.py` — 4 tests.

## How to Test

Reproduce the crash on `main`:

1. Give a profile a disabled skill: in `~/.hermes/profiles/researcher/config.yaml`, set `skills: {disabled: [kanban-orchestrator]}`.
2. Create a card pinning only that skill: `hermes kanban create --assignee researcher --skills kanban-orchestrator --title repro`.
3. The worker raises `ValueError: Unknown skill(s): kanban-orchestrator` at launch and the card ends up blocked after its retries.

With this PR the card is created with no pinned skills and the worker starts normally.

Automated:

```bash
pytest tests/hermes_cli/test_kanban_core_functionality.py -k "disabled or no_config" -q
```

The two regression tests fail on `main` (`assert ['kanban-orchestrator', 'arxiv'] is None`) and pass with the fix.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **not the full suite.** I ran the directly affected files and every test file that touches the functions I changed: `tests/hermes_cli/test_kanban_core_functionality.py`, `tests/agent/test_skill_utils.py`, `tests/agent/test_skill_commands.py`, `tests/agent/test_prompt_builder.py`, `tests/agent/test_skill_bundles.py`, `tests/gateway/test_stacked_skill_platform_disabled.py`, `tests/gateway/test_unavailable_skill_hint.py`, `tests/hermes_cli/test_skills_config.py`. I diffed the failure set against clean `main` on the same machine: **identical — this PR adds no new failures.** (For transparency: `main` itself has pre-existing failures on native Windows in the crash-detection / protocol-violation tests and in some path-handling skill tests. They are unrelated to this change and I have not touched them.)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (native, not WSL2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on both new/changed functions) — no user-facing docs affected
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — pure `pathlib` + existing config loader, no platform-specific paths; developed and tested on native Windows
