### PR TITLE
fix(kanban): distinguish orchestrator prompt guidance

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1408,16 +1408,16 @@ def init_agent(
     elif not agent.quiet_mode:
         print("🛠️  No tools loaded (all tools filtered out or unavailable)")
 
-    # Kanban worker/orchestrator lifecycle guidance is session-static:
-    # the dispatcher decides at spawn time whether this process is a kanban
-    # worker (kanban_show tool is present iff HERMES_KANBAN_TASK is set).
-    # Resolving the ~835-token block once here avoids re-running the
-    # membership test + reference on every system-prompt rebuild
-    # (init + each context compression).
-    from agent.prompt_builder import KANBAN_GUIDANCE
-    agent._kanban_worker_guidance = (
-        KANBAN_GUIDANCE if "kanban_show" in agent.valid_tool_names else ""
-    )
+    # Kanban guidance is session-static. Dispatcher workers and explicitly
+    # configured orchestrators share some tools, so tool presence alone cannot
+    # distinguish their protocols; task ownership comes from the dispatcher env.
+    from agent.prompt_builder import KANBAN_GUIDANCE, KANBAN_ORCHESTRATOR_GUIDANCE
+    if os.environ.get("HERMES_KANBAN_TASK") and "kanban_show" in agent.valid_tool_names:
+        agent._kanban_worker_guidance = KANBAN_GUIDANCE
+    elif "kanban_list" in agent.valid_tool_names:
+        agent._kanban_worker_guidance = KANBAN_ORCHESTRATOR_GUIDANCE
+    else:
+        agent._kanban_worker_guidance = ""
 
     # Check tool requirements
     if agent.tools and not agent.quiet_mode:

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -306,6 +306,23 @@ KANBAN_GUIDANCE = (
     "cross-agent handoffs that outlive one API loop."
 )
 
+KANBAN_ORCHESTRATOR_GUIDANCE = (
+    "# Kanban board orchestration protocol\n"
+    "This is a normal interactive session with board-routing access, not a "
+    "dispatcher-spawned worker assigned to one task. There is no implicit task "
+    "id.\n"
+    "\n"
+    "- To inspect the board, call `kanban_list()` first.\n"
+    "- To inspect one card, call `kanban_show(task_id=\"t_...\")` with an id "
+    "returned by `kanban_list`; never call `kanban_show()` without a task id.\n"
+    "- Use `kanban_create`, `kanban_link`, and `kanban_unblock` for durable "
+    "routing when appropriate.\n"
+    "- Use the `kanban_*` tools rather than shelling out to `hermes kanban`; "
+    "the tools reach the host board even when the terminal backend is remote.\n"
+    "- Do not complete, block, or otherwise mutate a task unless the user asked "
+    "you to route it or you have verified the task state and intended action."
+)
+
 TOOL_USE_ENFORCEMENT_GUIDANCE = (
     "# Tool-use enforcement\n"
     "You MUST use your tools to take action — do not describe what you would do "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -35,6 +35,7 @@ from agent.prompt_builder import (
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
     HERMES_AGENT_HELP_GUIDANCE,
     KANBAN_GUIDANCE,
+    KANBAN_ORCHESTRATOR_GUIDANCE,
     MEMORY_GUIDANCE,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
     PARALLEL_TOOL_CALL_GUIDANCE,
@@ -231,16 +232,17 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)
     if "skill_manage" in agent.valid_tool_names:
         tool_guidance.append(SKILLS_GUIDANCE)
-    # Kanban worker/orchestrator lifecycle — only present when the
-    # dispatcher spawned this process (kanban_show check_fn gates on
-    # HERMES_KANBAN_TASK env var). Normal chat sessions never see
-    # this block. Resolved once at __init__ (see _kanban_worker_guidance).
+    # Kanban worker/orchestrator guidance is resolved once at __init__.
+    # Workers are identified by HERMES_KANBAN_TASK; opted-in orchestrators
+    # have kanban_list but no implicit task id.
     _kanban_guidance = getattr(agent, "_kanban_worker_guidance", None)
     if _kanban_guidance:
         tool_guidance.append(_kanban_guidance)
-    elif _kanban_guidance is None and "kanban_show" in agent.valid_tool_names:
+    elif _kanban_guidance is None and os.environ.get("HERMES_KANBAN_TASK") and "kanban_show" in agent.valid_tool_names:
         # Fallback for code paths that bypass agent_init (rare).
         tool_guidance.append(KANBAN_GUIDANCE)
+    elif _kanban_guidance is None and "kanban_list" in agent.valid_tool_names:
+        tool_guidance.append(KANBAN_ORCHESTRATOR_GUIDANCE)
     if tool_guidance:
         stable_parts.append(" ".join(tool_guidance))
 

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -551,6 +551,37 @@ def test_worker_lifecycle_through_tools(worker_env):
 # ---------------------------------------------------------------------------
 
 
+def test_kanban_guidance_in_orchestrator_prompt(monkeypatch, tmp_path):
+    """An opted-in orchestrator gets board-routing guidance, not worker claims."""
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("toolsets:\n  - kanban\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from pathlib import Path as _P
+    monkeypatch.setattr(_P, "home", lambda: tmp_path)
+
+    from tools.registry import invalidate_check_fn_cache
+    from model_tools import _clear_tool_defs_cache
+    invalidate_check_fn_cache()
+    _clear_tool_defs_cache()
+
+    from run_agent import AIAgent
+    a = AIAgent(
+        api_key="test",
+        base_url="https://openrouter.ai/api/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    prompt = a._build_system_prompt()
+    assert "Kanban board orchestration protocol" in prompt
+    assert "kanban_list" in prompt
+    assert 'kanban_show(task_id="t_...")' in prompt
+    assert "You have been assigned ONE task" not in prompt
+    assert "Call `kanban_show()` first" not in prompt
+
+
 # ---------------------------------------------------------------------------
 # Worker task-ownership enforcement (regression tests for #19534)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- distinguish dispatcher workers from opted-in Kanban orchestrators using `HERMES_KANBAN_TASK`
- keep worker lifecycle guidance for assigned tasks
- give normal orchestrator sessions list-first guidance with an explicit task ID for `kanban_show`
- preserve session-static prompt caching and the fallback prompt path

## Root cause
`kanban_show` is available to both workers and configured orchestrators, but prompt selection treated tool presence as proof that the process owned a task. Normal orchestrator chats therefore received worker-only instructions to call `kanban_show()` without an ID.

## Verification
- `scripts/run_tests.sh tests/tools/test_kanban_tools.py tests/agent/test_system_prompt.py tests/agent/test_system_prompt_restore.py -q` — 52 passed
- `ruff check` on all changed files — passed
- real Geordi profile prompt probe confirmed orchestrator guidance present, worker claim absent, list-first and explicit-ID instructions present
- two independent reviews found no blocking correctness or security issues