### PR TITLE
fix(desktop): preserve concurrent session pin intent

### DIFF
--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -47,6 +47,15 @@ describe('watchSessionPins', () => {
     expect(patch).toHaveBeenCalledWith('a', true, 'work')
   })
 
+  it('keeps a new local pin while the loaded row still reports pinned=false', async () => {
+    $sessions.set([row('stale-pin', { pinned: false, profile: 'work' })])
+    $pinnedSessionIds.set(['stale-pin'])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toContain('stale-pin')
+    expect(patch).toHaveBeenCalledWith('stale-pin', true, 'work')
+  })
+
   it('mirrors an unpin as pinned=false', async () => {
     $sessions.set([row('b')])
     $pinnedSessionIds.set(['b'])
@@ -57,6 +66,18 @@ describe('watchSessionPins', () => {
     await flush()
 
     expect(patch).toHaveBeenCalledWith('b', false, undefined)
+  })
+
+  it('keeps a local unpin while the loaded row still reports pinned=true', async () => {
+    $sessions.set([row('stale-unpin', { pinned: true, profile: 'work' })])
+    await flush()
+    patch.mockClear()
+
+    $pinnedSessionIds.set([])
+    await flush()
+
+    expect($pinnedSessionIds.get()).not.toContain('stale-unpin')
+    expect(patch).toHaveBeenCalledWith('stale-unpin', false, 'work')
   })
 
   it('defers a pin whose row is not loaded, then flushes once it appears', async () => {

--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -279,4 +279,45 @@ describe('watchSessionPins remote pull', () => {
     expect(remainedUnpinned).toBe(true)
     expect(writeCount).toBe(2)
   })
+
+  it('retries the latest failed unpin without re-pinning locally', async () => {
+    patch.mockRejectedValueOnce(new Error('unpin failed'))
+
+    $sessions.set([row('retry-unpin', { pinned: true })])
+    await flush()
+    $pinnedSessionIds.set([])
+    await flush()
+    await flush()
+
+    expect(patch).toHaveBeenCalledTimes(1)
+    expect(patch).toHaveBeenLastCalledWith('retry-unpin', false, undefined)
+
+    $sessions.set([row('retry-unpin', { pinned: true }), row('other')])
+    await flush()
+    await flush()
+
+    expect(patch).toHaveBeenCalledTimes(2)
+    expect(patch).toHaveBeenLastCalledWith('retry-unpin', false, undefined)
+    expect($pinnedSessionIds.get()).not.toContain('retry-unpin')
+  })
+
+  it('retries the latest failed pin without unpinning locally', async () => {
+    patch.mockRejectedValueOnce(new Error('pin failed'))
+
+    $sessions.set([row('retry-pin', { pinned: false })])
+    $pinnedSessionIds.set(['retry-pin'])
+    await flush()
+    await flush()
+
+    expect(patch).toHaveBeenCalledTimes(1)
+    expect(patch).toHaveBeenLastCalledWith('retry-pin', true, undefined)
+
+    $sessions.set([row('retry-pin', { pinned: false }), row('other')])
+    await flush()
+    await flush()
+
+    expect(patch).toHaveBeenCalledTimes(2)
+    expect(patch).toHaveBeenLastCalledWith('retry-pin', true, undefined)
+    expect($pinnedSessionIds.get()).toContain('retry-pin')
+  })
 })

--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -186,4 +186,97 @@ describe('watchSessionPins remote pull', () => {
 
     expect($pinnedSessionIds.get()).not.toContain('race')
   })
+
+  it('does not let an older successful pin clear a newer unpin guard', async () => {
+    const settle: Array<(v: { ok: boolean }) => void> = []
+    patch.mockImplementation(
+      () => new Promise(resolve => settle.push(resolve))
+    )
+
+    $sessions.set([row('rapid', { pinned: false })])
+    $pinnedSessionIds.set(['rapid'])
+    await flush()
+    $pinnedSessionIds.set([])
+    await flush()
+
+    expect(settle).toHaveLength(2)
+    settle[0]?.({ ok: true })
+    await flush()
+    await flush()
+
+    $sessions.set([row('rapid', { pinned: true })])
+    await flush()
+    const remainedUnpinned = !$pinnedSessionIds.get().includes('rapid')
+
+    settle[1]?.({ ok: true })
+    await flush()
+    await flush()
+
+    expect(remainedUnpinned).toBe(true)
+  })
+
+  it('does not let an older successful unpin clear a newer pin guard', async () => {
+    const settle: Array<(v: { ok: boolean }) => void> = []
+    patch.mockImplementation(
+      () => new Promise(resolve => settle.push(resolve))
+    )
+
+    $sessions.set([row('rapid-repin', { pinned: true })])
+    await flush()
+    $pinnedSessionIds.set([])
+    await flush()
+    $pinnedSessionIds.set(['rapid-repin'])
+    await flush()
+
+    expect(settle).toHaveLength(2)
+    settle[0]?.({ ok: true })
+    await flush()
+    await flush()
+
+    $sessions.set([row('rapid-repin', { pinned: false })])
+    await flush()
+    const remainedPinned = $pinnedSessionIds.get().includes('rapid-repin')
+
+    settle[1]?.({ ok: true })
+    await flush()
+    await flush()
+
+    expect(remainedPinned).toBe(true)
+  })
+
+  it('does not let an older failed pin restart a newer unpin write', async () => {
+    const settle: Array<{ reject: (error: Error) => void; resolve: (v: { ok: boolean }) => void }> = []
+    patch.mockImplementation(
+      () =>
+        new Promise((resolve, reject) => {
+          settle.push({ reject, resolve })
+        })
+    )
+
+    $sessions.set([row('rapid-failure', { pinned: false })])
+    $pinnedSessionIds.set(['rapid-failure'])
+    await flush()
+    $pinnedSessionIds.set([])
+    await flush()
+
+    expect(settle).toHaveLength(2)
+    settle[0]?.reject(new Error('older write failed'))
+    await flush()
+    await flush()
+
+    $sessions.set([row('rapid-failure', { pinned: true })])
+    await flush()
+    const remainedUnpinned = !$pinnedSessionIds.get().includes('rapid-failure')
+    const writeCount = settle.length
+
+    for (const deferred of settle.slice(1)) {
+      deferred.resolve({ ok: true })
+    }
+
+    await flush()
+    await flush()
+
+    expect(remainedUnpinned).toBe(true)
+    expect(writeCount).toBe(2)
+  })
 })

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -99,10 +99,12 @@ function reconcile(): void {
     return
   }
 
-  pullRemotePins()
-
   const current = new Set($pinnedSessionIds.get())
 
+  // Push local intent before consulting the current session page. The page may
+  // still carry the value from before the click; writePin records that newer
+  // intent in `unconfirmed` so pullRemotePins cannot undo it.
+  //
   // Unpinned: anything we were tracking that's no longer in the set.
   for (const id of [...mirrored, ...pending]) {
     if (!current.has(id)) {
@@ -136,6 +138,10 @@ function reconcile(): void {
       pending.add(id)
     })
   }
+
+  // With local writes now guarded, adopt authoritative changes made by other
+  // clients without allowing an older page to clobber this app's latest click.
+  pullRemotePins()
 }
 
 // Sync once, then re-sync on pin-set and session-list changes. Call once per app.

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -124,7 +124,12 @@ function reconcile(): void {
     if (!current.has(id)) {
       mirrored.delete(id)
       pending.delete(id)
-      void writePin(id, false, profileFor(id)).catch(() => {})
+      void writePin(id, false, profileFor(id)).catch(() => {
+        // Preserve the unpin intent for the next reconcile. writePin suppresses
+        // failures from superseded generations, so only the latest failed
+        // unpin can restore this retry marker.
+        mirrored.add(id)
+      })
     }
   }
 

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -28,11 +28,15 @@ import { $sessions, sessionMatchesStoredId, sessionPinId } from '@/store/session
 const mirrored = new Set<string>()
 // pin ids awaiting their row so we can resolve the owning profile before PATCH.
 const pending = new Set<string>()
-// Writes we've issued but not yet had acked, id -> value written. A list page
-// already in flight when we PATCH still carries the old value, so it must not
-// be read as the server disagreeing with us. Cleared when the write settles —
-// the request's own lifetime is the guard, so nothing can leave one open.
-const unconfirmed = new Map<string, boolean>()
+interface PendingPinWrite {
+  generation: number
+  pinned: boolean
+}
+
+// Latest in-flight write per pin id. Generation identity prevents an older
+// request from clearing or retrying a newer click's guard.
+const unconfirmed = new Map<string, PendingPinWrite>()
+let nextWriteGeneration = 0
 
 function profileFor(pinId: string): null | string | undefined {
   return $sessions.get().find(row => sessionMatchesStoredId(row, pinId))?.profile
@@ -40,15 +44,24 @@ function profileFor(pinId: string): null | string | undefined {
 
 /** PATCH the flag, guarding reads against pages that predate the write. */
 function writePin(id: string, pinned: boolean, profile?: null | string): Promise<void> {
-  unconfirmed.set(id, pinned)
+  const generation = ++nextWriteGeneration
+  unconfirmed.set(id, { generation, pinned })
 
   return setSessionPinnedRemote(id, pinned, profile).then(
     () => {
-      unconfirmed.delete(id)
+      const current = unconfirmed.get(id)
+
+      if (current?.generation === generation) {
+        unconfirmed.delete(id)
+      }
     },
     (err: unknown) => {
-      unconfirmed.delete(id)
-      throw err
+      const current = unconfirmed.get(id)
+
+      if (current?.generation === generation) {
+        unconfirmed.delete(id)
+        throw err
+      }
     }
   )
 }
@@ -75,9 +88,10 @@ function pullRemotePins(): void {
     const heldLocally = local.has(pinId) || local.has(row.id)
 
     // A write of ours the page hasn't caught up to yet is newer than the page.
-    const awaited = unconfirmed.has(pinId) ? unconfirmed.get(pinId) : unconfirmed.get(row.id)
+    const awaitedId = unconfirmed.has(pinId) ? pinId : row.id
+    const awaited = unconfirmed.get(awaitedId)
 
-    if (awaited !== undefined && awaited !== row.pinned) {
+    if (awaited && awaited.pinned !== row.pinned) {
       continue
     }
 


### PR DESCRIPTION
## Summary

- preserve optimistic pin and unpin intent while session snapshots are stale
- order concurrent pin writes so older PATCH responses cannot clear newer intent
- retry the latest failed pin or unpin on the next reconciliation without a hot loop
- cover both Shift-click and the Pin/Unpin menu through their shared synchronization path

## Root cause

Both Desktop entry points update the same local pin store. The session watcher could then adopt an explicit but stale backend value before the PATCH was observed, or after an older PATCH resolved out of order. A failed latest unpin was also discarded, allowing the next backend refresh to re-pin the row.

## Test plan

- [x] `npm run test:ui --workspace apps/desktop -- src/store/session-pin-sync.test.ts` (18 tests)
- [x] `npm run test:ui --workspace apps/desktop` (2,983 tests)
- [x] `npm run typecheck --workspace apps/desktop`
- [x] `npm run lint --workspace apps/desktop` (0 errors; existing warnings only)
- [x] `npm run build --workspace apps/desktop`
- [x] staged-content secret scan and `git diff --check`

## Notes

The change is limited to the session pin synchronizer and its behavior tests. It does not alter Gateway lifecycle or restart behavior.