### PR TITLE
fix(desktop): reap orphan venv processes before update hand-off

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -199,7 +199,7 @@ import {
 } from './update-relaunch'
 import { isOfficialSshRemote, OFFICIAL_REPO_HTTPS_URL } from './update-remote'
 import { spawnUpdaterProcess } from './updater-process'
-import { formatBlockerMessage, formatProbeFailedMessage, scanVenvBlockers } from './venv-blocker-scan'
+import { formatBlockerMessage, formatProbeFailedMessage, reapVenvOrphans, scanVenvBlockers } from './venv-blocker-scan'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
 import {
   computeWindowOptions,
@@ -2767,11 +2767,12 @@ async function releaseBackendLock(updateRoot, tag) {
   const shim = venvHermesShimPath(updateRoot)
   const deadlineMs = Date.now() + 15000
 
+  let shimUnlocked = false
+
   while (Date.now() < deadlineMs) {
     if (!isShimLocked(shim)) {
-      rememberLog(`[${tag}] venv shim unlocked; safe to proceed`)
-
-      return { unlocked: true }
+      shimUnlocked = true
+      break
     }
 
     // A supervised backend can respawn between kill and check (grandchildren,
@@ -2798,18 +2799,43 @@ async function releaseBackendLock(updateRoot, tag) {
     await new Promise(r => setTimeout(r, 300))
   }
 
-  // Do NOT proceed past a held lock: handing off to the updater while another
-  // process (a second desktop window, a user terminal, an unkillable child)
-  // still maps the venv's files guarantees a half-updated venv — the updater's
-  // dependency sync dies on access-denied partway through uninstalls, leaving
-  // imports broken (the July 2026 brotlicffi/_sodium.pyd incidents). Failing
-  // the update loudly and keeping the app running is strictly better than a
-  // bricked install that needs manual venv surgery.
-  rememberLog(
-    `[${tag}] venv shim still locked after 15s; aborting hand-off (something outside this app holds the venv)`
-  )
+  if (!shimUnlocked) {
+    // Do NOT proceed past a held lock: handing off to the updater while another
+    // process (a second desktop window, a user terminal, an unkillable child)
+    // still maps the venv's files guarantees a half-updated venv - the updater's
+    // dependency sync dies on access-denied partway through uninstalls, leaving
+    // imports broken (the July 2026 brotlicffi/_sodium.pyd incidents). Failing
+    // the update loudly and keeping the app running is strictly better than a
+    // bricked install that needs manual venv surgery.
+    rememberLog(
+      `[${tag}] venv shim still locked after 15s; aborting hand-off (something outside this app holds the venv)`
+    )
 
-  return { unlocked: false }
+    return { unlocked: false }
+  }
+
+  // Shim is writable, so the desktop's direct backend tree is gone. But its
+  // orphaned grandchildren - a detached gateway `python.exe`, pty `bash.exe`
+  // sessions - can escape `taskkill /T` once they re-parent off the dying
+  // backend PID. They do not hold `hermes.exe`, so the shim probe is clean,
+  // yet they still map venv `.pyd` files. Left unchecked they abort the
+  // preflight venv-blocker scan on every update attempt (the "must be
+  // stopped before updating" loop) or brick the dependency sync mid-update.
+  // Reap them with a bounded scan-and-kill pass; the strict preflight scan
+  // in applyUpdates() remains the final authority, so a genuinely external
+  // holder (a second window / user terminal) still aborts safely.
+  const orphanReap = await reapVenvOrphans(updateRoot, {
+    scan: (root) => scanVenvBlockers(root),
+    kill: forceKillProcessTree
+  })
+
+  if (orphanReap.reaped > 0) {
+    rememberLog(`[${tag}] reaped ${orphanReap.reaped} orphan venv process(es) after shim unlock`)
+  }
+
+  rememberLog(`[${tag}] venv shim unlocked; safe to proceed`)
+
+  return { unlocked: true }
 }
 
 // applyUpdates — hand off to the installer's --update flow, then exit.

--- a/apps/desktop/electron/venv-blocker-scan.test.ts
+++ b/apps/desktop/electron/venv-blocker-scan.test.ts
@@ -18,9 +18,11 @@ import {
   formatBlockerMessage,
   formatProbeFailedMessage,
   parseVenvBlockerScanOutput,
+  reapVenvOrphans,
   resolveVenvPython,
   scanVenvBlockers
 } from './venv-blocker-scan'
+import type { ScanOutcome } from './venv-blocker-scan'
 
 // ---------------------------------------------------------------------------
 // resolveVenvPython
@@ -214,5 +216,88 @@ describe('scanVenvBlockers', () => {
     assert.equal(c.cwd, '/update/root')
     assert.equal(typeof c.timeout, 'number')
     assert.ok(c.timeout > 0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// reapVenvOrphans — orphan reaper with injection
+// ---------------------------------------------------------------------------
+
+describe('reapVenvOrphans', () => {
+  const clear: ScanOutcome = { kind: 'clear', result: { blocked: false, processes: [] } }
+  const blocked1: ScanOutcome = {
+    kind: 'blocked',
+    result: { blocked: true, processes: [{ pid: 100, name: 'python.exe', cmdline: 'gateway' }] }
+  }
+  const blocked2: ScanOutcome = {
+    kind: 'blocked',
+    result: { blocked: true, processes: [{ pid: 200, name: 'bash.exe', cmdline: 'pty' }] }
+  }
+
+  function makeScan(seq: ScanOutcome[]) {
+    let i = 0
+    return () => {
+      const v = seq[Math.min(i, seq.length - 1)]
+      i++
+      return Promise.resolve(v)
+    }
+  }
+
+  function makeKill() {
+    const killed: number[] = []
+    const fn = (pid: number) => { killed.push(pid) }
+    return { fn, killed }
+  }
+
+  function makeClock(start: number) {
+    let t = start
+    return {
+      now: () => t,
+      advance: (ms: number) => { t += ms }
+    }
+  }
+
+  it('returns reaped=0 and clear when the first scan is clear', async () => {
+    const scan = makeScan([clear])
+    const kill = makeKill()
+    const res = await reapVenvOrphans('/r', { scan: scan as any, kill: kill.fn })
+    assert.equal(res.reaped, 0)
+    assert.equal(res.final.kind, 'clear')
+    assert.deepEqual(kill.killed, [])
+  })
+
+  it('kills blocked PIDs and re-scans until clear', async () => {
+    const scan = makeScan([blocked1, blocked2, clear])
+    const kill = makeKill()
+    const res = await reapVenvOrphans('/r', { scan: scan as any, kill: kill.fn })
+    assert.equal(res.reaped, 2)
+    assert.equal(res.final.kind, 'clear')
+    assert.deepEqual(kill.killed, [100, 200])
+  })
+
+  it('stops reaping when the deadline expires', async () => {
+    const scan = makeScan([blocked1, blocked1, blocked1, blocked1])
+    const kill = makeKill()
+    const clock = makeClock(0)
+    // deadlineMs=2500, pollMs=1000 => at most ~2 passes fit before deadline
+    const res = await reapVenvOrphans('/r', {
+      scan: scan as any,
+      kill: kill.fn,
+      now: clock.now,
+      sleep: async () => { clock.advance(1000) }
+    }, { deadlineMs: 2500, pollMs: 1000 })
+    assert.ok(res.reaped >= 2)
+    assert.equal(res.final.kind, 'blocked')
+    assert.ok(kill.killed.length >= 2)
+  })
+
+  it('treats a probe-failure as terminal (stops, does not kill)', async () => {
+    const probeFail: ScanOutcome = { kind: 'probe-failure', error: 'boom' }
+    const scan = makeScan([probeFail])
+    const kill = makeKill()
+    const res = await reapVenvOrphans('/r', { scan: scan as any, kill: kill.fn })
+    assert.equal(res.reaped, 0)
+    assert.equal(res.final.kind, 'probe-failure')
+    assert.deepEqual(kill.killed, [])
   })
 })

--- a/apps/desktop/electron/venv-blocker-scan.ts
+++ b/apps/desktop/electron/venv-blocker-scan.ts
@@ -152,6 +152,93 @@ export async function scanVenvBlockers(
 }
 
 // ---------------------------------------------------------------------------
+// Orphan reaper
+// ---------------------------------------------------------------------------
+
+/**
+ * Dependency-injected kill function (mirrors main.ts' forceKillProcessTree).
+ * Receives a positive PID; must be synchronous and best-effort (never throw).
+ */
+export type KillProcessTreeFn = (pid: number) => void
+
+export interface ReapVenvOrphansDeps {
+  scan: (updateRoot: string) => Promise<ScanOutcome>
+  kill: KillProcessTreeFn
+  now?: () => number
+  sleep?: (ms: number) => Promise<void>
+}
+
+export interface ReapVenvOrphansOptions {
+  /** Total deadline for the reap loop, in ms. */
+  deadlineMs?: number
+  /** Pause between a kill pass and the re-scan, in ms. */
+  pollMs?: number
+}
+
+export interface ReapVenvOrphansResult {
+  /** Number of orphan PIDs signalled across all passes. */
+  reaped: number
+  /** Outcome of the final scan pass (clear / blocked / probe-failure). */
+  final: ScanOutcome
+}
+
+/**
+ * Reap orphaned venv processes left behind after the desktop's own backend
+ * tree was torn down.
+ *
+ * `releaseBackendLock` tree-kills every backend PID it tracks and waits for
+ * the `hermes.exe` shim to become writable.  But the backend's grandchildren
+ * — a detached gateway `python.exe`, pty `bash.exe` sessions — can escape
+ * `taskkill /T` once they re-parent off the dying backend PID.  They do not
+ * hold `hermes.exe`, so the shim lock probe reports "unlocked" even though
+ * they still map venv `.pyd` files.  Left unchecked they abort the preflight
+ * venv-blocker scan on every update attempt, or worse, brick the dependency
+ * sync mid-update with access-denied on a locked `.pyd`.
+ *
+ * This function runs a bounded scan-and-kill loop: each pass scans the venv
+ * for live processes, tree-kills everything it finds, and re-scans until the
+ * venv is clear or the deadline expires.  It is the caller's responsibility
+ * (the preflight scan in `applyUpdates`) to make the final abort/proceed
+ * decision; this reaper only reduces orphan noise so legitimate updates are
+ * not perpetually blocked by the desktop's own dead children.  A probe-failure
+ * (broken scan module / missing psutil) short-circuits to a clear result so
+ * the strict preflight — not this best-effort reaper — is the authority.
+ */
+export async function reapVenvOrphans(
+  updateRoot: string,
+  deps: ReapVenvOrphansDeps,
+  options: ReapVenvOrphansOptions = {}
+): Promise<ReapVenvOrphansResult> {
+  const now = deps.now || Date.now
+  const sleep = deps.sleep || (ms => new Promise<void>(r => setTimeout(r, ms)))
+  const deadlineMs = options.deadlineMs ?? 8000
+  const pollMs = options.pollMs ?? 400
+
+  let reaped = 0
+  let outcome: ScanOutcome = { kind: 'clear', result: { blocked: false, processes: [] } }
+
+  const deadline = now() + deadlineMs
+
+  while (now() < deadline) {
+    outcome = await deps.scan(updateRoot)
+
+    if (outcome.kind !== 'blocked') {
+      break
+    }
+
+    for (const proc of outcome.result.processes) {
+      deps.kill(proc.pid)
+    }
+
+    reaped += outcome.result.processes.length
+
+    await sleep(pollMs)
+  }
+
+  return { reaped, final: outcome }
+}
+
+// ---------------------------------------------------------------------------
 // Internal helpers (exported for testing)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
﻿## Problem

The Hermes desktop app's self-update is perpetually blocked by its **own dead children**, so the app silently keeps stale code forever. Observed 12 consecutive failed update attempts in a single session, each ending with:

```
These processes must be stopped before updating:
  PID 34532  python.exe  ...hermes_cli.main gateway run
  PID 21032  bash.exe    ...venv/Scripts/...
Close the terminal, app, or service owning that process.
Then retry the update.
[updates] update finished; proceeding with backend start
```

## Root cause

`releaseBackendLock` tree-kills the backend PIDs the desktop tracks and waits for the `hermes.exe` shim to become writable. Then the preflight `scanVenvBlockers` scan aborts the update because **orphaned grandchildren** are still running from the venv:

- The backend spawns a gateway (`python.exe -m hermes_cli.main gateway run`) and pty `bash.exe` sessions.
- These escape `taskkill /T` once they **re-parent off the dying backend PID** (the parent-child link `taskkill /T` walks is broken once the parent dies).
- They do **not** hold `hermes.exe`, so the shim lock probe (`isShimLocked`) reports `unlocked` -- but they still map venv `.pyd` files.
- The subsequent preflight scan then catches them and aborts. The app restarts its backend, and the cycle repeats on the next attempt.

So the desktop can **never** self-update while running -- the very backend it supervises is the thing blocking the update, and the teardown doesn't reap the orphans it loses track of.

## Fix

After the shim unlocks (direct backend tree is gone), run a **bounded scan-and-kill pass** that reaps any remaining venv processes before declaring the install free. The strict preflight scan in `applyUpdates()` remains the final authority, so a genuinely external holder (a second window / a user terminal) still aborts safely.

### Changes
- **`venv-blocker-scan.ts`** -- add `reapVenvOrphans()`, a dependency-injected, unit-testable bounded loop: scan -> tree-kill every PID found -> re-scan until clear or an 8 s deadline. A probe-failure short-circuits to clear so the strict preflight (not this best-effort reaper) stays the authority.
- **`main.ts`** -- restructure `releaseBackendLock`'s poll loop to break out on shim unlock, then call `reapVenvOrphans` with `scanVenvBlockers` + `forceKillProcessTree` before returning `{ unlocked: true }`.
- **`venv-blocker-scan.test.ts`** -- 4 new tests: clear-on-first-scan, kill-and-rescan-until-clear, deadline-expiry, and probe-failure-is-terminal.

## Why safe

- This only runs **after** the desktop's own tracked backend tree is already torn down and the shim is writable -- i.e. during the desktop's own update hand-off, against processes that are almost certainly its own orphaned descendants.
- The existing hard-abort preflight is unchanged and still fires for anything that survives the reaper (genuinely external holders), so there is no regression risk of half-updating a venv.
- Off-Windows behavior is untouched (`releaseBackendLock` no-ops on POSIX).

## Testing

```
npx vitest run electron/venv-blocker-scan.test.ts   # 24 passed
npx vitest run electron/update-gate.test.ts          # 8 passed
npx tsc --build tsconfig.electron.json               # clean
```