### PR TITLE
test(computer_use): fake Event class for timeout tests + approval-global isolation (salvage #69607, #70584)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1088,3 +1088,38 @@ def _audio_playback_guard(request, monkeypatch):
         monkeypatch.setattr(_voice, "play_audio_file", _blocked_play_audio_file)
 
     yield
+
+
+@pytest.fixture(autouse=True)
+def _isolate_computer_use_approval_state():
+    """Reset computer-use approval globals after every test.
+
+    ``tools.computer_use.tool`` keeps three module-globals for the CLI
+    approval flow: ``_approval_callback`` (set by the CLI console on init)
+    plus the per-session unlock stores ``_always_allow`` /
+    ``_session_auto_approve``. A test that installs a callback — or drives
+    CLI init far enough that the real one is registered — and does not reset
+    it poisons every later computer-use test in the same process:
+
+    * a leaked callback that raises (dead UI/queue infra, or a stale
+      two-argument signature — the real contract is ``(action, args,
+      summary)``) turns into ``verdict = "deny"`` in ``_request_approval``,
+      so dispatch tests fail with an empty backend call list;
+    * a leaked callback that blocks (the real CLI one waits on an answer
+      queue) hangs the whole single-process run forever — pytest-timeout is
+      the only thing that can cut it.
+
+    Both symptoms are order-dependent: the affected files pass in isolation
+    and only fail in full-suite runs. Teardown-only, so tests that install
+    their own callback keep it for their own duration.
+    """
+    yield
+    try:
+        from tools.computer_use import tool as _cu_tool
+
+        _cu_tool.set_approval_callback(None)
+        with _cu_tool._approval_lock:
+            _cu_tool._always_allow.clear()
+            _cu_tool._session_auto_approve.clear()
+    except Exception:
+        pass

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -4085,7 +4085,7 @@ class TestStartupTimeoutPhaseDetail:
     def test_timeout_error_includes_startup_phase(self):
         import threading
         from typing import Any, cast
-        from unittest.mock import MagicMock
+        from unittest.mock import MagicMock, patch as _patch
         from tools.computer_use.cua_backend import _CuaDriverSession
 
         session = cast(Any, _CuaDriverSession.__new__(_CuaDriverSession))
@@ -4101,8 +4101,20 @@ class TestStartupTimeoutPhaseDetail:
         session._bridge = fake_bridge
 
         import asyncio
-        from unittest.mock import patch as _patch
-        with _patch.object(session._ready_event, "wait", return_value=False), \
+
+        class _FakeEvent:
+            """Event whose wait() always returns False (timeout path).
+
+            #69372: _start_lifecycle_locked reassigns a fresh threading.Event()
+            at line 786, so patching the pre-made instance's wait() is lost.
+            Patching threading.Event itself ensures the fresh instance also
+            has the mocked wait()."""
+            def set(self): pass
+            def is_set(self): return False
+            def clear(self): pass
+            def wait(self, timeout=None): return False
+
+        with _patch.object(threading, "Event", _FakeEvent), \
              _patch.object(asyncio, "run_coroutine_threadsafe", return_value=MagicMock()), \
              _patch.object(_CuaDriverSession, "_lifecycle_coro", lambda self: None):
             try:
@@ -4131,7 +4143,13 @@ class TestStartupTimeoutPhaseDetail:
         fake_bridge._loop = MagicMock()
         session._bridge = fake_bridge
 
-        with _patch.object(session._ready_event, "wait", return_value=False), \
+        class _FakeEvent:
+            def set(self): pass
+            def is_set(self): return False
+            def clear(self): pass
+            def wait(self, timeout=None): return False
+
+        with _patch.object(threading, "Event", _FakeEvent), \
              _patch.object(asyncio, "run_coroutine_threadsafe", return_value=MagicMock()), \
              _patch.object(_CuaDriverSession, "_lifecycle_coro", lambda self: None):
             try:

--- a/tests/tools/test_computer_use_approval_isolation.py
+++ b/tests/tools/test_computer_use_approval_isolation.py
@@ -1,0 +1,75 @@
+"""Regression: leaked approval callbacks must not poison later tests.
+
+``tools.computer_use.tool._approval_callback`` and the per-session unlock
+stores are module-globals. Without the autouse reset fixture in
+``tests/conftest.py``, a test that installs a callback and "forgets" it
+changes the behavior of every later computer-use test in the process:
+a raising callback becomes ``verdict = "deny"`` (dispatch tests see an
+empty backend call list), a blocking callback hangs the run. The pair
+below simulates the forgetful test and asserts the next test still sees
+default-allow behavior.
+"""
+
+import json
+
+
+def _install_backend(cu_tool):
+    class _RecordingBackend:
+        def __init__(self):
+            self.calls = []
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+        def is_available(self):
+            return True
+
+        def click(self, **kw):
+            self.calls.append(("click", kw))
+            from tools.computer_use.backend import ActionResult
+
+            return ActionResult(ok=True, action="click")
+
+        def capture(self, mode="som", app=None):
+            from tools.computer_use.backend import CaptureResult
+
+            return CaptureResult(
+                mode=mode, width=1, height=1, png_b64=None, elements=[],
+                app="X", window_title="",
+            )
+
+    backend = _RecordingBackend()
+    cu_tool.reset_backend_for_tests()
+    cu_tool._backend = backend
+    return backend
+
+
+def test_a_forgets_a_poisoned_approval_callback():
+    """Simulates the polluter: installs a callback with the LEGACY
+    two-argument signature and deliberately does not reset it."""
+    from tools.computer_use import tool as cu_tool
+
+    def stale_two_arg_callback(action, args):  # wrong arity on purpose
+        return "approve_once"
+
+    cu_tool.set_approval_callback(stale_two_arg_callback)
+    # no reset — the autouse fixture must clean this up
+
+
+def test_b_still_dispatches_with_default_allow():
+    """Without the isolation fixture this fails: the stale callback raises
+    (arity), ``_request_approval`` converts that into a deny, and the
+    backend never sees the click."""
+    from tools.computer_use import tool as cu_tool
+
+    backend = _install_backend(cu_tool)
+    result = cu_tool.handle_computer_use({"action": "click", "element": 3})
+    call_names = [c[0] for c in backend.calls]
+    assert "click" in call_names, (
+        f"leaked approval callback poisoned this test: {result!r}"
+    )
+    payload = json.loads(result) if isinstance(result, str) else result
+    assert not (isinstance(payload, dict) and payload.get("error"))


### PR DESCRIPTION
Salvages two small, still-valid CUA **test-hygiene** fixes from the lifecycle/cleanup PR cluster (redundancy audit of #72159 / #22821 / #70536 / #70584 / #69607 / #63362 — the rest are redundant against main or superseded by #74166; see verdict comments on each).

## What's included

### 1. `fix(test): patch threading.Event class for CUA timeout tests` (#69607, fixes #69372) — @smfworks
`TestStartupTimeoutPhaseDetail` patches `session._ready_event.wait` on a **pre-made instance**, but `_start_lifecycle_locked()` (tools/computer_use/cua_backend.py:1057) reassigns `self._ready_event = threading.Event()`, so the patch is lost and both tests block on a **real 30s wait** each.

**Verified on current main:** the two tests take **60.32s**; with this fix they take **0.26s**. Same assertions, no behavior change — the fix substitutes a `_FakeEvent` class whose `wait()` returns `False`, so the fresh instance created inside the code under test also hits the timeout path.

### 2. `test: isolate computer-use approval globals between tests` (#70584) — @ai-ag2026
`tools.computer_use.tool` keeps module-globals for the CLI approval flow (`_approval_callback`, `_always_allow`, `_session_auto_approve`). Tests that install a callback and forget it (e.g. `tests/tools/test_computer_use_delivery_ladder.py` relies on try/finally today) poison later computer-use tests order-dependently: a raising callback becomes `verdict="deny"` (empty backend call list), a blocking callback hangs the run. Adds a teardown-only autouse fixture in `tests/conftest.py` plus a two-test regression pair (`test_computer_use_approval_isolation.py`) that simulates the polluter.

Cherry-picked with original authorship; conftest.py conflict resolved by appending the fixture after main's newer `_audio_playback_guard`. Contributor mappings for both authors already present in `contributors/emails/`.

## Test results

```
scripts/run_tests.sh tests/tools/test_computer_use.py \
  tests/tools/test_computer_use_approval_isolation.py \
  tests/tools/test_computer_use_delivery_ladder.py
=== Summary: 3 files, 246 tests passed, 0 failed (100% complete) in 3.0s ===
```

Stale-base gate: 0 commits behind origin/main at push time.

## Infographic

![salv-cua-tests infographic](https://v3b.fal.media/files/b/0aa436d5/3kN7HxD4uqmExg9bHRtN2_GfUMzB84.png)
