### PR TITLE
fix(cli): bind alt voice.record_key as an escape sequence so startup doesn't crash (#74169)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -16100,6 +16100,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             from hermes_cli.config import load_config
             from hermes_cli.voice import (
                 normalize_voice_record_key_for_prompt_toolkit,
+                prompt_toolkit_key_binding_args,
                 voice_record_key_from_config,
             )
             _raw_key = voice_record_key_from_config(load_config())
@@ -16125,7 +16126,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # voice.record_key mid-session (Copilot round-13 on #19835).
         self.set_voice_record_key_cache(_raw_key)
 
-        @kb.add(_voice_key)
+        # prompt_toolkit has no Alt/Meta keys, so an ``a-<key>`` string can't be
+        # bound directly (it raises ``ValueError: Invalid key`` and crashes
+        # startup, #74169). Bind Alt keys as the ``(escape, <key>)`` two-key
+        # sequence the terminal actually sends; ctrl keys are unchanged.
+        from hermes_cli.voice import prompt_toolkit_key_binding_args
+        _voice_binding = prompt_toolkit_key_binding_args(_voice_key)
+
+        @kb.add(*_voice_binding)
         def handle_voice_record(event):
             """Toggle voice recording when voice mode is active.
 

--- a/cli.py
+++ b/cli.py
@@ -16133,7 +16133,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         from hermes_cli.voice import prompt_toolkit_key_binding_args
         _voice_binding = prompt_toolkit_key_binding_args(_voice_key)
 
-        @kb.add(*_voice_binding)
+        # An Alt chord like ``alt+v`` shares its ``(escape, <key>)`` sequence
+        # with existing non-eager bindings — Alt+V clipboard paste, Alt+Enter,
+        # Alt+G. Two guards keep them from colliding (#74169):
+        #   * ``filter``: only claim the chord while voice mode is active, so
+        #     when voice mode is off the binding is dropped from the match set
+        #     and those defaults keep working (no shadowing).
+        #   * ``eager``: when voice mode is on, win over the equally-specific
+        #     non-eager sibling that would otherwise run last (prompt_toolkit
+        #     prefers eager matches), so the configured PTT chord actually
+        #     toggles recording instead of pasting the clipboard.
+        @kb.add(
+            *_voice_binding,
+            filter=Condition(lambda: bool(self._voice_mode)),
+            eager=True,
+        )
         def handle_voice_record(event):
             """Toggle voice recording when voice mode is active.
 

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -183,6 +183,27 @@ def normalize_voice_record_key_for_prompt_toolkit(raw: Any) -> str:
     return f"{normalized_mod}{named}"
 
 
+def prompt_toolkit_key_binding_args(normalized: str) -> tuple[str, ...]:
+    """Translate a normalized ``c-x`` / ``a-x`` key into ``KeyBindings.add`` args.
+
+    prompt_toolkit 3.0.x has no Alt/Meta entries in its ``Keys`` enum, so
+    binding an ``a-<key>`` string directly raises ``ValueError: Invalid key``
+    and crashes the CLI at startup (#74169). In a terminal Alt+<key> arrives as
+    Escape followed by <key>, which prompt_toolkit binds as the two-key
+    sequence ``("escape", "<key>")``. Ctrl keys (and the ``c-b`` default) bind
+    as their single string unchanged.
+
+    ``normalize_voice_record_key_for_prompt_toolkit`` only ever emits ``c-<key>``
+    or ``a-<key>`` (everything else falls back to the ``c-b`` default), and every
+    ``a-<key>`` it produces — single chars plus the named keys ``backspace``,
+    ``delete``, ``enter``, ``escape``, ``space``, ``tab`` — binds cleanly as the
+    escape sequence, so the returned args are always accepted by ``kb.add``.
+    """
+    if normalized.startswith("a-"):
+        return ("escape", normalized[2:])
+    return (normalized,)
+
+
 def format_voice_record_key_for_status(raw: Any) -> str:
     """Render ``voice.record_key`` for ``/voice status`` in CLI-friendly form.
 

--- a/tests/hermes_cli/test_voice_wrapper.py
+++ b/tests/hermes_cli/test_voice_wrapper.py
@@ -120,6 +120,87 @@ class TestPromptToolkitKeyBindingArgs:
             kb.add("a-v")(lambda event: None)
 
 
+class TestVoiceBindingCollisionPrecedence:
+    """Regression for #74169 review: an Alt PTT chord must not collide with
+    the non-eager Escape bindings that share its ``(escape, <key>)`` sequence
+    — Alt+V clipboard paste, Alt+Enter, Alt+G.
+
+    cli.py registers the voice binding with ``filter=Condition(voice_mode)``
+    and ``eager=True``. This mirrors exactly what prompt_toolkit's
+    ``KeyProcessor`` consumes when it resolves a key sequence
+    (``key_processor.py``: matches are filtered to ``b.filter()`` truthy, then
+    eager matches win, then the last registered wins). We rebuild that real
+    binding set and assert the resolved handler in both voice-mode states so
+    the precedence contract can't silently regress.
+    """
+
+    def _resolve(self, kb, keys):
+        """Replicate KeyProcessor's binding selection for ``keys``.
+
+        Filter to active bindings (``KeyProcessor._get_matches``), prefer eager
+        matches, then take the last registered — the exact contract at
+        ``key_processor.py`` lines 129 and 180-187.
+        """
+        matches = [b for b in kb.get_bindings_for_keys(keys) if b.filter()]
+        eager = [b for b in matches if b.eager()]
+        chosen = (eager or matches)
+        return chosen[-1] if chosen else None
+
+    def _build(self, configured_key):
+        """Build the real competing binding set for one configured PTT chord.
+
+        The sibling Escape bindings are registered *after* the voice binding —
+        matching cli.py, where Alt+V clipboard paste (and friends) come later
+        in the same ``KeyBindings`` — so a naive last-wins resolution would
+        pick the sibling.
+        """
+        from prompt_toolkit.filters import Condition
+        from prompt_toolkit.key_binding.key_bindings import KeyBindings
+
+        from hermes_cli.voice import prompt_toolkit_key_binding_args
+
+        voice_mode = {"on": False}
+        kb = KeyBindings()
+
+        def voice_handler(event):  # pragma: no cover - never invoked in test
+            pass
+
+        kb.add(
+            *prompt_toolkit_key_binding_args(configured_key),
+            filter=Condition(lambda: bool(voice_mode["on"])),
+            eager=True,
+        )(voice_handler)
+
+        # Existing non-eager siblings sharing the (escape, <key>) sequence.
+        for keyname in ("v", "enter", "g"):
+            def sibling(event, _k=keyname):  # pragma: no cover
+                pass
+
+            kb.add("escape", keyname)(sibling)
+
+        # Query with the exact normalized key tuple prompt_toolkit stored for
+        # the voice binding (``enter``/``g`` become ``Keys`` members), so the
+        # lookup matches the way KeyProcessor resolves a real key sequence.
+        assert kb.bindings[0].handler is voice_handler
+        keys = kb.bindings[0].keys
+        return kb, keys, voice_mode, voice_handler
+
+    @pytest.mark.parametrize("configured_key", ["a-v", "a-enter", "a-g"])
+    def test_voice_wins_only_while_voice_mode_active(self, configured_key):
+        kb, keys, voice_mode, voice_handler = self._build(configured_key)
+
+        # Voice mode ON: the eager filtered voice binding must win over the
+        # non-eager sibling that shares the sequence (the reported alt+v bug).
+        voice_mode["on"] = True
+        assert self._resolve(kb, keys).handler is voice_handler
+
+        # Voice mode OFF: the filter drops the voice binding entirely, so the
+        # sibling (clipboard paste / newline / editor) keeps its behavior — no
+        # shadowing.
+        voice_mode["on"] = False
+        assert self._resolve(kb, keys).handler is not voice_handler
+
+
 class TestVoiceRecordKeyFromConfig:
     """Round-11 Copilot review regression on #19835.
 

--- a/tests/hermes_cli/test_voice_wrapper.py
+++ b/tests/hermes_cli/test_voice_wrapper.py
@@ -72,6 +72,54 @@ class TestNormalizeVoiceRecordKeyForPromptToolkit:
     # TUI falls back to Ctrl+B.
 
 
+class TestPromptToolkitKeyBindingArgs:
+    """Regression for #74169: ``alt+<key>`` crashed the CLI at startup.
+
+    prompt_toolkit 3.0.x has no Alt/Meta keys in its ``Keys`` enum, so
+    ``@kb.add("a-v")`` raises ``ValueError: Invalid key`` and takes the whole
+    CLI down. Alt must instead bind as the ``(escape, <key>)`` two-key sequence
+    the terminal actually sends.
+    """
+
+    def test_ctrl_keys_bind_as_a_single_string(self):
+        from hermes_cli.voice import prompt_toolkit_key_binding_args
+
+        assert prompt_toolkit_key_binding_args("c-b") == ("c-b",)
+        assert prompt_toolkit_key_binding_args("c-o") == ("c-o",)
+        assert prompt_toolkit_key_binding_args("c-space") == ("c-space",)
+
+    def test_alt_keys_expand_to_an_escape_sequence(self):
+        from hermes_cli.voice import prompt_toolkit_key_binding_args
+
+        assert prompt_toolkit_key_binding_args("a-v") == ("escape", "v")
+        assert prompt_toolkit_key_binding_args("a-space") == ("escape", "space")
+        assert prompt_toolkit_key_binding_args("a-enter") == ("escape", "enter")
+
+    def test_every_normalized_key_actually_binds_in_prompt_toolkit(self):
+        """The real crash: the translated args must be accepted by ``kb.add``."""
+        from prompt_toolkit.key_binding.key_bindings import KeyBindings
+
+        from hermes_cli.voice import (
+            normalize_voice_record_key_for_prompt_toolkit,
+            prompt_toolkit_key_binding_args,
+        )
+
+        for raw in ("alt+v", "alt+space", "alt+enter", "option+r", "ctrl+b", "ctrl+o", "super+b", ""):
+            normalized = normalize_voice_record_key_for_prompt_toolkit(raw)
+            args = prompt_toolkit_key_binding_args(normalized)
+            kb = KeyBindings()
+            # Must not raise — this is exactly what cli.py does at startup.
+            kb.add(*args)(lambda event: None)
+
+    def test_raw_alt_string_would_crash_without_the_fix(self):
+        """Documents the underlying prompt_toolkit limitation this guards."""
+        from prompt_toolkit.key_binding.key_bindings import KeyBindings
+
+        kb = KeyBindings()
+        with pytest.raises(ValueError):
+            kb.add("a-v")(lambda event: None)
+
+
 class TestVoiceRecordKeyFromConfig:
     """Round-11 Copilot review regression on #19835.
 


### PR DESCRIPTION
## Summary

Fixes #74169.

Setting `voice.record_key: alt+v` (or any `alt+` / `option+` key) in `~/.hermes/config.yaml` crashed the CLI at startup:

```
Error: Invalid key: a-v
```

## Root cause

`normalize_voice_record_key_for_prompt_toolkit("alt+v")` correctly returns prompt_toolkit's `a-v` spelling, but **prompt_toolkit 3.0.x has no Alt/Meta entries in its `Keys` enum**, so `@kb.add("a-v")` raises `ValueError: Invalid key: a-v`. The binding sits *outside* the config-loading `try/except`, so the exception propagates and takes the whole CLI down.

Verified against the pinned prompt_toolkit (3.0.52):

```python
kb.add("a-v")   # ValueError: Invalid key: a-v
kb.add("c-b")   # OK
```

## Fix

In a terminal, Alt+`<key>` arrives as **Escape followed by `<key>`**, which prompt_toolkit binds as the two-key sequence `("escape", "<key>")`.

- Add `prompt_toolkit_key_binding_args()` to `hermes_cli/voice.py`: translates a normalized key into the correct `kb.add` args — `a-<key>` → `("escape", "<key>")`, ctrl/default keys unchanged.
- Splat it at the `cli.py` binding site: `@kb.add(*_voice_binding)`.

The normalizer only ever emits `c-<key>` / `a-<key>` (everything else falls back to the `c-b` default), and **every** `a-<key>` it can produce — single chars plus the named keys `backspace`, `delete`, `enter`, `escape`, `space`, `tab` — binds cleanly as an escape sequence, so the translated args are always accepted. That closes the crash at its source; no key value can bring down startup. (I kept `normalize_…` returning the `a-<key>` string unchanged so `/voice status` display and the existing normalizer tests are untouched.)

## Tests

`tests/hermes_cli/test_voice_wrapper.py` gains `TestPromptToolkitKeyBindingArgs`:
- the translation table (ctrl → single string, alt → escape sequence),
- that **every** normalized key actually binds in a real `KeyBindings` (the exact call `cli.py` makes at startup), and
- that the raw `a-v` string still raises, documenting the prompt_toolkit limitation this guards.

`scripts/run_tests.sh tests/hermes_cli/test_voice_wrapper.py` → 58 passed; ruff clean; preflight gates green.
