### PR TITLE
fix(state): close threaded SessionDB read conns without leaking FDs

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2083,10 +2083,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if getattr(self._read_local, "failed", False):
             return None
         try:
+            # check_same_thread=False matches the writer connection and the
+            # cross-profile read_only open. Without it, per-thread read conns
+            # can only be closed from the creating thread — SessionDB.close()
+            # (called from the owner / event-loop thread) hits
+            # sqlite3.ProgrammingError, swallows it, and permanently leaks
+            # the .db/.wal/.shm fds. Gateway + dashboard share one SessionDB
+            # across many worker threads, so this compounds into EMFILE.
             conn = _connect_tracked_db(
                 f"file:{self.db_path}?mode=ro",
                 tracking_path=self.db_path,
                 uri=True,
+                check_same_thread=False,
                 timeout=5.0,
                 isolation_level=None,
             )

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2083,13 +2083,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if getattr(self._read_local, "failed", False):
             return None
         try:
-            # check_same_thread=False matches the writer connection and the
-            # cross-profile read_only open. Without it, per-thread read conns
-            # can only be closed from the creating thread — SessionDB.close()
-            # (called from the owner / event-loop thread) hits
-            # sqlite3.ProgrammingError, swallows it, and permanently leaks
-            # the .db/.wal/.shm fds. Gateway + dashboard share one SessionDB
-            # across many worker threads, so this compounds into EMFILE.
+            # close() drains worker-created connections from its caller, so
+            # readers must permit cross-thread close after the worker exits.
             conn = _connect_tracked_db(
                 f"file:{self.db_path}?mode=ro",
                 tracking_path=self.db_path,
@@ -2660,14 +2655,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             try:
                 conn.close()
             except sqlite3.ProgrammingError as exc:
-                # Same-thread-only connections (missing check_same_thread=False)
-                # raise here when drained from the owner thread. Swallowing this
-                # silently hid an FD leak class that compounded into EMFILE on
-                # gateway/dashboard thread pools — keep the process alive but
-                # make the failure mode visible.
                 logger.warning(
-                    "SessionDB.close() could not close a per-thread read "
-                    "connection (likely missing check_same_thread=False): %s",
+                    "SessionDB.close() could not close a read connection: %s",
                     exc,
                 )
             except Exception:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2659,6 +2659,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         for conn in read_conns:
             try:
                 conn.close()
+            except sqlite3.ProgrammingError as exc:
+                # Same-thread-only connections (missing check_same_thread=False)
+                # raise here when drained from the owner thread. Swallowing this
+                # silently hid an FD leak class that compounded into EMFILE on
+                # gateway/dashboard thread pools — keep the process alive but
+                # make the failure mode visible.
+                logger.warning(
+                    "SessionDB.close() could not close a per-thread read "
+                    "connection (likely missing check_same_thread=False): %s",
+                    exc,
+                )
             except Exception:
                 pass
         self._read_local.conn = None

--- a/tests/test_session_db_read_path_split.py
+++ b/tests/test_session_db_read_path_split.py
@@ -131,16 +131,11 @@ def test_anchored_view_and_around_use_read_path(db):
         db._lock.release()
 
 
-def _count_state_db_fds(db_path) -> int:
-    """Count open fds whose path is this DB or its WAL/SHM sidecars."""
+def _process_num_fds() -> int:
+    """Process-wide open FD count (reliable on macOS where path probes lie)."""
     import psutil
 
-    root = str(db_path)
-    return sum(
-        1
-        for f in psutil.Process().open_files()
-        if f.path == root or f.path.startswith(root + "-")
-    )
+    return psutil.Process().num_fds()
 
 
 @pytest.mark.requires_wal
@@ -151,18 +146,25 @@ def test_read_conn_closeable_from_owner_thread(tmp_path):
     SessionDB.close() on the owner thread raised ProgrammingError for every
     worker-created read conn, swallowed it, and leaked .db/.wal/.shm fds.
     Under gateway/dashboard thread pools this accumulated into EMFILE.
+
+    Primary guard is cross-thread close succeeding (platform-independent).
+    Secondary guard is process num_fds dropping on close — macOS
+    ``open_files()`` path matching under-reports SQLite fds and would pass
+    even pre-fix, so we deliberately do not assert on it.
     """
+    import sqlite3
+
     d = SessionDB(db_path=tmp_path / "state.db")
     try:
         d.create_session(session_id="s1", source="cli", model="m")
         d.append_message("s1", role="user", content="fd leak probe")
 
-        barriers = []
         errors = []
 
         def worker(i):
             try:
-                assert d.get_session("s1")["id"] == "s1"
+                session = d.get_session("s1")
+                assert session is not None and session["id"] == "s1"
                 # Keep the thread alive long enough for close() to run while
                 # the connection objects still exist (registered in _read_conns).
                 barriers[i].wait(timeout=5.0)
@@ -186,14 +188,18 @@ def test_read_conn_closeable_from_owner_thread(tmp_path):
         assert not errors
         assert len(d._read_conns) >= n_threads
 
-        # Cross-thread close of a worker-created read conn must succeed
-        # (would raise ProgrammingError without check_same_thread=False).
+        # Primary regression guard: owner-thread close of a worker-created
+        # read conn must succeed. Pre-fix this raised ProgrammingError.
         sample = next(iter(d._read_conns))
-        sample.close()
+        try:
+            sample.close()
+        except sqlite3.ProgrammingError as exc:
+            pytest.fail(
+                "worker-created read conn not closeable from owner thread "
+                f"(missing check_same_thread=False?): {exc}"
+            )
 
-        fds_before_close = _count_state_db_fds(d.db_path)
-        assert fds_before_close > 0
-
+        fds_before = _process_num_fds()
         d.close()
         # Release barriers so workers exit cleanly after close.
         for b in barriers:
@@ -204,12 +210,15 @@ def test_read_conn_closeable_from_owner_thread(tmp_path):
         for t in threads:
             t.join(timeout=5.0)
 
-        fds_after = _count_state_db_fds(d.db_path)
-        assert fds_after == 0, (
-            f"SessionDB.close() left {fds_after} state.db fds open "
-            f"(had {fds_before_close} before close); threaded read conns leaked"
+        fds_after = _process_num_fds()
+        # Secondary: process FD table must drop. Pre-fix reclaim was ~1
+        # (writer only); fixed reclaim drops the bulk of worker read conns.
+        assert fds_after < fds_before, (
+            f"SessionDB.close() did not reclaim process FDs "
+            f"(before={fds_before}, after={fds_after}); threaded read conns leaked"
         )
         assert len(d._read_conns) == 0
+        assert d._conn is None
     finally:
         # Idempotent if already closed above.
         try:
@@ -221,6 +230,7 @@ def test_read_conn_closeable_from_owner_thread(tmp_path):
 @pytest.mark.requires_wal
 def test_close_after_threadpool_reads_reclaims_fds(tmp_path):
     """Thread-pool style reads (gateway/dashboard) must not leave FDs behind."""
+    import sqlite3
     from concurrent.futures import ThreadPoolExecutor
 
     d = SessionDB(db_path=tmp_path / "pool.db")
@@ -230,15 +240,37 @@ def test_close_after_threadpool_reads_reclaims_fds(tmp_path):
             d.append_message("s1", role="user", content=f"msg {i}")
 
         def read_once(_):
-            return d.get_session("s1")["id"]
+            session = d.get_session("s1")
+            assert session is not None
+            return session["id"]
 
         with ThreadPoolExecutor(max_workers=8) as pool:
             results = list(pool.map(read_once, range(32)))
         assert results == ["s1"] * 32
         assert len(d._read_conns) >= 1
 
+        # Primary: every worker-created read conn must close from this thread.
+        for conn in list(d._read_conns):
+            try:
+                conn.close()
+            except sqlite3.ProgrammingError as exc:
+                pytest.fail(
+                    "threadpool read conn not closeable from owner thread "
+                    f"(missing check_same_thread=False?): {exc}"
+                )
+
+        # Re-open pool once more so close() has live read conns to drain.
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(read_once, range(16)))
+        assert len(d._read_conns) >= 1
+
+        fds_before = _process_num_fds()
         d.close()
-        assert _count_state_db_fds(d.db_path) == 0
+        fds_after = _process_num_fds()
+        assert fds_after < fds_before, (
+            f"SessionDB.close() did not reclaim process FDs "
+            f"(before={fds_before}, after={fds_after})"
+        )
         assert d._conn is None
         assert len(d._read_conns) == 0
     finally:

--- a/tests/test_session_db_read_path_split.py
+++ b/tests/test_session_db_read_path_split.py
@@ -8,6 +8,9 @@ per-thread read-only connection under WAL, never touch self._lock, and fall
 back to the legacy locked path when WAL or the read connection is missing.
 """
 
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import suppress
+import sqlite3
 import threading
 
 import pytest
@@ -131,150 +134,20 @@ def test_anchored_view_and_around_use_read_path(db):
         db._lock.release()
 
 
-def _process_num_fds() -> int:
-    """Process-wide open FD count (reliable on macOS where path probes lie)."""
-    import psutil
-
-    return psutil.Process().num_fds()
-
-
 @pytest.mark.requires_wal
-def test_read_conn_closeable_from_owner_thread(tmp_path):
-    """Per-thread read conns must close from SessionDB.close()'s thread.
-
-    Regression: _get_read_conn omitted check_same_thread=False, so
-    SessionDB.close() on the owner thread raised ProgrammingError for every
-    worker-created read conn, swallowed it, and leaked .db/.wal/.shm fds.
-    Under gateway/dashboard thread pools this accumulated into EMFILE.
-
-    Primary guard is cross-thread close succeeding (platform-independent).
-    Secondary guard is process num_fds dropping on close — macOS
-    ``open_files()`` path matching under-reports SQLite fds and would pass
-    even pre-fix, so we deliberately do not assert on it.
-    """
-    import sqlite3
-
+def test_close_drains_read_conn_created_by_finished_worker(tmp_path):
+    """close() must reclaim a read connection created by another thread."""
     d = SessionDB(db_path=tmp_path / "state.db")
     try:
-        d.create_session(session_id="s1", source="cli", model="m")
-        d.append_message("s1", role="user", content="fd leak probe")
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            conn = pool.submit(d._get_read_conn).result(timeout=5.0)
+        assert conn is not None
 
-        errors = []
-
-        def worker(i):
-            try:
-                session = d.get_session("s1")
-                assert session is not None and session["id"] == "s1"
-                # Keep the thread alive long enough for close() to run while
-                # the connection objects still exist (registered in _read_conns).
-                barriers[i].wait(timeout=5.0)
-            except Exception as exc:  # pragma: no cover - surface in assert
-                errors.append(exc)
-
-        n_threads = 6
-        barriers = [threading.Barrier(2) for _ in range(n_threads)]
-        threads = [
-            threading.Thread(target=worker, args=(i,)) for i in range(n_threads)
-        ]
-        for t in threads:
-            t.start()
-        # Wait until every worker has opened its read conn.
-        for i in range(n_threads):
-            # Spin until this thread's conn is registered (or worker failed).
-            for _ in range(200):
-                if len(d._read_conns) >= i + 1 or errors:
-                    break
-                threading.Event().wait(0.01)
-        assert not errors
-        assert len(d._read_conns) >= n_threads
-
-        # Primary regression guard: owner-thread close of a worker-created
-        # read conn must succeed. Pre-fix this raised ProgrammingError.
-        sample = next(iter(d._read_conns))
-        try:
-            sample.close()
-        except sqlite3.ProgrammingError as exc:
-            pytest.fail(
-                "worker-created read conn not closeable from owner thread "
-                f"(missing check_same_thread=False?): {exc}"
-            )
-
-        fds_before = _process_num_fds()
         d.close()
-        # Release barriers so workers exit cleanly after close.
-        for b in barriers:
-            try:
-                b.wait(timeout=1.0)
-            except threading.BrokenBarrierError:
-                pass
-        for t in threads:
-            t.join(timeout=5.0)
 
-        fds_after = _process_num_fds()
-        # Secondary: process FD table must drop. Pre-fix reclaim was ~1
-        # (writer only); fixed reclaim drops the bulk of worker read conns.
-        assert fds_after < fds_before, (
-            f"SessionDB.close() did not reclaim process FDs "
-            f"(before={fds_before}, after={fds_after}); threaded read conns leaked"
-        )
-        assert len(d._read_conns) == 0
-        assert d._conn is None
+        assert not d._read_conns
+        with pytest.raises(sqlite3.ProgrammingError, match="closed database"):
+            conn.execute("SELECT 1")
     finally:
-        # Idempotent if already closed above.
-        try:
+        with suppress(Exception):
             d.close()
-        except Exception:
-            pass
-
-
-@pytest.mark.requires_wal
-def test_close_after_threadpool_reads_reclaims_fds(tmp_path):
-    """Thread-pool style reads (gateway/dashboard) must not leave FDs behind."""
-    import sqlite3
-    from concurrent.futures import ThreadPoolExecutor
-
-    d = SessionDB(db_path=tmp_path / "pool.db")
-    try:
-        d.create_session(session_id="s1", source="cli", model="m")
-        for i in range(5):
-            d.append_message("s1", role="user", content=f"msg {i}")
-
-        def read_once(_):
-            session = d.get_session("s1")
-            assert session is not None
-            return session["id"]
-
-        with ThreadPoolExecutor(max_workers=8) as pool:
-            results = list(pool.map(read_once, range(32)))
-        assert results == ["s1"] * 32
-        assert len(d._read_conns) >= 1
-
-        # Primary: every worker-created read conn must close from this thread.
-        for conn in list(d._read_conns):
-            try:
-                conn.close()
-            except sqlite3.ProgrammingError as exc:
-                pytest.fail(
-                    "threadpool read conn not closeable from owner thread "
-                    f"(missing check_same_thread=False?): {exc}"
-                )
-
-        # Re-open pool once more so close() has live read conns to drain.
-        with ThreadPoolExecutor(max_workers=8) as pool:
-            list(pool.map(read_once, range(16)))
-        assert len(d._read_conns) >= 1
-
-        fds_before = _process_num_fds()
-        d.close()
-        fds_after = _process_num_fds()
-        assert fds_after < fds_before, (
-            f"SessionDB.close() did not reclaim process FDs "
-            f"(before={fds_before}, after={fds_after})"
-        )
-        assert d._conn is None
-        assert len(d._read_conns) == 0
-    finally:
-        try:
-            d.close()
-        except Exception:
-            pass

--- a/tests/test_session_db_read_path_split.py
+++ b/tests/test_session_db_read_path_split.py
@@ -129,3 +129,120 @@ def test_anchored_view_and_around_use_read_path(db):
         assert done["view"]["window"]
     finally:
         db._lock.release()
+
+
+def _count_state_db_fds(db_path) -> int:
+    """Count open fds whose path is this DB or its WAL/SHM sidecars."""
+    import psutil
+
+    root = str(db_path)
+    return sum(
+        1
+        for f in psutil.Process().open_files()
+        if f.path == root or f.path.startswith(root + "-")
+    )
+
+
+@pytest.mark.requires_wal
+def test_read_conn_closeable_from_owner_thread(tmp_path):
+    """Per-thread read conns must close from SessionDB.close()'s thread.
+
+    Regression: _get_read_conn omitted check_same_thread=False, so
+    SessionDB.close() on the owner thread raised ProgrammingError for every
+    worker-created read conn, swallowed it, and leaked .db/.wal/.shm fds.
+    Under gateway/dashboard thread pools this accumulated into EMFILE.
+    """
+    d = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        d.create_session(session_id="s1", source="cli", model="m")
+        d.append_message("s1", role="user", content="fd leak probe")
+
+        barriers = []
+        errors = []
+
+        def worker(i):
+            try:
+                assert d.get_session("s1")["id"] == "s1"
+                # Keep the thread alive long enough for close() to run while
+                # the connection objects still exist (registered in _read_conns).
+                barriers[i].wait(timeout=5.0)
+            except Exception as exc:  # pragma: no cover - surface in assert
+                errors.append(exc)
+
+        n_threads = 6
+        barriers = [threading.Barrier(2) for _ in range(n_threads)]
+        threads = [
+            threading.Thread(target=worker, args=(i,)) for i in range(n_threads)
+        ]
+        for t in threads:
+            t.start()
+        # Wait until every worker has opened its read conn.
+        for i in range(n_threads):
+            # Spin until this thread's conn is registered (or worker failed).
+            for _ in range(200):
+                if len(d._read_conns) >= i + 1 or errors:
+                    break
+                threading.Event().wait(0.01)
+        assert not errors
+        assert len(d._read_conns) >= n_threads
+
+        # Cross-thread close of a worker-created read conn must succeed
+        # (would raise ProgrammingError without check_same_thread=False).
+        sample = next(iter(d._read_conns))
+        sample.close()
+
+        fds_before_close = _count_state_db_fds(d.db_path)
+        assert fds_before_close > 0
+
+        d.close()
+        # Release barriers so workers exit cleanly after close.
+        for b in barriers:
+            try:
+                b.wait(timeout=1.0)
+            except threading.BrokenBarrierError:
+                pass
+        for t in threads:
+            t.join(timeout=5.0)
+
+        fds_after = _count_state_db_fds(d.db_path)
+        assert fds_after == 0, (
+            f"SessionDB.close() left {fds_after} state.db fds open "
+            f"(had {fds_before_close} before close); threaded read conns leaked"
+        )
+        assert len(d._read_conns) == 0
+    finally:
+        # Idempotent if already closed above.
+        try:
+            d.close()
+        except Exception:
+            pass
+
+
+@pytest.mark.requires_wal
+def test_close_after_threadpool_reads_reclaims_fds(tmp_path):
+    """Thread-pool style reads (gateway/dashboard) must not leave FDs behind."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    d = SessionDB(db_path=tmp_path / "pool.db")
+    try:
+        d.create_session(session_id="s1", source="cli", model="m")
+        for i in range(5):
+            d.append_message("s1", role="user", content=f"msg {i}")
+
+        def read_once(_):
+            return d.get_session("s1")["id"]
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            results = list(pool.map(read_once, range(32)))
+        assert results == ["s1"] * 32
+        assert len(d._read_conns) >= 1
+
+        d.close()
+        assert _count_state_db_fds(d.db_path) == 0
+        assert d._conn is None
+        assert len(d._read_conns) == 0
+    finally:
+        try:
+            d.close()
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary

Fixes a specific file-descriptor leak in `SessionDB`'s per-thread WAL read path.

`SessionDB._get_read_conn()` creates read connections on worker threads, while `SessionDB.close()` drains the tracked connections from its caller after those workers finish. The read connections used SQLite's default `check_same_thread=True`, so owner-thread shutdown raised `sqlite3.ProgrammingError`. Because shutdown swallowed that exception, the SQLite `.db` / `.wal` / `.shm` descriptors remained open.

The observed behavior is consistent with the repeated SQLite handles seen in long-lived gateway/dashboard processes. This PR fixes that confirmed `SessionDB` lifecycle bug; it does not claim to address every possible source of process FD growth.

## Fix

- Open per-thread read connections with `check_same_thread=False`, matching the existing writer and cross-profile read-only connection policy.
- Log a concise warning if `SessionDB.close()` still encounters a thread-affinity `ProgrammingError` while draining a reader.

The lifecycle contract covered here is shutdown after the worker using the connection has finished. This patch does not introduce a new concurrent-close protocol for an in-flight query.

The read connections remain thread-local during normal use; the cross-thread reference exists only in the shutdown drain set. The runtime SQLite build is serialized (`THREADSAFE=1`), ordinary overlapping SQL close waits for the query to finish, and these connections register no Python SQLite callbacks (`create_function`, `create_aggregate`, `create_collation`, `set_progress_handler`, `set_trace_callback`, or `set_authorizer`). `sqlite3.Row` is the only read-path row factory. Existing `_read_conns_closed` handling immediately closes and rejects a reader opened after shutdown begins.

## Regression coverage

The test exercises the behavior directly and without platform-specific FD APIs:

1. A worker thread creates its per-thread read connection and exits.
2. The owner thread calls `SessionDB.close()`.
3. The retained connection must report `closed database`.

The same invariant fails on upstream `main` with the original same-thread `ProgrammingError` and passes on this branch.

## Test plan

- [x] `scripts/run_tests.sh tests/test_session_db_read_path_split.py` — 10 passed
- [x] `uv run ruff check hermes_state.py tests/test_session_db_read_path_split.py`
- [x] `git diff --check`
- [ ] Upstream CI

## Related reports — not claimed fixed by this PR

- Adjacent FD / EMFILE reports: #30230, #72782, #60859
