### PR TITLE
fix(model-metadata): resolve Claude 5 context length to 1M instead of the 200K catch-all

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -204,6 +204,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     # OpenRouter-prefixed models resolve via OpenRouter live API or models.dev.
     "claude-fable-5": 1000000,
     "claude-fable": 1000000,
+    "claude-opus-5": 1000000,
+    "claude-sonnet-5": 1000000,
     "claude-opus-4-8": 1000000,
     "claude-opus-4.8": 1000000,
     "claude-opus-4-7": 1000000,

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -222,6 +222,56 @@ class TestDefaultContextLengths:
                     f"{model_id}: expected {expected_ctx}, got {actual}"
                 )
 
+    def test_claude_5_family_1m_context(self):
+        """Claude 5 (Opus 5 / Sonnet 5) must resolve to 1M, not the 200K catch-all.
+
+        ``DEFAULT_CONTEXT_LENGTHS`` carries a ``"claude": 200000`` catch-all for
+        the older families. Without explicit Claude 5 entries, longest-first
+        substring matching lands ``claude-opus-5`` on that catch-all and the
+        window is under-reported by 5x — the compaction threshold is then
+        computed against 200K and long sessions compact far earlier than they
+        need to. Bedrock's ``AnthropicBedrock`` client already ships the
+        ``context-1m-2025-08-07`` beta, so the capacity is there.
+
+        Regional inference prefixes (``us.``/``global.``) and vendor prefixes
+        (``anthropic/``) must all resolve, and the older 200K families must
+        keep resolving to 200K so the catch-all is not broken.
+        """
+        from agent.model_metadata import get_model_context_length
+        from unittest.mock import patch as mock_patch
+
+        expected_keys = {
+            "claude-opus-5": 1_000_000,
+            "claude-sonnet-5": 1_000_000,
+        }
+        for key, value in expected_keys.items():
+            assert key in DEFAULT_CONTEXT_LENGTHS, f"{key} missing"
+            assert DEFAULT_CONTEXT_LENGTHS[key] == value, (
+                f"{key} should be {value}, got {DEFAULT_CONTEXT_LENGTHS[key]}"
+            )
+
+        with mock_patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata.get_cached_context_length", return_value=None):
+            cases = [
+                # Claude 5 — 1M
+                ("claude-opus-5", 1_000_000),
+                ("claude-sonnet-5", 1_000_000),
+                ("us.anthropic.claude-opus-5", 1_000_000),
+                ("us.anthropic.claude-sonnet-5", 1_000_000),
+                ("global.anthropic.claude-opus-5", 1_000_000),
+                ("anthropic/claude-opus-5", 1_000_000),
+                # Older families must still hit the 200K catch-all
+                ("claude-sonnet-4-5", 200_000),
+                ("claude-haiku-4-5", 200_000),
+                ("claude-3-opus-20240229", 200_000),
+            ]
+            for model_id, expected_ctx in cases:
+                actual = get_model_context_length(model_id)
+                assert actual == expected_ctx, (
+                    f"{model_id}: expected {expected_ctx}, got {actual}"
+                )
+
     def test_glm_52_context_1m(self):
         """GLM-5.2 must resolve to 1M, not the generic GLM fallback of 202K.
 


### PR DESCRIPTION
## Symptom

Sessions on `claude-opus-5` / `claude-sonnet-5` compact far earlier than the model's real budget allows, showing repeated:

```
⚠️  Session compressed 6 times — accuracy may degrade. Consider /new to start fresh.
```

...on short agentic runs (a single investigate-and-report task, ~10 tool calls).

## Root cause

`DEFAULT_CONTEXT_LENGTHS` (`agent/model_metadata.py:200`) lists the 1M Claude families explicitly and keeps a catch-all for the older ones:

```python
"claude-fable-5": 1000000,
"claude-opus-4-8": 1000000,
"claude-opus-4-7": 1000000,
"claude-opus-4-6": 1000000,
"claude-sonnet-4-6": 1000000,
# Catch-all for older Claude models (must sort after specific entries)
"claude": 200000,
```

`claude-opus-5` and `claude-sonnet-5` were never added. Longest-first substring matching (`agent/model_metadata.py:2279`) therefore lands them on `"claude": 200000` and the window is under-reported **5x**.

That value feeds the compaction threshold in `ContextCompressor._compute_threshold_tokens` (`agent/context_compressor.py:939-951`):

```python
effective_window = context_length - (max_tokens or 0)
pct_value = int(effective_window * threshold_percent)
floored = max(pct_value, MINIMUM_CONTEXT_LENGTH)   # MINIMUM = 64000
```

With a 200K window and a large `max_tokens`, the `MINIMUM_CONTEXT_LENGTH` floor dominates and compaction fires at ~64K of input:

| resolved `context_length` | `max_tokens` | effective input | compacts at | % of budget |
|---|---|---|---|---|
| 200000 (bug) | 128000 | 72000 | 64000 | 89% ← floor dominates |
| 1000000 (fixed) | 128000 | 872000 | 436000 | 50% |

The capacity is already there on the request side — `_create_bedrock_client` (`agent/anthropic_adapter.py:867`) attaches `context-1m-2025-08-07` as a client-level default header, which is precisely what unlocks 1M for these models on Bedrock. Only the metadata lookup was stale.

## Verification against live Bedrock

Not inferred from the table — measured. `invoke_model` against `us-east-1` with ~1.1M chars of filler and a needle placed **after** the filler, so a pass proves the whole context was actually read:

| model | input tokens accepted | needle retrieved |
|---|---|---|
| `us.anthropic.claude-opus-5` | **398,276** | ✅ |
| `us.anthropic.claude-sonnet-5` | **398,276** | ✅ |
| `us.anthropic.claude-haiku-4-5` | ❌ rejected | — |

Both Claude 5 models accept the request with **and** without an explicit per-request `anthropic_beta`, confirming the client-level header is doing the work.

The negative control matters: `us.anthropic.claude-haiku-4-5` rejects the identical request with

```
ValidationException: prompt is too long: 208188 tokens > 200000 maximum
```

so the `"claude": 200000` catch-all is still correct for that family and must not be widened.

## The fix

Two entries, following the existing convention of bare ids only (regional/vendor prefixes resolve via substring matching):

```python
"claude-opus-5": 1000000,
"claude-sonnet-5": 1000000,
```

## Test

`test_claude_5_family_1m_context` asserts a **behavior contract**, not a snapshot:

- Claude 5 resolves to 1M across bare ids, regional inference prefixes (`us.` / `global.`) and vendor-prefixed ids (`anthropic/`).
- `claude-sonnet-4-5`, `claude-haiku-4-5` and `claude-3-opus-20240229` still resolve to **200K**, so the catch-all is provably not broken by the new entries.

Validated both ways — the test fails without the two-line fix:

```
AssertionError: claude-opus-5 missing
```

`tests/agent/test_model_metadata.py`: **119 passed**.
