### PR TITLE
fix(dashboard): use config-only scope for /api/model/options to prevent lock-contention freeze

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6740,7 +6740,11 @@ async def get_model_options(
             # Keep the profile override inside the worker thread so the full
             # sync picker build (config load, pricing, refresh probes) runs
             # off the event loop under the requested profile.
-            with _profile_scope(profile):
+            # Use _config_profile_scope (contextvar only, no skill-module
+            # lock) — the payload build can block for 15s on a models.dev
+            # cache miss, and _profile_scope's RLock held across that block
+            # starves concurrent /api/config and freezes the server (#58576).
+            with _config_profile_scope(profile):
                 return build_model_options_payload(
                     load_picker_context(),
                     explicit_only=bool(explicit_only),

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7454,7 +7454,11 @@ async def get_model_options(
             # Keep the profile override inside the worker thread so the full
             # sync picker build (config load, pricing, refresh probes) runs
             # off the event loop under the requested profile.
-            with _profile_scope(profile):
+            # Use _config_profile_scope (contextvar only, no skill-module
+            # lock) — the payload build can block for 15s on a models.dev
+            # cache miss, and _profile_scope's RLock held across that block
+            # starves concurrent /api/config and freezes the server (#58576).
+            with _config_profile_scope(profile):
                 return build_model_options_payload(
                     load_picker_context(),
                     explicit_only=bool(explicit_only),

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -7,6 +7,7 @@ reads/writes land in the REQUESTED profile, the dashboard's own profile
 stays untouched, and the chat PTY env is scoped via HERMES_HOME.
 """
 import json
+from contextlib import contextmanager
 
 import pytest
 import yaml
@@ -352,6 +353,47 @@ class TestProfileScopedModel:
 
 
 
+
+    def test_model_options_uses_config_only_scope_for_selected_profile(
+        self, client, monkeypatch
+    ):
+        """Regression (#58576): _profile_scope holds _SKILLS_PROFILE_LOCK
+        across its body, and the payload build can block up to 15s on a
+        models.dev cache miss — a cold request would starve concurrent
+        /api/config on the same lock. The handler must scope the worker
+        through _config_profile_scope (contextvar only, no lock) for the
+        selected profile."""
+        import hermes_cli.web_server as web_server
+
+        scopes = []
+
+        @contextmanager
+        def _recording_config_scope(profile):
+            scopes.append(("config", profile))
+            yield object()
+
+        @contextmanager
+        def _recording_profile_scope(profile):
+            scopes.append(("full", profile))
+            yield object()
+
+        monkeypatch.setattr(
+            web_server, "_config_profile_scope", _recording_config_scope
+        )
+        monkeypatch.setattr(web_server, "_profile_scope", _recording_profile_scope)
+        monkeypatch.setattr(
+            "hermes_cli.inventory.load_picker_context", lambda: object()
+        )
+        monkeypatch.setattr(
+            "hermes_cli.inventory.build_model_options_payload",
+            lambda _ctx, **kwargs: {"providers": [], "model": "", "provider": ""},
+        )
+
+        resp = client.get("/api/model/options", params={"profile": "worker_beta"})
+        assert resp.status_code == 200
+        # Only the config-only scope may wrap the payload build; entering
+        # _profile_scope would hold _SKILLS_PROFILE_LOCK across it (#58576).
+        assert scopes == [("config", "worker_beta")]
 
     def test_model_info_unknown_profile_404(self, client, isolated_profiles):
         """Regression: the broad except used to convert the 404 into a 200

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -6,6 +6,8 @@ profile switcher can target any profile's HERMES_HOME. These tests pin:
 reads/writes land in the REQUESTED profile, the dashboard's own profile
 stays untouched, and the chat PTY env is scoped via HERMES_HOME.
 """
+from contextlib import contextmanager
+
 import pytest
 import yaml
 
@@ -417,6 +419,47 @@ class TestProfileScopedModel:
         resp = client.get("/api/model/options", params={"include_unconfigured": "1"})
         assert resp.status_code == 200
         assert calls[-1]["include_unconfigured"] is True
+
+    def test_model_options_uses_config_only_scope_for_selected_profile(
+        self, client, monkeypatch
+    ):
+        """Regression (#58576): _profile_scope holds _SKILLS_PROFILE_LOCK
+        across its body, and the payload build can block up to 15s on a
+        models.dev cache miss — a cold request would starve concurrent
+        /api/config on the same lock. The handler must scope the worker
+        through _config_profile_scope (contextvar only, no lock) for the
+        selected profile."""
+        import hermes_cli.web_server as web_server
+
+        scopes = []
+
+        @contextmanager
+        def _recording_config_scope(profile):
+            scopes.append(("config", profile))
+            yield object()
+
+        @contextmanager
+        def _recording_profile_scope(profile):
+            scopes.append(("full", profile))
+            yield object()
+
+        monkeypatch.setattr(
+            web_server, "_config_profile_scope", _recording_config_scope
+        )
+        monkeypatch.setattr(web_server, "_profile_scope", _recording_profile_scope)
+        monkeypatch.setattr(
+            "hermes_cli.inventory.load_picker_context", lambda: object()
+        )
+        monkeypatch.setattr(
+            "hermes_cli.inventory.build_model_options_payload",
+            lambda _ctx, **kwargs: {"providers": [], "model": "", "provider": ""},
+        )
+
+        resp = client.get("/api/model/options", params={"profile": "worker_beta"})
+        assert resp.status_code == 200
+        # Only the config-only scope may wrap the payload build; entering
+        # _profile_scope would hold _SKILLS_PROFILE_LOCK across it (#58576).
+        assert scopes == [("config", "worker_beta")]
 
     def test_model_info_unknown_profile_404(self, client, isolated_profiles):
         """Regression: the broad except used to convert the 404 into a 200


### PR DESCRIPTION
## Summary

`/api/model/options` (`get_model_options`) uses `_profile_scope` which holds `_SKILLS_PROFILE_LOCK` (a `threading.RLock`) across the entire context-manager yield. Inside the scope, `build_model_options_payload` runs in a worker thread and can block on `fetch_models_dev()` → `_fetch_models_dev_from_network()` → `requests.get(MODELS_DEV_URL, timeout=15)` for up to 15s on a models.dev cache miss. The lock stays held the full duration. Concurrent requests to `/api/config` (which also enters `_profile_scope`) then block the main asyncio event-loop thread on the same lock, freezing the entire server.

Root-caused via py-spy dump analysis in [#58576](https://github.com/NousResearch/hermes-agent/issues/58576#issuecomment-5115670384): MainThread stuck in `_profile_scope` → `get_config` while all tui-rpc threads are blocked in `fetch_models_dev` → `requests.get`.

## Fix

Replace `_profile_scope` with `_config_profile_scope` in `get_model_options`. `_config_profile_scope` already exists in the codebase (line 15797) and is documented as the "await-safe, config-only profile scope" — it only sets the contextvar-based `HERMES_HOME` override (thread-safe, no lock). This is exactly what `build_model_options_payload` needs for config reads + credential checks; none of the call chain (`load_picker_context` → `load_config` → `get_hermes_home` → `list_authenticated_providers` → `fetch_models_dev`) touches the skill-module globals that `_SKILLS_PROFILE_LOCK` protects.

`_config_profile_scope` is already used by other endpoints for the same reason (transcription, synthesis, gateway status).

## Changes

- `hermes_cli/web_server.py`: `get_model_options` uses `_config_profile_scope` instead of `_profile_scope` (1 line + comment)

## Validation

- `tests/hermes_cli/test_web_server.py`: 218 passed, 0 regressions (1 pre-existing SPA failure unrelated to this change)
- Cross-vendor review: Gemini 3.6 Flash (Medium) rated ACCEPTABLE — confirmed no skill-module dependency in the call chain and zero regression risk

Closes #58576
