### PR TITLE
feat: bridge Desktop approvals to Telegram

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -888,6 +888,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             : undefined,
           command,
           description,
+          requestId: typeof payload?.request_id === 'string' ? payload.request_id : undefined,
           sessionId: sessionId ?? null,
           smartDenied: payload?.smart_denied === true
         })

--- a/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
@@ -33,7 +33,7 @@ function part(toolName: string): ToolPart {
 function setRequest(
   command = 'rm -rf /tmp/x',
   allowPermanent?: boolean,
-  extra: { choices?: string[]; smartDenied?: boolean } = {}
+  extra: { choices?: string[]; requestId?: string; smartDenied?: boolean } = {}
 ) {
   $activeSessionId.set('sess-1')
   setApprovalRequest({ allowPermanent, command, description: 'dangerous command', sessionId: 'sess-1', ...extra })
@@ -86,6 +86,22 @@ describe('PendingToolApproval', () => {
       expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'once', session_id: 'sess-1' })
     })
     expect($approvalRequest.get()).toBeNull()
+  })
+
+  it('targets the exact backend approval when requestId is present', async () => {
+    const request = mockGateway()
+    setRequest('rm -rf /tmp/x', true, { requestId: 'opaque-request-id' })
+    render(<PendingToolApproval part={part('terminal')} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Run/ }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('approval.respond', {
+        choice: 'once',
+        request_id: 'opaque-request-id',
+        session_id: 'sess-1'
+      })
+    })
   })
 
   it('reveals the full command inline when the Command toggle is clicked', () => {

--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -144,6 +144,7 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
       try {
         await gateway.request<{ resolved?: boolean }>('approval.respond', {
           choice,
+          ...(request.requestId ? { request_id: request.requestId } : {}),
           session_id: request.sessionId ?? undefined
         })
         triggerHaptic(choice === 'deny' ? 'cancel' : 'submit')

--- a/apps/desktop/src/store/native-notifications.test.ts
+++ b/apps/desktop/src/store/native-notifications.test.ts
@@ -223,6 +223,24 @@ describe('respondToApprovalAction', () => {
     expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'deny', session_id: 'bg' })
   })
 
+  it('includes the exact approval request id when available', async () => {
+    setActiveSessionId('bg')
+    setApprovalRequest({
+      command: 'rm -rf /',
+      description: 'dangerous',
+      requestId: 'opaque-request-id',
+      sessionId: 'bg'
+    })
+
+    await respondToApprovalAction('bg', 'approve')
+
+    expect(request).toHaveBeenCalledWith('approval.respond', {
+      choice: 'once',
+      request_id: 'opaque-request-id',
+      session_id: 'bg'
+    })
+  })
+
   it('ignores unknown action ids', async () => {
     await respondToApprovalAction('bg', 'snooze')
     expect(request).not.toHaveBeenCalled()

--- a/apps/desktop/src/store/native-notifications.ts
+++ b/apps/desktop/src/store/native-notifications.ts
@@ -4,7 +4,7 @@ import { persistString, storedString } from '@/lib/storage'
 
 import { $gateway } from './gateway'
 import { withinNativeNotifyBaseline } from './notify-baseline'
-import { clearApprovalRequest } from './prompts'
+import { clearApprovalRequest, sessionApprovalRequest } from './prompts'
 import { $activeSessionId } from './session'
 
 // Native OS notifications (Electron `Notification`), separate from the in-app
@@ -199,7 +199,12 @@ export async function respondToApprovalAction(sessionId: null | string, actionId
   }
 
   try {
-    await gateway.request('approval.respond', { choice, session_id: sessionId ?? undefined })
+    const requestId = sessionApprovalRequest(sessionId).get()?.requestId
+    await gateway.request('approval.respond', {
+      choice,
+      ...(requestId ? { request_id: requestId } : {}),
+      session_id: sessionId ?? undefined
+    })
     clearApprovalRequest(sessionId)
   } catch {
     // Leave the prompt parked so the user can still resolve it in-app.

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -67,15 +67,16 @@ function keyedPromptStore<T extends KeyedPrompt>(): PromptStore<T> {
   }
 }
 
-// Approval is session-keyed on the backend (one in-flight approval per session,
-// resolved via approval.respond {choice, session_id}). It carries no request_id,
-// unlike sudo/secret which are _block()-style request/response.
+// Newer backends include an opaque request_id so parallel approvals and
+// cross-surface races resolve the exact in-memory gate. Keep it optional for
+// compatibility with older runtimes that only support session-keyed FIFO.
 export interface ApprovalRequest extends KeyedPrompt {
   // false when the backend won't honor a permanent allow (tirith warning) → hide "Always allow".
   allowPermanent?: boolean
   choices?: string[]
   command: string
   description: string
+  requestId?: string
   smartDenied?: boolean
 }
 

--- a/gateway/cross_surface_bridge.py
+++ b/gateway/cross_surface_bridge.py
@@ -1,0 +1,526 @@
+"""Local cross-process bridge for Desktop approvals and notifications.
+
+Desktop/TUI and the messaging gateway are separate processes.  This module
+provides a profile-local SQLite mailbox that lets the Desktop publish a
+redacted approval request, lets the gateway render it on a configured home
+channel, and carries an authenticated user's opaque-token decision back to the
+original in-memory Desktop approval queue.
+
+The model never receives a messaging capability.  Raw commands and Desktop
+session keys never enter the mailbox: callers must pass the already-redacted
+approval payload, and the Desktop keeps token -> session ownership in memory.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import secrets
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+from hermes_constants import (
+    get_hermes_home,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
+
+logger = logging.getLogger(__name__)
+
+_DB_NAME = "cross_surface_bridge.sqlite3"
+_ALLOWED_CHOICES = frozenset({"once", "session", "always", "deny"})
+_DEFAULT_POLL_SECONDS = 0.25
+_DEFAULT_NOTIFICATION_TTL = 3600.0
+_MAX_TEXT = 4000
+_SAFE_NOTIFICATION_TEXTS = frozenset(
+    {
+        "Desktop background process matched a notification watch.",
+        "Desktop background process watch notifications were rate-limited.",
+        "Desktop background process watch notifications were disabled.",
+        "Desktop background task completed.",
+        "Desktop background process status changed.",
+    }
+)
+_local_lock = threading.RLock()
+_local_approvals: Dict[str, tuple[str, str]] = {}  # token -> (session key, profile home)
+_resolver_thread: Optional[threading.Thread] = None
+_resolver_stop = threading.Event()
+_resolver_terminal = False
+
+
+def _settings() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        root = load_config() or {}
+    except Exception:
+        return {}
+    approvals = root.get("approvals") or {}
+    cfg = approvals.get("cross_surface") or {}
+    return cfg if isinstance(cfg, dict) else {}
+
+
+def enabled() -> bool:
+    return bool(_settings().get("enabled", False))
+
+
+def target_platform() -> str:
+    value = str(_settings().get("target", "telegram") or "telegram").strip().lower()
+    return value or "telegram"
+
+
+def process_notifications_enabled() -> bool:
+    cfg = _settings()
+    return bool(cfg.get("enabled", False) and cfg.get("process_notifications", True))
+
+
+def _db_path() -> Path:
+    root = Path(get_hermes_home()) / "runtime"
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    try:
+        os.chmod(root, 0o700)
+    except OSError:
+        pass
+    return root / _DB_NAME
+
+
+def _connect() -> sqlite3.Connection:
+    path = _db_path()
+    conn = sqlite3.connect(path, timeout=5.0, isolation_level=None)
+    conn.row_factory = sqlite3.Row
+    from hermes_state import apply_wal_with_fallback
+
+    apply_wal_with_fallback(conn, db_label="cross-surface bridge")
+    conn.execute("PRAGMA busy_timeout=5000")
+    conn.execute("BEGIN IMMEDIATE")
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS bridge_events (
+            token TEXT PRIMARY KEY,
+            kind TEXT NOT NULL CHECK(kind IN ('approval', 'notification')),
+            target TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            created_at REAL NOT NULL,
+            expires_at REAL NOT NULL,
+            status TEXT NOT NULL CHECK(status IN
+                ('pending', 'claimed', 'delivered', 'resolved', 'expired')),
+            claim_owner TEXT,
+            claim_until REAL,
+            message_id TEXT,
+            destination_chat_id TEXT,
+            destination_thread_id TEXT,
+            destination_user_id TEXT,
+            decision TEXT,
+            resolved_at REAL,
+            dedupe_key TEXT
+        )
+        """
+    )
+    existing_columns = {
+        str(row[1]) for row in conn.execute("PRAGMA table_info(bridge_events)").fetchall()
+    }
+    for column in (
+        "destination_chat_id",
+        "destination_thread_id",
+        "destination_user_id",
+    ):
+        if column not in existing_columns:
+            conn.execute(f"ALTER TABLE bridge_events ADD COLUMN {column} TEXT")
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS bridge_events_dedupe "
+        "ON bridge_events(dedupe_key) WHERE dedupe_key IS NOT NULL"
+    )
+    conn.commit()
+    for private_path in (path, Path(f"{path}-wal"), Path(f"{path}-shm")):
+        try:
+            if private_path.exists():
+                os.chmod(private_path, 0o600)
+        except OSError:
+            pass
+    return conn
+
+
+def _bounded_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    clean: Dict[str, Any] = {}
+    for key in ("command", "description"):
+        value = payload.get(key)
+        if value is not None:
+            clean[key] = str(value)[:_MAX_TEXT]
+    for key in ("allow_permanent", "allow_session", "smart_denied"):
+        if key in payload:
+            clean[key] = bool(payload.get(key))
+    choices = payload.get("choices")
+    if isinstance(choices, list):
+        clean["choices"] = [str(x) for x in choices if str(x) in _ALLOWED_CHOICES]
+    return clean
+
+
+def _payload_allowed_choices(payload: Dict[str, Any]) -> set[str]:
+    explicit = payload.get("choices")
+    if isinstance(explicit, list):
+        return {str(choice) for choice in explicit} & set(_ALLOWED_CHOICES)
+    if payload.get("smart_denied") or payload.get("allow_session") is False:
+        return {"once", "deny"}
+    if payload.get("allow_permanent") is False:
+        return {"once", "session", "deny"}
+    return set(_ALLOWED_CHOICES)
+
+
+def publish_approval(session_key: str, payload: Dict[str, Any]) -> Optional[str]:
+    """Publish a redacted Desktop approval and register local ownership.
+
+    ``request_id`` is generated by ``tools.approval`` for the exact in-memory
+    queue entry. Reusing it here makes remote resolution target-specific under
+    parallel tool calls instead of falling back to FIFO session resolution.
+    """
+    if not session_key or not enabled():
+        return None
+    now = time.time()
+    token = str((payload or {}).get("request_id") or "")
+    if len(token) != 43 or any(ch not in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_" for ch in token):
+        return None
+    try:
+        raw_expires_at = (payload or {}).get("expires_at")
+        if raw_expires_at is None:
+            return None
+        expires_at = float(raw_expires_at)
+    except (TypeError, ValueError):
+        return None
+    if expires_at <= now:
+        return None
+    body = _bounded_payload(payload or {})
+    with _local_lock:
+        if _resolver_terminal:
+            return None
+        with _connect() as conn:
+            conn.execute(
+                "INSERT INTO bridge_events "
+                "(token, kind, target, payload_json, created_at, expires_at, status) "
+                "VALUES (?, 'approval', ?, ?, ?, ?, 'pending')",
+                (
+                    token,
+                    target_platform(),
+                    json.dumps(body, separators=(",", ":")),
+                    now,
+                    expires_at,
+                ),
+            )
+        _local_approvals[token] = (session_key, str(get_hermes_home()))
+        _ensure_resolver_thread()
+    logger.info("Published cross-surface approval token=%s… target=%s", token[:8], target_platform())
+    return token
+
+
+def publish_notification(text: str, *, dedupe_key: Optional[str] = None) -> Optional[str]:
+    """Publish a one-way Desktop process notification to the home channel."""
+    if not text or not process_notifications_enabled():
+        return None
+    text = str(text)
+    if text not in _SAFE_NOTIFICATION_TEXTS and not re.fullmatch(
+        r"Desktop background process completed(?: \(exit code -?\d+\))?\.", text
+    ):
+        logger.warning("Rejected non-generic cross-surface process notification")
+        return None
+    now = time.time()
+    token = secrets.token_urlsafe(24)
+    body = {"text": text[:_MAX_TEXT]}
+    with _local_lock:
+        if _resolver_terminal:
+            return None
+        try:
+            with _connect() as conn:
+                conn.execute(
+                    "INSERT INTO bridge_events "
+                    "(token, kind, target, payload_json, created_at, expires_at, status, dedupe_key) "
+                    "VALUES (?, 'notification', ?, ?, ?, ?, 'pending', ?)",
+                    (
+                        token,
+                        target_platform(),
+                        json.dumps(body, separators=(",", ":")),
+                        now,
+                        now + _DEFAULT_NOTIFICATION_TTL,
+                        str(dedupe_key)[:500] if dedupe_key else None,
+                    ),
+                )
+        except sqlite3.IntegrityError:
+            return None
+    return token
+
+
+def claim_events(target: str, owner: str, *, limit: int = 20, lease_seconds: float = 30.0) -> list[Dict[str, Any]]:
+    """Atomically lease pending/abandoned events for one gateway watcher."""
+    now = time.time()
+    claimed: list[Dict[str, Any]] = []
+    with _connect() as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            "UPDATE bridge_events SET status='expired', claim_owner=NULL, claim_until=NULL "
+            "WHERE expires_at <= ? AND status IN ('pending','claimed','delivered')",
+            (now,),
+        )
+        rows = conn.execute(
+            "SELECT token, kind, payload_json, expires_at FROM bridge_events "
+            "WHERE target=? AND expires_at>? AND "
+            "(status='pending' OR (status='claimed' AND claim_until<?)) "
+            "ORDER BY created_at LIMIT ?",
+            (target, now, now, max(1, min(int(limit), 100))),
+        ).fetchall()
+        for row in rows:
+            updated = conn.execute(
+                "UPDATE bridge_events SET status='claimed', claim_owner=?, claim_until=? "
+                "WHERE token=? AND (status='pending' OR (status='claimed' AND claim_until<?))",
+                (owner, now + lease_seconds, row["token"], now),
+            ).rowcount
+            if updated:
+                try:
+                    payload = json.loads(row["payload_json"])
+                except Exception:
+                    payload = {}
+                claimed.append(
+                    {
+                        "token": row["token"],
+                        "kind": row["kind"],
+                        "payload": payload if isinstance(payload, dict) else {},
+                        "expires_at": float(row["expires_at"]),
+                    }
+                )
+        conn.commit()
+    return claimed
+
+
+def mark_delivered(
+    token: str,
+    owner: str,
+    message_id: Optional[str] = None,
+    *,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+) -> bool:
+    with _connect() as conn:
+        return bool(
+            conn.execute(
+                "UPDATE bridge_events SET status='delivered', message_id=?, "
+                "destination_chat_id=?, destination_thread_id=?, destination_user_id=?, "
+                "claim_owner=NULL, claim_until=NULL "
+                "WHERE token=? AND status='claimed' AND claim_owner=?",
+                (
+                    str(message_id or ""),
+                    str(chat_id),
+                    str(thread_id) if thread_id is not None else None,
+                    str(user_id) if user_id is not None else None,
+                    token,
+                    owner,
+                ),
+            ).rowcount
+        )
+
+
+def release_claim(token: str, owner: str) -> bool:
+    with _connect() as conn:
+        return bool(
+            conn.execute(
+                "UPDATE bridge_events SET status='pending', claim_owner=NULL, claim_until=NULL "
+                "WHERE token=? AND status='claimed' AND claim_owner=?",
+                (token, owner),
+            ).rowcount
+        )
+
+
+def resolve_request(
+    token: str,
+    choice: str,
+    *,
+    chat_id: str,
+    thread_id: Optional[str],
+    user_id: str,
+    message_id: Optional[str] = None,
+) -> bool:
+    """Record one authorized, unexpired, single-use Telegram decision."""
+    if choice not in _ALLOWED_CHOICES or not token:
+        return False
+    now = time.time()
+    with _connect() as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute(
+            "SELECT kind, status, expires_at, decision, payload_json, "
+            "destination_chat_id, destination_thread_id, destination_user_id, message_id "
+            "FROM bridge_events WHERE token=?",
+            (token,),
+        ).fetchone()
+        try:
+            stored_payload = json.loads(row["payload_json"]) if row else None
+        except Exception:
+            stored_payload = None
+        if (
+            not row
+            or row["kind"] != "approval"
+            or row["decision"] is not None
+            or row["status"] not in {"claimed", "delivered"}
+            or float(row["expires_at"]) <= now
+            or not isinstance(stored_payload, dict)
+            or choice not in _payload_allowed_choices(stored_payload)
+            or not row["destination_chat_id"]
+            or str(row["destination_chat_id"]) != str(chat_id)
+            or (
+                (str(row["destination_thread_id"]) if row["destination_thread_id"] is not None else None)
+                != (str(thread_id) if thread_id is not None else None)
+            )
+            or (
+                row["destination_user_id"] is not None
+                and str(row["destination_user_id"]) != str(user_id)
+            )
+            or (
+                str(row["message_id"] or "")
+                and str(row["message_id"]) != str(message_id or "")
+            )
+        ):
+            if row and float(row["expires_at"]) <= now and row["status"] != "resolved":
+                conn.execute("UPDATE bridge_events SET status='expired' WHERE token=?", (token,))
+            conn.commit()
+            return False
+        updated = conn.execute(
+            "UPDATE bridge_events SET decision=?, resolved_at=? "
+            "WHERE token=? AND decision IS NULL",
+            (choice, now, token),
+        ).rowcount
+        conn.commit()
+        return bool(updated)
+
+
+def _decision(token: str) -> tuple[Optional[str], Optional[str]]:
+    with _connect() as conn:
+        row = conn.execute(
+            "SELECT status, decision FROM bridge_events WHERE token=?", (token,)
+        ).fetchone()
+    if not row:
+        return None, None
+    return str(row["status"]), (str(row["decision"]) if row["decision"] else None)
+
+
+def wait_for_resolution(token: str, timeout: float = 3.0) -> str:
+    """Wait briefly for the Desktop authority to acknowledge a decision.
+
+    Returns ``resolved``, ``expired``, or ``pending``. Telegram must only claim
+    approval after this returns ``resolved``; accepting a DB decision alone is
+    not proof that the original in-memory gate was signalled.
+    """
+    deadline = time.monotonic() + max(0.0, timeout)
+    while True:
+        status, _choice = _decision(token)
+        if status in {"resolved", "expired"}:
+            return status
+        if time.monotonic() >= deadline:
+            return "pending"
+        time.sleep(0.05)
+
+
+def _finish_local(token: str, status: str) -> None:
+    with _connect() as conn:
+        conn.execute(
+            "UPDATE bridge_events SET status=?, claim_owner=NULL, claim_until=NULL "
+            "WHERE token=? AND status!='resolved'",
+            (status, token),
+        )
+    with _local_lock:
+        _local_approvals.pop(token, None)
+
+
+def _resolve_local_decisions_once() -> int:
+    """Apply available mailbox decisions to this process's Desktop queues."""
+    from tools.approval import has_blocking_approval, resolve_gateway_approval_by_id
+
+    resolved = 0
+    with _local_lock:
+        items = list(_local_approvals.items())
+    for token, (session_key, profile_home) in items:
+        home_scope = set_hermes_home_override(profile_home)
+        try:
+            status, decision = _decision(token)
+            # Linearize application against shutdown. stop_local_resolver() uses
+            # this same lock to set the stop flag and clear ownership, so a row
+            # snapshotted before shutdown cannot be applied afterward.
+            with _local_lock:
+                if (
+                    _resolver_stop.is_set()
+                    or _local_approvals.get(token) != (session_key, profile_home)
+                ):
+                    continue
+                if decision and status == "delivered":
+                    count = resolve_gateway_approval_by_id(session_key, token, decision)
+                    with _connect() as conn:
+                        conn.execute(
+                            "UPDATE bridge_events SET status=? WHERE token=?",
+                            ("resolved" if count else "expired", token),
+                        )
+                    _local_approvals.pop(token, None)
+                    resolved += count
+                elif status in {None, "expired", "resolved"} or not has_blocking_approval(
+                    session_key
+                ):
+                    _finish_local(token, "expired")
+        except Exception:
+            logger.warning("Cross-surface approval resolver iteration failed", exc_info=True)
+        finally:
+            reset_hermes_home_override(home_scope)
+    return resolved
+
+
+def _resolver_loop() -> None:
+    while not _resolver_stop.wait(_DEFAULT_POLL_SECONDS):
+        _resolve_local_decisions_once()
+
+
+def _ensure_resolver_thread() -> None:
+    global _resolver_thread
+    with _local_lock:
+        if _resolver_terminal:
+            return
+        if _resolver_thread is not None and _resolver_thread.is_alive():
+            return
+        _resolver_stop.clear()
+        _resolver_thread = threading.Thread(
+            target=_resolver_loop,
+            name="hermes-cross-surface-approval-resolver",
+            daemon=True,
+        )
+        _resolver_thread.start()
+
+
+def stop_local_resolver() -> None:
+    """Stop the Desktop resolver and fail closed all process-owned bridge rows."""
+    global _resolver_terminal, _resolver_thread
+    with _local_lock:
+        _resolver_terminal = True
+        _resolver_stop.set()
+        tokens = list(_local_approvals)
+        _local_approvals.clear()
+        thread = _resolver_thread
+        _resolver_thread = None
+    if tokens:
+        try:
+            with _connect() as conn:
+                placeholders = ",".join("?" for _ in tokens)
+                conn.execute(
+                    f"UPDATE bridge_events SET status='expired' "
+                    f"WHERE token IN ({placeholders}) AND status!='resolved'",
+                    tokens,
+                )
+        except Exception:
+            logger.warning("Could not expire cross-surface approvals on shutdown", exc_info=True)
+    if thread is not None and thread is not threading.current_thread():
+        thread.join(timeout=1.0)
+
+
+def cleanup_old_events(*, older_than_seconds: float = 86400.0) -> int:
+    cutoff = time.time() - max(60.0, older_than_seconds)
+    with _connect() as conn:
+        return conn.execute(
+            "DELETE FROM bridge_events WHERE created_at<? AND status IN ('resolved','expired','delivered')",
+            (cutoff,),
+        ).rowcount

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -33,6 +33,7 @@ import json
 import logging
 import os
 import re
+import secrets
 import shlex
 import site
 import sys
@@ -8929,6 +8930,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as e:
             logger.error("Recovered watcher setup error: %s", e)
 
+        # Start the profile-local Desktop → messaging bridge after adapters and
+        # their home channels are ready. It is inert unless explicitly enabled.
+        self._spawn_supervised(
+            self._cross_surface_bridge_watcher,
+            "cross_surface_bridge_watcher",
+        )
+
         # Start background session expiry watcher to finalize expired sessions
         self._spawn_supervised(self._session_expiry_watcher, "session_expiry_watcher")
 
@@ -9016,6 +9024,124 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         logger.info("Press Ctrl+C to stop")
         
         return True
+
+    async def _cross_surface_bridge_watcher(self) -> None:
+        """Deliver Desktop approvals/notifications to a configured home channel."""
+        from gateway.cross_surface_bridge import (
+            claim_events,
+            cleanup_old_events,
+            enabled as bridge_enabled,
+            mark_delivered,
+            release_claim,
+            target_platform,
+        )
+
+        owner = f"gateway:{os.getpid()}:{secrets.token_hex(8)}"
+        last_cleanup = 0.0
+        while self._running:
+            if not bridge_enabled():
+                await asyncio.sleep(2.0)
+                continue
+            target_name = target_platform()
+            if target_name != "telegram":
+                logger.error(
+                    "Cross-surface approvals currently support only Telegram; got %s",
+                    target_name,
+                )
+                await asyncio.sleep(5.0)
+                continue
+            try:
+                platform = Platform(target_name)
+            except ValueError:
+                logger.error("Cross-surface bridge target is unsupported: %s", target_name)
+                await asyncio.sleep(5.0)
+                continue
+            adapter = self.adapters.get(platform)
+            home = self.config.get_home_channel(platform)
+            if adapter is None or home is None or not home.chat_id:
+                await asyncio.sleep(2.0)
+                continue
+
+            events = claim_events(target_name, owner, limit=20, lease_seconds=120.0)
+            if not events:
+                await asyncio.sleep(0.5)
+            for event in events:
+                token = str(event.get("token") or "")
+                payload = event.get("payload") or {}
+                try:
+                    if event.get("kind") == "approval":
+                        send_exec_approval = getattr(adapter, "send_exec_approval", None)
+                        if send_exec_approval is None:
+                            raise RuntimeError(
+                                f"{target_name} adapter does not support interactive approvals"
+                            )
+                        result = await send_exec_approval(
+                            chat_id=home.chat_id,
+                            command=str(payload.get("command") or ""),
+                            session_key=f"xsurf:{token}",
+                            description=str(payload.get("description") or "dangerous command"),
+                            metadata=(
+                                {"thread_id": str(home.thread_id)}
+                                if home.thread_id is not None
+                                else None
+                            ),
+                            allow_permanent=payload.get("allow_permanent", True),
+                            allow_session=payload.get("allow_session", True),
+                            smart_denied=payload.get("smart_denied", False),
+                        )
+                    else:
+                        result = await adapter.send(
+                            home.chat_id,
+                            "🖥 Desktop notification\n\n" + str(payload.get("text") or ""),
+                            metadata=(
+                                {"thread_id": str(home.thread_id)}
+                                if home.thread_id is not None
+                                else None
+                            ),
+                        )
+                    if getattr(result, "success", False):
+                        recorded = mark_delivered(
+                            token,
+                            owner,
+                            getattr(result, "message_id", None),
+                            chat_id=str(home.chat_id),
+                            thread_id=(
+                                str(home.thread_id) if home.thread_id is not None else None
+                            ),
+                            user_id=(
+                                str(home.user_id) if home.user_id is not None else None
+                            ),
+                        )
+                        if recorded:
+                            logger.info(
+                                "Cross-surface %s delivered to %s:%s token=%s…",
+                                event.get("kind"), target_name, home.chat_id, token[:8],
+                            )
+                        else:
+                            logger.error(
+                                "Cross-surface delivery succeeded but lease acknowledgement "
+                                "was lost for token=%s…; duplicate delivery is possible",
+                                token[:8],
+                            )
+                    else:
+                        release_claim(token, owner)
+                        logger.warning(
+                            "Cross-surface %s delivery failed: %s",
+                            event.get("kind"), getattr(result, "error", "unknown error"),
+                        )
+                except asyncio.CancelledError:
+                    release_claim(token, owner)
+                    raise
+                except Exception:
+                    release_claim(token, owner)
+                    logger.warning("Cross-surface bridge delivery failed", exc_info=True)
+
+            now = time.time()
+            if now - last_cleanup > 3600:
+                cleanup_old_events()
+                last_cleanup = now
+
+        return None
 
     _MAX_SUPERVISED_RESTARTS = 5
     # A task that ran at least this long before crashing is treated as having

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1960,6 +1960,14 @@ DEFAULT_CONFIG = {
         # false.  TUI has its own modal overlay (HERMES_TUI_NO_CONFIRM=1 to
         # opt out there).
         "destructive_slash_confirm": True,
+        # Optional Desktop → messaging approval bridge. Disabled by default.
+        # The messaging gateway discovers the configured platform home channel;
+        # Desktop never receives or persists that destination.
+        "cross_surface": {
+            "enabled": False,
+            "target": "telegram",
+            "process_notifications": True,
+        },
     },
 
     # Permanently allowed dangerous command patterns (added via "always" approval)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5350,26 +5350,33 @@ class TelegramAdapter(BasePlatformAdapter):
             # Resolve thread context for thread replies
             thread_id = self._metadata_thread_id(metadata)
 
-            # We'll use the message_id as part of callback_data to look up session_key
-            # Send a placeholder first, then update — or use a counter.
-            # Simpler: use a monotonic counter to generate short IDs.
-            import itertools
-            if not hasattr(self, "_approval_counter"):
-                self._approval_counter = itertools.count(1)
-            approval_id = next(self._approval_counter)
+            # Local gateway approvals use an in-memory monotonic ID. Cross-surface
+            # Desktop approvals carry their unguessable opaque token directly in
+            # callback_data so a gateway restart does not invalidate a live button.
+            # token_urlsafe(32) is 43 chars; even ``ea:session:x:<token>`` stays
+            # below Telegram's 64-byte callback_data limit.
+            is_cross_surface = session_key.startswith("xsurf:")
+            if is_cross_surface:
+                callback_ref = "x:" + session_key.removeprefix("xsurf:")
+            else:
+                import itertools
+                if not hasattr(self, "_approval_counter"):
+                    self._approval_counter = itertools.count(1)
+                approval_id = next(self._approval_counter)
+                callback_ref = str(approval_id)
 
             buttons = [
-                InlineKeyboardButton("✅ Allow Once", callback_data=f"ea:once:{approval_id}")
+                InlineKeyboardButton("✅ Allow Once", callback_data=f"ea:once:{callback_ref}")
             ]
             if not smart_denied and allow_session:
                 buttons.append(
-                    InlineKeyboardButton("✅ Session", callback_data=f"ea:session:{approval_id}")
+                    InlineKeyboardButton("✅ Session", callback_data=f"ea:session:{callback_ref}")
                 )
                 if allow_permanent:
                     buttons.append(
-                        InlineKeyboardButton("✅ Always", callback_data=f"ea:always:{approval_id}")
+                        InlineKeyboardButton("✅ Always", callback_data=f"ea:always:{callback_ref}")
                     )
-            buttons.append(InlineKeyboardButton("❌ Deny", callback_data=f"ea:deny:{approval_id}"))
+            buttons.append(InlineKeyboardButton("❌ Deny", callback_data=f"ea:deny:{callback_ref}"))
             # Pair into rows (2x2 for the full set) so labels stay readable on
             # mobile — a single 4-button row truncates to "Allo… / Ses… / …".
             rows = [buttons[i:i + 2] for i in range(0, len(buttons), 2)]
@@ -5396,8 +5403,10 @@ class TelegramAdapter(BasePlatformAdapter):
 
             msg = await self._send_message_with_thread_fallback(**kwargs)
 
-            # Store session_key keyed by approval_id for the callback handler
-            self._approval_state[approval_id] = session_key
+            # Cross-surface ownership is persisted in the bridge DB and encoded
+            # by opaque token; only local approvals need process-memory state.
+            if not is_cross_surface:
+                self._approval_state[int(callback_ref)] = session_key
 
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
@@ -6209,6 +6218,7 @@ class TelegramAdapter(BasePlatformAdapter):
         query_chat = getattr(query_message, "chat", None)
         query_chat_type = getattr(query_chat, "type", None)
         query_thread_id = getattr(query_message, "message_thread_id", None)
+        query_message_id = getattr(query_message, "message_id", None)
         query_user_name = getattr(query.from_user, "first_name", None)
 
         # --- Model picker callbacks ---
@@ -6242,9 +6252,15 @@ class TelegramAdapter(BasePlatformAdapter):
             parts = data.split(":", 2)
             if len(parts) == 3:
                 choice = parts[1]  # once, session, always, deny
+                callback_ref = parts[2]
+                is_cross_surface = callback_ref.startswith("x:")
+                token = callback_ref.removeprefix("x:") if is_cross_surface else ""
                 try:
-                    approval_id = int(parts[2])
+                    approval_id = None if is_cross_surface else int(callback_ref)
                 except (ValueError, IndexError):
+                    await query.answer(text="Invalid approval data.")
+                    return
+                if is_cross_surface and not re.fullmatch(r"[A-Za-z0-9_-]{43}", token):
                     await query.answer(text="Invalid approval data.")
                     return
 
@@ -6260,26 +6276,63 @@ class TelegramAdapter(BasePlatformAdapter):
                     await query.answer(text="⛔ You are not authorized to approve commands.")
                     return
 
-                session_key = self._approval_state.pop(approval_id, None)
+                if is_cross_surface:
+                    session_key = f"xsurf:{token}"
+                else:
+                    assert approval_id is not None
+                    session_key = self._approval_state.pop(approval_id, None)
                 if not session_key:
                     await query.answer(text="This approval has already been resolved.")
                     return
 
                 user_display = getattr(query.from_user, "first_name", "User")
 
-                # Resolve the approval FIRST — unblocks the agent thread.
-                # Rendering happens after so the message reflects what
-                # actually occurred: a tap that lands after the approval
-                # wait timed out (count == 0) must NOT claim "Approved" —
-                # the command was already denied and will not run (#63501
-                # regression follow-up: 60s waits made stale taps common).
+                # Resolve the approval FIRST — unblocks the owning agent thread.
+                # ``xsurf:`` entries belong to a Desktop process, so record the
+                # opaque single-use decision in the profile-local bridge mailbox;
+                # ordinary entries resolve this gateway process's in-memory queue.
+                pending_desktop_ack = False
                 try:
-                    from tools.approval import resolve_gateway_approval
-                    count = resolve_gateway_approval(session_key, choice)
-                    logger.info(
-                        "Telegram button resolved %d approval(s) for session %s (choice=%s, user=%s)",
-                        count, session_key, choice, user_display,
-                    )
+                    if session_key.startswith("xsurf:"):
+                        from gateway.cross_surface_bridge import (
+                            resolve_request,
+                            wait_for_resolution,
+                        )
+
+                        bridge_token = session_key.removeprefix("xsurf:")
+                        accepted = resolve_request(
+                            bridge_token,
+                            choice,
+                            chat_id=str(query_chat_id or ""),
+                            thread_id=(
+                                str(query_thread_id) if query_thread_id is not None else None
+                            ),
+                            user_id=str(getattr(query.from_user, "id", "")),
+                            message_id=(
+                                str(query_message_id) if query_message_id is not None else None
+                            ),
+                        )
+                        bridge_status = (
+                            await asyncio.to_thread(wait_for_resolution, bridge_token, 3.0)
+                            if accepted
+                            else "expired"
+                        )
+                        count = 1 if bridge_status == "resolved" else 0
+                        pending_desktop_ack = accepted and bridge_status == "pending"
+                        logger.info(
+                            "Telegram cross-surface approval decision "
+                            "(accepted=%s, desktop_status=%s, choice=%s, user=%s)",
+                            accepted, bridge_status, choice, user_display,
+                        )
+                    else:
+                        from tools.approval import resolve_gateway_approval
+
+                        count = resolve_gateway_approval(session_key, choice)
+                        logger.info(
+                            "Telegram button resolved %d approval(s) for session %s "
+                            "(choice=%s, user=%s)",
+                            count, session_key, choice, user_display,
+                        )
                 except Exception as exc:
                     logger.error("Failed to resolve gateway approval from Telegram button: %s", exc)
                     count = 0
@@ -6294,6 +6347,11 @@ class TelegramAdapter(BasePlatformAdapter):
                     }
                     label = label_map.get(choice, "Resolved")
                     edit_text = f"{label} by {user_display}"
+                elif pending_desktop_ack:
+                    label = "📨 Decision sent"
+                    edit_text = (
+                        f"{label} by {user_display} — awaiting confirmation from Desktop."
+                    )
                 else:
                     label = "⌛ Approval expired"
                     edit_text = (

--- a/tests/gateway/test_cross_surface_bridge.py
+++ b/tests/gateway/test_cross_surface_bridge.py
@@ -1,0 +1,403 @@
+"""Cross-process Desktop → messaging approval bridge contracts."""
+
+from __future__ import annotations
+
+import secrets
+import stat
+import threading
+import time
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+import gateway.cross_surface_bridge as bridge
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+_DESTINATION = {
+    "chat_id": "8068859990",
+    "thread_id": None,
+    "user_id": "8068859990",
+}
+
+
+def _approval_payload(**overrides):
+    payload = {
+        "request_id": secrets.token_urlsafe(32),
+        "expires_at": time.time() + 300,
+        "command": "redacted",
+        "choices": ["once", "session", "always", "deny"],
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.fixture
+def isolated_bridge(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        bridge,
+        "_settings",
+        lambda: {
+            "enabled": True,
+            "target": "telegram",
+            "process_notifications": True,
+        },
+    )
+    monkeypatch.setattr(bridge, "_ensure_resolver_thread", lambda: None)
+    with bridge._local_lock:
+        bridge._local_approvals.clear()
+        bridge._resolver_stop.clear()
+        bridge._resolver_terminal = False
+    yield tmp_path
+    with bridge._local_lock:
+        bridge._local_approvals.clear()
+        bridge._resolver_stop.clear()
+        bridge._resolver_terminal = False
+
+
+def test_approval_mailbox_uses_opaque_single_use_token_and_omits_session_key(isolated_bridge):
+    token = bridge.publish_approval(
+        "desktop-secret-session-key",
+        _approval_payload(**{
+            "command": "redacted command",
+            "description": "dangerous command",
+            "allow_permanent": True,
+        }),
+    )
+    assert token and len(token) >= 32
+
+    claimed = bridge.claim_events("telegram", "gateway-A")
+    assert len(claimed) == 1
+    assert claimed[0]["token"] == token
+    assert claimed[0]["payload"]["command"] == "redacted command"
+
+    db_bytes = bridge._db_path().read_bytes()
+    assert b"desktop-secret-session-key" not in db_bytes
+    assert stat.S_IMODE(bridge._db_path().stat().st_mode) == 0o600
+    for suffix in ("-wal", "-shm"):
+        sidecar = type(bridge._db_path())(f"{bridge._db_path()}{suffix}")
+        if sidecar.exists():
+            assert stat.S_IMODE(sidecar.stat().st_mode) == 0o600
+            assert b"desktop-secret-session-key" not in sidecar.read_bytes()
+
+    assert bridge.mark_delivered(
+        token, "gateway-A", "telegram-message-1", **_DESTINATION
+    ) is True
+    assert bridge.resolve_request(
+        token,
+        "once",
+        chat_id=_DESTINATION["chat_id"],
+        thread_id="unexpected-topic",
+        user_id=_DESTINATION["user_id"],
+        message_id="telegram-message-1",
+    ) is False
+    assert bridge.resolve_request(
+        token, "once", message_id="telegram-message-1", **_DESTINATION
+    ) is True
+    assert bridge.resolve_request(token, "deny", **_DESTINATION) is False  # single-use
+    assert bridge.resolve_request(token, "bogus", **_DESTINATION) is False
+
+
+def test_resolution_rejects_wrong_destination_user_thread_and_choice(isolated_bridge):
+    payload = _approval_payload(choices=["once", "deny"])
+    token = bridge.publish_approval("desktop-session", payload)
+    assert token
+    assert bridge.claim_events("telegram", "gateway-A")
+    assert bridge.mark_delivered(
+        token,
+        "gateway-A",
+        "message-bound",
+        chat_id="home-chat",
+        thread_id="home-thread",
+        user_id="owner-user",
+    )
+
+    assert not bridge.resolve_request(
+        token, "once", chat_id="other-chat", thread_id="home-thread", user_id="owner-user",
+        message_id="message-bound",
+    )
+    assert not bridge.resolve_request(
+        token, "once", chat_id="home-chat", thread_id="other-thread", user_id="owner-user",
+        message_id="message-bound",
+    )
+    assert not bridge.resolve_request(
+        token, "once", chat_id="home-chat", thread_id="home-thread", user_id="other-user",
+        message_id="message-bound",
+    )
+    assert not bridge.resolve_request(
+        token, "always", chat_id="home-chat", thread_id="home-thread", user_id="owner-user",
+        message_id="message-bound",
+    )
+    assert not bridge.resolve_request(
+        token, "once", chat_id="home-chat", thread_id="home-thread", user_id="owner-user",
+        message_id="other-message",
+    )
+    assert bridge.resolve_request(
+        token, "deny", chat_id="home-chat", thread_id="home-thread", user_id="owner-user",
+        message_id="message-bound",
+    )
+
+
+def test_recorded_decision_resolves_original_desktop_session_once(isolated_bridge, monkeypatch):
+    token = bridge.publish_approval("desktop-session-A", _approval_payload())
+    assert token
+    assert bridge.claim_events("telegram", "gateway-A")
+    assert bridge.mark_delivered(token, "gateway-A", "message-2", **_DESTINATION)
+    assert bridge.resolve_request(
+        token, "session", message_id="message-2", **_DESTINATION
+    )
+
+    calls = []
+    monkeypatch.setattr("tools.approval.has_blocking_approval", lambda key: True)
+    monkeypatch.setattr(
+        "tools.approval.resolve_gateway_approval_by_id",
+        lambda key, request_id, choice: calls.append((key, request_id, choice)) or 1,
+    )
+
+    assert bridge._resolve_local_decisions_once() == 1
+    assert calls == [("desktop-session-A", token, "session")]
+    assert bridge._resolve_local_decisions_once() == 0
+    with bridge._connect() as conn:
+        row = conn.execute(
+            "SELECT status, decision FROM bridge_events WHERE token=?", (token,)
+        ).fetchone()
+    assert tuple(row) == ("resolved", "session")
+
+
+def test_resolver_restores_publishing_profile_home(isolated_bridge, monkeypatch):
+    profile_home = isolated_bridge / "profiles" / "secondary"
+    profile_home.mkdir(parents=True)
+    scope = set_hermes_home_override(profile_home)
+    try:
+        token = bridge.publish_approval("secondary-session", _approval_payload())
+        assert token
+        assert bridge.claim_events("telegram", "gateway-secondary")
+        assert bridge.mark_delivered(
+            token, "gateway-secondary", "message-profile", **_DESTINATION
+        )
+        assert bridge.resolve_request(
+            token, "once", message_id="message-profile", **_DESTINATION
+        )
+    finally:
+        reset_hermes_home_override(scope)
+
+    calls = []
+    monkeypatch.setattr("tools.approval.has_blocking_approval", lambda key: True)
+    monkeypatch.setattr(
+        "tools.approval.resolve_gateway_approval_by_id",
+        lambda key, request_id, choice: calls.append((key, request_id, choice)) or 1,
+    )
+    assert bridge._resolve_local_decisions_once() == 1
+    assert calls == [("secondary-session", token, "once")]
+
+
+def test_claim_lease_prevents_duplicate_gateway_delivery(isolated_bridge):
+    token = bridge.publish_notification(
+        "Desktop background process completed.", dedupe_key="process:one"
+    )
+    assert token
+    assert len(bridge.claim_events("telegram", "gateway-A", lease_seconds=30)) == 1
+    assert bridge.claim_events("telegram", "gateway-B") == []
+    assert bridge.release_claim(token, "gateway-B") is False
+    assert bridge.release_claim(token, "gateway-A") is True
+    assert len(bridge.claim_events("telegram", "gateway-B")) == 1
+
+
+def test_process_notification_deduplication(isolated_bridge):
+    text = "Desktop background process completed (exit code 0)."
+    first = bridge.publish_notification(text, dedupe_key="process:abc")
+    second = bridge.publish_notification(text, dedupe_key="process:abc")
+    assert first
+    assert second is None
+    assert len(bridge.claim_events("telegram", "gateway-A")) == 1
+
+
+def test_process_notification_api_rejects_freeform_sensitive_text(isolated_bridge):
+    assert bridge.publish_notification(
+        "command=curl secret-output", dedupe_key="process:sensitive"
+    ) is None
+    assert bridge.claim_events("telegram", "gateway-A") == []
+
+
+def test_shutdown_invalidates_item_snapshotted_by_resolver(isolated_bridge, monkeypatch):
+    token = bridge.publish_approval("desktop-session", _approval_payload())
+    assert token
+    assert bridge.claim_events("telegram", "gateway-A")
+    assert bridge.mark_delivered(token, "gateway-A", "message", **_DESTINATION)
+    assert bridge.resolve_request(token, "once", message_id="message", **_DESTINATION)
+
+    decision_started = threading.Event()
+    release_decision = threading.Event()
+    original_decision = bridge._decision
+
+    def blocked_decision(request_token):
+        decision_started.set()
+        assert release_decision.wait(2)
+        return original_decision(request_token)
+
+    calls = []
+    monkeypatch.setattr(bridge, "_decision", blocked_decision)
+    monkeypatch.setattr("tools.approval.has_blocking_approval", lambda _key: True)
+    monkeypatch.setattr(
+        "tools.approval.resolve_gateway_approval_by_id",
+        lambda *args: calls.append(args) or 1,
+    )
+
+    resolver = threading.Thread(target=bridge._resolve_local_decisions_once)
+    resolver.start()
+    assert decision_started.wait(2)
+    bridge.stop_local_resolver()
+    release_decision.set()
+    resolver.join(2)
+
+    assert calls == []
+    assert token not in bridge._local_approvals
+
+
+def test_shutdown_is_terminal_for_late_publication(isolated_bridge):
+    bridge.stop_local_resolver()
+
+    assert bridge.publish_approval("late-session", _approval_payload()) is None
+    assert bridge.publish_notification(
+        "Desktop background process completed.", dedupe_key="process:late"
+    ) is None
+    assert bridge._resolver_stop.is_set()
+    assert bridge._resolver_terminal is True
+    assert bridge._local_approvals == {}
+
+
+def test_expired_or_undelivered_request_cannot_be_resolved(isolated_bridge):
+    token = bridge.publish_approval(
+        "desktop-session", _approval_payload(command="safe preview")
+    )
+    assert token
+    assert bridge.resolve_request(token, "once", **_DESTINATION) is False
+
+    with bridge._connect() as conn:
+        conn.execute(
+            "UPDATE bridge_events SET expires_at=? WHERE token=?",
+            (time.time() - 1, token),
+        )
+    assert bridge.claim_events("telegram", "gateway-A") == []
+    assert bridge.resolve_request(token, "once", **_DESTINATION) is False
+
+
+def test_payload_is_bounded_and_allowlisted(isolated_bridge):
+    token = bridge.publish_approval(
+        "desktop-session",
+        _approval_payload(**{
+            "command": "x" * 9000,
+            "description": "y" * 9000,
+            "choices": ["once", "root", "deny"],
+            "untrusted": {"session_key": "must-not-persist"},
+        }),
+    )
+    event = bridge.claim_events("telegram", "gateway-A")[0]
+    assert len(event["payload"]["command"]) == bridge._MAX_TEXT
+    assert len(event["payload"]["description"]) == bridge._MAX_TEXT
+    assert event["payload"]["choices"] == ["once", "deny"]
+    assert "untrusted" not in event["payload"]
+
+
+@pytest.mark.asyncio
+async def test_gateway_watcher_routes_approval_to_home_with_opaque_session_key(
+    isolated_bridge, monkeypatch
+):
+    from gateway.config import Platform
+    from gateway.run import GatewayRunner
+
+    runner = cast(Any, object.__new__(GatewayRunner))
+    runner._running = True
+    adapter = SimpleNamespace()
+
+    async def send_exec_approval(**kwargs):
+        runner._running = False
+        return SimpleNamespace(success=True, message_id="tg-42", error=None)
+
+    adapter.send_exec_approval = AsyncMock(side_effect=send_exec_approval)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.config = SimpleNamespace(
+        get_home_channel=lambda platform: SimpleNamespace(
+            chat_id="8068859990", thread_id=None, user_id="8068859990"
+        )
+    )
+
+    token = bridge.publish_approval("desktop-owner", _approval_payload())
+    delivered = []
+    monkeypatch.setattr(
+        bridge,
+        "mark_delivered",
+        lambda token, owner, message_id=None, **destination: delivered.append(
+            (token, message_id, destination)
+        ) or True,
+    )
+
+    await runner._cross_surface_bridge_watcher()
+
+    kwargs = adapter.send_exec_approval.call_args.kwargs
+    assert kwargs["chat_id"] == "8068859990"
+    assert kwargs["session_key"] == f"xsurf:{token}"
+    assert kwargs["command"] == "redacted"
+    assert delivered == [
+        (
+            token,
+            "tg-42",
+            {"chat_id": "8068859990", "thread_id": None, "user_id": "8068859990"},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gateway_watcher_routes_notification_to_configured_topic(
+    isolated_bridge, monkeypatch
+):
+    from gateway.config import Platform
+    from gateway.run import GatewayRunner
+
+    runner = cast(Any, object.__new__(GatewayRunner))
+    runner._running = True
+
+    async def send(*args, **kwargs):
+        runner._running = False
+        return SimpleNamespace(success=True, message_id="tg-notice", error=None)
+
+    adapter = SimpleNamespace(send=AsyncMock(side_effect=send))
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.config = SimpleNamespace(
+        get_home_channel=lambda platform: SimpleNamespace(
+            chat_id="8068859990", thread_id="topic-7", user_id="8068859990"
+        )
+    )
+    token = bridge.publish_notification(
+        "Desktop background process completed.", dedupe_key="process:topic"
+    )
+    assert token
+    delivered = []
+    monkeypatch.setattr(
+        bridge,
+        "mark_delivered",
+        lambda token, owner, message_id=None, **destination: delivered.append(
+            (token, message_id, destination)
+        )
+        or True,
+    )
+
+    await runner._cross_surface_bridge_watcher()
+
+    args = adapter.send.call_args.args
+    kwargs = adapter.send.call_args.kwargs
+    assert args[0] == "8068859990"
+    assert kwargs["metadata"] == {"thread_id": "topic-7"}
+    assert delivered == [
+        (
+            token,
+            "tg-notice",
+            {
+                "chat_id": "8068859990",
+                "thread_id": "topic-7",
+                "user_id": "8068859990",
+            },
+        )
+    ]

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -347,6 +347,26 @@ class TestTelegramExecApproval:
         kwargs = adapter._bot.send_message.call_args[1]
         assert "..." in kwargs["text"]
         assert len(kwargs["text"]) < 5000
+
+    @pytest.mark.asyncio
+    async def test_cross_surface_buttons_are_restart_durable_and_within_limit(self):
+        adapter = _make_adapter()
+        mock_msg = MagicMock(message_id=1)
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+        token = "A" * 43
+
+        result = await adapter.send_exec_approval(
+            chat_id="12345", command="ls", session_key=f"xsurf:{token}"
+        )
+
+        assert result.success is True
+        keyboard = adapter._bot.send_message.call_args.kwargs["reply_markup"]
+        callback_data = [
+            button.callback_data for row in keyboard.inline_keyboard for button in row
+        ]
+        assert all(f"x:{token}" in value for value in callback_data)
+        assert all(len(value.encode("utf-8")) <= 64 for value in callback_data)
+        assert adapter._approval_state == {}
 # _handle_callback_query — approval button clicks
 # ===========================================================================
 
@@ -384,6 +404,117 @@ class TestTelegramApprovalCallback:
 
         # State should be cleaned up
         assert 1 not in adapter._approval_state
+
+    @pytest.mark.asyncio
+    async def test_cross_surface_click_records_opaque_bridge_decision(self):
+        adapter = _make_adapter()
+        token = "B" * 43
+
+        query = AsyncMock()
+        query.data = f"ea:once:x:{token}"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.chat.type = "private"
+        query.message.message_thread_id = None
+        query.message.message_id = 777
+        query.from_user = MagicMock()
+        query.from_user.id = "12345"
+        query.from_user.first_name = "Jimbo"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+        update = MagicMock(callback_query=query)
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with (
+                patch("gateway.cross_surface_bridge.resolve_request", return_value=True) as resolve,
+                patch("gateway.cross_surface_bridge.wait_for_resolution", return_value="resolved"),
+            ):
+                await adapter._handle_callback_query(update, MagicMock())
+
+        resolve.assert_called_once_with(
+            token,
+            "once",
+            chat_id="12345",
+            thread_id=None,
+            user_id="12345",
+            message_id="777",
+        )
+        assert "Approved" in query.edit_message_text.call_args.kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_cross_surface_stale_click_is_expired(self):
+        adapter = _make_adapter()
+        token = "C" * 43
+
+        query = AsyncMock()
+        query.data = f"ea:deny:x:{token}"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.chat.type = "private"
+        query.message.message_thread_id = None
+        query.from_user = MagicMock()
+        query.from_user.id = "12345"
+        query.from_user.first_name = "Jimbo"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+        update = MagicMock(callback_query=query)
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("gateway.cross_surface_bridge.resolve_request", return_value=False):
+                await adapter._handle_callback_query(update, MagicMock())
+
+        assert "expired" in query.answer.call_args.kwargs["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_cross_surface_pending_desktop_ack_does_not_claim_approval(self):
+        adapter = _make_adapter()
+        token = "E" * 43
+        query = AsyncMock()
+        query.data = f"ea:once:x:{token}"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.chat.type = "private"
+        query.message.message_thread_id = None
+        query.message.message_id = 778
+        query.from_user = MagicMock(id="12345", first_name="Jimbo")
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with (
+                patch("gateway.cross_surface_bridge.resolve_request", return_value=True),
+                patch("gateway.cross_surface_bridge.wait_for_resolution", return_value="pending"),
+            ):
+                await adapter._handle_callback_query(
+                    MagicMock(callback_query=query), MagicMock()
+                )
+
+        rendered = query.edit_message_text.call_args.kwargs["text"]
+        assert "Decision sent" in rendered
+        assert "Approved" not in rendered
+
+    @pytest.mark.asyncio
+    async def test_cross_surface_click_rejects_unauthorized_user(self):
+        adapter = _make_adapter()
+        runner = _AuthRunner(authorized=False)
+        adapter._message_handler = runner._handle_message
+        token = "D" * 43
+
+        query = AsyncMock()
+        query.data = f"ea:once:x:{token}"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.chat.type = "private"
+        query.from_user = MagicMock(id=222, first_name="Mallory")
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+        update = MagicMock(callback_query=query)
+
+        with patch("gateway.cross_surface_bridge.resolve_request") as resolve:
+            await adapter._handle_callback_query(update, MagicMock())
+
+        resolve.assert_not_called()
+        assert "not authorized" in query.answer.call_args.kwargs["text"].lower()
 
     @pytest.mark.asyncio
     async def test_resume_typing_after_inline_approval(self):

--- a/tests/gateway/test_tui_approval_redaction.py
+++ b/tests/gateway/test_tui_approval_redaction.py
@@ -34,6 +34,96 @@ class TestTuiApprovalEmitRedaction:
         assert emitted["payload"]["description"] == "x"
         assert "github.com" in emitted["payload"]["command"]
 
+    def test_cross_surface_bridge_receives_only_redacted_payload_and_session_owner(
+        self, monkeypatch
+    ):
+        from tui_gateway import server as tui_server
+
+        published = {}
+        monkeypatch.setattr(tui_server, "_emit", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            "gateway.cross_surface_bridge.publish_approval",
+            lambda session_key, payload: published.update(
+                {"session_key": session_key, "payload": dict(payload)}
+            ),
+        )
+        with tui_server._sessions_lock:
+            tui_server._sessions["ui-sid"] = {
+                "session_key": "desktop-session-owner",
+                "source": "desktop",
+            }
+        try:
+            raw = "curl -H 'Authorization: Bearer secret-value' https://example.test"
+            tui_server._emit_approval_request(
+                "ui-sid",
+                {
+                    "command": raw,
+                    "description": "token ghp_0123456789abcdefghijklmnopqrstuvwxyzABCD",
+                },
+            )
+        finally:
+            with tui_server._sessions_lock:
+                tui_server._sessions.pop("ui-sid", None)
+
+        assert published["session_key"] == "desktop-session-owner"
+        assert "secret-value" not in published["payload"]["command"]
+        assert "example.test" in published["payload"]["command"]
+        assert "ghp_0123456789abcdefghijklmnopqrstuvwxyzABCD" not in (
+            published["payload"]["description"]
+        )
+
+    def test_process_bridge_never_publishes_command_output_or_pattern(self, monkeypatch):
+        from tui_gateway import server as tui_server
+
+        published = {}
+        monkeypatch.setattr(
+            "gateway.cross_surface_bridge.publish_notification",
+            lambda text, dedupe_key=None: published.update(
+                {"text": text, "dedupe_key": dedupe_key}
+            ),
+        )
+        tui_server._publish_cross_surface_process_notification(
+            {
+                "type": "watch_match",
+                "session_id": "proc-opaque-1",
+                "message_id": "event-7",
+                "command": "curl -H 'Authorization: secret-value' example.test",
+                "pattern": "secret-pattern",
+                "output": "secret-output",
+            }
+        )
+
+        persisted = f"{published['text']} {published['dedupe_key']}"
+        assert "secret-value" not in persisted
+        assert "secret-pattern" not in persisted
+        assert "secret-output" not in persisted
+        assert "example.test" not in persisted
+        assert published["text"] == (
+            "Desktop background process matched a notification watch."
+        )
+
+    def test_process_bridge_binds_secondary_profile_home(self, monkeypatch, tmp_path):
+        from hermes_constants import get_hermes_home
+        from tui_gateway import server as tui_server
+
+        profile_home = tmp_path / "secondary"
+        profile_home.mkdir()
+        observed = {}
+
+        def capture(_text, dedupe_key=None):
+            observed["home"] = get_hermes_home()
+            observed["dedupe_key"] = dedupe_key
+
+        monkeypatch.setattr(
+            "gateway.cross_surface_bridge.publish_notification", capture
+        )
+        tui_server._publish_cross_surface_process_notification(
+            {"type": "completion", "session_id": "proc-1"},
+            profile_home=str(profile_home),
+        )
+
+        assert observed["home"] == profile_home
+
     def test_emit_approval_request_handles_missing_command(self, monkeypatch):
         from tui_gateway import server as tui_server
 

--- a/tests/tools/test_approval_targeted.py
+++ b/tests/tools/test_approval_targeted.py
@@ -1,0 +1,208 @@
+"""Request-targeted gateway approval resolution contracts."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, cast
+
+import pytest
+
+from tools import approval
+
+
+@pytest.fixture(autouse=True)
+def clean_gateway_queues():
+    with approval._lock:
+        approval._gateway_queues.clear()
+    yield
+    with approval._lock:
+        approval._gateway_queues.clear()
+
+
+def _entry(*, choices=None, **data):
+    payload = dict(data)
+    payload.setdefault("expires_at", time.time() + 60)
+    if choices is not None:
+        payload["choices"] = choices
+    return approval._ApprovalEntry(payload)
+
+
+def test_targeted_resolution_selects_exact_parallel_entry_not_fifo_head():
+    first = _entry(choices=["once", "deny"], command="first")
+    second = _entry(choices=["once", "deny"], command="second")
+    approval._gateway_queues["desktop-session"] = [first, second]
+
+    assert approval.resolve_gateway_approval_by_id(
+        "desktop-session", second.request_id, "once"
+    ) == 1
+    assert second.event.is_set()
+    assert second.result == "once"
+    assert not first.event.is_set()
+    assert approval._gateway_queues["desktop-session"] == [first]
+
+
+def test_targeted_resolution_rejects_wrong_session_stale_and_replay():
+    entry = _entry(choices=["once", "deny"])
+    approval._gateway_queues["owner-session"] = [entry]
+
+    assert approval.resolve_gateway_approval_by_id(
+        "other-session", entry.request_id, "once"
+    ) == 0
+    assert approval.resolve_gateway_approval_by_id(
+        "owner-session", "A" * 43, "once"
+    ) == 0
+    assert approval.resolve_gateway_approval_by_id(
+        "owner-session", entry.request_id, "deny"
+    ) == 1
+    assert approval.resolve_gateway_approval_by_id(
+        "owner-session", entry.request_id, "once"
+    ) == 0
+
+
+def test_targeted_resolution_rejects_choice_not_offered():
+    entry = _entry(choices=["once", "deny"], smart_denied=True)
+    approval._gateway_queues["desktop-session"] = [entry]
+
+    assert approval.resolve_gateway_approval_by_id(
+        "desktop-session", entry.request_id, "always"
+    ) == 0
+    assert not entry.event.is_set()
+    assert approval.resolve_gateway_approval_by_id(
+        "desktop-session", entry.request_id, "once"
+    ) == 1
+
+
+def test_targeted_resolution_publishes_result_while_timeout_lock_is_held():
+    entered_set = threading.Event()
+    release_set = threading.Event()
+
+    class BlockingEvent:
+        def set(self):
+            entered_set.set()
+            assert release_set.wait(2)
+
+        def is_set(self):
+            return entered_set.is_set()
+
+    entry = _entry(choices=["once", "deny"])
+    cast(Any, entry).event = BlockingEvent()
+    approval._gateway_queues["desktop-session"] = [entry]
+    result = []
+    resolver = threading.Thread(
+        target=lambda: result.append(
+            approval.resolve_gateway_approval_by_id(
+                "desktop-session", entry.request_id, "once"
+            )
+        )
+    )
+    resolver.start()
+    assert entered_set.wait(2)
+
+    acquired = threading.Event()
+
+    def observe_lock():
+        with approval._lock:
+            acquired.set()
+
+    observer = threading.Thread(target=observe_lock)
+    observer.start()
+    assert not acquired.wait(0.05)
+    assert entry.result == "once"
+
+    release_set.set()
+    resolver.join(2)
+    observer.join(2)
+    assert result == [1]
+    assert acquired.is_set()
+
+
+def test_targeted_resolution_rejects_expired_authoritative_entry():
+    entry = _entry(choices=["once", "deny"], expires_at=time.time() - 1)
+    approval._gateway_queues["desktop-session"] = [entry]
+
+    assert approval.resolve_gateway_approval_by_id(
+        "desktop-session", entry.request_id, "once"
+    ) == 0
+    assert not entry.event.is_set()
+
+
+def test_interrupt_atomically_owns_entry_before_late_remote_approval(monkeypatch):
+    payloads = []
+    monkeypatch.setattr(approval, "_get_approval_timeout", lambda: 60)
+    monkeypatch.setattr(approval, "is_interrupted", lambda: True)
+
+    result = approval._await_gateway_decision(
+        "desktop-session",
+        lambda payload: payloads.append(dict(payload)),
+        {
+            "command": "rm example",
+            "description": "test",
+            "choices": ["once", "deny"],
+        },
+        surface="desktop",
+    )
+
+    assert result["resolved"] is True
+    assert result["choice"] == "deny"
+    assert approval.resolve_gateway_approval_by_id(
+        "desktop-session", payloads[0]["request_id"], "once"
+    ) == 0
+
+
+def test_notify_effect_then_failure_honors_committed_targeted_choice(monkeypatch):
+    session_key = "desktop-session"
+    monkeypatch.setattr(approval, "_get_approval_timeout", lambda: 60)
+    monkeypatch.setattr(approval, "is_interrupted", lambda: False)
+
+    def notify(payload):
+        assert approval.resolve_gateway_approval_by_id(
+            session_key, payload["request_id"], "once"
+        ) == 1
+        raise RuntimeError("delivery acknowledged, notifier cleanup failed")
+
+    result = approval._await_gateway_decision(
+        session_key,
+        notify,
+        {
+            "command": "rm example",
+            "description": "test",
+            "choices": ["once", "deny"],
+        },
+        surface="desktop",
+    )
+
+    assert result["resolved"] is True
+    assert result["choice"] == "once"
+    assert "notify_failed" not in result
+
+
+def test_gateway_notification_receives_opaque_id_and_canonical_expiry(monkeypatch):
+    payloads = []
+    session_key = "desktop-session"
+
+    def notify(payload):
+        payloads.append(dict(payload))
+        approval.resolve_gateway_approval_by_id(
+            session_key, payload["request_id"], "deny"
+        )
+
+    monkeypatch.setattr(approval, "_get_approval_timeout", lambda: 60)
+    result = approval._await_gateway_decision(
+        session_key,
+        notify,
+        {
+            "command": "rm example",
+            "description": "test",
+            "choices": ["once", "deny"],
+        },
+        surface="desktop",
+    )
+
+    assert result["resolved"] is True
+    assert result["choice"] == "deny"
+    assert len(payloads) == 1
+    request_id = payloads[0]["request_id"]
+    assert len(request_id) == 43
+    assert payloads[0]["expires_at"] > time.time()
+    assert "session_key" not in payloads[0]

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -15,6 +15,7 @@ import hashlib
 import logging
 import os
 import re
+import secrets
 import shlex
 import sys
 import tempfile
@@ -2154,11 +2155,12 @@ def _denial_breaker_addendum(session_key: str) -> str:
 
 class _ApprovalEntry:
     """One pending dangerous-command approval inside a gateway session."""
-    __slots__ = ("event", "data", "result", "reason")
+    __slots__ = ("event", "data", "request_id", "result", "reason")
 
     def __init__(self, data: dict):
         self.event = threading.Event()
         self.data = data          # command, description, pattern_keys, …
+        self.request_id = secrets.token_urlsafe(32)
         self.result: Optional[str] = None  # "once"|"session"|"always"|"deny"
         # Optional free-text reason supplied with an explicit deny
         # (``/deny <reason>``) so the agent can adapt instead of only
@@ -2168,6 +2170,21 @@ class _ApprovalEntry:
 
 _gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, …]
 _gateway_notify_cbs: dict[str, object] = {}  # session_key → callable(approval_data)
+_ALLOWED_GATEWAY_CHOICES = frozenset({"once", "session", "always", "deny"})
+
+
+def _entry_allowed_choices(entry: _ApprovalEntry) -> set[str]:
+    """Return the exact choices allowed by a pending approval prompt."""
+    explicit = entry.data.get("choices")
+    if isinstance(explicit, (list, tuple, set)):
+        return {str(choice) for choice in explicit} & _ALLOWED_GATEWAY_CHOICES
+    if entry.data.get("smart_denied"):
+        return {"once", "deny"}
+    if entry.data.get("allow_session") is False:
+        return {"once", "deny"}
+    if entry.data.get("allow_permanent") is False:
+        return {"once", "session", "deny"}
+    return set(_ALLOWED_GATEWAY_CHOICES)
 
 
 def register_gateway_notify(session_key: str, cb) -> None:
@@ -2222,13 +2239,52 @@ def resolve_gateway_approval(session_key: str, choice: str,
             targets = [queue.pop(0)]
         if not queue:
             _gateway_queues.pop(session_key, None)
+        # Publish the result and wake the waiter while still holding the same
+        # lock used by timeout cleanup. Otherwise the waiter can remove/read the
+        # entry in the gap and report a timeout after this function returned 1.
+        for entry in targets:
+            entry.result = choice
+            if reason:
+                entry.reason = reason
+            entry.event.set()
+    return len(targets)
 
-    for entry in targets:
+
+def resolve_gateway_approval_by_id(
+    session_key: str,
+    request_id: str,
+    choice: str,
+    reason: Optional[str] = None,
+) -> int:
+    """Resolve one exact pending approval, never the FIFO head by accident.
+
+    Cross-process transports must use this request-targeted resolver.  The
+    caller still needs the process-local ``session_key`` and the opaque ID must
+    belong to that session. Invalid, stale, replayed, or disallowed choices
+    fail closed and return zero.
+    """
+    if not session_key or not request_id or choice not in _ALLOWED_GATEWAY_CHOICES:
+        return 0
+    with _lock:
+        queue = _gateway_queues.get(session_key)
+        if not queue:
+            return 0
+        entry = next((item for item in queue if item.request_id == request_id), None)
+        if (
+            entry is None
+            or choice not in _entry_allowed_choices(entry)
+            or float(entry.data.get("expires_at", 0)) <= time.time()
+        ):
+            return 0
+        queue.remove(entry)
+        if not queue:
+            _gateway_queues.pop(session_key, None)
+        # This transition must be atomic with _drop_entry()/timeout observation.
         entry.result = choice
         if reason:
             entry.reason = reason
         entry.event.set()
-    return len(targets)
+    return 1
 
 
 def has_blocking_approval(session_key: str) -> bool:
@@ -3262,22 +3318,34 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     notify callback raised.  Persistence of an approved choice and building
     the final tool-facing result dict remain the caller's responsibility.
     """
+    approval_data = dict(approval_data)
     command = approval_data.get("command", "")
     description = approval_data.get("description", "")
     primary_key = approval_data.get("pattern_key", "")
     all_keys = approval_data.get("pattern_keys", [primary_key])
+    timeout = _get_approval_timeout()
 
     entry = _ApprovalEntry(approval_data)
+    approval_data["request_id"] = entry.request_id
+    approval_data["expires_at"] = time.time() + max(timeout, 0)
+    entry.data = approval_data
     with _lock:
         _gateway_queues.setdefault(session_key, []).append(entry)
 
-    def _drop_entry() -> None:
+    def _drop_entry() -> Optional[str]:
+        """Atomically arbitrate response versus timeout and return the choice.
+
+        If timeout cleanup removes the entry first, a concurrent resolver can no
+        longer report success. If resolution removes it first, its result is
+        already visible under this same lock.
+        """
         with _lock:
             queue = _gateway_queues.get(session_key, [])
             if entry in queue:
                 queue.remove(entry)
             if not queue:
                 _gateway_queues.pop(session_key, None)
+            return entry.result
 
     # Notify plugins that an approval is being requested. Fires before the
     # gateway notify callback so observers get the event in real time.
@@ -3296,16 +3364,34 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         notify_cb(approval_data)
     except Exception as exc:
         logger.warning("Gateway approval notify failed: %s", exc)
-        _drop_entry()
-        return {"resolved": False, "choice": None, "notify_failed": True}
+        # The notifier may have delivered/resolved the request before raising
+        # (effect-then-failure). Arbitrate under the same queue lock and honor a
+        # choice that already committed; only a genuinely unresolved send is a
+        # notify failure.
+        committed_choice = _drop_entry()
+        if committed_choice is None:
+            return {"resolved": False, "choice": None, "notify_failed": True}
+        _fire_approval_hook(
+            "post_approval_response",
+            command=command,
+            description=description,
+            pattern_key=primary_key,
+            pattern_keys=list(all_keys),
+            session_key=session_key,
+            surface=surface,
+            choice=committed_choice,
+        )
+        return {
+            "resolved": True,
+            "choice": committed_choice,
+            "reason": entry.reason,
+        }
 
     # Block until the user responds or the canonical approval timeout elapses
     # (default 300s). Poll in short slices so we can fire activity heartbeats
     # every ~10s to the agent's inactivity tracker — otherwise the gateway
     # watchdog kills the agent while the user is still responding. Mirrors
     # _wait_for_process() cadence.
-    timeout = _get_approval_timeout()
-
     try:
         from tools.environments.base import touch_activity_if_due
     except Exception:  # pragma: no cover
@@ -3329,9 +3415,24 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
                 "returning deny for session %s",
                 session_key,
             )
-            entry.result = "deny"
-            entry.event.set()
-            resolved = True
+            # Arbitrate cancellation against every local/remote resolver under
+            # the queue lock. Whichever transition removes this entry first is
+            # authoritative; interrupt must never overwrite a completed remote
+            # decision, and a later remote decision must never overwrite deny.
+            with _lock:
+                queue = _gateway_queues.get(session_key, [])
+                if entry in queue:
+                    queue.remove(entry)
+                    if not queue:
+                        _gateway_queues.pop(session_key, None)
+                    entry.result = "deny"
+                    entry.event.set()
+                    resolved = True
+                    break
+                if entry.result is not None:
+                    resolved = True
+                    break
+            # Session cleanup may have removed the entry without a decision.
             break
         _remaining = _deadline - time.monotonic()
         if _remaining <= 0:
@@ -3342,9 +3443,8 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         if touch_activity_if_due is not None:
             touch_activity_if_due(_activity_state, "waiting for user approval")
 
-    _drop_entry()
-
-    choice = entry.result
+    choice = _drop_entry()
+    resolved = choice is not None
     # Normalize outcome for the post hook. Unresolved (timeout) and None both
     # mean the user never responded; report that explicitly so plugins can
     # distinguish timeout from explicit deny.

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -813,19 +813,27 @@ def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)
     if err:
         return err
+    assert session is not None
     try:
-        from tools.approval import resolve_gateway_approval
-
-        return _ok(
-            rid,
-            {
-                "resolved": resolve_gateway_approval(
-                    session["session_key"],
-                    params.get("choice", "deny"),
-                    resolve_all=params.get("all", False),
-                )
-            },
+        from tools.approval import (
+            resolve_gateway_approval,
+            resolve_gateway_approval_by_id,
         )
+
+        request_id = str(params.get("request_id") or "")
+        if request_id:
+            resolved = resolve_gateway_approval_by_id(
+                session["session_key"],
+                request_id,
+                params.get("choice", "deny"),
+            )
+        else:
+            resolved = resolve_gateway_approval(
+                session["session_key"],
+                params.get("choice", "deny"),
+                resolve_all=params.get("all", False),
+            )
+        return _ok(rid, {"resolved": resolved})
     except Exception as e:
         return _err(rid, 5004, str(e))
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -965,6 +965,12 @@ def _close_sessions_for_transport(
 
 def _shutdown_sessions() -> None:
     try:
+        from gateway.cross_surface_bridge import stop_local_resolver
+
+        stop_local_resolver()
+    except Exception:
+        logger.debug("cross-surface resolver shutdown failed", exc_info=True)
+    try:
         _release_gateway_wake_owner()
     except Exception:
         pass
@@ -1604,11 +1610,31 @@ def _emit_approval_request(sid: str, data: dict | None) -> None:
             payload["choices"] = ["once", "session", "deny"]
         elif "allow_permanent" in payload:
             payload["choices"] = ["once", "session", "always", "deny"]
-    if "command" in payload:
+    if "command" in payload or "description" in payload:
         from gateway.run import _redact_approval_command
 
-        payload["command"] = _redact_approval_command(payload.get("command"))
+        if "command" in payload:
+            payload["command"] = _redact_approval_command(payload.get("command"))
+        if "description" in payload:
+            payload["description"] = _redact_approval_command(
+                payload.get("description")
+            )
     _emit("approval.request", sid, payload)
+
+    # Optional cross-surface bridge: mirror the already-redacted prompt to the
+    # configured messaging home channel.  The opaque token is mapped to the
+    # Desktop session key only in this process; neither the raw command nor the
+    # session key is persisted in the bridge mailbox.
+    try:
+        from gateway.cross_surface_bridge import publish_approval
+
+        with _sessions_lock:
+            session = _sessions.get(sid)
+            session_key = str((session or {}).get("session_key") or "")
+        if _session_source(session) == "desktop":
+            publish_approval(session_key, payload)
+    except Exception:
+        logger.warning("Could not publish cross-surface Desktop approval", exc_info=True)
 
 
 def _status_update(sid: str, kind: str, text: str | None = None):
@@ -8311,6 +8337,50 @@ def _notification_event_requires_owner(evt: dict) -> bool:
     )
 
 
+def _publish_cross_surface_process_notification(
+    evt: dict, *, profile_home: str | None = None
+) -> None:
+    """Mirror only bounded status metadata; never command/output/watch text."""
+    try:
+        from gateway.cross_surface_bridge import publish_notification
+
+        evt_type = str(evt.get("type") or "completion")
+        if evt_type == "completion":
+            return_code = evt.get("returncode", evt.get("exit_code"))
+            suffix = (
+                f" (exit code {int(return_code)})"
+                if isinstance(return_code, int) and not isinstance(return_code, bool)
+                else ""
+            )
+            text = f"Desktop background process completed{suffix}."
+        elif evt_type == "watch_match":
+            text = "Desktop background process matched a notification watch."
+        elif evt_type.startswith("watch_overflow_"):
+            text = "Desktop background process watch notifications were rate-limited."
+        elif evt_type == "watch_disabled":
+            text = "Desktop background process watch notifications were disabled."
+        elif evt_type == "async_delegation":
+            text = "Desktop background task completed."
+        else:
+            text = "Desktop background process status changed."
+
+        # The mailbox dedupe key is intentionally built only from opaque/status
+        # identity fields; raw command, output, pattern, and message text stay local.
+        safe_key = (
+            str(evt.get("session_id") or evt.get("delegation_id") or ""),
+            evt_type,
+            str(evt.get("message_id") or ""),
+        )
+        home_scope = set_hermes_home_override(profile_home) if profile_home else None
+        try:
+            publish_notification(text, dedupe_key="process:" + repr(safe_key))
+        finally:
+            if home_scope is not None:
+                reset_hermes_home_override(home_scope)
+    except Exception:
+        logger.warning("Could not publish cross-surface process notification", exc_info=True)
+
+
 def _notification_event_dedup_key(evt: dict) -> tuple:
     """Return the UI-emission identity for a process notification event.
 
@@ -8614,6 +8684,10 @@ def _notification_poller_loop(
         _dedup_key = _notification_event_dedup_key(evt)
         if _dedup_key not in _emitted:
             _emit("status.update", sid, {"kind": "process", "text": text})
+            if _session_source(session) == "desktop":
+                _publish_cross_surface_process_notification(
+                    evt, profile_home=session.get("profile_home")
+                )
             _emitted.add(_dedup_key)
 
         _requeued = False
@@ -8700,6 +8774,10 @@ def _notification_poller_loop(
         _dedup_key = _notification_event_dedup_key(evt)
         if _dedup_key not in _emitted:
             _emit("status.update", sid, {"kind": "process", "text": text})
+            if _session_source(session) == "desktop":
+                _publish_cross_surface_process_notification(
+                    evt, profile_home=session.get("profile_home")
+                )
             _emitted.add(_dedup_key)
 
         with session["history_lock"]:

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -58,6 +58,40 @@ The full set of keys:
 Setting `approvals.mode: off` disables all safety prompts. Use only in trusted environments (CI/CD, containers, etc.).
 :::
 
+### Cross-surface Desktop approvals (optional)
+
+Desktop and messaging runs normally own separate approval queues. To mirror
+Desktop approval prompts to a configured Telegram home channel and allow an
+authorized Telegram button press to resolve the original Desktop gate:
+
+```yaml
+approvals:
+  cross_surface:
+    enabled: true
+    target: telegram
+    process_notifications: true
+```
+
+Run `/sethome` in the intended Telegram chat before enabling this. The bridge
+uses a profile-local mode-0600 SQLite mailbox containing only redacted prompt
+text and opaque, expiring, single-use tokens. Raw commands and Desktop session
+keys are not persisted. Telegram's normal allowlist/pairing authorization is
+checked before a button response is accepted. `process_notifications` also
+mirrors generic Desktop background-process completion/watch status; command
+text, watch patterns, and process output are never included. Set it to `false`
+if only approval prompts should be forwarded.
+
+Delivery uses expiring leases and persistent deduplication. As with most
+messaging APIs, a gateway crash after Telegram accepts a message but before the
+local acknowledgement is committed can rarely produce a duplicate prompt. The
+opaque decision remains single-use, so duplicate buttons cannot approve twice.
+
+:::warning
+This grants authorized users in the configured Telegram home chat the same
+command-approval power they have at the Desktop prompt. Keep that chat and the
+bot allowlist owner-only.
+:::
+
 ### YOLO Mode
 
 YOLO mode bypasses **all** dangerous command approval prompts for the current session. It can be activated three ways:


### PR DESCRIPTION
## Summary

- add an opt-in, profile-local bridge that mirrors Desktop dangerous-command approval prompts to Telegram
- resolve the exact authoritative Desktop approval request from authenticated Telegram buttons
- mirror only allowlisted generic Desktop background-process status notifications
- preserve local Desktop approval behavior and legacy FIFO responses for callers without request IDs

## Security model

- `tools.approval` remains the sole command-execution authority; Telegram and SQLite transport authenticated intent only
- cryptographically random opaque request IDs, canonical expiry, allowed-choice validation, single-use decisions, and replay rejection
- callbacks are bound to authorized Telegram user plus delivered chat, topic/thread, and message ID
- Telegram reports approval only after the Desktop-side authoritative queue acknowledges the exact request
- timeout, interrupt, notifier-failure, local-click, and shutdown arbitration are atomic and fail closed
- approval command/description are redacted before persistence; process command, output, watch patterns, and arbitrary event text are rejected
- profile-specific `HERMES_HOME` context is preserved across resolver threads
- SQLite uses WAL fallback handling and restrictive database/WAL/SHM permissions
- unsupported non-Telegram targets fail closed

## Configuration

Disabled by default:

```yaml
approvals:
  cross_surface:
    enabled: true
    target: telegram
    process_notifications: true
```

## Validation

- affected Python suite: **866 passed, 2 known baseline tests deselected**
- Desktop Vitest: **35 passed**
- Desktop TypeScript typecheck: passed
- Desktop ESLint: passed
- Ruff: passed
- Python compilation: passed
- diff checks: passed
- separate-context security review of rebased commit: **PASS**, no findings

## Live verification

Tested on macOS with a rebuilt Desktop app and launchd-supervised Telegram gateway:

1. Desktop emitted a real approval for a contained recursive deletion under `/tmp`.
2. Telegram delivered the exact approval with buttons.
3. An authorized `once` decision resolved the matching Desktop queue entry.
4. Desktop executed the command only after authoritative acknowledgement.
5. Filesystem checks confirmed the expected contained deletion.
6. A bounded Desktop background process produced the generic Telegram notification `Desktop background process completed (exit code 0).`
7. The bridge payload contained no raw command, process output, watch pattern, or Desktop session key.
