### PR TITLE
fix(kanban): share one worktree across every card in a worktree swarm

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -416,6 +416,20 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
     p_swarm.add_argument("--verifier", required=True, help="Verifier profile")
     p_swarm.add_argument("--synthesizer", required=True, help="Synthesizer/writer profile")
+    p_swarm.add_argument("--workspace", default="scratch",
+                         help="scratch | worktree | worktree:<path> | dir:<path> "
+                              "(default: scratch). For 'worktree', every card in the "
+                              "swarm (worker, verifier, synthesizer) shares the SAME "
+                              "checkout/branch so the verifier reviews the worker's "
+                              "actual changes instead of an empty dir. Only one "
+                              "--worker is allowed with worktree swarms.")
+    p_swarm.add_argument("--branch", default=None,
+                         help="Branch name for worktree swarms, e.g. wt/t6-wire "
+                              "(only valid with --workspace worktree)")
+    p_swarm.add_argument("--project", default=None,
+                         help="Link to a project (id or slug) so the shared worktree "
+                              "is anchored under the project's primary repo with a "
+                              "deterministic branch. See `hermes project list`.")
     p_swarm.add_argument("--tenant", default=None, help="Tenant namespace")
     p_swarm.add_argument("--priority", type=int, default=0, help="Priority tiebreaker")
     p_swarm.add_argument("--created-by", default=None, help="Creator/anchor profile")
@@ -1549,18 +1563,35 @@ def _cmd_swarm(args: argparse.Namespace) -> int:
     if not workers:
         print("kanban swarm: at least one --worker is required", file=sys.stderr)
         return 2
-    with kb.connect_closing() as conn:
-        created = ks.create_swarm(
-            conn,
-            goal=args.goal,
-            workers=workers,
-            verifier_assignee=args.verifier,
-            synthesizer_assignee=args.synthesizer,
-            tenant=args.tenant,
-            created_by=args.created_by or _profile_author(),
-            priority=args.priority,
-            idempotency_key=getattr(args, "idempotency_key", None),
-        )
+    try:
+        ws_kind, ws_path = _parse_workspace_flag(args.workspace)
+        branch_name = _parse_branch_flag(getattr(args, "branch", None))
+    except argparse.ArgumentTypeError as exc:
+        print(f"kanban swarm: {exc}", file=sys.stderr)
+        return 2
+    if branch_name and ws_kind != "worktree":
+        print("kanban swarm: --branch is only valid with --workspace worktree", file=sys.stderr)
+        return 2
+    try:
+        with kb.connect_closing() as conn:
+            created = ks.create_swarm(
+                conn,
+                goal=args.goal,
+                workers=workers,
+                verifier_assignee=args.verifier,
+                synthesizer_assignee=args.synthesizer,
+                tenant=args.tenant,
+                created_by=args.created_by or _profile_author(),
+                workspace_kind=ws_kind,
+                workspace_path=ws_path,
+                project_id=getattr(args, "project", None),
+                branch_name=branch_name,
+                priority=args.priority,
+                idempotency_key=getattr(args, "idempotency_key", None),
+            )
+    except ValueError as exc:
+        print(f"kanban swarm: {exc}", file=sys.stderr)
+        return 2
     if getattr(args, "json", False):
         print(json.dumps(created.as_dict(), indent=2, ensure_ascii=False))
     else:

--- a/hermes_cli/kanban_swarm.py
+++ b/hermes_cli/kanban_swarm.py
@@ -88,6 +88,8 @@ def create_swarm(
     created_by: str = "swarm-orchestrator",
     workspace_kind: str = "scratch",
     workspace_path: Optional[str] = None,
+    project_id: Optional[str] = None,
+    branch_name: Optional[str] = None,
     priority: int = 0,
     idempotency_key: Optional[str] = None,
 ) -> SwarmCreated:
@@ -96,6 +98,18 @@ def create_swarm(
     The returned graph is immediately dispatchable: the planning root is marked
     ``done`` with topology metadata, parallel workers are ``ready``, the verifier
     waits for every worker, and the synthesizer waits for the verifier.
+
+    For ``workspace_kind="worktree"`` swarms (code pipelines, e.g. a single
+    ``programmer`` worker handing off to a code-review ``verifier``), every
+    downstream card must land in the *same* git worktree the worker committed
+    to, or the verifier opens an empty checkout and reviews nothing.
+    ``kb.create_task`` normally hands each project-linked task its own fresh
+    ``<repo>/.worktrees/<task-id>`` dir, so left alone every card in the swarm
+    would get a different worktree. To avoid that, the first worker's
+    resolved ``workspace_path``/``branch_name`` (whether pinned explicitly via
+    ``workspace_path`` or auto-derived from ``project_id``) is captured after
+    it's created and reused verbatim for every remaining worker, the verifier,
+    and the synthesizer.
     """
 
     goal = _require_text(goal, "goal")
@@ -107,6 +121,14 @@ def create_swarm(
     for i, spec in enumerate(worker_specs, start=1):
         _require_text(spec.profile, f"workers[{i}].profile")
         _require_text(spec.title, f"workers[{i}].title")
+    if workspace_kind == "worktree" and len(worker_specs) > 1:
+        raise ValueError(
+            "swarm with workspace_kind='worktree' supports exactly one "
+            "--worker: multiple parallel workers writing to the same git "
+            "worktree/branch will clobber each other's changes. Use a "
+            "single worker for code pipelines, or drop --workspace/--project "
+            "to keep parallel workers on independent scratch dirs."
+        )
 
     root = kb.create_task(
         conn,
@@ -154,8 +176,16 @@ def create_swarm(
     )
 
     context_suffix = _swarm_context(root, goal)
+    # These start as the caller's request and get pinned to the first
+    # worker's *resolved* worktree right after it's created, so every later
+    # card (siblings, verifier, synthesizer) lands in that same checkout
+    # instead of each getting its own fresh `.worktrees/<task-id>` dir.
+    shared_ws_kind = workspace_kind
+    shared_ws_path = workspace_path
+    shared_branch = branch_name
+
     worker_ids: list[str] = []
-    for spec in worker_specs:
+    for i, spec in enumerate(worker_specs):
         worker_id = kb.create_task(
             conn,
             title=spec.title,
@@ -165,12 +195,22 @@ def create_swarm(
             parents=[root],
             tenant=tenant,
             priority=spec.priority or priority,
-            workspace_kind=workspace_kind,
-            workspace_path=workspace_path,
+            workspace_kind=shared_ws_kind,
+            workspace_path=shared_ws_path,
+            branch_name=shared_branch,
+            project_id=project_id if shared_ws_path is None else None,
             skills=spec.skills or None,
             max_runtime_seconds=spec.max_runtime_seconds,
         )
         worker_ids.append(worker_id)
+        if i == 0 and shared_ws_kind == "worktree" and shared_ws_path is None:
+            # project_id-only worktree: kb.create_task just auto-derived a
+            # fresh <repo>/.worktrees/<worker_id> dir + deterministic branch.
+            # Lock that exact path/branch in for the verifier + synthesizer.
+            created_worker = kb.get_task(conn, worker_id)
+            shared_ws_kind = created_worker.workspace_kind or shared_ws_kind
+            shared_ws_path = created_worker.workspace_path
+            shared_branch = created_worker.branch_name
 
     verifier_body = (
         "Review every worker handoff and blackboard update. Gate the swarm: "
@@ -187,8 +227,10 @@ def create_swarm(
         parents=worker_ids,
         tenant=tenant,
         priority=priority,
-        workspace_kind=workspace_kind,
-        workspace_path=workspace_path,
+        workspace_kind=shared_ws_kind,
+        workspace_path=shared_ws_path,
+        branch_name=shared_branch,
+        project_id=project_id if shared_ws_path is None else None,
         skills=["requesting-code-review"],
     )
 
@@ -206,8 +248,10 @@ def create_swarm(
         parents=[verifier],
         tenant=tenant,
         priority=priority,
-        workspace_kind=workspace_kind,
-        workspace_path=workspace_path,
+        workspace_kind=shared_ws_kind,
+        workspace_path=shared_ws_path,
+        branch_name=shared_branch,
+        project_id=project_id if shared_ws_path is None else None,
         skills=["humanizer"],
     )
 

--- a/hermes_cli/kanban_swarm.py
+++ b/hermes_cli/kanban_swarm.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import json
+from pathlib import Path
 import sqlite3
 from typing import Any, Iterable, Optional
 
@@ -63,6 +64,86 @@ def _require_text(value: str, field_name: str) -> str:
     return text
 
 
+def _effective_workspace_kind(workspace_kind: str, project_id: Optional[str]) -> str:
+    """Mirror ``kb.create_task``'s project-link promotion, up front.
+
+    ``create_task`` upgrades a ``scratch`` task to ``worktree`` when it carries
+    a resolvable ``project_id`` with a primary repo. That happens *after*
+    :func:`create_swarm` has run its single-worker guard and pinned the shared
+    checkout, so a ``--project`` swarm left on the default ``--workspace
+    scratch`` would skip both and still hand every card its own
+    ``<repo>/.worktrees/<task-id>``. Decide the kind the cards will actually
+    get before either of those steps runs.
+
+    An unresolvable project is left alone: ``create_task`` drops the dangling
+    link and keeps the task on ``scratch``, so the swarm must too.
+    """
+
+    if workspace_kind != "scratch" or not project_id:
+        return workspace_kind
+    from hermes_cli import projects_db as _pdb
+
+    try:
+        with _pdb.connect_closing() as pconn:
+            project = _pdb.get_project(pconn, str(project_id).strip())
+    except Exception:
+        return workspace_kind
+    if project is not None and project.primary_path:
+        return "worktree"
+    return workspace_kind
+
+
+def _board_default_repo() -> Optional[Path]:
+    """Repo root that a bare ``worktree`` task would be anchored on."""
+
+    try:
+        default_workdir = (
+            kb.read_board_metadata(kb.get_current_board()).get("default_workdir") or ""
+        ).strip()
+    except Exception:
+        return None
+    if not default_workdir:
+        return None
+    anchor = Path(default_workdir).expanduser()
+    if not anchor.is_absolute():
+        return None
+    return kb._git_toplevel(anchor)
+
+
+def _swarm_worktree_target(
+    root_id: str,
+    workspace_path: Optional[str],
+    branch_name: Optional[str],
+) -> tuple[Optional[str], Optional[str]]:
+    """Pick one concrete checkout + branch for a non-project worktree swarm.
+
+    ``kb.create_task`` only derives a path/branch for *project-linked*
+    worktrees. Without a project the cards keep exactly what they were handed,
+    and ``kb._resolve_worktree_workspace`` then improvises per card at dispatch:
+    a distinct ``wt/<task-id>`` branch whenever no branch was set, and a
+    distinct ``<repo>/.worktrees/<task-id>`` dir whenever the path is unset or
+    points at a repo root. Either one is enough to open the verifier on a
+    checkout the worker never touched, so anchor the whole swarm up front.
+
+    A path that points *inside* a repo is already shared by every card, so it
+    is kept verbatim and only the branch is pinned. When no repo can be found
+    the path is left alone and dispatch keeps its current behaviour, including
+    its existing "no anchor configured" error.
+    """
+
+    branch = branch_name or f"wt/{root_id}"
+    if workspace_path is None:
+        repo_root = _board_default_repo()
+    else:
+        candidate = Path(workspace_path).expanduser()
+        repo_root = kb._git_toplevel(candidate)
+        if repo_root is None or candidate.resolve(strict=False) != repo_root:
+            return workspace_path, branch
+    if repo_root is None:
+        return workspace_path, branch
+    return str(repo_root / ".worktrees" / root_id), branch
+
+
 def _swarm_context(root_id: str, goal: str) -> str:
     return (
         "\n\n## Swarm protocol\n"
@@ -105,11 +186,20 @@ def create_swarm(
     to, or the verifier opens an empty checkout and reviews nothing.
     ``kb.create_task`` normally hands each project-linked task its own fresh
     ``<repo>/.worktrees/<task-id>`` dir, so left alone every card in the swarm
-    would get a different worktree. To avoid that, the first worker's
-    resolved ``workspace_path``/``branch_name`` (whether pinned explicitly via
-    ``workspace_path`` or auto-derived from ``project_id``) is captured after
-    it's created and reused verbatim for every remaining worker, the verifier,
-    and the synthesizer.
+    would get a different worktree. To avoid that, one path/branch pair is
+    settled before the downstream cards exist and reused verbatim for every
+    remaining worker, the verifier, and the synthesizer:
+
+    * ``project_id`` swarms take the first worker's *resolved* path/branch,
+      which ``kb.create_task`` derived from the project's primary repo.
+    * every other worktree swarm (explicit ``workspace_path``, or bare
+      ``worktree`` anchored on the board's ``default_workdir``) is pinned to
+      ``<repo>/.worktrees/<root-id>`` on ``wt/<root-id>`` unless the caller
+      named a path inside a repo and/or a ``branch_name`` of its own.
+
+    Note that a ``project_id`` promotes ``scratch`` to ``worktree`` inside
+    ``kb.create_task``; :func:`_effective_workspace_kind` applies that here
+    first so such swarms are guarded and pinned like any other worktree swarm.
     """
 
     goal = _require_text(goal, "goal")
@@ -121,7 +211,8 @@ def create_swarm(
     for i, spec in enumerate(worker_specs, start=1):
         _require_text(spec.profile, f"workers[{i}].profile")
         _require_text(spec.title, f"workers[{i}].title")
-    if workspace_kind == "worktree" and len(worker_specs) > 1:
+    effective_ws_kind = _effective_workspace_kind(workspace_kind, project_id)
+    if effective_ws_kind == "worktree" and len(worker_specs) > 1:
         raise ValueError(
             "swarm with workspace_kind='worktree' supports exactly one "
             "--worker: multiple parallel workers writing to the same git "
@@ -176,13 +267,22 @@ def create_swarm(
     )
 
     context_suffix = _swarm_context(root, goal)
-    # These start as the caller's request and get pinned to the first
-    # worker's *resolved* worktree right after it's created, so every later
-    # card (siblings, verifier, synthesizer) lands in that same checkout
-    # instead of each getting its own fresh `.worktrees/<task-id>` dir.
-    shared_ws_kind = workspace_kind
+    # One checkout for the whole swarm, so every later card (siblings, verifier,
+    # synthesizer) lands where the worker committed instead of each getting its
+    # own fresh `.worktrees/<task-id>` dir on its own `wt/<task-id>` branch.
+    # Project swarms are settled after the first worker is created (below),
+    # because only then has `create_task` derived the project path/branch.
+    shared_ws_kind = effective_ws_kind
     shared_ws_path = workspace_path
     shared_branch = branch_name
+    # An explicit ``workspace_path`` wins over the project link (``create_task``
+    # only derives a path when it is given none), so only a project swarm that
+    # named no path can be settled from the created row.
+    project_derived = project_id is not None and workspace_path is None
+    if shared_ws_kind == "worktree" and not project_derived:
+        shared_ws_path, shared_branch = _swarm_worktree_target(
+            root, shared_ws_path, shared_branch
+        )
 
     worker_ids: list[str] = []
     for i, spec in enumerate(worker_specs):
@@ -203,7 +303,7 @@ def create_swarm(
             max_runtime_seconds=spec.max_runtime_seconds,
         )
         worker_ids.append(worker_id)
-        if i == 0 and shared_ws_kind == "worktree" and shared_ws_path is None:
+        if i == 0 and shared_ws_kind == "worktree" and project_derived:
             # project_id-only worktree: kb.create_task just auto-derived a
             # fresh <repo>/.worktrees/<worker_id> dir + deterministic branch.
             # Lock that exact path/branch in for the verifier + synthesizer.

--- a/tests/hermes_cli/test_kanban_swarm.py
+++ b/tests/hermes_cli/test_kanban_swarm.py
@@ -1,5 +1,7 @@
 
 import os
+import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -132,6 +134,32 @@ def _make_project(name="Web App", repo="/tmp/webapp"):
         return pdb.get_project(pc, pid)
 
 
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        [
+            "git", "-C", str(cwd),
+            "-c", "user.name=Test User",
+            "-c", "user.email=test@example.com",
+            "-c", "commit.gpgsign=false",
+            *args,
+        ],
+        check=True, capture_output=True, text=True,
+    )
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(
+        ["git", "init", "-b", "main", str(repo)],
+        check=True, capture_output=True, text=True,
+    )
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "init")
+    return repo
+
+
 def test_worktree_swarm_shares_explicit_checkout_across_all_cards(tmp_path):
     """An explicit worktree path/branch reaches the verifier and synthesizer.
 
@@ -200,6 +228,192 @@ def test_worktree_swarm_pins_project_derived_checkout_for_downstream_cards(tmp_p
         assert synthesizer.workspace_path == worker.workspace_path
         assert verifier.branch_name == worker.branch_name
         assert synthesizer.branch_name == worker.branch_name
+    finally:
+        conn.close()
+
+
+def test_worktree_swarm_pins_a_branch_when_none_was_given(tmp_path):
+    """``--workspace worktree:<path>`` with no ``--branch`` still shares a branch.
+
+    The path alone is not enough: ``_resolve_worktree_workspace`` falls back to
+    a per-card ``wt/<task-id>``, finds the worker's checkout on a different
+    branch, and forks the verifier into a fresh worktree of its own.
+    """
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        created = create_swarm(
+            conn,
+            goal="Wire the login endpoint and review it.",
+            workers=[SwarmWorkerSpec(profile="programmer", title="Wire login", body="Implement")],
+            verifier_assignee="code-reviewer",
+            synthesizer_assignee="writer",
+            workspace_kind="worktree",
+            workspace_path="/repo/checkout",  # inside a repo, no --branch
+        )
+
+        cards = [
+            kb.get_task(conn, created.worker_ids[0]),
+            kb.get_task(conn, created.verifier_id),
+            kb.get_task(conn, created.synthesizer_id),
+        ]
+        # A path inside a repo is already shared by every card, so it is kept
+        # verbatim — only the missing branch had to be settled.
+        assert {c.workspace_path for c in cards} == {"/repo/checkout"}
+        assert {c.branch_name for c in cards} == {f"wt/{created.root_id}"}
+    finally:
+        conn.close()
+
+
+def test_worktree_swarm_worker_and_verifier_resolve_to_one_checkout(tmp_path):
+    """End-to-end at the resolver: the verifier opens the worker's checkout.
+
+    This is the bug in one assertion — dispatch, not card creation, is where
+    the fork used to happen, so the cards are run through
+    ``_resolve_worktree_workspace`` against a real repo.
+    """
+    repo = _make_repo(tmp_path)
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        created = create_swarm(
+            conn,
+            goal="Add login and review it.",
+            workers=[SwarmWorkerSpec(profile="programmer", title="Add login", body="Implement")],
+            verifier_assignee="code-reviewer",
+            synthesizer_assignee="writer",
+            workspace_kind="worktree",
+            workspace_path=str(repo),  # a repo root, no --branch
+        )
+        worker = kb.get_task(conn, created.worker_ids[0])
+        verifier = kb.get_task(conn, created.verifier_id)
+    finally:
+        conn.close()
+
+    worker_ws, worker_branch = kb._resolve_worktree_workspace(worker)
+    (worker_ws / "login.py").write_text("def login(): ...\n", encoding="utf-8")
+    _git(worker_ws, "add", "login.py")
+    _git(worker_ws, "commit", "-m", "wire login")
+
+    verifier_ws, verifier_branch = kb._resolve_worktree_workspace(verifier)
+
+    assert verifier_ws.resolve() == worker_ws.resolve()
+    assert verifier_branch == worker_branch == f"wt/{created.root_id}"
+    # The whole point: there is something to review.
+    assert (verifier_ws / "login.py").exists()
+    # A repo root is not itself a worktree, so the swarm was anchored on one
+    # dir under it instead of letting each card claim `.worktrees/<its own id>`.
+    assert worker_ws.resolve() == (repo / ".worktrees" / created.root_id).resolve()
+
+
+def test_bare_worktree_swarm_shares_the_board_default_checkout(tmp_path):
+    """``--workspace worktree`` with no path anchors on the board default once.
+
+    ``create_task`` copies the board's ``default_workdir`` onto each card, and
+    that is a repo root, so dispatch would still hand every card its own
+    ``.worktrees/<task-id>``.
+    """
+    repo = _make_repo(tmp_path)
+    kb.write_board_metadata(None, default_workdir=str(repo))
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        created = create_swarm(
+            conn,
+            goal="Patch the parser and review it.",
+            workers=[SwarmWorkerSpec(profile="programmer", title="Patch parser", body="Implement")],
+            verifier_assignee="code-reviewer",
+            synthesizer_assignee="writer",
+            workspace_kind="worktree",
+        )
+        cards = [
+            kb.get_task(conn, created.worker_ids[0]),
+            kb.get_task(conn, created.verifier_id),
+            kb.get_task(conn, created.synthesizer_id),
+        ]
+    finally:
+        conn.close()
+
+    expected = str(repo / ".worktrees" / created.root_id)
+    assert {c.workspace_path for c in cards} == {expected}
+    assert {c.branch_name for c in cards} == {f"wt/{created.root_id}"}
+
+
+def test_project_swarm_on_default_scratch_workspace_shares_one_checkout(tmp_path):
+    """``--project`` without ``--workspace`` is a worktree swarm too.
+
+    ``create_task`` promotes a resolved project link from ``scratch`` to
+    ``worktree`` on its own, which used to happen *after* the swarm had already
+    decided not to pin anything.
+    """
+    proj = _make_project()
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        created = create_swarm(
+            conn,
+            goal="Add login and review it.",
+            workers=[SwarmWorkerSpec(profile="programmer", title="Add login", body="Implement")],
+            verifier_assignee="code-reviewer",
+            synthesizer_assignee="writer",
+            project_id=proj.slug,  # workspace_kind left at its "scratch" default
+        )
+        worker = kb.get_task(conn, created.worker_ids[0])
+        verifier = kb.get_task(conn, created.verifier_id)
+        synthesizer = kb.get_task(conn, created.synthesizer_id)
+
+        assert worker.workspace_kind == "worktree"
+        assert worker.workspace_path == os.path.join(
+            proj.primary_path, ".worktrees", worker.id
+        )
+        for card in (verifier, synthesizer):
+            assert card.workspace_kind == "worktree"
+            assert card.workspace_path == worker.workspace_path
+            assert card.branch_name == worker.branch_name
+    finally:
+        conn.close()
+
+
+def test_project_swarm_on_default_scratch_workspace_rejects_multiple_workers(tmp_path):
+    """The one-worker guard must see through the project promotion as well."""
+    proj = _make_project()
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        with pytest.raises(ValueError, match="exactly one"):
+            create_swarm(
+                conn,
+                goal="Two people editing one branch.",
+                workers=[
+                    SwarmWorkerSpec(profile="programmer", title="A", body="a"),
+                    SwarmWorkerSpec(profile="programmer", title="B", body="b"),
+                ],
+                verifier_assignee="code-reviewer",
+                synthesizer_assignee="writer",
+                project_id=proj.slug,
+            )
+    finally:
+        conn.close()
+
+
+def test_unresolvable_project_swarm_stays_on_scratch(tmp_path):
+    """A dangling project link is dropped by ``create_task`` — don't promote it.
+
+    Otherwise parallel scratch workers would start being rejected because of a
+    project that does not exist.
+    """
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        created = create_swarm(
+            conn,
+            goal="Two independent research tracks.",
+            workers=[
+                SwarmWorkerSpec(profile="researcher-a", title="A", body="a"),
+                SwarmWorkerSpec(profile="researcher-b", title="B", body="b"),
+            ],
+            verifier_assignee="reviewer",
+            synthesizer_assignee="writer",
+            project_id="no-such-project",
+        )
+        cards = [kb.get_task(conn, tid) for tid in created.worker_ids]
+        cards.append(kb.get_task(conn, created.verifier_id))
+        assert {c.workspace_kind for c in cards} == {"scratch"}
+        assert {c.branch_name for c in cards} == {None}
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_kanban_swarm.py
+++ b/tests/hermes_cli/test_kanban_swarm.py
@@ -1,5 +1,10 @@
 
+import os
+
+import pytest
+
 from hermes_cli import kanban_db as kb
+from hermes_cli import projects_db as pdb
 from hermes_cli.kanban_swarm import (
     SwarmWorkerSpec,
     create_swarm,
@@ -113,5 +118,131 @@ def test_swarm_verifier_and_synthesis_are_dependency_gated(tmp_path):
         )
         kb.recompute_ready(conn)
         assert kb.get_task(conn, created.synthesizer_id).status == "ready"
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Worktree swarms: every card shares one checkout
+# ---------------------------------------------------------------------------
+
+def _make_project(name="Web App", repo="/tmp/webapp"):
+    with pdb.connect_closing() as pc:
+        pid = pdb.create_project(pc, name=name, folders=[repo])
+        return pdb.get_project(pc, pid)
+
+
+def test_worktree_swarm_shares_explicit_checkout_across_all_cards(tmp_path):
+    """An explicit worktree path/branch reaches the verifier and synthesizer.
+
+    Without this the verifier opens its own checkout and reviews an empty
+    tree instead of what the worker committed.
+    """
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        created = create_swarm(
+            conn,
+            goal="Wire the login endpoint and review it.",
+            workers=[SwarmWorkerSpec(profile="programmer", title="Wire login", body="Implement")],
+            verifier_assignee="code-reviewer",
+            synthesizer_assignee="writer",
+            workspace_kind="worktree",
+            workspace_path="/repo/checkout",
+            branch_name="wt/login",
+        )
+
+        cards = [
+            kb.get_task(conn, created.worker_ids[0]),
+            kb.get_task(conn, created.verifier_id),
+            kb.get_task(conn, created.synthesizer_id),
+        ]
+        assert {c.workspace_kind for c in cards} == {"worktree"}
+        assert {c.workspace_path for c in cards} == {"/repo/checkout"}
+        # The branch matters as much as the path: resolve_workspace only reuses
+        # an existing checkout when the branch matches, and otherwise forks a
+        # fresh worktree — which would defeat the shared path.
+        assert {c.branch_name for c in cards} == {"wt/login"}
+    finally:
+        conn.close()
+
+
+def test_worktree_swarm_pins_project_derived_checkout_for_downstream_cards(tmp_path):
+    """With only --project, the first worker's *resolved* worktree is reused.
+
+    ``create_task`` hands each project-linked task its own fresh
+    ``<repo>/.worktrees/<task-id>``, so without pinning every card in the swarm
+    would land somewhere different.
+    """
+    proj = _make_project()
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        created = create_swarm(
+            conn,
+            goal="Add login and review it.",
+            workers=[SwarmWorkerSpec(profile="programmer", title="Add login", body="Implement")],
+            verifier_assignee="code-reviewer",
+            synthesizer_assignee="writer",
+            workspace_kind="worktree",
+            project_id=proj.slug,
+        )
+
+        worker = kb.get_task(conn, created.worker_ids[0])
+        verifier = kb.get_task(conn, created.verifier_id)
+        synthesizer = kb.get_task(conn, created.synthesizer_id)
+
+        # The worker got the deterministic project worktree...
+        assert worker.workspace_path == os.path.join(
+            proj.primary_path, ".worktrees", worker.id
+        )
+        # ...and the downstream cards were pinned to that exact path + branch,
+        # not to fresh dirs keyed on their own task ids.
+        assert verifier.workspace_path == worker.workspace_path
+        assert synthesizer.workspace_path == worker.workspace_path
+        assert verifier.branch_name == worker.branch_name
+        assert synthesizer.branch_name == worker.branch_name
+    finally:
+        conn.close()
+
+
+def test_worktree_swarm_rejects_multiple_workers(tmp_path):
+    """Parallel workers on one checkout would clobber each other — fail loudly."""
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        with pytest.raises(ValueError, match="exactly one"):
+            create_swarm(
+                conn,
+                goal="Two people editing one branch.",
+                workers=[
+                    SwarmWorkerSpec(profile="programmer", title="A", body="a"),
+                    SwarmWorkerSpec(profile="programmer", title="B", body="b"),
+                ],
+                verifier_assignee="code-reviewer",
+                synthesizer_assignee="writer",
+                workspace_kind="worktree",
+                workspace_path="/repo/checkout",
+            )
+    finally:
+        conn.close()
+
+
+def test_scratch_swarm_keeps_independent_workspaces(tmp_path):
+    """Regression: the default swarm is unchanged — no branch, no sharing."""
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        created = create_swarm(
+            conn,
+            goal="Two independent research tracks.",
+            workers=[
+                SwarmWorkerSpec(profile="researcher-a", title="A", body="a"),
+                SwarmWorkerSpec(profile="researcher-b", title="B", body="b"),
+            ],
+            verifier_assignee="reviewer",
+            synthesizer_assignee="writer",
+        )
+        cards = [kb.get_task(conn, tid) for tid in created.worker_ids]
+        cards += [kb.get_task(conn, created.verifier_id),
+                  kb.get_task(conn, created.synthesizer_id)]
+        assert {c.workspace_kind for c in cards} == {"scratch"}
+        assert {c.branch_name for c in cards} == {None}
     finally:
         conn.close()


### PR DESCRIPTION
## What does this PR do?

**A worktree swarm's verifier reviews an empty checkout instead of what the worker committed.**

The canonical code pipeline — one `programmer` worker handing off to a code-review `verifier` — is exactly the case that needs every card in the same checkout. Today the cards diverge, by two independent routes.

**Route 1 — the branch fallback.** A worktree task with no explicit branch gets `wt/<task-id>`:

```python
# kanban_db.py
branch_name = (task.branch_name or "").strip() or f"wt/{task.id}"
```

`create_swarm` passes `workspace_path` down but has no `branch_name` to pass, so each card derives its own branch. At dispatch, `resolve_workspace` finds the shared path already checked out on a *different* task's branch and deliberately forks a fresh `<repo>/.worktrees/<task-id>` — the right call in general (it is the guard against decompose siblings silently running on each other's branches), but it means the verifier lands in an empty tree.

**Route 2 — per-task project worktrees.** With `project_id`, `create_task` derives a fresh `<repo>/.worktrees/<task-id>` per task. The cards never shared a path in the first place.

**And none of it is reachable from the CLI.** `create_swarm` accepts `workspace_kind`/`workspace_path`, but `--workspace` is only wired to `kanban create` — `kanban swarm` has no such flag, so every swarm is `scratch` regardless.

### The fix

Pin the **resolved** path *and* branch of the first worker onto every later card (siblings, verifier, synthesizer). Pinning the branch is what makes the shared path stick: `resolve_workspace` reuses an existing checkout precisely when the branch matches, so this threads through the same-branch sharing the mechanism already supports, rather than working around it.

With `project_id` and no explicit path, the concrete worktree is only known *after* the first worker row exists, so it is read back and locked in — hence the `get_task` immediately after the first `create_task`.

## Open question for reviewers — the one-worker limit

Worktree swarms are restricted to a single `--worker`, raising otherwise. Parallel workers committing to one branch clobber each other, and I would rather fail loudly at creation than lose work silently at run time.

**But this restricts the abstraction swarm exists for, so it should be your call, not mine.** Alternatives, happy to switch to any of them:

1. **As implemented** — hard error, one worker for worktree swarms.
2. **Warn and continue** — I would argue against it: the failure mode is lost commits, which is exactly what should not be a warning.
3. **Per-worker worktrees + a verifier that spans them** — the most useful long-term shape, but it needs a decision about what the verifier's own workspace should be, which is beyond what I wanted to assume here.

If you prefer (3), I am happy to close this and re-cut it, or land the sharing fix now and leave multi-worker to a follow-up.

## Related Issue

None open that I could find — I searched PRs and issues for `swarm worktree`, `swarm workspace`, `swarm shared checkout` and found nothing covering this. Happy to split the problem statement into an issue if you would rather have one to track.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Also exposes existing `create_swarm` workspace params on the CLI

## Changes Made

- `hermes_cli/kanban_swarm.py` — `create_swarm` gains `project_id` / `branch_name`; pins the first worker's resolved path+branch onto every later card; rejects multi-worker worktree swarms.
- `hermes_cli/kanban.py` — `kanban swarm` gains `--workspace` / `--branch` / `--project`, reusing the existing `_parse_workspace_flag` / `_parse_branch_flag` helpers so the syntax matches `kanban create` exactly (`scratch | worktree | worktree:<path> | dir:<path>`).
- `tests/hermes_cli/test_kanban_swarm.py` — 4 tests.

Scratch swarms are untouched: with no `--workspace` the pinning branch is inert and every card stays on its own scratch dir (covered by a regression test).

## How to Test

```bash
pytest tests/hermes_cli/test_kanban_swarm.py -q
```

Three of the four new tests fail on `main`:

- `test_worktree_swarm_pins_project_derived_checkout_for_downstream_cards` — the actual divergence; verifier gets its own `.worktrees/<verifier-id>`.
- `test_worktree_swarm_shares_explicit_checkout_across_all_cards` — `branch_name` is not accepted at all today.
- `test_worktree_swarm_rejects_multiple_workers` — no guard exists.

End to end:

```bash
hermes kanban swarm --goal "wire the login endpoint" \
  --worker programmer:"Wire login" --verifier code-reviewer --synthesizer writer \
  --workspace worktree --project webapp
```

All four cards should report the same `workspace_path` and `branch_name`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **not the full suite.** I ran `test_kanban_swarm.py`, `test_kanban_project_link.py`, `test_kanban_cli.py`, `test_kanban_core_functionality.py`, `test_kanban_cli_dispatch_passthrough.py`, and diffed the failure set against clean `main` on the same machine: **identical — this PR adds no new failures.** (`main` has pre-existing failures on native Windows in the crash-detection / protocol-violation tests; unrelated to this change and untouched.)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (native, not WSL2)

### Documentation & Housekeeping

- [x] Docstrings updated on `create_swarm` and the new CLI flags — no user-facing docs affected
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture change; this wires up params that already existed
- [x] Cross-platform: paths flow through the existing `_parse_workspace_flag` / `create_task` handling, no new path logic; developed and tested on native Windows
