### PR TITLE
perf(install): parallel connectivity probes — blocked-network preflight 16s → 8s

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -949,12 +949,33 @@ check_network_prerequisites() {
         return 0
     fi
 
+    # Run the probes in parallel — serially, two blocked probes cost
+    # 2 × --max-time (16 s) before the user sees any useful error; in
+    # parallel the worst case is one --max-time (8 s).
+    local pids=()
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local i=0
     for url in "${checks[@]}"; do
-        if ! curl -fsSI --max-time 8 "$url" >/dev/null 2>&1; then
+        (
+            if curl -fsSI --max-time 8 "$url" >/dev/null 2>&1; then
+                : > "$tmpdir/ok_$i"
+            fi
+        ) &
+        pids+=($!)
+        i=$((i + 1))
+    done
+    wait "${pids[@]}" 2>/dev/null
+
+    i=0
+    for url in "${checks[@]}"; do
+        if [ ! -e "$tmpdir/ok_$i" ]; then
             failed=true
             log_warn "Could not reach $url"
         fi
+        i=$((i + 1))
     done
+    rm -rf "$tmpdir"
 
     if [ "$failed" = false ]; then
         log_success "Internet connectivity looks good"


### PR DESCRIPTION
## Summary
On a blocked network, `install.sh` now shows its connectivity guidance after 8 s instead of 16 s: the two preflight probes (pypi.org, duckduckgo.com) run in parallel background jobs instead of serially, capping the worst case at one `--max-time` instead of two.

## Changes
- `scripts/install.sh` `check_network_prerequisites()`: probes fan out as background subshells writing per-URL verdict files to a mktemp dir; verdicts gathered after `wait`. Per-URL warning messages and the failure guidance are unchanged.

## Validation
| | Before | After |
|---|---|---|
| both URLs reachable | ~0.5 s serial | **0.24 s** |
| fully blocked (blackholed 10.255.255.x, live-tested) | 16 s (2×8) | **8.02 s** |

`bash -n` clean; function extracted and run standalone against real reachable URLs and blackholed IPs — output text identical to before in both cases.

## Infographic

![install parallel probes infographic](https://v3b.fal.media/files/b/0aa43821/38-WdON7Na0Xp46C_FHlp_VZBNDyKk.png)
