### PR TITLE
fix(desktop): gate cold-start restore on profile initialization (#74387)

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -1,10 +1,10 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { closeActiveTab } from '@/app/chat/close-tab'
 import { openSession } from '@/app/open-session'
 import { storedSessionIdForNotification } from '@/lib/session-ids'
 import { respondToApprovalAction } from '@/store/native-notifications'
-import { $activeGatewayProfile } from '@/store/profile'
+import { $activeGatewayProfile, $profileInitialized } from '@/store/profile'
 import {
   $sessions,
   getRememberedRoute,
@@ -87,11 +87,33 @@ export function useDesktopIntegrations({
 
   const restoredRef = useRef(false)
 
+  // Reactive mirror of $profileInitialized so the restore effect below can
+  // depend on it. nanostores atoms are not React-reactive on their own — a
+  // bare `.get()` inside the effect body reads the value at call time but
+  // doesn't re-trigger when it changes.
+  const [profileReady, setProfileReady] = useState(() => $profileInitialized.get())
+
+  useEffect(() => {
+    return $profileInitialized.subscribe(setProfileReady)
+  }, [])
+
   // Restore once on cold start — only when the renderer booted at the default
-  // route (a hidden-then-shown window keeps its own route). Prefer the full
-  // remembered route (covers pages); fall back to the last session id.
+  // route (a hidden-then-shown window keeps its own route) AND the gateway
+  // profile has been resolved so profile-scoped localStorage keys read the
+  // correct entry. Prefer the full remembered route (covers pages); fall back
+  // to the last session id.
+  //
+  // Without the profileReady gate, the effect fires on mount with
+  // $activeGatewayProfile still at its initial value ('default') because
+  // adoptPrimaryProfile() resolves asynchronously during boot. The real
+  // profile is resolved after an IPC round-trip to the Electron main process
+  // — by the time it lands, restoredRef already blocks a second run.
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
+    if (!profileReady) {
+      return
+    }
+
     if (restoredRef.current || locationPathname !== NEW_CHAT_ROUTE) {
       restoredRef.current = true
 
@@ -113,7 +135,7 @@ export function useDesktopIntegrations({
     if (last) {
       navigate(sessionRoute(last), { replace: true })
     }
-  }, [locationPathname, navigate])
+  }, [locationPathname, navigate, profileReady])
 
   useEffect(() => {
     if (!resumeExhaustedSessionId) {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -25,7 +25,7 @@ import {
 } from '@/store/gateway'
 import { $gatewaySwitching, wipeSessionListsForGatewaySwitch } from '@/store/gateway-switch'
 import { notify, notifyError } from '@/store/notifications'
-import { $activeGatewayProfile, normalizeProfileKey, touchActiveGatewayBackend } from '@/store/profile'
+import { $activeGatewayProfile, normalizeProfileKey, $profileInitialized, touchActiveGatewayBackend } from '@/store/profile'
 import {
   $activeSessionId,
   $connection,
@@ -245,6 +245,8 @@ export function useGatewayBoot({
       } catch {
         $activeGatewayProfile.set('default')
       }
+
+      $profileInitialized.set(true)
     }
 
     // Seed the working dir from the backend default on a fresh view (nothing
@@ -550,6 +552,7 @@ export function useGatewayBoot({
 
       const profile = survivor?.profile ?? $activeGatewayProfile.get()
       $activeGatewayProfile.set(profile)
+      $profileInitialized.set(true)
       void ensureGatewayForProfile(profile)
 
       // Mirror the current (already-open) socket state into the composer so the

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -30,6 +30,12 @@ export function normalizeProfileKey(name: string | null | undefined): string {
 // preference (which may be unset) lives in the Electron main process.
 export const $activeProfile = atom<string>('default')
 
+// True once adoptPrimaryProfile() (or adoptBoot() during HMR) has resolved the
+// real gateway profile. The cold-start restore effect in use-desktop-integrations
+// gates on this so it reads the correct profile-scoped localStorage key instead
+// of the initial 'default' value.
+export const $profileInitialized = atom(false)
+
 // Cached profile list for the picker. Refreshed lazily; the dropdown also
 // re-fetches on open so a profile created elsewhere shows up.
 export const $profiles = atom<ProfileInfo[]>([])


### PR DESCRIPTION
## Description

Fixes #74387 — Desktop forgets last session on restart after per-profile route scoping.

### Root Cause

Commit c4212b945 scoped the remembered route and session id to per-profile localStorage keys. The **write** side (in the navigation-effect) writes to the correct scoped key. However, the **cold-start restore effect** in `use-desktop-integrations.ts` reads `$activeGatewayProfile.get()` inside the effect body without subscribing to it.

On mount, `$activeGatewayProfile` is `'default'` (its initial value). The real profile is resolved **asynchronously** by `adoptPrimaryProfile()` via an Electron IPC call to the main process. The restore effect fires before that IPC round-trip completes, so it reads profile-scoped keys from the `'default'` scope while the true profile's keys hold the correct values. By the time `adoptPrimaryProfile()` finishes, `restoredRef` already blocks a second run.

### Fix

1. **`$profileInitialized` atom** in `store/profile.ts` — starts `false`, set to `true` once the gateway profile is resolved
2. **Set it in `adoptPrimaryProfile()`** and **`adoptBoot()`** (HMR path) in `use-gateway-boot.ts`
3. **Mirror into React state** in `use-desktop-integrations.ts` via a `useEffect` subscription to `$profileInitialized`
4. **Gate the restore effect** on `profileReady` — it waits for the real profile before reading localStorage

### Files Changed

| File | Change |
|------|--------|
| `apps/desktop/src/store/profile.ts` | +6 | Add `$profileInitialized` atom |
| `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts` | +5/-1 | Set `$profileInitialized` after `adoptPrimaryProfile()` and `adoptBoot()` |
| `apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts` | +32/-6 | Gate restore effect on `profileReady` with nanostores subscription |