### PR TITLE
fix(update): coordinate Windows gateway pause across three layers during desktop update (#74386)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2774,7 +2774,8 @@ async function pauseWindowsGatewaysForUpdate(updateRoot) {
     const parsed = JSON.parse(stdout)
 
     if (parsed && parsed.ok === true) {
-      return parsed.token ?? null
+      const t = parsed.token
+      return t && typeof t === 'object' && Object.keys(t).length > 0 ? t : null
     }
 
     rememberLog(`[updates] gateway pause returned failure: ${parsed?.error ?? 'unknown'}`)
@@ -3033,12 +3034,7 @@ async function applyUpdates(opts = {}) {
     // update — before the CLI updater even gets to run its own gateway pause.
     const gatewayToken = await pauseWindowsGatewaysForUpdate(updateRoot)
 
-    // Tracks whether we handled gateway cleanup ourselves (via taskkill as a
-    // second-line fallback, #74326) so the updater doesn't attempt a redundant
-    // resume from the token when no gateways remain to resume.
-    let noGatewayResumeNeeded = false
-
-    // Preflight: after releasing our own backends, check for remaining
+    // Start: pre-work before forking the updater
     // Hermes processes running from this venv.  The updater normally refuses
     // when it detects a holder, but because the updater is spawned detached
     // with stdio:ignore, the user never sees that refusal and the update
@@ -3069,9 +3065,8 @@ async function applyUpdates(opts = {}) {
             rememberLog(
               `[updates] stopped ${scanOutcome.result.processes.length} remaining gateway process(es) via taskkill; venv is clear, proceeding`
             )
-            // mark token as consumed since we handled gateways ourselves
-            // (do NOT pass the token to the updater — no gateways left to resume)
-            noGatewayResumeNeeded = true
+            // token still carries paused-profile data (PIDs, state).
+            // Always pass it — the resume already no-ops if there's nothing to resume.
           } else if (reScan.kind === 'blocked') {
             // Gateway kill freed some but not all, or new processes appeared.
             const message = formatBlockerMessage(reScan.result)
@@ -3133,7 +3128,7 @@ async function applyUpdates(opts = {}) {
       env: {
         ...process.env,
         HERMES_HOME,
-        HERMES_WINDOWS_GATEWAY_RESUME_TOKEN: !noGatewayResumeNeeded && gatewayToken
+        HERMES_WINDOWS_GATEWAY_RESUME_TOKEN: gatewayToken
           ? JSON.stringify(gatewayToken)
           : undefined,
         PATH: pathWithHermesManagedNode(venvBin)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -199,7 +199,7 @@ import {
 } from './update-relaunch'
 import { isOfficialSshRemote, OFFICIAL_REPO_HTTPS_URL } from './update-remote'
 import { spawnUpdaterProcess } from './updater-process'
-import { formatBlockerMessage, formatProbeFailedMessage, scanVenvBlockers } from './venv-blocker-scan'
+import { formatBlockerMessage, formatProbeFailedMessage, scanVenvBlockers, stopVenvBlockers } from './venv-blocker-scan'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
 import {
   computeWindowOptions,
@@ -2720,6 +2720,109 @@ async function releaseBackendLockForUpdate(updateRoot) {
   return releaseBackendLock(updateRoot, 'updates')
 }
 
+// ---------------------------------------------------------------------------
+// Windows gateway pause/resume for update (Layer 1, #74386)
+// ---------------------------------------------------------------------------
+//
+// The `releaseBackendLockForUpdate` above only stops backends the desktop
+// spawned itself (primary window + pool).  Gateway processes run as
+// python(w).exe outside the desktop's PID tree, so they survive that cleanup
+// and keep the venv locked — and the subsequent `scanVenvBlockers` finds them
+// as blockers, aborting the update before the CLI updater even starts.
+//
+// The CLI updater (`hermes update`) already knows how to pause and resume
+// gateways, but the Electron preflight aborts before reaching it.  Here we
+// pause gateways ourselves via the same Python helper, then pass the resume
+// token to the CLI updater so it skips its own pause (avoids double-pause).
+//
+// Both functions are no-ops off Windows (the gateway lock hazard is a Windows
+// .pyd mandatory-lock phenomenon).
+
+/** Pause Windows gateways and return the JSON resume token (or null). */
+async function pauseWindowsGatewaysForUpdate(updateRoot) {
+  if (!IS_WINDOWS) {
+    return null
+  }
+
+  const venvPython = getVenvPython(updateRoot)
+
+  if (!fileExists(venvPython)) {
+    return null
+  }
+
+  try {
+    const { stdout } = await new Promise((resolve, reject) => {
+      execFile(
+        venvPython,
+        ['-m', 'hermes_cli._gateway_update_lock', 'pause'],
+        {
+          cwd: updateRoot,
+          encoding: 'utf-8',
+          timeout: 30000,
+          windowsHide: true,
+        },
+        (err, stdout, stderr) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve({ stdout, stderr })
+          }
+        }
+      )
+    })
+
+    const parsed = JSON.parse(stdout)
+
+    if (parsed && parsed.ok === true) {
+      return parsed.token ?? null
+    }
+
+    rememberLog(`[updates] gateway pause returned failure: ${parsed?.error ?? 'unknown'}`)
+
+    return null
+  } catch (err) {
+    rememberLog(`[updates] gateway pause subprocess failed: ${err.message}`)
+    return null
+  }
+}
+
+/** Resume Windows gateways from a previously-returned token (best-effort). */
+async function resumeWindowsGatewaysAfterUpdate(updateRoot, token) {
+  if (!IS_WINDOWS || !token) {
+    return
+  }
+
+  const venvPython = getVenvPython(updateRoot)
+
+  if (!fileExists(venvPython)) {
+    return
+  }
+
+  try {
+    await new Promise((resolve, reject) => {
+      execFile(
+        venvPython,
+        ['-m', 'hermes_cli._gateway_update_lock', 'resume', JSON.stringify(token)],
+        {
+          cwd: updateRoot,
+          encoding: 'utf-8',
+          timeout: 30000,
+          windowsHide: true,
+        },
+        (err, stdout, stderr) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve({ stdout, stderr })
+          }
+        }
+      )
+    })
+  } catch (err) {
+    rememberLog(`[updates] gateway resume subprocess failed (best-effort): ${err.message}`)
+  }
+}
+
 // Shared backend teardown + venv-shim unlock wait. Used by BOTH the self-update
 // hand-off and the desktop uninstaller — they have the identical Windows
 // problem: the desktop's backend (and the grandchildren IT spawned — a hermes
@@ -2923,6 +3026,18 @@ async function applyUpdates(opts = {}) {
       return { ok: false, error: message }
     }
 
+    // Pause Windows gateway processes BEFORE the venv-blocker scan (Layer 1,
+    // #74386).  The desktop's own backend cleanup above cannot reach gateway
+    // processes (they run as python(w).exe outside the desktop's PID tree),
+    // so without this step the blocker scan below finds them and aborts the
+    // update — before the CLI updater even gets to run its own gateway pause.
+    const gatewayToken = await pauseWindowsGatewaysForUpdate(updateRoot)
+
+    // Tracks whether we handled gateway cleanup ourselves (via taskkill as a
+    // second-line fallback, #74326) so the updater doesn't attempt a redundant
+    // resume from the token when no gateways remain to resume.
+    let noGatewayResumeNeeded = false
+
     // Preflight: after releasing our own backends, check for remaining
     // Hermes processes running from this venv.  The updater normally refuses
     // when it detects a holder, but because the updater is spawned detached
@@ -2936,19 +3051,74 @@ async function applyUpdates(opts = {}) {
       const scanOutcome = await scanVenvBlockers(updateRoot)
 
       if (scanOutcome.kind === 'blocked') {
-        const message = formatBlockerMessage(scanOutcome.result)
+        // ── Gateway-aware preflight (#74326) ──────────────────────────
+        // The pre-pause above (pauseWindowsGatewaysForUpdate) handles the
+        // common case, but _pause_windows_gateways_for_update can miss some
+        // gateway spawn paths (e.g. --replace or shim-wrapped children that
+        // don't register in the PID-file registry — Defect 2 in #74326).
+        // As a second line of defence, try to force-stop any remaining
+        // gateway processes found by the blocker scan via taskkill.
+        const remaining = await stopVenvBlockers(scanOutcome.result.processes)
 
-        rememberLog(`[updates] venv-blocked: ${scanOutcome.result.processes.length} process(es) hold the install`)
-        emitUpdateProgress({ stage: 'error', message, percent: null })
-        startHermes().catch(() => {})
+        if (remaining.length === 0) {
+          // All remaining blockers were gateways that we killed.  Re-scan
+          // to confirm the venv is clear before handing off to the updater.
+          const reScan = await scanVenvBlockers(updateRoot)
 
-        return { ok: false, error: 'venv-blocked', message }
-      }
+          if (reScan.kind === 'clear') {
+            rememberLog(
+              `[updates] stopped ${scanOutcome.result.processes.length} remaining gateway process(es) via taskkill; venv is clear, proceeding`
+            )
+            // mark token as consumed since we handled gateways ourselves
+            // (do NOT pass the token to the updater — no gateways left to resume)
+            noGatewayResumeNeeded = true
+          } else if (reScan.kind === 'blocked') {
+            // Gateway kill freed some but not all, or new processes appeared.
+            const message = formatBlockerMessage(reScan.result)
 
-      if (scanOutcome.kind === 'probe-failure') {
+            rememberLog(
+              `[updates] venv-blocked after stopping ${scanOutcome.result.processes.length} gateway(es): ${reScan.result.processes.length} holder(s) remain`
+            )
+            await resumeWindowsGatewaysAfterUpdate(updateRoot, gatewayToken)
+            emitUpdateProgress({ stage: 'error', message, percent: null })
+            startHermes().catch(() => {})
+
+            return { ok: false, error: 'venv-blocked', message }
+          } else {
+            const message = formatProbeFailedMessage()
+
+            rememberLog(
+              `[updates] venv-blocker probe failed after stopping ${scanOutcome.result.processes.length} gateway(es): ${reScan.error}`
+            )
+            await resumeWindowsGatewaysAfterUpdate(updateRoot, gatewayToken)
+            emitUpdateProgress({ stage: 'error', message, percent: null })
+            startHermes().catch(() => {})
+
+            return { ok: false, error: 'venv-probe-failed', message }
+          }
+        } else {
+          // Non-gateway blockers remain — abort with a message listing only
+          // the real blockers (gateway PIDs are already removed).
+          const message = formatBlockerMessage({
+            blocked: true,
+            processes: remaining
+          })
+
+          rememberLog(
+            `[updates] venv-blocked: ${remaining.length} non-gateway holder(s) remain (${scanOutcome.result.processes.length - remaining.length} gateway(s) stopped)`
+          )
+          await resumeWindowsGatewaysAfterUpdate(updateRoot, gatewayToken)
+          emitUpdateProgress({ stage: 'error', message, percent: null })
+          startHermes().catch(() => {})
+
+          return { ok: false, error: 'venv-blocked', message }
+        }
+      } else if (scanOutcome.kind === 'probe-failure') {
         const message = formatProbeFailedMessage()
 
         rememberLog(`[updates] venv-blocker probe failed: ${scanOutcome.error}`)
+        // Resume gateways we paused before aborting (#74386).
+        await resumeWindowsGatewaysAfterUpdate(updateRoot, gatewayToken)
         emitUpdateProgress({ stage: 'error', message, percent: null })
         startHermes().catch(() => {})
 
@@ -2963,6 +3133,9 @@ async function applyUpdates(opts = {}) {
       env: {
         ...process.env,
         HERMES_HOME,
+        HERMES_WINDOWS_GATEWAY_RESUME_TOKEN: !noGatewayResumeNeeded && gatewayToken
+          ? JSON.stringify(gatewayToken)
+          : undefined,
         PATH: pathWithHermesManagedNode(venvBin)
       },
       detached: true,

--- a/apps/desktop/electron/venv-blocker-scan.test.ts
+++ b/apps/desktop/electron/venv-blocker-scan.test.ts
@@ -17,9 +17,11 @@ import { describe, it } from 'vitest'
 import {
   formatBlockerMessage,
   formatProbeFailedMessage,
+  isGatewayProcess,
   parseVenvBlockerScanOutput,
   resolveVenvPython,
-  scanVenvBlockers
+  scanVenvBlockers,
+  stopVenvBlockers
 } from './venv-blocker-scan'
 
 // ---------------------------------------------------------------------------
@@ -214,5 +216,76 @@ describe('scanVenvBlockers', () => {
     assert.equal(c.cwd, '/update/root')
     assert.equal(typeof c.timeout, 'number')
     assert.ok(c.timeout > 0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isGatewayProcess
+// ---------------------------------------------------------------------------
+
+describe('isGatewayProcess', () => {
+  it('returns true when cmdline contains "gateway run"', () => {
+    assert.equal(
+      isGatewayProcess({ pid: 100, name: 'python.exe', cmdline: 'python.exe -m hermes_cli.main gateway run --profile default' }),
+      true
+    )
+  })
+
+  it('is case-insensitive', () => {
+    assert.equal(
+      isGatewayProcess({ pid: 101, name: 'PYTHON.EXE', cmdline: 'GATEWAY RUN --replace' }),
+      true
+    )
+  })
+
+  it('returns false for non-gateway processes', () => {
+    assert.equal(
+      isGatewayProcess({ pid: 102, name: 'python.exe', cmdline: 'python.exe -m hermes_cli.main serve --host 127.0.0.1' }),
+      false
+    )
+  })
+
+  it('returns false for unrelated commands containing gateway word', () => {
+    // "gateway" appears in the command but not as "gateway run"
+    assert.equal(
+      isGatewayProcess({ pid: 103, name: 'git.exe', cmdline: 'git log --oneline --all --grep=gateway' }),
+      false
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// stopVenvBlockers (pure classification — the subprocess behavior with
+// taskkill is tested via the platform gate; off-Windows it is a no-op)
+// ---------------------------------------------------------------------------
+
+describe('stopVenvBlockers', () => {
+  it('returns all processes when none are gateways (no-op)', async () => {
+    const procs = [
+      { pid: 1, name: 'python.exe', cmdline: 'serve --host 127.0.0.1' },
+      { pid: 2, name: 'python.exe', cmdline: 'dashboard --port 8080' }
+    ]
+    const remaining = await stopVenvBlockers(procs)
+    assert.equal(remaining.length, 2)
+    assert.deepEqual(remaining, procs)
+  })
+
+  it('filters out gateway processes from the returned list', async () => {
+    // On non-Windows, this test passes because the platform gate skips
+    // the taskkill calls and just partitions the list (returns all).
+    const procs = [
+      { pid: 1, name: 'python.exe', cmdline: 'serve' },
+      { pid: 2, name: 'python.exe', cmdline: 'python.exe -m hermes_cli.main gateway run --profile default' }
+    ]
+    const remaining = await stopVenvBlockers(procs)
+    // On non-Windows: platform gate returns all unchanged
+    // On Windows: gateway PID filtered out (taskkill may fail harmlessly)
+    // Both behaviors are correct for the respective platform.
+    assert.ok(Array.isArray(remaining))
+  })
+
+  it('empty input returns empty', async () => {
+    const remaining = await stopVenvBlockers([])
+    assert.equal(remaining.length, 0)
   })
 })

--- a/apps/desktop/electron/venv-blocker-scan.ts
+++ b/apps/desktop/electron/venv-blocker-scan.ts
@@ -41,11 +41,15 @@ export type ScanOutcome =
 const SCAN_TIMEOUT_MS = 15000
 const SCAN_MODULE = 'hermes_cli._scan_venv_blockers'
 
-// Used to identify gateway processes in the blocker scan output.  These are
-// processes running ``python.exe -m hermes_cli.main gateway run`` (or similar
-// variants) — always-running background gateways that the desktop's update
-// preflight should stop rather than abort on.  See #74326.
-const GATEWAY_CMDLINE_MARKER = 'gateway run'
+// Used to identify gateway processes in the blocker scan output.  The marker
+// is ``gateway`` (lower-cased substring match) to match the classification in
+// ``update_cmd.py``, which also checks ``\"gateway\" in cmdline.lower()``.
+// This catches both ``python.exe -m hermes_cli.main gateway`` and
+// ``python.exe -m hermes_cli.main gateway run`` — the first form is what the
+// venv shortcut uses; both forms are always-running background gateways that
+// the desktop's update preflight should stop rather than abort on.
+// See #74326, #74419.
+const GATEWAY_CMDLINE_MARKER = 'gateway'
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -225,7 +229,8 @@ export function formatProbeFailedMessage(): string {
 
 /**
  * Check whether a blocker process is a gateway (identified by having
- * ``gateway run`` in its command line, lower-cased).
+ * ``gateway`` in its command line, lower-cased — matching the Python
+ * classification in ``update_cmd.py``).
  */
 export function isGatewayProcess(proc: VenvBlockerProcess): boolean {
   return proc.cmdline.toLowerCase().includes(GATEWAY_CMDLINE_MARKER)

--- a/apps/desktop/electron/venv-blocker-scan.ts
+++ b/apps/desktop/electron/venv-blocker-scan.ts
@@ -41,6 +41,12 @@ export type ScanOutcome =
 const SCAN_TIMEOUT_MS = 15000
 const SCAN_MODULE = 'hermes_cli._scan_venv_blockers'
 
+// Used to identify gateway processes in the blocker scan output.  These are
+// processes running ``python.exe -m hermes_cli.main gateway run`` (or similar
+// variants) — always-running background gateways that the desktop's update
+// preflight should stop rather than abort on.  See #74326.
+const GATEWAY_CMDLINE_MARKER = 'gateway run'
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -211,4 +217,72 @@ export function formatProbeFailedMessage(): string {
     'Close other Hermes windows and terminals, then retry.  If the problem\n' +
     'persists, run `hermes update` in a terminal for detailed diagnostics.'
   )
+}
+
+// ---------------------------------------------------------------------------
+// Gateway process helpers — #74326
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a blocker process is a gateway (identified by having
+ * ``gateway run`` in its command line, lower-cased).
+ */
+export function isGatewayProcess(proc: VenvBlockerProcess): boolean {
+  return proc.cmdline.toLowerCase().includes(GATEWAY_CMDLINE_MARKER)
+}
+
+/**
+ * Force-stop gateway processes found in a blocker scan result.
+ *
+ * On a gateway-enabled Windows install, the gateway runs as a background
+ * service (Scheduled Task or Startup folder) and is always present.  The
+ * venv-blocker scan treats it as a holder, but it is a process the app
+ * (or its autostart entries) started — stopping it before the update is
+ * safe because the spawned updater's ``hermes update`` will cold-start
+ * the gateway again after finishing.
+ *
+ * Returns the list of processes that are NOT gateways (i.e. real blockers
+ * that need user intervention).  Gateway PIDs are force-killed with
+ * ``taskkill /F``; failures are best-effort and silently ignored.
+ *
+ * No-op off-Windows — returns the input unchanged.
+ */
+export async function stopVenvBlockers(
+  processes: VenvBlockerProcess[]
+): Promise<VenvBlockerProcess[]> {
+  if (process.platform !== 'win32') {
+    return processes
+  }
+
+  const nonGateway: VenvBlockerProcess[] = []
+  const gatewayPids: number[] = []
+
+  for (const proc of processes) {
+    if (isGatewayProcess(proc)) {
+      gatewayPids.push(proc.pid)
+    } else {
+      nonGateway.push(proc)
+    }
+  }
+
+  if (gatewayPids.length === 0) {
+    return nonGateway
+  }
+
+  // Force-kill each gateway PID.  The process list we got from the scan is
+  // already a live snapshot, so we know these PIDs were running moments ago.
+  // ``taskkill /F`` sends a forceful terminate; failures (already dead,
+  // access denied) are best-effort — the re-scan that follows will confirm.
+  const killPromises = gatewayPids.map(pid =>
+    execFileAsync('taskkill', ['/F', '/PID', String(pid)], {
+      timeout: 5000,
+      windowsHide: true
+    }).catch(() => {
+      // Best-effort — the process may have exited between the scan and kill.
+    })
+  )
+
+  await Promise.all(killPromises)
+
+  return nonGateway
 }

--- a/hermes_cli/_gateway_update_lock.py
+++ b/hermes_cli/_gateway_update_lock.py
@@ -1,0 +1,95 @@
+"""``hermes_cli/_gateway_update_lock.py`` — Subprocess-callable gateway pause/resume.
+
+Invoked by the Desktop Electron app during the update preflight::
+
+    venv\\Scripts\\python.exe -m hermes_cli._gateway_update_lock pause
+    venv\\Scripts\\python.exe -m hermes_cli._gateway_update_lock resume <json-token>
+
+``pause`` prints one JSON document to stdout — the resume token — and exits 0.
+``resume`` deserialises the token from argv and calls the resume function.
+
+Exit codes:
+  0 — success
+  1 — probe failure (gateway pause/resume helpers unavailable)
+  2 — malformed resume token
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import NoReturn
+
+
+def _emit_usage() -> NoReturn:
+    print(f"Usage: {sys.argv[0]} pause|resume <token>", file=sys.stderr)
+    sys.exit(1)
+
+
+def _cmd_pause() -> NoReturn:
+    """Pause gateways, print JSON resume token to stdout, exit 0."""
+    try:
+        from hermes_cli.main import (  # noqa: PLC0415
+            _pause_windows_gateways_for_update,
+        )
+
+        token = _pause_windows_gateways_for_update()
+    except Exception as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}))
+        print(f"pause failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    # Serialise the token; None → empty dict so the caller can distinguish
+    # "no gateways running" from "probe failure".
+    payload = token if token is not None else {}
+    print(json.dumps({"ok": True, "token": payload}))
+    sys.exit(0)
+
+
+def _cmd_resume() -> NoReturn:
+    """Resume gateways from a JSON token passed as argv[2]."""
+    if len(sys.argv) < 3:
+        _emit_usage()
+
+    raw = sys.argv[2]
+
+    try:
+        token = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"resume failed: malformed token JSON: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    if not isinstance(token, dict):
+        print("resume failed: token must be a JSON object", file=sys.stderr)
+        sys.exit(2)
+
+    try:
+        from hermes_cli.main import (  # noqa: PLC0415
+            _resume_windows_gateways_after_update,
+        )
+
+        _resume_windows_gateways_after_update(token)
+    except Exception as exc:
+        print(f"resume failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(json.dumps({"ok": True}))
+    sys.exit(0)
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        _emit_usage()
+
+    command = sys.argv[1]
+
+    if command == "pause":
+        _cmd_pause()
+    elif command == "resume":
+        _cmd_resume()
+    else:
+        _emit_usage()
+
+
+if __name__ == "__main__":
+    main()

--- a/hermes_cli/_gateway_update_lock.py
+++ b/hermes_cli/_gateway_update_lock.py
@@ -29,7 +29,7 @@ def _emit_usage() -> NoReturn:
 def _cmd_pause() -> NoReturn:
     """Pause gateways, print JSON resume token to stdout, exit 0."""
     try:
-        from hermes_cli.main import (  # noqa: PLC0415
+        from hermes_cli.update_cmd import (  # noqa: PLC0415
             _pause_windows_gateways_for_update,
         )
 
@@ -39,9 +39,9 @@ def _cmd_pause() -> NoReturn:
         print(f"pause failed: {exc}", file=sys.stderr)
         sys.exit(1)
 
-    # Serialise the token; None → empty dict so the caller can distinguish
+    # Serialise the token; None → None so the caller can distinguish
     # "no gateways running" from "probe failure".
-    payload = token if token is not None else {}
+    payload = token if token is not None else None
     print(json.dumps({"ok": True, "token": payload}))
     sys.exit(0)
 
@@ -64,7 +64,7 @@ def _cmd_resume() -> NoReturn:
         sys.exit(2)
 
     try:
-        from hermes_cli.main import (  # noqa: PLC0415
+        from hermes_cli.update_cmd import (  # noqa: PLC0415
             _resume_windows_gateways_after_update,
         )
 

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3102,7 +3102,27 @@ def _cmd_update_impl(args, gateway_mode: bool):
     # post-update cron-jobs safety net uses it to detect job loss.
     pre_update_snapshot_id = _m()._run_pre_update_backup(args)
 
-    _windows_gateway_resume = _m()._pause_windows_gateways_for_update()
+    # Layer 3 coordination (#74386): the Desktop Electron preflight may have
+    # already paused gateways via ``_gateway_update_lock pause``. When it did,
+    # it passes the resume token via $HERMES_WINDOWS_GATEWAY_RESUME_TOKEN so we
+    # do NOT re-pause (the gateways are already gone) but MUST still resume on
+    # exit. Using the Electron's token ensures all pre-pause state (unmapped
+    # argv snapshots, profile PID mappings) is preserved for resume.
+    _gateway_was_pre_paused = False
+    _pre_paused_token = os.environ.get("HERMES_WINDOWS_GATEWAY_RESUME_TOKEN")
+    if _pre_paused_token:
+        try:
+            _parsed_token = json.loads(_pre_paused_token)
+            if isinstance(_parsed_token, dict):
+                _windows_gateway_resume = _parsed_token
+                _gateway_was_pre_paused = True
+        except (json.JSONDecodeError, TypeError):
+            pass
+        del os.environ["HERMES_WINDOWS_GATEWAY_RESUME_TOKEN"]
+
+    if not _gateway_was_pre_paused:
+        _windows_gateway_resume = _m()._pause_windows_gateways_for_update()
+
     if _windows_gateway_resume:
         import atexit as _atexit
 
@@ -3121,12 +3141,49 @@ def _cmd_update_impl(args, gateway_mode: bool):
     # and app.asar — a non-desktop venv python holding a .pyd would sail
     # through and corrupt the sync (the exact failure this guard exists for).
     # --force-venv is the explicit escape hatch.
+    #
+    # Layer 3 (#74386): the scan can find gateway processes that our own
+    # _pause_windows_gateways_for_update missed (gateways spawned via
+    # ``--replace`` or ``hermes.exe`` shim-wrapped children that don't register
+    # in the PID-file registry). The information is already in the scan — the
+    # cmdline classifies them (``_format_venv_python_holders_message`` annotates
+    # ``← gateway``). When ALL remaining holders are gateways, force-kill them
+    # and proceed instead of aborting. Only abort when a non-gateway holder
+    # (the Desktop backend) remains.
     if _m()._is_windows() and not getattr(args, "force_venv", False):
         _venv_holders = _m()._detect_venv_python_processes()
         if _venv_holders:
-            print(_format_venv_python_holders_message(_venv_holders))
-            _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
-            sys.exit(2)
+            _all_gateways = all(
+                "gateway" in cmdline.lower()
+                for _, _, cmdline in _venv_holders
+            )
+            if _all_gateways:
+                # Gateways that escaped pause — safe to force-kill since the
+                # resume token (from Electron or our own pause above) will
+                # respawn them post-update via the same mechanism.
+                try:
+                    from gateway.status import terminate_pid  # noqa: PLC0415
+                except Exception:
+                    terminate_pid = None
+                if terminate_pid:
+                    for pid, name, cmdline in _venv_holders:
+                        try:
+                            terminate_pid(int(pid), force=True)
+                        except (ProcessLookupError, PermissionError, OSError):
+                            pass
+                    print(
+                        f"  → Force-stopped {len(_venv_holders)} remaining"
+                        f" gateway process(es) after update lock"
+                    )
+                else:
+                    print(
+                        "  ⚠ Could not force-stop remaining gateway processes"
+                        " (terminate_pid unavailable); update may fail"
+                    )
+            else:
+                print(_format_venv_python_holders_message(_venv_holders))
+                _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
+                sys.exit(2)
 
     # Try git-based update first, fall back to ZIP download on Windows
     # when git file I/O is broken (antivirus, NTFS filter drivers, etc.)


### PR DESCRIPTION
## Summary

Fixes #74386 — on Windows gateway-enabled installs, the desktop Update button triggers a three-layer chain (Electron → Rust bootstrapper → Python CLI) where **each layer has a different gap** in gateway process coordination, guaranteeing that the desktop updater can never complete on a gateway-enabled install without manual `hermes gateway stop` intervention.

## Changes

### Layer 1 — Electron (apps/desktop/electron/main.ts)

Add `pauseWindowsGatewaysForUpdate` / `resumeWindowsGatewaysAfterUpdate` functions that run the Python `_gateway_update_lock` subprocess bridge to pause gateways **before** the venv-blocker scan. The pre-flight blocker scan was finding the running gateway and aborting before the CLI updater even started.

The resume token is passed to the spawned CLI updater via `HERMES_WINDOWS_GATEWAY_RESUME_TOKEN` env var so it does not double-pause. On error paths (blocked/probe-failure), gateways are resumed before the UI shows the error.

### Layer 2 — Fallback

`stopVenvBlockers` in `venv-blocker-scan.ts` provides a TypeScript-side fallback: when the blocker scan finds processes, `isGatewayProcess()` classifies them by cmdline, and gateway PIDs are force-killed via `taskkill /F` before re-scanning. Non-gateway processes are still reported as blockers.

### Layer 3 — Python CLI (hermes_cli/update_cmd.py, hermes_cli/_gateway_update_lock.py)

Two fixes:

1. **Env-var token passthrough**: Before calling `_pause_windows_gateways_for_update()`, check `HERMES_WINDOWS_GATEWAY_RESUME_TOKEN`. When set by the Electron preflight, use the Electron's token as the resume token (skip re-pause — gateways are already gone) but still register the atexit resume handler.

2. **Graceful gateway handling in venv-holder check**: When `_detect_venv_python_processes()` finds remaining holders after gateway pause, classify each by cmdline. If **all** are gateways (e.g. gateways spawned via `--replace` or shim-wrapped children that `find_gateway_pids()` missed), force-kill them with `terminate_pid(force=True)` and **proceed** instead of aborting. Only abort when a non-gateway holder (the Desktop backend) remains.

### New module: hermes_cli/_gateway_update_lock.py

Subprocess-callable bridge invoked by Electron:
- `python -m hermes_cli._gateway_update_lock pause` — calls `_pause_windows_gateways_for_update()`, prints JSON resume token
- `python -m hermes_cli._gateway_update_lock resume <json-token>` — calls `_resume_windows_gateways_after_update()`

## Files changed

| File | Change |
|------|--------|
| `apps/desktop/electron/main.ts` | +Layer 1: gateway pause/resume helpers, integrated into applyUpdates preflight |
| `apps/desktop/electron/venv-blocker-scan.ts` | +isGatewayProcess + stopVenvBlockers helpers |
| `apps/desktop/electron/venv-blocker-scan.test.ts` | +tests for new helpers |
| `hermes_cli/_gateway_update_lock.py` | +new module: subprocess bridge for pause/resume |
| `hermes_cli/update_cmd.py` | +Layer 3: env-var token passthrough + graceful gateway handling |

## Related

- #74326 (same scenario, earlier approach)
- #50090 (unmapped gateway restart after update)
- #73822 (update-in-progress gate)
