### PR TITLE
chore: map ezell.matt@gmail.com -> mattezell for contributor attribution

### DIFF
--- a/contributors/emails/ezell.matt@gmail.com
+++ b/contributors/emails/ezell.matt@gmail.com
@@ -1,0 +1,1 @@
+mattezell


### PR DESCRIPTION
Adds the contributor email mapping for @mattezell ahead of merging #74087 (fix for #74086). Bare-gmail addresses do not auto-resolve in check-attribution; this file provides the login mapping.