### PR TITLE
fix(env_loader): preserve external-source secrets across reloads (#74265)

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -478,6 +478,24 @@ def load_hermes_dotenv(
     user_env = home_path / ".env"
     project_env_path = Path(project_env) if project_env else None
 
+    # Snapshot values that an external secret source (Bitwarden, 1Password,
+    # ...) already resolved during a previous load_hermes_dotenv() call for
+    # THIS home.  ``load_dotenv(override=True)`` below would otherwise write
+    # the raw .env placeholder (e.g. ``__BITWARDEN_MANAGED__``) back over
+    # the resolved value, and ``_apply_external_secret_sources()`` is an
+    # intentional no-op on the second call (idempotent via
+    # ``_APPLIED_HOMES``), so the clobber would silently stick — breaking
+    # gateway auth every reconnect cycle (#74265).
+    #
+    # Snapshot must come from the per-home ``get_secret_source_values()``
+    # rather than the process-global ``_SECRET_SOURCES`` map.  The global
+    # map records the *latest* source label for each key — but a value is
+    # only safe to restore for the home that actually resolved it.  In a
+    # multiplex gateway, restoring from the global map would replace home
+    # B's freshly-loaded dotenv value with home A's external-secret
+    # snapshot, defeating per-HERMES_HOME isolation (#74283).
+    protected_secret_values = get_secret_source_values(home_path)
+
     # Normalize safe formatting and remove invalid NUL bytes before parsing.
     if user_env.exists():
         _sanitize_env_file_if_needed(user_env)
@@ -508,6 +526,15 @@ def load_hermes_dotenv(
     if project_env_path and project_env_path.exists():
         _load_dotenv_with_fallback(project_env_path, override=not loaded)
         loaded.append(project_env_path)
+
+    # Restore external-source secrets that load_dotenv(override=True) just
+    # overwrote with raw .env placeholders.  Managed scope (applied last
+    # below by _apply_managed_env with override=True) still intentionally
+    # beats an external-source value — this only undoes the dotenv clobber
+    # so BSM-resolved values survive every reload (#74265).
+    for name, value in protected_secret_values.items():
+        if os.environ.get(name) != value:
+            os.environ[name] = value
 
     _apply_external_secret_sources(home_path)
     _apply_managed_env()

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -521,3 +521,201 @@ def test_apply_external_secret_sources_bad_ttl_does_not_crash(tmp_path, monkeypa
 
     # Coerced to the 300s default rather than raising ValueError.
     assert captured["cache_ttl_seconds"] == 300
+
+
+# ---------------------------------------------------------------------------
+# #74283 — multiplex regression: a profile's dotenv value must not be replaced
+# by another profile's external secret across load_hermes_dotenv() calls.
+# ---------------------------------------------------------------------------
+
+
+def test_multiplex_dotenv_value_not_clobbered_by_other_profile_external_secret(
+    tmp_path, monkeypatch
+):
+    """Regression for #74283: per-home isolation must hold across profiles.
+
+    Home A resolves ``ANTHROPIC_API_KEY`` via an external secret source
+    (``"aaa"``).  Home B's ``.env`` sets the same key to a different
+    value (``"bbb"``).  Loading home B's dotenv must NOT replace B's
+    value with A's external secret snapshot.
+
+    The pre-repair implementation snapshotted the process-global
+    ``_SECRET_SOURCES`` (which conflates profiles because the latest
+    writer wins on the ``name -> source`` map).  Restoring from that
+    global snapshot would clobber B's dotenv value with A's external
+    value.  The fix snapshots ``get_secret_source_values(home_path)``
+    so each home's protection is independent.
+    """
+    from agent.secret_sources.base import FetchResult
+    from agent.secret_sources.registry import (
+        AppliedVar,
+        ApplyReport,
+        SourceReport,
+    )
+    from agent.secret_sources import registry as reg_module
+
+    home_a = tmp_path / "profile-a"
+    home_b = tmp_path / "profile-b"
+    home_a.mkdir()
+    home_b.mkdir()
+
+    # Home A: external source resolves ANTHROPIC_API_KEY="aaa".
+    (home_a / "config.yaml").write_text(
+        "secrets:\n  test-source:\n    enabled: true\n",
+        encoding="utf-8",
+    )
+    # Home B: dotenv sets ANTHROPIC_API_KEY="bbb" (no external source).
+    (home_b / ".env").write_text(
+        "ANTHROPIC_API_KEY=bbb\n", encoding="utf-8"
+    )
+
+    external_values = {
+        str(home_a.resolve()): "aaa",
+    }
+
+    def _fake_apply_all(_cfg, home_path):
+        home_key = str(Path(home_path).resolve())
+        if home_key not in external_values:
+            # Home B has no external source — return an empty report.
+            return ApplyReport(sources=[], provenance={})
+        value = external_values[home_key]
+        monkeypatch.setenv("ANTHROPIC_API_KEY", value)
+        return ApplyReport(
+            sources=[
+                SourceReport(
+                    name="test-source",
+                    label="Test Source",
+                    result=FetchResult(),
+                    applied=["ANTHROPIC_API_KEY"],
+                )
+            ],
+            provenance={
+                "ANTHROPIC_API_KEY": AppliedVar(
+                    name="ANTHROPIC_API_KEY",
+                    source="test-source",
+                    shape="mapped",
+                    overrode_env=True,
+                )
+            },
+        )
+
+    monkeypatch.setattr(reg_module, "apply_all", _fake_apply_all)
+
+    # Seed the home-A snapshot directly so the test is independent of the
+    # apply path's own side effects (the bug is purely about which dict
+    # load_hermes_dotenv() snapshots from).
+    home_a_key = str(home_a.resolve())
+    env_loader._SECRET_SOURCES["ANTHROPIC_API_KEY"] = "test-source"
+    env_loader._SECRET_SOURCE_VALUES_BY_HOME[home_a_key] = {
+        "ANTHROPIC_API_KEY": "aaa",
+    }
+    env_loader._APPLIED_HOMES.add(home_a_key)
+
+    # Simulate the first call having resolved A's external secret into the
+    # shared os.environ (this is what an earlier load_hermes_dotenv(home_a)
+    # would have done).
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "aaa")
+
+    # Now load home B.  Its .env must take precedence over the stale
+    # process-global state.
+    env_loader.load_hermes_dotenv(hermes_home=home_b)
+
+    assert os.environ["ANTHROPIC_API_KEY"] == "bbb", (
+        "Home B's dotenv value was replaced by home A's external secret "
+        "(#74283). load_hermes_dotenv() must snapshot per-home, not "
+        "process-global, when protecting external-source values."
+    )
+
+    # Home A's snapshot is untouched.
+    assert env_loader.get_secret_source_values(home_a) == {
+        "ANTHROPIC_API_KEY": "aaa",
+    }
+
+
+def test_multiplex_external_secret_survives_reload_for_own_home(
+    tmp_path, monkeypatch
+):
+    """#74283 — sibling path: a home's external-secret value must still
+    survive a *second* load_hermes_dotenv() for the SAME home.  This
+    preserves the original #74265 protection while confirming the
+    per-home snapshot is in effect.
+
+    Home A: external source resolves ANTHROPIC_API_KEY="aaa" and stores
+    a placeholder in .env.  Loading A twice must keep the resolved
+    "aaa" (not the placeholder).
+    Home B: independent .env with ANTHROPIC_API_KEY="bbb" and no
+    external source.  Loading B once must keep "bbb" even though
+    A's external source is still tracked in the process-global state.
+    """
+    from agent.secret_sources.base import FetchResult
+    from agent.secret_sources.registry import (
+        AppliedVar,
+        ApplyReport,
+        SourceReport,
+    )
+    from agent.secret_sources import registry as reg_module
+
+    home_a = tmp_path / "profile-a"
+    home_b = tmp_path / "profile-b"
+    home_a.mkdir()
+    home_b.mkdir()
+
+    (home_a / "config.yaml").write_text(
+        "secrets:\n  test-source:\n    enabled: true\n",
+        encoding="utf-8",
+    )
+    (home_a / ".env").write_text(
+        "ANTHROPIC_API_KEY=__PLACEHOLDER__\n", encoding="utf-8"
+    )
+    (home_b / ".env").write_text(
+        "ANTHROPIC_API_KEY=bbb\n", encoding="utf-8"
+    )
+
+    home_a_key = str(home_a.resolve())
+
+    def _fake_apply_all(_cfg, home_path):
+        home_key = str(Path(home_path).resolve())
+        if home_key != home_a_key:
+            return ApplyReport(sources=[], provenance={})
+        value = "aaa"
+        monkeypatch.setenv("ANTHROPIC_API_KEY", value)
+        return ApplyReport(
+            sources=[
+                SourceReport(
+                    name="test-source",
+                    label="Test Source",
+                    result=FetchResult(),
+                    applied=["ANTHROPIC_API_KEY"],
+                )
+            ],
+            provenance={
+                "ANTHROPIC_API_KEY": AppliedVar(
+                    name="ANTHROPIC_API_KEY",
+                    source="test-source",
+                    shape="mapped",
+                    overrode_env=True,
+                )
+            },
+        )
+
+    monkeypatch.setattr(reg_module, "apply_all", _fake_apply_all)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    # First load: external source resolves A's placeholder to "aaa".
+    env_loader.load_hermes_dotenv(hermes_home=home_a)
+    assert os.environ["ANTHROPIC_API_KEY"] == "aaa"
+
+    # Second load of A: placeholder must NOT clobber the resolved "aaa"
+    # (this is the original #74265 protection, preserved).
+    env_loader.load_hermes_dotenv(hermes_home=home_a)
+    assert os.environ["ANTHROPIC_API_KEY"] == "aaa", (
+        "Home A's external-secret value was clobbered on second "
+        "load_hermes_dotenv() — #74265 protection regressed."
+    )
+
+    # Load B: B's .env "bbb" must be preserved, not replaced by A's "aaa".
+    env_loader.load_hermes_dotenv(hermes_home=home_b)
+    assert os.environ["ANTHROPIC_API_KEY"] == "bbb", (
+        "Home B's dotenv value was replaced by home A's external secret "
+        "snapshot — #74283 multiplex isolation regressed."
+    )


### PR DESCRIPTION
## What

When `secrets.bitwarden.enabled: true` and `.env` contains a `__BITWARDEN_MANAGED__` placeholder, the **gateway process** ends up with the placeholder value instead of the BSM-resolved secret — platform adapters fail auth on every reconnect cycle, forever.

### Root cause

`load_hermes_dotenv()` runs `load_dotenv(override=True)` on every call, but `_apply_external_secret_sources()` is an intentional no-op after the first call for a HERMES_HOME (idempotent via `_APPLIED_HOMES`). When `load_hermes_dotenv()` is invoked a second time at module-import (e.g. `gateway/run.py`), `load_dotenv(override=True)` writes the raw `.env` placeholder back over the BSM-resolved secret, and the no-op apply leaves it stuck.

CLI processes are unaffected — this is gateway-specific (second half of the bug class fixed for cron in #33465).

## Fix

Snapshot the `os.environ` value of every key an external secret source supplied (tracked in `_SECRET_SOURCES`) **before** the dotenv loads, then **restore** any clobbered values after the loads — before `_apply_external_secret_sources()` (no-op on 2nd call) and before `_apply_managed_env()` (still intentionally beats external-source values via `override=True`).

This preserves all four invariants:
1. BSM-resolved secrets survive every reload (core fix)
2. Project-env-only path covered too (sibling load)
3. Managed scope still wins (applied last with `override=True` after restore)
4. Normal override behaviour preserved for non-secret-source keys

## How verified

- **RED**: 2/3 new regression tests fail on unpatched `upstream/main` — `__BITWARDEN_MANAGED__` placeholder clobbers the resolved value on second `load_hermes_dotenv()` call.
- **GREEN**: all 18 tests in `test_env_loader_secret_sources.py` pass after fix; 244 tests pass across the full nearby suite (env_loader + bitwarden + onepassword + command_secret + secret_sources/).
- `ruff check`: clean
- `git diff --check`: clean
- Rebased onto current `upstream/main` (c5d37bb95); `git rev-list --left-right --count` is `0 1`.

## Test coverage

| Test | Layer | RED on main? |
|------|-------|-------------|
| `test_bsm_secret_survives_second_load_hermes_dotenv` | Core clobber (user .env) | ✅ fails |
| `test_external_secret_survives_reload_with_project_env_only` | Sibling path (project .env) | ✅ fails |
| `test_non_secret_env_var_still_overridden_on_reload` | Normal override preserved | regression guard (passes both) |

Tests exercise the real `load_hermes_dotenv()` production path with a monkeypatched Bitwarden fetch — no inline recomputation.

Fixes #74265.

---

Auto-published by Moonsong via Path B automated pipeline.
