### PR TITLE
fix(desktop): anchor the transcript through a session load

### DIFF
--- a/apps/desktop/scripts/perf/README.md
+++ b/apps/desktop/scripts/perf/README.md
@@ -57,6 +57,7 @@ directly via `window.__PERF_DRIVE__`, so no LLM credits are spent.
 | `first-token` | backend | Enter → first assistant token painted (TTFT) | (new) |
 | `submit` | backend | Enter → cleared → user msg painted, scroll jump | measure-submit, measure-jump |
 | `session-switch` | backend | route → first-paint → settle | profile-session-switch |
+| `session-load` | backend | how far a session's transcript moves after first paint | (new) |
 | `profile-switch` | backend | rail click → sidebar settled | measure-profile-switch |
 
 `ci` + `cold` scenarios need no backend/credits and are gated against

--- a/apps/desktop/scripts/perf/scenarios/index.mjs
+++ b/apps/desktop/scripts/perf/scenarios/index.mjs
@@ -8,6 +8,7 @@ import keystroke from './keystroke.mjs'
 import multitab from './multitab.mjs'
 import profileSwitch from './profile-switch.mjs'
 import renderChurn from './render-churn.mjs'
+import sessionLoad from './session-load.mjs'
 import sessionSwitch from './session-switch.mjs'
 import stream from './stream.mjs'
 import streamHistory from './stream-history.mjs'
@@ -25,6 +26,7 @@ export const SCENARIOS = {
   [coldStart.name]: coldStart,
   [firstToken.name]: firstToken,
   [submit.name]: submit,
+  [sessionLoad.name]: sessionLoad,
   [sessionSwitch.name]: sessionSwitch,
   [profileSwitch.name]: profileSwitch
 }

--- a/apps/desktop/scripts/perf/scenarios/session-load.mjs
+++ b/apps/desktop/scripts/perf/scenarios/session-load.mjs
@@ -1,0 +1,136 @@
+// Visual stability of a session LOAD. Sibling to `submit` (which measures the
+// jump on Enter); this one measures the jump on opening a session — the
+// prepend/settle path, not the append path.
+//
+// Clicks sidebar rows and tracks the bottom-most turn's on-screen top every
+// frame. A clean load never moves it after first paint; a janky one strands it
+// thousands of px away while the render-budget backfill and stick-to-bottom
+// argue. Backend tier: needs real stored sessions in the sidebar.
+//
+//   node scripts/perf/run.mjs session-load --rows 2,5,8 --rounds 2
+
+import { SELECTORS, sleep } from '../lib/cdp.mjs'
+import { summarize } from '../lib/stats.mjs'
+
+// Below this a shift is sub-perceptual (sub-pixel rounding, a settling caret).
+const SHIFT_PX = 4
+
+const ARM = `
+  (() => {
+    const samples = []
+    const t0 = performance.now()
+    let running = true
+
+    const tick = () => {
+      if (!running) return
+      const v = document.querySelector(${JSON.stringify(SELECTORS.threadViewport)})
+
+      if (v) {
+        const turns = v.querySelectorAll(
+          ${JSON.stringify(SELECTORS.turnPair)} + ',' + ${JSON.stringify(SELECTORS.assistantMessage)}
+        )
+        const last = turns[turns.length - 1]
+        const rect = last && last.getBoundingClientRect()
+        samples.push({
+          st: Math.round(v.scrollTop),
+          sh: v.scrollHeight,
+          ch: v.clientHeight,
+          bottomTop: rect ? Math.round(rect.top - v.getBoundingClientRect().top) : null,
+          turns: turns.length,
+          t: Math.round(performance.now() - t0)
+        })
+      }
+
+      requestAnimationFrame(tick)
+    }
+
+    requestAnimationFrame(tick)
+    window.__SL = { samples, stop() { running = false } }
+  })()
+`
+
+const CLICK = index => `
+  (() => {
+    const rows = [...document.querySelectorAll(${JSON.stringify(SELECTORS.rowButton)})].filter(el => el.offsetParent)
+    const row = rows[${index}]
+    if (!row) return null
+    row.click()
+    return (row.textContent ?? '').slice(0, 34)
+  })()
+`
+
+/** Total/max on-screen movement of the bottom turn after it first paints. */
+function measureLoad(samples) {
+  const painted = samples.findIndex(s => s.turns > 0)
+  const after = painted === -1 ? [] : samples.slice(painted)
+  const load = { maxShiftPx: 0, offBottomFrames: 0, settledMs: 0, shiftedPx: 0, shifts: 0 }
+  let previous = null
+
+  for (const sample of after) {
+    if (sample.sh - (sample.st + sample.ch) > 2) {
+      load.offBottomFrames += 1
+    }
+
+    if (previous?.bottomTop != null && sample.bottomTop != null) {
+      const delta = Math.abs(sample.bottomTop - previous.bottomTop)
+
+      if (delta > SHIFT_PX) {
+        load.maxShiftPx = Math.max(load.maxShiftPx, delta)
+        load.settledMs = sample.t
+        load.shiftedPx += delta
+        load.shifts += 1
+      }
+    }
+
+    previous = sample
+  }
+
+  return load
+}
+
+export default {
+  name: 'session-load',
+  tier: 'backend',
+  description: 'Visual stability of opening a session: how far the transcript moves after first paint.',
+  async run(cdp, opts = {}) {
+    const rows = String(opts.rows ?? '2,5,8').split(',').map(Number)
+    const rounds = Number(opts.rounds ?? 2)
+    const watchMs = Number(opts.watchMs ?? 4500)
+
+    await cdp.send('Runtime.enable')
+
+    const loads = []
+
+    for (let round = 0; round < rounds; round++) {
+      for (const index of rows) {
+        await cdp.eval(ARM)
+
+        if (!(await cdp.eval(CLICK(index)))) {
+          continue
+        }
+
+        await sleep(watchMs)
+        const { samples } = await cdp.eval('(() => { window.__SL.stop(); return window.__SL })()')
+        loads.push(measureLoad(samples))
+      }
+
+      await sleep(500)
+    }
+
+    if (!loads.length) {
+      throw new Error('session-load found no sidebar rows to click')
+    }
+
+    const total = key => loads.reduce((sum, load) => sum + load[key], 0)
+
+    return {
+      metrics: {
+        load_max_shift_px: Math.max(...loads.map(load => load.maxShiftPx)),
+        load_off_bottom_frames: Math.round(total('offBottomFrames') / loads.length),
+        load_settled_p95_ms: summarize(loads.map(load => load.settledMs)).p95,
+        load_shifted_px: Math.round(total('shiftedPx') / loads.length)
+      },
+      detail: { loads: loads.length, shiftsPerLoad: total('shifts') / loads.length }
+    }
+  }
+}

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -210,6 +210,27 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     }
   }
 
+  // Where to land after a prepend, in distance-from-bottom (survives the
+  // height change). Shared by "Show earlier" and the budget backfill below.
+  const restoreFromBottomRef = useRef<number | null>(null)
+  // False from a session switch until the settle loop below parks the
+  // transcript at its true bottom. While false, scrollTop is a way-point of a
+  // load in progress, not a reading position anyone chose — never anchor to it.
+  const loadSettledRef = useRef(false)
+  // Session the settle loop last armed for, so a re-arm within the same load
+  // is distinguishable from a switch to a different transcript.
+  const settleKeyRef = useRef(sessionKey)
+
+  // Record where the view should land once a prepend has grown the content,
+  // measured from the BOTTOM so the added height doesn't invalidate it. Only a
+  // settled load has an offset the user chose; mid-load the answer is simply
+  // the bottom.
+  const anchorBeforePrepend = useCallback(() => {
+    const el = scrollRef.current
+
+    restoreFromBottomRef.current = el && loadSettledRef.current ? el.scrollHeight - el.scrollTop : 0
+  }, [scrollRef])
+
   // Backfill from FIRST_PAINT_BUDGET to the full budget after the small
   // commit painted — as a TRANSITION, so the heavy markdown + syntax
   // highlight render of the older turns is interruptible instead of one long
@@ -223,6 +244,14 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     }
 
     const rafId = requestAnimationFrame(() => {
+      // The backfill PREPENDS older turns, so everything on screen slides down
+      // by their height. Anchor first and let the restore effect below re-apply
+      // it in the same commit the taller tree lands in — otherwise the view is
+      // stranded near the TOP until use-stick-to-bottom's ResizeObserver
+      // catches up a frame or two later (measured: an 11.5k px jump showing
+      // ~160ms of unrelated old turns, on every session load).
+      anchorBeforePrepend()
+
       // Functional max, not a plain set: an urgent "Show earlier" click can
       // land between scheduling and committing this transition, and a plain
       // set would rebase over it and shrink the budget back down.
@@ -230,7 +259,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     })
 
     return () => cancelAnimationFrame(rafId)
-  }, [renderBudget])
+  }, [anchorBeforePrepend, renderBudget])
 
   // Weights (per-message part counts) fold into the BUDGET only. Group
   // identity stays structural, so a streaming append re-runs this cheap sum —
@@ -249,7 +278,6 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
 
   const hiddenCount = firstVisibleGroupIndex(weightedGroups, renderBudget)
   const visibleGroups = hiddenCount > 0 ? groups.slice(hiddenCount) : groups
-  const restoreFromBottomRef = useRef<number | null>(null)
   // Secondary windows (new-session scratch, subagent watch, cmd-click pop-out)
   // hide the titlebar tool cluster + session header, but the OS traffic lights
   // still sit in the top-left, so reserve the titlebar gap above the transcript.
@@ -302,6 +330,16 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   // follow re-pins every frame to a moving target — visible as ~10 scroll jumps.
   // Instead: quiet it, glue to the true bottom until the height holds steady,
   // then hand back locked. Live streaming afterward uses the normal resize follow.
+  //
+  // `hasGroups` joins sessionKey as a dep because a COLD load changes the key
+  // while the transcript is still empty and publishes messages hundreds of ms
+  // later. Keyed on the switch alone the loop measured an EMPTY viewport, saw
+  // a stable height in two frames, and handed back "settled" before the
+  // transcript existed — so the turns painted at scrollTop 0 and only snapped
+  // down once use-stick-to-bottom's ResizeObserver noticed, a full-viewport
+  // lurch on every cold load. The empty→non-empty flip re-arms for the
+  // transcript that actually arrived; being a boolean, it cannot re-fire on a
+  // streaming append.
   useLayoutEffect(() => {
     const el = scrollRef.current
 
@@ -311,6 +349,15 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
 
     stopScroll()
     el.scrollTop = el.scrollHeight
+    loadSettledRef.current = false
+
+    // An anchor captured for the OUTGOING transcript must not be applied to
+    // this one — a switch owns the position outright. The empty→non-empty
+    // re-arm is the SAME load, whose in-flight anchor is still correct.
+    if (settleKeyRef.current !== sessionKey) {
+      settleKeyRef.current = sessionKey
+      restoreFromBottomRef.current = null
+    }
 
     let frame = 0
     let stableFrames = 0
@@ -334,6 +381,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
       // frames to minimize the settle-loop racing markdown paint on every switch.
       if (stableFrames >= 2 || ++frame > 15) {
         void scrollToBottom('instant')
+        loadSettledRef.current = true
 
         return
       }
@@ -344,17 +392,15 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     let rafId = requestAnimationFrame(settle)
 
     return () => cancelAnimationFrame(rafId)
-  }, [scrollRef, scrollToBottom, sessionKey, stopScroll])
+  }, [hasGroups, scrollRef, scrollToBottom, sessionKey, stopScroll])
 
   // Prepend an older page while preserving the on-screen position. The user is
   // scrolled up (reading history) so the stick-to-bottom lock is escaped and
   // won't fight this manual restore.
   const showEarlier = useCallback(() => {
-    const el = scrollRef.current
-
-    restoreFromBottomRef.current = el ? el.scrollHeight - el.scrollTop : null
+    anchorBeforePrepend()
     setRenderBudget(budget => budget + RENDER_BUDGET)
-  }, [scrollRef])
+  }, [anchorBeforePrepend])
 
   useLayoutEffect(() => {
     const el = scrollRef.current


### PR DESCRIPTION
Opening a session made the transcript jump around before it settled. Two things
in the load path caused it, and both fire on every fresh session render.

The render-budget backfill paints a small first budget, then prepends the rest
of the turns *above* the viewport — so everything on screen slides down by the
prepended height with nothing holding the position. The view ends up stranded
near the top of the transcript until `use-stick-to-bottom`'s ResizeObserver
catches up a frame or two later. `showEarlier` already solves exactly this with
`restoreFromBottomRef`; the backfill just never used it.

The settle loop couldn't cover for it either. Keyed on `sessionKey` alone, a
cold load changed the key while the transcript was still empty — the loop
measured an empty viewport, saw a stable height within two frames, and handed
back "settled" hundreds of ms before the messages arrived. The turns then
painted at scrollTop 0 and only snapped down once the ResizeObserver noticed.

So: anchor before the backfill prepends, and re-arm the settle loop when the
transcript actually lands. Both reuse machinery already in the file — three
refs and one added dep, no new abstractions.

This also explains the intermittent version, where a session you're already
sitting in jumps later on. The budget resets on empty→non-empty, not just on
session switch, so anything that momentarily empties the transcript (a warm
resume reconcile, a compression id rotation) replays the same sequence.

## Measured

A/B on one instance against a real session DB, 12 sidebar-click loads each,
with the dev server confirmed to be serving each version:

| metric | before | after |
|---|---|---|
| post-paint movement / load | 12,179 px | 544-769 px |
| worst single jump | 13,369 px | 2,296 px |

No perf cost — no new subscriptions, observers, or renders. `render-churn` on
the same instance came out lower on every real counter (commits 1561 → 801,
total renders 7806 → 6787, wasted 1849 → 1540). The existing budget, transition
backfill, live tail, and content-visibility optimizations are all untouched.

The second commit adds a `session-load` perf scenario. `submit` already measured
the scroll jump when a turn is appended; nothing measured the jump when a
session is opened, which is the path this fixes.
