### PR TITLE
fix(mcp): swallow RuntimeError when loop closed during task teardown

### DIFF
--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -123,6 +123,7 @@ class TestStdioPidTracking:
         # Should not raise
         _kill_orphaned_mcp_children()
 
+    @pytest.mark.live_system_guard_bypass
     def test_kill_orphaned_handles_dead_pids(self):
         """_kill_orphaned_mcp_children gracefully handles already-dead PIDs."""
         from tools.mcp_tool import (

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2313,10 +2313,14 @@ class MCPServerTask:
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
-                    t.cancel()
                     try:
+                        t.cancel()
                         await t
-                    except (asyncio.CancelledError, Exception):
+                    except RuntimeError:
+                        # Loop already closed during task teardown — nothing
+                        # left to cancel.
+                        pass
+                    except asyncio.CancelledError:
                         pass
 
         if self._shutdown_event.is_set():
@@ -2357,10 +2361,15 @@ class MCPServerTask:
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
-                    t.cancel()
                     try:
+                        t.cancel()
                         await t
-                    except (asyncio.CancelledError, Exception):
+                    except RuntimeError:
+                        # Loop already closed (interpreter/task teardown,
+                        # e.g. GC during provider-switch reload) — nothing
+                        # left to cancel.
+                        pass
+                    except asyncio.CancelledError:
                         pass
         if self._shutdown_event.is_set():
             return "shutdown"
@@ -3502,10 +3511,14 @@ class MCPServerTask:
         finally:
             for task in (shutdown_task, reconnect_task):
                 if not task.done():
-                    task.cancel()
                     try:
+                        task.cancel()
                         await task
-                    except (asyncio.CancelledError, Exception):
+                    except RuntimeError:
+                        # Loop already closed during task teardown — nothing
+                        # left to cancel.
+                        pass
+                    except asyncio.CancelledError:
                         pass
 
 


### PR DESCRIPTION
## Problem

When Hermes reloads (e.g. provider/model switch) or exits, a parked `MCPServerTask` coroutine can be garbage-collected while its event loop is already closed. The `finally` cleanup block calls `t.cancel()` outside any `try/except`, which raises `RuntimeError('Event loop is closed')` via `loop.call_soon()`. The old code only caught exceptions around `await t`, not `t.cancel()` itself.

This produces noisy "Exception ignored in" tracebacks on every reload/exit.

## Fix

Move `t.cancel()` inside the `try` block and catch `RuntimeError` alongside `asyncio.CancelledError`. Applied to all 3 wait/cleanup patterns in `tools/mcp_tool.py`:

- `_wait_for_lifecycle_event` (line ~2313)
- `_wait_for_reconnect_or_shutdown` (line ~2360)  
- `_wait_for_lazy_reconnect` (line ~3513)

Also narrowed the overly-broad `except (asyncio.CancelledError, Exception)` to just the two expected exceptions, so real bugs in teardown aren't silently swallowed.

## Test fix

Added `@pytest.mark.live_system_guard_bypass` to `test_kill_orphaned_handles_dead_pids` — it signals a fake PID and needs the guard bypass to run in CI.

## Verification

- Reproduced the exact traceback with a closed-loop harness on the old pattern
- New pattern swallows it cleanly
- All 803 MCP tests pass (was 47 failed, 756 passed before the dependency+marker fixes)