### PR TITLE
docs(acp): document the Buzz Desktop model picker

### DIFF
--- a/website/docs/user-guide/features/acp.md
+++ b/website/docs/user-guide/features/acp.md
@@ -241,6 +241,19 @@ Recent installs write both `hermes` and `hermes-acp` launchers into
 older installs. As a manual fallback, configure Buzz's agent command as
 `hermes` with args `["acp"]`.
 
+#### Model picker
+
+Buzz Desktop (v0.5.1+) renders Hermes' full model menu in the agent's runtime
+settings. The list comes from Hermes itself over ACP: it shows every model
+from providers you have authenticated in Hermes (the same inventory behind
+`hermes model` and the `/model` command), so a model missing from the menu
+means its provider has no credentials configured on the Hermes side.
+
+Entry IDs take the form `provider:model` (e.g. `openrouter:z-ai/glm-5.1`), or
+`custom:<name>:<model>` for custom OpenAI-compatible endpoints defined in
+`config.yaml`. Picking a model applies to that agent's session; it does not
+change your Hermes-wide default — use `hermes model` for that.
+
 #### Keep Buzz agents owner-only
 
 Buzz creates every agent with **Who can talk to this agent** set to `Owner only`.


### PR DESCRIPTION
## Summary
Documents the Buzz Desktop (v0.5.1+) model picker in the ACP docs — where the menu comes from and how its entry IDs map to Hermes model selection.

Buzz v0.5.1 shipped the model-menu UI for external ACP runtimes; Hermes already served the data (`availableModels` / `set_session_model` in `acp_adapter/server.py`), so this is docs-only — no code change needed on our side.

## Changes
- `website/docs/user-guide/features/acp.md`: new "Model picker" subsection under the Buzz Desktop host section — list source (shared authenticated-provider inventory behind `hermes model` / `/model`), `provider:model` and `custom:<name>:<model>` ID shapes, and that a pick is session-scoped, not a Hermes-wide default change.

## Validation
| | Before | After |
|---|---|---|
| Buzz Desktop section | No mention of the model menu | Explains source, ID format, scope |

## Infographic

![Buzz Desktop model picker docs](https://v3b.fal.media/files/b/0aa43f88/fKgweJi_onizcsyHVuHHL_pVIr1NWT.png)
