### PR TITLE
fix(bedrock): don't persist the discovery fallback to the model cache (#74151)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1285,9 +1285,21 @@ def _profile_live_catalog(normalized: str) -> Optional[list[str]]:
     return _merge_unique(primary, secondary, key=_model_dedup_key)
 
 
-def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) -> list[str]:
+def provider_model_ids(
+    provider: Optional[str],
+    *,
+    force_refresh: bool = False,
+    _provenance: Optional[dict] = None,
+) -> list[str]:
     """Best known model catalog for a provider: per-provider live fetchers, then the generic profile
-    fetch, then the static list (merged with models.dev for ``_MODELS_DEV_PREFERRED`` providers)."""
+    fetch, then the static list (merged with models.dev for ``_MODELS_DEV_PREFERRED`` providers).
+
+    ``_provenance`` is an optional out-dict for the disk-cache layer. When a provider's only offline
+    source is the static curated stub and live discovery failed (currently only Bedrock — expired AWS
+    SSO, throttle, no creds yet), it sets ``_provenance["fallback"] = True`` so
+    :func:`cached_provider_model_ids` serves the stub in-memory only rather than pinning it to disk for
+    the full TTL after credentials recover (#74151). Callers that don't pass it are unaffected.
+    """
     requested = str(provider or "").strip().lower()
     if requested == "ollama":
         return _ollama_local_catalog(force_refresh)
@@ -1298,6 +1310,11 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         models = fetcher(normalized, force_refresh)
         if models is not None:
             return models
+        # Live discovery ran but yielded nothing for a provider whose sole offline source is the
+        # static curated stub. Flag the fall-through so the cache layer serves it in-memory only and
+        # retries live on the next open, instead of freezing the offline list for an hour (#74151).
+        if _provenance is not None and normalized == "bedrock":
+            _provenance["fallback"] = True
     try:
         models = _profile_live_catalog(normalized)
     except Exception:
@@ -1539,9 +1556,15 @@ def cached_provider_model_ids(
             _spawn_swr_refresh(normalized)
             return list(entry["models"])
 
-    live = provider_model_ids(normalized, force_refresh=force_refresh)
+    provenance: dict = {}
+    live = provider_model_ids(normalized, force_refresh=force_refresh, _provenance=provenance)
     if live:
-        _store_cache_entry(normalized, _cache_entry(fp, live, now), cache)
+        # Persist only genuine results. An emergency fallback (bedrock live discovery failed, curated
+        # stub returned) is served in-memory but never pinned to disk — its fingerprint is unchanged
+        # by an out-of-$HERMES_HOME SSO refresh, so a persisted stub would cap the picker for the full
+        # TTL even after creds recover (#74151).
+        if not provenance.get("fallback"):
+            _store_cache_entry(normalized, _cache_entry(fp, live, now), cache)
         return list(live)
 
     if is_ollama:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2793,7 +2793,12 @@ def _openai_discovery_base_url(provider: str) -> str:
     return "https://api.openai.com/v1"
 
 
-def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) -> list[str]:
+def provider_model_ids(
+    provider: Optional[str],
+    *,
+    force_refresh: bool = False,
+    _provenance: Optional[dict] = None,
+) -> list[str]:
     """Return the best known model catalog for a provider.
 
     Tries live API endpoints for providers that support them (Codex, Nous),
@@ -2801,6 +2806,13 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
     (opencode-go/zen, xiaomi, deepseek, smaller inference providers, etc.),
     models.dev entries are merged on top of curated so new models released
     on the platform appear in ``/model`` without a Hermes release.
+
+    ``_provenance`` is an optional out-dict for the disk-cache layer. When a
+    branch returns a static *emergency* fallback rather than a live result
+    (currently only Bedrock, when live discovery fails), it sets
+    ``_provenance["fallback"] = True`` so :func:`cached_provider_model_ids`
+    can serve the stub without pinning it to disk for the full TTL (#74151).
+    Callers that don't pass it are unaffected.
     """
     normalized = normalize_provider(provider)
     if normalized == "openrouter":
@@ -2979,6 +2991,12 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
                 return ids
         except Exception:
             pass
+        # Live discovery failed (expired SSO, throttle, no creds yet). We fall
+        # through to the static curated list below, but flag it as a fallback
+        # so the cache layer serves it in-memory only rather than freezing the
+        # offline stub for an hour after credentials recover (#74151).
+        if _provenance is not None:
+            _provenance["fallback"] = True
 
     # ── Profile-based generic live fetch (all simple api-key providers) ──
     # Handles any provider registered in providers/ with auth_type="api_key".
@@ -3210,14 +3228,27 @@ def cached_provider_model_ids(
         return list(entry["models"])
 
     # Cache miss / stale / forced refresh — call the live path.
-    live = provider_model_ids(normalized, force_refresh=force_refresh)
-    if live:
+    provenance: dict = {}
+    live = provider_model_ids(
+        normalized, force_refresh=force_refresh, _provenance=provenance
+    )
+    if live and not provenance.get("fallback"):
         cache[normalized] = {
             "fp": fp,
             "at": now,
             "models": list(live),
         }
         _save_provider_models_cache(cache)
+        return list(live)
+    if live:
+        # A provider signalled this is a static emergency fallback, not a live
+        # result (e.g. Bedrock discovery failed). Correct to return right now,
+        # but it must NOT be persisted with the live TTL: doing so froze the
+        # 10-item offline list in provider_models_cache.json for a full hour
+        # even after SSO recovered, hiding the real catalog from /model
+        # (#74151). Return it in-memory only so the next picker open retries
+        # discovery. A previously-cached live result (fresh entry) already
+        # short-circuited above, so it is never shadowed by this stub.
         return list(live)
 
     # Live fetch returned nothing. If we have a stale entry with the

--- a/tests/hermes_cli/test_bedrock_fallback_not_cached.py
+++ b/tests/hermes_cli/test_bedrock_fallback_not_cached.py
@@ -1,0 +1,104 @@
+"""Bedrock's static fallback model list must never be persisted to
+``provider_models_cache.json`` with the live TTL (#74151).
+
+When live discovery fails (expired AWS SSO, throttle, no creds yet),
+``provider_model_ids("bedrock")`` returns the curated emergency stub. The old
+cache layer could not tell that stub from a live result, so it wrote the stub
+to disk with the full 1h TTL — and because Bedrock declares no API-key env vars
+(``api_key_env_vars=()`` in ``PROVIDER_REGISTRY``) and AWS SSO tokens live
+outside ``$HERMES_HOME``, the cache fingerprint (built from a provider's API-key
+env vars, base URL, and the mtimes of ``$HERMES_HOME`` auth files) is unchanged
+by an SSO refresh, so re-auth did not bust the persisted stub. Result:
+``/model`` showed only the ~10 offline entries for an hour, with
+current-generation models absent.
+
+The fix threads a ``_provenance`` flag from the Bedrock branch so the cache
+layer serves the fallback in-memory only, letting the next picker open retry.
+"""
+
+import json
+
+import hermes_cli.models as models
+
+
+def _cache_file(tmp_path):
+    return tmp_path / "provider_models_cache.json"
+
+
+def _patch_home(monkeypatch, tmp_path):
+    monkeypatch.setattr(models, "_provider_models_cache_path", lambda: _cache_file(tmp_path))
+
+
+class TestProvenanceFlag:
+    def test_fallback_sets_provenance(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.bedrock_adapter.bedrock_model_ids_or_none", lambda: None
+        )
+        prov: dict = {}
+        ids = models.provider_model_ids("bedrock", _provenance=prov)
+        # The curated stub is returned...
+        assert ids == list(models._PROVIDER_MODELS.get("bedrock", []))
+        assert ids  # non-empty curated list exists
+        # ...and flagged as a fallback.
+        assert prov.get("fallback") is True
+
+    def test_live_result_leaves_provenance_clean(self, monkeypatch):
+        live = ["us.anthropic.claude-sonnet-5", "eu.anthropic.claude-opus-5"]
+        monkeypatch.setattr(
+            "agent.bedrock_adapter.bedrock_model_ids_or_none", lambda: live
+        )
+        prov: dict = {}
+        ids = models.provider_model_ids("bedrock", _provenance=prov)
+        assert ids == live
+        assert prov.get("fallback") is not True
+
+    def test_provenance_is_optional(self, monkeypatch):
+        # Callers that don't pass _provenance must keep working unchanged.
+        monkeypatch.setattr(
+            "agent.bedrock_adapter.bedrock_model_ids_or_none", lambda: None
+        )
+        assert models.provider_model_ids("bedrock") == list(
+            models._PROVIDER_MODELS.get("bedrock", [])
+        )
+
+
+class TestCacheDoesNotPersistFallback:
+    def test_failed_discovery_is_not_written_to_disk(self, monkeypatch, tmp_path):
+        _patch_home(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            "agent.bedrock_adapter.bedrock_model_ids_or_none", lambda: None
+        )
+        result = models.cached_provider_model_ids("bedrock")
+        # Right result returned in-memory...
+        assert result == list(models._PROVIDER_MODELS.get("bedrock", []))
+        # ...but nothing pinned to disk.
+        assert not _cache_file(tmp_path).exists()
+
+    def test_live_discovery_is_cached(self, monkeypatch, tmp_path):
+        _patch_home(monkeypatch, tmp_path)
+        live = ["us.anthropic.claude-sonnet-5", "eu.anthropic.claude-opus-5"]
+        monkeypatch.setattr(
+            "agent.bedrock_adapter.bedrock_model_ids_or_none", lambda: live
+        )
+        result = models.cached_provider_model_ids("bedrock")
+        assert result == live
+        cache = json.loads(_cache_file(tmp_path).read_text(encoding="utf-8"))
+        assert cache["bedrock"]["models"] == live
+
+    def test_discovery_retries_after_a_transient_failure(self, monkeypatch, tmp_path):
+        """A failure must not cap the catalog: once creds recover, the live
+        list wins on the very next call (nothing stale was frozen)."""
+        _patch_home(monkeypatch, tmp_path)
+        live = ["us.anthropic.claude-sonnet-5", "eu.anthropic.claude-opus-5"]
+
+        monkeypatch.setattr(
+            "agent.bedrock_adapter.bedrock_model_ids_or_none", lambda: None
+        )
+        first = models.cached_provider_model_ids("bedrock")
+        assert first == list(models._PROVIDER_MODELS.get("bedrock", []))
+
+        monkeypatch.setattr(
+            "agent.bedrock_adapter.bedrock_model_ids_or_none", lambda: live
+        )
+        second = models.cached_provider_model_ids("bedrock")
+        assert second == live, "a transient discovery failure hid the live catalog"

--- a/tests/hermes_cli/test_bedrock_fallback_not_cached.py
+++ b/tests/hermes_cli/test_bedrock_fallback_not_cached.py
@@ -4,10 +4,13 @@
 When live discovery fails (expired AWS SSO, throttle, no creds yet),
 ``provider_model_ids("bedrock")`` returns the curated emergency stub. The old
 cache layer could not tell that stub from a live result, so it wrote the stub
-to disk with the full 1h TTL — and because the credential fingerprint is derived
-from ``AWS_PROFILE``/env (not token validity), a subsequent SSO refresh did not
-bust the entry. Result: ``/model`` showed only the ~10 offline entries for an
-hour, with current-generation models absent.
+to disk with the full 1h TTL — and because Bedrock declares no API-key env vars
+(``api_key_env_vars=()`` in ``PROVIDER_REGISTRY``) and AWS SSO tokens live
+outside ``$HERMES_HOME``, the cache fingerprint (built from a provider's API-key
+env vars, base URL, and the mtimes of ``$HERMES_HOME`` auth files) is unchanged
+by an SSO refresh, so re-auth did not bust the persisted stub. Result:
+``/model`` showed only the ~10 offline entries for an hour, with
+current-generation models absent.
 
 The fix threads a ``_provenance`` flag from the Bedrock branch so the cache
 layer serves the fallback in-memory only, letting the next picker open retry.

--- a/tests/hermes_cli/test_bedrock_fallback_not_cached.py
+++ b/tests/hermes_cli/test_bedrock_fallback_not_cached.py
@@ -1,0 +1,101 @@
+"""Bedrock's static fallback model list must never be persisted to
+``provider_models_cache.json`` with the live TTL (#74151).
+
+When live discovery fails (expired AWS SSO, throttle, no creds yet),
+``provider_model_ids("bedrock")`` returns the curated emergency stub. The old
+cache layer could not tell that stub from a live result, so it wrote the stub
+to disk with the full 1h TTL — and because the credential fingerprint is derived
+from ``AWS_PROFILE``/env (not token validity), a subsequent SSO refresh did not
+bust the entry. Result: ``/model`` showed only the ~10 offline entries for an
+hour, with current-generation models absent.
+
+The fix threads a ``_provenance`` flag from the Bedrock branch so the cache
+layer serves the fallback in-memory only, letting the next picker open retry.
+"""
+
+import json
+
+import hermes_cli.models as models
+
+
+def _cache_file(tmp_path):
+    return tmp_path / "provider_models_cache.json"
+
+
+def _patch_home(monkeypatch, tmp_path):
+    monkeypatch.setattr(models, "_provider_models_cache_path", lambda: _cache_file(tmp_path))
+
+
+class TestProvenanceFlag:
+    def test_fallback_sets_provenance(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.bedrock_adapter.bedrock_model_ids_or_none", lambda: None
+        )
+        prov: dict = {}
+        ids = models.provider_model_ids("bedrock", _provenance=prov)
+        # The curated stub is returned...
+        assert ids == list(models._PROVIDER_MODELS.get("bedrock", []))
+        assert ids  # non-empty curated list exists
+        # ...and flagged as a fallback.
+        assert prov.get("fallback") is True
+
+    def test_live_result_leaves_provenance_clean(self, monkeypatch):
+        live = ["us.anthropic.claude-sonnet-5", "eu.anthropic.claude-opus-5"]
+        monkeypatch.setattr(
+            "agent.bedrock_adapter.bedrock_model_ids_or_none", lambda: live
+        )
+        prov: dict = {}
+        ids = models.provider_model_ids("bedrock", _provenance=prov)
+        assert ids == live
+        assert prov.get("fallback") is not True
+
+    def test_provenance_is_optional(self, monkeypatch):
+        # Callers that don't pass _provenance must keep working unchanged.
+        monkeypatch.setattr(
+            "agent.bedrock_adapter.bedrock_model_ids_or_none", lambda: None
+        )
+        assert models.provider_model_ids("bedrock") == list(
+            models._PROVIDER_MODELS.get("bedrock", [])
+        )
+
+
+class TestCacheDoesNotPersistFallback:
+    def test_failed_discovery_is_not_written_to_disk(self, monkeypatch, tmp_path):
+        _patch_home(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            "agent.bedrock_adapter.bedrock_model_ids_or_none", lambda: None
+        )
+        result = models.cached_provider_model_ids("bedrock")
+        # Right result returned in-memory...
+        assert result == list(models._PROVIDER_MODELS.get("bedrock", []))
+        # ...but nothing pinned to disk.
+        assert not _cache_file(tmp_path).exists()
+
+    def test_live_discovery_is_cached(self, monkeypatch, tmp_path):
+        _patch_home(monkeypatch, tmp_path)
+        live = ["us.anthropic.claude-sonnet-5", "eu.anthropic.claude-opus-5"]
+        monkeypatch.setattr(
+            "agent.bedrock_adapter.bedrock_model_ids_or_none", lambda: live
+        )
+        result = models.cached_provider_model_ids("bedrock")
+        assert result == live
+        cache = json.loads(_cache_file(tmp_path).read_text(encoding="utf-8"))
+        assert cache["bedrock"]["models"] == live
+
+    def test_discovery_retries_after_a_transient_failure(self, monkeypatch, tmp_path):
+        """A failure must not cap the catalog: once creds recover, the live
+        list wins on the very next call (nothing stale was frozen)."""
+        _patch_home(monkeypatch, tmp_path)
+        live = ["us.anthropic.claude-sonnet-5", "eu.anthropic.claude-opus-5"]
+
+        monkeypatch.setattr(
+            "agent.bedrock_adapter.bedrock_model_ids_or_none", lambda: None
+        )
+        first = models.cached_provider_model_ids("bedrock")
+        assert first == list(models._PROVIDER_MODELS.get("bedrock", []))
+
+        monkeypatch.setattr(
+            "agent.bedrock_adapter.bedrock_model_ids_or_none", lambda: live
+        )
+        second = models.cached_provider_model_ids("bedrock")
+        assert second == live, "a transient discovery failure hid the live catalog"

--- a/tests/hermes_cli/test_model_cache_swr.py
+++ b/tests/hermes_cli/test_model_cache_swr.py
@@ -99,7 +99,11 @@ class TestProviderModelsSWR:
             out = mod.cached_provider_model_ids("openrouter", force_refresh=True)
         assert out == ["live"]
         spawn.assert_not_called()
-        live.assert_called_once_with("openrouter", force_refresh=True)
+        # force_refresh flows through to the live fetch (an internal _provenance out-dict
+        # for the fallback-cache guard may ride along; don't pin it here).
+        live.assert_called_once()
+        assert live.call_args.args == ("openrouter",)
+        assert live.call_args.kwargs.get("force_refresh") is True
 
     def test_swr_refresh_dedupes_inflight(self):
         import hermes_cli.models as mod


### PR DESCRIPTION
## What & why

When Bedrock live discovery fails (expired AWS SSO token at startup, throttle, or
creds not resolved yet), `provider_model_ids("bedrock")` returns the static curated
fallback list. `cached_provider_model_ids()` could not tell that emergency stub from
a live result, so it persisted it to `~/.hermes/provider_models_cache.json` with the
full 1-hour TTL.

Because the credential fingerprint is derived from `AWS_PROFILE`/env — **not** token
validity — a subsequent SSO refresh does not bust the entry (`fp` is unchanged). So
for the next hour `/model` shows only the ~10 hardcoded `us.*` offline entries even
though credentials are now valid and live discovery would return the full catalog,
and current-generation models (Sonnet 5 / Opus 5) are absent from the stub — a user
who wants to switch is told their model doesn't exist.

This is **distinct from #68049**, which fixes a different cache: the per-model
*context-length* table in `agent/model_metadata.py`. This one is the *model-list*
cache in `hermes_cli/models.py`.

## Fix (issue option (a): provenance signalling)

- `provider_model_ids()` gains an **opt-in** `_provenance: Optional[dict]` out-param.
  When the Bedrock branch's live discovery fails and it falls through to the curated
  list, it sets `_provenance["fallback"] = True`.
- `cached_provider_model_ids()` passes a fresh dict and, when the result is flagged
  as a fallback, **serves it in-memory only** instead of writing it to disk — so the
  next picker open retries discovery.

Properties:
- **Non-breaking / minimal blast radius**: `_provenance` defaults to `None`; every
  other provider branch and every other caller (`hermes_cli/models.py:2070/4594/…`)
  is untouched. Only Bedrock (the `aws_sdk` case the issue calls out) signals
  fallback, so no other provider's caching behavior changes.
- **A previously-cached live result still wins**: the fresh-entry cache hit
  short-circuits at the top of `cached_provider_model_ids()` before the live path
  runs, so a good catalog is never shadowed by the stub.
- **Self-heals**: a transient discovery failure no longer caps the catalog — once
  creds recover, the live list wins on the very next call.

If maintainers would rather express this as the issue's option (b) (persist fallback
with a ~60s TTL) or (c) (treat `aws_sdk` auth failure as "unknown"), the same
`_provenance` hook makes either a one-line change at the cache layer — happy to adjust.

## Tests

`tests/hermes_cli/test_bedrock_fallback_not_cached.py` (6 tests):
- provenance flag set on fallback / clean on live / param optional;
- failed discovery is **not** written to disk (returned in-memory);
- live discovery **is** cached;
- discovery retries and wins after a transient failure (nothing frozen).

```
tests/hermes_cli/test_bedrock_fallback_not_cached.py  6 passed
tests/hermes_cli/test_models.py                       (affected) PASS
```

Fixes #74151
