### PR TITLE
ci(codeql): add minimal-scope CodeQL workflow (security-extended, weekly + push-to-main)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,11 +1,13 @@
 # CodeQL security analysis for hermes-agent.
 #
 # Scope:
-#   - queries: security-extended (CVE-class findings only).
-#     We do NOT enable security-and-quality because the "quality" set
-#     is FP-heavy on a single-maintainer Python codebase (e.g. it
-#     flags standard library trust-boundary patterns the project
-#     explicitly relies on).
+#   - queries: security-extended, ADDED ON TOP OF CodeQL's default query
+#     suite (that's how `queries: security-extended` behaves — it augments
+#     the default suite, it does not replace it). We do NOT additionally
+#     enable security-and-quality because the "quality" set is FP-heavy on
+#     a single-maintainer Python codebase (e.g. it flags standard library
+#     trust-boundary patterns the project explicitly relies on) — that's
+#     the query-set boundary this workflow actually draws.
 #   - languages: python + javascript (the two source ecosystems on this
 #     side; TypeScript is bundled into the JS analysis per CodeQL docs).
 #     We do not analyze GitHub Actions workflows — actions are pinned
@@ -21,7 +23,7 @@
 #   - per-push: ~3-6 min
 #   - weekly scheduled: ~3-6 min
 # Branch protections: the per-push block can be skipped on a docs-only
-# change via `[skip ci]` or `[codeql skip]` in the commit message.
+# change via `[skip ci]` in the commit message.
 
 name: "CodeQL"
 
@@ -57,7 +59,7 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@3b0bd1d116c0bde30213346b22d4f634d96a2fb0  # v3
+        uses: github/codeql-action/init@a2983b8bed1923f44751c5c43237f479442827b3  # v3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -66,6 +68,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@3b0bd1d116c0bde30213346b22d4f634d96a2fb0  # v3
+        uses: github/codeql-action/analyze@a2983b8bed1923f44751c5c43237f479442827b3  # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,71 @@
+# CodeQL security analysis for hermes-agent.
+#
+# Scope:
+#   - queries: security-extended (CVE-class findings only).
+#     We do NOT enable security-and-quality because the "quality" set
+#     is FP-heavy on a single-maintainer Python codebase (e.g. it
+#     flags standard library trust-boundary patterns the project
+#     explicitly relies on).
+#   - languages: python + javascript (the two source ecosystems on this
+#     side; TypeScript is bundled into the JS analysis per CodeQL docs).
+#     We do not analyze GitHub Actions workflows — actions are pinned
+#     to full commit SHAs, and supply-chain-audit.yml already covers
+#     that surface.
+#
+# Triggers:
+#   - push to main (PR-critical findings)
+#   - weekly cron on Monday 06:00 UTC (one slow scan per week, catches
+#     findings between push events without blocking every PR)
+#
+# Minutes cost (rough, depends on repo size):
+#   - per-push: ~3-6 min
+#   - weekly scheduled: ~3-6 min
+# Branch protections: the per-push block can be skipped on a docs-only
+# change via `[skip ci]` or `[codeql skip]` in the commit message.
+
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@3b0bd1d116c0bde30213346b22d4f634d96a2fb0  # v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@3b0bd1d116c0bde30213346b22d4f634d96a2fb0  # v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Adds a minimal-scope GitHub CodeQL workflow for CVE-class findings on push-to-`main` and on a weekly Monday 06:00 UTC schedule.

## Scope (deliberately minimal)

- **queries:** `security-extended` only (NOT `security-and-quality` — too FP-heavy on a single-maintainer Python codebase)
- **languages:** `python` + `javascript-typescript` (the two source ecosystems on this side; workflow files are pinned to commit SHAs and already covered by `supply-chain-audit.yml`, so excluded here)
- **triggers:** push-to-main + weekly cron + `workflow_dispatch`
- **action pins:** full 40-char SHAs per repo convention (`actions/checkout@de0fac2e4…`, `github/codeql-action@3b0bd1d11…`)

## Why not also enable the other GitHub security toggles?

- `dependabot.yml` already exists and is scoped to `github-actions` only with an explicit pinning-vs-auto-bump policy in its header comment. Enabling general Dependabot version updates would conflict with that.
- `osv-scanner.yml` and `supply-chain-audit.yml` already exist in `.github/workflows/` — adding CodeQL on top gives incremental value (source-level taint analysis) without duplicating them.

## Cost estimate

- Per-push to main: ~3–6 min CI
- Weekly schedule: ~3–6 min CI
- Total new overhead: ~6–12 min/week on top of existing CI matrix

## Test plan

- [ ] Confirm the workflow file is valid YAML and passes actionlint in CI
- [ ] Trigger `workflow_dispatch` from this PR branch and confirm both matrix legs (`python`, `javascript-typescript`) complete successfully against the current `main`
- [ ] Wait for first weekly schedule (Monday 06:00 UTC) and confirm no false-positive spike beyond `security-extended`'s expected baseline
- [ ] After 1 week, review Security tab → Code scanning alerts and triage