### PR TITLE
fix(stt): thread confidence thresholds into faster-whisper's own gate (#74178)

### DIFF
--- a/tests/tools/test_stt_silence_hallucinations.py
+++ b/tests/tools/test_stt_silence_hallucinations.py
@@ -61,6 +61,28 @@ class TestBuildLocalTranscribeKwargs:
     def test_beam_size_kept(self):
         assert build_local_transcribe_kwargs({})["beam_size"] == 5
 
+    def test_confidence_thresholds_default_to_faster_whisper_values(self):
+        kwargs = build_local_transcribe_kwargs({})
+        assert kwargs["no_speech_threshold"] == _NO_SPEECH_PROB_THRESHOLD_DEFAULT
+        assert kwargs["log_prob_threshold"] == _LOGPROB_THRESHOLD_DEFAULT
+
+    def test_confidence_thresholds_configurable_reach_model_gate(self):
+        # The same stt.local knobs the post-filter reads must also be threaded
+        # into faster-whisper's internal gate, or non-English speech is dropped
+        # before it ever reaches our segment filter.
+        kwargs = build_local_transcribe_kwargs(
+            {"local": {"no_speech_prob_threshold": 0.9, "logprob_threshold": -2.0}}
+        )
+        assert kwargs["no_speech_threshold"] == 0.9
+        assert kwargs["log_prob_threshold"] == -2.0
+
+    def test_confidence_thresholds_garbage_falls_back(self):
+        kwargs = build_local_transcribe_kwargs(
+            {"local": {"no_speech_prob_threshold": "nope", "logprob_threshold": None}}
+        )
+        assert kwargs["no_speech_threshold"] == _NO_SPEECH_PROB_THRESHOLD_DEFAULT
+        assert kwargs["log_prob_threshold"] == _LOGPROB_THRESHOLD_DEFAULT
+
     def test_language_and_prompt_resolved(self, monkeypatch):
         monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
         cfg = {"language": "en", "local": {"initial_prompt": "Hermes glossary"}}
@@ -144,6 +166,8 @@ class TestTranscribeLocalWiring:
         assert captured["vad_filter"] is True
         assert captured["vad_parameters"] == {"min_silence_duration_ms": 500}
         assert captured["condition_on_previous_text"] is False
+        assert captured["no_speech_threshold"] == _NO_SPEECH_PROB_THRESHOLD_DEFAULT
+        assert captured["log_prob_threshold"] == _LOGPROB_THRESHOLD_DEFAULT
 
     def test_config_off_switch_reaches_model(self, monkeypatch):
         captured, _ = self._run(monkeypatch, {"local": {"vad": False}})

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1541,6 +1541,19 @@ def build_local_transcribe_kwargs(stt_config: Optional[Dict[str, Any]] = None) -
     else:
         kwargs["vad_filter"] = False
 
+    # Push the confidence gate down into faster-whisper itself. Without this the
+    # library's own internal defaults (no_speech_threshold=0.6, log_prob_
+    # threshold=-1.0) drop low-confidence segments BEFORE they reach our
+    # _is_hallucinated_segment post-filter, so the ``stt.local`` threshold knobs
+    # were dead for that first gate. Non-English speech decodes at a lower
+    # avg_logprob, so the English-tuned defaults silently discard whole
+    # utterances. Mapping the same config values through keeps both gates in
+    # sync and makes the knobs actually usable. Defaults are unchanged, so
+    # behavior is identical unless a user tunes them.
+    no_speech_threshold, log_prob_threshold = _confidence_thresholds(local_cfg)
+    kwargs["no_speech_threshold"] = no_speech_threshold
+    kwargs["log_prob_threshold"] = log_prob_threshold
+
     forced_lang = _resolve_stt_language("local", stt_config)
     if forced_lang:
         kwargs["language"] = forced_lang


### PR DESCRIPTION
## What & why

`build_local_transcribe_kwargs()` reads `stt.local.no_speech_prob_threshold` and
`stt.local.logprob_threshold` from config, but only uses them in Hermes' own
post-filter (`_is_hallucinated_segment` via `_join_confident_segments`). It never
passed them to faster-whisper's `model.transcribe()`, so the library's internal
defaults (`no_speech_threshold=0.6`, `log_prob_threshold=-1.0`) always applied and
silently dropped low-confidence segments **before** they ever reached our
post-filter. That made those two config knobs dead for the first (and decisive) gate.

Non-English speech decodes at a lower `avg_logprob`, so the English-tuned defaults
discard whole utterances — the caller gets an empty transcript even though the mic
captured audio and language detection succeeded (`lang=zh, prob=1.000`).

## Fix

Map the same config values through to `model.transcribe()` so faster-whisper's
internal gate and Hermes' post-filter use identical thresholds. Reuses the existing
`_confidence_thresholds()` helper (same parsing + fallback the post-filter already
uses), so there's a single source of truth. **Defaults are unchanged (0.6 / -1.0),
so behavior is byte-for-byte identical unless a user tunes them** — this only makes
the previously-dead knobs actually reach the model.

Users hitting this on non-English speech can now relax the gate, e.g.:

```bash
hermes config set stt.local.no_speech_prob_threshold 0.9
hermes config set stt.local.logprob_threshold -2.0
```

## Tests

`tests/tools/test_stt_silence_hallucinations.py`:
- `test_confidence_thresholds_default_to_faster_whisper_values` — defaults preserved.
- `test_confidence_thresholds_configurable_reach_model_gate` — tuned values reach the kwargs.
- `test_confidence_thresholds_garbage_falls_back` — bad config falls back to defaults.
- Extended `test_hardened_kwargs_reach_model` to assert both thresholds reach `model.transcribe()`.

```
tests/tools/test_stt_silence_hallucinations.py  21 passed
```

Note: 3 pre-existing failures in `tests/tools/test_transcription_tools.py`
(`test_config_device_and_compute_type_passed_to_whisper`,
`test_config_defaults_to_auto_when_not_set`,
`test_cublas_status_not_supported_retries_on_cpu`) reproduce on a pristine
`upstream/main` checkout with none of this change — they assert the device string
passed to the `WhisperModel` constructor (`auto`/`auto`) and are environment-specific
(local CUDA-less resolution), unrelated to this diff, which only adds
`transcribe()` kwargs.

## Scope

This narrows the confidence-threshold gate only; it deliberately does **not** touch the default-VAD path (`tools/transcription_tools.py:1533`), which is the other half of #74178 (VAD can strip all audio before decoding). Referencing #74178 with a non-closing keyword so that remaining VAD work stays tracked after this merges.

Refs #74178
