### PR TITLE
fix(webhook): accept Fireflies X-Hub-Signature header

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -993,7 +993,7 @@ class WebhookAdapter(BasePlatformAdapter):
     def _validate_signature(
         self, request: "web.Request", body: bytes, secret: str
     ) -> bool:
-        """Validate webhook signature (GitHub, GitLab, Svix, generic HMAC-SHA256)."""
+        """Validate webhook signature (GitHub, Fireflies, GitLab, Svix, generic HMAC-SHA256)."""
         def _header(name: str) -> str:
             return (
                 request.headers.get(name, "")
@@ -1020,12 +1020,23 @@ class WebhookAdapter(BasePlatformAdapter):
             )
 
         # GitHub: X-Hub-Signature-256 = sha256=<hex>
-        gh_sig = request.headers.get("X-Hub-Signature-256", "")
+        gh_sig = _header("X-Hub-Signature-256")
         if gh_sig:
             expected = "sha256=" + hmac.new(
                 secret.encode(), body, hashlib.sha256
             ).hexdigest()
             return _hmac_str_equal(gh_sig, expected)
+
+        # Fireflies: X-Hub-Signature = sha256=<hex>
+        # Fireflies does not use GitHub's `-256` header suffix.  Keep this
+        # separate from generic X-Webhook-Signature V1 below because the
+        # Fireflies value includes the `sha256=` prefix.
+        fireflies_sig = _header("X-Hub-Signature")
+        if fireflies_sig:
+            expected = "sha256=" + hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return _hmac_str_equal(fireflies_sig, expected)
 
         # GitLab: X-Gitlab-Token = <plain secret>
         gl_token = request.headers.get("X-Gitlab-Token", "")

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -147,6 +147,31 @@ class TestValidateSignature:
         req = _mock_request(headers={"X-Hub-Signature-256": "sha256=deadbeef"})
         assert adapter._validate_signature(req, body, secret) is False
 
+    def test_validate_fireflies_signature_valid(self):
+        """Valid Fireflies X-Hub-Signature is accepted."""
+        adapter = _make_adapter()
+        body = b'{"event": "Transcription completed"}'
+        secret = "fireflies-secret-42"
+        sig = _github_signature(body, secret)
+        req = _mock_request(headers={"X-Hub-Signature": sig})
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_fireflies_lowercase_signature_valid(self):
+        """Fireflies' lowercase x-hub-signature form is accepted."""
+        adapter = _make_adapter()
+        body = b'{"event": "Transcription completed"}'
+        secret = "fireflies-secret-42"
+        sig = _github_signature(body, secret)
+        req = _mock_request(headers={"x-hub-signature": sig})
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_fireflies_signature_invalid(self):
+        """Wrong Fireflies X-Hub-Signature is rejected."""
+        adapter = _make_adapter()
+        body = b'{"event": "Transcription completed"}'
+        req = _mock_request(headers={"X-Hub-Signature": "sha256=deadbeef"})
+        assert adapter._validate_signature(req, body, "fireflies-secret-42") is False
+
     def test_validate_gitlab_token(self):
         """GitLab plain-token match via X-Gitlab-Token."""
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary

- accept Fireflies Webhooks V2 signatures from `X-Hub-Signature`
- preserve existing GitHub `X-Hub-Signature-256` behavior
- add valid, lowercase-header, and invalid-signature coverage

## Problem

Fireflies signs the raw request body with HMAC-SHA256 and sends the value as:

```
X-Hub-Signature: sha256=<hex digest>
```

The generic webhook adapter only checked GitHub's `X-Hub-Signature-256`, so correctly configured Fireflies deliveries were rejected with HTTP 401.

Reference: https://docs.fireflies.ai/graphql-api/webhooks-v2#webhook-authentication

## Verification

- `pytest -q tests/gateway/test_webhook_adapter.py` — 104 passed
- `ruff check gateway/platforms/webhook.py tests/gateway/test_webhook_adapter.py` — passed
- local valid Fireflies-style signed request — HTTP 202
- local invalid Fireflies-style signature — HTTP 401
- public Cloudflare-routed valid Fireflies-style request — HTTP 202 and downstream webhook agent/API handoff completed
