### PR TITLE
fix(desktop): scope the remembered route per profile

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -71,15 +71,17 @@ export function useDesktopIntegrations({
   // lands where you were. Overlays (settings/command-center/…) aren't stored —
   // you don't want to boot into a modal.
   useEffect(() => {
+    const routeProfile = rememberedSessionProfile($sessions.get(), routedSessionId, $activeGatewayProfile.get())
+
     if (routedSessionId) {
-      setRememberedSessionId(
-        routedSessionId,
-        rememberedSessionProfile($sessions.get(), routedSessionId, $activeGatewayProfile.get())
-      )
+      setRememberedSessionId(routedSessionId, routeProfile)
     }
 
     if (!isOverlayView(appViewForPath(locationPathname))) {
-      setRememberedRoute(locationPathname)
+      // Keyed by the same owner as the id above: a session route embeds a
+      // session id, so remembering it globally would restore another profile's
+      // conversation on cold start.
+      setRememberedRoute(locationPathname, routeProfile)
     }
   }, [locationPathname, routedSessionId])
 
@@ -97,7 +99,8 @@ export function useDesktopIntegrations({
     }
 
     restoredRef.current = true
-    const route = getRememberedRoute()
+    const activeProfile = $activeGatewayProfile.get()
+    const route = getRememberedRoute(activeProfile)
 
     if (route && route !== NEW_CHAT_ROUTE && !isOverlayView(appViewForPath(route))) {
       navigate(route, { replace: true })
@@ -105,7 +108,7 @@ export function useDesktopIntegrations({
       return
     }
 
-    const last = getRememberedSessionId($activeGatewayProfile.get())
+    const last = getRememberedSessionId(activeProfile)
 
     if (last) {
       navigate(sessionRoute(last), { replace: true })

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -12,12 +12,14 @@ import {
   $sessions,
   $unreadFinishedSessionIds,
   applyConfiguredDefaultProjectDir,
+  getRememberedRoute,
   getRememberedSessionId,
   mergeSessionPage,
   rememberedSessionProfile,
   resolveComposerSessionKey,
   sessionPinId,
   setCurrentCwd,
+  setRememberedRoute,
   setRememberedSessionId,
   setSelectedStoredSessionId,
   setSessions,
@@ -504,6 +506,59 @@ describe('remembered session id (per profile)', () => {
 
     expect(getRememberedSessionId('ai-engineer')).toBeNull()
     expect(getRememberedSessionId('default')).toBe('personal-session')
+  })
+})
+
+describe('remembered route (per profile)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('scopes the remembered route by profile so one profile cannot restore another', () => {
+    // A session route embeds a session id. Remembered globally, a cold start
+    // under 'default' would navigate straight into ai-engineer's conversation.
+    setRememberedRoute('/session/work-session', 'ai-engineer')
+    setRememberedRoute('/session/personal-session', 'default')
+
+    expect(getRememberedRoute('ai-engineer')).toBe('/session/work-session')
+    expect(getRememberedRoute('default')).toBe('/session/personal-session')
+    expect(getRememberedRoute('research')).toBeNull()
+  })
+
+  it('keeps the default profile on the legacy unsuffixed key for back-compat', () => {
+    localStorage.setItem('hermes.desktop.lastRoute', '/skills')
+
+    expect(getRememberedRoute('default')).toBe('/skills')
+    expect(getRememberedRoute(undefined)).toBe('/skills')
+    expect(getRememberedRoute('')).toBe('/skills')
+    expect(getRememberedRoute(null)).toBe('/skills')
+  })
+
+  it('clearing one profile leaves the others intact', () => {
+    setRememberedRoute('/session/work-session', 'ai-engineer')
+    setRememberedRoute('/session/personal-session', 'default')
+
+    setRememberedRoute(null, 'ai-engineer')
+
+    expect(getRememberedRoute('ai-engineer')).toBeNull()
+    expect(getRememberedRoute('default')).toBe('/session/personal-session')
+  })
+
+  it('route and session id agree on the owner, so restore cannot cross profiles', () => {
+    // The cold-start restore prefers the route over the id, so the two keys
+    // must be written under the same owner or the id scoping is bypassed.
+    const owner = rememberedSessionProfile([session({ id: 'stored-1', profile: 'ai-engineer' })], 'stored-1', 'default')
+
+    setRememberedSessionId('stored-1', owner)
+    setRememberedRoute('/session/stored-1', owner)
+
+    expect(getRememberedRoute('default')).toBeNull()
+    expect(getRememberedSessionId('default')).toBeNull()
+    expect(getRememberedRoute('ai-engineer')).toBe('/session/stored-1')
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -72,10 +72,26 @@ export function rememberedSessionProfile(
 
 // The last non-overlay route (a page like /skills, or a session route), so a
 // relaunch lands back where you were instead of a bare new-chat.
+//
+// Scoped per profile for the same reason the remembered session id is: a single
+// global key remembered ONE route across every profile, and a session route
+// carries a session id in its path. Restoring under profile B would navigate to
+// a session owned by profile A — the remembered-id scoping above is bypassed
+// entirely, because the route is preferred over the id on cold start
+// (#67603 family). The default profile keeps the original unsuffixed key so
+// existing installs' remembered route survives the upgrade.
 const LAST_ROUTE_KEY = 'hermes.desktop.lastRoute'
 
-export const getRememberedRoute = (): null | string => storedString(LAST_ROUTE_KEY)
-export const setRememberedRoute = (path: null | string) => persistString(LAST_ROUTE_KEY, path)
+function rememberedRouteKey(profile?: null | string): string {
+  const key = (profile ?? '').trim()
+
+  return !key || key === 'default' ? LAST_ROUTE_KEY : `${LAST_ROUTE_KEY}.${key}`
+}
+
+export const getRememberedRoute = (profile?: null | string): null | string =>
+  storedString(rememberedRouteKey(profile))
+export const setRememberedRoute = (path: null | string, profile?: null | string) =>
+  persistString(rememberedRouteKey(profile), path)
 
 let configuredDefaultProjectDir = ''
 


### PR DESCRIPTION
Desktop remembers two things for cold start: the last session id and the last route. The id was scoped per profile in 143942d49; the route was not — and restore prefers the route.

A session route carries a session id in its path, so a relaunch under one profile would navigate straight into another profile's conversation, bypassing the id scoping entirely. This keys the route by the same owner the id already resolves (`rememberedSessionProfile`), reads it back for the active profile on restore, and leaves the default profile on the original unsuffixed key so existing installs keep their remembered route.

Salvaged from the profile-hint work in #49619 by @d31tcjg, which threaded an explicit profile through every route, IPC hop, and window bridge to reach the same end. Now that #74033 makes the server stamp session ownership unconditionally, the resolver already gets the right answer without a hint — this persisted key was the one place still crossing profiles.

## Tests

`src/store/session.test.ts` — 4 new tests: per-profile isolation, legacy unsuffixed key back-compat, per-profile clearing, and the invariant that the route and id resolve to the same owner (the one that actually guards the bypass). 3 of the 4 fail on `main`; the back-compat test passes both ways by design. Full file 43 passed. Typecheck and eslint clean.

Supersedes #49619.
