### PR TITLE
refactor: shared Retry-After parser, strip_ansi, and atomic-write consolidation

### DIFF
--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -8,7 +8,9 @@ rate-limited provider concurrently.
 import random
 import threading
 import time
-from typing import Any
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Any, Optional
 
 # Monotonic counter for jitter seed uniqueness within the same process.
 # Protected by a lock to avoid race conditions in concurrent retry paths
@@ -31,6 +33,58 @@ _ZAI_CODING_OVERLOAD_LONG_BACKOFF = (30.0, 60.0, 90.0, 120.0)
 # long-tier entry is reachable). Keeping it a single module constant prevents
 # the two from silently desyncing if the short-retry count is ever tuned.
 _ZAI_CODING_OVERLOAD_SHORT_ATTEMPTS = 3
+
+
+def parse_retry_after_seconds(value_or_headers: Any) -> Optional[float]:
+    """Parse a ``Retry-After`` value into non-negative seconds.
+
+    Accepts either a raw header value (numeric string / HTTP-date / number)
+    or a headers mapping, in which case the ``Retry-After`` key is looked up
+    case-insensitively (``.get`` on dict-like objects tries both common
+    casings; real HTTP header containers like httpx/requests are already
+    case-insensitive).
+
+    Returns:
+        Seconds as a ``float`` (negative deltas clamped to ``0.0``), or
+        ``None`` when the header is absent or unparseable.
+    """
+    raw = value_or_headers
+    if raw is not None and not isinstance(raw, (str, int, float)):
+        # Looks like a headers mapping — pull the header out of it.
+        getter = getattr(raw, "get", None)
+        if callable(getter):
+            try:
+                value = getter("Retry-After")
+                if value is None:
+                    value = getter("retry-after")
+            except Exception:
+                return None
+            raw = value
+        else:
+            return None
+    if raw is None:
+        return None
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, (int, float)):
+        return max(0.0, float(raw))
+    text = str(raw).strip()
+    if not text:
+        return None
+    try:
+        return max(0.0, float(text))
+    except (TypeError, ValueError):
+        pass
+    # HTTP-date form (RFC 7231): seconds until that instant, clamped at 0.
+    try:
+        when = parsedate_to_datetime(text)
+    except (TypeError, ValueError):
+        return None
+    if when is None:
+        return None
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    return max(0.0, (when - datetime.now(timezone.utc)).total_seconds())
 
 
 def jittered_backoff(

--- a/agent/secret_sources/base.py
+++ b/agent/secret_sources/base.py
@@ -239,6 +239,10 @@ _ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 # ANSI CSI/OSC escape sequences — helper-CLI stderr often carries color
 # codes that must not reach Hermes' own startup output.
+# NOTE: intentionally NOT migrated to tools.ansi_strip.strip_ansi — the
+# optional terminator here (``(?:\x07|\x1b\\)?``) also strips *unterminated*
+# OSC sequences (common when a CLI is killed mid-write), which strip_ansi
+# leaves untouched. strip_ansi is not a superset of this regex.
 _ANSI_RE = re.compile(r"\x1b(?:\[[0-9;?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\)?)")
 
 

--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -42,7 +42,6 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
-import re
 import shutil
 import subprocess
 import time
@@ -73,10 +72,10 @@ _OP_RUN_TIMEOUT = 30
 # looks for.
 _DEFAULT_TOKEN_ENV = "OP_SERVICE_ACCOUNT_TOKEN"
 
-# Strip whole ANSI CSI sequences (colour, cursor moves, line erases) from any
-# `op` diagnostic we surface — not just the lone ESC byte — so a control
-# sequence can't reposition the cursor or hide text after a redaction marker.
-_ANSI_CSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+# ANSI stripping for `op` diagnostics we surface uses the shared
+# tools.ansi_strip.strip_ansi (full ECMA-48: CSI, OSC, DCS/SOS/PM/APC,
+# C1) so a control sequence can't reposition the cursor or hide text
+# after a redaction marker.
 
 # Env vars the `op` child actually needs.  We build a minimal allowlisted env
 # rather than copying all of os.environ (which, post-dotenv, holds every
@@ -231,7 +230,10 @@ def find_op(binary_path: str = "") -> Optional[Path]:
 
 def _scrub(text: str) -> str:
     """Remove ANSI control sequences and trim, for safe message surfacing."""
-    return _ANSI_CSI_RE.sub("", text).replace("\x1b", "").strip()
+    from tools.ansi_strip import strip_ansi
+
+    # strip_ansi removes well-formed sequences; drop any stray lone ESC too.
+    return strip_ansi(text).replace("\x1b", "").strip()
 
 
 def _op_child_env(token_value: str) -> Dict[str, str]:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -39,7 +39,7 @@ from typing import Optional, Dict, List, Any, Set, Tuple, Union
 logger = logging.getLogger(__name__)
 
 from hermes_time import now as _hermes_now
-from utils import atomic_replace
+from utils import atomic_replace, atomic_write_text
 
 try:
     from croniter import croniter
@@ -824,24 +824,13 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
 def _atomic_write_epoch(path: Path) -> None:
     """Atomically write the current epoch time to ``path``.
 
-    Uses the same tmpfile + ``atomic_replace`` pattern as ``save_jobs`` so a
-    concurrent reader in another process (``hermes cron status``) never sees a
-    torn/truncated file. Best-effort: failures are swallowed by callers.
+    Delegates to :func:`utils.atomic_write_text` (tmpfile + fsync +
+    ``atomic_replace``, same pattern as ``save_jobs``) so a concurrent reader
+    in another process (``hermes cron status``) never sees a torn/truncated
+    file. Best-effort: failures are swallowed by callers.
     """
     ensure_dirs()
-    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp", prefix=".hb_")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(str(time.time()))
-            f.flush()
-            os.fsync(f.fileno())
-        atomic_replace(tmp_path, path)
-    except BaseException:
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
-        raise
+    atomic_write_text(path, str(time.time()), tmp_prefix=".hb_")
 
 
 def _atomic_write_counter(path: Path, value: int) -> None:

--- a/gateway/platforms/signal_rate_limit.py
+++ b/gateway/platforms/signal_rate_limit.py
@@ -21,6 +21,8 @@ import re
 import time
 from typing import Any, Optional
 
+from agent.retry_utils import parse_retry_after_seconds
+
 logger = logging.getLogger(__name__)
 
 
@@ -83,7 +85,9 @@ def _extract_retry_after_seconds(err: Any) -> Optional[float]:
        AttachmentInvalidException during attachment upload, where the
        structured field stays null.
 
-    Returns None when neither yields a value.
+    Numeric parsing delegates to the shared
+    :func:`agent.retry_utils.parse_retry_after_seconds` core.
+    Returns None when neither source yields a value.
     """
     msg = ""
     if isinstance(err, dict):
@@ -91,16 +95,17 @@ def _extract_retry_after_seconds(err: Any) -> Optional[float]:
         response = data.get("response") or {}
         results = response.get("results") or []
         candidates = [
-            r.get("retryAfterSeconds") for r in results
+            parse_retry_after_seconds(r.get("retryAfterSeconds")) for r in results
             if isinstance(r, dict) and r.get("retryAfterSeconds")
         ]
+        candidates = [c for c in candidates if c is not None]
         if candidates:
-            return float(max(candidates))
+            return max(candidates)
         msg = str(err.get("message", ""))
     else:
         msg = str(err)
     match = _RETRY_AFTER_RE.search(msg)
-    return float(match.group(1)) if match else None
+    return parse_retry_after_seconds(match.group(1)) if match else None
 
 
 def _is_signal_rate_limit_error(err: Any) -> bool:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17528,7 +17528,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return
 
         def _strip_ansi(text: str) -> str:
-            return re.sub(r'\x1b\[[0-9;]*[A-Za-z]', '', text)
+            from tools.ansi_strip import strip_ansi
+            return strip_ansi(text)
 
         bytes_sent = 0
         last_stream_time = loop.time()
@@ -17770,7 +17771,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     adapter=adapter,
                 )
                 # Strip ANSI escape codes for clean display
-                output = re.sub(r'\x1b\[[0-9;]*m', '', output).strip()
+                from tools.ansi_strip import strip_ansi
+                output = strip_ansi(output).strip()
                 if output:
                     if len(output) > 3500:
                         output = "…" + output[-3500:]

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -803,22 +803,14 @@ def is_rate_limited_auth_error(error: Exception) -> bool:
 def _parse_retry_after_seconds(headers: Any) -> Optional[int]:
     """Best-effort parse of a ``Retry-After`` header into whole seconds.
 
-    Supports the delta-seconds form (e.g. ``"120"``). HTTP-date forms and
-    missing/unparseable values return ``None`` rather than guessing.
+    Thin wrapper around :func:`agent.retry_utils.parse_retry_after_seconds`
+    (delta-seconds and HTTP-date forms; negatives clamp to 0; missing or
+    unparseable values return ``None``).
     """
-    if headers is None:
-        return None
-    try:
-        raw = headers.get("retry-after")
-    except Exception:
-        return None
-    if raw is None:
-        return None
-    try:
-        seconds = int(str(raw).strip())
-    except (TypeError, ValueError):
-        return None
-    return seconds if seconds >= 0 else None
+    from agent.retry_utils import parse_retry_after_seconds
+
+    seconds = parse_retry_after_seconds(headers)
+    return None if seconds is None else int(seconds)
 
 
 def format_auth_error(error: Exception) -> str:

--- a/hermes_cli/nous_billing.py
+++ b/hermes_cli/nous_billing.py
@@ -296,19 +296,15 @@ def _resolve_token_and_base(*, use_cache: bool = True) -> tuple[str, str]:
 
 
 def _retry_after_seconds(headers: Any) -> Optional[int]:
-    """Parse a ``Retry-After`` header (integer seconds) — None if absent/bad."""
-    if headers is None:
-        return None
-    try:
-        raw = headers.get("Retry-After")
-    except Exception:
-        raw = None
-    if raw is None:
-        return None
-    try:
-        return int(str(raw).strip())
-    except (TypeError, ValueError):
-        return None
+    """Parse a ``Retry-After`` header (integer seconds) — None if absent/bad.
+
+    Thin wrapper around :func:`agent.retry_utils.parse_retry_after_seconds`
+    (the shared parser also handles HTTP-date forms and clamps negatives).
+    """
+    from agent.retry_utils import parse_retry_after_seconds
+
+    seconds = parse_retry_after_seconds(headers)
+    return None if seconds is None else int(seconds)
 
 
 def _raise_for_error(

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -258,3 +258,61 @@ def test_zai_overload_ceiling_makes_long_tier_reachable(monkeypatch):
 
     assert long_waits, "long-backoff tier never reached within the retry ceiling"
     assert long_waits == [30.0, 60.0, 90.0, 120.0]
+
+
+# ---------------------------------------------------------------------------
+# parse_retry_after_seconds — shared Retry-After parser
+# ---------------------------------------------------------------------------
+
+
+class TestParseRetryAfterSeconds:
+    def test_numeric_string(self):
+        from agent.retry_utils import parse_retry_after_seconds
+        assert parse_retry_after_seconds("120") == 120.0
+        assert parse_retry_after_seconds(" 4.5 ") == 4.5
+
+    def test_numeric_value(self):
+        from agent.retry_utils import parse_retry_after_seconds
+        assert parse_retry_after_seconds(45) == 45.0
+        assert parse_retry_after_seconds(3.25) == 3.25
+
+    def test_negative_clamped_to_zero(self):
+        from agent.retry_utils import parse_retry_after_seconds
+        assert parse_retry_after_seconds("-5") == 0.0
+        assert parse_retry_after_seconds(-1.5) == 0.0
+
+    def test_http_date(self):
+        from datetime import datetime, timedelta, timezone
+        from email.utils import format_datetime
+        from agent.retry_utils import parse_retry_after_seconds
+
+        future = datetime.now(timezone.utc) + timedelta(seconds=90)
+        seconds = parse_retry_after_seconds(format_datetime(future, usegmt=True))
+        assert seconds is not None and 80 <= seconds <= 91
+
+        past = datetime.now(timezone.utc) - timedelta(seconds=90)
+        assert parse_retry_after_seconds(format_datetime(past, usegmt=True)) == 0.0
+
+    def test_missing_and_garbage(self):
+        from agent.retry_utils import parse_retry_after_seconds
+        assert parse_retry_after_seconds(None) is None
+        assert parse_retry_after_seconds({}) is None
+        assert parse_retry_after_seconds("") is None
+        assert parse_retry_after_seconds("soonish") is None
+        assert parse_retry_after_seconds(object()) is None
+        assert parse_retry_after_seconds(True) is None
+
+    def test_headers_case_insensitive(self):
+        from agent.retry_utils import parse_retry_after_seconds
+        assert parse_retry_after_seconds({"Retry-After": "30"}) == 30.0
+        assert parse_retry_after_seconds({"retry-after": "30"}) == 30.0
+        assert parse_retry_after_seconds({"Content-Type": "x"}) is None
+
+    def test_headers_get_raises(self):
+        from agent.retry_utils import parse_retry_after_seconds
+
+        class Explosive:
+            def get(self, _key):
+                raise RuntimeError("boom")
+
+        assert parse_retry_after_seconds(Explosive()) is None

--- a/tools/microsoft_graph_client.py
+++ b/tools/microsoft_graph_client.py
@@ -9,6 +9,7 @@ from typing import Any, AsyncIterator, Awaitable, Callable
 
 import httpx
 
+from agent.retry_utils import parse_retry_after_seconds
 from tools.microsoft_graph_auth import GraphCredentials, MicrosoftGraphTokenProvider
 
 
@@ -357,12 +358,9 @@ class MicrosoftGraphClient:
     @staticmethod
     def _retry_delay(response: httpx.Response | None, attempt: int) -> float:
         if response is not None:
-            retry_after = response.headers.get("Retry-After")
-            if retry_after:
-                try:
-                    return max(0.0, float(retry_after))
-                except ValueError:
-                    pass
+            retry_after = parse_retry_after_seconds(response.headers)
+            if retry_after is not None:
+                return retry_after
         return min(8.0, 0.5 * (2 ** attempt))
 
     @staticmethod
@@ -390,13 +388,7 @@ class MicrosoftGraphClient:
             elif isinstance(error, str):
                 message = error
 
-        retry_after: float | None = None
-        header_value = response.headers.get("Retry-After")
-        if header_value:
-            try:
-                retry_after = float(header_value)
-            except ValueError:
-                retry_after = None
+        retry_after: float | None = parse_retry_after_seconds(response.headers)
 
         return MicrosoftGraphAPIError(
             response.status_code,

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -814,16 +814,6 @@ def _resolve_skill_target(skill_dir: Path, file_path: str) -> Tuple[Optional[Pat
     return target, None
 
 
-def _atomic_write_text(file_path: Path, content: str, encoding: str = "utf-8") -> None:
-    """Atomically write text content to a file.
-
-    Thin wrapper around :func:`utils.atomic_write_text` so that every
-    destructive file rewrite in the codebase shares one implementation.
-    """
-    atomic_write_text(file_path, content, encoding=encoding,
-                      tmp_prefix=f".{file_path.name}.tmp.")
-
-
 # =============================================================================
 # Core actions
 # =============================================================================
@@ -874,7 +864,7 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
 
     # Write SKILL.md atomically
     skill_md = skill_dir / "SKILL.md"
-    _atomic_write_text(skill_md, content)
+    atomic_write_text(skill_md, content)
 
     # Security scan — roll back on block
     scan_error = _security_scan_skill(skill_dir)
@@ -935,13 +925,13 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
 
     # Back up original content for rollback
     original_content = skill_md.read_text(encoding="utf-8") if skill_md.exists() else None
-    _atomic_write_text(skill_md, content)
+    atomic_write_text(skill_md, content)
 
     # Security scan — roll back on block
     scan_error = _security_scan_skill(existing["path"])
     if scan_error:
         if original_content is not None:
-            _atomic_write_text(skill_md, original_content)
+            atomic_write_text(skill_md, original_content)
         return {"success": False, "error": scan_error}
 
     # Extract description from new content for verbose notifications
@@ -1057,12 +1047,12 @@ def _patch_skill(
             }
 
     original_content = content  # for rollback
-    _atomic_write_text(target, new_content)
+    atomic_write_text(target, new_content)
 
     # Security scan — roll back on block
     scan_error = _security_scan_skill(skill_dir)
     if scan_error:
-        _atomic_write_text(target, original_content)
+        atomic_write_text(target, original_content)
         return {"success": False, "error": scan_error}
 
     result = {
@@ -1226,13 +1216,13 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     target.parent.mkdir(parents=True, exist_ok=True)
     # Back up for rollback
     original_content = target.read_text(encoding="utf-8") if target.exists() else None
-    _atomic_write_text(target, file_content)
+    atomic_write_text(target, file_content)
 
     # Security scan — roll back on block
     scan_error = _security_scan_skill(existing["path"])
     if scan_error:
         if original_content is not None:
-            _atomic_write_text(target, original_content)
+            atomic_write_text(target, original_content)
         else:
             target.unlink(missing_ok=True)
         return {"success": False, "error": scan_error}


### PR DESCRIPTION
## Summary
Three shared-helper consolidations that each ended a fix-in-N-places pattern: one Retry-After parser (4 divergent copies — case-sensitivity and negative-clamp already drifted), shared `strip_ansi` for inline ANSI regexes that missed OSC/C1 escapes, and `utils.py` atomics for two private tmp+replace clones.

## Changes
- `agent/retry_utils.py`: `parse_retry_after_seconds()` (numeric, HTTP-date, case-insensitive, negative-clamped) — migrated nous_billing, auth, microsoft_graph_client ×2, signal_rate_limit
- gateway/run.py ×2 + secret_sources/onepassword.py: inline regexes → `tools/ansi_strip.strip_ansi`
- cron/jobs.py + tools/skill_manager_tool.py: private atomic-write clones → utils atomics (fsync discipline)

## Validation
| | Result |
|---|---|
| New parser unit tests (numeric/negative/HTTP-date/missing/case) | pass |
| Targeted tests (auth, billing, signal, cron, skill_manager) | pass |
| Public signatures preserved | ✓ |

## Infographic

![one parser one truth](https://v3b.fal.media/files/b/0aa43706/lcRNkzdYgcR_mf5OzZCnf_Uq0appf0.png)
