### PR TITLE
fix(buzz): keep DM replies flat

### DIFF
--- a/contributors/emails/carrion256@proton.me
+++ b/contributors/emails/carrion256@proton.me
@@ -1,0 +1,2 @@
+carrion256
+# PR #74507 salvage of #74185

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -575,18 +575,27 @@ class BuzzAdapter(BasePlatformAdapter):
 
     # ── Sending ───────────────────────────────────────────────────────────
 
-    def _reply_target_for_chat(self, chat_id: str, reply_target: Optional[str]) -> Optional[str]:
-        """Keep direct-message conversations flat while preserving channel replies.
+    def _reply_target(
+        self,
+        chat_id: str,
+        reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[str]:
+        """Keep top-level DMs flat without discarding real Buzz threads.
 
-        Buzz renders ``--reply-to`` as a nested reply-tree edge.  A DM is
-        already its own conversation, so anchoring every Hermes response to
-        the triggering message creates an ever-deepening tree instead of the
-        expected linear exchange.
+        The gateway supplies the triggering message as ``reply_to`` even for
+        an ordinary DM turn.  Buzz renders that value as a nested reply-tree
+        edge.  A genuine inbound NIP-10 thread is carried separately as
+        ``metadata.thread_id``; that explicit root remains authoritative for
+        DM replies.  Shared and not-yet-classified chats retain the gateway's
+        existing reply behavior.
         """
+        thread_id = (metadata or {}).get("thread_id")
         state = self._channel_state.get(str(chat_id))
         if state and state.get("chat_type") == "dm":
-            return None
-        return reply_target
+            return str(thread_id) if thread_id else None
+        reply_target = reply_to or thread_id
+        return str(reply_target) if reply_target else None
 
     async def send(
         self,
@@ -598,12 +607,9 @@ class BuzzAdapter(BasePlatformAdapter):
         if not content:
             return SendResult(success=False, error="Empty message")
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
-        reply_target = self._reply_target_for_chat(
-            chat_id,
-            reply_to or (metadata or {}).get("thread_id"),
-        )
+        reply_target = self._reply_target(chat_id, reply_to, metadata)
         if reply_target:
-            args += ["--reply-to", str(reply_target)]
+            args += ["--reply-to", reply_target]
         code, out, err = await self._run_cli(args, input_text=content)
         if code != 0:
             return SendResult(
@@ -673,9 +679,9 @@ class BuzzAdapter(BasePlatformAdapter):
                 "--file", str(local),
                 "--content", "-",
             ]
-            reply_target = self._reply_target_for_chat(chat_id, reply_to)
+            reply_target = self._reply_target(chat_id, reply_to, metadata)
             if reply_target:
-                args += ["--reply-to", str(reply_target)]
+                args += ["--reply-to", reply_target]
             code, out, err = await self._run_cli(args, input_text=caption or "")
             if code != 0:
                 return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)
@@ -1040,6 +1046,7 @@ class BuzzAdapter(BasePlatformAdapter):
         # open with "@Chip" even though no mention is required there, so the
         # strip applies to both chat types.
         dispatch_text = self._strip_mention(content)
+        thread_id = self._thread_id_from_event(event) if is_dm else None
 
         await self._dispatch_message(
             text=dispatch_text,
@@ -1049,6 +1056,7 @@ class BuzzAdapter(BasePlatformAdapter):
             user_name=await self._resolve_user_name(pubkey),
             message_id=event_id,
             created_at=created_at,
+            thread_id=thread_id,
         )
 
     # ── DM classification (issue #68871) ──────────────────────────────────
@@ -1128,6 +1136,30 @@ class BuzzAdapter(BasePlatformAdapter):
         state["chat_type"] = "dm"
         self._channel_names.setdefault(channel_id, "DM")
         logger.info("Buzz: conversation %s reclassified as DM (message p-tagged to self)", channel_id)
+
+    @staticmethod
+    def _thread_id_from_event(event: dict) -> Optional[str]:
+        """Return the root of an explicit NIP-10 reply thread, if present.
+
+        Marked NIP-10 ``e`` tags distinguish the stable thread root from the
+        immediate reply target.  Prefer the root so nested replies share one
+        Hermes session; fall back to the reply target when an event omits an
+        explicit root marker.
+        """
+        root_id = None
+        reply_id = None
+        for tag in event.get("tags") or []:
+            if not isinstance(tag, (list, tuple)) or len(tag) < 4 or tag[0] != "e":
+                continue
+            event_id = str(tag[1] or "")
+            if not event_id:
+                continue
+            marker = str(tag[3] or "").lower()
+            if marker == "root" and root_id is None:
+                root_id = event_id
+            elif marker == "reply" and reply_id is None:
+                reply_id = event_id
+        return root_id or reply_id
 
     def _is_mentioned(self, content: str) -> bool:
         """True when the message addresses this agent (npub, hex, or name)."""
@@ -1212,6 +1244,7 @@ class BuzzAdapter(BasePlatformAdapter):
         user_name: str,
         message_id: str,
         created_at: int,
+        thread_id: Optional[str] = None,
     ) -> None:
         """Build a MessageEvent and hand it to the base class handler."""
         if not self._message_handler:
@@ -1223,6 +1256,9 @@ class BuzzAdapter(BasePlatformAdapter):
             chat_type=chat_type,
             user_id=user_id,
             user_name=user_name,
+            thread_id=thread_id,
+            parent_chat_id=chat_id if thread_id else None,
+            message_id=message_id,
         )
 
         event = MessageEvent(

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -575,6 +575,19 @@ class BuzzAdapter(BasePlatformAdapter):
 
     # ── Sending ───────────────────────────────────────────────────────────
 
+    def _reply_target_for_chat(self, chat_id: str, reply_target: Optional[str]) -> Optional[str]:
+        """Keep direct-message conversations flat while preserving channel replies.
+
+        Buzz renders ``--reply-to`` as a nested reply-tree edge.  A DM is
+        already its own conversation, so anchoring every Hermes response to
+        the triggering message creates an ever-deepening tree instead of the
+        expected linear exchange.
+        """
+        state = self._channel_state.get(str(chat_id))
+        if state and state.get("chat_type") == "dm":
+            return None
+        return reply_target
+
     async def send(
         self,
         chat_id: str,
@@ -585,7 +598,10 @@ class BuzzAdapter(BasePlatformAdapter):
         if not content:
             return SendResult(success=False, error="Empty message")
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
-        reply_target = reply_to or (metadata or {}).get("thread_id")
+        reply_target = self._reply_target_for_chat(
+            chat_id,
+            reply_to or (metadata or {}).get("thread_id"),
+        )
         if reply_target:
             args += ["--reply-to", str(reply_target)]
         code, out, err = await self._run_cli(args, input_text=content)
@@ -657,8 +673,9 @@ class BuzzAdapter(BasePlatformAdapter):
                 "--file", str(local),
                 "--content", "-",
             ]
-            if reply_to:
-                args += ["--reply-to", str(reply_to)]
+            reply_target = self._reply_target_for_chat(chat_id, reply_to)
+            if reply_target:
+                args += ["--reply-to", str(reply_target)]
             code, out, err = await self._run_cli(args, input_text=caption or "")
             if code != 0:
                 return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -407,6 +407,29 @@ class TestBuzzAdapterSend:
         # Our own event id is marked seen for echo suppression
         assert "evt123" in adapter._channel_state[CHANNEL]["seen"]
 
+    @pytest.mark.asyncio
+    async def test_send_reply_to(self):
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt124", "message": ""})
+        adapter._run_cli = cli
+        await adapter.send(CHANNEL, "threaded", reply_to="root-event")
+        args, _stdin = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == "root-event"
+
+    @pytest.mark.asyncio
+    async def test_send_dm_does_not_create_reply_tree(self):
+        adapter = _make_adapter()
+        adapter._channel_state[DM_CHANNEL] = {"chat_type": "dm", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-dm", "message": ""})
+        adapter._run_cli = cli
+
+        await adapter.send(DM_CHANNEL, "flat reply", reply_to="user-event")
+
+        args, _stdin = cli.calls[0]
+        assert "--reply-to" not in args
 
     @pytest.mark.asyncio
     async def test_send_image_local_file_uses_file_flag(self, tmp_path):
@@ -420,6 +443,21 @@ class TestBuzzAdapterSend:
         assert result.success is True
         args, _stdin = cli.calls[0]
         assert args[args.index("--file") + 1] == str(img)
+
+    @pytest.mark.asyncio
+    async def test_send_image_in_dm_does_not_create_reply_tree(self, tmp_path):
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG fake")
+        adapter = _make_adapter()
+        adapter._channel_state[DM_CHANNEL] = {"chat_type": "dm", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-dm-image", "message": ""})
+        adapter._run_cli = cli
+
+        await adapter.send_image(DM_CHANNEL, str(img), reply_to="user-event")
+
+        args, _stdin = cli.calls[0]
+        assert "--reply-to" not in args
 
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────
@@ -536,5 +574,4 @@ class TestStandaloneSend:
         assert captured["input_text"] == "cron says hi"
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
-
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -321,6 +321,44 @@ class TestDmClassification:
         assert adapter._channel_state[DM_CHANNEL]["chat_type"] == "dm"
         assert [d["message_id"] for d in adapter._dispatched] == ["e1"]
         assert adapter._dispatched[0]["chat_type"] == "dm"
+        assert adapter._dispatched[0]["thread_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_dm_reply_propagates_nip10_root(self, adapter):
+        """Nested replies share the explicit root rather than their parent."""
+        adapter._channel_state[DM_CHANNEL]["chat_type"] = "dm"
+        event = _tagged_event(
+            "e2",
+            DM_CHANNEL,
+            content="reply in a thread",
+            p=SELF_PUBKEY,
+            reply_to="immediate-parent",
+        )
+        event["tags"].insert(1, ["e", "thread-root", "", "root"])
+
+        await self._poll_with(adapter, DM_CHANNEL, event)
+
+        assert len(adapter._dispatched) == 1
+        assert adapter._dispatched[0]["thread_id"] == "thread-root"
+
+    @pytest.mark.asyncio
+    async def test_direct_dm_reply_uses_nip10_reply_as_root(self, adapter):
+        """A direct reply with no separate root still forms a real thread."""
+        adapter._channel_state[DM_CHANNEL]["chat_type"] = "dm"
+
+        await self._poll_with(
+            adapter,
+            DM_CHANNEL,
+            _tagged_event(
+                "e3",
+                DM_CHANNEL,
+                content="first threaded reply",
+                p=SELF_PUBKEY,
+                reply_to="top-level-message",
+            ),
+        )
+
+        assert adapter._dispatched[0]["thread_id"] == "top-level-message"
 
 
     @pytest.mark.asyncio
@@ -432,6 +470,24 @@ class TestBuzzAdapterSend:
         assert "--reply-to" not in args
 
     @pytest.mark.asyncio
+    async def test_send_threaded_dm_preserves_explicit_root(self):
+        adapter = _make_adapter()
+        adapter._channel_state[DM_CHANNEL] = {"chat_type": "dm", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-dm-thread", "message": ""})
+        adapter._run_cli = cli
+
+        await adapter.send(
+            DM_CHANNEL,
+            "threaded reply",
+            reply_to="triggering-message",
+            metadata={"thread_id": "thread-root"},
+        )
+
+        args, _stdin = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == "thread-root"
+
+    @pytest.mark.asyncio
     async def test_send_image_local_file_uses_file_flag(self, tmp_path):
         img = tmp_path / "shot.png"
         img.write_bytes(b"\x89PNG fake")
@@ -458,6 +514,64 @@ class TestBuzzAdapterSend:
 
         args, _stdin = cli.calls[0]
         assert "--reply-to" not in args
+
+    @pytest.mark.asyncio
+    async def test_send_image_in_threaded_dm_preserves_explicit_root(self, tmp_path):
+        img = tmp_path / "threaded-shot.png"
+        img.write_bytes(b"\x89PNG fake")
+        adapter = _make_adapter()
+        adapter._channel_state[DM_CHANNEL] = {"chat_type": "dm", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-dm-thread-image", "message": ""})
+        adapter._run_cli = cli
+
+        await adapter.send_image(
+            DM_CHANNEL,
+            str(img),
+            reply_to="triggering-message",
+            metadata={"thread_id": "thread-root"},
+        )
+
+        args, _stdin = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == "thread-root"
+
+
+# ── Inbound thread source ─────────────────────────────────────────────────
+
+
+class TestBuzzAdapterDispatch:
+
+    @pytest.mark.asyncio
+    async def test_inbound_thread_stamps_threaded_dm_session_source(self):
+        from gateway.session import build_session_key
+
+        adapter = _make_adapter()
+        adapter._message_handler = AsyncMock()
+        adapter.handle_message = AsyncMock()
+        adapter.send_reaction = AsyncMock(return_value=True)
+        adapter._channel_state[DM_CHANNEL] = {"chat_type": "dm", "last_ts": 0, "seen": {}}
+        inbound = _tagged_event(
+            "reply-event",
+            DM_CHANNEL,
+            content="inside thread",
+            p=SELF_PUBKEY,
+            reply_to="immediate-parent",
+        )
+        inbound["tags"].insert(1, ["e", "thread-root", "", "root"])
+        cli = _ScriptedCli()
+        cli.script("messages", "get", [inbound])
+        adapter._run_cli = cli
+
+        await adapter._poll_channel(DM_CHANNEL)
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.message_id == "reply-event"
+        assert event.source.message_id == "reply-event"
+        assert event.source.thread_id == "thread-root"
+        assert event.source.parent_chat_id == DM_CHANNEL
+        assert build_session_key(event.source) == (
+            f"agent:main:buzz:dm:{DM_CHANNEL}:thread-root"
+        )
 
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────
@@ -574,4 +688,3 @@ class TestStandaloneSend:
         assert captured["input_text"] == "cron says hi"
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
-


### PR DESCRIPTION
## What does this PR do?

Keeps Hermes responses as top-level messages in Buzz direct-message conversations instead of nesting every turn under the preceding message.

The gateway supplies the triggering inbound event as `reply_to` for normal responses. The Buzz adapter previously translated that value unconditionally into `buzz messages send --reply-to ...`; Buzz correctly interprets that flag as a reply-tree edge, so an otherwise linear DM became progressively nested.

This change uses the adapter's existing per-chat `dm` / `group` classification at the outbound boundary. Known top-level DMs omit the synthetic reply edge, while group and unknown chats preserve the existing reply target. Marked NIP-10 roots now propagate through `SessionSource.thread_id`, so explicit DM threads retain their stable root and session across text, URL-image fallback, and local-image sends without changing gateway core behavior.

## Related Issue

Related to #68871. The original DM-flattening fix in this PR predates #74507 and was developed independently. PR #74507 preserves that commit and adds thread-aware DM routing plus Buzz presence; this review revision consulted its follow-up commit `c722fcce9c515a7d8dcaca006dd7e40124f13463` as a concrete reference for the explicit-root distinction.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/buzz/adapter.py`: distinguish the gateway's synthetic `reply_to` from an explicit NIP-10 `metadata.thread_id`; top-level DMs stay flat while real DM threads retain their root.
- `plugins/platforms/buzz/adapter.py`: propagate marked inbound thread roots into `SessionSource` and apply the same outbound rule to text, URL-image fallback, and local-image sends.
- `tests/gateway/test_buzz_adapter.py`: cover inbound root extraction, thread-specific session propagation, flat top-level DM replies, threaded DM text and image replies, and preserved group behavior.
- `contributors/emails/carrion256@proton.me`: map this PR author's email to the existing GitHub identity for release attribution.

## How to Test

1. Run the complete repository suite: `scripts/run_tests.sh`.
2. Run the focused Buzz suites: `scripts/run_tests.sh tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py -q`.
3. Send a top-level Buzz DM and confirm the Hermes response appears in the main DM timeline without a reply edge. Reply inside an explicit Buzz DM thread and confirm the response retains that thread root. Send a reply in a shared Buzz channel and confirm its reply anchor is retained.

Validation performed on exact PR head `eb5815c33ad71a7f75c310230fe3f36bb85a8e06`:

- Complete suite: **22,780 passed, 0 final failures** across 2,467 test files; one unrelated transcription idle-timeout test passed on the runner's automatic retry.
- Focused Buzz suites: **35 passed, 0 failed** across 2 test files.
- Ruff and `git diff --check`: passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the complete test suite with `scripts/run_tests.sh` (recommended; same as CI) and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: CachyOS Linux x86_64 (kernel 7.1.2-3-cachyos), Python 3.12.13, pytest 9.0.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing configuration or workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — argument selection is platform-neutral and unknown chats preserve prior behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model tool or schema changed

## Screenshots / Logs

Before:

<img width="1293" height="889" alt="Buzz DM before: nested replies" src="https://github.com/user-attachments/assets/64f18c0f-0940-4fbf-9b9e-d8c9b96e1fac" />

After:

<img width="917" height="487" alt="Buzz DM after: flat conversation" src="https://github.com/user-attachments/assets/f4c79f8e-d72c-4afb-b20c-c865e1775ecd" />