### PR TITLE
fix(kanban): honor explicit requeue after PR evidence

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7904,6 +7904,9 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         A GitHub PR URL appears in a recent task comment (within
         ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
         opened a PR; re-spawning risks a duplicate PR on the same task.
+        Bypassed when an explicit re-queue event arrives after the latest
+        matching PR comment, because that event deliberately requests more
+        work even though the task already has PR evidence.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -7986,12 +7989,30 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    #    As with recent_success, an explicit re-queue AFTER the latest matching
+    #    PR comment is a deliberate request to continue work. A re-queue before
+    #    that comment does not bypass the guard: the newer PR evidence wins.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
+    latest_pr_comment_at = None
     for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+        "SELECT body, created_at FROM task_comments "
+        "WHERE task_id = ? AND created_at >= ? "
+        "ORDER BY created_at DESC, id DESC",
         (task_id, pr_cutoff),
     ).fetchall():
         if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
+            latest_pr_comment_at = int(c["created_at"])
+            break
+
+    if latest_pr_comment_at is not None:
+        requeued_after = conn.execute(
+            "SELECT 1 FROM task_events "
+            "WHERE task_id = ? AND created_at > ? "
+            "AND kind IN ('status', 'promoted', 'unblocked', 'reclaimed') "
+            "LIMIT 1",
+            (task_id, latest_pr_comment_at),
+        ).fetchone()
+        if not requeued_after:
             return "active_pr"
 
     return None

--- a/tests/hermes_cli/test_kanban_respawn_guard.py
+++ b/tests/hermes_cli/test_kanban_respawn_guard.py
@@ -1,0 +1,111 @@
+"""Focused regression tests for Kanban respawn guard behavior."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _add_pr_comment(conn, task_id: str, created_at: int) -> None:
+    conn.execute(
+        "INSERT INTO task_comments (task_id, author, body, created_at) "
+        "VALUES (?, 'worker', ?, ?)",
+        (
+            task_id,
+            "Opened https://github.com/totemx-AI/subsidysmart/pull/42",
+            created_at,
+        ),
+    )
+
+
+def test_respawn_guard_recent_pr_without_requeue_is_active(kanban_home):
+    """Recent PR evidence with no later requeue keeps the active_pr guard."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="has-pr", assignee="alice")
+        _add_pr_comment(conn, task_id, int(time.time()) - 10)
+
+        reason = kb.check_respawn_guard(conn, task_id)
+
+    assert reason == "active_pr"
+
+
+@pytest.mark.parametrize("event_kind", ["promoted", "unblocked", "status", "reclaimed"])
+def test_respawn_guard_active_pr_bypassed_by_later_requeue(
+    kanban_home, event_kind
+):
+    """Every explicit requeue event after PR evidence permits more work."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title=f"requeued-after-pr-{event_kind}",
+            assignee="alice",
+        )
+        now = int(time.time())
+        _add_pr_comment(conn, task_id, now - 20)
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, created_at) VALUES (?, ?, ?)",
+            (task_id, event_kind, now - 10),
+        )
+
+        reason = kb.check_respawn_guard(conn, task_id)
+
+    assert reason is None
+
+
+def test_respawn_guard_active_pr_not_bypassed_by_earlier_requeue(kanban_home):
+    """A requeue before the PR comment does not supersede newer PR evidence."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="requeued-before-pr",
+            assignee="alice",
+        )
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, created_at) "
+            "VALUES (?, 'promoted', ?)",
+            (task_id, now - 20),
+        )
+        _add_pr_comment(conn, task_id, now - 10)
+
+        reason = kb.check_respawn_guard(conn, task_id)
+
+    assert reason == "active_pr"
+
+
+def test_respawn_guard_active_pr_not_bypassed_by_same_timestamp_requeue(
+    kanban_home,
+):
+    """A requeue at the PR comment timestamp is not strictly later evidence."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="requeued-at-pr-timestamp",
+            assignee="alice",
+        )
+        created_at = int(time.time()) - 10
+        _add_pr_comment(conn, task_id, created_at)
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, created_at) "
+            "VALUES (?, 'promoted', ?)",
+            (task_id, created_at),
+        )
+
+        reason = kb.check_respawn_guard(conn, task_id)
+
+    assert reason == "active_pr"


### PR DESCRIPTION
## Summary

- honor an explicit `status`, `promoted`, `unblocked`, or `reclaimed` event strictly after the latest matching PR comment
- preserve `active_pr` when no later requeue exists, when a requeue predates the PR evidence, or when both have the same timestamp
- cover no-requeue, all four later event kinds, earlier requeue, and same-timestamp equality with focused regression tests

Kanban: `t_c16af3c0`
Correction: `t_8feb7403`
Parent incident: `t_403b0839`

## Tests

- `pytest -q tests/hermes_cli/test_kanban_respawn_guard.py` (7 passed)
- `pytest -q tests/hermes_cli/test_kanban_db.py` (28 passed)
- `python -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_respawn_guard.py tests/hermes_cli/test_kanban_db.py`
- `git diff --check`

## Deployment impact

No deployment or live board mutation. The change affects only Kanban dispatcher respawn gating.

## Rollback

Revert commit `ce93897c7f720d3ec64f99d7fc397ef952eb7e1b`.
