### PR TITLE
fix(email): poll marked mail read before the sender allowlist ran

### DIFF
--- a/contributors/emails/mohammed.nazmy@gmail.com
+++ b/contributors/emails/mohammed.nazmy@gmail.com
@@ -1,0 +1,2 @@
+mohammednazmy
+# email: IMAP poll marked mail read (RFC822 fetch) before the sender allowlist ran

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -478,6 +478,10 @@ class EmailAdapter(BasePlatformAdapter):
 
         # Track message IDs we've already processed to avoid duplicates
         self._seen_uids: set = set()
+        # Highest UID present when this process connected. The poll search is
+        # bounded to UIDs ABOVE it, so the pre-existing backlog is structurally
+        # out of scope instead of relying on a flag to stay out of the way.
+        self._uid_watermark: int = 0
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
         self._poll_task: Optional[asyncio.Task] = None
 
@@ -591,6 +595,10 @@ class EmailAdapter(BasePlatformAdapter):
             if status == "OK" and data and data[0]:
                 for uid in data[0].split():
                     self._seen_uids.add(uid)
+                try:
+                    self._uid_watermark = max(int(u) for u in data[0].split())
+                except (ValueError, TypeError):
+                    self._uid_watermark = 0
             # Keep only the most recent UIDs to prevent unbounded growth
             self._trim_seen_uids()
             imap.logout()
@@ -657,7 +665,21 @@ class EmailAdapter(BasePlatformAdapter):
                 _send_imap_id(imap)
                 imap.select("INBOX")
 
-                status, data = imap.uid("search", None, "UNSEEN")
+                # Bounded to UIDs above the connect-time watermark. Without this,
+                # switching the fetch below to BODY.PEEK[] re-arms an unbounded
+                # re-fetch loop: _seen_uids is capped at 2000 and trimmed to the
+                # newest 1000 (see _trim_seen_uids), whose docstring notes that
+                # eviction is only safe because the \\Seen flag keeps evicted mail
+                # out of an UNSEEN search. PEEK stops setting that flag, so on a
+                # mailbox with a large unread backlog every evicted UID would be
+                # re-downloaded in full on every poll, forever. The watermark
+                # restores the same "only process new mail" intent connect()
+                # already states, without depending on mailbox state we mutate.
+                if self._uid_watermark > 0:
+                    criteria = ("UNSEEN", "UID", "%d:*" % (self._uid_watermark + 1))
+                else:
+                    criteria = ("UNSEEN",)
+                status, data = imap.uid("search", None, *criteria)
                 if status != "OK" or not data or not data[0]:
                     return results
 
@@ -669,7 +691,12 @@ class EmailAdapter(BasePlatformAdapter):
                     if len(self._seen_uids) > self._seen_uids_max:
                         self._trim_seen_uids()
 
-                    status, msg_data = imap.uid("fetch", uid, "(RFC822)")
+                    # BODY.PEEK[] rather than RFC822: a plain RFC822 fetch
+                    # implicitly sets \\Seen (RFC 3501 6.4.5), and this loop runs
+                    # before the sender allowlist is applied at dispatch — so the
+                    # poller marked mail read that the gateway then refused to act
+                    # on.
+                    status, msg_data = imap.uid("fetch", uid, "(BODY.PEEK[])")
                     if status != "OK":
                         continue
 

--- a/tests/gateway/test_email_peek_does_not_mark_read.py
+++ b/tests/gateway/test_email_peek_does_not_mark_read.py
@@ -1,0 +1,225 @@
+"""The email poller must not mark a mailbox read, and must not re-download it.
+
+`_fetch_new_messages` searched UNSEEN and fetched every hit with `(RFC822)`, a
+form that implicitly sets \\Seen (RFC 3501 6.4.5), before the sender allowlist is
+applied at dispatch — so it marked mail read that the gateway then refused to
+act on.
+
+The fix is two changes that only work together. `BODY.PEEK[]` stops the flag
+write; a UID watermark stops the re-download that removing the flag would
+otherwise cause. `_trim_seen_uids` evicts old UIDs and says in its own docstring
+that this is safe "because IMAP's UNSEEN flag prevents re-delivery regardless" —
+PEEK alone deletes that guarantee, so every evicted UID would be re-fetched in
+full on every poll. `test_backlog_is_not_refetched_every_poll` is the regression
+for that, and it fails on a PEEK-only patch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import unittest
+from email.mime.text import MIMEText
+from unittest.mock import MagicMock, patch
+
+
+BASE_ENV = {
+    "EMAIL_ADDRESS": "agent@test.com",
+    "EMAIL_PASSWORD": "secret",
+    "EMAIL_IMAP_HOST": "imap.test.com",
+    "EMAIL_IMAP_PORT": "993",
+    "EMAIL_SMTP_HOST": "smtp.test.com",
+    "EMAIL_SMTP_PORT": "587",
+    "EMAIL_POLL_INTERVAL": "15",
+}
+
+
+def _raw(sender: str = "someone@elsewhere.com") -> bytes:
+    msg = MIMEText("body text")
+    msg["From"] = sender
+    msg["Subject"] = "hello"
+    msg["Message-ID"] = "<m1@test.com>"
+    return msg.as_bytes()
+
+
+class _FakeIMAP:
+    """An IMAP fake that models the \\Seen flag the way RFC 3501 6.4.5 does.
+
+    Modelling the flag is the point: a fake that only records command strings
+    cannot tell a fetch that mutates the mailbox from one that does not, so a
+    test written against it passes with the bug fully restored.
+    """
+
+    def __init__(self, uids, raw=None):
+        self.uids = [u if isinstance(u, bytes) else str(u).encode() for u in uids]
+        self.raw = raw or _raw()
+        self.flags: dict[bytes, set[str]] = {u: set() for u in self.uids}
+        self.fetched: list[bytes] = []
+        self.searches: list[tuple] = []
+
+    def login(self, *a):
+        return ("OK", [b""])
+
+    def select(self, *a, **k):
+        return ("OK", [b""])
+
+    def logout(self):
+        return ("OK", [b""])
+
+    def xatom(self, *a, **k):
+        return ("OK", [b""])
+
+    def _unseen(self) -> list[bytes]:
+        return [u for u in self.uids if "\\Seen" not in self.flags[u]]
+
+    def uid(self, command, *args):
+        cmd = command.lower()
+        if cmd == "search":
+            self.searches.append(args)
+            hits = self._unseen() if "UNSEEN" in args else list(self.uids)
+            # Honour a `UID <lo>:*` range the way a real server would.
+            for a in args:
+                if isinstance(a, str) and ":" in a and a.split(":")[0].isdigit():
+                    lo = int(a.split(":")[0])
+                    hits = [u for u in hits if int(u) >= lo]
+            return ("OK", [b" ".join(hits)])
+        if cmd == "fetch":
+            uid = args[0]
+            spec = " ".join(str(a) for a in args[1:])
+            self.fetched.append(uid)
+            # THE RFC: a non-PEEK body fetch implicitly sets \Seen.
+            if "PEEK" not in spec.upper():
+                self.flags.setdefault(uid, set()).add("\\Seen")
+            return ("OK", [(b"1 (BODY[] {N}", self.raw)])
+        if cmd == "store":
+            uid = args[0]
+            if "+FLAGS" in " ".join(str(a) for a in args[1:]):
+                self.flags.setdefault(uid, set()).add("\\Seen")
+            return ("OK", [b""])
+        return ("OK", [b""])
+
+
+def _adapter(env=None):
+    from gateway.config import PlatformConfig
+
+    merged = dict(BASE_ENV)
+    merged.update(env or {})
+    with patch.dict(os.environ, merged, clear=False):
+        from plugins.platforms.email.adapter import EmailAdapter
+
+        return EmailAdapter(PlatformConfig(enabled=True))
+
+
+def _run(adapter, fake, env=None):
+    merged = dict(BASE_ENV)
+    merged.update(env or {})
+    with patch.dict(os.environ, merged, clear=False):
+        with patch("imaplib.IMAP4_SSL", return_value=fake):
+            with patch("plugins.platforms.email.adapter._send_imap_id", MagicMock()):
+                return adapter._fetch_new_messages()
+
+
+def _connect(adapter, fake):
+    """`connect()` is a coroutine; it establishes the UID watermark."""
+    with patch.dict(os.environ, BASE_ENV, clear=False):
+        with patch("imaplib.IMAP4_SSL", return_value=fake):
+            with patch("plugins.platforms.email.adapter._send_imap_id", MagicMock()):
+                return asyncio.run(adapter.connect())
+
+
+class TestPollDoesNotMutateTheMailbox(unittest.TestCase):
+    def test_polling_leaves_every_flag_untouched(self):
+        """The bug, asserted on mailbox STATE rather than on a command string."""
+        adapter = _adapter()
+        fake = _FakeIMAP([101, 102, 103])
+
+        _run(adapter, fake)
+
+        self.assertEqual(
+            [u for u, f in fake.flags.items() if f],
+            [],
+            "polling marked mail read: %r" % (fake.flags,),
+        )
+
+    def test_messages_are_still_delivered(self):
+        """Not mutating the mailbox must not mean not reading it."""
+        adapter = _adapter()
+        fake = _FakeIMAP([201])
+
+        results = _run(adapter, fake)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["sender_addr"], "someone@elsewhere.com")
+
+
+class TestBacklogIsBounded(unittest.TestCase):
+    def test_backlog_is_not_refetched_every_poll(self):
+        """The regression a PEEK-only fix introduces.
+
+        `_seen_uids` is capped and trimmed, and `_trim_seen_uids` documents that
+        eviction is safe only because \\Seen keeps evicted mail out of an UNSEEN
+        search. With PEEK and no watermark, every evicted UID comes back on the
+        next poll — a full re-download of the backlog, every interval, forever.
+        """
+        adapter = _adapter()
+        fake = _FakeIMAP(list(range(1, 51)))
+
+        # connect() establishes the watermark over the existing mailbox.
+        _connect(adapter, fake)
+
+        # Simulate eviction: a long-running process trims its in-memory set.
+        adapter._seen_uids = set()
+
+        first = _run(adapter, fake)
+        second = _run(adapter, fake)
+
+        self.assertEqual(first, [], "the pre-existing backlog is not new mail")
+        self.assertEqual(second, [], "and it must not come back on the next poll")
+        self.assertEqual(
+            fake.fetched, [], "no message body should have been downloaded at all"
+        )
+
+    def test_mail_arriving_after_connect_is_still_delivered(self):
+        """The watermark must bound the backlog WITHOUT muting new mail."""
+        adapter = _adapter()
+        fake = _FakeIMAP([10, 11, 12])
+
+        _connect(adapter, fake)
+
+        # A new message arrives above the watermark.
+        fake.uids.append(b"13")
+        fake.flags[b"13"] = set()
+
+        results = _run(adapter, fake)
+
+        self.assertEqual(len(results), 1, "new mail must still be delivered")
+        self.assertEqual(fake.fetched, [b"13"])
+
+    def test_search_is_bounded_by_the_watermark(self):
+        adapter = _adapter()
+        fake = _FakeIMAP([7, 8, 9])
+
+        _connect(adapter, fake)
+        fake.searches.clear()
+        _run(adapter, fake)
+
+        self.assertTrue(fake.searches, "no search was issued")
+        joined = " ".join(str(a) for a in fake.searches[-1])
+        self.assertIn("UNSEEN", joined)
+        self.assertIn("10:*", joined, "search must start above the highest known UID")
+
+    def test_an_empty_mailbox_still_polls(self):
+        """Watermark 0 must not degenerate into a search that matches nothing."""
+        adapter = _adapter()
+        fake = _FakeIMAP([])
+
+        _connect(adapter, fake)
+
+        fake.uids.append(b"1")
+        fake.flags[b"1"] = set()
+
+        self.assertEqual(len(_run(adapter, fake)), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

The email platform's poller marked mail as read as a side effect of looking at
it — including mail it then refused to act on.

`_fetch_new_messages` searches `UNSEEN` and fetches every hit with `(RFC822)`.
Per RFC 3501 §6.4.5 a non-PEEK body fetch implicitly sets `\Seen`, and the
sender allowlist isn't applied until dispatch, well after the fetch. So on any
mailbox the agent merely watches, an unattended poll silently clears the unread
state of everything that arrives — including messages from senders the gateway
was configured to ignore.

Observed on a real account: **503 messages marked read by one poller.**

The fix is two changes that only work together.

`BODY.PEEK[]` stops the flag write. But `_trim_seen_uids` evicts old UIDs from
the in-memory `_seen_uids` set, and its own docstring states that this is safe
*"because IMAP's UNSEEN flag prevents re-delivery regardless"* — PEEK deletes
exactly that guarantee. With PEEK alone, every evicted UID reappears in the next
`UNSEEN` search and is re-downloaded in full, on every interval, forever.

So `connect()` now records a UID watermark (the highest UID present when the
poller attaches) and the search is bounded by it: `UNSEEN UID <watermark+1>:*`.
Dedupe no longer depends on mutating the mailbox. Pre-existing mail is not new
mail; mail arriving after connect is still delivered exactly once.

## Related Issue

No existing issue — found in production on a self-hosted install.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/email/adapter.py`
  - `_fetch_new_messages` fetches with `(BODY.PEEK[])` instead of `(RFC822)`
  - `connect()` establishes `self._uid_watermark` from the highest existing UID
  - the poll's search is bounded by that watermark
- `tests/gateway/test_email_peek_does_not_mark_read.py` — new

## How Has This Been Tested?

The tests model the `\Seen` flag the way the RFC does, rather than recording
command strings. That distinction matters: a fake that only records commands
cannot tell a fetch that mutates the mailbox from one that does not, so a test
written against it passes with the bug fully restored. Assertions are on mailbox
*state*.

Against this branch: **6 passed.**

Reverting only `adapter.py` to `main` and re-running: **3 failed, 3 passed** —
including `test_polling_leaves_every_flag_untouched`, which shows `main` marking
all three test messages read.

`test_backlog_is_not_refetched_every_poll` is the regression guard for the
second half of the fix specifically: it fails on a PEEK-only patch, which is why
the watermark is not optional.

## Checklist

- [x] My code follows the project's style
- [x] I have performed a self-review
- [x] I have commented my code where the reasoning is non-obvious
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
