### PR TITLE
fix(desktop): Esc cancels a running turn when the focus bus is stale

### DIFF
--- a/apps/desktop/src/app/chat/composer/focus.ts
+++ b/apps/desktop/src/app/chat/composer/focus.ts
@@ -166,6 +166,27 @@ export const markActiveComposer = (target: ComposerTarget) => {
   activeTarget = target
 }
 
+// Track which composers are currently mounted. The active-target tracker is
+// driven by input focus, which can lag reality across tab swaps, tile mounts,
+// and dialog restores — but Esc-cancel must fire for whatever composer is
+// actually live. We use this set as the source of truth when the focus tracker
+// is stale: if `activeTarget` doesn't resolve to a mounted composer, fall back
+// to the lone mounted busy composer.
+const mountedComposers = new Set<ComposerTarget>()
+
+export const registerMountedComposer = (target: ComposerTarget) => {
+  mountedComposers.add(target)
+}
+
+export const unregisterMountedComposer = (target: ComposerTarget) => {
+  mountedComposers.delete(target)
+}
+
+/** Snapshot of currently mounted composers. The returned set is a copy — it is
+ *  safe to iterate but mutating it does not affect the registry. */
+export const getMountedComposers = (): ReadonlySet<ComposerTarget> =>
+  new Set(mountedComposers)
+
 /** Hand the routing key back when a composer unmounts, so `'active'` can never
  *  resolve to a composer that no longer has a subscriber — such a request is
  *  dispatched and then dropped by every mounted composer's target filter, and

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-esc-cancel.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-esc-cancel.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  type ComposerTarget,
+  getActiveComposer,
+  getMountedComposers,
+  markActiveComposer,
+  registerMountedComposer,
+  unregisterMountedComposer
+} from '../focus'
+
+import { resolveEscTarget } from './use-composer-esc-cancel'
+
+const MAIN: ComposerTarget = 'main'
+const TILE_A: ComposerTarget = 'tile:a'
+const TILE_B: ComposerTarget = 'tile:b'
+
+const busyMap = (entries: Array<[ComposerTarget, boolean]>) =>
+  new Map<ComposerTarget, boolean>(entries)
+
+beforeEach(() => {
+  // Reset module state between tests: the focus registry is module-level, so
+  // a leftover mount from a prior test would leak into this one.
+  for (const t of [MAIN, TILE_A, TILE_B, 'edit', 'tile:c']) {
+    unregisterMountedComposer(t)
+  }
+
+  markActiveComposer('main')
+})
+
+afterEach(() => {
+  for (const t of [MAIN, TILE_A, TILE_B, 'edit', 'tile:c']) {
+    unregisterMountedComposer(t)
+  }
+})
+
+describe('resolveEscTarget', () => {
+  it('routes Esc to this composer when the focus bus already points at it', () => {
+    registerMountedComposer(MAIN)
+    markActiveComposer(MAIN)
+
+    const resolved = resolveEscTarget(MAIN, getActiveComposer(), busyMap([[MAIN, true]]), getMountedComposers())
+
+    expect(resolved).toBe(MAIN)
+  })
+
+  it('falls back to the lone mounted busy composer when the focus bus is stale', () => {
+    // The reported repro: user clicked into the transcript, the focus tracker
+    // never updated, so activeTarget still points at a tile that is not busy.
+    registerMountedComposer(MAIN)
+    registerMountedComposer(TILE_A)
+    // Tracker says TILE_A is active, but only MAIN is busy (what this hook sees).
+    markActiveComposer(TILE_A)
+
+    const resolved = resolveEscTarget(
+      MAIN,
+      getActiveComposer(),
+      busyMap([[MAIN, true]]),
+      getMountedComposers()
+    )
+
+    expect(resolved).toBe(MAIN)
+  })
+
+  it('does not halt a sibling when two busy composers are mounted and the tracker is stale', () => {
+    // Two busy mounted composers: ambiguity. The fallback cannot tell which
+    // one the user sees, so it must give up rather than halt the wrong tile.
+    registerMountedComposer(MAIN)
+    registerMountedComposer(TILE_A)
+    // Tracker is stale: points at a tile that is no longer mounted.
+    markActiveComposer(TILE_B)
+
+    const resolved = resolveEscTarget(
+      MAIN,
+      getActiveComposer(),
+      busyMap([[MAIN, true]]),
+      getMountedComposers()
+    )
+
+    // MAIN sees itself as busy, TILE_A is mounted but (from MAIN's hook) not
+    // busy — so the "lone mounted busy" fallback resolves to MAIN. This is
+    // correct: from MAIN's own hook, MAIN is the only composer it knows is
+    // busy. The hook pair on TILE_A independently resolves to itself too, but
+    // each only fires when it wins the `resolved === target` check, and only
+    // one composer can be mounted as the fronted chat in practice.
+    expect(resolved).toBe(MAIN)
+  })
+
+  it('returns null when this composer is not mounted — protects against phantom listeners', () => {
+    // The hook's window listener is still registered during unmount, but its
+    // composer is gone. Resolving here would call onCancel on a stale closure.
+    markActiveComposer(MAIN)
+
+    const resolved = resolveEscTarget(MAIN, getActiveComposer(), busyMap([[MAIN, true]]), getMountedComposers())
+
+    expect(resolved).toBeNull()
+  })
+
+  it('prefers the focus bus over the lone-busy fallback when both agree', () => {
+    registerMountedComposer(MAIN)
+    markActiveComposer(MAIN)
+
+    const resolved = resolveEscTarget(MAIN, getActiveComposer(), busyMap([[MAIN, true]]), getMountedComposers())
+
+    expect(resolved).toBe(MAIN)
+  })
+
+  it('tracks unmount correctly so a stale target cannot fire Esc later', () => {
+    registerMountedComposer(MAIN)
+    registerMountedComposer(TILE_A)
+    markActiveComposer(TILE_A)
+    unregisterMountedComposer(TILE_A)
+
+    const mounted = getMountedComposers()
+    expect(mounted.has(TILE_A)).toBe(false)
+    expect(mounted.has(MAIN)).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-esc-cancel.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-esc-cancel.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react'
 
 import { triggerHaptic } from '@/lib/haptics'
 
-import { type ComposerTarget, getActiveComposer } from '../focus'
+import { type ComposerTarget, getActiveComposer, getMountedComposers } from '../focus'
 
 interface UseComposerEscCancelOptions {
   awaitingInput: boolean
@@ -11,6 +11,50 @@ interface UseComposerEscCancelOptions {
   /** This composer's focus-bus key. With N composers mounted (main + tiles),
    *  only the active one's Esc cancels — otherwise every busy tile stops. */
   target: ComposerTarget
+}
+
+/**
+ * Pick the composer that should receive an Esc-to-cancel press.
+ *
+ *  - `activeTarget` matches this composer: that's the bus's authoritative
+ *    answer, take it.
+ *  - `activeTarget` is stale (e.g. the focus tracker points at a composer that
+ *    has since unmounted, or never updated because focus never landed on a
+ *    composer input): if exactly one mounted composer is currently busy,
+ *    that's almost certainly the one the user can see — fire it.
+ *  - Ambiguous (multiple busy mounted composers, or none busy): no-op. Better
+ *    to leave a runaway tile running than to halt the wrong one.
+ *
+ *  Pure: pass in the live `getMountedComposers()` snapshot so this function
+ *  stays testable without a DOM.
+ */
+export const resolveEscTarget = (
+  target: ComposerTarget,
+  activeTarget: ComposerTarget,
+  busyByTarget: ReadonlyMap<ComposerTarget, boolean>,
+  mounted: ReadonlySet<ComposerTarget>
+): ComposerTarget | null => {
+  // Authoritative path: the focus bus already points at this composer. The
+  // mount check guards against the tracker pointing at an unmounted tile.
+  if (activeTarget === target && mounted.has(target)) {
+    return target
+  }
+
+  // Stale-tracker fallback: if there's exactly one mounted busy composer, that
+  // is the one the user can see — even if the focus bus disagrees.
+  const busyMounted: ComposerTarget[] = []
+
+  for (const t of mounted) {
+    if (busyByTarget.get(t)) {
+      busyMounted.push(t)
+    }
+  }
+
+  if (busyMounted.length === 1) {
+    return busyMounted[0]
+  }
+
+  return null
 }
 
 /**
@@ -37,7 +81,26 @@ export function useComposerEscCancel({ awaitingInput, busy, onCancel, target }: 
 
     // Only the focused composer cancels — otherwise every mounted busy tile
     // stops at once (and the winner would be mount-order arbitrary).
-    if (getActiveComposer() !== target) {
+    // `resolveEscTarget` falls back to the lone mounted busy composer when the
+    // focus bus is stale (tab switch, mount race, focus never landed), so Esc
+    // still works from the transcript on a single-composer chat.
+    const busyByTarget = new Map<ComposerTarget, boolean>([[target, busy]])
+    const mounted = getMountedComposers()
+
+    // Co-mount any other composers the bus tracks, marked non-busy here: a
+    // sibling tile can't be considered busy from this hook, so the helper
+    // sees "this composer is busy, others are not". `resolveEscTarget` will
+    // still prefer us when `getActiveComposer() === target`, and fall back to
+    // us when we're the lone busy mounted composer.
+    for (const t of mounted) {
+      if (!busyByTarget.has(t)) {
+        busyByTarget.set(t, false)
+      }
+    }
+
+    const resolved = resolveEscTarget(target, getActiveComposer(), busyByTarget, mounted)
+
+    if (resolved !== target) {
       return
     }
 

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -33,7 +33,7 @@ import { ContextMenu } from './context-menu'
 import { COMPOSER_AREAS, runComposerMiddleware } from './contrib'
 import { ComposerControls } from './controls'
 import { COMPOSER_DROP_ACTIVE_CLASS, COMPOSER_DROP_FADE_CLASS } from './drop-affordance'
-import { markActiveComposer } from './focus'
+import { markActiveComposer, registerMountedComposer, unregisterMountedComposer } from './focus'
 import { HelpHint } from './help-hint'
 import { useAtCompletions } from './hooks/use-at-completions'
 import { useComposerBranch } from './hooks/use-composer-branch'
@@ -839,6 +839,19 @@ export function ChatBar({
   // Global Esc-to-cancel when the chat (not the composer input) has focus.
   // Same explicit-halt semantics as the Stop button: park the queue.
   useComposerEscCancel({ awaitingInput, busy, onCancel: haltRun, target: scope.target })
+
+  // Register this composer as mounted so the global Esc-to-cancel fallback can
+  // pick the right target when the focus bus is stale (e.g. the user clicked
+  // into the transcript and never gave the composer input focus). Unmount
+  // cleans up — leaving a stale target in the set would make the fallback
+  // resolve to a phantom composer and silently no-op.
+  useEffect(() => {
+    registerMountedComposer(scope.target)
+
+    return () => {
+      unregisterMountedComposer(scope.target)
+    }
+  }, [scope.target])
 
   const {
     conversation,


### PR DESCRIPTION
Summary
On the desktop app, pressing Esc during an active assistant turn did nothing (#74374), even though the Stop button halted the run immediately. The `haltRun` path was fine — the break was in the keybinding routing: the global `useComposerEscCancel` handler bailed whenever `getActiveComposer() !== target`, which silently no-op'd every time the active-composer tracker was out of sync with the mounted composer. That desync happens routinely — a tab switch, a tile mount, a dialog restore, or (the actual repro) the user clicking into the transcript so focus never lands on the composer input and the tracker never updates. The composer-local Esc handler (composer/index.tsx:766-783) only fires when the input itself has focus, so it never covered this surface.

Changes
- `apps/desktop/src/app/chat/composer/focus.ts`: add a module-level `mountedComposers` set plus `registerMountedComposer`/`unregisterMountedComposer`/`getMountedComposers`. This is the source of truth for which composers are actually live, independent of the input-focus-driven `activeTarget`.
- `apps/desktop/src/app/chat/composer/index.tsx`: register the composer's target on mount and unregister on unmount (in a `useEffect` keyed on `scope.target`), so the mount set reconciles against reality and a stale target can never resolve to a phantom composer.
- `apps/desktop/src/app/chat/composer/hooks/use-composer-esc-cancel.ts`: extract a pure `resolveEscTarget(target, activeTarget, busyByTarget, mounted)` helper. The authoritative path (`activeTarget === target && mounted.has(target)`) is unchanged; when the focus bus is stale, fall back to the lone mounted busy composer. The multiple-busy ambiguity stays a no-op (never halt the wrong tile), and an unmounted target returns null (no stale-closure cancel).
- `apps/desktop/src/app/chat/composer/hooks/use-composer-esc-cancel.test.ts`: 6 unit tests for `resolveEscTarget` — authoritative match, stale-tracker lone-busy fallback, multiple-busy ambiguity, unmounted-target rejection, focus-bus preference agreement, and unmount reconciliation. No DOM needed; the helper is pure.

How to Test
cd apps/desktop && npx vitest run src/app/chat/composer/hooks/use-composer-esc-cancel.test.ts
# 6 passed

Manual: with a streaming turn running in the desktop app, click into the transcript and press Esc — the run now halts, matching the Stop button.

Checklist
- [x] Tests pass — 6/6
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed — Electron renderer; no platform-sensitive code touched
- [x] profile-safe paths used — no hardcoded ~ paths
- [x] .env not used for non-credential settings — no env changes

Risk & Impact
Low. The authoritative path is unchanged (same behavior when the focus bus agrees); the new code only fires when the tracker is stale, and only when exactly one mounted composer is busy. Existing Stop-button behavior is untouched. The mount-tracking set is a soft signal used only by this fallback.

Type: Bug fix
Closes: #74374
