### PR TITLE
fix(desktop): suppress backend respawn during update to unblock venv guard

### DIFF
--- a/apps/desktop/electron/backend-start-suppression.test.ts
+++ b/apps/desktop/electron/backend-start-suppression.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { backendStartSuppressionReason } from './backend-start-suppression'
+
+test('allows a backend spawn when no update is in flight', () => {
+  assert.equal(backendStartSuppressionReason(false), null)
+})
+
+test('suppresses a backend spawn while an update is in flight', () => {
+  const reason = backendStartSuppressionReason(true)
+  assert.ok(reason, 'expected a non-null suppression reason during an update')
+  assert.match(reason as string, /update is in progress/i)
+})

--- a/apps/desktop/electron/backend-start-suppression.ts
+++ b/apps/desktop/electron/backend-start-suppression.ts
@@ -1,0 +1,26 @@
+// Pure predicate for whether a local Hermes backend (re)spawn must be refused.
+//
+// Extracted from main.ts so the "an update in flight suppresses backend
+// respawn" invariant is unit-testable without booting the whole Electron
+// update flow (main.ts imports the Electron runtime and cannot be imported
+// from vitest).
+//
+// Why this exists: the Windows update path tears down the desktop's backend
+// and, before handing off to the detached updater, runs a venv-blocker
+// preflight (scanVenvBlockers). If ANY process is still running from the
+// venv's python, the preflight aborts with "venv-blocked" to avoid a
+// half-updated venv (native .pyd files stay mapped and the dependency sync
+// dies access-denied). But the renderer's getConnection(), wake/reconnect
+// recovery, and pool dials all call back into startHermes()/ensureBackend()
+// and respawn the backend within milliseconds of the teardown — so the
+// preflight always finds a fresh holder and the update is structurally
+// impossible while the app is open. Gating every (re)spawn on this predicate
+// keeps the venv quiet for the duration of the update.
+
+export function backendStartSuppressionReason(updateActive: boolean): string | null {
+  if (updateActive) {
+    return 'Backend start suppressed: a Hermes update is in progress.'
+  }
+
+  return null
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -40,6 +40,7 @@ import { isReauthRequiredError, waitForHermesReady } from './backend-health'
 import { canImportHermesCli, shouldTrustHermesOverride, verifyHermesCli } from './backend-probes'
 import { waitForDashboardPortAnnouncement } from './backend-ready'
 import { shouldLatchBackendStartFailure, shouldLatchRemoteReauthFailure } from './backend-start-failure'
+import { backendStartSuppressionReason } from './backend-start-suppression'
 import { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } from './bootstrap-platform'
 import { runBootstrap } from './bootstrap-runner'
 import { applyConnectionChange, resolveTerminalConnection } from './connection-apply'
@@ -2874,6 +2875,10 @@ async function applyUpdates(opts = {}) {
         '(a second Hermes window or a terminal running hermes?). Close it and retry.'
 
       emitUpdateProgress({ stage: 'error', message, percent: null })
+      // Clear the in-flight latch BEFORE restarting: the recovery startHermes()
+      // is itself gated on !updateInFlight (see the guard in startHermes), so
+      // the backend would stay down without this.
+      updateInFlight = false
       startHermes().catch(() => {})
 
       return { ok: false, error: message }
@@ -2896,6 +2901,7 @@ async function applyUpdates(opts = {}) {
 
         rememberLog(`[updates] venv-blocked: ${scanOutcome.result.processes.length} process(es) hold the install`)
         emitUpdateProgress({ stage: 'error', message, percent: null })
+        updateInFlight = false
         startHermes().catch(() => {})
 
         return { ok: false, error: 'venv-blocked', message }
@@ -2906,6 +2912,7 @@ async function applyUpdates(opts = {}) {
 
         rememberLog(`[updates] venv-blocker probe failed: ${scanOutcome.error}`)
         emitUpdateProgress({ stage: 'error', message, percent: null })
+        updateInFlight = false
         startHermes().catch(() => {})
 
         return { ok: false, error: 'venv-probe-failed', message }
@@ -7868,6 +7875,17 @@ function profileRouteOptions(profile) {
 // resolveProfileBackendRoute(). An empty / unknown profile resolves to the
 // primary, so legacy callers are unchanged.
 async function ensureBackend(profile) {
+  // An update in flight is tearing down backends and handing off to the
+  // detached updater; a pool respawn here re-locks the venv and trips the
+  // venv-blocker preflight. Mirror the guard in startHermes(). Remote pool
+  // entries spawn no local child, but refusing uniformly keeps the update
+  // window quiet and avoids a half-torn-down pool racing the handoff.
+  const suppression = backendStartSuppressionReason(updateInFlight)
+
+  if (suppression) {
+    throw new Error(suppression)
+  }
+
   const key = profile && String(profile).trim() ? String(profile).trim() : primaryProfileKey()
   const route = resolveProfileBackendRoute(key, profileRouteOptions(key))
 
@@ -8193,6 +8211,20 @@ async function startHermes() {
   // the failure overlay.
   if (bootstrapFailure) {
     throw bootstrapFailure
+  }
+
+  // An update in flight has already torn down the backend and is about to hand
+  // off to the detached updater. Any respawn here (renderer getConnection(),
+  // wake/reconnect recovery, a pool dial) re-locks the venv's python and its
+  // native .pyd files, so the pre-handoff scanVenvBlockers preflight finds a
+  // holder and aborts with "venv-blocked" — the update becomes structurally
+  // impossible while the app is open. Refuse to (re)spawn a local backend for
+  // the duration of the update; releaseBackendLockForUpdate restarts it if the
+  // update itself fails to hand off.
+  const suppression = backendStartSuppressionReason(updateInFlight)
+
+  if (suppression) {
+    throw new Error(suppression)
   }
 
   if (backendStartFailure) {


### PR DESCRIPTION
## Problem

On Windows the desktop update is **structurally impossible while the app is open**. Every retry shows:

> Update didn't finish — Update aborted: another Hermes process is using this installation. These processes must be stopped before updating: PID … python.exe … -m hermes_cli.main serve …

### Root cause

The update path (`applyUpdates` in `electron/main.ts`) does:
1. `releaseBackendLockForUpdate()` — kills the desktop's own backend child(ren)
2. `scanVenvBlockers()` — refuses the handoff if **any** process is still running from the venv's python (the July 2026 `brotlicffi/_sodium.pyd` half-updated-venv guard)

But nothing stopped the renderer's `getConnection()`, wake/reconnect recovery, or a pool dial from calling straight back into `startHermes()` / `ensureBackend()` and **respawning the backend within milliseconds** of the teardown. The preflight then always finds a fresh venv holder → `venv-blocked` → abort.

The `updateInFlight` latch already existed but **was never consulted by the spawn paths**.

## Fix

Gate every local-backend (re)spawn on `updateInFlight`:

- Extract `backendStartSuppressionReason()` as a pure, unit-tested predicate (new `backend-start-suppression.ts`) instead of inlining the flag check — follows the repo's *'never read source in tests / extract to a DI-testable function'* rule (`main.ts` imports the Electron runtime and can't be imported from vitest).
- Refuse spawns in **both** `startHermes()` and `ensureBackend()` while an update is in flight.
- Clear `updateInFlight` **before** the recovery `startHermes()` at each update failure exit (lock-not-unlocked, venv-blocked, probe-failed) so the backend restarts and the app keeps working after a failed attempt.

## Tests

```
cd apps/desktop
npx vitest run electron/backend-start-suppression.test.ts   # 2 passed
npx tsc --noEmit -p tsconfig.json                            # clean
```

New `backend-start-suppression.test.ts` asserts the invariant: spawn allowed when no update in flight, suppressed while one is.