### PR TITLE
fix(cli): parse provider:model syntax in -m/--model, not just the /model command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4287,6 +4287,25 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # through MoA instead of hitting the real provider with an unknown
         # model (#56828). A ``moa:`` prefix wins over an explicit ``--provider``.
         _moa_provider_override, self.model = _normalize_moa_model(self.model)
+        # A model string can also carry a provider:model (or the
+        # custom:<name>:<model> triple form for a named custom provider) --
+        # the SAME syntax the interactive /model command already parses via
+        # parse_model_input(). The -m/--model CLI flag never applied that
+        # split at all: the compound string was passed straight through as
+        # the model, provider stayed unset, and provider resolution fell
+        # back to the configured DEFAULT provider -- so `-m
+        # "custom:local-vllm:my-model"` silently sent the prompt to
+        # whatever cloud provider was configured as default, not the local
+        # endpoint the user named (issue #73943). Only applies when
+        # --provider wasn't explicitly passed, matching the moa: prefix
+        # precedent above (an explicit --provider flag still wins).
+        _model_provider_override: Optional[str] = None
+        if not provider and not _moa_provider_override:
+            from hermes_cli.models import parse_model_input
+            _split_provider, _split_model = parse_model_input(self.model, "")
+            if _split_provider:
+                _model_provider_override = _split_provider
+                self.model = _split_model
         # Read max_tokens from config (env var override: HERMES_MAX_TOKENS)
         _env_mt = os.environ.get("HERMES_MAX_TOKENS")
         if _env_mt:
@@ -4324,6 +4343,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.requested_provider = (
             _moa_provider_override
             or provider
+            or _model_provider_override
             or CLI_CONFIG["model"].get("provider")
             or os.getenv("HERMES_INFERENCE_PROVIDER")
             or "auto"

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -1011,3 +1011,146 @@ def test_custom_endpoint_key_env_separates_ports_on_one_host():
 
     assert custom_endpoint_key_env("127.0.0.1_8000") != custom_endpoint_key_env("127.0.0.1_8001")
     assert custom_endpoint_key_env("acme") == custom_endpoint_key_env("ACME")
+
+
+class TestCliInitParsesCompoundModelProviderString:
+    """Regression tests for issue #73943: `-m "custom:name:model"` (and the
+    plain `provider:model` form) was passed straight through as an unsplit
+    model string. requested_provider stayed at its default/config value, so
+    a user selecting a local custom endpoint had their prompt sent to
+    whatever cloud provider was configured as default instead -- a real
+    data-egress bug, not just a UX papercut. The interactive /model command
+    already parsed this via parse_model_input(); -m/--model never did.
+    """
+
+    def test_named_custom_provider_triple_syntax_splits_correctly(self, monkeypatch):
+        cli = _import_cli()
+        config_copy = dict(cli.CLI_CONFIG)
+        model_copy = dict(config_copy.get("model", {}))
+        model_copy["provider"] = None
+        config_copy["model"] = model_copy
+        monkeypatch.setattr(cli, "CLI_CONFIG", config_copy)
+        monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+
+        shell = cli.HermesCLI(
+            model="custom:jetson-vllm:nemotron-nano-30b", compact=True, max_turns=1
+        )
+
+        assert shell.requested_provider == "custom:jetson-vllm", (
+            "The named custom provider must be extracted from the compound "
+            "model string, not silently dropped to the default provider"
+        )
+        assert shell.model == "nemotron-nano-30b"
+
+    def test_provider_colon_model_syntax_splits_correctly(self, monkeypatch):
+        cli = _import_cli()
+        config_copy = dict(cli.CLI_CONFIG)
+        model_copy = dict(config_copy.get("model", {}))
+        model_copy["provider"] = None
+        config_copy["model"] = model_copy
+        monkeypatch.setattr(cli, "CLI_CONFIG", config_copy)
+        monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+
+        shell = cli.HermesCLI(model="nous:hermes-3", compact=True, max_turns=1)
+
+        assert shell.requested_provider == "nous"
+        assert shell.model == "hermes-3"
+
+    def test_explicit_provider_flag_wins_over_embedded_provider(self, monkeypatch):
+        """--provider must take precedence over any provider: prefix in the
+        model string -- mirrors the moa: precedence test above, and
+        prevents this fix from surprising a user who passes both."""
+        cli = _import_cli()
+        config_copy = dict(cli.CLI_CONFIG)
+        model_copy = dict(config_copy.get("model", {}))
+        model_copy["provider"] = None
+        config_copy["model"] = model_copy
+        monkeypatch.setattr(cli, "CLI_CONFIG", config_copy)
+        monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+
+        shell = cli.HermesCLI(
+            model="custom:jetson-vllm:nemotron-nano-30b",
+            provider="deepseek",
+            compact=True,
+            max_turns=1,
+        )
+
+        assert shell.requested_provider == "deepseek"
+        # The model string is left unsplit when an explicit --provider wins,
+        # matching existing behavior for any other provider-prefixed string.
+        assert shell.model == "custom:jetson-vllm:nemotron-nano-30b"
+
+    def test_plain_model_name_without_provider_prefix_unaffected(self, monkeypatch):
+        """A normal model name (no colon, or a colon that isn't a known
+        provider prefix) must not be touched -- this fix must not regress
+        the common case."""
+        cli = _import_cli()
+        config_copy = dict(cli.CLI_CONFIG)
+        model_copy = dict(config_copy.get("model", {}))
+        model_copy["provider"] = None
+        config_copy["model"] = model_copy
+        monkeypatch.setattr(cli, "CLI_CONFIG", config_copy)
+        monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+
+        shell = cli.HermesCLI(
+            model="anthropic/claude-3.5-sonnet:beta", compact=True, max_turns=1
+        )
+
+        assert shell.model == "anthropic/claude-3.5-sonnet:beta"
+        assert shell.requested_provider == "auto"
+
+    def test_moa_prefix_still_wins_over_provider_colon_split(self, monkeypatch):
+        """moa: precedence (#56828) must not regress: since 'moa' isn't a
+        registered provider name recognized by parse_model_input in the
+        same way, the moa branch runs first and this fix's split must not
+        fire on an already-moa-normalized model string."""
+        cli = _import_cli()
+        config_copy = dict(cli.CLI_CONFIG)
+        model_copy = dict(config_copy.get("model", {}))
+        model_copy["provider"] = None
+        config_copy["model"] = model_copy
+        monkeypatch.setattr(cli, "CLI_CONFIG", config_copy)
+        monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+
+        shell = cli.HermesCLI(model="moa:strategy", compact=True, max_turns=1)
+
+        assert shell.requested_provider == "moa"
+        assert shell.model == "strategy"
+
+    def test_end_to_end_resolves_to_named_custom_providers_own_base_url(self, monkeypatch):
+        """The actual reported symptom: verify the split provider string
+        reaches resolve_runtime_provider() correctly, rather than the
+        pre-fix behavior where the compound string was passed as the
+        model and no provider override was ever derived."""
+        cli = _import_cli()
+        config_copy = dict(cli.CLI_CONFIG)
+        model_copy = dict(config_copy.get("model", {}))
+        model_copy["provider"] = None
+        config_copy["model"] = model_copy
+        monkeypatch.setattr(cli, "CLI_CONFIG", config_copy)
+        monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+
+        shell = cli.HermesCLI(
+            model="custom:jetson-vllm:nemotron-nano-30b", compact=True, max_turns=1
+        )
+
+        captured = {}
+
+        def _fake_resolve_runtime_provider(**kwargs):
+            captured.update(kwargs)
+            return {
+                "provider": "custom", "api_mode": "chat_completions",
+                "base_url": "http://192.168.1.149:8000/v1",
+                "api_key": "EMPTY", "source": "test",
+            }
+
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            _fake_resolve_runtime_provider,
+        )
+        shell._ensure_runtime_credentials()
+
+        assert captured.get("requested") == "custom:jetson-vllm", (
+            f"resolve_runtime_provider must receive the split provider "
+            f"name, not the compound string or the default: {captured}"
+        )


### PR DESCRIPTION
## Context

Fixes #73943.

## Problem

The interactive `/model` command already correctly parses `provider:model` syntax (including `custom:<name>:<model>` for named custom providers) via `parse_model_input()`. The `-m/--model` CLI startup flag never applied that split: the compound string was passed straight through as the model, `requested_provider` stayed unset, and resolution fell back to the default provider.

Practical consequence: `-m "custom:jetson-vllm:nemotron-nano-30b"` sent the full prompt to the DEFAULT provider (e.g. Anthropic) with the meaningless unsplit model string, failing with a 404 -- but only after the prompt had already left the machine for a provider the user never selected. Genuine data egress.

## Fix

Mirrors the existing `moa:` prefix precedent (issue #56828, same `__init__`): after moa normalization, if `--provider` wasn't explicitly passed, run `self.model` through `parse_model_input()`. If it resolves a provider, use it as `requested_provider` and the remainder as `self.model`. An explicit `--provider` flag still wins.

## Verification

6 new tests pass: the reported triple syntax, plain `provider:model` syntax, explicit `--provider` precedence, plain model names left untouched, `moa:` precedence preserved, and an end-to-end check that `resolve_runtime_provider()` receives the split provider name. 35/35 in the full `test_cli_provider_resolution.py` file; 11/11 in `test_moa_command.py` (no regression).