### PR TITLE
fix(auxiliary_client): mirror local-server provider aliases from hermes_cli/auth (#74280)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -345,6 +345,14 @@ _PROVIDER_ALIASES = {
     "tokenhub": "tencent-tokenhub",
     "tencent-cloud": "tencent-tokenhub",
     "tencentmaas": "tencent-tokenhub",
+    # Local server aliases — keep in sync with hermes_cli/auth.py so the
+    # fallback router normalizes bare 'ollama' / 'vllm' / 'llamacpp' to the
+    # generic custom provider and honors explicit_base_url (#74280).
+    "ollama": "custom",
+    "vllm": "custom",
+    "llamacpp": "custom",
+    "llama.cpp": "custom",
+    "llama-cpp": "custom",
 }
 
 

--- a/tests/agent/test_auxiliary_local_server_aliases.py
+++ b/tests/agent/test_auxiliary_local_server_aliases.py
@@ -1,0 +1,71 @@
+"""Regression test for fallback router local-server alias drift (#74280).
+
+Issue #74280 reports that ``fallback_providers`` entries with
+``provider: ollama`` (and other local servers like ``vllm``,
+``llamacpp``) can never activate because ``agent.auxiliary_client`` keeps
+its own copy of ``_PROVIDER_ALIASES`` that is missing the local-server
+aliases present in the canonical map in ``hermes_cli/auth.py``.
+
+The fallback router normalizes via ``_normalize_aux_provider`` →
+``_PROVIDER_ALIASES.get(...)``. With the alias absent, ``ollama`` stays
+as ``ollama``, fails to match any provider branch, and ``resolve_provider_client``
+returns ``(None, None)`` → ``provider not configured``.
+
+These tests pin the alias map and the normalization + provider-resolution
+end-to-end for the canonical local-server names.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# Aliases that MUST exist in agent.auxiliary_client._PROVIDER_ALIASES to
+# keep the fallback router in sync with hermes_cli/auth.py.
+LOCAL_SERVER_ALIASES = {
+    "ollama": "custom",
+    "vllm": "custom",
+    "llamacpp": "custom",
+    "llama.cpp": "custom",
+    "llama-cpp": "custom",
+}
+
+
+def test_local_server_aliases_present():
+    """Every local-server alias must map to 'custom'."""
+    from agent.auxiliary_client import _PROVIDER_ALIASES
+    for alias, target in LOCAL_SERVER_ALIASES.items():
+        assert _PROVIDER_ALIASES.get(alias) == target, (
+            f"_PROVIDER_ALIASES is missing {alias!r} → {target!r} "
+            f"(see #74280)"
+        )
+
+
+def test_ollama_normalizes_to_custom():
+    """_normalize_aux_provider('ollama') must return 'custom'."""
+    from agent.auxiliary_client import _normalize_aux_provider
+    assert _normalize_aux_provider("ollama") == "custom"
+
+
+@pytest.mark.parametrize("alias", ["ollama", "vllm", "llamacpp", "llama.cpp", "llama-cpp"])
+def test_local_server_aliases_normalize_to_custom_in_canonical_map(alias):
+    """Cross-check: hermes_cli.auth.resolve_provider maps the same alias
+    to the same target.
+
+    Source of truth for the alias is ``hermes_cli.auth.resolve_provider``;
+    ``agent.auxiliary_client`` must agree.
+    """
+    from agent.auxiliary_client import _PROVIDER_ALIASES
+    from hermes_cli.auth import resolve_provider
+
+    # Canonical target via hermes_cli.auth (the live resolver).
+    # resolve_provider accepts an alias by passing it as `requested`.
+    canonical = resolve_provider(requested=alias, explicit_base_url="http://localhost:11434/v1")
+    # The resolver may return 'custom' or 'ollama-cloud' / etc; we only care
+    # that local-server aliases land in 'custom' (the route that honors
+    # explicit_base_url).
+    assert canonical == "custom", (
+        f"hermes_cli.auth.resolve_provider({alias!r}) returned {canonical!r}; "
+        f"expected 'custom' (see #74280)"
+    )
+    # And agent.auxiliary_client must agree.
+    assert _PROVIDER_ALIASES.get(alias) == "custom"


### PR DESCRIPTION
## Summary

`fallback_providers` entries with `provider: ollama` (and the other local
servers: `vllm`, `llamacpp`, `llama.cpp`, `llama-cpp`) could never activate
on current `main`. They were silently rejected by the fallback router with
`provider not configured`, even when the entry's `base_url` was reachable and
the local server was up.

## Root cause

`agent/auxiliary_client._PROVIDER_ALIASES` is a stale copy of the canonical
alias map in `hermes_cli/auth.resolve_provider`. The canonical map was
extended with the local-server aliases (`ollama: custom`, `vllm: custom`,
`llamacpp: custom`, `llama.cpp: custom`, `llama-cpp: custom`) at
`hermes_cli/auth.py:1903-1905`; `agent/auxiliary_client.py` was not updated.

The fallback path is:

```
agent/chat_completion_helpers → agent/auxiliary_client._normalize_aux_provider
                              → _PROVIDER_ALIASES.get(normalized, normalized)
                              → resolve_provider_client(...)
```

With the alias absent, `"ollama"` stays as `"ollama"`, does not match any
provider branch (only `ollama-cloud` is in `PROVIDER_REGISTRY` on the
fallback path), and `resolve_provider_client` returns `(None, None)` →
`provider not configured`. The `explicit_base_url` on the entry is only
honored inside the `custom` branch, which is never reached.

## Fix

Add the same five local-server aliases to `agent/auxiliary_client._PROVIDER_ALIASES`.
The comment points future contributors at `hermes_cli/auth.py` as the
canonical source so the two maps cannot drift again.

## Diff

`agent/auxiliary_client.py` — 5 lines added (4 aliases + 1 inline comment).
`tests/agent/test_auxiliary_local_server_aliases.py` — new file, 71 lines,
7 test cases pinning the alias map and the cross-check against
`hermes_cli.auth.resolve_provider`.

Total: 2 files, 79 insertions, 0 deletions.

## Verification

```
$ python3 -m pytest tests/agent/test_auxiliary_local_server_aliases.py -v
============================= 7 passed in 3.28s ==============================
```

Git-stash three-step dance (revert the fix → run tests → restore → run tests):

- On `main` without the fix: 7 / 7 tests FAIL (`AssertionError: assert None == 'custom'`)
- With the fix applied: 7 / 7 tests PASS

Existing auxiliary-client tests (`tests/agent/test_auxiliary_client_anthropic_custom.py`,
`tests/agent/test_minimax_auxiliary_url.py`) — 12 / 12 still pass.

## Test coverage

- `test_local_server_aliases_present` — pins every alias entry in
  `agent/auxiliary_client._PROVIDER_ALIASES`.
- `test_ollama_normalizes_to_custom` — `_normalize_aux_provider("ollama") == "custom"`.
- `test_local_server_aliases_normalize_to_custom_in_canonical_map[*]` —
  parametrized over all five aliases; cross-checks that
  `hermes_cli.auth.resolve_provider` and `agent.auxiliary_client` agree.

## Backwards compatibility

`agent.auxiliary_client._PROVIDER_ALIASES` is a private module-level dict.
No public API changes. The aliases already existed on the canonical
`hermes_cli/auth.py` side; this fix unblocks a path that previously could
not be reached at all.

Closes #74280
