### PR TITLE
fix(mcp): recognize nested application failures

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -17,7 +17,10 @@ from typing import Any
 
 from utils import safe_json_loads
 from agent.redact import redact_sensitive_text
-from agent.tool_result_classification import file_mutation_result_landed
+from agent.tool_result_classification import (
+    file_mutation_result_landed,
+    structured_tool_failure_message,
+)
 
 # ANSI escape codes for coloring tool failure indicators
 _RED = "\033[31m"
@@ -1296,11 +1299,10 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
             if data.get("success") is False and "exceed the limit" in data.get("error", ""):
                 return True, " [full]"
 
-    # Structured error in JSON result (any tool that surfaces {"error": ...}).
-    if isinstance(data, dict):
-        err = data.get("error") or data.get("message")
-        if err and (data.get("success") is False or "error" in data):
-            return True, f" [{_trim_error(str(err))}]"
+    # Structured error in a direct or MCP-wrapped application result.
+    failure_message = structured_tool_failure_message(data)
+    if failure_message:
+        return True, f" [{_trim_error(failure_message)}]"
 
     # Generic heuristic for non-terminal tools
     # Multimodal tool results (dicts with _multimodal=True) are not strings —
@@ -1506,5 +1508,3 @@ def get_cute_tool_message(
 # =========================================================================
 # Honcho session line (one-liner with clickable OSC 8 hyperlink)
 # =========================================================================
-
-

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -14,7 +14,10 @@ from dataclasses import dataclass, field
 from typing import Any, Mapping
 
 from utils import safe_json_loads
-from agent.tool_result_classification import file_mutation_result_landed
+from agent.tool_result_classification import (
+    file_mutation_result_landed,
+    structured_tool_failure_message,
+)
 
 
 IDEMPOTENT_TOOL_NAMES = frozenset(
@@ -262,6 +265,10 @@ def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str
         if isinstance(data, dict):
             if data.get("success") is False and "exceed the limit" in data.get("error", ""):
                 return True, " [full]"
+
+    failure_message = structured_tool_failure_message(result)
+    if failure_message:
+        return True, f" [{failure_message}]"
 
     lower = result[:500].lower()
     if '"error"' in lower or '"failed"' in lower or result.startswith("Error"):

--- a/agent/tool_result_classification.py
+++ b/agent/tool_result_classification.py
@@ -7,6 +7,64 @@ from typing import Any
 
 
 FILE_MUTATING_TOOL_NAMES = frozenset({"write_file", "patch"})
+TOOL_RESULT_ENVELOPE_KEYS = frozenset({"result", "content", "structuredContent"})
+
+
+def unwrap_tool_result_envelope(result: Any, *, max_depth: int = 3) -> Any:
+    """Decode bounded MCP-style result envelopes without scanning prose.
+
+    MCP adapters commonly return application payloads as
+    ``{"result": "{...}"}``, optionally alongside ``structuredContent``.
+    Failure classification must inspect that payload rather than treating the
+    transport-level wrapper as a successful result.
+    """
+
+    value = result
+    for _ in range(max_depth + 1):
+        if isinstance(value, str):
+            try:
+                value = json.loads(value.strip())
+            except Exception:
+                return value
+        if not isinstance(value, dict):
+            return value
+        if any(key in value for key in ("ok", "success", "error")):
+            return value
+        if not value or not set(value).issubset(TOOL_RESULT_ENVELOPE_KEYS):
+            return value
+        if "structuredContent" in value and value["structuredContent"] is not None:
+            value = value["structuredContent"]
+        elif "result" in value:
+            value = value["result"]
+        else:
+            value = value.get("content")
+    return value
+
+
+def structured_tool_failure_message(result: Any) -> str | None:
+    """Return a structured failure message, including nested MCP payloads."""
+
+    data = unwrap_tool_result_envelope(result)
+    if not isinstance(data, dict):
+        return None
+
+    error = data.get("error")
+    failed = data.get("ok") is False or data.get("success") is False
+    # A concrete error outranks an explicit success marker, while JSON-falsey
+    # placeholders such as ``null`` and ``false`` are not failures by
+    # themselves. This keeps the structured classifier value-aware without
+    # changing the separate generic string heuristic used by display callers.
+    if error:
+        if isinstance(error, dict):
+            message = error.get("message") or error.get("code")
+            return str(message or "tool returned a structured error")
+        if error is True:
+            return "tool returned a structured error"
+        return str(error)
+    if failed:
+        message = data.get("message")
+        return str(message or "tool returned an unsuccessful result")
+    return None
 
 
 # Tools whose interrupted/dangling execution is safe to discard because they

--- a/tests/agent/test_display_tool_failure.py
+++ b/tests/agent/test_display_tool_failure.py
@@ -97,6 +97,32 @@ class TestDetectToolFailureStructured:
         assert _detect_tool_failure("web_search", result) == (False, "")
 
 
+    def test_mcp_result_envelope_surfaces_typed_application_error(self):
+        application_error = {
+            "ok": False,
+            "error": {
+                "code": "duplicate_artifact",
+                "message": "generated artifact was already processed",
+                "retryable": True,
+            },
+        }
+        result = json.dumps({"result": json.dumps(application_error)})
+
+        is_failure, suffix = _detect_tool_failure(
+            "mcp_example_materialize_artifact", result
+        )
+
+        assert is_failure is True
+        assert "already processed" in suffix
+
+    def test_mcp_result_envelope_does_not_flag_successful_application_result(self):
+        result = json.dumps({"result": json.dumps({"ok": True, "data": "done"})})
+
+        assert _detect_tool_failure("mcp_example_inspect_artifact", result) == (
+            False,
+            "",
+        )
+
 
 class TestGetCuteToolMessageFailureSuffix:
     """End-to-end: failure suffix is appended by get_cute_tool_message."""

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -111,6 +111,28 @@ def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution()
 
 
 
+def test_mcp_wrapped_application_error_counts_as_guardrail_failure():
+    wrapped = json.dumps(
+        {
+            "result": json.dumps(
+                {
+                    "ok": False,
+                    "error": {
+                        "code": "duplicate_artifact",
+                        "message": "generated artifact was already processed",
+                        "retryable": True,
+                    },
+                }
+            )
+        }
+    )
+
+    failed, suffix = classify_tool_failure(
+        "mcp_example_materialize_artifact", wrapped
+    )
+
+    assert failed is True
+    assert "already processed" in suffix
 
 
 
@@ -167,7 +189,6 @@ def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
     assert decision.action == "block"
     assert decision.code == "loop_web_search_cap"
     assert decision.should_halt is True
-
 
 
 

--- a/tests/agent/test_tool_result_classification.py
+++ b/tests/agent/test_tool_result_classification.py
@@ -4,7 +4,57 @@ import json
 
 from agent.tool_result_classification import (
     file_mutation_result_landed,
+    structured_tool_failure_message,
+    unwrap_tool_result_envelope,
 )
+
+
+def test_unwraps_json_application_payload_from_mcp_result_envelope():
+    payload = {"ok": False, "error": {"message": "artifact already exists"}}
+    wrapped = json.dumps({"result": json.dumps(payload)})
+
+    assert unwrap_tool_result_envelope(wrapped) == payload
+
+
+def test_structured_content_is_preferred_for_mcp_failure_classification():
+    wrapped = {
+        "result": "human-readable summary",
+        "structuredContent": {
+            "success": False,
+            "message": "validation failed",
+        },
+    }
+
+    assert structured_tool_failure_message(wrapped) == "validation failed"
+
+
+def test_nested_mcp_success_is_not_a_structured_failure():
+    wrapped = {"result": json.dumps({"ok": True, "data": "done"})}
+
+    assert structured_tool_failure_message(wrapped) is None
+
+
+def test_falsey_error_placeholder_is_not_a_structured_failure():
+    wrapped = {"result": json.dumps({"success": True, "error": None})}
+
+    assert structured_tool_failure_message(wrapped) is None
+
+
+def test_concrete_error_outranks_explicit_success_marker():
+    wrapped = {
+        "result": json.dumps({"success": True, "error": "upstream rejected request"})
+    }
+
+    assert structured_tool_failure_message(wrapped) == "upstream rejected request"
+
+
+def test_unknown_wrapper_metadata_prevents_nested_failure_inference():
+    wrapped = {
+        "result": json.dumps({"ok": False, "error": "rejected"}),
+        "trace_id": "trace-123",
+    }
+
+    assert structured_tool_failure_message(wrapped) is None
 
 
 def test_write_file_with_nested_lint_error_counts_as_landed():

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -153,6 +153,32 @@ def test_sequential_after_call_appends_guidance_to_tool_result_without_extra_mes
     assert "repeated_exact_failure_warning" in messages[0]["content"]
 
 
+def test_mcp_wrapped_application_error_drives_runtime_guardrail_warning():
+    tool_name = "mcp_example_materialize_artifact"
+    agent = _make_agent(tool_name)
+    args = {"artifact_id": "example-1", "source": "same source"}
+    _seed_exact_failures(agent, tool_name, args, count=1)
+    tc = _mock_tool_call(tool_name, json.dumps(args), "c-mcp-warn")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+    application_error = {
+        "ok": False,
+        "error": {
+            "code": "duplicate_artifact",
+            "message": "generated artifact was already processed",
+            "retryable": True,
+        },
+    }
+    wrapped = json.dumps({"result": json.dumps(application_error)})
+
+    with patch("run_agent.handle_function_call", return_value=wrapped):
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    assert len(messages) == 1
+    assert "repeated_exact_failure_warning" in messages[0]["content"]
+    assert agent._tool_guardrail_halt_decision is None
+
+
 def test_same_tool_failure_warning_tells_model_to_recover_with_tools():
     agent = _make_agent("terminal")
     guardrails = getattr(agent, "_tool_guardrails")

--- a/tests/tools/test_mcp_structured_content.py
+++ b/tests/tools/test_mcp_structured_content.py
@@ -7,6 +7,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from agent.display import _detect_tool_failure
+from agent.tool_guardrails import classify_tool_failure
 from tools import mcp_tool
 
 
@@ -107,3 +109,35 @@ class TestStructuredContentPreservation:
         raw = handler({})
         data = json.loads(raw)
         assert data["result"] == payload
+
+    def test_transport_success_application_failure_is_classified(
+        self, _patch_mcp_server
+    ):
+        """Application failure remains visible when MCP transport succeeds."""
+        session = _patch_mcp_server
+        payload = {
+            "ok": False,
+            "error": {
+                "code": "operation_rejected",
+                "message": "operation was rejected",
+            },
+        }
+        session.call_tool = AsyncMock(
+            return_value=_FakeCallToolResult(
+                content=[_FakeContentBlock(json.dumps(payload))],
+                is_error=False,
+            )
+        )
+        handler = mcp_tool._make_tool_handler("test-server", "my-tool", 30.0)
+
+        result = handler({})
+
+        assert json.loads(result) == {"result": json.dumps(payload)}
+        assert _detect_tool_failure("mcp_test_server_my_tool", result) == (
+            True,
+            " [operation was rejected]",
+        )
+        assert classify_tool_failure("mcp_test_server_my_tool", result) == (
+            True,
+            " [operation was rejected]",
+        )


### PR DESCRIPTION
## What does this PR do?

Recognizes application-level MCP failures reported inside otherwise successful transport envelopes, so Hermes no longer labels a failed operation as successful or misses repeated-failure guardrails.

An MCP round trip can return `CallToolResult.isError == false` while its normalized application payload says `ok: false`, `success: false`, or contains a concrete `error`. Hermes wraps those values in shapes such as `{"result":"{\"ok\":false,\"error\":{\"message\":\"operation was rejected\"}}"}`. The display and fallback guardrail classifiers previously inspected only the outer wrapper and therefore treated the call as successful.

The new shared classifier unwraps only known MCP envelope keys (`result`, `content`, and `structuredContent`) to a bounded depth. It surfaces a concrete application error without recursively scanning arbitrary tool data, and both the visible completion label and loop guardrail use the same result. Transport health, reconnection, and circuit-breaker semantics remain unchanged: `isError == false` still means the MCP transport round trip succeeded.

## Related Issue

Related to #47867, but does not close it: that issue and PR #47871 cover transport-level `isError == true` error bodies. This PR independently covers application-level failures returned with `isError == false`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/tool_result_classification.py`: add bounded MCP-envelope unwrapping and a shared structured-failure message classifier.
- `agent/display.py`: use the shared classifier for the user-visible failed completion label and concrete error message.
- `agent/tool_guardrails.py`: use the same classifier for standalone/fallback guardrail decisions, keeping display and loop behavior consistent.
- Focused tests cover direct and wrapped payloads, `structuredContent` precedence, bounded/unknown shapes, successful payloads, the real MCP normalization path, and repeated-failure runtime warnings.

## How to Test

1. Run the complete repository suite: `scripts/run_tests.sh`.
2. Run the focused classifier, display, guardrail, runtime, and MCP normalization suites: `scripts/run_tests.sh tests/agent/test_display_tool_failure.py tests/agent/test_tool_guardrails.py tests/agent/test_tool_result_classification.py tests/run_agent/test_tool_call_guardrail_runtime.py tests/tools/test_mcp_structured_content.py -q`.
3. Return an MCP application payload such as `{"ok":false,"error":{"message":"operation was rejected"}}` with transport-level `isError == false`; confirm Hermes displays the concrete failure and repeated identical failures feed the existing loop-warning path.

Validation performed on this exact PR head:

- Complete suite: **22,783 passed, 0 failed** across 2,467 test files.
- Focused MCP/classification suites: **44 passed, 0 failed** across 5 test files.
- Ruff and `git diff --check`: passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the complete test suite with `scripts/run_tests.sh` (recommended; same as CI) and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: CachyOS Linux x86_64 (kernel 7.1.2-3-cachyos), Python 3.12.13, pytest 9.0.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is internal and covered by focused tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the change is pure JSON/result classification with no platform-specific APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema or invocation contract changed

## Screenshots / Logs

```text
Complete suite: 2467 files, 22783 tests passed, 0 failed (100% complete)
Focused suites: 5 files, 44 tests passed, 0 failed (100% complete)
Ruff: All checks passed
git diff --check: clean
```