### PR TITLE
fix(desktop): wrap full task titles in composer Tasks panel

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import type { ComposerStatusItem } from '@/store/composer-status'
+
+import { StatusItemRow } from './status-row'
+
+const longTodoTitle =
+  'Obtain independent Codex, Kimi, and xAI OAuth grants without sharing credentials across hosts'
+
+function renderRow(item: ComposerStatusItem) {
+  return render(
+    <I18nProvider configClient={null} initialLocale="en">
+      <StatusItemRow item={item} />
+    </I18nProvider>
+  )
+}
+
+describe('StatusItemRow todo readability', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('shows the full todo title without truncating classes', () => {
+    renderRow({
+      id: 'todo:1',
+      state: 'running',
+      title: longTodoTitle,
+      todoStatus: 'in_progress',
+      type: 'todo'
+    })
+
+    const title = screen.getByText(longTodoTitle)
+    expect(title).toBeTruthy()
+    expect(title.className).toMatch(/break-words/)
+    expect(title.className).toMatch(/whitespace-normal/)
+    expect(title.className).not.toMatch(/\btruncate\b/)
+    expect(title.className).not.toMatch(/max-w-\[18rem\]/)
+  })
+
+  it('keeps non-todo rows on the compact single-line truncate chrome', () => {
+    renderRow({
+      id: 'bg:1',
+      state: 'running',
+      title: longTodoTitle,
+      type: 'background'
+    })
+
+    const title = screen.getByText(longTodoTitle)
+    expect(title.className).toMatch(/\btruncate\b/)
+    expect(title.className).toMatch(/max-w-\[18rem\]/)
+    expect(title.className).not.toMatch(/break-words/)
+  })
+
+  it('keeps completed todo titles readable (not heavily muted)', () => {
+    renderRow({
+      id: 'todo:done',
+      state: 'done',
+      title: longTodoTitle,
+      todoStatus: 'completed',
+      type: 'todo'
+    })
+
+    const title = screen.getByText(longTodoTitle)
+    expect(title.className).toMatch(/text-foreground\/78/)
+    expect(title.className).not.toMatch(/text-muted-foreground\/75/)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
@@ -97,6 +97,10 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
   const s = t.statusStack
   const failed = item.state === 'failed'
   const running = item.state === 'running'
+  // Todo titles are the working plan the user reads mid-run — keep the full
+  // string visible (wrap) instead of a single truncated line. Other stack
+  // rows stay compact single-line chrome.
+  const isTodo = item.type === 'todo'
 
   const action =
     item.type === 'background'
@@ -114,6 +118,8 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
   return (
     <Fragment>
       <StatusRow
+        // Multi-line todo copy needs the glyph pinned to the first line.
+        className={isTodo ? 'items-start' : undefined}
         leading={leadingGlyph(item, s)}
         onActivate={onActivate}
         trailing={
@@ -140,12 +146,19 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
       >
         <span
           className={cn(
-            'min-w-0 max-w-[18rem] truncate text-[0.73rem] leading-4',
+            'min-w-0 text-[0.73rem] leading-4',
+            isTodo
+              ? 'flex-1 whitespace-normal break-words text-pretty'
+              : 'max-w-[18rem] truncate',
             failed
               ? 'text-destructive/90'
-              : item.todoStatus && item.todoStatus !== 'in_progress'
-                ? 'text-muted-foreground/75'
-                : 'text-foreground/92'
+              : isTodo
+                ? item.todoStatus === 'in_progress'
+                  ? 'text-foreground/92'
+                  : 'text-foreground/78'
+                : item.todoStatus && item.todoStatus !== 'in_progress'
+                  ? 'text-muted-foreground/75'
+                  : 'text-foreground/92'
           )}
         >
           {item.title}


### PR DESCRIPTION
## Summary

Todo titles in the Desktop composer **Tasks** panel were single-line truncated (`max-w-[18rem] truncate`) with muted completed styling, so longer plan items were unreadable mid-run.

- Wrap full todo titles (`whitespace-normal break-words text-pretty`)
- Drop the 18rem cap for todo rows only
- Top-align the status glyph for multi-line copy
- Slightly raise completed/pending todo contrast (`text-foreground/78`)
- Leave subagent/background/goal rows on the compact single-line chrome
- Unit tests cover wrap vs truncate and completed contrast

## Test plan

- [x] `npx vitest run src/app/chat/composer/status-stack/status-row.test.tsx`
- [x] `npx tsc -p . --noEmit` (desktop)
- [ ] Manual: start a session with a multi-item todo list containing long titles; confirm full text wraps in Tasks N/M and completed rows remain readable
