### PR TITLE
fix(auth): auto-detect scan skips CLAUDE_CODE_OAUTH_TOKEN — implicit credentials don't pick providers

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2009,6 +2009,15 @@ def resolve_provider(
         if pid in {"copilot", "lmstudio"}:
             continue
         for env_var in pconfig.api_key_env_vars:
+            # CLAUDE_CODE_OAUTH_TOKEN is written by Claude Code's own login,
+            # not by a user configuring Hermes — ambient presence must not
+            # auto-route inference onto the Anthropic HTTP lane. Same doctrine
+            # as is_provider_explicitly_configured's exclusion above (#7156)
+            # and the copilot/lmstudio skips: implicit credentials don't pick
+            # providers. Explicit `model.provider: anthropic` still uses the
+            # token via normal credential resolution.
+            if env_var == "CLAUDE_CODE_OAUTH_TOKEN":
+                continue
             if has_usable_secret(os.getenv(env_var, "")):
                 # An exported API key now wins over a logged-in OAuth provider
                 # (the #29285 fix). Surface that so a user who deliberately uses
@@ -2050,10 +2059,19 @@ def resolve_provider(
     except ImportError:
         pass  # boto3 not installed — skip Bedrock auto-detection
 
+    _implicit_hint = ""
+    if has_usable_secret(os.getenv("CLAUDE_CODE_OAUTH_TOKEN", "")):
+        # The token was seen and deliberately not auto-selected (above) —
+        # say so, or the refusal just looks broken to the one user who has it.
+        _implicit_hint = (
+            " CLAUDE_CODE_OAUTH_TOKEN was detected but is never auto-selected"
+            " (it belongs to Claude Code's own login); set `model.provider:"
+            " anthropic` explicitly to use it for inference."
+        )
     raise AuthError(
         "No inference provider configured. Run 'hermes model' to choose a "
         "provider and model, or set an API key (OPENROUTER_API_KEY, "
-        "OPENAI_API_KEY, etc.) in ~/.hermes/.env.",
+        "OPENAI_API_KEY, etc.) in ~/.hermes/.env." + _implicit_hint,
         code="no_provider_configured",
     )
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2245,6 +2245,15 @@ def resolve_provider(
         if pid in {"copilot", "lmstudio"}:
             continue
         for env_var in pconfig.api_key_env_vars:
+            # CLAUDE_CODE_OAUTH_TOKEN is written by Claude Code's own login,
+            # not by a user configuring Hermes — ambient presence must not
+            # auto-route inference onto the Anthropic HTTP lane. Same doctrine
+            # as is_provider_explicitly_configured's exclusion above (#7156)
+            # and the copilot/lmstudio skips: implicit credentials don't pick
+            # providers. Explicit `model.provider: anthropic` still uses the
+            # token via normal credential resolution.
+            if env_var == "CLAUDE_CODE_OAUTH_TOKEN":
+                continue
             if has_usable_secret(_scoped_key_env(env_var)):
                 # An exported API key now wins over a logged-in OAuth provider
                 # (the #29285 fix). Surface that so a user who deliberately uses
@@ -2286,10 +2295,19 @@ def resolve_provider(
     except ImportError:
         pass  # boto3 not installed — skip Bedrock auto-detection
 
+    _implicit_hint = ""
+    if has_usable_secret(_scoped_key_env("CLAUDE_CODE_OAUTH_TOKEN")):
+        # The token was seen and deliberately not auto-selected (above) —
+        # say so, or the refusal just looks broken to the one user who has it.
+        _implicit_hint = (
+            " CLAUDE_CODE_OAUTH_TOKEN was detected but is never auto-selected"
+            " (it belongs to Claude Code's own login); set `model.provider:"
+            " anthropic` explicitly to use it for inference."
+        )
     raise AuthError(
         "No inference provider configured. Run 'hermes model' to choose a "
         "provider and model, or set an API key (OPENROUTER_API_KEY, "
-        "OPENAI_API_KEY, etc.) in ~/.hermes/.env.",
+        "OPENAI_API_KEY, etc.) in ~/.hermes/.env." + _implicit_hint,
         code="no_provider_configured",
     )
 

--- a/tests/hermes_cli/test_provider_precedence.py
+++ b/tests/hermes_cli/test_provider_precedence.py
@@ -29,8 +29,13 @@ def _no_aws(monkeypatch):
 
 
 def _clear_provider_env(monkeypatch):
+    # ANTHROPIC_*/CLAUDE_CODE_OAUTH_TOKEN included: on a developer machine
+    # with a live Claude Code login these are exported, and without clearing
+    # them the auto-detect tests below pass or fail for the wrong reason.
     for var in ("OPENAI_API_KEY", "OPENROUTER_API_KEY", "GLM_API_KEY", "ZAI_API_KEY",
-                "KIMI_API_KEY", "MINIMAX_API_KEY", "HERMES_INFERENCE_PROVIDER"):
+                "KIMI_API_KEY", "MINIMAX_API_KEY", "HERMES_INFERENCE_PROVIDER",
+                "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "ANTHROPIC_AUTH_TOKEN",
+                "CLAUDE_CODE_OAUTH_TOKEN"):
         monkeypatch.delenv(var, raising=False)
 
 
@@ -90,3 +95,63 @@ class TestProviderPrecedence:
 
         monkeypatch.setattr("agent.credential_pool.load_pool", lambda name: _Pool())
         assert resolve_provider("auto") == "openrouter"
+
+
+class TestImplicitOAuthTokenNotAutoSelected:
+    """CLAUDE_CODE_OAUTH_TOKEN is written by Claude Code's own login, not by
+    the user configuring Hermes. The is_provider_explicitly_configured
+    doctrine (PR #7156) already excludes it from explicit-config detection;
+    the auto-detect scan must apply the same posture — ambient presence must
+    not route inference onto the Anthropic HTTP lane (metered overage per
+    Anthropic's third-party policy; see #58546, #70039)."""
+
+    @staticmethod
+    def _no_oauth_login(monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth._load_auth_store", lambda: {})
+        monkeypatch.setattr("hermes_cli.auth.get_auth_status",
+                            lambda p: {"logged_in": False})
+
+    def test_token_alone_does_not_auto_select_anthropic(self, monkeypatch):
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        self._no_oauth_login(monkeypatch)
+        _config(monkeypatch, {})
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-ambient")
+        with pytest.raises(AuthError) as exc_info:
+            resolve_provider("auto")
+        # The error must tell the user the token was seen and how to use it
+        # deliberately — silence here would just look broken.
+        assert "CLAUDE_CODE_OAUTH_TOKEN" in str(exc_info.value)
+
+    def test_profile_scoped_token_is_reported_but_not_auto_selected(self, monkeypatch):
+        """Multiplex profile secrets follow the same implicit-token posture."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        self._no_oauth_login(monkeypatch)
+        _config(monkeypatch, {})
+        monkeypatch.setattr(
+            "agent.auxiliary_client._scoped_key_env",
+            lambda name: "sk-ant-oat01-profile" if name == "CLAUDE_CODE_OAUTH_TOKEN" else "",
+        )
+        with pytest.raises(AuthError) as exc_info:
+            resolve_provider("auto")
+        assert "CLAUDE_CODE_OAUTH_TOKEN" in str(exc_info.value)
+
+    def test_explicit_anthropic_key_still_auto_selects(self, monkeypatch):
+        """No over-exclusion: ANTHROPIC_API_KEY is a user-exported credential
+        and keeps auto-selecting anthropic."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        self._no_oauth_login(monkeypatch)
+        _config(monkeypatch, {})
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-test")
+        assert resolve_provider("auto") == "anthropic"
+
+    def test_explicit_provider_still_uses_the_token(self, monkeypatch):
+        """Explicit selection is untouched: provider=anthropic with only the
+        Claude Code token resolves to anthropic (credential resolution then
+        finds the token via get_anthropic_key as before)."""
+        _clear_provider_env(monkeypatch)
+        self._no_oauth_login(monkeypatch)
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-ambient")
+        assert resolve_provider("anthropic") == "anthropic"

--- a/tests/hermes_cli/test_provider_precedence.py
+++ b/tests/hermes_cli/test_provider_precedence.py
@@ -29,8 +29,13 @@ def _no_aws(monkeypatch):
 
 
 def _clear_provider_env(monkeypatch):
+    # ANTHROPIC_*/CLAUDE_CODE_OAUTH_TOKEN included: on a developer machine
+    # with a live Claude Code login these are exported, and without clearing
+    # them the auto-detect tests below pass or fail for the wrong reason.
     for var in ("OPENAI_API_KEY", "OPENROUTER_API_KEY", "GLM_API_KEY", "ZAI_API_KEY",
-                "KIMI_API_KEY", "MINIMAX_API_KEY", "HERMES_INFERENCE_PROVIDER"):
+                "KIMI_API_KEY", "MINIMAX_API_KEY", "HERMES_INFERENCE_PROVIDER",
+                "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "ANTHROPIC_AUTH_TOKEN",
+                "CLAUDE_CODE_OAUTH_TOKEN"):
         monkeypatch.delenv(var, raising=False)
 
 
@@ -115,3 +120,49 @@ class TestProviderPrecedence:
 
         monkeypatch.setattr("agent.credential_pool.load_pool", lambda name: _Pool())
         assert resolve_provider("auto") == "openrouter"
+
+
+class TestImplicitOAuthTokenNotAutoSelected:
+    """CLAUDE_CODE_OAUTH_TOKEN is written by Claude Code's own login, not by
+    the user configuring Hermes. The is_provider_explicitly_configured
+    doctrine (PR #7156) already excludes it from explicit-config detection;
+    the auto-detect scan must apply the same posture — ambient presence must
+    not route inference onto the Anthropic HTTP lane (metered overage per
+    Anthropic's third-party policy; see #58546, #70039)."""
+
+    @staticmethod
+    def _no_oauth_login(monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth._load_auth_store", lambda: {})
+        monkeypatch.setattr("hermes_cli.auth.get_auth_status",
+                            lambda p: {"logged_in": False})
+
+    def test_token_alone_does_not_auto_select_anthropic(self, monkeypatch):
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        self._no_oauth_login(monkeypatch)
+        _config(monkeypatch, {})
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-ambient")
+        with pytest.raises(AuthError) as exc_info:
+            resolve_provider("auto")
+        # The error must tell the user the token was seen and how to use it
+        # deliberately — silence here would just look broken.
+        assert "CLAUDE_CODE_OAUTH_TOKEN" in str(exc_info.value)
+
+    def test_explicit_anthropic_key_still_auto_selects(self, monkeypatch):
+        """No over-exclusion: ANTHROPIC_API_KEY is a user-exported credential
+        and keeps auto-selecting anthropic."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        self._no_oauth_login(monkeypatch)
+        _config(monkeypatch, {})
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-test")
+        assert resolve_provider("auto") == "anthropic"
+
+    def test_explicit_provider_still_uses_the_token(self, monkeypatch):
+        """Explicit selection is untouched: provider=anthropic with only the
+        Claude Code token resolves to anthropic (credential resolution then
+        finds the token via get_anthropic_key as before)."""
+        _clear_provider_env(monkeypatch)
+        self._no_oauth_login(monkeypatch)
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-ambient")
+        assert resolve_provider("anthropic") == "anthropic"


### PR DESCRIPTION
## Summary
`resolve_provider("auto")`'s env-var scan treats `CLAUDE_CODE_OAUTH_TOKEN` like a user-exported API key and auto-selects the Anthropic HTTP lane from its mere presence. That token is written by **Claude Code's own login**, not by a user configuring Hermes — and the codebase already draws exactly this distinction elsewhere:

> the auxiliary fallback chain silently discovered and used Claude Code OAuth tokens... without consent. Adds `is_provider_explicitly_configured()` gate — credentials are only used when the user explicitly configured Anthropic

— PR #7156 (merged 2026-04-10), which put `CLAUDE_CODE_OAUTH_TOKEN` in `_IMPLICIT_ENV_VARS` for explicit-config detection; PR #13187 mirrored the guard in setup. The auto-detect scan is the one remaining path that ignores the doctrine — and the same loop already skips `copilot`/`lmstudio` for the same implicit-credential reason.

## Why it matters now
Ambient auto-selection routes exactly the users Anthropic's policy changed under: the OAuth-over-HTTP lane consistently 429s (#70039) or bills as metered "extra usage" overage (#58546 quotes Anthropic's response: *"Third-party apps now draw from your extra usage, not your plan limits"*). A user whose only credential is a Claude Code login gets silently metered — or broken — without ever choosing Anthropic as their Hermes provider.

## The change (+71/−2, one concern)
- Skip `CLAUDE_CODE_OAUTH_TOKEN` in the auto-detect env scan (3 lines + comment citing #7156).
- When the token is present and nothing else is configured, the `no_provider_configured` AuthError now says the token was seen and deliberately not auto-selected, with the one-line remedy (`model.provider: anthropic`).
- Untouched on purpose: explicit `model.provider: anthropic` still resolves and uses the token via normal credential resolution; `ANTHROPIC_API_KEY`/`ANTHROPIC_TOKEN` (user-managed) still auto-select; Hermes' own OAuth flows persist `ANTHROPIC_TOKEN`, not this var. `resolve_anthropic_token()` ordering (#58546 proper) is deliberately out of scope.

## Tests
- token-only auto → `AuthError` naming the token (was: silent `anthropic`) — RED before the fix.
- `ANTHROPIC_API_KEY` still auto-selects `anthropic` (no over-exclusion).
- explicit `resolve_provider("anthropic")` with only the token — unaffected.
- `_clear_provider_env` also learns the `ANTHROPIC_*`/`CLAUDE_CODE_OAUTH_TOKEN` vars, so the precedence suite stops depending on the developer machine's Claude Code login state.

Full canonical suite (`tests/agent/ tests/hermes_cli/ tests/hermes_state/`): failure set identical to pristine main at the branch base — nothing introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
