### PR TITLE
fix(acp): tolerate a null final_response when a turn is cancelled

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2158,7 +2158,12 @@ class HermesACPAgent(acp.Agent):
                     exc_info=True,
                 )
 
-        final_response = result.get("final_response", "")
+        # ``or ""`` rather than a ``.get`` default: the conversation loop can
+        # return the key with an explicit ``None`` (e.g. the truncation path's
+        # ``partial_response or None``), and a default only applies when the
+        # key is absent. Other consumers already tolerate None — see
+        # ``turn_finalizer``'s ``len(final_response) if final_response else 0``.
+        final_response = result.get("final_response") or ""
         cancelled = bool(state.cancel_event and state.cancel_event.is_set())
         interrupted = bool(result.get("interrupted")) or cancelled
         # Hermes' local "waiting for model response" interrupt status is metadata,

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -446,6 +446,39 @@ class TestPrompt:
 
         assert captured.get("child") == resp.session_id
 
+    @pytest.mark.asyncio
+    async def test_prompt_survives_null_final_response(self, agent):
+        """A None final_response must not crash the turn (#73693).
+
+        The conversation loop returns the key with an explicit None on some
+        paths (e.g. truncation's ``partial_response or None``), so the ``""``
+        default never applies and ``.startswith`` raised AttributeError. The
+        client saw a bare JSON-RPC "Internal error" and treated the session
+        as non-recoverable.
+        """
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        def mock_run(*args, **kwargs):
+            state.cancel_event.set()
+            return {
+                "final_response": None,
+                "messages": [],
+                "interrupted": True,
+                "completed": False,
+            }
+
+        state.agent.run_conversation = mock_run
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        prompt = [TextContentBlock(type="text", text="cancel me")]
+        resp = await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        assert resp.stop_reason == "cancelled"
+
 
 
 

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -479,6 +479,51 @@ class TestPrompt:
 
         assert resp.stop_reason == "cancelled"
 
+    @pytest.mark.asyncio
+    async def test_queued_prompt_drains_after_interrupted_turn(self, agent):
+        """A prompt queued behind an interrupted turn must still run (#86798).
+
+        The crash above happened *before* the queue drain, so a queued user
+        message was never dispatched and stayed "queued" forever. This guards
+        the drain loop independently of the None normalization: the first
+        turn is interrupted with ``final_response=None``; the queued prompt
+        must still reach ``run_conversation``.
+        """
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        runs: list[str] = []
+
+        def mock_run(*args, **kwargs):
+            text = kwargs.get("user_message") or (args[0] if args else "")
+            runs.append(text)
+            if len(runs) == 1:
+                state.cancel_event.set()
+                return {
+                    "final_response": None,
+                    "messages": [],
+                    "interrupted": True,
+                    "completed": False,
+                }
+            return {"final_response": "ok", "messages": [], "completed": True}
+
+        state.agent.run_conversation = mock_run
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        with state.runtime_lock:
+            state.queued_prompts.append("second")
+
+        prompt = [TextContentBlock(type="text", text="first")]
+        resp = await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        assert resp.stop_reason == "cancelled"
+        assert runs == ["first", "second"]
+        assert state.queued_prompts == []
+        assert not state.is_running
+
 
 
 


### PR DESCRIPTION
### What & why

Cancelling a turn could kill the session with:

```
AttributeError: 'NoneType' object has no attribute 'startswith'
```

surfaced to the client as a bare JSON-RPC "Internal error". JetBrains treats that
as a non-recoverable session failure: it tears down the session and kills the
agent process, so a cancel could destroy a session that was otherwise healthy.

`result.get("final_response", "")` assumed the key is absent-or-string, but the
conversation loop can return it present-and-`None` — the truncation path returns
`partial_response or None` outright (`agent/conversation_loop.py`). A `.get`
default only applies to a *missing* key, so the value stayed `None`.

The rest of the codebase already treats it as optional — `turn_finalizer` uses
`len(final_response) if final_response else 0`, which is why the turn log prints
`response_len=0` instead of crashing. The ACP adapter was the outlier.
Normalising at the single ingress point covers all five downstream uses.

### How to test

`tests/acp/test_server.py::TestPrompt::test_prompt_survives_null_final_response`
drives a cancelled turn returning `final_response: None`. It fails with
`AttributeError` on an unmodified checkout and passes with the fix.

### Platforms

Platform-independent. Full `tests/acp` suite run on Windows 11: 326 passed;
4 pre-existing failures (`test_approval_isolation`, `test_edit_approval`,
`test_ping_suppression`) reproduce on an unmodified checkout.

Reported as the secondary exception in #73693.

---