### PR TITLE
fix(desktop): persist sidebar unread dots across app restarts

### DIFF
--- a/apps/desktop/e2e/unread-dot-restart.spec.ts
+++ b/apps/desktop/e2e/unread-dot-restart.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * E2E test for PERSISTED unread state — the green "Finished — unread" dot
+ * must survive an app restart.
+ *
+ * Regression coverage for the reset-on-restart bug: the unread flag used to
+ * live only in the in-memory `$unreadFinishedSessionIds` atom, so closing and
+ * reopening the desktop app grayed out every green dot. The persisted layer
+ * (src/store/session-unread.ts) now rebuilds the dot from localStorage-backed
+ * finish markers + seen-count watermarks.
+ *
+ * The scenario uses TWO sessions on purpose: with a single session the app
+ * can reopen straight into it after a restart, which acks the session (the
+ * user is looking at it) and would mask the dot. Session A finishes in the
+ * background while session B is the selected one; the restart reopens into
+ * B, so A's dot is observable.
+ *
+ *  1. Session A: start a turn, hold its stream open.
+ *  2. Session B: new session, send a message, let it finish while SELECTED.
+ *  3. Release A's stream → its background finish paints A's green dot.
+ *  4. QUIT the app, relaunch on the SAME sandbox → A's dot must still be
+ *     there (previously it was lost).
+ *  5. Open session A → dot clears.
+ *  6. Restart once more → the cleared state must persist too (no zombie dot).
+ *
+ * Prerequisite: `npm run build` must have been run so dist/ exists.
+ */
+
+import { expect, type Page, test } from '@playwright/test'
+import { type ElectronApplication } from '@playwright/test'
+
+import {
+  buildAppEnv,
+  launchDesktop,
+  type MockBackendFixture,
+  setupMockBackend,
+  waitForAppReady,
+} from './fixtures'
+import { restartMockServer } from './mock-server'
+
+/** Finished-unread dot aria-label (from i18n en.ts). */
+const UNREAD_DOT_LABEL = 'Finished — unread'
+
+/** Held prompt — the mock pauses this stream until we release it, so the
+ *  turn is deterministically still running when we switch away. */
+const HELD_PROMPT = 'E2E unread restart: hold this stream until released.'
+/** Second session's prompt — completes normally while selected. */
+const SECOND_PROMPT = 'E2E unread restart: second session, read while open.'
+
+const unreadDots = (page: Page) => page.locator(`[aria-label="${UNREAD_DOT_LABEL}"]`)
+
+async function sendMessage(page: Page, text: string): Promise<void> {
+  const composer = page.locator('[contenteditable="true"]').first()
+  await composer.waitFor({ state: 'visible', timeout: 15_000 })
+  await composer.click()
+  await composer.type(text, { delay: 5 })
+  await page.keyboard.press('Enter')
+}
+
+test.describe('unread dot survives app restart', () => {
+  test.describe.configure({ mode: 'serial' })
+  // Three full app boots in one scenario — give it more than the global 90s.
+  test.setTimeout(300_000)
+
+  let fixture: MockBackendFixture
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeAll(async () => {
+    restartMockServer()
+    fixture = await setupMockBackend({
+      mockServer: { holdFirstStreamForPrompt: HELD_PROMPT },
+    })
+    app = fixture.app
+    page = fixture.page
+    await waitForAppReady(fixture, 120_000)
+  })
+
+  test.afterAll(async () => {
+    // The fixture's own app handle may already be closed by the restart
+    // steps — close whatever is current, then drop the sandbox + mock.
+    try {
+      await app?.close()
+    } catch {
+      // already closed
+    }
+
+    fixture?.mock.close()
+    fixture?.sandbox.cleanup()
+  })
+
+  /** Relaunch the desktop app against the SAME sandbox (same userData →
+   *  same localStorage, same HERMES_HOME → same session store). */
+  async function restartApp(): Promise<void> {
+    await app.close()
+
+    const relaunched = await launchDesktop(buildAppEnv(fixture.sandbox))
+    app = relaunched.app
+    page = relaunched.page
+    await waitForAppReady({ ...fixture, app, page }, 120_000)
+  }
+
+  test('green dot persists across restart and its clear persists too', async () => {
+    // ── 1. Session A: start a turn whose stream the mock holds open ────
+    await sendMessage(page, HELD_PROMPT)
+    await fixture.mock.waitForHeldStream()
+
+    // ── 2. Session B: complete a turn while SELECTED (stays read) ──────
+    await page.locator('button:has-text("New session")').first().click()
+    await sendMessage(page, SECOND_PROMPT)
+
+    // B's reply lands in the open transcript — this session is "read".
+    await page.waitForFunction(
+      () => (document.body.textContent ?? '').includes('Hello from the mock inference server'),
+      undefined,
+      { timeout: 30_000 },
+    )
+
+    // ── 3. Release A's stream → background finish paints A's dot ──────
+    fixture.mock.releaseHeldStream()
+
+    await expect
+      .poll(() => unreadDots(page).count(), {
+        timeout: 30_000,
+        message: 'green unread dot should appear after the background finish',
+      })
+      .toBeGreaterThan(0)
+
+    // ── 4. Restart the app — the dot must survive ──────────────────────
+    // The app reopens into session B (or a fresh draft), NOT session A, so
+    // A's dot is observable rather than being acked by the route restore.
+    await restartApp()
+
+    await expect
+      .poll(() => unreadDots(page).count(), {
+        timeout: 60_000,
+        message: 'green unread dot should be rebuilt from persisted state after restart',
+      })
+      .toBeGreaterThan(0)
+
+    // ── 5. Open session A — the dot clears ─────────────────────────────
+    // The dot sits inside A's sidebar row button; click that row.
+    await unreadDots(page)
+      .first()
+      .locator('xpath=ancestor::button[1]')
+      .click()
+
+    await expect
+      .poll(() => unreadDots(page).count(), {
+        timeout: 15_000,
+        message: 'opening the session should clear its unread dot',
+      })
+      .toBe(0)
+
+    // ── 6. Restart again — the CLEARED state must persist as well ──────
+    await restartApp()
+
+    // Give the sidebar a moment to load rows, then assert no dot returns.
+    await page.waitForSelector('[data-slot="sidebar"]', { timeout: 60_000 })
+    await page.waitForTimeout(5_000)
+    expect(await unreadDots(page).count(), 'acked session must stay read after restart').toBe(0)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -66,6 +66,7 @@ import {
   type TileDock
 } from '@/store/session-states'
 import { broadcastSessionsChanged } from '@/store/session-sync'
+import { forgetSessionUnread } from '@/store/session-unread'
 import { isWatchWindow } from '@/store/windows'
 import type { SessionCreateResponse, SessionMessage, SessionResumeResponse, UsageStats } from '@/types/hermes'
 
@@ -1333,6 +1334,9 @@ export function useSessionActions({
         }
 
         await deleteSession(storedSessionId, removed?.profile)
+        // Only after the RPC lands — the optimistic eviction above can roll
+        // back, and a rolled-back row must keep its watermark/marker.
+        forgetSessionUnread(removedIds, removed?.profile)
         clearQueuedPrompts(storedSessionId)
 
         if (closingRuntimeId) {
@@ -1423,6 +1427,9 @@ export function useSessionActions({
 
       try {
         await setSessionArchived(storedSessionId, true, archived?.profile)
+        // Archived rows never reach the sidebar, so their persisted unread can
+        // only rot. Dropped after the RPC so a failed archive keeps it.
+        forgetSessionUnread(archivedIds, archived?.profile)
         // An archived session is hidden from the sidebar; its tile must go too.
         const tiledRuntimeId = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
         closeSessionTile(storedSessionId)

--- a/apps/desktop/src/app/settings/sessions-settings.tsx
+++ b/apps/desktop/src/app/settings/sessions-settings.tsx
@@ -17,6 +17,7 @@ import { Archive, ArchiveOff, FolderOpen, Loader2, Trash2 } from '@/lib/icons'
 import { notify, notifyError } from '@/store/notifications'
 import { untombstoneSessions } from '@/store/projects'
 import { applyConfiguredDefaultProjectDir, ensureDefaultWorkspaceCwd, setSessions } from '@/store/session'
+import { forgetSessionUnread } from '@/store/session-unread'
 import type { HermesConfigRecord, SessionInfo } from '@/types/hermes'
 
 import { EmptyState, ListRow, SectionHeading, SettingsContent, SettingsSkeleton, ToggleRow } from './primitives'
@@ -98,6 +99,9 @@ export function SessionsSettings() {
 
       try {
         await deleteSession(session.id, session.profile)
+        // Permanent delete bypasses removeSession, so retire the persisted
+        // unread state here too rather than leaving it to rot.
+        forgetSessionUnread([session.id, session._lineage_root_id], session.profile)
         setLocalSessions(prev => prev.filter(s => s.id !== session.id))
         triggerHaptic('warning')
       } catch (err) {

--- a/apps/desktop/src/lib/persisted.test.ts
+++ b/apps/desktop/src/lib/persisted.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { Codecs, persistentAtom } from './persisted'
+
+// Unique key per test run — persistentAtom instances are singletons per call,
+// so tests mint fresh keys instead of sharing one.
+let counter = 0
+const freshKey = () => `test.persisted.${++counter}`
+
+describe('persistentAtom', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('seeds from a stored value', () => {
+    const key = freshKey()
+    window.localStorage.setItem(key, JSON.stringify({ a: 1 }))
+
+    const $value = persistentAtom<Record<string, number>>(key, {})
+
+    expect($value.get()).toEqual({ a: 1 })
+  })
+
+  it('does NOT write at creation — an empty read must never clobber storage', () => {
+    // A cold boot can evaluate the bundle against a storage snapshot that has
+    // not caught up yet (early hidden/boot load). If creation echoed the
+    // fallback back out, that load would overwrite the real record other
+    // loads are about to read. Creation must be read-only.
+    const key = freshKey()
+    persistentAtom<Record<string, number>>(key, {})
+
+    expect(window.localStorage.getItem(key)).toBeNull()
+  })
+
+  it('leaves an existing stored value untouched at creation even when it fails to decode', () => {
+    const key = freshKey()
+    window.localStorage.setItem(key, 'not json')
+
+    const $value = persistentAtom<Record<string, number>>(key, { fallback: 1 })
+
+    expect($value.get()).toEqual({ fallback: 1 })
+    // The corrupt value survives until a real write replaces it — creation
+    // never writes.
+    expect(window.localStorage.getItem(key)).toBe('not json')
+  })
+
+  it('persists real changes', () => {
+    const key = freshKey()
+    const $value = persistentAtom<Record<string, number>>(key, {})
+
+    $value.set({ b: 2 })
+
+    expect(window.localStorage.getItem(key)).toBe(JSON.stringify({ b: 2 }))
+  })
+
+  it('removes the key when the codec encodes null', () => {
+    const key = freshKey()
+    window.localStorage.setItem(key, JSON.stringify(['x']))
+
+    const $value = persistentAtom<string[]>(key, [], Codecs.stringArray)
+
+    $value.set([])
+
+    expect(window.localStorage.getItem(key)).toBeNull()
+  })
+})

--- a/apps/desktop/src/lib/persisted.ts
+++ b/apps/desktop/src/lib/persisted.ts
@@ -72,7 +72,26 @@ export function persistentAtom<T>(key: string, fallback: T, codec: Codec<T> = Co
 
   const $value = atom<T>(initial)
 
-  $value.subscribe(value => writeKey(key, codec.encode(value)))
+  // Persist CHANGES only — never the creation-time value. nanostores'
+  // subscribe fires immediately, and writing what was just read back is a
+  // no-op at best; at worst it is a data-loss clobber: on a cold boot the
+  // renderer bundle can run against a storage snapshot that has not caught
+  // up yet (an early hidden/boot load of the same bundle sees an empty
+  // area), and echoing the fallback back out overwrites the real record
+  // other loads are about to read. Observed with the unread-dot records:
+  // the early load wrote `{}` over a populated store between the disk read
+  // and the main window's module init.
+  let creationEmission = true
+
+  $value.subscribe(value => {
+    if (creationEmission) {
+      creationEmission = false
+
+      return
+    }
+
+    writeKey(key, codec.encode(value))
+  })
 
   return $value
 }

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -51,7 +51,11 @@ export function wipeSessionListsForGatewaySwitch(): void {
   setMessagingTruncated(false)
   // Clearing $sessionStates automatically clears $workingSessionIds and
   // $attentionSessionIds (computed) and $stalledSessionIds (owned beside it).
-  // $unreadFinishedSessionIds is separate, so wipe it explicitly.
+  // $unreadFinishedSessionIds is separate, so wipe it explicitly. Only the
+  // transient paint layer is wiped: the persisted markers/watermarks in
+  // session-unread.ts are keyed by durable session id and repaint the rows
+  // that are still unread once the next gateway's lists load — so a profile
+  // round-trip doesn't swallow green dots.
   clearAllSessionStates()
   resetLiveRuntimeTracking()
   resetLiveSync()

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -32,12 +32,8 @@ import { stableArray } from '@/lib/stable-array'
 import { readJson, writeJson } from '@/lib/storage'
 
 import { $activeGatewayProfile, normalizeProfileKey } from './profile'
-import {
-  $activeSessionId,
-  $selectedStoredSessionId,
-  $unreadFinishedSessionIds,
-  setActiveSessionStoredIdRotation
-} from './session'
+import { $activeSessionId, $selectedStoredSessionId, setActiveSessionStoredIdRotation } from './session'
+import { markSessionUnreadFinished } from './session-unread'
 import { isSecondaryWindow } from './windows'
 
 // ---------------------------------------------------------------------------
@@ -173,11 +169,9 @@ function handleTransition(previous: ClientSessionState | null, next: ClientSessi
     markSettled(storedId)
 
     if (storedId !== $selectedStoredSessionId.get()) {
-      const cur = $unreadFinishedSessionIds.get()
-
-      if (!cur.includes(storedId)) {
-        $unreadFinishedSessionIds.set([...cur, storedId])
-      }
+      // Flags the transient atom AND persists a marker, so the green dot
+      // survives an app restart (see session-unread.ts).
+      markSessionUnreadFinished(storedId)
     }
   }
 }

--- a/apps/desktop/src/store/session-unread.test.ts
+++ b/apps/desktop/src/store/session-unread.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { SessionInfo } from '@/types/hermes'
+
+import {
+  $cronSessions,
+  $messagingSessions,
+  $selectedStoredSessionId,
+  $sessions,
+  $unreadFinishedSessionIds,
+  setSelectedStoredSessionId,
+  setSessions
+} from './session'
+import { clearAllSessionStates } from './session-states'
+import { $sessionSeenCounts, $unreadFinishedMarkers, markSessionUnreadFinished } from './session-unread'
+
+const session = (over: Partial<SessionInfo>): SessionInfo => ({
+  archived: false,
+  cwd: null,
+  ended_at: null,
+  id: 'live',
+  input_tokens: 0,
+  is_active: false,
+  last_active: 0,
+  message_count: 0,
+  model: null,
+  output_tokens: 0,
+  preview: null,
+  source: null,
+  started_at: 0,
+  title: null,
+  tool_call_count: 0,
+  ...over
+})
+
+function resetAll() {
+  clearAllSessionStates()
+  // Lists first: their listeners recompute the unread atom, so wiping the
+  // atom afterwards leaves a genuinely clean slate.
+  $sessions.set([])
+  $cronSessions.set([])
+  $messagingSessions.set([])
+  $selectedStoredSessionId.set(null)
+  $sessionSeenCounts.set({})
+  $unreadFinishedMarkers.set([])
+  $unreadFinishedSessionIds.set([])
+}
+
+describe('persisted unread (session-unread)', () => {
+  beforeEach(resetAll)
+
+  it('reconstructs the green dot from a seen watermark after a cold start', () => {
+    // "Restart": persisted watermark says 3 messages were seen; the freshly
+    // loaded list says the session now has 5 — it finished while we were away.
+    $sessionSeenCounts.set({ s1: 3 })
+
+    setSessions([session({ id: 's1', message_count: 5 })])
+
+    expect($unreadFinishedSessionIds.get()).toEqual(['s1'])
+  })
+
+  it('seeds the watermark on first sight instead of painting every row green', () => {
+    setSessions([session({ id: 's1', message_count: 5 })])
+
+    expect($unreadFinishedSessionIds.get()).toEqual([])
+    expect($sessionSeenCounts.get()).toEqual({ s1: 5 })
+  })
+
+  it('keeps a live-edge marker across a transient wipe (gateway/profile switch)', () => {
+    setSessions([session({ id: 's1', message_count: 4 })])
+    markSessionUnreadFinished('s1')
+    expect($unreadFinishedSessionIds.get()).toEqual(['s1'])
+
+    // Gateway switch: transient paint layer wiped, lists drained…
+    setSessions([])
+    $unreadFinishedSessionIds.set([])
+
+    // …then the profile's lists load again: the persisted marker repaints.
+    setSessions([session({ id: 's1', message_count: 4 })])
+
+    expect($unreadFinishedSessionIds.get()).toEqual(['s1'])
+  })
+
+  it('acks watermark + marker when the user opens the session', () => {
+    $sessionSeenCounts.set({ s1: 3 })
+    setSessions([session({ id: 's1', message_count: 5 })])
+    markSessionUnreadFinished('s1')
+
+    setSelectedStoredSessionId('s1')
+
+    expect($unreadFinishedSessionIds.get()).toEqual([])
+    expect($unreadFinishedMarkers.get()).toEqual([])
+    expect($sessionSeenCounts.get()).toEqual({ s1: 5 })
+
+    // A later refresh with the same count stays read.
+    setSessions([session({ id: 's1', message_count: 5 })])
+    expect($unreadFinishedSessionIds.get()).toEqual([])
+  })
+
+  it('tracks the selected session’s count so on-screen activity never reads as unread', () => {
+    $selectedStoredSessionId.set('s1')
+    setSessions([session({ id: 's1', message_count: 2 })])
+
+    // The turn completes while the user is looking at it.
+    setSessions([session({ id: 's1', message_count: 7 })])
+
+    expect($unreadFinishedSessionIds.get()).toEqual([])
+    expect($sessionSeenCounts.get()).toEqual({ s1: 7 })
+
+    // Navigating away must not retroactively flag it.
+    setSelectedStoredSessionId(null)
+    setSessions([session({ id: 's1', message_count: 7 })])
+    expect($unreadFinishedSessionIds.get()).toEqual([])
+  })
+
+  it('follows auto-compression id rotation via the durable lineage id', () => {
+    $sessionSeenCounts.set({ root: 3 })
+
+    setSessions([session({ _lineage_root_id: 'root', id: 'tip-2', message_count: 6 })])
+
+    expect($unreadFinishedSessionIds.get()).toEqual(['tip-2'])
+
+    // Opening the rotated tip acks the lineage watermark.
+    setSelectedStoredSessionId('tip-2')
+    expect($sessionSeenCounts.get()).toEqual({ root: 6 })
+  })
+
+  it('reconstructs unread for cron rows too', () => {
+    $sessionSeenCounts.set({ cron1: 1 })
+
+    $cronSessions.set([session({ id: 'cron1', message_count: 3 })])
+
+    expect($unreadFinishedSessionIds.get()).toEqual(['cron1'])
+  })
+
+  it('never paints messaging rows from count growth, but honors live-edge markers', () => {
+    // First sight seeds…
+    $messagingSessions.set([session({ id: 'tg1', message_count: 10 })])
+    // …then inbound messages bump the count: NOT "finished — unread".
+    $messagingSessions.set([session({ id: 'tg1', message_count: 14 })])
+
+    expect($unreadFinishedSessionIds.get()).toEqual([])
+
+    // A real background turn edge still marks it, durably.
+    markSessionUnreadFinished('tg1')
+    $unreadFinishedSessionIds.set([])
+    $messagingSessions.set([session({ id: 'tg1', message_count: 14 })])
+
+    expect($unreadFinishedSessionIds.get()).toEqual(['tg1'])
+  })
+
+  it('preserves a live-edge id whose row is not in any loaded list yet', () => {
+    // A brand-new session's first turn isn't flushed to the sidebar list until
+    // persisted — the flag must survive list refreshes in the meantime.
+    markSessionUnreadFinished('fresh')
+
+    setSessions([session({ id: 'other', message_count: 2 })])
+
+    expect($unreadFinishedSessionIds.get()).toContain('fresh')
+  })
+})

--- a/apps/desktop/src/store/session-unread.test.ts
+++ b/apps/desktop/src/store/session-unread.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import type { SessionInfo } from '@/types/hermes'
 
+import { $activeGatewayProfile } from './profile'
 import {
   $cronSessions,
   $messagingSessions,
@@ -12,7 +13,12 @@ import {
   setSessions
 } from './session'
 import { clearAllSessionStates } from './session-states'
-import { $sessionSeenCounts, $unreadFinishedMarkers, markSessionUnreadFinished } from './session-unread'
+import {
+  $sessionSeenCounts,
+  $unreadFinishedMarkers,
+  forgetSessionUnread,
+  markSessionUnreadFinished
+} from './session-unread'
 
 const session = (over: Partial<SessionInfo>): SessionInfo => ({
   archived: false,
@@ -41,8 +47,9 @@ function resetAll() {
   $cronSessions.set([])
   $messagingSessions.set([])
   $selectedStoredSessionId.set(null)
+  $activeGatewayProfile.set('default')
   $sessionSeenCounts.set({})
-  $unreadFinishedMarkers.set([])
+  $unreadFinishedMarkers.set({})
   $unreadFinishedSessionIds.set([])
 }
 
@@ -52,7 +59,7 @@ describe('persisted unread (session-unread)', () => {
   it('reconstructs the green dot from a seen watermark after a cold start', () => {
     // "Restart": persisted watermark says 3 messages were seen; the freshly
     // loaded list says the session now has 5 — it finished while we were away.
-    $sessionSeenCounts.set({ s1: 3 })
+    $sessionSeenCounts.set({ default: { s1: 3 } })
 
     setSessions([session({ id: 's1', message_count: 5 })])
 
@@ -63,7 +70,7 @@ describe('persisted unread (session-unread)', () => {
     setSessions([session({ id: 's1', message_count: 5 })])
 
     expect($unreadFinishedSessionIds.get()).toEqual([])
-    expect($sessionSeenCounts.get()).toEqual({ s1: 5 })
+    expect($sessionSeenCounts.get()).toEqual({ default: { s1: 5 } })
   })
 
   it('keeps a live-edge marker across a transient wipe (gateway/profile switch)', () => {
@@ -82,15 +89,15 @@ describe('persisted unread (session-unread)', () => {
   })
 
   it('acks watermark + marker when the user opens the session', () => {
-    $sessionSeenCounts.set({ s1: 3 })
+    $sessionSeenCounts.set({ default: { s1: 3 } })
     setSessions([session({ id: 's1', message_count: 5 })])
     markSessionUnreadFinished('s1')
 
     setSelectedStoredSessionId('s1')
 
     expect($unreadFinishedSessionIds.get()).toEqual([])
-    expect($unreadFinishedMarkers.get()).toEqual([])
-    expect($sessionSeenCounts.get()).toEqual({ s1: 5 })
+    expect($unreadFinishedMarkers.get()).toEqual({})
+    expect($sessionSeenCounts.get()).toEqual({ default: { s1: 5 } })
 
     // A later refresh with the same count stays read.
     setSessions([session({ id: 's1', message_count: 5 })])
@@ -105,7 +112,7 @@ describe('persisted unread (session-unread)', () => {
     setSessions([session({ id: 's1', message_count: 7 })])
 
     expect($unreadFinishedSessionIds.get()).toEqual([])
-    expect($sessionSeenCounts.get()).toEqual({ s1: 7 })
+    expect($sessionSeenCounts.get()).toEqual({ default: { s1: 7 } })
 
     // Navigating away must not retroactively flag it.
     setSelectedStoredSessionId(null)
@@ -114,7 +121,7 @@ describe('persisted unread (session-unread)', () => {
   })
 
   it('follows auto-compression id rotation via the durable lineage id', () => {
-    $sessionSeenCounts.set({ root: 3 })
+    $sessionSeenCounts.set({ default: { root: 3 } })
 
     setSessions([session({ _lineage_root_id: 'root', id: 'tip-2', message_count: 6 })])
 
@@ -122,11 +129,11 @@ describe('persisted unread (session-unread)', () => {
 
     // Opening the rotated tip acks the lineage watermark.
     setSelectedStoredSessionId('tip-2')
-    expect($sessionSeenCounts.get()).toEqual({ root: 6 })
+    expect($sessionSeenCounts.get()).toEqual({ default: { root: 6 } })
   })
 
   it('reconstructs unread for cron rows too', () => {
-    $sessionSeenCounts.set({ cron1: 1 })
+    $sessionSeenCounts.set({ default: { cron1: 1 } })
 
     $cronSessions.set([session({ id: 'cron1', message_count: 3 })])
 
@@ -157,5 +164,82 @@ describe('persisted unread (session-unread)', () => {
     setSessions([session({ id: 'other', message_count: 2 })])
 
     expect($unreadFinishedSessionIds.get()).toContain('fresh')
+  })
+
+  it('keeps same-id sessions in different profiles independent', () => {
+    // Session ids are caller-supplied and every profile backend is its own
+    // namespace, so "s1" in alpha and "s1" in beta are different sessions —
+    // and cron/messaging lists always mix profiles into one array.
+    $sessionSeenCounts.set({ alpha: { s1: 3 }, beta: { s1: 5 } })
+    $unreadFinishedMarkers.set({ alpha: ['s1'] })
+
+    setSessions([
+      session({ id: 's1', message_count: 5, profile: 'beta' }),
+      session({ id: 's1', message_count: 5, profile: 'alpha' })
+    ])
+
+    // Only alpha's row is past its watermark; beta's sits exactly on it.
+    expect($unreadFinishedSessionIds.get()).toEqual(['s1'])
+    expect($sessionSeenCounts.get()).toEqual({ alpha: { s1: 3 }, beta: { s1: 5 } })
+
+    // Opening beta's row (the gateway is on beta) acks beta only.
+    $activeGatewayProfile.set('beta')
+    setSelectedStoredSessionId('s1')
+
+    expect($sessionSeenCounts.get()).toEqual({ alpha: { s1: 3 }, beta: { s1: 5 } })
+    // alpha's marker survives an ack of beta's identically-named session.
+    expect($unreadFinishedMarkers.get()).toEqual({ alpha: ['s1'] })
+
+    // A later refresh must not launder alpha's gap through beta's selection.
+    setSessions([
+      session({ id: 's1', message_count: 6, profile: 'beta' }),
+      session({ id: 's1', message_count: 5, profile: 'alpha' })
+    ])
+
+    expect($sessionSeenCounts.get()).toEqual({ alpha: { s1: 3 }, beta: { s1: 6 } })
+    expect($unreadFinishedMarkers.get()).toEqual({ alpha: ['s1'] })
+  })
+
+  it('files a live-edge marker with no loaded row under the active gateway profile', () => {
+    $activeGatewayProfile.set('work')
+
+    markSessionUnreadFinished('fresh')
+
+    expect($unreadFinishedMarkers.get()).toEqual({ work: ['fresh'] })
+    expect($unreadFinishedSessionIds.get()).toEqual(['fresh'])
+  })
+
+  it('forgets a deleted session’s persisted unread, per profile', () => {
+    $sessionSeenCounts.set({ alpha: { root: 3, other: 1 }, beta: { root: 9 } })
+    $unreadFinishedMarkers.set({ alpha: ['root', 'keep'], beta: ['root'] })
+    $unreadFinishedSessionIds.set(['tip-2'])
+
+    forgetSessionUnread(['tip-2', 'root', null, undefined], 'alpha')
+
+    expect($sessionSeenCounts.get()).toEqual({ alpha: { other: 1 }, beta: { root: 9 } })
+    expect($unreadFinishedMarkers.get()).toEqual({ alpha: ['keep'], beta: ['root'] })
+    expect($unreadFinishedSessionIds.get()).toEqual([])
+  })
+
+  it('drops an emptied profile bucket instead of persisting an empty shell', () => {
+    $sessionSeenCounts.set({ alpha: { s1: 3 } })
+    $unreadFinishedMarkers.set({ alpha: ['s1'] })
+
+    forgetSessionUnread(['s1'], 'alpha')
+
+    expect($sessionSeenCounts.get()).toEqual({})
+    expect($unreadFinishedMarkers.get()).toEqual({})
+  })
+
+  it('caps markers per profile, evicting the oldest', () => {
+    for (let i = 0; i < 201; i += 1) {
+      markSessionUnreadFinished(`s${i}`)
+    }
+
+    const markers = $unreadFinishedMarkers.get().default
+
+    expect(markers).toHaveLength(200)
+    expect(markers[0]).toBe('s1')
+    expect(markers.at(-1)).toBe('s200')
   })
 })

--- a/apps/desktop/src/store/session-unread.ts
+++ b/apps/desktop/src/store/session-unread.ts
@@ -1,0 +1,281 @@
+import { Codecs, persistentAtom } from '@/lib/persisted'
+import { stableArray } from '@/lib/stable-array'
+import type { SessionInfo } from '@/types/hermes'
+
+import {
+  $cronSessions,
+  $messagingSessions,
+  $selectedStoredSessionId,
+  $sessions,
+  $unreadFinishedSessionIds,
+  sessionMatchesStoredId,
+  sessionPinId
+} from './session'
+
+/**
+ * PERSISTED UNREAD ("finished — unread" green dot) — the durable layer under
+ * the transient `$unreadFinishedSessionIds` atom, ported from the webui's
+ * proven design (sessions.js: viewed-count watermarks + completion markers).
+ *
+ * Two persisted records, both keyed by the DURABLE lineage id (sessionPinId)
+ * so state survives auto-compression's session-id rotation — same rule as
+ * `$sessionColorOverrides`:
+ *
+ *  1. SEEN WATERMARKS — the message_count last acknowledged for a session
+ *     (set when the user opens it, kept current while it stays selected, and
+ *     seeded on FIRST SIGHT of an unknown session so a fresh install doesn't
+ *     paint every row green). A row whose live `message_count` exceeds its
+ *     watermark is unread — this is what reconstructs the green dot for a
+ *     session that finished while the app was CLOSED, which the live
+ *     busy→idle edge in session-states.ts can never replay after a restart.
+ *
+ *  2. EXPLICIT MARKERS — the live busy→idle edge, persisted. Covers the gap
+ *     where a turn finishes in the background but the sidebar list hasn't
+ *     refreshed its message_count yet (and any completion that adds no
+ *     stored messages), so a restart right after a finish keeps the dot.
+ *
+ * Keys are durable ids WITHOUT profile scoping on purpose: session ids are
+ * unique across profiles, and unread only ever PAINTS for rows present in the
+ * loaded lists (which are profile-scoped), so another profile's markers stay
+ * dormant instead of leaking — and survive a profile round-trip (the webui
+ * needed explicit per-profile scoping, commit 1a64fc68, because its markers
+ * painted by id lookup alone).
+ *
+ * Scope of watermark-based unread: chat + cron rows. Messaging rows get their
+ * message_count bumped by inbound human messages, so count-over-watermark
+ * would paint "finished — unread" on every new inbound text; they keep only
+ * the explicit live-edge markers (now persisted across restarts too).
+ */
+
+export const $sessionSeenCounts = persistentAtom<Record<string, number>>(
+  'hermes.desktop.sessionSeenCounts',
+  {},
+  Codecs.json(sanitizeSeenCounts)
+)
+
+export const $unreadFinishedMarkers = persistentAtom<string[]>(
+  'hermes.desktop.unreadFinishedSessions',
+  [],
+  Codecs.stringArray
+)
+
+function sanitizeSeenCounts(value: unknown): Record<string, number> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {}
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, number] => typeof entry[1] === 'number' && Number.isFinite(entry[1])
+    )
+  )
+}
+
+// Watermarks accrete one entry per session ever seen; keep the record bounded.
+// Past the cap, entries for sessions no longer in any loaded list (and not
+// explicitly marked) are dropped — a pruned session reseeds on next sight,
+// which reads as "not unread", the safe default.
+const SEEN_COUNTS_CAP = 2000
+
+const rowsFor = (lists: readonly SessionInfo[][]): SessionInfo[] => lists.flat()
+
+const isSelected = (row: SessionInfo, selected: null | string): boolean =>
+  Boolean(selected && sessionMatchesStoredId(row, selected))
+
+/** Durable id for a stored id, when the row is loaded; the stored id itself
+ *  otherwise (sessionPinId falls back to the live id anyway). */
+function durableIdForStoredId(storedSessionId: string): string {
+  const row = rowsFor([$sessions.get(), $cronSessions.get(), $messagingSessions.get()]).find(s =>
+    sessionMatchesStoredId(s, storedSessionId)
+  )
+
+  return row ? sessionPinId(row) : storedSessionId
+}
+
+/** LIVE-EDGE WRITER — called by session-states.ts on a background busy→idle
+ *  transition. Flags the transient atom (immediate paint) AND persists the
+ *  marker so the dot survives a restart. */
+export function markSessionUnreadFinished(storedSessionId: string): void {
+  const current = $unreadFinishedSessionIds.get()
+
+  if (!current.includes(storedSessionId)) {
+    $unreadFinishedSessionIds.set([...current, storedSessionId])
+  }
+
+  const durableId = durableIdForStoredId(storedSessionId)
+  const markers = $unreadFinishedMarkers.get()
+
+  if (!markers.includes(durableId)) {
+    $unreadFinishedMarkers.set([...markers, durableId])
+  }
+}
+
+/** ACK — the user opened (or is looking at) this session: watermark := its
+ *  current message_count, and any explicit marker is retired. */
+function ackSessionRow(row: SessionInfo): void {
+  const durableId = sessionPinId(row)
+
+  if (Number.isFinite(row.message_count)) {
+    const seen = $sessionSeenCounts.get()
+
+    if (seen[durableId] !== row.message_count) {
+      $sessionSeenCounts.set({ ...seen, [durableId]: row.message_count })
+    }
+  }
+
+  const markers = $unreadFinishedMarkers.get()
+  const next = markers.filter(id => id !== durableId && !sessionMatchesStoredId(row, id))
+
+  if (next.length !== markers.length) {
+    $unreadFinishedMarkers.set(next)
+  }
+}
+
+/** Clear persisted unread for a stored id even when its row isn't loaded —
+ *  the marker alone can be retired; the watermark needs the row's count. */
+export function ackStoredSessionId(storedSessionId: null | string): void {
+  if (!storedSessionId) {
+    return
+  }
+
+  const row = rowsFor([$sessions.get(), $cronSessions.get(), $messagingSessions.get()]).find(s =>
+    sessionMatchesStoredId(s, storedSessionId)
+  )
+
+  if (row) {
+    ackSessionRow(row)
+
+    return
+  }
+
+  const markers = $unreadFinishedMarkers.get()
+  const next = markers.filter(id => id !== storedSessionId)
+
+  if (next.length !== markers.length) {
+    $unreadFinishedMarkers.set(next)
+  }
+}
+
+/** Seed/refresh watermarks from freshly loaded lists: the SELECTED session
+ *  tracks its live count (it's on screen — nothing there is unread), and a
+ *  session never seen before seeds at its current count instead of lighting
+ *  up green on first sight. Known, unselected rows are left alone — the gap
+ *  between their watermark and live count IS the unread signal. */
+function ingestRows(rows: readonly SessionInfo[]): void {
+  const selected = $selectedStoredSessionId.get()
+  const seen = $sessionSeenCounts.get()
+  let next: null | Record<string, number> = null
+
+  for (const row of rows) {
+    if (!Number.isFinite(row.message_count)) {
+      continue
+    }
+
+    const durableId = sessionPinId(row)
+
+    if (isSelected(row, selected)) {
+      if (seen[durableId] !== row.message_count) {
+        ;(next ??= { ...seen })[durableId] = row.message_count
+      }
+
+      // Any lingering explicit marker for the on-screen session is stale.
+      const markers = $unreadFinishedMarkers.get()
+      const kept = markers.filter(id => id !== durableId && !sessionMatchesStoredId(row, id))
+
+      if (kept.length !== markers.length) {
+        $unreadFinishedMarkers.set(kept)
+      }
+    } else if (!(durableId in seen) && !(next && durableId in next)) {
+      ;(next ??= { ...seen })[durableId] = row.message_count
+    }
+  }
+
+  if (next) {
+    $sessionSeenCounts.set(pruneSeenCounts(next, rows))
+  }
+}
+
+function pruneSeenCounts(seen: Record<string, number>, rows: readonly SessionInfo[]): Record<string, number> {
+  const keys = Object.keys(seen)
+
+  if (keys.length <= SEEN_COUNTS_CAP) {
+    return seen
+  }
+
+  const keep = new Set<string>($unreadFinishedMarkers.get())
+
+  for (const row of rows) {
+    keep.add(sessionPinId(row))
+  }
+
+  return Object.fromEntries(keys.filter(key => keep.has(key)).map(key => [key, seen[key]]))
+}
+
+/** Recompute the transient unread atom from persisted state + loaded rows.
+ *  Runs after every list refresh — including the first one after a cold
+ *  start, which is what brings green dots back from a restart. Stored ids
+ *  already flagged by the live edge but not (yet) present in any list — a
+ *  brand-new session's first turn isn't flushed to the list until persisted —
+ *  are preserved, not dropped. */
+function recomputeUnread(): void {
+  const selected = $selectedStoredSessionId.get()
+  const markers = $unreadFinishedMarkers.get()
+  const seen = $sessionSeenCounts.get()
+  const unread: string[] = []
+
+  // Watermark + marker unread for chat and cron rows.
+  for (const row of rowsFor([$sessions.get(), $cronSessions.get()])) {
+    if (isSelected(row, selected)) {
+      continue
+    }
+
+    const durableId = sessionPinId(row)
+    const watermark = seen[durableId]
+
+    const exceedsWatermark =
+      typeof watermark === 'number' && Number.isFinite(row.message_count) && row.message_count > watermark
+
+    if (exceedsWatermark || markers.includes(durableId) || markers.includes(row.id)) {
+      unread.push(row.id)
+    }
+  }
+
+  // Messaging rows: explicit (live-edge) markers only — see header comment.
+  for (const row of $messagingSessions.get()) {
+    if (!isSelected(row, selected) && (markers.includes(sessionPinId(row)) || markers.includes(row.id))) {
+      unread.push(row.id)
+    }
+  }
+
+  // Preserve live-edge ids whose row isn't loaded yet.
+  const loadedRows = rowsFor([$sessions.get(), $cronSessions.get(), $messagingSessions.get()])
+
+  for (const id of $unreadFinishedSessionIds.get()) {
+    if (id !== selected && !unread.includes(id) && !loadedRows.some(row => sessionMatchesStoredId(row, id))) {
+      unread.push(id)
+    }
+  }
+
+  const current = $unreadFinishedSessionIds.get()
+  const next = stableArray(current, unread)
+
+  if (next !== current) {
+    $unreadFinishedSessionIds.set([...next])
+  }
+}
+
+function onListChange(): void {
+  ingestRows(rowsFor([$sessions.get(), $cronSessions.get(), $messagingSessions.get()]))
+  recomputeUnread()
+}
+
+// Wiring: module-scope listeners, same pattern as session-states.ts's
+// $selectedStoredSessionId listener. Loaded via session-states.ts (the live
+// edge imports markSessionUnreadFinished), so it's active wherever unread is.
+$sessions.listen(onListChange)
+$cronSessions.listen(onListChange)
+$messagingSessions.listen(onListChange)
+
+// Opening a session acks it durably (the transient atom is already cleared
+// synchronously by setSelectedStoredSessionId — this is the persisted half).
+$selectedStoredSessionId.listen(ackStoredSessionId)

--- a/apps/desktop/src/store/session-unread.ts
+++ b/apps/desktop/src/store/session-unread.ts
@@ -1,5 +1,7 @@
 import { Codecs, persistentAtom } from '@/lib/persisted'
 import { stableArray } from '@/lib/stable-array'
+import { readKey } from '@/lib/storage'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import type { SessionInfo } from '@/types/hermes'
 
 import {
@@ -11,15 +13,16 @@ import {
   sessionMatchesStoredId,
   sessionPinId
 } from './session'
+import { isSecondaryWindow } from './windows'
 
 /**
  * PERSISTED UNREAD ("finished — unread" green dot) — the durable layer under
  * the transient `$unreadFinishedSessionIds` atom, ported from the webui's
  * proven design (sessions.js: viewed-count watermarks + completion markers).
  *
- * Two persisted records, both keyed by the DURABLE lineage id (sessionPinId)
- * so state survives auto-compression's session-id rotation — same rule as
- * `$sessionColorOverrides`:
+ * Two persisted records, both bucketed BY PROFILE and then keyed by the
+ * DURABLE lineage id (sessionPinId) so state survives auto-compression's
+ * session-id rotation — same durable-id rule as `$sessionColorOverrides`:
  *
  *  1. SEEN WATERMARKS — the message_count last acknowledged for a session
  *     (set when the user opens it, kept current while it stays selected, and
@@ -34,12 +37,20 @@ import {
  *     refreshed its message_count yet (and any completion that adds no
  *     stored messages), so a restart right after a finish keeps the dot.
  *
- * Keys are durable ids WITHOUT profile scoping on purpose: session ids are
- * unique across profiles, and unread only ever PAINTS for rows present in the
- * loaded lists (which are profile-scoped), so another profile's markers stay
- * dormant instead of leaking — and survive a profile round-trip (the webui
- * needed explicit per-profile scoping, commit 1a64fc68, because its markers
- * painted by id lookup alone).
+ * PROFILE SCOPING is not optional: session ids are caller-supplied and each
+ * remote-profile backend is its own namespace, so two profiles can hold the
+ * same id — and the lists routinely mix profiles (cron/messaging are ALWAYS
+ * cross-profile, `$sessions` is too in all-profiles mode). Unscoped keys let
+ * one profile's watermark/marker paint (or silence) another's row. The bucket
+ * is always the ROW's own `profile` (normalizeProfileKey, absent → "default"),
+ * never the live gateway's — except for the live busy→idle edge with no loaded
+ * row, which only ever fires for the ACTIVE gateway's runtimes and therefore
+ * falls back to `$activeGatewayProfile`.
+ *
+ * Both records are BOUNDED: markers cap per profile (oldest evicted),
+ * watermarks cap in total (unlisted, unmarked entries dropped first), and
+ * deleting/archiving a session drops its entries outright via
+ * {@link forgetSessionUnread}.
  *
  * Scope of watermark-based unread: chat + cron rows. Messaging rows get their
  * message_count bumped by inbound human messages, so count-over-watermark
@@ -47,28 +58,79 @@ import {
  * the explicit live-edge markers (now persisted across restarts too).
  */
 
-export const $sessionSeenCounts = persistentAtom<Record<string, number>>(
+/** profile key → durable id → last acknowledged message_count. */
+type SeenCounts = Record<string, Record<string, number>>
+
+/** profile key → durable ids flagged by the live busy→idle edge. */
+type Markers = Record<string, string[]>
+
+export const $sessionSeenCounts = persistentAtom<SeenCounts>(
   'hermes.desktop.sessionSeenCounts',
   {},
   Codecs.json(sanitizeSeenCounts)
 )
 
-export const $unreadFinishedMarkers = persistentAtom<string[]>(
+export const $unreadFinishedMarkers = persistentAtom<Markers>(
   'hermes.desktop.unreadFinishedSessions',
-  [],
-  Codecs.stringArray
+  {},
+  Codecs.json(sanitizeMarkers)
 )
 
-function sanitizeSeenCounts(value: unknown): Record<string, number> {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+
+// Also the migration: a pre-profile-scoping flat record (durable id → number)
+// has non-object values, so it drops wholesale rather than mis-attributing
+// every id to a profile named after it. Dropped watermarks reseed on next
+// sight, which reads as "not unread" — the safe default.
+function sanitizeSeenCounts(value: unknown): SeenCounts {
+  if (!isPlainRecord(value)) {
     return {}
   }
 
-  return Object.fromEntries(
-    Object.entries(value).filter(
-      (entry): entry is [string, number] => typeof entry[1] === 'number' && Number.isFinite(entry[1])
+  const next: SeenCounts = {}
+
+  for (const [profile, bucket] of Object.entries(value)) {
+    if (!isPlainRecord(bucket)) {
+      continue
+    }
+
+    const counts = Object.fromEntries(
+      Object.entries(bucket).filter(
+        (entry): entry is [string, number] => typeof entry[1] === 'number' && Number.isFinite(entry[1])
+      )
     )
-  )
+
+    if (Object.keys(counts).length) {
+      next[profile] = counts
+    }
+  }
+
+  return next
+}
+
+// Same story for markers: the legacy flat shape was a bare string[], which is
+// not an object of arrays, so it decodes to {}.
+function sanitizeMarkers(value: unknown): Markers {
+  if (!isPlainRecord(value)) {
+    return {}
+  }
+
+  const next: Markers = {}
+
+  for (const [profile, bucket] of Object.entries(value)) {
+    if (!Array.isArray(bucket)) {
+      continue
+    }
+
+    const ids = bucket.filter((id): id is string => typeof id === 'string' && id.length > 0)
+
+    if (ids.length) {
+      next[profile] = ids
+    }
+  }
+
+  return next
 }
 
 // Watermarks accrete one entry per session ever seen; keep the record bounded.
@@ -77,24 +139,67 @@ function sanitizeSeenCounts(value: unknown): Record<string, number> {
 // which reads as "not unread", the safe default.
 const SEEN_COUNTS_CAP = 2000
 
+// Markers only matter while their session still exists, and a marker whose
+// session is gone is invisible (nothing paints it) but immortal — deletes we
+// never observed (another client, a wiped backend) would accrete forever. Cap
+// per profile and evict oldest-first: the freshest finishes are the ones the
+// user still cares about.
+const MARKERS_CAP = 200
+
 const rowsFor = (lists: readonly SessionInfo[][]): SessionInfo[] => lists.flat()
 
 const isSelected = (row: SessionInfo, selected: null | string): boolean =>
   Boolean(selected && sessionMatchesStoredId(row, selected))
 
-/** Durable id for a stored id, when the row is loaded; the stored id itself
- *  otherwise (sessionPinId falls back to the live id anyway). */
-function durableIdForStoredId(storedSessionId: string): string {
-  const row = rowsFor([$sessions.get(), $cronSessions.get(), $messagingSessions.get()]).find(s =>
-    sessionMatchesStoredId(s, storedSessionId)
+/** The persistence bucket a row belongs to — its OWN profile, never the live
+ *  gateway's (the lists are routinely cross-profile). */
+const profileKeyForRow = (row: SessionInfo): string => normalizeProfileKey(row.profile)
+
+/** The row a bare stored id refers to. Ids are caller-supplied and each
+ *  profile's backend is its own namespace, so two profiles can hold the same
+ *  id; a tie breaks toward the live gateway, since both opening a session and
+ *  running one swap the gateway onto that session's profile. */
+function resolveLoadedRow(storedSessionId: string): SessionInfo | undefined {
+  const matches = rowsFor([$sessions.get(), $cronSessions.get(), $messagingSessions.get()]).filter(row =>
+    sessionMatchesStoredId(row, storedSessionId)
   )
 
-  return row ? sessionPinId(row) : storedSessionId
+  if (matches.length < 2) {
+    return matches[0]
+  }
+
+  const gateway = normalizeProfileKey($activeGatewayProfile.get())
+
+  return matches.find(row => profileKeyForRow(row) === gateway) ?? matches[0]
+}
+
+/** Bucket for a bare stored id: its row's profile, else the live gateway's. */
+const resolveProfile = (storedSessionId: string): string => {
+  const row = resolveLoadedRow(storedSessionId)
+
+  return row ? profileKeyForRow(row) : normalizeProfileKey($activeGatewayProfile.get())
+}
+
+/** Write a profile's marker bucket, dropping the key when it empties so we
+ *  don't persist a graveyard of `[]`. */
+function setMarkerBucket(profile: string, ids: readonly string[]): void {
+  const markers = $unreadFinishedMarkers.get()
+  const next = { ...markers }
+
+  if (ids.length) {
+    next[profile] = [...ids]
+  } else {
+    delete next[profile]
+  }
+
+  $unreadFinishedMarkers.set(next)
 }
 
 /** LIVE-EDGE WRITER — called by session-states.ts on a background busy→idle
  *  transition. Flags the transient atom (immediate paint) AND persists the
- *  marker so the dot survives a restart. */
+ *  marker so the dot survives a restart. The marker lands in the row's own
+ *  profile; with no loaded row we use the active gateway's profile, which is
+ *  the only place a live edge can come from. */
 export function markSessionUnreadFinished(storedSessionId: string): void {
   const current = $unreadFinishedSessionIds.get()
 
@@ -102,45 +207,60 @@ export function markSessionUnreadFinished(storedSessionId: string): void {
     $unreadFinishedSessionIds.set([...current, storedSessionId])
   }
 
-  const durableId = durableIdForStoredId(storedSessionId)
-  const markers = $unreadFinishedMarkers.get()
+  const row = resolveLoadedRow(storedSessionId)
+  const profile = row ? profileKeyForRow(row) : normalizeProfileKey($activeGatewayProfile.get())
+  const durableId = row ? sessionPinId(row) : storedSessionId
+  const bucket = $unreadFinishedMarkers.get()[profile] ?? []
 
-  if (!markers.includes(durableId)) {
-    $unreadFinishedMarkers.set([...markers, durableId])
+  if (bucket.includes(durableId)) {
+    return
   }
+
+  const next = [...bucket, durableId]
+
+  setMarkerBucket(profile, next.length > MARKERS_CAP ? next.slice(next.length - MARKERS_CAP) : next)
 }
 
 /** ACK — the user opened (or is looking at) this session: watermark := its
  *  current message_count, and any explicit marker is retired. */
 function ackSessionRow(row: SessionInfo): void {
+
+  const profile = profileKeyForRow(row)
   const durableId = sessionPinId(row)
 
   if (Number.isFinite(row.message_count)) {
     const seen = $sessionSeenCounts.get()
+    const bucket = seen[profile]
 
-    if (seen[durableId] !== row.message_count) {
-      $sessionSeenCounts.set({ ...seen, [durableId]: row.message_count })
+    if (bucket?.[durableId] !== row.message_count) {
+      $sessionSeenCounts.set({ ...seen, [profile]: { ...bucket, [durableId]: row.message_count } })
     }
   }
 
-  const markers = $unreadFinishedMarkers.get()
+  const markers = $unreadFinishedMarkers.get()[profile]
+
+  if (!markers) {
+    return
+  }
+
   const next = markers.filter(id => id !== durableId && !sessionMatchesStoredId(row, id))
 
   if (next.length !== markers.length) {
-    $unreadFinishedMarkers.set(next)
+    setMarkerBucket(profile, next)
   }
 }
 
 /** Clear persisted unread for a stored id even when its row isn't loaded —
- *  the marker alone can be retired; the watermark needs the row's count. */
+ *  the marker alone can be retired; the watermark needs the row's count. With
+ *  no row there is no profile to read, so we retire it from the active
+ *  gateway's bucket (the profile whose sessions you can actually be opening);
+ *  other profiles' identically-named ids stay untouched. */
 export function ackStoredSessionId(storedSessionId: null | string): void {
   if (!storedSessionId) {
     return
   }
 
-  const row = rowsFor([$sessions.get(), $cronSessions.get(), $messagingSessions.get()]).find(s =>
-    sessionMatchesStoredId(s, storedSessionId)
-  )
+  const row = resolveLoadedRow(storedSessionId)
 
   if (row) {
     ackSessionRow(row)
@@ -148,11 +268,69 @@ export function ackStoredSessionId(storedSessionId: null | string): void {
     return
   }
 
-  const markers = $unreadFinishedMarkers.get()
+  const profile = normalizeProfileKey($activeGatewayProfile.get())
+  const markers = $unreadFinishedMarkers.get()[profile]
+
+  if (!markers) {
+    return
+  }
+
   const next = markers.filter(id => id !== storedSessionId)
 
   if (next.length !== markers.length) {
-    $unreadFinishedMarkers.set(next)
+    setMarkerBucket(profile, next)
+  }
+}
+
+/** DELETE/ARCHIVE CLEANUP — the session is gone from the user's world, so its
+ *  watermark and marker are dead weight. Drops every candidate id (stored id,
+ *  live id, lineage root) from both persisted records in `profile`'s bucket
+ *  and from the transient atom. Same-id sessions in other profiles survive. */
+export function forgetSessionUnread(
+  candidateIds: readonly (null | string | undefined)[],
+  profile?: null | string
+): void {
+  const ids = new Set(candidateIds.filter((id): id is string => Boolean(id)))
+
+  if (!ids.size) {
+    return
+  }
+
+  const key = normalizeProfileKey(profile)
+  const seen = $sessionSeenCounts.get()
+  const counts = seen[key]
+
+  if (counts) {
+    const kept = Object.fromEntries(Object.entries(counts).filter(([id]) => !ids.has(id)))
+
+    if (Object.keys(kept).length !== Object.keys(counts).length) {
+      const next = { ...seen }
+
+      if (Object.keys(kept).length) {
+        next[key] = kept
+      } else {
+        delete next[key]
+      }
+
+      $sessionSeenCounts.set(next)
+    }
+  }
+
+  const markers = $unreadFinishedMarkers.get()[key]
+
+  if (markers) {
+    const kept = markers.filter(id => !ids.has(id))
+
+    if (kept.length !== markers.length) {
+      setMarkerBucket(key, kept)
+    }
+  }
+
+  const current = $unreadFinishedSessionIds.get()
+  const nextIds = current.filter(id => !ids.has(id))
+
+  if (nextIds.length !== current.length) {
+    $unreadFinishedSessionIds.set(nextIds)
   }
 }
 
@@ -163,30 +341,43 @@ export function ackStoredSessionId(storedSessionId: null | string): void {
  *  between their watermark and live count IS the unread signal. */
 function ingestRows(rows: readonly SessionInfo[]): void {
   const selected = $selectedStoredSessionId.get()
+  // Only the OWNING profile's row counts as on-screen: a same-id row in
+  // another profile is a different session and keeps its unread gap.
+  const selectedProfile = selected ? resolveProfile(selected) : null
   const seen = $sessionSeenCounts.get()
-  let next: null | Record<string, number> = null
+  let next: null | SeenCounts = null
+
+  const write = (profile: string, durableId: string, count: number): void => {
+    next ??= { ...seen }
+    next[profile] = { ...next[profile], [durableId]: count }
+  }
 
   for (const row of rows) {
     if (!Number.isFinite(row.message_count)) {
       continue
     }
 
+    const profile = profileKeyForRow(row)
     const durableId = sessionPinId(row)
+    const bucket = next?.[profile] ?? seen[profile]
 
-    if (isSelected(row, selected)) {
-      if (seen[durableId] !== row.message_count) {
-        ;(next ??= { ...seen })[durableId] = row.message_count
+    if (profile === selectedProfile && isSelected(row, selected)) {
+      if (bucket?.[durableId] !== row.message_count) {
+        write(profile, durableId, row.message_count)
       }
 
       // Any lingering explicit marker for the on-screen session is stale.
-      const markers = $unreadFinishedMarkers.get()
-      const kept = markers.filter(id => id !== durableId && !sessionMatchesStoredId(row, id))
+      const markers = $unreadFinishedMarkers.get()[profile]
 
-      if (kept.length !== markers.length) {
-        $unreadFinishedMarkers.set(kept)
+      if (markers) {
+        const kept = markers.filter(id => id !== durableId && !sessionMatchesStoredId(row, id))
+
+        if (kept.length !== markers.length) {
+          setMarkerBucket(profile, kept)
+        }
       }
-    } else if (!(durableId in seen) && !(next && durableId in next)) {
-      ;(next ??= { ...seen })[durableId] = row.message_count
+    } else if (!bucket || !(durableId in bucket)) {
+      write(profile, durableId, row.message_count)
     }
   }
 
@@ -195,20 +386,43 @@ function ingestRows(rows: readonly SessionInfo[]): void {
   }
 }
 
-function pruneSeenCounts(seen: Record<string, number>, rows: readonly SessionInfo[]): Record<string, number> {
-  const keys = Object.keys(seen)
+function pruneSeenCounts(seen: SeenCounts, rows: readonly SessionInfo[]): SeenCounts {
+  const total = Object.values(seen).reduce((sum, bucket) => sum + Object.keys(bucket).length, 0)
 
-  if (keys.length <= SEEN_COUNTS_CAP) {
+  if (total <= SEEN_COUNTS_CAP) {
     return seen
   }
 
-  const keep = new Set<string>($unreadFinishedMarkers.get())
+  const markers = $unreadFinishedMarkers.get()
+  const keep = new Map<string, Set<string>>()
 
-  for (const row of rows) {
-    keep.add(sessionPinId(row))
+  const keepFor = (profile: string): Set<string> => {
+    let ids = keep.get(profile)
+
+    if (!ids) {
+      ids = new Set(markers[profile] ?? [])
+      keep.set(profile, ids)
+    }
+
+    return ids
   }
 
-  return Object.fromEntries(keys.filter(key => keep.has(key)).map(key => [key, seen[key]]))
+  for (const row of rows) {
+    keepFor(profileKeyForRow(row)).add(sessionPinId(row))
+  }
+
+  const next: SeenCounts = {}
+
+  for (const [profile, bucket] of Object.entries(seen)) {
+    const allowed = keepFor(profile)
+    const kept = Object.fromEntries(Object.entries(bucket).filter(([id]) => allowed.has(id)))
+
+    if (Object.keys(kept).length) {
+      next[profile] = kept
+    }
+  }
+
+  return next
 }
 
 /** Recompute the transient unread atom from persisted state + loaded rows.
@@ -223,26 +437,35 @@ function recomputeUnread(): void {
   const seen = $sessionSeenCounts.get()
   const unread: string[] = []
 
-  // Watermark + marker unread for chat and cron rows.
+  const isMarked = (row: SessionInfo, durableId: string): boolean => {
+    const bucket = markers[profileKeyForRow(row)]
+
+    return Boolean(bucket?.includes(durableId) || bucket?.includes(row.id))
+  }
+
+  // Watermark + marker unread for chat and cron rows. The selected skip stays
+  // profile-blind here (unlike the persisted writes): the paint layer is keyed
+  // by row id, so dotting a same-id row from another profile would just put a
+  // dot on the session you have open.
   for (const row of rowsFor([$sessions.get(), $cronSessions.get()])) {
     if (isSelected(row, selected)) {
       continue
     }
 
     const durableId = sessionPinId(row)
-    const watermark = seen[durableId]
+    const watermark = seen[profileKeyForRow(row)]?.[durableId]
 
     const exceedsWatermark =
       typeof watermark === 'number' && Number.isFinite(row.message_count) && row.message_count > watermark
 
-    if (exceedsWatermark || markers.includes(durableId) || markers.includes(row.id)) {
+    if (exceedsWatermark || isMarked(row, durableId)) {
       unread.push(row.id)
     }
   }
 
   // Messaging rows: explicit (live-edge) markers only — see header comment.
   for (const row of $messagingSessions.get()) {
-    if (!isSelected(row, selected) && (markers.includes(sessionPinId(row)) || markers.includes(row.id))) {
+    if (!isSelected(row, selected) && isMarked(row, sessionPinId(row))) {
       unread.push(row.id)
     }
   }
@@ -264,7 +487,53 @@ function recomputeUnread(): void {
   }
 }
 
+// COLD-BOOT REHYDRATE — module evaluation can race Chromium's storage-area
+// load: an early read comes back empty, the atoms seed their fallbacks, and
+// the first ingest would then re-seed every row and write that emptiness
+// back over the real record. By the time the first session list arrives
+// (seconds later, over IPC) storage is reliably readable, so re-read both
+// keys once right before the first ingest and adopt the disk state, keeping
+// any entry this window already wrote in the meantime (a live edge or an
+// ack beats the stale disk copy for its own key).
+let rehydratedFromDisk = false
+
+function rehydrateFromDiskOnce(): void {
+  if (rehydratedFromDisk) {
+    return
+  }
+
+  rehydratedFromDisk = true
+
+  try {
+    const rawSeen = readKey('hermes.desktop.sessionSeenCounts')
+    const diskSeen = rawSeen ? sanitizeSeenCounts(JSON.parse(rawSeen) as unknown) : {}
+    const memorySeen = $sessionSeenCounts.get()
+    const mergedSeen: SeenCounts = { ...diskSeen }
+
+    for (const [profile, bucket] of Object.entries(memorySeen)) {
+      mergedSeen[profile] = { ...mergedSeen[profile], ...bucket }
+    }
+
+    $sessionSeenCounts.set(mergedSeen)
+
+    const rawMarkers = readKey('hermes.desktop.unreadFinishedSessions')
+    const diskMarkers = rawMarkers ? sanitizeMarkers(JSON.parse(rawMarkers) as unknown) : {}
+    const memoryMarkers = $unreadFinishedMarkers.get()
+    const merged: Markers = { ...diskMarkers }
+
+    for (const [profile, ids] of Object.entries(memoryMarkers)) {
+      merged[profile] = [...new Set([...(merged[profile] ?? []), ...ids])]
+    }
+
+    $unreadFinishedMarkers.set(merged)
+  } catch {
+    // Unreadable storage: keep the in-memory state — same fallback the
+    // atoms started from.
+  }
+}
+
 function onListChange(): void {
+  rehydrateFromDiskOnce()
   ingestRows(rowsFor([$sessions.get(), $cronSessions.get(), $messagingSessions.get()]))
   recomputeUnread()
 }
@@ -272,10 +541,16 @@ function onListChange(): void {
 // Wiring: module-scope listeners, same pattern as session-states.ts's
 // $selectedStoredSessionId listener. Loaded via session-states.ts (the live
 // edge imports markSessionUnreadFinished), so it's active wherever unread is.
-$sessions.listen(onListChange)
-$cronSessions.listen(onListChange)
-$messagingSessions.listen(onListChange)
+// ONLY the primary window maintains the persisted records: a secondary window
+// (single-chat pop-out, watch window) sees a sliver of the session lists, and
+// letting it seed/ack against that partial view would clobber the primary's
+// whole-record writes — same isolation rule as the persisted session tiles.
+if (!isSecondaryWindow()) {
+  $sessions.listen(onListChange)
+  $cronSessions.listen(onListChange)
+  $messagingSessions.listen(onListChange)
 
-// Opening a session acks it durably (the transient atom is already cleared
-// synchronously by setSelectedStoredSessionId — this is the persisted half).
-$selectedStoredSessionId.listen(ackStoredSessionId)
+  // Opening a session acks it durably (the transient atom is already cleared
+  // synchronously by setSelectedStoredSessionId — this is the persisted half).
+  $selectedStoredSessionId.listen(ackStoredSessionId)
+}

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -429,8 +429,13 @@ export const setActiveSessionId = (next: Updater<string | null>) => updateAtom($
 export const setActiveSessionStoredIdRotation = (next: Updater<ActiveSessionStoredIdRotation | null>) =>
   updateAtom($activeSessionStoredIdRotation, next)
 
-// Transient: a background session finished and the user hasn't opened it since.
-// Written by session-states.ts (handleTransition), cleared here on session open.
+// A background session finished and the user hasn't opened it since. This atom
+// is the transient PAINT layer (what the dots subscribe to); durability lives
+// in session-unread.ts, which persists explicit finish markers + per-session
+// "seen message_count" watermarks and rebuilds this atom from them on every
+// list refresh — so the green dot survives an app restart, and a session that
+// finished while the app was CLOSED still comes up unread. Written by
+// session-states.ts (live busy→idle edge), cleared here on session open.
 export const $unreadFinishedSessionIds = atom<string[]>([])
 
 export const setSelectedStoredSessionId = (next: Updater<string | null>) => {


### PR DESCRIPTION
## Problem

The green "finished — unread" sidebar dot resets to gray whenever the desktop app is closed and reopened. The unread flag lived only in the in-memory `$unreadFinishedSessionIds` atom, set exclusively by a live busy→idle transition the renderer had to observe — so a restart wiped it, and a session that finished while the app was closed could never be flagged at all. (User-assigned dot colors already survived restarts via `persistentAtom`; unread state was the one transient piece.)

## Fix

New persisted layer in `apps/desktop/src/store/session-unread.ts`, ported from the webui's proven watermark design (`hermes-webui/static/sessions.js`):

- **Seen watermarks** (`hermes.desktop.sessionSeenCounts`) — the `message_count` last acknowledged per session, keyed by the durable lineage id (`sessionPinId`, same rule as session colors so compression id-rotation is survived). A row whose live count exceeds its watermark paints unread on every list refresh — this rebuilds dots after a restart **and** flags sessions that finished while the app was closed. First sight of an unknown session seeds the watermark, so a fresh install doesn't light up every row.
- **Explicit finish markers** (`hermes.desktop.unreadFinishedSessions`) — the live busy→idle edge, now persisted, covering the gap before the sidebar list refreshes its counts.

Behavior details:
- Opening a session acks both records; the selected session's watermark tracks its live count, so on-screen activity never reads as unread.
- Chat + cron rows get full watermark treatment; messaging rows keep explicit markers only (inbound human messages bump their counts and must not paint false completion dots).
- Gateway/profile switches wipe only the transient paint layer — persisted markers are keyed by durable id and repaint once the profile's lists reload.
- No backend changes; everything derives from `message_count`/`last_active` already present on `SessionInfo`.

## Testing

- 9 store unit tests (`session-unread.test.ts`): restart reconstruction, first-sight seeding, profile-switch survival, ack-on-open, compression rotation, cron rows, messaging scoping, unlisted live-edge preservation.
- New e2e spec (`unread-dot-restart.spec.ts`) boots the app three times: a held-stream session finishes in the background while another session is selected → dot appears → **app quit + relaunch → dot still there** → opening the session clears it → second restart → stays cleared. Passing locally.
- Full desktop vitest suite: 3837 passed.