### PR TITLE
feat(web): forward custom request headers from web_extract to Firecrawl (#74177)

### DIFF
--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -430,6 +430,10 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
         Accepted kwargs (others ignored for forward compat):
           - ``format``: ``"markdown"`` or ``"html"``; default is both
             (request both, return markdown when available).
+          - ``headers``: optional ``Dict[str, str]`` of HTTP request headers
+            (e.g. ``User-Agent``, ``Referer``, ``Authorization``) forwarded to
+            Firecrawl's scrape API. Omitted from the call entirely when unset,
+            so existing behavior is unchanged.
 
         Returns the legacy per-URL list-of-results shape. Per-URL failures
         (timeout, SSRF block, scrape error, policy block) become items
@@ -448,6 +452,13 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
             formats = ["html"]
         else:
             formats = ["markdown", "html"]
+
+        # Only forward request headers when the caller supplied a non-empty
+        # mapping — omitting the argument keeps the scrape call byte-for-byte
+        # identical to the previous behavior.
+        headers = kwargs.get("headers") or None
+        if headers is not None and not isinstance(headers, dict):
+            headers = None
 
         # check_website_access is the legacy policy gate; imported at
         # module level (lazy-friendly because the website_policy import is
@@ -486,11 +497,13 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
             try:
                 logger.info("Firecrawl scraping: %s", url)
                 try:
+                    scrape_kwargs: Dict[str, Any] = {"url": url, "formats": formats}
+                    if headers:
+                        scrape_kwargs["headers"] = headers
                     scrape_result = await asyncio.wait_for(
                         asyncio.to_thread(
                             _get_firecrawl_client().scrape,
-                            url=url,
-                            formats=formats,
+                            **scrape_kwargs,
                         ),
                         timeout=60,
                     )

--- a/tests/tools/test_web_extract_headers.py
+++ b/tests/tools/test_web_extract_headers.py
@@ -1,0 +1,128 @@
+"""``web_extract`` forwards optional request headers to the extract backend.
+
+Firecrawl's scrape API accepts a ``headers`` object; before #74177 Hermes never
+populated it, so there was no way to set a descriptive ``User-Agent``, a
+``Referer``, or an ``Authorization`` header on an extracted fetch. These tests
+pin the plumbing: the tool sanitizes the caller-supplied mapping and threads it
+to ``provider.extract(...)`` only when non-empty, leaving the no-header call
+shape byte-for-byte unchanged.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from agent.web_search_provider import WebSearchProvider
+from tools import web_tools
+from tools.web_tools import _sanitize_extract_headers
+
+
+class TestSanitizeExtractHeaders:
+    def test_none_and_non_mapping_become_none(self):
+        assert _sanitize_extract_headers(None) is None
+        assert _sanitize_extract_headers("User-Agent: x") is None
+        assert _sanitize_extract_headers(["a", "b"]) is None
+
+    def test_empty_mapping_becomes_none(self):
+        assert _sanitize_extract_headers({}) is None
+
+    def test_keeps_clean_string_pairs(self):
+        assert _sanitize_extract_headers(
+            {"User-Agent": "HermesBot/1.0", "Referer": "https://example.com"}
+        ) == {"User-Agent": "HermesBot/1.0", "Referer": "https://example.com"}
+
+    def test_drops_non_string_pairs(self):
+        assert _sanitize_extract_headers(
+            {"User-Agent": "ok", "X-Count": 3, 7: "nope"}
+        ) == {"User-Agent": "ok"}
+
+    def test_rejects_header_injection_via_control_chars(self):
+        # A stray CR/LF/NUL in a name or value is a header-injection primitive.
+        assert _sanitize_extract_headers(
+            {
+                "User-Agent": "ok",
+                "X-Bad": "a\r\nSet-Cookie: evil=1",
+                "X-Bad-Name\n": "v",
+            }
+        ) == {"User-Agent": "ok"}
+
+    def test_all_bad_becomes_none(self):
+        assert _sanitize_extract_headers({"a": "b\r\n"}) is None
+
+
+class _CapturingProvider(WebSearchProvider):
+    """Minimal extract provider that records the kwargs it was dispatched."""
+
+    def __init__(self):
+        self.calls = []
+
+    @property
+    def name(self):
+        return "firecrawl"
+
+    @property
+    def display_name(self):
+        return "Capturing Firecrawl"
+
+    def is_available(self):
+        return True
+
+    def supports_extract(self):
+        return True
+
+    async def extract(self, urls, **kwargs):
+        self.calls.append(kwargs)
+        return [
+            {"url": u, "title": "", "content": "ok", "raw_content": "ok", "metadata": {}}
+            for u in urls
+        ]
+
+
+@pytest.fixture
+def capturing_backend(monkeypatch):
+    from agent import web_search_registry
+
+    with web_search_registry._lock:
+        original = dict(web_search_registry._providers)
+        web_search_registry._providers.clear()
+
+    provider = _CapturingProvider()
+    monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        web_tools, "_load_web_config", lambda: {"extract_backend": "firecrawl"}
+    )
+    web_search_registry.register_provider(provider)
+    try:
+        yield provider
+    finally:
+        with web_search_registry._lock:
+            web_search_registry._providers.clear()
+            web_search_registry._providers.update(original)
+
+
+class TestHeadersReachBackend:
+    def _run(self, **kwargs):
+        return json.loads(
+            asyncio.run(web_tools.web_extract_tool(["https://example.com"], **kwargs))
+        )
+
+    def test_headers_forwarded_when_supplied(self, capturing_backend):
+        self._run(headers={"User-Agent": "HermesBot/1.0"})
+        assert capturing_backend.calls, "extract() was never dispatched"
+        assert capturing_backend.calls[0].get("headers") == {"User-Agent": "HermesBot/1.0"}
+
+    def test_no_headers_kwarg_when_unset(self, capturing_backend):
+        self._run()
+        assert capturing_backend.calls
+        assert "headers" not in capturing_backend.calls[0]
+
+    def test_empty_headers_are_not_forwarded(self, capturing_backend):
+        self._run(headers={})
+        assert capturing_backend.calls
+        assert "headers" not in capturing_backend.calls[0]
+
+    def test_dirty_headers_sanitized_before_dispatch(self, capturing_backend):
+        self._run(headers={"User-Agent": "ok", "X-Bad": "a\r\nInjected: 1"})
+        assert capturing_backend.calls
+        assert capturing_backend.calls[0].get("headers") == {"User-Agent": "ok"}

--- a/tests/tools/test_web_extract_headers.py
+++ b/tests/tools/test_web_extract_headers.py
@@ -126,3 +126,63 @@ class TestHeadersReachBackend:
         self._run(headers={"User-Agent": "ok", "X-Bad": "a\r\nInjected: 1"})
         assert capturing_backend.calls
         assert capturing_backend.calls[0].get("headers") == {"User-Agent": "ok"}
+
+
+class _CapturingFirecrawlClient:
+    """Fake Firecrawl SDK client that records the scrape() kwargs it receives."""
+
+    def __init__(self):
+        self.scrape_calls = []
+
+    def scrape(self, **kwargs):
+        self.scrape_calls.append(kwargs)
+        return {"markdown": "ok", "metadata": {"sourceURL": kwargs["url"], "title": "Ex"}}
+
+
+@pytest.fixture
+def firecrawl_scrape_client(monkeypatch):
+    """Patch the real Firecrawl provider's SDK seam + policy gates.
+
+    Exercises ``FirecrawlWebSearchProvider.extract`` end-to-end down to the
+    ``_get_firecrawl_client().scrape(**scrape_kwargs)`` boundary, so a
+    regression in ``scrape_kwargs`` construction (e.g. dropping ``headers``)
+    is caught — the generic-provider tests above only cover dispatcher
+    plumbing, not this SDK call shape.
+    """
+    from plugins.web.firecrawl import provider as fc_provider
+
+    client = _CapturingFirecrawlClient()
+    monkeypatch.setattr(fc_provider, "_get_firecrawl_client", lambda: client)
+    monkeypatch.setattr(fc_provider, "check_website_access", lambda url: None)
+    monkeypatch.setattr(fc_provider, "is_safe_url", lambda url: True)
+    return client
+
+
+class TestScrapeSDKBoundary:
+    """Verify the changed Firecrawl SDK boundary, not just the dispatcher."""
+
+    def _extract(self, provider_client, **kwargs):
+        from plugins.web.firecrawl.provider import FirecrawlWebSearchProvider
+
+        return asyncio.run(
+            FirecrawlWebSearchProvider().extract(["https://example.com"], **kwargs)
+        )
+
+    def test_scrape_receives_headers_when_supplied(self, firecrawl_scrape_client):
+        self._extract(
+            firecrawl_scrape_client, headers={"User-Agent": "HermesBot/1.0"}
+        )
+        assert firecrawl_scrape_client.scrape_calls, "scrape() was never called"
+        call = firecrawl_scrape_client.scrape_calls[0]
+        assert call.get("headers") == {"User-Agent": "HermesBot/1.0"}
+        assert call["url"] == "https://example.com"
+
+    def test_scrape_omits_headers_when_unset(self, firecrawl_scrape_client):
+        self._extract(firecrawl_scrape_client)
+        assert firecrawl_scrape_client.scrape_calls
+        assert "headers" not in firecrawl_scrape_client.scrape_calls[0]
+
+    def test_scrape_omits_headers_when_empty(self, firecrawl_scrape_client):
+        self._extract(firecrawl_scrape_client, headers={})
+        assert firecrawl_scrape_client.scrape_calls
+        assert "headers" not in firecrawl_scrape_client.scrape_calls[0]

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -321,9 +321,9 @@ _TOOL_STUBS = {
     ),
     "web_extract": (
         "web_extract",
-        "urls: list, char_limit: int = None",
-        '"""Extract content from URLs (no LLM summarization). Returns dict with results list of {url, title, content, error}. Pages over char_limit (default 15000) are head+tail truncated with the full text stored on disk; the content footer gives the path. content is markdown."""',
-        '{"urls": urls, "char_limit": char_limit}',
+        "urls: list, char_limit: int = None, headers: dict = None",
+        '"""Extract content from URLs (no LLM summarization). Returns dict with results list of {url, title, content, error}. Pages over char_limit (default 15000) are head+tail truncated with the full text stored on disk; the content footer gives the path. content is markdown. headers is an optional str→str map of HTTP request headers to send with the fetch (Firecrawl backend)."""',
+        '{"urls": urls, "char_limit": char_limit, "headers": headers}',
     ),
     "read_file": (
         "read_file",
@@ -1882,9 +1882,10 @@ _TOOL_DOC_LINES = [
      "  web_search(query: str, limit: int = 5) -> dict\n"
      "    Returns {\"data\": {\"web\": [{\"url\", \"title\", \"description\"}, ...]}}"),
     ("web_extract",
-     "  web_extract(urls: list[str], char_limit: int = None) -> dict\n"
+     "  web_extract(urls: list[str], char_limit: int = None, headers: dict = None) -> dict\n"
      "    Returns {\"results\": [{\"url\", \"title\", \"content\", \"error\"}, ...]} where content is markdown.\n"
-     "    No LLM summarization. Pages over char_limit (default 15000) are head+tail truncated; full text stored on disk (path in the content footer)."),
+     "    No LLM summarization. Pages over char_limit (default 15000) are head+tail truncated; full text stored on disk (path in the content footer).\n"
+     "    headers: optional str->str HTTP request headers sent with the fetch (Firecrawl backend)."),
     ("read_file",
      "  read_file(path: str, offset: int = 1, limit: int = 500) -> dict\n"
      "    Lines are 1-indexed. Returns {\"content\": \"...\", \"total_lines\": N}"),

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -739,10 +739,36 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         return tool_error(error_msg)
 
 
+def _sanitize_extract_headers(headers: Any) -> Optional[Dict[str, str]]:
+    """Coerce a caller-supplied ``headers`` value into a clean str→str map.
+
+    The tool schema already declares an object of strings, but tool arguments
+    arrive from a model and can't be trusted to match: drop non-mapping input,
+    skip pairs whose key or value isn't a string, and reject blank/control
+    characters in either (a stray newline is a header-injection primitive).
+    Returns ``None`` when nothing usable remains, so the caller omits the
+    argument entirely rather than forwarding an empty dict.
+    """
+    if not isinstance(headers, dict):
+        return None
+    cleaned: Dict[str, str] = {}
+    for key, value in headers.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            continue
+        name = key.strip()
+        if not name or any(c in key for c in "\r\n\x00") or any(
+            c in value for c in "\r\n\x00"
+        ):
+            continue
+        cleaned[name] = value
+    return cleaned or None
+
+
 async def web_extract_tool(
     urls: List[Any],
     format: str = None,
     char_limit: Optional[int] = None,
+    headers: Optional[Dict[str, str]] = None,
 ) -> str:
     """
     Extract content from specific web pages using available extraction API backend.
@@ -761,8 +787,16 @@ async def web_extract_tool(
         format (str): Desired output format ("markdown" or "html", optional)
         char_limit (Optional[int]): Per-page char budget sent to the model
             (default: web.extract_char_limit or 15000). Larger pages truncate.
+        headers (Optional[Dict[str, str]]): Optional HTTP request headers to
+            send with the fetch (e.g. a descriptive ``User-Agent``, a
+            ``Referer``, or an ``Authorization`` header for a partner
+            endpoint). Only the Firecrawl backend forwards these today; other
+            backends ignore them. Omitted entirely when unset, so default
+            behavior is unchanged.
 
-    Security: URLs are checked for embedded secrets before fetching.
+    Security: URLs are checked for embedded secrets before fetching, and
+    private/internal hosts are SSRF-filtered before any header reaches a
+    backend, so caller-supplied headers only ever accompany public fetches.
 
     Returns:
         str: JSON string with a ``results`` list; each entry has
@@ -930,16 +964,25 @@ async def web_extract_tool(
                 "Web extract via %s: %d URL(s)", provider.name, len(safe_urls)
             )
 
+            # Only forward well-formed string→string header pairs, and only
+            # when the caller actually supplied some. Passing ``{}`` / ``None``
+            # keeps the argument absent so backends that don't read headers see
+            # exactly their previous call shape.
+            extract_kwargs: Dict[str, Any] = {"format": format}
+            safe_headers = _sanitize_extract_headers(headers)
+            if safe_headers:
+                extract_kwargs["headers"] = safe_headers
+
             # Async-or-sync dispatch: parallel + firecrawl have async
             # extract(); exa + tavily are sync.
             import inspect
             if inspect.iscoroutinefunction(provider.extract):
-                results = await provider.extract(safe_urls, format=format)
+                results = await provider.extract(safe_urls, **extract_kwargs)
             else:
                 # Run sync extract() in a thread so we don't block the
                 # event loop on network I/O.
                 results = await asyncio.to_thread(
-                    provider.extract, safe_urls, format=format
+                    lambda: provider.extract(safe_urls, **extract_kwargs)
                 )
 
         # Reconstruct the original input order across invalid, blocked, and
@@ -1204,6 +1247,11 @@ WEB_EXTRACT_SCHEMA = {
                 "type": "integer",
                 "description": "Optional per-page character budget sent back (default 15000). Pages larger than this are head+tail truncated with the full text stored to disk. Raise it when you need more of a long page inline.",
                 "minimum": 2000
+            },
+            "headers": {
+                "type": "object",
+                "additionalProperties": {"type": "string"},
+                "description": "Optional HTTP request headers to send with the fetch (e.g. a descriptive User-Agent, a Referer, or an Authorization header for a partner endpoint). Currently applied by the Firecrawl backend."
             }
         },
         "required": ["urls"]
@@ -1228,6 +1276,7 @@ registry.register(
         args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else [],
         "markdown",
         char_limit=args.get("char_limit"),
+        headers=args.get("headers"),
     ),
     check_fn=check_web_api_key,
     requires_env=_web_requires_env(),


### PR DESCRIPTION
## What & why

`web_extract` could not set HTTP request headers on the pages it fetches. Firecrawl's
scrape API accepts a `headers` object, but Hermes never populated it — so there was no
way to supply a descriptive `User-Agent` (which some sites/feeds require), a `Referer`,
or an `Authorization`/API-key header for an internal or partner endpoint. The gap was
present at every layer (tool schema → provider → scrape call), so there was no
user-side workaround. Closes #74177.

## Change

Thread an optional `headers` mapping from the tool down to the SDK call:

1. **Tool schema** (`tools/web_tools.py`): add an optional `headers` object property
   (`additionalProperties: string`) to `WEB_EXTRACT_SCHEMA`, and pass `args.get("headers")`
   through the registry handler.
2. **`web_extract_tool()`**: new `headers` param, sanitized by a small
   `_sanitize_extract_headers()` helper before dispatch — keep only `str -> str` pairs,
   reject `\r`/`\n`/`\0` in names or values (header-injection primitives from
   model-supplied args), and drop empties. Forwarded through the **shared**
   `provider.extract()` dispatch **only when non-empty**, so backends that don't read
   headers get the exact previous call shape.
3. **`FirecrawlProvider.extract()`**: read `headers` from `kwargs` and add it to the
   `scrape` call via `scrape_kwargs`, omitting the argument entirely when unset.

## Safety / compatibility

- **No behavior change when unset**: with no `headers` (the default), neither the
  dispatch nor the Firecrawl scrape call receives a `headers` argument — byte-for-byte
  the previous call shape.
- **SSRF**: private/internal hosts are already filtered out *before* any backend
  dispatch, so caller-supplied headers only ever accompany public fetches.
- **Other backends**: Tavily / Exa / Parallel `extract()` all accept `**kwargs` and
  ignore `headers` (forward-compat), so the shared dispatch stays safe. The tool
  description notes headers are currently applied by the Firecrawl backend.
- **Injection**: the sanitizer strips control characters, so a value like
  `"a\r\nSet-Cookie: evil=1"` can't smuggle a second header.

## Tests

`tests/tools/test_web_extract_headers.py` (10 tests):
- `_sanitize_extract_headers`: None/non-mapping/empty → None; keeps clean pairs; drops
  non-string pairs; rejects CR/LF/NUL injection; all-bad → None.
- End-to-end via a capturing provider: headers forwarded when supplied; **no** `headers`
  kwarg when unset or empty; dirty headers sanitized before dispatch.

```
tests/tools/test_web_extract_headers.py                     10 passed
tests/tools/test_web_providers.py (+ robustness/tavily/…)   39 passed
```

Fixes #74177
