### PR TITLE
feat(web): forward custom HTTP request headers in web_extract

### DIFF
--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -440,6 +440,7 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
         if _is_interrupted():
             return [{"url": u, "error": "Interrupted", "title": ""} for u in urls]
 
+        headers = kwargs.get("headers") or None
         format = kwargs.get("format")
         formats: List[str] = []
         if format == "markdown":
@@ -485,12 +486,13 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
 
             try:
                 logger.info("Firecrawl scraping: %s", url)
+                scrape_kwargs: Dict[str, Any] = {"url": url, "formats": formats}
+                if headers:
+                    scrape_kwargs["headers"] = headers
                 try:
                     scrape_result = await asyncio.wait_for(
                         asyncio.to_thread(
-                            _get_firecrawl_client().scrape,
-                            url=url,
-                            formats=formats,
+                            lambda: _get_firecrawl_client().scrape(**scrape_kwargs)
                         ),
                         timeout=60,
                     )

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -744,6 +744,7 @@ async def web_extract_tool(
     urls: List[Any],
     format: str = None,
     char_limit: Optional[int] = None,
+    headers: Optional[Dict[str, str]] = None,
 ) -> str:
     """
     Extract content from specific web pages using available extraction API backend.
@@ -762,6 +763,7 @@ async def web_extract_tool(
         format (str): Desired output format ("markdown" or "html", optional)
         char_limit (Optional[int]): Per-page char budget sent to the model
             (default: web.extract_char_limit or 15000). Larger pages truncate.
+        headers (Optional[Dict[str, str]]): Optional HTTP headers sent with fetch.
 
     Security: URLs are checked for embedded secrets before fetching.
 
@@ -824,6 +826,7 @@ async def web_extract_tool(
             "urls": normalized_urls,
             "format": format,
             "char_limit": char_limit,
+            "headers": headers,
         },
         "error": None,
         "pages_extracted": 0,
@@ -935,12 +938,12 @@ async def web_extract_tool(
             # extract(); exa + tavily are sync.
             import inspect
             if inspect.iscoroutinefunction(provider.extract):
-                results = await provider.extract(safe_urls, format=format)
+                results = await provider.extract(safe_urls, format=format, headers=headers)
             else:
                 # Run sync extract() in a thread so we don't block the
                 # event loop on network I/O.
                 results = await asyncio.to_thread(
-                    provider.extract, safe_urls, format=format
+                    provider.extract, safe_urls, format=format, headers=headers
                 )
 
         # Reconstruct the original input order across invalid, blocked, and
@@ -1205,6 +1208,11 @@ WEB_EXTRACT_SCHEMA = {
                 "type": "integer",
                 "description": "Optional per-page character budget sent back (default 15000). Pages larger than this are head+tail truncated with the full text stored to disk. Raise it when you need more of a long page inline.",
                 "minimum": 2000
+            },
+            "headers": {
+                "type": "object",
+                "additionalProperties": {"type": "string"},
+                "description": "Optional HTTP request headers to send with the fetch (e.g. User-Agent)."
             }
         },
         "required": ["urls"]
@@ -1229,6 +1237,7 @@ registry.register(
         args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else [],
         "markdown",
         char_limit=args.get("char_limit"),
+        headers=args.get("headers"),
     ),
     check_fn=check_web_api_key,
     requires_env=_web_requires_env(),


### PR DESCRIPTION
## Problem or Use Case

`web_extract` cannot set HTTP request headers on the pages it fetches. Firecrawl's scrape API accepts a `headers` object, but Hermes never populates it, so there is no way to supply a descriptive `User-Agent`, `Authorization`, or `Referer` header when extracting a URL.

## Proposed Solution

1. Add optional `headers` object to `WEB_EXTRACT_SCHEMA` in `tools/web_tools.py` and pass `headers` from the tool handler.
2. Read `headers = kwargs.get("headers")` in `FirecrawlWebSearchProvider.extract` in `plugins/web/firecrawl/provider.py` and pass `headers` to `_get_firecrawl_client().scrape(url=url, formats=formats, headers=headers)`.

## Verification

- Tested `web_extract_tool` with optional `headers` parameter.
- `pytest tests/plugins/test_firecrawl.py tests/tools/test_web_tools.py` passed.

Closes #74177
