### PR TITLE
fix(desktop): key the completed-unread dot on the focused session, not the selected one

### DIFF
--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -172,7 +172,9 @@ function handleTransition(previous: ClientSessionState | null, next: ClientSessi
   } else if (!next.busy && wasWorking) {
     markSettled(storedId)
 
-    if (storedId !== $selectedStoredSessionId.get()) {
+    // FOCUSED, not selected: a session finishing in the tile the user is
+    // watching is already seen, and a tile is never the primary selection.
+    if (storedId !== $focusedStoredSessionId.get()) {
       const cur = $unreadFinishedSessionIds.get()
 
       if (!cur.includes(storedId)) {
@@ -770,6 +772,18 @@ export const $focusedSessionState = computed([$focusedRuntimeId, $sessionStates]
  *  behind the workspace (A+B "disappear" when switching to C). */
 export const selectionHomesToWorkspace = (selected: null | string, tiles: readonly SessionTile[]): boolean =>
   !(selected && tiles.some(t => t.storedSessionId === selected))
+
+// Bringing a finished session to the front clears its green dot. Keyed on the
+// FOCUSED session, not the selected one: a tile is never $selectedStoredSessionId,
+// and a tile tab click goes through activateTreePane rather than focusOpenSession,
+// so this is the one hook that catches every way a tile reaches the front.
+$focusedStoredSessionId.listen(focused => {
+  const cur = $unreadFinishedSessionIds.get()
+
+  if (focused && cur.includes(focused)) {
+    $unreadFinishedSessionIds.set(cur.filter(id => id !== focused))
+  }
+})
 
 // Cold-start restore is the one selection change that is NOT a navigation: the
 // route already pointed at the primary session before the window loaded, and

--- a/apps/desktop/src/store/session-unread-tile.test.ts
+++ b/apps/desktop/src/store/session-unread-tile.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The completed-unread dot is keyed on the FOCUSED session, not the selected
+// one. A tile is never $selectedStoredSessionId, so keying either half on the
+// selection left a tiled session's dot green with no way to clear it.
+
+describe('completed-unread dot follows the focused session', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  async function setup() {
+    const tree = await import('@/components/pane-shell/tree/store')
+    const model = await import('@/components/pane-shell/tree/model')
+    const { registry } = await import('@/contrib/registry')
+    const { createClientSessionState } = await import('@/lib/chat-runtime')
+    const session = await import('./session')
+    const states = await import('./session-states')
+
+    for (const id of ['workspace', 'session-tile:tiled']) {
+      registry.register({
+        area: 'panes',
+        data: id === 'workspace' ? { placement: 'main', uncloseable: true } : { placement: 'main' },
+        id,
+        render: () => null,
+        title: id
+      })
+    }
+
+    // The workspace holds the primary chat, a second zone holds the tile.
+    tree.declareDefaultTree(
+      model.split('row', [
+        model.group(['workspace'], { active: 'workspace', id: 'grp-main' }),
+        model.group(['session-tile:tiled'], { active: 'session-tile:tiled', id: 'grp-tile' })
+      ])
+    )
+
+    session.$unreadFinishedSessionIds.set([])
+    session.$selectedStoredSessionId.set('primary')
+
+    const finishTurn = (storedSessionId: string) => {
+      const working = { ...createClientSessionState(null), busy: true, storedSessionId }
+      states.publishSessionState(`rt-${storedSessionId}`, working)
+      states.publishSessionState(`rt-${storedSessionId}`, { ...working, busy: false })
+    }
+
+    return { finishTurn, session, tree }
+  }
+
+  it('clears the dot when an already-open tile is fronted', async () => {
+    const { finishTurn, session, tree } = await setup()
+
+    tree.noteActiveTreeGroup('grp-main')
+    finishTurn('tiled')
+    expect(session.$unreadFinishedSessionIds.get()).toEqual(['tiled'])
+
+    // Fronting the tile is what a tab click does. Before the fix nothing on
+    // this path cleared the marker, so the dot stayed green.
+    tree.noteActiveTreeGroup('grp-tile')
+    expect(session.$unreadFinishedSessionIds.get()).toEqual([])
+  })
+
+  it('never marks a tile that finishes while it is the focused one', async () => {
+    const { finishTurn, session, tree } = await setup()
+
+    tree.noteActiveTreeGroup('grp-tile')
+    finishTurn('tiled')
+
+    expect(session.$unreadFinishedSessionIds.get()).toEqual([])
+  })
+
+  it('marks the primary session when a tile has focus', async () => {
+    const { finishTurn, session, tree } = await setup()
+
+    tree.noteActiveTreeGroup('grp-tile')
+    finishTurn('primary')
+
+    expect(session.$unreadFinishedSessionIds.get()).toEqual(['primary'])
+  })
+})


### PR DESCRIPTION
## What does this PR do?

The completed-unread dot was both set and cleared against `$selectedStoredSessionId`, the primary
chat's selection. A session open as a tile is never the primary selection, so a tiled session that
finished in the background had no path to clear its green dot, and it stayed green through focusing
the tile, reading the response, and interacting with it. Both halves now key on
`$focusedStoredSessionId`, which already resolves the fronted tile and falls back to the selection.

## Related Issue

Fixes #74142

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/session-states.ts`: the busy to idle mark now compares against
  `$focusedStoredSessionId`, and a listener on it clears the marker when a session is fronted.
  Clearing has to live here rather than in `focusOpenSession`, which a tile tab click never reaches.
- `apps/desktop/src/store/session-unread-tile.test.ts`: fronting a tile, finishing inside a focused
  tile, and the primary finishing while a tile has focus.

One behavior change falls out of the same rule: the primary session finishing while a tile is
focused is now marked unread. It was not before, even though the user is looking at the tile.

## How to Test

1. Open conversation A as a tile and conversation B in the main thread, start a turn in A, focus B
   while A completes. A gets the green dot.
2. Click A's tile tab. The dot returns to the idle project color. On main it stays green.
3. `npm run test --workspace apps/desktop -- src/store/session-unread-tile.test.ts`. All three fail
   without the `session-states.ts` change and pass with it.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [ ] I've tested on my platform: unit tests pass on macOS, no end-to-end run of the packaged app yet

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A, renderer store logic with no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
