### PR TITLE
fix(dashboard): recycle the console executor when every worker is permanently stuck

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -48,7 +48,7 @@ import zipfile
 from hermes_cli._subprocess_compat import windows_detach_flags, windows_hide_flags
 import urllib.request
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple
+from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple
 
 import yaml
 
@@ -16826,29 +16826,119 @@ _CONSOLE_OUTPUT_LIMIT = 50000
 # default thread pool (asyncio.to_thread), we run console commands on a small
 # dedicated, bounded pool: a leaked worker is capped, and concurrent console
 # execution is bounded to a fixed number of threads regardless of reconnects.
+#
+# Bounding it alone isn't enough, though: a wedged worker holds its slot for the
+# life of the process, so once all four are wedged every later command queues
+# behind threads that will never return and the console is dead for every
+# session and profile until Hermes restarts. So track which submissions actually
+# timed out and swap in a fresh pool when none are left.
 _CONSOLE_EXECUTOR_MAX_WORKERS = 4
 _console_executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
 _console_executor_lock = threading.Lock()
+# Bumped on every recycle. Timeout bookkeeping is keyed by generation so state
+# recorded against a retired pool can never reach into its replacement.
+_console_executor_generation = 0
+# generation -> the futures that actually exceeded _CONSOLE_COMMAND_TIMEOUT_SECONDS
+# and are therefore presumed to hold a worker thread forever. Only the generation
+# that ran a future may hold or clear that future's mark, and a command that
+# never timed out is never in the set, so an ordinary completion cannot clear
+# some other command's mark. Bounded by _CONSOLE_EXECUTOR_MAX_WORKERS entries for
+# the live generation; a retired generation's marks are dropped wholesale.
+_console_stuck_futures: Dict[int, Set[concurrent.futures.Future[Any]]] = {}
 
 
-def _get_console_executor() -> concurrent.futures.ThreadPoolExecutor:
-    """Lazily create the bounded console worker pool (once per process)."""
+def _new_console_executor() -> concurrent.futures.ThreadPoolExecutor:
+    """Build a fresh bounded console worker pool and arm its exit teardown."""
+    executor = concurrent.futures.ThreadPoolExecutor(
+        max_workers=_CONSOLE_EXECUTOR_MAX_WORKERS,
+        thread_name_prefix="hermes-console",
+    )
+    # Bind teardown to THIS executor rather than reading the module global:
+    # after a recycle the global points at the replacement, so a global-reading
+    # callback would shut the wrong pool down and never touch the retired one.
+    # Don't wait on in-flight workers either -- a stuck 60s console command must
+    # not block shutdown (cancel_futures drops anything not yet started).
+    atexit.register(lambda: executor.shutdown(wait=False, cancel_futures=True))
+    return executor
+
+
+def _submit_console_command(
+    fn: Callable[[], Any],
+) -> Tuple[concurrent.futures.Future[Any], int]:
+    """Submit a console command, returning its future and the pool generation.
+
+    Selecting the pool and submitting to it happen under one lock so that a
+    concurrent recycle can never hand back an executor that is already shut
+    down by the time we submit.
+    """
     global _console_executor
-    if _console_executor is None:
-        with _console_executor_lock:
-            if _console_executor is None:
-                _console_executor = concurrent.futures.ThreadPoolExecutor(
-                    max_workers=_CONSOLE_EXECUTOR_MAX_WORKERS,
-                    thread_name_prefix="hermes-console",
-                )
-                # Ensure the pool is torn down on interpreter exit. Don't wait on
-                # in-flight workers: a stuck 60s console command must not block
-                # shutdown (cancel_futures drops anything not yet started).
-                atexit.register(
-                    lambda: _console_executor
-                    and _console_executor.shutdown(wait=False, cancel_futures=True)
-                )
-    return _console_executor
+    with _console_executor_lock:
+        if _console_executor is None:
+            _console_executor = _new_console_executor()
+        generation = _console_executor_generation
+        _console_stuck_futures.setdefault(generation, set())
+        future = _console_executor.submit(fn)
+    # Registered outside the lock: add_done_callback runs the callback inline
+    # when the future has already finished, and that callback takes this lock.
+    future.add_done_callback(
+        functools.partial(_release_console_future, generation=generation)
+    )
+    return future, generation
+
+
+def _release_console_future(
+    future: concurrent.futures.Future[Any], *, generation: int
+) -> None:
+    """Clear ``future``'s own stuck mark once it finally returns.
+
+    A no-op unless that future had previously timed out *and* the generation
+    that ran it is still live, which is what keeps a late completion from a
+    retired pool out of the replacement's bookkeeping.
+    """
+    with _console_executor_lock:
+        stuck = _console_stuck_futures.get(generation)
+        if stuck is not None:
+            stuck.discard(future)
+
+
+def _note_console_command_stuck(
+    future: concurrent.futures.Future[Any], generation: int
+) -> None:
+    """Mark a timed-out command's worker as wedged, recycling a full pool.
+
+    Only called from the timeout path, so a command that merely succeeded never
+    touches this state. Once every worker in the live pool is wedged the pool is
+    swapped for a fresh one; the old threads can't be killed, only abandoned.
+    """
+    global _console_executor, _console_executor_generation
+    retired: Optional[concurrent.futures.ThreadPoolExecutor] = None
+    with _console_executor_lock:
+        if generation != _console_executor_generation:
+            # Its pool is already retired, so its slot no longer matters.
+            return
+        if future.done():
+            # It returned while we were giving up on the await, so the worker is
+            # merely slow, not wedged, and must not count toward the threshold.
+            # ``done()`` flips before done-callbacks run and those callbacks take
+            # this same lock, so this check cannot race with the release path.
+            return
+        stuck = _console_stuck_futures.setdefault(generation, set())
+        stuck.add(future)
+        if len(stuck) < _CONSOLE_EXECUTOR_MAX_WORKERS:
+            return
+        retired = _console_executor
+        _console_stuck_futures.pop(generation, None)
+        _console_executor_generation = generation + 1
+        _console_executor = _new_console_executor()
+        _console_stuck_futures[_console_executor_generation] = set()
+    _log.warning(
+        "console worker pool exhausted by %d stuck commands; recycled generation %d -> %d",
+        _CONSOLE_EXECUTOR_MAX_WORKERS,
+        generation,
+        generation + 1,
+    )
+    if retired is not None:
+        retired.shutdown(wait=False, cancel_futures=True)
 
 
 def _console_profile_from_ws(ws: WebSocket) -> Optional[str]:
@@ -17115,20 +17205,29 @@ async def console_ws(ws: WebSocket) -> None:
     async def run_command(line: str, *, confirmed: bool, command_id: int) -> None:
         nonlocal active_task, pending_confirmation, command_generation
         try:
-            loop = asyncio.get_running_loop()
-            result = await asyncio.wait_for(
-                loop.run_in_executor(
-                    _get_console_executor(),
-                    functools.partial(
-                        _execute_console_line,
-                        engine,
-                        line,
-                        confirmed=confirmed,
-                        profile=profile,
-                    ),
-                ),
-                timeout=_CONSOLE_COMMAND_TIMEOUT_SECONDS,
+            # Submit directly rather than via loop.run_in_executor so we keep
+            # the raw concurrent.futures.Future: asyncio.wait_for can only
+            # abandon the *await*, never the worker thread, so that future is
+            # the only handle on whether the thread ever comes back.
+            cf_future, executor_generation = _submit_console_command(
+                functools.partial(
+                    _execute_console_line,
+                    engine,
+                    line,
+                    confirmed=confirmed,
+                    profile=profile,
+                )
             )
+            try:
+                result = await asyncio.wait_for(
+                    asyncio.wrap_future(cf_future),
+                    timeout=_CONSOLE_COMMAND_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                # Nothing can interrupt the worker, so record the wedged slot;
+                # the pool recycles itself once every worker is gone.
+                _note_console_command_stuck(cf_future, executor_generation)
+                raise
         except asyncio.CancelledError:
             raise
         except asyncio.TimeoutError:

--- a/tests/hermes_cli/test_web_server_console_ws.py
+++ b/tests/hermes_cli/test_web_server_console_ws.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import concurrent.futures
+import threading
 import time
 from urllib.parse import urlencode
 
@@ -117,3 +119,236 @@ def test_console_ws_cancel_returns_to_prompt(console_client, monkeypatch):
 
         complete = _recv_until(conn, "complete", status="cancelled")
         assert complete["prompt"] == "hermes> "
+
+
+# ---------------------------------------------------------------------------
+# Console worker pool: timeout bookkeeping + recycling.
+#
+# A console command that outlives the timeout keeps its (unkillable) worker
+# thread forever, so the bounded pool must notice when every worker is wedged
+# and replace itself. These drive the pool helpers directly: the websocket path
+# would need a real 60s timeout, which is neither fast nor deterministic.
+# ---------------------------------------------------------------------------
+
+_MAX_WORKERS = web_server._CONSOLE_EXECUTOR_MAX_WORKERS
+
+
+@pytest.fixture
+def console_pool():
+    """Give each test a pristine console pool and tear its threads down."""
+    saved = (
+        web_server._console_executor,
+        web_server._console_executor_generation,
+        dict(web_server._console_stuck_futures),
+    )
+    web_server._console_executor = None
+    web_server._console_executor_generation = 0
+    web_server._console_stuck_futures.clear()
+    created = []
+    try:
+        yield created
+    finally:
+        for executor in {id(e): e for e in created}.values():
+            executor.shutdown(wait=False, cancel_futures=True)
+        current = web_server._console_executor
+        if current is not None and current is not saved[0]:
+            current.shutdown(wait=False, cancel_futures=True)
+        (
+            web_server._console_executor,
+            web_server._console_executor_generation,
+            _stuck,
+        ) = saved
+        web_server._console_stuck_futures.clear()
+        web_server._console_stuck_futures.update(_stuck)
+
+
+class _Wedge:
+    """A console command that blocks until the test explicitly releases it."""
+
+    def __init__(self) -> None:
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def __call__(self) -> str:
+        self.started.set()
+        assert self.release.wait(30), "wedged console command was never released"
+        return "late"
+
+
+def _submit_wedged(created):
+    """Submit a blocking command and wait until its worker really holds a slot."""
+    wedge = _Wedge()
+    future, generation = web_server._submit_console_command(wedge)
+    created.append(web_server._console_executor)
+    assert wedge.started.wait(10), "console worker never started"
+    return wedge, future, generation
+
+
+def _run_to_completed_callback(created, value="ok"):
+    """Run a normal command and wait until its done-callbacks have all fired.
+
+    ``Future.result()`` can return before the callbacks run, so register a probe
+    afterwards: callbacks fire in registration order, so once the probe has run
+    the production callback has already finished.
+    """
+    future, generation = web_server._submit_console_command(lambda: value)
+    created.append(web_server._console_executor)
+    callbacks_done = threading.Event()
+    future.add_done_callback(lambda _f: callbacks_done.set())
+    assert future.result(timeout=10) == value
+    assert callbacks_done.wait(10), "console done-callback never ran"
+    return future, generation
+
+
+def test_console_pool_recycles_only_when_every_worker_is_stuck(console_pool):
+    """Four wedged workers replace the pool; a normal command never counts."""
+    original = None
+    wedges = []
+    try:
+        first_wedge, first_future, generation = _submit_wedged(console_pool)
+        wedges.append(first_wedge)
+        original = web_server._console_executor
+        assert original is not None
+        assert generation == 0
+
+        web_server._note_console_command_stuck(first_future, generation)
+        assert web_server._console_stuck_futures[0] == {first_future}
+
+        # Ordinary commands complete on the three free workers. None of them
+        # timed out, so none may clear the wedged worker's mark -- if they did,
+        # the pool would never reach the recycle threshold below.
+        for _ in range(3):
+            _run_to_completed_callback(console_pool)
+            assert web_server._console_stuck_futures[0] == {first_future}
+            assert web_server._console_executor is original
+
+        # Wedge the remaining workers. The pool is only replaced on the last one.
+        for expected in range(2, _MAX_WORKERS + 1):
+            wedge, future, gen = _submit_wedged(console_pool)
+            wedges.append(wedge)
+            assert gen == 0
+            web_server._note_console_command_stuck(future, gen)
+            if expected < _MAX_WORKERS:
+                assert web_server._console_executor is original
+                assert len(web_server._console_stuck_futures[0]) == expected
+
+        assert web_server._console_executor is not original
+        assert web_server._console_executor_generation == 1
+        assert web_server._console_stuck_futures == {1: set()}
+
+        # The console works again: new commands land on the replacement pool.
+        healthy, healthy_gen = web_server._submit_console_command(lambda: "alive")
+        assert healthy_gen == 1
+        assert healthy.result(timeout=10) == "alive"
+    finally:
+        for wedge in wedges:
+            wedge.release.set()
+
+
+def test_completed_console_command_is_never_marked_stuck(console_pool):
+    """A command that returns as we give up on the await is slow, not wedged."""
+    future, generation = _run_to_completed_callback(console_pool, value="fast")
+
+    web_server._note_console_command_stuck(future, generation)
+
+    assert web_server._console_stuck_futures[generation] == set()
+    assert web_server._console_executor_generation == 0
+
+
+def test_late_completion_from_retired_pool_leaves_replacement_untouched(console_pool):
+    """A retired generation's futures must not touch the replacement's state."""
+    wedges = []
+    retired_futures = []
+    try:
+        for _ in range(_MAX_WORKERS):
+            wedge, future, generation = _submit_wedged(console_pool)
+            wedges.append(wedge)
+            retired_futures.append(future)
+            assert generation == 0
+            web_server._note_console_command_stuck(future, generation)
+
+        replacement = web_server._console_executor
+        assert web_server._console_executor_generation == 1
+
+        # Wedge one worker on the replacement pool so it has state to corrupt.
+        new_wedge, new_future, new_generation = _submit_wedged(console_pool)
+        wedges.append(new_wedge)
+        assert new_generation == 1
+        web_server._note_console_command_stuck(new_future, new_generation)
+        assert web_server._console_stuck_futures == {1: {new_future}}
+
+        # A timeout reported against the retired generation -- whose workers are
+        # still wedged, so the "already finished" shortcut cannot absorb it --
+        # must be dropped on generation ownership alone. Otherwise these four
+        # would re-trip the threshold and retire the *live* pool.
+        for future in retired_futures:
+            assert not future.done()
+            web_server._note_console_command_stuck(future, 0)
+        assert web_server._console_stuck_futures == {1: {new_future}}
+        assert web_server._console_executor is replacement
+        assert web_server._console_executor_generation == 1
+
+        # Now let the retired pool's wedged workers finally return.
+        probes = []
+        for future in retired_futures:
+            done = threading.Event()
+            future.add_done_callback(lambda _f, ev=done: ev.set())
+            probes.append(done)
+        for wedge in wedges[:_MAX_WORKERS]:
+            wedge.release.set()
+        for future, done in zip(retired_futures, probes):
+            assert future.result(timeout=10) == "late"
+            assert done.wait(10), "retired console done-callback never ran"
+
+        # Generation 1's bookkeeping is exactly as it was.
+        assert web_server._console_stuck_futures == {1: {new_future}}
+        assert web_server._console_executor is replacement
+        assert web_server._console_executor_generation == 1
+
+        # A late timeout report from the retired generation is ignored too, so
+        # it can neither re-arm nor re-trip the replacement's threshold.
+        web_server._note_console_command_stuck(retired_futures[0], 0)
+        assert web_server._console_stuck_futures == {1: {new_future}}
+        assert web_server._console_executor is replacement
+
+        # The consequence that actually matters: the replacement still counts
+        # its own wedged worker, so it recycles on its own fourth one -- not on
+        # a fifth, which is what losing that mark to the old pool would cost.
+        for expected in range(2, _MAX_WORKERS + 1):
+            wedge, future, gen = _submit_wedged(console_pool)
+            wedges.append(wedge)
+            assert gen == 1
+            web_server._note_console_command_stuck(future, gen)
+            if expected < _MAX_WORKERS:
+                assert web_server._console_executor is replacement
+                assert len(web_server._console_stuck_futures[1]) == expected
+        assert web_server._console_executor_generation == 2
+        assert web_server._console_executor is not replacement
+    finally:
+        for wedge in wedges:
+            wedge.release.set()
+
+
+def test_console_executor_atexit_hook_shuts_down_its_own_pool(console_pool, monkeypatch):
+    """Each pool's exit hook targets that pool, not whatever the global holds."""
+    hooks = []
+    monkeypatch.setattr(
+        web_server.atexit, "register", lambda fn: (hooks.append(fn), fn)[1]
+    )
+
+    first = web_server._new_console_executor()
+    console_pool.append(first)
+    second = web_server._new_console_executor()
+    console_pool.append(second)
+    assert len(hooks) == 2
+    assert isinstance(first, concurrent.futures.ThreadPoolExecutor)
+
+    # Point the module global at the second pool, the way a recycle does.
+    web_server._console_executor = second
+
+    # The first pool's hook must tear down the first pool even though the
+    # global now names the replacement.
+    hooks[0]()
+    with pytest.raises(RuntimeError):
+        first.submit(lambda: "nope")
+    assert second.submit(lambda: "alive").result(timeout=10) == "alive"


### PR DESCRIPTION
## Supersedes #59240 — sibling follow-up to `a6b9597d5`

- `a6b9597d5` ("perf(console): cache CLI-surface summaries + bound console worker pool") introduced the bounded four-worker console pool this builds on.
- What it did **not** add is any way for that pool to recover once its workers are permanently wedged — the code comment on main concedes the hazard ("a genuinely stuck worker keeps running to completion") but nothing acts on it.
- This adds that recovery, implementing the per-future **and** per-executor-generation timeout ownership plus the three regression tests requested in the review on #59240.

#59240 is the only other open PR on this code and is abandoned: last commit `2026-07-05`, no force-pushes and no author reply since, currently `CONFLICTING`/`DIRTY`, and the review landed after its last commit. This is a fresh implementation on current `main` rather than a rebase, because the review's first two findings are design-level rather than textual.

## What does this PR do?

Dashboard console commands run on a process-global, bounded four-worker `ThreadPoolExecutor` (`hermes_cli/web_server.py`). `asyncio.wait_for` can only abandon the *await* — Python threads aren't preemptible, so a genuinely wedged command holds its worker for the life of the process.

After four such commands the pool is permanently exhausted. Every later console command, **from every dashboard session and every profile**, then queues behind threads that will never return, sits the full 60s, and returns:

> `Command timed out. Hermes Console returned to the prompt.`

...forever, until Hermes is restarted. That is an availability failure, not just a slow path: the dashboard console is dead with no user-visible indication of why and no way to recover short of a restart.

This tracks which submissions *actually* timed out and swaps in a fresh pool once none are left.

### How the review's findings are addressed

The review on #59240 named three problems. Each maps to a specific change here:

**1. "The done callback decrements the global count for every non-cancelled future, not just a future that previously timed out."**

There is no counter any more. A future is recorded only on the `asyncio.TimeoutError` path (`_note_console_command_stuck`), and the done-callback (`_release_console_future`) only ever `discard`s *that same future object* from the set. A command that never timed out is never in the set, so it structurally cannot clear another worker's mark or hold the pool below its recycle threshold.

**2. "`_console_executor_stuck_count` has no executor-generation ownership; a late completion from a retired executor can decrement timeout state accumulated by the replacement."**

Marks live in `Dict[generation, Set[Future]]` and every callback is bound to the generation that ran it. A retired generation's entry is dropped wholesale at recycle time, so both a late *completion* and a late *timeout report* from an old pool are no-ops. The generation guard on the mark path also prevents the worse case: without it, four stale timeout reports would re-trip the threshold and retire the **live** pool.

**3. "The diff adds no timeout/replacement regression test."**

Four added, covering exactly the requested cases — four blocked workers, replacement, and late completion from the old pool. See *How to Test*.

### Also fixed, because the recycle requires it

The `atexit` hook on main closes over the module global:

```python
atexit.register(
    lambda: _console_executor
    and _console_executor.shutdown(wait=False, cancel_futures=True)
)
```

Once a pool is recycled that global names the *replacement*, so the hook would shut down the wrong pool and leave the retired one registered. Teardown is now bound to each concrete executor via a `_new_console_executor()` factory.

### Scope

`_get_console_executor()` had exactly one call site, and a sweep of the root cause (`grep -rn ThreadPoolExecutor` over non-test sources) found no sibling site sharing it. Deliberately excluded, with reasons:

- The other `run_in_executor` calls in `web_server.py` pass `None` — they use the shared default loop executor, which is precisely what the dedicated console pool exists to protect. Different lifecycle, different concern.
- `tools/async_delegation.py::_get_executor` is also a persistent global pool, but it *grows* on demand rather than being fixed-cap, and has no per-call abandon-on-timeout, so it cannot reach this failure mode.
- `tools/vision_tools.py::_vision_cpu_executor` has no per-command timeout that abandons a worker.

## Related Issue

No linked issue exists — filing this as a supersede of #59240 rather than inventing one.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

`hermes_cli/web_server.py`

- Added `_console_executor_generation` and `_console_stuck_futures: Dict[int, Set[Future]]` beside the existing pool globals. (Named to avoid colliding with the unrelated per-connection `command_generation` counter in `console_ws`.)
- Added `_new_console_executor()` — builds a pool and registers an `atexit` hook bound to *that* executor.
- Added `_submit_console_command()` — selects the pool, submits, and attaches the generation-bound done-callback. Pool selection and submit happen under one lock so a concurrent recycle can never hand back an executor that is already shut down by the time we submit.
- Added `_release_console_future()` — discards a future's *own* mark from its *own* generation.
- Added `_note_console_command_stuck()` — marks a timed-out future, and atomically swaps in a fresh pool once `_CONSOLE_EXECUTOR_MAX_WORKERS` marks accumulate, logging a warning and abandoning the old pool (`shutdown(wait=False, cancel_futures=True)`).
- Removed `_get_console_executor()`; `console_ws.run_command` now submits via `_submit_console_command` and awaits `asyncio.wrap_future(cf_future)`, so the raw `concurrent.futures.Future` stays reachable after the await is abandoned.
- Added `Callable` and `Set` to the `typing` import.

`tests/hermes_cli/test_web_server_console_ws.py`

- Added a `console_pool` fixture (pristine pool per test, threads torn down after) and a `_Wedge` helper that blocks until the test releases it.
- Added four tests (below).

### Thread-safety notes

- The done-callback runs on a worker thread while a swap may be happening on the event loop thread; both take `_console_executor_lock`.
- `_note_console_command_stuck` skips a future that is already `done()` — it finished while we were giving up on the await, so it is slow, not wedged, and must not count toward the threshold. `Future.done()` flips *before* done-callbacks run, and those callbacks take the same lock, so this check cannot race the release path in either direction.
- Marks are bounded: at most `_CONSOLE_EXECUTOR_MAX_WORKERS` per live generation, dropped at recycle.

## How to Test

```
uv run --with pytest --with pytest-xdist --with pytest-asyncio \
  python3 -m pytest tests/hermes_cli/test_web_server_console_ws.py -v
```

Four new deterministic tests (no real 60s timeout — they drive the pool helpers directly):

| Test | Covers |
| --- | --- |
| `test_console_pool_recycles_only_when_every_worker_is_stuck` | Four blocked workers replace the pool; three interleaved *normal* commands never clear the wedged mark, and the replacement serves new commands |
| `test_completed_console_command_is_never_marked_stuck` | A command that returns as we abandon the await is slow, not wedged |
| `test_late_completion_from_retired_pool_leaves_replacement_untouched` | Late completion *and* a late timeout report from the retired pool leave generation 1 untouched, and the replacement still recycles on its own fourth wedged worker |
| `test_console_executor_atexit_hook_shuts_down_its_own_pool` | A pool's exit hook tears down that pool, not whatever the global currently names |

**Fails before, passes after.** Reverting the production hunk alone turns all four red. Each test was also verified against a targeted mutation, so the coverage binds to the logic rather than to the new symbol names — one mutation per test, no overlap:

| Mutation | Test that catches it |
| --- | --- |
| `_release_console_future` clears marks it doesn't own (the original finding #1) | `..._recycles_only_when_every_worker_is_stuck` |
| Mark path drops its executor-generation guard (the original finding #2) | `..._late_completion_from_retired_pool...` |
| `atexit` reads the module global instead of its own pool | `..._atexit_hook_shuts_down_its_own_pool` |
| Already-`done()` guard removed | `..._completed_console_command_is_never_marked_stuck` |

Adjacent suites run green (`627 passed, 1 skipped`): `test_web_server_console_ws.py`, `test_console_engine.py`, `test_web_server.py`, `test_web_server_boot_handshake.py`, `test_web_server_pty_reconnect.py`, `test_web_server_pty_import.py`, `test_verify_console_scripts.py`. `ruff check` is clean on both touched files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the console WS suite plus six adjacent `tests/hermes_cli/` web_server suites (627 passed, 1 skipped), not the full tree
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.4, arm64), Python 3.12.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — module comments and docstrings on the touched helpers; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — stdlib `threading`/`concurrent.futures` only, no platform-specific paths or APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Contract Protected

**Invariant:** a console command's timeout mark is owned by exactly one `(future, executor generation)` pair. Only that future's own completion may clear it, and only while its generation is live.

- **Known-bad inputs:** a successful command completing while another worker is wedged; a completion arriving from a pool that was already retired; a timeout reported against a retired generation; a command that finishes in the instant between the timeout and the mark.
- **Negative case:** an ordinary command must *not* decrement anything — asserted directly in `test_console_pool_recycles_only_when_every_worker_is_stuck`, which waits for the production done-callback to have actually run (via a probe callback registered afterwards, since callbacks fire in registration order) before asserting the mark survived.
- **Future inputs:** the recycle threshold reads `_CONSOLE_EXECUTOR_MAX_WORKERS` rather than a literal, and the tests derive their loop bounds from it too, so changing the pool size cannot silently invalidate either.
