### PR TITLE
perf(desktop): keep GlyphSpinner frames out of React commits

### DIFF
--- a/apps/desktop/src/components/ui/glyph-spinner.test.tsx
+++ b/apps/desktop/src/components/ui/glyph-spinner.test.tsx
@@ -1,0 +1,98 @@
+import { act, render, screen } from '@testing-library/react'
+import { Profiler, type ProfilerOnRenderCallback } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { PaneVisibleContext } from '@/components/pane-shell/pane-visibility'
+
+import { GlyphSpinner } from './glyph-spinner'
+
+describe('GlyphSpinner', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.spyOn(globalThis.document, 'hasFocus').mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('advances its glyph without an update-phase React commit', () => {
+    let updateCommits = 0
+
+    const onRender: ProfilerOnRenderCallback = (_id, phase) => {
+      if (phase !== 'mount') {
+        updateCommits += 1
+      }
+    }
+
+    render(
+      <Profiler id="glyph-spinner" onRender={onRender}>
+        <GlyphSpinner spinner="braille" />
+      </Profiler>
+    )
+
+    const status = screen.getByRole('status', { name: 'Loading' })
+    expect(status.textContent).toBe('⠋')
+
+    act(() => vi.advanceTimersByTime(80))
+
+    expect(status.textContent).toBe('⠙')
+    expect(updateCommits).toBe(0)
+  })
+
+  it('does not tick while its kept-alive pane is hidden', () => {
+    const { rerender } = render(
+      <PaneVisibleContext.Provider value={false}>
+        <GlyphSpinner spinner="braille" />
+      </PaneVisibleContext.Provider>
+    )
+
+    const status = screen.getByRole('status', { name: 'Loading' })
+
+    expect(status.textContent).toBe('⠋')
+    expect(vi.getTimerCount()).toBe(0)
+
+    rerender(
+      <PaneVisibleContext.Provider value>
+        <GlyphSpinner spinner="braille" />
+      </PaneVisibleContext.Provider>
+    )
+    expect(vi.getTimerCount()).toBe(1)
+
+    act(() => vi.advanceTimersByTime(80))
+    expect(status.textContent).toBe('⠙')
+
+    rerender(
+      <PaneVisibleContext.Provider value={false}>
+        <GlyphSpinner spinner="braille" />
+      </PaneVisibleContext.Provider>
+    )
+    expect(vi.getTimerCount()).toBe(0)
+
+    const frozen = status.textContent
+    act(() => vi.advanceTimersByTime(800))
+    expect(status.textContent).toBe(frozen)
+  })
+
+  it('suspends animation while the Desktop window is inactive', () => {
+    render(<GlyphSpinner spinner="braille" />)
+
+    const status = screen.getByRole('status', { name: 'Loading' })
+    expect(vi.getTimerCount()).toBe(1)
+
+    act(() => window.dispatchEvent(new Event('blur')))
+    expect(vi.getTimerCount()).toBe(0)
+
+    const frozen = status.textContent
+    act(() => vi.advanceTimersByTime(800))
+    expect(status.textContent).toBe(frozen)
+
+    act(() => window.dispatchEvent(new Event('focus')))
+    expect(vi.getTimerCount()).toBe(1)
+
+    act(() => vi.advanceTimersByTime(80))
+    expect(status.textContent).not.toBe(frozen)
+  })
+})

--- a/apps/desktop/src/components/ui/glyph-spinner.tsx
+++ b/apps/desktop/src/components/ui/glyph-spinner.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef } from 'react'
 import spinners, { type BrailleSpinnerName as SpinnerName } from 'unicode-animations'
 
 import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
+import { createRendererLoopPauseController } from '@/lib/renderer-loop-pause'
 import { cn } from '@/lib/utils'
 
 export type { SpinnerName }
@@ -43,29 +44,66 @@ interface GlyphSpinnerProps {
  */
 export function GlyphSpinner({ ariaLabel = 'Loading', className, spinner = 'braille' }: GlyphSpinnerProps) {
   const spin = FRAMES_BY_NAME[spinner] ?? FRAMES_BY_NAME.braille!
-  const [frame, setFrame] = useState(0)
+  const glyphRef = useRef<HTMLSpanElement>(null)
   // Pause when this surface is a hidden (kept-alive) tab: N mounted tabs each
-  // ticking a setInterval + setState burn CPU for pixels nobody can see.
+  // ticking a setInterval burns CPU for pixels nobody can see.
   const visible = usePaneVisible()
 
   useEffect(() => {
-    if (!visible) {
+    const glyph = glyphRef.current
+
+    if (!visible || !glyph) {
       return
     }
 
-    setFrame(0)
-    const id = window.setInterval(() => setFrame(f => (f + 1) % spin.frames.length), spin.interval)
+    let frame = 0
+    let timer: number | undefined
+    let pauseController: ReturnType<typeof createRendererLoopPauseController> | undefined
+    glyph.textContent = spin.frames[frame]
 
-    return () => window.clearInterval(id)
+    const stopAnimation = () => {
+      if (timer === undefined) {
+        return
+      }
+
+      window.clearInterval(timer)
+      timer = undefined
+    }
+
+    const syncAnimation = () => {
+      if (pauseController?.isPaused()) {
+        stopAnimation()
+
+        return
+      }
+
+      if (timer !== undefined) {
+        return
+      }
+
+      timer = window.setInterval(() => {
+        frame = (frame + 1) % spin.frames.length
+        glyph.textContent = spin.frames[frame]
+      }, spin.interval)
+    }
+
+    pauseController = createRendererLoopPauseController(syncAnimation)
+    syncAnimation()
+
+    return () => {
+      pauseController.dispose()
+      stopAnimation()
+    }
   }, [spin, visible])
 
   return (
     <span
       aria-label={ariaLabel}
       className={cn('inline-flex items-center justify-center font-mono leading-none tabular-nums', className)}
+      ref={glyphRef}
       role="status"
     >
-      {spin.frames[frame]}
+      {spin.frames[0]}
     </span>
   )
 }


### PR DESCRIPTION
## What does this PR do?

`GlyphSpinner` currently advances every Unicode frame through `setInterval` plus React state. The default braille cadence therefore commits the component about every 80 ms even when no application data changes.

This change keeps the existing animated Desktop status indicator while moving only its frame paint out of React:

- active spinners update the existing glyph node's `textContent`, so animation frames do not cause React commits;
- hidden kept-alive panes still own no timer;
- the existing `createRendererLoopPauseController` now suspends the timer while the Desktop window is hidden, minimized, or unfocused;
- cleanup, spinner-specific frames/cadence, classes, `role="status"`, and the accessible label remain intact.

This is intentionally a narrow performance fix. It removes the confirmed React amplification path but does not claim to resolve the broader remaining Renderer/GPU load.

### Relationship to #73033

#73033 addresses the same issue by making the Desktop glyph static. This is a materially different alternative: it preserves the component's existing animated-status contract while active, and reuses the shared inactive-window pause seam that recently landed on `main`. Thanks to @franco314 for the static approach and its focused regression coverage.

## Related Issue

Fixes #72844

Related to the broader investigation in #69645.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/ui/glyph-spinner.tsx`
  - replace per-frame React state with a direct glyph-node update;
  - reuse the shared renderer-loop pause controller for inactive windows;
  - preserve the existing pane-visibility gate and public component contract.
- `apps/desktop/src/components/ui/glyph-spinner.test.tsx`
  - prove the glyph advances at the original cadence with zero update-phase React commits;
  - prove hidden kept-alive panes schedule no timer;
  - prove blur suspends the timer and focus resumes animation.

## How to Test

1. Run `npm run test:ui -- src/components/ui/glyph-spinner.test.tsx` from `apps/desktop`.
2. Run `npm test`, `npm run typecheck`, and the focused Prettier/ESLint checks.
3. Run `npm run build`.
4. Run the isolated `idle-cost` scenario and confirm `GlyphSpinner` is absent from idle update owners.

## Verification

- TDD mutation check against pre-fix code:
  - frame advancement produced one update-phase React commit;
  - blurring the Desktop left one timer running.
- Focused regression: 3/3 passed.
- Full Desktop suite: 411 files passed, 1 skipped; 3,836 tests passed, 2 skipped.
- Renderer, Electron, and E2E TypeScript checks passed.
- Focused Prettier and ESLint checks passed with no warnings.
- Production Desktop build passed.
- Isolated 120-turn `idle-cost` run:
  - issue baseline: 14.0 idle commits/s;
  - this branch: 1.5 idle commits/s;
  - `GlyphSpinner` absent from idle update owners.
- Earlier same-machine tool-heavy A/B:
  - total React commits: 189 → 12 (-93.7%);
  - `GlyphSpinner`-attributed renders: 182 → 11 (-94.0%);
  - V8 renderer active time: 27.3% → 24.8% (-9.2%).

The active-time reduction deliberately does not meet the broader 20% CPU-resolution threshold; profiling continues to point at scroll/layout and retained transcript work as the larger remaining path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate; the alternative approach in #73033 is discussed above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - `scripts/run_tests.sh` was attempted after installing the declared development extras, but was stopped at 13.5% because unrelated Python tests read local AWS/profile state, attempted sandbox-blocked writes to `~/.hermes/logs`, and tripped the live-system process guard. This PR changes no Python.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 27.0 (26A5378n), Apple Silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no public API or user workflow changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; this reuses the existing pause controller
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — browser APIs and the existing cross-platform controller only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No visual change: the same Unicode frames advance at the same cadence while the window is active.
