### PR TITLE
fix(deps): refresh lazy DingTalk SDK pin

### DIFF
--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -232,7 +232,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     ),
     "platform.dingtalk": (
         "dingtalk-stream==0.24.3",
-        "alibabacloud-dingtalk==2.2.42",
+        "alibabacloud-dingtalk==2.2.54",
         "qrcode==7.4.2",
     ),
     "platform.feishu": (


### PR DESCRIPTION
## Summary

Updates the optional lazy DingTalk SDK pin from `alibabacloud-dingtalk==2.2.42` to `==2.2.54`.

The older resolved Tea OpenAPI package declares an upper bound that conflicts with the current `cryptography` resolution. The refreshed dependency resolves to `alibabacloud-tea-openapi==0.4.5`, whose modern-Python bound permits the current `cryptography` version.

Fixes #74402.

## Validation

```text
pytest -p no:cacheprovider -q tests/gateway/test_dingtalk.py tests/hermes_cli/test_dingtalk_auth.py
100 passed
```

Also verified `alibabacloud_dingtalk` and `alibabacloud_tea_openapi` imports, and `pip check` no longer reports the DingTalk/cryptography conflict.

## Scope

One lazy dependency pin only. No runtime configuration, credentials, services, or deployment behaviour changed.