### PR TITLE
fix(slack): use generated assistant thread titles

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25,6 +25,7 @@ except ModuleNotFoundError:
     pass
 
 import asyncio
+import copy
 import concurrent.futures
 import dataclasses
 import faulthandler
@@ -5353,6 +5354,14 @@ class TurnRunner:
                         ctx.source,
                         effective_session_id,
                         title,
+                    )
+                elif self._runner._is_slack_assistant_thread_lane(ctx.source):
+                    maybe_auto_title_kwargs["title_callback"] = lambda title: self._runner._schedule_slack_generated_thread_title(
+                        copy.copy(ctx.source),
+                        effective_session_id,
+                        title,
+                        ctx.session_key,
+                        int(ctx.run_generation or 0),
                     )
                 maybe_auto_title(
                     getattr(self._runner._session_db, "_db", self._runner._session_db),
@@ -18812,6 +18821,99 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             cleaned = cleaned[:117].rstrip() + "..."
         return cleaned
 
+    def _is_slack_assistant_thread_lane(self, source: SessionSource) -> bool:
+        """Return True for Slack Agent/Assistant DM threads with visible titles."""
+        return (
+            source.platform == Platform.SLACK
+            and source.chat_type == "dm"
+            and bool(source.chat_id)
+            and bool(source.thread_id)
+            and bool(source.scope_id)
+            and getattr(source, "_slack_assistant_lifecycle_provenance", False) is True
+        )
+
+    async def _set_slack_generated_thread_title(
+        self,
+        source: SessionSource,
+        session_id: str,
+        title: str,
+        session_key: str,
+        run_generation: int = 0,
+    ) -> None:
+        """Best-effort dispatch of a generated title to the Slack adapter."""
+        if not self._is_slack_assistant_thread_lane(source):
+            return
+        adapter = self._adapter_for_source(source) if getattr(self, "adapters", None) else None
+        set_title = getattr(adapter, "set_generated_assistant_thread_title", None)
+        if set_title is None:
+            return
+
+        def is_current_session() -> bool:
+            try:
+                state = self._peek_session_state(session_key)
+                if state is None:
+                    return False
+                return (
+                    self.session_store.peek_session_id(session_key) == session_id
+                    and int(state.persistent.last_invalidation_generation)
+                    <= int(run_generation)
+                )
+            except Exception:
+                return False
+
+        try:
+            await set_title(
+                str(source.chat_id),
+                str(source.thread_id),
+                title,
+                team_id=str(source.scope_id),
+                is_current_session=is_current_session,
+            )
+        except Exception:
+            logger.debug("Failed to set Slack assistant thread title", exc_info=True)
+
+    def _schedule_slack_generated_thread_title(
+        self,
+        source: SessionSource,
+        session_id: str,
+        title: str,
+        session_key: str,
+        run_generation: int,
+    ) -> None:
+        """Schedule a Slack title mutation from the auto-title background thread."""
+        if (
+            not session_id
+            or not session_key
+            or not title
+            or not self._is_slack_assistant_thread_lane(source)
+        ):
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = getattr(self, "_gateway_loop", None)
+        if loop is None or loop.is_closed():
+            return
+        copied_source = copy.copy(source)
+        future = safe_schedule_threadsafe(
+            self._set_slack_generated_thread_title(
+                copied_source, session_id, title, session_key, run_generation
+            ),
+            loop,
+            logger=logger,
+            log_message="Slack generated thread title failed to schedule",
+        )
+        if future is None:
+            return
+
+        def _log_title_failure(fut) -> None:
+            try:
+                fut.result()
+            except Exception:
+                logger.debug("Slack generated thread title failed", exc_info=True)
+
+        future.add_done_callback(_log_title_failure)
+
     def _is_discord_auto_thread_lane(self, source: SessionSource) -> bool:
         """Return True only for Discord threads Hermes just auto-created."""
         return (
@@ -21971,6 +22073,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _invalidate_session_run_generation(self, session_key: str, *, reason: str = "") -> int:
         """Invalidate any in-flight run token for ``session_key``."""
         generation = self._begin_session_run_generation(session_key)
+        if session_key:
+            self._session_state(
+                session_key
+            ).persistent.last_invalidation_generation = generation
         if reason:
             logger.info(
                 "Invalidated run generation for %s → %d (%s)",

--- a/gateway/session_state.py
+++ b/gateway/session_state.py
@@ -148,6 +148,10 @@ class PersistentState:
     # Monotonic run-generation counter (#28686).  NEVER reset: clearing it
     # would break stale-run detection.
     run_generation: int = 0
+    # Most recent generation created by an explicit invalidation (/new,
+    # /stop, stale-run eviction). Ordinary later turns advance
+    # run_generation without changing this boundary marker.
+    last_invalidation_generation: int = 0
 
 
 @dataclass

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1410,7 +1410,12 @@ class GatewaySlashCommandsMixin:
         # indicator can still be stuck — e.g. Slack's persistent
         # assistant.threads.setStatus survives a gateway restart or a turn
         # that died without a final send (#32295). Best-effort clear so
-        # /stop always dismisses a phantom "is thinking...".
+        # /stop always dismisses a phantom "is thinking...". Also fence any
+        # auxiliary callback (such as semantic title generation) scheduled by
+        # the just-finished turn but not yet fired.
+        self._invalidate_session_run_generation(
+            session_key, reason="stop_command_no_active"
+        )
         adapter = getattr(self, "adapters", {}).get(source.platform)
         if adapter and hasattr(adapter, "_stop_typing_with_metadata"):
             try:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -13,6 +13,7 @@ import contextvars
 import inspect
 import json
 import logging
+import math
 import os
 import re
 import time
@@ -968,6 +969,11 @@ class SlackAdapter(BasePlatformAdapter):
         # message events, and carry identity needed for stable session scoping.
         self._assistant_threads: Dict[Tuple[str, str, str], Dict[str, str]] = {}
         self._ASSISTANT_THREADS_MAX = 5000
+        # app_home_opened(messages) is Slack's Agent DM lifecycle equivalent
+        # to assistant_thread_started; keep its workspace/channel provenance
+        # separately named and bounded so classic DMs never inherit it.
+        self._agent_dm_lifecycle_channels: Dict[Tuple[str, str], None] = {}
+        self._AGENT_DM_LIFECYCLE_CHANNELS_MAX = 5000
         # Agent-view context is per workspace/user (not global): a context
         # change for one person's Slack split view must never appear in another
         # person's prompt. Slack also includes this in later DM events, but the
@@ -1009,7 +1015,11 @@ class SlackAdapter(BasePlatformAdapter):
         # Best-effort guard so automatic Slack AI thread titles are set once
         # per visible DM thread instead of on every reply.
         self._titled_assistant_threads: set = set()
+        # In-flight reservations are a subset of the bounded title cache and
+        # must not be evicted while Slack I/O is still unresolved.
+        self._assistant_thread_titles_inflight: set = set()
         self._TITLED_ASSISTANT_THREADS_MAX = 5000
+        self._assistant_thread_title_started_at = time.time()
         # Slash-command contexts: stash response_url + user_id so send()
         # can route the first reply ephemerally.  Keyed by
         # (team_id, channel_id, user_id) to avoid cross-workspace and
@@ -4558,51 +4568,100 @@ class SlackAdapter(BasePlatformAdapter):
         self,
         channel_id: str,
         thread_ts: str,
-        title_source: str,
+        title: str,
         *,
-        team_id: str = "",
+        client: Any,
     ) -> None:
         """Best-effort title for visible Slack AI DM threads."""
-        if (
-            not self._app
-            or not channel_id
-            or not thread_ts
-            or not title_source
-            or not self._assistant_thread_title_enabled()
-        ):
-            return
-
-        key = self._workspace_thread_key(team_id, channel_id, thread_ts)
-        if not key or key in self._titled_assistant_threads:
-            return
-
-        title = re.sub(r"\s+", " ", title_source).strip()
-        if not title or title.startswith("/"):
-            return
-        if len(title) > 80:
-            title = title[:77].rstrip() + "..."
-
         try:
-            await self._get_client(channel_id, team_id=team_id).assistant_threads_setTitle(
+            await client.assistant_threads_setTitle(
                 channel_id=channel_id,
                 thread_ts=thread_ts,
                 title=title,
             )
         except Exception as e:
             logger.debug("[Slack] assistant.threads.setTitle failed: %s", e)
+
+    async def set_generated_assistant_thread_title(
+        self,
+        channel_id: str,
+        thread_ts: str,
+        title: str,
+        *,
+        team_id: str = "",
+        is_current_session: Optional[Callable[[], bool]] = None,
+    ) -> None:
+        """Best-effort title attempt from Hermes's generated session title."""
+        try:
+            if not self._assistant_thread_title_enabled() or not self._app:
+                return
+            if not team_id or not channel_id or not thread_ts or not title:
+                return
+            client = self._team_clients.get(team_id)
+            if client is None:
+                return
+            title = re.sub(r"\s+", " ", title).strip()
+            if not title or title.startswith("/"):
+                return
+            if len(title) > 80:
+                title = title[:77].rstrip() + "..."
+            try:
+                parsed_thread_ts = float(thread_ts)
+                if (
+                    not math.isfinite(parsed_thread_ts)
+                    or parsed_thread_ts < self._assistant_thread_title_started_at
+                ):
+                    return
+            except (TypeError, ValueError):
+                return
+            key = self._workspace_thread_key(team_id, channel_id, thread_ts)
+            if not key or key in self._titled_assistant_threads:
+                return
+            if is_current_session is None or is_current_session() is not True:
+                return
+            if self._TITLED_ASSISTANT_THREADS_MAX <= 0:
+                return
+            if len(self._titled_assistant_threads) >= self._TITLED_ASSISTANT_THREADS_MAX:
+                excess = (
+                    len(self._titled_assistant_threads)
+                    - self._TITLED_ASSISTANT_THREADS_MAX // 2
+                )
+                # Trim completed reservations only. Active attempts remain
+                # reserved until their Slack call settles, even when newer
+                # threads apply cache pressure while an older call is blocked.
+                evictable = self._titled_assistant_threads.difference(
+                    self._assistant_thread_titles_inflight
+                )
+                before_trim = set(evictable)
+                self._discard_oldest_by_thread_ts(
+                    evictable, excess, lambda e: e[2]
+                )
+                self._titled_assistant_threads.difference_update(
+                    before_trim.difference(evictable)
+                )
+                if (
+                    len(self._titled_assistant_threads)
+                    >= self._TITLED_ASSISTANT_THREADS_MAX
+                ):
+                    return
+            self._titled_assistant_threads.add(key)
+            self._assistant_thread_titles_inflight.add(key)
+        except Exception:
+            logger.debug(
+                "[Slack] failed to validate generated assistant thread title",
+                exc_info=True,
+            )
             return
 
-        self._titled_assistant_threads.add(key)
-        if len(self._titled_assistant_threads) > self._TITLED_ASSISTANT_THREADS_MAX:
-            excess = (
-                len(self._titled_assistant_threads)
-                - self._TITLED_ASSISTANT_THREADS_MAX // 2
+        try:
+            await self._set_assistant_thread_title(
+                channel_id,
+                thread_ts,
+                title,
+                client=client,
             )
-            # Keys are (team_id, channel_id, thread_ts) — evict the oldest
-            # threads first so recently titled threads keep their guard.
-            self._discard_oldest_by_thread_ts(
-                self._titled_assistant_threads, excess, lambda e: e[2]
-            )
+        finally:
+            self._assistant_thread_titles_inflight.discard(key)
 
     def _seed_assistant_thread_session(self, metadata: Dict[str, str]) -> None:
         """Prime the session store so assistant threads get stable user scoping."""
@@ -4724,6 +4783,11 @@ class SlackAdapter(BasePlatformAdapter):
 
         if team_id and channel_id:
             self._remember_channel_team(channel_id, team_id)
+            self._agent_dm_lifecycle_channels[(str(team_id), str(channel_id))] = None
+            self._trim_oldest_dict_entries(
+                self._agent_dm_lifecycle_channels,
+                self._AGENT_DM_LIFECYCLE_CHANNELS_MAX,
+            )
 
         metadata = {
             "channel_id": str(channel_id) if channel_id else "",
@@ -6189,17 +6253,6 @@ class SlackAdapter(BasePlatformAdapter):
         # and agent context show #channel / peer names instead of raw IDs.
         channel_name = await self._resolve_channel_name(channel_id, team_id=team_id)
 
-        # Slack's AI Agent Messages tab shows visible app threads; title the
-        # first DM thread turn from the user's prompt when Slack AI APIs are
-        # available. This is best-effort and configurable via config.yaml.
-        if is_dm and thread_ts and msg_type != MessageType.COMMAND:
-            await self._set_assistant_thread_title(
-                channel_id,
-                thread_ts,
-                original_text or text,
-                team_id=team_id,
-            )
-
         # Build source
         source = self.build_source(
             chat_id=channel_id,
@@ -6215,6 +6268,16 @@ class SlackAdapter(BasePlatformAdapter):
             # (they carry no user_id to match against the allowlist).
             is_bot=bool(event.get("bot_id")) or event.get("subtype") == "bot_message",
         )
+        assistant_thread_key = self._workspace_thread_key(
+            str(team_id), str(channel_id), str(thread_ts or "")
+        )
+        if is_one_to_one_dm and (
+            assistant_thread_key in self._assistant_threads
+            or (str(team_id), str(channel_id)) in self._agent_dm_lifecycle_channels
+        ):
+            # Internal, wire-invisible per-event provenance. The gateway copies
+            # this source before scheduling and never persists/serializes it.
+            setattr(source, "_slack_assistant_lifecycle_provenance", True)
 
         # Per-channel ephemeral prompt
         from gateway.platforms.base import (

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -100,6 +100,19 @@ def _make_discord_auto_thread_source() -> SessionSource:
     )
 
 
+def _make_slack_assistant_thread_source() -> SessionSource:
+    source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="D123",
+        chat_type="dm",
+        user_id="U_USER",
+        thread_id="171.111",
+        scope_id="T_TEAM",
+    )
+    setattr(source, "_slack_assistant_lifecycle_provenance", True)
+    return source
+
+
 def _make_event(text: str) -> MessageEvent:
     return MessageEvent(text=text, source=_make_source(), message_id="m1")
 
@@ -168,5 +181,192 @@ async def test_session_fast_override_beats_config_default(monkeypatch, tmp_path)
     assert runner._resolve_session_service_tier(session_key=session_key) is None
     # A different session still gets the config default.
     assert runner._resolve_session_service_tier(session_key="other-session") == "priority"
+
+
+@pytest.mark.asyncio
+async def test_run_agent_passes_slack_generated_thread_title_callback(monkeypatch, tmp_path):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+    runner._session_db = SimpleNamespace(_db=MagicMock())  # type: ignore[assignment]
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+
+    import hermes_cli.tools_config as tools_config
+
+    monkeypatch.setattr(
+        tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"}
+    )
+    source = _make_slack_assistant_thread_source()
+    session_key = "agent:main:slack:dm:D123:thread:171.111"
+
+    with patch("agent.title_generator.maybe_auto_title") as mock_title:
+        await runner._run_agent(
+            message="raw user prompt",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="session-1",
+            session_key=session_key,
+            run_generation=7,
+        )
+
+    callback = mock_title.call_args.kwargs["title_callback"]
+    with patch.object(runner, "_schedule_slack_generated_thread_title") as mock_schedule:
+        callback("Semantic Session Title")
+
+    scheduled_source, session_id, title, scheduled_key, run_generation = (
+        mock_schedule.call_args.args
+    )
+    assert scheduled_source == source
+    assert scheduled_source is not source
+    assert getattr(scheduled_source, "_slack_assistant_lifecycle_provenance") is True
+    assert session_id == "session-1"
+    assert title == "Semantic Session Title"
+    assert scheduled_key == session_key
+    assert run_generation == 7
+    runner._telegram_topic_mode_enabled = lambda candidate: True
+    telegram_topic = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="user-1",
+        thread_id="42",
+    )
+    discord_thread = _make_discord_auto_thread_source()
+    assert runner._is_telegram_topic_lane(telegram_topic) is True
+    assert runner._is_discord_auto_thread_lane(discord_thread) is True
+    assert runner._is_slack_assistant_thread_lane(telegram_topic) is False
+    assert runner._is_slack_assistant_thread_lane(discord_thread) is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("chat_id", "chat_type"),
+    [("D_CLASSIC", "dm"), ("G_MPIM", "dm")],
+)
+async def test_run_agent_omits_slack_title_callback_without_lifecycle_provenance(
+    monkeypatch, tmp_path, chat_id, chat_type
+):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+    runner._session_db = SimpleNamespace(_db=MagicMock())  # type: ignore[assignment]
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+
+    import hermes_cli.tools_config as tools_config
+
+    monkeypatch.setattr(
+        tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"}
+    )
+    source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id=chat_id,
+        chat_type=chat_type,
+        user_id="U_USER",
+        thread_id="171.111",
+        scope_id="T_TEAM",
+    )
+
+    with patch("agent.title_generator.maybe_auto_title") as mock_title:
+        await runner._run_agent(
+            message="ordinary threaded DM",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="session-1",
+            session_key=f"agent:main:slack:dm:{chat_id}:thread:171.111",
+        )
+
+    assert "title_callback" not in mock_title.call_args.kwargs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("peek", [lambda key: "session-2", lambda key: (_ for _ in ()).throw(RuntimeError())])
+async def test_slack_generated_thread_title_uses_fail_closed_final_session_validator(peek):
+    runner = _make_runner()
+    source = _make_slack_assistant_thread_source()
+    session_key = "agent:main:slack:dm:D123:thread:171.111"
+    runner._session_state(session_key)
+    runner.session_store.peek_session_id = MagicMock(side_effect=peek)
+    validation_results = []
+
+    async def set_title(*args, **kwargs):
+        validation_results.append(kwargs["is_current_session"]())
+
+    runner._adapter_for_source = lambda candidate: SimpleNamespace(
+        set_generated_assistant_thread_title=set_title
+    )
+    runner.adapters = {Platform.SLACK: object()}
+
+    await runner._set_slack_generated_thread_title(
+        source,
+        "session-1",
+        "Semantic Session Title",
+        session_key,
+    )
+
+    assert validation_results == [False]
+    runner.session_store.peek_session_id.assert_called_once_with(session_key)
+
+
+@pytest.mark.asyncio
+async def test_slack_title_validator_allows_later_turn_but_rejects_explicit_invalidation():
+    runner = _make_runner()
+    source = _make_slack_assistant_thread_source()
+    session_key = "agent:main:slack:dm:D123:thread:171.111"
+    runner.session_store.peek_session_id = MagicMock(return_value="session-1")
+    captured_validators = []
+
+    async def set_title(*args, **kwargs):
+        captured_validators.append(kwargs["is_current_session"])
+
+    runner._adapter_for_source = lambda candidate: SimpleNamespace(
+        set_generated_assistant_thread_title=set_title
+    )
+    runner.adapters = {Platform.SLACK: object()}
+    title_run_generation = runner._begin_session_run_generation(session_key)
+
+    await runner._set_slack_generated_thread_title(
+        source,
+        "session-1",
+        "Semantic Session Title",
+        session_key,
+        title_run_generation,
+    )
+
+    runner._begin_session_run_generation(session_key)
+    assert captured_validators[0]() is True
+
+    runner._invalidate_session_run_generation(session_key, reason="test_reset")
+    assert captured_validators[0]() is False
 
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3008,7 +3008,7 @@ class TestAssistantThreadLifecycle:
         }
 
     @pytest.mark.asyncio
-    async def test_dm_message_sets_assistant_thread_title_once(
+    async def test_dm_message_defers_assistant_thread_title_until_generated(
         self, assistant_adapter
     ):
         assistant_adapter._app.client.users_info = AsyncMock(
@@ -3017,6 +3017,10 @@ class TestAssistantThreadLifecycle:
         assistant_adapter._app.client.reactions_add = AsyncMock()
         assistant_adapter._app.client.reactions_remove = AsyncMock()
         assistant_adapter._app.client.assistant_threads_setTitle = AsyncMock()
+        assistant_adapter._fetch_thread_context = AsyncMock(return_value=[])
+        assistant_adapter._fetch_thread_parent_text = AsyncMock(return_value=None)
+        assistant_adapter._team_clients = {"T_TEAM": assistant_adapter._app.client}
+        assistant_adapter._assistant_thread_title_started_at = 0.0
         event = {
             "text": "Please summarize this incident thread",
             "channel": "D123",
@@ -3031,13 +3035,420 @@ class TestAssistantThreadLifecycle:
             {**event, "ts": "171.222", "thread_ts": "171.111"}
         )
 
+        assistant_adapter._app.client.assistant_threads_setTitle.assert_not_awaited()
+
+        await assistant_adapter.set_generated_assistant_thread_title(
+            "D123",
+            "171.111",
+            "Incident Thread Summary",
+            team_id="T_TEAM",
+            is_current_session=lambda: True,
+        )
+
         assistant_adapter._app.client.assistant_threads_setTitle.assert_awaited_once_with(
             channel_id="D123",
             thread_ts="171.111",
-            title="Please summarize this incident thread",
+            title="Incident Thread Summary",
         )
         msg_event = assistant_adapter.handle_message.call_args[0][0]
         assert msg_event.metadata["slack_team_id"] == "T_TEAM"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("channel_type", ["im", "mpim"])
+    async def test_ordinary_threaded_dm_has_no_assistant_lifecycle_provenance(
+        self, assistant_adapter, channel_type
+    ):
+        assistant_adapter._app.client.reactions_add = AsyncMock()
+        assistant_adapter._app.client.reactions_remove = AsyncMock()
+        assistant_adapter._fetch_thread_context = AsyncMock(return_value=[])
+        assistant_adapter._fetch_thread_parent_text = AsyncMock(return_value=None)
+
+        await assistant_adapter._handle_slack_message(
+            {
+                "text": "<@U_BOT> ordinary threaded DM",
+                "channel": "D123" if channel_type == "im" else "G123",
+                "channel_type": channel_type,
+                "ts": "171.222",
+                "thread_ts": "171.111",
+                "team": "T_TEAM",
+                "user": "U_USER",
+            }
+        )
+
+        source = assistant_adapter.handle_message.await_args.args[0].source
+        assert not getattr(source, "_slack_assistant_lifecycle_provenance", False)
+
+    @pytest.mark.asyncio
+    async def test_assistant_thread_lifecycle_marks_matching_message_provenance(
+        self, assistant_adapter
+    ):
+        assistant_adapter._fetch_thread_context = AsyncMock(return_value=[])
+        assistant_adapter._fetch_thread_parent_text = AsyncMock(return_value=None)
+        await assistant_adapter._handle_assistant_thread_lifecycle_event(
+            {
+                "type": "assistant_thread_started",
+                "team_id": "T_TEAM",
+                "assistant_thread": {
+                    "channel_id": "D123",
+                    "thread_ts": "171.111",
+                    "user_id": "U_USER",
+                },
+            }
+        )
+        await assistant_adapter._handle_slack_message(
+            {
+                "text": "assistant lifecycle turn",
+                "channel": "D123",
+                "channel_type": "im",
+                "ts": "171.222",
+                "thread_ts": "171.111",
+                "team": "T_TEAM",
+                "user": "U_USER",
+            }
+        )
+
+        source = assistant_adapter.handle_message.await_args.args[0].source
+        assert getattr(source, "_slack_assistant_lifecycle_provenance") is True
+
+    @pytest.mark.asyncio
+    async def test_agent_dm_app_home_lifecycle_marks_root_message_provenance(
+        self, assistant_adapter
+    ):
+        await assistant_adapter._handle_app_home_opened(
+            {
+                "type": "app_home_opened",
+                "tab": "messages",
+                "team": "T_TEAM",
+                "channel": "D123",
+                "user": "U_USER",
+            }
+        )
+        await assistant_adapter._handle_slack_message(
+            {
+                "text": "agent DM root turn",
+                "channel": "D123",
+                "channel_type": "im",
+                "ts": "171.111",
+                "team": "T_TEAM",
+                "user": "U_USER",
+            }
+        )
+
+        source = assistant_adapter.handle_message.await_args.args[0].source
+        assert getattr(source, "_slack_assistant_lifecycle_provenance") is True
+
+    @pytest.mark.asyncio
+    async def test_generated_assistant_thread_title_reservation_stays_bounded(
+        self, assistant_adapter
+    ):
+        client = assistant_adapter._app.client
+        client.assistant_threads_setTitle = AsyncMock()
+        assistant_adapter._team_clients = {"T_TEAM": client}
+        assistant_adapter._assistant_thread_title_started_at = 0.0
+        assistant_adapter._TITLED_ASSISTANT_THREADS_MAX = 4
+
+        for i in range(12):
+            await assistant_adapter.set_generated_assistant_thread_title(
+                f"D{i}",
+                f"{1000 + i}.0",
+                f"Generated Title {i}",
+                team_id="T_TEAM",
+                is_current_session=lambda: True,
+            )
+
+        assert len(assistant_adapter._titled_assistant_threads) <= 4
+        assert client.assistant_threads_setTitle.await_count == 12
+
+    @pytest.mark.asyncio
+    async def test_generated_assistant_thread_title_reserves_before_concurrent_await(
+        self, assistant_adapter
+    ):
+        client = assistant_adapter._app.client
+        assistant_adapter._team_clients = {"T_TEAM": client}
+        assistant_adapter._assistant_thread_title_started_at = 0.0
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def set_title(**kwargs):
+            started.set()
+            await release.wait()
+
+        client.assistant_threads_setTitle = AsyncMock(side_effect=set_title)
+        first = asyncio.create_task(
+            assistant_adapter.set_generated_assistant_thread_title(
+                "D123",
+                "171.111",
+                "First Generated Title",
+                team_id="T_TEAM",
+                is_current_session=lambda: True,
+            )
+        )
+        await started.wait()
+        second = asyncio.create_task(
+            assistant_adapter.set_generated_assistant_thread_title(
+                "D123",
+                "171.111",
+                "Second Generated Title",
+                team_id="T_TEAM",
+                is_current_session=lambda: True,
+            )
+        )
+        release.set()
+        await asyncio.gather(first, second)
+
+        client.assistant_threads_setTitle.assert_awaited_once_with(
+            channel_id="D123",
+            thread_ts="171.111",
+            title="First Generated Title",
+        )
+
+    @pytest.mark.asyncio
+    async def test_full_newer_reservation_cache_cannot_self_evict_blocked_old_attempt(
+        self, assistant_adapter
+    ):
+        client = assistant_adapter._app.client
+        assistant_adapter._team_clients = {"T_TEAM": client}
+        assistant_adapter._assistant_thread_title_started_at = 0.0
+        assistant_adapter._TITLED_ASSISTANT_THREADS_MAX = 4
+        assistant_adapter._titled_assistant_threads = {
+            ("T_TEAM", f"D{i}", f"{200 + i}.0") for i in range(4)
+        }
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def set_title(**kwargs):
+            started.set()
+            await release.wait()
+
+        client.assistant_threads_setTitle = AsyncMock(side_effect=set_title)
+        first = asyncio.create_task(
+            assistant_adapter.set_generated_assistant_thread_title(
+                "D_OLD",
+                "100.0",
+                "Blocked Old Title",
+                team_id="T_TEAM",
+                is_current_session=lambda: True,
+            )
+        )
+        await started.wait()
+        second = asyncio.create_task(
+            assistant_adapter.set_generated_assistant_thread_title(
+                "D_OLD",
+                "100.0",
+                "Duplicate Old Title",
+                team_id="T_TEAM",
+                is_current_session=lambda: True,
+            )
+        )
+        await asyncio.sleep(0)
+        release.set()
+        await asyncio.gather(first, second)
+
+        assert client.assistant_threads_setTitle.await_count == 1
+        assert ("T_TEAM", "D_OLD", "100.0") in assistant_adapter._titled_assistant_threads
+
+    @pytest.mark.asyncio
+    async def test_cache_pressure_cannot_evict_inflight_reservation(
+        self, assistant_adapter
+    ):
+        client = assistant_adapter._app.client
+        assistant_adapter._team_clients = {"T_TEAM": client}
+        assistant_adapter._assistant_thread_title_started_at = 0.0
+        assistant_adapter._TITLED_ASSISTANT_THREADS_MAX = 4
+        assistant_adapter._titled_assistant_threads = {
+            ("T_TEAM", f"D{i}", f"{200 + i}.0") for i in range(4)
+        }
+        old_started = asyncio.Event()
+        release_old = asyncio.Event()
+        attempted_thread_timestamps = []
+
+        async def set_title(**kwargs):
+            attempted_thread_timestamps.append(kwargs["thread_ts"])
+            if kwargs["thread_ts"] == "100.0":
+                old_started.set()
+                await release_old.wait()
+
+        client.assistant_threads_setTitle = AsyncMock(side_effect=set_title)
+        first_old = asyncio.create_task(
+            assistant_adapter.set_generated_assistant_thread_title(
+                "D_OLD",
+                "100.0",
+                "Blocked Old Title",
+                team_id="T_TEAM",
+                is_current_session=lambda: True,
+            )
+        )
+        await old_started.wait()
+
+        for thread_ts in ("300.0", "301.0"):
+            await assistant_adapter.set_generated_assistant_thread_title(
+                f"D_{thread_ts}",
+                thread_ts,
+                "Newer Generated Title",
+                team_id="T_TEAM",
+                is_current_session=lambda: True,
+            )
+
+        duplicate_old = asyncio.create_task(
+            assistant_adapter.set_generated_assistant_thread_title(
+                "D_OLD",
+                "100.0",
+                "Duplicate Old Title",
+                team_id="T_TEAM",
+                is_current_session=lambda: True,
+            )
+        )
+        await asyncio.sleep(0)
+
+        assert attempted_thread_timestamps.count("100.0") == 1
+        assert len(assistant_adapter._titled_assistant_threads) <= 4
+
+        release_old.set()
+        await asyncio.gather(first_old, duplicate_old)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("thread_ts", ["nan", "inf", "-inf"])
+    async def test_non_finite_thread_timestamp_fails_closed_without_reservation_or_api(
+        self, assistant_adapter, thread_ts
+    ):
+        client = assistant_adapter._app.client
+        assistant_adapter._team_clients = {"T_TEAM": client}
+        assistant_adapter._assistant_thread_title_started_at = 0.0
+        client.assistant_threads_setTitle = AsyncMock()
+
+        await assistant_adapter.set_generated_assistant_thread_title(
+            "D123",
+            thread_ts,
+            "Generated Title",
+            team_id="T_TEAM",
+            is_current_session=lambda: True,
+        )
+
+        client.assistant_threads_setTitle.assert_not_awaited()
+        assert ("T_TEAM", "D123", thread_ts) not in assistant_adapter._titled_assistant_threads
+
+    @pytest.mark.asyncio
+    async def test_generated_assistant_thread_title_ambiguous_failure_stays_reserved(
+        self, assistant_adapter
+    ):
+        client = assistant_adapter._app.client
+        assistant_adapter._team_clients = {"T_TEAM": client}
+        assistant_adapter._assistant_thread_title_started_at = 0.0
+        client.assistant_threads_setTitle = AsyncMock(
+            side_effect=TimeoutError("response lost after Slack may have committed")
+        )
+
+        for _ in range(2):
+            await assistant_adapter.set_generated_assistant_thread_title(
+                "D123",
+                "171.111",
+                "Generated Title",
+                team_id="T_TEAM",
+                is_current_session=lambda: True,
+            )
+
+        assert client.assistant_threads_setTitle.await_count == 1
+        assert ("T_TEAM", "D123", "171.111") in assistant_adapter._titled_assistant_threads
+
+    @pytest.mark.asyncio
+    async def test_generated_assistant_thread_title_allows_distinct_thread(
+        self, assistant_adapter
+    ):
+        client = assistant_adapter._app.client
+        assistant_adapter._team_clients = {"T_TEAM": client}
+        assistant_adapter._assistant_thread_title_started_at = 0.0
+        client.assistant_threads_setTitle = AsyncMock()
+
+        for thread_ts in ("171.111", "171.222"):
+            await assistant_adapter.set_generated_assistant_thread_title(
+                "D123",
+                thread_ts,
+                "Generated Title",
+                team_id="T_TEAM",
+                is_current_session=lambda: True,
+            )
+
+        assert client.assistant_threads_setTitle.await_count == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("team_id", ["", "T_UNKNOWN"])
+    async def test_generated_assistant_thread_title_requires_explicit_known_workspace(
+        self, assistant_adapter, team_id
+    ):
+        client = assistant_adapter._app.client
+        assistant_adapter._team_clients = {"T_TEAM": client}
+        assistant_adapter._assistant_thread_title_started_at = 0.0
+        client.assistant_threads_setTitle = AsyncMock()
+
+        await assistant_adapter.set_generated_assistant_thread_title(
+            "D123",
+            "171.111",
+            "Generated Title",
+            team_id=team_id,
+            is_current_session=lambda: True,
+        )
+
+        client.assistant_threads_setTitle.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_generated_assistant_thread_title_honors_callback_time_disable(
+        self, assistant_adapter
+    ):
+        client = assistant_adapter._app.client
+        assistant_adapter._team_clients = {"T_TEAM": client}
+        assistant_adapter._assistant_thread_title_started_at = 0.0
+        assistant_adapter.config.extra["assistant_thread_titles"] = False
+        client.assistant_threads_setTitle = AsyncMock()
+
+        await assistant_adapter.set_generated_assistant_thread_title(
+            "D123",
+            "171.111",
+            "Generated Title",
+            team_id="T_TEAM",
+            is_current_session=lambda: True,
+        )
+
+        client.assistant_threads_setTitle.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("validator", [lambda: False, lambda: (_ for _ in ()).throw(RuntimeError())])
+    async def test_generated_assistant_thread_title_rejects_stale_or_failed_validator_without_reservation(
+        self, assistant_adapter, validator
+    ):
+        client = assistant_adapter._app.client
+        assistant_adapter._team_clients = {"T_TEAM": client}
+        assistant_adapter._assistant_thread_title_started_at = 0.0
+        client.assistant_threads_setTitle = AsyncMock()
+
+        await assistant_adapter.set_generated_assistant_thread_title(
+            "D123",
+            "171.111",
+            "Generated Title",
+            team_id="T_TEAM",
+            is_current_session=validator,
+        )
+
+        client.assistant_threads_setTitle.assert_not_awaited()
+        assert ("T_TEAM", "D123", "171.111") not in assistant_adapter._titled_assistant_threads
+
+    @pytest.mark.asyncio
+    async def test_generated_assistant_thread_title_rejects_pre_process_thread(
+        self, assistant_adapter
+    ):
+        client = assistant_adapter._app.client
+        assistant_adapter._team_clients = {"T_TEAM": client}
+        assistant_adapter._assistant_thread_title_started_at = time.time()
+        client.assistant_threads_setTitle = AsyncMock()
+
+        await assistant_adapter.set_generated_assistant_thread_title(
+            "D123",
+            "1.0",
+            "Generated Title",
+            team_id="T_TEAM",
+            is_current_session=lambda: True,
+        )
+
+        client.assistant_threads_setTitle.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_stop_thread_sibling.py
+++ b/tests/gateway/test_stop_thread_sibling.py
@@ -89,6 +89,7 @@ async def test_stop_does_not_interrupt_sibling_when_unauthorized(monkeypatch):
 
     runner._interrupt_and_clear_session = _fake_interrupt
     runner._is_user_authorized = lambda source: False
+    runner._invalidate_session_run_generation = lambda *args, **kwargs: 1
 
     event = MessageEvent(
         text="/stop", message_type=MessageType.TEXT, source=_thread_source("userA")
@@ -100,8 +101,34 @@ async def test_stop_does_not_interrupt_sibling_when_unauthorized(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# /stop with no active agent still clears a stuck platform status (#32295)
+# /stop with no active agent still fences late callbacks and clears a stuck
+# platform status (#32295)
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_no_active_agent_invalidates_late_callbacks():
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    key = _per_user_key("userA")
+    runner.session_store = _FakeStore(key)
+    runner._is_user_authorized = lambda source: True
+    runner.adapters = {}
+    invalidations = []
+
+    def _record_invalidation(session_key, *, reason=""):
+        invalidations.append((session_key, reason))
+        return 1
+
+    runner._invalidate_session_run_generation = _record_invalidation
+
+    event = MessageEvent(
+        text="/stop", message_type=MessageType.TEXT, source=_thread_source("userA")
+    )
+    result = await runner._handle_stop_command(event)
+
+    assert invalidations == [(key, "stop_command_no_active")]
+    assert "no active" in str(getattr(result, "text", result)).lower()
 
 
 class _FakeStatusAdapter:
@@ -126,6 +153,7 @@ async def test_stop_no_active_agent_survives_status_clear_failure():
             raise RuntimeError("boom")
 
     runner.adapters = {Platform.DISCORD: _BoomAdapter()}
+    runner._invalidate_session_run_generation = lambda *args, **kwargs: 1
     runner._thread_metadata_for_source = (
         lambda source, reply_to_message_id=None: None
     )

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -428,7 +428,8 @@ platforms:
       # {title: "Start here", prompts: [{title: "Plan", message: "..."}]}
       suggested_prompts: []
 
-      # Title Agent/Assistant DM threads from the first user message.
+      # Best-effort title newly handled Agent/Assistant DM threads from the
+      # generated Hermes session title after an early completed exchange.
       # Default: true. Set false to leave Slack's default thread titles.
       assistant_thread_titles: true
 
@@ -455,7 +456,7 @@ platforms:
 | `platforms.slack.extra.rich_blocks` | `false` | When `true`, agent messages are rendered as [Block Kit](https://docs.slack.dev/block-kit/) blocks (headers, dividers, true nested lists, and native tables). A plain-text fallback is always sent. Tables over Slack's limits fall back to aligned monospace. No app reinstall required — it's a send-side change only. |
 | `platforms.slack.extra.feedback_buttons` | `false` | When `true` with `rich_blocks`, appends Slack-native feedback controls to final replies. |
 | `platforms.slack.extra.suggested_prompts` | `[]` | Up to four `{title, message}` prompts for Agent/Assistant DM entry points; accepts either a list or `{title, prompts}`. |
-| `platforms.slack.extra.assistant_thread_titles` | `true` | When `true`, names Agent/Assistant DM threads from the first user message. |
+| `platforms.slack.extra.assistant_thread_titles` | `true` | For newly handled Agent/Assistant DM threads, Hermes best-effort sets an automatic Slack thread title from the generated session title after an early completed exchange. Title generation, gateway restarts, stale sessions, cache eviction, or Slack API failures may leave Slack's default title in place. Set to `false` to disable automatic titles. |
 | `platforms.slack.extra.allow_bots` | `"none"` | Controls messages from other Slack bots: `"none"` ignores them, `"mentions"` accepts a bot message only when **that message itself** @mentions Hermes, and `"all"` accepts all of them. Use `"mentions"` for the safest bot-to-bot collaboration mode. See [Accepting messages from other bots](#accepting-messages-from-other-bots-allow_bots). |
 | `platforms.slack.extra.cron_continuable_surface` | `"thread"` | Delivery surface for [continuable cron jobs](../features/cron.md#flat-in-channel-continuation-slack). `"thread"` opens a dedicated thread per delivery (default); `"in_channel"` delivers flat into the channel timeline. Pair `in_channel` with `reply_in_thread: false` (and `require_mention: false`) so a plain channel reply continues the job. |
 


### PR DESCRIPTION
## What does this PR do?

Slack Agent/Assistant DM threads were titled from the raw first user message even though Hermes already generates a concise semantic session title after an early completed exchange.

This change removes the raw-prompt title mutation and best-effort sends Hermes's generated session title to Slack instead.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Remove eager Slack thread titling from inbound raw user prompts.
- Route the generated Hermes session title through the current `TurnRunner` auto-title callback.
- Restrict title callbacks to Slack Agent/Assistant DM lifecycle provenance; ordinary threaded IMs and MPIMs do not enter this lane.
- Fail closed for stale sessions, unknown workspaces, disabled configuration, malformed or non-finite timestamps, and threads predating the current gateway process.
- Distinguish explicit run invalidation (`/new`, `/stop`, stale-run eviction) from ordinary later turns with a small in-memory marker in the existing session state, closing pre-rotation and late-auxiliary-callback races without suppressing the first valid generated title.
- Reserve a bounded workspace/channel/thread key before Slack I/O so concurrent duplicates and ambiguous Slack failures do not cause repeated attempts while the reservation remains cached.
- Keep in-flight reservations protected while trimming completed reservations, preventing both self-eviction and eviction by newer concurrent title attempts under cache pressure.
- Keep lifecycle provenance and title reservations workspace-scoped and bounded.
- Preserve Telegram and Discord title callback behavior.
- Document the bounded, best-effort contract honestly: restarts, stale sessions, cache eviction, title-generation failure, or Slack API failure may leave Slack's default title in place.

No persistence ledger, durable schema/database change, session-history lookup, or route metadata is added.

## How to Test

1. Configure Slack Agent/Assistant DMs with `assistant_thread_titles: true`.
2. Start a new Slack Agent/Assistant DM thread and complete the first exchange.
3. Confirm Slack changes from its default title to Hermes's generated semantic title rather than the raw prompt.
4. Confirm later turns do not immediately repeat the title call while the bounded reservation remains cached.

Automated verification on current upstream `main`:

```text
scripts/run_tests.sh tests/gateway/test_slack.py tests/gateway/test_fast_command.py tests/gateway/test_stop_thread_sibling.py -q
# 193 passed

scripts/run_tests.sh tests/gateway/ -q
# 4,455 passed; 4 failed
# The same four failures reproduce unchanged on the exact clean upstream base:
# - shutdown diagnostic subprocess environment (1)
# - Linux abstract systemd socket unsupported on macOS (1)
# - optional WeCom XML dependency unavailable in this local environment (2)

ruff check gateway/run.py gateway/session_state.py gateway/slash_commands.py \
  plugins/platforms/slack/adapter.py tests/gateway/test_fast_command.py \
  tests/gateway/test_slack.py tests/gateway/test_stop_thread_sibling.py
# All checks passed

python -m py_compile gateway/run.py gateway/session_state.py gateway/slash_commands.py \
  plugins/platforms/slack/adapter.py tests/gateway/test_fast_command.py \
  tests/gateway/test_slack.py tests/gateway/test_stop_thread_sibling.py
# passed

git diff --cached --check
# passed
```

RED-capability checks: applying the original feature tests to the exact clean upstream base produced 20 expected failures. Three later adversarial regressions also failed first—active reservation eviction under cache pressure, reset invalidation before session-ID rotation, and `/stop` with no active agent leaving a pending title authorized—then passed after focused fixes. The complete candidate passed all 193 focused tests.

A live macOS Slack Agent/Assistant DM smoke test on the reviewed predecessor candidate also confirmed generated semantic titling and normal response streaming before the change was replayed cleanly onto current upstream `main`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3

The focused candidate suites are green. The broader gateway suite has four current-main baseline failures in unrelated files; GitHub CI remains the authoritative supported-environment full run.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config key changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

No screenshot included. The behavior was verified live in a Slack Agent/Assistant DM and through focused deterministic regressions.
