### PR TITLE
fix(desktop): hide unknown cloud agent status

### DIFF
--- a/apps/desktop/src/app/settings/gateway-settings.test.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.test.tsx
@@ -4,6 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ProfileInfo } from '@/types/hermes'
 
+const cloudDiscover = vi.fn()
+const cloudStatus = vi.fn()
 const getConnectionConfig = vi.fn()
 const saveConnectionConfig = vi.fn()
 const profiles = atom<ProfileInfo[]>([])
@@ -47,9 +49,18 @@ beforeEach(() => {
   ])
   getConnectionConfig.mockResolvedValue(localConnection)
   saveConnectionConfig.mockResolvedValue(localConnection)
+  cloudStatus.mockResolvedValue({ portalBaseUrl: 'https://portal.nousresearch.com', signedIn: true })
+  cloudDiscover.mockResolvedValue({ agents: [], org: null })
   Object.defineProperty(window, 'hermesDesktop', {
     configurable: true,
-    value: { getConnectionConfig, saveConnectionConfig }
+    value: {
+      cloud: {
+        discover: cloudDiscover,
+        status: cloudStatus
+      },
+      getConnectionConfig,
+      saveConnectionConfig
+    }
   })
 })
 
@@ -117,5 +128,48 @@ describe('GatewaySettings', () => {
         })
       )
     )
+  })
+
+  it('hides an unknown cloud agent gateway status', async () => {
+    cloudDiscover.mockResolvedValue({
+      agents: [
+        {
+          dashboardGatewayState: 'unknown',
+          dashboardUrl: 'https://agent.example.com',
+          id: 'agent-1',
+          name: 'Cloud Agent',
+          status: 'active'
+        }
+      ],
+      org: null
+    })
+    const { GatewaySettings } = await import('./gateway-settings')
+
+    render(<GatewaySettings />)
+    fireEvent.click(await screen.findByRole('button', { name: /Hermes Cloud/ }))
+
+    expect(await screen.findByText('Cloud Agent')).toBeTruthy()
+    expect(screen.queryByText('Status: unknown')).toBeNull()
+  })
+
+  it('shows a known cloud agent gateway status', async () => {
+    cloudDiscover.mockResolvedValue({
+      agents: [
+        {
+          dashboardGatewayState: 'active',
+          dashboardUrl: 'https://agent.example.com',
+          id: 'agent-1',
+          name: 'Cloud Agent',
+          status: 'active'
+        }
+      ],
+      org: null
+    })
+    const { GatewaySettings } = await import('./gateway-settings')
+
+    render(<GatewaySettings />)
+    fireEvent.click(await screen.findByRole('button', { name: /Hermes Cloud/ }))
+
+    expect(await screen.findByText('Status: active')).toBeTruthy()
   })
 })

--- a/apps/desktop/src/app/settings/gateway-settings.test.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.test.tsx
@@ -152,6 +152,28 @@ describe('GatewaySettings', () => {
     expect(screen.queryByText('Status: unknown')).toBeNull()
   })
 
+  it('hides an empty cloud agent gateway status', async () => {
+    cloudDiscover.mockResolvedValue({
+      agents: [
+        {
+          dashboardGatewayState: '',
+          dashboardUrl: 'https://agent.example.com',
+          id: 'agent-1',
+          name: 'Cloud Agent',
+          status: 'active'
+        }
+      ],
+      org: null
+    })
+    const { GatewaySettings } = await import('./gateway-settings')
+
+    render(<GatewaySettings />)
+    fireEvent.click(await screen.findByRole('button', { name: /Hermes Cloud/ }))
+
+    expect(await screen.findByText('Cloud Agent')).toBeTruthy()
+    expect(screen.queryByText(/^Status:/)).toBeNull()
+  })
+
   it('shows a known cloud agent gateway status', async () => {
     cloudDiscover.mockResolvedValue({
       agents: [

--- a/apps/desktop/src/app/settings/gateway-settings.test.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.test.tsx
@@ -1,6 +1,8 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const cloudDiscover = vi.fn()
+const cloudStatus = vi.fn()
 const getConnectionConfig = vi.fn()
 const saveConnectionConfig = vi.fn()
 
@@ -24,9 +26,18 @@ const localConnection = {
 beforeEach(() => {
   getConnectionConfig.mockResolvedValue(localConnection)
   saveConnectionConfig.mockResolvedValue(localConnection)
+  cloudStatus.mockResolvedValue({ portalBaseUrl: 'https://portal.nousresearch.com', signedIn: true })
+  cloudDiscover.mockResolvedValue({ agents: [], org: null })
   Object.defineProperty(window, 'hermesDesktop', {
     configurable: true,
-    value: { getConnectionConfig, saveConnectionConfig }
+    value: {
+      cloud: {
+        discover: cloudDiscover,
+        status: cloudStatus
+      },
+      getConnectionConfig,
+      saveConnectionConfig
+    }
   })
 })
 
@@ -54,5 +65,48 @@ describe('GatewaySettings', () => {
     expect(screen.queryByText('Applies to')).toBeNull()
     expect(screen.queryByText('All profiles')).toBeNull()
     expect(screen.queryByText('Use default gateway')).toBeNull()
+  })
+
+  it('hides an unknown cloud agent gateway status', async () => {
+    cloudDiscover.mockResolvedValue({
+      agents: [
+        {
+          dashboardGatewayState: 'unknown',
+          dashboardUrl: 'https://agent.example.com',
+          id: 'agent-1',
+          name: 'Cloud Agent',
+          status: 'active'
+        }
+      ],
+      org: null
+    })
+    const { GatewaySettings } = await import('./gateway-settings')
+
+    render(<GatewaySettings />)
+    fireEvent.click(await screen.findByRole('button', { name: /Hermes Cloud/ }))
+
+    expect(await screen.findByText('Cloud Agent')).toBeTruthy()
+    expect(screen.queryByText('Status: unknown')).toBeNull()
+  })
+
+  it('shows a known cloud agent gateway status', async () => {
+    cloudDiscover.mockResolvedValue({
+      agents: [
+        {
+          dashboardGatewayState: 'active',
+          dashboardUrl: 'https://agent.example.com',
+          id: 'agent-1',
+          name: 'Cloud Agent',
+          status: 'active'
+        }
+      ],
+      org: null
+    })
+    const { GatewaySettings } = await import('./gateway-settings')
+
+    render(<GatewaySettings />)
+    fireEvent.click(await screen.findByRole('button', { name: /Hermes Cloud/ }))
+
+    expect(await screen.findByText('Status: active')).toBeTruthy()
   })
 })

--- a/apps/desktop/src/app/settings/gateway-settings.test.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.test.tsx
@@ -89,6 +89,28 @@ describe('GatewaySettings', () => {
     expect(screen.queryByText('Status: unknown')).toBeNull()
   })
 
+  it('hides an empty cloud agent gateway status', async () => {
+    cloudDiscover.mockResolvedValue({
+      agents: [
+        {
+          dashboardGatewayState: '',
+          dashboardUrl: 'https://agent.example.com',
+          id: 'agent-1',
+          name: 'Cloud Agent',
+          status: 'active'
+        }
+      ],
+      org: null
+    })
+    const { GatewaySettings } = await import('./gateway-settings')
+
+    render(<GatewaySettings />)
+    fireEvent.click(await screen.findByRole('button', { name: /Hermes Cloud/ }))
+
+    expect(await screen.findByText('Cloud Agent')).toBeTruthy()
+    expect(screen.queryByText(/^Status:/)).toBeNull()
+  })
+
   it('shows a known cloud agent gateway status', async () => {
     cloudDiscover.mockResolvedValue({
       agents: [

--- a/apps/desktop/src/app/settings/gateway-settings.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.tsx
@@ -1207,6 +1207,8 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
                   <div className="grid gap-1">
                     {cloudAgents.map(agent => {
                       const connected = isConnectedAgent(agent)
+                      const gatewayState = agent.dashboardGatewayState.trim()
+                      const hasKnownGatewayState = gatewayState.length > 0 && gatewayState.toLowerCase() !== 'unknown'
 
                       return (
                         <div
@@ -1235,7 +1237,7 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
                                 </Button>
                               )
                             }
-                            description={g.cloudStatusLabel(agent.dashboardGatewayState)}
+                            description={hasKnownGatewayState ? g.cloudStatusLabel(gatewayState) : undefined}
                             title={agent.name}
                           />
                         </div>

--- a/apps/desktop/src/app/settings/gateway-settings.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.tsx
@@ -1245,6 +1245,8 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
                   <div className="grid gap-1">
                     {cloudAgents.map(agent => {
                       const connected = isConnectedAgent(agent)
+                      const gatewayState = agent.dashboardGatewayState.trim()
+                      const hasKnownGatewayState = gatewayState.length > 0 && gatewayState.toLowerCase() !== 'unknown'
 
                       return (
                         <div
@@ -1273,7 +1275,7 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
                                 </Button>
                               )
                             }
-                            description={g.cloudStatusLabel(agent.dashboardGatewayState)}
+                            description={hasKnownGatewayState ? g.cloudStatusLabel(gatewayState) : undefined}
                             title={agent.name}
                           />
                         </div>


### PR DESCRIPTION
## Bug Description

Hermes Cloud agent rows display `Status: unknown` when the discovery response does not include a meaningful gateway state.

Closes #74135

## Root Cause

Cloud discovery normalizes a missing `dashboardGatewayState` to `"unknown"`, and the renderer always formats that value as a visible status description.

## Fix

- Omit the status description when the gateway state is empty or `unknown`.
- Preserve status labels for meaningful gateway states.
- Add renderer regression coverage for both behaviors.

## How to Verify

1. Open **Settings → Gateway** and select **Hermes Cloud**.
2. Discover an agent without a reported gateway state and confirm no `Status: unknown` line appears.
3. Confirm an agent with a known state still displays its status.

## Test Plan

- [x] Added regression tests for unknown and known gateway states
- [x] Desktop UI suite: 2,946 tests passed across 334 files
- [x] Desktop TypeScript typecheck passed
- [x] Desktop ESLint and Prettier checks passed

## Risk Assessment

Low — this is a renderer-only presentation change. Cloud discovery, connection behavior, valid status labels, and localization remain unchanged.
