### PR TITLE
fix(computer-use): Windows/WSL cua-driver salvage — autostart path spaces, hidden consoles, WSL manifest paths

### DIFF
--- a/contributors/emails/ZundamonnoVRChatkaisetu@users.noreply.github.com
+++ b/contributors/emails/ZundamonnoVRChatkaisetu@users.noreply.github.com
@@ -1,0 +1,2 @@
+ZundamonnoVRChatkaisetu
+# PR #62821 salvage

--- a/contributors/emails/motoblurr@users.noreply.github.com
+++ b/contributors/emails/motoblurr@users.noreply.github.com
@@ -1,0 +1,2 @@
+motoblurr
+# PR #63532 salvage

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1242,6 +1242,91 @@ def _clear_stale_cua_install_lock() -> None:
         logger.debug("stale cua install lock check failed: %s", e)
 
 
+def _ps_single_quote(value: str) -> str:
+    """Return a PowerShell single-quoted string literal."""
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _cua_driver_autostart_registered_windows() -> bool:
+    """Return whether the Windows cua-driver scheduled task is registered."""
+    if sys.platform != "win32":
+        return False
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["schtasks.exe", "/Query", "/TN", "cua-driver-serve"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+        )
+    except Exception:
+        return False
+    return result.returncode == 0
+
+
+def _repair_cua_driver_autostart_windows(driver_cmd: str, *, verbose: bool) -> bool:
+    """Best-effort repair for Windows installer autostart quoting failures.
+
+    Older install.ps1 builds invoked
+    ``& C:\\Users\\Name With Spaces\\...\\cua-driver`` from an elevated
+    PowerShell command string, which PowerShell split at the first space. If
+    the installer left the scheduled task missing, retry by
+    launching the resolved binary through Start-Process's structured
+    ``-FilePath`` / ``-ArgumentList`` parameters instead of interpolating a
+    path into a command string.
+    """
+    if sys.platform != "win32":
+        return True
+    if _cua_driver_autostart_registered_windows():
+        return True
+
+    import subprocess
+
+    binary = shutil.which(driver_cmd)
+    if not binary:
+        return False
+
+    ps = shutil.which("powershell") or shutil.which("powershell.exe") or "powershell"
+    ps_cmd = (
+        f"$exe = {_ps_single_quote(binary)}; "
+        "$proc = Start-Process -FilePath $exe "
+        "-ArgumentList @('autostart','enable') "
+        "-Verb RunAs -Wait -PassThru -ErrorAction Stop; "
+        "exit $proc.ExitCode"
+    )
+
+    if verbose:
+        _print_info("    Registering cua-driver auto-start...")
+    else:
+        _print_info("    Repairing cua-driver auto-start registration...")
+
+    try:
+        result = subprocess.run(
+            [ps, "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", ps_cmd],
+            capture_output=True,
+            text=True,
+            timeout=300,
+            env=_cua_driver_env(),
+        )
+    except subprocess.TimeoutExpired:
+        _print_warning("    cua-driver autostart registration timed out.")
+        return False
+    except Exception as exc:
+        _print_warning(f"    cua-driver autostart registration failed: {exc}")
+        return False
+
+    if result.returncode == 0:
+        return True
+
+    tail = (result.stderr or result.stdout or "").strip().splitlines()[-3:]
+    _print_warning("    cua-driver autostart registration failed.")
+    for line in tail:
+        _print_info(f"      {line[:200]}")
+    _print_info("    From an elevated shell, run: cua-driver autostart enable")
+    return False
+
+
 def _run_cua_driver_installer(
     label: str = "Installing",
     verbose: bool = True,
@@ -1461,6 +1546,12 @@ def _run_cua_driver_installer(
                 if result.returncode != 0:
                     logger.debug("cua-driver installer output:\n%s", result.stdout)
         if result.returncode == 0 and shutil.which(driver_cmd):
+            if is_windows and not _repair_cua_driver_autostart_windows(
+                driver_cmd, verbose=verbose
+            ):
+                _print_warning(
+                    "    cua-driver installed, but auto-start was not registered."
+                )
             if verbose:
                 _print_success(f"    {driver_cmd} installed.")
                 if is_windows:

--- a/tests/computer_use/test_cua_spawn_env_sanitization.py
+++ b/tests/computer_use/test_cua_spawn_env_sanitization.py
@@ -163,7 +163,7 @@ def test_windows_status_hides_every_reachable_subprocess(monkeypatch):
 
     monkeypatch.setattr(permissions.sys, "platform", "win32")
     monkeypatch.setattr(permissions, "windows_hide_flags", lambda: CREATE_NO_WINDOW)
-    monkeypatch.setattr(permissions.shutil, "which", lambda command: binary)
+    monkeypatch.setattr(permissions, "_resolve_driver_cmd", lambda command: binary)
     monkeypatch.setattr(permissions.subprocess, "run", fake_run)
 
     status = permissions.computer_use_status("cua-driver")

--- a/tests/computer_use/test_cua_spawn_env_sanitization.py
+++ b/tests/computer_use/test_cua_spawn_env_sanitization.py
@@ -111,6 +111,11 @@ def test_cli_fallback_sanitizes_env_and_hides_console_on_windows(monkeypatch):
 
     captured = {}
     _patch_windows_hide_flags(monkeypatch, cua_backend)
+    # Hermetic CI has no cua-driver binary; pin the resolver so the test
+    # exercises the spawn-env path instead of the install-hint early exit.
+    monkeypatch.setattr(
+        cua_backend, "resolve_cua_driver_cmd", lambda override=None: "cua-driver"
+    )
     monkeypatch.setattr(
         cua_backend.subprocess,
         "run",

--- a/tests/computer_use/test_cua_spawn_env_sanitization.py
+++ b/tests/computer_use/test_cua_spawn_env_sanitization.py
@@ -200,7 +200,11 @@ def test_doctor_spawn_sanitizes_env_and_hides_console_on_windows(monkeypatch):
             "jsonrpc": "2.0",
             "id": 2,
             "result": {
-                "structuredContent": {"schema_version": "1", "overall": "ok"}
+                "structuredContent": {
+                    "schema_version": "1",
+                    "overall": "ok",
+                    "checks": [],
+                }
             },
         }),
     ]

--- a/tests/computer_use/test_cua_spawn_env_sanitization.py
+++ b/tests/computer_use/test_cua_spawn_env_sanitization.py
@@ -17,6 +17,7 @@ import json
 from unittest.mock import MagicMock
 
 SECRET = "sk-super-secret-should-not-leak"
+CREATE_NO_WINDOW = 0x08000000
 
 
 def _fake_completed_process(stdout: str) -> MagicMock:
@@ -31,6 +32,7 @@ def _capture_run(captured, stdout=""):
     def fake_run(cmd, **kwargs):
         captured["cmd"] = cmd
         captured["env"] = kwargs.get("env")
+        captured["creationflags"] = kwargs.get("creationflags")
         return _fake_completed_process(stdout)
     return fake_run
 
@@ -45,6 +47,13 @@ def _assert_sanitized(captured):
     assert env.get("CUA_DRIVER_RS_TELEMETRY_ENABLED") == "0"
 
 
+def _patch_windows_hide_flags(monkeypatch, module):
+    monkeypatch.setattr(module, "IS_WINDOWS", True, raising=False)
+    monkeypatch.setattr(
+        module, "windows_hide_flags", lambda: CREATE_NO_WINDOW, raising=False
+    )
+
+
 def test_resolve_mcp_invocation_sanitizes_env(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", SECRET)
     monkeypatch.setenv("PATH", "/usr/bin:/bin")
@@ -53,6 +62,7 @@ def test_resolve_mcp_invocation_sanitizes_env(monkeypatch):
     from tools.computer_use import cua_backend
 
     captured = {}
+    _patch_windows_hide_flags(monkeypatch, cua_backend)
     manifest = json.dumps({"mcp_invocation": {"command": "cua-driver", "args": ["mcp"]}})
     monkeypatch.setattr(
         cua_backend.subprocess, "run", _capture_run(captured, stdout=manifest)
@@ -61,6 +71,7 @@ def test_resolve_mcp_invocation_sanitizes_env(monkeypatch):
     cmd, args = cua_backend._resolve_mcp_invocation("cua-driver")
     assert cmd == "cua-driver"
     _assert_sanitized(captured)
+    assert captured["creationflags"] == CREATE_NO_WINDOW
 
 
 def test_update_check_sanitizes_env(monkeypatch):
@@ -71,6 +82,7 @@ def test_update_check_sanitizes_env(monkeypatch):
     from tools.computer_use import cua_backend
 
     captured = {}
+    _patch_windows_hide_flags(monkeypatch, cua_backend)
     payload = json.dumps({
         "current_version": "1.0.0",
         "latest_version": "1.0.0",
@@ -87,6 +99,30 @@ def test_update_check_sanitizes_env(monkeypatch):
 
     cua_backend.cua_driver_update_check(timeout=1.0)
     _assert_sanitized(captured)
+    assert captured["creationflags"] == CREATE_NO_WINDOW
+
+
+def test_cli_fallback_sanitizes_env_and_hides_console_on_windows(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", SECRET)
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    monkeypatch.delenv("HERMES_CUA_TELEMETRY", raising=False)
+
+    from tools.computer_use import cua_backend
+
+    captured = {}
+    _patch_windows_hide_flags(monkeypatch, cua_backend)
+    monkeypatch.setattr(
+        cua_backend.subprocess,
+        "run",
+        _capture_run(captured, stdout=json.dumps({"tree_markdown": "root"})),
+    )
+
+    session = object.__new__(cua_backend._CuaDriverSession)
+    result = session._call_tool_via_cli("list_windows", {}, timeout=5.0)
+
+    assert result["isError"] is False
+    _assert_sanitized(captured)
+    assert captured["creationflags"] == CREATE_NO_WINDOW
 
 
 def test_permissions_run_sanitizes_env(monkeypatch):
@@ -103,6 +139,80 @@ def test_permissions_run_sanitizes_env(monkeypatch):
 
     permissions._run("cua-driver", "doctor", "--json", timeout=1.0)
     _assert_sanitized(captured)
+
+
+def test_windows_status_hides_every_reachable_subprocess(monkeypatch):
+    """The Desktop status API reaches only version + doctor spawns on Windows.
+
+    The permissions grant subprocess is intentionally excluded: its public
+    entry point returns before spawning anywhere except macOS, where
+    ``CREATE_NO_WINDOW`` is not applicable.
+    """
+    from tools.computer_use import permissions
+
+    binary = r"C:\Program Files\cua-driver\cua-driver.exe"
+    calls = []
+    stdout_by_args = {
+        ("--version",): "cua-driver 1.2.3\n",
+        ("doctor", "--json"): json.dumps({"ok": True, "probes": []}),
+    }
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return _fake_completed_process(stdout_by_args[tuple(cmd[1:])])
+
+    monkeypatch.setattr(permissions.sys, "platform", "win32")
+    monkeypatch.setattr(permissions, "windows_hide_flags", lambda: CREATE_NO_WINDOW)
+    monkeypatch.setattr(permissions.shutil, "which", lambda command: binary)
+    monkeypatch.setattr(permissions.subprocess, "run", fake_run)
+
+    status = permissions.computer_use_status("cua-driver")
+
+    assert status["version"] == "cua-driver 1.2.3"
+    assert status["ready"] is True
+    assert [cmd[1:] for cmd, _ in calls] == [
+        ["--version"],
+        ["doctor", "--json"],
+    ]
+    assert calls, "Windows status must exercise at least one subprocess boundary"
+    for cmd, kwargs in calls:
+        assert kwargs.get("creationflags") == CREATE_NO_WINDOW, cmd
+
+
+def test_doctor_spawn_sanitizes_env_and_hides_console_on_windows(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", SECRET)
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    monkeypatch.delenv("HERMES_CUA_TELEMETRY", raising=False)
+
+    from tools.computer_use import doctor
+
+    captured = {}
+    _patch_windows_hide_flags(monkeypatch, doctor)
+    proc = MagicMock()
+    proc.stdout.readline.side_effect = [
+        json.dumps({"jsonrpc": "2.0", "id": 1, "result": {}}),
+        json.dumps({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": {
+                "structuredContent": {"schema_version": "1", "overall": "ok"}
+            },
+        }),
+    ]
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs.get("env")
+        captured["creationflags"] = kwargs.get("creationflags")
+        return proc
+
+    monkeypatch.setattr(doctor.subprocess, "Popen", fake_popen)
+
+    report = doctor._drive_health_report("cua-driver", timeout=1.0)
+
+    assert report["overall"] == "ok"
+    _assert_sanitized(captured)
+    assert captured["creationflags"] == CREATE_NO_WINDOW
 
 
 def test_doctor_sanitized_env_helper(monkeypatch):

--- a/tests/computer_use/test_cua_wsl_manifest_path.py
+++ b/tests/computer_use/test_cua_wsl_manifest_path.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from tools.computer_use import cua_backend
+
+
+def test_wsl_windows_manifest_path_translates_to_drvfs():
+    with patch("hermes_constants.is_wsl", return_value=True):
+        assert cua_backend._wsl_windows_path_to_posix(
+            r"C:\Users\Fernando\AppData\Local\cua-driver\cua-driver.exe"
+        ) == "/mnt/c/Users/Fernando/AppData/Local/cua-driver/cua-driver.exe"
+
+
+def test_non_windows_path_is_unchanged_in_wsl():
+    with patch("hermes_constants.is_wsl", return_value=True):
+        assert cua_backend._wsl_windows_path_to_posix(
+            "/usr/local/bin/cua-driver"
+        ) == "/usr/local/bin/cua-driver"
+
+
+def test_windows_manifest_path_is_unchanged_outside_wsl():
+    path = r"D:\Tools\cua-driver.exe"
+    with patch("hermes_constants.is_wsl", return_value=False):
+        assert cua_backend._wsl_windows_path_to_posix(path) == path
+
+
+def test_resolve_mcp_invocation_normalizes_windows_manifest_command_in_wsl():
+    manifest = {
+        "mcp_invocation": {
+            "command": r"C:\Users\Fernando\AppData\Local\cua-driver\cua-driver.exe",
+            "args": ["mcp"],
+        }
+    }
+    proc = SimpleNamespace(returncode=0, stdout=json.dumps(manifest))
+    with (
+        patch.object(cua_backend.subprocess, "run", return_value=proc),
+        patch("hermes_constants.is_wsl", return_value=True),
+    ):
+        command, args = cua_backend._resolve_mcp_invocation("cua-driver")
+
+    assert command == "/mnt/c/Users/Fernando/AppData/Local/cua-driver/cua-driver.exe"
+    assert args == ["mcp"]

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -22,6 +22,7 @@ cleanly on missing-arch assets, and the upgrade path uses
 from __future__ import annotations
 
 import sys
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -786,7 +787,6 @@ class TestRunInstallerPinEnv:
     into the installer child env; unpinned runs leave it untouched."""
 
     def _run(self, pin_version):
-        import subprocess
         from unittest.mock import MagicMock
 
         from hermes_cli import tools_config
@@ -825,3 +825,105 @@ class TestRunInstallerPinEnv:
     def test_no_pin_leaves_env_untouched(self):
         env = self._run(None)
         assert "CUA_DRIVER_RS_VERSION" not in env
+
+
+class TestWindowsAutostartRepair:
+    def test_existing_task_skips_elevated_powershell_repair(self):
+        from hermes_cli import tools_config
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return SimpleNamespace(returncode=0)
+
+        with patch.object(tools_config.sys, "platform", "win32"), \
+             patch("subprocess.run", side_effect=fake_run), \
+             patch.object(tools_config.shutil, "which") as which:
+            ok = tools_config._repair_cua_driver_autostart_windows(
+                "cua-driver", verbose=False
+            )
+
+        assert ok is True
+        assert [cmd for cmd, _kwargs in calls] == [
+            ["schtasks.exe", "/Query", "/TN", "cua-driver-serve"]
+        ]
+        which.assert_not_called()
+
+    def test_windows_installer_runs_autostart_repair_after_success(self):
+        from unittest.mock import MagicMock
+        from hermes_cli import tools_config
+
+        captured = {}
+        fake_proc = MagicMock()
+        fake_proc.pid = 1
+        fake_proc.returncode = 0
+        fake_proc.communicate.return_value = ("", None)
+
+        def fake_popen(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            return fake_proc
+
+        def fake_which(name: str):
+            if name == "cua-driver":
+                return r"C:\Users\Ha Trung\AppData\Local\Programs\Cua\cua-driver\bin\cua-driver.exe"
+            return None
+
+        with patch("platform.system", return_value="Windows"), \
+             patch.object(tools_config.shutil, "which", side_effect=fake_which), \
+             patch("subprocess.Popen", side_effect=fake_popen), \
+             patch.object(tools_config, "_clear_stale_cua_install_lock"), \
+             patch.object(tools_config, "_repair_cua_driver_autostart_windows", return_value=True) as repair, \
+             patch.object(tools_config, "_print_warning"), \
+             patch.object(tools_config, "_print_info"), \
+             patch.object(tools_config, "_print_success"):
+            ok = tools_config._run_cua_driver_installer(label="Refreshing", verbose=False)
+
+        assert ok is True
+        assert captured["kwargs"].get("shell") is False
+        assert isinstance(captured["cmd"], list)
+        assert captured["cmd"][:4] == [
+            "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass",
+        ]
+        repair.assert_called_once_with("cua-driver", verbose=False)
+
+    def test_autostart_repair_quotes_username_space_path_via_file_path(self):
+        from hermes_cli import tools_config
+
+        calls = []
+        driver = (
+            r"C:\Users\Ha Trung\AppData\Local\Programs\Cua"
+            r"\cua-driver\bin\cua-driver.exe"
+        )
+
+        def fake_which(name: str):
+            if name == "cua-driver":
+                return driver
+            if name == "powershell":
+                return r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+            return None
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            if cmd[0] == "schtasks.exe":
+                return SimpleNamespace(returncode=1)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with patch.object(tools_config.sys, "platform", "win32"), \
+             patch.object(tools_config.shutil, "which", side_effect=fake_which), \
+             patch("subprocess.run", side_effect=fake_run), \
+             patch.object(tools_config, "_print_warning"), \
+             patch.object(tools_config, "_print_info"):
+            ok = tools_config._repair_cua_driver_autostart_windows(
+                "cua-driver", verbose=False
+            )
+
+        assert ok is True
+        ps_calls = [cmd for cmd, _kwargs in calls if cmd[0].endswith("powershell.exe")]
+        assert len(ps_calls) == 1
+        ps_command = ps_calls[0][-1]
+        assert "-FilePath $exe" in ps_command
+        assert "-ArgumentList @('autostart','enable')" in ps_command
+        assert f"$exe = '{driver}'" in ps_command
+        assert f"& {driver}" not in ps_command

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -50,6 +50,7 @@ import threading
 import uuid
 from typing import Any, Dict, List, Optional, Tuple
 
+from hermes_cli._subprocess_compat import windows_hide_flags
 from tools.computer_use.backend import (
     ActionResult,
     CaptureResult,
@@ -381,6 +382,7 @@ def _resolve_mcp_invocation(
             [driver_cmd, "manifest"],
             capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=timeout,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
             # cua-driver is a third-party binary — never hand it provider
             # API keys via inherited env (same policy as the MCP and CLI
             # fallback spawns below; #53503/#55709/#58889 lineage).
@@ -589,6 +591,7 @@ def cua_driver_update_check(*, timeout: Optional[float] = None) -> Optional[Dict
             # stdin-reading mode rather than erroring — DEVNULL gives them EOF
             # so they exit fast instead of blocking until the timeout.
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
             # Sanitized like every other cua-driver spawn: third-party
             # binary, no inherited provider keys (#53503/#55709/#58889).
             env=_sanitize_subprocess_env(cua_driver_child_env()),
@@ -1330,6 +1333,7 @@ class _CuaDriverSession:
                 try:
                     proc = _subprocess.run(
                         cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=max(15.0, timeout),
+                        creationflags=windows_hide_flags(),
                         env=_sanitize_subprocess_env(cua_driver_child_env()),
                     )
                 except Exception as e:  # pragma: no cover - subprocess spawn failure

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -479,6 +479,7 @@ def _cua_driver_supports_no_overlay(driver_cmd: str) -> bool:
             [driver_cmd, "--help"],
             capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=3.0,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
             env=_sanitize_subprocess_env(cua_driver_child_env()),
         )
         help_text = (proc.stdout or "") + (proc.stderr or "")

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -48,6 +48,7 @@ import subprocess
 import sys
 import threading
 import uuid
+from pathlib import PureWindowsPath
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_cli._subprocess_compat import windows_hide_flags
@@ -351,6 +352,30 @@ def _select_capture_target(
     return windows[0]
 
 
+def _wsl_windows_path_to_posix(path: str) -> str:
+    """Translate a Windows absolute manifest command when Hermes runs in WSL.
+
+    Windows cua-driver manifests can report ``C:\\Users\\...\\cua-driver.exe``
+    even though the Hermes process uses POSIX subprocess spawning inside WSL.
+    The same file is reachable through DrvFS as ``/mnt/c/Users/...``.
+    Non-Windows paths and non-WSL hosts are returned unchanged.
+    """
+    if not re.match(r"^[A-Za-z]:[\\/]", path):
+        return path
+    try:
+        from hermes_constants import is_wsl
+
+        if not is_wsl():
+            return path
+    except Exception:
+        return path
+    win = PureWindowsPath(path)
+    drive = (win.drive or "").rstrip(":").lower()
+    if not drive:
+        return path
+    return os.path.join("/mnt", drive, *(str(part) for part in win.parts[1:]))
+
+
 def _resolve_mcp_invocation(
     driver_cmd: str,
     *,
@@ -410,6 +435,11 @@ def _resolve_mcp_invocation(
         # The driver knows the subcommand but didn't surface its own path.
         # Keep our resolved driver_cmd; the args are still authoritative.
         return driver_cmd, _mcp_args_with_overlay_flag(args, driver_cmd=driver_cmd)
+    # A Windows-installed cua-driver can hand a WSL-hosted Hermes an absolute
+    # ``C:\...`` command; translate it to its DrvFS ``/mnt/<drive>/...`` form
+    # BEFORE the path-separator check (backslash is not a separator on POSIX,
+    # so the raw Windows string would otherwise be discarded here).
+    command = _wsl_windows_path_to_posix(command)
     if not _has_path_separator(command):
         # A manifest may legitimately retain the generic ``cua-driver`` name.
         # Under a GUI's thin PATH that would lose the resolved user-local path

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -30,6 +30,8 @@ import subprocess
 import sys
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 
 # Match the ALLOWED_STATUS_VALUES + ALLOWED_OVERALL_VALUES the cua-driver
 # integration test pins. If health_report widens its vocabulary, add here.
@@ -215,6 +217,7 @@ def _open_mcp(binary: str) -> subprocess.Popen:
         encoding="utf-8",
         errors="replace",
         bufsize=1,
+        creationflags=windows_hide_flags(),
         env=_sanitized_cua_env(),
     )
 

--- a/tools/computer_use/permissions.py
+++ b/tools/computer_use/permissions.py
@@ -29,6 +29,8 @@ import subprocess
 import sys
 from typing import Any, Dict, List, Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 # Platforms with a cua-driver runtime backend (mirrors the toolset platform_gate).
 _RUNTIME_PLATFORMS = frozenset({"darwin", "win32", "linux"})
 _BOOLS = ("accessibility", "screen_recording", "screen_recording_capturable")
@@ -70,6 +72,7 @@ def _run(binary: str, *args: str, timeout: float) -> subprocess.CompletedProcess
         timeout=timeout,
         env=_child_env(),
         stdin=subprocess.DEVNULL,
+        creationflags=windows_hide_flags(),
     )
 
 


### PR DESCRIPTION
## Summary

Consolidated salvage of the Windows/WSL cua-driver PR cluster — three valid fixes cherry-picked onto current `main` with authorship preserved, plus one follow-up commit.

### Salvaged

- **#60880 (@embwl0x)** — repair Windows cua-driver autostart registration for username paths with spaces: detect a missing `cua-driver-serve` scheduled task after install and retry via `Start-Process -FilePath/-ArgumentList` (structured params) instead of interpolating the path into a PowerShell command string. Related: #60808.
- **#62821 (@ZundamonnoVRChatkaisetu)** — hide Windows cua-driver subprocess consoles: `windows_hide_flags()` (CREATE_NO_WINDOW; 0 on POSIX) at the manifest probe, update checker, CLI fallback transport, doctor health-report spawn, and permissions/status runner. The env-probe half of the original PR was already implemented on main and was dropped. Follow-up commit extends the same flag to the `--no-overlay` help probe.
- **#63532 (@motoblurr)** — normalize Windows manifest paths in WSL: translate `C:\...` `mcp_invocation.command` values to `/mnt/<drive>/...` (DrvFS) before POSIX spawning, gated on `is_wsl()`; applied *before* main's path-separator check so the Windows path isn't discarded (backslash is not a separator on POSIX). Addresses #63938.

### Not salvaged (verdicts)

| PR/Issue | Verdict |
|---|---|
| #60097 (@otsune, UTF-8 decode) | implemented_on_main — all cua subprocess sites already use `encoding="utf-8", errors="replace"` |
| #60098 (@otsune, surface UIA-timeout) | implemented_on_main (superseded) — main's `_call_capture_tool` now raises on `isError` results, so the UIA-timeout error surfaces immediately instead of burning CLI retries; the PR's pre-refactor patch site no longer exists |
| #64937 (@Ahmett101, AppCompat BSOD bypass) | needs human review — the `=::=::\` env-var mechanism is an undocumented Windows-internals trick, unverifiable on Linux and safety-sensitive (kernel crash mitigation); see triage notes below |
| #60081 (@2ndNatureAI, screen-capture enumeration bypass) | defer until #74166 lands — rewrites `capture()` desktop routing in `tools/computer_use/cua_backend.py` head-on against the in-flight cua 0.9/0.10 contract work, and bundles unrelated "Block Logic threshold" gateway/TUI changes that don't belong in this cluster |
| #72969 (0.12.6 vs 0.8.3 version mismatch) | triage only — real report; status resolves the PATH `cua-driver.EXE` (0.12.6) while doctor/session resolve a different (stale) binary; consistent with a Windows runtime-resolution/stale-daemon split after #67052; left open for a dedicated fix |

### Contributor mapping

`contributors/emails/` mappings added for @ZundamonnoVRChatkaisetu and @motoblurr (their original commits carried placeholder identities: "Claude Code Enterprise" / "Hermes Agent <hermes@local>"; commits re-authored to GitHub noreply identities). @embwl0x mapping already present.

### Tests

```
=== Summary: 12 files, 346 tests passed, 0 failed (100% complete) in 64.9s (40 workers) ===
```

Covers `tests/hermes_cli/test_install_cua_driver.py`, all of `tests/computer_use/` (incl. new `test_cua_wsl_manifest_path.py`), `tests/tools/test_computer_use.py`, `tests/tools/test_computer_use_cua_backend_linux.py`. Ruff clean. Windows-only paths exercised via mocks per repo convention.

## Infographic

![Windows/WSL cua-driver salvage infographic](https://v3b.fal.media/files/b/0aa436de/p1mffgGjZ9c8rSTcSDkzU_UbW3YxUx.png)
