### PR TITLE
refactor(gateway): promote mention patterns, reaction-ack, and interactive-prompt formatting to base

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3622,6 +3622,91 @@ class BasePlatformAdapter(ABC):
             # about it never being awaited, then drop silently.
             coro.close()
 
+    # ── Shared interactive-prompt formatting cores ─────────────────────────
+    # Template attrs for ``_format_exec_approval``. Adapters override these to
+    # keep their historical, platform-specific wording byte-identical while
+    # sharing the assembly logic (header → fenced command preview → reason →
+    # optional smart-deny note).
+    _EA_HEADER: str = "⚠️ Command Approval Required\n\n"
+    _EA_CODE_OPEN: str = "```\n"
+    _EA_CODE_CLOSE: str = "\n```\n"
+    _EA_REASON_LABEL: str = "Reason: "
+    _EA_SMART_DENY_LINE: str = (
+        "\n\nSmart DENY: owner override applies to this one operation only."
+    )
+    _EA_CMD_BUDGET: int = 3000
+
+    @staticmethod
+    def _truncate_preview(text: str, budget: int, suffix: str = "...") -> str:
+        """Truncate ``text`` to ``budget`` chars, appending ``suffix`` when cut.
+
+        The shared ``x[:budget] + "..." if len(x) > budget else x`` idiom used
+        by every adapter's approval/confirm preview construction.
+        """
+        text = str(text or "")
+        return text[:budget] + suffix if len(text) > budget else text
+
+    def _ea_escape(self, text: str) -> str:
+        """Escape hook applied to the command preview and reason text.
+
+        Default is pass-through; HTML-mode platforms (Telegram) override.
+        """
+        return text
+
+    def _format_exec_approval(
+        self,
+        command: str,
+        description: str = "dangerous command",
+        smart_denied: bool = False,
+    ) -> str:
+        """Shared formatting core for exec-approval prompt text.
+
+        Assembles ``_EA_HEADER`` + fenced command preview (truncated to
+        ``_EA_CMD_BUDGET``) + ``_EA_REASON_LABEL`` + description, plus
+        ``_EA_SMART_DENY_LINE`` when ``smart_denied``. Button construction
+        stays platform-local; adapters with additional trailing instructions
+        (e.g. reaction legends) append them to this core.
+        """
+        cmd_preview = self._truncate_preview(str(command or ""), self._EA_CMD_BUDGET)
+        text = (
+            f"{self._EA_HEADER}"
+            f"{self._EA_CODE_OPEN}{self._ea_escape(cmd_preview)}{self._EA_CODE_CLOSE}"
+            f"{self._EA_REASON_LABEL}{self._ea_escape(description)}"
+        )
+        if smart_denied:
+            text += self._EA_SMART_DENY_LINE
+        return text
+
+    @staticmethod
+    def _format_choice_page(
+        options: list,
+        page: int,
+        per_page: int,
+    ) -> "tuple[list, Dict[str, Any]]":
+        """Shared pagination core for picker keyboards/menus.
+
+        Clamps ``page`` into range, slices ``options`` for that page and
+        returns ``(page_options, meta)`` where ``meta`` carries ``page``,
+        ``total_pages``, ``start``, ``end``, ``total`` and ``page_info`` —
+        the `` (N–M of T)`` suffix text (empty when everything fits on one
+        page). Option/button rendering stays platform-local.
+        """
+        total = len(options)
+        total_pages = max(1, (total + per_page - 1) // per_page)
+        page = max(0, min(page, total_pages - 1))
+        start = page * per_page
+        end = min(start + per_page, total)
+        page_info = f" ({start + 1}–{end} of {total})" if total_pages > 1 else ""
+        meta: Dict[str, Any] = {
+            "page": page,
+            "total_pages": total_pages,
+            "start": start,
+            "end": end,
+            "total": total,
+            "page_info": page_info,
+        }
+        return options[start:end], meta
+
     async def send_slash_confirm(
         self,
         chat_id: str,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4793,11 +4793,52 @@ class BasePlatformAdapter(ABC):
     # Subclasses override these to react to message processing events
     # (e.g. Discord adds 👀/✅/❌ reactions).
 
+    # Opt-in emoji set for the shared reaction-ack flow in
+    # ``on_processing_complete``. Adapters whose reaction primitives follow
+    # the ``_add_reaction(chat_id, message_id, emoji)`` /
+    # ``_remove_reaction(chat_id, message_id)`` shape can set these class
+    # attributes instead of overriding the hook. Left as ``None`` the hook
+    # stays a no-op (historical default).
+    _ACK_EMOJI: Optional[str] = None
+    _OK_EMOJI: Optional[str] = None
+    _FAIL_EMOJI: Optional[str] = None
+
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Hook called when background processing begins."""
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
-        """Hook called when background processing completes."""
+        """Hook called when background processing completes.
+
+        Default: shared reaction-ack flow — swap the in-progress reaction for
+        a final success/failure reaction. Runs only when the adapter opts in
+        by setting ``_OK_EMOJI`` / ``_FAIL_EMOJI`` class attributes AND
+        defines ``_add_reaction`` / ``_remove_reaction`` primitives taking
+        ``(chat_id, message_id[, emoji])``. Otherwise this is a no-op, as it
+        always was. Remove-then-add rather than a bare replace: deterministic
+        whether the platform replaces a sender's previous reaction or stacks
+        them. CANCELLED outcomes leave the message unreacted.
+        """
+        if self._OK_EMOJI is None and self._FAIL_EMOJI is None:
+            return
+        add: Any = getattr(self, "_add_reaction", None)
+        remove: Any = getattr(self, "_remove_reaction", None)
+        if not callable(add) or not callable(remove):
+            return
+        enabled = getattr(self, "_reactions_enabled", None)
+        if callable(enabled) and not enabled():
+            return
+        chat_id = getattr(event.source, "chat_id", None)
+        message_id = getattr(event, "message_id", None)
+        if not chat_id or not message_id:
+            return
+        await remove(chat_id, message_id)
+        if outcome == ProcessingOutcome.SUCCESS:
+            if self._OK_EMOJI:
+                await add(chat_id, message_id, self._OK_EMOJI)
+        elif outcome == ProcessingOutcome.FAILURE:
+            if self._FAIL_EMOJI:
+                await add(chat_id, message_id, self._FAIL_EMOJI)
+        # CANCELLED: leave the message unreacted.
 
     async def _run_processing_hook(self, hook_name: str, *args: Any, **kwargs: Any) -> None:
         """Run a lifecycle hook without letting failures break message flow."""

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -32,7 +32,7 @@ from gateway.platforms.base import (
     cache_document_from_bytes,
 )
 from .media_cache import ext_for_mime
-from gateway.platforms.helpers import strip_markdown
+from gateway.platforms.helpers import compile_mention_patterns, strip_markdown
 
 # Historical BlueBubbles mime→ext maps, preserved verbatim as overrides for
 # the shared dispatch in gateway.platforms.media_cache. Both maps are
@@ -194,34 +194,12 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         ``raw`` is a list (from config or env JSON), a string (raw env var:
         JSON list, or comma/newline-separated), or None (use Hermes defaults).
         """
-        if raw is None:
-            patterns = list(DEFAULT_MENTION_PATTERNS)
-        elif isinstance(raw, str):
-            text = raw.strip()
-            try:
-                loaded = json.loads(text) if text else []
-            except Exception:
-                loaded = None
-            patterns = loaded if isinstance(loaded, list) else [
-                part.strip()
-                for line in text.splitlines()
-                for part in line.split(",")
-            ]
-        elif isinstance(raw, list):
-            patterns = raw
-        else:
-            patterns = [raw]
-
-        compiled: List["re.Pattern"] = []
-        for pattern in patterns:
-            text = str(pattern).strip()
-            if not text:
-                continue
-            try:
-                compiled.append(re.compile(text, re.IGNORECASE))
-            except re.error as exc:
-                logger.warning("[bluebubbles] Invalid mention pattern %r: %s", text, exc)
-        return compiled
+        return compile_mention_patterns(
+            raw,
+            log_prefix="bluebubbles",
+            defaults=DEFAULT_MENTION_PATTERNS,
+            logger_=logger,
+        )
 
     def _message_matches_mention_patterns(self, text: str) -> bool:
         if not text or not self._mention_patterns:

--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -417,3 +417,105 @@ def convert_table_to_bullets(text: str) -> str:
         i += 1
 
     return '\n'.join(out)
+
+
+# ─── Mention-pattern compilation ─────────────────────────────────────────────
+
+
+def compile_mention_patterns(
+    raw,
+    *,
+    log_prefix: str,
+    platform_label: str | None = None,
+    display_label: str | None = None,
+    defaults: 'list[str] | None' = None,
+    logger_: 'logging.Logger | None' = None,
+) -> 'list[re.Pattern]':
+    """Compile regex wake-word/mention patterns from config or env values.
+
+    Two adapter families share this logic:
+
+    * **Config-style** (dingtalk, telegram): pass ``platform_label`` (e.g.
+      ``"dingtalk"``). ``raw`` is the value from ``config.extra`` after env
+      fallback parsing; must be a list or string, anything else logs a warning
+      and yields ``[]``. Non-string entries are skipped. A summary info log is
+      emitted when patterns load.
+    * **Wakeword-style** (photon, bluebubbles): pass ``defaults``. ``raw`` may
+      be None (use defaults), a string (JSON list or comma/newline separated),
+      a list, or a scalar (wrapped in a list). Entries are coerced via
+      ``str()``.
+
+    ``log_prefix`` is interpolated into every log message so per-adapter log
+    output stays byte-identical to the historical inline implementations.
+    """
+    log = logger_ or logger
+
+    if platform_label is not None:
+        # Config-style (dingtalk/telegram) semantics.
+        display = display_label or platform_label
+        patterns = raw
+        if patterns is None:
+            return []
+        if isinstance(patterns, str):
+            patterns = [patterns]
+        if not isinstance(patterns, list):
+            log.warning(
+                "[%s] %s mention_patterns must be a list or string; got %s",
+                log_prefix,
+                platform_label,
+                type(patterns).__name__,
+            )
+            return []
+
+        compiled: list[re.Pattern] = []
+        for pattern in patterns:
+            if not isinstance(pattern, str) or not pattern.strip():
+                continue
+            try:
+                compiled.append(re.compile(pattern, re.IGNORECASE))
+            except re.error as exc:
+                log.warning(
+                    "[%s] Invalid %s mention pattern %r: %s",
+                    log_prefix,
+                    display,
+                    pattern,
+                    exc,
+                )
+        if compiled:
+            log.info(
+                "[%s] Loaded %d %s mention pattern(s)",
+                log_prefix,
+                len(compiled),
+                display,
+            )
+        return compiled
+
+    # Wakeword-style (photon/bluebubbles) semantics.
+    if raw is None:
+        patterns = list(defaults or [])
+    elif isinstance(raw, str):
+        text = raw.strip()
+        try:
+            loaded = json.loads(text) if text else []
+        except Exception:
+            loaded = None
+        patterns = loaded if isinstance(loaded, list) else [
+            part.strip()
+            for line in text.splitlines()
+            for part in line.split(",")
+        ]
+    elif isinstance(raw, list):
+        patterns = raw
+    else:
+        patterns = [raw]
+
+    compiled = []
+    for pattern in patterns:
+        text = str(pattern).strip()
+        if not text:
+            continue
+        try:
+            compiled.append(re.compile(text, re.IGNORECASE))
+        except re.error as exc:
+            log.warning("[%s] Invalid mention pattern %r: %s", log_prefix, text, exc)
+    return compiled

--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -95,7 +95,7 @@ except Exception:
     tea_util_models = None
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.helpers import MessageDeduplicator
+from gateway.platforms.helpers import MessageDeduplicator, compile_mention_patterns
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -458,29 +458,13 @@ class DingTalkAdapter(BasePlatformAdapter):
                         loaded = [part.strip() for part in raw.split(",") if part.strip()]
                 patterns = loaded
 
-        if patterns is None:
-            return []
-        if isinstance(patterns, str):
-            patterns = [patterns]
-        if not isinstance(patterns, list):
-            logger.warning(
-                "[%s] dingtalk mention_patterns must be a list or string; got %s",
-                self.name,
-                type(patterns).__name__,
-            )
-            return []
-
-        compiled: List[re.Pattern] = []
-        for pattern in patterns:
-            if not isinstance(pattern, str) or not pattern.strip():
-                continue
-            try:
-                compiled.append(re.compile(pattern, re.IGNORECASE))
-            except re.error as exc:
-                logger.warning("[%s] Invalid DingTalk mention pattern %r: %s", self.name, pattern, exc)
-        if compiled:
-            logger.info("[%s] Loaded %d DingTalk mention pattern(s)", self.name, len(compiled))
-        return compiled
+        return compile_mention_patterns(
+            patterns,
+            log_prefix=self.name,
+            platform_label="dingtalk",
+            display_label="DingTalk",
+            logger_=logger,
+        )
 
     def _load_allowed_users(self) -> Set[str]:
         """Load allowed-users list from config.extra or env var.

--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -458,6 +458,12 @@ class DingTalkAdapter(BasePlatformAdapter):
                         loaded = [part.strip() for part in raw.split(",") if part.strip()]
                 patterns = loaded
 
+        if patterns is None:
+            # Parity with the historical inline implementation: return before
+            # evaluating ``self.name`` (avoids touching adapter attributes on
+            # the no-patterns path).
+            return []
+
         return compile_mention_patterns(
             patterns,
             log_prefix=self.name,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1999,6 +1999,13 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.error("[Feishu] Failed to edit message %s: %s", message_id, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
 
+    # Template attrs for the shared _format_exec_approval core. The card
+    # header carries the title, so the text core starts at the code fence.
+    _EA_HEADER = ""
+    _EA_REASON_LABEL = "**Reason:** "
+    _EA_SMART_DENY_LINE = "\n\n**Smart DENY:** owner override applies to this one operation only."
+    _EA_CMD_BUDGET = 3000
+
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
@@ -2018,7 +2025,6 @@ class FeishuAdapter(BasePlatformAdapter):
 
         try:
             approval_id = next(self._approval_counter)
-            cmd_preview = command[:3000] + "..." if len(command) > 3000 else command
 
             def _btn(label: str, action_name: str, btn_type: str = "default") -> dict:
                 return {
@@ -2034,7 +2040,6 @@ class FeishuAdapter(BasePlatformAdapter):
                 if allow_permanent:
                     actions.append(_btn("✅ Always", "approve_always"))
             actions.append(_btn("❌ Deny", "deny", "danger"))
-            scope_note = "\n\n**Smart DENY:** owner override applies to this one operation only." if smart_denied else ""
             card = {
                 "config": {"wide_screen_mode": True},
                 "header": {
@@ -2044,7 +2049,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 "elements": [
                     {
                         "tag": "markdown",
-                        "content": f"```\n{cmd_preview}\n```\n**Reason:** {description}{scope_note}",
+                        "content": self._format_exec_approval(command, description, smart_denied),
                     },
                     {
                         "tag": "action",

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2225,6 +2225,12 @@ class MatrixAdapter(BasePlatformAdapter):
             chat_id, video_path, "m.video", caption, reply_to, metadata=metadata
         )
 
+    # Template attrs for the shared _format_exec_approval core. Matrix keeps
+    # the smart-deny/scope wording in its local tail (reaction legend), so the
+    # core is used for the header + fence + reason head only.
+    _EA_HEADER = "⚠️ **Dangerous command requires approval**\n"
+    _EA_CMD_BUDGET = 2000
+
     async def send_exec_approval(
         self,
         chat_id: str,
@@ -2241,7 +2247,6 @@ class MatrixAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         requester_user_id = str((metadata or {}).get("requester_user_id") or "") or None
-        cmd_preview = command[:2000] + "..." if len(command) > 2000 else command
         scope_choices = ""
         if smart_denied:
             scope_choices = "Smart DENY: owner override applies to this one operation only.\n"
@@ -2258,9 +2263,7 @@ class MatrixAdapter(BasePlatformAdapter):
                 reaction_legend_parts.append("♾️ = approve always")
         reaction_legend_parts.append("❎ = deny")
         text = (
-            "⚠️ **Dangerous command requires approval**\n"
-            f"```\n{cmd_preview}\n```\n"
-            f"Reason: {description}\n\n"
+            f"{self._format_exec_approval(command, description)}\n\n"
             f"{scope_choices}Reply `!approve` to execute once, or `!deny` to cancel.\n\n"
             "You can also click the reaction to approve:\n"
             + "\n".join(reaction_legend_parts)

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -2295,27 +2295,13 @@ class PhotonAdapter(BasePlatformAdapter):
         if chat_id and message_id:
             await self._add_reaction(chat_id, message_id, "\U0001f440")
 
-    async def on_processing_complete(
-        self, event: MessageEvent, outcome: ProcessingOutcome
-    ) -> None:
-        """Swap the 👀 progress tapback for a 👍/👎 result.
-
-        Remove-then-add rather than a bare replace: deterministic whether the
-        platform replaces a sender's previous tapback or stacks them, and it
-        keeps the sidecar's reaction-handle slot coherent.
-        """
-        if not self._reactions_enabled():
-            return
-        chat_id = getattr(event.source, "chat_id", None)
-        message_id = getattr(event, "message_id", None)
-        if not chat_id or not message_id:
-            return
-        await self._remove_reaction(chat_id, message_id)
-        if outcome == ProcessingOutcome.SUCCESS:
-            await self._add_reaction(chat_id, message_id, "\U0001f44d")
-        elif outcome == ProcessingOutcome.FAILURE:
-            await self._add_reaction(chat_id, message_id, "\U0001f44e")
-        # CANCELLED: leave the message unreacted.
+    # Shared reaction-ack flow (base.on_processing_complete): swap the 👀
+    # progress tapback for a 👍/👎 result. Remove-then-add rather than a bare
+    # replace: deterministic whether the platform replaces a sender's previous
+    # tapback or stacks them, and it keeps the sidecar's reaction-handle slot
+    # coherent. CANCELLED: leave the message unreacted.
+    _OK_EMOJI = "\U0001f44d"
+    _FAIL_EMOJI = "\U0001f44e"
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return whatever we know about a Spectrum space id.

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -63,7 +63,7 @@ from gateway.platforms.base import (
     ProcessingOutcome,
     SendResult,
 )
-from gateway.platforms.helpers import strip_markdown
+from gateway.platforms.helpers import compile_mention_patterns, strip_markdown
 
 from .auth import load_project_credentials
 
@@ -823,34 +823,12 @@ class PhotonAdapter(BasePlatformAdapter):
         Mirrors the BlueBubbles implementation so both iMessage channels
         accept the same configuration shapes.
         """
-        if raw is None:
-            patterns = list(_DEFAULT_MENTION_PATTERNS)
-        elif isinstance(raw, str):
-            text = raw.strip()
-            try:
-                loaded = json.loads(text) if text else []
-            except Exception:
-                loaded = None
-            patterns = loaded if isinstance(loaded, list) else [
-                part.strip()
-                for line in text.splitlines()
-                for part in line.split(",")
-            ]
-        elif isinstance(raw, list):
-            patterns = raw
-        else:
-            patterns = [raw]
-
-        compiled: "list[re.Pattern]" = []
-        for pattern in patterns:
-            text = str(pattern).strip()
-            if not text:
-                continue
-            try:
-                compiled.append(re.compile(text, re.IGNORECASE))
-            except re.error as exc:
-                logger.warning("[photon] Invalid mention pattern %r: %s", text, exc)
-        return compiled
+        return compile_mention_patterns(
+            raw,
+            log_prefix="photon",
+            defaults=_DEFAULT_MENTION_PATTERNS,
+            logger_=logger,
+        )
 
     def _message_matches_mention_patterns(self, text: str) -> bool:
         if not text or not self._mention_patterns:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -490,6 +490,7 @@ def _separate_chunk_indicator_from_fence(text: str) -> str:
 
 from gateway.platforms.helpers import (
     TABLE_SEPARATOR_RE as _TABLE_SEPARATOR_RE,
+    compile_mention_patterns,
     convert_table_to_bullets as _wrap_markdown_tables,
 )
 
@@ -7821,29 +7822,13 @@ class TelegramAdapter(BasePlatformAdapter):
                         loaded = [part.strip() for part in raw.split(",") if part.strip()]
                 patterns = loaded
 
-        if patterns is None:
-            return []
-        if isinstance(patterns, str):
-            patterns = [patterns]
-        if not isinstance(patterns, list):
-            logger.warning(
-                "[%s] telegram mention_patterns must be a list or string; got %s",
-                self.name,
-                type(patterns).__name__,
-            )
-            return []
-
-        compiled: List[re.Pattern] = []
-        for pattern in patterns:
-            if not isinstance(pattern, str) or not pattern.strip():
-                continue
-            try:
-                compiled.append(re.compile(pattern, re.IGNORECASE))
-            except re.error as exc:
-                logger.warning("[%s] Invalid Telegram mention pattern %r: %s", self.name, pattern, exc)
-        if compiled:
-            logger.info("[%s] Loaded %d Telegram mention pattern(s)", self.name, len(compiled))
-        return compiled
+        return compile_mention_patterns(
+            patterns,
+            log_prefix=self.name,
+            platform_label="telegram",
+            display_label="Telegram",
+            logger_=logger,
+        )
 
     def _is_group_chat(self, message: Message) -> bool:
         chat = getattr(message, "chat", None)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5318,6 +5318,16 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_update_prompt failed: %s", self.name, _redact_telegram_error_text(e))
             return SendResult(success=False, error=_redact_telegram_error_text(e))
 
+    # Template attrs for the shared _format_exec_approval core (HTML mode).
+    _EA_HEADER = "⚠️ <b>Command Approval Required</b>\n\n"
+    _EA_CODE_OPEN = "<pre>"
+    _EA_CODE_CLOSE = "</pre>\n\n"
+    _EA_SMART_DENY_LINE = "\n\n<b>Smart DENY:</b> owner override applies to this one operation only."
+    _EA_CMD_BUDGET = 3800
+
+    def _ea_escape(self, text: str) -> str:
+        return _html.escape(text)
+
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
@@ -5335,14 +5345,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
-            cmd_preview = command[:3800] + "..." if len(command) > 3800 else command
-            text = (
-                f"⚠️ <b>Command Approval Required</b>\n\n"
-                f"<pre>{_html.escape(cmd_preview)}</pre>\n\n"
-                f"Reason: {_html.escape(description)}"
-            )
-            if smart_denied:
-                text += "\n\n<b>Smart DENY:</b> owner override applies to this one operation only."
+            text = self._format_exec_approval(command, description, smart_denied)
 
             # Resolve thread context for thread replies
             thread_id = self._metadata_thread_id(metadata)
@@ -5410,7 +5413,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
-            preview = self.format_message(message if len(message) <= 3800 else message[:3800] + "...")
+            preview = self.format_message(self._truncate_preview(message, 3800))
 
             keyboard = InlineKeyboardMarkup([
                 [
@@ -5774,14 +5777,11 @@ class TelegramAdapter(BasePlatformAdapter):
             for p in providers:
                 buttons.append(_provider_button(p))
 
-        page_size = self._PROVIDER_PAGE_SIZE
-        total = len(buttons)
-        total_pages = max(1, (total + page_size - 1) // page_size)
-        page = max(0, min(page, total_pages - 1))
-
-        start = page * page_size
-        end = min(start + page_size, total)
-        page_buttons = buttons[start:end]
+        page_buttons, page_meta = self._format_choice_page(
+            buttons, page, self._PROVIDER_PAGE_SIZE
+        )
+        page = page_meta["page"]
+        total_pages = page_meta["total_pages"]
 
         rows = [page_buttons[i : i + 2] for i in range(0, len(page_buttons), 2)]
 
@@ -5796,19 +5796,16 @@ class TelegramAdapter(BasePlatformAdapter):
 
         rows.append([InlineKeyboardButton("✗ Cancel", callback_data="mx")])
 
-        page_info = f" ({start + 1}–{end} of {total})" if total_pages > 1 else ""
-        return InlineKeyboardMarkup(rows), page_info
+        return InlineKeyboardMarkup(rows), page_meta["page_info"]
 
     def _build_model_keyboard(self, models: list, page: int) -> tuple:
         """Build paginated model buttons. Returns (keyboard, page_info_text)."""
-        page_size = self._MODEL_PAGE_SIZE
-        total = len(models)
-        total_pages = max(1, (total + page_size - 1) // page_size)
-        page = max(0, min(page, total_pages - 1))
-
-        start = page * page_size
-        end = min(start + page_size, total)
-        page_models = models[start:end]
+        page_models, page_meta = self._format_choice_page(
+            models, page, self._MODEL_PAGE_SIZE
+        )
+        page = page_meta["page"]
+        total_pages = page_meta["total_pages"]
+        start = page_meta["start"]
 
         buttons: list = []
         for i, model_id in enumerate(page_models):
@@ -5837,8 +5834,7 @@ class TelegramAdapter(BasePlatformAdapter):
             InlineKeyboardButton("✗ Cancel", callback_data="mx"),
         ])
 
-        page_info = f" ({start + 1}–{end} of {total})" if total_pages > 1 else ""
-        return InlineKeyboardMarkup(rows), page_info
+        return InlineKeyboardMarkup(rows), page_meta["page_info"]
 
     async def _handle_model_picker_callback(
         self, query, data: str, chat_id: str

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7818,6 +7818,12 @@ class TelegramAdapter(BasePlatformAdapter):
                         loaded = [part.strip() for part in raw.split(",") if part.strip()]
                 patterns = loaded
 
+        if patterns is None:
+            # Parity with the historical inline implementation: return before
+            # evaluating ``self.name`` (tests construct bare adapters via
+            # object.__new__ that lack the attributes ``name`` reads).
+            return []
+
         return compile_mention_patterns(
             patterns,
             log_prefix=self.name,

--- a/tests/gateway/test_interactive_prompt_base.py
+++ b/tests/gateway/test_interactive_prompt_base.py
@@ -1,0 +1,216 @@
+"""Tests for the shared interactive-prompt formatting cores in BasePlatformAdapter.
+
+Covers ``_format_exec_approval`` (template-attr driven exec-approval text),
+``_format_choice_page`` (picker pagination core), ``_truncate_preview``, and
+byte-parity of the rewired adapters (telegram/feishu/matrix) against their
+historical inline formatting.
+"""
+
+import html as _html
+
+from gateway.platforms.base import BasePlatformAdapter
+
+
+def _bare(cls):
+    """Bare instance without running __init__ (documented test pattern)."""
+    return object.__new__(cls)
+
+
+class _DefaultAdapter(BasePlatformAdapter):
+    """Concrete subclass using only base-class template attrs."""
+
+    async def connect(self):  # pragma: no cover - not used
+        pass
+
+    async def disconnect(self):  # pragma: no cover - not used
+        pass
+
+    async def get_chat_info(self, chat_id):  # pragma: no cover - not used
+        return {}
+
+    async def send(self, *a, **k):  # pragma: no cover - not used
+        raise NotImplementedError
+
+
+class TestTruncatePreview:
+    def test_short_text_unchanged(self):
+        assert BasePlatformAdapter._truncate_preview("abc", 10) == "abc"
+
+    def test_exact_budget_unchanged(self):
+        assert BasePlatformAdapter._truncate_preview("x" * 10, 10) == "x" * 10
+
+    def test_over_budget_truncates_with_suffix(self):
+        out = BasePlatformAdapter._truncate_preview("x" * 11, 10)
+        assert out == "x" * 10 + "..."
+
+    def test_none_coerced_to_empty(self):
+        assert BasePlatformAdapter._truncate_preview(None, 10) == ""
+
+    def test_custom_suffix(self):
+        out = BasePlatformAdapter._truncate_preview("abcdef", 3, suffix="!")
+        assert out == "abc!"
+
+
+class TestFormatExecApproval:
+    def test_default_template(self):
+        ad = _bare(_DefaultAdapter)
+        text = ad._format_exec_approval("rm -rf /", "scary")
+        assert text == (
+            "⚠️ Command Approval Required\n\n"
+            "```\nrm -rf /\n```\n"
+            "Reason: scary"
+        )
+
+    def test_smart_denied_appends_line(self):
+        ad = _bare(_DefaultAdapter)
+        text = ad._format_exec_approval("ls", "d", smart_denied=True)
+        assert text.endswith(
+            "\n\nSmart DENY: owner override applies to this one operation only."
+        )
+
+    def test_command_truncated_to_budget(self):
+        ad = _bare(_DefaultAdapter)
+        text = ad._format_exec_approval("x" * 5000, "d")
+        assert "x" * 3000 + "..." in text
+        assert "x" * 3001 not in text
+
+    def test_escape_hook_applied_to_command_and_reason(self):
+        class Escaping(_DefaultAdapter):
+            def _ea_escape(self, text: str) -> str:
+                return _html.escape(text)
+
+        ad = _bare(Escaping)
+        text = ad._format_exec_approval("echo <hi>", "a & b")
+        assert "echo &lt;hi&gt;" in text
+        assert "a &amp; b" in text
+
+    def test_empty_command(self):
+        ad = _bare(_DefaultAdapter)
+        text = ad._format_exec_approval("", "d")
+        assert "```\n\n```" in text
+
+
+class TestFormatChoicePage:
+    def test_single_page_no_page_info(self):
+        opts, meta = BasePlatformAdapter._format_choice_page([1, 2, 3], 0, 10)
+        assert opts == [1, 2, 3]
+        assert meta["page_info"] == ""
+        assert meta["total_pages"] == 1
+        assert meta["page"] == 0
+
+    def test_multi_page_slicing_and_info(self):
+        options = list(range(25))
+        opts, meta = BasePlatformAdapter._format_choice_page(options, 1, 10)
+        assert opts == list(range(10, 20))
+        assert meta == {
+            "page": 1,
+            "total_pages": 3,
+            "start": 10,
+            "end": 20,
+            "total": 25,
+            "page_info": " (11–20 of 25)",
+        }
+
+    def test_page_clamped_high(self):
+        opts, meta = BasePlatformAdapter._format_choice_page(list(range(25)), 99, 10)
+        assert meta["page"] == 2
+        assert opts == list(range(20, 25))
+        assert meta["page_info"] == " (21–25 of 25)"
+
+    def test_page_clamped_negative(self):
+        opts, meta = BasePlatformAdapter._format_choice_page(list(range(25)), -5, 10)
+        assert meta["page"] == 0
+        assert opts == list(range(10))
+
+    def test_empty_options(self):
+        opts, meta = BasePlatformAdapter._format_choice_page([], 0, 10)
+        assert opts == []
+        assert meta["total_pages"] == 1
+        assert meta["page_info"] == ""
+
+    def test_last_partial_page(self):
+        opts, meta = BasePlatformAdapter._format_choice_page(list(range(11)), 1, 10)
+        assert opts == [10]
+        assert meta["page_info"] == " (11–11 of 11)"
+
+
+class TestAdapterParity:
+    """Rewired adapters produce byte-identical text vs their historical inline code."""
+
+    def test_telegram_parity(self):
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        def old(command, description, smart_denied):
+            cmd_preview = command[:3800] + "..." if len(command) > 3800 else command
+            text = (
+                f"⚠️ <b>Command Approval Required</b>\n\n"
+                f"<pre>{_html.escape(cmd_preview)}</pre>\n\n"
+                f"Reason: {_html.escape(description)}"
+            )
+            if smart_denied:
+                text += "\n\n<b>Smart DENY:</b> owner override applies to this one operation only."
+            return text
+
+        ad = _bare(TelegramAdapter)
+        for cmd in ["rm -rf /", "x" * 5000, "echo <hi> & 'stuff'", ""]:
+            for sd in (False, True):
+                assert ad._format_exec_approval(cmd, "why <b>&</b>", sd) == old(
+                    cmd, "why <b>&</b>", sd
+                )
+
+    def test_feishu_parity(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        def old(command, description, smart_denied):
+            cmd_preview = command[:3000] + "..." if len(command) > 3000 else command
+            scope_note = (
+                "\n\n**Smart DENY:** owner override applies to this one operation only."
+                if smart_denied
+                else ""
+            )
+            return f"```\n{cmd_preview}\n```\n**Reason:** {description}{scope_note}"
+
+        ad = _bare(FeishuAdapter)
+        for cmd in ["rm -rf /", "x" * 5000, ""]:
+            for sd in (False, True):
+                assert ad._format_exec_approval(cmd, "reason", sd) == old(cmd, "reason", sd)
+
+    def test_matrix_parity(self):
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        def old_head(command, description):
+            cmd_preview = command[:2000] + "..." if len(command) > 2000 else command
+            return (
+                "⚠️ **Dangerous command requires approval**\n"
+                f"```\n{cmd_preview}\n```\n"
+                f"Reason: {description}"
+            )
+
+        ad = _bare(MatrixAdapter)
+        for cmd in ["rm -rf /", "x" * 5000, ""]:
+            assert ad._format_exec_approval(cmd, "reason") == old_head(cmd, "reason")
+
+    def test_telegram_pagination_parity(self):
+        """_format_choice_page matches the old _build_*_keyboard arithmetic."""
+
+        def old(options, page, page_size):
+            total = len(options)
+            total_pages = max(1, (total + page_size - 1) // page_size)
+            page = max(0, min(page, total_pages - 1))
+            start = page * page_size
+            end = min(start + page_size, total)
+            page_info = f" ({start + 1}–{end} of {total})" if total_pages > 1 else ""
+            return options[start:end], page, total_pages, page_info
+
+        for n in (0, 1, 8, 9, 10, 25):
+            options = list(range(n))
+            for page in (-3, 0, 1, 2, 99):
+                for per in (8, 10):
+                    o_opts, o_page, o_tp, o_info = old(options, page, per)
+                    n_opts, meta = BasePlatformAdapter._format_choice_page(
+                        options, page, per
+                    )
+                    assert n_opts == o_opts
+                    assert meta["page"] == o_page
+                    assert meta["total_pages"] == o_tp
+                    assert meta["page_info"] == o_info


### PR DESCRIPTION
## Summary
Promotes four duplicated adapter families to the gateway base layer: mention-pattern compilation (4 adapters, 0.96 similarity), the reaction-ack outcome policy (eyes → check/cross), and the exec-approval/choice-picker formatting cores (6 adapters) — button construction stays platform-local, every user-visible string byte-identical.

## Changes (3 commits)
1. `compile_mention_patterns` → `gateway/platforms/helpers.py`; dingtalk/telegram/photon/bluebubbles delegate (log prefixes preserved)
2. Shared reaction-ack policy in base `on_processing_complete`; adapters with matching behavior drop overrides, divergent emoji sets kept via class attrs
3. `_format_exec_approval` + `_format_choice_page` cores in base; slack/discord/telegram/matrix/feishu/teams rewired for formatting only
- New `tests/gateway/test_interactive_prompt_base.py`

## Validation
| | Result |
|---|---|
| Mention-pattern parity: 17 input shapes × 4 adapters | identical compiled patterns |
| Formatted-text parity on representative adapters | identical |
| Adapter + new base tests | pass |
| Net | +522/−163 (dup logic now single-owner; new adapters inherit instead of copy) |

## Infographic

![base-class promotions](https://v3b.fal.media/files/b/0aa437fd/3S8vTvr2dKioLbaJ6ymu0_AMIH7E1g.png)
