### PR TITLE
fix(update): reconcile removed runtime marker during autostash restore

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1240,6 +1240,58 @@ def _stash_apply_failed_only_on_existing_untracked(stderr: str) -> bool:
             return False
     return saw_untracked_error
 
+
+def _reconcile_removed_lazy_refresh_marker_conflict(
+    git_cmd: list[str],
+    cwd: Path,
+    stash_ref: str,
+    conflicted_files: list[str],
+) -> bool:
+    """Preserve a historical tracked marker without tracking it again.
+
+    A short-lived release accidentally tracked ``.lazy-refresh-incomplete``.
+    Later releases removed and ignored that runtime file. Restoring an
+    autostash from the affected release therefore creates a modify/delete
+    conflict when the marker contains live PID/timestamp data.
+
+    Reconcile only that exact conflict. The stashed bytes become ignored,
+    untracked runtime state while the index retains current main's deletion.
+    Any additional conflict falls through to the normal safe reset path.
+    """
+    marker_name = ".lazy-refresh-incomplete"
+    if conflicted_files != [marker_name]:
+        return False
+
+    saved = subprocess.run(
+        git_cmd + ["show", f"{stash_ref}:{marker_name}"],
+        cwd=cwd,
+        capture_output=True,
+    )
+    if saved.returncode != 0:
+        return False
+
+    resolved = subprocess.run(
+        git_cmd + ["rm", "--cached", "--force", "--", marker_name],
+        cwd=cwd,
+        capture_output=True,
+    )
+    if resolved.returncode != 0:
+        return False
+
+    try:
+        (cwd / marker_name).write_bytes(saved.stdout)
+    except OSError:
+        return False
+
+    remaining = subprocess.run(
+        git_cmd + ["diff", "--name-only", "--diff-filter=U"],
+        cwd=cwd,
+        capture_output=True,
+        text=True, encoding="utf-8", errors="replace",
+    )
+    return remaining.returncode == 0 and not remaining.stdout.strip()
+
+
 def _restore_stashed_changes(
     git_cmd: list[str],
     cwd: Path,
@@ -1280,9 +1332,30 @@ def _restore_stashed_changes(
         capture_output=True,
         text=True, encoding="utf-8", errors="replace",
     )
-    has_conflicts = bool(unmerged.stdout.strip())
+    conflicted_files = [
+        line.strip() for line in unmerged.stdout.splitlines() if line.strip()
+    ]
+    has_conflicts = bool(conflicted_files)
 
-    if restore.returncode != 0 and not has_conflicts and (
+    marker_reconciled = False
+    if has_conflicts:
+        marker_reconciled = _reconcile_removed_lazy_refresh_marker_conflict(
+            git_cmd,
+            cwd,
+            stash_ref,
+            conflicted_files,
+        )
+        if marker_reconciled:
+            has_conflicts = False
+            print(
+                "  ✓ Preserved the lazy-refresh recovery marker as ignored runtime state."
+            )
+
+    if restore.returncode != 0 and not has_conflicts and marker_reconciled:
+        # Git reported the original modify/delete conflict, but the only
+        # conflict was the historical runtime marker and it is now reconciled.
+        pass
+    elif restore.returncode != 0 and not has_conflicts and (
         _stash_apply_failed_only_on_existing_untracked(restore.stderr)
     ):
         # Permission-denied autostash tail end: the tracked changes applied
@@ -1302,11 +1375,10 @@ def _restore_stashed_changes(
             print(restore.stderr.strip())
 
         # Show which files conflicted
-        conflicted_files = unmerged.stdout.strip()
         if conflicted_files:
             print("\nConflicted files:")
-            for f in conflicted_files.splitlines():
-                print(f"  • {f}")
+            for path in conflicted_files:
+                print(f"  • {path}")
 
         print("\nYour stashed changes are preserved — nothing is lost.")
         print(f"  Stash ref: {stash_ref}")

--- a/tests/hermes_cli/test_lazy_refresh_marker_migration.py
+++ b/tests/hermes_cli/test_lazy_refresh_marker_migration.py
@@ -1,0 +1,82 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.update_cmd import (
+    _reconcile_removed_lazy_refresh_marker_conflict,
+    _restore_stashed_changes,
+    _stash_local_changes_if_needed,
+)
+
+
+MARKER = ".lazy-refresh-incomplete"
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.name", "Hermes Test")
+    _git(repo, "config", "user.email", "hermes@example.invalid")
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="needs git")
+def test_historical_tracked_marker_restores_as_ignored_runtime_state(tmp_path):
+    """Updating from the accidental tracked-marker release stays conflict-free."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    marker_payload = b"started=live\npid=999\n"
+    (repo / MARKER).write_text("started=release\npid=1\n", encoding="utf-8")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", MARKER, "README.md")
+    _git(repo, "commit", "-qm", "affected release")
+    legacy_head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    _git(repo, "rm", "-q", MARKER)
+    (repo / ".gitignore").write_text(f"{MARKER}\n", encoding="utf-8")
+    (repo / "release.txt").write_text("new release\n", encoding="utf-8")
+    _git(repo, "add", ".gitignore", "release.txt")
+    _git(repo, "commit", "-qm", "remove and ignore runtime marker")
+    update_head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    _git(repo, "checkout", "-q", legacy_head)
+    (repo / MARKER).write_bytes(marker_payload)
+    (repo / "README.md").write_text("user edit\n", encoding="utf-8")
+
+    stash_ref = _stash_local_changes_if_needed(["git"], repo)
+    assert stash_ref
+    _git(repo, "reset", "--hard", update_head)
+
+    assert _restore_stashed_changes(["git"], repo, stash_ref) is True
+    assert (repo / MARKER).read_bytes() == marker_payload
+    assert (repo / "README.md").read_text(encoding="utf-8") == "user edit\n"
+    assert (repo / "release.txt").read_text(encoding="utf-8") == "new release\n"
+    assert _git(repo, "diff", "--name-only", "--diff-filter=U").stdout == ""
+    assert _git(repo, "ls-files", "--", MARKER).stdout == ""
+    assert _git(repo, "check-ignore", "-q", "--", MARKER, check=False).returncode == 0
+    assert _git(repo, "stash", "list").stdout == ""
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="needs git")
+def test_marker_reconciliation_refuses_any_additional_conflict(tmp_path):
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    assert (
+        _reconcile_removed_lazy_refresh_marker_conflict(
+            ["git"], repo, "stash@{0}", [MARKER, "README.md"]
+        )
+        is False
+    )


### PR DESCRIPTION
1|## Summary
2|
3|Reconcile the historical `.lazy-refresh-incomplete` modify/delete conflict when Hermes restores update autostash state from the short-lived release that accidentally tracked this runtime marker.
4|
5|This revision follows current `main` exactly:
6|
7|- `.lazy-refresh-incomplete` remains the canonical runtime marker;
8|- the marker remains ignored and **untracked**;
9|- no replacement marker pathname is introduced;
10|- the historical tracked PID/timestamp artifact is not restored to the repository.
11|
12|## Root cause
13|
14|One release accidentally committed `.lazy-refresh-incomplete`. Current main correctly removed and ignored it. A user updating from the affected release can still have live PID/timestamp data modifying the tracked file. The update autostash captures that modification, then `git stash apply` encounters a modify/delete conflict after moving to current main.
15|
16|The generic conflict handler safely resets the checkout and preserves the stash, but leaves the user to recover manually even though this one conflict has deterministic semantics.
17|
18|## Fix
19|
20|During autostash restore, detect only the exact case where the sole unmerged path is `.lazy-refresh-incomplete`:
21|
22|1. read the marker bytes from the stash;
23|2. resolve the index in favor of current main's deletion;
24|3. restore the bytes to the ignored working-tree path;
25|4. verify that no unmerged entries remain;
26|5. continue the normal successful restore/drop flow.
27|
28|Any additional conflict, missing stash blob, Git failure, or filesystem failure falls through to the existing conservative reset path. Unrelated conflicts are never auto-resolved.
29|
30|## Regression coverage
31|
32|The real-Git regression creates:
33|
34|1. a historical release with a tracked marker;
35|2. a later release that removes and ignores it;
36|3. live marker PID/timestamp data plus an unrelated user README edit;
37|4. the real Hermes autostash/restore flow.
38|
39|It asserts that:
40|
41|- no unmerged entry remains;
42|- exact marker bytes survive as ignored, untracked runtime state;
43|- the unrelated user edit is restored;
44|- new release files remain present;
45|- the successfully restored stash is dropped.
46|
47|A separate guard asserts that marker reconciliation refuses any conflict set containing another path.
48|
49|## Validation
50|
51|Against current `origin/main`:
52|
53|- `17 passed, 1 skipped` across marker migration, checkout mutation guards, early recovery, and update autostash suites
54|- Ruff passed
55|- `py_compile` passed
56|- `git diff --check` passed
57|- `git ls-files .lazy-refresh-incomplete` confirms the runtime marker is not tracked
58|
59|## Review reconciliation
60|
61|Addresses Teknium's review by preserving the post-`f3082198d262` / `0fe6a36e6e34` marker contract and removing the pathname change that broke `test_sandboxed_root_still_recovers`.
62|