### PR TITLE
fix(desktop): gate session restore on profile initialization

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
@@ -1,0 +1,106 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $activeGatewayProfile, $profileInitialized } from '@/store/profile'
+import { stopUpdatePoller } from '@/store/updates'
+
+import { NEW_CHAT_ROUTE, sessionRoute } from '../../routes'
+
+import { useDesktopIntegrations } from './use-desktop-integrations'
+
+// Regression coverage for the cold-start restore race (issue #74387): the
+// restore effect must not read $activeGatewayProfile until adoptPrimaryProfile()
+// has resolved the real profile from the Electron backend. On mount the atom is
+// still the placeholder 'default', and reading profile-scoped localStorage keys
+// under 'default' restores the stale global key instead of the named profile's
+// scoped route/session.
+describe('useDesktopIntegrations cold-start restore', () => {
+  function baseProps(
+    navigate: (to: string, options?: { replace?: boolean }) => void
+  ): Parameters<typeof useDesktopIntegrations>[0] {
+    return {
+      chatOpen: false,
+      hasPreview: false,
+      locationPathname: NEW_CHAT_ROUTE,
+      navigate,
+      refreshSessions: vi.fn(),
+      resumeExhaustedSessionId: null,
+      routedSessionId: null,
+      runtimeIdByStoredSessionId: { current: new Map<string, string>() }
+    }
+  }
+
+  beforeEach(() => {
+    localStorage.clear()
+    $activeGatewayProfile.set('default')
+    $profileInitialized.set(false)
+  })
+
+  afterEach(() => {
+    cleanup()
+    stopUpdatePoller()
+    localStorage.clear()
+  })
+
+  it('waits for profile initialization, then restores the named profile\'s scoped route', () => {
+    // The named profile's prior run remembered a session route under its scoped
+    // key. The global keys hold pre-scoping leftovers that an un-gated restore
+    // would wrongly read at 'default'. (On mount the remember-route WRITE
+    // effect — declared before this one — runs first and overwrites the global
+    // route key with '/', so the unfixed code's leak surfaces via the stale
+    // global session id below; the scoped keys are untouched either way.)
+    localStorage.setItem('hermes.desktop.lastRoute', '/skills')
+    localStorage.setItem('hermes.desktop.lastRoute.atlas', '/session/atlas-session')
+    localStorage.setItem('hermes.desktop.lastSessionId', 'legacy-session')
+
+    const navigate = vi.fn()
+    renderHook(() => useDesktopIntegrations(baseProps(navigate)))
+
+    // Mounted with the placeholder 'default' profile: the restore must wait.
+    expect(navigate).not.toHaveBeenCalled()
+
+    // adoptPrimaryProfile() resolves the real profile after an IPC round-trip.
+    act(() => {
+      $activeGatewayProfile.set('atlas')
+      $profileInitialized.set(true)
+    })
+
+    expect(navigate).toHaveBeenCalledTimes(1)
+    expect(navigate).toHaveBeenCalledWith('/session/atlas-session', { replace: true })
+  })
+
+  it('falls back to the named profile\'s scoped session id, not a stale global one', () => {
+    // The route fallback path: no scoped route remembered, but the named
+    // profile did remember a session. The global id is a stale pre-scoping
+    // leftover that the un-gated restore would navigate to instead.
+    localStorage.setItem('hermes.desktop.lastSessionId', 'legacy-session')
+    localStorage.setItem('hermes.desktop.lastSessionId.atlas', 'atlas-session')
+
+    // Profile already resolved before the integrations mount (HMR survivor /
+    // adoptBoot path) — restore must run immediately on the correct profile.
+    $activeGatewayProfile.set('atlas')
+    $profileInitialized.set(true)
+
+    const navigate = vi.fn()
+    renderHook(() => useDesktopIntegrations(baseProps(navigate)))
+
+    expect(navigate).toHaveBeenCalledTimes(1)
+    expect(navigate).toHaveBeenCalledWith(sessionRoute('atlas-session'), { replace: true })
+  })
+
+  it('never restores when the window started away from the new-chat route', () => {
+    // A hidden-then-shown window keeps its own route: profile resolution later
+    // must not trigger a restore into the remembered route.
+    localStorage.setItem('hermes.desktop.lastRoute.atlas', '/session/atlas-session')
+    $activeGatewayProfile.set('atlas')
+
+    const navigate = vi.fn()
+    renderHook(() => useDesktopIntegrations({ ...baseProps(navigate), locationPathname: '/skills' }))
+
+    act(() => {
+      $profileInitialized.set(true)
+    })
+
+    expect(navigate).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -1,10 +1,11 @@
+import { useStore } from '@nanostores/react'
 import { useEffect, useRef } from 'react'
 
 import { closeActiveTab } from '@/app/chat/close-tab'
 import { openSession } from '@/app/open-session'
 import { storedSessionIdForNotification } from '@/lib/session-ids'
 import { respondToApprovalAction } from '@/store/native-notifications'
-import { $activeGatewayProfile } from '@/store/profile'
+import { $activeGatewayProfile, $profileInitialized } from '@/store/profile'
 import { openFolderAsProject } from '@/store/projects'
 import {
   $sessions,
@@ -87,14 +88,21 @@ export function useDesktopIntegrations({
   }, [locationPathname, routedSessionId])
 
   const restoredRef = useRef(false)
+  const profileInitialized = useStore($profileInitialized)
 
   // Restore once on cold start — only when the renderer booted at the default
   // route (a hidden-then-shown window keeps its own route). Prefer the full
   // remembered route (covers pages); fall back to the last session id.
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
-    if (restoredRef.current || locationPathname !== NEW_CHAT_ROUTE) {
-      restoredRef.current = true
+    // Don't restore until the gateway profile has been resolved from the
+    // backend. $activeGatewayProfile starts as 'default' but the real profile
+    // is set asynchronously by adoptPrimaryProfile(). Restoring before the
+    // real profile is known reads from the wrong scoped localStorage key.
+    if (restoredRef.current || locationPathname !== NEW_CHAT_ROUTE || !profileInitialized) {
+      if (locationPathname !== NEW_CHAT_ROUTE) {
+        restoredRef.current = true
+      }
 
       return
     }
@@ -114,7 +122,7 @@ export function useDesktopIntegrations({
     if (last) {
       navigate(sessionRoute(last), { replace: true })
     }
-  }, [locationPathname, navigate])
+  }, [locationPathname, navigate, profileInitialized])
 
   useEffect(() => {
     if (!resumeExhaustedSessionId) {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -26,7 +26,12 @@ import {
 } from '@/store/gateway'
 import { $gatewaySwitching, wipeSessionListsForGatewaySwitch } from '@/store/gateway-switch'
 import { notify, notifyError } from '@/store/notifications'
-import { $activeGatewayProfile, normalizeProfileKey, touchActiveGatewayBackend } from '@/store/profile'
+import {
+  $activeGatewayProfile,
+  $profileInitialized,
+  normalizeProfileKey,
+  touchActiveGatewayBackend
+} from '@/store/profile'
 import {
   $activeSessionId,
   $connection,
@@ -263,6 +268,8 @@ export function useGatewayBoot({
         void ensureGatewayForProfile(profileKey)
       } catch {
         $activeGatewayProfile.set('default')
+      } finally {
+        $profileInitialized.set(true)
       }
     }
 
@@ -571,6 +578,7 @@ export function useGatewayBoot({
 
       const profile = survivor?.profile ?? $activeGatewayProfile.get()
       $activeGatewayProfile.set(profile)
+      $profileInitialized.set(true)
       void ensureGatewayForProfile(profile)
 
       // Mirror the current (already-open) socket state into the composer so the

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -150,6 +150,14 @@ export async function switchProfile(name: string): Promise<void> {
 // to the primary (window) backend's profile on boot.
 export const $activeGatewayProfile = atom<string>('default')
 
+// Set to true after the primary profile has been resolved from the Electron
+// backend (adoptPrimaryProfile / adoptBoot). Cold-start restore effects that
+// read $activeGatewayProfile MUST wait for this flag — the initial 'default'
+// value is a placeholder, and restoring before the real profile is known reads
+// the wrong scoped localStorage key (hermes.desktop.lastRoute instead of
+// hermes.desktop.lastRoute.<profile>).
+export const $profileInitialized = atom<boolean>(false)
+
 // Profile for the NEXT new chat (chosen via the new-chat picker). null = primary
 // / default, so single-profile users are unaffected.
 export const $newChatProfile = atom<string | null>(null)


### PR DESCRIPTION
## Description

After `c4212b945` scoped `getRememberedRoute`/`setRememberedRoute` to per-profile localStorage keys, the cold-start restore effect in `use-desktop-integrations.ts` still reads `$activeGatewayProfile.get()` inside the effect body without subscribing to it. On mount, `$activeGatewayProfile` is `'default'` (its initial value). The real profile is set asynchronously by `adoptPrimaryProfile()`. The restore effect fires first, reads from the **global** unsuffixed key `hermes.desktop.lastRoute`, and finds the stale value from before per-profile scoping was introduced. The write side correctly writes to the **scoped** key — but that key is never read at startup, so every restart restores the stale global key.

## The fix

A `$profileInitialized` atom (initialized `false`, set `true` in `adoptPrimaryProfile` / `adoptBoot` after the real profile is resolved) gates the restore effect. The restore waits until the profile is known, then reads from the correct scoped key.

Simply adding `$activeGatewayProfile` to the dependency array is insufficient — the first render still runs with `'default'`, and `restoredRef` blocks the second run with the correct profile. A separate readiness signal is needed.

## Changes

- **`store/profile.ts`**: Add `$profileInitialized` atom
- **`app/gateway/hooks/use-gateway-boot.ts`**: Set `$profileInitialized` after profile resolution in `adoptPrimaryProfile()` (finally block) and `adoptBoot()`
- **`app/contrib/hooks/use-desktop-integrations.ts`**: Subscribe to `$profileInitialized` via `useStore`, gate the restore effect on `profileInitialized`, add to dependency array

## Reviewer Notes

- The `restoredRef` logic is adjusted: when `!profileInitialized`, we return WITHOUT setting `restoredRef.current = true`, so the effect re-runs when `profileInitialized` becomes true. The original behavior (set `restoredRef` when not at `NEW_CHAT_ROUTE`) is preserved.
- For the default profile, `rememberedRouteKey('default')` returns the global unsuffixed key — the same key used before scoping. No behavioral change for single-profile users.
- The `adoptBoot()` HMR path also sets `$profileInitialized` to cover the case where the Desktop window persists across a hot-reload update.
- The `finally` block in `adoptPrimaryProfile` guarantees `$profileInitialized` is set even when the IPC call throws or profile setup fails — the error path falls back to `'default'` in the `catch`, and the `finally` unblocks the restore effect regardless.

Closes https://github.com/NousResearch/hermes-agent/issues/74387