### PR TITLE
fix(desktop): About panel 'Update now' targets client, not backend, in remote mode

### DIFF
--- a/apps/desktop/src/app/settings/about-settings.tsx
+++ b/apps/desktop/src/app/settings/about-settings.tsx
@@ -144,7 +144,7 @@ export function AboutSettings() {
 
             {behind > 0 && supported && !applying && (
               <>
-                <Button onClick={() => startActiveUpdate()} size="sm">
+                <Button onClick={() => startActiveUpdate('client')} size="sm">
                   {a.updateNow}
                 </Button>
                 <Button onClick={() => openUpdatesWindow()} size="sm" variant="textStrong">

--- a/apps/desktop/src/app/settings/about-settings.tsx
+++ b/apps/desktop/src/app/settings/about-settings.tsx
@@ -147,7 +147,7 @@ export function AboutSettings() {
                 <Button onClick={() => startActiveUpdate('client')} size="sm">
                   {a.updateNow}
                 </Button>
-                <Button onClick={() => openUpdatesWindow()} size="sm" variant="textStrong">
+                <Button onClick={() => openUpdatesWindow('client')} size="sm" variant="textStrong">
                   {a.seeWhatsNew}
                 </Button>
               </>

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -53,6 +53,8 @@ const {
   $updateOverlayOpen,
   $updateOverlayTarget,
   requestActiveUpdate,
+  openUpdatesWindow,
+  startActiveUpdate,
   resetUpdateApplyState,
   startUpdatePoller,
   stopUpdatePoller,
@@ -347,6 +349,70 @@ describe('requestActiveUpdate', () => {
 
     requestActiveUpdate()
     await vi.waitFor(() => expect(updateHermesSpy).toHaveBeenCalled())
+  })
+})
+
+describe('Desktop update entry points', () => {
+  const applyClientMock = vi.fn()
+  const checkClientMock = vi.fn()
+
+  beforeEach(() => {
+    storage.clear()
+    notifySpy.mockClear()
+    dismissSpy.mockClear()
+    applyClientMock.mockReset().mockResolvedValue({ ok: false, error: 'test-stop' })
+    checkClientMock.mockReset().mockResolvedValue(status({ behind: 0 }))
+    updateHermesSpy.mockReset().mockResolvedValue({ ok: true, name: 'update' })
+    checkHermesUpdateSpy.mockReset().mockResolvedValue({
+      install_method: 'git',
+      current_version: '0.4.2',
+      behind: 0,
+      update_available: false,
+      can_apply: true,
+      update_command: null,
+      message: null
+    })
+    getActionStatusSpy.mockReset().mockResolvedValue({ lines: [], running: false, exit_code: 0 })
+    resetUpdateApplyState()
+    $updateStatus.set(null)
+    $backendUpdateStatus.set(null)
+    $updateOverlayOpen.set(false)
+    $updateOverlayTarget.set('client')
+    setRemote(true)
+    ;(globalThis as unknown as { window: unknown }).window = {
+      hermesDesktop: { updates: { apply: applyClientMock, check: checkClientMock } }
+    }
+    vi.useRealTimers()
+  })
+
+  afterEach(async () => {
+    await vi.waitFor(() => expect($backendUpdateApply.get().applying).toBe(false), { timeout: 5000 })
+    setRemote(false)
+    delete (globalThis as unknown as { window?: unknown }).window
+  })
+
+  it('applies the CLIENT update from the About panel while connected to a remote backend', async () => {
+    startActiveUpdate('client')
+
+    expect($updateOverlayTarget.get()).toBe('client')
+    expect(applyClientMock).toHaveBeenCalledTimes(1)
+    expect(updateHermesSpy).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect($updateApply.get().applying).toBe(false))
+  })
+
+  it('opens the CLIENT changelog from the About panel while connected to a remote backend', async () => {
+    openUpdatesWindow('client')
+
+    expect($updateOverlayTarget.get()).toBe('client')
+    await vi.waitFor(() => expect(checkClientMock).toHaveBeenCalledTimes(1))
+    expect(checkHermesUpdateSpy).not.toHaveBeenCalled()
+  })
+
+  it('preserves the connection-mode auto-select when no target is passed', () => {
+    openUpdatesWindow()
+
+    expect($updateOverlayTarget.get()).toBe('backend')
+    expect(checkClientMock).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -236,8 +236,15 @@ export function maybeNotifyUpdateAvailable(status: DesktopUpdateStatus | null) {
   })
 }
 
-export function openUpdatesWindow(): void {
-  openUpdateOverlayFor(isRemoteMode() ? 'backend' : 'client')
+/**
+ * Open the updates overlay for the active target (auto-selected from the
+ * connection mode) and kick off its check. When `target` is passed explicitly
+ * it overrides the auto-select. Callers that know which component they want
+ * (e.g. the About panel, whose status is always the client's) should pass the
+ * target so the user action matches the displayed state.
+ */
+export function openUpdatesWindow(target?: UpdateTarget): void {
+  openUpdateOverlayFor(target ?? (isRemoteMode() ? 'backend' : 'client'))
 }
 
 /**

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -246,12 +246,18 @@ export function openUpdatesWindow(): void {
  * renders ApplyingView once `applying` flips true), then kicks off the install.
  * Used by the "Update now" affordance on the About panel, which would otherwise
  * only be able to open the changelog overlay.
+ *
+ * When `target` is passed explicitly it overrides the remote-mode auto-select.
+ * Callers that know which component they want (e.g. the About panel always
+ * wants the client) should pass the target so the user action matches the
+ * displayed state.
  */
-export function startActiveUpdate(): void {
-  const target: UpdateTarget = isRemoteMode() ? 'backend' : 'client'
-  $updateOverlayTarget.set(target)
+export function startActiveUpdate(target?: UpdateTarget): void {
+  const effectiveTarget: UpdateTarget =
+    target ?? (isRemoteMode() ? 'backend' : 'client')
+  $updateOverlayTarget.set(effectiveTarget)
   $updateOverlayOpen.set(true)
-  void (target === 'backend' ? applyBackendUpdate() : applyUpdates())
+  void (effectiveTarget === 'backend' ? applyBackendUpdate() : applyUpdates())
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the remote update loop: when Desktop is connected to a remote backend, Settings → About shows the local client behindness but the "Update now" button targets the backend instead of the client, creating a repeatable loop when the backend is already current.

## Root cause

In `startActiveUpdate()`, the target was unconditionally selected based on connection mode:

```ts
const target: UpdateTarget = isRemoteMode() ? 'backend' : 'client'
```

The About panel reads `$updateStatus` (client status) and displays the client-behind count, but calls `startActiveUpdate()` which always picks `'backend'` in remote mode — regardless of what the panel is showing. The same mismatch applies to the panel's "See what's new" button, which calls `openUpdatesWindow()` (also backend in remote mode).

## Fix

Added an optional `target` parameter to `startActiveUpdate()` and `openUpdatesWindow()`. Callers that know which component they want can pass it explicitly:

```ts
export function startActiveUpdate(target?: UpdateTarget): void
export function openUpdatesWindow(target?: UpdateTarget): void
```

- **About panel** passes `'client'` for both **Update now** and **See what's new**, so the user action matches the displayed status
- **Command palette** (`requestActiveUpdate`), the native "Check for Updates" entry, and the update-notification toast continue to auto-select based on connection mode (no argument = original behavior)

The default (`target ?? (isRemoteMode() ? 'backend' : 'client')`) preserves the existing behavior for callers that don't pass an explicit target.

**Scope:** limited to the About panel. The notification-toast and native-entry surfaces are addressed separately in #70612, which hard-switches those store helpers to the client target.

## Validation

- `apps/desktop/src/store/updates.test.ts`: 46 passed (43 existing + 3 new remote-mode entry-point tests)
- TypeScript type-check passes (`tsc -p . --noEmit && tsc -p tsconfig.electron.json --noEmit && tsc -p tsconfig.e2e.json --noEmit`)
- Full desktop UI suite: 3492 passed (396 files), 0 failures

Closes #70056
