### PR TITLE
fix(agent): rotate Gemini API keys immediately on HTTP 429 quota errors

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1106,7 +1106,12 @@ def recover_with_credential_pool(
                 or "usage limit reached" in context_message
                 or "usage limit has been reached" in context_message
             )
-        if not has_retried_429 and not usage_limit_reached:
+        provider_name = str(getattr(agent, "provider", "") or "").strip().lower()
+        if (
+            not has_retried_429
+            and not usage_limit_reached
+            and provider_name != "gemini"
+        ):
             return False, True
         rotate_status = status_code if status_code is not None else 429
         next_entry = _rotate_failed_credential(rotate_status)


### PR DESCRIPTION
Google Gemini rate limits are key/project-scoped. Retrying the same key on an HTTP 429 quota error resends large prompts into an exhausted bucket before eventually rotating. This patch checks provider_name != 'gemini' before applying the retry-once delay, so Gemini credentials immediately mark as exhausted and rotate to the next key in the pool.