### PR TITLE
fix(desktop): dedupe persisted sidebar order ids to stop duplicate repo headers

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/order.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.test.ts
@@ -37,6 +37,11 @@ describe('orderByIds', () => {
     const items = [{ id: 'fresh' }, { id: 'a' }, { id: 'b' }]
     expect(orderByIds(items, id, ['b', 'a'])).toEqual([{ id: 'fresh' }, { id: 'b' }, { id: 'a' }])
   })
+
+  it('never duplicates an item when the persisted order repeats its id', () => {
+    const items = [{ id: 'a' }, { id: 'b' }]
+    expect(orderByIds(items, id, ['a', 'a', 'b'])).toEqual([{ id: 'a' }, { id: 'b' }])
+  })
 })
 
 describe('reconcileOrderIds', () => {
@@ -50,6 +55,10 @@ describe('reconcileOrderIds', () => {
 
   it('puts newly-seen ids ahead of the retained saved order', () => {
     expect(reconcileOrderIds(['fresh', 'a', 'b'], ['b', 'a', 'gone'])).toEqual(['fresh', 'b', 'a'])
+  })
+
+  it('dedupes a corrupted saved order instead of perpetuating it', () => {
+    expect(reconcileOrderIds(['a', 'b'], ['a', 'a', 'b'])).toEqual(['a', 'b'])
   })
 })
 

--- a/apps/desktop/src/app/chat/sidebar/order.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.ts
@@ -1,10 +1,12 @@
 /** New ids first, then ids still present in the persisted order. */
 export function reconcileFreshFirst(currentIds: string[], orderIds: string[]): string[] {
   const current = new Set(currentIds)
+  // Dedupe while retaining: a corrupted persisted order (same id twice) must
+  // not self-perpetuate through reconcile — it paints as duplicate headers.
   const retained = orderIds.filter(id => current.has(id))
   const retainedSet = new Set(retained)
 
-  return [...currentIds.filter(id => !retainedSet.has(id)), ...retained]
+  return [...currentIds.filter(id => !retainedSet.has(id)), ...new Set(retained)]
 }
 
 export function resolveManualSessionOrderIds(currentIds: string[], orderIds: string[], manual: boolean): string[] {
@@ -35,7 +37,10 @@ export function orderByIds<T>(items: T[], getId: (item: T) => string, orderIds: 
   for (const id of orderIds) {
     const item = byId.get(id)
 
-    if (item) {
+    // Guard against duplicates in the persisted order: pushing the same item
+    // twice renders the row/header twice (e.g. two identical repo headers
+    // under one project).
+    if (item && !seen.has(id)) {
       ordered.push(item)
       seen.add(id)
     }


### PR DESCRIPTION
## What does this PR do?

Fixes a desktop sidebar bug: the same repo header can appear twice inside one project.

**What we saw.** In the desktop app, one project ("Sendvo") showed the same repo ("sendvo-app") two times in the sidebar, each with its own session lanes below it. The backend data was correct — the project tree from `projects.tree` had only one "sendvo-app" repo. Only the drawing was wrong.

**How we found it.** The sidebar saves repo order in localStorage (key `hermes.desktop.workspaceParentOrder`). While the app was running, we decoded its localStorage leveldb on disk (Snappy-compressed tables) and read the saved list. The same repo id was in the list two times, at two positions. Then we read the code that uses the list:

- `orderByIds()` (`apps/desktop/src/app/chat/sidebar/order.ts`) adds one item to the screen for every entry in the saved list. Two entries with the same id → the same header drawn two times.
- `reconcileFreshFirst()` cleans the saved list on every refresh, but only removed ids that no longer exist — never duplicates. So once a duplicate got in, it stayed forever. Even clearing localStorage did not help, because the app re-saved the bad list.

**The fix.** Both functions now skip ids they have already seen. A saved list with duplicates can no longer draw duplicate headers, and the next persist writes a clean list, so corrupted state self-heals.

We did not find the code that first wrote the duplicate id (it may come from an older version). This fix treats persisted UI order as untrusted input, which is the safe contract either way.

## Related Issue

Fixes #74131

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/sidebar/order.ts` — `orderByIds()` skips ids already emitted; `reconcileFreshFirst()` dedupes the retained tail.
- `apps/desktop/src/app/chat/sidebar/order.test.ts` — two regression tests: `orderByIds` never duplicates an item when the order repeats an id; `reconcileOrderIds` dedupes a corrupted saved order.

## How to Test

1. `cd apps/desktop && npx vitest run src/app/chat/sidebar/order.test.ts` — 12 tests pass (10 existing + 2 new).
2. `npx vitest run src/app/chat/sidebar/projects/workspace-groups.test.ts` — 55 tests pass, no regressions.
3. Manual check on the affected machine: before the fix, the persisted `workspaceParentOrder` contained the same repo id twice and the sidebar drew two identical headers. With the fix, `orderByIds` returns one item for that id (covered by the new unit test), and the next reconcile writes a deduped list back to storage.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A: this change is desktop TypeScript only; ran the desktop vitest suites instead (67 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1 (Apple Silicon)

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (internal helper, no docs surface)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure TypeScript, no platform APIs)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Evidence from the affected install — the persisted `hermes.desktop.workspaceParentOrder` in the app's localStorage leveldb, decoded while the bug was visible:

```
count=15 unique=14 DUPES=['/Users/jerry/Projects/sendvo/sendvo-app']
  ...
  [13] /Users/jerry/Projects/sendvo/sendvo-app  <-- DUPE
  [14] /Users/jerry/Projects/sendvo/sendvo-app  <-- DUPE
```

The backend project tree at the same moment contained exactly one repo with that path, so the duplicate could only come from the persisted order list.
