### PR TITLE
fix(sanitization): log full content instead of 80 chars on unrepairable tool_call args

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -270,11 +270,14 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
         pass
 
     # Last resort: replace with empty object so the API request doesn't
-    # crash the entire session.
+    # crash the entire session. Log the full original content (not just
+    # 80 chars) since this is the only remaining copy of whatever the
+    # caller was trying to send — the request payload is discarded right
+    # after this point with no other buffer, retry, or persistence.
     logger.warning(
         "Unrepairable tool_call arguments for %s — "
         "replaced with empty object (was: %s)",
-        tool_name, raw_stripped[:80],
+        tool_name, raw_stripped,
     )
     return "{}"
 


### PR DESCRIPTION
## What does this PR do?

Fixes #74146. The last-resort branch in `_repair_tool_call_arguments()` truncates the original malformed argument string to 80 chars before logging it and discarding it for good. This is the only place that content exists once this branch runs — no other buffer, retry, or persistence keeps it. For a large argument (e.g. a long `write_file`/`skill_manage` patch body), 80 characters isn't enough to reconstruct or manually reapply whatever the caller was trying to send.

## Changes Made

- `agent/message_sanitization.py` — in the last-resort branch of `_repair_tool_call_arguments()`, log `raw_stripped` in full instead of `raw_stripped[:80]`. The other, successful-repair log lines earlier in the same function keep their existing 80-char preview since those cases don't lose data — only this final, data-loss branch needed the change.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Test plan

- [x] `python3 -m py_compile` on the changed file
- [x] Confirmed against a production deployment: this exact branch fires repeatedly (background_review self-patch attempts hitting malformed JSON), and the fix has been running there with full content now appearing in logs