### PR TITLE
feat(web): configurable search/extract fallback chains

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -326,6 +326,8 @@ DEFAULT_CONFIG = {
         "backend": "",           # shared fallback — applies to both search and extract
         "search_backend": "",    # per-capability override for web_search (e.g. "searxng")
         "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
+        "search_fallbacks": [],  # ordered list tried when search_backend fails (e.g. ["exa", "tavily"])
+        "extract_fallbacks": [], # ordered list tried when extract_backend raises (e.g. ["tavily", "exa"])
         "extract_char_limit": 15000,  # per-page char budget for web_extract; larger pages truncate + store full text in cache/web
     },
 

--- a/tests/tools/test_web_fallback_chains.py
+++ b/tests/tools/test_web_fallback_chains.py
@@ -1,0 +1,450 @@
+"""Tests for configurable web search/extract fallback chains.
+
+Covers:
+- _get_fallback_backends() — config parsing (list, comma/space string,
+  bracketed string, dedup, primary removal, empty/whitespace handling)
+- _run_search_fallbacks() — primary fails → first healthy fallback wins;
+  all fail → primary error surfaced; empty chain → primary result unchanged;
+  unavailable / unregistered / search-incapable candidates skipped
+- web_search_tool() end-to-end — brave-free 402 → exa fallback returns results
+- _run_extract_fallbacks() — primary raises → fallback result returned;
+  all raise → primary exception re-raised; per-URL errors do NOT trigger fallback
+- web_extract_tool() end-to-end — primary raises → fallback extract used
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import patch
+
+import pytest
+
+from tests.tools.conftest import register_all_web_providers
+
+
+# ---------------------------------------------------------------------------
+# _get_fallback_backends — config parsing
+# ---------------------------------------------------------------------------
+
+
+class TestGetFallbackBackends:
+    def test_list_value_preserved_in_order(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"search_fallbacks": ["exa", "tavily"]})
+        assert web_tools._get_fallback_backends("search") == ["exa", "tavily"]
+
+    def test_comma_separated_string_split(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"search_fallbacks": "exa, tavily"})
+        assert web_tools._get_fallback_backends("search") == ["exa", "tavily"]
+
+    def test_bracketed_string_parsed(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"search_fallbacks": "[exa, tavily]"})
+        assert web_tools._get_fallback_backends("search") == ["exa", "tavily"]
+
+    def test_missing_key_yields_empty_chain(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+        assert web_tools._get_fallback_backends("search") == []
+
+    def test_null_value_yields_empty_chain(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"search_fallbacks": None})
+        assert web_tools._get_fallback_backends("search") == []
+
+    def test_primary_dropped_from_chain(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"search_fallbacks": ["brave-free", "exa"]})
+        assert web_tools._get_fallback_backends("search", primary="brave-free") == ["exa"]
+
+    def test_duplicates_collapsed_first_wins(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"search_fallbacks": ["exa", "tavily", "exa"]})
+        assert web_tools._get_fallback_backends("search") == ["exa", "tavily"]
+
+    def test_whitespace_and_empty_entries_discarded(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"search_fallbacks": ["  ", "", "exa"]})
+        assert web_tools._get_fallback_backends("search") == ["exa"]
+
+    def test_case_normalized(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"search_fallbacks": ["EXA", "Tavily"]})
+        assert web_tools._get_fallback_backends("search") == ["exa", "tavily"]
+
+    def test_extract_capability_reads_its_own_key(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {
+            "search_fallbacks": ["exa"],
+            "extract_fallbacks": ["tavily"],
+        })
+        assert web_tools._get_fallback_backends("extract") == ["tavily"]
+
+
+# ---------------------------------------------------------------------------
+# _run_search_fallbacks — dispatch behavior
+# ---------------------------------------------------------------------------
+
+
+class _FakeSearchProvider:
+    """Minimal registered-shaped provider for fallback dispatch tests."""
+
+    def __init__(self, name, result=None, available=True, supports=True, raises=None):
+        self._name = name
+        self._result = result
+        self._available = available
+        self._supports = supports
+        self._raises = raises
+        self.calls = 0
+
+    @property
+    def name(self):
+        return self._name
+
+    def supports_search(self):
+        return self._supports
+
+    def is_available(self):
+        return self._available
+
+    def search(self, query, limit=5):
+        self.calls += 1
+        if self._raises:
+            raise self._raises
+        return self._result
+
+
+class TestRunSearchFallbacks:
+    def _registry(self, providers):
+        table = {p.name: p for p in providers}
+        return lambda name: table.get(name)
+
+    def test_first_healthy_fallback_wins(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"search_fallbacks": ["exa", "tavily"]})
+        exa = _FakeSearchProvider("exa", result={"success": True, "data": {"web": [{"title": "from exa"}]}})
+        tavily = _FakeSearchProvider("tavily", result={"success": True, "data": {"web": []}})
+        primary_result = {"success": False, "error": "Brave Search returned HTTP 402"}
+
+        out = web_tools._run_search_fallbacks(
+            "q", 5, primary_result, primary="brave-free",
+            _wsp_get_provider=self._registry([exa, tavily]),
+        )
+        assert out["success"] is True
+        assert out["data"]["web"][0]["title"] == "from exa"
+        assert exa.calls == 1
+        assert tavily.calls == 0  # never reached
+
+    def test_skips_failing_fallback_to_next(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"search_fallbacks": ["exa", "tavily"]})
+        exa = _FakeSearchProvider("exa", result={"success": False, "error": "exa down"})
+        tavily = _FakeSearchProvider("tavily", result={"success": True, "data": {"web": [{"title": "ok"}]}})
+        primary_result = {"success": False, "error": "primary dead"}
+
+        out = web_tools._run_search_fallbacks(
+            "q", 5, primary_result, primary="brave-free",
+            _wsp_get_provider=self._registry([exa, tavily]),
+        )
+        assert out["success"] is True
+        assert exa.calls == 1
+        assert tavily.calls == 1
+
+    def test_all_fail_returns_primary_error(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"search_fallbacks": ["exa"]})
+        exa = _FakeSearchProvider("exa", result={"success": False, "error": "exa down"})
+        primary_result = {"success": False, "error": "Brave Search returned HTTP 402"}
+
+        out = web_tools._run_search_fallbacks(
+            "q", 5, primary_result, primary="brave-free",
+            _wsp_get_provider=self._registry([exa]),
+        )
+        # Primary's error is more actionable than the fallback's.
+        assert out is primary_result
+        assert "402" in out["error"]
+
+    def test_empty_chain_returns_primary_untouched(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+        primary_result = {"success": False, "error": "boom"}
+        out = web_tools._run_search_fallbacks(
+            "q", 5, primary_result, primary="brave-free",
+            _wsp_get_provider=self._registry([]),
+        )
+        assert out is primary_result
+
+    def test_unavailable_fallback_skipped(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"search_fallbacks": ["exa", "tavily"]})
+        exa = _FakeSearchProvider("exa", available=False)
+        tavily = _FakeSearchProvider("tavily", result={"success": True, "data": {"web": []}})
+        primary_result = {"success": False, "error": "primary dead"}
+
+        out = web_tools._run_search_fallbacks(
+            "q", 5, primary_result, primary="brave-free",
+            _wsp_get_provider=self._registry([exa, tavily]),
+        )
+        assert out["success"] is True
+        assert exa.calls == 0  # skipped — not available
+        assert tavily.calls == 1
+
+    def test_unregistered_fallback_skipped(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"search_fallbacks": ["ghost", "tavily"]})
+        tavily = _FakeSearchProvider("tavily", result={"success": True, "data": {"web": []}})
+        primary_result = {"success": False, "error": "primary dead"}
+
+        out = web_tools._run_search_fallbacks(
+            "q", 5, primary_result, primary="brave-free",
+            _wsp_get_provider=self._registry([tavily]),  # "ghost" not registered
+        )
+        assert out["success"] is True
+        assert tavily.calls == 1
+
+    def test_raising_fallback_treated_as_failure(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"search_fallbacks": ["exa", "tavily"]})
+        exa = _FakeSearchProvider("exa", raises=RuntimeError("kaboom"))
+        tavily = _FakeSearchProvider("tavily", result={"success": True, "data": {"web": []}})
+        primary_result = {"success": False, "error": "primary dead"}
+
+        out = web_tools._run_search_fallbacks(
+            "q", 5, primary_result, primary="brave-free",
+            _wsp_get_provider=self._registry([exa, tavily]),
+        )
+        assert out["success"] is True
+        assert tavily.calls == 1
+
+
+# ---------------------------------------------------------------------------
+# web_search_tool end-to-end — brave 402 → exa fallback
+# ---------------------------------------------------------------------------
+
+
+class TestWebSearchToolFallbackE2E:
+    @pytest.fixture(autouse=True)
+    def _populate_web_registry(self):
+        register_all_web_providers()
+        yield
+        from agent.web_search_registry import _reset_for_tests
+        _reset_for_tests()
+
+    def test_brave_402_falls_back_to_exa(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {
+            "search_backend": "brave-free",
+            "search_fallbacks": ["exa"],
+        })
+        monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
+        monkeypatch.setenv("EXA_API_KEY", "exa-key")
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+
+        # Brave returns a 402 failure; exa returns results.
+        brave_fail = {"success": False, "error": "Brave Search returned HTTP 402"}
+        exa_ok = {"success": True, "data": {"web": [{"title": "exa hit", "url": "https://x", "description": "", "position": 1}]}}
+
+        from plugins.web.brave_free.provider import BraveFreeWebSearchProvider
+        from plugins.web.exa.provider import ExaWebSearchProvider
+        monkeypatch.setattr(BraveFreeWebSearchProvider, "search", lambda self, q, limit=5: brave_fail)
+        monkeypatch.setattr(ExaWebSearchProvider, "search", lambda self, q, limit=5: exa_ok)
+
+        result = json.loads(web_tools.web_search_tool("test", limit=5))
+        assert result["success"] is True
+        assert result["data"]["web"][0]["title"] == "exa hit"
+
+    def test_no_fallback_configured_surfaces_brave_error(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {
+            "search_backend": "brave-free",
+        })
+        monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+
+        brave_fail = {"success": False, "error": "Brave Search returned HTTP 402"}
+        from plugins.web.brave_free.provider import BraveFreeWebSearchProvider
+        monkeypatch.setattr(BraveFreeWebSearchProvider, "search", lambda self, q, limit=5: brave_fail)
+
+        result = json.loads(web_tools.web_search_tool("test", limit=5))
+        assert result["success"] is False
+        assert "402" in result["error"]
+
+    def test_empty_successful_result_does_not_fallback(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {
+            "search_backend": "brave-free",
+            "search_fallbacks": ["exa"],
+        })
+        monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
+        monkeypatch.setenv("EXA_API_KEY", "exa-key")
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+
+        brave_empty = {"success": True, "data": {"web": []}}
+        from plugins.web.brave_free.provider import BraveFreeWebSearchProvider
+        from plugins.web.exa.provider import ExaWebSearchProvider
+        monkeypatch.setattr(BraveFreeWebSearchProvider, "search", lambda self, q, limit=5: brave_empty)
+
+        exa_called = {"hit": False}
+
+        def _exa_search(self, q, limit=5):
+            exa_called["hit"] = True
+            return {"success": True, "data": {"web": [{"title": "should not appear"}]}}
+
+        monkeypatch.setattr(ExaWebSearchProvider, "search", _exa_search)
+
+        result = json.loads(web_tools.web_search_tool("test", limit=5))
+        assert result["success"] is True
+        assert result["data"]["web"] == []
+        assert exa_called["hit"] is False  # empty-but-successful = no fallback
+
+
+# ---------------------------------------------------------------------------
+# _run_extract_fallbacks — dispatch behavior
+# ---------------------------------------------------------------------------
+
+
+class _FakeExtractProvider:
+    def __init__(self, name, result=None, available=True, supports=True, raises=None):
+        self._name = name
+        self._result = result
+        self._available = available
+        self._supports = supports
+        self._raises = raises
+        self.calls = 0
+
+    @property
+    def name(self):
+        return self._name
+
+    def supports_extract(self):
+        return self._supports
+
+    def is_available(self):
+        return self._available
+
+    def extract(self, urls, **kwargs):
+        self.calls += 1
+        if self._raises:
+            raise self._raises
+        return self._result
+
+
+class TestRunExtractFallbacks:
+    def _registry(self, providers):
+        table = {p.name: p for p in providers}
+        return lambda name: table.get(name)
+
+    def test_fallback_result_returned_when_primary_raises(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"extract_fallbacks": ["tavily"]})
+        tavily = _FakeExtractProvider("tavily", result=[{"url": "https://x", "title": "t", "content": "c"}])
+        primary = _FakeExtractProvider("firecrawl")
+        primary_exc = RuntimeError("firecrawl unreachable")
+
+        out = asyncio.get_event_loop().run_until_complete(
+            web_tools._run_extract_fallbacks(
+                ["https://x"], None, primary, primary_exc,
+                _wsp_get_provider=self._registry([tavily]),
+            )
+        )
+        assert out[0]["title"] == "t"
+        assert tavily.calls == 1
+
+    def test_all_raise_reraises_primary(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"extract_fallbacks": ["tavily"]})
+        tavily = _FakeExtractProvider("tavily", raises=RuntimeError("tavily down"))
+        primary = _FakeExtractProvider("firecrawl")
+        primary_exc = RuntimeError("firecrawl unreachable")
+
+        with pytest.raises(RuntimeError, match="firecrawl unreachable"):
+            asyncio.get_event_loop().run_until_complete(
+                web_tools._run_extract_fallbacks(
+                    ["https://x"], None, primary, primary_exc,
+                    _wsp_get_provider=self._registry([tavily]),
+                )
+            )
+
+    def test_empty_chain_reraises_primary(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+        primary = _FakeExtractProvider("firecrawl")
+        primary_exc = RuntimeError("primary dead")
+
+        with pytest.raises(RuntimeError, match="primary dead"):
+            asyncio.get_event_loop().run_until_complete(
+                web_tools._run_extract_fallbacks(
+                    ["https://x"], None, primary, primary_exc,
+                    _wsp_get_provider=self._registry([]),
+                )
+            )
+
+    def test_unavailable_fallback_skipped(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"extract_fallbacks": ["exa", "tavily"]})
+        exa = _FakeExtractProvider("exa", available=False)
+        tavily = _FakeExtractProvider("tavily", result=[{"url": "https://x", "title": "t", "content": "c"}])
+        primary = _FakeExtractProvider("firecrawl")
+        primary_exc = RuntimeError("primary dead")
+
+        out = asyncio.get_event_loop().run_until_complete(
+            web_tools._run_extract_fallbacks(
+                ["https://x"], None, primary, primary_exc,
+                _wsp_get_provider=self._registry([exa, tavily]),
+            )
+        )
+        assert out[0]["title"] == "t"
+        assert exa.calls == 0
+        assert tavily.calls == 1
+
+
+# ---------------------------------------------------------------------------
+# web_extract_tool end-to-end — primary raises → fallback used
+# ---------------------------------------------------------------------------
+
+
+class TestWebExtractToolFallbackE2E:
+    @pytest.fixture(autouse=True)
+    def _populate_web_registry(self):
+        register_all_web_providers()
+        yield
+        from agent.web_search_registry import _reset_for_tests
+        _reset_for_tests()
+
+    def test_primary_raises_falls_back_to_tavily(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {
+            "extract_backend": "exa",
+            "extract_fallbacks": ["tavily"],
+        })
+        monkeypatch.setenv("EXA_API_KEY", "exa-key")
+        monkeypatch.setenv("TAVILY_API_KEY", "tvly")
+
+        async def _allow_ssrf(_url):
+            return True
+
+        monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_ssrf)
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+
+        from plugins.web.exa.provider import ExaWebSearchProvider
+        from plugins.web.tavily.provider import TavilyWebSearchProvider
+
+        def _exa_raise(self, urls, **kwargs):
+            raise RuntimeError("exa backend down")
+
+        monkeypatch.setattr(ExaWebSearchProvider, "extract", _exa_raise)
+        monkeypatch.setattr(
+            TavilyWebSearchProvider, "extract",
+            lambda self, urls, **kwargs: [{"url": urls[0], "title": "tavily", "content": "body", "raw_content": "body"}],
+        )
+
+        result = json.loads(asyncio.get_event_loop().run_until_complete(
+            web_tools.web_extract_tool(["https://example.com"])
+        ))
+        # Fallback content reached the post-processing pipeline.
+        assert any("tavily" in (r.get("title") or "") for r in result["results"])

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -308,6 +308,58 @@ def _get_capability_backend(capability: str) -> str:
     return _get_backend()
 
 
+def _get_fallback_backends(capability: str, primary: Optional[str] = None) -> List[str]:
+    """Return the ordered fallback chain for a capability ("search"|"extract").
+
+    Reads ``web.{capability}_fallbacks`` from config.yaml — an ordered list of
+    provider names tried in sequence when the primary backend fails (returns
+    ``{"success": False}`` or raises). Example::
+
+        web:
+          search_backend: brave-free
+          search_fallbacks: [exa, tavily]
+
+    Normalization rules:
+    - Non-list values (a bare string, null) are coerced: a comma/space-separated
+      string is split, anything else yields an empty chain.
+    - Entries are lowercased, stripped, and de-duplicated (first occurrence wins).
+    - The *primary* backend name is dropped so a misconfigured chain that repeats
+      the primary never retries the same provider that just failed.
+    - Empty / whitespace-only entries are discarded.
+
+    Availability is NOT filtered here — the dispatcher probes each candidate at
+    call time and skips unavailable ones, so a chain can name a provider whose
+    key is added later without a config edit.
+    """
+    cfg = _load_web_config()
+    raw = cfg.get(f"{capability}_fallbacks")
+
+    if raw is None:
+        items: List[str] = []
+    elif isinstance(raw, str):
+        # Tolerate a comma/space-separated string written by hand or by a tool
+        # that can't emit a YAML list (``hermes config set`` writes scalars).
+        # Strip list-literal brackets and surrounding quotes so both
+        # ``"exa, tavily"`` and ``"[exa, tavily]"`` parse cleanly.
+        cleaned = raw.strip().strip("[]").replace(",", " ")
+        items = [part.strip("'\"") for part in cleaned.split()]
+    elif isinstance(raw, (list, tuple)):
+        items = [str(item) for item in raw]
+    else:
+        items = []
+
+    primary_norm = (primary or "").lower().strip()
+    seen = set()
+    chain: List[str] = []
+    for item in items:
+        name = item.lower().strip()
+        if not name or name == primary_norm or name in seen:
+            continue
+        seen.add(name)
+        chain.append(name)
+    return chain
+
+
 def _is_backend_available(backend: str) -> bool:
     """Return True when the selected backend is currently usable.
 
@@ -615,6 +667,61 @@ def _ensure_web_plugins_loaded() -> None:
         logger.warning("Web plugin discovery failed (non-fatal): %s", exc)
 
 
+def _run_search_fallbacks(
+    query: str,
+    limit: int,
+    primary_result: Dict[str, Any],
+    *,
+    primary: Optional[str],
+    _wsp_get_provider,
+) -> Dict[str, Any]:
+    """Walk ``web.search_fallbacks`` after the primary search provider failed.
+
+    Called only when the primary returned ``success=False`` (or raised, which
+    the dispatcher normalizes to a failure dict). Each candidate is resolved
+    via the registry; unavailable / unregistered / search-incapable candidates
+    are skipped. The first candidate that returns ``success=True`` wins and its
+    result is returned. If every candidate fails, the *primary's* original
+    error is returned (it names the configured backend the user actually set up,
+    which is more actionable than the last fallback's error).
+
+    ``_wsp_get_provider`` is the registry ``get_provider`` callable, passed in so
+    this helper shares the dispatcher's already-imported registry handle.
+    """
+    chain = _get_fallback_backends("search", primary=primary)
+    if not chain:
+        return primary_result
+
+    errors = [f"{primary}: {primary_result.get('error', 'unknown error')}"]
+    for name in chain:
+        candidate = _wsp_get_provider(name)
+        if candidate is None or not candidate.supports_search():
+            logger.debug("search fallback '%s' unavailable (unregistered/search-incapable); skipping", name)
+            continue
+        try:
+            available = bool(candidate.is_available())
+        except Exception as exc:  # noqa: BLE001 — a broken provider is "unavailable"
+            logger.debug("search fallback '%s'.is_available() raised: %s", name, exc)
+            available = False
+        if not available:
+            logger.debug("search fallback '%s' not available (missing credentials); skipping", name)
+            continue
+
+        logger.info("Web search falling back to %s: '%s'", name, query)
+        try:
+            result = candidate.search(query, limit)
+        except Exception as exc:  # noqa: BLE001 — a raising fallback is a failure
+            logger.warning("search fallback %s raised: %s", name, exc)
+            errors.append(f"{name}: {exc}")
+            continue
+        if result.get("success"):
+            return result
+        errors.append(f"{name}: {result.get('error', 'unknown error')}")
+
+    logger.warning("All web search fallbacks exhausted: %s", "; ".join(errors))
+    return primary_result
+
+
 def web_search_tool(query: str, limit: int = 5) -> str:
     """
     Search the web for information using available search API backend.
@@ -719,7 +826,28 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                 "Web search via %s: '%s' (limit: %d)",
                 provider.name, query, limit,
             )
-            response_data = provider.search(query, limit)
+            try:
+                response_data = provider.search(query, limit)
+            except Exception as exc:  # noqa: BLE001 — a raising provider is a failure
+                # Only intercept when the user opted into a fallback chain;
+                # otherwise re-raise so the top-level handler produces the
+                # standard "Error searching web:" envelope (unchanged behavior
+                # for installs without web.search_fallbacks configured).
+                if not _get_fallback_backends("search", primary=provider.name):
+                    raise
+                logger.warning("Web search provider %s raised: %s", provider.name, exc)
+                response_data = {"success": False, "error": f"{provider.name} failed: {exc}"}
+
+            # Fallback chain: when the primary returns success=False (quota
+            # exhausted, HTTP 402/429, transient outage), walk web.search_fallbacks
+            # in order and use the first candidate that returns a usable result.
+            # An empty-but-successful result set is NOT a failure — no fallback.
+            if not response_data.get("success"):
+                response_data = _run_search_fallbacks(
+                    query, limit, response_data,
+                    primary=provider.name,
+                    _wsp_get_provider=_wsp_get_provider,
+                )
 
         debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
@@ -737,6 +865,63 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         _debug.save()
 
         return tool_error(error_msg)
+
+
+async def _dispatch_extract(provider, safe_urls, format):
+    """Call a provider's extract(), handling async and sync implementations.
+
+    Mirrors the inline dispatch in :func:`web_extract_tool`: parallel +
+    firecrawl expose ``async def extract()``, exa + tavily are sync. Sync
+    implementations run in a thread so blocking network I/O doesn't stall
+    the event loop.
+    """
+    import inspect
+    if inspect.iscoroutinefunction(provider.extract):
+        return await provider.extract(safe_urls, format=format)
+    return await asyncio.to_thread(provider.extract, safe_urls, format=format)
+
+
+async def _run_extract_fallbacks(safe_urls, format, primary, primary_exc, _wsp_get_provider):
+    """Walk ``web.extract_fallbacks`` after the primary extract provider raised.
+
+    Extract providers signal a hard failure by *raising* (unreachable backend,
+    missing SDK, auth error); per-URL ``error`` entries in a returned list are
+    normal and do NOT trigger a fallback. So this helper is only invoked when
+    the primary raised ``primary_exc``.
+
+    Each candidate must be registered, support extract, and report
+    ``is_available()``. The first candidate whose ``extract()`` returns without
+    raising wins. If every candidate raises (or none is usable), the primary's
+    original exception is re-raised so the caller's existing error handling
+    produces the same message it did before fallbacks existed.
+    """
+    chain = _get_fallback_backends("extract", primary=getattr(primary, "name", None))
+    if not chain:
+        raise primary_exc
+
+    for name in chain:
+        candidate = _wsp_get_provider(name)
+        if candidate is None or not candidate.supports_extract():
+            logger.debug("extract fallback '%s' unavailable (unregistered/extract-incapable); skipping", name)
+            continue
+        try:
+            available = bool(candidate.is_available())
+        except Exception as exc:  # noqa: BLE001 — a broken provider is "unavailable"
+            logger.debug("extract fallback '%s'.is_available() raised: %s", name, exc)
+            available = False
+        if not available:
+            logger.debug("extract fallback '%s' not available (missing credentials); skipping", name)
+            continue
+
+        logger.info("Web extract falling back to %s: %d URL(s)", name, len(safe_urls))
+        try:
+            return await _dispatch_extract(candidate, safe_urls, format)
+        except Exception as exc:  # noqa: BLE001 — try the next candidate
+            logger.warning("extract fallback %s raised: %s", name, exc)
+            continue
+
+    logger.warning("All web extract fallbacks exhausted; surfacing primary error")
+    raise primary_exc
 
 
 async def web_extract_tool(
@@ -930,16 +1115,15 @@ async def web_extract_tool(
                 "Web extract via %s: %d URL(s)", provider.name, len(safe_urls)
             )
 
-            # Async-or-sync dispatch: parallel + firecrawl have async
-            # extract(); exa + tavily are sync.
-            import inspect
-            if inspect.iscoroutinefunction(provider.extract):
-                results = await provider.extract(safe_urls, format=format)
-            else:
-                # Run sync extract() in a thread so we don't block the
-                # event loop on network I/O.
-                results = await asyncio.to_thread(
-                    provider.extract, safe_urls, format=format
+            # Async-or-sync dispatch with fallback chain: parallel + firecrawl
+            # have async extract(); exa + tavily are sync. When the primary
+            # raises (hard failure), walk web.extract_fallbacks in order.
+            try:
+                results = await _dispatch_extract(provider, safe_urls, format)
+            except Exception as extract_exc:  # noqa: BLE001 — try fallbacks before failing
+                results = await _run_extract_fallbacks(
+                    safe_urls, format, provider, extract_exc,
+                    _wsp_get_provider=_wsp_get_provider,
                 )
 
         # Reconstruct the original input order across invalid, blocked, and

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1960,6 +1960,18 @@ web:
 
 **SearXNG** is a free, self-hosted, privacy-respecting metasearch engine that queries 70+ search engines. No API key needed — just set `SEARXNG_URL` to your instance (e.g., `http://localhost:8080`). SearXNG is search-only; `web_extract` requires a separate extract provider (set `web.extract_backend`). See the [Web Search setup guide](/user-guide/features/web-search) for Docker setup instructions.
 
+**Fallback chains:** When a backend fails at runtime (e.g. a free-tier quota returning HTTP 402), Hermes can walk an ordered list of fallbacks. Search falls back when the primary returns `success: false`; extract falls back when the primary raises. Unavailable candidates are skipped automatically.
+
+```yaml
+web:
+  search_backend: "brave-free"
+  search_fallbacks: ["exa", "tavily"]
+  extract_backend: "firecrawl"
+  extract_fallbacks: ["tavily", "exa"]
+```
+
+Set from the CLI: `hermes config set web.search_fallbacks "exa, tavily"`. See the [Web Search setup guide](/user-guide/features/web-search#fallback-chains) for full semantics.
+
 **Self-hosted Firecrawl:** Set `FIRECRAWL_API_URL` to point at your own instance. When a custom URL is set, the API key becomes optional (set `USE_DB_AUTHENTICATION=*** on the server to disable auth).
 
 **Parallel search modes:** Set `PARALLEL_SEARCH_MODE` to control search behavior — `fast`, `one-shot`, or `agentic` (default: `agentic`).

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -347,6 +347,42 @@ When per-capability keys are empty, both fall through to `web.backend`. When `we
 2. `web.backend` (shared fallback)
 3. Auto-detect from environment variables
 
+### Fallback chains
+
+A single backend can fail at runtime — a free-tier quota running out (Brave's
+HTTP 402), a transient outage, or a revoked key. Configure an ordered list of
+fallbacks and Hermes walks them in sequence when the primary fails, using the
+first provider that returns a usable result:
+
+```yaml
+# ~/.hermes/config.yaml
+web:
+  search_backend: "brave-free"
+  search_fallbacks: ["exa", "tavily"]   # tried in order if brave-free fails
+  extract_backend: "firecrawl"
+  extract_fallbacks: ["tavily", "exa"]  # tried in order if firecrawl raises
+```
+
+Behavior:
+
+- **Search** falls back when the primary returns a failure (`success: false`).
+  An empty-but-successful result set is *not* a failure, so a query with no
+  matches does not burn through your fallbacks.
+- **Extract** falls back when the primary *raises* (unreachable backend, missing
+  SDK, auth error). Per-URL errors inside a returned result are normal and do not
+  trigger a fallback.
+- Candidates that are unregistered, lack the capability, or report
+  `is_available() == false` (missing credentials) are skipped automatically, so a
+  chain can name a provider whose key you add later with no config edit.
+- If every fallback fails, the primary's original error is surfaced — it names
+  the backend you actually configured, which is more actionable.
+
+Set it from the CLI too (the value is parsed as a comma/space-separated list):
+
+```bash
+hermes config set web.search_fallbacks "exa, tavily"
+```
+
 ### Auto-detection
 
 If no backend is explicitly configured, Hermes picks the first available one based on which credentials are set:


### PR DESCRIPTION
## What does this PR do?

Adds `web.search_fallbacks` and `web.extract_fallbacks` — ordered provider lists that Hermes walks in sequence when the primary web backend fails at runtime.

A single backend can fail without any config change: a free-tier quota running out (Brave returns HTTP 402), a transient outage, or a revoked key. Previously the dispatcher surfaced that error immediately and the user had to edit config and restart. With this change, the dispatcher tries each configured fallback in order and uses the first provider that returns a usable result.

## Related Issue

Observed in the wild: `brave-free` as the search backend started returning `Brave Search returned HTTP 402` once the free tier was exhausted, breaking all web search until config was manually changed. This makes that a one-line config fix instead.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/web_tools.py`
  - `_get_fallback_backends(capability, primary)` — reads `web.{capability}_fallbacks`, normalizes list/comma-string/bracketed-string input, dedups, strips the primary, drops empties.
  - `_run_search_fallbacks(...)` — walks the chain after a `success: false` primary; skips unregistered/incapable/unavailable candidates; returns first healthy result or the primary error if all fail.
  - `_dispatch_extract(...)` / `_run_extract_fallbacks(...)` — async/sync-aware extract dispatch; falls back only when the primary *raises* (per-URL errors are normal and do not trigger fallback); re-raises the primary exception if the chain is empty or exhausted.
  - `web_search_tool` / `web_extract_tool` wired to the helpers. The raising-provider path in search re-raises when no chain is configured, so the standard `"Error searching web:"` envelope is byte-for-byte unchanged for existing installs.
- `hermes_cli/config.py` — registers `web.search_fallbacks` / `web.extract_fallbacks` defaults (`[]`) so `hermes config set` recognizes them.
- `website/docs/user-guide/features/web-search.md` — new "Fallback chains" section with semantics.
- `website/docs/user-guide/configuration.md` — reference blurb plus example.
- `tests/tools/test_web_fallback_chains.py` — 25 tests covering parsing, dispatch, skip logic, error surfacing, and two end-to-end paths (brave 402 to exa; extract raise to tavily).

## How to Test

1. `pytest tests/tools/test_web_fallback_chains.py -q` → 25 passed.
2. Full web suite: `pytest tests/tools/test_web_tools_config.py tests/tools/test_web_providers*.py tests/tools/test_web_extract_robustness.py tests/tools/test_web_tools_*.py -q` → 252 passed (no regressions).
3. Live: with `web.search_backend: brave-free` (currently 402ing) and `web.search_fallbacks: "exa, tavily"`, `web_search_tool("current weather sydney")` returns `success: true` with 3 results via exa.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass (web and config suites green)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Linux 7.0.14-4-pve)

### Documentation and Housekeeping

- [x] I've updated relevant documentation (web-search.md, configuration.md, docstrings)
- [x] N/A `cli-config.yaml.example` (no `web:` section exists there)
- [x] N/A CONTRIBUTING.md / AGENTS.md (no architecture/workflow change)
- [x] Cross-platform: pure-Python dispatch logic, no platform-specific syscalls
- [x] N/A tool descriptions/schemas (tool signatures unchanged)

## Screenshots / Logs

Live fallback in action (brave 402 to exa):
```
Brave Search HTTP error: Client error '402 Payment Required' ...
success: True
results: 3
first: Sydney, New South Wales
```
