### PR TITLE
perf(banner): scope startup update-check fetch to origin/main (6x faster)

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -219,7 +219,15 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     is_shallow = shallow == "true"
 
     try:
-        fetch_args = ["git", "fetch", "origin"]
+        # Scope the fetch to the one branch the behind-count compares against.
+        # An unscoped ``git fetch origin`` transfers every remote head (~1,400
+        # on this repo — measured 3.0 s vs 0.55 s scoped) and can burn the full
+        # 10 s timeout on slow links. ``cmd_update`` already scopes its fetch
+        # for the same reason. Modern git updates the ``origin/main`` tracking
+        # ref on a scoped fetch, so the ``HEAD..origin/main`` count below is
+        # unaffected; the shallow path compares against FETCH_HEAD, which a
+        # scoped fetch also updates.
+        fetch_args = ["git", "fetch", "origin", "main"]
         if is_shallow:
             fetch_args += ["--depth", "1"]
         fetch_args.append("--quiet")

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -165,8 +165,9 @@ def test_check_via_local_git_shallow_clone_behind_reports_no_count(tmp_path):
         result = banner._check_via_local_git(repo_dir)
 
     assert result == banner.UPDATE_AVAILABLE_NO_COUNT
-    # The shallow fetch must preserve the boundary (--depth 1), not unshallow.
-    assert ["git", "fetch", "origin", "--depth", "1", "--quiet"] in calls
+    # The shallow fetch must preserve the boundary (--depth 1), not unshallow,
+    # and must stay scoped to main (unscoped fetches transfer ~1,400 heads).
+    assert ["git", "fetch", "origin", "main", "--depth", "1", "--quiet"] in calls
 
 
 def test_check_via_local_git_shallow_clone_up_to_date(tmp_path):


### PR DESCRIPTION
## Summary
The startup banner update-check now fetches only `origin/main` instead of every remote head — 6x faster (3.0 s → 0.55 s dry-run on this repo's ~1,400 heads; up to 70 s → <1 s on a cold ref store) and far less likely to burn its full 10 s timeout on slow links.

Root cause: `_check_via_local_git` in `hermes_cli/banner.py` used an unscoped `git fetch origin`, while `cmd_update` already deliberately scopes its fetch to one branch for the same reason ("unscoped fetch can stall for minutes").

## Changes
- `hermes_cli/banner.py`: `git fetch origin` → `git fetch origin main` in the banner update-check (both full-clone and shallow paths).
- `tests/hermes_cli/test_update_check.py`: shallow-fetch argv contract updated to the scoped form.

## Validation
| | Before | After |
|---|---|---|
| fetch dry-run (warm) | 3.0 s (up to 70 s cold) | 0.55–0.9 s |
| behind-count (full clone, rewound ref) | 3 | 3 (tracking ref updated by scoped fetch) |
| shallow clone FETCH_HEAD | updated | updated, boundary preserved |
| tests (update_check + banner_git_state + banner) | — | 33/33 pass |

Empirically verified on a real full clone (rewound `origin/main` tracking ref restored to tip by the scoped fetch, `rev-list --count` correct) and a real `--depth 1` shallow clone (FETCH_HEAD updated, repo stays shallow).

## Infographic

![banner scoped fetch infographic](https://v3b.fal.media/files/b/0aa436f7/T8hUkPeE1MjXeCcopun-l_D9vzcAVN.png)
