### PR TITLE
fix(tts): fall back from opus to mp3 when OpenAI-compatible backends reject it (#73470)

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1559,7 +1559,29 @@ def _generate_openai_tts(
             create_kwargs["instructions"] = instructions
         if language:
             create_kwargs["extra_body"] = {"lang_code": language}
-        response = client.audio.speech.create(**create_kwargs)
+
+        try:
+            response = client.audio.speech.create(**create_kwargs)
+        except Exception as exc:
+            # Some OpenAI-compatible TTS backends (e.g. Kokoro/Speaches)
+            # reject response_format=opus outright (HTTP 4xx). Retry with a
+            # widely-supported format, then let _repair_ogg_container (called
+            # by text_to_speech_tool) transcode back to Ogg/Opus when needed.
+            if (
+                response_format == "opus"
+                and hasattr(exc, "status_code")
+                and isinstance(exc.status_code, int)
+                and 400 <= exc.status_code < 500
+            ):
+                logger.warning(
+                    "TTS: server rejected response_format=opus (HTTP %s: %s) "
+                    "— retrying with mp3; post-synthesis repair will transcode",
+                    exc.status_code, exc,
+                )
+                create_kwargs["response_format"] = "mp3"
+                response = client.audio.speech.create(**create_kwargs)
+            else:
+                raise
 
         response.stream_to_file(output_path)
         return output_path


### PR DESCRIPTION
## Problem

OpenAI-compatible TTS backends that don't support `response_format=opus` (e.g. Speaches/Kokoro, which accept only mp3/flac/wav/pcm) reject the request outright with HTTP 4xx. The existing `_repair_ogg_container` (added by #57184) only helps when a backend silently ignores the format request and writes MP3/WAV bytes into a .ogg path — it cannot act when the request 4xxs before any bytes exist.


## Solution

In `_generate_openai_tts()`, catch the 4xx error when the requested format is `opus` and retry with `response_format=mp3`, which every OpenAI-compatible TTS backend supports. The existing `_repair_ogg_container` mechanism in `text_to_speech_tool` will then transcode the MP3 bytes back to Ogg/Opus when the platform needs it (Telegram etc.).


## Testing

- 48 existing TTS tests pass (openai_config, instructions, max_text_length, container_repair, deepinfra, speed)
- The fix is a safe retry-with-fallback pattern that only activates on 4xx errors when opus was requested