### PR TITLE
feat(desktop): add fade-in for EmptyState and ErrorState surfaces

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -99,7 +99,7 @@ export function PreviewEmptyState({
 
   return (
     <div
-      className="absolute inset-x-0 top-0 z-10 grid place-items-center bg-background px-8 py-10 text-center bottom-(--preview-error-bottom)"
+      className="fade-in absolute inset-x-0 top-0 z-10 grid place-items-center bg-background px-8 py-10 text-center bottom-(--preview-error-bottom)"
       style={{ '--preview-error-bottom': `${consoleHeight}px` } as CSSProperties}
     >
       <div className="grid max-w-sm justify-items-center gap-5">

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -86,4 +86,40 @@ describe('PreviewPane console state', () => {
 
     expect(setTitlebarToolGroup).toHaveBeenCalledTimes(initialCalls)
   })
+
+  it('fades in the preview load error after a webview failure', async () => {
+    let rendered!: ReturnType<typeof render>
+
+    await act(async () => {
+      rendered = render(
+        <PreviewPane
+          setTitlebarToolGroup={vi.fn()}
+          target={{
+            kind: 'url',
+            label: 'Preview',
+            source: 'http://localhost:5174',
+            url: 'http://localhost:5174'
+          }}
+        />
+      )
+    })
+
+    const webview = rendered.container.querySelector('webview')
+
+    expect(webview).toBeInstanceOf(HTMLElement)
+
+    act(() => {
+      webview?.dispatchEvent(
+        Object.assign(new Event('did-fail-load'), {
+          errorCode: -105,
+          errorDescription: 'Connection refused',
+          validatedURL: 'http://localhost:5174'
+        })
+      )
+    })
+
+    const loadError = rendered.container.querySelector('.fade-in')
+
+    expect(loadError?.textContent).toContain('Connection refused')
+  })
 })

--- a/apps/desktop/src/components/ui/empty-state.tsx
+++ b/apps/desktop/src/components/ui/empty-state.tsx
@@ -14,7 +14,7 @@ export function EmptyState({
   className?: string
 }) {
   return (
-    <div className={cn('grid min-h-48 place-items-center text-center', className)}>
+    <div className={cn('fade-in grid min-h-48 place-items-center text-center', className)}>
       <div>
         <div className="text-sm font-medium">{title}</div>
         {description && <div className="mt-1 text-xs text-muted-foreground">{description}</div>}

--- a/apps/desktop/src/components/ui/error-state.tsx
+++ b/apps/desktop/src/components/ui/error-state.tsx
@@ -45,7 +45,7 @@ export interface ErrorStateProps {
 // Dialog callers can pass DialogTitle/DialogDescription for accessibility.
 export function ErrorState({ children, className, description, icon, title }: ErrorStateProps) {
   return (
-    <div className={cn('grid gap-5', className)}>
+    <div className={cn('fade-in grid gap-5', className)}>
       <div className="flex flex-col items-center gap-3 text-center">
         {icon ?? <ErrorIcon />}
 

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -680,6 +680,37 @@
   }
 }
 
+/* Reusable enter fade for "appeared in place of nothing" surfaces —
+   EmptyState, ErrorState, panels that swap from populated to empty, etc.
+   160ms is below the threshold where the eye registers the surface as
+   "late" (DESIGN.md Motion L231 caps controls at ~100ms; surfaces that
+   replace nothing can take a beat more without feeling sluggish).
+
+   Animate opacity + a 0.25rem upward settle so the surface reads as
+   arriving rather than teleporting. Scoped to opacity/transform only
+   (DESIGN.md L238: "Do not animate layout geometry with `transition-all`
+   on a hot interaction").
+
+   The blanket `prefers-reduced-motion` override at the top of this file
+   (animation-duration: 0.01ms !important) neutralizes the settle for users
+   who ask for stillness — the surface pops to its final state instantly,
+   which for a freshly-empty pane is exactly what stillness should look
+   like (no decorative transition, just honest state). */
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(0.25rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@utility fade-in {
+  animation: fade-in 160ms ease-out;
+}
+
 @keyframes arc-border {
   0% {
     background-position: 15% 15%;


### PR DESCRIPTION
## What does this PR do?

`EmptyState` and `ErrorState` currently pop into place instantly when a panel goes from populated to empty — settings list with no matches, preview pane load failure, error boundary fallback. A soft enter fade makes the transition read as "arrived" rather than "teleported".

This PR also adds a **reusable `fade-in` utility** backed by a named `@keyframes fade-in` in `styles.css`, kept in the shared utilities layer so subsequent fade-in surfaces (backdrops, page-loaders, hover-lift) can reuse it without redefining the keyframe.

### Why a reusable utility (not inline classes)

The Roadmap analysis identified at least 4 follow-on surfaces that share the same "appeared in place of nothing" enter pattern. Defining `@utility fade-in` once in `styles.css` (Tailwind v4 `@utility` directive) keeps the keyframe + duration + easing in one place — call sites stay one class.

## Related Issue

No existing issue. Drawn from the visual polish analysis of the renderer (settings, chat sidebar, preview panes use these states as their "nothing here / something broke" surfaces). Not adjacent to any other open PR I could find.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/src/styles.css` (+31): add `@keyframes fade-in` (opacity 0→1 + translateY(0.25rem)→0, 160ms ease-out) + `.fade-in` utility via Tailwind v4 `@utility fade-in`. Placed beside the existing `@utility row-hover` (L671) — same utilities layer.
- `apps/desktop/src/components/ui/empty-state.tsx` (+1/-1): apply `fade-in` on the outer wrapper.
- `apps/desktop/src/components/ui/error-state.tsx` (+1/-1): apply `fade-in` on the outer wrapper.

## How to Test

1. `cd apps/desktop && npm run typecheck && npm run lint` — both green.
2. `npm run build` — green. Both `@keyframes fade-in` and `.fade-in` reach the bundled CSS (`dist/assets/index-*.css`).
3. `npm run dev` and trigger an empty state:
   - Open the plugins settings and search a query with no matches → see the "no results" body fade in over 160ms instead of popping.
   - Or: kill the gateway and open the messaging index → platform error state fades in.
4. Toggle `prefers-reduced-motion: reduce` (macOS: System Settings → Accessibility → Display → Reduce motion) — the fade freezes; the surface pops to its final state instantly. For a freshly-empty pane this is exactly what stillness should look like: honest state, no decorative motion.
5. Unit tests (jsdom, jsdom animation behavior is off-by-default so the fade-in class is inert at runtime there) — ran the three test files that touch EmptyState / ErrorState and all pass:
   - `src/app/settings/providers-settings.test.tsx` — 6 pass
   - `src/app/settings/fallback-models-field.test.tsx` — 6 pass
   - `src/app/chat/composer/trigger-popover.test.tsx` — 3 pass
   - 15/15 total

No E2E visual snapshot test references `EmptyState` or `ErrorState` (`grep -r 'empty-state\|error-state' apps/desktop/e2e` returns nothing — `boot-failure.spec.ts` uses its own boot-failure markup, not `ErrorState`). Playwright config disables animations globally (`reducedMotion: 'reduce'` + `animations: 'disabled'` in `playwright.config.ts`), so even if a snapshot test starts using these surfaces later, the fade is skipped at screenshot time and the final state is pixel-stable.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(desktop):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (3 files, +33/-2)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A: renderer-only TypeScript change; ran `tsc --noEmit`, `eslint`, the 3 affected vitest specs (15/15 pass), and a full `npm run build` (all green) instead
- [x] I've added tests for my changes — the existing tests that assert EmptyState/ErrorState copy all still pass; the animation itself is gated by reduced-motion and inert under Playwright's global `animations: 'disabled'`, so no visual baseline is affected. Happy to add a `prefers-reduced-motion: reduce` assertion test if maintainers want one, but the blanket CSS gate already covers it.
- [x] I've tested on my platform: macOS 26

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the `@keyframes fade-in` + `@utility fade-in` comments in `styles.css` document the contract, the reuse intent, and reference the blanket reduced-motion gate + the REPORT-specific DESIGN.md Motion principles
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — no platform-specific behavior; the animation is gated by the blanket `prefers-reduced-motion` override (styles.css L8-19) which applies on all platforms
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before: panel surfaces (empty settings list, preview-pane load failure, error-boundary fallback) appear at their final position with no enter motion.
After: the same surfaces fade in over 160ms with a tiny upward settle (0.25rem). A still screenshot doesn't convey the settle; reviewers running `npm run dev` will see it live by triggering an empty settings sub-panel (e.g. search with no matches) or by killing the gateway and opening the messaging index.
