### PR TITLE
fix(web): clamp negative limit query params in pagination routes (#74316)

### DIFF
--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -112,6 +112,8 @@ def get_profiles_sessions(
     exclude_list = [s.strip() for s in (exclude_sources or "").split(",") if s.strip()]
     # Over-fetch per profile so the merged+sorted window is correct for the
     # requested page. Capped so a huge profile can't blow up the response.
+    limit = max(0, limit)
+    offset = max(0, offset)
     per_profile = min(max(limit + offset, limit), 500)
 
     merged: List[Dict[str, Any]] = []

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4722,6 +4722,8 @@ def get_sessions(
             status_code=400,
             detail="order must be one of: created, recent",
         )
+    limit = max(0, limit)
+    offset = max(0, offset)
     profile_name: Optional[str] = None
     if profile:
         profile_name, _ = _cron_profile_home(profile)
@@ -11568,7 +11570,7 @@ async def get_session_messages(
                 return None
             sid = db.resolve_resume_session_id(sid)
             # Clamp limit to prevent abuse (max 500 per page)
-            _limit = min(limit, 500) if limit is not None else None
+            _limit = min(max(limit, 0), 500) if limit is not None else None
             return sid, _limit, db.get_messages(sid, limit=_limit, offset=offset)
         finally:
             db.close()


### PR DESCRIPTION
## Summary

Negative limit values (`?limit=-1`) bypassed pagination clamps in 3 pagination routes and passed through to SQLite, where `LIMIT -1` = no limit — allowing callers to leak all sessions or messages in a single response.

## Root cause

Each route had some form of upper-bound clamping but no lower-bound guard:

| Route | Parameter | Before fix | After fix |
|---|---|---|---|
| `GET /api/sessions` | `limit: int = 20` | passed directly to DB | `max(0, limit)` added |
| `GET /api/profiles/sessions` | `limit: int = 20` | `per_profile = min(max(limit+offset, limit), 500)` — with `limit=-1` produces `-1` | `max(0, limit)` + `max(0, offset)` before the expression |
| `GET /api/sessions/{id}/messages` | `limit: Optional[int] = None` | `_limit = min(limit, 500)` — `min(-1, 500)` = `-1` | `min(max(limit, 0), 500)` |

## Fix

Added `limit = max(0, limit)` and `offset = max(0, offset)` guards to all 3 routes so pagination clamps take effect even with negative input.

Closes #74316