### PR TITLE
fix(tools): stop the Git Bash probe from inheriting host stdin

### DIFF
--- a/tests/tools/test_find_shell.py
+++ b/tests/tools/test_find_shell.py
@@ -145,6 +145,32 @@ class TestGitBashExternalProgramProbe:
         assert local_mod._bash_starts(r"C:\Git\bin\bash.exe") is True
         assert calls[0][0][-1] == "/usr/bin/true; /usr/bin/cat --version >/dev/null"
 
+    def test_probe_never_inherits_host_stdin(self, monkeypatch):
+        """The probe must not inherit fd 0 (#73693).
+
+        Under a JSON-RPC stdio host — ACP, or the TUI gateway of #14036 —
+        stdin is the protocol pipe. MSYS bash blocks on it at startup, and
+        the probe's own timeout only reaps the Git wrapper process, so the
+        surviving mingw child holds the pipe and hangs the turn.
+        """
+        import tools.environments.local as local_mod
+
+        local_mod._bash_starts_cache.clear()
+        local_mod._bash_probe_details_cache.clear()
+        calls = []
+
+        def fake_run(argv, **kwargs):
+            calls.append(kwargs)
+            return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(local_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+
+        local_mod._bash_starts(r"C:\Git\bin\bash.exe")
+
+        assert calls, "expected the probe to spawn bash"
+        assert calls[0].get("stdin") is subprocess.DEVNULL
+
     def test_aslr_failure_surfaces_targeted_windows_command(
         self, tmp_path, monkeypatch
     ):

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -845,6 +845,7 @@ def _mandatory_aslr_enabled() -> "bool | None":
                 "(Get-ProcessMitigation -System).Aslr.ForceRelocateImages.ToString()",
             ],
             capture_output=True,
+            stdin=subprocess.DEVNULL,
             text=True, encoding="utf-8", errors="replace",
             timeout=10,
             creationflags=windows_hide_flags(),
@@ -911,6 +912,12 @@ def _bash_starts(bash: str) -> bool:
         result = subprocess.run(
             [bash, "--noprofile", "--norc", "-c", _BASH_EXTERNAL_PROGRAM_PROBE],
             capture_output=True,
+            # Never let the probe inherit the host's stdin. Under a JSON-RPC
+            # stdio host (ACP/TUI gateway) fd 0 is the protocol pipe; MSYS
+            # bash blocks on it at startup, and the timeout below then kills
+            # only the Git\bin wrapper — the surviving mingw child keeps the
+            # pipe open and communicate() hangs the turn. See #73693.
+            stdin=subprocess.DEVNULL,
             text=True, encoding="utf-8", errors="replace",
             timeout=15,
             creationflags=windows_hide_flags() if _IS_WINDOWS else 0,


### PR DESCRIPTION
### What & why

`read_file` and `terminal` hang forever when Hermes runs as an ACP agent in a
JetBrains IDE on Windows (#73693). A plain local read builds `ShellFileOperations`,
which initialises `LocalEnvironment` and runs the Git Bash health probe.

`_bash_starts` and `_mandatory_aslr_enabled` spawned children without an explicit
`stdin=`, so both inherited fd 0. Under a JSON-RPC stdio host that fd is the
protocol pipe — the same hazard as #14036/#39257 in the TUI gateway, but it
presents as a hang instead of an EOF exit:

1. MSYS bash blocks on the inherited pipe during startup.
2. `timeout=15` fires, but on Windows `bash` resolves to a `Git\bin` wrapper that
   spawns the real mingw binary. Killing the wrapper leaves the grandchild alive,
   still holding the pipe.
3. `subprocess.run`'s post-kill `communicate()` takes no timeout, so the calling
   thread blocks forever — and with it the agent turn.

That third step is why the existing timeout doesn't save us, and why the same
call is harmless from the CLI, where fd 0 is a console.

### Note for maintainers: the guard that should have caught this

`scripts/check_subprocess_stdin.py` exists to prevent exactly this class. It
misses both call sites because detection is line-based and the regex requires an
argument character immediately after the open paren:

```python
r"subprocess\.(run|Popen|call|check_output|check_call)\s*\([\"'a-zA-Z_\[\(]"
```

So any call formatted as `subprocess.run(` + newline — the standard formatting for
long calls — is never examined. A scan for that shape across the TUI-context dirs
finds **29 calls** the guard currently cannot see, including both fixed here.
I've left the guard alone to keep this PR focused; happy to send that as a
follow-up (tightening it turns those 29 red, so it wants its own review).

Note `scripts/check_subprocess_stdin.py` also crashes on Windows before printing
results (`UnicodeEncodeError` on the ❌ emoji under cp1252) — already fixed in #42775.

### How to test

Regression test added to `TestGitBashExternalProgramProbe`; it asserts the probe
passes `stdin=subprocess.DEVNULL`.

Manual, on Windows + JetBrains:
1. Configure Hermes as an ACP agent, open a project, start a session.
2. Ask it to read a local file, or run `pwd && ls` through `terminal`.
3. Before: hangs indefinitely. After: completes.

### Platforms

Verified on Windows 11, Python 3.11.14, Hermes 0.19.0, DataGrip 2026.2.1 (ACP v1).
POSIX is unaffected in practice — native git/bash don't block on an inherited
pipe at startup, `SIGKILL` reaps the direct child (no wrapper/grandchild split),
and CPython's POSIX timeout path doesn't do an unbounded post-kill drain. The
change is still correct there: it stops children sharing the protocol fd.

Two pre-existing failures in `tests/tools/test_find_shell.py`
(`TestFindShellPrefersUserShell`) reproduce on an unmodified checkout on Windows
and are unrelated.

Fixes #73693

---