### PR TITLE
fix(desktop-ssh): stop resolving exec-wrappers to python in locateHermes (#74411)

### DIFF
--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -128,25 +128,16 @@ function expandRemotePath(p) {
 // non-login `ssh host cmd` PATH misses user installs), then known install paths.
 async function locateHermes(ssh, remoteHermesPath) {
   const resolveLauncher = async (candidate: string) => {
-    const script =
-      'import os,shlex,sys\n' +
-      `p=os.path.expanduser(${shq(candidate)})\n` +
-      'out=p\n' +
-      'try:\n' +
-      ' data=open(p,"r",encoding="utf-8",errors="ignore").read(4096)\n' +
-      ' for line in data.splitlines():\n' +
-      '  words=shlex.split(line)\n' +
-      '  if len(words)>1 and words[0]=="exec":\n' +
-      '   target=os.path.expanduser(words[1])\n' +
-      '   if os.path.isabs(target) and os.access(target,os.X_OK):out=target\n' +
-      '   break\n' +
-      'except (OSError,ValueError):pass\n' +
-      'print(out)'
-
-    const resolved = (await ssh.exec(`python3 -c ${shq(script)}`)).trim()
-
-    return resolved || candidate
-  }
+      // Return the candidate path directly. The hermes binary or wrapper script
+      // is executable and handles argument forwarding (e.g. `exec <python> <script> "$@"`)
+      // correctly on its own. Previously, this function followed `exec` wrappers and
+      // returned only the python interpreter, which broke:
+      //   - version checking: `<python> --version` printed "Python x.y.z" instead of
+      //     the Hermes version, and
+      //   - capability probing: `<python> serve --help` failed entirely.
+      // See https://github.com/NousResearch/hermes-agent/issues/74411
+      return candidate
+    }
 
   const isExecutable = async (candidate: string) => {
     try {


### PR DESCRIPTION
## Summary

Fixes #74411 — two bugs in the Desktop SSH lifecycle's version-check step:

**Problem 1: Wrong argument order / wrong binary probed**

`resolveLauncher()` read bash `exec <python> <script>` wrapper scripts (e.g. `~/.local/bin/hermes`) and returned **only the python interpreter path** (e.g. `<venv>/bin/python`), discarding the hermes script entirely. This caused:
- `probeHermesVersion()` to run `<python> --version` → always printed "Python 3.x.y" instead of the actual Hermes version
- `remoteSupportsSshOwnership()` to run `<python> serve --help` → failed completely since there's no `serve` module in Python stdlib, triggering the false "does not support --ssh-session-token-file" error

**Problem 2: `remoteHermesPath` override ignored**

When a user set the explicit `remoteHermesPath` override in the SSH connection config, `resolveLauncher()` resolved it to the underlying python interpreter, silently replacing the user's specified path. The override was effectively ignored for version checking and capability probing.

## Fix

`resolveLauncher()` now returns the candidate path directly instead of following `exec` wrappers. The Hermes binary or wrapper script is already executable and handles argument forwarding (e.g. `exec <python> <script> "$@"`) correctly on its own. This eliminates an unnecessary SSH round-trip (the python script that read and parsed the wrapper) and fixes both bugs at the root.

- `probeHermesVersion()` now correctly runs `<hermes_wrapper> --version` → `Hermes Agent v0.x.y ...`
- `remoteSupportsSshOwnership()` now correctly runs `<hermes_wrapper> serve --help`
- When `remoteHermesPath` is set, it is honored directly without wrapper resolution

## Changes

- **`apps/desktop/electron/remote-lifecycle.ts`**: Simplified `resolveLauncher` to return `candidate` directly (removed the exec-following python script).