### PR TITLE
feat: honor model temperature configuration

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -818,6 +818,7 @@ def init_agent(
     
     # Model response configuration
     agent.max_tokens = max_tokens  # None = use model default
+    agent.temperature = None  # None = let the provider/model choose its default
     agent.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
     agent.service_tier = service_tier
     agent.request_overrides = dict(request_overrides or {})
@@ -2025,6 +2026,36 @@ def init_agent(
                     file=sys.stderr,
                 )
     agent._session_init_model_config["max_tokens"] = agent.max_tokens
+
+    # Read an optional sampling-temperature override. The OpenAI-compatible
+    # and Gemini native APIs accept the shared [0, 2] range; leave it unset to
+    # preserve each model's native default. Provider profiles can still pin or
+    # omit the field for models with stricter sampling contracts.
+    if isinstance(_model_cfg, dict):
+        _config_temperature = _model_cfg.get("temperature")
+    else:
+        _config_temperature = None
+    if _config_temperature is not None:
+        try:
+            if isinstance(_config_temperature, bool):
+                raise ValueError
+            _parsed_temperature = float(_config_temperature)
+            if not 0.0 <= _parsed_temperature <= 2.0:
+                raise ValueError
+            agent.temperature = _parsed_temperature
+        except (TypeError, ValueError, OverflowError):
+            _ra().logger.warning(
+                "Invalid model.temperature in config.yaml: %r — "
+                "must be a number from 0.0 to 2.0. Falling back to the provider default.",
+                _config_temperature,
+            )
+            print(
+                f"\n⚠ Invalid model.temperature in config.yaml: {_config_temperature!r}\n"
+                "  Must be a number from 0.0 to 2.0.\n"
+                "  Falling back to the provider default.\n",
+                file=sys.stderr,
+            )
+    agent._session_init_model_config["temperature"] = agent.temperature
 
     # Read explicit context_length override from model config
     if isinstance(_model_cfg, dict):

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2691,6 +2691,7 @@ def build_anthropic_kwargs(
     base_url: str | None = None,
     fast_mode: bool = False,
     drop_context_1m_beta: bool = False,
+    temperature: Optional[float] = None,
 ) -> Dict[str, Any]:
     """Build kwargs for anthropic.messages.create().
 
@@ -2830,6 +2831,9 @@ def build_anthropic_kwargs(
 
     if system:
         kwargs["system"] = system
+
+    if temperature is not None:
+        kwargs["temperature"] = temperature
 
     if anthropic_tools:
         kwargs["tools"] = anthropic_tools

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1049,7 +1049,14 @@ def build_converse_kwargs(
 
     if not _forbids_sampling_params(model):
         if temperature is not None:
-            kwargs["inferenceConfig"]["temperature"] = temperature
+            if 0.0 <= temperature <= 1.0:
+                kwargs["inferenceConfig"]["temperature"] = temperature
+            else:
+                logger.warning(
+                    "Bedrock temperature %s is outside its supported [0.0, 1.0] range; "
+                    "omitting it and using the model default.",
+                    temperature,
+                )
 
         if top_p is not None:
             kwargs["inferenceConfig"]["topP"] = top_p

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1137,6 +1137,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             messages=anthropic_messages,
             tools=tools_for_api,
             max_tokens=ephemeral_out if ephemeral_out is not None else agent.max_tokens,
+            temperature=agent.temperature,
             reasoning_config=agent.reasoning_config,
             is_oauth=agent._is_anthropic_oauth,
             preserve_dots=agent._anthropic_preserve_dots(),
@@ -1163,6 +1164,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             messages=api_messages,
             tools=tools_for_api,
             max_tokens=agent.max_tokens or 4096,
+            temperature=agent.temperature,
             region=region,
             guardrail_config=guardrail,
         )
@@ -1323,6 +1325,12 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             base_url=agent.base_url,
             timeout=agent._resolved_api_call_timeout(),
             max_tokens=agent.max_tokens,
+            # Model-specific constraints are resolved before choosing the
+            # provider-profile path too. Without these, registered profiles
+            # would bypass the same fixed/omit guard used by legacy providers.
+            fixed_temperature=_fixed_temp,
+            omit_temperature=_omit_temp,
+            temperature=agent.temperature,
             ephemeral_max_output_tokens=_ephemeral_out,
             max_tokens_param_fn=agent._max_tokens_param,
             reasoning_config=agent.reasoning_config,
@@ -1355,6 +1363,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         base_url=agent.base_url,
         timeout=agent._resolved_api_call_timeout(),
         max_tokens=agent.max_tokens,
+        temperature=agent.temperature,
         ephemeral_max_output_tokens=_ephemeral_out,
         max_tokens_param_fn=agent._max_tokens_param,
         reasoning_config=agent.reasoning_config,

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -67,6 +67,7 @@ class AnthropicTransport(ProviderTransport):
             messages=messages,
             tools=tools,
             max_tokens=params.get("max_tokens", 16384),
+            temperature=params.get("temperature"),
             reasoning_config=params.get("reasoning_config"),
             tool_choice=params.get("tool_choice"),
             is_oauth=params.get("is_oauth", False),

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -360,6 +360,16 @@ class ChatCompletionsTransport(ProviderTransport):
             "messages": sanitized,
         }
 
+        # Model-specific constraints take precedence over the configured
+        # default. Otherwise send the configured value only when the user set
+        # one, preserving the provider/model native default when it is absent.
+        if not params.get("omit_temperature", False):
+            temperature = params.get("fixed_temperature")
+            if temperature is None:
+                temperature = params.get("temperature")
+            if temperature is not None:
+                api_kwargs["temperature"] = temperature
+
         timeout = params.get("timeout")
         if timeout is not None:
             api_kwargs["timeout"] = timeout
@@ -536,13 +546,16 @@ class ChatCompletionsTransport(ProviderTransport):
             "messages": sanitized,
         }
 
-        # Temperature
-        if profile.fixed_temperature is OMIT_TEMPERATURE:
+        # Temperature. Both profile- and model-specific contracts override the
+        # configured default; the latter is passed by build_api_kwargs for every
+        # provider path (including registered profiles).
+        if params.get("omit_temperature", False) or profile.fixed_temperature is OMIT_TEMPERATURE:
             pass  # Don't include temperature at all
         elif profile.fixed_temperature is not None:
             api_kwargs["temperature"] = profile.fixed_temperature
+        elif params.get("fixed_temperature") is not None:
+            api_kwargs["temperature"] = params["fixed_temperature"]
         else:
-            # Use caller's temperature if provided
             temp = params.get("temperature")
             if temp is not None:
                 api_kwargs["temperature"] = temp

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -76,8 +76,10 @@ model:
 # temperature: Sampling randomness for the main model (0.0–2.0).
 #   Leave unset to preserve the provider/model default. Hermes forwards this
 #   to regular chat-completions, native Gemini generateContent, Anthropic
-#   Messages, and Bedrock Converse transports. Some model/provider profiles
-#   pin or omit it when their API requires that.
+#   Messages, and Bedrock Converse transports. Bedrock accepts only 0.0–1.0:
+#   values above 1.0 are omitted there (with a warning) while still applying to
+#   providers that support the full range. Some model/provider profiles pin or
+#   omit it when their API requires that.
 #
 # temperature: 0.2
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -72,6 +72,14 @@ model:
   #   Set only if you want to deliberately limit individual response length.
   #
 # max_tokens: 8192
+#
+# temperature: Sampling randomness for the main model (0.0–2.0).
+#   Leave unset to preserve the provider/model default. Hermes forwards this
+#   to regular chat-completions, native Gemini generateContent, Anthropic
+#   Messages, and Bedrock Converse transports. Some model/provider profiles
+#   pin or omit it when their API requires that.
+#
+# temperature: 0.2
 
   # ── Custom request headers (optional) ─────────────────────────────────────
   #

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -29,9 +29,30 @@ from agent.anthropic_adapter import (
 from agent.transports import get_transport
 
 
-# ---------------------------------------------------------------------------
-# Auth helpers
-# ---------------------------------------------------------------------------
+def test_temperature_is_included_for_anthropic_models_that_allow_sampling():
+    kwargs = build_anthropic_kwargs(
+        model="claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "Hi"}],
+        tools=None,
+        max_tokens=1024,
+        reasoning_config=None,
+        temperature=0.2,
+    )
+
+    assert kwargs["temperature"] == 0.2
+
+
+def test_temperature_is_omitted_for_anthropic_models_that_forbid_sampling():
+    kwargs = build_anthropic_kwargs(
+        model="claude-opus-4-7",
+        messages=[{"role": "user", "content": "Hi"}],
+        tools=None,
+        max_tokens=1024,
+        reasoning_config=None,
+        temperature=0.2,
+    )
+
+    assert "temperature" not in kwargs
 
 
 class TestIsOAuthToken:

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -377,6 +377,17 @@ class TestBuildConverseKwargs:
         assert kwargs["system"] is not None
         assert len(kwargs["messages"]) >= 1
 
+    def test_temperature_is_included_for_models_that_support_sampling(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+
+        kwargs = build_converse_kwargs(
+            model="meta.llama3-70b-instruct-v1:0",
+            messages=[{"role": "user", "content": "Hi"}],
+            temperature=0.2,
+        )
+
+        assert kwargs["inferenceConfig"]["temperature"] == 0.2
+
     def test_includes_tools(self):
         from agent.bedrock_adapter import build_converse_kwargs
         tools = [{"type": "function", "function": {

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -388,6 +388,17 @@ class TestBuildConverseKwargs:
 
         assert kwargs["inferenceConfig"]["temperature"] == 0.2
 
+    def test_temperature_above_bedrock_limit_is_omitted(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+
+        kwargs = build_converse_kwargs(
+            model="meta.llama3-70b-instruct-v1:0",
+            messages=[{"role": "user", "content": "Hi"}],
+            temperature=1.5,
+        )
+
+        assert "temperature" not in kwargs["inferenceConfig"]
+
     def test_includes_tools(self):
         from agent.bedrock_adapter import build_converse_kwargs
         tools = [{"type": "function", "function": {

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -148,11 +148,13 @@ def test_native_client_uses_x_goog_api_key_and_native_models_endpoint(monkeypatc
     response = client.chat.completions.create(
         model="gemini-2.5-flash",
         messages=[{"role": "user", "content": "Hello"}],
+        temperature=0.2,
     )
 
     assert recorded["url"] == "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent"
     assert recorded["headers"]["x-goog-api-key"] == "AIza-test"
     assert "Authorization" not in recorded["headers"]
+    assert recorded["json"]["generationConfig"]["temperature"] == 0.2
     assert response.choices[0].message.content == "hello"
 
 

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -217,6 +217,56 @@ class TestBuildApiKwargsOpenRouter:
         }
         assert "extra_body" not in kwargs["extra_body"]
 
+    def test_model_temperature_config_reaches_gemini_native_client(self, monkeypatch):
+        """model.temperature must be emitted for Gemini's native transport."""
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"model": {"temperature": 0.2}},
+        )
+        agent = _make_agent(
+            monkeypatch,
+            "gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta",
+            model="gemini-3-flash-preview",
+        )
+
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+
+        assert agent.temperature == 0.2
+        assert kwargs["temperature"] == 0.2
+
+    def test_out_of_range_temperature_falls_back_without_crashing(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"model": {"temperature": 10**400}},
+        )
+
+        agent = _make_agent(monkeypatch, "gemini", model="gemini-3-flash-preview")
+
+        assert agent.temperature is None
+
+    def test_model_fixed_temperature_wins_for_registered_profile(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"model": {"temperature": 0.2}},
+        )
+        agent = _make_agent(monkeypatch, "openrouter", model="arcee-ai/trinity-large-thinking")
+
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+
+        assert kwargs["temperature"] == 0.5
+
+    def test_model_temperature_is_omitted_when_registered_profile_requires_it(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"model": {"temperature": 0.2}},
+        )
+        agent = _make_agent(monkeypatch, "openrouter", model="moonshotai/kimi-k2.5")
+
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+
+        assert "temperature" not in kwargs
+
 
     def test_should_sanitize_tool_calls_codex_vs_chat(self, monkeypatch):
         """Codex API should NOT sanitize, all other APIs should sanitize."""


### PR DESCRIPTION
## Summary
- make `model.temperature` (0.0–2.0) effective for standard agent inference
- forward it through chat-completions, Gemini native, Anthropic Messages, and Bedrock Converse
- retain provider/model fixed and omitted temperature contracts

## Validation
- `127 passed` across the targeted provider, Gemini, Anthropic, and Bedrock suites
- `ruff check` and `git diff --check` pass

## Notes
- Invalid values, including numeric values too large to convert to float, fall back to the provider default.