### PR TITLE
fix(gateway): persist session hygiene compression-failure cooldown to state DB (#74136)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13834,18 +13834,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
 
                 if _needs_compress:
-                    _cooldowns = getattr(self, "_hygiene_compression_failure_cooldowns", None)
-                    if _cooldowns is None:
-                        _cooldowns = {}
-                        self._hygiene_compression_failure_cooldowns = _cooldowns
-                    _cooldown_key = session_entry.session_id
-                    _cooldown_until = float(_cooldowns.get(_cooldown_key) or 0.0)
-                    if _cooldown_until > time.time():
+                    _cooldown = None
+                    _session_db_ref = getattr(self, "_session_db", None)
+                    if _session_db_ref is not None:
+                        try:
+                            _cooldown = await _session_db_ref.get_compression_failure_cooldown(
+                                session_entry.session_id
+                            )
+                        except Exception:
+                            pass
+                    if _cooldown is not None:
                         logger.info(
                             "Session hygiene: skipping compression for %s; "
                             "previous failure cooldown active for %.1fs",
-                            _cooldown_key,
-                            max(0.0, _cooldown_until - time.time()),
+                            session_entry.session_id,
+                            _cooldown.get("remaining_seconds", 0),
                         )
                         _needs_compress = False
 
@@ -14018,9 +14021,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             )
                                             _hyg_cleanup_deferred = True
                                             if _hyg_failure_cooldown_seconds >= 0:
-                                                self._hygiene_compression_failure_cooldowns[
-                                                    session_entry.session_id
-                                                ] = time.time() + _hyg_failure_cooldown_seconds
+                                                _session_db_ref = getattr(self, "_session_db", None)
+                                                if _session_db_ref is not None:
+                                                    try:
+                                                        await _session_db_ref.record_compression_failure_cooldown(
+                                                            session_entry.session_id,
+                                                            time.time() + _hyg_failure_cooldown_seconds,
+                                                            "hygiene timeout",
+                                                        )
+                                                    except Exception:
+                                                        pass
                                             logger.warning(
                                                 "Session hygiene compression for session %s "
                                                 "made no progress for %.1fs "
@@ -14183,16 +14193,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     # fresh.
                                     _comp = getattr(_hyg_agent, "context_compressor", None)
                                     if _comp is not None and getattr(_comp, "_last_compress_aborted", False):
-                                        if _hyg_failure_cooldown_seconds >= 0:
-                                            self._hygiene_compression_failure_cooldowns[
-                                                session_entry.session_id
-                                            ] = time.time() + _hyg_failure_cooldown_seconds
                                         _err = getattr(_comp, "_last_summary_error", None) or "unknown error"
                                         # Force-redact: provider exception text
                                         # may contain credentials; this message
                                         # reaches gateway users directly.
                                         from agent.redact import redact_sensitive_text
                                         _err = redact_sensitive_text(_err, force=True)
+                                        _err_redacted = _err
+                                        if _hyg_failure_cooldown_seconds >= 0:
+                                            _session_db_ref = getattr(self, "_session_db", None)
+                                            if _session_db_ref is not None:
+                                                try:
+                                                    await _session_db_ref.record_compression_failure_cooldown(
+                                                        session_entry.session_id,
+                                                        time.time() + _hyg_failure_cooldown_seconds,
+                                                        _err_redacted,
+                                                    )
+                                                except Exception:
+                                                    pass
                                         _warn_msg = (
                                             "⚠️ Context compression aborted "
                                             f"({_err}). No messages were dropped — "

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -646,8 +646,14 @@ async def test_session_hygiene_skips_compression_during_failure_cooldown(monkeyp
     runner._running_agents = {}
     runner._pending_messages = {}
     runner._pending_approvals = {}
-    runner._session_db = None
-    runner._hygiene_compression_failure_cooldowns = {"sess-1": time.time() + 300}
+    # Make get_compression_failure_cooldown return an active cooldown for sess-1
+    _fake_db = MagicMock()
+    _fake_db.get_compression_failure_cooldown.return_value = {
+        "cooldown_until": time.time() + 300,
+        "remaining_seconds": 300,
+        "error": "previous failure",
+    }
+    runner._session_db = SimpleNamespace(_db=_fake_db)
     runner._is_user_authorized = lambda _source: True
     runner._set_session_env = lambda _context: None
     runner._run_agent = AsyncMock(
@@ -818,7 +824,11 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
     assert elapsed < 2.0
     assert worker_started.is_set()
     assert runner._run_agent.await_count == 1
-    assert runner._hygiene_compression_failure_cooldowns["sess-timeout"] > time.time()
+    assert fake_db.record_compression_failure_cooldown.call_count == 1
+    _call_args = fake_db.record_compression_failure_cooldown.call_args[0]
+    assert _call_args[0] == "sess-timeout"  # session_id
+    assert _call_args[1] > time.time()  # cooldown_until
+    assert _call_args[2] == "hygiene timeout"  # error
     timeout_warnings = [s for s in adapter.sent if "Context compression timed out" in s["content"]]
     assert len(timeout_warnings) == 1
     fake_db.archive_and_compact.assert_not_called()
@@ -1553,7 +1563,7 @@ async def test_hygiene_slow_but_streaming_worker_survives_past_timeout(
         "  hygiene_total_ceiling_seconds: 10\n"
         "  hygiene_failure_cooldown_seconds: 120\n",
     )
-    runner._hygiene_compression_failure_cooldowns = {}
+    runner._session_db = SimpleNamespace(_db=MagicMock())
 
     result = await runner._handle_message(event)
 
@@ -1566,7 +1576,8 @@ async def test_hygiene_slow_but_streaming_worker_survives_past_timeout(
         s for s in adapter.sent if "Context compression timed out" in s["content"]
     ]
     assert timeout_warnings == []
-    assert "sess-progress" not in runner._hygiene_compression_failure_cooldowns
+    # No cooldown was recorded because compression succeeded
+    runner._session_db._db.record_compression_failure_cooldown.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1616,7 +1627,6 @@ async def test_hygiene_trickle_stream_is_bounded_by_total_ceiling(
         "  hygiene_total_ceiling_seconds: 0.3\n"
         "  hygiene_failure_cooldown_seconds: 120\n",
     )
-    runner._hygiene_compression_failure_cooldowns = {}
     runner._session_db = SimpleNamespace(_db=MagicMock())
 
     started = time.monotonic()
@@ -1635,7 +1645,8 @@ async def test_hygiene_trickle_stream_is_bounded_by_total_ceiling(
         s for s in adapter.sent if "Context compression timed out" in s["content"]
     ]
     assert len(timeout_warnings) == 1
-    assert runner._hygiene_compression_failure_cooldowns["sess-progress"] > time.time()
+    # A cooldown was recorded because the stream timed out
+    runner._session_db._db.record_compression_failure_cooldown.assert_called_once()
 
 @pytest.mark.asyncio
 async def test_session_hygiene_does_not_repoint_when_rotated_transcript_write_fails(


### PR DESCRIPTION
## Problem

The session hygiene compression path tracked its per-session failure cooldown in an **in-memory dict** (`_hygiene_compression_failure_cooldowns`) on the gateway process. When the gateway restarts, that dict is lost, so the same failing compression is immediately re-triggered on the next message - wedging session storage.

The user-visible symptom: after a compression failure (timeout, API error, abort), every message across all sessions gets the "session storage could not be written" error. Restarting the gateway does not recover - it clears the in-memory cooldown and the cycle repeats.

## Root Cause

The state DB already has a persistent column `sessions.compression_failure_cooldown_until` and full read/write/clear methods (`record_compression_failure_cooldown` / `get_compression_failure_cooldown` / `clear_compression_failure_cooldown` in `hermes_state.py`). The **in-conversation** compression path (`agent/context_compressor.py`) already uses these persistent methods correctly. But the **session hygiene** path in `gateway/run.py` used its own in-memory dict instead - the two paths disagreed on durability.

## Fix

1. **Cooldown check** (line ~13836): Replace the in-memory dict lookup with `await session_db.get_compression_failure_cooldown(session_id)`, consistent with the in-conversation path.
2. **Timeout cooldown write** (line ~14020): Replace in-memory dict write with `await session_db.record_compression_failure_cooldown(...)`.
3. **Abort cooldown write** (line ~14186): Same replacement, with proper error text redaction before persistence.
4. **Tests** (6 assertions across 4 test functions): Updated to assert against `session_db._db` mocks instead of the removed in-memory dict.

Fixes #74136