### PR TITLE
feat(discord): configure voice turn timing

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -740,6 +740,14 @@ group_sessions_per_user: true
 # key (``extra.key`` / API_SERVER_KEY).
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Discord Voice Turn Detection
+# ─────────────────────────────────────────────────────────────────────────────
+# Positive durations in seconds. Invalid values retain these defaults.
+# discord:
+#   voice_silence_seconds: 2.0
+#   voice_min_speech_seconds: 0.5
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Gateway Streaming
 # ─────────────────────────────────────────────────────────────────────────────
 # Stream tokens to messaging platforms in real-time. The bot sends a message

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -424,6 +424,10 @@ def _discord_ready_timeout_seconds() -> float:
     return 30.0
 
 
+_DISCORD_VOICE_SILENCE_SECONDS_DEFAULT = 2.0
+_DISCORD_VOICE_MIN_SPEECH_SECONDS_DEFAULT = 0.5
+
+
 class VoiceReceiver:
     """Captures and decodes voice audio from a Discord voice channel.
 
@@ -433,14 +437,31 @@ class VoiceReceiver:
     completed utterances via a callback.
     """
 
-    SILENCE_THRESHOLD = 1.5    # seconds of silence → end of utterance
-    MIN_SPEECH_DURATION = 0.5  # minimum seconds to process (skip noise)
+    SILENCE_THRESHOLD = _DISCORD_VOICE_SILENCE_SECONDS_DEFAULT
+    MIN_SPEECH_DURATION = _DISCORD_VOICE_MIN_SPEECH_SECONDS_DEFAULT
     SAMPLE_RATE = 48000        # Discord native rate
     CHANNELS = 2               # Discord sends stereo
 
-    def __init__(self, voice_client, allowed_user_ids: set = None):
+    def __init__(
+        self,
+        voice_client,
+        allowed_user_ids: set = None,
+        *,
+        silence_threshold: Optional[float] = None,
+        min_speech_duration: Optional[float] = None,
+    ):
         self._vc = voice_client
         self._allowed_user_ids = allowed_user_ids or set()
+        self.SILENCE_THRESHOLD = (
+            float(silence_threshold)
+            if silence_threshold is not None
+            else type(self).SILENCE_THRESHOLD
+        )
+        self.MIN_SPEECH_DURATION = (
+            float(min_speech_duration)
+            if min_speech_duration is not None
+            else type(self).MIN_SPEECH_DURATION
+        )
         self._running = False
 
         # Decryption
@@ -932,6 +953,14 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_timeout_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> timeout task
         self._voice_timeout_seconds = self._load_voice_timeout()
         self._playback_timeout_seconds = self._load_playback_timeout()
+        self._voice_silence_seconds = self._positive_config_float_or_default(
+            "voice_silence_seconds",
+            _DISCORD_VOICE_SILENCE_SECONDS_DEFAULT,
+        )
+        self._voice_min_speech_seconds = self._positive_config_float_or_default(
+            "voice_min_speech_seconds",
+            _DISCORD_VOICE_MIN_SPEECH_SECONDS_DEFAULT,
+        )
         # Phase 2: voice listening
         self._voice_receivers: Dict[int, VoiceReceiver] = {}  # guild_id -> VoiceReceiver
         self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
@@ -1034,6 +1063,17 @@ class DiscordAdapter(BasePlatformAdapter):
         except (TypeError, ValueError):
             return 0.0
         return value if math.isfinite(value) and value > 0 else 0.0
+
+    def _positive_config_float_or_default(self, key: str, default: float) -> float:
+        """Resolve a positive duration from Discord config, preserving defaults."""
+        raw = self._config_value(key, default)
+        if isinstance(raw, bool):
+            return default
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            return default
+        return value if math.isfinite(value) and value > 0 else default
 
     def _config_int(
         self, key: str, default: int, *, env_key: Optional[str] = None
@@ -4031,7 +4071,12 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Start voice receiver (Phase 2: listen to users)
             try:
-                receiver = VoiceReceiver(vc, allowed_user_ids=self._allowed_user_ids)
+                receiver = VoiceReceiver(
+                    vc,
+                    allowed_user_ids=self._allowed_user_ids,
+                    silence_threshold=self._voice_silence_seconds,
+                    min_speech_duration=self._voice_min_speech_seconds,
+                )
                 receiver.start()
                 self._voice_receivers[guild_id] = receiver
                 self._voice_listen_tasks[guild_id] = asyncio.ensure_future(
@@ -9740,11 +9785,16 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
                 os.environ[env_key] = str(allow_mentions_cfg[yaml_key]).lower()
     # reply_to_mode: top-level preferred, falls back to extra.reply_to_mode.
     # YAML 1.1 parses bare 'off' as boolean False — coerce to string "off".
-    _discord_extra = discord_cfg.get("extra") if isinstance(discord_cfg.get("extra"), dict) else {}
+    _discord_extra_raw = discord_cfg.get("extra")
+    _discord_extra = _discord_extra_raw if isinstance(_discord_extra_raw, dict) else {}
     _discord_rtm = (
         discord_cfg["reply_to_mode"] if "reply_to_mode" in discord_cfg
         else _discord_extra.get("reply_to_mode")
     )
+    for key in ("voice_silence_seconds", "voice_min_speech_seconds"):
+        value = discord_cfg.get(key, _discord_extra.get(key))
+        if value is not None:
+            seeded_extra[key] = value
     if _discord_rtm is not None and not os.getenv("DISCORD_REPLY_TO_MODE"):
         _rtm_str = "off" if _discord_rtm is False else str(_discord_rtm).lower()
         os.environ["DISCORD_REPLY_TO_MODE"] = _rtm_str

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -644,6 +644,19 @@ class TestVoiceReceiver:
         assert len(receiver._buffers) == 0
         assert len(receiver._ssrc_to_user) == 0
 
+    def test_turn_timing_can_be_configured_per_receiver(self):
+        from plugins.platforms.discord.adapter import VoiceReceiver
+
+        mock_vc = MagicMock()
+        receiver = VoiceReceiver(
+            mock_vc,
+            silence_threshold=2.0,
+            min_speech_duration=0.75,
+        )
+
+        assert receiver.SILENCE_THRESHOLD == 2.0
+        assert receiver.MIN_SPEECH_DURATION == 0.75
+
     def test_start_sets_running(self):
         receiver = self._make_receiver()
         receiver.start()
@@ -1364,6 +1377,57 @@ class TestDiscordVoiceChannelMethods:
 
         assert adapter._voice_timeout_seconds == 0
         assert adapter._playback_timeout_seconds == 240
+
+    def test_discord_voice_turn_timing_config_loaded(self, tmp_path, monkeypatch):
+        from plugins.platforms.discord.adapter import DiscordAdapter
+        from gateway.config import Platform, load_gateway_config
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "discord:\n"
+            "  voice_silence_seconds: 2.25\n"
+            "  voice_min_speech_seconds: 0.75\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+        adapter = DiscordAdapter(config.platforms[Platform.DISCORD])
+
+        assert adapter._voice_silence_seconds == 2.25
+        assert adapter._voice_min_speech_seconds == 0.75
+
+    @pytest.mark.parametrize(
+        "raw",
+        [True, False, None, 0, -1, "", "invalid", "nan", "inf", "-inf"],
+    )
+    def test_discord_voice_turn_timing_invalid_values_use_defaults(self, raw):
+        from plugins.platforms.discord.adapter import DiscordAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = DiscordAdapter(PlatformConfig(
+            enabled=True,
+            token="x",
+            extra={
+                "voice_silence_seconds": raw,
+                "voice_min_speech_seconds": raw,
+            },
+        ))
+
+        assert adapter._voice_silence_seconds == 2.0
+        assert adapter._voice_min_speech_seconds == 0.5
+
+    def test_discord_voice_turn_timing_missing_values_use_safe_defaults(self, monkeypatch):
+        from plugins.platforms.discord.adapter import DiscordAdapter, VoiceReceiver
+        from gateway.config import PlatformConfig
+
+        monkeypatch.setattr(VoiceReceiver, "SILENCE_THRESHOLD", 99.0)
+        monkeypatch.setattr(VoiceReceiver, "MIN_SPEECH_DURATION", 99.0)
+        adapter = DiscordAdapter(PlatformConfig(enabled=True, token="x"))
+
+        assert adapter._voice_silence_seconds == 2.0
+        assert adapter._voice_min_speech_seconds == 0.5
 
     @pytest.mark.asyncio
     async def test_playback_timeout_scales_with_audio_duration(self):

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -100,6 +100,18 @@ discord:
 
 The old `liveness_interval_seconds` and `liveness_failure_threshold` names remain compatibility aliases only; they no longer mean REST probing.
 
+### Voice turn detection
+
+When Hermes listens in a voice channel, it ends an utterance after two seconds of silence and ignores speech shorter than half a second. You can tune both durations in `config.yaml`:
+
+```yaml
+discord:
+  voice_silence_seconds: 2.0
+  voice_min_speech_seconds: 0.5
+```
+
+Both values must be finite positive numbers. Missing or invalid values retain the defaults above.
+
 ## Step 1: Create a Discord Application
 
 1. Go to the [Discord Developer Portal](https://discord.com/developers/applications) and sign in with your Discord account.


### PR DESCRIPTION
## Summary

- make Discord voice-channel silence and minimum-speech thresholds configurable through `config.yaml`
- pass the resolved values into each `VoiceReceiver`, with finite positive validation and safe defaults
- document the settings and cover the real YAML → plugin bridge → adapter path

## Why

Discord voice turn detection was fixed at 1.5 seconds of silence and 0.5 seconds of speech. A short pause could end a user's turn before they finished speaking, and operators had no supported way to tune either threshold.

This sets the silence default to 2.0 seconds, keeps the 0.5-second noise floor, and lets operators override both values:

```yaml
discord:
  voice_silence_seconds: 2.0
  voice_min_speech_seconds: 0.5
```

Booleans, zero, negatives, empty strings, non-numeric strings, NaN, and infinities retain the safe defaults.

## Testing

- [x] New regression tests fail on exact base `8714040954757c653a6acfd0fd8c2984dc8fd741` (`13 failed`)
- [x] New regression tests pass with the change (`13 passed`)
- [x] `pytest tests/gateway/test_voice_command.py tests/gateway/test_config.py tests/gateway/test_discord_liveness.py` (`385 passed`)
- [x] `ruff 0.15.10 check plugins/platforms/discord/adapter.py tests/gateway/test_voice_command.py`
- [x] `cli-config.yaml.example` parses as YAML
- [x] `git diff --check`

## Change type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [x] Documentation
- [ ] Other

## Checklist

- [x] My code follows the existing style of this project
- [x] I have tested my changes locally
- [x] I have updated `cli-config.yaml.example` if I added new config keys
- [x] I have updated docs in `website/docs/` if user-facing behavior changed
- [x] I have not committed secrets, tokens, or credentials
- [x] New and existing focused tests pass

## Notes for reviewers

The plugin's existing YAML hook seeds these values into `PlatformConfig.extra`; it does not add new environment variables. Invalid values preserve defaults instead of disabling voice turn detection.