### PR TITLE
fix(computer-use): guard unsafe Linux uinput fallback

### DIFF
--- a/tests/computer_use/test_doctor.py
+++ b/tests/computer_use/test_doctor.py
@@ -454,6 +454,7 @@ class TestUinputLeakRiskGuard:
 
         with patch("tools.computer_use.doctor._drive_health_report",
                    return_value=_linux_report(driver_version="0.12.6", overall="ok")), \
+             patch.object(doctor, "_read_cli_version", return_value="cua-driver 0.12.6"), \
              patch("tools.computer_use.doctor.uinput_read_write_accessible", return_value=False), \
              patch.dict(os.environ, {"DISPLAY": ":0"}), \
              patch("shutil.which", return_value="/fake/cua-driver"), \
@@ -476,6 +477,7 @@ class TestUinputLeakRiskGuard:
 
         with patch("tools.computer_use.doctor._drive_health_report",
                    return_value=_linux_report(driver_version="0.12.6", overall="failed")), \
+             patch.object(doctor, "_read_cli_version", return_value="cua-driver 0.12.6"), \
              patch("tools.computer_use.doctor.uinput_read_write_accessible", return_value=False), \
              patch.dict(os.environ, {"DISPLAY": ":0"}), \
              patch("shutil.which", return_value="/fake/cua-driver"), \
@@ -510,6 +512,7 @@ class TestUinputLeakRiskGuard:
         env.pop("DISPLAY", None)
         with patch("tools.computer_use.doctor._drive_health_report",
                    return_value=_linux_report(driver_version="0.12.6", overall="ok")), \
+             patch.object(doctor, "_read_cli_version", return_value="cua-driver 0.12.6"), \
              patch("tools.computer_use.doctor.uinput_read_write_accessible", return_value=False), \
              patch.dict(os.environ, env, clear=True), \
              patch("shutil.which", return_value="/fake/cua-driver"), \
@@ -526,6 +529,7 @@ class TestUinputLeakRiskGuard:
 
         with patch("tools.computer_use.doctor._drive_health_report",
                    return_value=_linux_report(driver_version="0.13.1", overall="ok")), \
+             patch.object(doctor, "_read_cli_version", return_value="cua-driver 0.13.1"), \
              patch("tools.computer_use.doctor.uinput_read_write_accessible", return_value=False), \
              patch.dict(os.environ, {"DISPLAY": ":0"}), \
              patch("shutil.which", return_value="/fake/cua-driver"), \
@@ -543,6 +547,7 @@ class TestUinputLeakRiskGuard:
 
         with patch("tools.computer_use.doctor._drive_health_report",
                    return_value=_linux_report(driver_version="unknown", overall="ok")), \
+             patch.object(doctor, "_read_cli_version", return_value="cua-driver unknown"), \
              patch("tools.computer_use.doctor.uinput_read_write_accessible", return_value=False), \
              patch.dict(os.environ, {"DISPLAY": ":0"}), \
              patch("shutil.which", return_value="/fake/cua-driver"), \
@@ -559,6 +564,7 @@ class TestUinputLeakRiskGuard:
 
         with patch("tools.computer_use.doctor._drive_health_report",
                    return_value=_linux_report(driver_version="0.12.6", overall="ok")), \
+             patch.object(doctor, "_read_cli_version", return_value="cua-driver 0.12.6"), \
              patch("tools.computer_use.doctor.uinput_read_write_accessible", return_value=True), \
              patch.dict(os.environ, {"DISPLAY": ":0"}), \
              patch("shutil.which", return_value="/fake/cua-driver"), \
@@ -577,6 +583,7 @@ class TestUinputLeakRiskGuard:
 
         with patch("tools.computer_use.doctor._drive_health_report",
                    return_value=_linux_report(driver_version="0.13.1", overall="ok")), \
+             patch.object(doctor, "_read_cli_version", return_value="cua-driver 0.13.1"), \
              patch("tools.computer_use.doctor.uinput_read_write_accessible") as accessible, \
              patch.dict(os.environ, {"DISPLAY": ":0"}), \
              patch("shutil.which", return_value="/fake/cua-driver"), \
@@ -590,6 +597,7 @@ class TestUinputLeakRiskGuard:
 
         with patch("tools.computer_use.doctor._drive_health_report",
                    return_value=_linux_report(driver_version="unknown", overall="ok")), \
+             patch.object(doctor, "_read_cli_version", return_value="cua-driver unknown"), \
              patch("tools.computer_use.doctor.uinput_read_write_accessible") as accessible, \
              patch.dict(os.environ, {"DISPLAY": ":0"}), \
              patch("shutil.which", return_value="/fake/cua-driver"), \
@@ -618,6 +626,7 @@ class TestUinputLeakRiskGuard:
         env.pop("DISPLAY", None)
         with patch("tools.computer_use.doctor._drive_health_report",
                    return_value=_linux_report(driver_version="0.12.6", overall="ok")), \
+             patch.object(doctor, "_read_cli_version", return_value="cua-driver 0.12.6"), \
              patch("tools.computer_use.doctor.uinput_read_write_accessible") as accessible, \
              patch.dict(os.environ, env, clear=True), \
              patch("shutil.which", return_value="/fake/cua-driver"), \
@@ -632,6 +641,7 @@ class TestUinputLeakRiskGuard:
 
         with patch("tools.computer_use.doctor._drive_health_report",
                    return_value=_linux_report(driver_version="0.12.6", overall="ok")), \
+             patch.object(doctor, "_read_cli_version", return_value="cua-driver 0.12.6"), \
              patch("tools.computer_use.doctor.uinput_read_write_accessible",
                    return_value=False) as accessible, \
              patch.dict(os.environ, {"DISPLAY": ":0"}), \
@@ -648,6 +658,7 @@ class TestUinputLeakRiskGuard:
 
         with patch("tools.computer_use.doctor._drive_health_report",
                    return_value=_linux_report(driver_version="0.12.6", overall="ok")), \
+             patch.object(doctor, "_read_cli_version", return_value="cua-driver 0.12.6"), \
              patch("tools.computer_use.doctor.uinput_read_write_accessible", return_value=False), \
              patch.dict(os.environ, {"DISPLAY": ":0"}), \
              patch("shutil.which", return_value="/fake/cua-driver"), \
@@ -659,3 +670,48 @@ class TestUinputLeakRiskGuard:
         blob = json.dumps(check).lower()
         for forbidden in ("chmod", "sudo"):
             assert forbidden not in blob
+
+    def test_uses_resolved_binary_version_when_report_disagrees(self):
+        """health_report can lag/lie about driver_version (the same case
+        hermes_identity.version_mismatch already flags). The guard must
+        trust the resolved binary's own --version, not the stale report
+        value, or a fixed-looking report can mask a still-vulnerable binary."""
+        from tools.computer_use import doctor
+
+        with patch("tools.computer_use.doctor._drive_health_report",
+                   return_value=_linux_report(driver_version="0.13.1", overall="ok")), \
+             patch.object(doctor, "_read_cli_version", return_value="cua-driver 0.12.6"), \
+             patch("tools.computer_use.doctor.uinput_read_write_accessible", return_value=False), \
+             patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("sys.stdout", new_callable=StringIO) as out:
+            code = doctor.run_doctor(json_output=True)
+
+        report = json.loads(out.getvalue())
+        assert report["overall"] == "degraded"
+        names = [c["name"] for c in report["checks"]]
+        assert "linux_uinput_xinput_leak_risk" in names
+        assert code == 1
+
+    def test_falls_back_to_report_version_when_cli_token_is_unparseable(self):
+        """A present-but-unparseable CLI --version token (a dev/packaging
+        banner with no dotted version anywhere in it) must NOT blank out a
+        parseable, still-vulnerable health_report driver_version — that
+        would silently skip the check for a genuinely vulnerable host."""
+        from tools.computer_use import doctor
+
+        with patch("tools.computer_use.doctor._drive_health_report",
+                   return_value=_linux_report(driver_version="0.12.6", overall="ok")), \
+             patch.object(doctor, "_read_cli_version",
+                           return_value="cua-driver (dev build, no version)"), \
+             patch("tools.computer_use.doctor.uinput_read_write_accessible", return_value=False), \
+             patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("sys.stdout", new_callable=StringIO) as out:
+            code = doctor.run_doctor(json_output=True)
+
+        report = json.loads(out.getvalue())
+        assert report["overall"] == "degraded"
+        names = [c["name"] for c in report["checks"]]
+        assert "linux_uinput_xinput_leak_risk" in names
+        assert code == 1

--- a/tests/computer_use/test_doctor.py
+++ b/tests/computer_use/test_doctor.py
@@ -20,6 +20,7 @@ shape.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from io import StringIO
 from unittest.mock import MagicMock, patch
@@ -429,3 +430,232 @@ class TestDoctorVersionIdentity:
         payload = json.loads(out.getvalue())
         assert payload["hermes_identity"]["version_mismatch"] is False
 
+
+# ── Linux/X11 uinput XInput-leak guard (#74148 / trycua/cua#2618 #2631) ────
+
+
+def _linux_report(driver_version: str = "0.12.6", overall: str = "ok") -> dict:
+    """Well-formed health_report response reporting Linux + a given
+    cua-driver version, otherwise matching ``_ok_report``'s shape."""
+    return {
+        "schema_version": "1",
+        "platform": "linux",
+        "driver_version": driver_version,
+        "overall": overall,
+        "checks": [
+            {"name": "binary_version", "status": "pass", "message": f"cua-driver {driver_version}"},
+        ],
+    }
+
+
+class TestUinputLeakRiskGuard:
+    def test_appends_failing_check_and_degrades_ok_overall(self):
+        from tools.computer_use import doctor
+
+        with patch("tools.computer_use.doctor._drive_health_report",
+                   return_value=_linux_report(driver_version="0.12.6", overall="ok")), \
+             patch("tools.computer_use.doctor.uinput_read_write_accessible", return_value=False), \
+             patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("sys.stdout", new_callable=StringIO) as out:
+            code = doctor.run_doctor(json_output=True)
+
+        report = json.loads(out.getvalue())
+        assert report["overall"] == "degraded"
+        names = [c["name"] for c in report["checks"]]
+        assert "linux_uinput_xinput_leak_risk" in names
+        check = next(c for c in report["checks"] if c["name"] == "linux_uinput_xinput_leak_risk")
+        assert check["status"] in ("fail", "degraded")
+        assert "2618" in check["message"]
+        assert "2631" in check["message"]
+        assert "74148" in check["message"]
+        assert code == 1  # degraded => exit 1
+
+    def test_does_not_downgrade_already_failed_overall(self):
+        from tools.computer_use import doctor
+
+        with patch("tools.computer_use.doctor._drive_health_report",
+                   return_value=_linux_report(driver_version="0.12.6", overall="failed")), \
+             patch("tools.computer_use.doctor.uinput_read_write_accessible", return_value=False), \
+             patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("sys.stdout", new_callable=StringIO) as out:
+            doctor.run_doctor(json_output=True)
+
+        report = json.loads(out.getvalue())
+        assert report["overall"] == "failed"
+        names = [c["name"] for c in report["checks"]]
+        assert "linux_uinput_xinput_leak_risk" in names
+
+    def test_no_check_appended_on_non_linux(self):
+        from tools.computer_use import doctor
+
+        with patch("tools.computer_use.doctor._drive_health_report",
+                   return_value=_ok_report()), \
+             patch("tools.computer_use.doctor.uinput_read_write_accessible", return_value=False), \
+             patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("sys.stdout", new_callable=StringIO) as out:
+            doctor.run_doctor(json_output=True)
+
+        report = json.loads(out.getvalue())
+        assert report["overall"] == "ok"
+        names = [c.get("name") for c in report["checks"]]
+        assert "linux_uinput_xinput_leak_risk" not in names
+
+    def test_no_check_appended_without_display(self):
+        from tools.computer_use import doctor
+
+        env = dict(os.environ)
+        env.pop("DISPLAY", None)
+        with patch("tools.computer_use.doctor._drive_health_report",
+                   return_value=_linux_report(driver_version="0.12.6", overall="ok")), \
+             patch("tools.computer_use.doctor.uinput_read_write_accessible", return_value=False), \
+             patch.dict(os.environ, env, clear=True), \
+             patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("sys.stdout", new_callable=StringIO) as out:
+            doctor.run_doctor(json_output=True)
+
+        report = json.loads(out.getvalue())
+        assert report["overall"] == "ok"
+        names = [c.get("name") for c in report["checks"]]
+        assert "linux_uinput_xinput_leak_risk" not in names
+
+    def test_no_check_appended_for_fixed_driver_version(self):
+        from tools.computer_use import doctor
+
+        with patch("tools.computer_use.doctor._drive_health_report",
+                   return_value=_linux_report(driver_version="0.13.1", overall="ok")), \
+             patch("tools.computer_use.doctor.uinput_read_write_accessible", return_value=False), \
+             patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("sys.stdout", new_callable=StringIO) as out:
+            doctor.run_doctor(json_output=True)
+
+        report = json.loads(out.getvalue())
+        assert report["overall"] == "ok"
+        names = [c.get("name") for c in report["checks"]]
+        assert "linux_uinput_xinput_leak_risk" not in names
+
+    def test_no_check_appended_for_unparseable_driver_version(self):
+        """Unknown/malformed versions must preserve current (no-guard) behavior."""
+        from tools.computer_use import doctor
+
+        with patch("tools.computer_use.doctor._drive_health_report",
+                   return_value=_linux_report(driver_version="unknown", overall="ok")), \
+             patch("tools.computer_use.doctor.uinput_read_write_accessible", return_value=False), \
+             patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("sys.stdout", new_callable=StringIO) as out:
+            doctor.run_doctor(json_output=True)
+
+        report = json.loads(out.getvalue())
+        assert report["overall"] == "ok"
+        names = [c.get("name") for c in report["checks"]]
+        assert "linux_uinput_xinput_leak_risk" not in names
+
+    def test_no_check_appended_when_uinput_accessible(self):
+        from tools.computer_use import doctor
+
+        with patch("tools.computer_use.doctor._drive_health_report",
+                   return_value=_linux_report(driver_version="0.12.6", overall="ok")), \
+             patch("tools.computer_use.doctor.uinput_read_write_accessible", return_value=True), \
+             patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("sys.stdout", new_callable=StringIO) as out:
+            doctor.run_doctor(json_output=True)
+
+        report = json.loads(out.getvalue())
+        assert report["overall"] == "ok"
+        names = [c.get("name") for c in report["checks"]]
+        assert "linux_uinput_xinput_leak_risk" not in names
+
+    def test_device_not_opened_for_fixed_driver_version(self):
+        """A current driver has nothing to learn from ``/dev/uinput`` — doctor
+        must not open it just to discard the answer."""
+        from tools.computer_use import doctor
+
+        with patch("tools.computer_use.doctor._drive_health_report",
+                   return_value=_linux_report(driver_version="0.13.1", overall="ok")), \
+             patch("tools.computer_use.doctor.uinput_read_write_accessible") as accessible, \
+             patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("sys.stdout", new_callable=StringIO):
+            doctor.run_doctor(json_output=True)
+
+        accessible.assert_not_called()
+
+    def test_device_not_opened_for_unparseable_driver_version(self):
+        from tools.computer_use import doctor
+
+        with patch("tools.computer_use.doctor._drive_health_report",
+                   return_value=_linux_report(driver_version="unknown", overall="ok")), \
+             patch("tools.computer_use.doctor.uinput_read_write_accessible") as accessible, \
+             patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("sys.stdout", new_callable=StringIO):
+            doctor.run_doctor(json_output=True)
+
+        accessible.assert_not_called()
+
+    def test_device_not_opened_on_non_linux(self):
+        from tools.computer_use import doctor
+
+        with patch("tools.computer_use.doctor._drive_health_report",
+                   return_value=_ok_report()), \
+             patch("tools.computer_use.doctor.uinput_read_write_accessible") as accessible, \
+             patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("sys.stdout", new_callable=StringIO):
+            doctor.run_doctor(json_output=True)
+
+        accessible.assert_not_called()
+
+    def test_device_not_opened_without_display(self):
+        from tools.computer_use import doctor
+
+        env = dict(os.environ)
+        env.pop("DISPLAY", None)
+        with patch("tools.computer_use.doctor._drive_health_report",
+                   return_value=_linux_report(driver_version="0.12.6", overall="ok")), \
+             patch("tools.computer_use.doctor.uinput_read_write_accessible") as accessible, \
+             patch.dict(os.environ, env, clear=True), \
+             patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("sys.stdout", new_callable=StringIO):
+            doctor.run_doctor(json_output=True)
+
+        accessible.assert_not_called()
+
+    def test_device_is_still_opened_for_a_vulnerable_driver_version(self):
+        """The short-circuit must not disable the check it fronts."""
+        from tools.computer_use import doctor
+
+        with patch("tools.computer_use.doctor._drive_health_report",
+                   return_value=_linux_report(driver_version="0.12.6", overall="ok")), \
+             patch("tools.computer_use.doctor.uinput_read_write_accessible",
+                   return_value=False) as accessible, \
+             patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("sys.stdout", new_callable=StringIO) as out:
+            doctor.run_doctor(json_output=True)
+
+        accessible.assert_called()
+        report = json.loads(out.getvalue())
+        assert "linux_uinput_xinput_leak_risk" in [c["name"] for c in report["checks"]]
+
+    def test_guidance_never_recommends_permission_changes(self):
+        from tools.computer_use import doctor
+
+        with patch("tools.computer_use.doctor._drive_health_report",
+                   return_value=_linux_report(driver_version="0.12.6", overall="ok")), \
+             patch("tools.computer_use.doctor.uinput_read_write_accessible", return_value=False), \
+             patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("sys.stdout", new_callable=StringIO) as out:
+            doctor.run_doctor(json_output=True)
+
+        report = json.loads(out.getvalue())
+        check = next(c for c in report["checks"] if c["name"] == "linux_uinput_xinput_leak_risk")
+        blob = json.dumps(check).lower()
+        for forbidden in ("chmod", "sudo"):
+            assert forbidden not in blob

--- a/tests/computer_use/test_uinput_safety.py
+++ b/tests/computer_use/test_uinput_safety.py
@@ -1,0 +1,305 @@
+"""Tests for ``tools.computer_use.uinput_safety`` — the shared predicate
+guarding against trycua/cua#2618: cua-driver <0.13.1 can leak XInput master
+pointers on Linux/X11 when ``/dev/uinput`` is not read+write accessible.
+Fixed upstream by trycua/cua#2631 (cua-driver-rs-v0.13.1). Hermes #74148.
+
+This module is pure and dependency-injected (no subprocess/env reads) so the
+matrix of platform/display/version/uinput-accessibility combinations can be
+tested directly, without mocking subprocess calls. Doctor- and backend-level
+wiring (which resolve the live values) are covered in their own test files.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+# ── version parsing ─────────────────────────────────────────────────────────
+
+
+class TestParseDriverVersion:
+    def test_parses_bare_semver(self):
+        from tools.computer_use.uinput_safety import parse_driver_version
+
+        assert parse_driver_version("0.13.1") == (0, 13, 1)
+        assert parse_driver_version("0.12.6") == (0, 12, 6)
+        assert parse_driver_version("1.0.0") == (1, 0, 0)
+
+    def test_parses_v_prefixed_semver(self):
+        from tools.computer_use.uinput_safety import parse_driver_version
+
+        assert parse_driver_version("v0.13.1") == (0, 13, 1)
+
+    def test_returns_none_for_none(self):
+        from tools.computer_use.uinput_safety import parse_driver_version
+
+        assert parse_driver_version(None) is None
+
+    def test_returns_none_for_non_string(self):
+        from tools.computer_use.uinput_safety import parse_driver_version
+
+        assert parse_driver_version(1.0) is None  # type: ignore[arg-type]
+        assert parse_driver_version(("0", "13", "1")) is None  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "malformed",
+        ["", "unknown", "dev", "0.13", "0.13.1-beta", "0.13.1.4", "abc.def.ghi", "  "],
+    )
+    def test_returns_none_for_malformed(self, malformed):
+        from tools.computer_use.uinput_safety import parse_driver_version
+
+        assert parse_driver_version(malformed) is None
+
+
+class TestDriverVersionIsVulnerable:
+    def test_below_fixed_version_is_vulnerable(self):
+        from tools.computer_use.uinput_safety import driver_version_is_vulnerable
+
+        assert driver_version_is_vulnerable("0.12.6") is True
+        assert driver_version_is_vulnerable("0.0.1") is True
+        assert driver_version_is_vulnerable("0.13.0") is True
+
+    def test_at_or_above_fixed_version_is_not_vulnerable(self):
+        from tools.computer_use.uinput_safety import driver_version_is_vulnerable
+
+        assert driver_version_is_vulnerable("0.13.1") is False
+        assert driver_version_is_vulnerable("0.13.2") is False
+        assert driver_version_is_vulnerable("0.14.0") is False
+        assert driver_version_is_vulnerable("1.0.0") is False
+
+    def test_unparseable_version_is_unknown(self):
+        from tools.computer_use.uinput_safety import driver_version_is_vulnerable
+
+        assert driver_version_is_vulnerable(None) is None
+        assert driver_version_is_vulnerable("unknown") is None
+        assert driver_version_is_vulnerable("") is None
+
+
+# ── uinput device accessibility ─────────────────────────────────────────────
+
+
+class TestUinputReadWriteAccessible:
+    def test_accessible_when_open_for_rdwr_succeeds(self, tmp_path):
+        from tools.computer_use.uinput_safety import uinput_read_write_accessible
+
+        fake_device = tmp_path / "uinput"
+        fake_device.write_bytes(b"")
+        assert uinput_read_write_accessible(str(fake_device)) is True
+
+    def test_not_accessible_when_missing(self, tmp_path):
+        from tools.computer_use.uinput_safety import uinput_read_write_accessible
+
+        missing = tmp_path / "does-not-exist"
+        assert uinput_read_write_accessible(str(missing)) is False
+
+    def test_not_accessible_when_permission_denied(self, tmp_path):
+        from tools.computer_use.uinput_safety import uinput_read_write_accessible
+
+        if os.name != "posix" or os.geteuid() == 0:
+            pytest.skip("requires a non-root POSIX user to test permission denial")
+        fake_device = tmp_path / "uinput"
+        fake_device.write_bytes(b"")
+        fake_device.chmod(0o000)
+        try:
+            assert uinput_read_write_accessible(str(fake_device)) is False
+        finally:
+            fake_device.chmod(0o644)
+
+    def test_defaults_to_real_uinput_path(self):
+        from tools.computer_use.uinput_safety import (
+            UINPUT_DEVICE_PATH,
+            uinput_read_write_accessible,
+        )
+
+        assert UINPUT_DEVICE_PATH == "/dev/uinput"
+        # Must not raise regardless of the real host's device state.
+        assert uinput_read_write_accessible() in (True, False)
+
+
+# ── the combined predicate ──────────────────────────────────────────────────
+
+
+class TestDetectUinputLeakRisk:
+    def _base_kwargs(self, **overrides):
+        kwargs = dict(
+            platform="linux",
+            display=":0",
+            driver_version="0.12.6",
+            uinput_accessible=False,
+        )
+        kwargs.update(overrides)
+        return kwargs
+
+    def test_flags_the_known_unsafe_combination(self):
+        from tools.computer_use.uinput_safety import (
+            UINPUT_LEAK_RISK_CODE,
+            detect_uinput_leak_risk,
+        )
+
+        risk = detect_uinput_leak_risk(**self._base_kwargs())
+        assert risk is not None
+        assert risk["code"] == UINPUT_LEAK_RISK_CODE
+        assert risk["driver_version"] == "0.12.6"
+        assert risk["uinput_path"] == "/dev/uinput"
+
+    def test_non_linux_preserves_current_behavior(self):
+        from tools.computer_use.uinput_safety import detect_uinput_leak_risk
+
+        for plat in ("darwin", "win32", "freebsd"):
+            assert detect_uinput_leak_risk(**self._base_kwargs(platform=plat)) is None
+
+    def test_no_display_preserves_current_behavior(self):
+        from tools.computer_use.uinput_safety import detect_uinput_leak_risk
+
+        assert detect_uinput_leak_risk(**self._base_kwargs(display=None)) is None
+        assert detect_uinput_leak_risk(**self._base_kwargs(display="")) is None
+
+    def test_fixed_version_preserves_current_behavior(self):
+        from tools.computer_use.uinput_safety import detect_uinput_leak_risk
+
+        assert detect_uinput_leak_risk(**self._base_kwargs(driver_version="0.13.1")) is None
+        assert detect_uinput_leak_risk(**self._base_kwargs(driver_version="0.14.0")) is None
+
+    def test_unknown_or_malformed_version_preserves_current_behavior(self):
+        """Unknown/malformed versions must not be guessed at either way."""
+        from tools.computer_use.uinput_safety import detect_uinput_leak_risk
+
+        assert detect_uinput_leak_risk(**self._base_kwargs(driver_version=None)) is None
+        assert detect_uinput_leak_risk(**self._base_kwargs(driver_version="unknown")) is None
+        assert detect_uinput_leak_risk(**self._base_kwargs(driver_version="dev-build")) is None
+
+    def test_accessible_uinput_preserves_current_behavior(self):
+        from tools.computer_use.uinput_safety import detect_uinput_leak_risk
+
+        assert detect_uinput_leak_risk(**self._base_kwargs(uinput_accessible=True)) is None
+
+
+# ── the device-free precheck ────────────────────────────────────────────────
+
+
+class TestUinputLeakRiskPossible:
+    """The cheap, device-free half of the predicate. Callers use it to skip
+    opening ``/dev/uinput`` entirely when the platform/display/version alone
+    already rule the risk out."""
+
+    def _base_kwargs(self, **overrides):
+        kwargs = dict(platform="linux", display=":0", driver_version="0.12.6")
+        kwargs.update(overrides)
+        return kwargs
+
+    def test_true_only_for_linux_x11_and_a_vulnerable_version(self):
+        from tools.computer_use.uinput_safety import uinput_leak_risk_possible
+
+        assert uinput_leak_risk_possible(**self._base_kwargs()) is True
+
+    def test_false_off_linux(self):
+        from tools.computer_use.uinput_safety import uinput_leak_risk_possible
+
+        for plat in ("darwin", "win32", "freebsd"):
+            assert uinput_leak_risk_possible(**self._base_kwargs(platform=plat)) is False
+
+    def test_false_without_display(self):
+        from tools.computer_use.uinput_safety import uinput_leak_risk_possible
+
+        assert uinput_leak_risk_possible(**self._base_kwargs(display=None)) is False
+        assert uinput_leak_risk_possible(**self._base_kwargs(display="")) is False
+
+    def test_false_for_fixed_version(self):
+        from tools.computer_use.uinput_safety import uinput_leak_risk_possible
+
+        assert uinput_leak_risk_possible(**self._base_kwargs(driver_version="0.13.1")) is False
+        assert uinput_leak_risk_possible(**self._base_kwargs(driver_version="0.14.0")) is False
+
+    def test_false_for_unparseable_version(self):
+        from tools.computer_use.uinput_safety import uinput_leak_risk_possible
+
+        assert uinput_leak_risk_possible(**self._base_kwargs(driver_version=None)) is False
+        assert uinput_leak_risk_possible(**self._base_kwargs(driver_version="unknown")) is False
+
+    def test_agrees_with_detect_when_the_device_is_inaccessible(self):
+        """Precheck is exactly ``detect_uinput_leak_risk``'s device-free part:
+        whenever it says "possible", an inaccessible device must flag risk, and
+        whenever it says "impossible", no device state can flag risk."""
+        from tools.computer_use.uinput_safety import (
+            detect_uinput_leak_risk,
+            uinput_leak_risk_possible,
+        )
+
+        for platform in ("linux", "darwin"):
+            for display in (":0", None):
+                for version in ("0.12.6", "0.13.1", "unknown", None):
+                    kwargs = dict(platform=platform, display=display, driver_version=version)
+                    possible = uinput_leak_risk_possible(**kwargs)
+                    flagged = detect_uinput_leak_risk(**kwargs, uinput_accessible=False) is not None
+                    assert possible is flagged, kwargs
+                    if not possible:
+                        assert detect_uinput_leak_risk(**kwargs, uinput_accessible=True) is None
+
+
+# ── message / doctor-check / ActionResult builders ──────────────────────────
+
+
+class TestUinputLeakRiskMessaging:
+    @pytest.fixture
+    def risk(self):
+        from tools.computer_use.uinput_safety import detect_uinput_leak_risk
+
+        return detect_uinput_leak_risk(
+            platform="linux", display=":0", driver_version="0.12.6",
+            uinput_accessible=False,
+        )
+
+    def test_message_cites_upstream_and_hermes_issues(self, risk):
+        from tools.computer_use.uinput_safety import uinput_leak_risk_message
+
+        msg = uinput_leak_risk_message(risk)
+        assert "2618" in msg
+        assert "2631" in msg
+        assert "74148" in msg
+        assert "0.12.6" in msg
+
+    def test_message_and_hint_never_recommend_permission_changes(self, risk):
+        from tools.computer_use.uinput_safety import (
+            uinput_leak_risk_hint,
+            uinput_leak_risk_message,
+        )
+
+        combined = (uinput_leak_risk_message(risk) + " " + uinput_leak_risk_hint()).lower()
+        for forbidden in ("chmod", "sudo", "udev", "add.*group", "777", "666"):
+            assert forbidden not in combined, f"unexpected {forbidden!r} in guidance"
+
+    def test_message_and_hint_recommend_upgrade(self, risk):
+        from tools.computer_use.uinput_safety import (
+            uinput_leak_risk_hint,
+            uinput_leak_risk_message,
+        )
+
+        combined = uinput_leak_risk_message(risk) + " " + uinput_leak_risk_hint()
+        assert "0.13.1" in combined
+        assert "upgrade" in combined.lower()
+
+    def test_doctor_check_shape(self, risk):
+        from tools.computer_use.uinput_safety import uinput_leak_risk_check
+
+        check = uinput_leak_risk_check(risk)
+        assert check["status"] in ("fail", "degraded")
+        assert isinstance(check["name"], str) and check["name"]
+        assert "2618" in check["message"]
+        assert isinstance(check.get("data"), dict)
+        assert check["data"]["driver_version"] == "0.12.6"
+
+    def test_action_result_shape(self, risk):
+        from tools.computer_use.backend import ActionResult
+        from tools.computer_use.uinput_safety import (
+            UINPUT_LEAK_RISK_CODE,
+            uinput_leak_risk_action_result,
+        )
+
+        result = uinput_leak_risk_action_result("click", risk)
+        assert isinstance(result, ActionResult)
+        assert result.ok is False
+        assert result.action == "click"
+        assert result.code == UINPUT_LEAK_RISK_CODE
+        assert "2618" in result.message

--- a/tests/tools/test_computer_use_uinput_guard.py
+++ b/tests/tools/test_computer_use_uinput_guard.py
@@ -1,0 +1,500 @@
+"""Tests for the Linux/X11 uinput XInput-leak refusal guard on cua-driver
+input actions.
+
+Protects against trycua/cua#2618 (cua-driver <0.13.1 can leak XInput master
+pointers when /dev/uinput is not read+write accessible on Linux/X11), fixed
+upstream by trycua/cua#2631 (cua-driver-rs-v0.13.1). Hermes #74148.
+
+Input actions (click/drag/scroll/type_text/key/set_value) must refuse BEFORE
+declaring an input session or invoking the driver whenever the known-unsafe
+combination is detected, returning a structured ActionResult with a stable
+code and actionable message. Capture/list/inspection must remain unaffected,
+and every other combination (fixed driver, non-Linux, no DISPLAY, accessible
+uinput, unparseable version) must preserve current behavior.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class _RecordingSession:
+    """Session stub. Input actions must refuse before ever touching this —
+    tests assert ``call_tool_calls`` stays empty for a refused action."""
+
+    def __init__(self, out: Optional[Dict[str, Any]] = None):
+        self._out = out or {"isError": False, "data": {}, "structuredContent": {}}
+        self.call_tool_calls = []
+
+    def call_tool(self, name: str, args: Dict[str, Any], timeout: float = 30.0):
+        self.call_tool_calls.append((name, dict(args)))
+        return self._out
+
+    def supports_capability(self, capability: str, tool: Optional[str] = None) -> bool:
+        return False
+
+
+def _make_backend(session=None):
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    be = CuaDriverBackend.__new__(CuaDriverBackend)
+    be._session = session if session is not None else _RecordingSession()
+    be._session_id = "test-run"
+    be._snapshot_tokens = {}
+    be._active_pid = 4242
+    be._active_window_id = 7
+    return be
+
+
+def _unsafe_combo_patches(driver_version="0.12.6", uinput_accessible=False,
+                          platform="linux"):
+    return (
+        patch("tools.computer_use.cua_backend.sys.platform", platform),
+        patch(
+            "tools.computer_use.cua_backend._probe_cua_driver_version_for_uinput_guard",
+            return_value=driver_version,
+        ),
+        patch(
+            "tools.computer_use.cua_backend.uinput_read_write_accessible",
+            return_value=uinput_accessible,
+        ),
+    )
+
+
+INPUT_ACTIONS = [
+    ("click", lambda be: be.click(element=1)),
+    ("drag", lambda be: be.drag(from_element=1, to_element=2)),
+    ("scroll", lambda be: be.scroll(direction="down", element=1)),
+    ("type_text", lambda be: be.type_text("hi")),
+    ("key", lambda be: be.key("return")),
+    ("set_value", lambda be: be.set_value("x", element=1)),
+]
+
+
+class TestInputActionsRefuseOnUnsafeCombo:
+    @pytest.mark.parametrize("name,call", INPUT_ACTIONS, ids=[n for n, _ in INPUT_ACTIONS])
+    def test_refuses_before_touching_the_driver(self, name, call):
+        session = _RecordingSession()
+        be = _make_backend(session)
+
+        with patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("tools.computer_use.cua_backend.sys.platform", "linux"), \
+             patch(
+                 "tools.computer_use.cua_backend._probe_cua_driver_version_for_uinput_guard",
+                 return_value="0.12.6",
+             ), \
+             patch(
+                 "tools.computer_use.cua_backend.uinput_read_write_accessible",
+                 return_value=False,
+             ):
+            result = call(be)
+
+        assert result.ok is False
+        assert result.action == name
+        assert result.code == "linux_uinput_xinput_leak_risk"
+        assert "2618" in result.message
+        assert "2631" in result.message
+        assert "74148" in result.message
+        for forbidden in ("chmod", "sudo"):
+            assert forbidden not in result.message.lower()
+        # The driver must never be touched by a refused input action.
+        assert session.call_tool_calls == []
+
+    @pytest.mark.parametrize("name,call", INPUT_ACTIONS, ids=[n for n, _ in INPUT_ACTIONS])
+    def test_proceeds_normally_when_driver_is_fixed(self, name, call):
+        session = _RecordingSession()
+        be = _make_backend(session)
+
+        with patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("tools.computer_use.cua_backend.sys.platform", "linux"), \
+             patch(
+                 "tools.computer_use.cua_backend._probe_cua_driver_version_for_uinput_guard",
+                 return_value="0.13.1",
+             ), \
+             patch(
+                 "tools.computer_use.cua_backend.uinput_read_write_accessible",
+                 return_value=False,
+             ):
+            call(be)
+
+        assert len(session.call_tool_calls) == 1
+
+    @pytest.mark.parametrize("name,call", INPUT_ACTIONS, ids=[n for n, _ in INPUT_ACTIONS])
+    def test_proceeds_normally_on_non_linux(self, name, call):
+        session = _RecordingSession()
+        be = _make_backend(session)
+
+        with patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("tools.computer_use.cua_backend.sys.platform", "darwin"), \
+             patch(
+                 "tools.computer_use.cua_backend._probe_cua_driver_version_for_uinput_guard",
+                 return_value="0.12.6",
+             ), \
+             patch(
+                 "tools.computer_use.cua_backend.uinput_read_write_accessible",
+                 return_value=False,
+             ):
+            call(be)
+
+        assert len(session.call_tool_calls) == 1
+
+    @pytest.mark.parametrize("name,call", INPUT_ACTIONS, ids=[n for n, _ in INPUT_ACTIONS])
+    def test_proceeds_normally_without_display(self, name, call):
+        session = _RecordingSession()
+        be = _make_backend(session)
+
+        env = dict(os.environ)
+        env.pop("DISPLAY", None)
+        with patch.dict(os.environ, env, clear=True), \
+             patch("tools.computer_use.cua_backend.sys.platform", "linux"), \
+             patch(
+                 "tools.computer_use.cua_backend._probe_cua_driver_version_for_uinput_guard",
+                 return_value="0.12.6",
+             ), \
+             patch(
+                 "tools.computer_use.cua_backend.uinput_read_write_accessible",
+                 return_value=False,
+             ):
+            call(be)
+
+        assert len(session.call_tool_calls) == 1
+
+    @pytest.mark.parametrize("name,call", INPUT_ACTIONS, ids=[n for n, _ in INPUT_ACTIONS])
+    def test_proceeds_normally_when_uinput_accessible(self, name, call):
+        session = _RecordingSession()
+        be = _make_backend(session)
+
+        with patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("tools.computer_use.cua_backend.sys.platform", "linux"), \
+             patch(
+                 "tools.computer_use.cua_backend._probe_cua_driver_version_for_uinput_guard",
+                 return_value="0.12.6",
+             ), \
+             patch(
+                 "tools.computer_use.cua_backend.uinput_read_write_accessible",
+                 return_value=True,
+             ):
+            call(be)
+
+        assert len(session.call_tool_calls) == 1
+
+    @pytest.mark.parametrize("name,call", INPUT_ACTIONS, ids=[n for n, _ in INPUT_ACTIONS])
+    def test_proceeds_normally_for_unparseable_version(self, name, call):
+        """Unknown/malformed versions must preserve current (no-guard) behavior."""
+        session = _RecordingSession()
+        be = _make_backend(session)
+
+        with patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("tools.computer_use.cua_backend.sys.platform", "linux"), \
+             patch(
+                 "tools.computer_use.cua_backend._probe_cua_driver_version_for_uinput_guard",
+                 return_value=None,
+             ), \
+             patch(
+                 "tools.computer_use.cua_backend.uinput_read_write_accessible",
+                 return_value=False,
+             ):
+            call(be)
+
+        assert len(session.call_tool_calls) == 1
+
+
+class TestCaptureAndInspectionRemainAvailable:
+    def test_list_apps_is_not_guarded(self):
+        session = _RecordingSession({
+            "isError": False, "data": {}, "structuredContent": {"apps": [{"name": "x", "pid": 1}]},
+        })
+        be = _make_backend(session)
+
+        with patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("tools.computer_use.cua_backend.sys.platform", "linux"), \
+             patch(
+                 "tools.computer_use.cua_backend._probe_cua_driver_version_for_uinput_guard",
+                 return_value="0.12.6",
+             ), \
+             patch(
+                 "tools.computer_use.cua_backend.uinput_read_write_accessible",
+                 return_value=False,
+             ):
+            apps = be.list_apps()
+
+        assert apps == [{"name": "x", "pid": 1}]
+        assert len(session.call_tool_calls) == 1
+
+    def test_capture_exact_target_is_not_guarded(self):
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        session = _RecordingSession({
+            "data": "✅ Chrome — 0 elements",
+            "images": [],
+            "structuredContent": {"elements": []},
+            "isError": False,
+        })
+        be = CuaDriverBackend.__new__(CuaDriverBackend)
+        be._session = session
+        be._session_id = "test-run"
+        be._snapshot_tokens = {}
+        be._active_pid = None
+        be._active_window_id = None
+        be._last_app = None
+        be._last_target = None
+
+        with patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("tools.computer_use.cua_backend.sys.platform", "linux"), \
+             patch(
+                 "tools.computer_use.cua_backend._probe_cua_driver_version_for_uinput_guard",
+                 return_value="0.12.6",
+             ), \
+             patch(
+                 "tools.computer_use.cua_backend.uinput_read_write_accessible",
+                 return_value=False,
+             ):
+            be.capture(mode="ax", pid=1816017, window_id=60817412)
+
+        assert be._active_pid == 1816017
+        assert len(session.call_tool_calls) >= 1
+
+
+class TestUinputDeviceIsNotOpenedWhenIrrelevant:
+    """``/dev/uinput`` must only be opened when platform/DISPLAY/version alone
+    leave the risk open. A fixed (or non-Linux, display-less, unparseable)
+    setup has nothing to learn from the device, so it must not touch it."""
+
+    def test_device_not_opened_for_fixed_driver_version(self):
+        be = _make_backend()
+
+        with patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("tools.computer_use.cua_backend.sys.platform", "linux"), \
+             patch(
+                 "tools.computer_use.cua_backend._probe_cua_driver_version_for_uinput_guard",
+                 return_value="0.13.1",
+             ), \
+             patch(
+                 "tools.computer_use.cua_backend.uinput_read_write_accessible",
+             ) as accessible:
+            be.click(element=1)
+
+        accessible.assert_not_called()
+
+    def test_device_not_opened_for_unparseable_driver_version(self):
+        be = _make_backend()
+
+        with patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("tools.computer_use.cua_backend.sys.platform", "linux"), \
+             patch(
+                 "tools.computer_use.cua_backend._probe_cua_driver_version_for_uinput_guard",
+                 return_value=None,
+             ), \
+             patch(
+                 "tools.computer_use.cua_backend.uinput_read_write_accessible",
+             ) as accessible:
+            be.click(element=1)
+
+        accessible.assert_not_called()
+
+    def test_device_not_opened_off_linux(self):
+        be = _make_backend()
+
+        with patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("tools.computer_use.cua_backend.sys.platform", "darwin"), \
+             patch(
+                 "tools.computer_use.cua_backend.uinput_read_write_accessible",
+             ) as accessible:
+            be.click(element=1)
+
+        accessible.assert_not_called()
+
+    def test_device_not_opened_without_display(self):
+        be = _make_backend()
+
+        env = dict(os.environ)
+        env.pop("DISPLAY", None)
+        with patch.dict(os.environ, env, clear=True), \
+             patch("tools.computer_use.cua_backend.sys.platform", "linux"), \
+             patch(
+                 "tools.computer_use.cua_backend.uinput_read_write_accessible",
+             ) as accessible:
+            be.click(element=1)
+
+        accessible.assert_not_called()
+
+    def test_device_is_still_opened_for_a_vulnerable_version(self):
+        """The short-circuit must not disable the guard it fronts."""
+        be = _make_backend()
+
+        with patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("tools.computer_use.cua_backend.sys.platform", "linux"), \
+             patch(
+                 "tools.computer_use.cua_backend._probe_cua_driver_version_for_uinput_guard",
+                 return_value="0.12.6",
+             ), \
+             patch(
+                 "tools.computer_use.cua_backend.uinput_read_write_accessible",
+                 return_value=False,
+             ) as accessible:
+            result = be.click(element=1)
+
+        accessible.assert_called()
+        assert result.ok is False
+        assert result.code == "linux_uinput_xinput_leak_risk"
+
+
+class TestDriverVersionProbeIsCached:
+    def test_probe_runs_at_most_once_per_backend_instance(self):
+        session = _RecordingSession()
+        be = _make_backend(session)
+
+        with patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("tools.computer_use.cua_backend.sys.platform", "linux"), \
+             patch(
+                 "tools.computer_use.cua_backend._probe_cua_driver_version_for_uinput_guard",
+                 return_value="0.13.1",
+             ) as probe, \
+             patch(
+                 "tools.computer_use.cua_backend.uinput_read_write_accessible",
+                 return_value=False,
+             ):
+            be.click(element=1)
+            be.click(element=1)
+            be.type_text("hi")
+
+        assert probe.call_count == 1
+
+    def test_probe_never_runs_off_linux(self):
+        session = _RecordingSession()
+        be = _make_backend(session)
+
+        with patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("tools.computer_use.cua_backend.sys.platform", "darwin"), \
+             patch(
+                 "tools.computer_use.cua_backend._probe_cua_driver_version_for_uinput_guard",
+             ) as probe:
+            be.click(element=1)
+
+        probe.assert_not_called()
+
+    def test_probe_never_runs_without_display(self):
+        session = _RecordingSession()
+        be = _make_backend(session)
+
+        env = dict(os.environ)
+        env.pop("DISPLAY", None)
+        with patch.dict(os.environ, env, clear=True), \
+             patch("tools.computer_use.cua_backend.sys.platform", "linux"), \
+             patch(
+                 "tools.computer_use.cua_backend._probe_cua_driver_version_for_uinput_guard",
+             ) as probe:
+            be.click(element=1)
+
+        probe.assert_not_called()
+
+
+class TestGuardProbesTheActuallyLaunchedCommand:
+    """Regression test (independent-review finding, #74148): the guard must
+    probe ``--version`` on the exact command ``_CuaDriverSession.start()``
+    launched, not a separately re-resolved default/PATH binary.
+
+    ``_resolve_mcp_invocation`` can return a manifest-relocated executable
+    (trycua/cua#1961) that differs from what ``resolve_cua_driver_cmd()``
+    would resolve on its own — e.g. a thin-PATH GUI session resolving a
+    generic wrapper while the manifest points at the real relocated
+    binary. If the guard probes the wrong binary, a fixed wrapper can mask
+    a vulnerable actual MCP executable and let unsafe input through.
+    """
+
+    def test_probes_the_manifest_relocated_command_actually_launched(self):
+        from tools.computer_use.cua_backend import CuaDriverBackend, _CuaDriverSession, _AsyncBridge
+
+        relocated_cmd = "/opt/cua/relocated-cua-driver-bin"
+        default_resolved_cmd = "/usr/local/bin/cua-driver"
+
+        session = _CuaDriverSession(_AsyncBridge())
+        # Simulate what a completed start() recorded: the manifest hop
+        # resolved a DIFFERENT binary than the generic default one.
+        session._resolved_mcp_command = relocated_cmd
+
+        be = CuaDriverBackend.__new__(CuaDriverBackend)
+        be._session = session
+        be._session_id = "test-run"
+
+        version_proc = MagicMock(stdout="0.12.6", stderr="", returncode=0)
+        with patch.dict(os.environ, {"DISPLAY": ":0"}), \
+             patch("tools.computer_use.cua_backend.sys.platform", "linux"), \
+             patch(
+                 "tools.computer_use.cua_backend.resolve_cua_driver_cmd",
+                 return_value=default_resolved_cmd,
+             ), \
+             patch("subprocess.run", return_value=version_proc) as run:
+            be._uinput_leak_guard("click")
+
+        assert run.call_args is not None, "guard never probed --version"
+        probed_cmd = run.call_args.args[0][0]
+        assert probed_cmd == relocated_cmd, (
+            f"guard probed {probed_cmd!r} (the default-resolved binary) "
+            f"instead of {relocated_cmd!r} (the manifest-relocated binary "
+            "actually launched by _CuaDriverSession.start()) — a fixed "
+            "wrapper could mask a vulnerable actual MCP executable"
+        )
+
+
+class TestSessionRecordsTheResolvedMcpCommand:
+    """``_CuaDriverSession._lifecycle_coro`` must record the command it
+    actually spawns so guard callers can probe that exact binary instead
+    of independently re-resolving (and potentially picking a different
+    wrapper/default)."""
+
+    def test_lifecycle_records_manifest_relocated_command(self):
+        from unittest.mock import AsyncMock
+        import asyncio
+        from tools.computer_use.cua_backend import _AsyncBridge, _CuaDriverSession
+
+        bridge = _AsyncBridge()
+        session = _CuaDriverSession(bridge)
+        relocated_cmd = "/opt/cua/relocated-cua-driver-bin"
+
+        async def drive_lifecycle():
+            with patch("tools.computer_use.cua_backend.resolve_cua_driver_cmd",
+                       return_value="cua-driver"), \
+                 patch("tools.computer_use.cua_backend._resolve_mcp_invocation",
+                       return_value=(relocated_cmd, ["mcp"])), \
+                 patch("mcp.StdioServerParameters", return_value=MagicMock()), \
+                 patch("mcp.client.stdio.stdio_client") as mock_stdio, \
+                 patch("mcp.ClientSession") as mock_session_class:
+
+                mock_stdio.return_value.__aenter__ = AsyncMock(
+                    return_value=(MagicMock(), MagicMock()))
+                mock_stdio.return_value.__aexit__ = AsyncMock(return_value=None)
+
+                fake_session = MagicMock()
+                fake_session.initialize = AsyncMock()
+                fake_session.list_tools = AsyncMock(return_value=MagicMock(tools=[]))
+                mock_session_class.return_value.__aenter__ = AsyncMock(
+                    return_value=fake_session)
+                mock_session_class.return_value.__aexit__ = AsyncMock(return_value=None)
+
+                async def _signal_shutdown_when_ready():
+                    for _ in range(200):
+                        if session._shutdown_event is not None:
+                            session._shutdown_event.set()
+                            return
+                        await asyncio.sleep(0.005)
+
+                signal_task = asyncio.create_task(_signal_shutdown_when_ready())
+                try:
+                    await session._lifecycle_coro()
+                except BaseException:
+                    pass
+                finally:
+                    signal_task.cancel()
+                    try:
+                        await signal_task
+                    except (asyncio.CancelledError, BaseException):
+                        pass
+
+        asyncio.run(drive_lifecycle())
+
+        assert session._resolved_mcp_command == relocated_cmd

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -62,6 +62,12 @@ from tools.computer_use.backend import (
     UIElement,
 )
 from tools.computer_use.browser_route import CuaTypedBrowserRoute
+from tools.computer_use.uinput_safety import (
+    detect_uinput_leak_risk,
+    uinput_leak_risk_action_result,
+    uinput_leak_risk_possible,
+    uinput_read_write_accessible,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -646,6 +652,40 @@ def _cua_driver_supports_no_overlay(driver_cmd: str) -> bool:
     except Exception:
         return False
 
+
+_DRIVER_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
+
+
+def _probe_cua_driver_version_for_uinput_guard(driver_cmd: Optional[str] = None) -> Optional[str]:
+    """Best-effort ``cua-driver --version`` probe for the Linux/X11 uinput
+    leak guard (Hermes #74148, trycua/cua#2618 / trycua/cua#2631).
+
+    ``--version`` is resolved before any other argument parsing in
+    cua-driver's CLI, so this never touches a display or MCP session — it
+    is safe to call ahead of ``CuaDriverBackend.start()``. Returns ``None``
+    on any failure (missing binary, spawn error, unparseable output); an
+    indeterminate version preserves current behavior via
+    ``detect_uinput_leak_risk``.
+    """
+    resolved = driver_cmd if driver_cmd is not None else resolve_cua_driver_cmd()
+    if not resolved:
+        return None
+    try:
+        from tools.environments.local import _sanitize_subprocess_env
+        proc = subprocess.run(
+            [resolved, "--version"],
+            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=3.0,
+            stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
+            env=_sanitize_subprocess_env(cua_driver_child_env()),
+        )
+    except Exception:
+        return None
+    out = (proc.stdout or "") + (proc.stderr or "")
+    m = _DRIVER_VERSION_RE.search(out)
+    return m.group(1) if m else None
+
+
 # Regex to parse element lines from get_window_state AX tree markdown.
 #
 # cua-driver renders each actionable node as one of:
@@ -1116,6 +1156,13 @@ class _CuaDriverSession:
         # Used to revive a logical ended-session rejection without
         # recursive call_tool re-entry or backend-owned state (#71166).
         self._declared_session_id: Optional[str] = None
+        # The command `_lifecycle_coro` actually spawned for the MCP stdio
+        # transport — may differ from `resolve_cua_driver_cmd()` when
+        # `_resolve_mcp_invocation` surfaces a manifest-relocated executable
+        # (trycua/cua#1961). Guard callers (Hermes #74148) must probe THIS
+        # exact command rather than independently re-resolving, or a fixed
+        # wrapper could mask a vulnerable actual MCP executable.
+        self._resolved_mcp_command: Optional[str] = None
 
     def _require_started(self) -> None:
         if not self._started:
@@ -1158,6 +1205,7 @@ class _CuaDriverSession:
             else:
                 command, args = _resolve_mcp_invocation(driver_cmd)
                 child_env = cua_driver_child_env()
+            self._resolved_mcp_command = command
             _t_manifest = _time.monotonic()
             params = StdioServerParameters(
                 command=command,
@@ -1900,6 +1948,11 @@ def _apps_from_windows(windows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return apps
 
 
+# Sentinel distinguishing "never probed" from a probe that legitimately
+# returned None (indeterminate version) — see _uinput_leak_guard below.
+_UNRESOLVED = object()
+
+
 # ---------------------------------------------------------------------------
 # The backend itself
 # ---------------------------------------------------------------------------
@@ -1956,6 +2009,10 @@ class CuaDriverBackend(ComputerUseBackend):
             call_tool=self._session.call_tool,
             has_tool=self._session._has_tool,
         )
+        # Lazily-resolved, per-instance cache for the Linux/X11 uinput leak
+        # guard (#74148) — unset until the first guarded action needs a
+        # version, and only ever probed on Linux with a DISPLAY set.
+        self._uinput_guard_driver_version: Optional[str] = _UNRESOLVED
 
     def _browser_route(self) -> CuaTypedBrowserRoute:
         """Return the per-backend typed route, including test-constructed instances."""
@@ -2058,6 +2115,50 @@ class CuaDriverBackend(ComputerUseBackend):
         if sys.platform not in ("darwin", "win32", "linux"):
             return False
         return cua_driver_binary_available()
+
+    # ── Linux/X11 uinput leak guard (#74148, trycua/cua#2618 / #2631) ──
+    def _uinput_leak_guard(self, action: str) -> Optional[ActionResult]:
+        """Refuse ``action`` before it declares an input session or invokes
+        the driver, when this host hits the known-unsafe combination:
+        Linux, X11 (``DISPLAY`` set), a cua-driver version below 0.13.1,
+        and ``/dev/uinput`` not read+write accessible.
+
+        Checks run cheapest-first, and each one that rules the risk out
+        stops the next from running at all: the (still fast, but non-zero)
+        ``--version`` probe only ever runs on Linux/X11 and is cached per
+        backend instance, and ``/dev/uinput`` is only ever opened once the
+        platform/DISPLAY/version triple still leaves risk open — a
+        fixed (>=0.13.1) or unknown driver never touches the device.
+        Returns ``None`` — proceed as before — for every other combination.
+        """
+        display = os.environ.get("DISPLAY")
+        if sys.platform != "linux" or not display:
+            return None
+        version = getattr(self, "_uinput_guard_driver_version", _UNRESOLVED)
+        if version is _UNRESOLVED:
+            # Probe the command _CuaDriverSession.start() actually launched
+            # (may be a manifest-relocated binary, trycua/cua#1961) rather
+            # than independently re-resolving — otherwise a fixed wrapper
+            # could mask a vulnerable actual MCP executable. Test doubles
+            # and legacy/not-yet-started sessions lack the attribute; the
+            # probe falls back to resolve_cua_driver_cmd() on None rather
+            # than guessing a fixed version.
+            resolved_cmd = getattr(self._session, "_resolved_mcp_command", None)
+            version = _probe_cua_driver_version_for_uinput_guard(resolved_cmd)
+            self._uinput_guard_driver_version = version
+        if not uinput_leak_risk_possible(
+            platform=sys.platform, display=display, driver_version=version
+        ):
+            return None
+        risk = detect_uinput_leak_risk(
+            platform=sys.platform,
+            display=display,
+            driver_version=version,
+            uinput_accessible=uinput_read_write_accessible(),
+        )
+        if risk is None:
+            return None
+        return uinput_leak_risk_action_result(action, risk)
 
     def _clear_active_target(self) -> None:
         """Forget a capture/focus target so a failed lookup cannot misroute input."""
@@ -2657,6 +2758,9 @@ class CuaDriverBackend(ComputerUseBackend):
         delivery_mode: Optional[str] = None,
         bring_to_front: bool = False,
     ) -> ActionResult:
+        guard = self._uinput_leak_guard("click")
+        if guard is not None:
+            return guard
         pid = self._active_pid
         if pid is None:
             return ActionResult(ok=False, action="click",
@@ -2710,6 +2814,9 @@ class CuaDriverBackend(ComputerUseBackend):
         delivery_mode: Optional[str] = None,
         bring_to_front: bool = False,
     ) -> ActionResult:
+        guard = self._uinput_leak_guard("drag")
+        if guard is not None:
+            return guard
         pid = self._active_pid
         if pid is None:
             return ActionResult(ok=False, action="drag",
@@ -2746,6 +2853,9 @@ class CuaDriverBackend(ComputerUseBackend):
         delivery_mode: Optional[str] = None,
         bring_to_front: bool = False,
     ) -> ActionResult:
+        guard = self._uinput_leak_guard("scroll")
+        if guard is not None:
+            return guard
         pid = self._active_pid
         if pid is None:
             return ActionResult(ok=False, action="scroll",
@@ -2779,6 +2889,9 @@ class CuaDriverBackend(ComputerUseBackend):
     # ── Keyboard ───────────────────────────────────────────────────
     def type_text(self, text: str, *, delivery_mode: Optional[str] = None,
                   bring_to_front: bool = False) -> ActionResult:
+        guard = self._uinput_leak_guard("type_text")
+        if guard is not None:
+            return guard
         pid = self._active_pid
         window_id = self._active_window_id
         if pid is None or window_id is None:
@@ -2789,6 +2902,9 @@ class CuaDriverBackend(ComputerUseBackend):
 
     def key(self, keys: str, *, delivery_mode: Optional[str] = None,
             bring_to_front: bool = False) -> ActionResult:
+        guard = self._uinput_leak_guard("key")
+        if guard is not None:
+            return guard
         pid = self._active_pid
         window_id = self._active_window_id
         if pid is None or window_id is None:
@@ -2812,6 +2928,9 @@ class CuaDriverBackend(ComputerUseBackend):
     # ── Value setter ────────────────────────────────────────────────
     def set_value(self, value: str, element: Optional[int] = None) -> ActionResult:
         """Set a value on an element. Handles AXPopUpButton selects natively."""
+        guard = self._uinput_leak_guard("set_value")
+        if guard is not None:
+            return guard
         pid = self._active_pid
         window_id = self._active_window_id
         if pid is None or window_id is None:

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -31,6 +31,13 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from hermes_cli._subprocess_compat import windows_hide_flags
 
+from tools.computer_use.uinput_safety import (
+    detect_uinput_leak_risk,
+    uinput_leak_risk_check,
+    uinput_leak_risk_possible,
+    uinput_read_write_accessible,
+)
+
 
 # Match the ALLOWED_STATUS_VALUES + ALLOWED_OVERALL_VALUES the cua-driver
 # integration test pins. If health_report widens its vocabulary, add here.
@@ -702,6 +709,52 @@ def _drive_health_report_or_fallback(
         )
 
 
+def _augment_report_with_uinput_leak_risk(report: Dict[str, Any]) -> None:
+    """Append an actionable check when this host hits the known-unsafe
+    Linux/X11 + old-cua-driver + inaccessible-uinput combination
+    (trycua/cua#2618, fixed by trycua/cua#2631; Hermes #74148).
+
+    Mutates ``report`` in place: appends to ``checks`` and, when the report
+    was otherwise ``ok``, downgrades ``overall`` to ``degraded`` (an
+    already-``degraded``/``failed`` overall is left as-is — this only ever
+    adds signal, never removes it). No-op when the combination isn't
+    detected, so a healthy/non-Linux/fixed-driver host's report is
+    byte-for-byte unchanged.
+
+    The platform/DISPLAY/version triple is checked first and, when it
+    already rules the risk out, ``/dev/uinput`` is never opened at all —
+    running doctor against a fixed (>=0.13.1) or non-Linux host does no
+    device I/O.
+    """
+    platform_value = report.get("platform")
+    if not isinstance(platform_value, str):
+        platform_value = sys.platform
+    driver_version = report.get("driver_version")
+    if not isinstance(driver_version, str):
+        driver_version = None
+    display = os.environ.get("DISPLAY")
+
+    if not uinput_leak_risk_possible(
+        platform=platform_value, display=display, driver_version=driver_version
+    ):
+        return
+
+    risk = detect_uinput_leak_risk(
+        platform=platform_value,
+        display=display,
+        driver_version=driver_version,
+        uinput_accessible=uinput_read_write_accessible(),
+    )
+    if risk is None:
+        return
+
+    checks = report.setdefault("checks", [])
+    if isinstance(checks, list):
+        checks.append(uinput_leak_risk_check(risk))
+    if report.get("overall") == "ok":
+        report["overall"] = "degraded"
+
+
 def _print_text_report(
     report: Dict[str, Any],
     color: bool,
@@ -839,6 +892,8 @@ def run_doctor(
     except RuntimeError as e:
         print(f"cua-driver health_report failed: {e}", file=sys.stderr)
         return 2
+
+    _augment_report_with_uinput_leak_risk(report)
 
     identity = _build_identity(binary, report)
 

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -33,6 +33,7 @@ from hermes_cli._subprocess_compat import windows_hide_flags
 
 from tools.computer_use.uinput_safety import (
     detect_uinput_leak_risk,
+    parse_driver_version,
     uinput_leak_risk_check,
     uinput_leak_risk_possible,
     uinput_read_write_accessible,
@@ -709,7 +710,9 @@ def _drive_health_report_or_fallback(
         )
 
 
-def _augment_report_with_uinput_leak_risk(report: Dict[str, Any]) -> None:
+def _augment_report_with_uinput_leak_risk(
+    report: Dict[str, Any], identity: Optional[Dict[str, Any]] = None,
+) -> None:
     """Append an actionable check when this host hits the known-unsafe
     Linux/X11 + old-cua-driver + inaccessible-uinput combination
     (trycua/cua#2618, fixed by trycua/cua#2631; Hermes #74148).
@@ -725,6 +728,13 @@ def _augment_report_with_uinput_leak_risk(report: Dict[str, Any]) -> None:
     already rules the risk out, ``/dev/uinput`` is never opened at all —
     running doctor against a fixed (>=0.13.1) or non-Linux host does no
     device I/O.
+
+    Prefers the resolved binary's own ``--version`` (``identity.cli_version``,
+    the same value ``hermes_identity.version_mismatch`` is built from) over
+    health_report's self-reported ``driver_version``: a stale/wrong report
+    version could otherwise claim "fixed" for a binary that is actually still
+    vulnerable, silently dropping the check. Falls back to the report's
+    version when no identity/CLI version is available.
     """
     platform_value = report.get("platform")
     if not isinstance(platform_value, str):
@@ -732,6 +742,18 @@ def _augment_report_with_uinput_leak_risk(report: Dict[str, Any]) -> None:
     driver_version = report.get("driver_version")
     if not isinstance(driver_version, str):
         driver_version = None
+    if identity:
+        cli_version = identity.get("cli_version")
+        if isinstance(cli_version, str) and cli_version:
+            normalized_cli_version = _normalize_version_token(cli_version)
+            # Only override when the CLI token actually parses for the
+            # guard (_normalize_version_token falls back to the raw,
+            # lowercased text on no regex match, which is non-empty but
+            # unusable) — otherwise a dev/packaging banner would blank out
+            # a parseable, still-vulnerable report version and silently
+            # skip the check.
+            if parse_driver_version(normalized_cli_version) is not None:
+                driver_version = normalized_cli_version
     display = os.environ.get("DISPLAY")
 
     if not uinput_leak_risk_possible(
@@ -893,9 +915,9 @@ def run_doctor(
         print(f"cua-driver health_report failed: {e}", file=sys.stderr)
         return 2
 
-    _augment_report_with_uinput_leak_risk(report)
-
     identity = _build_identity(binary, report)
+
+    _augment_report_with_uinput_leak_risk(report, identity)
 
     if json_output:
         # Additive envelope: preserve the upstream health_report keys and

--- a/tools/computer_use/uinput_safety.py
+++ b/tools/computer_use/uinput_safety.py
@@ -1,0 +1,194 @@
+"""Guard against trycua/cua#2618 on Linux/X11 computer-use sessions.
+
+``ensure_master_pointer`` in cua-driver-rs created an XInput master pointer
+pair *before* opening ``/dev/uinput``. When that device wasn't read+write
+accessible, every real-pointer input attempt (click/drag/scroll/keyboard)
+created and abandoned a fresh XInput master, and a sustained session
+eventually hit Xorg's ``BadAlloc`` once too many masters had piled up,
+killing the driver connection outright.
+
+Fixed upstream by trycua/cua#2631 (released as ``cua-driver-rs-v0.13.1``):
+the driver now checks uinput accessibility before touching the XInput
+hierarchy at all. This module is Hermes' front-line guard for users still on
+an older driver (Hermes #74148) — it detects the exact known-unsafe
+combination and lets both ``hermes computer-use doctor``
+(:mod:`tools.computer_use.doctor`) and the cua-driver backend
+(:mod:`tools.computer_use.cua_backend`) react to it consistently from one
+tested predicate.
+
+Deliberately conservative: any input this module can't positively confirm as
+unsafe (wrong platform, no X11 DISPLAY, an unparseable/missing driver
+version, an already-fixed driver, or an accessible device) preserves current
+(no-guard) behavior rather than guessing.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any, Dict, Optional, Tuple
+
+from tools.computer_use.backend import ActionResult
+
+UINPUT_DEVICE_PATH = "/dev/uinput"
+UINPUT_LEAK_RISK_CODE = "linux_uinput_xinput_leak_risk"
+
+# First cua-driver-rs release containing the trycua/cua#2631 fix.
+_FIXED_VERSION: Tuple[int, int, int] = (0, 13, 1)
+
+_VERSION_RE = re.compile(r"^\s*v?(\d+)\.(\d+)\.(\d+)\s*$")
+
+
+def parse_driver_version(version: Optional[str]) -> Optional[Tuple[int, int, int]]:
+    """Parse a bare semver-ish string ("0.13.1", "v0.9.0") into a comparable
+    ``(major, minor, patch)`` tuple.
+
+    Returns ``None`` for missing / non-string / malformed input (extra
+    suffixes, missing components, non-numeric parts, ...) so callers treat
+    it as "unknown" rather than guessing a side.
+    """
+    if not isinstance(version, str):
+        return None
+    m = _VERSION_RE.match(version)
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+
+
+def driver_version_is_vulnerable(version: Optional[str]) -> Optional[bool]:
+    """True if ``version`` predates the trycua/cua#2631 fix (< 0.13.1),
+    False if it's fixed (>= 0.13.1), None if unparseable/unknown."""
+    parsed = parse_driver_version(version)
+    if parsed is None:
+        return None
+    return parsed < _FIXED_VERSION
+
+
+def uinput_read_write_accessible(path: str = UINPUT_DEVICE_PATH) -> bool:
+    """True if this process can open ``path`` for both reading and writing.
+
+    Mirrors cua-driver's own ``uinput_accessible()`` gate (trycua/cua#2631):
+    an actual read+write ``open()`` attempt, not just a permission-bit
+    check, since that's the real operation the vulnerable code path
+    performs. Any failure (missing device, permission denied, ...) is
+    "not accessible" — this function never raises.
+    """
+    try:
+        fd = os.open(path, os.O_RDWR)
+    except OSError:
+        return False
+    else:
+        os.close(fd)
+        return True
+
+
+def uinput_leak_risk_possible(
+    *,
+    platform: str,
+    display: Optional[str],
+    driver_version: Optional[str],
+) -> bool:
+    """True if platform, display and driver version alone leave the
+    trycua/cua#2618 risk open — i.e. Linux, an X11 session (``DISPLAY``
+    set), and a parseable cua-driver version below 0.13.1.
+
+    This is exactly the device-free half of :func:`detect_uinput_leak_risk`,
+    factored out so callers can skip the ``/dev/uinput`` probe entirely when
+    it could not change the answer. A False here means no device state can
+    produce risk, so a fixed/current driver (or a non-Linux, display-less,
+    or unknown-version host) never opens the device unnecessarily.
+    """
+    if platform != "linux":
+        return False
+    if not display:
+        return False
+    return driver_version_is_vulnerable(driver_version) is True
+
+
+def detect_uinput_leak_risk(
+    *,
+    platform: str,
+    display: Optional[str],
+    driver_version: Optional[str],
+    uinput_accessible: bool,
+) -> Optional[Dict[str, Any]]:
+    """Return a risk descriptor when the known-unsafe combination from
+    trycua/cua#2618 is present, else ``None``.
+
+    Unsafe combination: Linux, an X11 session (``DISPLAY`` set), a
+    parseable cua-driver version below 0.13.1, and ``/dev/uinput`` not
+    read+write accessible. Every other combination — non-Linux, no
+    ``DISPLAY``, an unparseable/missing version, a fixed version, or an
+    accessible device — preserves current (no-guard) behavior.
+
+    Callers that must pay to learn ``uinput_accessible`` should gate on
+    :func:`uinput_leak_risk_possible` first; this function stays total so
+    it can also be called with a value already in hand.
+    """
+    if not uinput_leak_risk_possible(
+        platform=platform, display=display, driver_version=driver_version
+    ):
+        return None
+    if uinput_accessible:
+        return None
+    return {
+        "code": UINPUT_LEAK_RISK_CODE,
+        "driver_version": driver_version,
+        "uinput_path": UINPUT_DEVICE_PATH,
+    }
+
+
+def uinput_leak_risk_message(risk: Dict[str, Any]) -> str:
+    version = risk.get("driver_version") or "unknown"
+    path = risk.get("uinput_path", UINPUT_DEVICE_PATH)
+    return (
+        f"cua-driver {version} on Linux/X11 can leak XInput master pointers "
+        f"when {path} is not read+write accessible, eventually crashing the "
+        "session (trycua/cua#2618, fixed in trycua/cua#2631; Hermes #74148). "
+        "Upgrade cua-driver to >=0.13.1: `hermes computer-use install --upgrade`."
+    )
+
+
+def uinput_leak_risk_hint() -> str:
+    return (
+        "Upgrade cua-driver to >=0.13.1 (`hermes computer-use install --upgrade`). "
+        "This is a driver-side fix (trycua/cua#2631) — do not work around it by "
+        "changing /dev/uinput's permissions or running as a more privileged user."
+    )
+
+
+def uinput_leak_risk_check(risk: Dict[str, Any]) -> Dict[str, Any]:
+    """Build a ``health_report``-shaped check dict for
+    ``hermes computer-use doctor`` to append to its checks list."""
+    return {
+        "name": "linux_uinput_xinput_leak_risk",
+        "status": "fail",
+        "message": uinput_leak_risk_message(risk),
+        "hint": uinput_leak_risk_hint(),
+        "data": {
+            "driver_version": risk.get("driver_version"),
+            "uinput_path": risk.get("uinput_path"),
+            "upstream_issue": "trycua/cua#2618",
+            "upstream_fix": "trycua/cua#2631",
+            "hermes_issue": "#74148",
+        },
+    }
+
+
+def uinput_leak_risk_action_result(action: str, risk: Dict[str, Any]) -> ActionResult:
+    """Build the refusal ``ActionResult`` an input action returns when
+    ``detect_uinput_leak_risk`` reports risk, instead of declaring an input
+    session or invoking the driver."""
+    return ActionResult(
+        ok=False,
+        action=action,
+        message=uinput_leak_risk_message(risk),
+        code=UINPUT_LEAK_RISK_CODE,
+        meta={
+            "driver_version": risk.get("driver_version"),
+            "uinput_path": risk.get("uinput_path"),
+            "upstream_issue": "trycua/cua#2618",
+            "upstream_fix": "trycua/cua#2631",
+            "hermes_issue": "#74148",
+        },
+    )


### PR DESCRIPTION
Closes #74148

## Summary

- add a shared Linux/X11 safety predicate for the cua-driver `/dev/uinput` XInput-master leak fixed by trycua/cua#2631
- augment `hermes computer-use doctor` with an actionable degraded check when the exact unsafe combination is detected
- refuse native input before any driver action when Linux + X11 + cua-driver `<0.13.1` + inaccessible `/dev/uinput` are all true
- keep capture, app/window listing, and inspection available
- probe the exact manifest-resolved MCP executable rather than a potentially different wrapper/PATH binary

## Why

[cua-driver issue #2618](https://github.com/trycua/cua/issues/2618) documents a Linux/X11 failure in which the driver created an XInput master pair before opening `/dev/uinput`. If opening uinput failed, the pair was not recorded for cleanup and repeated input attempts could leak additional master keyboard/pointer pairs.

The ordering was fixed by [trycua/cua#2631](https://github.com/trycua/cua/pull/2631) and released in [cua-driver-rs-v0.13.1](https://github.com/trycua/cua/releases/tag/cua-driver-rs-v0.13.1). Because `0.13.1` is currently a pre-release while the stable updater can still report `0.12.6`, Hermes needs a local fail-safe for affected Linux users.

## Safety behavior

The guard activates only when all four facts are known:

1. `sys.platform == "linux"`
2. `DISPLAY` is set
3. the driver version is parseable and `<0.13.1`
4. `/dev/uinput` cannot actually be opened read/write

Unknown/malformed versions preserve current behavior. Fixed drivers, non-Linux platforms, display-less sessions, and accessible uinput preserve current behavior. Fixed/irrelevant environments do not open `/dev/uinput` unnecessarily.

The remediation recommends upgrading the driver. It does not change device permissions, invoke privilege escalation, install a pre-release automatically, or alter service lifecycle.

## Verification

```text
scripts/run_tests.sh \
  tests/computer_use/test_doctor.py \
  tests/computer_use/test_uinput_safety.py \
  tests/tools/test_computer_use.py \
  tests/tools/test_computer_use_cua_backend_linux.py \
  tests/tools/test_computer_use_delivery_ladder.py \
  tests/tools/test_computer_use_uinput_guard.py \
  tests/computer_use/test_cua_no_overlay.py \
  tests/computer_use/test_cua_spawn_env_sanitization.py -q

394 passed, 0 failed
```

Real Linux/X11 validation against installed cua-driver `0.13.1` with inaccessible `/dev/uinput`:

```json
{
  "platform": "linux",
  "driver_version": "0.13.1",
  "overall": "ok",
  "risk_checks": []
}
```

A live Chrome/GitHub computer-use regression using `0.13.1` completed an authenticated issue submission, followed by clean teardown with no local cua-driver process and no CUA XInput devices.

## Review provenance

Implementation used Tank/Claude Code under a constrained worktree. A separate local-only Codex review found that the first implementation could probe a wrapper rather than the actual manifest-relocated MCP executable. That blocking finding was fixed by recording and probing the exact launched command; the fresh post-fix review reported no blocking findings. Hermes independently reran the CI-parity test suite and live runtime checks.
