### PR TITLE
fix(hindsight): secure embedded profile environment writes

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -559,16 +559,51 @@ def _embedded_profile_env_path(config: dict[str, Any]):
     return Path.home() / ".hindsight" / "profiles" / f"{_embedded_profile_name(config)}.env"
 
 
-def _materialize_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None):
+def _materialize_embedded_profile_env(
+    config: dict[str, Any], *, llm_api_key: str | None = None
+):
     """Write the profile-scoped env file that standalone hindsight-embed uses."""
+    import tempfile
+
     profile_env = _embedded_profile_env_path(config)
     profile_env.parent.mkdir(parents=True, exist_ok=True)
     env_values = _build_embedded_profile_env(config, llm_api_key=llm_api_key)
-    profile_env.write_text(
-        "".join(f"{key}={value}\n" for key, value in env_values.items()),
-        encoding="utf-8",
+    content = "".join(f"{key}={value}\n" for key, value in env_values.items())
+
+    # This file contains the embedded daemon's plaintext LLM API key. Create
+    # the replacement at 0600 before writing any bytes so a normal 022 umask
+    # never exposes credentials, even briefly between write and chmod.
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(profile_env.parent),
+        prefix=f".{profile_env.stem}_",
+        suffix=".tmp",
     )
+    try:
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        from utils import atomic_replace
+
+        real_path = atomic_replace(tmp_path, profile_env)
+        try:
+            os.chmod(real_path, 0o600)
+        except OSError:
+            pass
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
     return profile_env
+
 
 def _sanitize_bank_segment(value: str) -> str:
     """Sanitize a bank_id_template placeholder value.

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -559,6 +559,46 @@ def _embedded_profile_env_path(config: dict[str, Any]):
     return Path.home() / ".hindsight" / "profiles" / f"{_embedded_profile_name(config)}.env"
 
 
+def _inspect_embedded_profile_env_metadata(profile_env) -> tuple[bool, bool]:
+    """Return ``(is_regular, is_secure)`` for the resolved profile target."""
+    import stat
+
+    try:
+        metadata = profile_env.stat()
+    except OSError:
+        return False, False
+
+    is_regular = stat.S_ISREG(metadata.st_mode)
+    if not is_regular:
+        return False, False
+    if os.name != "posix" or not hasattr(os, "geteuid"):
+        # POSIX mode and owner checks do not model Windows ACLs.
+        return True, True
+
+    is_secure = (
+        metadata.st_uid == os.geteuid()
+        and stat.S_IMODE(metadata.st_mode) == 0o600
+    )
+    return True, is_secure
+
+
+def _embedded_profile_env_status(
+    profile_env, expected_env: dict[str, str]
+) -> tuple[bool, bool]:
+    """Return ``(config_changed, metadata_secure)`` without reading special files."""
+    is_regular, metadata_secure = _inspect_embedded_profile_env_metadata(profile_env)
+    if not is_regular:
+        return True, False
+
+    try:
+        saved = _load_simple_env(profile_env)
+    except OSError:
+        # Unknown daemon inputs require conservative restart semantics after
+        # secure rematerialization; they cannot be treated as matching.
+        return True, metadata_secure
+    return saved != expected_env, metadata_secure
+
+
 def _materialize_embedded_profile_env(
     config: dict[str, Any], *, llm_api_key: str | None = None
 ):
@@ -567,6 +607,7 @@ def _materialize_embedded_profile_env(
 
     profile_env = _embedded_profile_env_path(config)
     profile_env.parent.mkdir(parents=True, exist_ok=True)
+    resolved_profile_env = profile_env.resolve(strict=False)
     env_values = _build_embedded_profile_env(config, llm_api_key=llm_api_key)
     content = "".join(f"{key}={value}\n" for key, value in env_values.items())
 
@@ -574,29 +615,41 @@ def _materialize_embedded_profile_env(
     # the replacement at 0600 before writing any bytes so a normal 022 umask
     # never exposes credentials, even briefly between write and chmod.
     fd, tmp_path = tempfile.mkstemp(
-        dir=str(profile_env.parent),
+        # Stage beside the resolved target so a managed symlink crossing
+        # filesystems still takes the atomic rename path rather than EXDEV copy.
+        dir=str(resolved_profile_env.parent),
         prefix=f".{profile_env.stem}_",
         suffix=".tmp",
     )
     try:
         if hasattr(os, "fchmod"):
             os.fchmod(fd, 0o600)
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle = os.fdopen(fd, "w", encoding="utf-8")
+        fd = None
+        with handle:
             handle.write(content)
             handle.flush()
             os.fsync(handle.fileno())
         from utils import atomic_replace
 
-        real_path = atomic_replace(tmp_path, profile_env)
+        installed_path = atomic_replace(
+            tmp_path, profile_env, allow_copy_fallback=False
+        )
         try:
-            os.chmod(real_path, 0o600)
+            os.chmod(installed_path, 0o600)
         except OSError:
             pass
+        _, metadata_secure = _inspect_embedded_profile_env_metadata(profile_env)
+        if not metadata_secure:
+            raise PermissionError(
+                f"Embedded Hindsight profile environment is not owner-only: {profile_env}"
+            )
     except BaseException:
-        try:
-            os.close(fd)
-        except OSError:
-            pass
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
         try:
             os.unlink(tmp_path)
         except OSError:
@@ -1461,12 +1514,13 @@ class HindsightMemoryProvider(MemoryProvider):
                     # If the config changed and the daemon is running, stop it.
                     profile_env = _embedded_profile_env_path(self._config)
                     expected_env = _build_embedded_profile_env(self._config)
-                    saved = _load_simple_env(profile_env)
-                    config_changed = saved != expected_env
+                    config_changed, metadata_secure = _embedded_profile_env_status(
+                        profile_env, expected_env
+                    )
 
-                    if config_changed:
+                    if config_changed or not metadata_secure:
                         profile_env = _materialize_embedded_profile_env(self._config)
-                        if client._manager.is_running(profile):
+                        if config_changed and client._manager.is_running(profile):
                             with open(log_path, "a", encoding="utf-8") as f:
                                 f.write("\n=== Config changed, restarting daemon ===\n")
                             client._manager.stop(profile)

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -25,6 +25,7 @@ from plugins.memory.hindsight import (
     _load_config,
     _load_simple_env,
     _build_embedded_profile_env,
+    _materialize_embedded_profile_env,
     _normalize_observation_scopes,
     _normalize_retain_tags,
     _resolve_bank_id_template,
@@ -398,6 +399,12 @@ class TestPostSetup:
         monkeypatch.setattr("getpass.getpass", lambda prompt="": "sk-local-test")
         saved_configs = []
         monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: saved_configs.append(cfg.copy()))
+        monkeypatch.setattr(
+            "tools.lazy_deps.install_specs",
+            lambda *args, **kwargs: SimpleNamespace(
+                ok=True, blocked=False, reason="", stderr=""
+            ),
+        )
 
         provider = HindsightMemoryProvider()
         provider.post_setup(str(hermes_home), {"memory": {}})
@@ -410,6 +417,8 @@ class TestPostSetup:
 
         profile_env = user_home / ".hindsight" / "profiles" / "hermes.env"
         assert profile_env.exists()
+        if os.name != "nt":
+            assert stat.S_IMODE(profile_env.stat().st_mode) == 0o600
         assert profile_env.read_text() == (
             "HINDSIGHT_API_LLM_PROVIDER=openai\n"
             "HINDSIGHT_API_LLM_API_KEY=sk-local-test\n"
@@ -417,6 +426,60 @@ class TestPostSetup:
             "HINDSIGHT_API_LOG_LEVEL=info\n"
             "HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT=300\n"
         )
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits are not enforced on Windows")
+    def test_embedded_profile_env_rewrite_tightens_existing_permissions(
+        self, tmp_path, monkeypatch
+    ):
+        user_home = tmp_path / "user-home"
+        profile_env = user_home / ".hindsight" / "profiles" / "hermes.env"
+        profile_env.parent.mkdir(parents=True)
+        profile_env.write_text("HINDSIGHT_API_LLM_API_KEY=stale\n", encoding="utf-8")
+        os.chmod(profile_env, 0o644)
+        monkeypatch.setenv("HOME", str(user_home))
+
+        _materialize_embedded_profile_env(
+            {
+                "profile": "hermes",
+                "llm_provider": "openai",
+                "llm_model": "gpt-4o-mini",
+            },
+            llm_api_key="sk-current",
+        )
+
+        assert stat.S_IMODE(profile_env.stat().st_mode) == 0o600
+        assert "HINDSIGHT_API_LLM_API_KEY=sk-current\n" in profile_env.read_text(
+            encoding="utf-8"
+        )
+
+    def test_embedded_profile_env_replace_failure_preserves_existing_file(
+        self, tmp_path, monkeypatch
+    ):
+        user_home = tmp_path / "user-home"
+        profile_env = user_home / ".hindsight" / "profiles" / "hermes.env"
+        profile_env.parent.mkdir(parents=True)
+        profile_env.write_text("HINDSIGHT_API_LLM_API_KEY=stale\n", encoding="utf-8")
+        monkeypatch.setenv("HOME", str(user_home))
+
+        def fail_replace(*args, **kwargs):
+            raise OSError("simulated replace failure")
+
+        monkeypatch.setattr("utils.atomic_replace", fail_replace)
+
+        with pytest.raises(OSError, match="simulated replace failure"):
+            _materialize_embedded_profile_env(
+                {
+                    "profile": "hermes",
+                    "llm_provider": "openai",
+                    "llm_model": "gpt-4o-mini",
+                },
+                llm_api_key="sk-current",
+            )
+
+        assert profile_env.read_text(encoding="utf-8") == (
+            "HINDSIGHT_API_LLM_API_KEY=stale\n"
+        )
+        assert list(profile_env.parent.glob(".hermes_*.tmp")) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -10,6 +10,7 @@ import os
 import re
 import stat
 import sys
+import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -25,6 +26,8 @@ from plugins.memory.hindsight import (
     _load_config,
     _load_simple_env,
     _build_embedded_profile_env,
+    _embedded_profile_env_status,
+    _inspect_embedded_profile_env_metadata,
     _materialize_embedded_profile_env,
     _normalize_observation_scopes,
     _normalize_retain_tags,
@@ -480,6 +483,239 @@ class TestPostSetup:
             "HINDSIGHT_API_LLM_API_KEY=stale\n"
         )
         assert list(profile_env.parent.glob(".hermes_*.tmp")) == []
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX descriptor reuse test")
+    def test_embedded_profile_env_failure_does_not_close_reused_descriptor(
+        self, tmp_path, monkeypatch
+    ):
+        user_home = tmp_path / "user-home"
+        monkeypatch.setenv("HOME", str(user_home))
+        source_path = tmp_path / "source.fd"
+        source_fd = os.open(source_path, os.O_CREAT | os.O_RDWR, 0o600)
+        created_fd = None
+        real_mkstemp = tempfile.mkstemp
+
+        def track_mkstemp(*args, **kwargs):
+            nonlocal created_fd
+            created_fd, tmp_name = real_mkstemp(*args, **kwargs)
+            return created_fd, tmp_name
+
+        def fail_after_reuse(*args, **kwargs):
+            assert created_fd is not None
+            os.dup2(source_fd, created_fd)
+            raise OSError("simulated replace failure after descriptor reuse")
+
+        monkeypatch.setattr("tempfile.mkstemp", track_mkstemp)
+        monkeypatch.setattr("utils.atomic_replace", fail_after_reuse)
+
+        try:
+            with pytest.raises(
+                OSError, match="simulated replace failure after descriptor reuse"
+            ):
+                _materialize_embedded_profile_env(
+                    {
+                        "profile": "hermes",
+                        "llm_provider": "openai",
+                        "llm_model": "gpt-4o-mini",
+                    },
+                    llm_api_key="sk-current",
+                )
+
+            assert created_fd is not None
+            os.fstat(created_fd)
+        finally:
+            for open_fd in {source_fd, created_fd}:
+                if open_fd is None:
+                    continue
+                try:
+                    os.close(open_fd)
+                except OSError:
+                    pass
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX ownership test")
+    def test_embedded_profile_env_security_rejects_different_owner(
+        self, tmp_path, monkeypatch
+    ):
+        profile_env = tmp_path / "hermes.env"
+        profile_env.write_text("SECRET=value\n", encoding="utf-8")
+        os.chmod(profile_env, 0o600)
+
+        assert _inspect_embedded_profile_env_metadata(profile_env) == (True, True)
+        owner_uid = profile_env.stat().st_uid
+        monkeypatch.setattr(os, "geteuid", lambda: owner_uid + 1)
+
+        assert _inspect_embedded_profile_env_metadata(profile_env) == (True, False)
+
+    def test_embedded_profile_env_status_does_not_read_nonregular_target(
+        self, tmp_path, monkeypatch
+    ):
+        profile_env = tmp_path / "hermes.env"
+        profile_env.mkdir()
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._load_simple_env",
+            MagicMock(side_effect=AssertionError("non-regular target must not be read")),
+        )
+
+        assert _embedded_profile_env_status(profile_env, {"SECRET": "value"}) == (
+            True,
+            False,
+        )
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX permission test")
+    def test_embedded_profile_env_status_treats_unreadable_content_as_changed(
+        self, tmp_path, monkeypatch
+    ):
+        profile_env = tmp_path / "hermes.env"
+        profile_env.write_text("SECRET=value\n", encoding="utf-8")
+        os.chmod(profile_env, 0o600)
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._load_simple_env",
+            MagicMock(side_effect=PermissionError("unreadable")),
+        )
+
+        assert _embedded_profile_env_status(profile_env, {"SECRET": "value"}) == (
+            True,
+            True,
+        )
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX permission test")
+    def test_embedded_profile_env_rejects_insecure_replacement_result(
+        self, tmp_path, monkeypatch
+    ):
+        user_home = tmp_path / "user-home"
+        profile_env = user_home / ".hindsight" / "profiles" / "hermes.env"
+        profile_env.parent.mkdir(parents=True)
+        profile_env.write_text("HINDSIGHT_API_LLM_API_KEY=stale\n", encoding="utf-8")
+        os.chmod(profile_env, 0o644)
+        monkeypatch.setenv("HOME", str(user_home))
+
+        def insecure_replace(tmp_path, target, **kwargs):
+            target.write_bytes(Path(tmp_path).read_bytes())
+            os.unlink(tmp_path)
+            return str(target)
+
+        monkeypatch.setattr("utils.atomic_replace", insecure_replace)
+        monkeypatch.setattr(
+            os,
+            "chmod",
+            MagicMock(side_effect=PermissionError("chmod denied")),
+        )
+
+        with pytest.raises(PermissionError, match="is not owner-only"):
+            _materialize_embedded_profile_env(
+                {
+                    "profile": "hermes",
+                    "llm_provider": "openai",
+                    "llm_model": "gpt-4o-mini",
+                },
+                llm_api_key="sk-current",
+            )
+
+        assert stat.S_IMODE(profile_env.stat().st_mode) == 0o644
+
+    @pytest.mark.skipif(
+        os.name != "posix" or os.geteuid() == 0,
+        reason="requires POSIX metadata owned by a non-root test user",
+    )
+    @pytest.mark.parametrize(
+        ("contents_match", "initial_mode", "expect_materialization", "expect_restart"),
+        (
+            (True, 0o600, False, False),
+            (True, 0o644, True, False),
+            (False, 0o600, True, True),
+        ),
+        ids=("secure-fast-path", "insecure-repair", "content-change"),
+    )
+    def test_local_embedded_start_validates_profile_env_state(
+        self,
+        tmp_path,
+        monkeypatch,
+        contents_match,
+        initial_mode,
+        expect_materialization,
+        expect_restart,
+    ):
+        hermes_home = tmp_path / "hermes-home"
+        config = {
+            "mode": "local_embedded",
+            "profile": "hermes",
+            "llm_provider": "openai",
+            "llm_api_key": "sk-current",
+            "llm_model": "gpt-4o-mini",
+            "idle_timeout": 300,
+        }
+        config_path = hermes_home / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True)
+        config_path.write_text(json.dumps(config), encoding="utf-8")
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: hermes_home
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_local_runtime", lambda: (True, "")
+        )
+
+        profile_env = tmp_path / "user-home" / ".hindsight" / "profiles" / "hermes.env"
+        profile_env.parent.mkdir(parents=True)
+        expected_env = _build_embedded_profile_env(config)
+        initial_content = (
+            "".join(f"{key}={value}\n" for key, value in expected_env.items())
+            if contents_match
+            else "HINDSIGHT_API_LLM_API_KEY=stale\n"
+        )
+        profile_env.write_text(initial_content, encoding="utf-8")
+        os.chmod(profile_env, initial_mode)
+
+        daemon_module = SimpleNamespace(console=None)
+        hindsight_embed = SimpleNamespace(daemon_embed_manager=daemon_module)
+        monkeypatch.setitem(sys.modules, "hindsight_embed", hindsight_embed)
+        monkeypatch.setitem(
+            sys.modules, "hindsight_embed.daemon_embed_manager", daemon_module
+        )
+
+        client = MagicMock()
+        client._manager.is_running.return_value = True
+        monkeypatch.setattr(HindsightMemoryProvider, "_get_client", lambda self: client)
+        from plugins.memory import hindsight as hindsight_module
+
+        materialize_spy = MagicMock(
+            wraps=hindsight_module._materialize_embedded_profile_env
+        )
+        monkeypatch.setattr(
+            hindsight_module, "_materialize_embedded_profile_env", materialize_spy
+        )
+
+        class ImmediateThread:
+            def __init__(self, *, target, **kwargs):
+                self._target = target
+
+            def start(self):
+                self._target()
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.threading.Thread", ImmediateThread
+        )
+
+        provider = HindsightMemoryProvider()
+        provider.initialize(
+            session_id="test-session",
+            hermes_home=str(hermes_home),
+            platform="cli",
+        )
+
+        metadata = profile_env.stat()
+        assert metadata.st_uid == os.geteuid()
+        assert stat.S_IMODE(metadata.st_mode) == 0o600
+        assert _load_simple_env(profile_env) == expected_env
+        if expect_materialization:
+            materialize_spy.assert_called_once_with(config)
+        else:
+            materialize_spy.assert_not_called()
+        if expect_restart:
+            client._manager.stop.assert_called_once_with("hermes")
+        else:
+            client._manager.stop.assert_not_called()
+        client._ensure_started.assert_called_once_with()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_atomic_replace_symlinks.py
+++ b/tests/test_atomic_replace_symlinks.py
@@ -71,6 +71,25 @@ def test_atomic_replace_regular_file(tmp_path: Path) -> None:
     assert not target.is_symlink()
 
 
+def test_atomic_replace_can_disable_non_atomic_copy_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "secret.env"
+    target.write_text("old-secret\n", encoding="utf-8")
+    tmp = _write_tmp(tmp_path, "new-secret\n")
+
+    def fail_replace(*args, **kwargs):
+        raise OSError(errno.EBUSY, "simulated busy target")
+
+    monkeypatch.setattr(os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="simulated busy target"):
+        atomic_replace(tmp, target, allow_copy_fallback=False)
+
+    assert target.read_text(encoding="utf-8") == "old-secret\n"
+    assert tmp.read_text(encoding="utf-8") == "new-secret\n"
+
+
 
 
 def test_atomic_replace_accepts_pathlike_and_str(tmp_path: Path) -> None:

--- a/utils.py
+++ b/utils.py
@@ -88,7 +88,12 @@ def _restore_file_mode(path: Path, mode: "int | None") -> None:
         pass
 
 
-def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
+def atomic_replace(
+    tmp_path: Union[str, Path],
+    target: Union[str, Path],
+    *,
+    allow_copy_fallback: bool = True,
+) -> str:
     """Atomically move *tmp_path* onto *target*, preserving symlinks.
 
     ``os.replace(tmp, target)`` atomically swaps ``tmp`` into place at
@@ -107,6 +112,10 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
 
     Returns the resolved real path used for the replace, so callers that
     need to re-apply permissions can target it instead of the symlink.
+
+    Set ``allow_copy_fallback=False`` when the caller must fail rather than
+    temporarily expose partial or weakly permissioned data through a
+    non-atomic EXDEV / EBUSY copy.
     """
     target_str = str(target)
     real_path = os.path.realpath(target_str) if os.path.islink(target_str) else target_str
@@ -114,7 +123,7 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     try:
         os.replace(tmp_str, real_path)
     except OSError as exc:
-        if exc.errno not in (errno.EXDEV, errno.EBUSY):
+        if exc.errno not in (errno.EXDEV, errno.EBUSY) or not allow_copy_fallback:
             raise
         logger.debug(
             "atomic_replace: %s -> %s failed with %s; falling back to copy",


### PR DESCRIPTION
## What does this PR do?

Prevents embedded Hindsight profile materialization from exposing plaintext LLM credentials through permissive filesystem modes.

`_materialize_embedded_profile_env()` previously used `Path.write_text()`. On first creation the mode followed the process umask—commonly `0644`—even though the file contains `HINDSIGHT_API_LLM_API_KEY`. This path runs during setup and when local embedded Hindsight starts, so the exposure could recur on shared hosts.

The replacement file is now created with owner-only permissions before credential bytes are written, fully flushed and `fsync`ed, and atomically installed with the repository's symlink-aware helper. On POSIX, startup also validates that the resolved target is a regular file owned by the effective user with exact `0600` permissions. Matching legacy files with insecure metadata are repaired without restarting Hindsight; changed or unreadable content is rematerialized and conservatively restarts a running daemon.

Secret installation stages beside the resolved target, disables the shared helper's non-atomic `EXDEV`/`EBUSY` copy fallback, and verifies the post-install metadata before the daemon can start. Descriptor ownership is cleared after `fdopen()` so exception cleanup cannot close a descriptor number reused by unrelated code.

## Related Issue

N/A — no issue was filed. This independently developed fix supersedes #41345, which is currently conflicted and has remained unmaintained with its single-`os.write()` short-write correctness issue unresolved. No code was taken from #41345.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/hindsight/__init__.py`: stage the replacement beside the resolved target, restrict it to `0600` before writing, install it atomically, and fail closed unless the resulting POSIX target is regular, effective-user-owned, and exactly `0600`.
- `plugins/memory/hindsight/__init__.py`: inspect type and metadata before reading legacy state; repair matching insecure metadata without restart, while changed or unreadable state keeps conservative restart semantics.
- `utils.py`: add an opt-out for the shared `EXDEV`/`EBUSY` copy fallback; all existing callers retain the previous default, while the credential writer requires atomic replacement.
- Regression tests cover descriptor reuse, wrong ownership, non-regular and unreadable targets, post-install verification, real daemon-start behavior, and disabled copy fallback.

## How to Test

1. Run the complete repository suite: `scripts/run_tests.sh`.
2. Run the focused Hindsight and shared atomic-replacement suites: `scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py tests/test_atomic_replace_symlinks.py -q`.
3. On POSIX, materialize under a normal `022` umask and verify exact `0600` ownership metadata. Exercise a cross-filesystem managed symlink, force `EBUSY`, and verify the symlink/old target are preserved with no non-atomic credential copy.

Validation performed on this exact PR head:

- Complete suite: **22,783 passed, 0 failed** across 2,467 test files.
- Focused Hindsight/atomic suites: **68 passed, 0 failed** across 2 test files.
- Ruff and `git diff --check`: passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the complete test suite with `scripts/run_tests.sh` (recommended; same as CI) and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: CachyOS Linux x86_64 (kernel 7.1.2-3-cachyos), Python 3.12.13, pytest 9.0.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing configuration or workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — exact owner/mode enforcement is POSIX-specific; Windows ACL hardening is not claimed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model tool or schema changed

## Screenshots / Logs

```text
Complete suite: 2467 files, 22783 tests passed, 0 failed (100% complete)
Focused suites: 2 files, 68 tests passed, 0 failed (100% complete)
Ruff: All checks passed
git diff --check: clean
```