### PR TITLE
fix(agent): preserve in-flight marker on flush failure

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1814,12 +1814,14 @@ class AIAgent:
 
         Ensures conversations are never lost, even on errors or early returns.
 
-        Trailing empty-response scaffolding is dropped from the live list in
-        place (it is ephemeral junk the real transcript should shed). The
-        persist user-message *override* is NOT applied here — it is resolved
-        inside ``_flush_messages_to_session_db`` and written only to the DB row,
-        never mutating the live message list used by the API call (#48677 is
-        thus closed for every persist caller, not just this one).
+        Returns ``False`` only when the canonical SQLite flush explicitly failed;
+        otherwise returns ``True``. Trailing empty-response scaffolding is
+        dropped from the live list in place (it is ephemeral junk the real
+        transcript should shed). The persist user-message *override* is NOT
+        applied here — it is resolved inside ``_flush_messages_to_session_db``
+        and written only to the DB row, never mutating the live message list
+        used by the API call (#48677 is thus closed for every persist caller,
+        not just this one).
         """
         # Scaffolding removal mutates the live list (desired — ephemeral
         # retry/failure sentinels must not survive into the real transcript).
@@ -1830,24 +1832,26 @@ class AIAgent:
 
         persist_lock = getattr(self, "_session_persist_lock", None)
 
-        def _persist_and_drain() -> None:
+        def _persist_and_drain() -> bool:
             self._drop_trailing_empty_response_scaffolding(messages)
             self._session_messages = messages
             self._save_session_log(messages)
-            self._flush_messages_to_session_db(messages, conversation_history)
+            flush_ok = self._flush_messages_to_session_db(messages, conversation_history)
+            if flush_ok is False:
+                return False
             # Drain async token-accounting deltas at every persist point (turn
             # finalize + error exits) so a crash after this line loses at most
             # the in-flight API call's delta. Cheap no-op when nothing queued.
             if self._session_db is not None:
                 self._session_db.flush_token_counts()
             note_turn_persisted(self)
+            return True
 
         if persist_lock is None:
-            _persist_and_drain()
-            return
+            return _persist_and_drain()
 
         with persist_lock:
-            _persist_and_drain()
+            return _persist_and_drain()
 
     def _drop_trailing_empty_response_scaffolding(self, messages: List[Dict]) -> None:
         """Remove private empty-response retry/failure scaffolding from transcript tails.

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -207,6 +207,9 @@ def test_direct_session_db_flushes_share_marker_claim(agent):
                 assert self.release.wait(timeout=5)
             self.rows.append(kwargs["content"])
 
+        def flush_token_counts(self):
+            return None
+
     db = _BarrierDB()
     agent._session_db = db
     agent._session_db_created = True
@@ -237,6 +240,48 @@ def test_direct_session_db_flushes_share_marker_claim(agent):
     assert not normal.is_alive()
     assert not direct.is_alive()
     assert db.rows == ["exactly once"]
+
+
+def test_persist_session_does_not_clear_inflight_marker_when_db_flush_fails(agent):
+    """A failed canonical flush must not be reported as a completed persist."""
+    from agent import agent_runtime_helpers as _helpers
+
+    agent._session_db = MagicMock()
+    agent._session_db_created = True
+    agent.session_id = "session-123"
+    agent._last_flushed_db_idx = 0
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = None
+    agent._persist_user_message_idx = None
+    agent._persist_user_message_override = None
+    agent._persist_user_message_timestamp = None
+    agent._persist_disabled = False
+    agent._session_persist_lock = threading.RLock()
+    agent._session_json_enabled = False
+    agent._inflight_turn_id = "session-123:t1:aaaa"
+    agent._inflight_turn_session_id = agent.session_id
+
+    with _helpers._INFLIGHT_TURNS_LOCK:
+        _helpers._INFLIGHT_TURNS_BY_SESSION.clear()
+        _helpers._INFLIGHT_TURNS_BY_SESSION[agent.session_id] = (
+            agent._inflight_turn_id,
+            time.time(),
+        )
+
+    agent._flush_messages_to_session_db = MagicMock(return_value=False)
+
+    try:
+        result = agent._persist_session([{"role": "user", "content": "hello"}], [])
+
+        assert result is False
+        assert agent._inflight_turn_id == "session-123:t1:aaaa"
+        with _helpers._INFLIGHT_TURNS_LOCK:
+            assert _helpers._INFLIGHT_TURNS_BY_SESSION[agent.session_id][0] == (
+                "session-123:t1:aaaa"
+            )
+    finally:
+        with _helpers._INFLIGHT_TURNS_LOCK:
+            _helpers._INFLIGHT_TURNS_BY_SESSION.clear()
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary

Thread the canonical flush result through `AIAgent._persist_session()` so a failed SessionDB flush is not acknowledged as a completed turn-end persist.

## Problem

`_flush_messages_to_session_db()` already uses `False` as a meaningful signal for “canonical SessionDB append failed”.

But `_persist_session()` ignored that return value and still:

- drained token counts; and
- called `note_turn_persisted()`.

That meant a failed canonical flush still cleared the in-flight turn marker and session registry entry as if the durable persist had completed successfully.

This does not try to solve the broader SQLite contention architecture. It only fixes the remaining correctness gap in the current failure contract.

## Changes

- make `_persist_session()` return `False` when `_flush_messages_to_session_db()` explicitly returns `False`
- skip `note_turn_persisted()` on that failed canonical flush path
- keep successful persistence behavior unchanged
- add a regression test proving the in-flight marker is preserved when the canonical flush fails
- align the local `_BarrierDB` test helper with the real `SessionDB` interface by adding a no-op `flush_token_counts()`

## Testing

RED:
- `.venv/bin/python -m pytest -q tests/run_agent/test_run_agent.py -k persist_session_does_not_clear_inflight_marker_when_db_flush_fails`

GREEN / widened:
- `.venv/bin/python -m pytest -q tests/run_agent/test_run_agent.py`
- `.venv/bin/python -m pytest -q tests/agent/test_turn_overlap_tripwire.py`

## Scope

Out of scope on purpose:

- single-writer coordination
- fallback/replay spool design
- timeout tuning / broader SQLite availability work
- retention / auto-prune / cron session-volume changes

Fixes #74284.

Related upstream context lives in the broader contention and growth threads; this PR only fixes the truthfulness of the current turn-persist boundary.
