### PR TITLE
fix(auth): stop Codex OAuth worker on cancel, pin resolved profile

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10588,6 +10588,9 @@ def _new_oauth_session(
         "created_at": time.time(),
         "status": "pending",  # pending | approved | denied | expired | error
         "error_message": None,
+        # Set by DELETE /api/providers/oauth/sessions/{id}; background
+        # pollers check this to abort without writing credentials.
+        "cancel_event": threading.Event(),
     }
     with _oauth_sessions_lock:
         _oauth_sessions[sid] = sess
@@ -11263,6 +11266,17 @@ def _codex_full_login_worker(session_id: str) -> None:
     single function — we need to surface the user_code to the dashboard the
     moment we receive it, well before polling completes.
     """
+    with _oauth_sessions_lock:
+        sess = _oauth_sessions.get(session_id)
+        if sess is None:
+            return
+        cancel_event: threading.Event = sess["cancel_event"]
+        # Pin the target profile now, while the session entry still exists.
+        # Cancellation pops the session from _oauth_sessions, so resolving
+        # the profile lazily at write time would silently fall back to
+        # whatever profile happens to be "current" (see _oauth_session_profile).
+        target_profile = sess.get("profile")
+
     try:
         import httpx
         from hermes_cli.auth import (
@@ -11303,7 +11317,11 @@ def _codex_full_login_worker(session_id: str) -> None:
         code_resp = None
         with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
             while time.monotonic() < deadline:
+                if cancel_event.is_set():
+                    return
                 time.sleep(poll_interval)
+                if cancel_event.is_set():
+                    return
                 poll = client.post(
                     f"{issuer}/api/accounts/deviceauth/token",
                     json={"device_auth_id": device_auth_id, "user_code": user_code},
@@ -11315,6 +11333,9 @@ def _codex_full_login_worker(session_id: str) -> None:
                 if poll.status_code in {403, 404}:
                     continue  # user hasn't authorized yet
                 raise RuntimeError(f"deviceauth/token poll returned {poll.status_code}")
+
+        if cancel_event.is_set():
+            return
 
         if code_resp is None:
             with _oauth_sessions_lock:
@@ -11349,7 +11370,14 @@ def _codex_full_login_worker(session_id: str) -> None:
 
         from hermes_cli.auth import _save_codex_tokens
 
-        with _profile_scope(_oauth_session_profile(session_id)):
+        # Refuse to write if cancellation raced past the checks above.
+        if cancel_event.is_set():
+            _log.info(
+                "oauth/device: openai-codex session %s cancelled before token write", session_id,
+            )
+            return
+
+        with _profile_scope(target_profile):
             _save_codex_tokens({
                 "access_token": access_token,
                 "refresh_token": refresh_token,
@@ -11456,6 +11484,10 @@ async def cancel_oauth_session(
     _require_token(request)
     with _oauth_sessions_lock:
         sess = _oauth_sessions.pop(session_id, None)
+        if sess is not None:
+            cancel_event = sess.get("cancel_event")
+            if cancel_event is not None:
+                cancel_event.set()
     if sess is None:
         return {"ok": False, "message": "session not found"}
     return {"ok": True, "session_id": session_id}

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -341,6 +341,92 @@ def test_codex_dashboard_worker_persists_inside_session_profile(tmp_path, monkey
         ws._oauth_sessions.pop(sid, None)
 
 
+def test_codex_dashboard_worker_aborts_after_cancel(tmp_path, monkeypatch):
+    """DELETE /api/providers/oauth/sessions/{id} must stop the codex poll
+    worker before it exchanges the device code and writes tokens.
+
+    Regression for issue #74308: cancelling mid-poll used to leave the
+    background worker running to completion, and — since the session dict
+    entry had already been popped — the eventual token write resolved its
+    target profile as ``None`` and fell back to whatever profile happened
+    to be "current" instead of the profile the session actually targeted.
+    """
+    from hermes_cli import auth as auth_mod
+    from hermes_cli import web_server as ws
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    save_calls = []
+    monkeypatch.setattr(
+        auth_mod,
+        "_save_codex_tokens",
+        lambda tokens: save_calls.append(tokens),
+    )
+
+    class _Resp:
+        def __init__(self, status_code, payload):
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    class _Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def post(self, url, **kwargs):
+            if url.endswith("/deviceauth/usercode"):
+                return _Resp(200, {
+                    "device_auth_id": "device-auth-id",
+                    "interval": 3,
+                    "user_code": "CODEX-1234",
+                })
+            if url.endswith("/deviceauth/token"):
+                # The user "approves" on the very first poll — if the worker
+                # doesn't check cancellation, this looks like a success.
+                return _Resp(200, {
+                    "authorization_code": "authorization-code",
+                    "code_verifier": "code-verifier",
+                })
+            return _Resp(200, {
+                "access_token": "codex-access-should-not-be-saved",
+                "refresh_token": "codex-refresh-should-not-be-saved",
+            })
+
+    monkeypatch.setattr(httpx, "Client", _Client)
+
+    sid, _ = ws._new_oauth_session("openai-codex", "device_code", profile="coder")
+
+    # Cancel the session the moment the worker calls time.sleep() inside the
+    # poll loop — simulates the user clicking "Cancel" while the worker is
+    # paused between poll attempts, published device code already in hand.
+    def fake_sleep(_seconds):
+        resp = client.delete(
+            f"/api/providers/oauth/sessions/{sid}", headers=HEADERS,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["ok"] is True
+
+    monkeypatch.setattr(ws.time, "sleep", fake_sleep)
+
+    try:
+        ws._codex_full_login_worker(sid)
+    finally:
+        ws._oauth_sessions.pop(sid, None)
+
+    # Cancellation must have removed the session before the worker exits.
+    assert sid not in ws._oauth_sessions
+    # And the worker must have aborted BEFORE persisting any credentials.
+    assert save_calls == []
+
+
 def test_codex_dashboard_start_rewords_device_authorization_error(monkeypatch):
     from hermes_cli import web_server as ws
 


### PR DESCRIPTION
```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[🔒 Cancel Request] --> B{Old Behavior}
    A --> C{Fixed Behavior}

    B --> D[⚠️ Session Removed]
    D --> E[🐛 Worker Keeps Polling]
    E --> F[🐛 Code Approved Late]
    F --> G[💀 Profile Lookup Returns None]
    G --> H[💀 Tokens Written To Wrong Profile]

    C --> I[⚡ Cancel Event Set]
    I --> J[🚀 Worker Checks Event]
    J --> K[✅ Safe Abort - No Write]

    style B fill:#3a0a12,stroke:#ff007f
    style D fill:#3a0a12,stroke:#ff007f
    style E fill:#3a0a12,stroke:#ff007f
    style F fill:#3a0a12,stroke:#ff007f
    style G fill:#3a0a12,stroke:#ff007f
    style H fill:#3a0a12,stroke:#ff007f
    style C fill:#0a2a2f,stroke:#00f0ff
    style I fill:#0a2a2f,stroke:#00f0ff
    style J fill:#0a2a2f,stroke:#00f0ff
    style K fill:#0a2a2f,stroke:#00f0ff
```

## Summary

- Cancelling an OpenAI Codex device-code OAuth flow from the dashboard did not stop the background polling worker, and the worker could still write credentials afterward — potentially to the wrong profile.
- Adds a per-session `threading.Event` that the cancel endpoint sets, and wires it into every checkpoint of the Codex device-code worker (poll loop, code exchange, token write).
- Pins the worker's target profile once at session start instead of re-resolving it lazily at write time, so a cancelled/removed session can never fall back to whatever profile happens to be "current".

## Root Cause

In `hermes_cli/web_server.py`:

1. `_codex_full_login_worker`'s poll loop (`while time.monotonic() < deadline: time.sleep(poll_interval); poll = client.post(...)`) never checked any cancellation signal — it ran to completion regardless of whether the dashboard had cancelled the session.
2. `DELETE /api/providers/oauth/sessions/{session_id}` only did `_oauth_sessions.pop(session_id, None)` — it removed the session bookkeeping but never signalled the worker thread to stop.
3. The token-write path resolved the destination profile lazily, at write time, via `_oauth_session_profile(session_id)`. Once the session had been popped by cancellation, that lookup returned `None`, and `_profile_scope(None)` silently fell back to whatever profile was currently active — not the profile the session was originally started for.

Net effect: cancel a Codex login, then approve the device code late (or race the cancel against an in-flight approval) → the worker kept running, "succeeded", and wrote OAuth tokens into the wrong profile with no user-visible error.

## Fix

- `_new_oauth_session` now stores a `threading.Event()` (`cancel_event`) alongside each session.
- `DELETE /api/providers/oauth/sessions/{session_id}` sets that event before popping the session from `_oauth_sessions`.
- `_codex_full_login_worker`:
  - Captures `cancel_event` and the resolved `target_profile` once, at the very start, while the session entry is still guaranteed to exist.
  - Checks `cancel_event.is_set()` before and after each poll-loop sleep, before exchanging the device code for tokens, and immediately before calling `_save_codex_tokens`.
  - Returns immediately (no write, thread exits) the moment cancellation is observed.
  - Uses the pinned `target_profile` for the write instead of re-resolving `_oauth_session_profile(session_id)`, so even a raced write always lands on the originally-intended profile — and only happens if the session was never cancelled.

The other device-code pollers (Nous, MiniMax, xAI) are unchanged — this fix is scoped to the Codex flow reported in the issue, since it's the only one that inlines its own poll loop directly in `web_server.py`.

## Test Plan

- [x] Added `test_codex_dashboard_worker_aborts_after_cancel` in `tests/hermes_cli/test_web_oauth_dispatch.py`: starts a Codex session, cancels it via the real `DELETE /api/providers/oauth/sessions/{id}` endpoint from inside a monkeypatched `time.sleep` (simulating "user clicks Cancel while the worker is paused between polls"), then lets the poll "succeed" and code-exchange "succeed" — asserts `_save_codex_tokens` was never called and the session stays removed.
- [x] `pytest tests/hermes_cli/test_web_oauth_dispatch.py -v` → 25 passed (new test + all pre-existing OAuth dispatch tests, including the two pre-existing Codex worker tests, confirming no regression).
- [x] `python -m py_compile hermes_cli/web_server.py` → compiles cleanly.
- [x] Confirmed `test_dashboard_oauth_write_uses_owner_only_permissions` failure in `test_web_server_oauth_write.py` is pre-existing (fails identically on `main` before this change) — Windows file-mode semantics, unrelated to this fix.

Closes #74308
