### PR TITLE
fix(desktop): preserve local pin intent during sync

### DIFF
--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -40,16 +40,16 @@ afterEach(() => {
 
 describe('watchSessionPins', () => {
   it('mirrors a new pin as pinned=true with the row profile', async () => {
-    $sessions.set([row('a', { profile: 'work' })])
+    $sessions.set([row('a', { pinned: false, profile: 'work' })])
     $pinnedSessionIds.set(['a'])
     await flush()
 
+    expect($pinnedSessionIds.get()).toContain('a')
     expect(patch).toHaveBeenCalledWith('a', true, 'work')
   })
 
   it('mirrors an unpin as pinned=false', async () => {
-    $sessions.set([row('b')])
-    $pinnedSessionIds.set(['b'])
+    $sessions.set([row('b', { pinned: true })])
     await flush()
     patch.mockClear()
 

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -56,9 +56,10 @@ function writePin(id: string, pinned: boolean, profile?: null | string): Promise
 /**
  * Adopt the server's pin state for every row in the current page.
  *
- * Runs before the push pass so a remote pin is already in the local set by the
- * time we reconcile — it gets marked as mirrored rather than echoed straight
- * back as a redundant PATCH.
+ * Runs after the push pass so a new local pin or unpin has already installed
+ * its `unconfirmed` guard before a stale list row can contradict it. Remote
+ * changes are still adopted without an echo because they are marked mirrored
+ * when pulled.
  */
 function pullRemotePins(): void {
   const local = new Set($pinnedSessionIds.get())
@@ -99,8 +100,6 @@ function reconcile(): void {
     return
   }
 
-  pullRemotePins()
-
   const current = new Set($pinnedSessionIds.get())
 
   // Unpinned: anything we were tracking that's no longer in the set.
@@ -136,6 +135,8 @@ function reconcile(): void {
       pending.add(id)
     })
   }
+
+  pullRemotePins()
 }
 
 // Sync once, then re-sync on pin-set and session-list changes. Call once per app.


### PR DESCRIPTION
## What does this PR do?

Preserves a user's new local pin or unpin while the Desktop reconciles session rows from the backend.

#74234 made the server row authoritative, but `reconcile()` pulled remote state before the local push pass installed its in-flight guard. With realistic list data, clicking Pin updates the local store, then the still-stale `pinned: false` row immediately removes it before any PATCH is sent. The inverse race also prevents an unpin while the row still says `pinned: true`.

This moves `pullRemotePins()` after the push pass. `writePin()` installs the existing `unconfirmed` guard synchronously before issuing the PATCH, so a stale list row cannot contradict the user's newest local action. Remote adoption/drop behavior remains unchanged.

## Related Issue

Regression introduced by #74234.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/session-pin-sync.ts`: push local pin intent before pulling remote rows, allowing the existing in-flight guard to reject stale list state.
- `apps/desktop/src/store/session-pin-sync.test.ts`: exercise realistic `pinned: false` and `pinned: true` rows for both local pin and local unpin.

## How to Test

1. Run `npm exec -- vitest run src/store/session-pin-sync.test.ts` from `apps/desktop`.
2. Confirm a new local pin remains selected and sends `PATCH pinned=true` while the loaded row still reports `pinned: false`.
3. Confirm a new local unpin remains removed and sends `PATCH pinned=false` while the loaded row still reports `pinned: true`.

Before the production change, those two realistic cases fail: the pin is removed locally and the unpin sends no PATCH. After the change, all 11 focused tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — attempted with `scripts/run_tests.sh`; the local Python suite is not green due unrelated optional-dependency/platform baseline failures. This PR changes no Python.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6, Node 24.18.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior and code comments only
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific APIs changed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No visual surface changed.

Validation:

- `npm test`: 411 files passed, 1 skipped; 3,842 tests passed, 2 skipped
- `npm run typecheck`: passed
- `npm run lint`: passed with 0 errors (existing repository warnings remain)
- `npm exec -- vitest run src/store/session-pin-sync.test.ts`: 11/11 passed
- `git diff --check`: passed
