### PR TITLE
fix: honor wait directives in Kanban goal loops

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -1669,6 +1669,7 @@ def run_kanban_goal_loop(
     max_turns: int = DEFAULT_MAX_TURNS,
     first_response: str = "",
     log=None,
+    sleep_fn=time.sleep,
 ) -> Dict[str, Any]:
     """Drive a kanban worker through a Ralph-style goal loop.
 
@@ -1734,11 +1735,27 @@ def run_kanban_goal_loop(
             return {"outcome": "stopped", "turns_used": turns_used, "reason": f"status={status}"}
 
         # Still open — judge whether the latest response satisfies the card.
-        # The kanban worker loop has no wait-barrier concept (workers finish
-        # via kanban_complete / kanban_block, not by parking), so a WAIT
-        # verdict is treated as CONTINUE here.
         verdict, reason, _parse_failed, _wait, _transport_failed = judge_goal(goal_text, last_response)
         if verdict == "wait":
+            # A seconds-based WAIT commonly follows a provider rate limit or
+            # another time-bounded external dependency. Honour it before the
+            # next worker turn instead of immediately replaying the same API
+            # call and exhausting the card's turn budget.  The injected
+            # sleeper keeps this branch deterministic in tests. PID waits are
+            # left to the normal continuation path because kanban workers do
+            # not share the interactive goal loop's process wait barrier.
+            wait_seconds = _wait.get("seconds") if isinstance(_wait, dict) else None
+            if (
+                isinstance(wait_seconds, (int, float))
+                and wait_seconds > 0
+                and turns_used < max_turns
+            ):
+                wait_seconds = min(float(wait_seconds), 3600.0)
+                _log(
+                    f"kanban goal loop: task {task_id} waiting "
+                    f"{wait_seconds:g}s before retry"
+                )
+                sleep_fn(wait_seconds)
             verdict = "continue"
         _log(f"kanban goal loop: turn {turns_used}/{max_turns} verdict={verdict} reason={_truncate(reason, 120)}")
 

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -298,6 +298,58 @@ def test_loop_stops_if_task_reclaimed(monkeypatch):
     assert res["outcome"] == "stopped"
 
 
+def test_loop_honors_seconds_wait_before_retry(monkeypatch):
+    verdicts = iter([
+        ("wait", "provider rate limited", False, {"seconds": 900}, False),
+        ("done", "finished after retry", False, None, False),
+    ])
+    monkeypatch.setattr(goals, "judge_goal", lambda *_a, **_kw: next(verdicts))
+    statuses = iter(["running", "done"])
+    sleeps = []
+    turns = []
+
+    res = goals.run_kanban_goal_loop(
+        task_id="t-wait",
+        goal_text="retry after provider recovery",
+        run_turn=lambda p: turns.append(p) or "retried",
+        task_status_fn=lambda: next(statuses),
+        block_fn=lambda r: pytest.fail(f"should not block: {r}"),
+        sleep_fn=sleeps.append,
+        max_turns=4,
+        first_response="HTTP 429",
+    )
+
+    assert res["outcome"] == "completed_by_worker"
+    assert sleeps == [900.0]
+    assert len(turns) == 1
+
+
+def test_loop_clamps_seconds_wait(monkeypatch):
+    monkeypatch.setattr(
+        goals,
+        "judge_goal",
+        lambda *_a, **_kw: (
+            "wait", "usage window resets later", False,
+            {"seconds": 86_400}, False,
+        ),
+    )
+    sleeps = []
+
+    res = goals.run_kanban_goal_loop(
+        task_id="t-long-wait",
+        goal_text="wait safely",
+        run_turn=lambda _p: "retry attempted",
+        task_status_fn=lambda: "running",
+        block_fn=lambda _r: None,
+        sleep_fn=sleeps.append,
+        max_turns=2,
+        first_response="HTTP 429",
+    )
+
+    assert res["outcome"] == "blocked_budget"
+    assert sleeps == [3600.0]
+
+
 # ---------------------------------------------------------------------------
 # CLI judge gate tests (hermes kanban complete bypass fix)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Kanban goal-mode workers convert every judge `wait` verdict into an immediate continuation. When a provider returned HTTP 429, the judge correctly requested waits of 60–3600 seconds, but the worker immediately retried the exhausted provider until all 40 goal turns were consumed and the card was blocked.

## Fix

Honor seconds-based wait directives before the next worker turn, clamp a single wait to one hour, and do not sleep after the turn budget is already exhausted. PID waits retain the existing continuation behavior because Kanban workers do not share the interactive process wait barrier. `sleep_fn` is injectable so tests remain deterministic.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_kanban_goal_mode.py -q` — 18 passed
- `.venv/bin/ruff check hermes_cli/goals.py tests/hermes_cli/test_kanban_goal_mode.py` — passed
- `git diff --check` — passed

## Regression coverage

- A 900-second provider wait is honored before one retry.
- A day-long wait is clamped to 3600 seconds.
- No additional wait occurs once the turn budget is exhausted.