### PR TITLE
perf(config): kill per-turn config deepcopies — telemetry gate 54x faster

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4028,9 +4028,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # env var ``HERMES_LOCAL_STREAM_STALE_TIMEOUT`` overrides for escape-hatch.
         _local_default = 900.0
         try:
-            from hermes_cli.config import load_config
+            from hermes_cli.config import load_config_readonly
 
-            _cfg = load_config()
+            _cfg = load_config_readonly()  # read-only consumer — no deepcopy
             _agent_cfg = _cfg.get("agent") if isinstance(_cfg, dict) else None
             if isinstance(_agent_cfg, dict):
                 _v = _agent_cfg.get("local_stream_stale_timeout")

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -731,8 +731,8 @@ def get_inbound_media_max_bytes() -> int:
     unreadable — falls back to the default.
     """
     try:
-        from hermes_cli.config import load_config as _load_config
-        cfg = _load_config()
+        from hermes_cli.config import load_config_readonly as _load_config
+        cfg = _load_config()  # read-only: .get() only, never mutated
     except Exception:
         return DEFAULT_INBOUND_MEDIA_MAX_BYTES
     gw = cfg.get("gateway", {}) if isinstance(cfg, dict) else {}
@@ -3572,11 +3572,11 @@ class BasePlatformAdapter(ABC):
         auto-deletion.  Non-fatal if config is unreadable.
         """
         try:
-            from hermes_cli.config import load_config as _load_config
+            from hermes_cli.config import load_config_readonly as _load_config
         except Exception:
             return 0
         try:
-            cfg = _load_config()
+            cfg = _load_config()  # read-only: .get() only, never mutated
         except Exception:
             return 0
         display = cfg.get("display", {}) if isinstance(cfg, dict) else {}

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2937,6 +2937,51 @@ def read_user_config_raw(config_path: Optional[Path] = None) -> Dict[str, Any]:
     return data if isinstance(data, dict) else {}
 
 
+def read_raw_config_readonly() -> Dict[str, Any]:
+    """Fast-path variant of ``read_raw_config()`` for callers that ONLY READ.
+
+    Returns the cached raw-config dict directly, skipping the per-call
+    ``copy.deepcopy`` that ``read_raw_config()`` performs (needed there
+    because some callers mutate the result before ``save_config``).
+
+    **Mutating the returned dict corrupts the in-process cache for every
+    subsequent caller.** Only use on read-only paths — e.g. per-turn policy
+    checks like the shared-metrics gate, which runs 2-3x per agent turn and
+    was paying a full config deepcopy each time.
+
+    Same (mtime_ns, size) freshness key as ``read_raw_config()`` — an edited
+    config.yaml is picked up on the next call.
+    """
+    with _CONFIG_LOCK:
+        try:
+            config_path = get_config_path()
+            st = config_path.stat()
+            cache_key = (st.st_mtime_ns, st.st_size)
+        except (FileNotFoundError, OSError):
+            return {}
+
+        path_key = str(config_path)
+        cached = _RAW_CONFIG_CACHE.get(path_key)
+        if cached is not None and cached[:2] == cache_key:
+            return cached[2]
+
+        try:
+            with open(config_path, encoding="utf-8") as f:
+                data = fast_safe_load(f) or {}
+        except Exception as e:
+            _warn_config_parse_failure(config_path, e)
+            return {}
+
+        if not isinstance(data, dict):
+            data = {}
+        # Store and return THE SAME object (identity invariant): the first
+        # caller must see the exact dict later cache hits return, so a test
+        # asserting ``ro1 is ro2`` holds from the very first call.
+        cached_copy = copy.deepcopy(data)
+        _RAW_CONFIG_CACHE[path_key] = (cache_key[0], cache_key[1], cached_copy)
+        return cached_copy
+
+
 def require_readable_config_before_write(config_path: Optional[Path] = None) -> None:
     """Refuse to replace an existing config.yaml that cannot be read."""
     if config_path is None:

--- a/hermes_cli/observability/relay_shared_metrics.py
+++ b/hermes_cli/observability/relay_shared_metrics.py
@@ -634,12 +634,14 @@ def enabled() -> bool:
     """Return the shared-metrics policy for the active Hermes profile."""
     profile_key = relay_runtime.current_profile_key()
     try:
-        from hermes_cli.config import read_raw_config
+        from hermes_cli.config import read_raw_config_readonly
 
         # Collection consent is profile-owned. Managed config overlays may
         # control runtime policy, but cannot opt a profile into or out of
-        # shared metrics.
-        config = read_raw_config() or {}
+        # shared metrics. Read-only fast path: this gate runs 2-3x per agent
+        # turn, and the mutable read_raw_config() paid a full config deepcopy
+        # on every call.
+        config = read_raw_config_readonly() or {}
     except Exception:
         logger.debug("Unable to read Hermes shared-metrics policy", exc_info=True)
         value = False

--- a/tests/hermes_cli/test_read_raw_config_readonly.py
+++ b/tests/hermes_cli/test_read_raw_config_readonly.py
@@ -1,0 +1,92 @@
+"""Tests for read_raw_config_readonly() — the no-deepcopy raw config read.
+
+The readonly variant exists for per-turn policy checks (e.g. the
+shared-metrics gate) that were paying a full config deepcopy on every call.
+Contract under test:
+
+1. identity invariant — repeat calls return the SAME cached object,
+   including across the very first (cache-miss) call;
+2. freshness — an edited config.yaml (mtime/size change) is picked up;
+3. parity — content equals read_raw_config()'s result;
+4. missing/broken config degrades to {} exactly like read_raw_config().
+"""
+
+import os
+import time
+
+import pytest
+import yaml
+
+
+@pytest.fixture()
+def isolated_hermes_home():
+    """Per-test HERMES_HOME dir (already redirected by the autouse conftest
+    fixture) as a Path, with the raw-config cache cleared around the test."""
+    from pathlib import Path
+
+    import hermes_cli.config as config_mod
+
+    home = Path(os.environ["HERMES_HOME"])
+    home.mkdir(parents=True, exist_ok=True)
+    config_mod._RAW_CONFIG_CACHE.clear()
+    yield home
+    config_mod._RAW_CONFIG_CACHE.clear()
+
+
+def _write_config(home, data):
+    cfg = home / "config.yaml"
+    cfg.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return cfg
+
+
+def test_identity_invariant_from_first_call(isolated_hermes_home):
+    from hermes_cli.config import read_raw_config_readonly
+
+    _write_config(isolated_hermes_home, {"telemetry": {"shared_metrics": {"enabled": True}}})
+    ro1 = read_raw_config_readonly()
+    ro2 = read_raw_config_readonly()
+    assert ro1 is ro2, "cache-miss return must be the same object later hits serve"
+    assert ro1["telemetry"]["shared_metrics"]["enabled"] is True
+
+
+def test_parity_with_mutable_read(isolated_hermes_home):
+    from hermes_cli.config import read_raw_config, read_raw_config_readonly
+
+    _write_config(isolated_hermes_home, {"gateway": {"max_inbound_media_bytes": 123}})
+    assert read_raw_config_readonly() == read_raw_config()
+
+
+def test_freshness_after_config_edit(isolated_hermes_home):
+    from hermes_cli.config import read_raw_config_readonly
+
+    cfg = _write_config(isolated_hermes_home, {"display": {"ephemeral_system_ttl": 1}})
+    first = read_raw_config_readonly()
+    assert first["display"]["ephemeral_system_ttl"] == 1
+
+    _write_config(isolated_hermes_home, {"display": {"ephemeral_system_ttl": 7}})
+    # Force a distinct mtime_ns even on coarse-timestamp filesystems.
+    st = cfg.stat()
+    os.utime(cfg, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
+
+    second = read_raw_config_readonly()
+    assert second["display"]["ephemeral_system_ttl"] == 7
+
+
+def test_missing_config_returns_empty(isolated_hermes_home):
+    from hermes_cli.config import read_raw_config_readonly
+
+    cfg = isolated_hermes_home / "config.yaml"
+    if cfg.exists():
+        cfg.unlink()
+    assert read_raw_config_readonly() == {}
+
+
+def test_mutable_variant_still_isolated(isolated_hermes_home):
+    """read_raw_config() callers may mutate; that must not corrupt the
+    readonly cache entry."""
+    from hermes_cli.config import read_raw_config, read_raw_config_readonly
+
+    _write_config(isolated_hermes_home, {"a": {"b": 1}})
+    mutable = read_raw_config()
+    mutable["a"]["b"] = 999
+    assert read_raw_config_readonly()["a"]["b"] == 1

--- a/tests/hermes_cli/test_relay_shared_metrics_runtime.py
+++ b/tests/hermes_cli/test_relay_shared_metrics_runtime.py
@@ -148,7 +148,7 @@ def direct_runtime(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
     monkeypatch.setattr(relay_runtime, "_load_nemo_relay", lambda: fake)
     monkeypatch.setattr(
-        "hermes_cli.config.read_raw_config",
+        "hermes_cli.config.read_raw_config_readonly",
         lambda: {"telemetry": {"shared_metrics": {"enabled": True}}},
     )
     relay_shared_metrics._reset_for_tests()
@@ -166,7 +166,7 @@ def real_binding_runtime(tmp_path, monkeypatch):
         pytest.skip("NeMo Relay native binding is unavailable on this platform")
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
     monkeypatch.setattr(
-        "hermes_cli.config.read_raw_config",
+        "hermes_cli.config.read_raw_config_readonly",
         lambda: {"telemetry": {"shared_metrics": {"enabled": True}}},
     )
     relay_shared_metrics._reset_for_tests()
@@ -492,7 +492,7 @@ def test_direct_runtime_is_disabled_by_default(tmp_path, monkeypatch):
     fake = _Relay()
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
     monkeypatch.setattr(relay_runtime, "_load_nemo_relay", lambda: fake)
-    monkeypatch.setattr("hermes_cli.config.read_raw_config", lambda: {})
+    monkeypatch.setattr("hermes_cli.config.read_raw_config_readonly", lambda: {})
     relay_shared_metrics._reset_for_tests()
     relay_runtime._reset_for_tests()
     monkeypatch.setattr(plugins, "_plugin_manager", PluginManager())
@@ -919,7 +919,7 @@ def test_core_mark_does_not_start_relay_without_metrics_or_a_plugin(
         return _Relay()
 
     monkeypatch.setattr(relay_runtime, "_load_nemo_relay", load_relay)
-    monkeypatch.setattr("hermes_cli.config.read_raw_config", lambda: {})
+    monkeypatch.setattr("hermes_cli.config.read_raw_config_readonly", lambda: {})
     relay_shared_metrics._reset_for_tests()
     relay_runtime._reset_for_tests()
     monkeypatch.setattr(plugins, "_plugin_manager", PluginManager())
@@ -1056,7 +1056,7 @@ def test_shared_metrics_policy_and_store_are_profile_scoped(tmp_path, monkeypatc
     profile_b = tmp_path / "profile-b"
     monkeypatch.setattr(relay_runtime, "_load_nemo_relay", lambda: fake)
     monkeypatch.setattr(
-        "hermes_cli.config.read_raw_config",
+        "hermes_cli.config.read_raw_config_readonly",
         lambda: {
             "telemetry": {
                 "shared_metrics": {"enabled": get_hermes_home() == profile_a}
@@ -1112,7 +1112,7 @@ def test_shared_metrics_subscribers_isolate_two_enabled_profiles(tmp_path, monke
     profile_b = tmp_path / "profile-b"
     monkeypatch.setattr(relay_runtime, "_load_nemo_relay", lambda: fake)
     monkeypatch.setattr(
-        "hermes_cli.config.read_raw_config",
+        "hermes_cli.config.read_raw_config_readonly",
         lambda: {"telemetry": {"shared_metrics": {"enabled": True}}},
     )
     relay_shared_metrics._reset_for_tests()
@@ -1249,7 +1249,7 @@ def test_disabling_shared_metrics_stops_collection_and_shutdown_export(
     monkeypatch.setenv("HERMES_HOME", str(profile))
     monkeypatch.setattr(relay_runtime, "_load_nemo_relay", lambda: fake)
     monkeypatch.setattr(
-        "hermes_cli.config.read_raw_config",
+        "hermes_cli.config.read_raw_config_readonly",
         lambda: {"telemetry": {"shared_metrics": dict(policy)}},
     )
     relay_shared_metrics._reset_for_tests()

--- a/tests/plugins/test_nemo_relay_plugin.py
+++ b/tests/plugins/test_nemo_relay_plugin.py
@@ -381,7 +381,7 @@ def test_shared_metrics_and_rich_plugin_share_one_core_session(
         "HERMES_NEMO_RELAY_ATIF_OUTPUT_DIRECTORY", str(tmp_path / "atif")
     )
     monkeypatch.setattr(
-        "hermes_cli.config.read_raw_config",
+        "hermes_cli.config.read_raw_config_readonly",
         lambda: {"telemetry": {"shared_metrics": {"enabled": True}}},
     )
     plugin = _fresh_plugin(monkeypatch, fake)


### PR DESCRIPTION
## Summary
Per-turn config reads no longer deepcopy the whole config: the telemetry gate drops 248 µs → 4.6 µs per call (54x) and three streaming/gateway hot paths drop 346 µs → 12 µs, together removing ~90% of the ~1,900 `copy.deepcopy` primitives per agent turn measured in a stubbed-LLM 26-call profile.

Root cause: `relay_shared_metrics.enabled()` (runs 2-3x per turn via lifecycle + post-tool hooks) used `read_raw_config()`, which deepcopies on every call; the local-endpoint stale-timeout branch inside `interruptible_streaming_api_call` and two gateway per-message helpers used full `load_config()` for pure `.get()` reads.

## Changes
- `hermes_cli/config.py`: new `read_raw_config_readonly()` — cached-dict fast path with the same `(mtime_ns, size)` freshness key; identity invariant (cache-miss returns the same object later hits serve) explicitly preserved. Mutable `read_raw_config()` untouched for save-path callers.
- `hermes_cli/observability/relay_shared_metrics.py`: `enabled()` → readonly raw read.
- `agent/chat_completion_helpers.py`: local stale-timeout branch → `load_config_readonly()` (was `load_config()` once per API call for every local-model user).
- `gateway/platforms/base.py`: `get_inbound_media_max_bytes()` + `_get_ephemeral_system_ttl_default()` → `load_config_readonly()`.
- `tests/hermes_cli/test_read_raw_config_readonly.py`: identity (`is`), freshness-after-edit, parity, missing-config, and mutable-isolation regression tests.

## Validation
| call | before | after |
|---|---|---|
| `read_raw_config` → readonly (real 77-key config) | 248 µs | **4.6 µs (54x)** |
| `load_config` → readonly | 346 µs | **12 µs (29x)** |
| deepcopy primitives per turn | ~1,900 | ~10% remain |

Tests: new readonly suite 5/5; config (193), relay metrics ×2 (147), ephemeral reply + platform base (224) — 0 failures. All consumers audited: every switched call site only `.get()`s the result.

This is CPU/allocation cleanup on the per-turn path (established `load_config_readonly` pattern, PR #28866 lineage) — honest framing: µs-scale per event, but it fires on every API call, every tool call, and every gateway message.

## Infographic

![config readonly infographic](https://v3b.fal.media/files/b/0aa43782/d5JgJWp6yzFheJu8SZfcR_SE6JBnm0.png)
