### PR TITLE
fix(redact): add opt-in sensitive-data controls

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -11,6 +11,7 @@ import logging
 import os
 import re
 import shlex
+from collections.abc import Collection
 from urllib.parse import unquote_plus
 
 logger = logging.getLogger(__name__)
@@ -175,6 +176,21 @@ _YAML_ASSIGN_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
+_CLI_SENSITIVE_SPACE_VALUE_RE = re.compile(
+    r"(?<![A-Za-z0-9_\-])"
+    r"(--(?:password|passwd|secret|token|api[-_]key|client-secret))"
+    r"([ \t]+)"
+    r"(?:(['\"])([^\r\n'\"]*)\3|((?!--)[^\s'\"]+))",
+    re.IGNORECASE,
+)
+_CLI_SENSITIVE_EQUALS_VALUE_RE = re.compile(
+    r"(?<![A-Za-z0-9_\-])"
+    r"(--(?:password|passwd|secret|token|api[-_]key|client-secret))"
+    r"(=)"
+    r"(?:(['\"])([^\r\n'\"]*)\3|([^\s'\"]+))",
+    re.IGNORECASE,
+)
+
 # Word-boundary validation for the mixed/lowercase key patterns above
 # (_CFG_DOTTED_RE, _CFG_ANCHORED_RE, _YAML_ASSIGN_RE).
 #
@@ -253,6 +269,129 @@ def _key_has_secret_keyword(key: str) -> bool:
         if _is_word_start(key, m.start()) and _is_word_end(key, m.end()):
             return True
     return False
+
+
+def _normalize_sensitive_key(key: str) -> str:
+    """Canonicalize a caller-supplied exact sensitive key name."""
+    return key.strip().casefold().replace("-", "_")
+
+
+def _normalize_extra_sensitive_keys(
+    extra_sensitive_keys: Collection[str] | None,
+) -> frozenset[str]:
+    """Validate and normalize per-call exact sensitive keys.
+
+    Empty strings are ignored after ``strip()`` so an accidental blank entry
+    cannot create an empty-key pattern. ``str`` and ``bytes`` are rejected as
+    the top-level collection because they almost always mean the caller passed
+    one key directly instead of an iterable of keys.
+    """
+    if extra_sensitive_keys is None:
+        return frozenset()
+    if isinstance(extra_sensitive_keys, (str, bytes)):
+        raise TypeError("extra_sensitive_keys must be a collection of strings, not a string")
+    normalized: set[str] = set()
+    for key in extra_sensitive_keys:
+        if not isinstance(key, str):
+            raise TypeError("extra_sensitive_keys entries must be strings")
+        normalized_key = _normalize_sensitive_key(key)
+        if normalized_key:
+            normalized.add(normalized_key)
+    return frozenset(normalized)
+
+
+def _extra_key_matches(key: str, extra_sensitive_keys: frozenset[str]) -> bool:
+    """Return True only for an exact caller-supplied key match."""
+    return bool(extra_sensitive_keys) and _normalize_sensitive_key(key) in extra_sensitive_keys
+
+
+def _extra_sensitive_key_pattern(extra_sensitive_keys: frozenset[str]) -> str:
+    """Build a bounded regex alternation for exact per-call keys."""
+    variants = []
+    for key in sorted(extra_sensitive_keys, key=len, reverse=True):
+        parts = key.split("_")
+        variants.append(r"[-_]".join(re.escape(part) for part in parts))
+    return "(?:" + "|".join(variants) + ")"
+
+
+def _redact_extra_sensitive_key_values(text: str, extra_sensitive_keys: frozenset[str]) -> str:
+    """Redact KEY=value / JSON / YAML values for explicit per-call keys."""
+    if not extra_sensitive_keys or not text:
+        return text
+
+    key_pat = _extra_sensitive_key_pattern(extra_sensitive_keys)
+
+    def _mask_value(value: str) -> str:
+        return _mask_token(value) if value else value
+
+    if "=" in text:
+        assign_re = re.compile(
+            rf"(^[ \t]*(?:export[ \t]+)?|(?<![A-Za-z0-9_.\-]))({key_pat})(\s*=\s*)(['\"]?)([^\s&'\"]*)\4(?=[\s&]|$)",
+            re.IGNORECASE | re.MULTILINE,
+        )
+
+        def _redact_assignment(match: re.Match) -> str:
+            if not _extra_key_matches(match.group(2), extra_sensitive_keys):
+                return match.group(0)
+            return f"{match.group(1)}{match.group(2)}{match.group(3)}{match.group(4)}{_mask_value(match.group(5))}{match.group(4)}"
+
+        text = assign_re.sub(_redact_assignment, text)
+
+    if ":" in text:
+        json_re = re.compile(
+            rf'("({key_pat})"\s*:\s*")([^"]*)(")',
+            re.IGNORECASE,
+        )
+        yaml_unquoted_re = re.compile(
+            rf"(^[ \t]*({key_pat})(:[ \t]*)(?!['\"])([^\s&]+))",
+            re.IGNORECASE | re.MULTILINE,
+        )
+        yaml_quoted_re = re.compile(
+            rf"(^[ \t]*({key_pat})(:[ \t]*)(['\"])([^\r\n'\"]*)\4)",
+            re.IGNORECASE | re.MULTILINE,
+        )
+
+        def _redact_json(match: re.Match) -> str:
+            if not _extra_key_matches(match.group(2), extra_sensitive_keys):
+                return match.group(0)
+            return f"{match.group(1)}{_mask_value(match.group(3))}{match.group(4)}"
+
+        def _redact_yaml_unquoted(match: re.Match) -> str:
+            if not _extra_key_matches(match.group(2), extra_sensitive_keys):
+                return match.group(0)
+            return f"{match.group(2)}{match.group(3)}{_mask_value(match.group(4))}"
+
+        def _redact_yaml_quoted(match: re.Match) -> str:
+            if not _extra_key_matches(match.group(2), extra_sensitive_keys):
+                return match.group(0)
+            return f"{match.group(2)}{match.group(3)}{match.group(4)}{_mask_value(match.group(5))}{match.group(4)}"
+
+        text = json_re.sub(_redact_json, text)
+        text = yaml_unquoted_re.sub(_redact_yaml_unquoted, text)
+        text = yaml_quoted_re.sub(_redact_yaml_quoted, text)
+
+    return text
+
+
+def _redact_cli_sensitive_space_values(text: str) -> str:
+    """Redact values passed with sensitive CLI flags."""
+    if "--" not in text:
+        return text
+
+    def _redact_flag_value(match: re.Match) -> str:
+        quote = match.group(3) or ""
+        quoted_value = match.group(4)
+        bare_value = match.group(5)
+        if quote:
+            if quoted_value == "":
+                return match.group(0)
+            return f"{match.group(1)}{match.group(2)}{quote}***{quote}"
+        if not bare_value:
+            return match.group(0)
+        return f"{match.group(1)}{match.group(2)}***"
+
+    text = _CLI_SENSITIVE_SPACE_VALUE_RE.sub(_redact_flag_value, text)
+    return _CLI_SENSITIVE_EQUALS_VALUE_RE.sub(_redact_flag_value, text)
 
 # JSON field patterns: "apiKey": "value", "token": "value", etc.
 _JSON_KEY_NAMES = r"(?:api_?[Kk]ey|token|secret|password|access_token|refresh_token|auth_token|bearer|secret_value|raw_secret|secret_input|key_material)"
@@ -518,7 +657,7 @@ def _canonical_url_param_name(name: str) -> str:
     return decoded.casefold().replace("-", "_")
 
 
-def _redact_strict_url_credentials(text: str) -> str:
+def _redact_strict_url_credentials(text: str, *, redact_usernames: bool = False) -> str:
     """Redact credentials from absolute, relative, and network URL references.
 
     This is intentionally stricter than display/log redaction and is used only
@@ -535,7 +674,11 @@ def _redact_strict_url_credentials(text: str) -> str:
         userinfo = match.group(2)
         if ":" in userinfo:
             username, _, _password = userinfo.partition(":")
+            if redact_usernames:
+                return f"{match.group(1)}***:***@"
             return f"{match.group(1)}{username}:***@"
+        if redact_usernames:
+            return f"{match.group(1)}***@"
         return f"{match.group(1)}***@"
 
     text = _STRICT_URL_PARAM_RE.sub(_redact_param, text)
@@ -626,6 +769,8 @@ def redact_sensitive_text(
     code_file: bool = False,
     file_read: bool = False,
     redact_url_credentials: bool = False,
+    extra_sensitive_keys: Collection[str] | None = None,
+    redact_url_usernames: bool = False,
 ) -> str:
     """Apply all redaction patterns to a block of text.
 
@@ -638,6 +783,14 @@ def redact_sensitive_text(
     additionally redact credential-named query parameters and ``user:pass@``
     URL userinfo. The default remains False because actionable OAuth callback,
     magic-link, and pre-signed URLs must survive ordinary tool flows unchanged.
+    Set redact_url_usernames=True with redact_url_credentials=True to also
+    hide usernames in URL userinfo; alone it has no effect.
+
+    Set extra_sensitive_keys={...} to add exact per-call key names to the
+    KEY=value / JSON / YAML redaction passes. Keys are stripped, casefolded,
+    and normalized so hyphens and underscores are equivalent. Empty keys are
+    ignored. This does not mutate global sensitive-key sets or persist between
+    calls.
 
     Set code_file=True to skip the ENV-assignment and JSON-field regex
     patterns when the text is known to be source code (e.g. MAX_TOKENS=***
@@ -677,6 +830,14 @@ def redact_sensitive_text(
     # paths either (it's config/data, not log lines).
     if file_read:
         code_file = True
+
+    normalized_extra_sensitive_keys = _normalize_extra_sensitive_keys(extra_sensitive_keys)
+
+    if normalized_extra_sensitive_keys:
+        text = _redact_extra_sensitive_key_values(text, normalized_extra_sensitive_keys)
+
+    if "--" in text:
+        text = _redact_cli_sensitive_space_values(text)
 
     # Known prefixes (sk-, ghp_, etc.) — gate on substring presence
     if _has_known_prefix_substring(text):
@@ -816,7 +977,7 @@ def redact_sensitive_text(
     # left to pass through per #34029.
 
     if redact_url_credentials:
-        text = _redact_strict_url_credentials(text)
+        text = _redact_strict_url_credentials(text, redact_usernames=redact_url_usernames)
 
     # Form-urlencoded bodies (only triggers on clean k=v&k=v inputs).
     if "&" in text and "=" in text:

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -1,5 +1,6 @@
 """Tests for agent.redact -- secret masking in logs and output."""
 
+import inspect
 import logging
 
 import pytest
@@ -1190,3 +1191,205 @@ class TestKeywordWordBoundary:
         text = "MYTOKEN=abcdefgh1234567890123456"
         result = redact_sensitive_text(text)
         assert "abcdefgh1234567890123456" not in result
+
+
+class TestRedactSensitiveTextApiCompatibility:
+    def test_old_signature_prefix_still_valid_and_new_args_are_trailing_keyword_only(self):
+        sig = inspect.signature(redact_sensitive_text)
+        assert list(sig.parameters) == [
+            "text",
+            "force",
+            "code_file",
+            "file_read",
+            "redact_url_credentials",
+            "extra_sensitive_keys",
+            "redact_url_usernames",
+        ]
+        assert sig.parameters["force"].default is False
+        assert sig.parameters["code_file"].default is False
+        assert sig.parameters["file_read"].default is False
+        assert sig.parameters["redact_url_credentials"].default is False
+        assert sig.parameters["extra_sensitive_keys"].default is None
+        assert sig.parameters["redact_url_usernames"].default is False
+        assert redact_sensitive_text("normal", force=True, code_file=True, file_read=False, redact_url_credentials=False) == "normal"
+
+
+class TestExtraSensitiveKeys:
+    def test_session_id_without_opt_in_is_unchanged(self):
+        text = "session_id=session-value"
+        assert redact_sensitive_text(text, force=True) == text
+
+    @pytest.mark.parametrize(
+        "text,key,secret",
+        [
+            ("session_id=session-value", "session_id", "session-value"),
+            ("session-id=session-value", "session_id", "session-value"),
+            ("SESSION_ID=session-value", "session_id", "session-value"),
+            ('"session_id": "session-value"', "session_id", "session-value"),
+            ("session_id: session-value", "session_id", "session-value"),
+            ("session_id='session-value'", "session_id", "session-value"),
+            ('session_id="session-value"', "session_id", "session-value"),
+            ("  session_id: 'session-value'", "session_id", "session-value"),
+        ],
+    )
+    def test_explicit_key_redacts_supported_textual_forms(self, text, key, secret):
+        result = redact_sensitive_text(text, force=True, extra_sensitive_keys={key})
+        assert secret not in result
+        assert "***" in result
+
+    def test_hyphen_key_opt_in_matches_underscore(self):
+        result = redact_sensitive_text(
+            "session_id=session-value",
+            force=True,
+            extra_sensitive_keys={"session-id"},
+        )
+        assert "session-value" not in result
+
+    def test_unrelated_similar_keys_remain_unchanged(self):
+        text = "session_name=session-value token_count=12345678901234567890"
+        assert redact_sensitive_text(text, force=True, extra_sensitive_keys={"session_id"}) == text
+
+    @pytest.mark.parametrize("bad", ["session_id", b"session_id"])
+    def test_top_level_string_collections_rejected(self, bad):
+        with pytest.raises(TypeError):
+            redact_sensitive_text("session_id=session-value", force=True, extra_sensitive_keys=bad)
+
+    def test_non_string_entry_rejected(self):
+        with pytest.raises(TypeError):
+            redact_sensitive_text("session_id=session-value", force=True, extra_sensitive_keys={object()})  # type: ignore[arg-type]
+
+    def test_empty_collection_does_not_change_behavior(self):
+        text = "session_id=session-value"
+        assert redact_sensitive_text(text, force=True, extra_sensitive_keys=set()) == text
+
+    def test_empty_keys_are_ignored(self):
+        text = "session_id=session-value"
+        assert redact_sensitive_text(text, force=True, extra_sensitive_keys={"", "   "}) == text
+
+    def test_does_not_persist_between_calls(self):
+        first = redact_sensitive_text("session_id=session-value", force=True, extra_sensitive_keys={"session_id"})
+        second = redact_sensitive_text("session_id=session-value", force=True)
+        assert "session-value" not in first
+        assert second == "session_id=session-value"
+
+    def test_code_file_explicit_key_still_redacts(self):
+        text = "SESSION_ID=session-value"
+        result = redact_sensitive_text(text, force=True, code_file=True, extra_sensitive_keys={"session_id"})
+        assert "session-value" not in result
+
+    def test_file_read_explicit_key_redacts_and_preserves_prefix_sentinel(self):
+        prefixed = "sk-" + "a" * 30
+        text = f"session_id=session-value\nOPENAI_API_KEY={prefixed}"
+        result = redact_sensitive_text(text, force=True, file_read=True, extra_sensitive_keys={"session_id"})
+        assert "session-value" not in result
+        assert "«redacted:sk-…»" in result
+
+
+class TestCliSensitiveSeparateValues:
+    @pytest.mark.parametrize(
+        "text,secret,expected",
+        [
+            ("cmd --password secret-value", "secret-value", "cmd --password ***"),
+            ('cmd --password "secret-value"', "secret-value", 'cmd --password "***"'),
+            ("cmd --password 'secret-value'", "secret-value", "cmd --password '***'"),
+            ("cmd --passwd secret-value", "secret-value", "cmd --passwd ***"),
+            ("cmd --secret secret-value", "secret-value", "cmd --secret ***"),
+            ("cmd --token secret-value", "secret-value", "cmd --token ***"),
+            ("cmd --api-key secret-value", "secret-value", "cmd --api-key ***"),
+            ("cmd --api_key secret-value", "secret-value", "cmd --api_key ***"),
+            ("cmd --client-secret secret-value", "secret-value", "cmd --client-secret ***"),
+            ("cmd --password   secret-value", "secret-value", "cmd --password   ***"),
+        ],
+    )
+    def test_space_separated_sensitive_flag_values(self, text, secret, expected):
+        result = redact_sensitive_text(text, force=True)
+        assert secret not in result
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "cmd --password=secret-value",
+            "cmd --token=secret-value",
+            "cmd --api-key=secret-value",
+        ],
+    )
+    def test_equals_form_still_redacts(self, text):
+        result = redact_sensitive_text(text, force=True)
+        assert "secret-value" not in result
+
+    def test_multiple_sensitive_flags_one_line(self):
+        result = redact_sensitive_text("cmd --password one --token two", force=True)
+        assert "one" not in result
+        assert "two" not in result
+        assert result == "cmd --password *** --token ***"
+
+    def test_flag_at_end_stable(self):
+        assert redact_sensitive_text("cmd --password", force=True) == "cmd --password"
+
+    def test_next_flag_not_consumed(self):
+        assert redact_sensitive_text("cmd --password --verbose", force=True) == "cmd --password --verbose"
+
+    def test_quoted_empty_not_changed(self):
+        assert redact_sensitive_text('cmd --password ""', force=True) == 'cmd --password ""'
+
+    def test_does_not_cross_newline(self):
+        text = "cmd --password\nsecret-value"
+        assert redact_sensitive_text(text, force=True) == text
+
+    def test_positional_ordinary_unchanged(self):
+        text = "cmd positional secret-value"
+        assert redact_sensitive_text(text, force=True) == text
+
+    def test_similar_prefix_flag_unchanged(self):
+        text = "cmd --password-file path"
+        assert redact_sensitive_text(text, force=True) == text
+
+
+class TestUrlUsernameOptIn:
+    def test_default_without_strict_mode_unchanged(self):
+        text = "https://user:password@example.invalid/"
+        assert redact_sensitive_text(text, force=True) == text
+
+    def test_strict_without_username_opt_in_preserves_username(self):
+        text = "https://user:password@example.invalid/"
+        result = redact_sensitive_text(text, force=True, redact_url_credentials=True)
+        assert result == "https://user:***@example.invalid/"
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("http://user:password@example.invalid/", "http://***:***@example.invalid/"),
+            ("https://user:password@example.invalid/", "https://***:***@example.invalid/"),
+            ("//user:password@example.invalid/", "//***:***@example.invalid/"),
+            ("ws://user:password@example.invalid/", "ws://***:***@example.invalid/"),
+            ("wss://user:password@example.invalid/", "wss://***:***@example.invalid/"),
+            ("https://user@example.invalid/", "https://***@example.invalid/"),
+            ("https://user%40name:p%40ss@example.invalid/", "https://***:***@example.invalid/"),
+            ("https://δοκιμή:κωδικός@example.invalid/", "https://***:***@example.invalid/"),
+            ("https://user:password@example.invalid/?token=query-secret", "https://***:***@example.invalid/?token=***"),
+        ],
+    )
+    def test_strict_with_username_opt_in_masks_userinfo(self, text, expected):
+        assert redact_sensitive_text(
+            text,
+            force=True,
+            redact_url_credentials=True,
+            redact_url_usernames=True,
+        ) == expected
+
+    def test_username_opt_in_without_strict_mode_does_not_change_url(self):
+        text = "https://user:password@example.invalid/"
+        assert redact_sensitive_text(text, force=True, redact_url_usernames=True) == text
+
+
+class TestPrivateKeyBlocks:
+    def test_private_key_block_redacted_with_sentinel(self):
+        begin = "-----BEGIN " + "PRIVATE KEY-----"
+        end = "-----END " + "PRIVATE KEY-----"
+        payload = "synthetic-private-key-payload"
+        text = f"before\n{begin}\n{payload}\n{end}\nafter"
+        result = redact_sensitive_text(text, force=True)
+        assert payload not in result
+        assert "[REDACTED PRIVATE KEY]" in result
+        assert result == "before\n[REDACTED PRIVATE KEY]\nafter"


### PR DESCRIPTION
## Summary

- add opt-in `extra_sensitive_keys` support to `redact_sensitive_text`
- redact values supplied through sensitive CLI flags such as `--password value`
- add opt-in URL username redaction while preserving existing defaults
- add explicit central coverage for private-key blocks

## Compatibility

Existing defaults remain unchanged:

- `session_id` is not globally sensitive without opt-in
- URL usernames remain visible unless `redact_url_usernames=True`
- `code_file`, `file_read`, `redact_cdp_url`, terminal redaction and formatter behavior are preserved
- home-path privacy remains contextual and is not added globally

## Validation

- `tests/agent/test_redact.py`: 223 passed
- AST parse: passed
- `git diff --check`: passed

## Scope

This prerequisite is independent of the Executive report adapter and modifies only:

- `agent/redact.py`
- `tests/agent/test_redact.py`