### PR TITLE
salvage(computer-use): hyphen key-combo block, doctor 0.10 fallback + version identity (#62915, #68452, #71590)

### DIFF
--- a/contributors/emails/203146215+monerostar@users.noreply.github.com
+++ b/contributors/emails/203146215+monerostar@users.noreply.github.com
@@ -1,0 +1,2 @@
+monerostar
+# PR #71590 salvage

--- a/contributors/emails/225291640+camaleonidas@users.noreply.github.com
+++ b/contributors/emails/225291640+camaleonidas@users.noreply.github.com
@@ -1,0 +1,2 @@
+camaleonidas
+# PR #68452 salvage

--- a/contributors/emails/48723787+chuenchen309@users.noreply.github.com
+++ b/contributors/emails/48723787+chuenchen309@users.noreply.github.com
@@ -1,0 +1,2 @@
+chuenchen309
+# PR #62915 salvage

--- a/tests/computer_use/test_cua_spawn_env_sanitization.py
+++ b/tests/computer_use/test_cua_spawn_env_sanitization.py
@@ -106,14 +106,17 @@ def test_permissions_run_sanitizes_env(monkeypatch):
 
 
 def test_doctor_sanitized_env_helper(monkeypatch):
-    """_drive_health_report spawns via Popen; assert the env helper it uses
-    strips secrets (mocking the whole JSON-RPC handshake is not worth it)."""
+    """The doctor MCP spawn site must pass the sanitized env to Popen.
+
+    Behavioral check: intercept subprocess.Popen at the `_open_mcp` spawn
+    seam and assert the env it receives strips secrets and applies the
+    telemetry opt-out (no source-text inspection — that breaks on any
+    refactor with identical runtime behavior)."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", SECRET)
     monkeypatch.setenv("PATH", "/usr/bin:/bin")
     monkeypatch.delenv("HERMES_CUA_TELEMETRY", raising=False)
 
     from tools.computer_use import doctor
-    import inspect
 
     env = doctor._sanitized_cua_env()
     assert "ANTHROPIC_API_KEY" not in env
@@ -121,5 +124,20 @@ def test_doctor_sanitized_env_helper(monkeypatch):
     assert env.get("CUA_DRIVER_RS_TELEMETRY_ENABLED") == "0"
 
     # The Popen spawn site must actually use the sanitized helper.
-    src = inspect.getsource(doctor._drive_health_report)
-    assert "_sanitized_cua_env()" in src
+    captured = {}
+
+    class _FakeProc:
+        stdin = None
+        stdout = None
+        stderr = None
+
+    def _fake_popen(*args, **kwargs):
+        captured["env"] = kwargs.get("env")
+        return _FakeProc()
+
+    monkeypatch.setattr(doctor.subprocess, "Popen", _fake_popen)
+    doctor._open_mcp("cua-driver")
+    spawn_env = captured["env"]
+    assert spawn_env is not None, "_open_mcp must pass an explicit env"
+    assert "ANTHROPIC_API_KEY" not in spawn_env
+    assert spawn_env.get("CUA_DRIVER_RS_TELEMETRY_ENABLED") == "0"

--- a/tests/computer_use/test_doctor.py
+++ b/tests/computer_use/test_doctor.py
@@ -322,9 +322,10 @@ class TestDriverCmdResolution:
         )
         with patch("shutil.which", return_value="/env/path/cua-driver") as which_mock, \
              patch("subprocess.Popen", return_value=proc), \
-             patch("sys.stdout", new_callable=StringIO):
+             patch("sys.stdout", new_callable=StringIO), \
+             patch("hermes_cli.tools_config._cua_driver_cmd", side_effect=Exception("force env")):
+            # Force env-var resolution path inside run_doctor.
             doctor.run_doctor()
-        # First (and only) which call should have used the env var.
         which_mock.assert_called_with("/env/path/cua-driver")
 
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX user-local path regression")
@@ -345,4 +346,238 @@ class TestDriverCmdResolution:
              patch("sys.stdout", new_callable=StringIO):
             assert doctor.run_doctor() == 0
 
-        health.assert_called_once_with(str(driver), include=(), skip=())
+        health.assert_called_once_with(str(driver), include=(), skip=(), timeout=12.0)
+
+
+# ── cua-driver 0.10 unclassified health_report fallback ────────────────────
+
+
+def _unclassified_health_result() -> dict:
+    """MCP tools/call result shape from cua-driver 0.10.x denial."""
+    return {
+        "isError": True,
+        "content": [
+            {
+                "type": "text",
+                "text": (
+                    "Permission denied: tool 'health_report' has no "
+                    "reviewed risk classification"
+                ),
+            }
+        ],
+        "structuredContent": {"exit_code": 1},
+    }
+
+
+def _perms_ok_result() -> dict:
+    return {
+        "isError": False,
+        "content": [{"type": "text", "text": "ok"}],
+        "structuredContent": {
+            "accessibility": True,
+            "screen_recording": True,
+            "screen_recording_capturable": True,
+        },
+    }
+
+
+def _list_apps_ok_result() -> dict:
+    return {
+        "isError": False,
+        "content": [{"type": "text", "text": "Found 1 app"}],
+        "structuredContent": {
+            "apps": [{"name": "Finder", "pid": 1, "running": True}],
+        },
+    }
+
+
+class TestHealthReportFallback:
+    """cua-driver 0.10 marks health_report risk-unclassified → isError.
+
+    Doctor must NOT treat structuredContent={exit_code:1} as a real report
+    (that produced '• cua-driver ? on ? — ?'). It synthesizes schema_version=1
+    via check_permissions / list_apps / CLI --version instead.
+    """
+
+    def test_isError_unclassified_uses_fallback_overall_ok(self):
+        from tools.computer_use import doctor
+
+        health_proc = _fake_proc_with_responses(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {"serverInfo": {"name": "cua-driver", "version": "0.10.0"}},
+            },
+            {"jsonrpc": "2.0", "id": 2, "result": _unclassified_health_result()},
+        )
+        probe_proc = _fake_proc_with_responses(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {"serverInfo": {"name": "cua-driver", "version": "0.10.0"}},
+            },
+            {"jsonrpc": "2.0", "id": 2, "result": _perms_ok_result()},
+            {"jsonrpc": "2.0", "id": 3, "result": _list_apps_ok_result()},
+        )
+        procs = iter([health_proc, probe_proc])
+        run_mock = MagicMock(
+            return_value=MagicMock(returncode=0, stdout="cua-driver 0.10.0\n", stderr=""),
+        )
+
+        with patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("subprocess.Popen", side_effect=lambda *a, **k: next(procs)), \
+             patch("subprocess.run", run_mock), \
+             patch("sys.stdout", new_callable=StringIO) as out:
+            code = doctor.run_doctor(color=False)
+
+        assert code == 0
+        text = out.getvalue()
+        assert "ok" in text
+        assert "0.10.0" in text
+        # Fallback path must be visible in the check list
+        assert "health_report_path" in text
+        assert "fallback composite" in text
+        assert "tcc_accessibility" in text
+        assert "binary_version" in text
+
+    def test_isError_unclassified_json_payload_has_schema_and_fallback_flag(self):
+        from tools.computer_use import doctor
+
+        health_proc = _fake_proc_with_responses(
+            {"jsonrpc": "2.0", "id": 1, "result": {"serverInfo": {"version": "0.10.0"}}},
+            {"jsonrpc": "2.0", "id": 2, "result": _unclassified_health_result()},
+        )
+        probe_proc = _fake_proc_with_responses(
+            {"jsonrpc": "2.0", "id": 1, "result": {"serverInfo": {"version": "0.10.0"}}},
+            {"jsonrpc": "2.0", "id": 2, "result": _perms_ok_result()},
+            {"jsonrpc": "2.0", "id": 3, "result": _list_apps_ok_result()},
+        )
+        procs = iter([health_proc, probe_proc])
+        run_mock = MagicMock(
+            return_value=MagicMock(returncode=0, stdout="cua-driver 0.10.0\n", stderr=""),
+        )
+
+        with patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("subprocess.Popen", side_effect=lambda *a, **k: next(procs)), \
+             patch("subprocess.run", run_mock), \
+             patch("sys.stdout", new_callable=StringIO) as out:
+            code = doctor.run_doctor(json_output=True)
+
+        assert code == 0
+        parsed = json.loads(out.getvalue())
+        assert parsed["schema_version"] == "1"
+        assert parsed["overall"] == "ok"
+        assert parsed.get("fallback") is True
+        names = [c["name"] for c in parsed["checks"]]
+        assert "binary_version" in names
+        assert "tcc_accessibility" in names
+        assert "tcc_screen_recording" in names
+        assert "ax_capability" in names
+        assert "health_report_path" in names
+        # Must not be the raw denial payload
+        assert "exit_code" not in parsed
+
+    def test_structuredContent_exit_code_only_triggers_fallback(self):
+        """Even without isError, bare {exit_code:1} is not a valid report."""
+        from tools.computer_use import doctor
+
+        # Some gateways might drop isError but still ship exit_code-only SC.
+        health_proc = _fake_proc_with_responses(
+            {"jsonrpc": "2.0", "id": 1, "result": {}},
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "result": {
+                    "isError": False,
+                    "structuredContent": {"exit_code": 1},
+                    "content": [{"type": "text", "text": "Permission denied"}],
+                },
+            },
+        )
+        probe_proc = _fake_proc_with_responses(
+            {"jsonrpc": "2.0", "id": 1, "result": {"serverInfo": {"version": "0.10.0"}}},
+            {"jsonrpc": "2.0", "id": 2, "result": _perms_ok_result()},
+            {"jsonrpc": "2.0", "id": 3, "result": _list_apps_ok_result()},
+        )
+        procs = iter([health_proc, probe_proc])
+        run_mock = MagicMock(
+            return_value=MagicMock(returncode=0, stdout="cua-driver 0.10.0\n", stderr=""),
+        )
+
+        with patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("subprocess.Popen", side_effect=lambda *a, **k: next(procs)), \
+             patch("subprocess.run", run_mock), \
+             patch("sys.stdout", new_callable=StringIO) as out:
+            code = doctor.run_doctor(json_output=True)
+
+        assert code == 0
+        parsed = json.loads(out.getvalue())
+        assert parsed["schema_version"] == "1"
+        assert parsed.get("fallback") is True
+
+    def test_real_schema_version_1_preferred_over_fallback(self):
+        """When health_report returns a real schema_version=1 payload, use it
+        and never call the composite fallback path."""
+        from tools.computer_use import doctor
+
+        proc = _fake_proc_with_responses(
+            {"jsonrpc": "2.0", "id": 1, "result": {}},
+            {"jsonrpc": "2.0", "id": 2, "result": {"structuredContent": _ok_report()}},
+        )
+        with patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("subprocess.Popen", return_value=proc), \
+             patch.object(doctor, "_compose_fallback_report") as fallback_mock, \
+             patch("sys.stdout", new_callable=StringIO) as out:
+            code = doctor.run_doctor(json_output=True)
+
+        assert code == 0
+        fallback_mock.assert_not_called()
+        parsed = json.loads(out.getvalue())
+        assert parsed == _ok_report()
+        assert "fallback" not in parsed
+
+    def test_extract_raises_health_report_unavailable_on_isError(self):
+        from tools.computer_use import doctor
+
+        with __import__("pytest").raises(doctor.HealthReportUnavailable) as ei:
+            doctor._extract_health_report_from_result(_unclassified_health_result())
+        assert "Permission denied" in str(ei.value) or "unclassified" in str(ei.value).lower() or "risk" in str(ei.value).lower()
+
+    def test_fallback_degraded_when_accessibility_denied(self):
+        from tools.computer_use import doctor
+
+        health_proc = _fake_proc_with_responses(
+            {"jsonrpc": "2.0", "id": 1, "result": {"serverInfo": {"version": "0.10.0"}}},
+            {"jsonrpc": "2.0", "id": 2, "result": _unclassified_health_result()},
+        )
+        denied_perms = {
+            "isError": False,
+            "structuredContent": {
+                "accessibility": False,
+                "screen_recording": False,
+            },
+        }
+        probe_proc = _fake_proc_with_responses(
+            {"jsonrpc": "2.0", "id": 1, "result": {"serverInfo": {"version": "0.10.0"}}},
+            {"jsonrpc": "2.0", "id": 2, "result": denied_perms},
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "result": {"isError": True, "content": [{"type": "text", "text": "no ax"}]},
+            },
+        )
+        procs = iter([health_proc, probe_proc])
+        run_mock = MagicMock(
+            return_value=MagicMock(returncode=0, stdout="cua-driver 0.10.0\n", stderr=""),
+        )
+
+        with patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("subprocess.Popen", side_effect=lambda *a, **k: next(procs)), \
+             patch("subprocess.run", run_mock), \
+             patch("sys.stdout", new_callable=StringIO) as out:
+            code = doctor.run_doctor(json_output=True)
+
+        assert code == 1
+        parsed = json.loads(out.getvalue())
+        assert parsed["overall"] == "degraded"
+        assert parsed.get("fallback") is True

--- a/tests/computer_use/test_doctor.py
+++ b/tests/computer_use/test_doctor.py
@@ -79,6 +79,24 @@ def _degraded_report() -> dict:
     }
 
 
+
+
+@pytest.fixture(autouse=True)
+def _default_cli_version_matches_report(monkeypatch):
+    """Existing tests mock only the MCP Popen handshake. ``subprocess.run``
+    (used for ``--version``) goes through Popen too, so without this the
+    mock breaks version probing. Default to a CLI version that matches
+    ``_ok_report`` / ``_degraded_report`` (0.5.8); identity tests override.
+    """
+    from tools.computer_use import doctor
+
+    monkeypatch.setattr(
+        doctor,
+        "_read_cli_version",
+        lambda binary, timeout=5.0: "cua-driver 0.5.8",
+    )
+
+
 # ── exit codes ─────────────────────────────────────────────────────────────
 
 
@@ -286,11 +304,14 @@ class TestJsonOutput:
              patch("subprocess.Popen", return_value=proc), \
              patch("sys.stdout", new_callable=StringIO) as out:
             doctor.run_doctor(json_output=True)
-        # Verify the captured text round-trips through json.loads and matches
-        # the input report (the contract: --json passes the structured payload
-        # through unchanged so downstream tooling can consume it directly).
+        # Verify the captured text round-trips through json.loads. Upstream
+        # health_report keys are preserved; Hermes adds hermes_identity.
         parsed = json.loads(out.getvalue())
-        assert parsed == _ok_report()
+        report = _ok_report()
+        for key, value in report.items():
+            assert parsed[key] == value
+        assert "hermes_identity" in parsed
+        assert parsed["hermes_identity"]["resolved_binary"]
 
 
 # ── HERMES_CUA_DRIVER_CMD resolution ───────────────────────────────────────
@@ -533,7 +554,11 @@ class TestHealthReportFallback:
         assert code == 0
         fallback_mock.assert_not_called()
         parsed = json.loads(out.getvalue())
-        assert parsed == _ok_report()
+        # Upstream health_report keys pass through unchanged; Hermes adds
+        # only the additive hermes_identity envelope.
+        for key, value in _ok_report().items():
+            assert parsed[key] == value
+        assert "hermes_identity" in parsed
         assert "fallback" not in parsed
 
     def test_extract_raises_health_report_unavailable_on_isError(self):
@@ -581,3 +606,68 @@ class TestHealthReportFallback:
         parsed = json.loads(out.getvalue())
         assert parsed["overall"] == "degraded"
         assert parsed.get("fallback") is True
+
+
+# ── binary identity (CLI --version vs health_report) ───────────────────────
+
+
+class TestDoctorVersionIdentity:
+    def test_header_prefers_cli_version_on_mismatch(self):
+        """Windows has been observed reporting 0.8.3 via health_report while
+        the resolved binary is 0.12.6 — doctor must surface the real version."""
+        from tools.computer_use import doctor
+
+        proc = _fake_proc_with_responses(
+            {"jsonrpc": "2.0", "id": 1, "result": {}},
+            {"jsonrpc": "2.0", "id": 2, "result": {"structuredContent": _ok_report()}},
+        )
+        # _ok_report claims 0.5.8; CLI says 0.12.6
+        with patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("subprocess.Popen", return_value=proc), \
+             patch.object(doctor, "_read_cli_version", return_value="cua-driver 0.12.6"), \
+             patch("sys.stdout", new_callable=StringIO) as out:
+            code = doctor.run_doctor()
+        assert code == 0
+        text = out.getvalue()
+        assert "0.12.6" in text
+        assert "version mismatch" in text.lower()
+        assert "0.5.8" in text  # health_report value still shown
+
+    def test_json_includes_hermes_identity(self):
+        from tools.computer_use import doctor
+
+        proc = _fake_proc_with_responses(
+            {"jsonrpc": "2.0", "id": 1, "result": {}},
+            {"jsonrpc": "2.0", "id": 2, "result": {"structuredContent": _ok_report()}},
+        )
+        with patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("subprocess.Popen", return_value=proc), \
+             patch.object(doctor, "_read_cli_version", return_value="cua-driver 0.12.6"), \
+             patch("sys.stdout", new_callable=StringIO) as out:
+            code = doctor.run_doctor(json_output=True)
+        assert code == 0
+        payload = json.loads(out.getvalue())
+        assert payload["overall"] == "ok"
+        assert "hermes_identity" in payload
+        ident = payload["hermes_identity"]
+        assert ident["version_mismatch"] is True
+        assert "0.12.6" in (ident.get("cli_version") or "")
+        assert ident.get("health_report_driver_version") == "0.5.8"
+        assert ident.get("resolved_binary")
+
+    def test_matching_versions_no_mismatch_flag(self):
+        from tools.computer_use import doctor
+
+        proc = _fake_proc_with_responses(
+            {"jsonrpc": "2.0", "id": 1, "result": {}},
+            {"jsonrpc": "2.0", "id": 2, "result": {"structuredContent": _ok_report()}},
+        )
+        with patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("subprocess.Popen", return_value=proc), \
+             patch.object(doctor, "_read_cli_version", return_value="cua-driver 0.5.8"), \
+             patch("sys.stdout", new_callable=StringIO) as out:
+            code = doctor.run_doctor(json_output=True)
+        assert code == 0
+        payload = json.loads(out.getvalue())
+        assert payload["hermes_identity"]["version_mismatch"] is False
+

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -394,9 +394,35 @@ class TestSafetyGuards:
         assert "error" in parsed
         assert "blocked key combo" in parsed["error"]
 
+    @pytest.mark.parametrize("keys", [
+        "ctrl-alt-delete",          # hyphen notation (alt -> option)
+        "alt-f4",                   # force-quit window
+        "cmd-shift-q",              # log out, hyphenated
+        "cmd+shift-backspace",      # mixed + and - separators
+    ])
+    def test_blocked_key_combos_hyphen_notation(self, keys, noop_backend):
+        # The cua-driver backend splits key strings on both '+' and '-'
+        # (cua_backend._parse_key_combo), so "ctrl-alt-delete" executes as the
+        # real destructive combo. The block must canonicalize the same way or
+        # it is trivially bypassed with hyphen notation.
+        from tools.computer_use.tool import handle_computer_use
+        out = handle_computer_use({"action": "key", "keys": keys})
+        parsed = json.loads(out)
+        assert "error" in parsed
+        assert "blocked key combo" in parsed["error"]
+
     def test_safe_key_combos_pass(self, noop_backend):
         from tools.computer_use.tool import handle_computer_use
         out = handle_computer_use({"action": "key", "keys": "cmd+s"})
+        parsed = json.loads(out)
+        assert "error" not in parsed
+
+    @pytest.mark.parametrize("keys", ["cmd-c", "ctrl-c", "cmd+-"])
+    def test_safe_hyphen_key_combos_pass(self, keys, noop_backend):
+        # Non-destructive combos written with hyphens (and the literal '-'
+        # zoom key) must not be caught by the widened separator.
+        from tools.computer_use.tool import handle_computer_use
+        out = handle_computer_use({"action": "key", "keys": keys})
         parsed = json.loads(out)
         assert "error" not in parsed
 

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -98,6 +98,57 @@ def _is_valid_health_report(payload: Any) -> bool:
     return True
 
 
+def _read_cli_version(binary: str, *, timeout: float = 5.0) -> Optional[str]:
+    """Return ``cua-driver --version`` stdout (stripped), or None on failure.
+
+    health_report's ``driver_version`` / binary_version check can disagree
+    with the actual binary (observed on Windows: health_report claims
+    0.8.3 while ``--version`` and the on-disk release are 0.12.6). Doctor
+    surfaces both so operators are not misled when debugging session
+    issues against a "wrong" version string.
+    """
+    try:
+        completed = subprocess.run(
+            [binary, "--version"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            env=_sanitized_cua_env(),
+        )
+    except (OSError, subprocess.TimeoutExpired, ValueError, TypeError):
+        return None
+    text = (completed.stdout or completed.stderr or "").strip()
+    if not text:
+        return None
+    # First non-empty line only — keep the banner compact.
+    return text.splitlines()[0].strip()
+
+
+def _normalize_version_token(text: str) -> str:
+    """Pull a dotted version-ish token out of a free-form version string."""
+    if not text:
+        return ""
+    m = re.search(r"(\d+\.\d+(?:\.\d+)?(?:[-+][\w.]+)?)", text)
+    return m.group(1) if m else text.strip().lower()
+
+
+def _build_identity(binary: str, report: Dict[str, Any]) -> Dict[str, Any]:
+    """Hermes-side identity block comparing resolved binary vs health_report."""
+    cli = _read_cli_version(binary) or ""
+    report_v = str(report.get("driver_version") or "")
+    cli_tok = _normalize_version_token(cli)
+    report_tok = _normalize_version_token(report_v)
+    mismatch = bool(cli_tok and report_tok and cli_tok != report_tok)
+    return {
+        "resolved_binary": binary,
+        "cli_version": cli or None,
+        "health_report_driver_version": report_v or None,
+        "version_mismatch": mismatch,
+    }
+
+
 def _extract_health_report_from_result(result: Dict[str, Any]) -> Dict[str, Any]:
     """Pull a schema_version=1 report out of an MCP tools/call result.
 
@@ -649,13 +700,28 @@ def _drive_health_report_or_fallback(
         )
 
 
-def _print_text_report(report: Dict[str, Any], color: bool) -> None:
+def _print_text_report(
+    report: Dict[str, Any],
+    color: bool,
+    *,
+    identity: Optional[Dict[str, Any]] = None,
+) -> None:
     """Render the report in the same style as `cua-driver call health_report`
-    would (one line per check + a summary footer)."""
+    would (one line per check + a summary footer).
+
+    When *identity* is provided (resolved binary + ``--version``), the header
+    prefers the CLI version if health_report's ``driver_version`` disagrees,
+    and a short identity block is printed under the header.
+    """
     schema = report.get("schema_version", "?")
     platform = report.get("platform", "?")
-    driver_v = report.get("driver_version", "?")
+    report_v = report.get("driver_version", "?")
     overall = report.get("overall", "?")
+    identity = identity or {}
+    cli_v = identity.get("cli_version") or ""
+    mismatch = bool(identity.get("version_mismatch"))
+    # Prefer the binary's own --version when health_report is wrong/stale.
+    header_v = cli_v or report_v
 
     header_glyph = _OVERALL_GLYPH.get(overall, "•")
 
@@ -673,9 +739,32 @@ def _print_text_report(report: Dict[str, Any], color: bool) -> None:
         col_for = ""
 
     print(
-        f"{header_glyph} cua-driver {driver_v} on {platform} — "
+        f"{header_glyph} cua-driver {header_v} on {platform} — "
         f"{col_for}{overall}{col_reset}"
     )
+    if identity.get("resolved_binary"):
+        print(f"  {col_dim}binary: {identity['resolved_binary']}{col_reset}")
+    if cli_v and report_v and str(report_v) not in str(cli_v) and str(cli_v) not in str(report_v):
+        # Only annotate when the free-form strings clearly differ.
+        print(
+            f"  {col_dim}--version: {cli_v}{col_reset}"
+        )
+        print(
+            f"  {col_dim}health_report.driver_version: {report_v}{col_reset}"
+        )
+    elif cli_v and not mismatch:
+        # Still show the resolved path; version already matches header.
+        pass
+    if mismatch:
+        warn = col_yellow if color else ""
+        print(
+            f"  {warn}⚠️ version mismatch: health_report says {report_v!r} "
+            f"but binary --version is {cli_v!r}{col_reset}"
+        )
+        print(
+            f"  {col_dim}→ trust --version / packages/current for debugging; "
+            f"health_report's binary_version check can lag on Windows{col_reset}"
+        )
 
     for check in report.get("checks", []):
         name = check.get("name", "?")
@@ -749,13 +838,20 @@ def run_doctor(
         print(f"cua-driver health_report failed: {e}", file=sys.stderr)
         return 2
 
+    identity = _build_identity(binary, report)
+
     if json_output:
-        json.dump(report, sys.stdout, indent=2, sort_keys=True)
+        # Additive envelope: preserve the upstream health_report keys and
+        # attach Hermes identity under hermes_identity so existing parsers
+        # that only read overall/checks keep working.
+        payload = dict(report)
+        payload["hermes_identity"] = identity
+        json.dump(payload, sys.stdout, indent=2, sort_keys=True)
         sys.stdout.write("\n")
     else:
         if color is None:
             color = sys.stdout.isatty()
-        _print_text_report(report, color=bool(color))
+        _print_text_report(report, color=bool(color), identity=identity)
 
     overall = report.get("overall")
     if overall in ("degraded", "failed"):

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -7,6 +7,12 @@ renders the structured response. When the driver gets new checks, they
 flow through here without code changes on the Hermes side — the only
 contract is the stable `schema_version="1"` payload shape.
 
+cua-driver 0.10.x marks `health_report` with risk.class='unclassified', so
+MCP tools/call returns isError=true ("Permission denied: ... no reviewed
+risk classification") with structuredContent ``{"exit_code": 1}``. That is
+NOT a schema_version=1 report — we detect it and synthesize a composite
+report via working probes (check_permissions, list_apps, CLI --version).
+
 Exit code conventions:
 - 0: overall == "ok"
 - 1: overall in ("degraded", "failed")
@@ -17,9 +23,12 @@ from __future__ import annotations
 
 import json
 import os
+import platform as _platform_mod
+import re
+import shutil
 import subprocess
 import sys
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 
 # Match the ALLOWED_STATUS_VALUES + ALLOWED_OVERALL_VALUES the cua-driver
@@ -34,6 +43,14 @@ _OVERALL_GLYPH = {
     "degraded": "⚠️",
     "failed":   "❌",
 }
+
+
+class HealthReportUnavailable(RuntimeError):
+    """health_report MCP tool denied or returned a non-schema payload.
+
+    Raised so ``run_doctor`` can fall back to composite probes that work on
+    cua-driver builds where ``health_report`` is risk-unclassified (0.10.x).
+    """
 
 
 def _cua_child_env() -> Dict[str, str]:
@@ -68,33 +85,77 @@ def _sanitized_cua_env() -> Dict[str, str]:
         return env
 
 
-def _drive_health_report(
-    binary: str,
-    *,
-    include: Sequence[str] = (),
-    skip: Sequence[str] = (),
-    timeout: float = 12.0,
-) -> Dict[str, Any]:
-    """Spawn `<binary> mcp`, perform the JSON-RPC handshake, call
-    `health_report`, and return the parsed `structuredContent` dict.
+def _is_valid_health_report(payload: Any) -> bool:
+    """True when *payload* looks like a schema_version=1 health_report."""
+    if not isinstance(payload, dict):
+        return False
+    if "schema_version" not in payload:
+        return False
+    if "overall" not in payload:
+        return False
+    if not isinstance(payload.get("checks"), list):
+        return False
+    return True
 
-    Raises `RuntimeError` on a protocol-level failure (binary crash,
-    malformed response, JSON-RPC error). Never raises on a `health_report`
-    that has failing checks — the tool's contract is to always return a
-    well-formed report with `overall` set, never to set `isError`.
+
+def _extract_health_report_from_result(result: Dict[str, Any]) -> Dict[str, Any]:
+    """Pull a schema_version=1 report out of an MCP tools/call result.
+
+    Raises ``HealthReportUnavailable`` when the tool denied the call
+    (isError) or the payload is not a real health report (e.g. 0.10's
+    ``{"exit_code": 1}`` structuredContent on unclassified denial).
+    Raises ``RuntimeError`` when the response shape is unusable for other
+    reasons (no content at all).
     """
-    args: Dict[str, Any] = {}
-    if include:
-        args["include"] = list(include)
-    if skip:
-        args["skip"] = list(skip)
+    if result.get("isError") is True:
+        # Prefer the human text; fall back to a generic denial message.
+        denial = "health_report returned isError=true"
+        for item in result.get("content") or []:
+            if isinstance(item, dict) and item.get("type") == "text":
+                text = (item.get("text") or "").strip()
+                if text:
+                    denial = text
+                    break
+        raise HealthReportUnavailable(denial)
 
+    sc = result.get("structuredContent")
+    if _is_valid_health_report(sc):
+        return sc  # type: ignore[return-value]
+
+    # Older builds: JSON text block with schema_version.
+    for item in result.get("content") or []:
+        if not isinstance(item, dict) or item.get("type") != "text":
+            continue
+        text = item.get("text", "")
+        try:
+            parsed = json.loads(text)
+        except (ValueError, TypeError):
+            continue
+        if _is_valid_health_report(parsed):
+            return parsed
+
+    # structuredContent present but not a real report (the 0.10 unclassified
+    # path ships {"exit_code": 1}) — treat as unavailable, not fatal protocol.
+    if isinstance(sc, dict):
+        raise HealthReportUnavailable(
+            "health_report structuredContent lacks schema_version/overall/checks "
+            f"(keys={sorted(sc.keys())})"
+        )
+
+    raise RuntimeError(
+        "health_report response carried neither structuredContent nor a parseable "
+        f"JSON text block. Result keys: {list(result.keys())}"
+    )
+
+
+def _open_mcp(binary: str) -> subprocess.Popen:
+    """Spawn ``<binary> mcp`` with UTF-8 + sanitized env."""
     # cua-driver emits UTF-8 (containing emoji in check messages on macOS
     # and arbitrary file paths on Windows). The Python default
     # text-mode encoding follows the system locale — `cp1252` on a
     # default Windows install — which raises UnicodeDecodeError on the
     # first non-ASCII byte. Pin the codec.
-    proc = subprocess.Popen(
+    return subprocess.Popen(
         [binary, "mcp"],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
@@ -105,74 +166,487 @@ def _drive_health_report(
         bufsize=1,
         env=_sanitized_cua_env(),
     )
+
+
+def _mcp_rpc(proc: subprocess.Popen, msg_id: int, method: str, params: Any = None) -> Dict[str, Any]:
+    """Write one JSON-RPC request and read one response line."""
+    assert proc.stdin is not None and proc.stdout is not None
+    payload: Dict[str, Any] = {"jsonrpc": "2.0", "id": msg_id, "method": method}
+    if params is not None:
+        payload["params"] = params
+    proc.stdin.write(json.dumps(payload) + "\n")
+    proc.stdin.flush()
+    line = proc.stdout.readline()
+    if not line:
+        stderr_tail: List[str] = []
+        if proc.stderr is not None:
+            try:
+                raw_err = proc.stderr.read() or ""
+                stderr_tail = [str(x) for x in raw_err.strip().splitlines()[-3:]]
+            except Exception:
+                pass
+        raise RuntimeError(
+            f"cua-driver mcp produced no response for {method!r}. "
+            f"stderr tail: {stderr_tail or '(empty)'}"
+        )
+    try:
+        resp = json.loads(line)
+    except (ValueError, TypeError) as e:
+        raise RuntimeError(f"{method} response was not valid JSON: {e}\nraw: {line[:200]}")
+    if "error" in resp:
+        raise RuntimeError(f"{method} JSON-RPC error: {resp['error']}")
+    return resp
+
+
+def _close_mcp(proc: subprocess.Popen, timeout: float) -> None:
+    try:
+        if proc.stdin is not None:
+            proc.stdin.close()
+    except Exception:
+        pass
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _drive_health_report(
+    binary: str,
+    *,
+    include: Sequence[str] = (),
+    skip: Sequence[str] = (),
+    timeout: float = 12.0,
+) -> Dict[str, Any]:
+    """Spawn `<binary> mcp`, perform the JSON-RPC handshake, call
+    `health_report`, and return the parsed schema_version=1 report.
+
+    Raises:
+      HealthReportUnavailable: tool denied (isError) or non-schema payload
+        (cua-driver 0.10 unclassified). Caller should fall back.
+      RuntimeError: protocol-level failure (binary crash, malformed JSON,
+        JSON-RPC error, empty content).
+    """
+    args: Dict[str, Any] = {}
+    if include:
+        args["include"] = list(include)
+    if skip:
+        args["skip"] = list(skip)
+
+    proc = _open_mcp(binary)
     try:
         # 1. initialize
-        proc.stdin.write(json.dumps({
-            "jsonrpc": "2.0", "id": 1,
-            "method": "initialize", "params": {},
-        }) + "\n")
-        proc.stdin.flush()
-        init_line = proc.stdout.readline()
-        if not init_line:
-            stderr_tail = (proc.stderr.read() or "").strip().splitlines()[-3:]
-            raise RuntimeError(
-                f"cua-driver mcp produced no initialize response. "
-                f"stderr tail: {stderr_tail or '(empty)'}"
-            )
+        init_resp = _mcp_rpc(proc, 1, "initialize", {})
+        _ = init_resp  # handshake only
 
         # 2. tools/call health_report
-        proc.stdin.write(json.dumps({
-            "jsonrpc": "2.0", "id": 2,
-            "method": "tools/call",
-            "params": {"name": "health_report", "arguments": args},
-        }) + "\n")
-        proc.stdin.flush()
-        call_line = proc.stdout.readline()
-        if not call_line:
-            raise RuntimeError("cua-driver mcp closed stdout without responding to health_report.")
+        call_resp = _mcp_rpc(
+            proc,
+            2,
+            "tools/call",
+            {"name": "health_report", "arguments": args},
+        )
     finally:
-        try:
-            proc.stdin.close()
-        except Exception:
-            pass
-        try:
-            proc.wait(timeout=timeout)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait()
+        _close_mcp(proc, timeout)
 
+    result = call_resp.get("result") or {}
+    if not isinstance(result, dict):
+        raise RuntimeError(f"health_report result was not an object: {type(result).__name__}")
+    return _extract_health_report_from_result(result)
+
+
+def _cli_driver_version(binary: str, timeout: float = 5.0) -> Tuple[str, Optional[str]]:
+    """Return (status, version_or_message) from ``cua-driver --version``."""
     try:
-        resp = json.loads(call_line)
-    except (ValueError, TypeError) as e:
-        raise RuntimeError(f"health_report response was not valid JSON: {e}\nraw: {call_line[:200]}")
+        completed = subprocess.run(
+            [binary, "--version"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            env=_sanitized_cua_env(),
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        return "fail", f"--version failed: {e}"
 
-    if "error" in resp:
-        raise RuntimeError(f"health_report JSON-RPC error: {resp['error']}")
+    text = ((completed.stdout or "") + (completed.stderr or "")).strip()
+    if completed.returncode != 0 and not text:
+        return "fail", f"--version exited {completed.returncode}"
 
-    result = resp.get("result") or {}
+    # Typical: "cua-driver 0.10.0"
+    m = re.search(r"(\d+\.\d+\.\d+(?:[-+][\w.]+)?)", text)
+    version = m.group(1) if m else (text.splitlines()[0] if text else "unknown")
+    if completed.returncode != 0:
+        return "fail", version
+    return "pass", version
 
-    # Preferred: structuredContent (cua-driver-rs always emits it on the
-    # health_report response). Fall back to parsing the first text item
-    # as JSON for older cua-driver builds that didn't carry structuredContent.
-    sc = result.get("structuredContent")
-    if isinstance(sc, dict):
-        return sc
 
-    for item in result.get("content", []):
-        if item.get("type") == "text":
-            text = item.get("text", "")
-            try:
-                # Many health_report payloads ship JSON in the text item too.
-                parsed = json.loads(text)
-                if isinstance(parsed, dict) and "schema_version" in parsed:
-                    return parsed
-            except (ValueError, TypeError):
-                pass
+def _cli_doctor_snippet(binary: str, timeout: float = 8.0) -> Optional[str]:
+    """Optional one-shot ``cua-driver doctor`` text (best-effort, never fatal)."""
+    try:
+        completed = subprocess.run(
+            [binary, "doctor"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            env=_sanitized_cua_env(),
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    out = ((completed.stdout or "") + (completed.stderr or "")).strip()
+    return out or None
 
-    raise RuntimeError(
-        "health_report response carried neither structuredContent nor a parseable "
-        f"JSON text block. Result keys: {list(result.keys())}"
-    )
+
+def _drive_fallback_probes(
+    binary: str,
+    *,
+    timeout: float = 12.0,
+) -> Dict[str, Any]:
+    """Call working MCP tools (check_permissions, list_apps) in one session.
+
+    Returns a dict with keys:
+      - init_version: str | None (from initialize serverInfo)
+      - permissions: structuredContent dict | None
+      - permissions_error: str | None
+      - list_apps_ok: bool | None
+      - list_apps_error: str | None
+      - list_apps_count: int | None
+    """
+    out: Dict[str, Any] = {
+        "init_version": None,
+        "permissions": None,
+        "permissions_error": None,
+        "list_apps_ok": None,
+        "list_apps_error": None,
+        "list_apps_count": None,
+    }
+    proc = _open_mcp(binary)
+    try:
+        init_resp = _mcp_rpc(proc, 1, "initialize", {})
+        server_info = ((init_resp.get("result") or {}).get("serverInfo") or {})
+        if isinstance(server_info, dict):
+            out["init_version"] = server_info.get("version")
+
+        # check_permissions — primary TCC signal on 0.10
+        try:
+            perm_resp = _mcp_rpc(
+                proc, 2, "tools/call", {"name": "check_permissions", "arguments": {}}
+            )
+            perm_result = perm_resp.get("result") or {}
+            if perm_result.get("isError") is True:
+                msg = "check_permissions isError"
+                for item in perm_result.get("content") or []:
+                    if isinstance(item, dict) and item.get("type") == "text":
+                        t = (item.get("text") or "").strip()
+                        if t:
+                            msg = t
+                            break
+                out["permissions_error"] = msg
+            else:
+                sc = perm_result.get("structuredContent")
+                out["permissions"] = sc if isinstance(sc, dict) else {}
+        except RuntimeError as e:
+            out["permissions_error"] = str(e)
+
+        # list_apps — light AX capability probe
+        try:
+            apps_resp = _mcp_rpc(
+                proc, 3, "tools/call", {"name": "list_apps", "arguments": {}}
+            )
+            apps_result = apps_resp.get("result") or {}
+            if apps_result.get("isError") is True:
+                msg = "list_apps isError"
+                for item in apps_result.get("content") or []:
+                    if isinstance(item, dict) and item.get("type") == "text":
+                        t = (item.get("text") or "").strip()
+                        if t:
+                            msg = t
+                            break
+                out["list_apps_ok"] = False
+                out["list_apps_error"] = msg
+            else:
+                sc = apps_result.get("structuredContent") or {}
+                apps = sc.get("apps") if isinstance(sc, dict) else None
+                if isinstance(apps, list):
+                    out["list_apps_ok"] = True
+                    out["list_apps_count"] = len(apps)
+                else:
+                    # text-only success still counts as AX working
+                    out["list_apps_ok"] = True
+                    out["list_apps_count"] = None
+        except RuntimeError as e:
+            out["list_apps_ok"] = False
+            out["list_apps_error"] = str(e)
+    finally:
+        _close_mcp(proc, timeout)
+
+    return out
+
+
+def _platform_name() -> str:
+    sysname = (_platform_mod.system() or "").lower()
+    if sysname == "darwin":
+        return "darwin"
+    if sysname == "windows":
+        return "windows"
+    if sysname == "linux":
+        return "linux"
+    return sysname or "unknown"
+
+
+def _compose_fallback_report(
+    binary: str,
+    *,
+    reason: str = "",
+    timeout: float = 12.0,
+) -> Dict[str, Any]:
+    """Build a schema_version=1 report from CLI + working MCP probes.
+
+    Used when ``health_report`` is denied (unclassified risk on 0.10) or
+    returns a non-schema payload. Compatible with ``_print_text_report``.
+    """
+    plat = _platform_name()
+    checks: List[Dict[str, Any]] = []
+
+    ver_status, ver_value = _cli_driver_version(binary)
+    driver_version = ver_value if ver_status == "pass" else (ver_value or "?")
+    # Prefer MCP initialize version when CLI parse is messy
+    probes = _drive_fallback_probes(binary, timeout=timeout)
+    if probes.get("init_version"):
+        driver_version = str(probes["init_version"])
+        ver_status = "pass"
+        ver_msg = f"cua-driver {driver_version}"
+    else:
+        ver_msg = (
+            f"cua-driver {ver_value}" if ver_status == "pass" else (ver_value or "version unknown")
+        )
+
+    checks.append({
+        "name": "binary_version",
+        "status": ver_status,
+        "message": ver_msg,
+    })
+
+    # platform_supported — doctor runs wherever the binary runs
+    supported = plat in ("darwin", "linux", "windows")
+    checks.append({
+        "name": "platform_supported",
+        "status": "pass" if supported else "fail",
+        "message": f"platform={plat}" + ("" if supported else " (unsupported)"),
+    })
+
+    # session_active — we don't start a session in doctor; mark skip
+    checks.append({
+        "name": "session_active",
+        "status": "skip",
+        "message": "not probed (doctor does not open a cua session)",
+    })
+
+    perms = probes.get("permissions") if isinstance(probes.get("permissions"), dict) else None
+    perm_err = probes.get("permissions_error")
+
+    if perms is not None:
+        ax = perms.get("accessibility")
+        scr = perms.get("screen_recording")
+        capturable = perms.get("screen_recording_capturable")
+
+        if ax is True:
+            checks.append({
+                "name": "tcc_accessibility",
+                "status": "pass",
+                "message": "Accessibility is granted.",
+                "data": {"accessibility": True},
+            })
+        elif ax is False:
+            checks.append({
+                "name": "tcc_accessibility",
+                "status": "fail",
+                "message": "Accessibility is not granted.",
+                "hint": "Grant Accessibility to CuaDriver in System Settings → Privacy & Security.",
+                "data": {"accessibility": False},
+            })
+        else:
+            checks.append({
+                "name": "tcc_accessibility",
+                "status": "skip",
+                "message": "accessibility field absent from check_permissions",
+            })
+
+        if scr is True and capturable is False:
+            checks.append({
+                "name": "tcc_screen_recording",
+                "status": "fail",
+                "message": "Screen Recording granted but not capturable.",
+                "hint": (
+                    "Screen Recording permission may need a restart of CuaDriver "
+                    "or a re-grant in System Settings."
+                ),
+                "data": {
+                    "screen_recording": True,
+                    "screen_recording_capturable": False,
+                },
+            })
+        elif scr is True:
+            checks.append({
+                "name": "tcc_screen_recording",
+                "status": "pass",
+                "message": "Screen Recording is granted.",
+                "data": {
+                    "screen_recording": True,
+                    "screen_recording_capturable": capturable,
+                },
+            })
+        elif scr is False:
+            checks.append({
+                "name": "tcc_screen_recording",
+                "status": "fail",
+                "message": "Screen Recording is not granted.",
+                "hint": "Grant Screen Recording to CuaDriver in System Settings → Privacy & Security.",
+                "data": {"screen_recording": False},
+            })
+        else:
+            # Non-macOS or field absent
+            if plat == "darwin":
+                checks.append({
+                    "name": "tcc_screen_recording",
+                    "status": "skip",
+                    "message": "screen_recording field absent from check_permissions",
+                })
+            else:
+                checks.append({
+                    "name": "tcc_screen_recording",
+                    "status": "skip",
+                    "message": f"not applicable on {plat}",
+                })
+    else:
+        checks.append({
+            "name": "tcc_accessibility",
+            "status": "fail" if perm_err else "skip",
+            "message": perm_err or "check_permissions unavailable",
+        })
+        checks.append({
+            "name": "tcc_screen_recording",
+            "status": "fail" if perm_err else "skip",
+            "message": perm_err or "check_permissions unavailable",
+        })
+
+    # ax_capability — infer from list_apps success or accessibility grant
+    list_ok = probes.get("list_apps_ok")
+    list_err = probes.get("list_apps_error")
+    list_count = probes.get("list_apps_count")
+    ax_granted = bool(perms and perms.get("accessibility") is True)
+    if list_ok is True:
+        count_msg = f" ({list_count} apps)" if isinstance(list_count, int) else ""
+        checks.append({
+            "name": "ax_capability",
+            "status": "pass",
+            "message": f"list_apps succeeded{count_msg}",
+        })
+    elif list_ok is False:
+        checks.append({
+            "name": "ax_capability",
+            "status": "fail",
+            "message": (
+                list_err
+                or (
+                    "list_apps failed despite accessibility grant"
+                    if ax_granted
+                    else "list_apps failed"
+                )
+            ),
+        })
+    elif ax_granted:
+        checks.append({
+            "name": "ax_capability",
+            "status": "pass",
+            "message": "inferred from accessibility grant (list_apps not probed)",
+        })
+    else:
+        checks.append({
+            "name": "ax_capability",
+            "status": "skip",
+            "message": "not probed",
+        })
+
+    # Annotate that we used the fallback path
+    reason_short = (reason or "health_report unavailable").strip()
+    if len(reason_short) > 160:
+        reason_short = reason_short[:157] + "..."
+    checks.append({
+        "name": "health_report_path",
+        "status": "skip",
+        "message": (
+            "fallback composite (cua-driver 0.10 unclassified health_report); "
+            f"cause: {reason_short}"
+        ),
+    })
+
+    # Optional CLI doctor text (best-effort)
+    doctor_txt = _cli_doctor_snippet(binary)
+    if doctor_txt:
+        first = doctor_txt.splitlines()[0].strip()
+        cli_ok = "[ok" in doctor_txt.lower() or "ok  ]" in doctor_txt
+        checks.append({
+            "name": "cli_doctor",
+            "status": "pass" if cli_ok else "skip",
+            "message": first,
+            "data": {"snippet": doctor_txt[:2000]},
+        })
+
+    # Normalize any accidental non-vocab status values
+    for c in checks:
+        if c.get("status") not in ("pass", "fail", "skip"):
+            c["status"] = "fail"
+
+    # overall: ok if TCC+binary ok; degraded if partial; failed if binary missing/bad
+    status_by_name = {c.get("name"): c.get("status") for c in checks}
+    binary_ok = status_by_name.get("binary_version") == "pass"
+    tcc_ax_status = status_by_name.get("tcc_accessibility")
+    tcc_ok = tcc_ax_status in ("pass", "skip", None)
+    fail_count = sum(1 for c in checks if c.get("status") == "fail")
+
+    if not binary_ok:
+        overall = "failed"
+    elif tcc_ok and fail_count == 0:
+        overall = "ok"
+    elif tcc_ok and fail_count > 0:
+        # Binary + accessibility fine, but something else failed (e.g. screen
+        # recording) → degraded rather than failed.
+        overall = "degraded"
+    else:
+        # Accessibility denied or broken — computer-use is partially/fully blocked.
+        overall = "degraded"
+
+    return {
+        "schema_version": "1",
+        "platform": plat,
+        "driver_version": str(driver_version),
+        "overall": overall,
+        "checks": checks,
+        "fallback": True,
+        "fallback_reason": reason or "health_report unavailable",
+    }
+
+
+def _drive_health_report_or_fallback(
+    binary: str,
+    *,
+    include: Sequence[str] = (),
+    skip: Sequence[str] = (),
+    timeout: float = 12.0,
+) -> Dict[str, Any]:
+    """Prefer real health_report; on denial/non-schema, synthesize via probes."""
+    try:
+        return _drive_health_report(
+            binary, include=include, skip=skip, timeout=timeout,
+        )
+    except HealthReportUnavailable as e:
+        return _compose_fallback_report(
+            binary, reason=str(e), timeout=timeout,
+        )
 
 
 def _print_text_report(report: Dict[str, Any], color: bool) -> None:
@@ -241,6 +715,11 @@ def run_doctor(
 
     Honors `HERMES_CUA_DRIVER_CMD` via the shared runtime resolver, so the
     doctor diagnoses what your `computer_use` toolset will actually invoke.
+
+    On cua-driver 0.10.x, ``health_report`` may be risk-unclassified and
+    denied; doctor then synthesizes a schema_version=1 report from
+    check_permissions / list_apps / CLI probes instead of printing
+    ``• cua-driver ? on ? — ?``.
     """
     # Windows ships stdout/stderr wrapped with the system ANSI codec
     # (`cp1252` on a US locale, `cp936` on zh-CN, etc.). The check-matrix
@@ -263,7 +742,9 @@ def run_doctor(
         return 2
 
     try:
-        report = _drive_health_report(binary, include=include, skip=skip)
+        report = _drive_health_report_or_fallback(
+            binary, include=include, skip=skip,
+        )
     except RuntimeError as e:
         print(f"cua-driver health_report failed: {e}", file=sys.stderr)
         return 2
@@ -278,5 +759,8 @@ def run_doctor(
 
     overall = report.get("overall")
     if overall in ("degraded", "failed"):
+        return 1
+    if overall != "ok":
+        # Unknown / missing overall after fallback should not look like success.
         return 1
     return 0

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -110,7 +110,11 @@ _KEY_ALIASES = {
 
 
 def _canon_key_combo(keys: str) -> frozenset:
-    parts = [p.strip().lower() for p in re.split(r"\s*\+\s*", keys) if p.strip()]
+    # Split on both "+" and "-": the cua-driver backend's _parse_key_combo
+    # accepts hyphen-separated combos too, so "ctrl-alt-delete" executes as
+    # the real destructive shortcut. Mirror its separators here, otherwise the
+    # _BLOCKED_KEY_COMBOS gate is trivially bypassed with hyphen notation.
+    parts = [p.strip().lower() for p in re.split(r"\s*[+\-]\s*", keys) if p.strip()]
     parts = [_KEY_ALIASES.get(p, p) for p in parts]
     return frozenset(parts)
 


### PR DESCRIPTION
## Summary

Consolidated salvage of the cua-driver **verdict/targeting/diagnostics** PR cluster. This PR lands the three fixes that are valid against current `main` and do **not** collide with the in-flight cua 0.9/0.10 contract branch (#74166 / `salv-cua-0-9`). Authorship is preserved via cherry-pick; contributor email→login mappings added for all three authors.

### Cluster verdicts

| PR | Author | Verdict |
|----|--------|---------|
| #62915 — block destructive key combos in hyphen notation | @chuenchen309 | ✅ **Salvaged** — premise verified: `_canon_key_combo` split only on `+` while `cua_backend._parse_key_combo` splits on `+` and `-`, so `ctrl-alt-delete` bypassed the hard block. Fix mirrors the backend's separators (guard-alignment, not a new blocklist); tests prove `cmd-c` / `ctrl-c` / `cmd+-` still pass. |
| #68452 — fallback doctor when cua-driver health_report is unclassified | @camaleonidas | ✅ **Salvaged** — cua-driver 0.10.x denies `health_report` (`risk.class=unclassified` → `isError` + `{"exit_code": 1}`); doctor previously printed `• cua-driver ? on ? — ?`. Now detects the denial and synthesizes a `schema_version=1` composite report from `check_permissions` / `list_apps` / CLI `--version`. #74166 does not touch `doctor.py`. |
| #71590 — surface CLI --version when health_report version lies | @monerostar | ✅ **Salvaged** (rebased on top of #68452's refactor) — doctor now compares `cua-driver --version` against `health_report.driver_version`, prefers the CLI version in the header on mismatch (observed on Windows: report says 0.8.3, binary is 0.12.6), and adds an additive `hermes_identity` block to `--json` output. |
| #72233 — preserve action verdict after capture | @cresslank | ⏸ **Defer until #74166 lands** — #74166 rewrites `_maybe_follow_capture` with `_action_payload(res)` + `action_result` embedding, implementing the same verdict-lossless capture_after semantics; cherry-picking now conflicts head-on in `tool.py`. Re-check for residual delta (e.g. the `Action result:` text prefix) after #74166 merges. |
| #68097 — forward drag button and modifiers | @cresslank | ⏸ **Defer until #74166 lands** — fix is valid (drag drops non-default `button`/`modifiers` at the `CuaDriverBackend` boundary), but #74166 rewrites the same `drag()`/dispatch region (`_run_input_action`, per-session backends) and merge-tree shows head-on conflicts in `cua_backend.py` + `tool.py`. Rebase onto post-#74166 main; also widen the pointer-modifier validation to click/scroll per the review notes. |
| #73252 — allow exact Cua targets for input actions | @Minoo7 | ⏸ **Defer until #74166 lands** — adds `pid`/`window_id` exact-target threading through `backend.py`/`cua_backend.py`/`tool.py`/`schema.py`, all regions #74166 restructures (schema changes, `_resolve_input_target` vs `_run_input_action`); merge-tree conflicts in `cua_backend.py`. No per-session approval-state coupling (explicit per-call args, not the gateway session_key namespace), so it is safe to rebase after #74166. |

## Changes

- `tools/computer_use/tool.py` — `_canon_key_combo` splits on `+` **and** `-`, mirroring `cua_backend._parse_key_combo`, so the `_BLOCKED_KEY_COMBOS` gate can't be bypassed with hyphen notation (#62915).
- `tools/computer_use/doctor.py` —
  - `HealthReportUnavailable` + `_extract_health_report_from_result` detect the 0.10.x unclassified denial (`isError`, bare `{"exit_code": 1}`) instead of rendering it as a report; `_drive_health_report_or_fallback` synthesizes a composite `schema_version=1` report from `check_permissions`, `list_apps`, and CLI `--version` probes, flagged `"fallback": true` (#68452).
  - `_read_cli_version` / `_normalize_version_token` / `_build_identity`: header prefers the binary's real `--version` on mismatch with `health_report.driver_version`, prints a `⚠️ version mismatch` note, and `--json` gains an additive `hermes_identity` envelope (existing keys untouched) (#71590).
- `tests/tools/test_computer_use.py` — hyphen/mixed-separator blocked-combo cases + safe hyphen combos (`cmd-c`, `cmd+-`) regression tests.
- `tests/computer_use/test_doctor.py` — fallback-path suite (unclassified denial → composite ok/degraded, JSON schema + `fallback` flag, real report preferred over fallback) and version-identity suite (mismatch header, `hermes_identity` JSON, matching-version no-flag).
- `contributors/emails/` — mappings for chuenchen309, camaleonidas, monerostar.

## Validation

- `HERMES_PYTHON=.venv/bin/python3 scripts/run_tests.sh tests/tools/test_computer_use.py tests/computer_use/test_doctor.py tests/tools/test_computer_use_delivery_ladder.py`
  → `=== Summary: 3 files, 275 tests passed, 0 failed (100% complete) in 62.7s (40 workers) ===`
- Stale-base gate: rebased; `git rev-list --count HEAD..origin/main` = **0**.
- Authorship preserved on all three cherry-picks (`git log` shows original authors).

## Infographic

![salvage infographic](https://v3b.fal.media/files/b/0aa436f2/FWHZU7BleeUDfX88wwxY2_00aogyJO.png)
