### PR TITLE
fix(delegation): finalize children before timeout

### DIFF
--- a/tests/tools/test_delegate_subagent_timeout_diagnostic.py
+++ b/tests/tools/test_delegate_subagent_timeout_diagnostic.py
@@ -11,8 +11,8 @@ These tests pin:
 - the diagnostic writer's output format and content
 - the timeout branch in _run_single_child only dumps when api_calls == 0
 - the error message surfaces the diagnostic path
-- api_calls > 0 timeouts do NOT write a dump (the old "stuck on slow API
-  call" explanation still applies)
+- api_calls > 0 timeouts do NOT write a zero-call dump and return a bounded,
+  explicitly incomplete checkpoint without guessing at a root cause
 """
 from __future__ import annotations
 
@@ -79,6 +79,129 @@ class _StubChild:
 
     def interrupt(self):
         self._hang.set()
+
+
+class _ProgressChild(_StubChild):
+    """Timed-out child with durable in-memory tool-call progress."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._live_transcript_path = "/tmp/deleg-test/task-0.log"
+        self._session_messages = [
+            {"role": "user", "content": "research"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "function": {
+                            "name": "web_search",
+                            "arguments": '{"query":"one"}',
+                        },
+                    },
+                    {
+                        "id": "call-2",
+                        "function": {
+                            "name": "web_extract",
+                            "arguments": '{"urls":["https://example.test"]}',
+                        },
+                    },
+                    {
+                        "id": "malformed-call",
+                        "function": "not-a-dict",
+                    },
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call-1",
+                "content": "untrusted result content must not be copied",
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call-2",
+                "content": "another raw result that must stay out of the checkpoint",
+            },
+        ]
+
+
+class _ChildRaisedTimeout(_StubChild):
+    """Child failure that happens to use Python's TimeoutError type."""
+
+    def run_conversation(self, user_message, task_id=None, stream_callback=None):
+        raise TimeoutError("child-internal timeout")
+
+
+class _ImmediateChild(_StubChild):
+    """Successful child used to verify the default no-timeout contract."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.steer_calls = 0
+
+    def run_conversation(self, user_message, task_id=None, stream_callback=None):
+        return {
+            "final_response": "Immediate completion",
+            "completed": True,
+            "api_calls": 1,
+            "messages": [
+                {"role": "assistant", "content": "Immediate completion"}
+            ],
+        }
+
+    def steer(self, message):
+        self.steer_calls += 1
+        return True
+
+
+class _DeadlineAwareChild(_StubChild):
+    """Child that can turn an approaching deadline into a final response."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._finalize = threading.Event()
+        self.steer_message = None
+
+    def steer(self, message):
+        self.steer_message = message
+        self._finalize.set()
+        return True
+
+    def run_conversation(self, user_message, task_id=None, stream_callback=None):
+        if self._finalize.wait(self._hang_seconds):
+            self._api_call_count += 1
+            return {
+                "final_response": "Deadline-safe partial findings",
+                "completed": True,
+                "api_calls": self._api_call_count,
+                "messages": [
+                    {"role": "user", "content": user_message},
+                    {
+                        "role": "assistant",
+                        "content": "Deadline-safe partial findings",
+                    },
+                ],
+            }
+        return {
+            "final_response": "",
+            "completed": False,
+            "api_calls": self._api_call_count,
+        }
+
+
+class _BlockingSteerChild(_StubChild):
+    """Child whose steer implementation blocks until the test releases it."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.steer_started = threading.Event()
+        self.release_steer = threading.Event()
+
+    def steer(self, message):
+        self.steer_started.set()
+        self.release_steer.wait(10.0)
+        return True
 
 
 # ── _dump_subagent_timeout_diagnostic ──────────────────────────────────
@@ -234,11 +357,13 @@ class TestRunSingleChildTimeoutDump:
     """The timeout branch in _run_single_child must emit the diagnostic
     dump when api_calls == 0, and must NOT emit it when api_calls > 0."""
 
-    def _invoke_with_short_timeout(self, child, monkeypatch):
+    def _invoke_with_short_timeout(
+        self, child, monkeypatch, timeout: float | None = 0.3
+    ):
         """Run _run_single_child with a tiny timeout to force the timeout branch."""
         from tools import delegate_tool
-        # Force a 0.3s timeout so the test is fast
-        monkeypatch.setattr(delegate_tool, "_get_child_timeout", lambda: 0.3)
+        # Bypass the production 30s config floor so the unit test stays fast.
+        monkeypatch.setattr(delegate_tool, "_get_child_timeout", lambda: timeout)
 
         parent = MagicMock()
         parent._touch_activity = MagicMock()
@@ -266,17 +391,20 @@ class TestRunSingleChildTimeoutDump:
         assert "Diagnostic:" in result["error"]
         assert str(dump_path) in result["error"]
 
-    def test_nonzero_api_calls_skips_dump_and_uses_old_message(self, hermes_home, monkeypatch):
+    def test_nonzero_api_calls_skips_dump_and_reports_hard_deadline(
+        self, hermes_home, monkeypatch
+    ):
         child = _StubChild(api_call_count=5, hang_seconds=10.0)
         result = self._invoke_with_short_timeout(child, monkeypatch)
 
         assert result["status"] == "timeout"
         assert result["api_calls"] == 5
-        # No diagnostic file should be written for timeouts that made
-        # actual API calls — the old generic "stuck on slow call" message
-        # still applies.
+        # No zero-call diagnostic file should be written for a child that made
+        # progress. The message must report the configured deadline without
+        # inventing a slow-call/network root cause.
         assert result.get("diagnostic_path") is None
-        assert "stuck on a slow API call" in result["error"]
+        assert "configured hard deadline expired" in result["error"]
+        assert "stuck on a slow API call" not in result["error"]
         # And no subagent-timeout-* file should exist under logs/
         logs_dir = hermes_home / "logs"
         if logs_dir.is_dir():
@@ -326,3 +454,191 @@ class TestRunSingleChildTimeoutDump:
         assert result["timeout_seconds"] is None
         assert result["timed_out_after_seconds"] is None
         assert result["timeout_phase"] is None
+
+    def test_progress_timeout_returns_labeled_partial_checkpoint(
+        self, hermes_home, monkeypatch
+    ):
+        child = _ProgressChild(api_call_count=5, hang_seconds=10.0)
+        result = self._invoke_with_short_timeout(child, monkeypatch)
+
+        assert result["status"] == "timeout"
+        assert result["partial"] is True
+        assert result["summary"].startswith(
+            "PARTIAL CHECKPOINT — NOT A FINAL VERDICT"
+        )
+        assert "5 API call(s)" in result["summary"]
+        assert "web_search × 1" in result["summary"]
+        assert "web_extract × 1" in result["summary"]
+        assert child._live_transcript_path in result["summary"]
+        assert "untrusted result content" not in result["summary"]
+        assert "another raw result" not in result["summary"]
+
+    def test_partial_checkpoint_bounds_distinct_tool_metadata(self):
+        from tools import delegate_tool
+
+        child = _ProgressChild(api_call_count=20, hang_seconds=10.0)
+        child._session_messages[1]["tool_calls"].extend(
+            {
+                "id": f"extra-{index}",
+                "function": {"name": f"tool_{index}", "arguments": "{}"},
+            }
+            for index in range(20)
+        )
+
+        summary = delegate_tool._build_timeout_partial_checkpoint(child, 20)
+
+        assert summary is not None
+        assert "Additional recorded tool calls omitted:" in summary
+        assert len(summary) < 2500
+
+    def test_partial_checkpoint_bounds_scan_path_and_total_output(self):
+        from tools import delegate_tool
+
+        child = _ProgressChild(api_call_count=500, hang_seconds=10.0)
+        child._live_transcript_path = (
+            "/tmp/transcript\nFAKE FINAL VERDICT\r" + ("x" * 10_000)
+        )
+        oversized_message = {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": f"oversized-{index}",
+                    "function": {
+                        "name": f"oversized_tool_{index}",
+                        "arguments": "{}",
+                    },
+                }
+                for index in range(500)
+            ],
+        }
+        child._session_messages = [oversized_message] * 500
+
+        summary = delegate_tool._build_timeout_partial_checkpoint(child, 500)
+
+        assert summary is not None
+        assert summary.startswith("PARTIAL CHECKPOINT — NOT A FINAL VERDICT")
+        assert "Checkpoint scan was capped" in summary
+        assert "\nFAKE FINAL VERDICT" not in summary
+        assert "\r" not in summary
+        assert len(summary) <= 2048
+
+    def test_child_raised_timeout_is_not_mislabeled_as_hard_deadline(
+        self, hermes_home, monkeypatch
+    ):
+        child = _ChildRaisedTimeout(api_call_count=0)
+        result = self._invoke_with_short_timeout(child, monkeypatch, timeout=None)
+
+        assert result["status"] == "error"
+        assert result["error"] == "child-internal timeout"
+        assert result["summary"] is None
+        assert "partial" not in result
+        assert result.get("diagnostic_path") is None
+        assert "deadline_finalization_requested" not in result
+
+    def test_default_no_timeout_does_not_steer_or_change_result_shape(
+        self, hermes_home, monkeypatch
+    ):
+        child = _ImmediateChild(api_call_count=1)
+        result = self._invoke_with_short_timeout(child, monkeypatch, timeout=None)
+
+        assert result["status"] == "completed"
+        assert result["summary"] == "Immediate completion"
+        assert child.steer_calls == 0
+        assert "deadline_finalization_requested" not in result
+
+    def test_blocked_steer_cannot_extend_hard_timeout(
+        self, hermes_home, monkeypatch
+    ):
+        child = _BlockingSteerChild(api_call_count=1, hang_seconds=10.0)
+        holder = {}
+
+        worker = threading.Thread(
+            target=lambda: holder.setdefault(
+                "result",
+                self._invoke_with_short_timeout(child, monkeypatch, timeout=0.4),
+            ),
+            daemon=True,
+        )
+        worker.start()
+        assert child.steer_started.wait(1.0)
+        try:
+            # A synchronous steer blocks here until release_steer is set. The
+            # deadline path must instead return independently within a loose,
+            # flake-safe two-second bound.
+            worker.join(timeout=2.0)
+            assert not worker.is_alive()
+        finally:
+            child.release_steer.set()
+            worker.join(timeout=2.0)
+
+        assert holder["result"]["status"] == "timeout"
+        assert holder["result"]["deadline_finalization_requested"] is True
+
+    def test_boundary_completion_recovers_finished_future_result(
+        self, hermes_home, monkeypatch
+    ):
+        from concurrent.futures import TimeoutError as FuturesTimeoutError
+        from tools import daemon_pool, delegate_tool
+
+        class BoundaryFuture:
+            def __init__(self):
+                self.calls = 0
+
+            def result(self, timeout=None):
+                self.calls += 1
+                if self.calls == 1:
+                    raise FuturesTimeoutError()
+                return {
+                    "final_response": "Boundary completion",
+                    "completed": True,
+                    "api_calls": 1,
+                    "messages": [
+                        {"role": "assistant", "content": "Boundary completion"}
+                    ],
+                }
+
+            def done(self):
+                return True
+
+        class BoundaryExecutor:
+            def __init__(self, *args, **kwargs):
+                self.future = BoundaryFuture()
+
+            def submit(self, *args, **kwargs):
+                return self.future
+
+            def shutdown(self, wait=False, cancel_futures=False):
+                return None
+
+        monkeypatch.setattr(delegate_tool, "_get_child_timeout", lambda: 0.4)
+        monkeypatch.setattr(
+            daemon_pool, "DaemonThreadPoolExecutor", BoundaryExecutor
+        )
+
+        parent = MagicMock()
+        parent._touch_activity = MagicMock()
+        parent._interrupt_requested = False
+        parent.session_id = "parent-test"
+        parent._active_children = []
+
+        result = delegate_tool._run_single_child(
+            task_index=0,
+            goal="boundary race",
+            child=_StubChild(api_call_count=1),
+            parent_agent=parent,
+        )
+
+        assert result["status"] == "completed"
+        assert result["summary"] == "Boundary completion"
+
+    def test_soft_deadline_requests_final_summary_before_hard_timeout(
+        self, hermes_home, monkeypatch
+    ):
+        child = _DeadlineAwareChild(api_call_count=3, hang_seconds=2.0)
+        result = self._invoke_with_short_timeout(child, monkeypatch, timeout=0.4)
+
+        assert result["status"] == "completed"
+        assert result["summary"] == "Deadline-safe partial findings"
+        assert child.steer_message is not None
+        assert "deadline" in child.steer_message.lower()
+        assert "do not call more tools" in child.steer_message.lower()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -729,6 +729,23 @@ _MIN_SUMMARY_CHARS = 2000
 # detection lives in the heartbeat staleness monitor below. Users can opt back
 # in via delegation.child_timeout_seconds.
 DEFAULT_CHILD_TIMEOUT: Optional[float] = None
+# When an operator opts into a hard child timeout, reserve a bounded tail of
+# that budget for the child to stop starting work and write its final summary.
+# This does not affect the default no-timeout path and adds no model-tool schema.
+_DEADLINE_FINALIZATION_FRACTION = 0.10
+_DEADLINE_FINALIZATION_MIN_SECONDS = 5.0
+_DEADLINE_FINALIZATION_MAX_SECONDS = 60.0
+_DEADLINE_FINALIZATION_STEER = (
+    "[Delegation deadline approaching. Stop starting new work and summarize "
+    "the best verified findings now. Clearly label incomplete items and any "
+    "missing verdict. Do not call more tools.]"
+)
+_TIMEOUT_CHECKPOINT_MAX_TOOL_NAMES = 12
+_TIMEOUT_CHECKPOINT_MAX_TOOL_NAME_CHARS = 80
+_TIMEOUT_CHECKPOINT_MAX_MESSAGES = 100
+_TIMEOUT_CHECKPOINT_MAX_TOOL_CALLS = 200
+_TIMEOUT_CHECKPOINT_MAX_PATH_CHARS = 512
+_TIMEOUT_CHECKPOINT_MAX_CHARS = 2048
 _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during delegation
 # Stale-heartbeat thresholds. A child with no API-call progress is either:
 #   - idle between turns (no current_tool) — probably stuck on a slow API call
@@ -1961,6 +1978,161 @@ def _apply_summary_budget(results: List[Dict[str, Any]], parent_agent) -> None:
         )
 
 
+def _deadline_finalization_grace(timeout_seconds: float) -> float:
+    """Return the portion of an explicit hard timeout reserved for summary.
+
+    The production config floor is 30 seconds, but clamping to half the supplied
+    timeout also keeps direct/unit callers with smaller values well-defined.
+    """
+    timeout = max(0.0, float(timeout_seconds))
+    if timeout == 0:
+        return 0.0
+    requested = max(
+        _DEADLINE_FINALIZATION_MIN_SECONDS,
+        timeout * _DEADLINE_FINALIZATION_FRACTION,
+    )
+    return min(_DEADLINE_FINALIZATION_MAX_SECONDS, requested, timeout / 2.0)
+
+
+def _request_deadline_finalization(child: Any, task_index: int) -> bool:
+    """Launch a best-effort summary request without consuming deadline budget.
+
+    ``AIAgent.steer`` is normally an immediate lock-protected assignment, but
+    children can be substituted by adapters/tests. Run it on a daemon thread so
+    a blocking implementation can never extend the configured hard timeout.
+    The return value means the request was launched, not that steer accepted it.
+    """
+    steer = getattr(child, "steer", None)
+    if not callable(steer):
+        return False
+
+    def _invoke() -> None:
+        try:
+            accepted = bool(steer(_DEADLINE_FINALIZATION_STEER))
+        except Exception:
+            logger.debug(
+                "Subagent %d deadline-finalization steer failed",
+                task_index,
+                exc_info=True,
+            )
+            return
+        if accepted:
+            logger.info(
+                "Subagent %d entered deadline-finalization window",
+                task_index,
+            )
+
+    request_thread = threading.Thread(
+        target=_invoke,
+        name=f"delegate-finalize-{task_index}",
+        daemon=True,
+    )
+    try:
+        request_thread.start()
+    except Exception:
+        logger.debug(
+            "Subagent %d deadline-finalization thread failed to start",
+            task_index,
+            exc_info=True,
+        )
+        return False
+    return True
+
+
+def _build_timeout_partial_checkpoint(child: Any, api_calls: int) -> Optional[str]:
+    """Build a safe operational checkpoint for a progressed timed-out child.
+
+    Raw tool results are intentionally excluded: they can contain untrusted web
+    text, secrets, or huge payloads. The parent gets only bounded execution
+    metadata plus a bounded, escaped live-transcript path for deliberate inspection.
+    """
+    if api_calls <= 0:
+        return None
+
+    messages = getattr(child, "_session_messages", None)
+    tool_counts: Dict[str, int] = {}
+    omitted_tool_calls = 0
+    scan_capped = False
+    if isinstance(messages, list):
+        scan_capped = len(messages) > _TIMEOUT_CHECKPOINT_MAX_MESSAGES
+        # Snapshot only the recent bounded tail. The child worker may still be
+        # appending to the original list while timeout recovery runs.
+        messages_snapshot = messages[-_TIMEOUT_CHECKPOINT_MAX_MESSAGES :]
+        scanned_tool_calls = 0
+        for msg in messages_snapshot:
+            if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                continue
+            tool_calls = msg.get("tool_calls") or []
+            if not isinstance(tool_calls, list):
+                continue
+            remaining = _TIMEOUT_CHECKPOINT_MAX_TOOL_CALLS - scanned_tool_calls
+            if remaining <= 0:
+                if tool_calls:
+                    scan_capped = True
+                break
+            if len(tool_calls) > remaining:
+                scan_capped = True
+            selected_tool_calls = tool_calls[:remaining]
+            scanned_tool_calls += len(selected_tool_calls)
+            for tool_call in selected_tool_calls:
+                if not isinstance(tool_call, dict):
+                    continue
+                function = tool_call.get("function") or {}
+                if not isinstance(function, dict):
+                    continue
+                name = str(function.get("name") or "unknown")
+                name = name.replace("\r", " ").replace("\n", " ")[
+                    :_TIMEOUT_CHECKPOINT_MAX_TOOL_NAME_CHARS
+                ]
+                if name in tool_counts:
+                    tool_counts[name] += 1
+                elif len(tool_counts) < _TIMEOUT_CHECKPOINT_MAX_TOOL_NAMES:
+                    tool_counts[name] = 1
+                else:
+                    omitted_tool_calls += 1
+
+    lines = [
+        "PARTIAL CHECKPOINT — NOT A FINAL VERDICT",
+        "",
+        f"- The configured hard deadline expired after {api_calls} API call(s).",
+        "- No final model summary was produced; do not treat this task as completed.",
+    ]
+    if tool_counts:
+        activity = ", ".join(
+            f"{name} × {count}" for name, count in tool_counts.items()
+        )
+        lines.append(f"- Recorded tool calls: {activity}.")
+        if omitted_tool_calls:
+            lines.append(
+                f"- Additional recorded tool calls omitted: {omitted_tool_calls}."
+            )
+    else:
+        lines.append("- No completed tool-call metadata was available to summarize safely.")
+
+    if scan_capped:
+        lines.append("- Checkpoint scan was capped; additional activity may exist.")
+
+    live_path = getattr(child, "_live_transcript_path", None)
+    if isinstance(live_path, str) and live_path:
+        path_was_truncated = len(live_path) > _TIMEOUT_CHECKPOINT_MAX_PATH_CHARS
+        escaped_path = json.dumps(
+            live_path[:_TIMEOUT_CHECKPOINT_MAX_PATH_CHARS],
+            ensure_ascii=True,
+        )
+        if path_was_truncated:
+            escaped_path += "…"
+        lines.append(f"- Full live transcript: {escaped_path}")
+
+    summary = "\n".join(lines)
+    if len(summary) > _TIMEOUT_CHECKPOINT_MAX_CHARS:
+        suffix = "\n[Checkpoint metadata truncated.]"
+        summary = (
+            summary[: _TIMEOUT_CHECKPOINT_MAX_CHARS - len(suffix)].rstrip()
+            + suffix
+        )
+    return summary
+
+
 def _run_single_child(
     task_index: int,
     goal: str,
@@ -2189,8 +2361,49 @@ def _run_single_child(
             _child_context.run,
             _run_with_thread_capture,
         )
+        deadline_finalization_requested = False
+        hard_deadline_expired = False
         try:
-            result = _child_future.result(timeout=child_timeout)
+            if child_timeout is None:
+                result = _child_future.result(timeout=None)
+            else:
+                hard_deadline = time.monotonic() + child_timeout
+                finalization_grace = _deadline_finalization_grace(child_timeout)
+                work_window = max(
+                    0.0,
+                    hard_deadline - finalization_grace - time.monotonic(),
+                )
+                try:
+                    result = _child_future.result(timeout=work_window)
+                except FuturesTimeoutError:
+                    # A TimeoutError raised *by* the child also emerges from
+                    # Future.result(). If completion won the boundary race,
+                    # recover its actual result/exception before deciding this
+                    # was the soft deadline.
+                    if _child_future.done():
+                        result = _child_future.result()
+                    else:
+                        deadline_finalization_requested = (
+                            _request_deadline_finalization(child, task_index)
+                        )
+                        remaining = max(0.0, hard_deadline - time.monotonic())
+                        if remaining <= 0.0:
+                            if _child_future.done():
+                                result = _child_future.result()
+                            else:
+                                hard_deadline_expired = True
+                                raise FuturesTimeoutError()
+                        else:
+                            try:
+                                result = _child_future.result(timeout=remaining)
+                            except FuturesTimeoutError:
+                                # Recover a result/child exception that landed
+                                # exactly as the remaining-budget wait expired.
+                                if _child_future.done():
+                                    result = _child_future.result()
+                                else:
+                                    hard_deadline_expired = True
+                                    raise
         except Exception as _timeout_exc:
             # Signal the child to stop so its thread can exit cleanly.
             try:
@@ -2201,7 +2414,10 @@ def _run_single_child(
             except Exception:
                 pass
 
-            is_timeout = isinstance(_timeout_exc, (FuturesTimeoutError, TimeoutError))
+            # Do not infer from the exception class: a child can itself raise
+            # TimeoutError. Only the unfinished-future branch above proves the
+            # configured hard deadline elapsed.
+            is_timeout = hard_deadline_expired
             duration = round(time.monotonic() - child_start, 2)
             logger.warning(
                 "Subagent %d %s after %.1fs",
@@ -2238,6 +2454,12 @@ def _run_single_child(
                         diagnostic_path,
                     )
 
+            partial_checkpoint = (
+                _build_timeout_partial_checkpoint(child, child_api_calls)
+                if is_timeout
+                else None
+            )
+
             if child_progress_cb:
                 try:
                     child_progress_cb(
@@ -2249,7 +2471,7 @@ def _run_single_child(
                         ),
                         status="timeout" if is_timeout else "error",
                         duration_seconds=duration,
-                        summary="",
+                        summary=partial_checkpoint or "",
                     )
                 except Exception:
                     pass
@@ -2267,19 +2489,16 @@ def _run_single_child(
                 else:
                     _err = (
                         f"Subagent timed out after {child_timeout}s with "
-                        f"{child_api_calls} API call(s) completed — likely "
-                        f"stuck on a slow API call, tool call, or unresponsive "
-                        f"network request."
+                        f"{child_api_calls} API call(s) completed — the configured "
+                        f"hard deadline expired before a final response."
                     )
-                    if diagnostic_path:
-                        _err += f" Diagnostic: {diagnostic_path}"
             else:
                 _err = str(_timeout_exc)
 
-            return {
+            error_entry = {
                 "task_index": task_index,
                 "status": "timeout" if is_timeout else "error",
-                "summary": None,
+                "summary": partial_checkpoint,
                 "error": _err,
                 "exit_reason": "timeout" if is_timeout else "error",
                 "api_calls": child_api_calls,
@@ -2294,6 +2513,12 @@ def _run_single_child(
                 "_child_role": getattr(child, "_delegate_role", None),
                 "diagnostic_path": diagnostic_path,
             }
+            if is_timeout:
+                error_entry["partial"] = bool(partial_checkpoint)
+                error_entry["deadline_finalization_requested"] = (
+                    deadline_finalization_requested
+                )
+            return error_entry
         finally:
             # Shut down executor without waiting — if the child thread
             # is stuck on blocking I/O, wait=True would hang forever.
@@ -2416,6 +2641,10 @@ def _run_single_child(
                 else 0.0
             ),
         }
+        if child_timeout is not None:
+            entry["deadline_finalization_requested"] = (
+                deadline_finalization_requested
+            )
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
 


### PR DESCRIPTION
## Summary

- give explicitly timed subagents a bounded opportunity to finalize through the existing cache/role-safe `steer()` path before the absolute deadline
- return a deterministic, size-bounded `PARTIAL CHECKPOINT — NOT A FINAL VERDICT` when a progressing child still reaches the hard cap
- recover deadline-boundary completions and keep child-raised `TimeoutError` distinct from parent deadline expiration
- preserve default no-timeout behavior and result shape

## Behavioral contracts

- `DEFAULT_CHILD_TIMEOUT` remains `None`
- finalization reserve is 10% of the configured timeout, clamped to 5–60 seconds, and never extends the original monotonic hard deadline
- blocked/custom steering runs outside the caller's critical path
- hard deadline expiration remains `status="timeout"`
- checkpoints exclude transcript/tool output content and are bounded by message, tool-call, tool-name, path, and total-character limits
- existing zero-API-call diagnostics and structured timeout metadata remain intact

## Test plan

- `scripts/run_tests.sh` over delegation, async delegation, process registry, CLI async delivery, steering, and concurrent interrupt suites: **427 passed**
- focused timeout diagnostics: **18 passed**
- Ruff: passed
- `git diff --check`: passed
- real configured-timeout probe: completed in **27.305s** within a 30s cap with the steered exact summary
- real hard-fallback probe: returned timeout in **30.047s** without extending the cap
- real no-timeout probe: completed with timeout-only fields absent
- broader tools run: **9,289 passed**; 10 unrelated host/baseline failures reproduced unchanged on a clean base
