### PR TITLE
fix(compression): keep long tool turns recoverable

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2212,6 +2212,10 @@ class ContextCompressor(ContextEngine):
         self._active_compression_telemetry: Optional[Dict[str, Any]] = None
         self._compression_telemetry_seed: Optional[Dict[str, Any]] = None
 
+    def compression_made_progress(self) -> bool:
+        """Return the built-in compressor's explicit per-call progress verdict."""
+        return self._last_compression_made_progress
+
     def update_from_response(self, usage: Dict[str, Any]):
         """Update tracked token usage from API response."""
         self.last_prompt_tokens = usage.get("prompt_tokens", 0)
@@ -4587,56 +4591,28 @@ This compaction should PRIORITISE preserving all information related to the focu
         cut_idx: int,
         head_end: int,
     ) -> int:
-        """Guarantee the most recent assistant message is in the protected tail.
+        """Keep the current turn's visible assistant reply in the tail.
 
-        WebUI / TUI / SessionsPage bug (#29824). Without this anchor,
-        ``_find_tail_cut_by_tokens`` can leave the user's most recent
-        visible assistant response inside the compressed middle region —
-        especially when the conversation has a single oversized tool
-        result or a long stretch of tool-call/result pairs after the
-        last assistant reply. The summariser then rolls that reply up
-        into the single ``[CONTEXT COMPACTION — REFERENCE ONLY]`` block
-        persisted as ``role="user"`` or ``role="assistant"``. From the
-        operator's perspective the WebUI session viewer
-        (``web/src/pages/SessionsPage.tsx``) and the TUI chat panel
-        both suddenly show the opaque "Context compaction" block in the
-        slot where they were just reading the assistant's actual reply:
-
-            User:       "i cant see the output of the last message you
-                         sent, i did see it previously, however now see
-                         'context compaction'"
-
-        Mirror of ``_ensure_last_user_message_in_tail`` but anchors on
-        the last assistant-role message. Re-runs the tool-group
-        alignment so we don't split a ``tool_call`` / ``tool_result``
-        group that immediately precedes the anchored message — orphaned
-        tool messages would otherwise be removed by
-        ``_sanitize_tool_pairs`` and trigger the same data-loss symptom
-        we're trying to prevent.
+        The #29824 UI anchor is only relevant when the reply belongs to the
+        latest actionable user turn.  A visible assistant message before a
+        newer user request is completed-turn history; letting it pull the cut
+        backward can make an entire long-running tool turn incompressible.
         """
         last_asst_idx = self._find_last_assistant_message_idx(messages, head_end)
-        if last_asst_idx < 0:
-            # No assistant message in the compressible region — nothing
-            # to anchor (single-turn pre-reply state, etc.).
+        latest_user_idx = self._find_last_user_message_idx(messages, head_end)
+        if (
+            last_asst_idx < 0
+            or last_asst_idx < latest_user_idx
+            or last_asst_idx >= cut_idx
+        ):
             return cut_idx
-        if last_asst_idx >= cut_idx:
-            # Already in the tail — the token-budget walk did the right
-            # thing on its own.
-            return cut_idx
-        # Pull cut_idx back to the assistant message, then re-align so
-        # we don't split a tool group that immediately precedes it
-        # (e.g. an ``assistant(tool_calls)`` → ``tool(result)`` →
-        # ``assistant(final reply)`` sequence would otherwise leave the
-        # ``tool`` orphan when cut lands at the final reply).
         new_cut = self._align_boundary_backward(messages, last_asst_idx)
         if not self.quiet_mode:
             logger.debug(
-                "Anchoring tail cut to last assistant message at index %d "
-                "(was %d, aligned to %d) to keep the previously-visible "
-                "reply out of the compaction summary (#29824)",
+                "Anchoring tail cut to current-turn assistant message at index %d "
+                "(was %d, aligned to %d) (#29824)",
                 last_asst_idx, cut_idx, new_cut,
             )
-        # Safety: never go back into the head region.
         return max(new_cut, head_end + 1)
 
     def _ensure_last_user_message_in_tail(
@@ -5070,6 +5046,13 @@ This compaction should PRIORITISE preserving all information related to the focu
             ]
             n_messages = len(messages)
         latest_actionable_idx = self._find_last_user_message_idx(messages, 0)
+        # Phase-1 pruning and blank-echo cleanup are real context reductions even
+        # when the protected-tail calculation leaves no summary window. Expose
+        # that progress so a successful provider response can reset the
+        # consecutive no-progress attempt streak.
+        self._last_compression_made_progress = bool(
+            pruned_count or blank_echo_indices
+        )
 
         # Phase 2: Determine boundaries
         compress_start = self._protect_head_size(messages)

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -189,6 +189,14 @@ class ContextEngine(ABC):
                 host filters unsupported optional arguments by signature.
         """
 
+    def compression_made_progress(self) -> bool:
+        """Whether the most recent ``compress()`` call materially changed context.
+
+        Engines that do not expose a progress verdict keep the conservative
+        default so no-progress attempts still trip the anti-thrash backstop.
+        """
+        return False
+
     # -- Optional: proactive tool-result prune -----------------------------
 
     def prune_tool_results_only(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -117,6 +117,41 @@ def _context_admission_input_limit(
     )
     return max(1, limit - max(estimator_margin, output_reserve))
 
+
+def _compression_made_progress(compressor: Any) -> bool:
+    """Read an optional engine progress verdict without trusting duck-typed mocks."""
+    probe = getattr(compressor, "compression_made_progress", None)
+    if not callable(probe):
+        return False
+    try:
+        return probe() is True
+    except Exception as exc:
+        logger.debug("Context engine progress probe failed: %s", exc)
+        return False
+
+
+def _context_admission_pressure(compressor: Any, rough_tokens: int) -> int:
+    """Remove only provider-proven fixed over-count from a rough estimate.
+
+    The full rough growth since the fitting baseline is retained. Missing or
+    inconsistent calibration falls back to the unmodified estimate.
+    """
+    rough = max(0, int(rough_tokens or 0))
+    baseline_rough = int(
+        getattr(compressor, "last_rough_tokens_when_real_prompt_fit", 0) or 0
+    )
+    baseline_real = int(getattr(compressor, "last_real_prompt_tokens", 0) or 0)
+    threshold = int(getattr(compressor, "threshold_tokens", 0) or 0)
+    if (
+        baseline_rough <= 0
+        or baseline_real <= 0
+        or baseline_real >= baseline_rough
+        or (threshold > 0 and baseline_real >= threshold)
+        or rough < baseline_rough
+    ):
+        return rough
+    return baseline_real + (rough - baseline_rough)
+
 # Stable prefix of the local interrupt status string emitted when a turn is
 # cancelled while waiting on the provider. Surfaces (ACP, TUI) match on this
 # to treat it as cancellation metadata rather than assistant prose.
@@ -1230,6 +1265,11 @@ def run_conversation(
     truncated_tool_call_retries = 0
     truncated_response_parts: List[str] = []
     compression_attempts = 0
+    # ``compression_attempts`` is a consecutive no-progress streak, not a
+    # lifetime budget for a long tool turn. Arm this latch only when the engine
+    # reports real context reduction; clear the streak after the next successful
+    # model response.
+    _last_compression_effective = False
     # One resolved per-turn compression attempt cap, shared by every site that
     # consumes ``compression_attempts``: the pre-API pressure gate, the
     # overflow/413 retry handlers, and the post-tool compaction gate.
@@ -1832,9 +1872,12 @@ def run_conversation(
             _configured_context_limit,
             reserved_output_tokens=getattr(agent, "max_tokens", 0),
         )
+        _admission_pressure_tokens = _context_admission_pressure(
+            _compressor, request_pressure_tokens
+        )
         _request_over_safe_limit = (
             _safe_input_limit > 0
-            and request_pressure_tokens >= _safe_input_limit
+            and _admission_pressure_tokens >= _safe_input_limit
         )
         _preflight_threshold = int(
             getattr(_compressor, "threshold_tokens", 0) or 0
@@ -1951,6 +1994,8 @@ def run_conversation(
                 if pending_moa_prepared_request is _moa_prepared_request:
                     pending_moa_prepared_request = None
             else:
+                if _compression_made_progress(agent.context_compressor):
+                    _last_compression_effective = True
                 # Reset retry/empty-response state so the compacted request
                 # gets a fresh chance instead of inheriting stale recovery
                 # counters from the pre-compaction history.
@@ -2014,8 +2059,9 @@ def run_conversation(
                 pass
             logger.error(
                 "Blocking provider call above safe input limit: "
-                "estimated_input=%s safe_input_limit=%s configured_context=%s "
-                "compression_attempts=%s/%s model=%s session=%s",
+                "admission_input=%s rough_input=%s safe_input_limit=%s "
+                "configured_context=%s compression_attempts=%s/%s model=%s session=%s",
+                _admission_pressure_tokens,
                 request_pressure_tokens,
                 _safe_input_limit,
                 _configured_context_limit,
@@ -2033,7 +2079,8 @@ def run_conversation(
                 "completed": False,
                 "api_calls": api_call_count,
                 "provider_call_blocked": True,
-                "estimated_input_tokens": request_pressure_tokens,
+                "estimated_input_tokens": _admission_pressure_tokens,
+                "rough_input_tokens": request_pressure_tokens,
                 "safe_input_limit": _safe_input_limit,
                 "configured_context_limit": _configured_context_limit,
             }
@@ -2674,6 +2721,9 @@ def run_conversation(
                     continue  # Retry the API call
 
                 agent._turn_received_provider_response = True
+                if _last_compression_effective:
+                    compression_attempts = 0
+                    _last_compression_effective = False
 
                 # Check finish_reason before proceeding
                 if agent.api_mode == "codex_responses":
@@ -4318,6 +4368,7 @@ def run_conversation(
                                 )
                             )
                             time.sleep(2)
+                            _last_compression_effective = True
                             _retry.restart_with_compressed_messages = True
                             break
                     # Fall through to normal error handling if compression
@@ -4593,6 +4644,7 @@ def run_conversation(
                         else:
                             agent._buffer_status(COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE.format(before=original_tokens, after=new_tokens))
                         time.sleep(2)  # Brief pause between compression retries
+                        _last_compression_effective = True
                         _retry.restart_with_compressed_messages = True
                         break
                     else:
@@ -4847,6 +4899,7 @@ def run_conversation(
                         elif new_tokens > 0 and new_tokens < original_tokens * 0.95:
                             agent._buffer_status(COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE.format(before=original_tokens, after=new_tokens))
                         time.sleep(2)  # Brief pause between compression retries
+                        _last_compression_effective = True
                         _retry.restart_with_compressed_messages = True
                         break
                     else:
@@ -6300,6 +6353,8 @@ def run_conversation(
                         # compression_exhausted (#9893/#35809).
                         compression_attempts -= 1
                     else:
+                        if _compression_made_progress(agent.context_compressor):
+                            _last_compression_effective = True
                         conversation_history = conversation_history_after_compression(
                             agent, messages, conversation_history
                         )

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -88,6 +88,35 @@ from utils import base_url_host_matches, env_var_enabled
 
 logger = logging.getLogger(__name__)
 
+_CONTEXT_ADMISSION_MARGIN_MIN = 512
+_CONTEXT_ADMISSION_MARGIN_MAX = 4096
+_CONTEXT_ADMISSION_MARGIN_DIVISOR = 64
+
+
+def _context_admission_input_limit(
+    context_limit: int,
+    *,
+    reserved_output_tokens: int = 0,
+) -> int:
+    """Return a conservative pre-provider input ceiling."""
+    try:
+        limit = int(context_limit or 0)
+    except (TypeError, ValueError):
+        return 0
+    if limit <= 0:
+        return 0
+
+    try:
+        output_reserve = max(0, int(reserved_output_tokens or 0))
+    except (TypeError, ValueError):
+        output_reserve = 0
+
+    estimator_margin = min(
+        _CONTEXT_ADMISSION_MARGIN_MAX,
+        max(_CONTEXT_ADMISSION_MARGIN_MIN, limit // _CONTEXT_ADMISSION_MARGIN_DIVISOR),
+    )
+    return max(1, limit - max(estimator_margin, output_reserve))
+
 # Stable prefix of the local interrupt status string emitted when a turn is
 # cancelled while waiting on the provider. Surfaces (ACP, TUI) match on this
 # to treat it as cancellation metadata rather than assistant prose.
@@ -1796,6 +1825,17 @@ def run_conversation(
         # LLM cooldown + anti-thrash guards (#11529). compression_attempts is a
         # hard per-turn backstop shared with the overflow error handlers.
         _compressor = agent.context_compressor
+        _configured_context_limit = int(
+            getattr(_compressor, "context_length", 0) or 0
+        )
+        _safe_input_limit = _context_admission_input_limit(
+            _configured_context_limit,
+            reserved_output_tokens=getattr(agent, "max_tokens", 0),
+        )
+        _request_over_safe_limit = (
+            _safe_input_limit > 0
+            and request_pressure_tokens >= _safe_input_limit
+        )
         _preflight_threshold = int(
             getattr(_compressor, "threshold_tokens", 0) or 0
         )
@@ -1833,12 +1873,17 @@ def run_conversation(
         _compression_cooldown = getattr(
             _compressor, "get_active_compression_failure_cooldown", lambda: None
         )()
+        _preflight_deferred = False
+        if not _request_over_safe_limit:
+            _preflight_deferred = bool(
+                _defer_preflight(request_pressure_tokens)
+            )
         if (
             agent.compression_enabled
             and len(messages) > 1
             and compression_attempts < max_compression_attempts
             and not _preflight_compression_blocked
-            and not _defer_preflight(request_pressure_tokens)
+            and not _preflight_deferred
             and not _compression_cooldown
             and _compressor.should_compress(request_pressure_tokens)
         ):
@@ -1898,9 +1943,9 @@ def run_conversation(
                 # attempt (it must not burn the shared overflow-recovery
                 # budget toward compression_exhausted → gateway auto-reset,
                 # #9893/#35809) and leave the insufficient-progress blocker
-                # unarmed. Proceed with the current request: if it truly does
-                # not fit, the provider's 413/overflow handler returns the
-                # soft compression_deferred result with that stronger signal.
+                # unarmed. Requests below the safe admission boundary may
+                # proceed for a stronger provider signal; oversized requests
+                # are blocked by the final local gate below.
                 compression_attempts -= 1
                 _last_preflight_pressure = None
                 if pending_moa_prepared_request is _moa_prepared_request:
@@ -1934,7 +1979,7 @@ def run_conversation(
             agent.compression_enabled
             and len(messages) > 1
             and compression_attempts < max_compression_attempts
-            and not _defer_preflight(request_pressure_tokens)
+            and not _preflight_deferred
             and _compression_cooldown
         ):
             # Blocked by the summary-LLM cooldown. Surface a deduped warning
@@ -1956,6 +2001,42 @@ def run_conversation(
                     request_pressure_tokens,
                     int(getattr(_compressor, "threshold_tokens", 0) or 0),
                 )
+
+        # Compression above is the remediation path. If it was unavailable,
+        # exhausted, or made insufficient progress, do not dispatch a request
+        # that is already at the configured context boundary.
+        if _request_over_safe_limit:
+            api_call_count -= 1
+            agent._api_call_count = api_call_count
+            try:
+                agent.iteration_budget.refund()
+            except Exception:
+                pass
+            logger.error(
+                "Blocking provider call above safe input limit: "
+                "estimated_input=%s safe_input_limit=%s configured_context=%s "
+                "compression_attempts=%s/%s model=%s session=%s",
+                request_pressure_tokens,
+                _safe_input_limit,
+                _configured_context_limit,
+                compression_attempts,
+                max_compression_attempts,
+                agent.model,
+                agent.session_id,
+            )
+            return {
+                "final_response": (
+                    "Request remains above the configured safe input limit after "
+                    "available context compression. Provider call blocked locally."
+                ),
+                "messages": messages,
+                "completed": False,
+                "api_calls": api_call_count,
+                "provider_call_blocked": True,
+                "estimated_input_tokens": request_pressure_tokens,
+                "safe_input_limit": _safe_input_limit,
+                "configured_context_limit": _configured_context_limit,
+            }
         
         # Thinking spinner for quiet mode (animated during API call)
         thinking_spinner = None

--- a/tests/agent/test_compression_prune_progress.py
+++ b/tests/agent/test_compression_prune_progress.py
@@ -1,0 +1,76 @@
+"""Progress semantics for prune-only compaction passes."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from agent.context_compressor import ContextCompressor
+
+
+def _compressor() -> ContextCompressor:
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=100_000,
+    ):
+        return ContextCompressor(
+            model="test/model",
+            threshold_percent=0.75,
+            protect_first_n=1,
+            protect_last_n=2,
+            quiet_mode=True,
+        )
+
+
+def test_prune_only_no_summary_window_reports_progress():
+    compressor = _compressor()
+    messages = [
+        {"role": "user", "content": "task"},
+        {"role": "assistant", "content": None, "tool_calls": []},
+        {"role": "tool", "content": "large old result"},
+        {"role": "assistant", "content": "working"},
+        {"role": "user", "content": "continue"},
+        {"role": "assistant", "content": "tail"},
+    ]
+    pruned = [dict(message) for message in messages]
+    pruned[2]["content"] = "[tool result pruned]"
+
+    with (
+        patch.object(
+            compressor,
+            "_prune_old_tool_results",
+            return_value=(pruned, 1),
+        ),
+        patch.object(compressor, "_find_tail_cut_by_tokens", return_value=1),
+        patch.object(compressor, "_generate_summary") as summarize,
+    ):
+        result = compressor.compress(messages, current_tokens=90_000)
+
+    assert result[2]["content"] == "[tool result pruned]"
+    assert compressor.compression_made_progress() is True
+    summarize.assert_not_called()
+
+
+def test_identity_no_summary_window_reports_no_progress():
+    compressor = _compressor()
+    messages = [
+        {"role": "user", "content": "task"},
+        {"role": "assistant", "content": "working"},
+        {"role": "user", "content": "continue"},
+        {"role": "assistant", "content": "still working"},
+        {"role": "user", "content": "status"},
+        {"role": "assistant", "content": "tail"},
+    ]
+
+    with (
+        patch.object(
+            compressor,
+            "_prune_old_tool_results",
+            return_value=(messages, 0),
+        ),
+        patch.object(compressor, "_find_tail_cut_by_tokens", return_value=1),
+        patch.object(compressor, "_generate_summary") as summarize,
+    ):
+        compressor.compress(messages, current_tokens=90_000)
+
+    assert compressor.compression_made_progress() is False
+    summarize.assert_not_called()

--- a/tests/agent/test_compressor_assistant_tail_anchor.py
+++ b/tests/agent/test_compressor_assistant_tail_anchor.py
@@ -142,23 +142,28 @@ class TestEnsureLastAssistantMessageInTail:
         )
         assert new_cut == 1
 
-    def test_walks_cut_idx_back_to_include_reply(self, compressor):
+    def test_completed_turn_reply_does_not_expand_new_active_turn(self, compressor):
         messages = [
             {"role": "user", "content": "q1"},
             {"role": "assistant", "content": "REPLY"},  # idx 1
             {"role": "user", "content": "q2"},
             {"role": "user", "content": "q3"},
         ]
-        # cut_idx=2 leaves the reply outside the tail; anchor must pull
-        # cut_idx back to 1 so messages[1:] contains the reply.
         new_cut = compressor._ensure_last_assistant_message_in_tail(
             messages, cut_idx=2, head_end=0
         )
-        assert new_cut == 1
-        assert any(
-            isinstance(m.get("content"), str) and "REPLY" in m["content"]
-            for m in messages[new_cut:]
-        )
+        assert new_cut == 2
+
+    def test_walks_cut_idx_back_for_current_turn_reply(self, compressor):
+        messages = [
+            {"role": "user", "content": "q1"},
+            {"role": "user", "content": "q2"},
+            {"role": "assistant", "content": "REPLY"},
+            {"role": "assistant", "content": None, "tool_calls": []},
+        ]
+        assert compressor._ensure_last_assistant_message_in_tail(
+            messages, cut_idx=3, head_end=0
+        ) == 2
 
 
     def test_re_aligns_through_preceding_tool_group(self, compressor):
@@ -174,7 +179,7 @@ class TestEnsureLastAssistantMessageInTail:
                                           "arguments": "{}"}}]},
             {"role": "tool", "content": "result", "tool_call_id": "c1"},
             {"role": "assistant", "content": "REPLY"},  # idx 3
-            {"role": "user", "content": "q2"},
+            {"role": "assistant", "content": None, "tool_calls": []},
         ]
         # cut_idx=4 leaves the reply outside the tail. Anchor pulls
         # back to 3, then _align_boundary_backward sees the preceding
@@ -213,10 +218,9 @@ class TestFindTailCutByTokensAnchorsAssistant:
         messages = [
             {"role": "system", "content": "sys"},
             {"role": "user", "content": "msg1"},                # head_end=2
-            {"role": "user", "content": "q1"},
+            {"role": "user", "content": "q2"},
             {"role": "assistant",
              "content": "PREVIOUSLY VISIBLE REPLY"},           # idx 3
-            {"role": "user", "content": "q2"},
             {"role": "assistant", "content": None,
              "tool_calls": [{"id": "c1",
                              "function": {"name": "t",
@@ -244,9 +248,9 @@ class TestFindTailCutByTokensAnchorsAssistant:
         c.tail_token_budget = 10
         messages = [
             {"role": "user", "content": "q1"},
-            {"role": "assistant", "content": "VISIBLE REPLY"},
             {"role": "user", "content": "follow-up question"},
-            {"role": "user", "content": "and another"},
+            {"role": "assistant", "content": "VISIBLE REPLY"},
+            {"role": "assistant", "content": None, "tool_calls": []},
         ]
         cut = c._find_tail_cut_by_tokens(messages, head_end=0)
         tail_contents = [
@@ -254,7 +258,36 @@ class TestFindTailCutByTokensAnchorsAssistant:
             if isinstance(m.get("content"), str)
         ]
         assert any("VISIBLE REPLY" in (t or "") for t in tail_contents)
-        assert any("and another" in (t or "") for t in tail_contents)
+        assert any("follow-up question" in (t or "") for t in tail_contents)
+
+    def test_stale_reply_does_not_pin_long_active_tool_turn(self, compressor):
+        """A completed-turn reply must not drag the tail ahead of a newer task."""
+        c = compressor
+        c.tail_token_budget = 100
+        messages: list[dict] = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old visible reply"},
+            {"role": "user", "content": "new long-running task"},
+        ]
+        for index in range(80):
+            call_id = f"call-{index}"
+            messages.extend([
+                {"role": "assistant", "content": None, "tool_calls": [{
+                    "id": call_id,
+                    "function": {"name": "read_file", "arguments": "{}"},
+                }]},
+                {"role": "tool", "tool_call_id": call_id, "content": "x" * 200},
+            ])
+
+        cut = c._find_tail_cut_by_tokens(messages, head_end=1)
+
+        assert cut >= 3
+        assert messages[3]["content"] == "new long-running task"
+        assert all(
+            message.get("content") != "old visible reply"
+            for message in messages[cut:]
+        )
 
     def test_oversized_tool_output_does_not_strand_reply(self, compressor):
         """The soft-ceiling logic in ``_find_tail_cut_by_tokens``
@@ -265,7 +298,6 @@ class TestFindTailCutByTokensAnchorsAssistant:
         messages = [
             {"role": "user", "content": "earlier"},
             {"role": "assistant", "content": "VISIBLE REPLY"},
-            {"role": "user", "content": "read big file"},
             {"role": "assistant", "content": None,
              "tool_calls": [{"id": "c1",
                              "function": {"name": "read",
@@ -273,7 +305,6 @@ class TestFindTailCutByTokensAnchorsAssistant:
             # ~500 chars ⇒ ~135 tokens, blows past soft ceiling of 150
             {"role": "tool", "content": "y" * 500,
              "tool_call_id": "c1"},
-            {"role": "user", "content": "ok"},
         ]
         cut = c._find_tail_cut_by_tokens(messages, head_end=0)
         tail_contents = [
@@ -320,9 +351,9 @@ class TestCompactionRollupReproduction:
             ]
             + [
                 {"role": "user", "content": "the visible question"},
+                {"role": "user", "content": "follow up"},
                 {"role": "assistant",
                  "content": "THE VISIBLE REPLY THE USER JUST READ"},
-                {"role": "user", "content": "follow up"},
                 {"role": "assistant", "content": None,
                  "tool_calls": [{"id": "c1",
                                  "function": {"name": "t",
@@ -388,9 +419,9 @@ class TestCompactionRollupReproduction:
             ]
             + [
                 {"role": "user", "content": "the visible question"},
+                {"role": "user", "content": "follow up"},
                 {"role": "assistant",
                  "content": "THE VISIBLE REPLY THE USER JUST READ"},
-                {"role": "user", "content": "follow up"},
             ]
         )
         with patch.object(

--- a/tests/run_agent/test_post_tool_compression_attempt_cap.py
+++ b/tests/run_agent/test_post_tool_compression_attempt_cap.py
@@ -197,3 +197,12 @@ class TestPostToolCompressionAttemptCap:
 
         assert len(first) == 3
         assert len(second) == 3
+
+    def test_effective_compactions_reset_streak_after_success(self, agent):
+        """A long tool turn may keep compacting when every pass really helps."""
+        agent.context_compressor.compression_made_progress.return_value = True
+
+        result, compress_calls = _run_tool_loop(agent, n_tool_iterations=7)
+
+        assert result["completed"] is True
+        assert len(compress_calls) == 7

--- a/tests/run_agent/test_preflight_compression_cap_e2e.py
+++ b/tests/run_agent/test_preflight_compression_cap_e2e.py
@@ -21,11 +21,15 @@ import contextlib
 import io
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from agent.conversation_loop import _context_admission_input_limit
+from agent.conversation_loop import (
+    _context_admission_input_limit,
+    _context_admission_pressure,
+)
 from hermes_state import SessionDB
 from run_agent import AIAgent
 
@@ -166,6 +170,26 @@ def test_context_admission_limit(context_limit, output_reserve, expected):
     ) == expected
 
 
+def test_context_admission_pressure_removes_only_proven_fixed_overcount():
+    compressor = SimpleNamespace(
+        last_rough_tokens_when_real_prompt_fit=200_000,
+        last_real_prompt_tokens=160_000,
+        threshold_tokens=204_000,
+    )
+
+    assert _context_admission_pressure(compressor, 270_000) == 230_000
+
+
+def test_context_admission_pressure_fails_closed_without_valid_calibration():
+    compressor = SimpleNamespace(
+        last_rough_tokens_when_real_prompt_fit=200_000,
+        last_real_prompt_tokens=210_000,
+        threshold_tokens=204_000,
+    )
+
+    assert _context_admission_pressure(compressor, 270_000) == 270_000
+
+
 def test_pre_provider_admission_blocks_uncompressible_request(monkeypatch, tmp_path):
     agent = _make_agent(monkeypatch, tmp_path, max_attempts=3)
     agent.context_compressor.context_length = 200_000
@@ -258,5 +282,36 @@ def test_request_below_safe_boundary_reaches_provider(monkeypatch, tmp_path):
     ):
         result = agent.run_conversation("hello")
 
+    assert result["completed"] is True
+    provider_call.assert_called_once()
+
+
+def test_provider_proven_calibration_avoids_false_local_block(monkeypatch, tmp_path):
+    agent: Any = _make_agent(monkeypatch, tmp_path, max_attempts=3)
+    compressor = agent.context_compressor
+    compressor.context_length = 200_000
+    compressor.threshold_tokens = 150_000
+    compressor.last_rough_tokens_when_real_prompt_fit = 180_000
+    compressor.last_real_prompt_tokens = 100_000
+    agent.compression_enabled = False
+    agent.max_tokens = 0
+
+    with (
+        patch(
+            "agent.conversation_loop.estimate_messages_tokens_rough",
+            return_value=270_000,
+        ),
+        patch.object(
+            agent,
+            "_interruptible_api_call",
+            return_value=_stop_response(),
+        ) as provider_call,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("hello")
+
+    assert _context_admission_pressure(compressor, 270_000) == 190_000
     assert result["completed"] is True
     provider_call.assert_called_once()

--- a/tests/run_agent/test_preflight_compression_cap_e2e.py
+++ b/tests/run_agent/test_preflight_compression_cap_e2e.py
@@ -23,6 +23,9 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from agent.conversation_loop import _context_admission_input_limit
 from hermes_state import SessionDB
 from run_agent import AIAgent
 
@@ -147,3 +150,113 @@ def test_preflight_runs_fourth_compaction_pass_at_cap_six(monkeypatch, tmp_path)
     assert len(compress_calls) == 6
 
 
+@pytest.mark.parametrize(
+    ("context_limit", "output_reserve", "expected"),
+    [
+        (272_000, 0, 267_904),
+        (200_000, 10_000, 190_000),
+        (32_000, 0, 31_488),
+        (0, 0, 0),
+    ],
+)
+def test_context_admission_limit(context_limit, output_reserve, expected):
+    assert _context_admission_input_limit(
+        context_limit,
+        reserved_output_tokens=output_reserve,
+    ) == expected
+
+
+def test_pre_provider_admission_blocks_uncompressible_request(monkeypatch, tmp_path):
+    agent = _make_agent(monkeypatch, tmp_path, max_attempts=3)
+    agent.context_compressor.context_length = 200_000
+    agent.max_tokens = 0
+    safe_limit = _context_admission_input_limit(200_000)
+
+    with (
+        patch(
+            "agent.conversation_loop.estimate_messages_tokens_rough",
+            return_value=safe_limit,
+        ),
+        patch.object(
+            agent,
+            "_interruptible_api_call",
+            side_effect=AssertionError("provider call must remain local"),
+        ),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("hello")
+
+    assert result["completed"] is False
+    assert result["provider_call_blocked"] is True
+    assert result["api_calls"] == 0
+    assert result["safe_input_limit"] == safe_limit
+
+
+def test_safe_boundary_overrides_preflight_deferral(monkeypatch, tmp_path):
+    agent = _make_agent(monkeypatch, tmp_path, max_attempts=3)
+    compressor = agent.context_compressor
+    compressor.context_length = 200_000
+    compressor.threshold_tokens = 100_000
+    agent.max_tokens = 0
+    safe_limit = _context_admission_input_limit(200_000)
+    defer = MagicMock(return_value=True)
+    compressor.should_defer_preflight_to_real_usage = defer
+    compress_calls = []
+
+    def _fake_compress(messages, system_message, **_kwargs):
+        compress_calls.append(len(messages))
+        return messages, system_message
+
+    history = [
+        {"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"}
+        for i in range(40)
+    ]
+
+    with (
+        patch(
+            "agent.conversation_loop.estimate_messages_tokens_rough",
+            return_value=safe_limit,
+        ),
+        patch.object(agent, "_compress_context", side_effect=_fake_compress),
+        patch.object(
+            agent,
+            "_interruptible_api_call",
+            side_effect=AssertionError("provider call must remain local"),
+        ),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("hello", conversation_history=history)
+
+    assert len(compress_calls) == 1
+    # The turn-start estimator may consult deferral for its small real input;
+    # the oversized loop request must not.
+    assert all(call.args[0] < safe_limit for call in defer.call_args_list)
+    assert result["provider_call_blocked"] is True
+
+
+def test_request_below_safe_boundary_reaches_provider(monkeypatch, tmp_path):
+    agent = _make_agent(monkeypatch, tmp_path, max_attempts=3)
+    agent.context_compressor.context_length = 200_000
+    agent.max_tokens = 0
+    safe_limit = _context_admission_input_limit(200_000)
+
+    with (
+        patch(
+            "agent.conversation_loop.estimate_messages_tokens_rough",
+            return_value=safe_limit - 1,
+        ),
+        patch.object(
+            agent,
+            "_interruptible_api_call",
+            return_value=_stop_response(),
+        ) as provider_call,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("hello")
+
+    assert result["completed"] is True
+    provider_call.assert_called_once()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3898,9 +3898,12 @@ class TestRunConversation:
         mock_compress.assert_not_called()
 
     def test_output_cap_retry_with_large_api_only_content(self, agent):
-        """When a large system prompt makes api_messages huge while persisted
-        messages stay tiny, the retry cap must still respect provider
-        available_tokens — not blow up to the full context window.
+        """Large API-only content is included in final admission pressure.
+
+        The ordinary output-cap retry remains covered above. Here the system
+        prompt alone makes the initial request unsafe, so it must be blocked
+        before any provider call rather than using the tiny persisted history
+        to admit an oversized request.
         """
         self._setup_agent(agent)
         agent.api_mode = "chat_completions"
@@ -3914,17 +3917,6 @@ class TestRunConversation:
         # Huge API-only system prompt; persisted messages are tiny.
         agent._cached_system_prompt = "S" * 796_000
 
-        error_msg = (
-            "max_tokens: 65536 > context_window: 200000 "
-            "- input_tokens: 199000 = available_tokens: 1000"
-        )
-        exc = Exception(error_msg)
-        exc.status_code = 400
-        exc.code = 400
-
-        ok_resp = _mock_response(content="done", finish_reason="stop")
-        agent.client.chat.completions.create.side_effect = [exc, ok_resp]
-
         mock_compress = MagicMock()
         with (
             patch.object(agent, "_persist_session"),
@@ -3935,11 +3927,12 @@ class TestRunConversation:
         ):
             result = agent.run_conversation("hello")
 
-        second_call = agent.client.chat.completions.create.call_args_list[1].kwargs
-        assert result["completed"] is True
-        # The current branch (messages-only estimate) would send max_tokens
-        # near 199927 — this test fails on it.
-        assert second_call["max_tokens"] <= 936
+        assert result["completed"] is False
+        assert result["provider_call_blocked"] is True
+        assert result["api_calls"] == 0
+        assert result["estimated_input_tokens"] > result["safe_input_limit"]
+        assert result["configured_context_limit"] == 200_000
+        agent.client.chat.completions.create.assert_not_called()
         assert agent.context_compressor.context_length == 200_000
         mock_compress.assert_not_called()
 


### PR DESCRIPTION
## Problem

A visible assistant reply from an older completed turn can pull the protected-tail boundary behind a newer long-running tool turn. In the reported 354-message session this moved the cut from 142 to 4, retaining ~215k rough tokens and leaving no useful summary window. Prune-only passes were also recorded as ineffective, exhausting the per-turn attempt state, while rough Codex replay estimates could false-block requests despite proven lower provider usage.

## Fix

- anchor the visible assistant reply only when it belongs to the newest actionable user turn;
- count deterministic tool-result pruning as progress and treat `max_attempts` as a consecutive no-progress streak, reset only after progress plus a real provider response;
- calibrate final admission with provider-proven fixed over-count while retaining the configured fail-closed input ceiling.

The exact stored-session fixture now cuts at 142 (~128k rough tail) instead of 4 (~215k). The historical 270,324 rough estimate calibrates to 233,403 against a 267,904 safe ceiling.

Supersedes #72531 with the complete progress lifecycle and regression coverage.

## Validation

- 148 focused compression/admission tests passed on current `main`
- Ruff, `py_compile`, and `git diff --check` passed
