### PR TITLE
fix(stt): pass no_speech_threshold and log_prob_threshold to model.transcribe

### DIFF
--- a/tests/tools/test_stt_silence_hallucinations.py
+++ b/tests/tools/test_stt_silence_hallucinations.py
@@ -161,6 +161,22 @@ class TestTranscribeLocalWiring:
         assert captured["vad_filter"] is False
         assert "vad_parameters" not in captured
 
+    def test_vad_parameters_configurable(self, monkeypatch):
+        stt_cfg = {
+            "local": {
+                "vad_min_silence_ms": 300,
+                "vad_threshold": 0.35,
+                "vad_min_speech_duration_ms": 250,
+            }
+        }
+        captured, _ = self._run(monkeypatch, stt_cfg)
+        assert captured["vad_filter"] is True
+        assert captured["vad_parameters"] == {
+            "min_silence_duration_ms": 300,
+            "threshold": 0.35,
+            "min_speech_duration_ms": 250,
+        }
+
     def test_hallucinated_segments_filtered_from_transcript(self, monkeypatch):
         segments = [
             _seg(" real speech"),

--- a/tests/tools/test_stt_silence_hallucinations.py
+++ b/tests/tools/test_stt_silence_hallucinations.py
@@ -168,3 +168,31 @@ class TestTranscribeLocalWiring:
         ]
         _, result = self._run(monkeypatch, {}, segments=segments)
         assert result["transcript"] == "real speech"
+
+    def test_thresholds_reach_model_defaults(self, monkeypatch):
+        captured, _ = self._run(monkeypatch, {})
+        assert captured["no_speech_threshold"] == 0.6
+        assert captured["log_prob_threshold"] == -1.0
+
+    def test_thresholds_reach_model_configured(self, monkeypatch):
+        stt_cfg = {
+            "local": {
+                "no_speech_prob_threshold": 0.4,
+                "logprob_threshold": -0.7,
+            }
+        }
+        captured, _ = self._run(monkeypatch, stt_cfg)
+        assert captured["no_speech_threshold"] == 0.4
+        assert captured["log_prob_threshold"] == -0.7
+
+    def test_thresholds_reach_model_invalid_fallback(self, monkeypatch):
+        stt_cfg = {
+            "local": {
+                "no_speech_prob_threshold": "invalid",
+                "logprob_threshold": None,
+            }
+        }
+        captured, _ = self._run(monkeypatch, stt_cfg)
+        assert captured["no_speech_threshold"] == 0.6
+        assert captured["log_prob_threshold"] == -1.0
+

--- a/tests/tools/test_stt_silence_hallucinations.py
+++ b/tests/tools/test_stt_silence_hallucinations.py
@@ -68,6 +68,17 @@ class TestBuildLocalTranscribeKwargs:
         assert kwargs["language"] == "en"
         assert kwargs["initial_prompt"] == "Hermes glossary"
 
+    def test_thresholds_configurable_in_transcribe(self):
+        cfg = {
+            "local": {
+                "no_speech_prob_threshold": 0.8,
+                "logprob_threshold": -2.0,
+            }
+        }
+        kwargs = build_local_transcribe_kwargs(cfg)
+        assert kwargs["no_speech_threshold"] == 0.8
+        assert kwargs["log_prob_threshold"] == -2.0
+
 
 class TestConfidenceGate:
     def test_high_no_speech_and_low_logprob_dropped(self):

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1569,16 +1569,6 @@ def build_local_transcribe_kwargs(stt_config: Optional[Dict[str, Any]] = None) -
     if isinstance(initial_prompt, str) and initial_prompt.strip():
         kwargs["initial_prompt"] = initial_prompt
 
-    for fw_key, cfg_key, default in (
-        ("no_speech_threshold", "no_speech_prob_threshold", _NO_SPEECH_PROB_THRESHOLD_DEFAULT),
-        ("log_prob_threshold", "logprob_threshold", _LOGPROB_THRESHOLD_DEFAULT),
-    ):
-        try:
-            val = float(local_cfg.get(cfg_key, default))
-        except (TypeError, ValueError):
-            val = default
-        kwargs[fw_key] = val
-
     return kwargs
 
 

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1541,7 +1541,23 @@ def build_local_transcribe_kwargs(stt_config: Optional[Dict[str, Any]] = None) -
             )
         except (TypeError, ValueError):
             min_silence_ms = _VAD_MIN_SILENCE_MS_DEFAULT
-        kwargs["vad_parameters"] = {"min_silence_duration_ms": min_silence_ms}
+
+        vad_params: Dict[str, Any] = {"min_silence_duration_ms": min_silence_ms}
+        if "vad_threshold" in local_cfg:
+            try:
+                vad_params["threshold"] = float(local_cfg["vad_threshold"])
+            except (TypeError, ValueError):
+                pass
+        if "vad_min_speech_duration_ms" in local_cfg:
+            try:
+                vad_params["min_speech_duration_ms"] = int(local_cfg["vad_min_speech_duration_ms"])
+            except (TypeError, ValueError):
+                pass
+        cfg_vad_params = local_cfg.get("vad_parameters")
+        if isinstance(cfg_vad_params, dict):
+            vad_params.update(cfg_vad_params)
+
+        kwargs["vad_parameters"] = vad_params
     else:
         kwargs["vad_filter"] = False
 

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1526,6 +1526,10 @@ def build_local_transcribe_kwargs(stt_config: Optional[Dict[str, Any]] = None) -
         "condition_on_previous_text": False,
     }
 
+    no_speech_threshold, logprob_threshold = _confidence_thresholds(local_cfg)
+    kwargs["no_speech_threshold"] = no_speech_threshold
+    kwargs["log_prob_threshold"] = logprob_threshold
+
     vad_enabled = local_cfg.get("vad", True)
     if vad_enabled is None:
         vad_enabled = True

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1549,6 +1549,16 @@ def build_local_transcribe_kwargs(stt_config: Optional[Dict[str, Any]] = None) -
     if isinstance(initial_prompt, str) and initial_prompt.strip():
         kwargs["initial_prompt"] = initial_prompt
 
+    for fw_key, cfg_key, default in (
+        ("no_speech_threshold", "no_speech_prob_threshold", _NO_SPEECH_PROB_THRESHOLD_DEFAULT),
+        ("log_prob_threshold", "logprob_threshold", _LOGPROB_THRESHOLD_DEFAULT),
+    ):
+        try:
+            val = float(local_cfg.get(cfg_key, default))
+        except (TypeError, ValueError):
+            val = default
+        kwargs[fw_key] = val
+
     return kwargs
 
 


### PR DESCRIPTION
## Problem

Local STT (`faster-whisper`) can return empty transcriptions for non-English speech because:
1. `build_local_transcribe_kwargs()` reads `stt.local.no_speech_prob_threshold` and `stt.local.logprob_threshold` from config but only uses them in Hermes' own post-filter (`_join_confident_segments`). It does **not** pass them to `model.transcribe()`, so `faster-whisper`'s internal defaults (0.6, -1.0) apply and silently drop low-confidence non-English segments.
2. VAD parameters (`vad_threshold`, `vad_min_speech_duration_ms`, custom `vad_parameters` dict) specified in `stt.local` were not passed to `kwargs["vad_parameters"]`, leaving VAD filter customization unavailable.

## Solution

1. In `build_local_transcribe_kwargs()`, resolve confidence thresholds via `_confidence_thresholds(local_cfg)` and pass `no_speech_threshold` / `log_prob_threshold` through to `model.transcribe()`.
2. Pass `vad_threshold`, `vad_min_speech_duration_ms`, and custom `vad_parameters` from `stt.local` into `kwargs["vad_parameters"]`.
3. Extend `TestTranscribeLocalWiring` harness in `tests/tools/test_stt_silence_hallucinations.py` to verify confidence thresholds and VAD parameter resolution reach `FakeModel.transcribe()`.

## Verification

- Added `test_thresholds_reach_model_defaults`, `test_thresholds_reach_model_configured`, `test_thresholds_reach_model_invalid_fallback`, and `test_vad_parameters_configurable` in `tests/tools/test_stt_silence_hallucinations.py`.
- All 19 tests in `tests/tools/test_stt_silence_hallucinations.py` pass cleanly.

Closes #74178
