### PR TITLE
fix(discord): retry command sync after failed fingerprint

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1773,18 +1773,24 @@ class DiscordAdapter(BasePlatformAdapter):
         if retry_after_until > now:
             remaining = max(1, int(retry_after_until - now))
             return f"Discord asked us to wait before syncing slash commands; retry in {remaining}s"
-        if entry.get("fingerprint") == fingerprint and entry.get("last_success_at"):
+        last_success_at = float(entry.get("last_success_at") or 0)
+        last_attempt_at = float(entry.get("last_attempt_at") or 0)
+        if (
+            entry.get("fingerprint") == fingerprint
+            and last_success_at
+            and last_success_at >= last_attempt_at
+        ):
             return "same slash-command fingerprint already synced"
         return None
 
     def _record_command_sync_attempt(self, app_id: Any, fingerprint: str) -> None:
         state = self._read_command_sync_state()
-        state[self._command_sync_state_key(app_id)] = {
-            **(
-                state.get(self._command_sync_state_key(app_id))
-                if isinstance(state.get(self._command_sync_state_key(app_id)), dict)
-                else {}
-            ),
+        key = self._command_sync_state_key(app_id)
+        entry = state.get(key) if isinstance(state.get(key), dict) else {}
+        entry.pop("last_success_at", None)
+        entry.pop("summary", None)
+        state[key] = {
+            **entry,
             "fingerprint": fingerprint,
             "last_attempt_at": time.time(),
         }

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -755,6 +755,72 @@ async def test_post_connect_initialization_skips_same_fingerprint_after_success(
 
 
 @pytest.mark.asyncio
+async def test_post_connect_initialization_retries_fingerprint_after_timeout(tmp_path, monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+    class _DesiredCommand:
+        def to_dict(self, tree):
+            return {
+                "name": "skill",
+                "description": "Run a skill",
+                "type": 1,
+                "options": [],
+            }
+
+    adapter._client = SimpleNamespace(
+        tree=SimpleNamespace(get_commands=lambda: [_DesiredCommand()]),
+        application_id=999,
+        user=SimpleNamespace(id=999),
+    )
+    desired_fingerprint = adapter._desired_command_sync_fingerprint()
+    state_path = (
+        tmp_path
+        / discord_platform._DISCORD_COMMAND_SYNC_STATE_SUBDIR
+        / discord_platform._DISCORD_COMMAND_SYNC_STATE_FILENAME
+    )
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "999": {
+                    "fingerprint": desired_fingerprint,
+                    "last_attempt_at": 102.0,
+                    "last_success_at": 101.0,
+                    "summary": {"total": 1},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    summary = {
+        "total": 1,
+        "unchanged": 0,
+        "updated": 0,
+        "recreated": 0,
+        "created": 1,
+        "deleted": 0,
+    }
+    sync = AsyncMock(side_effect=[asyncio.TimeoutError(), summary])
+    monkeypatch.setattr(adapter, "_safe_sync_slash_commands", sync)
+
+    await adapter._run_post_connect_initialization()
+
+    timed_out_entry = json.loads(state_path.read_text(encoding="utf-8"))["999"]
+    assert timed_out_entry["fingerprint"] == desired_fingerprint
+    assert "last_success_at" not in timed_out_entry
+    assert "summary" not in timed_out_entry
+
+    await adapter._run_post_connect_initialization()
+
+    assert sync.await_count == 2
+    recovered_entry = json.loads(state_path.read_text(encoding="utf-8"))["999"]
+    assert recovered_entry["last_success_at"] >= recovered_entry["last_attempt_at"]
+    assert recovered_entry["summary"] == summary
+
+
+@pytest.mark.asyncio
 async def test_post_connect_initialization_respects_discord_retry_after(tmp_path, monkeypatch):
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
     monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
@@ -788,7 +854,7 @@ async def test_post_connect_initialization_respects_discord_retry_after(tmp_path
         / discord_platform._DISCORD_COMMAND_SYNC_STATE_SUBDIR
         / discord_platform._DISCORD_COMMAND_SYNC_STATE_FILENAME
     )
-    state = json.loads(state_path.read_text())
+    state = json.loads(state_path.read_text(encoding="utf-8"))
     entry = state["999"]
     assert entry["retry_after"] == 123.0
     assert entry["retry_after_until"] > entry["last_attempt_at"]
@@ -828,7 +894,11 @@ async def test_post_connect_initialization_reraises_non_rate_limit_exceptions(tm
         / discord_platform._DISCORD_COMMAND_SYNC_STATE_SUBDIR
         / discord_platform._DISCORD_COMMAND_SYNC_STATE_FILENAME
     )
-    state = json.loads(state_path.read_text()) if state_path.exists() else {}
+    state = (
+        json.loads(state_path.read_text(encoding="utf-8"))
+        if state_path.exists()
+        else {}
+    )
     entry = state.get("4242", {})
     # Attempt was recorded before the sync call, but no rate-limit cooldown
     # should have been persisted from the unrelated exception.


### PR DESCRIPTION
## What does this PR do?

Fixes a Discord slash-command sync state bug that can make a failed command-tree update look successful forever.

`_record_command_sync_attempt()` previously preserved an older `last_success_at` while replacing the entry's fingerprint with the newly desired fingerprint. If that sync timed out, hit a rate limit, or otherwise failed, the next gateway reconnect saw the new fingerprint plus the old success timestamp and skipped the retry as `same slash-command fingerprint already synced`.

The fix makes success attempt-specific:

- A cached fingerprint is skipped only when its success timestamp is at least as recent as its latest attempt.
- Starting a sync attempt clears the prior success marker and summary until that attempt actually succeeds.
- Already-poisoned state files recover automatically on the next reconnect because their latest attempt is newer than their retained success.

This preserves the successful unchanged-fingerprint fast path while ensuring failed command-tree updates are retried.

## Related Issue

Reported in [Discord support](https://discord.com/channels/1053877538025386074/1532080188119318570). No GitHub issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `plugins/platforms/discord/adapter.py` so fingerprint skips require a success belonging to the latest sync attempt.
- Invalidated stale success metadata when a new Discord command sync begins.
- Added a focused regression in `tests/gateway/test_discord_connect.py` covering poisoned state, a timed-out sync, and a successful retry on reconnect.
- Made the touched command-sync state reads explicitly UTF-8 for native Windows safety.

## How to Test

1. Seed `discord_command_sync_state.json` with the desired fingerprint, but with `last_attempt_at` newer than `last_success_at`.
2. Force the first `_safe_sync_slash_commands()` call to time out, then run post-connect initialization again.
3. Verify the second initialization retries the sync, records success, and that an unchanged fingerprint with a confirmed latest-attempt success still skips.

Focused validation completed:

- Direct async runtime probe: poisoned state → timeout → reconnect retry → success.
- Direct async runtime probe: confirmed unchanged fingerprint skips without syncing.
- `python -m compileall -q plugins/platforms/discord/adapter.py tests/gateway/test_discord_connect.py`
- `uvx --from ruff==0.15.10 ruff check plugins/platforms/discord/adapter.py tests/gateway/test_discord_connect.py`
- `python scripts/check-windows-footguns.py` against the staged files.
- `git diff --check`

The full pytest suite was not run locally; GitHub CI owns full-suite validation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

The regression is state-machine behavior with no UI change. The runtime probe reproduced the timeout warning, retried on the next initialization, and persisted a success for the latest attempt.
