### PR TITLE
fix(cli): convert Alt key shortcuts to sequence tuple for prompt_toolkit

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15523,6 +15523,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             from hermes_cli.config import load_config
             from hermes_cli.voice import (
                 normalize_voice_record_key_for_prompt_toolkit,
+                pt_key_to_sequence,
                 voice_record_key_from_config,
             )
             _raw_key = voice_record_key_from_config(load_config())
@@ -15548,7 +15549,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # voice.record_key mid-session (Copilot round-13 on #19835).
         self.set_voice_record_key_cache(_raw_key)
 
-        @kb.add(_voice_key)
+        @kb.add(*pt_key_to_sequence(_voice_key))
         def handle_voice_record(event):
             """Toggle voice recording when voice mode is active.
 

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -183,6 +183,17 @@ def normalize_voice_record_key_for_prompt_toolkit(raw: Any) -> str:
     return f"{normalized_mod}{named}"
 
 
+def pt_key_to_sequence(pt_key: str) -> tuple[str, ...]:
+    """Convert a prompt_toolkit key specifier (e.g. 'c-b' or 'a-v') to a sequence tuple.
+
+    prompt_toolkit's ``@kb.add`` rejects 'a-x' strings directly (raises ValueError),
+    expecting ('escape', 'x') instead for Alt-modifier shortcuts.
+    """
+    if isinstance(pt_key, str) and pt_key.startswith("a-"):
+        return ("escape", pt_key[2:])
+    return (pt_key,)
+
+
 def format_voice_record_key_for_status(raw: Any) -> str:
     """Render ``voice.record_key`` for ``/voice status`` in CLI-friendly form.
 

--- a/tests/hermes_cli/test_voice_wrapper.py
+++ b/tests/hermes_cli/test_voice_wrapper.py
@@ -170,6 +170,13 @@ class TestNormalizeVoiceRecordKeyForPromptToolkit:
         assert normalize_voice_record_key_for_prompt_toolkit("alt+d") == "a-d"
         assert normalize_voice_record_key_for_prompt_toolkit("alt+l") == "a-l"
 
+    def test_pt_key_to_sequence(self):
+        from hermes_cli.voice import pt_key_to_sequence
+
+        assert pt_key_to_sequence("c-b") == ("c-b",)
+        assert pt_key_to_sequence("a-v") == ("escape", "v")
+        assert pt_key_to_sequence("a-space") == ("escape", "space")
+
 
 class TestVoiceRecordKeyFromConfig:
     """Round-11 Copilot review regression on #19835.


### PR DESCRIPTION
## Problem

CLI crashes on startup when `voice.record_key` uses `alt` (e.g., `alt+v`). `normalize_voice_record_key_for_prompt_toolkit()` produces `a-v`, which `prompt_toolkit`'s `@kb.add()` rejects with `ValueError: Invalid key: a-v`.

## Solution

1. Add `pt_key_to_sequence(pt_key: str) -> tuple[str, ...]` helper in `hermes_cli/voice.py` to convert specifiers starting with `a-` (e.g., `a-v`) to sequence tuples expected by `prompt_toolkit` (e.g., `("escape", "v")`).
2. Update `@kb.add` registration site in `cli.py` to call `@kb.add(*pt_key_to_sequence(_voice_key))`.

## Verification

- Added `test_pt_key_to_sequence` in `tests/hermes_cli/test_voice_wrapper.py`.
- Tested `prompt_toolkit` key registration with `alt+v`.
- All tests in `tests/hermes_cli/test_voice_wrapper.py` pass cleanly.

Closes #74169
