### PR TITLE
feat(cli): add option to hide the startup banner

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1365,6 +1365,14 @@ display:
   #   false: Full ASCII banner with tool/skill summary (default)
   compact: false
 
+  # Show the welcome banner at startup and on /clear.
+  # Set to false for a minimal startup experience — the screen is still
+  # cleared, and diagnostic warnings (disabled tools, low context) still
+  # appear, but the ASCII-art / tool / skill summary panel is skipped.
+  #   true:  Render the welcome banner (default)
+  #   false: Skip the banner for a clean startup
+  show_banner: true
+
   # Tool progress display level (CLI and gateway)
   #   off:     Silent — no tool activity shown, just the final response
   #   new:     Show a tool indicator only when the tool changes (skip repeats)

--- a/cli.py
+++ b/cli.py
@@ -486,6 +486,7 @@ def load_cli_config() -> Dict[str, Any]:
 
         "display": {
             "compact": False,
+            "show_banner": True,
             "resume_display": "full",
             # Recap tuning for /resume — see hermes_cli/config.py DEFAULT_CONFIG.
             "resume_exchanges": 10,
@@ -4308,6 +4309,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.console = Console()
         self.config = CLI_CONFIG
         self.compact = compact if compact is not None else CLI_CONFIG["display"].get("compact", False)
+        # show_banner: when False, suppress the ASCII-art / compact welcome
+        # banner at startup and on /clear for a minimal "Ctrl+L" feel.
+        # Diagnostic warnings (disabled tools, low context) are still shown.
+        self.show_startup_banner = CLI_CONFIG["display"].get("show_banner", True)
         # tool_progress: "off", "new", "all", "verbose" (from config.yaml display section)
         # YAML 1.1 parses bare `off` as boolean False — normalise to string.
         _raw_tp = CLI_CONFIG["display"].get("tool_progress", "all")
@@ -7411,110 +7416,118 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         ctx_len = None
         if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
             ctx_len = self.agent.context_compressor.context_length
-        
-        # Auto-compact for narrow terminals — the full banner with caduceus
-        # + tool list needs ~80 columns minimum to render without wrapping.
-        term_width = shutil.get_terminal_size().columns
-        use_compact = self.compact or term_width < 80
-        
-        if use_compact:
-            self._console_print(_build_compact_banner())
-            self._show_status()
-        else:
-            # Warm-launch fast path: replay last launch's tool panel when the
-            # snapshot fingerprint (config.yaml + .env + checkout rev +
-            # toolsets) is unchanged, skipping the ~0.5-0.9s cold
-            # get_tool_definitions walk. The agent's REAL tool list is still
-            # computed fresh at first message; a background refresh below
-            # re-verifies the snapshot so any drift self-heals next launch.
-            from hermes_cli.banner import (
-                compute_toolset_availability,
-                load_banner_snapshot,
-                save_banner_snapshot,
-            )
+        # display.show_banner: false opts into a minimal startup — skip the
+        # visual banner entirely. Diagnostic warnings further below still run.
+        if self.show_startup_banner:
+            # Auto-compact for narrow terminals — the full banner with caduceus
+            # + tool list needs ~80 columns minimum to render without wrapping.
+            term_width = shutil.get_terminal_size().columns
+            use_compact = self.compact or term_width < 80
 
-            snapshot = None
-            try:
-                snapshot = load_banner_snapshot(self.enabled_toolsets)
-            except Exception:
-                snapshot = None
-
-            # Get terminal working directory (where commands will execute)
-            cwd = os.getenv("TERMINAL_CWD", os.getcwd())
-
-            if snapshot is not None:
-                self._defer_tool_warnings = True
-                toolset_map = snapshot["toolset_map"]
-                build_welcome_banner(
-                    console=self.console,
-                    model=self.model,
-                    cwd=cwd,
-                    tools=snapshot["tools"],
-                    enabled_toolsets=self.enabled_toolsets,
-                    session_id=self.session_id,
-                    get_toolset_for_tool=lambda name: toolset_map.get(name),
-                    context_length=ctx_len,
-                    provider=self.provider,
-                    availability=snapshot["availability"],
-                    skills_by_category=snapshot.get("skills_by_category"),
+            if use_compact:
+                self._console_print(_build_compact_banner())
+                self._show_status()
+            else:
+                # Warm-launch fast path: replay last launch's tool panel when the
+                # snapshot fingerprint (config.yaml + .env + checkout rev +
+                # toolsets) is unchanged, skipping the ~0.5-0.9s cold
+                # get_tool_definitions walk. The agent's REAL tool list is still
+                # computed fresh at first message; a background refresh below
+                # re-verifies the snapshot so any drift self-heals next launch.
+                from hermes_cli.banner import (
+                    compute_toolset_availability,
+                    load_banner_snapshot,
+                    save_banner_snapshot,
                 )
 
-                def _refresh_banner_snapshot() -> None:
+                snapshot = None
+                try:
+                    snapshot = load_banner_snapshot(self.enabled_toolsets)
+                except Exception:
+                    snapshot = None
+
+                # Get terminal working directory (where commands will execute)
+                cwd = os.getenv("TERMINAL_CWD", os.getcwd())
+
+                if snapshot is not None:
+                    self._defer_tool_warnings = True
+                    toolset_map = snapshot["toolset_map"]
+                    build_welcome_banner(
+                        console=self.console,
+                        model=self.model,
+                        cwd=cwd,
+                        tools=snapshot["tools"],
+                        enabled_toolsets=self.enabled_toolsets,
+                        session_id=self.session_id,
+                        get_toolset_for_tool=lambda name: toolset_map.get(name),
+                        context_length=ctx_len,
+                        provider=self.provider,
+                        availability=snapshot["availability"],
+                        skills_by_category=snapshot.get("skills_by_category"),
+                    )
+
+                    def _refresh_banner_snapshot() -> None:
+                        try:
+                            from model_tools import get_toolset_for_tool
+
+                            tools = get_tool_definitions(
+                                enabled_toolsets=self.enabled_toolsets, quiet_mode=True
+                            )
+                            availability = compute_toolset_availability(self.enabled_toolsets)
+                            tmap = {
+                                t["function"]["name"]: get_toolset_for_tool(
+                                    t["function"]["name"]
+                                )
+                                for t in tools
+                            }
+                            for item in availability.get("unavailable_toolsets", []):
+                                for name in item.get("tools", []):
+                                    tmap.setdefault(
+                                        name, item.get("id", item.get("name", ""))
+                                    )
+                            save_banner_snapshot(
+                                tools, self.enabled_toolsets, availability, tmap
+                            )
+                        except Exception:
+                            logger.debug("banner snapshot refresh failed", exc_info=True)
+
+                    threading.Thread(
+                        target=_refresh_banner_snapshot,
+                        name="banner-snapshot-refresh",
+                        daemon=True,
+                    ).start()
+                else:
+                    # Cold path: compute everything live, then persist the snapshot
+                    # so the next launch replays it.
+                    from model_tools import get_toolset_for_tool
+
+                    tools = get_tool_definitions(
+                        enabled_toolsets=self.enabled_toolsets, quiet_mode=True
+                    )
+                    availability = compute_toolset_availability(self.enabled_toolsets)
+
+                    build_welcome_banner(
+                        console=self.console,
+                        model=self.model,
+                        cwd=cwd,
+                        tools=tools,
+                        enabled_toolsets=self.enabled_toolsets,
+                        session_id=self.session_id,
+                        context_length=ctx_len,
+                        provider=self.provider,
+                        availability=availability,
+                    )
                     try:
-                        from model_tools import get_toolset_for_tool
-                        tools = get_tool_definitions(
-                            enabled_toolsets=self.enabled_toolsets, quiet_mode=True
-                        )
-                        availability = compute_toolset_availability(self.enabled_toolsets)
                         tmap = {
                             t["function"]["name"]: get_toolset_for_tool(t["function"]["name"])
                             for t in tools
                         }
                         for item in availability.get("unavailable_toolsets", []):
                             for name in item.get("tools", []):
-                                tmap.setdefault(
-                                    name, item.get("id", item.get("name", ""))
-                                )
-                        save_banner_snapshot(
-                            tools, self.enabled_toolsets, availability, tmap
-                        )
+                                tmap.setdefault(name, item.get("id", item.get("name", "")))
+                        save_banner_snapshot(tools, self.enabled_toolsets, availability, tmap)
                     except Exception:
-                        logger.debug("banner snapshot refresh failed", exc_info=True)
-
-                threading.Thread(
-                    target=_refresh_banner_snapshot,
-                    name="banner-snapshot-refresh",
-                    daemon=True,
-                ).start()
-            else:
-                # Cold path: compute everything live, then persist the snapshot
-                # so the next launch replays it.
-                from model_tools import get_toolset_for_tool
-                tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
-                availability = compute_toolset_availability(self.enabled_toolsets)
-
-                build_welcome_banner(
-                    console=self.console,
-                    model=self.model,
-                    cwd=cwd,
-                    tools=tools,
-                    enabled_toolsets=self.enabled_toolsets,
-                    session_id=self.session_id,
-                    context_length=ctx_len,
-                    provider=self.provider,
-                    availability=availability,
-                )
-                try:
-                    tmap = {
-                        t["function"]["name"]: get_toolset_for_tool(t["function"]["name"])
-                        for t in tools
-                    }
-                    for item in availability.get("unavailable_toolsets", []):
-                        for name in item.get("tools", []):
-                            tmap.setdefault(name, item.get("id", item.get("name", "")))
-                    save_banner_snapshot(tools, self.enabled_toolsets, availability, tmap)
-                except Exception:
-                    logger.debug("banner snapshot save failed", exc_info=True)
+                        logger.debug("banner snapshot save failed", exc_info=True)
         
         # Tool discovery is intentionally deferred on the Termux bare prompt
         # path; availability warnings are shown once tools are initialized.
@@ -10217,25 +10230,26 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # and gets mangled by patch_stdout).
             if self._app:
                 cc = ChatConsole()
-                term_w = shutil.get_terminal_size().columns
-                if self.compact or term_w < 80:
-                    cc.print(_build_compact_banner())
-                else:
-                    tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
-                    cwd = os.getenv("TERMINAL_CWD", os.getcwd())
-                    ctx_len = None
-                    if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
-                        ctx_len = self.agent.context_compressor.context_length
-                    build_welcome_banner(
-                        console=cc,
-                        model=self.model,
-                        cwd=cwd,
-                        tools=tools,
-                        enabled_toolsets=self.enabled_toolsets,
-                        session_id=self.session_id,
-                        context_length=ctx_len,
-                        provider=self.provider,
-                    )
+                if self.show_startup_banner:
+                    term_w = shutil.get_terminal_size().columns
+                    if self.compact or term_w < 80:
+                        cc.print(_build_compact_banner())
+                    else:
+                        tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
+                        cwd = os.getenv("TERMINAL_CWD", os.getcwd())
+                        ctx_len = None
+                        if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
+                            ctx_len = self.agent.context_compressor.context_length
+                        build_welcome_banner(
+                            console=cc,
+                            model=self.model,
+                            cwd=cwd,
+                            tools=tools,
+                            enabled_toolsets=self.enabled_toolsets,
+                            session_id=self.session_id,
+                            context_length=ctx_len,
+                            provider=self.provider,
+                        )
                 _cprint("  ✨ (◕‿◕)✨ Fresh start! Screen cleared and conversation reset.\n")
                 # Show a random tip on new session
                 try:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1126,6 +1126,9 @@ DEFAULT_CONFIG = {
     
     "display": {
         "compact": False,
+        # Render the classic CLI welcome banner at startup and after /clear.
+        # Set false for a minimal screen while retaining diagnostic warnings.
+        "show_banner": True,
         "personality": "",
         "resume_display": "full",
         # Recap tuning for /resume and startup resume. The defaults match the

--- a/tests/cli/test_cli_context_warning.py
+++ b/tests/cli/test_cli_context_warning.py
@@ -30,6 +30,7 @@ def cli_obj(_isolate):
         obj.model = "test-model"
         obj.enabled_toolsets = ["hermes-core"]
         obj.compact = False
+        obj.show_startup_banner = True
         obj.console = MagicMock()
         obj.session_id = None
         obj.api_key = "test"

--- a/tests/cli/test_cli_show_banner_option.py
+++ b/tests/cli/test_cli_show_banner_option.py
@@ -1,0 +1,210 @@
+"""Tests for the display.show_banner config option.
+
+The option (default true) lets users skip the welcome banner at startup
+and on /new for a minimal startup experience — without disabling the
+diagnostic warnings that follow.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+
+def test_shared_config_default_enables_show_banner():
+    """Setup and reset flows preserve the classic banner by default."""
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["display"]["show_banner"] is True
+
+
+def _make_real_cli(show_banner_value, **kwargs):
+    """Build a HermesCLI instance and also return its bound cli module.
+
+    ``_make_real_cli`` from sibling test files only returns the instance, but
+    after ``importlib.reload`` inside a ``patch.dict(sys.modules, ...)`` block
+    the reloaded module is dropped from ``sys.modules`` on exit. A later
+    ``import cli`` then yields a *different* module than the one cli_obj's
+    class methods reference via __globals__. We need a handle on the right
+    module to patch attributes that show_banner() looks up.
+    """
+    clean_config = {
+        "model": {
+            "default": "anthropic/claude-opus-4.6",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "auto",
+        },
+        "display": {
+            "compact": False,
+            "tool_progress": "all",
+            "show_banner": show_banner_value,
+        },
+        "agent": {},
+        "terminal": {"env_type": "local"},
+    }
+    clean_env = {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}
+    prompt_toolkit_stubs = {
+        "prompt_toolkit": MagicMock(),
+        "prompt_toolkit.history": MagicMock(),
+        "prompt_toolkit.styles": MagicMock(),
+        "prompt_toolkit.patch_stdout": MagicMock(),
+        "prompt_toolkit.application": MagicMock(),
+        "prompt_toolkit.layout": MagicMock(),
+        "prompt_toolkit.layout.processors": MagicMock(),
+        "prompt_toolkit.filters": MagicMock(),
+        "prompt_toolkit.layout.dimension": MagicMock(),
+        "prompt_toolkit.layout.menus": MagicMock(),
+        "prompt_toolkit.widgets": MagicMock(),
+        "prompt_toolkit.key_binding": MagicMock(),
+        "prompt_toolkit.completion": MagicMock(),
+        "prompt_toolkit.formatted_text": MagicMock(),
+    }
+    with (
+        patch.dict(sys.modules, prompt_toolkit_stubs),
+        patch.dict("os.environ", clean_env, clear=False),
+    ):
+        import cli as cli_mod
+
+        cli_mod = importlib.reload(cli_mod)
+        with (
+            patch.object(cli_mod, "get_tool_definitions", return_value=[]),
+            patch.dict(cli_mod.__dict__, {"CLI_CONFIG": clean_config}),
+        ):
+            return cli_mod.HermesCLI(**kwargs), cli_mod
+
+
+@contextmanager
+def _patch_banner_calls(cli_mod):
+    """Patch the banner helpers + terminal size for the test's cli module.
+
+    Uses patch.object on the bound cli_mod (not "cli.foo") because the cli_obj
+    holds a reference to the reloaded module which gets dropped from
+    sys.modules — a top-level "import cli" patch would target a different
+    module than the one show_banner actually looks up.
+    """
+    with (
+        patch.object(cli_mod, "build_welcome_banner") as mock_banner,
+        patch.object(cli_mod, "_build_compact_banner") as mock_compact,
+        patch.object(cli_mod, "get_tool_definitions", return_value=[]),
+        patch.object(
+            cli_mod.shutil,
+            "get_terminal_size",
+            return_value=os.terminal_size((120, 40)),
+        ),
+    ):
+        yield mock_banner, mock_compact
+
+
+def test_show_banner_renders_when_show_banner_true():
+    cli_obj, cli_mod = _make_real_cli(show_banner_value=True, compact=False)
+    cli_obj.console = MagicMock()
+
+    with _patch_banner_calls(cli_mod) as (mock_banner, mock_compact):
+        cli_obj.show_banner()
+
+    assert mock_banner.call_count == 1
+    assert mock_compact.call_count == 0
+
+
+def test_show_banner_skipped_when_show_banner_false():
+    """display.show_banner: false suppresses both full and compact banners."""
+    cli_obj, cli_mod = _make_real_cli(show_banner_value=False, compact=False)
+    cli_obj.console = MagicMock()
+
+    with (
+        _patch_banner_calls(cli_mod) as (mock_banner, mock_compact),
+        patch.object(cli_obj, "_show_tool_availability_warnings") as mock_warnings,
+    ):
+        cli_obj.show_banner()
+
+    # Screen is still cleared, but no banner gets rendered.
+    cli_obj.console.clear.assert_called_once()
+    assert mock_banner.call_count == 0
+    assert mock_compact.call_count == 0
+    mock_warnings.assert_called_once()
+
+
+def test_show_banner_skipped_in_compact_mode_when_disabled():
+    """Even when compact=True, show_banner=False suppresses the compact banner."""
+    cli_obj, cli_mod = _make_real_cli(show_banner_value=False, compact=True)
+    cli_obj.console = MagicMock()
+
+    with _patch_banner_calls(cli_mod) as (mock_banner, mock_compact):
+        cli_obj.show_banner()
+
+    assert mock_banner.call_count == 0
+    assert mock_compact.call_count == 0
+
+
+def test_show_banner_defaults_to_true_when_missing():
+    """When display.show_banner is not configured, the banner is shown (back-compat)."""
+    clean_config = {
+        "model": {
+            "default": "anthropic/claude-opus-4.6",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "auto",
+        },
+        # No show_banner key — exercise the default.
+        "display": {"compact": False, "tool_progress": "all"},
+        "agent": {},
+        "terminal": {"env_type": "local"},
+    }
+    prompt_toolkit_stubs = {
+        "prompt_toolkit": MagicMock(),
+        "prompt_toolkit.history": MagicMock(),
+        "prompt_toolkit.styles": MagicMock(),
+        "prompt_toolkit.patch_stdout": MagicMock(),
+        "prompt_toolkit.application": MagicMock(),
+        "prompt_toolkit.layout": MagicMock(),
+        "prompt_toolkit.layout.processors": MagicMock(),
+        "prompt_toolkit.filters": MagicMock(),
+        "prompt_toolkit.layout.dimension": MagicMock(),
+        "prompt_toolkit.layout.menus": MagicMock(),
+        "prompt_toolkit.widgets": MagicMock(),
+        "prompt_toolkit.key_binding": MagicMock(),
+        "prompt_toolkit.completion": MagicMock(),
+        "prompt_toolkit.formatted_text": MagicMock(),
+    }
+    with (
+        patch.dict(sys.modules, prompt_toolkit_stubs),
+        patch.dict(
+            "os.environ", {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}, clear=False
+        ),
+    ):
+        import cli as cli_mod
+
+        cli_mod = importlib.reload(cli_mod)
+        with (
+            patch.object(cli_mod, "get_tool_definitions", return_value=[]),
+            patch.dict(cli_mod.__dict__, {"CLI_CONFIG": clean_config}),
+        ):
+            cli_obj = cli_mod.HermesCLI(compact=False)
+
+    assert cli_obj.show_startup_banner is True
+
+
+def test_clear_in_prompt_toolkit_skips_banner_when_disabled():
+    """The prompt-toolkit /clear path honors display.show_banner."""
+    cli_obj, cli_mod = _make_real_cli(show_banner_value=False, compact=False)
+    cli_obj._pending_resume_sessions = None
+    cli_obj._app = MagicMock()
+    cli_obj._confirm_destructive_slash = MagicMock(return_value=True)
+    cli_obj.new_session = MagicMock()
+
+    with (
+        patch.object(cli_mod, "ChatConsole") as mock_chat_console,
+        patch.object(cli_mod, "build_welcome_banner") as mock_banner,
+        patch.object(cli_mod, "_build_compact_banner") as mock_compact,
+    ):
+        assert cli_obj.process_command("/clear") is True
+
+    cli_obj.new_session.assert_called_once_with(silent=True)
+    cli_obj._app.output.erase_screen.assert_called_once()
+    cli_obj._app.output.cursor_goto.assert_called_once_with(0, 0)
+    cli_obj._app.output.flush.assert_called_once()
+    mock_banner.assert_not_called()
+    mock_compact.assert_not_called()
+    mock_chat_console.return_value.print.assert_called()


### PR DESCRIPTION
## What changed and why

- Supersedes closed #23679 with its `display.show_banner` option for the classic CLI. Set `display.show_banner: false` to clear the screen without rendering the startup or `/clear` banner; diagnostic warnings continue to appear.
- Adds `display.show_banner: true` to the shared `DEFAULT_CONFIG`, so fresh, setup, and reset configurations resolve the documented default consistently.
- Adds coverage for full and compact banner suppression, `/clear`, and the shared config default.

## How to test

- Run `pytest tests/cli/test_cli_show_banner_option.py tests/cli/test_cli_context_warning.py -q -x --timeout=60`.
- Run `pytest tests/ -q -x --timeout=60`.
- Start the classic CLI with `display.show_banner: false` and run `/clear`; the screen clears without the banner while warnings are still rendered.

## What platforms tested on

- macOS (Darwin)

Fixes #23487

<!-- autocontrib:worker-id=issue-followup-3ec403ad kind=pr-open -->