### PR TITLE
fix(agent): decouple user-visible retry counter from the retry budget reset

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1978,6 +1978,19 @@ def run_conversation(
         api_start_time = time.time()
         retry_count = 0
         max_retries = agent._api_max_retries
+        # Separate, monotonic counter for user-facing "(attempt X/Y)" status
+        # messages. retry_count itself resets to 0 whenever a fallback
+        # provider activates (see _try_activate_fallback() call sites below)
+        # -- that reset is intentional: it's a fresh retry BUDGET for the
+        # new endpoint, and touching it would break the backoff/give-up
+        # logic that depends on it. But the same reset made the visible
+        # counter look like it jumped backward mid-sequence (e.g. "attempt
+        # 2/3" followed by "attempt 1/3" after a silent provider switch),
+        # which read as a bug even though the underlying retry accounting
+        # was correct (issue #12956). _display_attempt increments in
+        # lockstep with every retry_count += 1 but is never reset, so the
+        # number shown to the user only ever goes up.
+        _display_attempt = 0
         _retry = TurnRetryState()
 
         finish_reason = "stop"
@@ -2435,6 +2448,7 @@ def run_conversation(
                     # Invalid response — could be rate limiting, provider timeout,
                     # upstream server error, or malformed response.
                     retry_count += 1
+                    _display_attempt += 1
                     
                     # Eager fallback: empty/malformed responses are a common
                     # rate-limit symptom.  Switch to fallback immediately
@@ -2504,7 +2518,7 @@ def run_conversation(
                     else:
                         _failure_hint = f"response time {api_duration:.1f}s"
 
-                    agent._buffer_vprint(f"⚠️  Invalid API response (attempt {retry_count}/{max_retries}): {', '.join(error_details)}")
+                    agent._buffer_vprint(f"⚠️  Invalid API response (attempt {_display_attempt}/{max_retries}): {', '.join(error_details)}")
                     agent._buffer_vprint(f"   🏢 Provider: {provider_name}")
                     cleaned_provider_error = agent._clean_error_message(error_msg)
                     agent._buffer_vprint(f"   📝 Provider message: {cleaned_provider_error}")
@@ -2539,7 +2553,7 @@ def run_conversation(
                     # Backoff before retry — jittered exponential: 5s base, 120s cap
                     wait_time = jittered_backoff(retry_count, base_delay=5.0, max_delay=120.0)
                     agent._buffer_vprint(f"⏳ Retrying in {wait_time:.1f}s ({_failure_hint})...")
-                    logger.warning(f"Invalid API response (retry {retry_count}/{max_retries}): {', '.join(error_details)} | Provider: {provider_name}")
+                    logger.warning(f"Invalid API response (retry {_display_attempt}/{max_retries}): {', '.join(error_details)} | Provider: {provider_name}")
                     
                     # Sleep in small increments to stay responsive to interrupts
                     sleep_end = time.time() + wait_time
@@ -2558,7 +2572,7 @@ def run_conversation(
                                 _retry.restart_with_redirected_messages = True
                                 break
                             agent._vprint(f"{agent.log_prefix}⚡ Interrupt detected during retry wait, aborting.", force=True)
-                            _interrupt_text = f"Operation interrupted during retry ({_failure_hint}, attempt {retry_count}/{max_retries})."
+                            _interrupt_text = f"Operation interrupted during retry ({_failure_hint}, attempt {_display_attempt}/{max_retries})."
                             close_interrupted_tool_sequence(messages, _interrupt_text)
                             agent._persist_session(messages, conversation_history)
                             agent.clear_interrupt()
@@ -2575,7 +2589,7 @@ def run_conversation(
                         _backoff_touch_counter += 1
                         if _backoff_touch_counter % 150 == 0:  # 150 × 0.2s = 30s
                             agent._touch_activity(
-                                f"retry backoff ({retry_count}/{max_retries}), "
+                                f"retry backoff ({_display_attempt}/{max_retries}), "
                                 f"{int(sleep_end - time.time())}s remaining"
                             )
                     if _retry.restart_with_redirected_messages:
@@ -4027,9 +4041,10 @@ def run_conversation(
                     )
 
                 retry_count += 1
+                _display_attempt += 1
                 elapsed_time = time.time() - api_start_time
                 agent._touch_activity(
-                    f"API error recovery (attempt {retry_count}/{max_retries})"
+                    f"API error recovery (attempt {_display_attempt}/{max_retries})"
                 )
                 
                 error_type = type(api_error).__name__
@@ -4048,7 +4063,7 @@ def run_conversation(
                 _base = getattr(agent, "base_url", "unknown")
                 _model = getattr(agent, "model", "unknown")
                 _status_code_str = f" [HTTP {status_code}]" if status_code else ""
-                agent._buffer_vprint(f"⚠️  API call failed (attempt {retry_count}/{max_retries}): {error_type}{_status_code_str}")
+                agent._buffer_vprint(f"⚠️  API call failed (attempt {_display_attempt}/{max_retries}): {error_type}{_status_code_str}")
                 agent._buffer_vprint(f"   🔌 Provider: {_provider}  Model: {_model}")
                 agent._buffer_vprint(f"   🌐 Endpoint: {_base}")
                 agent._buffer_vprint(f"   📝 Error: {_error_summary}")
@@ -5309,7 +5324,7 @@ def run_conversation(
                     else:
                         agent._buffer_status(_rate_limit_status)
                 else:
-                    agent._buffer_status(f"⏳ Retrying in {wait_time:.1f}s (attempt {retry_count}/{max_retries})...")
+                    agent._buffer_status(f"⏳ Retrying in {wait_time:.1f}s (attempt {_display_attempt}/{max_retries})...")
                 logger.warning(
                     "Retrying API call in %ss (attempt %s/%s) %s policy=%s error=%s",
                     wait_time,
@@ -5332,7 +5347,7 @@ def run_conversation(
                             _retry.restart_with_redirected_messages = True
                             break
                         agent._vprint(f"{agent.log_prefix}⚡ Interrupt detected during retry wait, aborting.", force=True)
-                        _interrupt_text = f"Operation interrupted: retrying API call after error (retry {retry_count}/{max_retries})."
+                        _interrupt_text = f"Operation interrupted: retrying API call after error (retry {_display_attempt}/{max_retries})."
                         close_interrupted_tool_sequence(messages, _interrupt_text)
                         agent._persist_session(messages, conversation_history)
                         agent.clear_interrupt()
@@ -5349,7 +5364,7 @@ def run_conversation(
                     _backoff_touch_counter += 1
                     if _backoff_touch_counter % 150 == 0:  # 150 × 0.2s = 30s
                         agent._touch_activity(
-                            f"error retry backoff ({retry_count}/{max_retries}), "
+                            f"error retry backoff ({_display_attempt}/{max_retries}), "
                             f"{int(sleep_end - time.time())}s remaining"
                         )
                 if _retry.restart_with_redirected_messages:
@@ -5379,6 +5394,7 @@ def run_conversation(
             # infinite loops when compression reduces messages but not enough
             # to fit the context window.
             retry_count += 1
+            _display_attempt += 1
             _retry.restart_with_compressed_messages = False
             # In-loop compression rebuilt `messages` with fresh compaction
             # copies, so the pre-compression current-turn index is stale.

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -9139,3 +9139,102 @@ class TestMemoryProviderTurnStart:
         # The extracted body uses ``agent.X`` rather than ``self.X``;
         # assert the extracted-form spelling directly.
         assert "on_turn_start(agent._user_turn_count" in src
+
+
+class TestRetryDisplayCounterMonotonic:
+    """Regression tests for issue #12956: the user-visible '(attempt X/Y)'
+    status counter appeared to reset mid-sequence -- (1/3) (2/3) (1/3)
+    (2/3) -- whenever a fallback provider activated, because it displayed
+    retry_count directly, and retry_count intentionally resets to 0 on
+    every successful _try_activate_fallback() call (a fresh retry BUDGET
+    for the new endpoint -- that reset itself is correct and must not be
+    removed, per the triage review on the now-closed PR #12967, which
+    targeted the wrong/obsolete file and conflated the budget reset with
+    the display).
+
+    A separate, purely additive _display_attempt counter now drives every
+    user-facing '(attempt X/Y)' message; retry_count/max_retries keep
+    their existing reset-on-fallback semantics for the actual backoff and
+    give-up logic, verified unchanged by structural source inspection
+    (parsing the function body directly is more robust here than mocking
+    the full multi-provider retry+fallback state machine end to end).
+    """
+
+    def _loop_source(self):
+        import inspect
+        from agent import conversation_loop
+        return inspect.getsource(conversation_loop)
+
+    def test_display_attempt_initialized_exactly_once(self):
+        src = self._loop_source()
+        assert src.count("_display_attempt = 0") == 1, (
+            "_display_attempt must only be assigned 0 at its single "
+            "initialization -- if it's reset anywhere else, the fix "
+            "regresses to the reported bug"
+        )
+
+    def test_display_attempt_never_reset_alongside_retry_count(self):
+        """Every retry_count = 0 reset site (fallback activation) must NOT
+        have a matching _display_attempt reset nearby -- that's the whole
+        point of decoupling them."""
+        src = self._loop_source()
+        # retry_count = 0 must still appear multiple times (the intentional
+        # per-fallback budget resets are preserved, not removed).
+        assert src.count("retry_count = 0") >= 4, (
+            "The intentional retry-budget resets on fallback activation "
+            "must be preserved, not removed by this fix"
+        )
+        # But _display_attempt must never be reset back to 0 after its
+        # single initialization -- only incremented.
+        assert src.count("_display_attempt = 0") == 1
+        assert src.count("_display_attempt +=") >= 3, (
+            "The display counter must increment alongside every "
+            "retry_count += 1 site"
+        )
+
+    def test_increment_sites_paired(self):
+        """Every retry_count += 1 line must be immediately followed by a
+        _display_attempt += 1 line, so the two counters never drift apart
+        (a future retry_count += 1 added without the paired display
+        increment would silently reintroduce a stuck/wrong display count)."""
+        src = self._loop_source()
+        lines = src.splitlines()
+        retry_increment_indices = [
+            i for i, line in enumerate(lines) if line.strip() == "retry_count += 1"
+        ]
+        assert len(retry_increment_indices) >= 3
+        for idx in retry_increment_indices:
+            # Allow a couple of intervening blank/comment lines.
+            window = "\n".join(lines[idx + 1: idx + 3])
+            assert "_display_attempt += 1" in window, (
+                f"retry_count += 1 at source line {idx} has no paired "
+                f"_display_attempt increment nearby:\n{window}"
+            )
+
+    def test_no_user_facing_attempt_message_still_uses_retry_count(self):
+        """Every '(attempt {X}/{max_retries})'-shaped display string must
+        use _display_attempt as X, not the resettable retry_count --
+        this is the literal fix for the reported bug."""
+        import re
+        src = self._loop_source()
+        # Match f-string content like "(attempt {retry_count}/{max_retries})"
+        # or "({retry_count}/{max_retries})" appearing inside a quoted
+        # display string (buffer_vprint/buffer_status/logger calls).
+        leaked = re.findall(r"\{retry_count\}/\{max_retries\}", src)
+        assert not leaked, (
+            f"Found {len(leaked)} display string(s) still directly "
+            f"interpolating the resettable retry_count instead of "
+            f"_display_attempt"
+        )
+
+    def test_debug_dump_kwargs_still_use_real_retry_count(self):
+        """The fix must be display-only: structured debug/dump payloads
+        (request_dump kwargs, etc.) must keep reporting the REAL
+        retry-budget state (retry_count), not the display-only counter --
+        those consumers need the actual budget accounting, not the
+        monotonic UI number."""
+        src = self._loop_source()
+        assert "retry_count=retry_count" in src, (
+            "Debug/dump call sites must still pass the real retry_count, "
+            "not be silently switched to the display counter"
+        )


### PR DESCRIPTION
## Context

Fixes #12956.

## Problem

Every user-facing "(attempt X/Y)" status message displayed `retry_count` directly. `retry_count` intentionally resets to 0 whenever a fallback provider activates (a fresh retry budget for the new endpoint), so the visible sequence jumped backward mid-run: `(attempt 1/3) -> (attempt 2/3) -> (attempt 1/3) -> (attempt 2/3)`, even though the underlying retry accounting was working correctly.

An earlier attempt at this fix (#12967, my own PR from an earlier session) targeted the wrong location: it changed `retry_count = 0` to `max_retries += 1` in `run_agent.py`, an obsolete file -- the retry loop has since moved to `agent/conversation_loop.py`, and mutating `max_retries` still leaves budget and display coupled. Per the review that correctly rejected it: current main intentionally resets recovery/fallback state, and a fix needs a separate monotonic display counter while preserving that reset.

## Fix

Added `_display_attempt`, a purely additive counter initialized once alongside `retry_count`, incremented in lockstep with every `retry_count += 1` (3 sites), but never reset when `retry_count` resets on fallback activation. All 9 user-facing status/log messages now read `_display_attempt` instead. `retry_count`/`max_retries` themselves, and every non-display consumer, are completely untouched.

## Verification

5 new tests pass, using structural source inspection rather than mocking the full multi-provider retry+fallback state machine: initialized exactly once, intentional resets preserved, every increment site paired, no display string still uses the resettable counter, debug/dump kwargs still report the real value. 21/21 retry-related and 16/16 fallback-related tests pass in the full `tests/run_agent/test_run_agent.py` file (no regression).