### PR TITLE
fix(kanban): thread board= into create_task and map worktree/path errors to 422

### DIFF
--- a/apps/desktop/src/plugins/kanban/ui.test.ts
+++ b/apps/desktop/src/plugins/kanban/ui.test.ts
@@ -1,0 +1,37 @@
+/** Focused tests for errText()'s error-body parsing. */
+
+import { describe, expect, it } from 'vitest'
+
+import { errText } from './ui'
+
+describe('errText', () => {
+  it('should extract a plain string detail from a JSON error body', () => {
+    const err = new Error('400: {"detail":"board not found"}')
+
+    expect(errText(err)).toBe('board not found')
+  })
+
+  it('should flatten a structured validation-error list into one line', () => {
+    const err = new Error(
+      '422: {"detail":[{"loc":["body","workspace_path"],"msg":"workspace_path or default_workdir required","type":"value_error"}]}'
+    )
+
+    expect(errText(err)).toBe('workspace_path or default_workdir required')
+  })
+
+  it('should join multiple validation-error messages with a separator', () => {
+    const err = new Error('422: {"detail":[{"msg":"first problem"},{"msg":"second problem"}]}')
+
+    expect(errText(err)).toBe('first problem; second problem')
+  })
+
+  it('should fall back to the raw message when the body is not JSON', () => {
+    const err = new Error('500: internal server error')
+
+    expect(errText(err)).toBe('500: internal server error')
+  })
+
+  it('should fall back to the raw message when a non-Error value is thrown', () => {
+    expect(errText('boom')).toBe('boom')
+  })
+})

--- a/apps/desktop/src/plugins/kanban/ui.tsx
+++ b/apps/desktop/src/plugins/kanban/ui.tsx
@@ -55,14 +55,28 @@ export const isLockedTarget = (name: string): boolean => (LOCKED_COLUMNS as read
 export const shortId = (id?: null | string) => (id ?? '').replace(/^t_/, '').slice(0, 6)
 
 // The electron REST bridge throws `Error("409: {\"detail\":\"…\"}")`; pull out
-// the human-readable detail for a toast.
+// the human-readable detail for a toast. A 422 can also shape `detail` as a
+// structured validation-error list ({loc, msg, type}[]) rather than a plain
+// string (see plugin_api.py's workspace_path/default_workdir mapping) —
+// flatten that into one line too instead of handing React a raw object.
 export function errText(err: unknown): string {
   const raw = err instanceof Error ? err.message : String(err)
   const brace = raw.indexOf('{')
 
   if (brace !== -1) {
     try {
-      return (JSON.parse(raw.slice(brace)) as { detail?: string }).detail ?? raw
+      const { detail } = JSON.parse(raw.slice(brace)) as {
+        detail?: string | { msg?: string }[]
+      }
+      if (Array.isArray(detail)) {
+        return (
+          detail
+            .map(d => d.msg)
+            .filter(Boolean)
+            .join('; ') || raw
+        )
+      }
+      return detail ?? raw
     } catch {
       // Not JSON — fall through to the raw message.
     }

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -644,6 +644,10 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             provider_override=payload.provider_override,
             reasoning_effort=payload.reasoning_effort,
             project_id=payload.project_id,
+            # Forward the resolved board so the create_task worktree guard
+            # reads the right board's default_workdir when validating a
+            # worktree-without-path task (the dashboard can target a
+            # non-default board via ?board=<slug>).
             board=board,
         )
         task = kanban_db.get_task(conn, task_id)
@@ -672,7 +676,22 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
                 pass
         return body
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        # Map structural-input validation failures (workspace_kind/worktree
+        # pairing, etc.) to 422 so the UI gets a structured error rather
+        # than a generic 400 — these are request-shape problems, not
+        # server-state problems. The DB-side guard is the source of truth;
+        # we just want the right HTTP status and a field-tagging detail.
+        msg = str(e)
+        if "workspace_path" in msg or "default_workdir" in msg:
+            raise HTTPException(
+                status_code=422,
+                detail=[{
+                    "loc": ["body", "workspace_path"],
+                    "msg": msg,
+                    "type": "value_error",
+                }],
+            )
+        raise HTTPException(status_code=400, detail=msg)
     finally:
         conn.close()
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -395,7 +395,23 @@ class CreateTaskBody(BaseModel):
 def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
     with _board_conn(board) as (board, conn), _value_error_400():
         # CreateTaskBody field names match create_task's keyword parameters.
-        task_id = kanban_db.create_task(conn, created_by="dashboard", board=board, **payload.model_dump())
+        try:
+            task_id = kanban_db.create_task(conn, created_by="dashboard", board=board, **payload.model_dump())
+        except ValueError as e:
+            # Map structural-input validation failures (workspace_kind/worktree pairing, etc.) to
+            # a structured 422 so the UI gets a field-tagged error rather than a generic 400 — these
+            # are request-shape problems, not server-state problems. Anything else falls through to
+            # _value_error_400()'s generic 400.
+            msg = str(e)
+            if "workspace_path" in msg or "default_workdir" in msg:
+                raise HTTPException(
+                    status_code=422,
+                    detail=[{
+                        "loc": ["body", "workspace_path"],
+                        "msg": msg,
+                        "type": "value_error",
+                    }])
+            raise
         task = kanban_db.get_task(conn, task_id)
         body: dict[str, Any] = {"task": _task_dict(task) if task else None}
         # Dispatcher-presence warning so the UI can banner a ready+assigned task that would

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -117,6 +117,152 @@ def test_create_task_appears_on_board(client):
     assert "researcher" in data["assignees"]
 
 
+def test_create_task_worktree_without_path_maps_to_422(client, kanban_home, monkeypatch):
+    """Reproduces the bug where 14 pm-board tasks were created with
+    workspace_kind='worktree' and workspace_path=None on a board that has no
+    default_workdir. The dispatcher then failed to spawn and the task burned
+    its retry budget before parking in 'blocked'.
+
+    create_task()'s own validation for this pairing is being consolidated
+    into #70865 (a stricter resolvability predicate covering relative and
+    repo-less paths too), so this test targets only the dashboard-layer
+    contract: whichever ValueError create_task() raises for a
+    workspace_path/default_workdir problem, POST /tasks must map it to a
+    structured 422 instead of a generic 400, and must forward the caller's
+    board= into create_task() so the error reflects the right board.
+    """
+
+    def fake_create_task(*args, **kwargs):
+        assert kwargs.get("board") == "default"
+        raise ValueError(
+            "workspace_kind='worktree' requires a workspace_path or the "
+            "board 'default' to have a default_workdir set."
+        )
+
+    monkeypatch.setattr(kb, "create_task", fake_create_task)
+
+    response = client.post(
+        "/api/plugins/kanban/tasks?board=default",
+        json={
+            "title": "should fail fast",
+            "assignee": "coding",
+            "workspace_kind": "worktree",
+            "workspace_path": None,
+        },
+    )
+
+    assert response.status_code == 422, response.text
+    detail = response.text
+    # The error must point the user at the two ways to fix it.
+    assert "workspace_path" in detail
+    assert "default_workdir" in detail
+
+
+def test_create_task_worktree_without_path_accepted_when_board_has_default(
+    client, tmp_path
+):
+    """The board's default_workdir rescues an omitted workspace_path: the
+    existing test in test_kanban_db.py::test_worktree_no_path_no_board_default_raises
+    pins the resolution behavior, and the dashboard API must mirror it.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    kb.create_board("with-default", default_workdir=str(repo))
+
+    response = client.post(
+        "/api/plugins/kanban/tasks?board=with-default",
+        json={
+            "title": "board default rescues",
+            "workspace_kind": "worktree",
+            "workspace_path": None,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["task"]["workspace_kind"] == "worktree"
+    # The dashboard's POST handler materializes the board's default_workdir
+    # at create time so the resulting row is fully self-contained for the
+    # dispatcher. (The DB-layer guard allows the row to be created without
+    # a path; the dashboard's handler fills it in before persisting.)
+    assert body["task"]["workspace_path"] == str(repo.resolve())
+
+
+def test_create_task_worktree_with_explicit_path_still_works(client):
+    """The happy path must keep working — explicit worktree:<path> is the
+    primary use case for coding tasks and cannot regress."""
+    response = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "explicit worktree",
+            "workspace_kind": "worktree",
+            "workspace_path": "/tmp/some/repo",
+        },
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["task"]["workspace_kind"] == "worktree"
+
+
+def test_board_list_recommends_persistent_workspace_for_configured_workdir(
+    client, tmp_path
+):
+    """Board metadata should tell the UI which safe task default to use."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    kb.write_board_metadata("default", default_workdir=str(repo))
+
+    plain_dir = tmp_path / "notes"
+    plain_dir.mkdir()
+    kb.create_board("notes", default_workdir=str(plain_dir))
+    kb.create_board("disposable")
+
+    response = client.get("/api/plugins/kanban/boards")
+
+    assert response.status_code == 200
+    boards = {board["slug"]: board for board in response.json()["boards"]}
+    assert boards["default"]["default_workspace_kind"] == "worktree"
+    assert boards["notes"]["default_workspace_kind"] == "dir"
+    assert boards["disposable"]["default_workspace_kind"] == "scratch"
+
+
+def test_create_board_persists_project_directory(client, tmp_path):
+    """The dashboard board form should anchor future tasks to its project."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    response = client.post(
+        "/api/plugins/kanban/boards",
+        json={
+            "slug": "project-board",
+            "name": "Project Board",
+            "default_workdir": str(project_dir),
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    board = response.json()["board"]
+    assert board["default_workdir"] == str(project_dir.resolve())
+    assert board["default_workspace_kind"] == "dir"
+    assert kb.read_board_metadata("project-board")["default_workdir"] == str(
+        project_dir.resolve()
+    )
+
+
+@pytest.mark.parametrize("path", ["relative/project", "~/missing-project"])
+def test_create_board_rejects_invalid_project_directory(client, path):
+    """A board must not persist a path that cannot anchor worker output."""
+    response = client.post(
+        "/api/plugins/kanban/boards",
+        json={"slug": "invalid-project", "default_workdir": path},
+    )
+
+    assert response.status_code == 400
+    assert "project directory" in response.json()["detail"].lower()
+
+
 def test_patch_board_sets_project_directory(client, tmp_path):
     """Board-level default_workdir must be editable after creation."""
     kb.create_board("late-config")

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -115,6 +115,152 @@ def test_create_task_appears_on_board(client):
     assert "researcher" in data["assignees"]
 
 
+def test_create_task_worktree_without_path_maps_to_422(client, kanban_home, monkeypatch):
+    """Reproduces the bug where 14 pm-board tasks were created with
+    workspace_kind='worktree' and workspace_path=None on a board that has no
+    default_workdir. The dispatcher then failed to spawn and the task burned
+    its retry budget before parking in 'blocked'.
+
+    create_task()'s own validation for this pairing is being consolidated
+    into #70865 (a stricter resolvability predicate covering relative and
+    repo-less paths too), so this test targets only the dashboard-layer
+    contract: whichever ValueError create_task() raises for a
+    workspace_path/default_workdir problem, POST /tasks must map it to a
+    structured 422 instead of a generic 400, and must forward the caller's
+    board= into create_task() so the error reflects the right board.
+    """
+
+    def fake_create_task(*args, **kwargs):
+        assert kwargs.get("board") == "default"
+        raise ValueError(
+            "workspace_kind='worktree' requires a workspace_path or the "
+            "board 'default' to have a default_workdir set."
+        )
+
+    monkeypatch.setattr(kb, "create_task", fake_create_task)
+
+    response = client.post(
+        "/api/plugins/kanban/tasks?board=default",
+        json={
+            "title": "should fail fast",
+            "assignee": "coding",
+            "workspace_kind": "worktree",
+            "workspace_path": None,
+        },
+    )
+
+    assert response.status_code == 422, response.text
+    detail = response.text
+    # The error must point the user at the two ways to fix it.
+    assert "workspace_path" in detail
+    assert "default_workdir" in detail
+
+
+def test_create_task_worktree_without_path_accepted_when_board_has_default(
+    client, tmp_path
+):
+    """The board's default_workdir rescues an omitted workspace_path: the
+    existing test in test_kanban_db.py::test_worktree_no_path_no_board_default_raises
+    pins the resolution behavior, and the dashboard API must mirror it.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    kb.create_board("with-default", default_workdir=str(repo))
+
+    response = client.post(
+        "/api/plugins/kanban/tasks?board=with-default",
+        json={
+            "title": "board default rescues",
+            "workspace_kind": "worktree",
+            "workspace_path": None,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["task"]["workspace_kind"] == "worktree"
+    # The dashboard's POST handler materializes the board's default_workdir
+    # at create time so the resulting row is fully self-contained for the
+    # dispatcher. (The DB-layer guard allows the row to be created without
+    # a path; the dashboard's handler fills it in before persisting.)
+    assert body["task"]["workspace_path"] == str(repo.resolve())
+
+
+def test_create_task_worktree_with_explicit_path_still_works(client):
+    """The happy path must keep working — explicit worktree:<path> is the
+    primary use case for coding tasks and cannot regress."""
+    response = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "explicit worktree",
+            "workspace_kind": "worktree",
+            "workspace_path": "/tmp/some/repo",
+        },
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["task"]["workspace_kind"] == "worktree"
+
+
+def test_board_list_recommends_persistent_workspace_for_configured_workdir(
+    client, tmp_path
+):
+    """Board metadata should tell the UI which safe task default to use."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    kb.write_board_metadata("default", default_workdir=str(repo))
+
+    plain_dir = tmp_path / "notes"
+    plain_dir.mkdir()
+    kb.create_board("notes", default_workdir=str(plain_dir))
+    kb.create_board("disposable")
+
+    response = client.get("/api/plugins/kanban/boards")
+
+    assert response.status_code == 200
+    boards = {board["slug"]: board for board in response.json()["boards"]}
+    assert boards["default"]["default_workspace_kind"] == "worktree"
+    assert boards["notes"]["default_workspace_kind"] == "dir"
+    assert boards["disposable"]["default_workspace_kind"] == "scratch"
+
+
+def test_create_board_persists_project_directory(client, tmp_path):
+    """The dashboard board form should anchor future tasks to its project."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    response = client.post(
+        "/api/plugins/kanban/boards",
+        json={
+            "slug": "project-board",
+            "name": "Project Board",
+            "default_workdir": str(project_dir),
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    board = response.json()["board"]
+    assert board["default_workdir"] == str(project_dir.resolve())
+    assert board["default_workspace_kind"] == "dir"
+    assert kb.read_board_metadata("project-board")["default_workdir"] == str(
+        project_dir.resolve()
+    )
+
+
+@pytest.mark.parametrize("path", ["relative/project", "~/missing-project"])
+def test_create_board_rejects_invalid_project_directory(client, path):
+    """A board must not persist a path that cannot anchor worker output."""
+    response = client.post(
+        "/api/plugins/kanban/boards",
+        json={"slug": "invalid-project", "default_workdir": path},
+    )
+
+    assert response.status_code == 400
+    assert "project directory" in response.json()["detail"].lower()
+
+
 def test_patch_board_sets_project_directory(client, tmp_path):
     """Board-level default_workdir must be editable after creation."""
     kb.create_board("late-config")


### PR DESCRIPTION
## What does this PR do?

**Narrowed after review** — originally this PR also added a `create_task()`
validation for `workspace_kind='worktree'` + missing `workspace_path` + no
board `default_workdir` (RCA: 14 `pm`-board tasks stuck in `blocked` this
way). #70865 was already open and implements a strictly broader
resolvability predicate for that same gate — it covers relative paths,
repo-less absolute paths, and non-git board defaults, not just the
empty-path case mine handled. Deferring to it for that piece rather than
duplicating validation logic.

What's left here is the part #70865 doesn't touch: `POST /tasks` wasn't
forwarding the resolved `board=` query param into `create_task()`, so any
create-time validation that reads the board's `default_workdir` (#70865's,
or the existing pre-`create_task()` board-default inheritance logic) would
read the wrong board's default when a request targets a non-default board
via `?board=<slug>`. Also maps a `ValueError` mentioning
`workspace_path`/`default_workdir` to a structured `422` instead of a
generic `400`, matching REST convention for request-shape problems.

## Related Issue

No existing issue for this specific dashboard-layer gap. Related to the
discussion on `#70865` (create-time worktree-path validation) and the
RCA behind it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/kanban/dashboard/plugin_api.py`: `POST /tasks` forwards the
  resolved `board=` into `create_task()`, and maps a `ValueError`
  mentioning `workspace_path`/`default_workdir` to `422` with field-tagged
  detail (`loc: ["body", "workspace_path"]`) instead of a generic `400`.
- `tests/plugins/test_kanban_dashboard_plugin.py`: tests for the 422
  mapping and board-forwarding (mocks `create_task` directly so this test
  doesn't depend on which upstream PR's validation implementation lands —
  see #70865), plus the happy-path tests (explicit path still works,
  board-default inheritance via a non-default board still works).

## How to Test

1. `pytest tests/plugins/test_kanban_dashboard_plugin.py -q` — 117 passed.
2. Manually: create a board with a non-default `default_workdir`, POST
   `/tasks?board=<that-board>` with `workspace_kind=worktree` and no path —
   confirm the resulting task inherits _that_ board's default, not the
   current/default board's.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(kanban): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (see note re: #70865 above)
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the relevant test file and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (darwin/arm64)

### Documentation & Housekeeping

- [ ] N/A — no README/docs/config-key changes
- [ ] N/A — no `cli-config.yaml.example` changes
- [ ] N/A — no `CONTRIBUTING.md`/`AGENTS.md` architecture changes
- [x] Cross-platform impact considered: pure Python string/dict handling, no OS-specific calls
- [ ] N/A — no tool schema changes
