### PR TITLE
fix(whatsapp): attribute poll votes to the voter, not the poll author

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -44,6 +44,7 @@ import {
   mediaPayloadForFile,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
+  resolvePollVoterId,
 } from './bridge_helpers.js';
 
 // Parse CLI args
@@ -319,13 +320,18 @@ function logPollUpdateDiagnostic({ sourcePath, pollId, pollCreation, pollUpdates
   } catch {}
 }
 
-function enqueuePollUpdateEvent({ key, update, selectedOptions, aggregation }) {
+function enqueuePollUpdateEvent({ key, update, selectedOptions, aggregation, voterId }) {
   const chatId = normalizeWhatsAppId(key?.remoteJid || update?.pollUpdates?.[0]?.pollUpdateMessageKey?.remoteJid || '');
-  const senderId = normalizeWhatsAppId(
-    key?.participant
-    || update?.pollUpdates?.[0]?.pollUpdateMessageKey?.participant
-    || chatId
-  );
+  // Attribute the event to the VOTER, not the poll's author. `key` is the poll
+  // creation key, whose participant is the bot for any clarify() poll — using it
+  // makes the gateway reject the vote as an unauthorized sender. See
+  // resolvePollVoterId in bridge_helpers.js.
+  const senderId = normalizeWhatsAppId(resolvePollVoterId({
+    voterId,
+    pollUpdateKey: update?.pollUpdates?.[0]?.pollUpdateMessageKey,
+    pollCreationKey: key,
+    chatId,
+  }));
   const pollId = key?.id
     || update?.pollUpdates?.[0]?.pollCreationMessageKey?.id
     || update?.pollUpdates?.[0]?.pollUpdateMessageKey?.id
@@ -710,6 +716,9 @@ async function startSocket() {
           update: { pollUpdates },
           selectedOptions,
           aggregation,
+          // `msg` is the vote message, so its participant/sender is the voter;
+          // `pollKey` above is the poll creation key (authored by the bot).
+          voterId: normalizeWhatsAppId(msg.key?.participant || senderId || ''),
         });
         continue;
       }

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -22,6 +22,7 @@ import {
   mediaPayloadForFile,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
+  resolvePollVoterId,
 } from './bridge_helpers.js';
 
 // -- inbound read receipts ------------------------------------------------
@@ -409,6 +410,61 @@ import {
   assert.equal(event.body, 'see attached\n[document could not be downloaded]');
   assert.equal(event.mediaUrls.length, 0);
   console.log('  ✓ captioned failed download keeps caption and appends note');
+}
+
+// -- poll voter attribution ----------------------------------------------
+{
+  // A poll update carries the poll *creation* key (authored by the bot, for any
+  // clarify() poll) and the *vote* key (authored by the human who voted). If
+  // the creation key wins, the gateway sees the bot's own id as the sender and
+  // rejects the vote as an unauthorized user, so the poll never appears to be
+  // answered. The vote-side key must therefore take precedence.
+  const botLid = '100000000000001@lid';
+  const voterJid = '15550001111@s.whatsapp.net';
+  const groupJid = '120363000000000001@g.us';
+
+  assert.equal(
+    resolvePollVoterId({
+      voteMessageKey: { participant: voterJid },
+      pollCreationKey: { participant: botLid },
+      chatId: groupJid,
+    }),
+    voterJid,
+    'vote message key must win over the poll creation key',
+  );
+
+  assert.equal(
+    resolvePollVoterId({
+      pollUpdateKey: { participant: voterJid },
+      pollCreationKey: { participant: botLid },
+    }),
+    voterJid,
+    'poll update key must win over the poll creation key',
+  );
+
+  assert.equal(
+    resolvePollVoterId({
+      voterId: voterJid,
+      pollCreationKey: { participant: botLid },
+    }),
+    voterJid,
+    'an explicit voterId wins outright',
+  );
+
+  // The creation key is a last resort, and the chat id last of all.
+  assert.equal(
+    resolvePollVoterId({ pollCreationKey: { participant: botLid } }),
+    botLid,
+    'creation key is still used when no vote-side id exists',
+  );
+  assert.equal(
+    resolvePollVoterId({ chatId: groupJid }),
+    groupJid,
+    'chat id is the final fallback',
+  );
+  assert.equal(resolvePollVoterId({}), '', 'an unknowable voter yields an empty string');
+
+  console.log('  ✓ poll votes are attributed to the voter, not the poll author');
 }
 
 console.log('\n✅ All WhatsApp native bridge helper tests passed.');

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -506,6 +506,38 @@ export function inboundReadReceiptKeys({ key, enabled }) {
   return [key];
 }
 
+/**
+ * Resolve who cast a vote on a poll.
+ *
+ * A poll update carries two distinct keys and they have different authors:
+ *   - the poll *creation* key (`pollCreationKey`) — authored by whoever created
+ *     the poll, which is the bot itself for any `clarify()` poll Hermes sends;
+ *   - the poll *update* key (`pollUpdateKey`) / vote message key
+ *     (`voteMessageKey`) — authored by the person who actually voted.
+ *
+ * Preferring the creation key attributes every vote to the poll's author. For a
+ * bot-authored poll that means the bot's own JID/LID is reported as the sender,
+ * so the gateway's authorization check rejects it ("Unauthorized user") and the
+ * vote is discarded before it reaches the agent — the poll simply never appears
+ * to be answered.
+ *
+ * @returns {string} the voter's raw identifier, or '' when unknowable.
+ */
+export function resolvePollVoterId({ voterId, pollUpdateKey, voteMessageKey, pollCreationKey, chatId } = {}) {
+  const candidates = [
+    voterId,
+    voteMessageKey?.participant,
+    pollUpdateKey?.participant,
+    // Only fall back to the poll author / chat when no vote-side id exists.
+    pollCreationKey?.participant,
+    chatId,
+  ];
+  for (const candidate of candidates) {
+    if (candidate) return candidate;
+  }
+  return '';
+}
+
 export function mediaPayloadForFile({ buffer, filePath, mediaType, caption, fileName }) {
   const ext = filePath.toLowerCase().split('.').pop();
   const type = mediaType || inferMediaType(ext);


### PR DESCRIPTION
## Summary

`enqueuePollUpdateEvent` in the WhatsApp bridge resolved the inbound sender from the poll **creation** message key before the vote key. The creation key's author is whoever created the poll — which, for any `clarify()` poll Hermes sends, is the bot itself. So every vote was reported to the gateway as coming from the bot's own JID/LID.

The gateway's authorization check then rejected that sender and discarded the vote before it reached the agent:

```
WARNING gateway.run: Unauthorized user: <bot lid>@lid (<bot lid>) on whatsapp
```

**The failure is silent on both ends.** The user taps an option and sees a normal poll. The bridge decodes the choice correctly — `bridge.log` shows the right option with `voterCount: 1`. And `clarify()` still times out reporting that the user never responded. Nothing surfaces an error to either side, which is presumably why this survived: the only trace is one `WARNING` line whose id looks like the harmless bot self-echo.

## Root cause

A poll update carries two keys with different authors:

| key | author |
|---|---|
| `pollCreationMessageKey` | whoever created the poll — the **bot**, for a `clarify()` poll |
| `pollUpdateMessageKey` / vote message key | the person who **voted** |

The precedence preferred the creation key:

```js
const senderId = normalizeWhatsAppId(
  key?.participant                                              // poll author (bot)
  || update?.pollUpdates?.[0]?.pollUpdateMessageKey?.participant // actual voter
  || chatId
);
```

The `messages.upsert` path was the more clearly wrong of the two — it passed `pollKey`, explicitly the poll *creation* key, while the voter's id sat available on `msg.key.participant`.

Note this is **not** an allowlist/config issue. The LID↔phone resolver (`expandWhatsAppIdentifiers`) works correctly, and the voter's phone and LID forms both resolve and match. The rejected identifier simply wasn't the voter's — it was the bot's, and allowlisting the bot would not fix attribution (the vote would still be credited to the wrong sender, and it would open the door to self-echo).

## Fix

Resolution order is now explicit and documented in `resolvePollVoterId()`:

1. explicit `voterId`
2. vote message key
3. poll update key
4. poll creation key — only when no vote-side identity exists
5. chat id

Both call sites (`messages.update` and `messages.upsert`) route through it, and the upsert path passes `voterId: msg.key?.participant`.

## Verification

Differential check against the **real** allowlist matcher (`matchesAllowedUser` from `allowlist.js`), with a bot-authored poll voted on by an allowlisted user:

```
OLD precedence -> sender=<bot lid>@lid              votes accepted: 0
NEW precedence -> sender=<voter>@s.whatsapp.net     votes accepted: 1
untouched case (no vote-side id): OLD == NEW  identical=true

VERDICT: PASS — defect reproduced under old code, fixed under new, untouched cases identical
```

Also confirmed end-to-end on a live gateway: poll answered, vote delivered to the agent, and zero `Unauthorized user` warnings on the path that previously produced one.

Regression test added in `bridge.native.test.mjs` asserting the vote-side key beats the creation key (and that the creation key is still used as a fallback when no vote-side id exists). It was checked against the old precedence to confirm it actually fails there rather than merely passing on the new code. Full bridge suite: 22 tests, all passing.

Test fixtures use the file's existing synthetic identifiers (`15550001111@s.whatsapp.net`, reserved-fictional NANP range) — no real identities.

## Scope

Affects any Hermes deployment where `clarify()` renders as a native WhatsApp poll — the vote is discarded regardless of allowlist configuration. Introduced with the native-polls feature (`11627fdcb`) and present on current `main`.
