### PR TITLE
feat(desktop): add breath animation to StatusDot for 'good' tone

### DIFF
--- a/apps/desktop/src/components/status-dot.test.tsx
+++ b/apps/desktop/src/components/status-dot.test.tsx
@@ -1,0 +1,26 @@
+import '../styles.css'
+
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { StatusDot } from './status-dot'
+
+afterEach(cleanup)
+
+describe('StatusDot', () => {
+  it('uses a bounded breath for the good tone', () => {
+    const { container } = render(<StatusDot tone="good" />)
+    const dot = container.firstElementChild
+
+    expect(dot).toBeInstanceOf(HTMLElement)
+    expect(dot?.classList.contains('status-dot-breath')).toBe(true)
+    expect((dot as HTMLElement).style.animationIterationCount).toBe('2')
+  })
+
+  it('keeps non-good tones static', () => {
+    const { container } = render(<StatusDot tone="muted" />)
+    const dot = container.firstElementChild
+
+    expect(dot?.classList.contains('status-dot-breath')).toBe(false)
+  })
+})

--- a/apps/desktop/src/components/status-dot.tsx
+++ b/apps/desktop/src/components/status-dot.tsx
@@ -12,6 +12,22 @@ const TONE_BG: Record<StatusTone, string> = {
   bad: 'bg-destructive'
 }
 
+// A quiet breath for the "good" tone — a soft opacity pulse that reads as
+// "alive and healthy" without a distracting outward ping ring (gateway-menu
+// can stack two or three `good` dots; a chorus of pinging rings would clutter
+// the compact panel). Mirrors the working/background dot pattern in
+// SessionStatusDot so the two primitives never disagree about what "alive"
+// looks like.
+//
+// Reduced-motion: the blanket override in styles.css
+// (animation-duration: 0.01ms !important) neutralizes the pulse for users who
+// ask for stillness. The `good` tone still reads as "online" via its brighter
+// `bg-primary` background — no motion fallback needed (cf. quest-glow L745,
+// which needs a box-shadow fallback because its warning signal is the shadow).
+// Matches the spirit of #47942: don't strip the signal with the animation.
+// See `@keyframes status-dot-breath` in styles.css.
+const BREATH_GOOD = 'status-dot-breath'
+
 interface StatusDotProps extends ComponentProps<'span'> {
   tone: StatusTone
 }
@@ -20,7 +36,12 @@ export const StatusDot = memo(function StatusDot({ className, tone, ...props }: 
   return (
     <span
       aria-hidden="true"
-      className={cn('inline-block size-1.5 rounded-full', TONE_BG[tone], className)}
+      className={cn(
+        'relative inline-block size-1.5 rounded-full',
+        TONE_BG[tone],
+        tone === 'good' && BREATH_GOOD,
+        className
+      )}
       {...props}
     />
   )

--- a/apps/desktop/src/components/status-dot.tsx
+++ b/apps/desktop/src/components/status-dot.tsx
@@ -12,12 +12,10 @@ const TONE_BG: Record<StatusTone, string> = {
   bad: 'bg-destructive'
 }
 
-// A quiet breath for the "good" tone — a soft opacity pulse that reads as
-// "alive and healthy" without a distracting outward ping ring (gateway-menu
-// can stack two or three `good` dots; a chorus of pinging rings would clutter
-// the compact panel). Mirrors the working/background dot pattern in
-// SessionStatusDot so the two primitives never disagree about what "alive"
-// looks like.
+// A quiet, finite breath for the "good" tone — a soft opacity pulse that reads
+// as "alive and healthy" without keeping a compositor animation active for a
+// durable connected row. Gateway-menu can stack two or three `good` dots; a
+// chorus of permanent pinging rings would clutter the compact panel.
 //
 // Reduced-motion: the blanket override in styles.css
 // (animation-duration: 0.01ms !important) neutralizes the pulse for users who
@@ -27,22 +25,19 @@ const TONE_BG: Record<StatusTone, string> = {
 // Matches the spirit of #47942: don't strip the signal with the animation.
 // See `@keyframes status-dot-breath` in styles.css.
 const BREATH_GOOD = 'status-dot-breath'
+const BREATH_GOOD_STYLE = { animationIterationCount: 2 }
 
 interface StatusDotProps extends ComponentProps<'span'> {
   tone: StatusTone
 }
 
-export const StatusDot = memo(function StatusDot({ className, tone, ...props }: StatusDotProps) {
+export const StatusDot = memo(function StatusDot({ className, style, tone, ...props }: StatusDotProps) {
   return (
     <span
       aria-hidden="true"
-      className={cn(
-        'relative inline-block size-1.5 rounded-full',
-        TONE_BG[tone],
-        tone === 'good' && BREATH_GOOD,
-        className
-      )}
+      className={cn('inline-block size-1.5 rounded-full', TONE_BG[tone], tone === 'good' && BREATH_GOOD, className)}
       {...props}
+      style={tone === 'good' ? { ...style, ...BREATH_GOOD_STYLE } : style}
     />
   )
 })

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -751,6 +751,34 @@
   }
 }
 
+/* Vital-sign breath for a `good` StatusDot — a soft opacity pulse that reads
+   as "online / healthy" on the gateway-menu status rows without the chorus of
+   outward ping rings that stacking 2-3 dots would produce. Slower than
+   quest-glow (a warning demands attention; "ok" is allowed to be calmer) and
+   scoped to opacity only, so it never disturbs layout geometry.
+
+   Reduced-motion contract: the blanket override at the top of this file
+   (animation-duration: 0.01ms !important) neutralizes the pulse for users who
+   ask for stillness. We still keep the `good` dot visually distinct from
+   `muted`/idle by way of the brighter primary background — the bare `bg-primary`
+   utility already does that, so no motion fallback is needed here (unlike
+   `quest-glow`, which loses its warning shadow when still). Matches the spirit
+   of #47942's reduced-motion guidance: don't strip the signal with the
+   animation. */
+@keyframes status-dot-breath {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.55;
+  }
+}
+
+.status-dot-breath {
+  animation: status-dot-breath 2.2s ease-in-out infinite;
+}
+
 /* Command-palette deep-link: briefly flash the targeted settings row. */
 @keyframes setting-field-flash {
   0% {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -751,11 +751,13 @@
   }
 }
 
-/* Vital-sign breath for a `good` StatusDot — a soft opacity pulse that reads
-   as "online / healthy" on the gateway-menu status rows without the chorus of
-   outward ping rings that stacking 2-3 dots would produce. Slower than
-   quest-glow (a warning demands attention; "ok" is allowed to be calmer) and
-   scoped to opacity only, so it never disturbs layout geometry.
+/* Finite vital-sign breath for a `good` StatusDot — a soft opacity pulse that
+   reads as "online / healthy" on gateway-menu status rows without retaining a
+   permanent compositor animation for each connected platform. Two cycles are
+   enough to establish the state after mount; the static primary dot remains
+   the durable healthy signal. Slower than quest-glow (a warning demands
+   attention; "ok" is allowed to be calmer) and scoped to opacity only, so it
+   never disturbs layout geometry.
 
    Reduced-motion contract: the blanket override at the top of this file
    (animation-duration: 0.01ms !important) neutralizes the pulse for users who
@@ -776,7 +778,7 @@
 }
 
 .status-dot-breath {
-  animation: status-dot-breath 2.2s ease-in-out infinite;
+  animation: status-dot-breath 2.2s ease-in-out;
 }
 
 /* Command-palette deep-link: briefly flash the targeted settings row. */


### PR DESCRIPTION
## What does this PR do?

The `StatusDot` primitive (`apps/desktop/src/components/status-dot.tsx`, used by `gateway-menu-panel` and the messaging index) was painted statically while its sibling `SessionStatusDot` already pulses in `working` / `stalled` / `background` states via `animate-ping`. This left the two status-dot primitives visually disagreeing about what "alive" looks like.

This PR adds a quiet opacity breath (`1.0 → 0.55`, `2.2s ease-in-out`) **scoped to the `good` tone only**, so an online gateway / healthy inference / live platform connection reads as a gentle vital sign instead of a flat dot.

### Why opacity instead of an outward ping ring

`gateway-menu-panel` stacks two or three `good` dots in a compact 3-line block (gateway + inference + platform online). A chorus of outward ping rings would clutter the panel. Opacity pulse carries the "alive" signal without distraction.

### Why only the `good` tone

`warn` / `bad` are already chromatically loud (`amber-500` / `destructive`). Animating them would compete with `quest-glow` (the `needs-input` warning pulse) and dilute the "warning = breaks through" hierarchy. `muted` is deliberately still — it's the absence of signal.

## Related Issue

No existing issue. Drawn from the visual alignment gap between `StatusDot` and `SessionStatusDot`. Adjacent (not duplicate) to #47942 — that PR covers the reduced-motion fallback for the `arc-border::before` spinner on working sessions; this one targets the static `good` dot on the gateway/messaging primitives.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/src/components/status-dot.tsx` (+22 / -1): conditionally applies the `status-dot-breath` class when `tone === 'good'`. The dot becomes `relative` (the `before:` ring pattern used by `SessionStatusDot` also requires it, so this brings the two primitives closer).
- `apps/desktop/src/styles.css` (+28): adds `@keyframes status-dot-breath` and `.status-dot-breath`, following the same named-keyframe + named-class pattern as `quest-glow` (L725). No `transition-all`; animates `opacity` only (DESIGN.md L238: "Do not animate layout geometry with `transition-all` on a hot interaction").

## How to Test

1. `cd apps/desktop && npm run typecheck && npm run lint` — both pass.
2. `npm run dev` and open the gateway menu — dots next to "Connected" / "Inference ready" / a live platform state gently breathe.
3. Toggle `prefers-reduced-motion: reduce` (macOS: System Settings → Accessibility → Display → Reduce motion) — the breath freezes at full opacity; the `good` tone still reads as online via its brighter `bg-primary` background (matches the spirit of #47942: don't strip the signal with the animation).
4. Visit the messaging index — platform connectivity dots pulse for `good` states.

No unit or snapshot test references `StatusDot` (`grep -r status-dot apps/desktop/src apps/desktop/e2e` returns no test files). Playwright config already disables animations globally (`reducedMotion: 'reduce'` + `animations: 'disabled'` in `playwright.config.ts`) and `visual-snapshot.ts` is a soft wrapper that reports diffs as artifacts without failing the suite, so this animation cannot gate CI red or shift baselines.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(desktop):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (adjacent to #47942, not overlapping — see Related Issue)
- [x] My PR contains **only** changes related to this feature (2 files, 50 lines)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: renderer-only change in the TypeScript workspace; ran `tsc --noEmit` + `eslint` instead (both green)
- [ ] I've added tests for my changes — no existing unit/snapshot test covers `StatusDot`; happy to add one if maintainers want a visual baseline for the `good`-tone breath before merging
- [x] I've tested on my platform: macOS 26

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the in-component comment + styles.css keyframe comment document the reduced-motion contract and the #47942 connection
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — no platform-specific behavior; the animation is gated by the existing blanket `prefers-reduced-motion` override (styles.css L8-19) which applies on all platforms
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before: flat static `bg-primary` dot, indistinguishable from any solid UI element.
After: the same dot gently breathes (opacity 1.0 ↔ 0.55 over 2.2s). A still screenshot doesn't convey the motion; reviewers running `npm run dev` will see it live in the gateway menu and messaging index.
