### PR TITLE
fix(tests): don't assert host-OS state in the IS_WINDOWS=False no-op test

### DIFF
--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -1059,8 +1059,9 @@ def test_lazy_deps_ensurepip_hides_console_window(monkeypatch):
 
 
 def test_suppress_platform_ver_console_posix_noop(monkeypatch):
-    """On POSIX the helper must do nothing at all and never raise."""
+    """With IS_WINDOWS off, the helper must do nothing at all and never raise."""
     import platform
+    import sys
 
     from hermes_cli import _subprocess_compat
 
@@ -1070,8 +1071,15 @@ def test_suppress_platform_ver_console_posix_noop(monkeypatch):
     _subprocess_compat.suppress_platform_ver_console()
 
     assert platform._syscmd_ver is original
-    # win32_ver stays functional (returns empty fields off Windows).
-    assert platform.win32_ver() == ("", "", "", "")
+    # win32_ver stays functional — the helper must not have broken it.
+    version = platform.win32_ver()
+    assert isinstance(version, tuple) and len(version) == 4
+    # The emptiness of those fields is a property of the *host* OS, not of the
+    # helper: off Windows they are blank, on a real Windows host they carry the
+    # actual release. monkeypatching IS_WINDOWS does not change what
+    # platform.win32_ver() reads, so only assert emptiness where it holds.
+    if sys.platform != "win32":
+        assert version == ("", "", "", "")
 
 
 def test_suppress_platform_ver_console_stubs_syscmd_ver(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

`test_suppress_platform_ver_console_posix_noop` fails on a native Windows host — not
because the code under test is wrong, but because the test asserts a fact about the
machine it runs on.

```
tests\test_windows_subprocess_no_window_flags.py:1074:
    assert platform.win32_ver() == ("", "", "", "")
E   AssertionError: assert ('10', '10.0.26200', 'SP0', 'Multiprocessor Free')
                       == ('', '', '', '')
```

The test monkeypatches `_subprocess_compat.IS_WINDOWS` to `False` and verifies that
`suppress_platform_ver_console()` then leaves `platform._syscmd_ver` untouched. That part
is sound and platform-independent, and it is the actual contract being tested.

The final line is different in kind: `platform.win32_ver()` reads the real OS.
Monkeypatching `IS_WINDOWS` does not change what it reports, so on Windows the assertion
compares the host's genuine version tuple against the blanks you get on Linux.

This is precisely the pitfall CONTRIBUTING's **Testing cross-platform** section warns
about:

> If you monkeypatch `sys.platform` for cross-platform tests, also patch
> `platform.system()` / `platform.release()` / `platform.mac_ver()` — each re-reads the
> real OS independently, so half-patched tests still route through the wrong branch on a
> Windows runner.

## The change

Keep the behavioural assertion on **every** platform — `win32_ver()` must still be
callable and still return a 4-tuple, which is what actually proves the helper did not
damage it — and gate only the emptiness check, which holds off Windows and cannot hold on
it.

```python
    version = platform.win32_ver()
    assert isinstance(version, tuple) and len(version) == 4
    if sys.platform != "win32":
        assert version == ("", "", "", "")
```

POSIX behaviour is unchanged: the emptiness assertion still runs there exactly as before.
No production code is touched.

## How to test

On native Windows:

```powershell
python -m pytest tests/test_windows_subprocess_no_window_flags.py -q
```

**Before:** `39 passed, 1 failed`
**After:** `40 passed`

On Linux/macOS the file is unaffected — the added branch is simply taken.

## Why CI never caught this

All CI jobs run on `ubuntu-latest` (the only `matrix.runner` value in the tree is
`ubuntu-24.04-arm`, in `docker.yml`). There is no Windows runner, so a test that asserts
"we are not on Windows" always passes in CI and only fails for contributors actually
developing on the platform.

## Platforms tested

Native Windows 11 Home, build 26200 · Python 3.11.6.

## Related

Same family, different files, already covered elsewhere — deliberately **not** duplicated
here:

- #57016 — fixes `test_no_op_on_posix` and `test_getattr_fallback_prefers_sigkill_when_present`
  in `tests/tools/test_windows_native_support.py`.
- #42872 — fixes the `which`-based collection error in `tests/tools/test_search_hidden_dirs.py`.
- #48986 — the broader Windows-native baseline-failure tracking issue.

To my knowledge no open PR touches `tests/test_windows_subprocess_no_window_flags.py`.
