### PR TITLE
fix(mcp): clean up stale mcp-remote OAuth locks before spawning stdio servers

### DIFF
--- a/tests/tools/test_mcp_stdio_watchdog.py
+++ b/tests/tools/test_mcp_stdio_watchdog.py
@@ -1,5 +1,6 @@
 """Contract tests for the direct POSIX stdio MCP child watchdog."""
 
+import json
 import os
 import sys
 
@@ -45,3 +46,52 @@ def test_wrap_command_uses_stable_parent_pid_and_preserves_command_tail():
         *command_args,
     ]
     assert "--create-time" not in wrapped_args
+
+
+@pytest.mark.skipif(os.name != "posix", reason="lock cleanup is POSIX-only")
+class TestCleanupStaleMcpRemoteLocks:
+    def _write_lock(self, tmp_path, server_dir, name, pid):
+        d = tmp_path / server_dir
+        d.mkdir(parents=True, exist_ok=True)
+        lock_path = d / name
+        lock_path.write_text(json.dumps({"pid": pid, "port": 1234, "timestamp": 0}))
+        return lock_path
+
+    def test_removes_lock_with_dead_pid(self, tmp_path):
+        # A PID essentially guaranteed not to exist.
+        dead_pid = 2**30
+        lock_path = self._write_lock(
+            tmp_path, "mcp-remote-0.1.37", "abc_lock.json", dead_pid
+        )
+
+        mcp_stdio_watchdog._cleanup_stale_mcp_remote_locks(str(tmp_path))
+
+        assert not lock_path.exists()
+
+    def test_keeps_lock_with_live_pid(self, tmp_path):
+        live_pid = os.getpid()
+        lock_path = self._write_lock(
+            tmp_path, "mcp-remote-0.1.37", "abc_lock.json", live_pid
+        )
+
+        mcp_stdio_watchdog._cleanup_stale_mcp_remote_locks(str(tmp_path))
+
+        assert lock_path.exists()
+
+    def test_ignores_malformed_lock_file(self, tmp_path):
+        d = tmp_path / "mcp-remote-0.1.37"
+        d.mkdir(parents=True, exist_ok=True)
+        lock_path = d / "garbage_lock.json"
+        lock_path.write_text("not json")
+
+        # Should not raise.
+        mcp_stdio_watchdog._cleanup_stale_mcp_remote_locks(str(tmp_path))
+
+        assert lock_path.exists()
+
+    def test_no_mcp_auth_dir_is_a_noop(self, tmp_path):
+        missing = tmp_path / "does-not-exist"
+
+        # Should not raise even though the directory doesn't exist.
+        mcp_stdio_watchdog._cleanup_stale_mcp_remote_locks(str(missing))
+

--- a/tools/mcp_stdio_watchdog.py
+++ b/tools/mcp_stdio_watchdog.py
@@ -43,6 +43,8 @@ Usage (see ``tools/mcp_tool.py::_run_stdio``)::
 from __future__ import annotations
 
 import argparse
+import glob
+import json
 import os
 import signal
 import subprocess
@@ -52,6 +54,54 @@ import time
 
 _POLL_INTERVAL_S = 2.0
 _TERM_GRACE_S = 3.0
+
+# mcp-remote (https://github.com/geelen/mcp-remote) serializes concurrent
+# OAuth handshakes against the same remote MCP server URL using a lock file
+# under ~/.mcp-auth/mcp-remote-<version>/<url_hash>_lock.json containing the
+# PID that currently holds it. If the process holding the lock is killed hard
+# (crash, force-quit, kill -9) instead of exiting gracefully, the lock file is
+# never removed. The next mcp-remote invocation against that same server URL
+# then sees a "held" lock from a PID that no longer exists and gets wedged —
+# manifesting to the MCP client as repeated connection failures ("Invalid
+# request parameters" / stuck tool discovery) that look like zombie process
+# buildup. mcp-remote has no self-healing for this case, so sweep dead-PID
+# locks before every stdio MCP spawn (this watchdog already runs on every one).
+
+
+def _cleanup_stale_mcp_remote_locks(mcp_auth_dir: str | None = None) -> None:
+    """Delete ``*_lock.json`` files under ``~/.mcp-auth/`` whose recorded PID
+    is no longer alive.
+
+    Best-effort and intentionally silent on any failure — this is a
+    preflight hygiene step, not something that should ever block or fail
+    the real MCP server launch.
+    """
+    if os.name != "posix":
+        return
+    base = mcp_auth_dir or os.path.expanduser("~/.mcp-auth")
+    try:
+        lock_paths = glob.glob(os.path.join(base, "*", "*_lock.json"))
+    except OSError:
+        return
+    for lock_path in lock_paths:
+        try:
+            with open(lock_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            pid = int(data.get("pid"))
+        except (OSError, ValueError, TypeError, json.JSONDecodeError):
+            continue
+        try:
+            os.kill(pid, 0)
+            # Process exists (or we lack permission to signal it, which on a
+            # single-user dev machine still implies it exists) — leave the
+            # lock alone, a live client genuinely holds it.
+        except ProcessLookupError:
+            try:
+                os.remove(lock_path)
+            except OSError:
+                pass
+        except PermissionError:
+            continue
 
 
 def _is_orphaned(original_ppid: int, getppid=os.getppid) -> bool:
@@ -114,6 +164,10 @@ def main(argv: list[str] | None = None) -> int:
     if not real_argv:
         print("mcp_stdio_watchdog: no command given after '--'", file=sys.stderr)
         return 2
+
+    # Sweep dead-PID mcp-remote OAuth locks before spawning — see module
+    # docstring comment above _cleanup_stale_mcp_remote_locks for why.
+    _cleanup_stale_mcp_remote_locks()
 
     # New process group so we can killpg() the whole tree the real command
     # may spawn (e.g. mcp-remote's own child `node` process), without


### PR DESCRIPTION
## Problem

`mcp-remote` serializes concurrent OAuth handshakes against the same remote MCP server URL using a lock file (`~/.mcp-auth/mcp-remote-<version>/<url_hash>_lock.json`) that records the holding PID. If the process holding that lock is killed hard (crash, force-quit, `kill -9`) instead of exiting gracefully, the lock file is never removed.

The next `mcp-remote` invocation against that same server URL then sees a lock held by a PID that no longer exists and gets wedged, surfacing to the MCP client as repeated connection failures ("Invalid request parameters", stuck tool discovery) that look like zombie process buildup — even though Hermes's own parent-death watchdog (`mcp_stdio_watchdog.py`) is already correctly reaping the orphaned subprocess tree. The dangling lock file, not an orphaned process, is the actual root cause in this failure mode.

## Fix

`mcp_stdio_watchdog.py` already runs ahead of every stdio MCP subprocess spawn. Add a preflight sweep there: for each `*_lock.json` under `~/.mcp-auth/`, check whether the recorded PID is still alive (`os.kill(pid, 0)`) and delete the lock file if it is not. Best-effort, stdlib-only, silent on any failure — matches this module's existing philosophy (thin, fast, can't itself become a resource leak).

## Testing

Added `TestCleanupStaleMcpRemoteLocks` covering: dead-PID lock removed, live-PID lock preserved, malformed lock file ignored without raising, missing `~/.mcp-auth` dir is a no-op.

```
scripts/run_tests.sh tests/tools/test_mcp_stdio_watchdog.py -v --tb=short
=== Summary: 1 files, 7 tests passed, 0 failed ===
```

---
Created with Hermes Agent v1.7.2-rc4, model claude-sonnet-4.6.