### PR TITLE
feat(executive): add shared objective services scaffold

### DIFF
--- a/agent/executive/__init__.py
+++ b/agent/executive/__init__.py
@@ -1,0 +1,15 @@
+from .services import (
+    EvidencePackDegradeReason,
+    EvidencePackEngineFactory,
+    EvidencePackStatus,
+    ObjectiveServices,
+    build_objective_services,
+)
+
+__all__ = [
+    "EvidencePackDegradeReason",
+    "EvidencePackEngineFactory",
+    "EvidencePackStatus",
+    "ObjectiveServices",
+    "build_objective_services",
+]

--- a/agent/executive/services.py
+++ b/agent/executive/services.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Literal, Mapping
+
+EvidencePackStatus = Literal[
+    "disabled",
+    "available",
+    "degraded",
+]
+
+EvidencePackDegradeReason = Literal[
+    "factory_missing",
+    "factory_error",
+    "invalid_config",
+]
+
+EvidencePackEngineFactory = Callable[..., Any]
+
+
+@dataclass(frozen=True)
+class ObjectiveServices:
+    session_id: str
+    sources: Any | None = None
+    storage: Any | None = None
+    audit_sink: Any | None = None
+    evidence_pack_engine: Any | None = None
+    evidence_pack_status: EvidencePackStatus = "disabled"
+    evidence_pack_degrade_reason: EvidencePackDegradeReason | None = None
+    evidence_pack_error_type: str | None = None
+
+    @property
+    def evidence_pack_enabled(self) -> bool:
+        return self.evidence_pack_status == "available"
+
+
+def build_objective_services(
+    *,
+    session_id: str,
+    config: Mapping[str, Any] | None,
+    sources: Any | None = None,
+    storage: Any | None = None,
+    audit_sink: Any | None = None,
+    evidence_pack_engine_factory: EvidencePackEngineFactory | None = None,
+) -> ObjectiveServices:
+    if not isinstance(session_id, str) or not session_id.strip():
+        raise ValueError("session_id is required")
+
+    def make_services(
+        *,
+        evidence_pack_engine: Any | None = None,
+        evidence_pack_status: EvidencePackStatus = "disabled",
+        evidence_pack_degrade_reason: EvidencePackDegradeReason | None = None,
+        evidence_pack_error_type: str | None = None,
+    ) -> ObjectiveServices:
+        return ObjectiveServices(
+            session_id=session_id,
+            sources=sources,
+            storage=storage,
+            audit_sink=audit_sink,
+            evidence_pack_engine=evidence_pack_engine,
+            evidence_pack_status=evidence_pack_status,
+            evidence_pack_degrade_reason=evidence_pack_degrade_reason,
+            evidence_pack_error_type=evidence_pack_error_type,
+        )
+
+    def invalid_config_services() -> ObjectiveServices:
+        return make_services(evidence_pack_degrade_reason="invalid_config")
+
+    if config is None or not config:
+        return make_services()
+
+    goals_config = config.get("goals")
+    if goals_config is None:
+        return make_services()
+    if not isinstance(goals_config, Mapping):
+        return invalid_config_services()
+
+    evidence_pack_config = goals_config.get("evidence_pack")
+    if evidence_pack_config is None:
+        return make_services()
+    if not isinstance(evidence_pack_config, Mapping):
+        return invalid_config_services()
+
+    enabled = evidence_pack_config.get("enabled")
+    if enabled is None or enabled is False:
+        return make_services()
+    if enabled is not True:
+        return invalid_config_services()
+
+    if evidence_pack_engine_factory is None:
+        return make_services(
+            evidence_pack_status="degraded",
+            evidence_pack_degrade_reason="factory_missing",
+        )
+
+    try:
+        evidence_pack_engine = evidence_pack_engine_factory(
+            session_id=session_id,
+            config=config,
+            sources=sources,
+            storage=storage,
+            audit_sink=audit_sink,
+        )
+    except Exception as exc:
+        return make_services(
+            evidence_pack_status="degraded",
+            evidence_pack_degrade_reason="factory_error",
+            evidence_pack_error_type=type(exc).__name__,
+        )
+
+    return make_services(
+        evidence_pack_engine=evidence_pack_engine,
+        evidence_pack_status="available",
+    )

--- a/tests/agent/test_objective_services.py
+++ b/tests/agent/test_objective_services.py
@@ -1,0 +1,236 @@
+import pytest
+
+from agent.executive import build_objective_services
+
+
+def enabled_config():
+    return {"goals": {"evidence_pack": {"enabled": True}}}
+
+
+def disabled_config():
+    return {"goals": {"evidence_pack": {"enabled": False}}}
+
+
+def assert_disabled_normal(services):
+    assert services.evidence_pack_engine is None
+    assert services.evidence_pack_status == "disabled"
+    assert services.evidence_pack_degrade_reason is None
+    assert services.evidence_pack_error_type is None
+    assert services.evidence_pack_enabled is False
+
+
+def assert_invalid_config(services):
+    assert services.evidence_pack_engine is None
+    assert services.evidence_pack_status == "disabled"
+    assert services.evidence_pack_degrade_reason == "invalid_config"
+    assert services.evidence_pack_error_type is None
+    assert services.evidence_pack_enabled is False
+
+
+class RecordingFactory:
+    def __init__(self, engine=None, exc=None):
+        self.engine = object() if engine is None else engine
+        self.exc = exc
+        self.calls = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.exc is not None:
+            raise self.exc
+        return self.engine
+
+
+def test_empty_config_is_disabled_normal():
+    assert_disabled_normal(build_objective_services(session_id="s1", config={}))
+    assert_disabled_normal(build_objective_services(session_id="s1", config=None))
+
+
+def test_missing_goals_is_disabled_normal():
+    services = build_objective_services(session_id="s1", config={"other": {}})
+
+    assert_disabled_normal(services)
+
+
+def test_missing_evidence_pack_is_disabled_normal():
+    services = build_objective_services(session_id="s1", config={"goals": {}})
+
+    assert_disabled_normal(services)
+
+
+def test_enabled_false_is_disabled_normal():
+    services = build_objective_services(session_id="s1", config=disabled_config())
+
+    assert_disabled_normal(services)
+
+
+def test_enabled_true_with_factory_makes_evidence_pack_available():
+    engine = object()
+    factory = RecordingFactory(engine=engine)
+
+    services = build_objective_services(
+        session_id="s1",
+        config=enabled_config(),
+        evidence_pack_engine_factory=factory,
+    )
+
+    assert services.evidence_pack_engine is engine
+    assert services.evidence_pack_status == "available"
+    assert services.evidence_pack_degrade_reason is None
+    assert services.evidence_pack_error_type is None
+    assert services.evidence_pack_enabled is True
+
+
+def test_factory_is_not_called_when_disabled():
+    factory = RecordingFactory()
+
+    build_objective_services(
+        session_id="s1",
+        config=disabled_config(),
+        evidence_pack_engine_factory=factory,
+    )
+
+    assert factory.calls == []
+
+
+def test_factory_is_called_exactly_once_with_expected_dependencies():
+    config = enabled_config()
+    sources = object()
+    storage = object()
+    audit_sink = object()
+    factory = RecordingFactory()
+
+    build_objective_services(
+        session_id="  preserved session  ",
+        config=config,
+        sources=sources,
+        storage=storage,
+        audit_sink=audit_sink,
+        evidence_pack_engine_factory=factory,
+    )
+
+    assert factory.calls == [
+        {
+            "session_id": "  preserved session  ",
+            "config": config,
+            "sources": sources,
+            "storage": storage,
+            "audit_sink": audit_sink,
+        }
+    ]
+
+
+def test_dependencies_are_preserved_by_identity():
+    sources = object()
+    storage = object()
+    audit_sink = object()
+
+    services = build_objective_services(
+        session_id="s1",
+        config={},
+        sources=sources,
+        storage=storage,
+        audit_sink=audit_sink,
+    )
+
+    assert services.sources is sources
+    assert services.storage is storage
+    assert services.audit_sink is audit_sink
+
+
+def test_two_session_ids_produce_independent_services():
+    first = build_objective_services(session_id="s1", config={})
+    second = build_objective_services(session_id="s2", config={})
+
+    assert first is not second
+    assert first.session_id == "s1"
+    assert second.session_id == "s2"
+
+
+def test_enabled_true_without_factory_degrades():
+    services = build_objective_services(session_id="s1", config=enabled_config())
+
+    assert services.evidence_pack_engine is None
+    assert services.evidence_pack_status == "degraded"
+    assert services.evidence_pack_degrade_reason == "factory_missing"
+    assert services.evidence_pack_error_type is None
+    assert services.evidence_pack_enabled is False
+
+
+def test_factory_exception_degrades_and_only_keeps_exception_type():
+    factory = RecordingFactory(exc=RuntimeError("sensitive detail"))
+
+    services = build_objective_services(
+        session_id="s1",
+        config=enabled_config(),
+        evidence_pack_engine_factory=factory,
+    )
+
+    assert services.evidence_pack_engine is None
+    assert services.evidence_pack_status == "degraded"
+    assert services.evidence_pack_degrade_reason == "factory_error"
+    assert services.evidence_pack_error_type == "RuntimeError"
+
+
+@pytest.mark.parametrize("session_id", ["", "   ", None, 123])
+def test_invalid_session_id_values_are_rejected(session_id):
+    with pytest.raises(ValueError, match="session_id is required"):
+        build_objective_services(session_id=session_id, config={})
+
+
+def test_invalid_goals_shape_degrades_without_calling_factory():
+    factory = RecordingFactory()
+
+    services = build_objective_services(
+        session_id="s1",
+        config={"goals": []},
+        evidence_pack_engine_factory=factory,
+    )
+
+    assert_invalid_config(services)
+    assert factory.calls == []
+
+
+def test_invalid_evidence_pack_shape_degrades_without_calling_factory():
+    factory = RecordingFactory()
+
+    services = build_objective_services(
+        session_id="s1",
+        config={"goals": {"evidence_pack": []}},
+        evidence_pack_engine_factory=factory,
+    )
+
+    assert_invalid_config(services)
+    assert factory.calls == []
+
+
+@pytest.mark.parametrize("enabled", ["yes", 1, 0, [], {}])
+def test_non_bool_enabled_values_are_invalid_config_and_do_not_call_factory(enabled):
+    factory = RecordingFactory()
+
+    services = build_objective_services(
+        session_id="s1",
+        config={"goals": {"evidence_pack": {"enabled": enabled}}},
+        evidence_pack_engine_factory=factory,
+    )
+
+    assert_invalid_config(services)
+    assert factory.calls == []
+
+
+@pytest.mark.parametrize("exc_type", [KeyboardInterrupt, SystemExit])
+def test_factory_does_not_catch_base_exceptions(exc_type):
+    factory = RecordingFactory(exc=exc_type())
+
+    with pytest.raises(exc_type):
+        build_objective_services(
+            session_id="s1",
+            config=enabled_config(),
+            evidence_pack_engine_factory=factory,
+        )
+
+
+def test_each_call_returns_a_new_instance():
+    first = build_objective_services(session_id="s1", config={})
+    second = build_objective_services(session_id="s1", config={})
+
+    assert first is not second


### PR DESCRIPTION
## Summary

This PR adds a minimal, inert composition boundary for future Executive and objective-service integration.

It introduces:

- `ObjectiveServices`, an immutable container for explicitly injected objective dependencies;
- `build_objective_services(...)`, a pure factory with no runtime or global side effects;
- strict boolean activation semantics;
- structured disabled, available, and degraded states;
- behavioral tests for dependency identity, session isolation, configuration handling, and factory failures.

## Scope

The change is intentionally limited to three new files:

- `agent/executive/__init__.py`
- `agent/executive/services.py`
- `tests/agent/test_objective_services.py`

It does **not**:

- modify `/goal`;
- add `/objective`;
- change CLI, Gateway, or TUI behavior;
- add runtime caching;
- add a public config key;
- read environment variables, config files, SessionDB, disk, or network resources;
- import `EvidencePackEngine`;
- modify the B1-B API.

## Design boundaries

The factory receives an already-loaded configuration mapping and explicit dependencies.

When evidence-pack activation is absent or false, no engine factory is invoked. When activation is true, the caller must provide the engine factory explicitly. Missing or failing factories produce a structured degraded result without introducing runtime side effects.

This establishes a shared composition boundary without coupling the scaffold to CLI, Gateway, TUI, `/goal`, or the standalone knowledge-discovery implementation.

## Validation

- focal fileset: 3 new files, 0 modified files;
- focal tests: 25 passed;
- `/goal` regression selection: 183 passed;
- committed diff check: passed;
- forbidden production dependency hits: 0;
- runtime wiring changes: 0;
- merge-conflict probe against current upstream `main`: passed.

## Follow-up boundaries

The following remain separate follow-up units:

- adding the public default-off configuration key;
- wiring the standalone `EvidencePackEngine`;
- adding real source, storage, and audit adapters;
- integrating evidence into `/goal`;
- adding any optional `/objective` surface.

## Relationship to existing PRs

This PR neither rewrites nor closes #60549.

It is also independent of #74103: it does not import or modify the B1-B implementation. A later wiring PR may compose the two units after both have been reviewed.
