### PR TITLE
fix(minimax): recognize Anthropic-compatible /anthropic endpoint in M3 reasoning controls

### DIFF
--- a/plugins/model-providers/minimax/__init__.py
+++ b/plugins/model-providers/minimax/__init__.py
@@ -21,13 +21,21 @@ def _is_minimax_global_openai_base_url(base_url: str | None) -> bool:
     return path == "/v1"
 
 
+def _is_minimax_global_anthropic_base_url(base_url: str | None) -> bool:
+    parsed = urlparse(str(base_url or "").strip())
+    if (parsed.hostname or "").lower() != "api.minimax.io":
+        return False
+    path = parsed.path.rstrip("/").lower()
+    return path == "/anthropic"
+
+
 def _is_minimax_m3(model: str | None) -> bool:
     normalized = str(model or "").strip().lower()
     return normalized in {"minimax-m3", "minimax/minimax-m3"}
 
 
 class MiniMaxProfile(ProviderProfile):
-    """MiniMax — M3 OpenAI-compatible reasoning controls."""
+    """MiniMax — M3 reasoning controls (OpenAI-compatible + Anthropic-compatible routes)."""
 
     def build_api_kwargs_extras(
         self,
@@ -37,23 +45,31 @@ class MiniMaxProfile(ProviderProfile):
         base_url: str | None = None,
         **context: Any,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
-        """Emit M3 reasoning controls for api.minimax.io/v1.
+        """Emit M3 reasoning controls for api.minimax.io (both /v1 and /anthropic).
 
-        MiniMax-M3's OpenAI-compatible endpoint keeps thinking inline unless
-        ``reasoning_split`` is sent, so always request the split format on that
-        route. ``thinking`` controls the M3 mode; Hermes' effort levels are not
-        a MiniMax depth knob here, so they only select adaptive vs disabled.
+        MiniMax-M3's /v1 endpoint keeps thinking inline unless ``reasoning_split``
+        is sent, so always request the split format on that route. The /anthropic
+        endpoint returns thinking as native ``thinking`` content blocks already, so
+        no split flag is needed there. ``thinking`` controls the M3 mode; Hermes'
+        effort levels are not a MiniMax depth knob here — they only select
+        adaptive vs disabled. On /anthropic, omitting ``thinking`` causes M3 to
+        default to OFF (per MiniMax docs), which is the bug this branch fixes.
         """
-        if not _is_minimax_global_openai_base_url(base_url) or not _is_minimax_m3(model):
+        is_m3 = _is_minimax_m3(model)
+        is_oai = _is_minimax_global_openai_base_url(base_url)
+        is_ant = _is_minimax_global_anthropic_base_url(base_url)
+
+        if not is_m3 or (not is_oai and not is_ant):
             return {}, {}
 
-        extra_body: dict[str, Any] = {"reasoning_split": True}
+        extra_body: dict[str, Any] = {}
+
+        if is_oai:
+            extra_body["reasoning_split"] = True
 
         if isinstance(reasoning_config, dict) and reasoning_config.get("enabled") is False:
             extra_body["thinking"] = {"type": "disabled"}
-            return extra_body, {}
-
-        if reasoning_config is not None:
+        elif reasoning_config is not None:
             extra_body["thinking"] = {"type": "adaptive"}
 
         return extra_body, {}


### PR DESCRIPTION
Extends the `MiniMaxProfile.build_api_kwargs_extras` provider plugin to recognize MiniMax's Anthropic-compatible `/anthropic` endpoint at `api.minimax.io/anthropic`, in addition to the existing `api.minimax.io/v1` OpenAI-compatible route.

## Why this is separate from #66694

#66694 (`fix(minimax): preserve M3 adaptive thinking on Anthropic routes`) covers the Anthropic adapter layer — the request kwargs that go out as Anthropic `thinking: {"type": "adaptive"}` on the `auxiliary_client` adapter path. That's correct and stays open.

This PR covers the provider plugin layer — the `extra_body` that goes out on the OpenAI-compatible request shape that MiniMax's `/anthropic` endpoint also accepts. Different code path, different kwargs structure.

## The bug

On the `/anthropic` endpoint, omitting `thinking` causes MiniMax-M3 to default to OFF (per MiniMax docs). Previously, the provider plugin only matched `/v1`, so requests to `/anthropic` got an empty `extra_body` and M3 returned thinking as disabled.

## The fix

Add `_is_minimax_global_anthropic_base_url()` helper that matches `api.minimax.io/anthropic`. Update `build_api_kwargs_extras` to:
- Accept both `/v1` and `/anthropic` (the existing `/v1` condition becomes an OR with the new `/anthropic` condition).
- Send `reasoning_split=True` only on `/v1` (the `/anthropic` endpoint already returns thinking as native content blocks, no split flag needed).
- Send `thinking: {type: adaptive}` (or `disabled` if reasoning is explicitly disabled) on both routes.

## Out of scope

The `/anthropic` route also requires stateful replay preservation across multi-turn tool calls, which is the focus of the Anthropic adapter work in #66694. The provider plugin here only handles the request-shape kwargs.