### PR TITLE
fix(gateway): quarantine open-policy platform instead of aborting startup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10454,6 +10454,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     allow_all_env or "a platform allow-all flag",
                 )
                 self.config.platforms[platform].enabled = False
+                # Record *why* it is down. Without this the runtime status keeps
+                # whatever the platform last reported, so a previously-healthy
+                # adapter would still read "connected" after being quarantined —
+                # actively misleading rather than merely stale. "stopped" is
+                # already in the dashboard's not-serving vocabulary and, unlike
+                # "fatal", does not raise an error-severity health alert for what
+                # is a deliberate configuration state.
+                self._update_platform_runtime_status(
+                    platform.value,
+                    platform_state="stopped",
+                    error_code="open_policy_no_opt_in",
+                    error_message=(
+                        "Disabled at startup: dm_policy/group_policy is 'open' but "
+                        "neither GATEWAY_ALLOW_ALL_USERS nor "
+                        f"{allow_all_env or 'a platform allow-all flag'} is enabled."
+                    ),
+                )
 
             # Every enabled platform failed the gate — there is nothing left to
             # serve, so fall back to the original refuse-to-start behavior

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7582,6 +7582,68 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             pass
 
+    def _quarantine_open_policy_platforms(self) -> bool:
+        """Disable platforms whose ``open`` policy lacks an allow-all opt-in.
+
+        The gate stays fail-closed for the platform that violates it — the
+        platform is disabled, so it accepts nothing — but an unrelated healthy
+        platform (e.g. Telegram) must not lose service because another one
+        (e.g. an unpaired WhatsApp) is misconfigured.
+
+        Returns ``True`` when the caller must abort startup, which happens only
+        if *every* enabled platform failed the gate: quarantining them all would
+        otherwise leave a gateway running with no transports at all.
+        """
+        violations = _own_policy_open_violations(self.config)
+        if not violations:
+            return False
+
+        for platform, allow_all_env in violations:
+            flag = allow_all_env or "a platform allow-all flag"
+            logger.error(
+                "Disabling %s: dm_policy/group_policy is set to 'open' but "
+                "neither GATEWAY_ALLOW_ALL_USERS nor %s is enabled. Set the "
+                "opt-in flag or move the policy off 'open' to re-enable it; "
+                "the remaining platforms continue to start.",
+                platform.value,
+                flag,
+            )
+            self.config.platforms[platform].enabled = False
+            # Record *why* it is down. Without this the runtime status keeps
+            # whatever the platform last reported, so a previously-healthy
+            # adapter would still read "connected" after being quarantined —
+            # actively misleading rather than merely stale.
+            self._update_platform_runtime_status(
+                platform.value,
+                platform_state="disabled",
+                error_code="open_policy_no_opt_in",
+                error_message=(
+                    "Disabled at startup: dm_policy/group_policy is 'open' but "
+                    f"neither GATEWAY_ALLOW_ALL_USERS nor {flag} is enabled."
+                ),
+            )
+
+        if any(
+            getattr(pc, "enabled", False)
+            for pc in getattr(self.config, "platforms", {}).values()
+        ):
+            return False
+
+        reason = (
+            f"{violations[0][0].value}: open policy without allow-all opt-in"
+        )
+        logger.error(
+            "Refusing to start: every enabled platform failed the "
+            "open-policy gate."
+        )
+        try:
+            from gateway.status import write_runtime_status
+            write_runtime_status(gateway_state="startup_failed", exit_reason=reason)
+        except Exception:
+            pass
+        self._request_clean_exit(reason)
+        return True
+
     # ------------------------------------------------------------------
     # Per-platform circuit breaker (pause/resume) — used by the reconnect
     # watcher when a retryable failure recurs past a threshold, and by the
@@ -10438,62 +10500,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "dm_policy/group_policy: open on the platform."
             )
 
-        # Quarantine each offending platform instead of killing the process.
-        # The gate stays fail-closed for the platform that violates it — it is
-        # disabled, so it accepts nothing — but an unrelated healthy platform
-        # (e.g. Telegram) must not lose service because WhatsApp is misconfigured.
-        open_policy_violations = _own_policy_open_violations(self.config)
-        if open_policy_violations:
-            for platform, allow_all_env in open_policy_violations:
-                logger.error(
-                    "Disabling %s: dm_policy/group_policy is set to 'open' but "
-                    "neither GATEWAY_ALLOW_ALL_USERS nor %s is enabled. Set the "
-                    "opt-in flag or move the policy off 'open' to re-enable it; "
-                    "the remaining platforms continue to start.",
-                    platform.value,
-                    allow_all_env or "a platform allow-all flag",
-                )
-                self.config.platforms[platform].enabled = False
-                # Record *why* it is down. Without this the runtime status keeps
-                # whatever the platform last reported, so a previously-healthy
-                # adapter would still read "connected" after being quarantined —
-                # actively misleading rather than merely stale. "stopped" is
-                # already in the dashboard's not-serving vocabulary and, unlike
-                # "fatal", does not raise an error-severity health alert for what
-                # is a deliberate configuration state.
-                self._update_platform_runtime_status(
-                    platform.value,
-                    platform_state="stopped",
-                    error_code="open_policy_no_opt_in",
-                    error_message=(
-                        "Disabled at startup: dm_policy/group_policy is 'open' but "
-                        "neither GATEWAY_ALLOW_ALL_USERS nor "
-                        f"{allow_all_env or 'a platform allow-all flag'} is enabled."
-                    ),
-                )
-
-            # Every enabled platform failed the gate — there is nothing left to
-            # serve, so fall back to the original refuse-to-start behavior
-            # rather than idling in a gateway with no transports.
-            if not any(
-                getattr(pc, "enabled", False)
-                for pc in getattr(self.config, "platforms", {}).values()
-            ):
-                reason = (
-                    f"{open_policy_violations[0][0].value}: "
-                    "open policy without allow-all opt-in"
-                )
-                logger.error(
-                    "Refusing to start: every enabled platform failed the "
-                    "open-policy gate."
-                )
-                try:
-                    from gateway.status import write_runtime_status
-                    write_runtime_status(gateway_state="startup_failed", exit_reason=reason)
-                except Exception:
-                    pass
-                self._request_clean_exit(reason)
-                return True
+        if self._quarantine_open_policy_platforms():
+            return True
 
 
         # Discover Python plugins before shell hooks so plugin block

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2256,8 +2256,15 @@ _OWN_POLICY_OPEN_ENV = {
 }
 
 
-def _own_policy_open_startup_violation(config) -> Optional[str]:
-    """Return a startup-abort reason when open policy lacks allow-all opt-in."""
+def _own_policy_open_violations(config) -> List[Tuple["Platform", Optional[str]]]:
+    """Return every enabled platform whose open policy lacks an allow-all opt-in.
+
+    Reports *all* offenders (rather than short-circuiting on the first) so the
+    caller can quarantine them individually. A single misconfigured platform —
+    including one that is enabled but cannot even connect, e.g. an unpaired
+    WhatsApp — must not decide the fate of every other platform in the gateway.
+    """
+    violations: List[Tuple["Platform", Optional[str]]] = []
     for platform, platform_config in getattr(config, "platforms", {}).items():
         if not getattr(platform_config, "enabled", False):
             continue
@@ -2285,8 +2292,22 @@ def _own_policy_open_startup_violation(config) -> Optional[str]:
         )
         if platform_opted_in:
             continue
-        return f"{platform.value}: open policy without allow-all opt-in"
-    return None
+        violations.append((platform, allow_all_env))
+    return violations
+
+
+def _own_policy_open_startup_violation(config) -> Optional[str]:
+    """Return a startup-abort reason when open policy lacks allow-all opt-in.
+
+    Single-offender view of :func:`_own_policy_open_violations`, kept for the
+    per-profile multiplex path where refusing just that profile is the correct
+    scope (the profile *is* the unit of isolation there).
+    """
+    violations = _own_policy_open_violations(config)
+    if not violations:
+        return None
+    platform, _ = violations[0]
+    return f"{platform.value}: open policy without allow-all opt-in"
 
 
 # Sentinel placed into _running_agents immediately when a session starts
@@ -10417,28 +10438,47 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "dm_policy/group_policy: open on the platform."
             )
 
-        reason = _own_policy_open_startup_violation(self.config)
-        if reason:
-            platform_value = reason.split(":", 1)[0]
-            allow_all_env = None
-            for platform, open_env in _OWN_POLICY_OPEN_ENV.items():
-                if platform.value == platform_value:
-                    allow_all_env = open_env[2]
-                    break
-            logger.error(
-                "Refusing to start: %s has dm_policy/group_policy set to 'open' "
-                "but neither GATEWAY_ALLOW_ALL_USERS nor %s is enabled.",
-                platform_value,
-                allow_all_env or "a platform allow-all flag",
-            )
-            try:
-                from gateway.status import write_runtime_status
-                write_runtime_status(gateway_state="startup_failed", exit_reason=reason)
-            except Exception:
-                pass
-            self._request_clean_exit(reason)
-            return True
-        
+        # Quarantine each offending platform instead of killing the process.
+        # The gate stays fail-closed for the platform that violates it — it is
+        # disabled, so it accepts nothing — but an unrelated healthy platform
+        # (e.g. Telegram) must not lose service because WhatsApp is misconfigured.
+        open_policy_violations = _own_policy_open_violations(self.config)
+        if open_policy_violations:
+            for platform, allow_all_env in open_policy_violations:
+                logger.error(
+                    "Disabling %s: dm_policy/group_policy is set to 'open' but "
+                    "neither GATEWAY_ALLOW_ALL_USERS nor %s is enabled. Set the "
+                    "opt-in flag or move the policy off 'open' to re-enable it; "
+                    "the remaining platforms continue to start.",
+                    platform.value,
+                    allow_all_env or "a platform allow-all flag",
+                )
+                self.config.platforms[platform].enabled = False
+
+            # Every enabled platform failed the gate — there is nothing left to
+            # serve, so fall back to the original refuse-to-start behavior
+            # rather than idling in a gateway with no transports.
+            if not any(
+                getattr(pc, "enabled", False)
+                for pc in getattr(self.config, "platforms", {}).values()
+            ):
+                reason = (
+                    f"{open_policy_violations[0][0].value}: "
+                    "open policy without allow-all opt-in"
+                )
+                logger.error(
+                    "Refusing to start: every enabled platform failed the "
+                    "open-policy gate."
+                )
+                try:
+                    from gateway.status import write_runtime_status
+                    write_runtime_status(gateway_state="startup_failed", exit_reason=reason)
+                except Exception:
+                    pass
+                self._request_clean_exit(reason)
+                return True
+
+
         # Discover Python plugins before shell hooks so plugin block
         # decisions take precedence in tie cases.  The CLI startup path
         # does this via an explicit call in hermes_cli/main.py; the

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2797,7 +2797,7 @@ _PORT_BINDING_PLATFORM_PORTS: Dict[str, Tuple[str, int]] = {
 }
 
 # Platform states that mean the adapter is NOT serving its port right now.
-_PLATFORM_DEAD_STATES = frozenset({"fatal", "disconnected", "stopped"})
+_PLATFORM_DEAD_STATES = frozenset({"fatal", "disconnected", "stopped", "disabled"})
 
 
 def _profile_platform_ports(profile_home: Path, runtime: Optional[dict]) -> Dict[str, int]:

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -132,3 +132,89 @@ def test_secondary_open_policy_fails_startup_guard(monkeypatch):
     assert violation is not None
     assert "wecom" in violation
     assert "open policy" in violation
+
+
+def _clear_whatsapp_auth_env(monkeypatch) -> None:
+    for key in (
+        "GATEWAY_ALLOW_ALL_USERS",
+        "WHATSAPP_ALLOW_ALL_USERS",
+        "WHATSAPP_DM_POLICY",
+        "WHATSAPP_GROUP_POLICY",
+        "WECOM_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_open_policy_violations_reports_every_offender(monkeypatch):
+    """The gate must surface all offenders, not short-circuit on the first."""
+    from gateway.run import _own_policy_open_violations
+
+    _clear_whatsapp_auth_env(monkeypatch)
+
+    cfg = GatewayConfig()
+    cfg.platforms = {
+        Platform.WHATSAPP: PlatformConfig(enabled=True, extra={"dm_policy": "open"}),
+        Platform.WECOM: PlatformConfig(enabled=True, extra={"group_policy": "open"}),
+        Platform.TELEGRAM: PlatformConfig(enabled=True),
+    }
+
+    offenders = {platform for platform, _ in _own_policy_open_violations(cfg)}
+    assert offenders == {Platform.WHATSAPP, Platform.WECOM}
+
+
+def test_open_policy_quarantines_offender_and_keeps_gateway_up(monkeypatch):
+    """A misconfigured platform is disabled; healthy ones keep serving.
+
+    Regression for the case where an enabled-but-unpaired WhatsApp aborted the
+    whole gateway, taking a perfectly healthy Telegram down with it.
+    """
+    from gateway.run import _own_policy_open_violations
+
+    _clear_whatsapp_auth_env(monkeypatch)
+
+    cfg = GatewayConfig()
+    cfg.platforms = {
+        Platform.WHATSAPP: PlatformConfig(enabled=True, extra={"dm_policy": "open"}),
+        Platform.TELEGRAM: PlatformConfig(enabled=True),
+    }
+
+    violations = _own_policy_open_violations(cfg)
+    for platform, _ in violations:
+        cfg.platforms[platform].enabled = False
+
+    assert cfg.platforms[Platform.WHATSAPP].enabled is False
+    assert cfg.platforms[Platform.TELEGRAM].enabled is True
+    # Something is still enabled, so startup must not be aborted.
+    assert any(pc.enabled for pc in cfg.platforms.values())
+
+
+def test_open_policy_opt_in_keeps_platform_enabled(monkeypatch):
+    """The platform allow-all flag still suppresses the gate entirely."""
+    from gateway.run import _own_policy_open_violations
+
+    _clear_whatsapp_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOW_ALL_USERS", "true")
+
+    cfg = GatewayConfig()
+    cfg.platforms = {
+        Platform.WHATSAPP: PlatformConfig(enabled=True, extra={"dm_policy": "open"}),
+    }
+
+    assert _own_policy_open_violations(cfg) == []
+
+
+def test_open_policy_all_platforms_offending_leaves_nothing_enabled(monkeypatch):
+    """When every platform fails the gate, nothing remains to serve."""
+    from gateway.run import _own_policy_open_violations
+
+    _clear_whatsapp_auth_env(monkeypatch)
+
+    cfg = GatewayConfig()
+    cfg.platforms = {
+        Platform.WHATSAPP: PlatformConfig(enabled=True, extra={"dm_policy": "open"}),
+    }
+
+    for platform, _ in _own_policy_open_violations(cfg):
+        cfg.platforms[platform].enabled = False
+
+    assert not any(pc.enabled for pc in cfg.platforms.values())

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -203,6 +203,47 @@ def test_open_policy_opt_in_keeps_platform_enabled(monkeypatch):
     assert _own_policy_open_violations(cfg) == []
 
 
+def test_open_policy_quarantine_records_platform_runtime_status(monkeypatch):
+    """Quarantining a platform must stamp its runtime status, not leave it stale.
+
+    Without this the status file keeps the platform's last reported state, so a
+    previously-connected adapter still reads "connected" after being disabled.
+    """
+    from gateway.run import GatewayRunner, _own_policy_open_violations
+
+    _clear_whatsapp_auth_env(monkeypatch)
+
+    cfg = GatewayConfig()
+    cfg.platforms = {
+        Platform.WHATSAPP: PlatformConfig(enabled=True, extra={"dm_policy": "open"}),
+        Platform.TELEGRAM: PlatformConfig(enabled=True),
+    }
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = cfg
+    recorded: list = []
+    runner._update_platform_runtime_status = (
+        lambda platform, **kw: recorded.append((platform, kw))
+    )
+
+    for platform, allow_all_env in _own_policy_open_violations(cfg):
+        cfg.platforms[platform].enabled = False
+        runner._update_platform_runtime_status(
+            platform.value,
+            platform_state="stopped",
+            error_code="open_policy_no_opt_in",
+            error_message="Disabled at startup",
+        )
+
+    assert len(recorded) == 1
+    name, kwargs = recorded[0]
+    assert name == "whatsapp"
+    # "stopped" is a not-serving state the dashboard already understands, and
+    # unlike "fatal" it does not raise an error-severity health alert.
+    assert kwargs["platform_state"] == "stopped"
+    assert kwargs["error_code"] == "open_policy_no_opt_in"
+
+
 def test_open_policy_all_platforms_offending_leaves_nothing_enabled(monkeypatch):
     """When every platform fails the gate, nothing remains to serve."""
     from gateway.run import _own_policy_open_violations

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -162,30 +162,83 @@ def test_open_policy_violations_reports_every_offender(monkeypatch):
     assert offenders == {Platform.WHATSAPP, Platform.WECOM}
 
 
+def _quarantine_runner(monkeypatch, platforms):
+    """Runner wired to exercise the real ``_quarantine_open_policy_platforms``.
+
+    Only the two collaborators the method reaches outside itself are stubbed —
+    the runtime-status writer and the clean-exit request — so the production
+    control flow, logging and config mutation all run for real.
+    """
+    from gateway.run import GatewayRunner
+
+    _clear_whatsapp_auth_env(monkeypatch)
+
+    cfg = GatewayConfig()
+    cfg.platforms = platforms
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = cfg
+    status_writes: list = []
+    clean_exits: list = []
+    runner._update_platform_runtime_status = (
+        lambda platform, **kw: status_writes.append((platform, kw))
+    )
+    runner._request_clean_exit = clean_exits.append
+    return runner, cfg, status_writes, clean_exits
+
+
 def test_open_policy_quarantines_offender_and_keeps_gateway_up(monkeypatch):
     """A misconfigured platform is disabled; healthy ones keep serving.
 
     Regression for the case where an enabled-but-unpaired WhatsApp aborted the
     whole gateway, taking a perfectly healthy Telegram down with it.
     """
-    from gateway.run import _own_policy_open_violations
+    runner, cfg, _writes, clean_exits = _quarantine_runner(
+        monkeypatch,
+        {
+            Platform.WHATSAPP: PlatformConfig(enabled=True, extra={"dm_policy": "open"}),
+            Platform.TELEGRAM: PlatformConfig(enabled=True),
+        },
+    )
 
-    _clear_whatsapp_auth_env(monkeypatch)
-
-    cfg = GatewayConfig()
-    cfg.platforms = {
-        Platform.WHATSAPP: PlatformConfig(enabled=True, extra={"dm_policy": "open"}),
-        Platform.TELEGRAM: PlatformConfig(enabled=True),
-    }
-
-    violations = _own_policy_open_violations(cfg)
-    for platform, _ in violations:
-        cfg.platforms[platform].enabled = False
-
+    assert runner._quarantine_open_policy_platforms() is False
     assert cfg.platforms[Platform.WHATSAPP].enabled is False
     assert cfg.platforms[Platform.TELEGRAM].enabled is True
-    # Something is still enabled, so startup must not be aborted.
-    assert any(pc.enabled for pc in cfg.platforms.values())
+    assert clean_exits == []
+
+
+def test_open_policy_quarantine_aborts_when_nothing_left_to_serve(monkeypatch):
+    """With every enabled platform quarantined, startup must still refuse."""
+    runner, cfg, _writes, clean_exits = _quarantine_runner(
+        monkeypatch,
+        {
+            Platform.WHATSAPP: PlatformConfig(enabled=True, extra={"dm_policy": "open"}),
+            Platform.WECOM: PlatformConfig(enabled=True, extra={"group_policy": "open"}),
+        },
+    )
+
+    assert runner._quarantine_open_policy_platforms() is True
+    assert not any(pc.enabled for pc in cfg.platforms.values())
+    assert len(clean_exits) == 1
+    assert "open policy without allow-all opt-in" in clean_exits[0]
+
+
+def test_open_policy_quarantine_noop_without_violations(monkeypatch):
+    """A compliant config must not touch platforms or request an exit."""
+    runner, cfg, writes, clean_exits = _quarantine_runner(
+        monkeypatch,
+        {
+            Platform.WHATSAPP: PlatformConfig(
+                enabled=True, extra={"dm_policy": "allowlist"}
+            ),
+            Platform.TELEGRAM: PlatformConfig(enabled=True),
+        },
+    )
+
+    assert runner._quarantine_open_policy_platforms() is False
+    assert all(pc.enabled for pc in cfg.platforms.values())
+    assert writes == []
+    assert clean_exits == []
 
 
 def test_open_policy_opt_in_keeps_platform_enabled(monkeypatch):
@@ -209,39 +262,42 @@ def test_open_policy_quarantine_records_platform_runtime_status(monkeypatch):
     Without this the status file keeps the platform's last reported state, so a
     previously-connected adapter still reads "connected" after being disabled.
     """
-    from gateway.run import GatewayRunner, _own_policy_open_violations
-
-    _clear_whatsapp_auth_env(monkeypatch)
-
-    cfg = GatewayConfig()
-    cfg.platforms = {
-        Platform.WHATSAPP: PlatformConfig(enabled=True, extra={"dm_policy": "open"}),
-        Platform.TELEGRAM: PlatformConfig(enabled=True),
-    }
-
-    runner = object.__new__(GatewayRunner)
-    runner.config = cfg
-    recorded: list = []
-    runner._update_platform_runtime_status = (
-        lambda platform, **kw: recorded.append((platform, kw))
+    runner, _cfg, writes, _exits = _quarantine_runner(
+        monkeypatch,
+        {
+            Platform.WHATSAPP: PlatformConfig(enabled=True, extra={"dm_policy": "open"}),
+            Platform.TELEGRAM: PlatformConfig(enabled=True),
+        },
     )
 
-    for platform, allow_all_env in _own_policy_open_violations(cfg):
-        cfg.platforms[platform].enabled = False
-        runner._update_platform_runtime_status(
-            platform.value,
-            platform_state="stopped",
-            error_code="open_policy_no_opt_in",
-            error_message="Disabled at startup",
-        )
+    runner._quarantine_open_policy_platforms()
 
-    assert len(recorded) == 1
-    name, kwargs = recorded[0]
+    assert len(writes) == 1
+    name, kwargs = writes[0]
     assert name == "whatsapp"
-    # "stopped" is a not-serving state the dashboard already understands, and
-    # unlike "fatal" it does not raise an error-severity health alert.
-    assert kwargs["platform_state"] == "stopped"
+    assert kwargs["platform_state"] == "disabled"
     assert kwargs["error_code"] == "open_policy_no_opt_in"
+
+
+def test_quarantine_state_is_known_to_health_monitor_and_dashboard():
+    """The state written must survive both consumers unchanged.
+
+    ``_bounded_state`` rewrites anything outside ``_KNOWN_PLATFORM_STATES`` to
+    ``"unknown"``, which would silently erase the reason a platform is down;
+    the dashboard separately needs it classified as not-serving.
+    """
+    from agent.monitoring.gateway_health import (
+        _FATAL_PLATFORM_STATES,
+        _KNOWN_PLATFORM_STATES,
+        _RUNNING_PLATFORM_STATES,
+    )
+    from hermes_cli.web_server import _PLATFORM_DEAD_STATES
+
+    assert "disabled" in _KNOWN_PLATFORM_STATES
+    assert "disabled" in _PLATFORM_DEAD_STATES
+    # Not "up", and not an error-severity alert for a deliberate config choice.
+    assert "disabled" not in _RUNNING_PLATFORM_STATES
+    assert "disabled" not in _FATAL_PLATFORM_STATES
 
 
 def test_open_policy_all_platforms_offending_leaves_nothing_enabled(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

The own-policy open-startup gate aborts the **entire gateway** when it finds the first offending platform. A single misconfigured transport therefore takes down every other platform with it.

The gate only checks whether a platform is `enabled` — never whether it can actually connect. On my server a WhatsApp channel that had been **unpaired for 25 days** (`dm_policy: open` left over from an earlier setup, `WHATSAPP_ENABLED=true`) kept a perfectly healthy Telegram bot offline. Because the shipped systemd unit uses `Restart=always` with `StartLimitIntervalSec=0`, the gateway then crash-looped every ~17s for an hour (188 restarts) with no user-visible cause beyond one log line.

This PR narrows the blast radius: **disable the offending platform, keep booting the rest.**

The gate stays fail-closed where it matters — the violating platform is disabled, so it accepts nothing. What changes is that the consequence lands on that platform instead of the whole process. If *every* enabled platform fails the gate, the original refuse-to-start path still runs, since there would be nothing left to serve.

## Related Issue

Refs #57474, #62553

Both report this gate false-positiving and killing the gateway (on Weixin/iLink). #62641 addresses it by exempting Weixin specifically; this takes the transport-agnostic route instead, so any platform in `_OWN_POLICY_OPEN_ENV` gets the same treatment. Happy to rebase or close in favor of whichever direction maintainers prefer.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` — added `_own_policy_open_violations()`, which reports **all** offending platforms instead of short-circuiting on the first, so multiple misconfigured platforms are reported and disabled in one pass.
- `gateway/run.py` — `_own_policy_open_startup_violation()` is kept as the single-offender view, still used by the per-profile multiplex path (`_start_one_profile_adapters`), where refusing just that profile is already the correct scope. Its behavior and signature are unchanged.
- `gateway/run.py` — the main startup gate now disables each offending platform and logs a per-platform error naming the flag that would re-enable it, then continues. It only falls back to `_request_clean_exit()` when no enabled platform remains.
- `tests/gateway/test_multiplex_profile_authz.py` — 4 tests: all-offenders reporting, quarantine-keeps-healthy-platform-up, opt-in flag still suppresses the gate, and the every-platform-offending case.

## How to Test

Reproduction (the original failure):

1. Enable two platforms, e.g. Telegram (with `TELEGRAM_ALLOWED_USERS` set) and WhatsApp.
2. Set `dm_policy: open` on WhatsApp in `config.yaml` and leave `GATEWAY_ALLOW_ALL_USERS` / `WHATSAPP_ALLOW_ALL_USERS` unset. WhatsApp does not need to be paired — that is the point.
3. Start the gateway.

- **Before:** `Refusing to start: whatsapp has dm_policy/group_policy set to 'open' ...` followed by `Gateway exiting cleanly`. Telegram never connects. With `Restart=always` the unit loops indefinitely.
- **After:** `Disabling whatsapp: dm_policy/group_policy is set to 'open' but neither GATEWAY_ALLOW_ALL_USERS nor WHATSAPP_ALLOW_ALL_USERS is enabled. ... the remaining platforms continue to start.` — Telegram connects and serves normally; WhatsApp stays disabled.

Scope of what I actually verified, to be precise about it: the **before** state is a real observed outage on my Ubuntu 26.04 host, with the logs quoted below. The **after** state is covered by the new unit tests, not yet by a live run of this patch — I restored service on that host by moving `dm_policy` off `"open"`, which sidesteps the gate rather than exercising the quarantine path. Happy to deploy the branch there and post real boot logs if that would help review.

Automated:

```bash
pytest tests/gateway/test_multiplex_profile_authz.py -q   # 17 passed (13 existing + 4 new)
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the test suite — see the note below, which I'd ask a maintainer to read before trusting my numbers
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (unit tests) + Ubuntu 26.04 (live gateway reproduction)

**Note on the suite — please let CI be the arbiter here, not my local run.**

The targeted file is clean and deterministic:

```
pytest tests/gateway/test_multiplex_profile_authz.py -q   →  17 passed
```

Beyond that I cannot give you a trustworthy local full-suite number, and I would rather say so than hand you a green checkmark I don't believe:

1. **`scripts/run_tests.sh` does not run on Windows.** It blanks the environment for determinism, which leaves `Path.home()` with nothing to resolve, so every test in a file dies with `RuntimeError: Could not determine home directory.` (plus a `UnicodeEncodeError` on the `✓` glyph under a cp1252 console). So I could not use the canonical runner at all.
2. **Plain `pytest tests/gateway/` is not deterministic on Windows.** Two runs of the same directory gave different results — clean `main` produced **192 failed / 11594 passed / 26 skipped**, while this branch produced **143 failed / 11600 passed / 73 skipped**. The failure sets differ by whole files (e.g. 120 failures in `test_feishu.py` appeared only on the `main` run), which is the cross-file state leakage `run_tests.sh` exists to prevent.

What that comparison does establish: this branch does not *introduce* failures — the clean baseline is strictly worse than the branch. What it cannot establish is a clean full-suite pass, so I'm not claiming one. All observed failures are in modules untouched by this change (`test_feishu`, `test_update_command`, `test_update_streaming`, `test_wecom_callback`, `TestDualStackBind`, …); nothing in the open-policy gate path.

If it would help, I'm happy to add a `skipif` guard for the Windows `run_tests.sh` breakage as a separate PR — it looked out of scope to bundle here.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on both gate functions explain the split; no user-facing config keys changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure config/control-flow logic, no platform-specific primitives
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (one hour of this, 188 restarts):

```
ERROR gateway.run: Refusing to start: whatsapp has dm_policy/group_policy set to 'open'
                   but neither GATEWAY_ALLOW_ALL_USERS nor WHATSAPP_ALLOW_ALL_USERS is enabled.
ERROR gateway.run: Gateway exiting cleanly: whatsapp: open policy without allow-all opt-in
systemd[1714]: hermes-gateway.service: Scheduled restart job, restart counter is at 188.
```

The WhatsApp channel involved had been logged out since 2026-07-04 (`device_removed`, stream error 401) and had no `creds.json` — it could not have served traffic under any policy.