### PR TITLE
fix(routing): stop stale api_mode from leaking across provider switches

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1602,8 +1602,9 @@ def _resolve_explicit_runtime(
         elif provider == "xai":
             api_mode = "codex_responses"
         else:
+            configured_provider = str(model_cfg.get("provider") or "").strip().lower()
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-            if configured_mode:
+            if configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
                 api_mode = configured_mode
             else:
                 # Auto-detect from URL (Anthropic /anthropic suffix,

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -535,6 +535,65 @@ def test_resolve_runtime_provider_openrouter_explicit(monkeypatch):
     assert resolved["source"] == "explicit"
 
 
+@pytest.mark.parametrize(
+    "case_name, model_cfg, expected_api_mode",
+    [
+        (
+            "stale_anthropic_api_mode_is_ignored_on_provider_switch",
+            {
+                "provider": "anthropic",
+                "api_mode": "anthropic_messages",
+                "default": "claude-3-5-sonnet",
+            },
+            "chat_completions",
+        ),
+        (
+            "matching_provider_still_honors_persisted_api_mode",
+            {
+                "provider": "gemini",
+                "api_mode": "anthropic_messages",
+                "default": "gemini-2.5-pro",
+            },
+            "anthropic_messages",
+        ),
+        (
+            "no_persisted_provider_still_honors_api_mode",
+            {
+                "api_mode": "anthropic_messages",
+                "default": "gemini-2.5-pro",
+            },
+            "anthropic_messages",
+        ),
+    ],
+)
+def test_resolve_runtime_provider_gemini_explicit_api_mode_provider_guard(
+    monkeypatch, case_name, model_cfg, expected_api_mode
+):
+    """A persisted model.api_mode from a different provider must not leak
+    into an explicitly-resolved provider after a switch (issue #74318).
+
+    Only when ``model_cfg["provider"]`` matches the provider actually being
+    resolved (or is unset) should the persisted api_mode be honoured.
+    """
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "gemini")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: model_cfg)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(
+        requested="gemini",
+        explicit_api_key="fake-gemini-key",
+        explicit_base_url="https://fake-gemini-endpoint.example.com/v1beta/",
+    )
+
+    assert resolved["provider"] == "gemini", case_name
+    assert resolved["api_mode"] == expected_api_mode, case_name
+    assert resolved["api_key"] == "fake-gemini-key", case_name
+    assert resolved["base_url"] == "https://fake-gemini-endpoint.example.com/v1beta", case_name
+    assert resolved["source"] == "explicit", case_name
+
+
 def test_resolve_runtime_provider_auto_uses_openrouter_pool(monkeypatch):
     class _Entry:
         access_token = "pool-key"


### PR DESCRIPTION

![Infographic](https://raw.githubusercontent.com/JoaoMarcos44/hermes-agent/img-hosting/pr-74344-infographic-russian.png)

## Summary

- `_resolve_explicit_runtime()`'s generic-provider branch accepted a persisted `model.api_mode` unconditionally whenever it was set, with no check that it actually belonged to the provider being resolved.
- Switching providers explicitly (e.g. from Anthropic to Gemini via `explicit_api_key`/`explicit_base_url`) could therefore inherit a stale `api_mode: anthropic_messages` left over from the previous provider, sending Gemini requests over an incompatible transport.
- The fix reuses the existing `_provider_supports_explicit_api_mode()` guard — already wired into the copilot and named-custom-provider resolution paths for exactly this scenario — inside `_resolve_explicit_runtime`'s mode-selection so the persisted mode is only honored when it actually belongs to the provider being resolved.

## Root Cause

In `hermes_cli/runtime_provider.py`, `_resolve_explicit_runtime()`'s generic-provider branch (~line 1605) did:

```python
configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
if configured_mode:
    api_mode = configured_mode
```

This accepts `model_cfg["api_mode"]` regardless of which provider it was persisted under. A guard function for exactly this case, `_provider_supports_explicit_api_mode(provider, configured_provider)`, already exists and is documented as preventing "stale api_mode from a previous provider leaking into a different one after a provider switch" — but it was only wired into the copilot path and the named-custom-provider / auto-resolution path (`resolve_provider` generic branch), never into `_resolve_explicit_runtime`.

Result: an explicit provider switch (e.g. `gemini`) that reused a `model_cfg` persisted from a prior `anthropic` session (`provider: anthropic`, `api_mode: anthropic_messages`) would resolve `api_mode = "anthropic_messages"` for the Gemini endpoint, sending requests over the wrong transport.

## Fix

`hermes_cli/runtime_provider.py`, `_resolve_explicit_runtime()`'s generic-provider branch:

```python
configured_provider = str(model_cfg.get("provider") or "").strip().lower()
configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
if configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
    api_mode = configured_mode
else:
    detected = _detect_api_mode_for_url(base_url)
    if detected:
        api_mode = detected
```

This mirrors the exact pattern already used at the other two call sites of `_provider_supports_explicit_api_mode` (copilot resolution and the generic auto-resolution branch). When the persisted provider doesn't match, the code falls through to URL-based auto-detection (or the `chat_completions` default) instead of trusting the stale mode. When the persisted provider matches — or no provider was recorded at all — the existing behavior is preserved.

## Test Plan

- [x] Added a parametrized table-driven test, `test_resolve_runtime_provider_gemini_explicit_api_mode_provider_guard`, in `tests/hermes_cli/test_runtime_provider_resolution.py`, covering:
  - Explicit switch to `gemini` with `model_cfg` persisted from a prior `anthropic` config (`provider: anthropic`, `api_mode: anthropic_messages`) → resolves to Gemini's correct default `chat_completions`, not the stale `anthropic_messages`.
  - Explicit switch to `gemini` with `model_cfg["provider"] == "gemini"` matching the resolved provider → persisted `api_mode` (`anthropic_messages`) is still honored (no regression for the legitimate same-provider case).
  - Explicit switch to `gemini` with no `provider` recorded in `model_cfg` → persisted `api_mode` is still honored (guard's documented "no configured provider" pass-through).
- [x] Ran `pytest tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_anthropic_oauth_routes_to_messages_api.py`: 160 passed, 2 failed. The 2 failures (`test_resolve_runtime_provider_qwen_oauth`, `test_qwen_oauth_auto_fallthrough_on_auth_failure`) are pre-existing and unrelated — verified identical failures on `main` before this change (confirmed by stashing the fix and re-running).

Closes #74318

