### PR TITLE
fix(routing): stop misclassifying non-Azure hosts via azure.com path substring

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1679,7 +1679,7 @@ def resolve_runtime_provider(
     # return provider="custom" with chat_completions api_mode and no valid key).
     # Instead, use the Azure key directly with anthropic_messages api_mode.
     _eff_base = (explicit_base_url or "").strip()
-    if requested_provider == "anthropic" and "azure.com" in _eff_base:
+    if requested_provider == "anthropic" and base_url_host_matches(_eff_base, "azure.com"):
         _azure_key = (
             (explicit_api_key or "").strip()
             or _getenv("AZURE_ANTHROPIC_KEY", "").strip()
@@ -2019,8 +2019,8 @@ def resolve_runtime_provider(
         # would find the Claude Code OAuth token first (priority 3) and return
         # that instead, causing 401s. Detect Azure endpoints and use the env
         # key directly to bypass the OAuth priority chain.
-        _is_azure_endpoint = "azure.com" in base_url.lower() or (
-            cfg_base_url and "azure.com" in cfg_base_url.lower()
+        _is_azure_endpoint = base_url_host_matches(base_url, "azure.com") or (
+            cfg_base_url and base_url_host_matches(cfg_base_url, "azure.com")
         )
         if _is_azure_endpoint:
             # Honor user-specified env var hints on the model config before

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -246,6 +246,63 @@ def test_resolve_runtime_provider_anthropic_explicit_override_skips_pool(monkeyp
     assert resolved.get("credential_pool") is None
 
 
+def test_resolve_runtime_provider_anthropic_azure_com_in_path_not_classified_as_azure(monkeypatch):
+    """A base URL whose PATH (not hostname) contains "azure.com" must not be
+    routed through the Azure Anthropic short-circuit — the explicit Anthropic
+    credential should win instead of an Azure key lookup. Regression for
+    issue #74312."""
+
+    def _unexpected_pool(provider):
+        raise AssertionError(f"load_pool should not be called for {provider}")
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "anthropic", "base_url": ""},
+    )
+    monkeypatch.setattr(rp, "load_pool", _unexpected_pool)
+    # If the buggy substring check fired, it would look for an Azure key and
+    # ignore the explicit token entirely — so no need to set AZURE_ANTHROPIC_KEY.
+    monkeypatch.delenv("AZURE_ANTHROPIC_KEY", raising=False)
+
+    resolved = rp.resolve_runtime_provider(
+        requested="anthropic",
+        explicit_api_key="explicit-anthropic-token",
+        explicit_base_url="https://example.invalid/proxy/azure.com/v1",
+    )
+
+    assert resolved["provider"] == "anthropic"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["api_key"] == "explicit-anthropic-token"
+    assert resolved["base_url"] == "https://example.invalid/proxy/azure.com/v1"
+    assert resolved["source"] == "explicit"
+
+
+def test_resolve_runtime_provider_anthropic_real_azure_host_still_short_circuits(monkeypatch):
+    """Regression guard: a genuine Azure host must still take the Azure
+    Anthropic short-circuit (using the Azure key, not the OAuth chain)."""
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "anthropic", "base_url": ""},
+    )
+    monkeypatch.setenv("AZURE_ANTHROPIC_KEY", "azure-env-key")
+
+    resolved = rp.resolve_runtime_provider(
+        requested="anthropic",
+        explicit_base_url="https://foo.openai.azure.com/anthropic/v1",
+    )
+
+    assert resolved["provider"] == "anthropic"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["api_key"] == "azure-env-key"
+    assert resolved["base_url"] == "https://foo.openai.azure.com/anthropic/v1"
+    assert resolved["source"] == "azure-explicit"
+
+
 def test_resolve_runtime_provider_falls_back_when_pool_empty(monkeypatch):
     class _Pool:
         def has_credentials(self):
@@ -2580,6 +2637,40 @@ class TestAzureAnthropicEnvVarHint:
         # The normal chain runs — key_env is not consulted off-Azure.
         assert called["resolve_anthropic_token"] is True
         assert resolved["api_key"] == "token-from-resolver"
+
+    def test_azure_com_in_path_ignores_key_env(self, monkeypatch):
+        """A cfg base_url whose PATH (not hostname) contains "azure.com" must
+        not be classified as Azure — key_env is not consulted and the regular
+        resolve_anthropic_token chain runs. Regression for issue #74312.
+
+        The path ends with "/anthropic" so it clears the unrelated
+        `_anthropic_base_url_override_ok` gate (which would otherwise reset
+        cfg_base_url to "" before the Azure check ever runs), keeping this
+        test focused on the substring-vs-hostname bug specifically."""
+        monkeypatch.setenv("MY_KEY", "custom-key-value")
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+        monkeypatch.setattr(rp, "_get_model_config", lambda: {
+            "provider": "anthropic",
+            "base_url": "https://example.invalid/azure.com/anthropic",  # host isn't Azure
+            "key_env": "MY_KEY",
+        })
+        monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+        called = {"resolve_anthropic_token": False}
+
+        def _fake_resolve():
+            called["resolve_anthropic_token"] = True
+            return "token-from-resolver"
+
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.resolve_anthropic_token",
+            _fake_resolve,
+        )
+
+        resolved = rp.resolve_runtime_provider(requested="anthropic")
+
+        assert called["resolve_anthropic_token"] is True
+        assert resolved["api_key"] == "token-from-resolver"
+        assert resolved["base_url"] == "https://example.invalid/azure.com/anthropic"
 
 
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[🔒 URL Received] -->|Old: Broken| B[⚠️ Substring Match on Full URL]
    B -->|"'azure.com' in path"| C[❌ Wrong Credential Selected]

    A -->|New: Fixed| D[⚡ Parsed Hostname Match]
    D -->|"host == azure.com or endswith '.azure.com'"| E[🚀 Correct Credential Selected]

    style C fill:#ff007f,stroke:#ff007f,color:#ffffff
    style E fill:#00f0ff,stroke:#00f0ff,color:#0a0a16
```

## Summary

- Fixes a routing bug where a URL is classified as an Azure endpoint whenever the literal text `azure.com` appears **anywhere in the URL string** — including the path or query — instead of only when the actual **hostname** is `azure.com` or a subdomain of it.
- This could cause requests to a non-Azure host (e.g. a proxy at `https://example.invalid/proxy/azure.com/v1`) to be routed with the Azure credential-resolution chain instead of the explicit Anthropic token the caller provided (or vice versa for a genuine Azure host whose credential should be used).

## Root Cause

Two call sites in `hermes_cli/runtime_provider.py` classified a base URL as "Azure" using a raw substring test against the **full effective base URL string** (scheme + host + path + query), rather than parsing out the hostname first:

1. `resolve_runtime_provider()` — the `requested_provider == "anthropic"` Azure short-circuit:
   ```python
   if requested_provider == "anthropic" and "azure.com" in _eff_base:
   ```
2. The native Anthropic branch's Azure-key-selection check:
   ```python
   _is_azure_endpoint = "azure.com" in base_url.lower() or (
       cfg_base_url and "azure.com" in cfg_base_url.lower()
   )
   ```

Both are the same false-positive class already documented and solved elsewhere in this file via `base_url_host_matches()` (a hostname-boundary helper used correctly at lines ~1054, ~1113, ~1239, and ~1780) — `domain in base_url` matches path segments, query strings, and even user-controlled proxy routes that merely happen to contain `azure.com`.

## Fix

Replaced both raw substring checks with calls to the existing `base_url_host_matches(url, "azure.com")` helper, which parses the URL, extracts the hostname, and matches only when `host == "azure.com"` or `host.endswith(".azure.com")`. No new helper was introduced — this reuses the boundary-matching logic already proven correct at the other call sites in the same file.

Files changed:
- `hermes_cli/runtime_provider.py` (2 call sites, minimal diff)
- `tests/hermes_cli/test_runtime_provider_resolution.py` (new regression tests)

## Test Plan

- [x] Added `test_resolve_runtime_provider_anthropic_azure_com_in_path_not_classified_as_azure` — a base URL with `azure.com` only in the path (`https://example.invalid/proxy/azure.com/v1`) must resolve using the **explicit Anthropic credential**, not the Azure key chain.
- [x] Added `test_resolve_runtime_provider_anthropic_real_azure_host_still_short_circuits` — a genuine Azure host (`https://foo.openai.azure.com/anthropic/v1`) must still take the Azure short-circuit and resolve `AZURE_ANTHROPIC_KEY` (no regression).
- [x] Added `test_azure_com_in_path_ignores_key_env` (in `TestAzureAnthropicEnvVarHint`) — a `model.base_url` with `azure.com` only in the path must not trigger Azure-specific `key_env` handling; the normal `resolve_anthropic_token()` chain runs instead.
- [x] Existing Azure regression coverage (`TestAzureFoundryResolution`, `TestAzureAnthropicEnvVarHint`, `test_resolve_runtime_provider_anthropic_keeps_azure_base_url`) still passes — real Azure hosts (`*.azure.com`, `*.openai.azure.com`, `*.services.ai.azure.com`) are unaffected.
- [x] Ran `pytest tests/hermes_cli/test_runtime_provider_resolution.py -q`: 153 passed. (2 unrelated pre-existing failures — `test_resolve_runtime_provider_qwen_oauth` and `test_qwen_oauth_auto_fallthrough_on_auth_failure` — reproduce identically on unmodified `main` and are unaffected by this change.)

Closes #74312
