### PR TITLE
feat(tui): fire message:pre_route hook in tui_gateway path

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -102,8 +102,12 @@ class HookRegistry:
         """
         self._register_builtin_hooks()
 
-        hooks_dir = self._hooks_dir if self._hooks_dir is not None else HOOKS_DIR
-        if not hooks_dir.exists():
+        hooks_dir = (
+            self._hooks_dir
+            if self._hooks_dir is not None
+            else get_hermes_home() / "hooks"
+        )
+        if not hooks_dir.is_dir():
             return
 
         for hook_dir in sorted(hooks_dir.iterdir()):

--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -59,10 +59,22 @@ class HookRegistry:
         await registry.emit("agent:start", {"platform": "telegram", ...})
     """
 
-    def __init__(self):
+    def __init__(self, hooks_dir: Optional["Path"] = None):
+        """Create a registry.
+
+        Args:
+            hooks_dir: Directory to scan for hook sub-directories.  Defaults
+                to ``get_hermes_home() / "hooks"`` resolved at call-time so
+                that a context-local :func:`~hermes_constants.set_hermes_home_override`
+                or a non-default profile path is respected.  Pass an explicit
+                path to pin the registry to a specific profile home (e.g. in
+                the TUI gateway, where profile selection happens after module
+                import).
+        """
         # event_type -> [handler_fn, ...]
         self._handlers: Dict[str, List[Callable]] = {}
         self._loaded_hooks: List[dict] = []  # metadata for listing
+        self._hooks_dir = hooks_dir
 
     @property
     def loaded_hooks(self) -> List[dict]:
@@ -90,10 +102,11 @@ class HookRegistry:
         """
         self._register_builtin_hooks()
 
-        if not HOOKS_DIR.exists():
+        hooks_dir = self._hooks_dir if self._hooks_dir is not None else HOOKS_DIR
+        if not hooks_dir.exists():
             return
 
-        for hook_dir in sorted(HOOKS_DIR.iterdir()):
+        for hook_dir in sorted(hooks_dir.iterdir()):
             if not hook_dir.is_dir():
                 continue
 

--- a/tests/test_tui_pre_route_hook.py
+++ b/tests/test_tui_pre_route_hook.py
@@ -1,0 +1,171 @@
+import asyncio
+import logging
+import threading
+import types
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from tui_gateway import server
+
+
+class _SyncThread:
+    """Fake Thread class that runs the target synchronously."""
+    def __init__(self, target, name=None, args=(), kwargs=None, daemon=None):
+        self.target = target
+        self.args = args
+        self.kwargs = kwargs or {}
+
+    def start(self):
+        self.target(*self.args, **self.kwargs)
+
+    def is_alive(self):
+        return False
+
+
+@pytest.fixture
+def mock_sync_thread(monkeypatch):
+    monkeypatch.setattr(server.threading, "Thread", _SyncThread)
+
+
+@pytest.fixture
+def mock_get_tui_hook_registry(monkeypatch):
+    mock_registry = Mock()
+    mock_emit_collect = AsyncMock(return_value=[])
+    mock_registry.emit_collect = mock_emit_collect
+    monkeypatch.setattr(server, "_get_tui_hook_registry", lambda: mock_registry)
+    return mock_registry
+
+
+def test_tui_pre_route_hook_fires(mock_sync_thread, mock_get_tui_hook_registry, monkeypatch):
+    """Test that the hook fires when a message is processed."""
+    agent = types.SimpleNamespace(
+        run_conversation=Mock(return_value={}),
+        clear_interrupt=Mock(),
+    )
+    session = {
+        "history_lock": threading.Lock(),
+        "history": [],
+        "agent": agent,
+        "session_key": "test-session-key",
+    }
+    
+    # Mock helpers inside tui_gateway.server to avoid real database/home side effects
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_start_inflight_turn", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_clear_inflight_turn", lambda *a, **k: None)
+    monkeypatch.setattr(server, "record_turn_start", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_retire_turn_marker", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_session_home", lambda *a, **k: "")
+    monkeypatch.setattr(server, "_session_cwd", lambda *a, **k: "")
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_set_session_context", lambda *a, **k: [])
+    monkeypatch.setattr(server, "_tts_stream_begin", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_voice_mode_enabled", lambda *a, **k: False)
+    monkeypatch.setattr("tools.tts_streaming.take_speech_interrupted", lambda *a, **k: False)
+    monkeypatch.setattr(server, "_load_interim_assistant_messages", lambda *a, **k: False)
+    monkeypatch.setattr(server, "render_message", lambda *a, **k: "")
+    monkeypatch.setattr(server, "_get_usage", lambda *a, **k: {})
+    
+    text = "hello tui pre-route"
+    server._run_prompt_submit("rid-1", "sid-1", session, text)
+    
+    # Verify hook was called with proper context
+    mock_get_tui_hook_registry.emit_collect.assert_called_once()
+    args, kwargs = mock_get_tui_hook_registry.emit_collect.call_args
+    assert args[0] == "message:pre_route"
+    
+    ctx = args[1]
+    assert ctx["platform"] == "desktop"
+    assert ctx["user_id"] == ""
+    assert ctx["chat_id"] == "test-session-key"
+    assert ctx["thread_id"] is None
+    assert ctx["chat_type"] == ""
+    assert ctx["session_id"] == "test-session-key"
+    assert ctx["session_key"] == "test-session-key"
+    assert ctx["message"] == "hello tui pre-route"
+
+
+def test_tui_pre_route_hook_exception_handling(mock_sync_thread, mock_get_tui_hook_registry, monkeypatch):
+    """Test that exceptions in the hook don't break message processing."""
+    mock_get_tui_hook_registry.emit_collect.side_effect = Exception("Hook failed!")
+    
+    agent = types.SimpleNamespace(
+        run_conversation=Mock(return_value={"final_response": "handled"}),
+        clear_interrupt=Mock(),
+    )
+    session = {
+        "history_lock": threading.Lock(),
+        "history": [],
+        "agent": agent,
+        "session_key": "test-session-key",
+    }
+    
+    # Mock helpers
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_start_inflight_turn", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_clear_inflight_turn", lambda *a, **k: None)
+    monkeypatch.setattr(server, "record_turn_start", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_retire_turn_marker", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_session_home", lambda *a, **k: "")
+    monkeypatch.setattr(server, "_session_cwd", lambda *a, **k: "")
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_set_session_context", lambda *a, **k: [])
+    monkeypatch.setattr(server, "_tts_stream_begin", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_voice_mode_enabled", lambda *a, **k: False)
+    monkeypatch.setattr("tools.tts_streaming.take_speech_interrupted", lambda *a, **k: False)
+    monkeypatch.setattr(server, "_load_interim_assistant_messages", lambda *a, **k: False)
+    monkeypatch.setattr(server, "render_message", lambda *a, **k: "")
+    monkeypatch.setattr(server, "_get_usage", lambda *a, **k: {})
+
+    with patch.object(server.logger, "warning") as mock_warn:
+        server._run_prompt_submit("rid-2", "sid-2", session, "hello exception")
+        # Exception should be caught and logged
+        mock_warn.assert_any_call("Failed to fire message:pre_route hook in TUI path: %s", mock_get_tui_hook_registry.emit_collect.side_effect)
+
+    # Message processing should continue and complete successfully
+    agent.run_conversation.assert_called_once()
+
+
+def test_tui_pre_route_hook_switch_session_logged(mock_sync_thread, mock_get_tui_hook_registry, monkeypatch):
+    """Test that switch_session decisions are logged but not acted on (TUI limitation)."""
+    # Mock emit_collect returning a switch_session decision
+    mock_get_tui_hook_registry.emit_collect.return_value = [
+        {"decision": "switch_session", "session_id": "target-session-id"}
+    ]
+    
+    agent = types.SimpleNamespace(
+        run_conversation=Mock(return_value={}),
+        clear_interrupt=Mock(),
+    )
+    session = {
+        "history_lock": threading.Lock(),
+        "history": [],
+        "agent": agent,
+        "session_key": "test-session-key",
+    }
+    
+    # Mock helpers
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_start_inflight_turn", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_clear_inflight_turn", lambda *a, **k: None)
+    monkeypatch.setattr(server, "record_turn_start", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_retire_turn_marker", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_session_home", lambda *a, **k: "")
+    monkeypatch.setattr(server, "_session_cwd", lambda *a, **k: "")
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_set_session_context", lambda *a, **k: [])
+    monkeypatch.setattr(server, "_tts_stream_begin", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_voice_mode_enabled", lambda *a, **k: False)
+    monkeypatch.setattr("tools.tts_streaming.take_speech_interrupted", lambda *a, **k: False)
+    monkeypatch.setattr(server, "_load_interim_assistant_messages", lambda *a, **k: False)
+    monkeypatch.setattr(server, "render_message", lambda *a, **k: "")
+    monkeypatch.setattr(server, "_get_usage", lambda *a, **k: {})
+
+    with patch.object(server.logger, "warning") as mock_warn:
+        server._run_prompt_submit("rid-3", "sid-3", session, "hello switch")
+        # Warning about switch_session should be logged
+        mock_warn.assert_any_call("Session switching is not yet supported in TUI path (switch_session target: %s)", "target-session-id")
+
+    # Message processing should continue normally with the same agent/session
+    agent.run_conversation.assert_called_once()

--- a/tests/test_tui_pre_route_hook.py
+++ b/tests/test_tui_pre_route_hook.py
@@ -1,7 +1,9 @@
 import asyncio
 import logging
+import textwrap
 import threading
 import types
+from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -169,3 +171,83 @@ def test_tui_pre_route_hook_switch_session_logged(mock_sync_thread, mock_get_tui
 
     # Message processing should continue normally with the same agent/session
     agent.run_conversation.assert_called_once()
+
+
+# ── Integration test: real HOOK.yaml + handler.py discovery ────────────────
+
+def test_real_hook_yaml_discovery_and_invocation(tmp_path):
+    """Integration test: _get_tui_hook_registry discovers hooks from a real
+    temp HERMES_HOME and emit_collect actually invokes the handler.
+
+    This test exercises the full discovery pipeline (HOOK.yaml parsing,
+    handler.py dynamic loading, event registration) without mocking the
+    registry — verifying the code path that was broken by the module-level
+    HOOKS_DIR singleton (blocker #1).
+    """
+    # Build a minimal HERMES_HOME with one hook for message:pre_route
+    hooks_root = tmp_path / "hooks"
+    hook_dir = hooks_root / "test-pre-route"
+    hook_dir.mkdir(parents=True)
+
+    # Write HOOK.yaml
+    (hook_dir / "HOOK.yaml").write_text(
+        textwrap.dedent("""\
+            name: test-pre-route
+            description: Integration test hook for message:pre_route
+            events:
+              - message:pre_route
+        """),
+        encoding="utf-8",
+    )
+
+    # Write handler.py — sets a sentinel in a shared list so the test can
+    # confirm the handler was actually called.
+    invocations: list = []
+    handler_source = textwrap.dedent("""\
+        _invocations = []
+
+        def handle(event_type, context):
+            _invocations.append({"event": event_type, "message": context.get("message")})
+            return {"decision": "allow"}
+    """)
+    (hook_dir / "handler.py").write_text(handler_source, encoding="utf-8")
+
+    # Ask for a registry pointed at our temp HERMES_HOME — bypasses the
+    # module-level HOOKS_DIR singleton.
+    from gateway.hooks import HookRegistry
+    registry = HookRegistry(hooks_dir=hooks_root)
+    registry.discover_and_load()
+
+    # Confirm discovery found the hook
+    loaded_names = [h["name"] for h in registry.loaded_hooks]
+    assert "test-pre-route" in loaded_names, (
+        f"Hook not discovered. Loaded: {loaded_names}"
+    )
+
+    # emit_collect should invoke the handler and return its non-None result
+    results = asyncio.run(
+        registry.emit_collect(
+            "message:pre_route",
+            {"message": "integration-test-payload", "platform": "desktop"},
+        )
+    )
+
+    assert results == [{"decision": "allow"}], (
+        f"emit_collect returned unexpected results: {results}"
+    )
+
+    # Also confirm that _get_tui_hook_registry accepts the explicit hermes_home
+    # kwarg and returns a registry that can discover from the same temp dir.
+    # (Clears the cache entry first so the test is independent of call order.)
+    hermes_home_str = str(tmp_path)
+    server._tui_hook_registries.pop(str(tmp_path.resolve()), None)
+    tui_registry = server._get_tui_hook_registry(hermes_home=hermes_home_str)
+    tui_results = asyncio.run(
+        tui_registry.emit_collect(
+            "message:pre_route",
+            {"message": "via-tui-registry", "platform": "desktop"},
+        )
+    )
+    assert tui_results == [{"decision": "allow"}], (
+        f"TUI registry emit_collect returned unexpected results: {tui_results}"
+    )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -176,22 +176,26 @@ def _get_tui_hook_registry(hermes_home: Optional[str] = None) -> HookRegistry:
     """
     from pathlib import Path as _Path
     resolved = str(_Path(hermes_home).resolve()) if hermes_home else str(get_hermes_home().resolve())
-    if resolved not in _tui_hook_registries:
-        with _tui_hooks_lock:
-            if resolved not in _tui_hook_registries:
-                hooks_dir = _Path(resolved) / "hooks"
-                registry = HookRegistry(hooks_dir=hooks_dir)
-                try:
-                    registry.discover_and_load()
-                    # Only cache on success — a failed load leaves the registry in a
-                    # broken state.  Not caching allows a retry on the next message
-                    # (e.g. after the user corrects a bad hook file) rather than
-                    # silently serving an empty/half-loaded registry forever.
-                    _tui_hook_registries[resolved] = registry
-                except Exception as e:
-                    logger.error("Failed to load hooks for %s: %s", resolved, e)
-                    # do not cache — allow retry on next message
-    return _tui_hook_registries[resolved]
+    registry = _tui_hook_registries.get(resolved)
+    if registry is not None:
+        return registry
+    with _tui_hooks_lock:
+        registry = _tui_hook_registries.get(resolved)
+        if registry is not None:
+            return registry
+        hooks_dir = _Path(resolved) / "hooks"
+        registry = HookRegistry(hooks_dir=hooks_dir)
+        try:
+            registry.discover_and_load()
+            # Only cache on success — a failed load leaves the registry in a
+            # broken state.  Not caching allows a retry on the next message
+            # (e.g. after the user corrects a bad hook file) rather than
+            # silently serving an empty/half-loaded registry forever.
+            _tui_hook_registries[resolved] = registry
+        except Exception as e:
+            logger.error("Failed to load hooks for %s: %s", resolved, e)
+            # do not cache — allow retry on next message
+        return registry
 _cfg_cache: dict | None = None
 _cfg_mtime: float | None = None
 _cfg_path = None

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -183,9 +183,14 @@ def _get_tui_hook_registry(hermes_home: Optional[str] = None) -> HookRegistry:
                 registry = HookRegistry(hooks_dir=hooks_dir)
                 try:
                     registry.discover_and_load()
+                    # Only cache on success — a failed load leaves the registry in a
+                    # broken state.  Not caching allows a retry on the next message
+                    # (e.g. after the user corrects a bad hook file) rather than
+                    # silently serving an empty/half-loaded registry forever.
+                    _tui_hook_registries[resolved] = registry
                 except Exception as e:
-                    logger.error("Failed to discover and load hooks: %s", e)
-                _tui_hook_registries[resolved] = registry
+                    logger.error("Failed to load hooks for %s: %s", resolved, e)
+                    # do not cache — allow retry on next message
     return _tui_hook_registries[resolved]
 _cfg_cache: dict | None = None
 _cfg_mtime: float | None = None
@@ -12345,17 +12350,31 @@ def _run_prompt_submit(
                     "chat_id": session.get("session_key", sid),
                     "thread_id": None,
                     "chat_type": "",
+                    # NOTE: in the TUI path there is no distinct session_id concept
+                    # separate from session_key — the routing key *is* the session
+                    # identifier.  Per the hook contract (gateway/hooks.py) these two
+                    # fields should be distinct, but the TUI deliberately collapses
+                    # them here.  Hooks can detect this surface via the "surface" key
+                    # and bail early if they require a true separate session_id.
                     "session_id": session.get("session_key", sid),
                     "session_key": session.get("session_key", sid),
+                    "surface": "tui",
                     "message": text if isinstance(text, str) else "",
                 }
                 _registry = _get_tui_hook_registry()
-                _pre_route_results = asyncio.run(
-                    asyncio.wait_for(
-                        _registry.emit_collect("message:pre_route", _pre_route_ctx),
-                        timeout=5.0,
+                # asyncio.run() raises RuntimeError when called from a thread that
+                # already has a running event loop (e.g. asyncio.to_thread workers).
+                # Use an explicit new loop to avoid that and to guarantee cleanup.
+                _loop = asyncio.new_event_loop()
+                try:
+                    _pre_route_results = _loop.run_until_complete(
+                        asyncio.wait_for(
+                            _registry.emit_collect("message:pre_route", _pre_route_ctx),
+                            timeout=5.0,
+                        )
                     )
-                )
+                finally:
+                    _loop.close()
                 for _pr in _pre_route_results:
                     if not isinstance(_pr, dict):
                         continue

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from gateway.hooks import HookRegistry
 from hermes_cli.config import get_hermes_home
 from pathlib import Path
-from typing import Any, NamedTuple, Optional
+from typing import Any, Dict, NamedTuple, Optional
 
 from agent.secret_scope import (
     build_profile_secret_scope,
@@ -153,19 +153,37 @@ _cfg_lock = threading.Lock()
 _sessions_lock = threading.RLock()  # reentrant: _close_session_by_id may run under callers that already hold it
 _prompt_lock = threading.Lock()
 
-_tui_hook_registry: Optional[HookRegistry] = None
+# Per-profile-home cache: keyed by resolved HERMES_HOME path string so that
+# TUI sessions running under a non-default profile discover hooks from that
+# profile's hooks/ dir, not the module-import-time default.
+_tui_hook_registries: Dict[str, HookRegistry] = {}
 _tui_hooks_lock = threading.Lock()
 
 
-def _get_tui_hook_registry() -> HookRegistry:
-    global _tui_hook_registry
-    if _tui_hook_registry is None:
+def _get_tui_hook_registry(hermes_home: Optional[str] = None) -> HookRegistry:
+    """Return the HookRegistry for *hermes_home* (or the active home if None).
+
+    Registries are cached by resolved home path so repeated calls within a
+    profile are cheap (single dict lookup) while each profile gets its own
+    registry that points at ``<profile_home>/hooks/``.
+
+    Args:
+        hermes_home: Absolute path to the profile home whose hooks to use.
+            ``None`` resolves the current active home via
+            :func:`~hermes_constants.get_hermes_home` at call-time, which
+            respects the context-local override set by
+            :func:`~hermes_constants.set_hermes_home_override`.
+    """
+    from pathlib import Path as _Path
+    resolved = str(_Path(hermes_home).resolve()) if hermes_home else str(get_hermes_home().resolve())
+    if resolved not in _tui_hook_registries:
         with _tui_hooks_lock:
-            if _tui_hook_registry is None:
-                registry = HookRegistry()
+            if resolved not in _tui_hook_registries:
+                hooks_dir = _Path(resolved) / "hooks"
+                registry = HookRegistry(hooks_dir=hooks_dir)
                 registry.discover_and_load()
-                _tui_hook_registry = registry
-    return _tui_hook_registry
+                _tui_hook_registries[resolved] = registry
+    return _tui_hook_registries[resolved]
 _cfg_cache: dict | None = None
 _cfg_mtime: float | None = None
 _cfg_path = None

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -181,7 +181,10 @@ def _get_tui_hook_registry(hermes_home: Optional[str] = None) -> HookRegistry:
             if resolved not in _tui_hook_registries:
                 hooks_dir = _Path(resolved) / "hooks"
                 registry = HookRegistry(hooks_dir=hooks_dir)
-                registry.discover_and_load()
+                try:
+                    registry.discover_and_load()
+                except Exception as e:
+                    logger.error("Failed to discover and load hooks: %s", e)
                 _tui_hook_registries[resolved] = registry
     return _tui_hook_registries[resolved]
 _cfg_cache: dict | None = None
@@ -12347,7 +12350,12 @@ def _run_prompt_submit(
                     "message": text if isinstance(text, str) else "",
                 }
                 _registry = _get_tui_hook_registry()
-                _pre_route_results = asyncio.run(_registry.emit_collect("message:pre_route", _pre_route_ctx))
+                _pre_route_results = asyncio.run(
+                    asyncio.wait_for(
+                        _registry.emit_collect("message:pre_route", _pre_route_ctx),
+                        timeout=5.0,
+                    )
+                )
                 for _pr in _pre_route_results:
                     if not isinstance(_pr, dict):
                         continue

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12,9 +12,12 @@ import queue
 import subprocess
 import sys
 import threading
+import asyncio
 import time
 import uuid
 from datetime import datetime
+from gateway.hooks import HookRegistry
+from hermes_cli.config import get_hermes_home
 from pathlib import Path
 from typing import Any, NamedTuple, Optional
 
@@ -149,6 +152,20 @@ _stdout_lock = threading.Lock()
 _cfg_lock = threading.Lock()
 _sessions_lock = threading.RLock()  # reentrant: _close_session_by_id may run under callers that already hold it
 _prompt_lock = threading.Lock()
+
+_tui_hook_registry: Optional[HookRegistry] = None
+_tui_hooks_lock = threading.Lock()
+
+
+def _get_tui_hook_registry() -> HookRegistry:
+    global _tui_hook_registry
+    if _tui_hook_registry is None:
+        with _tui_hooks_lock:
+            if _tui_hook_registry is None:
+                registry = HookRegistry()
+                registry.discover_and_load()
+                _tui_hook_registry = registry
+    return _tui_hook_registry
 _cfg_cache: dict | None = None
 _cfg_mtime: float | None = None
 _cfg_path = None
@@ -12299,6 +12316,28 @@ def _run_prompt_submit(
             if display_kind and "persist_user_display_kind" in _run_params:
                 run_kwargs["persist_user_display_kind"] = display_kind
                 run_kwargs["persist_user_display_metadata"] = display_metadata
+            # ── message:pre_route — hook-driven session redirect ──────────
+            try:
+                _pre_route_ctx = {
+                    "platform": "desktop",
+                    "user_id": "",
+                    "chat_id": session.get("session_key", sid),
+                    "thread_id": None,
+                    "chat_type": "",
+                    "session_id": session.get("session_key", sid),
+                    "session_key": session.get("session_key", sid),
+                    "message": text if isinstance(text, str) else "",
+                }
+                _registry = _get_tui_hook_registry()
+                _pre_route_results = asyncio.run(_registry.emit_collect("message:pre_route", _pre_route_ctx))
+                for _pr in _pre_route_results:
+                    if not isinstance(_pr, dict):
+                        continue
+                    if _pr.get("decision") == "switch_session" and _pr.get("session_id"):
+                        logger.warning("Session switching is not yet supported in TUI path (switch_session target: %s)", _pr.get("session_id"))
+            except Exception as _hook_err:
+                logger.warning("Failed to fire message:pre_route hook in TUI path: %s", _hook_err)
+
             result = agent.run_conversation(run_message, **run_kwargs)
             if display_kind and isinstance(text, str):
                 db = getattr(agent, "_session_db", None)

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -82,6 +82,7 @@ async def handle(event_type: str, context: dict):
 | `agent:start` | Agent begins processing a message | `platform`, `user_id`, `chat_id`, `thread_id` (forum-topic / thread root id; empty when not in a thread), `chat_type` (`"dm"` \| `"group"` \| `"forum"`; empty if unknown), `session_id`, `message` (truncated to 500 chars) |
 | `agent:step` | Each iteration of the tool-calling loop | `platform`, `user_id`, `session_id`, `iteration`, `tool_names` |
 | `agent:end` | Agent finishes processing | same keys as `agent:start`, plus `response` (truncated to 500 chars) |
+| `message:pre_route` | Fires before a message is dispatched to the agent — after the internal-event guard and before auth/pairing. **Surfaces:** gateway (Telegram, Discord, Slack, WhatsApp, Teams) and **desktop/TUI**. Handlers can return a `{"decision": "switch_session", "session_id": "..."}` dict; on gateway this redirects the message to the named session. On desktop/TUI the decision is logged but not yet acted on (pending #64178). | `platform`, `user_id`, `chat_id`, `thread_id`, `chat_type`, `session_id`, `session_key`, `message` |
 | `reaction:added` | An emoji reaction was added to a message the bot can see (Slack adapter currently). Requires the `reactions:read` scope + the `reaction_added` bot event subscription; the bot must be a member of the channel. | `platform`, `reaction`, `user_id`, `item_user_id`, `item_type`, `channel_id`, `message_ts`, `team_id`, `event_ts`, `raw_event` |
 | `reaction:removed` | An emoji reaction was removed from a message the bot can see. Requires the `reaction_removed` bot event subscription. | same shape as `reaction:added` |
 | `command:*` | Any slash command executed | `platform`, `user_id`, `command`, `args` |
@@ -354,7 +355,9 @@ An earlier version of Hermes shipped this as a built-in hook and silently spawne
 5. Errors in any handler are caught and logged — a broken hook never crashes the agent
 
 :::info
-Gateway hooks only fire in the **gateway** (Telegram, Discord, Slack, WhatsApp, Teams). The CLI does not load gateway hooks. For hooks that work everywhere, use [plugin hooks](#plugin-hooks).
+Gateway hooks fire in the **gateway** (Telegram, Discord, Slack, WhatsApp, Teams). The CLI does not load gateway hooks. For hooks that work everywhere, use [plugin hooks](#plugin-hooks).
+
+**Exception:** `message:pre_route` also fires in the **desktop/TUI** path (the Ink TUI and dashboard embedded chat). `switch_session` decisions from TUI handlers are logged but not yet acted on pending #64178.
 :::
 
 ## Plugin Hooks


### PR DESCRIPTION
## Summary

Extends the `message:pre_route` hook event (added in #74272 for the gateway path) to also fire in the `tui_gateway/server.py` path used by the desktop app and TUI.

**The gap:** `HookRegistry` and `emit_collect` only existed in `GatewayRunner` (gateway/run.py). The desktop app goes through `tui_gateway/server.py` → `_run_prompt_submit()` → `agent.run_conversation()` with no hook system involved. This means hooks registered for `message:pre_route` were silently dead on the desktop surface — the same class of bug tracked in #64178.

**The fix:**
- Module-level `HookRegistry` singleton in `tui_gateway/server.py` (lazily initialized, not per-message)
- `emit_collect("message:pre_route", ...)` fired inside `_run_prompt_submit()` before `agent.run_conversation()`, wrapped with `asyncio.wait_for(timeout=5.0)` to prevent a hanging hook from freezing the TUI
- `switch_session` decisions are logged but not acted on — the TUI path has no equivalent of `GatewayRunner.async_session_store.switch_session()`. Full session switching in TUI is deferred to #64178's parity work.
- Full try/except guard — hook failures never break message processing
- `discover_and_load` is wrapped in try/except; on failure the registry is **not** cached (to allow retry on next message, e.g. after the user fixes a bad hook file), but the uncached registry is still returned so callers always get a valid instance

## Relationship to open routing proposals

Two open issues propose routing hooks at adjacent but distinct layers:

- **#72942** proposes extending `pre_gateway_dispatch` with `{"action": "route", "profile": "..."}` — this fires at **gateway ingress, before session auth**.
- **#69693** proposes a `pre_agent_dispatch` event — this fires at the **agent dispatch layer**, after the session is fully resolved and a worker is selected.

`message:pre_route` fires **between** these two: after session resolution is complete, and **before** the turn-lease is claimed. This is a distinct layer with different semantics — session context is fully available, but the turn has not yet been committed. This PR extends that same event to the TUI surface so hooks fire consistently regardless of which path a message enters through.

The three hooks are **complementary**, not competing:

```
gateway ingress → [#72942: pre_gateway_dispatch + route action]
  ↓  session auth + resolution
message:pre_route  ← #74272 (gateway) + this PR (TUI)
  ↓  turn-lease acquired
  ↓  agent selected
agent dispatch  → [#69693: pre_agent_dispatch]
```

A new event name is justified because the layer is different: `pre_gateway_dispatch` has no session context, `pre_agent_dispatch` has already committed a turn, and `message:pre_route` sits between them with full session state but no turn commitment.

**Note for maintainers:** `message:pre_route` could also serve as the implementation vehicle for #72942's `route` action if preferred — the `switch_session` primitive it uses is equivalent to what #72942 describes. The hook contract could be extended to accept `{"action": "route", "profile": "..."}` alongside the existing `{"decision": "switch_session", "session_id": "..."}` form. This PR defers that design choice to maintainer preference.

## Test plan

- [ ] `python -m pytest tests/test_tui_pre_route_hook.py -v` — 4 tests, all pass
- [ ] `ruff check tui_gateway/server.py tests/test_tui_pre_route_hook.py` — clean
- [ ] `python scripts/check-windows-footguns.py tui_gateway/server.py` — clean
- [ ] Hook fires on desktop message: install a HOOK.yaml hook for `message:pre_route`, send a message in the desktop app, confirm handler is invoked

## Platform tested

macOS 15.5 (Apple Silicon), Python 3.11.15, Hermes v0.19.0

## Notes for reviewers

- Companion to #74272 (gateway path). Together they give `message:pre_route` full surface coverage except cron/kanban workers (which is #64178's broader scope)
- The singleton avoids re-scanning `~/.hermes/hooks/` on every message
- Session switching in TUI intentionally deferred — logged clearly so it's visible when #64178 lands
- `asyncio.wait_for(timeout=5.0)` bounds hook execution to prevent freezing the TUI message thread
- `discover_and_load` exception is caught and logged; the registry is **not** cached on failure (allows retry after user fixes the hook dir) but is returned uncached so callers never hit a KeyError


Related: #64178, #69693, #72942, #74272

Note: Does not close #67798 — that issue requires the full surface-matrix contract from #64178 to be decided first.