### PR TITLE
fix(tools): Python 3.14 compatibility for DaemonThreadPoolExecutor

### DIFF
--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -26,6 +26,7 @@ explicit bounded joins.
 
 from __future__ import annotations
 
+import sys
 import threading
 import weakref
 from concurrent.futures import ThreadPoolExecutor
@@ -38,8 +39,10 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
     """ThreadPoolExecutor variant whose workers do not block process exit."""
 
     def _adjust_thread_count(self) -> None:
-        # Mirrors CPython's implementation (3.8–3.13) with two changes:
+        # Mirrors CPython's implementation with two changes:
         # daemon=True and no _threads_queues registration.
+        # Python 3.14 removed _initializer / _initargs, replacing them
+        # with _create_worker_context() and a 3-arg _worker signature.
         if self._idle_semaphore.acquire(timeout=0):
             return
 
@@ -49,15 +52,23 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
         num_threads = len(self._threads)
         if num_threads < self._max_workers:
             thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
-            t = threading.Thread(
-                name=thread_name,
-                target=_worker,
-                args=(
+            if sys.version_info >= (3, 14):
+                worker_args = (
+                    weakref.ref(self, weakref_cb),
+                    self._create_worker_context(),
+                    self._work_queue,
+                )
+            else:
+                worker_args = (
                     weakref.ref(self, weakref_cb),
                     self._work_queue,
                     self._initializer,
                     self._initargs,
-                ),
+                )
+            t = threading.Thread(
+                name=thread_name,
+                target=_worker,
+                args=worker_args,
                 daemon=True,
             )
             t.start()


### PR DESCRIPTION
## Problem

Python 3.14 removed `_initializer` / `_initargs` from `ThreadPoolExecutor.__init__`, replacing them with `_create_worker_context()`. The `_worker` function signature also changed from 4 args to 3. `DaemonThreadPoolExecutor._adjust_thread_count()` still referenced the old API, causing:

```
AttributeError: 'DaemonThreadPoolExecutor' object has no attribute '_initializer'
```

This breaks `read_file`, `search_files`, `skill_view`, and other tools that use the thread pool for dispatch.

Fixes: #69359, #58596

## Fix

Version-guarded branch that uses `_create_worker_context()` on Python 3.14+ (3-arg `_worker`) and the existing `_initializer`/`_initargs` path on Python 3.13- (4-arg `_worker`).

## Why not the approach in #57459?

PR #57459 uses `getattr(self, '_initializer', None)` which avoids the `AttributeError` but still passes 4 args to `_worker`. On Python 3.14, `_worker` takes only 3 args — so it would fail with `TypeError: _worker() takes 3 positional arguments but 4 were given`.

## Testing

- ✅ Python 3.14.6: `DaemonThreadPoolExecutor.submit(lambda: 42).result()` returns 42
- ✅ Python 3.13.14: same test passes
- ✅ Live Hermes gateway (Python 3.14): `read_file`, `search_files`, `skill_view` all work after applying this patch