### PR TITLE
fix(codex): support dict-shaped usage in normalize_usage()

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -987,6 +988,20 @@ def _to_int(value: Any) -> int:
         return 0
 
 
+def _usage_field(obj: Any, field: str, default: Any = None) -> Any:
+    """Read ``field`` off a usage object that may be a mapping or an attribute-style object.
+
+    API SDK response types expose fields as attributes, but some code paths
+    (e.g. dict-shaped Codex Responses events) hand ``normalize_usage`` a plain
+    dict instead. ``getattr()`` silently returns the default for dicts, which
+    zeroed out every token count for that shape. Check mapping-ness first so
+    both shapes are read correctly.
+    """
+    if isinstance(obj, Mapping):
+        return obj.get(field, default)
+    return getattr(obj, field, default)
+
+
 def resolve_billing_route(
     model_name: str,
     provider: Optional[str] = None,
@@ -1226,32 +1241,32 @@ def normalize_usage(
     mode = (api_mode or "").strip().lower()
 
     if mode == "anthropic_messages" or provider_name == "anthropic":
-        input_tokens = _to_int(getattr(response_usage, "input_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "output_tokens", 0))
-        cache_read_tokens = _to_int(getattr(response_usage, "cache_read_input_tokens", 0))
-        cache_write_tokens = _to_int(getattr(response_usage, "cache_creation_input_tokens", 0))
+        input_tokens = _to_int(_usage_field(response_usage, "input_tokens", 0))
+        output_tokens = _to_int(_usage_field(response_usage, "output_tokens", 0))
+        cache_read_tokens = _to_int(_usage_field(response_usage, "cache_read_input_tokens", 0))
+        cache_write_tokens = _to_int(_usage_field(response_usage, "cache_creation_input_tokens", 0))
     elif mode == "codex_responses":
-        input_total = _to_int(getattr(response_usage, "input_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "output_tokens", 0))
-        details = getattr(response_usage, "input_tokens_details", None)
-        cache_read_tokens = _to_int(getattr(details, "cached_tokens", 0) if details else 0)
+        input_total = _to_int(_usage_field(response_usage, "input_tokens", 0))
+        output_tokens = _to_int(_usage_field(response_usage, "output_tokens", 0))
+        details = _usage_field(response_usage, "input_tokens_details", None)
+        cache_read_tokens = _to_int(_usage_field(details, "cached_tokens", 0) if details else 0)
         cache_write_tokens = _to_int(
-            getattr(details, "cache_creation_tokens", 0) if details else 0
+            _usage_field(details, "cache_creation_tokens", 0) if details else 0
         )
         input_tokens = max(0, input_total - cache_read_tokens - cache_write_tokens)
     else:
-        prompt_total = _to_int(getattr(response_usage, "prompt_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "completion_tokens", 0))
-        details = getattr(response_usage, "prompt_tokens_details", None)
+        prompt_total = _to_int(_usage_field(response_usage, "prompt_tokens", 0))
+        output_tokens = _to_int(_usage_field(response_usage, "completion_tokens", 0))
+        details = _usage_field(response_usage, "prompt_tokens_details", None)
         # Primary: OpenAI-style prompt_tokens_details. Fallback: Anthropic-style
         # top-level fields that some OpenAI-compatible proxies (OpenRouter, Cline)
         # expose when routing Claude models — without this
         # fallback, cache writes are undercounted as 0 and cache reads can be
         # missed when the proxy only surfaces them at the top level.
         # Port of cline/cline#10266.
-        cache_read_tokens = _to_int(getattr(details, "cached_tokens", 0) if details else 0)
+        cache_read_tokens = _to_int(_usage_field(details, "cached_tokens", 0) if details else 0)
         if not cache_read_tokens:
-            cache_read_tokens = _to_int(getattr(response_usage, "cache_read_input_tokens", 0))
+            cache_read_tokens = _to_int(_usage_field(response_usage, "cache_read_input_tokens", 0))
         if not cache_read_tokens:
             # DeepSeek's native API (api.deepseek.com) reports context-cache
             # hits as top-level prompt_cache_hit_tokens (+ the complementary
@@ -1259,14 +1274,14 @@ def normalize_usage(
             # OpenAI nested shape. Without this, direct DeepSeek sessions
             # always showed 0 cache-hit tokens (#61871).
             cache_read_tokens = _to_int(
-                getattr(response_usage, "prompt_cache_hit_tokens", 0)
+                _usage_field(response_usage, "prompt_cache_hit_tokens", 0)
             )
         cache_write_tokens = _to_int(
-            getattr(details, "cache_write_tokens", 0) if details else 0
+            _usage_field(details, "cache_write_tokens", 0) if details else 0
         )
         if not cache_write_tokens:
             cache_write_tokens = _to_int(
-                getattr(response_usage, "cache_creation_input_tokens", 0)
+                _usage_field(response_usage, "cache_creation_input_tokens", 0)
             )
         input_tokens = max(0, prompt_total - cache_read_tokens - cache_write_tokens)
 
@@ -1278,14 +1293,14 @@ def normalize_usage(
     # hidden thinking was invisible in session accounting even though it
     # dominates output spend on models like deepseek-v4-flash (measured:
     # single calls burning 21K reasoning tokens to emit 500 visible tokens).
-    output_details = getattr(response_usage, "output_tokens_details", None)
+    output_details = _usage_field(response_usage, "output_tokens_details", None)
     if output_details:
-        reasoning_tokens = _to_int(getattr(output_details, "reasoning_tokens", 0))
+        reasoning_tokens = _to_int(_usage_field(output_details, "reasoning_tokens", 0))
     if not reasoning_tokens:
-        completion_details = getattr(response_usage, "completion_tokens_details", None)
+        completion_details = _usage_field(response_usage, "completion_tokens_details", None)
         if completion_details:
             reasoning_tokens = _to_int(
-                getattr(completion_details, "reasoning_tokens", 0)
+                _usage_field(completion_details, "reasoning_tokens", 0)
             )
 
     return CanonicalUsage(

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -166,6 +166,38 @@ def test_normalize_usage_openai_prefers_prompt_tokens_details_over_top_level():
     assert normalized.cache_write_tokens == 150
 
 
+def test_normalize_usage_codex_responses_dict_and_object_shapes_match():
+    """The Codex Responses terminal-event handler stores ``usage`` as a plain
+    dict when the SDK response object is itself a dict (see
+    agent/codex_runtime.py's dict fallback for resp_obj). normalize_usage()
+    must read dict-shaped usage the same way it reads attribute-style SDK
+    objects — getattr() alone silently returns 0 for every field on a dict,
+    including nested cache/reasoning detail counts."""
+    payload = {
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "input_tokens_details": {"cached_tokens": 60},
+        "output_tokens_details": {"reasoning_tokens": 7},
+    }
+    object_usage = SimpleNamespace(
+        input_tokens=100,
+        output_tokens=20,
+        input_tokens_details=SimpleNamespace(cached_tokens=60),
+        output_tokens_details=SimpleNamespace(reasoning_tokens=7),
+    )
+
+    dict_normalized = normalize_usage(payload, provider="openai", api_mode="codex_responses")
+    object_normalized = normalize_usage(
+        object_usage, provider="openai", api_mode="codex_responses"
+    )
+
+    assert dict_normalized == object_normalized
+    assert dict_normalized.input_tokens == 40
+    assert dict_normalized.output_tokens == 20
+    assert dict_normalized.cache_read_tokens == 60
+    assert dict_normalized.reasoning_tokens == 7
+
+
 def test_openrouter_models_api_pricing_is_converted_from_per_token_to_per_million(monkeypatch):
     monkeypatch.setattr(
         "agent.usage_pricing.fetch_model_metadata",


### PR DESCRIPTION
 

## Summary

- `normalize_usage()` in `agent/usage_pricing.py` read every usage field exclusively via `getattr()`. When the Codex Responses terminal-event handler passes a plain `dict` (which it does whenever the SDK response object itself arrives as a `dict`), `getattr()` silently falls back to the default of `0` for every field.
- This zeroed out `input_tokens`, `output_tokens`, and the nested cache/reasoning detail counts (`input_tokens_details.cached_tokens`, `output_tokens_details.reasoning_tokens`, etc.) whenever the dict shape was in play, corrupting session usage/cost accounting for that code path.

## Root Cause

- `agent/codex_runtime.py` (terminal-event handling, `_TERMINAL_EVENT_TYPES` branch) already has a dict fallback for the response object (`resp_obj.get("usage")` when `resp_obj` is a `dict`), so `terminal_usage` can legitimately be a plain mapping rather than an attribute-style SDK object.
- `agent/usage_pricing.py`'s `normalize_usage()` was written assuming `response_usage` always exposes fields as attributes, reading them with `getattr(response_usage, "input_tokens", 0)` etc. `getattr({...}, "input_tokens", 0)` on a `dict` returns the default (`0`) instead of raising or reading the key, so no error was ever surfaced — the bug was silent.

## Fix

- Added a small helper, `_usage_field(obj, field, default)`, that checks `isinstance(obj, collections.abc.Mapping)` and uses `.get(field, default)` in that case, else falls back to `getattr(obj, field, default)`.
- Replaced every raw `getattr()` call inside `normalize_usage()` with `_usage_field()`, including the nested `input_tokens_details` / `output_tokens_details` / `prompt_tokens_details` / `completion_tokens_details` sub-objects, which may themselves be dicts.
- Scope kept to `normalize_usage()` and its immediate helper — the already-correct dict handling in `_record_codex_app_server_usage` (`agent/codex_runtime.py`) was left untouched.

## Test Plan

- Added `test_normalize_usage_codex_responses_dict_and_object_shapes_match` to `tests/agent/test_usage_pricing.py`: feeds the identical payload (`input_tokens=100, output_tokens=20, input_tokens_details={"cached_tokens": 60}, output_tokens_details={"reasoning_tokens": 7}`) once as a plain `dict` and once as an equivalent `SimpleNamespace`, and asserts `normalize_usage()` returns identical `CanonicalUsage` results for both shapes (`input_tokens=40`, `output_tokens=20`, `cache_read_tokens=60`, `reasoning_tokens=7`).
- Ran `python -m pytest tests/agent/test_usage_pricing.py -q` — all 36 tests pass (35 pre-existing + 1 new).

Closes #74314
