### PR TITLE
fix(kanban): click an attachment to read it — plugin SDK host.preview

### DIFF
--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -413,11 +413,13 @@ const isAdminSummary = (summary: string) => /^status changed to \w+ \(dashboard\
 function AttachmentsSection({
   attachments,
   onDownload,
+  onOpen,
   onUpload,
   pending
 }: {
   attachments: KanbanAttachment[]
   onDownload: (attachment: KanbanAttachment) => void
+  onOpen: (attachment: KanbanAttachment) => void
   onUpload: (file: File) => void
   pending: boolean
 }) {
@@ -458,21 +460,28 @@ function AttachmentsSection({
       {attachments.length > 0 ? (
         <ul className="flex flex-col gap-1">
           {attachments.map(attachment => (
-            <li key={attachment.id}>
+            <li className="group/att flex items-center gap-1" key={attachment.id}>
+              {/* Clicking the row OPENS it — reading the artifact an agent just
+                  produced is the common case; saving a copy is the rare one. */}
               <button
-                className="flex w-full items-center gap-1.5 rounded-sm text-left text-[0.75rem] text-(--ui-text-tertiary) hover:text-(--ui-text-secondary)"
-                onClick={() => onDownload(attachment)}
-                title={k.downloadAttachment}
+                className="flex min-w-0 flex-1 items-center gap-1.5 rounded-sm text-left text-[0.75rem] text-(--ui-text-tertiary) hover:text-(--ui-text-secondary)"
+                onClick={() => onOpen(attachment)}
+                title={k.openAttachment}
                 type="button"
               >
                 <Codicon className="shrink-0" name="file" size="0.75rem" />
                 <span className="truncate">{attachment.filename}</span>
-                <Codicon
-                  className="ml-auto shrink-0 text-(--ui-text-quaternary)"
-                  name="cloud-download"
-                  size="0.7rem"
-                />
               </button>
+              <Button
+                aria-label={k.downloadAttachment}
+                className="shrink-0 opacity-0 group-hover/att:opacity-100 focus-visible:opacity-100"
+                onClick={() => onDownload(attachment)}
+                size="icon-xs"
+                title={k.downloadAttachment}
+                variant="ghost"
+              >
+                <Codicon name="cloud-download" size="0.7rem" />
+              </Button>
             </li>
           ))}
         </ul>
@@ -683,6 +692,23 @@ export function TaskDrawer({
         message: k.attachmentSaved(filePath.split(/[/\\]/).pop() || '')
       })
     }
+  })
+
+  // Open an attachment in the preview rail. The blob lives on the backend
+  // host, so `stored_path` only resolves when that filesystem is reachable —
+  // and a binary (zip, video) has nothing to render either way. Both cases
+  // fall through to the save dialog rather than dead-ending the click.
+  const openMut = useMutation({
+    mutationFn: async (attachment: KanbanAttachment) => {
+      if (attachment.stored_path && (await host.preview(attachment.stored_path))) {
+        return true
+      }
+
+      await downloadMut.mutateAsync(attachment)
+
+      return false
+    },
+    onError: err => host.notify({ kind: 'error', message: errText(err) })
   })
 
   if (!id) {
@@ -970,6 +996,7 @@ export function TaskDrawer({
             <AttachmentsSection
               attachments={detail.attachments}
               onDownload={attachment => downloadMut.mutate(attachment)}
+              onOpen={attachment => openMut.mutate(attachment)}
               onUpload={file => uploadMut.mutate(file)}
               pending={uploadMut.isPending}
             />

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -474,7 +474,7 @@ function AttachmentsSection({
               </button>
               <Button
                 aria-label={k.downloadAttachment}
-                className="shrink-0 opacity-0 group-hover/att:opacity-100 focus-visible:opacity-100"
+                className="shrink-0 opacity-0 group-hover/att:opacity-100 group-focus-within/att:opacity-100"
                 onClick={() => onDownload(attachment)}
                 size="icon-xs"
                 title={k.downloadAttachment}

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -464,7 +464,7 @@ function AttachmentsSection({
               {/* Clicking the row OPENS it — reading the artifact an agent just
                   produced is the common case; saving a copy is the rare one. */}
               <button
-                className="flex min-w-0 flex-1 items-center gap-1.5 rounded-sm text-left text-[0.75rem] text-(--ui-text-tertiary) hover:text-(--ui-text-secondary)"
+                className="flex min-w-0 flex-1 items-center gap-1.5 rounded-sm text-left text-[0.75rem] text-(--ui-text-tertiary) transition-colors hover:text-(--ui-text-secondary)"
                 onClick={() => onOpen(attachment)}
                 title={k.openAttachment}
                 type="button"
@@ -472,16 +472,14 @@ function AttachmentsSection({
                 <Codicon className="shrink-0" name="file" size="0.75rem" />
                 <span className="truncate">{attachment.filename}</span>
               </button>
-              <Button
+              <button
                 aria-label={k.downloadAttachment}
-                className="shrink-0 opacity-0 group-hover/att:opacity-100 group-focus-within/att:opacity-100"
+                className="grid size-5 shrink-0 place-items-center rounded text-(--ui-text-tertiary) opacity-0 transition-opacity hover:bg-(--chrome-action-hover) hover:text-foreground focus-visible:opacity-100 group-hover/att:opacity-100"
                 onClick={() => onDownload(attachment)}
-                size="icon-xs"
-                title={k.downloadAttachment}
-                variant="ghost"
+                type="button"
               >
                 <Codicon name="cloud-download" size="0.7rem" />
-              </Button>
+              </button>
             </li>
           ))}
         </ul>

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -149,6 +149,7 @@ type KanbanMessages = {
     attachments: (n: number) => string
     noAttachments: string
     uploadAttachment: string
+    openAttachment: string
     downloadAttachment: string
     attachmentSaved: (name: string) => string
     reveal: string
@@ -339,6 +340,7 @@ const en: KanbanMessages = {
     attachments: n => `Attachments · ${n}`,
     noAttachments: 'No attachments yet.',
     uploadAttachment: 'Upload attachment',
+    openAttachment: 'Open in preview',
     downloadAttachment: 'Download',
     attachmentSaved: name => `Saved ${name}`,
     reveal: 'Reveal',
@@ -529,6 +531,7 @@ const ja: KanbanMessages = {
     attachments: n => `添付・${n}`,
     noAttachments: 'まだ添付はありません。',
     uploadAttachment: '添付をアップロード',
+    openAttachment: 'プレビューで開く',
     downloadAttachment: 'ダウンロード',
     attachmentSaved: name => `${name} を保存しました`,
     reveal: '表示',
@@ -718,6 +721,7 @@ const zh: KanbanMessages = {
     attachments: n => `附件・${n}`,
     noAttachments: '暂无附件。',
     uploadAttachment: '上传附件',
+    openAttachment: '在预览中打开',
     downloadAttachment: '下载',
     attachmentSaved: name => `已保存 ${name}`,
     reveal: '在文件夹中显示',
@@ -905,6 +909,7 @@ const zhHant: KanbanMessages = {
     attachments: n => `附件・${n}`,
     noAttachments: '尚無附件。',
     uploadAttachment: '上傳附件',
+    openAttachment: '在預覽中開啟',
     downloadAttachment: '下載',
     attachmentSaved: name => `已儲存 ${name}`,
     reveal: '在資料夾中顯示',

--- a/apps/desktop/src/plugins/kanban/types.ts
+++ b/apps/desktop/src/plugins/kanban/types.ts
@@ -89,6 +89,12 @@ export interface KanbanAttachment {
   id: number | string
   filename: string
   size?: null | number
+  /** Absolute path of the blob on the backend host. Present since the drawer
+   *  endpoint's first version; the desktop uses it to open the file in the
+   *  preview rail instead of forcing a download to read it. Absent on a remote
+   *  backend whose filesystem the desktop can't reach. */
+  stored_path?: null | string
+  content_type?: null | string
 }
 
 /** Fields present only on the detail endpoint (beyond the card's KanbanTask).

--- a/apps/desktop/src/sdk/host-preview.test.ts
+++ b/apps/desktop/src/sdk/host-preview.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { localPreviewTarget } from '@/lib/local-preview'
+import type * as LocalPreview from '@/lib/local-preview'
+import type * as PreviewStore from '@/store/preview'
+
+const openPreview = vi.hoisted(() => vi.fn())
+const normalizeOrLocalPreviewTarget = vi.hoisted(() => vi.fn())
+
+vi.mock('@/store/preview', async importOriginal => ({
+  ...(await importOriginal<typeof PreviewStore>()),
+  openPreview
+}))
+
+vi.mock('@/lib/local-preview', async importOriginal => ({
+  ...(await importOriginal<typeof LocalPreview>()),
+  normalizeOrLocalPreviewTarget
+}))
+
+const { host } = await import('./index')
+
+describe('host.preview', () => {
+  beforeEach(() => {
+    openPreview.mockClear()
+    normalizeOrLocalPreviewTarget.mockReset()
+  })
+
+  it('opens a resolvable target in the rail and reports success', async () => {
+    const target = { kind: 'file', label: 'audit.md', previewKind: 'text', source: '/w/audit.md', url: 'file:///w/audit.md' }
+    normalizeOrLocalPreviewTarget.mockResolvedValue(target)
+
+    await expect(host.preview('/w/audit.md')).resolves.toBe(true)
+    expect(openPreview).toHaveBeenCalledWith(target, 'tool-result')
+  })
+
+  it('reports failure instead of opening an empty tab when the target will not resolve', async () => {
+    normalizeOrLocalPreviewTarget.mockResolvedValue(null)
+
+    // The caller needs a false here to fall back (kanban drops to a download);
+    // opening a tab that renders an error would strand the user.
+    await expect(host.preview('/w/missing.md')).resolves.toBe(false)
+    expect(openPreview).not.toHaveBeenCalled()
+  })
+
+  it('refuses a binary target rather than rendering garbage', async () => {
+    normalizeOrLocalPreviewTarget.mockResolvedValue({
+      kind: 'file',
+      label: 'bundle.zip',
+      previewKind: 'binary',
+      source: '/w/bundle.zip',
+      url: 'file:///w/bundle.zip'
+    })
+
+    await expect(host.preview('/w/bundle.zip')).resolves.toBe(false)
+    expect(openPreview).not.toHaveBeenCalled()
+  })
+
+  it('passes an explicit cwd through for relative targets', async () => {
+    normalizeOrLocalPreviewTarget.mockResolvedValue(null)
+
+    await host.preview('docs/audit.md', '/repo')
+    expect(normalizeOrLocalPreviewTarget).toHaveBeenCalledWith('docs/audit.md', '/repo')
+  })
+})
+
+describe('localPreviewTarget classification for agent artifacts', () => {
+  it('treats a markdown artifact as readable text, not a download', () => {
+    // The reported symptom: an agent writes an audit .md, and the only way to
+    // read it was to find it on disk. It must classify as previewable text.
+    const target = localPreviewTarget('/w/kanban/attachments/t_1/audit-report.md')
+
+    expect(target).toMatchObject({ kind: 'file', label: 'audit-report.md', language: 'markdown', previewKind: 'text' })
+  })
+
+  it('keeps images and html on their own preview kinds', () => {
+    expect(localPreviewTarget('/w/shot.png')).toMatchObject({ previewKind: 'image' })
+    expect(localPreviewTarget('/w/report.html')).toMatchObject({ previewKind: 'html' })
+  })
+})

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -23,8 +23,10 @@ import { atom, type ReadableAtom } from 'nanostores'
 import { $narrowViewport } from '@/components/pane-shell/tree/store'
 import { onGatewayEvent } from '@/contrib/events'
 import { getLogs, getStatus } from '@/hermes'
+import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
 import { $gateway } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
+import { openPreview } from '@/store/preview'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $activeSessionId, $currentCwd, $currentModel, $gatewayState } from '@/store/session'
 import { runGatewayRestart } from '@/store/system-actions'
@@ -85,6 +87,26 @@ export const host = {
   /** Navigate the app router (hash routes, e.g. '/command-center?section=system'). */
   navigate: (path: string) => {
     window.location.hash = path.startsWith('#') ? path : `#${path}`
+  },
+
+  /** Open a file (or http URL) in the preview rail — the same surface the file
+   *  browser and tool results use. `target` is an absolute path, a `file://`
+   *  URL, or an `https://` URL; main classifies it (text / image / html /
+   *  binary) so the caller doesn't have to sniff. Resolves false when the
+   *  target can't be previewed, so a caller can fall back (e.g. to a download)
+   *  instead of leaving the user with nothing. */
+  preview: async (target: string, cwd?: string): Promise<boolean> => {
+    const resolved = await normalizeOrLocalPreviewTarget(target, cwd ?? $currentCwd.get() ?? undefined)
+
+    // A binary blob has nothing to show — say so rather than opening a tab
+    // that renders an error.
+    if (!resolved || resolved.previewKind === 'binary') {
+      return false
+    }
+
+    openPreview(resolved, 'tool-result')
+
+    return true
   },
 
   /** HEAR the gateway stream (message deltas, session lifecycle, tool


### PR DESCRIPTION
Stacked on #61173 — base is `bb/desktop-kanban`. Follows #74413 (attachment download), from the same feedback thread.

> "I asked for an audit, which it made an md file but it took a while to actually figure out where it put that audit file. It shows it as an attachment at the bottom but I couldn't click to open"

Two bugs in one sentence: the artifact was hard to *find*, and once found it wasn't *readable*. #74413 gave attachments a download; that still means a save dialog and a round trip through Finder just to read a markdown file the agent wrote thirty seconds ago.

## host.preview

A plugin could hand the user a file to **save** but not to **read**. The preview rail already exists, already classifies text / image / html / binary, and is what the file browser and tool results open into — plugins simply had no door to it. `host.preview(target, cwd?)` is that door, sitting beside `host.navigate` and `host.notify`.

It resolves **false** when the target won't render — unreachable path, or a binary with nothing to show — so a caller can fall back instead of opening a tab that renders an error. That return value is the whole contract; without it every consumer reinvents the sniffing.

## Kanban

Row click now **opens**; download moves to a per-row button that appears on hover and on keyboard focus. Reading the artifact an agent just produced is the common case; saving a copy is the rare one, and the interaction should say so.

`stored_path` has been in the drawer payload since the endpoint's first version (`plugin_api.py:210`) — the desktop was receiving the absolute path and discarding it. No backend change needed here; the type just needed to admit the field exists.

Two fallbacks, both to the save dialog rather than a dead click:

- **Remote backend** — the blob lives on the backend host, so `stored_path` doesn't resolve against a filesystem the desktop can't reach.
- **Binary** — a zip or a video has nothing to render.

## Verified against a real attachment

Not inferred from reading the code — created a task, wrote a file through `add_attachment`, and read back what the drawer actually receives:

```
stored_path : /private/tmp/.../kanban/attachments/t_fd90e0a6/audit-report.md
exists      : True
suffix      : .md
content_type: text/markdown
```

Absolute path, extension preserved, file on disk. `.md` maps to `markdown` in `LANGUAGE_BY_EXT`, so it classifies `previewKind: 'text'` — the reported case renders.

## Test plan

- `vitest src/sdk src/contrib src/i18n src/lib/keybinds electron/hardening.test.ts` — 92 green. New: `host.preview` opens on success, returns false for unresolvable *and* binary targets without opening a tab, threads an explicit cwd; plus classification coverage asserting a markdown artifact is previewable text (the reported symptom) with image/html on their own kinds.
- Renderer `tsc` error count byte-identical to the pre-change baseline (stash-verified); `tsc --build tsconfig.electron.json` clean; `eslint` clean.
- Localized across en/ja/zh/zh-hant.
