### PR TITLE
fix(desktop): release profile backend before rename

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -165,6 +165,7 @@ import {
   revalidatePooledRemoteBackends,
   revalidateRemoteConnection
 } from './remote-liveness'
+import { prepareProfileRenameLifecycle } from './profile-rename-routing'
 import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,
@@ -8252,6 +8253,24 @@ async function prepareProfileDeleteRequest(request) {
   return decision.profile
 }
 
+async function prepareProfileRenameRequest(request) {
+  return prepareProfileRenameLifecycle(request, {
+    isValidProfileName: profile => PROFILE_NAME_RE.test(profile),
+    primaryProfileKey,
+    reloadPrimaryWindow: () => {
+      mainWindow?.reload()
+    },
+    restartPrimaryBackend: async () => {
+      await startHermes()
+    },
+    teardownPoolBackendAndWait,
+    teardownPrimaryBackendAndWait,
+    writeActiveDesktopProfile: profile => {
+      writeActiveDesktopProfile(profile)
+    }
+  })
+}
+
 async function startHermes() {
   // Latched-failure short-circuit: once bootstrap has failed in this
   // process, every subsequent startHermes() call re-throws the same error
@@ -10095,64 +10114,81 @@ ipcMain.handle('hermes:api', async (_event, request) => {
     return rerouted
   }
 
+  const profileRename = await prepareProfileRenameRequest(request)
   const tornDownProfile = await prepareProfileDeleteRequest(request)
 
   const profile = request?.profile
-  // After tearing down a backend for profile deletion, route to the primary
-  // backend instead of spawning a fresh pool backend.  A freshly spawned
-  // backend calls ensure_hermes_home() which recreates the profile directory,
-  // defeating the deletion and leaving a zombie process.
-  const routeProfile = resolveRouteProfile(tornDownProfile, profile)
-  const connection = await ensureBackend(routeProfile)
-  const timeoutMs = resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
+  // Route profile mutations through the current primary after teardown instead
+  // of respawning the affected pool backend. For a primary rename, the lifecycle
+  // has already made `default` the temporary primary until the PATCH settles.
+  const routeProfile = profileRename ? profileRename.routeProfile : resolveRouteProfile(tornDownProfile, profile)
+  let response
 
-  const requestPath = pathWithGlobalRemoteProfile(request.path, profile, profileRouteOptions(profile))
+  try {
+    const connection = await ensureBackend(routeProfile)
+    const timeoutMs = resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
 
-  const url = `${connection.baseUrl}${requestPath}`
+    const requestPath = pathWithGlobalRemoteProfile(request.path, profile, profileRouteOptions(profile))
+    const url = `${connection.baseUrl}${requestPath}`
 
-  // OAuth gateways authenticate REST via EITHER a native bearer token
-  // (cookieless RFC 8252 flow) OR the HttpOnly session cookie held in the OAuth
-  // partition. Prefer the native bearer when present (mirroring
-  // mintGatewayWsTicket): the native flow never sets a cookie, so routing an
-  // oauth-mode REST call through the cookie-only path returns 401 no_cookie even
-  // though a valid bearer is held. Cookie mode rides Electron's net stack bound
-  // to the OAuth partition so the cookie attaches automatically. Token/local
-  // modes keep using the static session-token header.
-  if (connection.authMode === 'oauth') {
-    // The OAuth path rides electron.net with JSON headers; multipart isn't
-    // wired there. Fail loudly rather than corrupting the upload.
-    if (request?.upload) {
-      throw new Error('File uploads are not supported against OAuth-gated remote backends yet.')
-    }
+    // OAuth gateways authenticate REST via EITHER a native bearer token
+    // (cookieless RFC 8252 flow) OR the HttpOnly session cookie held in the OAuth
+    // partition. Prefer the native bearer when present (mirroring
+    // mintGatewayWsTicket): the native flow never sets a cookie, so routing an
+    // oauth-mode REST call through the cookie-only path returns 401 no_cookie even
+    // though a valid bearer is held. Cookie mode rides Electron's net stack bound
+    // to the OAuth partition so the cookie attaches automatically. Token/local
+    // modes keep using the static session-token header.
+    if (connection.authMode === 'oauth') {
+      // The OAuth path rides electron.net with JSON headers; multipart isn't
+      // wired there. Fail loudly rather than corrupting the upload.
+      if (request?.upload) {
+        throw new Error('File uploads are not supported against OAuth-gated remote backends yet.')
+      }
 
-    // Native bearer first (cookieless). ensureNativeAccessToken transparently
-    // refreshes a near-expiry AT via /auth/native/refresh; a null return means
-    // no native session (resolveOauthRestAuth then selects the cookie path).
-    const nativeAt = await ensureNativeAccessToken(connection.baseUrl).catch(() => null)
-    const restAuth = resolveOauthRestAuth(nativeAt)
+      // Native bearer first (cookieless). ensureNativeAccessToken transparently
+      // refreshes a near-expiry AT via /auth/native/refresh; a null return means
+      // no native session (resolveOauthRestAuth then selects the cookie path).
+      const nativeAt = await ensureNativeAccessToken(connection.baseUrl).catch(() => null)
+      const restAuth = resolveOauthRestAuth(nativeAt)
 
-    if (restAuth.kind === 'bearer') {
-      return fetchJson(url, null, {
+      if (restAuth.kind === 'bearer') {
+        response = await fetchJson(url, null, {
+          method: request?.method,
+          body: request?.body,
+          timeoutMs,
+          bearer: restAuth.token
+        })
+      } else {
+        response = await fetchJsonViaOauthSession(url, {
+          method: request?.method,
+          body: request?.body,
+          timeoutMs
+        })
+      }
+    } else {
+      response = await fetchJson(url, connection.token, {
         method: request?.method,
         body: request?.body,
-        timeoutMs,
-        bearer: restAuth.token
+        upload: request?.upload,
+        timeoutMs
       })
     }
+  } catch (error) {
+    if (profileRename) {
+      try {
+        await profileRename.rollback()
+      } catch (rollbackError) {
+        rememberLog(`Failed to restore primary profile after rename error: ${String(rollbackError)}`)
+      }
+    }
 
-    return fetchJsonViaOauthSession(url, {
-      method: request?.method,
-      body: request?.body,
-      timeoutMs
-    })
+    throw error
   }
 
-  return fetchJson(url, connection.token, {
-    method: request?.method,
-    body: request?.body,
-    upload: request?.upload,
-    timeoutMs
-  })
+  await profileRename?.complete()
+
+  return response
 })
 
 // One deduper per cross-window cue — the choke point every window shares. Main

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -155,6 +155,7 @@ import { createKeepAwake } from './power-save'
 import { FirstRunSetupResetError, runPrimaryBackendStartup } from './primary-backend-startup'
 import { rehomePrimaryConnection } from './primary-connection-rehome'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
+import { prepareProfileRenameLifecycle } from './profile-rename-routing'
 import { fetchPrimaryProfileSessions } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
@@ -165,7 +166,6 @@ import {
   revalidatePooledRemoteBackends,
   revalidateRemoteConnection
 } from './remote-liveness'
-import { prepareProfileRenameLifecycle } from './profile-rename-routing'
 import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,

--- a/apps/desktop/electron/profile-delete-routing.ts
+++ b/apps/desktop/electron/profile-delete-routing.ts
@@ -9,17 +9,9 @@
 //
 // These helpers are pure so they can be unit-tested without Electron.
 
-/**
- * Parse a `hermes:api` request into the profile name a DELETE targets, or
- * null when the request is not a profile-delete at all (wrong method, wrong
- * path, empty/invalid name).
- */
-export function profileNameFromDeleteRequest(request) {
-  if (!request || String(request.method || 'GET').toUpperCase() !== 'DELETE') {
-    return null
-  }
-
-  const match = String(request.path || '').match(/^\/api\/profiles\/([^/?#]+)(?:[?#].*)?$/)
+/** Parse a profile name from an `/api/profiles/<name>` request path. */
+export function profileNameFromPath(path: unknown): string | null {
+  const match = String(path || '').match(/^\/api\/profiles\/([^/?#]+)(?:[?#].*)?$/)
 
   if (!match) {
     return null
@@ -44,6 +36,15 @@ export function profileNameFromDeleteRequest(request) {
   }
 
   return name.toLowerCase()
+}
+
+/** Parse a `hermes:api` request into the profile name a DELETE targets. */
+export function profileNameFromDeleteRequest(request) {
+  if (!request || String(request.method || 'GET').toUpperCase() !== 'DELETE') {
+    return null
+  }
+
+  return profileNameFromPath(request.path)
 }
 
 export type ProfileDeleteAction = 'noop' | 'teardown-primary' | 'teardown-pool'

--- a/apps/desktop/electron/profile-rename-routing.test.ts
+++ b/apps/desktop/electron/profile-rename-routing.test.ts
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  prepareProfileRenameLifecycle,
+  profileRenameFromRequest,
+  type ProfileRenameLifecycleDeps
+} from './profile-rename-routing'
+
+const renameRequest = {
+  body: { new_name: 'renamed-profile' },
+  method: 'PATCH',
+  path: '/api/profiles/primary-profile'
+}
+
+function lifecycleDeps(events: string[]): ProfileRenameLifecycleDeps {
+  return {
+    isValidProfileName: profile => /^[a-z0-9][a-z0-9_-]{0,63}$/.test(profile),
+    primaryProfileKey: () => 'primary-profile',
+    reloadPrimaryWindow: () => events.push('reload-primary-window'),
+    restartPrimaryBackend: async () => {
+      events.push('restart-primary-backend')
+    },
+    teardownPoolBackendAndWait: async profile => {
+      events.push(`teardown-pool:${profile}`)
+    },
+    teardownPrimaryBackendAndWait: async () => {
+      events.push('teardown-primary')
+    },
+    writeActiveDesktopProfile: profile => {
+      events.push(`write-active:${profile}`)
+    }
+  }
+}
+
+test('profileRenameFromRequest parses string and object JSON bodies', () => {
+  assert.deepEqual(profileRenameFromRequest(renameRequest), {
+    newName: 'renamed-profile',
+    oldName: 'primary-profile'
+  })
+  assert.deepEqual(profileRenameFromRequest({ ...renameRequest, body: JSON.stringify({ new_name: 'String-Body' }) }), {
+    newName: 'string-body',
+    oldName: 'primary-profile'
+  })
+})
+
+test('profileRenameFromRequest rejects malformed and reserved rename requests', () => {
+  assert.equal(profileRenameFromRequest({ ...renameRequest, method: 'DELETE' }), null)
+  assert.equal(profileRenameFromRequest({ ...renameRequest, body: '{' }), null)
+  assert.equal(profileRenameFromRequest({ ...renameRequest, body: { new_name: 'default' } }), null)
+  assert.equal(profileRenameFromRequest({ ...renameRequest, path: '/api/profiles/default' }), null)
+})
+
+test('prepareProfileRenameLifecycle tears down a pooled backend and routes through the primary', async () => {
+  const events: string[] = []
+
+  const lifecycle = await prepareProfileRenameLifecycle(
+    { ...renameRequest, path: '/api/profiles/worker-profile' },
+    lifecycleDeps(events)
+  )
+
+  assert.equal(lifecycle?.kind, 'pool')
+  assert.equal(lifecycle?.routeProfile, null)
+  assert.deepEqual(events, ['teardown-pool:worker-profile'])
+
+  await lifecycle?.complete()
+  await lifecycle?.rollback()
+  assert.deepEqual(events, ['teardown-pool:worker-profile'])
+})
+
+test('prepareProfileRenameLifecycle re-homes a renamed primary after success', async () => {
+  const events: string[] = []
+  const lifecycle = await prepareProfileRenameLifecycle(renameRequest, lifecycleDeps(events))
+
+  assert.equal(lifecycle?.kind, 'primary')
+  assert.equal(lifecycle?.routeProfile, null)
+  assert.deepEqual(events, ['write-active:default', 'teardown-primary'])
+
+  await lifecycle?.complete()
+  assert.deepEqual(events, [
+    'write-active:default',
+    'teardown-primary',
+    'write-active:renamed-profile',
+    'teardown-primary',
+    'reload-primary-window'
+  ])
+})
+
+test('prepareProfileRenameLifecycle restores the original primary after failure', async () => {
+  const events: string[] = []
+  const lifecycle = await prepareProfileRenameLifecycle(renameRequest, lifecycleDeps(events))
+
+  await lifecycle?.rollback()
+  assert.deepEqual(events, [
+    'write-active:default',
+    'teardown-primary',
+    'write-active:primary-profile',
+    'teardown-primary',
+    'restart-primary-backend'
+  ])
+})
+
+test('prepareProfileRenameLifecycle restores the original primary when initial teardown fails', async () => {
+  const events: string[] = []
+  const deps = lifecycleDeps(events)
+
+  deps.teardownPrimaryBackendAndWait = async () => {
+    events.push('teardown-primary')
+    throw new Error('teardown failed')
+  }
+
+  await assert.rejects(prepareProfileRenameLifecycle(renameRequest, deps), /teardown failed/)
+  assert.deepEqual(events, [
+    'write-active:default',
+    'teardown-primary',
+    'write-active:primary-profile',
+    'restart-primary-backend'
+  ])
+})
+
+test('prepareProfileRenameLifecycle ignores invalid profile names without side effects', async () => {
+  const events: string[] = []
+
+  const lifecycle = await prepareProfileRenameLifecycle(
+    { ...renameRequest, body: { new_name: 'Not Valid!' } },
+    lifecycleDeps(events)
+  )
+
+  assert.equal(lifecycle, null)
+  assert.deepEqual(events, [])
+})

--- a/apps/desktop/electron/profile-rename-routing.ts
+++ b/apps/desktop/electron/profile-rename-routing.ts
@@ -1,0 +1,138 @@
+import { profileNameFromPath } from './profile-delete-routing'
+
+export interface ProfileRenameRequest {
+  body?: unknown
+  method?: unknown
+  path?: unknown
+}
+
+export interface ProfileRename {
+  newName: string
+  oldName: string
+}
+
+export interface ProfileRenameLifecycleDeps {
+  isValidProfileName: (profile: string) => boolean
+  primaryProfileKey: () => string
+  reloadPrimaryWindow: () => void
+  restartPrimaryBackend: () => Promise<void>
+  teardownPoolBackendAndWait: (profile: string) => Promise<void>
+  teardownPrimaryBackendAndWait: () => Promise<void>
+  writeActiveDesktopProfile: (profile: string) => void
+}
+
+export interface ProfileRenameLifecycle {
+  complete: () => Promise<void>
+  kind: 'pool' | 'primary'
+  rename: ProfileRename
+  rollback: () => Promise<void>
+  routeProfile: null
+}
+
+function parseJsonBody(body: unknown): Record<string, unknown> {
+  if (body == null || body === '') {
+    return {}
+  }
+
+  if (typeof body === 'object' && !Array.isArray(body)) {
+    return body as Record<string, unknown>
+  }
+
+  try {
+    const parsed = JSON.parse(String(body))
+
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+export function profileRenameFromRequest(request: ProfileRenameRequest | null | undefined): ProfileRename | null {
+  if (!request || String(request.method || 'GET').toUpperCase() !== 'PATCH') {
+    return null
+  }
+
+  const oldName = profileNameFromPath(request.path)
+
+  if (!oldName || oldName === 'default') {
+    return null
+  }
+
+  const body = parseJsonBody(request.body)
+
+  const newName = String(body.new_name || '')
+    .trim()
+    .toLowerCase()
+
+  if (!newName || newName === 'default') {
+    return null
+  }
+
+  return { newName, oldName }
+}
+
+export async function prepareProfileRenameLifecycle(
+  request: ProfileRenameRequest | null | undefined,
+  deps: ProfileRenameLifecycleDeps
+): Promise<ProfileRenameLifecycle | null> {
+  const rename = profileRenameFromRequest(request)
+
+  if (!rename || !deps.isValidProfileName(rename.oldName) || !deps.isValidProfileName(rename.newName)) {
+    return null
+  }
+
+  if (rename.oldName !== deps.primaryProfileKey()) {
+    await deps.teardownPoolBackendAndWait(rename.oldName)
+
+    return {
+      complete: async () => {},
+      kind: 'pool',
+      rename,
+      rollback: async () => {},
+      routeProfile: null
+    }
+  }
+
+  // Make `default` the temporary primary before stopping the old backend.
+  // Concurrent primary requests then share the temporary connection instead
+  // of respawning the old profile and recreating its directory mid-rename.
+  deps.writeActiveDesktopProfile('default')
+
+  try {
+    await deps.teardownPrimaryBackendAndWait()
+  } catch (error) {
+    deps.writeActiveDesktopProfile(rename.oldName)
+
+    try {
+      await deps.restartPrimaryBackend()
+    } catch {
+      // Preserve the teardown error that prevented the rename from starting.
+    }
+
+    throw error
+  }
+
+  return {
+    complete: async () => {
+      deps.writeActiveDesktopProfile(rename.newName)
+
+      try {
+        await deps.teardownPrimaryBackendAndWait()
+      } finally {
+        deps.reloadPrimaryWindow()
+      }
+    },
+    kind: 'primary',
+    rename,
+    rollback: async () => {
+      deps.writeActiveDesktopProfile(rename.oldName)
+
+      try {
+        await deps.teardownPrimaryBackendAndWait()
+      } finally {
+        await deps.restartPrimaryBackend()
+      }
+    },
+    routeProfile: null
+  }
+}


### PR DESCRIPTION
## Summary

- stop the affected Desktop backend before renaming its profile directory
- route the rename through a safe primary backend so Windows releases open log and SQLite handles
- re-home the primary backend after success and restore it after failure
- add lifecycle coverage for pooled, primary, success, and rollback paths

## Root cause

Desktop already tears down profile backends before deletion, but not before `PATCH /api/profiles/<name>`. On Windows, the running backend keeps files open under the profile directory, so `Path.rename()` fails with `PermissionError: [WinError 5] Access is denied`.

This ports the work from #51852 onto current `main` while preserving the original contributor commit and authorship.

Related: #45474, #51852

## Validation

- `npm run test:desktop:platforms -- electron/profile-delete-routing.test.ts electron/profile-rename-routing.test.ts electron/profile-session-routing.test.ts` — 23 passed
- `npx tsc -p tsconfig.electron.json --noEmit`
- `npx eslint electron/profile-delete-routing.ts electron/profile-rename-routing.ts electron/profile-rename-routing.test.ts electron/main.ts --max-warnings=0`
- `npx prettier --check electron/profile-delete-routing.ts electron/profile-rename-routing.ts electron/profile-rename-routing.test.ts electron/main.ts`

The full Electron platform run completed 831 tests successfully but retains 17 unrelated Windows-host failures in existing POSIX/SSH/packaging tests.
