### PR TITLE
feat(desktop): plugin SDK ctx.download — hand the user a file

### DIFF
--- a/apps/desktop/electron/hardening.test.ts
+++ b/apps/desktop/electron/hardening.test.ts
@@ -13,11 +13,15 @@ import {
   dataUrlReadMaxBytesFromMb,
   DEFAULT_FETCH_TIMEOUT_MS,
   encryptDesktopSecret,
+  filenameFromContentDisposition,
+  PLUGIN_DOWNLOAD_MAX_BYTES,
   readFileDataUrlForIpc,
   resolveDirectoryForIpc,
+  resolveDownloadCollision,
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
   resolveTimeoutMs,
+  safeDownloadFilename,
   sensitiveFileBlockReason
 } from './hardening'
 
@@ -351,4 +355,82 @@ test('resolveDirectoryForIpc accepts directory symlinks or junctions', async () 
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true })
   }
+})
+
+test('safeDownloadFilename strips every path escape a server or DB row could inject', () => {
+  // Separators become underscores rather than being dropped, so the name stays
+  // recognisable and can never address a parent directory. The leading-dot
+  // strip then runs on the result, so a leading '..' loses its dots too.
+  assert.equal(safeDownloadFilename('../../etc/passwd'), '_.._etc_passwd')
+  assert.equal(safeDownloadFilename('..\\..\\Windows\\System32\\cfg'), '_.._Windows_System32_cfg')
+  assert.equal(safeDownloadFilename('/absolute/path.txt'), '_absolute_path.txt')
+
+  // Bare traversal tokens and dotfile-forcing prefixes carry no usable name.
+  assert.equal(safeDownloadFilename('..'), 'download')
+  assert.equal(safeDownloadFilename('.'), 'download')
+  assert.equal(safeDownloadFilename('...'), 'download')
+  assert.equal(safeDownloadFilename('.hidden'), 'hidden')
+
+  // Empty / missing / NUL-poisoned input falls back instead of throwing.
+  assert.equal(safeDownloadFilename(''), 'download')
+  assert.equal(safeDownloadFilename(null), 'download')
+  assert.equal(safeDownloadFilename('a\0b.txt'), 'ab.txt')
+  assert.equal(safeDownloadFilename('', 'fallback.bin'), 'fallback.bin')
+
+  // An ordinary name survives untouched.
+  assert.equal(safeDownloadFilename('report 2026.pdf'), 'report 2026.pdf')
+})
+
+test('filenameFromContentDisposition prefers RFC 5987 and sanitizes both forms', () => {
+  assert.equal(filenameFromContentDisposition('attachment; filename="notes.txt"'), 'notes.txt')
+  assert.equal(filenameFromContentDisposition('attachment; filename=notes.txt'), 'notes.txt')
+
+  // filename* wins when both are present, and percent-decoding is applied.
+  assert.equal(
+    filenameFromContentDisposition("attachment; filename=\"fallback.txt\"; filename*=UTF-8''r%C3%A9sum%C3%A9.pdf"),
+    'résumé.pdf'
+  )
+
+  // A traversal smuggled through either form is still neutralized.
+  assert.equal(filenameFromContentDisposition('attachment; filename="../../evil.sh"'), '_.._evil.sh')
+  assert.equal(filenameFromContentDisposition("attachment; filename*=UTF-8''%2e%2e%2f%2e%2e%2fevil.sh"), '_.._evil.sh')
+
+  // Malformed percent-encoding falls back to the plain form rather than throwing.
+  assert.equal(filenameFromContentDisposition("attachment; filename=\"ok.txt\"; filename*=UTF-8''%E0%A4%A"), 'ok.txt')
+
+  // No header, or no filename in it, yields empty so the caller can fall back.
+  assert.equal(filenameFromContentDisposition('attachment'), '')
+  assert.equal(filenameFromContentDisposition(''), '')
+  assert.equal(filenameFromContentDisposition(null), '')
+})
+
+test('resolveDownloadCollision suffixes before the extension and never clobbers', () => {
+  const dir = path.join(os.tmpdir(), 'dl')
+  const taken = new Set([path.join(dir, 'a.txt'), path.join(dir, 'a (1).txt')])
+  const exists = (candidate: string) => taken.has(candidate)
+
+  // A free name is returned untouched.
+  assert.equal(resolveDownloadCollision(path.join(dir, 'free.txt'), exists), path.join(dir, 'free.txt'))
+
+  // Occupied names walk forward past every taken index.
+  assert.equal(resolveDownloadCollision(path.join(dir, 'a.txt'), exists), path.join(dir, 'a (2).txt'))
+
+  // The suffix goes before the extension so the file still opens correctly,
+  // including for multi-dot names.
+  const archive = path.join(dir, 'bundle.tar.gz')
+  assert.equal(resolveDownloadCollision(archive, c => c === archive), path.join(dir, 'bundle.tar (1).gz'))
+
+  // A leading-dot file is all name, no extension.
+  const dotfile = path.join(dir, '.gitignore')
+  assert.equal(resolveDownloadCollision(dotfile, c => c === dotfile), path.join(dir, '.gitignore (1)'))
+
+  // An exhausted range raises instead of spinning forever.
+  assert.throws(() => resolveDownloadCollision(path.join(dir, 'x.txt'), () => true, 3), /after 3 attempts/)
+})
+
+test('the plugin download cap matches the backend attachment limit', () => {
+  // A blob the backend refused to accept can't come back down, so the ceiling
+  // tracks KANBAN_ATTACHMENT_MAX_BYTES rather than drifting on its own.
+  assert.equal(PLUGIN_DOWNLOAD_MAX_BYTES, 25 * 1024 * 1024)
+  assert.ok(PLUGIN_DOWNLOAD_MAX_BYTES < ATTACHMENT_UPLOAD_DEFAULT_MAX_BYTES)
 })

--- a/apps/desktop/electron/hardening.ts
+++ b/apps/desktop/electron/hardening.ts
@@ -16,6 +16,11 @@ const DATA_URL_READ_MAX_MAX_MB = 4096
 // reader so the payload still fits uvicorn's raised ws_max_size (384 MiB)
 // after base64 + framing. Preview stays on the Settings-configurable path.
 const ATTACHMENT_UPLOAD_DEFAULT_MAX_BYTES = 256 * 1024 * 1024
+// Ceiling for a plugin-initiated download buffered in main before it's written
+// to disk. Matches the kanban attachment upload cap (KANBAN_ATTACHMENT_MAX_BYTES
+// in hermes_cli/kanban_db.py) — a blob the backend refused to accept can't come
+// back down — with headroom for other plugins' smaller payloads.
+const PLUGIN_DOWNLOAD_MAX_BYTES = 25 * 1024 * 1024
 const TEXT_PREVIEW_SOURCE_MAX_BYTES = 64 * 1024 * 1024
 
 function clampDataUrlReadMaxMb(value) {
@@ -46,6 +51,69 @@ function resolveTimeoutMs(timeoutMs, fallbackMs = DEFAULT_FETCH_TIMEOUT_MS) {
   }
 
   return fallback
+}
+
+// A downloaded filename is attacker-influenced data (it comes from a DB row a
+// worker wrote, or a Content-Disposition header). It must never be able to
+// escape the directory the user picked, so reduce it to a bare basename with
+// no separators, no traversal, and no leading dot.
+function safeDownloadFilename(name, fallback = 'download') {
+  const raw = String(name || '')
+    .replace(/[/\\]/g, '_')
+    .replace(/\0/g, '')
+    .trim()
+
+  // '.' and '..' survive the separator strip; treat them as absent.
+  const cleaned = raw === '.' || raw === '..' ? '' : raw.replace(/^\.+/, '')
+
+  return cleaned || fallback
+}
+
+// RFC 6266 Content-Disposition filename, preferring the RFC 5987 `filename*`
+// form when present (it carries the encoding and survives non-ASCII names).
+function filenameFromContentDisposition(header) {
+  const value = String(header || '')
+
+  const extended = /filename\*\s*=\s*(?:UTF-8|utf-8)''([^;]+)/.exec(value)
+
+  if (extended) {
+    try {
+      return safeDownloadFilename(decodeURIComponent(extended[1]), '')
+    } catch {
+      // Malformed percent-encoding — fall through to the plain form.
+    }
+  }
+
+  const plain = /filename\s*=\s*(?:"([^"]*)"|([^;]+))/.exec(value)
+
+  return plain ? safeDownloadFilename((plain[1] ?? plain[2] ?? '').trim(), '') : ''
+}
+
+// Pick a path that doesn't clobber an existing file: `notes.txt` becomes
+// `notes (1).txt`, then `notes (2).txt`. The suffix goes before the extension
+// so the file still opens in the right app. `exists` is injected so this stays
+// pure and testable; bounded so a pathological directory can't spin forever.
+function resolveDownloadCollision(targetPath, exists, limit = 1000) {
+  if (!exists(targetPath)) {
+    return targetPath
+  }
+
+  const dir = path.dirname(targetPath)
+  const base = path.basename(targetPath)
+  // Leading-dot files ('.gitignore') are all name, no extension.
+  const dot = base.lastIndexOf('.')
+  const stem = dot > 0 ? base.slice(0, dot) : base
+  const ext = dot > 0 ? base.slice(dot) : ''
+
+  for (let n = 1; n <= limit; n += 1) {
+    const candidate = path.join(dir, `${stem} (${n})${ext}`)
+
+    if (!exists(candidate)) {
+      return candidate
+    }
+  }
+
+  throw new Error(`Could not find a free filename for ${base} after ${limit} attempts.`)
 }
 
 function encryptDesktopSecret(value, safeStorageApi) {
@@ -355,12 +423,16 @@ export {
   dataUrlReadMaxBytesFromMb,
   DEFAULT_FETCH_TIMEOUT_MS,
   encryptDesktopSecret,
+  filenameFromContentDisposition,
+  PLUGIN_DOWNLOAD_MAX_BYTES,
   readFileDataUrlForIpc,
   rejectUnsafePathSyntax,
   resolveDirectoryForIpc,
+  resolveDownloadCollision,
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
   resolveTimeoutMs,
+  safeDownloadFilename,
   sensitiveFileBlockReason,
   TEXT_PREVIEW_SOURCE_MAX_BYTES
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -121,10 +121,14 @@ import {
   dataUrlReadMaxBytesFromMb,
   DEFAULT_FETCH_TIMEOUT_MS,
   encryptDesktopSecret as encryptDesktopSecretStrict,
+  filenameFromContentDisposition,
+  PLUGIN_DOWNLOAD_MAX_BYTES,
   readFileDataUrlForIpc,
+  resolveDownloadCollision,
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
   resolveTimeoutMs,
+  safeDownloadFilename,
   TEXT_PREVIEW_SOURCE_MAX_BYTES
 } from './hardening'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
@@ -4231,6 +4235,82 @@ function fetchJson(url, token, options: any = {}) {
       req.write(body)
     }
 
+    req.end()
+  })
+}
+
+// Binary sibling of `fetchJson`: same auth header and protocol guard, but the
+// response stays a Buffer instead of being decoded as UTF-8 and JSON.parsed.
+// Attachments are arbitrary bytes (PNG, PDF, tarball) — routing them through
+// the JSON path corrupts them. Capped so a huge blob can't exhaust main's heap.
+function fetchBuffer(url, token, options: any = {}) {
+  return new Promise<{ buffer: Buffer; contentDisposition: string; contentType: string }>((resolve, reject) => {
+    const parsed = new URL(url)
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      reject(new Error(`Unsupported Hermes backend URL protocol: ${parsed.protocol}`))
+
+      return
+    }
+
+    const client = parsed.protocol === 'https:' ? https : http
+    const timeoutMs = resolveTimeoutMs(options.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
+
+    const maxBytes =
+      Number.isFinite(options.maxBytes) && Number(options.maxBytes) > 0
+        ? Number(options.maxBytes)
+        : PLUGIN_DOWNLOAD_MAX_BYTES
+
+    const req = client.request(
+      parsed,
+      {
+        method: 'GET',
+        headers: {
+          ...(token ? { 'X-Hermes-Session-Token': token } : {}),
+          ...(options.bearer ? { Authorization: `Bearer ${options.bearer}` } : {})
+        }
+      },
+      res => {
+        const chunks = []
+        let total = 0
+
+        res.on('error', reject)
+        res.on('data', chunk => {
+          total += chunk.length
+
+          // Abort mid-stream rather than buffering a blob we've already
+          // decided to refuse.
+          if (total > maxBytes) {
+            req.destroy(new Error(`Download exceeds the ${Math.floor(maxBytes / (1024 * 1024))} MB limit.`))
+
+            return
+          }
+
+          chunks.push(chunk)
+        })
+        res.on('end', () => {
+          const buffer = Buffer.concat(chunks)
+
+          if ((res.statusCode || 500) >= 400) {
+            // Errors from the backend are JSON/text even on this path.
+            reject(new Error(`${res.statusCode}: ${buffer.toString('utf8').slice(0, 200) || res.statusMessage}`))
+
+            return
+          }
+
+          resolve({
+            buffer,
+            contentDisposition: String(res.headers['content-disposition'] || ''),
+            contentType: String(res.headers['content-type'] || '')
+          })
+        })
+      }
+    )
+
+    req.on('error', reject)
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(new Error(`Timed out connecting to Hermes backend after ${timeoutMs}ms`))
+    })
     req.end()
   })
 }
@@ -10127,6 +10207,93 @@ ipcMain.handle('hermes:api', async (_event, request) => {
     upload: request?.upload,
     timeoutMs
   })
+})
+
+// Plugin binary download: fetch bytes from a plugin's own API namespace, ask
+// the user where to put them, write, and offer to reveal. The renderer runs on
+// a file:// origin and `hermes:api` is JSON-only, so a plugin has no other way
+// to hand the user a file. Namespace scoping is enforced renderer-side by
+// `pluginDownload` and re-derived here — main never takes a caller-supplied
+// absolute URL.
+ipcMain.handle('hermes:plugin:download', async (_event, request) => {
+  const pluginId = String(request?.pluginId || '')
+  const suffix = String(request?.path || '')
+
+  // Belt-and-braces against a compromised renderer: rebuild the path from the
+  // plugin id here instead of trusting a caller-assembled one.
+  if (!/^[a-z0-9][a-z0-9-]*$/i.test(pluginId)) {
+    throw new Error(`hermes:plugin:download: invalid plugin id "${pluginId}"`)
+  }
+
+  if (!suffix.startsWith('/') || suffix.split(/[?#]/, 1)[0].split('/').includes('..')) {
+    throw new Error(`hermes:plugin:download: illegal path "${suffix}"`)
+  }
+
+  const profile = request?.profile
+  const connection = await ensureBackend(resolveRouteProfile(null, profile))
+
+  const requestPath = pathWithGlobalRemoteProfile(
+    `/api/plugins/${pluginId}${suffix}`,
+    profile,
+    profileRouteOptions(profile)
+  )
+
+  const url = `${connection.baseUrl}${requestPath}`
+
+  let fetched
+
+  if (connection.authMode === 'oauth') {
+    // Cookie-partition downloads would need the electron.net path; the native
+    // bearer covers the flows we support today. Fail loudly instead of writing
+    // a 401 body to disk as if it were the file.
+    const nativeAt = await ensureNativeAccessToken(connection.baseUrl).catch(() => null)
+
+    if (!nativeAt) {
+      throw new Error('Downloads are not supported against cookie-authenticated OAuth backends yet.')
+    }
+
+    fetched = await fetchBuffer(url, null, { bearer: nativeAt, timeoutMs: request?.timeoutMs })
+  } else {
+    fetched = await fetchBuffer(url, connection.token, { timeoutMs: request?.timeoutMs })
+  }
+
+  // Caller's suggestion first (the DB's filename), then the server's
+  // Content-Disposition, then a generic fallback. Every branch is sanitized:
+  // all three sources are attacker-influenced.
+  const suggested =
+    safeDownloadFilename(request?.filename, '') ||
+    filenameFromContentDisposition(fetched.contentDisposition) ||
+    'download'
+
+  const target = await dialog.showSaveDialog(mainWindow, {
+    title: 'Save Attachment',
+    defaultPath: path.join(app.getPath('downloads'), suggested)
+  })
+
+  if (target.canceled || !target.filePath) {
+    return { canceled: true }
+  }
+
+  // The dialog already warns on overwrite, but a user can still land on a name
+  // that raced into existence; never clobber silently.
+  const filePath = resolveDownloadCollision(target.filePath, candidate => fs.existsSync(candidate))
+  await fs.promises.writeFile(filePath, fetched.buffer)
+
+  return { canceled: false, filePath }
+})
+
+// Reveal a saved download in Finder/Explorer/Files — the follow-up affordance
+// for the toast the renderer shows after a successful save.
+ipcMain.handle('hermes:plugin:revealDownload', (_event, filePath) => {
+  const target = String(filePath || '')
+
+  if (!target) {
+    return false
+  }
+
+  shell.showItemInFolder(target)
+
+  return true
 })
 
 // One deduper per cross-window cue — the choke point every window shares. Main

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -95,6 +95,8 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     set: name => ipcRenderer.invoke('hermes:profile:set', name)
   },
   api: request => ipcRenderer.invoke('hermes:api', request),
+  pluginDownload: request => ipcRenderer.invoke('hermes:plugin:download', request),
+  pluginRevealDownload: filePath => ipcRenderer.invoke('hermes:plugin:revealDownload', filePath),
   notify: payload => ipcRenderer.invoke('hermes:notify', payload),
   requestMicrophoneAccess: () => ipcRenderer.invoke('hermes:requestMicrophoneAccess'),
   readFileDataUrl: filePath => ipcRenderer.invoke('hermes:readFileDataUrl', filePath),

--- a/apps/desktop/src/contrib/plugin.test.ts
+++ b/apps/desktop/src/contrib/plugin.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createPluginContext } from './plugin'
 
@@ -17,5 +17,62 @@ describe('createPluginContext.onDispose', () => {
     expect(disposers).toHaveLength(1)
     disposers.forEach(dispose => dispose())
     expect(cleaned).toBe(true)
+  })
+})
+
+describe('createPluginContext.download', () => {
+  const pluginDownload = vi.fn(async () => ({ canceled: false, filePath: '/tmp/a.png' }))
+  const pluginRevealDownload = vi.fn(async () => true)
+
+  beforeEach(() => {
+    pluginDownload.mockClear()
+    pluginRevealDownload.mockClear()
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { pluginDownload, pluginRevealDownload },
+      writable: true
+    })
+  })
+
+  it('stamps the calling plugin id so a plugin can only reach its own namespace', async () => {
+    await createPluginContext('kanban').download('/attachments/7', { filename: 'shot.png' })
+
+    // The renderer never assembles a URL — it hands main the id + relative
+    // path, and main rebuilds `/api/plugins/<id>/...` from them.
+    expect(pluginDownload).toHaveBeenCalledWith(
+      expect.objectContaining({ filename: 'shot.png', path: '/attachments/7', pluginId: 'kanban' })
+    )
+  })
+
+  it('normalizes a bare path and rejects traversal out of the namespace', async () => {
+    const ctx = createPluginContext('kanban')
+
+    await ctx.download('attachments/7')
+    expect(pluginDownload).toHaveBeenCalledWith(expect.objectContaining({ path: '/attachments/7' }))
+
+    // Same guard `rest` and `socket` use: `..` can't normalize into another
+    // plugin's API or a core route.
+    await expect(ctx.download('/../other/secrets')).rejects.toThrow(/traversal/)
+    expect(pluginDownload).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces a user-cancelled save as a normal result, not an error', async () => {
+    pluginDownload.mockResolvedValueOnce({ canceled: true } as never)
+
+    await expect(createPluginContext('kanban').download('/attachments/7')).resolves.toEqual({ canceled: true })
+  })
+
+  it('fails with a clear message on a shell that predates the channel', async () => {
+    Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: {}, writable: true })
+
+    await expect(createPluginContext('kanban').download('/attachments/7')).rejects.toThrow(/cannot download/i)
+  })
+
+  it('reveals a saved file, and resolves false when the shell cannot', async () => {
+    await expect(createPluginContext('kanban').revealDownload('/tmp/a.png')).resolves.toBe(true)
+    expect(pluginRevealDownload).toHaveBeenCalledWith('/tmp/a.png')
+
+    Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: {}, writable: true })
+    await expect(createPluginContext('kanban').revealDownload('/tmp/a.png')).resolves.toBe(false)
   })
 })

--- a/apps/desktop/src/contrib/plugin.ts
+++ b/apps/desktop/src/contrib/plugin.ts
@@ -12,7 +12,7 @@
  * through the plugin host loader (next phase); this is that seam.
  */
 
-import { pluginRest, type PluginRestOptions, pluginSocket } from '@/hermes'
+import { pluginDownload, pluginRest, type PluginRestOptions, pluginSocket, revealDownload } from '@/hermes'
 import { createPluginI18n, type PluginI18n } from '@/i18n'
 import { readKey, writeKey } from '@/lib/storage'
 
@@ -54,6 +54,18 @@ export interface PluginContext {
    *  returned. Resolves to a no-op on OAuth remotes — treat it as an
    *  accelerator over your polling, never a replacement. */
   socket: (path: string, onMessage: (data: unknown) => void) => () => void
+  /** Hand the user a FILE from this plugin's namespace. `rest` decodes every
+   *  response as JSON, so it corrupts binary payloads; this fetches the bytes
+   *  in the main process, prompts for a save location, and writes with
+   *  collision resolution. Resolves `{ canceled: true }` if the user dismisses
+   *  the dialog — that's a normal outcome, not an error. */
+  download: (
+    path: string,
+    opts?: { filename?: string; timeoutMs?: number }
+  ) => Promise<{ canceled: boolean; filePath?: string }>
+  /** Reveal a saved download in Finder/Explorer/Files — the natural follow-up
+   *  to `download`. Resolves false on shells that don't support it. */
+  revealDownload: (filePath: string) => Promise<boolean>
   /** Plugin-scoped persistence. */
   storage: PluginStorage
   /** Plugin-scoped i18n: ship + register locale bundles under this plugin,
@@ -115,6 +127,8 @@ export function createPluginContext(pluginId: string, onDispose?: (dispose: () =
     onDispose: fn => void track(fn),
     rest: <T>(path: string, opts?: PluginRestOptions) => pluginRest<T>(pluginId, path, opts),
     socket: (path, onMessage) => track(pluginSocket(pluginId, path, onMessage)),
+    download: (path, opts) => pluginDownload(pluginId, path, opts),
+    revealDownload,
     storage: createPluginStorage(pluginId),
     i18n: createPluginI18n(pluginId, track)
   }

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -111,6 +111,13 @@ declare global {
         set: (name: string | null) => Promise<DesktopActiveProfile>
       }
       api: <T>(request: HermesApiRequest) => Promise<T>
+      /** Binary download from a plugin's own API namespace: fetches the bytes,
+       *  prompts for a save location, writes with collision resolution. The
+       *  renderer is a file:// origin and `api` is JSON-only, so this is the
+       *  only path a plugin has to hand the user a file. */
+      pluginDownload?: (request: HermesPluginDownloadRequest) => Promise<HermesPluginDownloadResult>
+      /** Reveal a saved download in Finder/Explorer/Files. */
+      pluginRevealDownload?: (filePath: string) => Promise<boolean>
       notify: (payload: HermesNotification) => Promise<boolean>
       requestMicrophoneAccess: () => Promise<boolean>
       readFileDataUrl: (filePath: string) => Promise<string>
@@ -750,6 +757,27 @@ export interface HermesApiRequest {
   // (window) backend. Read-only cross-profile data is served by the primary, so
   // this is only needed for profile-scoped live/settings calls.
   profile?: string | null
+}
+
+export interface HermesPluginDownloadRequest {
+  /** Plugin id — main rebuilds `/api/plugins/<id><path>` from it, so a caller
+   *  can't reach another namespace by assembling its own URL. */
+  pluginId: string
+  /** Path relative to the plugin's namespace, leading slash ('/attachments/7'). */
+  path: string
+  /** Suggested save name. Sanitized in main; falls back to the response's
+   *  Content-Disposition when empty. */
+  filename?: string
+  timeoutMs?: number
+  profile?: string | null
+}
+
+export interface HermesPluginDownloadResult {
+  /** True when the user dismissed the save dialog — not an error. */
+  canceled: boolean
+  /** Where the file actually landed (may differ from the chosen name when a
+   *  collision was resolved). Absent when canceled. */
+  filePath?: string
 }
 
 export interface HermesNotification {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -1,5 +1,6 @@
 import { JsonRpcGatewayClient } from '@hermes/shared'
 
+import type { HermesPluginDownloadResult } from '@/global'
 import type {
   ActionResponse,
   ActionStatusResponse,
@@ -301,6 +302,41 @@ export async function pluginRest<T>(pluginId: string, path: string, opts: Plugin
     timeoutMs: opts.timeoutMs,
     ...profileScoped()
   })
+}
+
+/** The plugin binary door — `pluginRest`'s counterpart for bytes. `pluginRest`
+ *  decodes every response as JSON, so it corrupts a PNG or a PDF; and the
+ *  renderer can't fetch the URL itself (file:// origin, and the plugin API
+ *  doesn't accept a query token). Main fetches, prompts for a location, and
+ *  writes. Scoped the same way — `path` is relative to `/api/plugins/<id>`,
+ *  and main re-derives the namespace rather than trusting an assembled URL.
+ *  Resolves `{ canceled: true }` when the user dismisses the dialog. */
+export async function pluginDownload(
+  pluginId: string,
+  path: string,
+  opts: { filename?: string; timeoutMs?: number } = {}
+): Promise<HermesPluginDownloadResult> {
+  const download = window.hermesDesktop?.pluginDownload
+
+  // Older shells (renderer updated ahead of the Electron bundle) lack the
+  // channel — surface it as a plain failure the caller can toast.
+  if (!download) {
+    throw new Error('This version of Hermes Desktop cannot download plugin files.')
+  }
+
+  return download({
+    pluginId,
+    path: pluginPathSuffix('pluginDownload', path),
+    filename: opts.filename,
+    timeoutMs: opts.timeoutMs,
+    ...profileScoped()
+  })
+}
+
+/** Reveal a previously downloaded file in Finder/Explorer/Files. No-ops on a
+ *  shell that predates the channel. */
+export async function revealDownload(filePath: string): Promise<boolean> {
+  return (await window.hermesDesktop?.pluginRevealDownload?.(filePath)) ?? false
 }
 
 /** The plugin WebSocket door — the live twin of `pluginRest`, scoped the same

--- a/apps/desktop/src/plugins/kanban/api.ts
+++ b/apps/desktop/src/plugins/kanban/api.ts
@@ -26,8 +26,15 @@ import type {
 
 type Rest = <T>(path: string, opts?: PluginRestOptions) => Promise<T>
 type Socket = (path: string, onMessage: (data: unknown) => void) => () => void
+type Download = (
+  path: string,
+  opts?: { filename?: string; timeoutMs?: number }
+) => Promise<{ canceled: boolean; filePath?: string }>
+type Reveal = (filePath: string) => Promise<boolean>
 
 let rest: null | Rest = null
+let download: null | Download = null
+let reveal: null | Reveal = null
 
 /** Selected board slug ('' = the server's current board). Persisted. */
 export const $boardSlug = atom<string>('')
@@ -79,8 +86,10 @@ interface Persisted<T> {
  *  runs on unload/disable — so nothing (store sync, socket) survives a toggle
  *  or duplicates on re-enable. The events socket is pinned to a board at
  *  handshake, so a board switch closes + reopens it. */
-export function bindApi(r: Rest, storage: PluginStorage, socket: Socket): () => void {
+export function bindApi(r: Rest, storage: PluginStorage, socket: Socket, d: Download, rv: Reveal): () => void {
   rest = r
+  download = d
+  reveal = rv
   const unsubs: Array<() => void> = []
 
   // Hydrate an atom from storage and keep storage in sync with it.
@@ -108,6 +117,8 @@ export function bindApi(r: Rest, storage: PluginStorage, socket: Socket): () => 
     unsubs.forEach(unsub => unsub())
     close?.()
     rest = null
+    download = null
+    reveal = null
   }
 }
 
@@ -217,6 +228,17 @@ export const reclaimTask = (id: string) => nudged(call(withBoard(`/tasks/${id}/r
 
 export const uploadAttachment = (id: string, upload: { filename: string; contentType?: string; bytes: ArrayBuffer }) =>
   call(withBoard(`/tasks/${id}/attachments`), { method: 'POST', upload })
+
+/** Save an attachment to disk. Binary, so it takes the `download` door rather
+ *  than `rest` (which would JSON-decode and corrupt it). Board-scoped like
+ *  every other call — the blob is resolved against the selected board's root. */
+export const downloadAttachment = (attachmentId: number | string, filename: string) =>
+  download
+    ? download(withBoard(`/attachments/${encodeURIComponent(String(attachmentId))}`), { filename })
+    : Promise.reject(new Error('kanban api not ready'))
+
+/** Reveal a saved attachment in the OS file manager. */
+export const revealAttachment = (filePath: string) => (reveal ? reveal(filePath) : Promise.resolve(false))
 
 export const createBoard = (slug: string, name: string, projectId?: string) =>
   call<{ board: { slug: string } }>('/boards', {

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -33,6 +33,7 @@ import {
   $boardSlug,
   addComment,
   deleteTask,
+  downloadAttachment,
   estimateTask,
   fetchLog,
   fetchProfiles,
@@ -42,6 +43,7 @@ import {
   PROFILES_KEY,
   reassignTask,
   reclaimTask,
+  revealAttachment,
   taskKey,
   uploadAttachment
 } from './api'
@@ -410,10 +412,12 @@ const isAdminSummary = (summary: string) => /^status changed to \w+ \(dashboard\
 
 function AttachmentsSection({
   attachments,
+  onDownload,
   onUpload,
   pending
 }: {
   attachments: KanbanAttachment[]
+  onDownload: (attachment: KanbanAttachment) => void
   onUpload: (file: File) => void
   pending: boolean
 }) {
@@ -454,9 +458,21 @@ function AttachmentsSection({
       {attachments.length > 0 ? (
         <ul className="flex flex-col gap-1">
           {attachments.map(attachment => (
-            <li className="flex items-center gap-1.5 text-[0.75rem] text-(--ui-text-tertiary)" key={attachment.id}>
-              <Codicon name="file" size="0.75rem" />
-              {attachment.filename}
+            <li key={attachment.id}>
+              <button
+                className="flex w-full items-center gap-1.5 rounded-sm text-left text-[0.75rem] text-(--ui-text-tertiary) hover:text-(--ui-text-secondary)"
+                onClick={() => onDownload(attachment)}
+                title={k.downloadAttachment}
+                type="button"
+              >
+                <Codicon className="shrink-0" name="file" size="0.75rem" />
+                <span className="truncate">{attachment.filename}</span>
+                <Codicon
+                  className="ml-auto shrink-0 text-(--ui-text-quaternary)"
+                  name="cloud-download"
+                  size="0.7rem"
+                />
+              </button>
             </li>
           ))}
         </ul>
@@ -648,6 +664,25 @@ export function TaskDrawer({
       }),
     onError: err => host.notify({ kind: 'error', message: errText(err) }),
     onSuccess: invalidate
+  })
+
+  const downloadMut = useMutation({
+    mutationFn: (attachment: KanbanAttachment) => downloadAttachment(attachment.id, attachment.filename),
+    onError: err => host.notify({ kind: 'error', message: errText(err) }),
+    onSuccess: result => {
+      // Dismissing the save dialog is a normal outcome — don't toast it.
+      if (result.canceled || !result.filePath) {
+        return
+      }
+
+      const filePath = result.filePath
+
+      host.notify({
+        action: { label: k.reveal, onClick: () => void revealAttachment(filePath) },
+        kind: 'success',
+        message: k.attachmentSaved(filePath.split(/[/\\]/).pop() || '')
+      })
+    }
   })
 
   if (!id) {
@@ -934,6 +969,7 @@ export function TaskDrawer({
 
             <AttachmentsSection
               attachments={detail.attachments}
+              onDownload={attachment => downloadMut.mutate(attachment)}
               onUpload={file => uploadMut.mutate(file)}
               pending={uploadMut.isPending}
             />

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -149,6 +149,9 @@ type KanbanMessages = {
     attachments: (n: number) => string
     noAttachments: string
     uploadAttachment: string
+    downloadAttachment: string
+    attachmentSaved: (name: string) => string
+    reveal: string
     taskActions: string
     copyTaskId: string
     copyTitle: string
@@ -336,6 +339,9 @@ const en: KanbanMessages = {
     attachments: n => `Attachments · ${n}`,
     noAttachments: 'No attachments yet.',
     uploadAttachment: 'Upload attachment',
+    downloadAttachment: 'Download',
+    attachmentSaved: name => `Saved ${name}`,
+    reveal: 'Reveal',
     taskActions: 'Task actions',
     copyTaskId: 'Copy task id',
     copyTitle: 'Copy title',
@@ -523,6 +529,9 @@ const ja: KanbanMessages = {
     attachments: n => `添付・${n}`,
     noAttachments: 'まだ添付はありません。',
     uploadAttachment: '添付をアップロード',
+    downloadAttachment: 'ダウンロード',
+    attachmentSaved: name => `${name} を保存しました`,
+    reveal: '表示',
     taskActions: 'タスクの操作',
     copyTaskId: 'タスク ID をコピー',
     copyTitle: 'タイトルをコピー',
@@ -709,6 +718,9 @@ const zh: KanbanMessages = {
     attachments: n => `附件・${n}`,
     noAttachments: '暂无附件。',
     uploadAttachment: '上传附件',
+    downloadAttachment: '下载',
+    attachmentSaved: name => `已保存 ${name}`,
+    reveal: '在文件夹中显示',
     taskActions: '任务操作',
     copyTaskId: '复制任务 ID',
     copyTitle: '复制标题',
@@ -893,6 +905,9 @@ const zhHant: KanbanMessages = {
     attachments: n => `附件・${n}`,
     noAttachments: '尚無附件。',
     uploadAttachment: '上傳附件',
+    downloadAttachment: '下載',
+    attachmentSaved: name => `已儲存 ${name}`,
+    reveal: '在資料夾中顯示',
     taskActions: '任務操作',
     copyTaskId: '複製任務 ID',
     copyTitle: '複製標題',

--- a/apps/desktop/src/plugins/kanban/plugin.tsx
+++ b/apps/desktop/src/plugins/kanban/plugin.tsx
@@ -83,7 +83,7 @@ const plugin: HermesPlugin = {
   defaultEnabled: false,
   register(ctx) {
     ctx.i18n.register(KANBAN_LOCALES)
-    ctx.onDispose(bindApi(ctx.rest, ctx.storage, ctx.socket))
+    ctx.onDispose(bindApi(ctx.rest, ctx.storage, ctx.socket, ctx.download, ctx.revealDownload))
 
     // The plugin command pattern: ONE action id (`kanban.newTask`) wired into
     // two areas — a keybind (dispatch + rebindable panel row) and a palette row


### PR DESCRIPTION
Stacked on #61173 — base is `bb/desktop-kanban`, review that one first.

A plugin that ships **files** had no door. Kanban could upload an attachment and list it, but never hand one back: a file a worker produced was reachable only by digging for its `stored_path` on disk. The backend has served `GET /attachments/{id}` all along.

## Why this needed a new primitive rather than a link

Three independent walls, and a plain `<a href>` clears none of them:

- **The renderer is a `file://` origin.** Chromium blocks `file://` navigation, which is why the artifacts panel already routes through `shell.openPath`. There's no origin to hang a relative href off.
- **`?token=` is rejected here.** `_QUERY_TOKEN_API_PATHS` is a deliberate one-entry allowlist (`/api/files/download`). Adding the plugin namespace to it would widen a narrow security surface for *every* plugin at once, to save a dialog.
- **`ctx.rest` is JSON-only.** `fetchJson` does `Buffer.concat(chunks).toString('utf8')` then `JSON.parse` — a PNG arrives as mojibake and throws.

## The primitive

`ctx.download` / `ctx.revealDownload` — the third generic SDK surface this plugin's real needs pushed into shared code, after `ctx.onDispose` and `ctx.i18n` (both in #61173).

Scoped exactly like `rest` and `socket`: `path` is relative to the plugin's own namespace and runs through the same `pluginPathSuffix` traversal guard. **Main re-derives `/api/plugins/<id><path>` from the id it was handed** rather than trusting a caller-assembled URL, so a compromised renderer can't reach another plugin's API or a core route.

`fetchBuffer` is `fetchJson`'s binary sibling — same auth header and protocol guard, response stays a `Buffer`, and the stream aborts mid-flight once it passes the cap instead of buffering a blob we've already decided to refuse.

Three behaviors worth calling out:

- A dismissed save dialog resolves `{ canceled: true }`. That's a normal outcome, not an error, and it doesn't toast.
- OAuth **cookie** mode fails loudly. Writing a 401 body to disk as if it were the file is worse than refusing; native bearer works today, cookie-partition is the follow-up.
- Shells that predate the channel get a clear message, not a `TypeError` — the renderer can update ahead of the Electron bundle.

## Hardening

Every filename that reaches a save dialog is attacker-influenced: it comes from a DB row a worker wrote, or from a server's `Content-Disposition`. `safeDownloadFilename` reduces all of them to a bare basename — no separators, no traversal token, no leading dot. `resolveDownloadCollision` takes an injected `exists` so it stays pure and testable; the suffix lands *before* the extension (`notes (1).txt`) so the file still opens in the right app.

The 25 MB ceiling is tied by a test invariant to `KANBAN_ATTACHMENT_MAX_BYTES` rather than hardcoded twice — a blob the backend refused to accept can't come back down.

## Kanban, the first consumer

Attachment rows become buttons. A successful save toasts with a **Reveal** action that opens Finder/Explorer/Files. Localized across en/ja/zh/zh-hant under the plugin's own bundle — core `en.ts` stays untouched.

## Prior art

The download UX follows what #58338 built (collision-resolved save + reveal). Credit to @rod-nxtlevel — this delivers that behavior through an SDK door instead of app-level Electron surface, so any plugin gets it.

## Test plan

- `vitest electron/hardening.test.ts src/contrib src/i18n src/lib/keybinds` — 86 green. New coverage: filename sanitization (traversal, Windows separators, NUL, dotfile-forcing, empty), RFC 5987 vs plain `Content-Disposition` precedence with malformed-percent fallback, collision walk incl. multi-dot and leading-dot names, bounded-exhaustion throw, and the `ctx.download` contract (id stamping, path normalization, traversal rejection, cancel-is-not-an-error, old-shell fallback, reveal).
- `tsc --build tsconfig.electron.json` clean; renderer `tsc` error count byte-identical to the pre-change baseline (stash-verified).
- `eslint` clean across all 12 touched files.
