### PR TITLE
feat(verification): add read-only status accessor

### DIFF
--- a/agent/verification_evidence.py
+++ b/agent/verification_evidence.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Iterator, Optional
+from urllib.parse import quote
 
 from hermes_constants import get_hermes_home
 
@@ -30,6 +31,7 @@ _MAX_TOTAL_UNREFERENCED_EVENTS = 10_000
 _AD_HOC_SCRIPT_NAME_PREFIXES = ("hermes-verify-", "hermes-ad-hoc-")
 _VERIFY_SCHEMA_VERSION = 1
 _SHELL_SPLIT_RE = re.compile(r"\s*(?:&&|\|\||;)\s*")
+_REQUIRED_STATUS_TABLES = frozenset({"verification_state", "verification_events"})
 
 
 @dataclass(frozen=True)
@@ -411,6 +413,76 @@ def _prune_old_events(conn: sqlite3.Connection, *, session_id: str, root: str) -
     )
 
 
+def _unverified_status(*, session_id: str, root: str, changed_paths: list[str] | None = None) -> dict[str, Any]:
+    return {
+        "status": "unverified",
+        "evidence": None,
+        "root": root,
+        "session_id": session_id,
+        "changed_paths": changed_paths or [],
+    }
+
+
+def _status_from_rows(
+    *,
+    session_id: str,
+    root: str,
+    state: sqlite3.Row | None,
+    event: sqlite3.Row | None,
+) -> dict[str, Any]:
+    if state is None:
+        return _unverified_status(session_id=session_id, root=root)
+
+    changed_paths: list[str] = []
+    try:
+        changed_paths = json.loads(state["changed_paths_json"] or "[]")
+    except (TypeError, ValueError):
+        changed_paths = []
+
+    if event is None:
+        return _unverified_status(session_id=session_id, root=root, changed_paths=changed_paths)
+
+    evidence = dict(event)
+    if state["last_edit_at"] and state["last_edit_at"] > evidence["created_at"]:
+        status = "stale"
+    else:
+        status = evidence["status"]
+    return {
+        "status": status,
+        "evidence": evidence,
+        "root": root,
+        "session_id": session_id,
+        "changed_paths": changed_paths,
+    }
+
+
+def _fetch_status_rows(
+    conn: sqlite3.Connection,
+    *,
+    session_id: str,
+    root: str,
+) -> tuple[sqlite3.Row | None, sqlite3.Row | None]:
+    state = conn.execute(
+        """
+        SELECT last_event_id, last_edit_at, changed_paths_json
+        FROM verification_state
+        WHERE session_id = ? AND root = ?
+        """,
+        (session_id, root),
+    ).fetchone()
+    event = None
+    if state is not None and state["last_event_id"] is not None:
+        event = conn.execute(
+            "SELECT * FROM verification_events WHERE id = ?",
+            (state["last_event_id"],),
+        ).fetchone()
+    return state, event
+
+
+def _sqlite_readonly_uri(path: Path) -> str:
+    return f"file:{quote(str(path), safe='/:')}?mode=ro"
+
+
 def classify_verification_command(
     command: str,
     *,
@@ -597,53 +669,41 @@ def verification_status(
     root = str(facts.get("root") or Path(cwd or ".").resolve())
     with _DB_LOCK:
         with _transaction() as conn:
-            state = conn.execute(
-                """
-                SELECT last_event_id, last_edit_at, changed_paths_json
-                FROM verification_state
-                WHERE session_id = ? AND root = ?
-                """,
-                (sid, root),
-            ).fetchone()
-            if state is None:
-                return {
-                    "status": "unverified",
-                    "evidence": None,
-                    "root": root,
-                    "session_id": sid,
-                    "changed_paths": [],
-                }
-            event = None
-            if state["last_event_id"] is not None:
-                event = conn.execute(
-                    "SELECT * FROM verification_events WHERE id = ?",
-                    (state["last_event_id"],),
-                ).fetchone()
+            state, event = _fetch_status_rows(conn, session_id=sid, root=root)
 
-    changed_paths: list[str] = []
+    return _status_from_rows(session_id=sid, root=root, state=state, event=event)
+
+
+def verification_status_readonly(
+    *,
+    session_id: str,
+    root: str | Path,
+    db_path: str | Path,
+) -> dict[str, Any]:
+    """Return verification state from an existing ledger without mutating it."""
+
+    sid = str(session_id)
+    root_str = str(root)
+    path = Path(db_path)
+    if not path.exists():
+        return _unverified_status(session_id=sid, root=root_str)
+
+    conn = sqlite3.connect(_sqlite_readonly_uri(path), uri=True)
+    conn.row_factory = sqlite3.Row
     try:
-        changed_paths = json.loads(state["changed_paths_json"] or "[]")
-    except (TypeError, ValueError):
-        changed_paths = []
-
-    if event is None:
-        return {
-            "status": "unverified",
-            "evidence": None,
-            "root": root,
-            "session_id": sid,
-            "changed_paths": changed_paths,
-        }
-
-    evidence = dict(event)
-    if state["last_edit_at"] and state["last_edit_at"] > evidence["created_at"]:
-        status = "stale"
-    else:
-        status = evidence["status"]
-    return {
-        "status": status,
-        "evidence": evidence,
-        "root": root,
-        "session_id": sid,
-        "changed_paths": changed_paths,
-    }
+        conn.execute("PRAGMA query_only=ON")
+        conn.execute("PRAGMA busy_timeout=5000")
+        rows = conn.execute(
+            """
+            SELECT name FROM sqlite_master
+            WHERE type = 'table'
+              AND name IN ('verification_state', 'verification_events')
+            """
+        ).fetchall()
+        existing_tables = {row["name"] for row in rows}
+        if not _REQUIRED_STATUS_TABLES.issubset(existing_tables):
+            return _unverified_status(session_id=sid, root=root_str)
+        state, event = _fetch_status_rows(conn, session_id=sid, root=root_str)
+        return _status_from_rows(session_id=sid, root=root_str, state=state, event=event)
+    finally:
+        conn.close()

--- a/tests/agent/test_verification_evidence.py
+++ b/tests/agent/test_verification_evidence.py
@@ -1,14 +1,18 @@
 import json
+import os
 import sqlite3
+import subprocess
 import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from agent.verification_evidence import (
+    _ensure_schema,
     classify_verification_command,
     mark_workspace_edited,
     record_terminal_result,
     verification_status,
+    verification_status_readonly,
 )
 
 
@@ -24,6 +28,59 @@ def _node_project(root: Path) -> None:
 
 def _python_project(root: Path) -> None:
     (root / "pyproject.toml").write_text("[tool.pytest.ini_options]\n")
+
+
+def _create_verification_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        _ensure_schema(conn)
+
+
+def _insert_verification_event(
+    db_path: Path,
+    *,
+    session_id: str = "s1",
+    root: Path,
+    status: str = "passed",
+    created_at: str = "2026-01-01T00:00:00+00:00",
+    last_edit_at: str | None = None,
+    changed_paths_json: str = "[]",
+    state_event_id: int | None = None,
+) -> int:
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.execute(
+            """
+            INSERT INTO verification_events(
+                created_at, session_id, cwd, root, command, canonical_command,
+                kind, scope, status, exit_code, output_summary
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                created_at,
+                session_id,
+                str(root),
+                str(root),
+                "python -m pytest",
+                "pytest",
+                "test",
+                "full",
+                status,
+                0 if status == "passed" else 1,
+                "summary",
+            ),
+        )
+        if cur.lastrowid is None:
+            raise RuntimeError("verification event insert did not return an id")
+        event_id = int(cur.lastrowid)
+        conn.execute(
+            """
+            INSERT INTO verification_state(
+                session_id, root, last_event_id, last_edit_at, changed_paths_json
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (session_id, str(root), state_event_id if state_event_id is not None else event_id, last_edit_at, changed_paths_json),
+        )
+        conn.commit()
+        return event_id
 
 
 def test_classifies_targeted_project_verify_command(tmp_path, monkeypatch):
@@ -424,3 +481,241 @@ def test_windows_backslash_ad_hoc_script_path_is_matched(tmp_path, monkeypatch):
     assert result is not None, (
         "Windows backslash path should be matched via posix=False fallback"
     )
+
+
+def test_readonly_status_returns_unverified_for_missing_db_without_sidecars(tmp_path):
+    db_path = tmp_path / "missing" / "verification_evidence.db"
+
+    status = verification_status_readonly(session_id="s1", root=tmp_path, db_path=db_path)
+
+    assert status == {
+        "status": "unverified",
+        "evidence": None,
+        "root": str(tmp_path),
+        "session_id": "s1",
+        "changed_paths": [],
+    }
+    assert not db_path.exists()
+    assert not db_path.parent.exists()
+    assert not (tmp_path / "missing" / "verification_evidence.db-wal").exists()
+    assert not (tmp_path / "missing" / "verification_evidence.db-shm").exists()
+    assert not (tmp_path / "missing" / "verification_evidence.db-journal").exists()
+
+
+def test_readonly_status_returns_unverified_for_missing_schema_without_creating_tables(tmp_path):
+    db_path = tmp_path / "verification_evidence.db"
+    with sqlite3.connect(db_path):
+        pass
+
+    status = verification_status_readonly(session_id="s1", root=tmp_path, db_path=db_path)
+
+    assert status["status"] == "unverified"
+    with sqlite3.connect(db_path) as conn:
+        tables = conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+    assert tables == []
+
+
+def test_readonly_status_returns_unverified_when_state_is_missing(tmp_path):
+    db_path = tmp_path / "verification_evidence.db"
+    _create_verification_db(db_path)
+
+    status = verification_status_readonly(session_id="s1", root=tmp_path, db_path=db_path)
+
+    assert status["status"] == "unverified"
+    assert status["evidence"] is None
+    assert status["changed_paths"] == []
+
+
+def test_readonly_status_returns_unverified_when_referenced_event_is_missing(tmp_path):
+    db_path = tmp_path / "verification_evidence.db"
+    _create_verification_db(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO verification_state(
+                session_id, root, last_event_id, last_edit_at, changed_paths_json
+            ) VALUES (?, ?, 999, NULL, '[]')
+            """,
+            ("s1", str(tmp_path)),
+        )
+        conn.commit()
+
+    status = verification_status_readonly(session_id="s1", root=tmp_path, db_path=db_path)
+
+    assert status["status"] == "unverified"
+    assert status["evidence"] is None
+
+
+def test_readonly_status_returns_passed_evidence_and_changed_paths(tmp_path):
+    db_path = tmp_path / "verification_evidence.db"
+    _create_verification_db(db_path)
+    event_id = _insert_verification_event(
+        db_path,
+        root=tmp_path,
+        status="passed",
+        changed_paths_json=json.dumps(["b.py", "a.py"]),
+    )
+
+    status = verification_status_readonly(session_id="s1", root=tmp_path, db_path=db_path)
+
+    assert status["status"] == "passed"
+    assert status["changed_paths"] == ["b.py", "a.py"]
+    assert status["evidence"]["id"] == event_id
+    assert status["evidence"]["status"] == "passed"
+    assert status["evidence"]["canonical_command"] == "pytest"
+
+
+def test_readonly_status_returns_failed_evidence(tmp_path):
+    db_path = tmp_path / "verification_evidence.db"
+    _create_verification_db(db_path)
+    _insert_verification_event(db_path, root=tmp_path, status="failed")
+
+    status = verification_status_readonly(session_id="s1", root=tmp_path, db_path=db_path)
+
+    assert status["status"] == "failed"
+    assert status["evidence"]["status"] == "failed"
+
+
+def test_readonly_status_returns_stale_when_edit_is_after_evidence(tmp_path):
+    db_path = tmp_path / "verification_evidence.db"
+    _create_verification_db(db_path)
+    _insert_verification_event(
+        db_path,
+        root=tmp_path,
+        status="passed",
+        created_at="2026-01-01T00:00:00+00:00",
+        last_edit_at="2026-01-01T00:00:01+00:00",
+    )
+
+    status = verification_status_readonly(session_id="s1", root=tmp_path, db_path=db_path)
+
+    assert status["status"] == "stale"
+
+
+def test_readonly_status_uses_empty_changed_paths_for_corrupt_json_without_repair(tmp_path):
+    db_path = tmp_path / "verification_evidence.db"
+    _create_verification_db(db_path)
+    _insert_verification_event(db_path, root=tmp_path, changed_paths_json="not-json")
+
+    status = verification_status_readonly(session_id="s1", root=tmp_path, db_path=db_path)
+
+    assert status["changed_paths"] == []
+    with sqlite3.connect(db_path) as conn:
+        stored = conn.execute("SELECT changed_paths_json FROM verification_state").fetchone()[0]
+    assert stored == "not-json"
+
+
+def test_readonly_status_opens_sqlite_uri_readonly_and_executes_no_ddl_or_dml(tmp_path, monkeypatch):
+    import agent.verification_evidence as verification_evidence
+
+    db_path = tmp_path / "verification_evidence.db"
+    _create_verification_db(db_path)
+    _insert_verification_event(db_path, root=tmp_path)
+    original_connect = sqlite3.connect
+    calls = []
+    statements = []
+
+    class CursorProxy:
+        def __init__(self, cursor):
+            self._cursor = cursor
+
+        def fetchone(self):
+            return self._cursor.fetchone()
+
+        def fetchall(self):
+            return self._cursor.fetchall()
+
+    class ConnectionProxy:
+        def __init__(self, conn):
+            self._conn = conn
+
+        @property
+        def row_factory(self):
+            return self._conn.row_factory
+
+        @row_factory.setter
+        def row_factory(self, value):
+            self._conn.row_factory = value
+
+        def execute(self, sql, parameters=()):
+            statements.append(sql.strip())
+            first = sql.lstrip().split(None, 1)[0].upper()
+            assert first not in {"CREATE", "INSERT", "UPDATE", "DELETE", "REPLACE"}
+            return CursorProxy(self._conn.execute(sql, parameters))
+
+        def close(self):
+            self._conn.close()
+
+    def connect_proxy(database, *args, **kwargs):
+        calls.append((database, args, kwargs))
+        return ConnectionProxy(original_connect(database, *args, **kwargs))
+
+    monkeypatch.setattr(sqlite3, "connect", connect_proxy)
+    monkeypatch.setattr(verification_evidence, "_connect", lambda: (_ for _ in ()).throw(AssertionError("_connect called")))
+    monkeypatch.setattr(verification_evidence, "_ensure_schema", lambda conn: (_ for _ in ()).throw(AssertionError("_ensure_schema called")))
+
+    status = verification_status_readonly(session_id="s1", root=tmp_path, db_path=db_path)
+
+    assert status["status"] == "passed"
+    assert len(calls) == 1
+    database, _, kwargs = calls[0]
+    assert kwargs["uri"] is True
+    assert "mode=ro" in str(database)
+    assert all(not sql.upper().startswith("PRAGMA JOURNAL_MODE") for sql in statements)
+
+
+def test_readonly_status_does_not_call_project_discovery(tmp_path, monkeypatch):
+    import agent.coding_context as coding_context
+
+    db_path = tmp_path / "verification_evidence.db"
+    _create_verification_db(db_path)
+    _insert_verification_event(db_path, root=tmp_path)
+    monkeypatch.setattr(coding_context, "project_facts_for", lambda cwd: (_ for _ in ()).throw(AssertionError("project discovery called")))
+
+    status = verification_status_readonly(session_id="s1", root=tmp_path, db_path=db_path)
+
+    assert status["status"] == "passed"
+
+
+def test_readonly_status_does_not_use_cwd_home_or_hermes_home(tmp_path, monkeypatch):
+    db_path = tmp_path / "verification_evidence.db"
+    _create_verification_db(db_path)
+    _insert_verification_event(db_path, root=tmp_path)
+    monkeypatch.setattr(os, "getcwd", lambda: (_ for _ in ()).throw(AssertionError("cwd discovery called")))
+    monkeypatch.setattr(Path, "cwd", lambda: (_ for _ in ()).throw(AssertionError("Path.cwd called")))
+    monkeypatch.setattr(Path, "home", lambda: (_ for _ in ()).throw(AssertionError("Path.home called")))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "different-home"))
+
+    status = verification_status_readonly(session_id="s1", root=tmp_path, db_path=db_path)
+
+    assert status["status"] == "passed"
+
+
+def test_readonly_status_does_not_use_subprocess(tmp_path, monkeypatch):
+    db_path = tmp_path / "verification_evidence.db"
+    _create_verification_db(db_path)
+    _insert_verification_event(db_path, root=tmp_path)
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("subprocess.run called")))
+    monkeypatch.setattr(subprocess, "Popen", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("subprocess.Popen called")))
+    monkeypatch.setattr(subprocess, "check_output", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("subprocess.check_output called")))
+
+    status = verification_status_readonly(session_id="s1", root=tmp_path, db_path=db_path)
+
+    assert status["status"] == "passed"
+
+
+def test_readonly_status_propagates_corrupt_database_error_without_sidecars(tmp_path):
+    db_path = tmp_path / "verification_evidence.db"
+    db_path.write_text("not sqlite", encoding="utf-8")
+
+    try:
+        verification_status_readonly(session_id="s1", root=tmp_path, db_path=db_path)
+    except sqlite3.DatabaseError:
+        pass
+    else:
+        raise AssertionError("expected corrupt database to propagate DatabaseError")
+
+    assert db_path.read_text(encoding="utf-8") == "not sqlite"
+    assert not (tmp_path / "verification_evidence.db-wal").exists()
+    assert not (tmp_path / "verification_evidence.db-shm").exists()
+    assert not (tmp_path / "verification_evidence.db-journal").exists()


### PR DESCRIPTION
## Summary

- Adds `verification_status_readonly(...)` with explicit `session_id`, `root`, and `db_path` arguments.
- Opens SQLite using URI `mode=ro` and does not create, migrate, repair, or modify the verification ledger.
- Returns `unverified` for missing database, schema, state, or event without creating files or sidecars.
- Propagates SQLite corruption instead of silently treating it as missing evidence.
- Preserves the existing mutable `verification_status()` API and behavior.

## Scope

- `agent/verification_evidence.py`
- `tests/agent/test_verification_evidence.py`

No GoalManager, EvidencePackEngine, ObjectiveServices, CLI, Gateway, TUI, or configuration wiring is included.

## Validation

- 31 focal tests passed.
- `git diff --check` passed.
- Runtime audit confirmed no database or sidecar mutation for missing, valid, and corrupt databases.
- Existing mutable and new read-only APIs coexist.

## Context

This is an isolated prerequisite for a future read-only verification-report adapter feeding EvidencePackEngine.

Related: #60549, #74103, #74303, #74367