### PR TITLE
feat(usage): surface Kimi Coding Plan quota in account usage

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -5,6 +5,7 @@ import math
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Optional
+from urllib.parse import urlparse
 
 import httpx
 
@@ -809,6 +810,173 @@ def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
     )
 
 
+_KIMI_USAGE_DEFAULT_BASE_URL = "https://api.kimi.com/coding"
+
+
+def _is_kimi_coding_base_url(base_url: Optional[str]) -> bool:
+    """Return whether *base_url* is the confirmed Kimi Coding Plan runtime."""
+    try:
+        parsed = urlparse((base_url or "").strip())
+        port = parsed.port
+    except ValueError:
+        return False
+    return (
+        parsed.scheme.lower() == "https"
+        and (parsed.hostname or "").lower() == "api.kimi.com"
+        and port in (None, 443)
+        and parsed.username is None
+        and parsed.password is None
+        and parsed.path.rstrip("/") in {"/coding", "/coding/v1"}
+        and not parsed.query
+        and not parsed.fragment
+    )
+
+
+def _kimi_usages_url(base_url: Optional[str]) -> str:
+    """Resolve the Kimi Code ``/usages`` endpoint from a chat base URL.
+
+    The quota endpoint lives next to the chat routes: ``/coding/v1/usages``.
+    Accepts a base URL with or without the trailing ``/v1`` so both the
+    canonical ``https://api.kimi.com/coding`` config value and the
+    ``.../coding/v1`` variant used by some resolvers work.
+    """
+    normalized = (base_url or "").strip().rstrip("/")
+    if not normalized:
+        normalized = _KIMI_USAGE_DEFAULT_BASE_URL
+    if normalized.endswith("/v1"):
+        normalized = normalized[: -len("/v1")]
+    return normalized + "/v1/usages"
+
+
+def _kimi_window_label(window: Any) -> str:
+    """Human label for a Kimi ``limits[]`` rolling window (e.g. 300 minutes)."""
+    w = window if isinstance(window, dict) else {}
+    duration = w.get("duration")
+    unit = str(w.get("timeUnit") or "").strip().upper()
+    try:
+        n = float(duration)
+    except (TypeError, ValueError):
+        return "Rolling window"
+    if n <= 0:
+        return "Rolling window"
+    if unit == "TIME_UNIT_MINUTE":
+        if n % 60 == 0:
+            hours = int(n // 60)
+            return f"{hours}-hour" if hours != 1 else "Hourly"
+        return f"{int(n)}-minute"
+    if unit == "TIME_UNIT_HOUR":
+        return f"{int(n)}-hour"
+    if unit == "TIME_UNIT_DAY":
+        return f"{int(n)}-day"
+    return "Rolling window"
+
+
+def _percent_from_counts(detail: Any) -> Optional[float]:
+    """Compute used_percent from a {limit, used, remaining} quota object."""
+    if not isinstance(detail, dict):
+        return None
+    limit_raw = detail.get("limit")
+    used_raw = detail.get("used")
+    if not isinstance(limit_raw, (int, float, str)) or isinstance(limit_raw, bool):
+        return None
+    if not isinstance(used_raw, (int, float, str)) or isinstance(used_raw, bool):
+        return None
+    try:
+        limit = float(limit_raw)
+        used = float(used_raw)
+    except (TypeError, ValueError):
+        return None
+    if limit <= 0:
+        return None
+    return used / limit * 100.0
+
+
+def _fetch_kimi_account_usage(
+    provider: str,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> Optional[AccountUsageSnapshot]:
+    """Fetch Kimi Code (Coding Plan) quota from ``/coding/v1/usages``.
+
+    Response schema (verified against the live endpoint 2026-07)::
+
+        {
+          "user": {"membership": {"level": "LEVEL_ADVANCED"}, ...},
+          "usage": {"limit": "100", "used": "1", "remaining": "99",
+                    "resetTime": "..."},          # weekly quota (percent)
+          "limits": [{"window": {"duration": 300,
+                                 "timeUnit": "TIME_UNIT_MINUTE"},
+                      "detail": {"limit": "100", "used": "3", ...}}],
+          "parallel": {"limit": "30"}
+        }
+    """
+    runtime = resolve_runtime_provider(
+        requested=provider,
+        explicit_base_url=base_url,
+        explicit_api_key=api_key,
+    )
+    token = str(runtime.get("api_key", "") or "").strip()
+    runtime_base_url = str(runtime.get("base_url", "") or "").strip()
+    if not token or not _is_kimi_coding_base_url(runtime_base_url):
+        return None
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    with httpx.Client(timeout=15.0) as client:
+        response = client.get(
+            _kimi_usages_url(runtime_base_url),
+            headers=headers,
+        )
+        response.raise_for_status()
+    payload = response.json() or {}
+    windows: list[AccountUsageWindow] = []
+    weekly = payload.get("usage") or {}
+    weekly_percent = _percent_from_counts(weekly)
+    if weekly_percent is not None:
+        windows.append(
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=weekly_percent,
+                reset_at=_parse_dt(weekly.get("resetTime")),
+            )
+        )
+    rolling = payload.get("limits") or []
+    if isinstance(rolling, list):
+        for entry in rolling:
+            if not isinstance(entry, dict):
+                continue
+            detail = entry.get("detail") or {}
+            percent = _percent_from_counts(detail)
+            if percent is None:
+                continue
+            windows.append(
+                AccountUsageWindow(
+                    label=_kimi_window_label(entry.get("window")),
+                    used_percent=percent,
+                    reset_at=_parse_dt(detail.get("resetTime")),
+                )
+            )
+    details: list[str] = []
+    parallel = (payload.get("parallel") or {}).get("limit")
+    try:
+        if parallel is not None and int(parallel) > 0:
+            details.append(f"Parallel requests: {int(parallel)} max")
+    except (TypeError, ValueError):
+        pass
+    plan = _title_case_slug(
+        ((payload.get("user") or {}).get("membership") or {}).get("level")
+    )
+    return AccountUsageSnapshot(
+        provider=provider,
+        source="usage_api",
+        fetched_at=_utc_now(),
+        plan=plan,
+        windows=tuple(windows),
+        details=tuple(details),
+    )
+
+
 def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[str]) -> Optional[AccountUsageSnapshot]:
     runtime = resolve_runtime_provider(
         requested="openrouter",
@@ -895,6 +1063,9 @@ def fetch_account_usage(
             return _fetch_codex_account_usage(base_url=base_url, api_key=api_key)
         if normalized == "anthropic":
             return _fetch_anthropic_account_usage()
+        if normalized in {"kimi", "kimi-coding", "kimi-coding-cn", "moonshot", "kimi-cn", "moonshot-cn"}:
+            kimi_provider = "kimi-coding-cn" if normalized in {"kimi-coding-cn", "kimi-cn", "moonshot-cn"} else "kimi-coding"
+            return _fetch_kimi_account_usage(kimi_provider, base_url=base_url, api_key=api_key)
         if normalized == "openrouter":
             return _fetch_openrouter_account_usage(base_url, api_key)
     except Exception:

--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -4,6 +4,7 @@ import logging
 import math
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import httpx
@@ -11,6 +12,7 @@ import httpx
 from agent.anthropic_credentials import _is_oauth_token, resolve_anthropic_token
 from hermes_cli.auth import AuthError, _read_codex_tokens, resolve_codex_runtime_credentials
 from hermes_cli.runtime_provider import resolve_runtime_provider
+from utils import is_kimi_coding_base_url
 
 if TYPE_CHECKING:
     from typing import TypeGuard
@@ -520,6 +522,162 @@ def _fetch_anthropic_account_usage(
     return _snapshot("anthropic", "oauth_usage_api", windows, details)
 
 
+# All provider spellings that may resolve to a Kimi runtime. The CN set keeps
+# its own snapshot label; the actual Coding Plan gate is the resolved base URL
+# (utils.is_kimi_coding_base_url), not the alias.
+_KIMI_PROVIDER_ALIASES = frozenset({
+    "kimi",
+    "kimi-coding",
+    "kimi-coding-cn",
+    "moonshot",
+    "kimi-cn",
+    "moonshot-cn",
+})
+_KIMI_CN_PROVIDER_ALIASES = frozenset({"kimi-coding-cn", "kimi-cn", "moonshot-cn"})
+
+
+def _kimi_provider_label(alias: str) -> str:
+    return "kimi-coding-cn" if alias in _KIMI_CN_PROVIDER_ALIASES else "kimi-coding"
+
+
+def _kimi_usages_url(base_url: str) -> str:
+    """Resolve the Kimi Code ``/usages`` endpoint from a chat base URL.
+
+    The quota endpoint lives next to the chat routes: ``/coding/v1/usages``.
+    Accepts a base URL with or without the trailing ``/v1`` so both the
+    canonical ``https://api.kimi.com/coding`` config value and the
+    ``.../coding/v1`` variant used by some resolvers work.
+    """
+    normalized = base_url.strip().rstrip("/")
+    if normalized.endswith("/v1"):
+        normalized = normalized[: -len("/v1")]
+    return normalized + "/v1/usages"
+
+
+def _kimi_window_label(window: Any) -> str:
+    """Human label for a Kimi ``limits[]`` rolling window (e.g. 300 minutes)."""
+    w = window if isinstance(window, dict) else {}
+    duration = w.get("duration")
+    unit = str(w.get("timeUnit") or "").strip().upper()
+    try:
+        n = float(duration)
+    except (TypeError, ValueError):
+        return "Rolling window"
+    if n <= 0:
+        return "Rolling window"
+    if unit == "TIME_UNIT_MINUTE":
+        if n % 60 == 0:
+            hours = int(n // 60)
+            return f"{hours}-hour" if hours != 1 else "Hourly"
+        return f"{int(n)}-minute"
+    if unit == "TIME_UNIT_HOUR":
+        return f"{int(n)}-hour"
+    if unit == "TIME_UNIT_DAY":
+        return f"{int(n)}-day"
+    return "Rolling window"
+
+
+def _percent_from_counts(detail: Any) -> Optional[float]:
+    """Compute used_percent from a {limit, used, remaining} quota object.
+
+    Deliberately preserve values above 100: an over-quota response is useful
+    provider data. The renderer floors the remaining percentage at zero while
+    continuing to show the actual used percentage.
+    """
+    if not isinstance(detail, dict):
+        return None
+    limit_raw = detail.get("limit")
+    used_raw = detail.get("used")
+    if not isinstance(limit_raw, (int, float, str)) or isinstance(limit_raw, bool):
+        return None
+    if not isinstance(used_raw, (int, float, str)) or isinstance(used_raw, bool):
+        return None
+    try:
+        limit = float(limit_raw)
+        used = float(used_raw)
+    except (TypeError, ValueError):
+        return None
+    if limit <= 0:
+        return None
+    return used / limit * 100.0
+
+
+def _fetch_kimi_account_usage(
+    provider: str,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> Optional[AccountUsageSnapshot]:
+    """Fetch Kimi Code (Coding Plan) quota from ``/coding/v1/usages``.
+
+    ``provider`` is the caller's original alias (``kimi``, ``moonshot``,
+    ``kimi-coding-cn``, …). Resolution happens under that alias — the same
+    name the runtime credential records are keyed on — and the Coding Plan
+    gate is the *resolved* base URL, mirroring ``resolve_billing_route``.
+    Legacy ``api.moonshot.ai/v1`` and custom routes return no snapshot.
+
+    Response schema (verified against the live endpoint 2026-07)::
+
+        {
+          "user": {"membership": {"level": "LEVEL_ADVANCED"}, ...},
+          "usage": {"limit": "100", "used": "1", "remaining": "99",
+                    "resetTime": "..."},          # weekly quota (percent)
+          "limits": [{"window": {"duration": 300,
+                                 "timeUnit": "TIME_UNIT_MINUTE"},
+                      "detail": {"limit": "100", "used": "3", ...}}],
+          "parallel": {"limit": "30"}
+        }
+    """
+    runtime = resolve_runtime_provider(
+        requested=provider,
+        explicit_base_url=base_url,
+        explicit_api_key=api_key,
+    )
+    token = str(runtime.get("api_key", "") or "").strip()
+    runtime_base_url = str(runtime.get("base_url", "") or "").strip()
+    if not token or not is_kimi_coding_base_url(runtime_base_url):
+        return None
+    headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+    payload = _get_json(_kimi_usages_url(runtime_base_url), headers, timeout=15.0)
+    windows: list[AccountUsageWindow] = []
+    weekly = payload.get("usage") or {}
+    weekly_percent = _percent_from_counts(weekly)
+    if weekly_percent is not None:
+        windows.append(
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=weekly_percent,
+                reset_at=_parse_dt(weekly.get("resetTime")),
+            )
+        )
+    rolling = payload.get("limits") or []
+    if isinstance(rolling, list):
+        for entry in rolling:
+            if not isinstance(entry, dict):
+                continue
+            detail = entry.get("detail") or {}
+            percent = _percent_from_counts(detail)
+            if percent is None:
+                continue
+            windows.append(
+                AccountUsageWindow(
+                    label=_kimi_window_label(entry.get("window")),
+                    used_percent=percent,
+                    reset_at=_parse_dt(detail.get("resetTime")),
+                )
+            )
+    details: list[str] = []
+    parallel = (payload.get("parallel") or {}).get("limit")
+    try:
+        if parallel is not None and int(parallel) > 0:
+            details.append(f"Parallel requests: {int(parallel)} max")
+    except (TypeError, ValueError):
+        pass
+    plan = _title_case_slug(
+        ((payload.get("user") or {}).get("membership") or {}).get("level")
+    )
+    return _snapshot(_kimi_provider_label(provider), "usage_api", windows, details, plan=plan)
+
+
 def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[str]) -> Optional[AccountUsageSnapshot]:
     runtime = resolve_runtime_provider(requested="openrouter", explicit_base_url=base_url, explicit_api_key=api_key)
     token = str(runtime.get("api_key", "") or "").strip()
@@ -560,6 +718,10 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
 _USAGE_FETCHERS: dict[str, Callable[[Optional[str], Optional[str]], Optional[AccountUsageSnapshot]]] = {
     "openai-codex": _fetch_codex_account_usage, "anthropic": _fetch_anthropic_account_usage,
     "openrouter": _fetch_openrouter_account_usage,
+    # Resolve under the caller's own alias — runtime credential records for
+    # legacy `moonshot`/`moonshot-cn` users are keyed on that name, and
+    # resolving under a substituted `kimi-coding` would silently miss them.
+    **{alias: partial(_fetch_kimi_account_usage, alias) for alias in _KIMI_PROVIDER_ALIASES},
 }
 
 

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, Dict, Literal, Optional
+from urllib.parse import urlparse
 
 from agent.model_metadata import fetch_endpoint_model_metadata, fetch_model_metadata
 from utils import base_url_host_matches
@@ -987,6 +988,25 @@ def _to_int(value: Any) -> int:
         return 0
 
 
+def _is_kimi_coding_base_url(base_url: Optional[str]) -> bool:
+    """Return whether billing is confirmed to use the Kimi Coding Plan."""
+    try:
+        parsed = urlparse((base_url or "").strip())
+        port = parsed.port
+    except ValueError:
+        return False
+    return (
+        parsed.scheme.lower() == "https"
+        and (parsed.hostname or "").lower() == "api.kimi.com"
+        and port in (None, 443)
+        and parsed.username is None
+        and parsed.password is None
+        and parsed.path.rstrip("/") in {"/coding", "/coding/v1"}
+        and not parsed.query
+        and not parsed.fragment
+    )
+
+
 def resolve_billing_route(
     model_name: str,
     provider: Optional[str] = None,
@@ -1003,6 +1023,11 @@ def resolve_billing_route(
 
     if provider_name == "openai-codex":
         return BillingRoute(provider="openai-codex", model=model, base_url=base_url or "", billing_mode="subscription_included")
+    # Only the confirmed api.kimi.com/coding runtime is a flat weekly-quota
+    # subscription. Legacy Moonshot and custom routes retain unknown billing.
+    if provider_name in {"kimi-coding", "kimi-coding-cn", "kimi", "moonshot", "kimi-cn", "moonshot-cn"} and _is_kimi_coding_base_url(base_url):
+        kimi_provider = "kimi-coding-cn" if provider_name in {"kimi-coding-cn", "kimi-cn", "moonshot-cn"} else "kimi-coding"
+        return BillingRoute(provider=kimi_provider, model=model.split("/")[-1], base_url=base_url or "", billing_mode="subscription_included")
     if provider_name == "openrouter" or base_url_host_matches(base_url or "", "openrouter.ai"):
         return BillingRoute(provider="openrouter", model=model, base_url=base_url or "", billing_mode="official_models_api")
     if provider_name == "nous" or base_url_host_matches(base_url or "", "inference-api.nousresearch.com"):

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 from typing import Any, Dict, Literal, Optional
 
 from agent.model_metadata import fetch_endpoint_model_metadata, fetch_model_metadata
-from utils import base_url_host_matches, base_url_hostname
+from utils import base_url_host_matches, base_url_hostname, is_kimi_coding_base_url
 
 logger = logging.getLogger(__name__)
 
@@ -301,6 +301,10 @@ _SNAPSHOT_PROVIDER_ALIASES = {
 # AI Studio and Vertex host the same Gemini models (the Vertex "google/" vendor
 # prefix is stripped with the rest of the path).
 _GOOGLE_PROVIDER_NAMES = {"google", "gemini", "vertex", "google-gemini", "google-ai-studio", "google-vertex", "vertex-ai"}
+# Every picker/alias spelling that may resolve to a Kimi runtime; the Coding
+# Plan gate is the resolved base URL (utils.is_kimi_coding_base_url), not the alias.
+_KIMI_CN_PROVIDER_NAMES = {"kimi-coding-cn", "kimi-cn", "moonshot-cn"}
+_KIMI_PROVIDER_NAMES = {"kimi-coding", "kimi", "moonshot", *_KIMI_CN_PROVIDER_NAMES}
 
 
 def resolve_billing_route(
@@ -325,6 +329,11 @@ def resolve_billing_route(
 
     if provider_name == "openai-codex":
         return BillingRoute(provider="openai-codex", model=model, base_url=url, billing_mode="subscription_included")
+    # Only the confirmed api.kimi.com/coding runtime is a flat weekly-quota
+    # subscription. Legacy Moonshot and custom routes retain unknown billing.
+    if provider_name in _KIMI_PROVIDER_NAMES and is_kimi_coding_base_url(url):
+        kimi_provider = "kimi-coding-cn" if provider_name in _KIMI_CN_PROVIDER_NAMES else "kimi-coding"
+        return BillingRoute(provider=kimi_provider, model=bare, base_url=url, billing_mode="subscription_included")
     if provider_name == "openrouter" or host("openrouter.ai"):
         return BillingRoute(provider="openrouter", model=model, base_url=url, billing_mode="official_models_api")
     if provider_name == "nous" or host("inference-api.nousresearch.com"):

--- a/plugins/model-providers/kimi-coding/__init__.py
+++ b/plugins/model-providers/kimi-coding/__init__.py
@@ -2,32 +2,18 @@
 redirected to api.kimi.com/coding by core)."""
 
 from typing import Any
-from urllib.parse import urlparse
 
 from agent.reasoning_effort import KIMI_K3_EFFORTS, KIMI_K3_OVERRIDES, clamp_effort, requested_effort
 from hermes_cli import __version__ as _HERMES_VERSION
 from providers import register_provider
 from providers.base import OMIT_TEMPERATURE, ProviderProfile
+from utils import is_kimi_coding_base_url
 
 _HEADERS = {
     "HTTP-Referer": "https://hermes-agent.nousresearch.com",
     "X-Title": "Hermes Agent",
     "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
 }
-
-
-def _is_confirmed_kimi_coding_url(base_url: str) -> bool:
-    """True only for Kimi Code's canonical HTTPS API surfaces."""
-    try:
-        p = urlparse(base_url)
-        port = p.port
-    except ValueError:
-        return False
-    return (
-        p.scheme.lower() == "https" and (p.hostname or "").lower() == "api.kimi.com" and port in (None, 443)
-        and p.username is None and p.password is None
-        and p.path.rstrip("/") in {"/coding", "/coding/v1"} and not p.query and not p.fragment
-    )
 
 
 class KimiProfile(ProviderProfile):
@@ -39,8 +25,8 @@ class KimiProfile(ProviderProfile):
         """Use Kimi Code's OpenAI-compatible surface for model discovery; the bare
         ``k3`` slug is only served there, so it is filtered off other endpoints."""
         effective_base = (base_url or self.base_url or "").rstrip("/")
-        confirmed_coding_endpoint = _is_confirmed_kimi_coding_url(effective_base)
-        if confirmed_coding_endpoint and urlparse(effective_base).path.rstrip("/") == "/coding":
+        confirmed_coding_endpoint = is_kimi_coding_base_url(effective_base)
+        if confirmed_coding_endpoint and effective_base.endswith("/coding"):
             effective_base += "/v1"
         models = super().fetch_models(api_key=api_key, base_url=effective_base or None, timeout=timeout)
         if models is None or confirmed_coding_endpoint:

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -227,3 +227,236 @@ def test_redeem_missing_credentials_reports_unavailable(monkeypatch):
 
     assert result.status == "unavailable"
     assert "hermes auth" in result.message
+
+
+@pytest.fixture
+def kimi_usage_payload():
+    """Minimal synthetic shape returned by the Coding Plan usage endpoint."""
+    return {
+        "user": {"membership": {"level": "LEVEL_ADVANCED"}},
+        "usage": {
+            "limit": "100",
+            "used": "1",
+            "remaining": "99",
+            "resetTime": "2026-08-05T21:53:56Z",
+        },
+        "limits": [
+            {
+                "window": {"duration": 300, "timeUnit": "TIME_UNIT_MINUTE"},
+                "detail": {
+                    "limit": "100",
+                    "used": "3",
+                    "remaining": "97",
+                    "resetTime": "2026-07-30T02:53:56Z",
+                },
+            }
+        ],
+        "parallel": {"limit": "30"},
+    }
+
+
+def _install_fake_kimi_client(monkeypatch, calls, payload):
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, payload),
+    )
+
+
+def _write_saved_moonshot_provider(base_url):
+    """Store a provider under its legacy alias in the isolated HERMES_HOME."""
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "providers:\n"
+        "  moonshot:\n"
+        "    name: Moonshot saved runtime\n"
+        f"    api: {base_url}\n"
+        "    api_key: synthetic-test-key\n",
+        encoding="utf-8",
+    )
+
+
+def test_kimi_usage_maps_quota_via_real_runtime_resolution(
+    monkeypatch, kimi_usage_payload
+):
+    calls = []
+    _install_fake_kimi_client(monkeypatch, calls, kimi_usage_payload)
+
+    snapshot = account_usage.fetch_account_usage(
+        "kimi-coding",
+        base_url="https://api.kimi.com/coding",
+        api_key="synthetic-test-key",
+    )
+
+    assert snapshot is not None
+    assert snapshot.provider == "kimi-coding"
+    assert snapshot.plan == "Level Advanced"
+    assert [window.label for window in snapshot.windows] == ["Weekly", "5-hour"]
+    assert [window.used_percent for window in snapshot.windows] == pytest.approx([
+        1.0,
+        3.0,
+    ])
+    assert snapshot.windows[0].reset_at is not None
+    assert snapshot.details == ("Parallel requests: 30 max",)
+    assert calls == [
+        {
+            "url": "https://api.kimi.com/coding/v1/usages",
+            "headers": {
+                "Authorization": "Bearer synthetic-test-key",
+                "Accept": "application/json",
+            },
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://api.kimi.com/coding",
+        "https://api.kimi.com/coding/",
+        "https://api.kimi.com/coding/v1",
+        "https://api.kimi.com:443/coding",
+    ],
+)
+def test_kimi_coding_base_url_gate_accepts_only_canonical_variants(base_url):
+    from utils import is_kimi_coding_base_url
+
+    assert is_kimi_coding_base_url(base_url)
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        None,
+        "http://api.kimi.com/coding",
+        "https://api.moonshot.ai/v1",
+        "https://proxy.example.com/coding",
+        "https://api.kimi.com.example/coding",
+        "https://api.kimi.com/coding/extra",
+        "https://api.kimi.com/coding?mode=legacy",
+        "https://user@api.kimi.com/coding",
+    ],
+)
+def test_kimi_coding_base_url_gate_rejects_legacy_custom_and_ambiguous_urls(base_url):
+    from utils import is_kimi_coding_base_url
+
+    assert not is_kimi_coding_base_url(base_url)
+
+
+@pytest.mark.parametrize(
+    ("base_url", "expect_snapshot"),
+    [
+        ("https://api.kimi.com/coding", True),
+        ("https://api.moonshot.ai/v1", False),
+    ],
+)
+def test_kimi_legacy_alias_uses_its_saved_runtime_record(
+    monkeypatch,
+    kimi_usage_payload,
+    base_url,
+    expect_snapshot,
+):
+    """Exercise the real resolver; remapping to kimi-coding would miss this row."""
+    calls = []
+    _install_fake_kimi_client(monkeypatch, calls, kimi_usage_payload)
+    _write_saved_moonshot_provider(base_url)
+
+    snapshot = account_usage.fetch_account_usage("moonshot")
+
+    if expect_snapshot:
+        assert snapshot is not None
+        assert snapshot.provider == "kimi-coding"
+        assert calls[0]["url"] == "https://api.kimi.com/coding/v1/usages"
+    else:
+        assert snapshot is None
+        assert calls == []
+
+
+@pytest.mark.parametrize(
+    ("api_key", "expect_snapshot"),
+    [
+        ("sk-kimi-synthetic-test", True),
+        ("legacy-moonshot-test-key", False),
+    ],
+)
+def test_kimi_builtin_alias_distinguishes_coding_plan_from_legacy_key(
+    monkeypatch,
+    kimi_usage_payload,
+    api_key,
+    expect_snapshot,
+):
+    """Use the real auth/runtime chain rather than replacing its resolver."""
+    calls = []
+    _install_fake_kimi_client(monkeypatch, calls, kimi_usage_payload)
+    monkeypatch.setenv("KIMI_API_KEY", api_key)
+    monkeypatch.delenv("KIMI_CODING_API_KEY", raising=False)
+    monkeypatch.delenv("KIMI_BASE_URL", raising=False)
+
+    snapshot = account_usage.fetch_account_usage("moonshot")
+
+    assert (snapshot is not None) is expect_snapshot
+    if expect_snapshot:
+        assert calls[0]["url"] == "https://api.kimi.com/coding/v1/usages"
+    else:
+        assert calls == []
+
+
+def test_kimi_custom_runtime_fails_closed_without_request(monkeypatch):
+    calls = []
+    _install_fake_kimi_client(monkeypatch, calls, {})
+
+    snapshot = account_usage.fetch_account_usage(
+        "kimi",
+        base_url="https://proxy.example.com/coding",
+        api_key="synthetic-test-key",
+    )
+
+    assert snapshot is None
+    assert calls == []
+
+
+def test_kimi_over_quota_percent_is_preserved_and_renders_safely(monkeypatch):
+    calls = []
+    _install_fake_kimi_client(
+        monkeypatch,
+        calls,
+        {"usage": {"limit": "100", "used": "130"}},
+    )
+
+    snapshot = account_usage.fetch_account_usage(
+        "kimi-coding",
+        base_url="https://api.kimi.com/coding",
+        api_key="synthetic-test-key",
+    )
+
+    assert account_usage._percent_from_counts({"limit": "100", "used": "130"}) == 130.0
+    assert snapshot is not None
+    assert snapshot.windows[0].used_percent == 130.0
+    assert (
+        "Weekly: 0% remaining (130% used)"
+        in account_usage.render_account_usage_lines(snapshot)
+    )
+
+
+def test_kimi_usage_tolerates_missing_optional_sections(monkeypatch):
+    calls = []
+    _install_fake_kimi_client(
+        monkeypatch,
+        calls,
+        {"usage": {"limit": "100", "used": "40"}},
+    )
+
+    snapshot = account_usage.fetch_account_usage(
+        "kimi-coding",
+        base_url="https://api.kimi.com/coding/v1",
+        api_key="synthetic-test-key",
+    )
+
+    assert snapshot is not None
+    assert [window.label for window in snapshot.windows] == ["Weekly"]
+    assert snapshot.windows[0].used_percent == pytest.approx(40.0)
+    assert snapshot.windows[0].reset_at is None
+    assert snapshot.details == ()

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -227,3 +227,157 @@ def test_redeem_missing_credentials_reports_unavailable(monkeypatch):
 
     assert result.status == "unavailable"
     assert "hermes auth" in result.message
+
+
+@pytest.fixture
+def kimi_usage_payload():
+    # Mirrors the live GET https://api.kimi.com/coding/v1/usages response
+    # captured 2026-07-29.
+    return {
+        "user": {
+            "userId": "d9h7qm6mcu0rlmtg0v9g",
+            "region": "REGION_OVERSEA",
+            "membership": {"level": "LEVEL_ADVANCED"},
+            "businessId": "",
+        },
+        "usage": {
+            "limit": "100",
+            "used": "1",
+            "remaining": "99",
+            "resetTime": "2026-08-05T21:53:56.360821Z",
+        },
+        "limits": [
+            {
+                "window": {"duration": 300, "timeUnit": "TIME_UNIT_MINUTE"},
+                "detail": {
+                    "limit": "100",
+                    "used": "3",
+                    "remaining": "97",
+                    "resetTime": "2026-07-30T02:53:56.360821Z",
+                },
+            }
+        ],
+        "parallel": {"limit": "30"},
+        "authentication": {"method": "METHOD_API_KEY", "scope": "FEATURE_CODING"},
+    }
+
+
+def _patch_kimi_runtime(monkeypatch, base_url="https://api.kimi.com/coding"):
+    monkeypatch.setattr(
+        account_usage,
+        "resolve_runtime_provider",
+        lambda **kwargs: {"api_key": "kimi-test-key", "base_url": base_url},
+    )
+
+
+def test_kimi_usage_maps_weekly_and_rolling_windows(monkeypatch, kimi_usage_payload):
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, kimi_usage_payload),
+    )
+    _patch_kimi_runtime(monkeypatch)
+
+    snapshot = account_usage.fetch_account_usage("kimi-coding")
+
+    assert snapshot is not None
+    assert snapshot.provider == "kimi-coding"
+    assert snapshot.plan == "Level Advanced"
+    assert [w.label for w in snapshot.windows] == ["Weekly", "5-hour"]
+    assert snapshot.windows[0].used_percent == pytest.approx(1.0)
+    assert snapshot.windows[1].used_percent == pytest.approx(3.0)
+    assert snapshot.windows[0].reset_at is not None
+    assert snapshot.details == ("Parallel requests: 30 max",)
+    assert calls[0]["url"] == "https://api.kimi.com/coding/v1/usages"
+    assert calls[0]["headers"]["Authorization"] == "Bearer kimi-test-key"
+
+
+def test_kimi_usages_url_strips_trailing_v1():
+    assert (
+        account_usage._kimi_usages_url("https://api.kimi.com/coding/v1")
+        == "https://api.kimi.com/coding/v1/usages"
+    )
+    assert (
+        account_usage._kimi_usages_url("https://api.kimi.com/coding/")
+        == "https://api.kimi.com/coding/v1/usages"
+    )
+    assert (
+        account_usage._kimi_usages_url(None)
+        == "https://api.kimi.com/coding/v1/usages"
+    )
+
+
+def test_kimi_usage_returns_none_without_credentials(monkeypatch):
+    monkeypatch.setattr(
+        account_usage,
+        "resolve_runtime_provider",
+        lambda **kwargs: {"api_key": "", "base_url": ""},
+    )
+
+    assert account_usage.fetch_account_usage("kimi-coding") is None
+
+
+def test_kimi_aliases_route_to_confirmed_coding_plan(monkeypatch, kimi_usage_payload):
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, kimi_usage_payload),
+    )
+    _patch_kimi_runtime(monkeypatch)
+
+    for alias in ("kimi", "moonshot", "kimi-coding-cn", "kimi-cn", "moonshot-cn"):
+        snapshot = account_usage.fetch_account_usage(alias)
+        assert snapshot is not None, alias
+        expected_provider = (
+            "kimi-coding-cn"
+            if alias in {"kimi-coding-cn", "kimi-cn", "moonshot-cn"}
+            else "kimi-coding"
+        )
+        assert snapshot.provider == expected_provider
+        assert [w.label for w in snapshot.windows] == ["Weekly", "5-hour"]
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    ["https://api.moonshot.ai/v1", "https://proxy.example.com/coding"],
+)
+def test_kimi_usage_skips_legacy_and_custom_runtimes(monkeypatch, base_url):
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, {}),
+    )
+    _patch_kimi_runtime(monkeypatch, base_url=base_url)
+
+    assert account_usage.fetch_account_usage("moonshot") is None
+    assert calls == []
+
+
+def test_kimi_window_labels():
+    assert account_usage._kimi_window_label({"duration": 300, "timeUnit": "TIME_UNIT_MINUTE"}) == "5-hour"
+    assert account_usage._kimi_window_label({"duration": 60, "timeUnit": "TIME_UNIT_MINUTE"}) == "Hourly"
+    assert account_usage._kimi_window_label({"duration": 30, "timeUnit": "TIME_UNIT_MINUTE"}) == "30-minute"
+    assert account_usage._kimi_window_label({"duration": 1, "timeUnit": "TIME_UNIT_DAY"}) == "1-day"
+    assert account_usage._kimi_window_label({}) == "Rolling window"
+    assert account_usage._kimi_window_label(None) == "Rolling window"
+
+
+def test_kimi_usage_tolerates_missing_sections(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, {"usage": {"limit": "100", "used": "40"}}),
+    )
+    _patch_kimi_runtime(monkeypatch)
+
+    snapshot = account_usage.fetch_account_usage("kimi-coding")
+
+    assert snapshot is not None
+    assert [w.label for w in snapshot.windows] == ["Weekly"]
+    assert snapshot.windows[0].used_percent == pytest.approx(40.0)
+    assert snapshot.windows[0].reset_at is None
+    assert snapshot.details == ()

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from agent.usage_pricing import (
     CanonicalUsage,
     estimate_usage_cost,
@@ -312,3 +314,43 @@ def test_vertex_default_model_estimates_cached_usage(monkeypatch):
 
     assert result.status == "estimated"
     assert result.amount_usd is not None and result.amount_usd > 0
+
+
+def test_kimi_coding_route_is_subscription_included():
+    route = resolve_billing_route("kimi-k3", provider="kimi-coding", base_url="https://api.kimi.com/coding")
+    assert route.billing_mode == "subscription_included"
+    assert route.provider == "kimi-coding"
+
+
+def test_kimi_coding_cn_route_is_subscription_included():
+    route = resolve_billing_route("kimi-k3", provider="kimi-coding-cn", base_url="https://api.kimi.com/coding/v1")
+    assert route.billing_mode == "subscription_included"
+    assert route.provider == "kimi-coding-cn"
+
+
+def test_kimi_aliases_route_to_coding_subscription():
+    for alias in ("kimi", "moonshot"):
+        route = resolve_billing_route("kimi-k3", provider=alias, base_url="https://api.kimi.com/coding")
+        assert route.billing_mode == "subscription_included"
+        assert route.provider == "kimi-coding"
+
+
+def test_kimi_estimate_usage_cost_is_included():
+    result = estimate_usage_cost(
+        "kimi-k3",
+        CanonicalUsage(input_tokens=1000, output_tokens=500),
+        provider="kimi-coding",
+        base_url="https://api.kimi.com/coding",
+    )
+
+    assert result.status == "included"
+    assert float(result.amount_usd) == 0.0
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [None, "https://api.moonshot.ai/v1", "https://proxy.example.com/coding"],
+)
+def test_kimi_legacy_and_custom_routes_are_not_subscription_included(base_url):
+    route = resolve_billing_route("kimi-k3", provider="moonshot", base_url=base_url)
+    assert route.billing_mode != "subscription_included"

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from agent.usage_pricing import (
     CanonicalUsage,
     format_cost_label,
@@ -909,3 +911,52 @@ def test_flat_entries_unaffected_by_tier_machinery():
     )
     # 250k * $0.25/M + 10k * $1.50/M
     assert result.amount_usd == Decimal("0.0775")
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected_provider"),
+    [
+        ("kimi-coding", "kimi-coding"),
+        ("kimi", "kimi-coding"),
+        ("moonshot", "kimi-coding"),
+        ("kimi-coding-cn", "kimi-coding-cn"),
+        ("kimi-cn", "kimi-coding-cn"),
+        ("moonshot-cn", "kimi-coding-cn"),
+    ],
+)
+def test_kimi_coding_plan_is_subscription_included(provider, expected_provider):
+    route = resolve_billing_route(
+        "kimi-k3",
+        provider=provider,
+        base_url="https://api.kimi.com/coding/v1",
+    )
+    assert route.billing_mode == "subscription_included"
+    assert route.provider == expected_provider
+
+
+@pytest.mark.parametrize(
+    ("provider", "base_url"),
+    [
+        ("kimi-coding", None),
+        ("moonshot", "https://api.moonshot.ai/v1"),
+        ("moonshot-cn", "https://api.moonshot.cn/v1"),
+        ("kimi", "https://proxy.example.com/coding"),
+        ("kimi", "http://api.kimi.com/coding"),
+        ("custom", "https://api.kimi.com/coding"),
+    ],
+)
+def test_kimi_legacy_and_custom_routes_fail_closed(provider, base_url):
+    route = resolve_billing_route("kimi-k3", provider=provider, base_url=base_url)
+    assert route.billing_mode == "unknown"
+
+
+def test_kimi_estimate_usage_cost_is_included():
+    result = estimate_usage_cost(
+        "kimi-k3",
+        CanonicalUsage(input_tokens=1000, output_tokens=500),
+        provider="moonshot",
+        base_url="https://api.kimi.com/coding",
+    )
+
+    assert result.status == "included"
+    assert float(result.amount_usd) == 0.0

--- a/utils.py
+++ b/utils.py
@@ -489,3 +489,33 @@ def base_url_host_matches(base_url: str, domain: str) -> bool:
     hostname = base_url_hostname(base_url)
     domain = (domain or "").strip().lower().rstrip(".")
     return bool(hostname and domain) and (hostname == domain or hostname.endswith("." + domain))
+
+
+def is_kimi_coding_base_url(base_url: str | None) -> bool:
+    """Return whether *base_url* is the confirmed Kimi Coding Plan runtime.
+
+    Kimi Code (Coding Plan) lives at ``https://api.kimi.com/coding`` — only
+    that exact scheme/host/path (optionally with the ``/v1`` suffix some
+    resolvers append) gets Coding Plan behavior: the ``/usages`` quota probe
+    and ``subscription_included`` billing. Legacy Moonshot
+    (``api.moonshot.ai/v1``) and custom/proxy routes must NOT match — they
+    keep their unknown/no-snapshot behavior.
+
+    Shared by ``agent.account_usage`` and ``agent.usage_pricing`` so the
+    endpoint check cannot drift between the quota and billing paths.
+    """
+    try:
+        parsed = urlparse((base_url or "").strip())
+        port = parsed.port
+    except ValueError:
+        return False
+    return (
+        parsed.scheme.lower() == "https"
+        and (parsed.hostname or "").lower() == "api.kimi.com"
+        and port in (None, 443)
+        and parsed.username is None
+        and parsed.password is None
+        and parsed.path.rstrip("/") in {"/coding", "/coding/v1"}
+        and not parsed.query
+        and not parsed.fragment
+    )


### PR DESCRIPTION
## Summary

`fetch_account_usage()` had no route for Kimi providers, so `/usage` showed nothing for Kimi Coding Plan accounts and session cost accounting reported `unknown`.

Kimi Code exposes an official quota endpoint — `GET {base}/v1/usages` next to the chat routes — verified live against `https://api.kimi.com/coding/v1/usages`:

```json
{
  "user": {"membership": {"level": "LEVEL_ADVANCED"}},
  "usage":    {"limit": "100", "used": "1", "resetTime": "..."},
  "limits":  [{"window": {"duration": 300, "timeUnit": "TIME_UNIT_MINUTE"},
               "detail": {"limit": "100", "used": "3", "resetTime": "..."}}],
  "parallel": {"limit": "30"}
}
```

This PR:

- **`agent/account_usage.py`** — new `_fetch_kimi_account_usage()` mapping the weekly quota and rolling windows (e.g. 5-hour) as used-percent `AccountUsageWindow`s, membership level as plan, and the parallel-request cap as a detail line; `fetch_account_usage()` routes `kimi` / `kimi-coding` / `kimi-coding-cn` / `moonshot` aliases (CN variants keep their own provider label).
- **`agent/usage_pricing.py`** — Kimi Coding Plan providers route as `subscription_included` (flat weekly-quota subscription like `openai-codex`), so session accounting shows `included` instead of `unknown`.

Rendered output (live smoke):

```
📈 Account limits
Provider: kimi-coding (Level Advanced)
Weekly: 99% remaining (1% used) • resets in 6d 23h
5-hour: 95% remaining (5% used) • resets in 4h 31m
Parallel requests: 30 max
```

## Tests

- 7 new tests in `tests/agent/test_account_usage.py` (schema-realistic payload, URL resolution incl. trailing `/v1`, alias routing, missing-credential and partial-payload degradation).
- 4 new tests in `tests/agent/test_usage_pricing.py` (billing route + `estimate_usage_cost` → `included`, 0 USD).
- `pytest tests/agent/test_account_usage.py tests/agent/test_usage_pricing.py` → 58 passed.

## Risk

Low: additive code path, no existing provider behavior changed; fetch failures fail open (snapshot omitted) exactly like the Codex/Anthropic paths.