### PR TITLE
fix(context): preserve Codex GPT-5.6 model context pin

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2197,18 +2197,17 @@ def init_agent(
             except (TypeError, ValueError):
                 pass
         _active_base_url = _normalize_route_base_url(_active_route_url)
-        _route_mismatch = _context_route_mismatch(
+        from hermes_cli.route_identity import should_clear_context_pin
+
+        if should_clear_context_pin(
+            _configured_default_runtime_model,
+            _active_runtime_model,
             _configured_base_url,
             _active_base_url,
             _configured_provider,
             agent.provider,
-            already_normalized=True,
-        )
-        _model_mismatch = bool(
-            _configured_default_runtime_model
-            and _configured_default_runtime_model != _active_runtime_model
-        )
-        if _model_mismatch or _route_mismatch:
+            already_normalized_route=True,
+        ):
             _ra().logger.debug(
                 "Ignoring model.context_length=%s for startup runtime %s at %s "
                 "(configured default is %s at %s)",

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -58,6 +58,71 @@ def _ra():
     return run_agent
 
 
+def refresh_builtin_compression_threshold(agent: Any, config: Any) -> None:
+    """Refresh the built-in compressor's route-scoped threshold policy.
+
+    The configured global threshold is the input to the compressor's normal
+    per-model ``model_thresholds`` resolution.  Codex's 85% threshold is a
+    separate, route-scoped autoraising policy, so it must be re-applied when
+    recovery or ``/model`` replaces the runtime.  Do not mutate plugin context
+    engines: they own their threshold policy themselves.
+    """
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is None:
+        return
+    try:
+        from agent.context_compressor import ContextCompressor
+
+        if not isinstance(compressor, ContextCompressor):
+            return
+        compression_config = config.get("compression", {}) if isinstance(config, dict) else {}
+        if not isinstance(compression_config, dict):
+            compression_config = {}
+        global_threshold = float(compression_config.get("threshold", 0.50))
+        allow_codex_autoraise = str(
+            compression_config.get("codex_gpt55_autoraise", True)
+        ).lower() in {"true", "1", "yes"}
+
+        from agent.agent_init import _resolve_compression_threshold
+        from agent.auxiliary_client import (
+            _compression_threshold_for_model,
+            _is_codex_gpt54_or_gpt55,
+            _is_codex_spark,
+        )
+
+        model_threshold = _compression_threshold_for_model(
+            getattr(agent, "model", ""),
+            getattr(agent, "provider", ""),
+            allow_codex_gpt55_autoraise=allow_codex_autoraise,
+        )
+        effective_threshold, autoraise = _resolve_compression_threshold(
+            global_threshold,
+            model_threshold,
+            model=getattr(agent, "model", ""),
+            is_codex_autoraise=(
+                _is_codex_gpt54_or_gpt55(
+                    getattr(agent, "model", ""),
+                    getattr(agent, "provider", ""),
+                )
+                or _is_codex_spark(
+                    getattr(agent, "model", ""),
+                    getattr(agent, "provider", ""),
+                )
+            ),
+        )
+        # ``update_model`` resolves per-model config overrides from this raw
+        # value, so updating it before the model swap keeps startup, switch,
+        # and fallback behavior aligned.
+        compressor._config_threshold_percent = effective_threshold
+        compressor._configured_threshold_percent = effective_threshold
+        agent._compression_threshold_autoraised = autoraise
+    except Exception:
+        logger.debug(
+            "Could not refresh compression threshold policy for runtime switch",
+            exc_info=True,
+        )
+
+
 AGENT_RUNTIME_POST_HOOK_TOOL_NAMES = frozenset(
     {"todo", "session_search", "memory", "clarify", "read_terminal", "delegate_task"}
 )
@@ -2355,6 +2420,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         raise
 
     # ── LM Studio: preload before probing context length ──
+    _sm_cfg: dict[str, Any] | None = None
     _sm_custom_providers = None
     try:
         from hermes_cli.config import (
@@ -2363,13 +2429,22 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             load_config,
         )
 
-        _sm_cfg = load_config()
+        _sm_cfg = load_config() or {}
         _sm_custom_providers = get_compatible_custom_providers(_sm_cfg)
-        _destination_context_intent = get_custom_provider_context_length(
-            model=agent.model,
-            base_url=agent.base_url,
-            custom_providers=_sm_custom_providers,
+        from hermes_cli.route_identity import resolve_model_context_pin
+
+        _destination_context_intent = resolve_model_context_pin(
+            _sm_cfg.get("model", {}),
+            active_model=agent.model,
+            active_base_url=agent.base_url,
+            active_provider=agent.provider,
         )
+        if _destination_context_intent is None:
+            _destination_context_intent = get_custom_provider_context_length(
+                model=agent.model,
+                base_url=agent.base_url,
+                custom_providers=_sm_custom_providers,
+            )
     except Exception:
         _destination_context_intent = None
     agent._config_context_length = _destination_context_intent
@@ -2400,6 +2475,8 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     # ── Update context compressor ──
     if hasattr(agent, "context_compressor") and agent.context_compressor:
         from agent.model_metadata import get_model_context_length
+        if _sm_cfg is not None:
+            refresh_builtin_compression_threshold(agent, _sm_cfg)
         if _sm_custom_providers is None:
             try:
                 from hermes_cli.config import get_compatible_custom_providers, load_config

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1979,8 +1979,46 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             )
         )
 
+        # Re-resolve the configured context pin for the fallback runtime.  A
+        # pin must never leak to another model/provider/endpoint, but the
+        # Codex GPT-5.6 Sol/Terra/Luna peers deliberately share their explicit
+        # allocation on the same Codex route.
+        _fb_custom_providers = getattr(agent, "_custom_providers", None)
+        _fb_cfg = None
+        try:
+            from hermes_cli.config import (
+                get_compatible_custom_providers,
+                get_custom_provider_context_length,
+                load_config,
+            )
+            from hermes_cli.route_identity import resolve_model_context_pin
+
+            _fb_cfg = load_config() or {}
+            _fb_custom_providers = get_compatible_custom_providers(_fb_cfg)
+            _fallback_context_intent = resolve_model_context_pin(
+                _fb_cfg.get("model", {}),
+                active_model=agent.model,
+                active_base_url=agent.base_url,
+                active_provider=agent.provider,
+            )
+            if _fallback_context_intent is None:
+                _fallback_context_intent = get_custom_provider_context_length(
+                    model=agent.model,
+                    base_url=agent.base_url,
+                    custom_providers=_fb_custom_providers,
+                )
+        except Exception:
+            _fallback_context_intent = None
+        agent._config_context_length = _fallback_context_intent
+
         # LM Studio: preload before probing the fallback's context length.
-        agent._ensure_lmstudio_runtime_loaded()
+        _runtime_context_length = agent._ensure_lmstudio_runtime_loaded(
+            _fallback_context_intent
+        )
+        _effective_context_length = agent._effective_lmstudio_context_length(
+            _fallback_context_intent,
+            _runtime_context_length,
+        )
 
         # Update context compressor limits for the fallback model.
         # Without this, compression decisions use the primary model's
@@ -1990,6 +2028,12 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # (model.context_length in config.yaml) is respected — without this,
         # the fallback activation drops to 128K even when config says 204800.
         if hasattr(agent, 'context_compressor') and agent.context_compressor:
+            if isinstance(_fb_cfg, dict):
+                from agent.agent_runtime_helpers import (
+                    refresh_builtin_compression_threshold,
+                )
+
+                refresh_builtin_compression_threshold(agent, _fb_cfg)
             from agent.model_metadata import get_model_context_length
             # ``agent.api_key`` may be callable (Entra ID); the
             # context-length resolver expects a string for live
@@ -1999,8 +2043,8 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             fb_context_length = get_model_context_length(
                 agent.model, base_url=agent.base_url,
                 api_key=_fb_ctx_api_key, provider=agent.provider,
-                config_context_length=getattr(agent, "_config_context_length", None),
-                custom_providers=getattr(agent, "_custom_providers", None),
+                config_context_length=_effective_context_length,
+                custom_providers=_fb_custom_providers,
             )
             agent.context_compressor.update_model(
                 model=agent.model,

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -785,16 +785,43 @@ def check_compression_model_feasibility(agent: Any) -> None:
         # than minting a bearer JWT just to look up a context length.
         _raw_aux_key = getattr(client, "api_key", "")
         aux_api_key = "" if (callable(_raw_aux_key) and not isinstance(_raw_aux_key, str)) else str(_raw_aux_key or "")
+        aux_provider = (
+            _aux_cfg_provider
+            if _aux_cfg_provider and _aux_cfg_provider != "auto"
+            else getattr(agent, "provider", "")
+        )
+        aux_context_config = getattr(
+            agent, "_aux_compression_context_length_config", None
+        )
+        # In auto mode compression follows the live main runtime.  Re-resolve
+        # its scoped model.context_length pin here as well, so a configured
+        # GPT-5.6 Codex allocation survives a Sol/Terra/Luna switch without
+        # leaking into an unrelated auxiliary route.  An explicit
+        # auxiliary.compression.context_length remains the more specific
+        # override and wins unchanged.
+        if aux_context_config is None:
+            try:
+                from hermes_cli.config import load_config
+                from hermes_cli.route_identity import resolve_model_context_pin
+
+                aux_context_config = resolve_model_context_pin(
+                    (load_config() or {}).get("model", {}),
+                    active_model=aux_model,
+                    active_base_url=aux_base_url,
+                    active_provider=aux_provider,
+                )
+            except Exception:
+                aux_context_config = None
 
         aux_context = get_model_context_length(
             aux_model,
             base_url=aux_base_url,
             api_key=aux_api_key,
-            config_context_length=getattr(agent, "_aux_compression_context_length_config", None),
+            config_context_length=aux_context_config,
             # Each model must be resolved with its own provider so that
             # provider-specific paths (e.g. Bedrock static table, OpenRouter API)
             # are invoked for the correct client, not inherited from the main model.
-            provider=(_aux_cfg_provider if _aux_cfg_provider and _aux_cfg_provider != "auto" else getattr(agent, "provider", "")),
+            provider=aux_provider,
             custom_providers=agent._custom_providers,
         )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13893,15 +13893,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if isinstance(_msg_model_cfg, dict)
                     else _msg_model_cfg
                 )
-                if _msg_model != _msg_configured_model:
-                    _msg_config_ctx = None
                 if _msg_config_ctx is not None and isinstance(_msg_model_cfg, dict):
                     try:
                         from hermes_cli.route_identity import should_clear_context_pin_async
 
                         if await should_clear_context_pin_async(
-                            None,  # model match already checked above
-                            None,
+                            _msg_configured_model,
+                            _msg_model,
                             _msg_model_cfg.get("base_url"),
                             _msg_base_url,
                             _msg_model_cfg.get("provider"),

--- a/hermes_cli/route_identity.py
+++ b/hermes_cli/route_identity.py
@@ -6,6 +6,38 @@ from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
 
+# A configured Codex context pin is normally owned by one exact model.  These
+# three GPT-5.6 Codex tiers are the deliberate exception: the Codex route
+# allocates the same user-selected window to Sol, Terra, and Luna, so moving
+# between the tiers must retain that explicit allocation.  Keep this set
+# narrow; a pin must never escape to another Codex family, provider, or route.
+_CODEX_GPT56_CONTEXT_PEERS = frozenset({
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+})
+
+
+def _model_slug(model: Any) -> str:
+    """Return the bare, lower-case model identity used for pin scoping."""
+    return str(model or "").strip().lower().rsplit("/", 1)[-1]
+
+
+def _is_codex_gpt56_context_peer(
+    configured_model: Any,
+    active_model: Any,
+    configured_provider: Any,
+    active_provider: Any,
+) -> bool:
+    """Whether two model identities share the explicit GPT-5.6 Codex pin."""
+    return (
+        str(configured_provider or "").strip().lower() == "openai-codex"
+        and str(active_provider or "").strip().lower() == "openai-codex"
+        and _model_slug(configured_model) in _CODEX_GPT56_CONTEXT_PEERS
+        and _model_slug(active_model) in _CODEX_GPT56_CONTEXT_PEERS
+    )
+
+
 def normalize_route_base_url(base_url: Any) -> str:
     """Canonicalize only proven-equivalent endpoint URL components."""
     raw = str(base_url or "")
@@ -54,6 +86,8 @@ def should_clear_context_pin(
     active_base_url: Any,
     configured_provider: Any,
     active_provider: Any,
+    *,
+    already_normalized_route: bool = False,
 ) -> bool:
     """True when a configured ``model.context_length`` pin no longer matches its runtime route.
 
@@ -61,7 +95,17 @@ def should_clear_context_pin(
     so a stale window never silently inflates the compression threshold.
     """
     configured_model = str(configured_model or "").strip()
-    if configured_model and configured_model != str(active_model or "").strip():
+    active_model = str(active_model or "").strip()
+    if (
+        configured_model
+        and configured_model != active_model
+        and not _is_codex_gpt56_context_peer(
+            configured_model,
+            active_model,
+            configured_provider,
+            active_provider,
+        )
+    ):
         return True
     try:
         from agent.agent_init import _context_route_mismatch
@@ -71,9 +115,54 @@ def should_clear_context_pin(
             active_base_url,
             configured_provider,
             active_provider,
+            already_normalized=already_normalized_route,
         )
     except Exception:
         return True
+
+
+def resolve_model_context_pin(
+    model_config: Any,
+    *,
+    active_model: Any,
+    active_base_url: Any,
+    active_provider: Any,
+) -> int | None:
+    """Resolve a global ``model.context_length`` pin for one live runtime.
+
+    The pin applies only when its configured model/provider/route owns the
+    active runtime.  ``should_clear_context_pin`` keeps the normal exact-model
+    guard and narrowly admits the GPT-5.6 Codex peer group above.
+    """
+    if not isinstance(model_config, dict):
+        return None
+    raw_context = model_config.get("context_length")
+    if raw_context is None:
+        return None
+    try:
+        context_length = int(raw_context)
+    except (TypeError, ValueError):
+        return None
+    if context_length <= 0:
+        return None
+
+    configured_model = model_config.get("default") or model_config.get("model")
+    configured_provider = model_config.get("provider")
+    configured_base_url = model_config.get("base_url")
+    if (
+        configured_model
+        or configured_provider
+        or configured_base_url
+    ) and should_clear_context_pin(
+        configured_model,
+        active_model,
+        configured_base_url,
+        active_base_url,
+        configured_provider,
+        active_provider,
+    ):
+        return None
+    return context_length
 
 
 async def should_clear_context_pin_async(
@@ -83,6 +172,8 @@ async def should_clear_context_pin_async(
     active_base_url: Any,
     configured_provider: Any,
     active_provider: Any,
+    *,
+    already_normalized_route: bool = False,
 ) -> bool:
     """Async wrapper for ``should_clear_context_pin``.
 
@@ -101,4 +192,5 @@ async def should_clear_context_pin_async(
         active_base_url,
         configured_provider,
         active_provider,
+        already_normalized_route=already_normalized_route,
     )

--- a/tests/hermes_cli/test_model_switch_context_display.py
+++ b/tests/hermes_cli/test_model_switch_context_display.py
@@ -191,3 +191,22 @@ class TestResolveDisplayContextLength:
 
         assert ctx == 256_000
         assert resolver.call_args.kwargs["config_context_length"] is None
+
+    def test_codex_gpt56_peer_uses_configured_context_pin(self):
+        """The /model confirmation mirrors the live Sol/Terra/Luna policy."""
+        with patch(
+            "agent.model_metadata.get_model_context_length",
+            side_effect=lambda _model, **kwargs: kwargs["config_context_length"],
+        ) as resolver:
+            ctx = resolve_display_context_length(
+                "gpt-5.6-terra",
+                "openai-codex",
+                base_url="https://chatgpt.com/backend-api/codex",
+                config_context_length=372_000,
+                configured_model="gpt-5.6-sol",
+                configured_provider="openai-codex",
+                configured_base_url="https://chatgpt.com/backend-api/codex",
+            )
+
+        assert ctx == 372_000
+        assert resolver.call_args.kwargs["config_context_length"] == 372_000

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -236,6 +236,88 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
     )
 
 
+def test_feasibility_inherits_scoped_codex_gpt56_context_pin(monkeypatch):
+    """Auto compression follows the live GPT-5.6 Codex peer allocation."""
+    context_pin = 372_000
+    codex_url = "https://chatgpt.com/backend-api/codex"
+    agent = _make_agent(main_context=context_pin, threshold_percent=0.85)
+    agent.model = "gpt-5.6-sol"
+    agent.provider = "openai-codex"
+    agent.base_url = codex_url
+    agent.api_key = "codex-token"
+    agent._aux_compression_context_length_config = None
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "model": {
+                "default": "gpt-5.6-sol",
+                "provider": "openai-codex",
+                "base_url": codex_url,
+                "context_length": context_pin,
+            }
+        },
+    )
+
+    with (
+        patch("agent.auxiliary_client.get_text_auxiliary_client") as mock_get_client,
+        patch("agent.model_metadata.get_model_context_length", return_value=context_pin) as mock_ctx_len,
+    ):
+        mock_client = MagicMock()
+        mock_client.base_url = codex_url
+        mock_client.api_key = "codex-token"
+        mock_get_client.return_value = (mock_client, "gpt-5.6-terra")
+        agent._emit_status = lambda msg: None
+        agent._check_compression_model_feasibility()
+
+    mock_ctx_len.assert_called_once_with(
+        "gpt-5.6-terra",
+        base_url=codex_url,
+        api_key="codex-token",
+        config_context_length=context_pin,
+        provider="openai-codex",
+        custom_providers=[],
+    )
+
+
+def test_feasibility_drops_codex_peer_pin_on_different_aux_endpoint(monkeypatch):
+    """An auto auxiliary client on another endpoint cannot borrow the pin."""
+    context_pin = 372_000
+    codex_url = "https://chatgpt.com/backend-api/codex"
+    agent = _make_agent(main_context=context_pin, threshold_percent=0.85)
+    agent.model = "gpt-5.6-sol"
+    agent.provider = "openai-codex"
+    agent.base_url = codex_url
+    agent.api_key = "codex-token"
+    agent._aux_compression_context_length_config = None
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "model": {
+                "default": "gpt-5.6-sol",
+                "provider": "openai-codex",
+                "base_url": codex_url,
+                "context_length": context_pin,
+            }
+        },
+    )
+
+    with (
+        patch("agent.auxiliary_client.get_text_auxiliary_client") as mock_get_client,
+        patch("agent.model_metadata.get_model_context_length", return_value=372_000) as mock_ctx_len,
+    ):
+        mock_client = MagicMock()
+        mock_client.base_url = "https://api.openai.com/v1"
+        mock_client.api_key = "sk-openai"
+        mock_get_client.return_value = (mock_client, "gpt-5.6-terra")
+        agent._emit_status = lambda msg: None
+        agent._check_compression_model_feasibility()
+
+    assert mock_ctx_len.call_args.kwargs["config_context_length"] is None
+    assert mock_ctx_len.call_args.kwargs["provider"] == "openai-codex"
+
+
 def test_init_feasibility_check_uses_aux_context_override_from_config():
     """Lazy feasibility check should cache and forward auxiliary.compression.context_length.
 

--- a/tests/run_agent/test_compressor_fallback_update.py
+++ b/tests/run_agent/test_compressor_fallback_update.py
@@ -89,3 +89,51 @@ def test_compressor_not_present_does_not_crash(mock_ctx_len, mock_resolve):
 
     result = agent._try_activate_fallback()
     assert result is True
+
+
+def test_fallback_reresolves_codex_gpt56_peer_context_pin(monkeypatch):
+    """Fallback recovery keeps the scoped Sol/Terra/Luna Codex allocation."""
+    context_pin = 372_000
+    codex_url = "https://chatgpt.com/backend-api/codex"
+    agent = _make_agent_with_compressor()
+    agent.model = "gpt-5.6-sol"
+    agent.provider = "openai-codex"
+    agent.base_url = codex_url
+    agent.api_key = "codex-token"
+    agent.api_mode = "codex_responses"
+    agent._fallback_model = {"provider": "openai-codex", "model": "gpt-5.6-terra"}
+    agent._fallback_chain = [agent._fallback_model]
+    agent._fallback_index = 0
+    agent._custom_providers = []
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "model": {
+                "default": "gpt-5.6-sol",
+                "provider": "openai-codex",
+                "base_url": codex_url,
+                "context_length": context_pin,
+            }
+        },
+    )
+    monkeypatch.setattr("hermes_cli.config.get_compatible_custom_providers", lambda _cfg: [])
+
+    def resolve_context(model, **kwargs):
+        assert model == "gpt-5.6-terra"
+        assert kwargs["config_context_length"] == context_pin
+        return context_pin
+
+    monkeypatch.setattr("agent.model_metadata.get_model_context_length", resolve_context)
+    agent._emit_status = lambda msg: None
+
+    with patch("agent.auxiliary_client.resolve_provider_client") as mock_resolve:
+        fb_client = MagicMock()
+        fb_client.base_url = codex_url
+        fb_client.api_key = "codex-token"
+        mock_resolve.return_value = (fb_client, None)
+
+        assert agent._try_activate_fallback() is True
+    assert agent._config_context_length == context_pin
+    assert agent.context_compressor.context_length == context_pin
+    assert agent.context_compressor.threshold_tokens == int(context_pin * 0.85)

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -8,6 +8,7 @@ from hermes_cli.models import LMStudioLoadResult
 from run_agent import AIAgent
 from agent.agent_init import _normalize_route_base_url
 from agent.context_compressor import ContextCompressor
+from agent.context_breakdown import compute_session_context_breakdown
 
 
 class _StubStartupCompressor:
@@ -183,6 +184,98 @@ def test_switch_model_without_config_context_length():
         mock_ctx_len.assert_called_once()
         call_kwargs = mock_ctx_len.call_args.kwargs
         assert call_kwargs.get("config_context_length") is None
+
+
+def test_codex_gpt56_context_pin_survives_peer_switches_and_restores_after_route_change(monkeypatch):
+    """Sol/Terra/Luna share only their explicit Codex-route context pin."""
+    context_pin = 372_000
+    codex_url = "https://chatgpt.com/backend-api/codex"
+    cfg = {
+        "model": {
+            "default": "gpt-5.6-sol",
+            "provider": "openai-codex",
+            "base_url": codex_url,
+            "context_length": context_pin,
+        }
+    }
+    agent = _make_agent_with_compressor(config_context_length=context_pin)
+    agent.model = "gpt-5.6-sol"
+    agent.provider = "openai-codex"
+    agent.base_url = codex_url
+    agent.api_key = "codex-token"
+    agent.api_mode = "codex_responses"
+    agent.context_compressor.update_model(
+        model=agent.model,
+        context_length=context_pin,
+        base_url=agent.base_url,
+        api_key=agent.api_key,
+        provider=agent.provider,
+        api_mode=agent.api_mode,
+    )
+
+    seen_context_pins = []
+
+    def resolve_context(model, **kwargs):
+        pin = kwargs.get("config_context_length")
+        seen_context_pins.append((model, pin))
+        return pin or 272_000
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+    monkeypatch.setattr("hermes_cli.config.get_compatible_custom_providers", lambda _cfg: [])
+    monkeypatch.setattr("agent.model_metadata.get_model_context_length", resolve_context)
+
+    for model in ("gpt-5.6-terra", "gpt-5.6-luna"):
+        agent.switch_model(model, "openai-codex", api_key="codex-token", base_url=codex_url)
+        assert agent._config_context_length == context_pin
+        assert agent.context_compressor.context_length == context_pin
+        assert agent.context_compressor.threshold_tokens == int(context_pin * 0.85)
+
+    # A peer-tier slug is not enough: this allocation belongs only to the
+    # configured Codex provider and endpoint, never the direct OpenAI API.
+    agent.switch_model(
+        "gpt-5.6-terra",
+        "openai",
+        api_key="sk-openai",
+        base_url="https://api.openai.com/v1",
+    )
+    assert agent._config_context_length is None
+    assert agent.context_compressor.context_length == 272_000
+    # The normal small-window floor remains, but the Codex-only 85% policy
+    # must not escape to the direct OpenAI route.
+    assert agent.context_compressor.threshold_tokens == int(272_000 * 0.75)
+
+    # A different provider/model drops the Codex-only pin.
+    agent.switch_model(
+        "unrelated-model",
+        "openrouter",
+        api_key="sk-openrouter",
+        base_url="https://openrouter.ai/api/v1",
+    )
+    assert agent._config_context_length is None
+    assert agent.context_compressor.context_length == 272_000
+    assert agent.context_compressor.threshold_tokens == int(272_000 * 0.75)
+
+    # Switching back to a Codex peer re-resolves the configured allocation.
+    agent.switch_model("gpt-5.6-sol", "openai-codex", api_key="codex-token", base_url=codex_url)
+    assert agent._config_context_length == context_pin
+    assert agent.context_compressor.context_length == context_pin
+    assert agent.context_compressor.threshold_tokens == int(context_pin * 0.85)
+    assert seen_context_pins == [
+        ("gpt-5.6-terra", context_pin),
+        ("gpt-5.6-luna", context_pin),
+        ("gpt-5.6-terra", None),
+        ("unrelated-model", None),
+        ("gpt-5.6-sol", context_pin),
+    ]
+
+    # The Desktop context meter reads this backend payload's context_max.
+    agent.context_compressor.last_prompt_tokens = 186_000
+    with patch(
+        "agent.system_prompt.build_system_prompt_parts",
+        return_value={"stable": "", "context": "", "volatile": ""},
+    ):
+        payload = compute_session_context_breakdown(agent, [])
+    assert payload["context_max"] == context_pin
 
 
 def test_direct_start_model_override_does_not_inherit_profile_context_length():
@@ -361,6 +454,29 @@ def test_direct_start_preserves_context_for_codex_default_endpoint():
     )
 
     assert agent.context_compressor.config_context_length == 272_000
+
+
+@pytest.mark.parametrize("runtime_model", ["gpt-5.6-terra", "gpt-5.6-luna"])
+def test_direct_start_preserves_codex_gpt56_peer_context_pin(runtime_model):
+    """A fresh peer-tier session retains the matching Codex allocation."""
+    cfg = {
+        "model": {
+            "default": "gpt-5.6-sol",
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "context_length": 372_000,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model=runtime_model,
+        provider="openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    assert agent.context_compressor.config_context_length == 372_000
+    assert agent.context_compressor.context_length == 372_000
 
 
 def test_direct_start_drops_context_for_codex_wrong_path():


### PR DESCRIPTION
## Summary
- Re-resolves the explicit model.context_length pin after model switches and fallback activation.
- Shares the 372K pin only among gpt-5.6-sol, gpt-5.6-terra, and gpt-5.6-luna on the exact openai-codex route.
- Keeps the primary runtime, automatic compression route, recovery snapshot, and Desktop context-meter backend value aligned.
- Reapplies the route-scoped Codex compression threshold on switch and fallback.

## Safety
- The pin still drops for unrelated models, providers, and endpoints.
- This is intentionally separate from Desktop PR #72399.
- No Desktop or Gateway restart was performed.

## Validation
- scripts/run_tests.sh: switch, fallback, compression feasibility, and Desktop-context tests: 94 passed.
- scripts/run_tests.sh: CLI context-guard tests: 12 passed.