### PR TITLE
feat(gateway): add per-thread automatic reset policies

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -681,13 +681,14 @@ memory:
 # Modes:
 #   "none"  - Never auto-reset (default); context lives until /reset or compression
 #   "idle"  - Reset after N minutes of inactivity
-#   "daily" - Reset at a fixed hour each day
+#   "daily" - Reset at a fixed local time each day
 #   "both"  - Reset on EITHER inactivity timeout or daily boundary
 #
 session_reset:
   mode: none           # "none", "idle", "daily", or "both"
   idle_minutes: 1440   # Inactivity timeout in minutes (used by "idle"/"both")
   at_hour: 4           # Daily reset hour, 0-23 local time (used by "daily"/"both")
+  at_minute: 0         # Daily reset minute, 0-59 local time (used by "daily"/"both")
 
 # Maximum number of simultaneously active chat sessions across CLI, TUI,
 # dashboard chat, and messaging gateway. Set to null, 0, or omit to allow

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -856,13 +856,14 @@ memory:
 # Modes:
 #   "none"  - Never auto-reset (default); context lives until /reset or compression
 #   "idle"  - Reset after N minutes of inactivity
-#   "daily" - Reset at a fixed hour each day
+#   "daily" - Reset at a fixed local time each day
 #   "both"  - Reset on EITHER inactivity timeout or daily boundary
 #
 session_reset:
   mode: none           # "none", "idle", "daily", or "both"
   idle_minutes: 1440   # Inactivity timeout in minutes (used by "idle"/"both")
   at_hour: 4           # Daily reset hour, 0-23 local time (used by "daily"/"both")
+  at_minute: 0         # Daily reset minute, 0-59 local time (used by "daily"/"both")
 
 # Maximum number of simultaneously active chat sessions across CLI, TUI,
 # dashboard chat, and messaging gateway. Set to null, 0, or omit to allow

--- a/cli.py
+++ b/cli.py
@@ -9516,7 +9516,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             print("  " + "-" * 55)
             policy = config.default_reset_policy
             print(f"    Mode: {policy.mode}")
-            print(f"    Daily reset at: {policy.at_hour}:00")
+            print(
+                f"    Daily reset at: "
+                f"{policy.at_hour:02d}:{policy.at_minute:02d}"
+            )
             print(f"    Idle timeout: {policy.idle_minutes} minutes")
             
             print()

--- a/cli.py
+++ b/cli.py
@@ -11942,7 +11942,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             print("  " + "-" * 55)
             policy = config.default_reset_policy
             print(f"    Mode: {policy.mode}")
-            print(f"    Daily reset at: {policy.at_hour}:00")
+            print(
+                f"    Daily reset at: "
+                f"{policy.at_hour:02d}:{policy.at_minute:02d}"
+            )
             print(f"    Idle timeout: {policy.idle_minutes} minutes")
             
             print()

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -299,10 +299,10 @@ Reset policies control when a session automatically loses context (gets a new `s
 
 | Mode | Behavior | Default Config |
 |---|---|---|
-| `"none"` | Never auto-reset. Context managed only by compression. | — |
+| `"none"` | Never auto-reset. Context managed only by compression. | **(default)** |
 | `"idle"` | Reset after N minutes of inactivity from `updated_at`. | `idle_minutes: 1440` (24h) |
-| `"daily"` | Reset at a specific hour each day (local time). | `at_hour: 4` (4 AM) |
-| `"both"` | Whichever triggers first — daily boundary OR idle timeout. | **(default)** |
+| `"daily"` | Reset at a specific local time each day. | `at_hour: 4`, `at_minute: 0` (04:00) |
+| `"both"` | Whichever triggers first — daily boundary OR idle timeout. | — |
 
 ### Policy Evaluation
 
@@ -312,8 +312,10 @@ idle_deadline = entry.updated_at + timedelta(minutes=policy.idle_minutes)
 if now > idle_deadline: return "idle"
 
 # Daily check
-today_reset = now.replace(hour=policy.at_hour, minute=0, second=0, microsecond=0)
-if now.hour < policy.at_hour:
+today_reset = now.replace(
+    hour=policy.at_hour, minute=policy.at_minute, second=0, microsecond=0
+)
+if (now.hour, now.minute) < (policy.at_hour, policy.at_minute):
     today_reset -= timedelta(days=1)  # Reset hasn't happened yet today
 if entry.updated_at < today_reset: return "daily"
 ```
@@ -323,6 +325,25 @@ if entry.updated_at < today_reset: return "daily"
 Reset policies are configurable per platform and session type via `config.get_reset_policy()`.
 This allows different platforms to have different expiry rules (e.g., Telegram DMs reset
 after 24h idle, but Slack groups persist indefinitely).
+
+### Per-Thread Overrides
+
+Private and public Telegram topics, Discord threads, and Slack threads may
+persist an explicit `daily` or `none` override with `/autoreset` whenever both
+the chat ID and thread ID are stable, non-empty strings. Root DMs, parent
+channels, and other non-thread conversations are not supported. The durable
+route key is the profile namespace plus platform, chat ID, and thread ID; it
+never includes the user ID or live session ID. Resolution order is:
+
+```text
+thread override > platform policy > session-type policy > global policy
+```
+
+`/autoreset on` selects `04:00`, `/autoreset daily HH:MM` selects an exact
+server-local time, `/autoreset off` disables automatic reset for the thread,
+and `/autoreset inherit` deletes the override. Slack uses `!autoreset` because
+native slash commands cannot be typed inside Slack threads. Overrides are
+stored atomically in `thread_reset_policies.json` and survive session resets.
 
 ### Exclusions
 
@@ -672,6 +693,7 @@ When a session expires:
 session_reset:
   mode: none            # none (default) | idle | daily | both
   at_hour: 4            # daily reset hour (local time)
+  at_minute: 0          # daily reset minute (local time)
   idle_minutes: 1440    # idle timeout (24h)
   notify: true          # notify user on auto-reset
 ```

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -299,10 +299,10 @@ Reset policies control when a session automatically loses context (gets a new `s
 
 | Mode | Behavior | Default Config |
 |---|---|---|
-| `"none"` | Never auto-reset. Context managed only by compression. | — |
+| `"none"` | Never auto-reset. Context managed only by compression. | **(default)** |
 | `"idle"` | Reset after N minutes of inactivity from `updated_at`. | `idle_minutes: 1440` (24h) |
-| `"daily"` | Reset at a specific hour each day (local time). | `at_hour: 4` (4 AM) |
-| `"both"` | Whichever triggers first — daily boundary OR idle timeout. | **(default)** |
+| `"daily"` | Reset at a specific local time each day. | `at_hour: 4`, `at_minute: 0` (04:00) |
+| `"both"` | Whichever triggers first — daily boundary OR idle timeout. | — |
 
 ### Policy Evaluation
 
@@ -312,8 +312,10 @@ idle_deadline = entry.updated_at + timedelta(minutes=policy.idle_minutes)
 if now > idle_deadline: return "idle"
 
 # Daily check
-today_reset = now.replace(hour=policy.at_hour, minute=0, second=0, microsecond=0)
-if now.hour < policy.at_hour:
+today_reset = now.replace(
+    hour=policy.at_hour, minute=policy.at_minute, second=0, microsecond=0
+)
+if (now.hour, now.minute) < (policy.at_hour, policy.at_minute):
     today_reset -= timedelta(days=1)  # Reset hasn't happened yet today
 if entry.updated_at < today_reset: return "daily"
 ```
@@ -323,6 +325,25 @@ if entry.updated_at < today_reset: return "daily"
 Reset policies are configurable per platform and session type via `config.get_reset_policy()`.
 This allows different platforms to have different expiry rules (e.g., Telegram DMs reset
 after 24h idle, but Slack groups persist indefinitely).
+
+### Per-Thread Overrides
+
+Private and public Telegram topics, Discord threads, and Slack threads may
+persist an explicit `daily` or `none` override with `/autoreset` whenever both
+the chat ID and thread ID are stable, non-empty strings. Root DMs, parent
+channels, and other non-thread conversations are not supported. The durable
+route key is the profile namespace plus platform, chat ID, and thread ID; it
+never includes the user ID or live session ID. Resolution order is:
+
+```text
+thread override > platform policy > session-type policy > global policy
+```
+
+`/autoreset on` selects `04:00`, `/autoreset daily HH:MM` selects an exact
+server-local time, `/autoreset off` disables automatic reset for the thread,
+and `/autoreset inherit` deletes the override. Slack uses `!autoreset` because
+native slash commands cannot be typed inside Slack threads. Overrides are
+stored atomically in `thread_reset_policies.json` and survive session resets.
 
 ### Exclusions
 
@@ -630,6 +651,7 @@ When a session expires:
 session_reset:
   mode: none            # none (default) | idle | daily | both
   at_hour: 4            # daily reset hour (local time)
+  at_minute: 0          # daily reset minute (local time)
   idle_minutes: 1440    # idle timeout (24h)
   notify: true          # notify user on auto-reset
 ```

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -488,7 +488,7 @@ class SessionResetPolicy:
     Controls when sessions reset (lose context).
     
     Modes:
-    - "daily": Reset at a specific hour each day
+    - "daily": Reset at a specific local hour and minute each day
     - "idle": Reset after N minutes of inactivity
     - "both": Whichever triggers first (daily boundary OR idle timeout)
     - "none": Never auto-reset (context managed only by compression)
@@ -509,11 +509,15 @@ class SessionResetPolicy:
     # by the reset guard. Raise this if you run legitimate multi-day jobs whose
     # liveness should pin the conversation open.
     bg_process_max_age_hours: int = 24
+    # Kept last to preserve the positional constructor contract for existing
+    # callers while extending daily schedules to minute precision.
+    at_minute: int = 0  # Minute for daily reset (0-59, local time)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
             "mode": self.mode,
             "at_hour": self.at_hour,
+            "at_minute": self.at_minute,
             "idle_minutes": self.idle_minutes,
             "notify": self.notify,
             "notify_exclude_platforms": list(self.notify_exclude_platforms),
@@ -526,6 +530,7 @@ class SessionResetPolicy:
         # Handle both missing keys and explicit null values (YAML null → None)
         mode = data.get("mode")
         at_hour = data.get("at_hour")
+        at_minute = data.get("at_minute")
         idle_minutes = data.get("idle_minutes")
         notify = data.get("notify")
         exclude = data.get("notify_exclude_platforms")
@@ -533,6 +538,7 @@ class SessionResetPolicy:
         return cls(
             mode=mode if mode is not None else "none",
             at_hour=at_hour if at_hour is not None else 4,
+            at_minute=at_minute if at_minute is not None else 0,
             idle_minutes=idle_minutes if idle_minutes is not None else 1440,
             notify=_coerce_bool(notify, True),
             notify_exclude_platforms=tuple(exclude) if exclude is not None else ("api_server", "webhook"),
@@ -1756,20 +1762,44 @@ def _validate_gateway_config(config: "GatewayConfig") -> None:
     Called by ``load_gateway_config()`` after all config sources are merged.
     Extracted as a separate function for testability.
     """
-    policy = config.default_reset_policy
+    policies = [
+        config.default_reset_policy,
+        *config.reset_by_type.values(),
+        *config.reset_by_platform.values(),
+    ]
+    for policy in policies:
+        if (
+            isinstance(policy.at_hour, bool)
+            or not isinstance(policy.at_hour, int)
+            or not 0 <= policy.at_hour <= 23
+        ):
+            logger.warning(
+                "Invalid at_hour=%s (must be 0-23). Using default 4.",
+                policy.at_hour,
+            )
+            policy.at_hour = 4
 
-    if not (0 <= policy.at_hour <= 23):
-        logger.warning(
-            "Invalid at_hour=%s (must be 0-23). Using default 4.", policy.at_hour
-        )
-        policy.at_hour = 4
+        if (
+            isinstance(policy.at_minute, bool)
+            or not isinstance(policy.at_minute, int)
+            or not 0 <= policy.at_minute <= 59
+        ):
+            logger.warning(
+                "Invalid at_minute=%s (must be 0-59). Using default 0.",
+                policy.at_minute,
+            )
+            policy.at_minute = 0
 
-    if policy.idle_minutes is None or policy.idle_minutes <= 0:
-        logger.warning(
-            "Invalid idle_minutes=%s (must be positive). Using default 1440.",
-            policy.idle_minutes,
-        )
-        policy.idle_minutes = 1440
+        if (
+            isinstance(policy.idle_minutes, bool)
+            or not isinstance(policy.idle_minutes, int)
+            or policy.idle_minutes <= 0
+        ):
+            logger.warning(
+                "Invalid idle_minutes=%s (must be positive). Using default 1440.",
+                policy.idle_minutes,
+            )
+            policy.idle_minutes = 1440
 
     # Warn about empty bot tokens — platforms that loaded an empty string
     # won't connect and the cause can be confusing without a log line.

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -541,7 +541,7 @@ class SessionResetPolicy:
     Controls when sessions reset (lose context).
     
     Modes:
-    - "daily": Reset at a specific hour each day
+    - "daily": Reset at a specific local hour and minute each day
     - "idle": Reset after N minutes of inactivity
     - "both": Whichever triggers first (daily boundary OR idle timeout)
     - "none": Never auto-reset (context managed only by compression)
@@ -562,11 +562,15 @@ class SessionResetPolicy:
     # by the reset guard. Raise this if you run legitimate multi-day jobs whose
     # liveness should pin the conversation open.
     bg_process_max_age_hours: int = 24
+    # Kept last to preserve the positional constructor contract for existing
+    # callers while extending daily schedules to minute precision.
+    at_minute: int = 0  # Minute for daily reset (0-59, local time)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
             "mode": self.mode,
             "at_hour": self.at_hour,
+            "at_minute": self.at_minute,
             "idle_minutes": self.idle_minutes,
             "notify": self.notify,
             "notify_exclude_platforms": list(self.notify_exclude_platforms),
@@ -579,6 +583,7 @@ class SessionResetPolicy:
         # Handle both missing keys and explicit null values (YAML null → None)
         mode = data.get("mode")
         at_hour = data.get("at_hour")
+        at_minute = data.get("at_minute")
         idle_minutes = data.get("idle_minutes")
         notify = data.get("notify")
         exclude = data.get("notify_exclude_platforms")
@@ -586,6 +591,7 @@ class SessionResetPolicy:
         return cls(
             mode=mode if mode is not None else "none",
             at_hour=at_hour if at_hour is not None else 4,
+            at_minute=at_minute if at_minute is not None else 0,
             idle_minutes=idle_minutes if idle_minutes is not None else 1440,
             notify=_coerce_bool(notify, True),
             notify_exclude_platforms=tuple(exclude) if exclude is not None else ("api_server", "webhook"),
@@ -1909,20 +1915,44 @@ def _validate_gateway_config(config: "GatewayConfig") -> None:
     Called by ``load_gateway_config()`` after all config sources are merged.
     Extracted as a separate function for testability.
     """
-    policy = config.default_reset_policy
+    policies = [
+        config.default_reset_policy,
+        *config.reset_by_type.values(),
+        *config.reset_by_platform.values(),
+    ]
+    for policy in policies:
+        if (
+            isinstance(policy.at_hour, bool)
+            or not isinstance(policy.at_hour, int)
+            or not 0 <= policy.at_hour <= 23
+        ):
+            logger.warning(
+                "Invalid at_hour=%s (must be 0-23). Using default 4.",
+                policy.at_hour,
+            )
+            policy.at_hour = 4
 
-    if not (0 <= policy.at_hour <= 23):
-        logger.warning(
-            "Invalid at_hour=%s (must be 0-23). Using default 4.", policy.at_hour
-        )
-        policy.at_hour = 4
+        if (
+            isinstance(policy.at_minute, bool)
+            or not isinstance(policy.at_minute, int)
+            or not 0 <= policy.at_minute <= 59
+        ):
+            logger.warning(
+                "Invalid at_minute=%s (must be 0-59). Using default 0.",
+                policy.at_minute,
+            )
+            policy.at_minute = 0
 
-    if policy.idle_minutes is None or policy.idle_minutes <= 0:
-        logger.warning(
-            "Invalid idle_minutes=%s (must be positive). Using default 1440.",
-            policy.idle_minutes,
-        )
-        policy.idle_minutes = 1440
+        if (
+            isinstance(policy.idle_minutes, bool)
+            or not isinstance(policy.idle_minutes, int)
+            or policy.idle_minutes <= 0
+        ):
+            logger.warning(
+                "Invalid idle_minutes=%s (must be positive). Using default 1440.",
+                policy.idle_minutes,
+            )
+            policy.idle_minutes = 1440
 
     # Warn about empty bot tokens — platforms that loaded an empty string
     # won't connect and the cause can be confusing without a log line.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14274,6 +14274,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "topic":
             return await self._handle_topic_command(event)
+
+        if canonical == "autoreset":
+            return await self._handle_autoreset_command(event)
         
         if canonical == "help":
             return await self._handle_help_command(event)
@@ -15668,10 +15671,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # - the platform is excluded (e.g. api_server, webhook)
             # - the expired session had no activity (nothing was cleared)
             try:
-                policy = self.session_store.config.get_reset_policy(
-                    platform=source.platform,
-                    session_type=getattr(source, 'chat_type', 'dm'),
+                _get_effective_policy = getattr(
+                    self.session_store,
+                    "get_effective_reset_policy",
+                    None,
                 )
+                _resolved_policy = (
+                    _get_effective_policy(source=source)
+                    if callable(_get_effective_policy)
+                    else None
+                )
+                if (
+                    isinstance(_resolved_policy, tuple)
+                    and len(_resolved_policy) == 2
+                ):
+                    policy = _resolved_policy[0]
+                else:
+                    # Compatibility for lightweight/custom session-store
+                    # fixtures that predate route-aware reset policies.
+                    policy = self.session_store.config.get_reset_policy(
+                        platform=source.platform,
+                        session_type=getattr(source, "chat_type", "dm"),
+                    )
                 platform_name = source.platform.value if source.platform else ""
                 had_activity = getattr(session_entry, 'reset_had_activity', False)
                 # Suspended and restart-recovery-expired sessions always notify
@@ -15691,7 +15712,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         elif reset_reason == "resume_pending_expired":
                             reason_text = "gateway restart recovery timed out"
                         elif reset_reason == "daily":
-                            reason_text = f"daily schedule at {policy.at_hour}:00"
+                            reason_text = (
+                                f"daily schedule at "
+                                f"{policy.at_hour:02d}:{policy.at_minute:02d}"
+                            )
                         else:
                             hours = policy.idle_minutes // 60
                             mins = policy.idle_minutes % 60

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17603,6 +17603,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "topic":
             return await self._handle_topic_command(event)
+
+        if canonical == "autoreset":
+            return await self._handle_autoreset_command(event)
         
         if canonical == "help":
             return await self._handle_help_command(event)
@@ -19279,10 +19282,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # - the platform is excluded (e.g. api_server, webhook)
             # - the expired session had no activity (nothing was cleared)
             try:
-                policy = self.session_store.config.get_reset_policy(
-                    platform=source.platform,
-                    session_type=getattr(source, 'chat_type', 'dm'),
+                _get_effective_policy = getattr(
+                    self.session_store,
+                    "get_effective_reset_policy",
+                    None,
                 )
+                _resolved_policy = (
+                    _get_effective_policy(source=source)
+                    if callable(_get_effective_policy)
+                    else None
+                )
+                if (
+                    isinstance(_resolved_policy, tuple)
+                    and len(_resolved_policy) == 2
+                ):
+                    policy = _resolved_policy[0]
+                else:
+                    # Compatibility for lightweight/custom session-store
+                    # fixtures that predate route-aware reset policies.
+                    policy = self.session_store.config.get_reset_policy(
+                        platform=source.platform,
+                        session_type=getattr(source, "chat_type", "dm"),
+                    )
                 platform_name = source.platform.value if source.platform else ""
                 had_activity = getattr(session_entry, 'reset_had_activity', False)
                 # Suspended and restart-recovery-expired sessions always notify
@@ -19302,7 +19323,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         elif reset_reason == "resume_pending_expired":
                             reason_text = "gateway restart recovery timed out"
                         elif reset_reason == "daily":
-                            reason_text = f"daily schedule at {policy.at_hour}:00"
+                            reason_text = (
+                                f"daily schedule at "
+                                f"{policy.at_hour:02d}:{policy.at_minute:02d}"
+                            )
                         else:
                             hours = policy.idle_minutes // 60
                             mins = policy.idle_minutes % 60

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -90,6 +90,10 @@ from .config import (
     SessionResetPolicy,  # noqa: F401 — re-exported via gateway/__init__.py
     HomeChannel,
 )
+from .thread_reset_policy import (
+    ThreadResetPolicyStore,
+    ThreadResetResolution,
+)
 from .whatsapp_identity import (
     canonical_whatsapp_identifier,
     normalize_whatsapp_identifier,  # noqa: F401 - re-exported for gateway.session callers
@@ -1195,6 +1199,9 @@ class SessionStore:
         self._transcript_append_failures: Dict[str, int] = {}
         self._fts_rebuild_attempted = False
         self._has_active_processes_fn = has_active_processes_fn
+        self._thread_reset_policies = ThreadResetPolicyStore(
+            Path(self.sessions_dir) / "thread_reset_policies.json"
+        )
         # Whether to keep writing the legacy sessions.json mirror alongside
         # the primary gateway_routing table in state.db. Default True for
         # backward compatibility; disable via gateway.write_sessions_json.
@@ -1573,6 +1580,75 @@ class SessionStore:
             profile=self._resolve_profile_for_key(source),
         )
 
+    @staticmethod
+    def _is_supported_thread(source: Optional[SessionSource]) -> bool:
+        return bool(
+            source is not None
+            and source.platform in {
+                Platform.TELEGRAM,
+                Platform.DISCORD,
+                Platform.SLACK,
+            }
+            and isinstance(source.chat_id, str)
+            and source.chat_id.strip()
+            and isinstance(source.thread_id, str)
+            and source.thread_id.strip()
+        )
+
+    def _thread_reset_route_key(self, source: SessionSource) -> str:
+        """Build a durable, user- and session-free identity for one thread."""
+        route_source = SessionSource(
+            platform=source.platform,
+            chat_id=str(source.chat_id),
+            chat_type="thread",
+            thread_id=str(source.thread_id),
+        )
+        return build_session_key(
+            route_source,
+            group_sessions_per_user=False,
+            thread_sessions_per_user=False,
+            profile=self._resolve_profile_for_key(source),
+        )
+
+    def get_effective_reset_policy(
+        self,
+        *,
+        source: Optional[SessionSource] = None,
+        entry: Optional[SessionEntry] = None,
+    ) -> tuple[SessionResetPolicy, ThreadResetResolution]:
+        """Resolve thread override > platform > type > global reset policy."""
+        if source is None and entry is not None:
+            source = entry.origin
+        platform = source.platform if source is not None else (
+            entry.platform if entry is not None else None
+        )
+        session_type = source.chat_type if source is not None else (
+            entry.chat_type if entry is not None else None
+        )
+        inherited = self.config.get_reset_policy(
+            platform=platform,
+            session_type=session_type,
+        )
+        if not self._is_supported_thread(source):
+            return inherited, "inherited"
+        assert source is not None
+        route_key = self._thread_reset_route_key(source)
+        return self._thread_reset_policies.resolve(route_key, inherited)
+
+    def set_thread_reset_policy(
+        self,
+        source: SessionSource,
+        policy: Optional[SessionResetPolicy],
+    ) -> None:
+        """Set an explicit policy or delete (``None``) a thread override."""
+        if not self._is_supported_thread(source):
+            raise ValueError("source is not a supported thread")
+        route_key = self._thread_reset_route_key(source)
+        if policy is None:
+            self._thread_reset_policies.delete(route_key)
+        else:
+            self._thread_reset_policies.set(route_key, policy)
+
     def _legacy_slack_session_key(self, source: SessionSource) -> Optional[str]:
         """Return the pre-workspace Slack key for an explicitly scoped source.
 
@@ -1933,10 +2009,7 @@ class SessionStore:
             )
             return False
 
-        policy = self.config.get_reset_policy(
-            platform=entry.platform,
-            session_type=entry.chat_type,
-        )
+        policy, _resolution = self.get_effective_reset_policy(entry=entry)
 
         if policy.mode == "none":
             return False
@@ -1951,9 +2024,9 @@ class SessionStore:
         if policy.mode in {"daily", "both"}:
             today_reset = now.replace(
                 hour=policy.at_hour,
-                minute=0, second=0, microsecond=0,
+                minute=policy.at_minute, second=0, microsecond=0,
             )
-            if now.hour < policy.at_hour:
+            if (now.hour, now.minute) < (policy.at_hour, policy.at_minute):
                 today_reset -= timedelta(days=1)
             if entry.updated_at < today_reset:
                 return True
@@ -1983,10 +2056,7 @@ class SessionStore:
         sweep falls back to reaping the agent rather than pinning it).
         """
         try:
-            policy = self.config.get_reset_policy(
-                platform=entry.platform,
-                session_type=entry.chat_type,
-            )
+            policy, _resolution = self.get_effective_reset_policy(entry=entry)
             return policy.mode != "none"
         except Exception:
             return False
@@ -2034,10 +2104,7 @@ class SessionStore:
             )
             return None
 
-        policy = self.config.get_reset_policy(
-            platform=source.platform,
-            session_type=source.chat_type
-        )
+        policy, _resolution = self.get_effective_reset_policy(source=source)
         
         if policy.mode == "none":
             return None
@@ -2052,11 +2119,11 @@ class SessionStore:
         if policy.mode in {"daily", "both"}:
             today_reset = now.replace(
                 hour=policy.at_hour, 
-                minute=0, 
+                minute=policy.at_minute,
                 second=0, 
                 microsecond=0
             )
-            if now.hour < policy.at_hour:
+            if (now.hour, now.minute) < (policy.at_hour, policy.at_minute):
                 today_reset -= timedelta(days=1)
             
             if entry.updated_at < today_reset:
@@ -2281,9 +2348,8 @@ class SessionStore:
                     # resume marker must fall through to a normal resume of
                     # the preserved transcript, never a silent fresh session
                     # (#61052).
-                    _policy = self.config.get_reset_policy(
-                        platform=source.platform,
-                        session_type=source.chat_type,
+                    _policy, _resolution = self.get_effective_reset_policy(
+                        source=source
                     )
                     if _policy.mode != "none":
                         _fw = auto_continue_freshness_window()

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -9,6 +9,7 @@ Handles:
 """
 
 import asyncio
+import base64
 import hashlib
 import logging
 import os
@@ -89,6 +90,10 @@ from .config import (
     GatewayConfig,
     SessionResetPolicy,  # noqa: F401 — re-exported via gateway/__init__.py
     HomeChannel,
+)
+from .thread_reset_policy import (
+    ThreadResetPolicyStore,
+    ThreadResetResolution,
 )
 from .whatsapp_identity import (
     canonical_whatsapp_identifier,
@@ -1289,6 +1294,9 @@ class SessionStore:
         self._transcript_append_failures: Dict[str, int] = {}
         self._fts_rebuild_attempted = False
         self._has_active_processes_fn = has_active_processes_fn
+        self._thread_reset_policies = ThreadResetPolicyStore(
+            Path(self.sessions_dir) / "thread_reset_policies.json"
+        )
         # Whether to keep writing the legacy sessions.json mirror alongside
         # the primary gateway_routing table in state.db. Default True for
         # backward compatibility; disable via gateway.write_sessions_json.
@@ -1998,6 +2006,82 @@ class SessionStore:
             profile=self._resolve_profile_for_key(source),
         )
 
+    @staticmethod
+    def _is_supported_thread(source: Optional[SessionSource]) -> bool:
+        return bool(
+            source is not None
+            and source.platform in {
+                Platform.TELEGRAM,
+                Platform.DISCORD,
+                Platform.SLACK,
+            }
+            and isinstance(source.chat_id, str)
+            and source.chat_id.strip()
+            and isinstance(source.thread_id, str)
+            and source.thread_id.strip()
+        )
+
+    def _thread_reset_route_key(self, source: SessionSource) -> str:
+        """Build a durable, user- and session-free identity for one thread."""
+        route_source = SessionSource(
+            platform=source.platform,
+            chat_id=str(source.chat_id),
+            chat_type="thread",
+            thread_id=str(source.thread_id),
+            scope_id=source.scope_id,
+        )
+        route_key = build_session_key(
+            route_source,
+            group_sessions_per_user=False,
+            thread_sessions_per_user=False,
+            profile=self._resolve_profile_for_key(source),
+        )
+        if source.scope_id and source.platform != Platform.SLACK:
+            encoded_scope = base64.urlsafe_b64encode(
+                str(source.scope_id).encode("utf-8")
+            ).decode("ascii")
+            return f"{route_key}:scope:{encoded_scope}"
+        return route_key
+
+    def get_effective_reset_policy(
+        self,
+        *,
+        source: Optional[SessionSource] = None,
+        entry: Optional[SessionEntry] = None,
+    ) -> tuple[SessionResetPolicy, ThreadResetResolution]:
+        """Resolve thread override > platform > type > global reset policy."""
+        if source is None and entry is not None:
+            source = entry.origin
+        platform = source.platform if source is not None else (
+            entry.platform if entry is not None else None
+        )
+        session_type = source.chat_type if source is not None else (
+            entry.chat_type if entry is not None else None
+        )
+        inherited = self.config.get_reset_policy(
+            platform=platform,
+            session_type=session_type,
+        )
+        if not self._is_supported_thread(source):
+            return inherited, "inherited"
+        assert source is not None
+        route_key = self._thread_reset_route_key(source)
+        return self._thread_reset_policies.resolve(route_key, inherited)
+
+    def set_thread_reset_policy(
+        self,
+        source: SessionSource,
+        policy: Optional[SessionResetPolicy],
+    ) -> None:
+        """Set an explicit policy or delete (``None``) a thread override."""
+        if not self._is_supported_thread(source):
+            raise ValueError("source is not a supported thread")
+        route_key = self._thread_reset_route_key(source)
+        if policy is None:
+            self._thread_reset_policies.delete(route_key)
+        else:
+            self._thread_reset_policies.set(route_key, policy)
+
     def _legacy_slack_session_key(self, source: SessionSource) -> Optional[str]:
         """Return the pre-workspace Slack key for an explicitly scoped source.
 
@@ -2400,10 +2484,7 @@ class SessionStore:
             )
             return False
 
-        policy = self.config.get_reset_policy(
-            platform=entry.platform,
-            session_type=entry.chat_type,
-        )
+        policy, _resolution = self.get_effective_reset_policy(entry=entry)
 
         if policy.mode == "none":
             return False
@@ -2418,9 +2499,9 @@ class SessionStore:
         if policy.mode in {"daily", "both"}:
             today_reset = now.replace(
                 hour=policy.at_hour,
-                minute=0, second=0, microsecond=0,
+                minute=policy.at_minute, second=0, microsecond=0,
             )
-            if now.hour < policy.at_hour:
+            if (now.hour, now.minute) < (policy.at_hour, policy.at_minute):
                 today_reset -= timedelta(days=1)
             if entry.updated_at < today_reset:
                 return True
@@ -2450,10 +2531,7 @@ class SessionStore:
         sweep falls back to reaping the agent rather than pinning it).
         """
         try:
-            policy = self.config.get_reset_policy(
-                platform=entry.platform,
-                session_type=entry.chat_type,
-            )
+            policy, _resolution = self.get_effective_reset_policy(entry=entry)
             return policy.mode != "none"
         except Exception:
             return False
@@ -2501,10 +2579,7 @@ class SessionStore:
             )
             return None
 
-        policy = self.config.get_reset_policy(
-            platform=source.platform,
-            session_type=source.chat_type
-        )
+        policy, _resolution = self.get_effective_reset_policy(source=source)
         
         if policy.mode == "none":
             return None
@@ -2519,11 +2594,11 @@ class SessionStore:
         if policy.mode in {"daily", "both"}:
             today_reset = now.replace(
                 hour=policy.at_hour, 
-                minute=0, 
+                minute=policy.at_minute,
                 second=0, 
                 microsecond=0
             )
-            if now.hour < policy.at_hour:
+            if (now.hour, now.minute) < (policy.at_hour, policy.at_minute):
                 today_reset -= timedelta(days=1)
             
             if entry.updated_at < today_reset:
@@ -2758,9 +2833,8 @@ class SessionStore:
                     # resume marker must fall through to a normal resume of
                     # the preserved transcript, never a silent fresh session
                     # (#61052).
-                    _policy = self.config.get_reset_policy(
-                        platform=source.platform,
-                        session_type=source.chat_type,
+                    _policy, _resolution = self.get_effective_reset_policy(
+                        source=source
                     )
                     if _policy.mode != "none":
                         _fw = auto_continue_freshness_window()

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -32,7 +32,13 @@ from typing import Any, Optional, Union
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.i18n import t
 from agent.turn_context import extract_api_content_sidecar
-from gateway.config import HomeChannel, Platform, PlatformConfig, persist_home_channel
+from gateway.config import (
+    HomeChannel,
+    Platform,
+    PlatformConfig,
+    SessionResetPolicy,
+    persist_home_channel,
+)
 from gateway.platforms.base import EphemeralReply, MessageEvent, MessageType
 from gateway.session import (
     AsyncSessionStore,
@@ -40,6 +46,7 @@ from gateway.session import (
     build_session_key,
     is_shared_multi_user_session,
 )
+from gateway.thread_reset_policy import ThreadResetPolicyStateError
 from hermes_cli.config import atomic_config_write, cfg_get, clear_model_endpoint_credentials
 from utils import (
     atomic_json_write,
@@ -4225,6 +4232,104 @@ class GatewaySlashCommandsMixin:
             return t("gateway.topic.thread_ready")
 
         return await self._telegram_topic_root_status_message(source)
+
+    @staticmethod
+    def _format_autoreset_policy(policy) -> str:
+        if policy.mode == "none":
+            return t("gateway.autoreset.policy_off")
+        if policy.mode == "daily":
+            return t(
+                "gateway.autoreset.policy_daily",
+                hour=f"{policy.at_hour:02d}",
+                minute=f"{policy.at_minute:02d}",
+            )
+        if policy.mode == "idle":
+            return t(
+                "gateway.autoreset.policy_idle",
+                minutes=policy.idle_minutes,
+            )
+        if policy.mode == "both":
+            return t(
+                "gateway.autoreset.policy_both",
+                hour=f"{policy.at_hour:02d}",
+                minute=f"{policy.at_minute:02d}",
+                minutes=policy.idle_minutes,
+            )
+        return t("gateway.autoreset.policy_unknown", mode=policy.mode)
+
+    async def _handle_autoreset_command(self, event: MessageEvent) -> str:
+        """Manage the durable automatic-reset override for a supported thread."""
+        source = event.source
+        prefix = self._typed_command_prefix_for(source.platform)
+        if source.platform not in {
+            Platform.TELEGRAM,
+            Platform.DISCORD,
+            Platform.SLACK,
+        }:
+            return t("gateway.autoreset.unsupported_platform", prefix=prefix)
+        if not await self.async_session_store._is_supported_thread(source):
+            return t("gateway.autoreset.thread_only", prefix=prefix)
+
+        action = event.get_command_args().strip().lower() or "status"
+        policy = None
+        if action == "on":
+            policy = SessionResetPolicy(mode="daily", at_hour=4, at_minute=0)
+        elif action == "off":
+            policy = SessionResetPolicy(mode="none")
+        elif action.startswith("daily"):
+            match = re.fullmatch(r"daily ([01]\d|2[0-3]):([0-5]\d)", action)
+            if match is None:
+                return t("gateway.autoreset.usage", prefix=prefix)
+            policy = SessionResetPolicy(
+                mode="daily",
+                at_hour=int(match.group(1)),
+                at_minute=int(match.group(2)),
+            )
+        elif action not in {"status", "inherit"}:
+            return t("gateway.autoreset.usage", prefix=prefix)
+
+        if action != "status":
+            try:
+                await self.async_session_store.set_thread_reset_policy(
+                    source,
+                    None if action == "inherit" else policy,
+                )
+            except ThreadResetPolicyStateError as exc:
+                logger.warning(
+                    "Thread auto-reset state is not writable: %s",
+                    exc,
+                )
+                return t("gateway.autoreset.invalid_state")
+            except Exception as exc:
+                logger.warning(
+                    "Failed to save thread auto-reset policy: %s",
+                    exc,
+                )
+                return t("gateway.autoreset.save_failed")
+
+        try:
+            policy, resolution = await self.async_session_store.get_effective_reset_policy(
+                source=source,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to resolve thread auto-reset policy: %s",
+                exc,
+            )
+            return t("gateway.autoreset.read_failed")
+
+        if resolution == "invalid":
+            return t("gateway.autoreset.invalid_status")
+        scope = (
+            t("gateway.autoreset.scope_override")
+            if resolution == "override"
+            else t("gateway.autoreset.scope_inherited")
+        )
+        return t(
+            "gateway.autoreset.status",
+            policy=self._format_autoreset_policy(policy),
+            scope=scope,
+        )
 
     async def _handle_title_command(self, event: MessageEvent) -> str:
         """Handle /title command — set or show the current session's title."""

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -32,7 +32,13 @@ from typing import Any, Optional, Union
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.i18n import t
 from agent.turn_context import extract_api_content_sidecar
-from gateway.config import HomeChannel, Platform, PlatformConfig, persist_home_channel
+from gateway.config import (
+    HomeChannel,
+    Platform,
+    PlatformConfig,
+    SessionResetPolicy,
+    persist_home_channel,
+)
 from gateway.platforms.base import EphemeralReply, MessageEvent, MessageType
 from gateway.session import (
     AsyncSessionStore,
@@ -40,6 +46,7 @@ from gateway.session import (
     build_session_key,
     is_shared_multi_user_session,
 )
+from gateway.thread_reset_policy import ThreadResetPolicyStateError
 from hermes_cli.config import atomic_config_write, cfg_get, clear_model_endpoint_credentials
 from utils import (
     atomic_json_write,
@@ -4789,6 +4796,104 @@ class GatewaySlashCommandsMixin:
                 os.rmdir(temp_dir)
             except Exception:
                 pass
+
+    @staticmethod
+    def _format_autoreset_policy(policy) -> str:
+        if policy.mode == "none":
+            return t("gateway.autoreset.policy_off")
+        if policy.mode == "daily":
+            return t(
+                "gateway.autoreset.policy_daily",
+                hour=f"{policy.at_hour:02d}",
+                minute=f"{policy.at_minute:02d}",
+            )
+        if policy.mode == "idle":
+            return t(
+                "gateway.autoreset.policy_idle",
+                minutes=policy.idle_minutes,
+            )
+        if policy.mode == "both":
+            return t(
+                "gateway.autoreset.policy_both",
+                hour=f"{policy.at_hour:02d}",
+                minute=f"{policy.at_minute:02d}",
+                minutes=policy.idle_minutes,
+            )
+        return t("gateway.autoreset.policy_unknown", mode=policy.mode)
+
+    async def _handle_autoreset_command(self, event: MessageEvent) -> str:
+        """Manage the durable automatic-reset override for a supported thread."""
+        source = event.source
+        prefix = self._typed_command_prefix_for(source.platform)
+        if source.platform not in {
+            Platform.TELEGRAM,
+            Platform.DISCORD,
+            Platform.SLACK,
+        }:
+            return t("gateway.autoreset.unsupported_platform", prefix=prefix)
+        if not await self.async_session_store._is_supported_thread(source):
+            return t("gateway.autoreset.thread_only", prefix=prefix)
+
+        action = event.get_command_args().strip().lower() or "status"
+        policy = None
+        if action == "on":
+            policy = SessionResetPolicy(mode="daily", at_hour=4, at_minute=0)
+        elif action == "off":
+            policy = SessionResetPolicy(mode="none")
+        elif action.startswith("daily"):
+            match = re.fullmatch(r"daily ([01]\d|2[0-3]):([0-5]\d)", action)
+            if match is None:
+                return t("gateway.autoreset.usage", prefix=prefix)
+            policy = SessionResetPolicy(
+                mode="daily",
+                at_hour=int(match.group(1)),
+                at_minute=int(match.group(2)),
+            )
+        elif action not in {"status", "inherit"}:
+            return t("gateway.autoreset.usage", prefix=prefix)
+
+        if action != "status":
+            try:
+                await self.async_session_store.set_thread_reset_policy(
+                    source,
+                    None if action == "inherit" else policy,
+                )
+            except ThreadResetPolicyStateError as exc:
+                logger.warning(
+                    "Thread auto-reset state is not writable: %s",
+                    exc,
+                )
+                return t("gateway.autoreset.invalid_state")
+            except Exception as exc:
+                logger.warning(
+                    "Failed to save thread auto-reset policy: %s",
+                    exc,
+                )
+                return t("gateway.autoreset.save_failed")
+
+        try:
+            policy, resolution = await self.async_session_store.get_effective_reset_policy(
+                source=source,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to resolve thread auto-reset policy: %s",
+                exc,
+            )
+            return t("gateway.autoreset.read_failed")
+
+        if resolution == "invalid":
+            return t("gateway.autoreset.invalid_status")
+        scope = (
+            t("gateway.autoreset.scope_override")
+            if resolution == "override"
+            else t("gateway.autoreset.scope_inherited")
+        )
+        return t(
+            "gateway.autoreset.status",
+            policy=self._format_autoreset_policy(policy),
+            scope=scope,
+        )
 
     async def _handle_title_command(self, event: MessageEvent) -> str:
         """Handle /title command — set or show the current session's title."""

--- a/gateway/thread_reset_policy.py
+++ b/gateway/thread_reset_policy.py
@@ -1,0 +1,197 @@
+"""Durable per-route automatic reset policies for supported threads."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+import threading
+from pathlib import Path
+from typing import Literal
+
+from gateway.config import SessionResetPolicy
+from utils import atomic_json_write
+
+logger = logging.getLogger(__name__)
+
+ThreadResetResolution = Literal["override", "inherited", "invalid"]
+
+_STATE_VERSION = 1
+
+
+class ThreadResetPolicyStateError(RuntimeError):
+    """Raised when a command cannot safely mutate thread reset state."""
+
+
+def _policy_to_state(policy: SessionResetPolicy) -> dict[str, object]:
+    """Return the strict persisted representation of a route policy."""
+    if policy.mode == "none":
+        return {"mode": "none"}
+    if policy.mode != "daily":
+        raise ValueError("thread reset policy mode must be 'daily' or 'none'")
+    if (
+        isinstance(policy.at_hour, bool)
+        or not isinstance(policy.at_hour, int)
+        or not 0 <= policy.at_hour <= 23
+    ):
+        raise ValueError("thread reset policy at_hour must be an integer from 0 to 23")
+    if (
+        isinstance(policy.at_minute, bool)
+        or not isinstance(policy.at_minute, int)
+        or not 0 <= policy.at_minute <= 59
+    ):
+        raise ValueError(
+            "thread reset policy at_minute must be an integer from 0 to 59"
+        )
+    return {
+        "mode": "daily",
+        "at_hour": policy.at_hour,
+        "at_minute": policy.at_minute,
+    }
+
+
+def _policy_from_state(value: object) -> SessionResetPolicy:
+    """Strictly validate and decode one persisted route policy."""
+    if not isinstance(value, dict):
+        raise ValueError("thread policies must be objects")
+    mode = value.get("mode")
+    if mode == "none":
+        if set(value) != {"mode"}:
+            raise ValueError("'none' thread policies may only contain 'mode'")
+        return SessionResetPolicy(mode="none")
+    if mode == "daily":
+        if set(value) != {"mode", "at_hour", "at_minute"}:
+            raise ValueError(
+                "'daily' thread policies require mode, at_hour, and at_minute"
+            )
+        hour = value["at_hour"]
+        minute = value["at_minute"]
+        if isinstance(hour, bool) or not isinstance(hour, int) or not 0 <= hour <= 23:
+            raise ValueError("daily at_hour must be an integer from 0 to 23")
+        if (
+            isinstance(minute, bool)
+            or not isinstance(minute, int)
+            or not 0 <= minute <= 59
+        ):
+            raise ValueError("daily at_minute must be an integer from 0 to 59")
+        return SessionResetPolicy(mode="daily", at_hour=hour, at_minute=minute)
+    raise ValueError("thread policy mode must be 'daily' or 'none'")
+
+
+class ThreadResetPolicyStore:
+    """Atomic JSON persistence for explicit thread reset policies.
+
+    Route keys are constructed by :class:`gateway.session.SessionStore`; this
+    helper deliberately knows nothing about users or live session IDs.
+    """
+
+    def __init__(self, path: Path):
+        self.path = Path(path)
+        self._lock = threading.RLock()
+        self._policies: dict[str, SessionResetPolicy] = {}
+        self._malformed = False
+        self._load()
+
+    @property
+    def malformed(self) -> bool:
+        return self._malformed
+
+    def _load(self) -> None:
+        if not self.path.exists():
+            return
+        try:
+            with self.path.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+            if (
+                not isinstance(data, dict)
+                or set(data) != {"version", "threads"}
+                or isinstance(data.get("version"), bool)
+                or data.get("version") != _STATE_VERSION
+            ):
+                raise ValueError("expected a version 1 object")
+            threads = data["threads"]
+            if not isinstance(threads, dict):
+                raise ValueError("'threads' must be an object")
+            loaded: dict[str, SessionResetPolicy] = {}
+            for route_key, value in threads.items():
+                if not isinstance(route_key, str) or not route_key.strip():
+                    raise ValueError("thread route keys must be non-empty strings")
+                loaded[route_key] = _policy_from_state(value)
+            self._policies = loaded
+        except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
+            # A corrupt explicit "off" must never degrade into an inherited
+            # enabled policy. Keep the store marked invalid so resolution
+            # fails closed and commands cannot overwrite evidence/state.
+            self._malformed = True
+            self._policies = {}
+            logger.warning(
+                "Malformed thread auto-reset state at %s; "
+                "automatic resets for supported threads are disabled: %s",
+                self.path,
+                exc,
+            )
+
+    def resolve(
+        self,
+        route_key: str,
+        inherited: SessionResetPolicy,
+    ) -> tuple[SessionResetPolicy, ThreadResetResolution]:
+        """Resolve a route override ahead of an inherited reset policy."""
+        with self._lock:
+            if self._malformed:
+                return dataclasses.replace(inherited, mode="none"), "invalid"
+            override = self._policies.get(route_key)
+
+        if override is not None:
+            return (
+                dataclasses.replace(
+                    inherited,
+                    mode=override.mode,
+                    at_hour=override.at_hour,
+                    at_minute=override.at_minute,
+                ),
+                "override",
+            )
+        return inherited, "inherited"
+
+    def set(self, route_key: str, policy: SessionResetPolicy) -> None:
+        # Validate before taking the lock or touching last-known-good state.
+        if not isinstance(route_key, str) or not route_key.strip():
+            raise ValueError("thread route key must be a non-empty string")
+        _policy_to_state(policy)
+        with self._lock:
+            self._ensure_writable()
+            updated = dict(self._policies)
+            updated[route_key] = dataclasses.replace(policy)
+            self._write(updated)
+            self._policies = updated
+
+    def delete(self, route_key: str) -> None:
+        if not isinstance(route_key, str) or not route_key.strip():
+            raise ValueError("thread route key must be a non-empty string")
+        with self._lock:
+            self._ensure_writable()
+            if route_key not in self._policies:
+                return
+            updated = dict(self._policies)
+            del updated[route_key]
+            self._write(updated)
+            self._policies = updated
+
+    def _ensure_writable(self) -> None:
+        if self._malformed:
+            raise ThreadResetPolicyStateError(
+                "thread auto-reset state is malformed; no changes were written"
+            )
+
+    def _write(self, policies: dict[str, SessionResetPolicy]) -> None:
+        atomic_json_write(
+            self.path,
+            {
+                "version": _STATE_VERSION,
+                "threads": {
+                    route_key: _policy_to_state(policy)
+                    for route_key, policy in policies.items()
+                },
+            },
+        )

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -107,6 +107,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
                busy_policy="interrupt_then_dispatch", busy_handler="new"),
     CommandDef("topic", "Enable or inspect Telegram DM topic sessions", "Session",
                gateway_only=True, args_hint="[off|help|session-id]"),
+    CommandDef("autoreset", "Manage automatic reset for this thread", "Session",
+               gateway_only=True,
+               args_hint="[status|on|daily HH:MM|off|inherit]"),
     CommandDef("clear", "Clear screen and start a new session", "Session",
                cli_only=True),
     CommandDef("redraw", "Force a full UI repaint (recovers from terminal drift)", "Session",
@@ -1256,7 +1259,10 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #     /hermes update on Slack. Demoted to free the native slot /approvals now
 #     claims — without this entry /approvals tips the registry past the 50-cap
 #     and silently clamps /update off, breaking Telegram parity.
-_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update"})
+#   - autoreset: typed as !autoreset in Slack threads; no native slash slot.
+_SLACK_VIA_HERMES_ONLY = frozenset(
+    {"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "autoreset"}
+)
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -148,6 +148,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
                busy_policy="interrupt_then_dispatch", busy_handler="new"),
     CommandDef("topic", "Enable or inspect Telegram DM topic sessions", "Session",
                gateway_only=True, args_hint="[off|help|session-id]"),
+    CommandDef("autoreset", "Manage automatic reset for this thread", "Session",
+               gateway_only=True,
+               args_hint="[status|on|daily HH:MM|off|inherit]"),
     CommandDef("clear", "Clear screen and start a new session", "Session",
                cli_only=True),
     CommandDef("redraw", "Force a full UI repaint (recovers from terminal drift)", "Session",
@@ -1368,7 +1371,26 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #     (session export is an interactive surface; platform is a rare
 #     informational lookup) — without this entry /save tips the registry
 #     past the 50-cap and silently clamps /platform, breaking parity.
-_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat", "refine", "review", "pause", "whoami", "platform"})
+#   - autoreset: typed as !autoreset in Slack threads; no native slash slot.
+_SLACK_VIA_HERMES_ONLY = frozenset(
+    {
+        "topup",
+        "moa",
+        "debug",
+        "egress",
+        "init",
+        "version",
+        "diff",
+        "update",
+        "heartbeat",
+        "refine",
+        "review",
+        "pause",
+        "whoami",
+        "platform",
+        "autoreset",
+    }
+)
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1625,7 +1625,7 @@ def setup_agent_settings(config: dict):
     reset_choices = [
         "Inactivity + daily reset (reset whichever comes first)",
         "Inactivity only (reset after N minutes of no messages)",
-        "Daily only (reset at a fixed hour each day)",
+        "Daily only (reset at a fixed local time each day)",
         "Never auto-reset (recommended - context lives until /reset or context compression)",
         "Keep current settings",
     ]
@@ -1634,6 +1634,29 @@ def setup_agent_settings(config: dict):
     current_mode = current_policy.get("mode", "none")
     current_idle = current_policy.get("idle_minutes", 1440)
     current_hour = current_policy.get("at_hour", 4)
+    current_minute = current_policy.get("at_minute", 0)
+    if (
+        isinstance(current_hour, bool)
+        or not isinstance(current_hour, int)
+        or not 0 <= current_hour <= 23
+    ):
+        current_hour = 4
+    if (
+        isinstance(current_minute, bool)
+        or not isinstance(current_minute, int)
+        or not 0 <= current_minute <= 59
+    ):
+        current_minute = 0
+
+    def prompt_daily_time() -> None:
+        current_time = f"{current_hour:02d}:{current_minute:02d}"
+        raw = prompt("  Daily reset time (HH:MM, local time)", current_time)
+        match = re.fullmatch(r"([01]\d|2[0-3]):([0-5]\d)", raw.strip())
+        if match is None:
+            print_warning(f"Invalid time; keeping {current_time}.")
+            return
+        config["session_reset"]["at_hour"] = int(match.group(1))
+        config["session_reset"]["at_minute"] = int(match.group(2))
 
     default_reset = {"both": 0, "idle": 1, "daily": 2, "none": 3}.get(current_mode, 3)
 
@@ -1650,15 +1673,9 @@ def setup_agent_settings(config: dict):
                 config["session_reset"]["idle_minutes"] = idle_val
         except ValueError:
             pass
-        hour_str = prompt("  Daily reset hour (0-23, local time)", str(current_hour))
-        try:
-            hour_val = int(hour_str)
-            if 0 <= hour_val <= 23:
-                config["session_reset"]["at_hour"] = hour_val
-        except ValueError:
-            pass
+        prompt_daily_time()
         print_success(
-            f"Sessions reset after {config['session_reset'].get('idle_minutes', 1440)} min idle or daily at {config['session_reset'].get('at_hour', 4)}:00"
+            f"Sessions reset after {config['session_reset'].get('idle_minutes', 1440)} min idle or daily at {config['session_reset'].get('at_hour', 4):02d}:{config['session_reset'].get('at_minute', 0):02d}"
         )
     elif reset_idx == 1:  # Idle only
         config["session_reset"]["mode"] = "idle"
@@ -1674,15 +1691,9 @@ def setup_agent_settings(config: dict):
         )
     elif reset_idx == 2:  # Daily only
         config["session_reset"]["mode"] = "daily"
-        hour_str = prompt("  Daily reset hour (0-23, local time)", str(current_hour))
-        try:
-            hour_val = int(hour_str)
-            if 0 <= hour_val <= 23:
-                config["session_reset"]["at_hour"] = hour_val
-        except ValueError:
-            pass
+        prompt_daily_time()
         print_success(
-            f"Sessions reset daily at {config['session_reset'].get('at_hour', 4)}:00"
+            f"Sessions reset daily at {config['session_reset'].get('at_hour', 4):02d}:{config['session_reset'].get('at_minute', 0):02d}"
         )
     elif reset_idx == 3:  # None
         config["session_reset"]["mode"] = "none"

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1896,7 +1896,7 @@ def setup_agent_settings(config: dict):
     reset_choices = [
         "Inactivity + daily reset (reset whichever comes first)",
         "Inactivity only (reset after N minutes of no messages)",
-        "Daily only (reset at a fixed hour each day)",
+        "Daily only (reset at a fixed local time each day)",
         "Never auto-reset (recommended - context lives until /reset or context compression)",
         "Keep current settings",
     ]
@@ -1905,6 +1905,29 @@ def setup_agent_settings(config: dict):
     current_mode = current_policy.get("mode", "none")
     current_idle = current_policy.get("idle_minutes", 1440)
     current_hour = current_policy.get("at_hour", 4)
+    current_minute = current_policy.get("at_minute", 0)
+    if (
+        isinstance(current_hour, bool)
+        or not isinstance(current_hour, int)
+        or not 0 <= current_hour <= 23
+    ):
+        current_hour = 4
+    if (
+        isinstance(current_minute, bool)
+        or not isinstance(current_minute, int)
+        or not 0 <= current_minute <= 59
+    ):
+        current_minute = 0
+
+    def prompt_daily_time() -> None:
+        current_time = f"{current_hour:02d}:{current_minute:02d}"
+        raw = prompt("  Daily reset time (HH:MM, local time)", current_time)
+        match = re.fullmatch(r"([01]\d|2[0-3]):([0-5]\d)", raw.strip())
+        if match is None:
+            print_warning(f"Invalid time; keeping {current_time}.")
+            return
+        config["session_reset"]["at_hour"] = int(match.group(1))
+        config["session_reset"]["at_minute"] = int(match.group(2))
 
     default_reset = {"both": 0, "idle": 1, "daily": 2, "none": 3}.get(current_mode, 3)
 
@@ -1921,15 +1944,9 @@ def setup_agent_settings(config: dict):
                 config["session_reset"]["idle_minutes"] = idle_val
         except ValueError:
             pass
-        hour_str = prompt("  Daily reset hour (0-23, local time)", str(current_hour))
-        try:
-            hour_val = int(hour_str)
-            if 0 <= hour_val <= 23:
-                config["session_reset"]["at_hour"] = hour_val
-        except ValueError:
-            pass
+        prompt_daily_time()
         print_success(
-            f"Sessions reset after {config['session_reset'].get('idle_minutes', 1440)} min idle or daily at {config['session_reset'].get('at_hour', 4)}:00"
+            f"Sessions reset after {config['session_reset'].get('idle_minutes', 1440)} min idle or daily at {config['session_reset'].get('at_hour', 4):02d}:{config['session_reset'].get('at_minute', 0):02d}"
         )
     elif reset_idx == 1:  # Idle only
         config["session_reset"]["mode"] = "idle"
@@ -1945,15 +1962,9 @@ def setup_agent_settings(config: dict):
         )
     elif reset_idx == 2:  # Daily only
         config["session_reset"]["mode"] = "daily"
-        hour_str = prompt("  Daily reset hour (0-23, local time)", str(current_hour))
-        try:
-            hour_val = int(hour_str)
-            if 0 <= hour_val <= 23:
-                config["session_reset"]["at_hour"] = hour_val
-        except ValueError:
-            pass
+        prompt_daily_time()
         print_success(
-            f"Sessions reset daily at {config['session_reset'].get('at_hour', 4)}:00"
+            f"Sessions reset daily at {config['session_reset'].get('at_hour', 4):02d}:{config['session_reset'].get('at_minute', 0):02d}"
         )
     elif reset_idx == 3:  # None
         config["session_reset"]["mode"] = "none"

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -240,6 +240,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ Titel is leeg na opruiming — sessie sonder titel begin."
     tip:                   "\n✦ Wenk: {tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset is slegs in Telegram-, Discord- en Slack-drade beskikbaar."
+    thread_only:           "Voer {prefix}autoreset uit binne die draad wat jy wil opstel (nie in 'n hoofgesprek of ouerkanaal nie)."
+    usage:                 "Gebruik: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "gedeaktiveer"
+    policy_daily:          "daagliks om {hour}:{minute}"
+    policy_idle:           "ná {minutes} minute se onaktiwiteit"
+    policy_both:           "daagliks om {hour}:{minute} of ná {minutes} minute se onaktiwiteit"
+    policy_unknown:        "{mode}"
+    scope_override:        "draadspesifieke beleid"
+    scope_inherited:       "oorgeërfde beleid"
+    status:                "Outomatiese terugstelling: {policy} ({scope})."
+    invalid_state:         "Die draad se outomatiese-terugstellingstaat is ongeldig; geen veranderinge is aangebring nie."
+    invalid_status:        "Outomatiese terugstelling: gedeaktiveer (veilige terugval; die draadbeleidstaat is ongeldig)."
+    save_failed:           "Kon nie die draad se outomatiese-terugstellingbeleid stoor nie."
+    read_failed:           "Kon nie die draad se outomatiese-terugstellingbeleid lees nie."
+
   restart:
     in_progress:           "⏳ Gateway-herbegin reeds aan die gang..."
     restarting:            "♻ Herbegin van gateway. As jy nie binne 60 sekondes in kennis gestel word nie, herbegin vanaf die konsole met `hermes gateway restart`."

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -238,6 +238,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ Titel is leeg na opruiming — sessie sonder titel begin."
     tip:                   "\n✦ Wenk: {tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset is slegs in Telegram-, Discord- en Slack-drade beskikbaar."
+    thread_only:           "Voer {prefix}autoreset uit binne die draad wat jy wil opstel (nie in 'n hoofgesprek of ouerkanaal nie)."
+    usage:                 "Gebruik: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "gedeaktiveer"
+    policy_daily:          "daagliks om {hour}:{minute}"
+    policy_idle:           "ná {minutes} minute se onaktiwiteit"
+    policy_both:           "daagliks om {hour}:{minute} of ná {minutes} minute se onaktiwiteit"
+    policy_unknown:        "{mode}"
+    scope_override:        "draadspesifieke beleid"
+    scope_inherited:       "oorgeërfde beleid"
+    status:                "Outomatiese terugstelling: {policy} ({scope})."
+    invalid_state:         "Die draad se outomatiese-terugstellingstaat is ongeldig; geen veranderinge is aangebring nie."
+    invalid_status:        "Outomatiese terugstelling: gedeaktiveer (veilige terugval; die draadbeleidstaat is ongeldig)."
+    save_failed:           "Kon nie die draad se outomatiese-terugstellingbeleid stoor nie."
+    read_failed:           "Kon nie die draad se outomatiese-terugstellingbeleid lees nie."
+
   restart:
     in_progress:           "⏳ Gateway-herbegin reeds aan die gang..."
     restarting:            "♻ Herbegin van gateway. As jy nie binne 60 sekondes in kennis gestel word nie, herbegin vanaf die konsole met `hermes gateway restart`."

--- a/locales/ar.yaml
+++ b/locales/ar.yaml
@@ -263,6 +263,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ العنوان فارغ بعد التنظيف — بدأت الجلسة دون عنوان."
     tip:                   "\n✦ نصيحة: {tip}"
 
+  autoreset:
+    unsupported_platform:  "لا يتوفر {prefix}autoreset إلا في سلاسل محادثات Telegram وDiscord وSlack."
+    thread_only:           "شغّل {prefix}autoreset داخل سلسلة المحادثة التي تريد إعدادها (وليس في محادثة جذرية أو قناة أصلية)."
+    usage:                 "الاستخدام: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "مُعطّل"
+    policy_daily:          "يوميًا عند {hour}:{minute}"
+    policy_idle:           "بعد {minutes} دقيقة من عدم النشاط"
+    policy_both:           "يوميًا عند {hour}:{minute} أو بعد {minutes} دقيقة من عدم النشاط"
+    policy_unknown:        "{mode}"
+    scope_override:        "تجاوز خاص بسلسلة المحادثة"
+    scope_inherited:       "السياسة الموروثة"
+    status:                "إعادة الضبط التلقائية: {policy} ({scope})."
+    invalid_state:         "حالة إعادة الضبط التلقائية لسلاسل المحادثات غير صالحة؛ لم تُجرَ أي تغييرات."
+    invalid_status:        "إعادة الضبط التلقائية: مُعطّلة (وضع احتياطي آمن؛ حالة سياسة سلسلة المحادثة غير صالحة)."
+    save_failed:           "تعذّر حفظ سياسة إعادة الضبط التلقائية لسلسلة المحادثة."
+    read_failed:           "تعذّرت قراءة سياسة إعادة الضبط التلقائية لسلسلة المحادثة."
+
   restart:
     in_progress:           "⏳ إعادة تشغيل البوابة قيد التنفيذ بالفعل..."
     restarting:            "♻ جارٍ إعادة تشغيل البوابة. إن لم تُخطَر خلال 60 ثانية، أعِد التشغيل من وحدة التحكّم باستخدام `hermes gateway restart`."

--- a/locales/ar.yaml
+++ b/locales/ar.yaml
@@ -261,6 +261,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ العنوان فارغ بعد التنظيف — بدأت الجلسة دون عنوان."
     tip:                   "\n✦ نصيحة: {tip}"
 
+  autoreset:
+    unsupported_platform:  "لا يتوفر {prefix}autoreset إلا في سلاسل محادثات Telegram وDiscord وSlack."
+    thread_only:           "شغّل {prefix}autoreset داخل سلسلة المحادثة التي تريد إعدادها (وليس في محادثة جذرية أو قناة أصلية)."
+    usage:                 "الاستخدام: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "مُعطّل"
+    policy_daily:          "يوميًا عند {hour}:{minute}"
+    policy_idle:           "بعد {minutes} دقيقة من عدم النشاط"
+    policy_both:           "يوميًا عند {hour}:{minute} أو بعد {minutes} دقيقة من عدم النشاط"
+    policy_unknown:        "{mode}"
+    scope_override:        "تجاوز خاص بسلسلة المحادثة"
+    scope_inherited:       "السياسة الموروثة"
+    status:                "إعادة الضبط التلقائية: {policy} ({scope})."
+    invalid_state:         "حالة إعادة الضبط التلقائية لسلاسل المحادثات غير صالحة؛ لم تُجرَ أي تغييرات."
+    invalid_status:        "إعادة الضبط التلقائية: مُعطّلة (وضع احتياطي آمن؛ حالة سياسة سلسلة المحادثة غير صالحة)."
+    save_failed:           "تعذّر حفظ سياسة إعادة الضبط التلقائية لسلسلة المحادثة."
+    read_failed:           "تعذّرت قراءة سياسة إعادة الضبط التلقائية لسلسلة المحادثة."
+
   restart:
     in_progress:           "⏳ إعادة تشغيل البوابة قيد التنفيذ بالفعل..."
     restarting:            "♻ جارٍ إعادة تشغيل البوابة. إن لم تُخطَر خلال 60 ثانية، أعِد التشغيل من وحدة التحكّم باستخدام `hermes gateway restart`."

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -240,6 +240,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ Titel ist nach Bereinigung leer — Sitzung ohne Titel gestartet."
     tip:                   "\n✦ Tipp: {tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset ist nur in Telegram-, Discord- und Slack-Threads verfügbar."
+    thread_only:           "Führen Sie {prefix}autoreset in dem Thread aus, den Sie konfigurieren möchten (nicht in einer Stammkonversation oder einem übergeordneten Kanal)."
+    usage:                 "Verwendung: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "deaktiviert"
+    policy_daily:          "täglich um {hour}:{minute}"
+    policy_idle:           "nach {minutes} Minuten Inaktivität"
+    policy_both:           "täglich um {hour}:{minute} oder nach {minutes} Minuten Inaktivität"
+    policy_unknown:        "{mode}"
+    scope_override:        "Thread-Überschreibung"
+    scope_inherited:       "geerbte Richtlinie"
+    status:                "Automatische Zurücksetzung: {policy} ({scope})."
+    invalid_state:         "Der Status der automatischen Thread-Zurücksetzung ist ungültig; es wurden keine Änderungen vorgenommen."
+    invalid_status:        "Automatische Zurücksetzung: deaktiviert (sicherer Rückfall; Thread-Richtlinienstatus ist ungültig)."
+    save_failed:           "Die Richtlinie zur automatischen Thread-Zurücksetzung konnte nicht gespeichert werden."
+    read_failed:           "Die Richtlinie zur automatischen Thread-Zurücksetzung konnte nicht gelesen werden."
+
   restart:
     in_progress:           "⏳ Gateway-Neustart läuft bereits..."
     restarting:            "♻ Gateway wird neu gestartet. Falls Sie nicht innerhalb von 60 Sekunden benachrichtigt werden, starten Sie über die Konsole mit `hermes gateway restart` neu."

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -238,6 +238,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ Titel ist nach Bereinigung leer — Sitzung ohne Titel gestartet."
     tip:                   "\n✦ Tipp: {tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset ist nur in Telegram-, Discord- und Slack-Threads verfügbar."
+    thread_only:           "Führen Sie {prefix}autoreset in dem Thread aus, den Sie konfigurieren möchten (nicht in einer Stammkonversation oder einem übergeordneten Kanal)."
+    usage:                 "Verwendung: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "deaktiviert"
+    policy_daily:          "täglich um {hour}:{minute}"
+    policy_idle:           "nach {minutes} Minuten Inaktivität"
+    policy_both:           "täglich um {hour}:{minute} oder nach {minutes} Minuten Inaktivität"
+    policy_unknown:        "{mode}"
+    scope_override:        "Thread-Überschreibung"
+    scope_inherited:       "geerbte Richtlinie"
+    status:                "Automatische Zurücksetzung: {policy} ({scope})."
+    invalid_state:         "Der Status der automatischen Thread-Zurücksetzung ist ungültig; es wurden keine Änderungen vorgenommen."
+    invalid_status:        "Automatische Zurücksetzung: deaktiviert (sicherer Rückfall; Thread-Richtlinienstatus ist ungültig)."
+    save_failed:           "Die Richtlinie zur automatischen Thread-Zurücksetzung konnte nicht gespeichert werden."
+    read_failed:           "Die Richtlinie zur automatischen Thread-Zurücksetzung konnte nicht gelesen werden."
+
   restart:
     in_progress:           "⏳ Gateway-Neustart läuft bereits..."
     restarting:            "♻ Gateway wird neu gestartet. Falls Sie nicht innerhalb von 60 Sekunden benachrichtigt werden, starten Sie über die Konsole mit `hermes gateway restart` neu."

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -255,6 +255,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ Title is empty after cleanup — session started untitled."
     tip:                   "\n✦ Tip: {tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset is only available in Telegram, Discord, and Slack threads."
+    thread_only:           "Run {prefix}autoreset inside the thread you want to configure (not a root conversation or parent channel)."
+    usage:                 "Usage: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "disabled"
+    policy_daily:          "daily at {hour}:{minute}"
+    policy_idle:           "after {minutes} minutes idle"
+    policy_both:           "daily at {hour}:{minute} or after {minutes} minutes idle"
+    policy_unknown:        "{mode}"
+    scope_override:        "thread override"
+    scope_inherited:       "inherited policy"
+    status:                "Automatic reset: {policy} ({scope})."
+    invalid_state:         "Thread auto-reset state is invalid; no changes were made."
+    invalid_status:        "Automatic reset: disabled (safe fallback; thread policy state is invalid)."
+    save_failed:           "Could not save the thread auto-reset policy."
+    read_failed:           "Could not read the thread auto-reset policy."
+
   restart:
     in_progress:           "⏳ Gateway restart already in progress..."
     restarting:            "♻ Restarting gateway. If you aren't notified within 60 seconds, restart from the console with `hermes gateway restart`."

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -253,6 +253,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ Title is empty after cleanup — session started untitled."
     tip:                   "\n✦ Tip: {tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset is only available in Telegram, Discord, and Slack threads."
+    thread_only:           "Run {prefix}autoreset inside the thread you want to configure (not a root conversation or parent channel)."
+    usage:                 "Usage: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "disabled"
+    policy_daily:          "daily at {hour}:{minute}"
+    policy_idle:           "after {minutes} minutes idle"
+    policy_both:           "daily at {hour}:{minute} or after {minutes} minutes idle"
+    policy_unknown:        "{mode}"
+    scope_override:        "thread override"
+    scope_inherited:       "inherited policy"
+    status:                "Automatic reset: {policy} ({scope})."
+    invalid_state:         "Thread auto-reset state is invalid; no changes were made."
+    invalid_status:        "Automatic reset: disabled (safe fallback; thread policy state is invalid)."
+    save_failed:           "Could not save the thread auto-reset policy."
+    read_failed:           "Could not read the thread auto-reset policy."
+
   restart:
     in_progress:           "⏳ Gateway restart already in progress..."
     restarting:            "♻ Restarting gateway. If you aren't notified within 60 seconds, restart from the console with `hermes gateway restart`."

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -240,6 +240,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ El título queda vacío tras la limpieza — sesión iniciada sin título."
     tip:                   "\n✦ Consejo: {tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset solo está disponible en hilos de Telegram, Discord y Slack."
+    thread_only:           "Ejecuta {prefix}autoreset dentro del hilo que quieras configurar (no en una conversación raíz ni en el canal principal)."
+    usage:                 "Uso: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "desactivado"
+    policy_daily:          "cada día a las {hour}:{minute}"
+    policy_idle:           "tras {minutes} minutos de inactividad"
+    policy_both:           "cada día a las {hour}:{minute} o tras {minutes} minutos de inactividad"
+    policy_unknown:        "{mode}"
+    scope_override:        "configuración específica del hilo"
+    scope_inherited:       "política heredada"
+    status:                "Restablecimiento automático: {policy} ({scope})."
+    invalid_state:         "El estado del restablecimiento automático de hilos no es válido; no se ha realizado ningún cambio."
+    invalid_status:        "Restablecimiento automático: desactivado (modo seguro; el estado de la política del hilo no es válido)."
+    save_failed:           "No se pudo guardar la política de restablecimiento automático del hilo."
+    read_failed:           "No se pudo leer la política de restablecimiento automático del hilo."
+
   restart:
     in_progress:           "⏳ El reinicio del gateway ya está en curso..."
     restarting:            "♻ Reiniciando el gateway. Si no recibes notificación en 60 segundos, reinicia desde la consola con `hermes gateway restart`."

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -238,6 +238,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ El título queda vacío tras la limpieza — sesión iniciada sin título."
     tip:                   "\n✦ Consejo: {tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset solo está disponible en hilos de Telegram, Discord y Slack."
+    thread_only:           "Ejecuta {prefix}autoreset dentro del hilo que quieras configurar (no en una conversación raíz ni en el canal principal)."
+    usage:                 "Uso: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "desactivado"
+    policy_daily:          "cada día a las {hour}:{minute}"
+    policy_idle:           "tras {minutes} minutos de inactividad"
+    policy_both:           "cada día a las {hour}:{minute} o tras {minutes} minutos de inactividad"
+    policy_unknown:        "{mode}"
+    scope_override:        "configuración específica del hilo"
+    scope_inherited:       "política heredada"
+    status:                "Restablecimiento automático: {policy} ({scope})."
+    invalid_state:         "El estado del restablecimiento automático de hilos no es válido; no se ha realizado ningún cambio."
+    invalid_status:        "Restablecimiento automático: desactivado (modo seguro; el estado de la política del hilo no es válido)."
+    save_failed:           "No se pudo guardar la política de restablecimiento automático del hilo."
+    read_failed:           "No se pudo leer la política de restablecimiento automático del hilo."
+
   restart:
     in_progress:           "⏳ El reinicio del gateway ya está en curso..."
     restarting:            "♻ Reiniciando el gateway. Si no recibes notificación en 60 segundos, reinicia desde la consola con `hermes gateway restart`."

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -240,6 +240,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ Le titre est vide après nettoyage — session démarrée sans titre."
     tip:                   "\n✦ Astuce : {tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset est disponible uniquement dans les fils Telegram, Discord et Slack."
+    thread_only:           "Exécutez {prefix}autoreset dans le fil à configurer (pas dans une conversation racine ni dans le canal parent)."
+    usage:                 "Utilisation : {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "désactivée"
+    policy_daily:          "tous les jours à {hour}:{minute}"
+    policy_idle:           "après {minutes} minutes d’inactivité"
+    policy_both:           "tous les jours à {hour}:{minute} ou après {minutes} minutes d’inactivité"
+    policy_unknown:        "{mode}"
+    scope_override:        "politique propre au fil"
+    scope_inherited:       "politique héritée"
+    status:                "Réinitialisation automatique : {policy} ({scope})."
+    invalid_state:         "L’état de réinitialisation automatique des fils est invalide ; aucune modification effectuée."
+    invalid_status:        "Réinitialisation automatique : désactivée (repli sûr ; état de politique de fil invalide)."
+    save_failed:           "Impossible d’enregistrer la politique de réinitialisation automatique du fil."
+    read_failed:           "Impossible de lire la politique de réinitialisation automatique du fil."
+
   restart:
     in_progress:           "⏳ Redémarrage du gateway déjà en cours..."
     restarting:            "♻ Redémarrage du gateway. Si vous n'êtes pas notifié dans les 60 secondes, redémarrez depuis la console avec `hermes gateway restart`."

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -238,6 +238,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ Le titre est vide après nettoyage — session démarrée sans titre."
     tip:                   "\n✦ Astuce : {tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset est disponible uniquement dans les fils Telegram, Discord et Slack."
+    thread_only:           "Exécutez {prefix}autoreset dans le fil à configurer (pas dans une conversation racine ni dans le canal parent)."
+    usage:                 "Utilisation : {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "désactivée"
+    policy_daily:          "tous les jours à {hour}:{minute}"
+    policy_idle:           "après {minutes} minutes d’inactivité"
+    policy_both:           "tous les jours à {hour}:{minute} ou après {minutes} minutes d’inactivité"
+    policy_unknown:        "{mode}"
+    scope_override:        "politique propre au fil"
+    scope_inherited:       "politique héritée"
+    status:                "Réinitialisation automatique : {policy} ({scope})."
+    invalid_state:         "L’état de réinitialisation automatique des fils est invalide ; aucune modification effectuée."
+    invalid_status:        "Réinitialisation automatique : désactivée (repli sûr ; état de politique de fil invalide)."
+    save_failed:           "Impossible d’enregistrer la politique de réinitialisation automatique du fil."
+    read_failed:           "Impossible de lire la politique de réinitialisation automatique du fil."
+
   restart:
     in_progress:           "⏳ Redémarrage du gateway déjà en cours..."
     restarting:            "♻ Redémarrage du gateway. Si vous n'êtes pas notifié dans les 60 secondes, redémarrez depuis la console avec `hermes gateway restart`."

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -244,6 +244,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ Tá an teideal folamh tar éis glanta — seisiún tosaithe gan teideal."
     tip:                   "\n✦ Leid: {tip}"
 
+  autoreset:
+    unsupported_platform:  "Níl {prefix}autoreset ar fáil ach i snáitheanna Telegram, Discord agus Slack."
+    thread_only:           "Rith {prefix}autoreset taobh istigh den snáithe is mian leat a chumrú (ní sa phríomhchomhrá ná sa mháthairchainéal)."
+    usage:                 "Úsáid: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "díchumasaithe"
+    policy_daily:          "gach lá ag {hour}:{minute}"
+    policy_idle:           "tar éis {minutes} nóiméad neamhghníomhaíochta"
+    policy_both:           "gach lá ag {hour}:{minute} nó tar éis {minutes} nóiméad neamhghníomhaíochta"
+    policy_unknown:        "{mode}"
+    scope_override:        "sárú an tsnáithe"
+    scope_inherited:       "polasaí oidhreachta"
+    status:                "Athshocrú uathoibríoch: {policy} ({scope})."
+    invalid_state:         "Tá staid athshocraithe uathoibríoch an tsnáithe neamhbhailí; ní dhearnadh aon athrú."
+    invalid_status:        "Athshocrú uathoibríoch: díchumasaithe (cúlréiteach sábháilte; tá staid pholasaí an tsnáithe neamhbhailí)."
+    save_failed:           "Níorbh fhéidir polasaí athshocraithe uathoibríoch an tsnáithe a shábháil."
+    read_failed:           "Níorbh fhéidir polasaí athshocraithe uathoibríoch an tsnáithe a léamh."
+
   restart:
     in_progress:           "⏳ Tá atosú gateway ar siúl cheana féin..."
     restarting:            "♻ Ag atosú gateway. Mura gcuirfear in iúl duit laistigh de 60 soicind, atosaigh ón gconsól le `hermes gateway restart`."

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -242,6 +242,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ Tá an teideal folamh tar éis glanta — seisiún tosaithe gan teideal."
     tip:                   "\n✦ Leid: {tip}"
 
+  autoreset:
+    unsupported_platform:  "Níl {prefix}autoreset ar fáil ach i snáitheanna Telegram, Discord agus Slack."
+    thread_only:           "Rith {prefix}autoreset taobh istigh den snáithe is mian leat a chumrú (ní sa phríomhchomhrá ná sa mháthairchainéal)."
+    usage:                 "Úsáid: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "díchumasaithe"
+    policy_daily:          "gach lá ag {hour}:{minute}"
+    policy_idle:           "tar éis {minutes} nóiméad neamhghníomhaíochta"
+    policy_both:           "gach lá ag {hour}:{minute} nó tar éis {minutes} nóiméad neamhghníomhaíochta"
+    policy_unknown:        "{mode}"
+    scope_override:        "sárú an tsnáithe"
+    scope_inherited:       "polasaí oidhreachta"
+    status:                "Athshocrú uathoibríoch: {policy} ({scope})."
+    invalid_state:         "Tá staid athshocraithe uathoibríoch an tsnáithe neamhbhailí; ní dhearnadh aon athrú."
+    invalid_status:        "Athshocrú uathoibríoch: díchumasaithe (cúlréiteach sábháilte; tá staid pholasaí an tsnáithe neamhbhailí)."
+    save_failed:           "Níorbh fhéidir polasaí athshocraithe uathoibríoch an tsnáithe a shábháil."
+    read_failed:           "Níorbh fhéidir polasaí athshocraithe uathoibríoch an tsnáithe a léamh."
+
   restart:
     in_progress:           "⏳ Tá atosú gateway ar siúl cheana féin..."
     restarting:            "♻ Ag atosú gateway. Mura gcuirfear in iúl duit laistigh de 60 soicind, atosaigh ón gconsól le `hermes gateway restart`."

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -240,6 +240,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ Tisztítás után a cím üres — a munkamenet cím nélkül indult."
     tip:                   "\n✦ Tipp: {tip}"
 
+  autoreset:
+    unsupported_platform:  "A {prefix}autoreset csak Telegram-, Discord- és Slack-szálakban érhető el."
+    thread_only:           "Futtasd a {prefix}autoreset parancsot a beállítani kívánt szálban (ne gyökérbeszélgetésben vagy szülőcsatornában)."
+    usage:                 "Használat: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "kikapcsolva"
+    policy_daily:          "naponta {hour}:{minute}-kor"
+    policy_idle:           "{minutes} perc tétlenség után"
+    policy_both:           "naponta {hour}:{minute}-kor vagy {minutes} perc tétlenség után"
+    policy_unknown:        "{mode}"
+    scope_override:        "szálspecifikus felülbírálás"
+    scope_inherited:       "örökölt házirend"
+    status:                "Automatikus visszaállítás: {policy} ({scope})."
+    invalid_state:         "A szál automatikus visszaállítási állapota érvénytelen; nem történt módosítás."
+    invalid_status:        "Automatikus visszaállítás: kikapcsolva (biztonságos tartalék; a szál házirendjének állapota érvénytelen)."
+    save_failed:           "Nem sikerült menteni a szál automatikus visszaállítási házirendjét."
+    read_failed:           "Nem sikerült beolvasni a szál automatikus visszaállítási házirendjét."
+
   restart:
     in_progress:           "⏳ Az átjáró újraindítása már folyamatban van..."
     restarting:            "♻ Átjáró újraindítása. Ha 60 másodpercen belül nem kapsz értesítést, indítsd újra a konzolból a `hermes gateway restart` paranccsal."

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -238,6 +238,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ Tisztítás után a cím üres — a munkamenet cím nélkül indult."
     tip:                   "\n✦ Tipp: {tip}"
 
+  autoreset:
+    unsupported_platform:  "A {prefix}autoreset csak Telegram-, Discord- és Slack-szálakban érhető el."
+    thread_only:           "Futtasd a {prefix}autoreset parancsot a beállítani kívánt szálban (ne gyökérbeszélgetésben vagy szülőcsatornában)."
+    usage:                 "Használat: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "kikapcsolva"
+    policy_daily:          "naponta {hour}:{minute}-kor"
+    policy_idle:           "{minutes} perc tétlenség után"
+    policy_both:           "naponta {hour}:{minute}-kor vagy {minutes} perc tétlenség után"
+    policy_unknown:        "{mode}"
+    scope_override:        "szálspecifikus felülbírálás"
+    scope_inherited:       "örökölt házirend"
+    status:                "Automatikus visszaállítás: {policy} ({scope})."
+    invalid_state:         "A szál automatikus visszaállítási állapota érvénytelen; nem történt módosítás."
+    invalid_status:        "Automatikus visszaállítás: kikapcsolva (biztonságos tartalék; a szál házirendjének állapota érvénytelen)."
+    save_failed:           "Nem sikerült menteni a szál automatikus visszaállítási házirendjét."
+    read_failed:           "Nem sikerült beolvasni a szál automatikus visszaállítási házirendjét."
+
   restart:
     in_progress:           "⏳ Az átjáró újraindítása már folyamatban van..."
     restarting:            "♻ Átjáró újraindítása. Ha 60 másodpercen belül nem kapsz értesítést, indítsd újra a konzolból a `hermes gateway restart` paranccsal."

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -240,6 +240,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ Il titolo è vuoto dopo la pulizia — sessione avviata senza titolo."
     tip:                   "\n✦ Suggerimento: {tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset è disponibile solo nei thread di Telegram, Discord e Slack."
+    thread_only:           "Esegui {prefix}autoreset nel thread da configurare (non in una conversazione principale o nel canale padre)."
+    usage:                 "Uso: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "disattivato"
+    policy_daily:          "ogni giorno alle {hour}:{minute}"
+    policy_idle:           "dopo {minutes} minuti di inattività"
+    policy_both:           "ogni giorno alle {hour}:{minute} o dopo {minutes} minuti di inattività"
+    policy_unknown:        "{mode}"
+    scope_override:        "impostazione specifica del thread"
+    scope_inherited:       "criterio ereditato"
+    status:                "Reimpostazione automatica: {policy} ({scope})."
+    invalid_state:         "Lo stato della reimpostazione automatica dei thread non è valido; non è stata apportata alcuna modifica."
+    invalid_status:        "Reimpostazione automatica: disattivata (ripiego sicuro; lo stato del criterio del thread non è valido)."
+    save_failed:           "Impossibile salvare il criterio di reimpostazione automatica del thread."
+    read_failed:           "Impossibile leggere il criterio di reimpostazione automatica del thread."
+
   restart:
     in_progress:           "⏳ Riavvio del gateway già in corso..."
     restarting:            "♻ Riavvio del gateway. Se non ricevi una notifica entro 60 secondi, riavvia dalla console con `hermes gateway restart`."

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -238,6 +238,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ Il titolo è vuoto dopo la pulizia — sessione avviata senza titolo."
     tip:                   "\n✦ Suggerimento: {tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset è disponibile solo nei thread di Telegram, Discord e Slack."
+    thread_only:           "Esegui {prefix}autoreset nel thread da configurare (non in una conversazione principale o nel canale padre)."
+    usage:                 "Uso: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "disattivato"
+    policy_daily:          "ogni giorno alle {hour}:{minute}"
+    policy_idle:           "dopo {minutes} minuti di inattività"
+    policy_both:           "ogni giorno alle {hour}:{minute} o dopo {minutes} minuti di inattività"
+    policy_unknown:        "{mode}"
+    scope_override:        "impostazione specifica del thread"
+    scope_inherited:       "criterio ereditato"
+    status:                "Reimpostazione automatica: {policy} ({scope})."
+    invalid_state:         "Lo stato della reimpostazione automatica dei thread non è valido; non è stata apportata alcuna modifica."
+    invalid_status:        "Reimpostazione automatica: disattivata (ripiego sicuro; lo stato del criterio del thread non è valido)."
+    save_failed:           "Impossibile salvare il criterio di reimpostazione automatica del thread."
+    read_failed:           "Impossibile leggere il criterio di reimpostazione automatica del thread."
+
   restart:
     in_progress:           "⏳ Riavvio del gateway già in corso..."
     restarting:            "♻ Riavvio del gateway. Se non ricevi una notifica entro 60 secondi, riavvia dalla console con `hermes gateway restart`."

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -240,6 +240,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ クリーンアップ後にタイトルが空になりました — タイトルなしでセッションを開始しました。"
     tip:                   "\n✦ ヒント: {tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset は Telegram、Discord、Slack のスレッドでのみ使用できます。"
+    thread_only:           "設定するスレッド内で {prefix}autoreset を実行してください（ルート会話や親チャンネルでは実行できません）。"
+    usage:                 "使用方法: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "無効"
+    policy_daily:          "毎日 {hour}:{minute}"
+    policy_idle:           "{minutes} 分間操作がない場合"
+    policy_both:           "毎日 {hour}:{minute}、または {minutes} 分間操作がない場合"
+    policy_unknown:        "{mode}"
+    scope_override:        "スレッド固有の設定"
+    scope_inherited:       "継承されたポリシー"
+    status:                "自動リセット: {policy}（{scope}）。"
+    invalid_state:         "スレッドの自動リセット状態が無効です。変更は行われませんでした。"
+    invalid_status:        "自動リセット: 無効（安全なフォールバック。スレッドポリシーの状態が無効です）。"
+    save_failed:           "スレッドの自動リセットポリシーを保存できませんでした。"
+    read_failed:           "スレッドの自動リセットポリシーを読み取れませんでした。"
+
   restart:
     in_progress:           "⏳ ゲートウェイの再起動はすでに進行中です..."
     restarting:            "♻ ゲートウェイを再起動しています。60 秒以内に通知が届かない場合は、コンソールで `hermes gateway restart` を実行してください。"

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -238,6 +238,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ クリーンアップ後にタイトルが空になりました — タイトルなしでセッションを開始しました。"
     tip:                   "\n✦ ヒント: {tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset は Telegram、Discord、Slack のスレッドでのみ使用できます。"
+    thread_only:           "設定するスレッド内で {prefix}autoreset を実行してください（ルート会話や親チャンネルでは実行できません）。"
+    usage:                 "使用方法: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "無効"
+    policy_daily:          "毎日 {hour}:{minute}"
+    policy_idle:           "{minutes} 分間操作がない場合"
+    policy_both:           "毎日 {hour}:{minute}、または {minutes} 分間操作がない場合"
+    policy_unknown:        "{mode}"
+    scope_override:        "スレッド固有の設定"
+    scope_inherited:       "継承されたポリシー"
+    status:                "自動リセット: {policy}（{scope}）。"
+    invalid_state:         "スレッドの自動リセット状態が無効です。変更は行われませんでした。"
+    invalid_status:        "自動リセット: 無効（安全なフォールバック。スレッドポリシーの状態が無効です）。"
+    save_failed:           "スレッドの自動リセットポリシーを保存できませんでした。"
+    read_failed:           "スレッドの自動リセットポリシーを読み取れませんでした。"
+
   restart:
     in_progress:           "⏳ ゲートウェイの再起動はすでに進行中です..."
     restarting:            "♻ ゲートウェイを再起動しています。60 秒以内に通知が届かない場合は、コンソールで `hermes gateway restart` を実行してください。"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -240,6 +240,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ 정리 후 제목이 비어 있습니다 — 제목 없이 세션을 시작했습니다."
     tip:                   "\n✦ 팁: {tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset은 Telegram, Discord 및 Slack 스레드에서만 사용할 수 있습니다."
+    thread_only:           "설정할 스레드 안에서 {prefix}autoreset을 실행하세요(최상위 대화나 상위 채널에서는 실행할 수 없습니다)."
+    usage:                 "사용법: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "비활성화됨"
+    policy_daily:          "매일 {hour}:{minute}"
+    policy_idle:           "{minutes}분 동안 활동이 없을 때"
+    policy_both:           "매일 {hour}:{minute} 또는 {minutes}분 동안 활동이 없을 때"
+    policy_unknown:        "{mode}"
+    scope_override:        "스레드별 재정의"
+    scope_inherited:       "상속된 정책"
+    status:                "자동 재설정: {policy}({scope})."
+    invalid_state:         "스레드 자동 재설정 상태가 올바르지 않아 변경하지 않았습니다."
+    invalid_status:        "자동 재설정: 비활성화됨(안전 대체 동작; 스레드 정책 상태가 올바르지 않음)."
+    save_failed:           "스레드 자동 재설정 정책을 저장할 수 없습니다."
+    read_failed:           "스레드 자동 재설정 정책을 읽을 수 없습니다."
+
   restart:
     in_progress:           "⏳ 게이트웨이 재시작이 이미 진행 중입니다..."
     restarting:            "♻ 게이트웨이를 재시작 중입니다. 60초 이내에 알림이 오지 않으면 콘솔에서 `hermes gateway restart`로 재시작하세요."

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -238,6 +238,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ 정리 후 제목이 비어 있습니다 — 제목 없이 세션을 시작했습니다."
     tip:                   "\n✦ 팁: {tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset은 Telegram, Discord 및 Slack 스레드에서만 사용할 수 있습니다."
+    thread_only:           "설정할 스레드 안에서 {prefix}autoreset을 실행하세요(최상위 대화나 상위 채널에서는 실행할 수 없습니다)."
+    usage:                 "사용법: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "비활성화됨"
+    policy_daily:          "매일 {hour}:{minute}"
+    policy_idle:           "{minutes}분 동안 활동이 없을 때"
+    policy_both:           "매일 {hour}:{minute} 또는 {minutes}분 동안 활동이 없을 때"
+    policy_unknown:        "{mode}"
+    scope_override:        "스레드별 재정의"
+    scope_inherited:       "상속된 정책"
+    status:                "자동 재설정: {policy}({scope})."
+    invalid_state:         "스레드 자동 재설정 상태가 올바르지 않아 변경하지 않았습니다."
+    invalid_status:        "자동 재설정: 비활성화됨(안전 대체 동작; 스레드 정책 상태가 올바르지 않음)."
+    save_failed:           "스레드 자동 재설정 정책을 저장할 수 없습니다."
+    read_failed:           "스레드 자동 재설정 정책을 읽을 수 없습니다."
+
   restart:
     in_progress:           "⏳ 게이트웨이 재시작이 이미 진행 중입니다..."
     restarting:            "♻ 게이트웨이를 재시작 중입니다. 60초 이내에 알림이 오지 않으면 콘솔에서 `hermes gateway restart`로 재시작하세요."

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -240,6 +240,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ O título fica vazio após a limpeza — sessão iniciada sem título."
     tip:                   "\n✦ Dica: {tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset só está disponível em tópicos do Telegram, Discord e Slack."
+    thread_only:           "Executa {prefix}autoreset dentro do tópico que queres configurar (não numa conversa principal nem no canal pai)."
+    usage:                 "Utilização: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "desativada"
+    policy_daily:          "diariamente às {hour}:{minute}"
+    policy_idle:           "após {minutes} minutos de inatividade"
+    policy_both:           "diariamente às {hour}:{minute} ou após {minutes} minutos de inatividade"
+    policy_unknown:        "{mode}"
+    scope_override:        "configuração específica do tópico"
+    scope_inherited:       "política herdada"
+    status:                "Reinicialização automática: {policy} ({scope})."
+    invalid_state:         "O estado da reinicialização automática dos tópicos é inválido; não foi feita qualquer alteração."
+    invalid_status:        "Reinicialização automática: desativada (alternativa segura; o estado da política do tópico é inválido)."
+    save_failed:           "Não foi possível guardar a política de reinicialização automática do tópico."
+    read_failed:           "Não foi possível ler a política de reinicialização automática do tópico."
+
   restart:
     in_progress:           "⏳ O reinício do gateway já está em curso..."
     restarting:            "♻ A reiniciar o gateway. Se não fores notificado em 60 segundos, reinicia a partir da consola com `hermes gateway restart`."

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -238,6 +238,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ O título fica vazio após a limpeza — sessão iniciada sem título."
     tip:                   "\n✦ Dica: {tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset só está disponível em tópicos do Telegram, Discord e Slack."
+    thread_only:           "Executa {prefix}autoreset dentro do tópico que queres configurar (não numa conversa principal nem no canal pai)."
+    usage:                 "Utilização: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "desativada"
+    policy_daily:          "diariamente às {hour}:{minute}"
+    policy_idle:           "após {minutes} minutos de inatividade"
+    policy_both:           "diariamente às {hour}:{minute} ou após {minutes} minutos de inatividade"
+    policy_unknown:        "{mode}"
+    scope_override:        "configuração específica do tópico"
+    scope_inherited:       "política herdada"
+    status:                "Reinicialização automática: {policy} ({scope})."
+    invalid_state:         "O estado da reinicialização automática dos tópicos é inválido; não foi feita qualquer alteração."
+    invalid_status:        "Reinicialização automática: desativada (alternativa segura; o estado da política do tópico é inválido)."
+    save_failed:           "Não foi possível guardar a política de reinicialização automática do tópico."
+    read_failed:           "Não foi possível ler a política de reinicialização automática do tópico."
+
   restart:
     in_progress:           "⏳ O reinício do gateway já está em curso..."
     restarting:            "♻ A reiniciar o gateway. Se não fores notificado em 60 segundos, reinicia a partir da consola com `hermes gateway restart`."

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -240,6 +240,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ После очистки название пусто — сеанс запущен без названия."
     tip:                   "\n✦ Совет: {tip}"
 
+  autoreset:
+    unsupported_platform:  "Команда {prefix}autoreset доступна только в ветках Telegram, Discord и Slack."
+    thread_only:           "Запустите {prefix}autoreset внутри ветки, которую хотите настроить (не в корневом диалоге или родительском канале)."
+    usage:                 "Использование: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "отключён"
+    policy_daily:          "ежедневно в {hour}:{minute}"
+    policy_idle:           "после {minutes} минут бездействия"
+    policy_both:           "ежедневно в {hour}:{minute} или после {minutes} минут бездействия"
+    policy_unknown:        "{mode}"
+    scope_override:        "настройка для ветки"
+    scope_inherited:       "унаследованная политика"
+    status:                "Автоматический сброс: {policy} ({scope})."
+    invalid_state:         "Состояние автоматического сброса веток недействительно; изменения не внесены."
+    invalid_status:        "Автоматический сброс: отключён (безопасный режим; состояние политики ветки недействительно)."
+    save_failed:           "Не удалось сохранить политику автоматического сброса ветки."
+    read_failed:           "Не удалось прочитать политику автоматического сброса ветки."
+
   restart:
     in_progress:           "⏳ Перезапуск шлюза уже выполняется..."
     restarting:            "♻ Перезапуск шлюза. Если уведомление не придёт в течение 60 секунд, перезапустите из консоли командой `hermes gateway restart`."

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -238,6 +238,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ После очистки название пусто — сеанс запущен без названия."
     tip:                   "\n✦ Совет: {tip}"
 
+  autoreset:
+    unsupported_platform:  "Команда {prefix}autoreset доступна только в ветках Telegram, Discord и Slack."
+    thread_only:           "Запустите {prefix}autoreset внутри ветки, которую хотите настроить (не в корневом диалоге или родительском канале)."
+    usage:                 "Использование: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "отключён"
+    policy_daily:          "ежедневно в {hour}:{minute}"
+    policy_idle:           "после {minutes} минут бездействия"
+    policy_both:           "ежедневно в {hour}:{minute} или после {minutes} минут бездействия"
+    policy_unknown:        "{mode}"
+    scope_override:        "настройка для ветки"
+    scope_inherited:       "унаследованная политика"
+    status:                "Автоматический сброс: {policy} ({scope})."
+    invalid_state:         "Состояние автоматического сброса веток недействительно; изменения не внесены."
+    invalid_status:        "Автоматический сброс: отключён (безопасный режим; состояние политики ветки недействительно)."
+    save_failed:           "Не удалось сохранить политику автоматического сброса ветки."
+    read_failed:           "Не удалось прочитать политику автоматического сброса ветки."
+
   restart:
     in_progress:           "⏳ Перезапуск шлюза уже выполняется..."
     restarting:            "♻ Перезапуск шлюза. Если уведомление не придёт в течение 60 секунд, перезапустите из консоли командой `hermes gateway restart`."

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -240,6 +240,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ Temizlik sonrası başlık boş — oturum başlıksız başlatıldı."
     tip:                   "\n✦ İpucu: {tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset yalnızca Telegram, Discord ve Slack ileti dizilerinde kullanılabilir."
+    thread_only:           "{prefix}autoreset komutunu yapılandırmak istediğiniz ileti dizisinin içinde çalıştırın (kök konuşmada veya üst kanalda değil)."
+    usage:                 "Kullanım: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "devre dışı"
+    policy_daily:          "her gün {hour}:{minute}"
+    policy_idle:           "{minutes} dakika hareketsizlikten sonra"
+    policy_both:           "her gün {hour}:{minute} veya {minutes} dakika hareketsizlikten sonra"
+    policy_unknown:        "{mode}"
+    scope_override:        "ileti dizisine özel ayar"
+    scope_inherited:       "devralınan ilke"
+    status:                "Otomatik sıfırlama: {policy} ({scope})."
+    invalid_state:         "İleti dizisi otomatik sıfırlama durumu geçersiz; hiçbir değişiklik yapılmadı."
+    invalid_status:        "Otomatik sıfırlama: devre dışı (güvenli geri dönüş; ileti dizisi ilke durumu geçersiz)."
+    save_failed:           "İleti dizisi otomatik sıfırlama ilkesi kaydedilemedi."
+    read_failed:           "İleti dizisi otomatik sıfırlama ilkesi okunamadı."
+
   restart:
     in_progress:           "⏳ Gateway yeniden başlatma zaten sürüyor..."
     restarting:            "♻ Gateway yeniden başlatılıyor. 60 saniye içinde bildirim almazsanız konsoldan `hermes gateway restart` ile yeniden başlatın."

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -238,6 +238,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ Temizlik sonrası başlık boş — oturum başlıksız başlatıldı."
     tip:                   "\n✦ İpucu: {tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset yalnızca Telegram, Discord ve Slack ileti dizilerinde kullanılabilir."
+    thread_only:           "{prefix}autoreset komutunu yapılandırmak istediğiniz ileti dizisinin içinde çalıştırın (kök konuşmada veya üst kanalda değil)."
+    usage:                 "Kullanım: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "devre dışı"
+    policy_daily:          "her gün {hour}:{minute}"
+    policy_idle:           "{minutes} dakika hareketsizlikten sonra"
+    policy_both:           "her gün {hour}:{minute} veya {minutes} dakika hareketsizlikten sonra"
+    policy_unknown:        "{mode}"
+    scope_override:        "ileti dizisine özel ayar"
+    scope_inherited:       "devralınan ilke"
+    status:                "Otomatik sıfırlama: {policy} ({scope})."
+    invalid_state:         "İleti dizisi otomatik sıfırlama durumu geçersiz; hiçbir değişiklik yapılmadı."
+    invalid_status:        "Otomatik sıfırlama: devre dışı (güvenli geri dönüş; ileti dizisi ilke durumu geçersiz)."
+    save_failed:           "İleti dizisi otomatik sıfırlama ilkesi kaydedilemedi."
+    read_failed:           "İleti dizisi otomatik sıfırlama ilkesi okunamadı."
+
   restart:
     in_progress:           "⏳ Gateway yeniden başlatma zaten sürüyor..."
     restarting:            "♻ Gateway yeniden başlatılıyor. 60 saniye içinde bildirim almazsanız konsoldan `hermes gateway restart` ile yeniden başlatın."

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -240,6 +240,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ Після очищення назва порожня — сесію запущено без назви."
     tip:                   "\n✦ Порада: {tip}"
 
+  autoreset:
+    unsupported_platform:  "Команда {prefix}autoreset доступна лише в гілках Telegram, Discord і Slack."
+    thread_only:           "Запустіть {prefix}autoreset усередині гілки, яку потрібно налаштувати (не в кореневій розмові чи батьківському каналі)."
+    usage:                 "Використання: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "вимкнено"
+    policy_daily:          "щодня о {hour}:{minute}"
+    policy_idle:           "після {minutes} хвилин бездіяльності"
+    policy_both:           "щодня о {hour}:{minute} або після {minutes} хвилин бездіяльності"
+    policy_unknown:        "{mode}"
+    scope_override:        "налаштування для гілки"
+    scope_inherited:       "успадкована політика"
+    status:                "Автоматичне скидання: {policy} ({scope})."
+    invalid_state:         "Стан автоматичного скидання гілок недійсний; зміни не внесено."
+    invalid_status:        "Автоматичне скидання: вимкнено (безпечний режим; стан політики гілки недійсний)."
+    save_failed:           "Не вдалося зберегти політику автоматичного скидання гілки."
+    read_failed:           "Не вдалося прочитати політику автоматичного скидання гілки."
+
   restart:
     in_progress:           "⏳ Перезапуск гейтвея вже виконується..."
     restarting:            "♻ Перезапуск гейтвея. Якщо ви не отримаєте сповіщення протягом 60 секунд, перезапустіть із консолі командою `hermes gateway restart`."

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -238,6 +238,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ Після очищення назва порожня — сесію запущено без назви."
     tip:                   "\n✦ Порада: {tip}"
 
+  autoreset:
+    unsupported_platform:  "Команда {prefix}autoreset доступна лише в гілках Telegram, Discord і Slack."
+    thread_only:           "Запустіть {prefix}autoreset усередині гілки, яку потрібно налаштувати (не в кореневій розмові чи батьківському каналі)."
+    usage:                 "Використання: {prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "вимкнено"
+    policy_daily:          "щодня о {hour}:{minute}"
+    policy_idle:           "після {minutes} хвилин бездіяльності"
+    policy_both:           "щодня о {hour}:{minute} або після {minutes} хвилин бездіяльності"
+    policy_unknown:        "{mode}"
+    scope_override:        "налаштування для гілки"
+    scope_inherited:       "успадкована політика"
+    status:                "Автоматичне скидання: {policy} ({scope})."
+    invalid_state:         "Стан автоматичного скидання гілок недійсний; зміни не внесено."
+    invalid_status:        "Автоматичне скидання: вимкнено (безпечний режим; стан політики гілки недійсний)."
+    save_failed:           "Не вдалося зберегти політику автоматичного скидання гілки."
+    read_failed:           "Не вдалося прочитати політику автоматичного скидання гілки."
+
   restart:
     in_progress:           "⏳ Перезапуск гейтвея вже виконується..."
     restarting:            "♻ Перезапуск гейтвея. Якщо ви не отримаєте сповіщення протягом 60 секунд, перезапустіть із консолі командою `hermes gateway restart`."

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -240,6 +240,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ 清理後標題為空 — 工作階段以未命名方式啟動。"
     tip:                   "\n✦ 提示：{tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset 僅適用於 Telegram、Discord 和 Slack 討論串。"
+    thread_only:           "請在要設定的討論串內執行 {prefix}autoreset（不能在根對話或上層頻道中執行）。"
+    usage:                 "用法：{prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "已停用"
+    policy_daily:          "每天 {hour}:{minute}"
+    policy_idle:           "閒置 {minutes} 分鐘後"
+    policy_both:           "每天 {hour}:{minute}，或閒置 {minutes} 分鐘後"
+    policy_unknown:        "{mode}"
+    scope_override:        "討論串專屬設定"
+    scope_inherited:       "繼承的政策"
+    status:                "自動重設：{policy}（{scope}）。"
+    invalid_state:         "討論串自動重設狀態無效；未進行任何變更。"
+    invalid_status:        "自動重設：已停用（安全備援；討論串政策狀態無效）。"
+    save_failed:           "無法儲存討論串自動重設政策。"
+    read_failed:           "無法讀取討論串自動重設政策。"
+
   restart:
     in_progress:           "⏳ 閘道重新啟動已在進行中……"
     restarting:            "♻ 正在重新啟動閘道。如果 60 秒內未收到通知，請在主控台執行 `hermes gateway restart` 重新啟動。"

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -238,6 +238,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ 清理後標題為空 — 工作階段以未命名方式啟動。"
     tip:                   "\n✦ 提示：{tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset 僅適用於 Telegram、Discord 和 Slack 討論串。"
+    thread_only:           "請在要設定的討論串內執行 {prefix}autoreset（不能在根對話或上層頻道中執行）。"
+    usage:                 "用法：{prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "已停用"
+    policy_daily:          "每天 {hour}:{minute}"
+    policy_idle:           "閒置 {minutes} 分鐘後"
+    policy_both:           "每天 {hour}:{minute}，或閒置 {minutes} 分鐘後"
+    policy_unknown:        "{mode}"
+    scope_override:        "討論串專屬設定"
+    scope_inherited:       "繼承的政策"
+    status:                "自動重設：{policy}（{scope}）。"
+    invalid_state:         "討論串自動重設狀態無效；未進行任何變更。"
+    invalid_status:        "自動重設：已停用（安全備援；討論串政策狀態無效）。"
+    save_failed:           "無法儲存討論串自動重設政策。"
+    read_failed:           "無法讀取討論串自動重設政策。"
+
   restart:
     in_progress:           "⏳ 閘道重新啟動已在進行中……"
     restarting:            "♻ 正在重新啟動閘道。如果 60 秒內未收到通知，請在主控台執行 `hermes gateway restart` 重新啟動。"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -240,6 +240,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ 清理后标题为空 — 会话以未命名方式启动。"
     tip:                   "\n✦ 提示：{tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset 仅适用于 Telegram、Discord 和 Slack 话题串。"
+    thread_only:           "请在要配置的话题串内运行 {prefix}autoreset（不能在根对话或父频道中运行）。"
+    usage:                 "用法：{prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "已禁用"
+    policy_daily:          "每天 {hour}:{minute}"
+    policy_idle:           "空闲 {minutes} 分钟后"
+    policy_both:           "每天 {hour}:{minute}，或空闲 {minutes} 分钟后"
+    policy_unknown:        "{mode}"
+    scope_override:        "话题串专属设置"
+    scope_inherited:       "继承的策略"
+    status:                "自动重置：{policy}（{scope}）。"
+    invalid_state:         "话题串自动重置状态无效；未进行任何更改。"
+    invalid_status:        "自动重置：已禁用（安全回退；话题串策略状态无效）。"
+    save_failed:           "无法保存话题串自动重置策略。"
+    read_failed:           "无法读取话题串自动重置策略。"
+
   restart:
     in_progress:           "⏳ 网关重启已在进行中……"
     restarting:            "♻ 正在重启网关。如果 60 秒内没有收到通知，请在控制台运行 `hermes gateway restart` 重启。"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -238,6 +238,23 @@ gateway:
     title_empty_untitled:  "\n⚠️ 清理后标题为空 — 会话以未命名方式启动。"
     tip:                   "\n✦ 提示：{tip}"
 
+  autoreset:
+    unsupported_platform:  "{prefix}autoreset 仅适用于 Telegram、Discord 和 Slack 话题串。"
+    thread_only:           "请在要配置的话题串内运行 {prefix}autoreset（不能在根对话或父频道中运行）。"
+    usage:                 "用法：{prefix}autoreset [status|on|daily HH:MM|off|inherit]"
+    policy_off:            "已禁用"
+    policy_daily:          "每天 {hour}:{minute}"
+    policy_idle:           "空闲 {minutes} 分钟后"
+    policy_both:           "每天 {hour}:{minute}，或空闲 {minutes} 分钟后"
+    policy_unknown:        "{mode}"
+    scope_override:        "话题串专属设置"
+    scope_inherited:       "继承的策略"
+    status:                "自动重置：{policy}（{scope}）。"
+    invalid_state:         "话题串自动重置状态无效；未进行任何更改。"
+    invalid_status:        "自动重置：已禁用（安全回退；话题串策略状态无效）。"
+    save_failed:           "无法保存话题串自动重置策略。"
+    read_failed:           "无法读取话题串自动重置策略。"
+
   restart:
     in_progress:           "⏳ 网关重启已在进行中……"
     restarting:            "♻ 正在重启网关。如果 60 秒内没有收到通知，请在控制台运行 `hermes gateway restart` 重启。"

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -22,6 +22,7 @@ from gateway.config import (
     SessionResetPolicy,
     StreamingConfig,
     _apply_env_overrides,
+    _validate_gateway_config,
     load_gateway_config,
     persist_home_channel,
 )
@@ -170,25 +171,82 @@ class TestGetConnectedPlatforms:
 
 class TestSessionResetPolicy:
     def test_roundtrip(self):
-        policy = SessionResetPolicy(mode="idle", at_hour=6, idle_minutes=120,
+        policy = SessionResetPolicy(mode="idle", at_hour=6, at_minute=37,
+                                    idle_minutes=120,
                                     bg_process_max_age_hours=48)
         d = policy.to_dict()
         restored = SessionResetPolicy.from_dict(d)
         assert restored.mode == "idle"
         assert restored.at_hour == 6
+        assert restored.at_minute == 37
         assert restored.idle_minutes == 120
         assert restored.bg_process_max_age_hours == 48
 
+    def test_defaults(self):
+        policy = SessionResetPolicy()
+        assert policy.mode == "none"
+        assert policy.at_hour == 4
+        assert policy.at_minute == 0
+        assert policy.idle_minutes == 1440
+        assert policy.bg_process_max_age_hours == 24
 
     def test_from_dict_treats_null_values_as_defaults(self):
         restored = SessionResetPolicy.from_dict(
-            {"mode": None, "at_hour": None, "idle_minutes": None,
+            {"mode": None, "at_hour": None, "at_minute": None, "idle_minutes": None,
              "bg_process_max_age_hours": None}
         )
         assert restored.mode == "none"
         assert restored.at_hour == 4
+        assert restored.at_minute == 0
         assert restored.idle_minutes == 1440
         assert restored.bg_process_max_age_hours == 24
+
+    def test_from_dict_coerces_quoted_false_notify(self):
+        restored = SessionResetPolicy.from_dict({"notify": "false"})
+        assert restored.notify is False
+
+    def test_from_dict_malformed_section_falls_back_to_defaults(self):
+        restored = SessionResetPolicy.from_dict("oops")
+        assert restored.mode == SessionResetPolicy().mode
+        assert restored.at_hour == 4
+        assert restored.at_minute == 0
+        assert restored.idle_minutes == 1440
+
+    def test_legacy_at_hour_without_minute_keeps_midnight_minute_default(self):
+        restored = SessionResetPolicy.from_dict({"mode": "daily", "at_hour": 17})
+        assert restored.to_dict()["at_hour"] == 17
+        assert restored.to_dict()["at_minute"] == 0
+
+    def test_legacy_positional_constructor_keeps_existing_field_order(self):
+        policy = SessionResetPolicy(
+            "daily",
+            17,
+            90,
+            False,
+            ("api_server",),
+            48,
+        )
+        assert policy.idle_minutes == 90
+        assert policy.notify is False
+        assert policy.notify_exclude_platforms == ("api_server",)
+        assert policy.bg_process_max_age_hours == 48
+        assert policy.at_minute == 0
+
+    @pytest.mark.parametrize("invalid", [-1, 60, True, "30", None])
+    def test_validation_replaces_invalid_at_minute_for_every_policy_scope(
+        self, invalid
+    ):
+        config = GatewayConfig(
+            default_reset_policy=SessionResetPolicy(at_minute=invalid),
+            reset_by_type={"thread": SessionResetPolicy(at_minute=invalid)},
+            reset_by_platform={
+                Platform.SLACK: SessionResetPolicy(at_minute=invalid)
+            },
+        )
+        _validate_gateway_config(config)
+        assert config.default_reset_policy.at_minute == 0
+        assert config.reset_by_type["thread"].at_minute == 0
+        assert config.reset_by_platform[Platform.SLACK].at_minute == 0
 
 
 class TestStreamingConfig:

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -175,6 +175,59 @@ async def test_run_simple_slash_executes_when_defer_interaction_expired(adapter)
 
 
 @pytest.mark.asyncio
+async def test_auto_registers_missing_gateway_commands(adapter):
+    """Commands in COMMAND_REGISTRY that aren't explicitly registered should
+    be auto-registered by the dynamic catch-all block."""
+    adapter._run_simple_slash = AsyncMock()
+    adapter._register_slash_commands()
+
+    tree_names = set(adapter._client.tree.commands.keys())
+
+    # These commands are gateway-available but were not in the original
+    # hardcoded registration list — they should be auto-registered.
+    expected_auto = {"autoreset", "debug", "yolo", "profile"}
+    for name in expected_auto:
+        assert name in tree_names, f"/{name} should be auto-registered on Discord"
+
+
+@pytest.mark.asyncio
+async def test_auto_registered_command_dispatches_correctly(adapter):
+    """Auto-registered commands should dispatch via _run_simple_slash."""
+    adapter._run_simple_slash = AsyncMock()
+    adapter._register_slash_commands()
+
+    # /debug has no args — test parameterless dispatch
+    debug_cmd = adapter._client.tree.commands["debug"]
+    interaction = SimpleNamespace()
+    adapter._run_simple_slash.reset_mock()
+    await debug_cmd.callback(interaction)
+    adapter._run_simple_slash.assert_awaited_once_with(interaction, "/debug")
+
+
+@pytest.mark.asyncio
+async def test_auto_registered_command_with_args(adapter):
+    """Auto-registered commands with args_hint should accept an optional args param."""
+    adapter._run_simple_slash = AsyncMock()
+    adapter._register_slash_commands()
+
+    # /branch has args_hint="[name]" — test dispatch with args
+    branch_cmd = adapter._client.tree.commands["branch"]
+    interaction = SimpleNamespace()
+    adapter._run_simple_slash.reset_mock()
+    await branch_cmd.callback(interaction, args="my-branch")
+    adapter._run_simple_slash.assert_awaited_once_with(
+        interaction, "/branch my-branch"
+    )
+
+    autoreset_cmd = adapter._client.tree.commands["autoreset"]
+    adapter._run_simple_slash.reset_mock()
+    await autoreset_cmd.callback(interaction, args="daily 08:07")
+    adapter._run_simple_slash.assert_awaited_once_with(
+        interaction, "/autoreset daily 08:07"
+    )
+
+
+@pytest.mark.asyncio
 async def test_auto_registers_plugin_commands_for_discord(adapter):
     """Plugin slash commands should appear as native Discord app commands."""
     adapter._run_simple_slash = AsyncMock()

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1273,6 +1273,25 @@ class TestBangPrefixCommands:
 
 
     @pytest.mark.asyncio
+    async def test_bang_autoreset_reaches_normal_thread_command_handler(self, adapter):
+        adapter.config.extra["require_mention"] = False
+        adapter._has_active_session_for_thread = MagicMock(return_value=True)
+        evt = self._make_event(
+            "!autoreset daily 08:07",
+            thread_ts="1111111111.000001",
+            channel_type="channel",
+            channel="C123",
+        )
+        await adapter._handle_slack_message(evt)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/autoreset daily 08:07"
+        assert msg_event.message_type == MessageType.COMMAND
+        assert msg_event.source.chat_id == "C123"
+        assert msg_event.source.chat_type == "group"
+        assert msg_event.source.thread_id == "1111111111.000001"
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "authored_text", ["!queue  --flag  value  ", "/queue  --flag  value  "]
     )

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -22,7 +22,7 @@ from unittest.mock import AsyncMock, MagicMock, patch, call
 import pytest
 
 import agent.secret_scope as secret_scope
-from gateway.config import Platform, PlatformConfig
+from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.run import GatewayRunner
 from gateway.platforms.base import (
     MessageEvent,
@@ -32,6 +32,8 @@ from gateway.platforms.base import (
     SendResult,
     is_host_excluded_by_no_proxy,
 )
+from gateway.session import AsyncSessionStore, SessionStore
+from gateway.slash_commands import GatewaySlashCommandsMixin
 
 
 # ---------------------------------------------------------------------------
@@ -1271,6 +1273,147 @@ class TestBangPrefixCommands:
             evt["thread_ts"] = thread_ts
         return evt
 
+    def _production_autoreset_adapter(self, tmp_path):
+        config = PlatformConfig(enabled=True, token="***", typing_indicator=False)
+        config.extra["require_mention"] = False
+        adapter = SlackAdapter(config)
+        adapter._app = MagicMock()
+        adapter._app.client = AsyncMock()
+        adapter._bot_user_id = "U_BOT"
+        adapter._running = True
+        adapter._has_active_session_for_thread = MagicMock(return_value=True)
+        adapter._resolve_user_name = AsyncMock(return_value="Test User")
+        adapter._resolve_channel_name = AsyncMock(return_value="test-channel")
+        adapter._fetch_thread_parent_text = AsyncMock(return_value=None)
+
+        gateway_config = GatewayConfig()
+        gateway_config.sessions_dir = tmp_path
+        store = SessionStore(tmp_path, gateway_config)
+        store._db = None
+        runner = GatewaySlashCommandsMixin()
+        runner.session_store = store
+        runner.async_session_store = AsyncSessionStore(store)
+        runner.adapters = {Platform.SLACK: adapter}
+        dispatches = asyncio.Queue()
+
+        async def dispatch(event):
+            response = await runner._handle_autoreset_command(event)
+            await dispatches.put((event, response, asyncio.current_task()))
+
+        adapter.set_message_handler(dispatch)
+        return adapter, store, dispatches
+
+    async def _dispatch_autoreset(
+        self, adapter, dispatches, command, *, team_id, ts
+    ):
+        event = self._make_event(
+            command,
+            thread_ts="1712345678.000001",
+            channel_type="channel",
+            channel="C123",
+        )
+        event.update(type="message", ts=ts, client_msg_id=f"client-{team_id}-{ts}")
+
+        await adapter._handle_slack_message(event, {"team_id": team_id})
+        message, response, task = await asyncio.wait_for(dispatches.get(), timeout=2)
+        await asyncio.wait_for(task, timeout=2)
+        return message, response
+
+    @pytest.mark.asyncio
+    async def test_bang_autoreset_commands_dispatch_with_slack_thread_scope(
+        self, tmp_path
+    ):
+        adapter, _store, dispatches = self._production_autoreset_adapter(tmp_path)
+        cases = [
+            ("status", "Automatic reset: disabled (inherited policy)."),
+            ("on", "Automatic reset: daily at 04:00 (thread override)."),
+            ("daily 08:07", "Automatic reset: daily at 08:07 (thread override)."),
+            ("off", "Automatic reset: disabled (thread override)."),
+            ("inherit", "Automatic reset: disabled (inherited policy)."),
+        ]
+
+        for index, (args, expected_response) in enumerate(cases, start=1):
+            message, response = await self._dispatch_autoreset(
+                adapter,
+                dispatches,
+                f"!autoreset {args}",
+                team_id="T_WORKSPACE",
+                ts=f"1712345679.00000{index}",
+            )
+
+            assert message.text == f"/autoreset {args}"
+            assert message.message_type == MessageType.COMMAND
+            assert message.source.scope_id == "T_WORKSPACE"
+            assert message.source.chat_id == "C123"
+            assert message.source.thread_id == "1712345678.000001"
+            assert response == expected_response
+
+    @pytest.mark.asyncio
+    async def test_adapter_derived_slack_sources_persist_workspace_isolation(
+        self, tmp_path
+    ):
+        adapter, _store, dispatches = self._production_autoreset_adapter(tmp_path)
+        workspace_a, response_a = await self._dispatch_autoreset(
+            adapter,
+            dispatches,
+            "!autoreset daily 06:15",
+            team_id="T_A",
+            ts="1712345679.100001",
+        )
+        workspace_b, response_b = await self._dispatch_autoreset(
+            adapter,
+            dispatches,
+            "!autoreset off",
+            team_id="T_B",
+            ts="1712345679.100002",
+        )
+
+        assert response_a == "Automatic reset: daily at 06:15 (thread override)."
+        assert response_b == "Automatic reset: disabled (thread override)."
+        assert workspace_a.source.scope_id == "T_A"
+        assert workspace_b.source.scope_id == "T_B"
+        assert workspace_a.source.chat_id == workspace_b.source.chat_id == "C123"
+        assert (
+            workspace_a.source.thread_id
+            == workspace_b.source.thread_id
+            == "1712345678.000001"
+        )
+
+        reloaded = SessionStore(tmp_path, GatewayConfig())
+        reloaded._db = None
+        policy_a, resolution_a = reloaded.get_effective_reset_policy(
+            source=workspace_a.source
+        )
+        policy_b, resolution_b = reloaded.get_effective_reset_policy(
+            source=workspace_b.source
+        )
+        assert (policy_a.mode, policy_a.at_hour, policy_a.at_minute, resolution_a) == (
+            "daily",
+            6,
+            15,
+            "override",
+        )
+        assert (policy_b.mode, resolution_b) == ("none", "override")
+
+
+    @pytest.mark.asyncio
+    async def test_bang_autoreset_reaches_normal_thread_command_handler(self, adapter):
+        adapter.config.extra["require_mention"] = False
+        adapter._has_active_session_for_thread = MagicMock(return_value=True)
+        evt = self._make_event(
+            "!autoreset daily 08:07",
+            thread_ts="1111111111.000001",
+            channel_type="channel",
+            channel="C123",
+        )
+        await adapter._handle_slack_message(evt)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/autoreset daily 08:07"
+        assert msg_event.message_type == MessageType.COMMAND
+        assert msg_event.source.chat_id == "C123"
+        assert msg_event.source.chat_type == "group"
+        assert msg_event.source.thread_id == "1111111111.000001"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/gateway/test_thread_autoreset.py
+++ b/tests/gateway/test_thread_autoreset.py
@@ -1,0 +1,605 @@
+"""Per-thread automatic reset policy tests."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, SessionResetPolicy
+from gateway.platforms.base import MessageEvent
+from gateway.session import AsyncSessionStore, SessionEntry, SessionSource, SessionStore
+from gateway.slash_commands import GatewaySlashCommandsMixin
+from gateway.thread_reset_policy import ThreadResetPolicyStateError
+from hermes_cli.commands import (
+    resolve_command,
+    slack_native_slashes,
+    telegram_bot_commands,
+)
+
+
+def _source(
+    thread_id: str | None = "10",
+    *,
+    chat_id: str = "-1001",
+    chat_type: str | None = None,
+    user_id: str = "user-a",
+    platform: Platform = Platform.TELEGRAM,
+    profile: str | None = None,
+    scope_id: str | None = None,
+) -> SessionSource:
+    if chat_type is None:
+        chat_type = {
+            Platform.TELEGRAM: "forum",
+            Platform.DISCORD: "thread",
+            Platform.SLACK: "group",
+        }.get(platform, "group")
+    return SessionSource(
+        platform=platform,
+        chat_id=chat_id,
+        chat_type=chat_type,
+        thread_id=thread_id,
+        user_id=user_id,
+        profile=profile,
+        scope_id=scope_id,
+    )
+
+
+def _store(tmp_path, config: GatewayConfig | None = None) -> SessionStore:
+    config = config or GatewayConfig()
+    config.sessions_dir = tmp_path
+    store = SessionStore(tmp_path, config)
+    store._db = None
+    return store
+
+
+def _entry(
+    source: SessionSource,
+    updated_at: datetime,
+    *,
+    session_id: str | None = None,
+) -> SessionEntry:
+    return SessionEntry(
+        session_key="route",
+        session_id=session_id or f"session-{source.thread_id}",
+        created_at=updated_at,
+        updated_at=updated_at,
+        origin=source,
+        platform=source.platform,
+        chat_type=source.chat_type,
+    )
+
+
+def _runner(store: SessionStore, *, slack_prefix: bool = False):
+    runner = GatewaySlashCommandsMixin()
+    runner.session_store = store
+    runner.async_session_store = AsyncSessionStore(store)
+    runner.adapters = (
+        {Platform.SLACK: SimpleNamespace(typed_command_prefix="!")}
+        if slack_prefix
+        else {}
+    )
+    return runner
+
+
+def test_thread_identity_isolates_profile_platform_chat_and_thread_not_user_or_session(
+    tmp_path,
+):
+    store = _store(tmp_path, GatewayConfig(multiplex_profiles=True))
+    source = _source(profile="work")
+    store.set_thread_reset_policy(
+        source,
+        SessionResetPolicy(mode="daily", at_hour=6, at_minute=15),
+    )
+
+    same_route_other_user = _source(user_id="user-b", profile="work")
+    same_route_other_session = _entry(
+        same_route_other_user,
+        datetime(2026, 7, 29),
+        session_id="completely-unrelated-session-id",
+    )
+    isolated = (
+        _source(thread_id="11", profile="work"),
+        _source(chat_id="-1002", profile="work"),
+        _source(profile="personal"),
+        _source(platform=Platform.DISCORD, profile="work"),
+        _source(platform=Platform.SLACK, profile="work"),
+    )
+
+    policy, resolution = store.get_effective_reset_policy(
+        entry=same_route_other_session
+    )
+    assert (policy.at_hour, policy.at_minute, resolution) == (6, 15, "override")
+    assert all(
+        store.get_effective_reset_policy(source=other)[1] == "inherited"
+        for other in isolated
+    )
+
+
+def test_slack_thread_overrides_are_isolated_by_workspace_scope(tmp_path):
+    store = _store(tmp_path)
+    workspace_a = _source(
+        platform=Platform.SLACK,
+        chat_id="C123",
+        thread_id="1712345678.000001",
+        scope_id="T-A",
+    )
+    workspace_b = _source(
+        platform=Platform.SLACK,
+        chat_id="C123",
+        thread_id="1712345678.000001",
+        scope_id="T-B",
+    )
+
+    store.set_thread_reset_policy(
+        workspace_a,
+        SessionResetPolicy(mode="daily", at_hour=6, at_minute=15),
+    )
+    store.set_thread_reset_policy(workspace_b, SessionResetPolicy(mode="none"))
+
+    reloaded = _store(tmp_path)
+    policy_a, resolution_a = reloaded.get_effective_reset_policy(source=workspace_a)
+    policy_b, resolution_b = reloaded.get_effective_reset_policy(source=workspace_b)
+    assert (policy_a.mode, policy_a.at_hour, policy_a.at_minute, resolution_a) == (
+        "daily",
+        6,
+        15,
+        "override",
+    )
+    assert (policy_b.mode, resolution_b) == ("none", "override")
+
+
+def test_discord_thread_overrides_are_isolated_by_guild_scope(tmp_path):
+    store = _store(tmp_path)
+    guild_a = _source(
+        platform=Platform.DISCORD,
+        chat_id="1234567890",
+        thread_id="9876543210",
+        scope_id="guild:alpha/β",
+    )
+    guild_b = _source(
+        platform=Platform.DISCORD,
+        chat_id="1234567890",
+        thread_id="9876543210",
+        scope_id="guild:alpha%2Fβ",
+    )
+
+    store.set_thread_reset_policy(
+        guild_a,
+        SessionResetPolicy(mode="daily", at_hour=7, at_minute=45),
+    )
+    store.set_thread_reset_policy(guild_b, SessionResetPolicy(mode="none"))
+
+    reloaded = _store(tmp_path)
+    policy_a, resolution_a = reloaded.get_effective_reset_policy(source=guild_a)
+    policy_b, resolution_b = reloaded.get_effective_reset_policy(source=guild_b)
+    assert (policy_a.mode, policy_a.at_hour, policy_a.at_minute, resolution_a) == (
+        "daily",
+        7,
+        45,
+        "override",
+    )
+    assert (policy_b.mode, resolution_b) == ("none", "override")
+
+
+def test_explicit_policy_persists_in_versioned_generic_state(tmp_path):
+    source = _source()
+    first = _store(tmp_path)
+    first.set_thread_reset_policy(
+        source,
+        SessionResetPolicy(mode="daily", at_hour=23, at_minute=59),
+    )
+
+    state_path = tmp_path / "thread_reset_policies.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["version"] == 1
+    assert list(state) == ["version", "threads"]
+    assert list(state["threads"].values()) == [
+        {"mode": "daily", "at_hour": 23, "at_minute": 59}
+    ]
+    assert not (tmp_path / "telegram_topic_reset_policies.json").exists()
+
+    reloaded = _store(tmp_path)
+    policy, resolution = reloaded.get_effective_reset_policy(source=source)
+    assert (policy.mode, policy.at_hour, policy.at_minute, resolution) == (
+        "daily",
+        23,
+        59,
+        "override",
+    )
+
+    reloaded.set_thread_reset_policy(source, SessionResetPolicy(mode="none"))
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert list(state["threads"].values()) == [{"mode": "none"}]
+
+
+def test_failed_atomic_write_keeps_last_known_policy(tmp_path, monkeypatch):
+    source = _source()
+    store = _store(tmp_path)
+    store.set_thread_reset_policy(source, SessionResetPolicy(mode="none"))
+
+    def fail_write(*_args, **_kwargs):
+        raise OSError("disk unavailable")
+
+    monkeypatch.setattr(
+        "gateway.thread_reset_policy.atomic_json_write",
+        fail_write,
+    )
+    with pytest.raises(OSError, match="disk unavailable"):
+        store.set_thread_reset_policy(
+            source,
+            SessionResetPolicy(mode="daily", at_hour=4, at_minute=30),
+        )
+
+    assert store.get_effective_reset_policy(source=source)[0].mode == "none"
+    assert _store(tmp_path).get_effective_reset_policy(source=source)[0].mode == "none"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "not json",
+        '{"version": 2, "threads": {}}',
+        '{"version": 1, "threads": {}, "extra": true}',
+        '{"version": 1, "threads": []}',
+        '{"version": 1, "threads": {"route": "off"}}',
+        '{"version": 1, "threads": {"route": {"mode": "none", "at_hour": 4}}}',
+        '{"version": 1, "threads": {"route": {"mode": "daily", "at_hour": 4}}}',
+        '{"version": 1, "threads": {"route": {"mode": "daily", "at_hour": true, "at_minute": 0}}}',
+        '{"version": 1, "threads": {"route": {"mode": "daily", "at_hour": 4, "at_minute": 60}}}',
+        '{"version": 1, "threads": {"route": {"mode": "idle"}}}',
+    ],
+)
+def test_malformed_persistence_fails_closed_and_preserves_evidence(
+    tmp_path, caplog, raw
+):
+    state_path = tmp_path / "thread_reset_policies.json"
+    state_path.write_text(raw, encoding="utf-8")
+    config = GatewayConfig(
+        default_reset_policy=SessionResetPolicy(mode="daily", at_hour=4, at_minute=30)
+    )
+
+    with caplog.at_level("WARNING"):
+        store = _store(tmp_path, config)
+
+    policy, resolution = store.get_effective_reset_policy(source=_source())
+    assert (policy.mode, resolution) == ("none", "invalid")
+    assert "Malformed thread auto-reset state" in caplog.text
+    with pytest.raises(ThreadResetPolicyStateError):
+        store.set_thread_reset_policy(_source(), SessionResetPolicy(mode="none"))
+    assert state_path.read_text(encoding="utf-8") == raw
+
+
+def test_invalid_in_memory_policy_is_rejected_without_losing_last_known_good(tmp_path):
+    source = _source()
+    store = _store(tmp_path)
+    store.set_thread_reset_policy(source, SessionResetPolicy(mode="none"))
+
+    with pytest.raises(ValueError, match="mode"):
+        store.set_thread_reset_policy(
+            source,
+            SessionResetPolicy(mode="idle", idle_minutes=10),
+        )
+    with pytest.raises(ValueError, match="at_minute"):
+        store.set_thread_reset_policy(
+            source,
+            SessionResetPolicy(mode="daily", at_hour=4, at_minute=60),
+        )
+
+    assert store.get_effective_reset_policy(source=source)[0].mode == "none"
+
+
+def test_thread_policy_precedes_platform_then_type_then_global(tmp_path):
+    config = GatewayConfig(
+        default_reset_policy=SessionResetPolicy(mode="idle", idle_minutes=30),
+        reset_by_type={
+            "forum": SessionResetPolicy(
+                mode="both", at_hour=7, at_minute=20, idle_minutes=45
+            ),
+            "thread": SessionResetPolicy(mode="daily", at_hour=6, at_minute=25),
+        },
+        reset_by_platform={
+            Platform.TELEGRAM: SessionResetPolicy(mode="daily", at_hour=9, at_minute=15)
+        },
+    )
+    store = _store(tmp_path, config)
+    source = _source()
+
+    inherited, resolution = store.get_effective_reset_policy(source=source)
+    assert (
+        inherited.mode,
+        inherited.at_hour,
+        inherited.at_minute,
+        resolution,
+    ) == ("daily", 9, 15, "inherited")
+
+    store.set_thread_reset_policy(
+        source,
+        SessionResetPolicy(mode="daily", at_hour=5, at_minute=40),
+    )
+    overridden, resolution = store.get_effective_reset_policy(source=source)
+    assert (
+        overridden.mode,
+        overridden.at_hour,
+        overridden.at_minute,
+        resolution,
+    ) == ("daily", 5, 40, "override")
+
+    store.set_thread_reset_policy(source, None)
+    restored, resolution = store.get_effective_reset_policy(source=source)
+    assert (
+        restored.mode,
+        restored.at_hour,
+        restored.at_minute,
+        resolution,
+    ) == ("daily", 9, 15, "inherited")
+
+    discord = _source(platform=Platform.DISCORD)
+    by_type, resolution = store.get_effective_reset_policy(source=discord)
+    assert (
+        by_type.mode,
+        by_type.at_hour,
+        by_type.at_minute,
+        resolution,
+    ) == ("daily", 6, 25, "inherited")
+
+
+def test_two_threads_can_hold_different_daily_policies(tmp_path):
+    store = _store(tmp_path)
+    early = _source(thread_id="early")
+    late = _source(thread_id="late")
+    store.set_thread_reset_policy(
+        early, SessionResetPolicy(mode="daily", at_hour=4, at_minute=5)
+    )
+    store.set_thread_reset_policy(
+        late, SessionResetPolicy(mode="daily", at_hour=22, at_minute=55)
+    )
+
+    early_policy = store.get_effective_reset_policy(source=early)[0]
+    late_policy = store.get_effective_reset_policy(source=late)[0]
+    assert (early_policy.at_hour, early_policy.at_minute) == (4, 5)
+    assert (late_policy.at_hour, late_policy.at_minute) == (22, 55)
+
+
+@pytest.mark.asyncio
+async def test_autoreset_command_on_daily_off_inherit_and_status(tmp_path):
+    store = _store(tmp_path)
+    runner = _runner(store)
+    source = _source()
+
+    assert resolve_command("autoreset").name == "autoreset"
+    assert (
+        await runner._handle_autoreset_command(
+            MessageEvent(text="/autoreset", source=source)
+        )
+        == "Automatic reset: disabled (inherited policy)."
+    )
+    assert (
+        await runner._handle_autoreset_command(
+            MessageEvent(text="/autoreset on", source=source)
+        )
+        == "Automatic reset: daily at 04:00 (thread override)."
+    )
+    assert (
+        await runner._handle_autoreset_command(
+            MessageEvent(text="/autoreset daily 17:43", source=source)
+        )
+        == "Automatic reset: daily at 17:43 (thread override)."
+    )
+    assert (
+        await runner._handle_autoreset_command(
+            MessageEvent(text="/autoreset status", source=source)
+        )
+        == "Automatic reset: daily at 17:43 (thread override)."
+    )
+    assert (
+        await runner._handle_autoreset_command(
+            MessageEvent(text="/autoreset off", source=source)
+        )
+        == "Automatic reset: disabled (thread override)."
+    )
+    assert (
+        await runner._handle_autoreset_command(
+            MessageEvent(text="/autoreset inherit", source=source)
+        )
+        == "Automatic reset: disabled (inherited policy)."
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "args",
+    [
+        "daily",
+        "daily ",
+        "daily 4:00",
+        "daily 04:0",
+        "daily 24:00",
+        "daily 23:60",
+        "daily 12:30 extra",
+        "maybe",
+    ],
+)
+async def test_autoreset_command_rejects_invalid_times_without_rounding(tmp_path, args):
+    store = _store(tmp_path)
+    result = await _runner(store)._handle_autoreset_command(
+        MessageEvent(text=f"/autoreset {args}", source=_source())
+    )
+    assert result == ("Usage: /autoreset [status|on|daily HH:MM|off|inherit]")
+    assert not (tmp_path / "thread_reset_policies.json").exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("platform", "chat_type"),
+    [
+        (Platform.TELEGRAM, "forum"),
+        (Platform.DISCORD, "thread"),
+        (Platform.SLACK, "group"),
+        (Platform.TELEGRAM, "dm"),
+        (Platform.DISCORD, "dm"),
+        (Platform.SLACK, "dm"),
+    ],
+)
+async def test_autoreset_accepts_supported_thread_sources(
+    tmp_path, platform, chat_type
+):
+    store = _store(tmp_path)
+    source = _source(platform=platform, chat_type=chat_type)
+    result = await _runner(
+        store, slack_prefix=platform == Platform.SLACK
+    )._handle_autoreset_command(
+        MessageEvent(
+            text="/autoreset daily 08:07",
+            source=source,
+        )
+    )
+
+    assert result == "Automatic reset: daily at 08:07 (thread override)."
+    assert store.get_effective_reset_policy(source=source)[1] == "override"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "source",
+    [
+        _source(platform=Platform.TELEGRAM, thread_id=None, chat_type="dm"),
+        _source(platform=Platform.DISCORD, thread_id=None, chat_type="group"),
+        _source(platform=Platform.SLACK, thread_id=None),
+        _source(platform=Platform.SLACK, chat_id=" "),
+        _source(platform=Platform.SLACK, thread_id=" "),
+    ],
+)
+async def test_autoreset_rejects_root_and_non_thread_sources(tmp_path, source):
+    store = _store(tmp_path)
+    runner = _runner(store, slack_prefix=source.platform == Platform.SLACK)
+    result = await runner._handle_autoreset_command(
+        MessageEvent(text="/autoreset on", source=source)
+    )
+
+    prefix = "!" if source.platform == Platform.SLACK else "/"
+    assert result == (
+        f"Run {prefix}autoreset inside the thread you want to configure "
+        "(not a root conversation or parent channel)."
+    )
+    assert not (tmp_path / "thread_reset_policies.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_autoreset_rejects_unsupported_platform(tmp_path):
+    result = await _runner(_store(tmp_path))._handle_autoreset_command(
+        MessageEvent(
+            text="/autoreset on",
+            source=_source(platform=Platform.MATRIX),
+        )
+    )
+    assert result == (
+        "/autoreset is only available in Telegram, Discord, and Slack threads."
+    )
+
+
+@pytest.mark.asyncio
+async def test_malformed_state_command_fails_safely(tmp_path):
+    (tmp_path / "thread_reset_policies.json").write_text(
+        "not json",
+        encoding="utf-8",
+    )
+    store = _store(
+        tmp_path,
+        GatewayConfig(default_reset_policy=SessionResetPolicy(mode="daily")),
+    )
+    runner = _runner(store)
+
+    status = await runner._handle_autoreset_command(
+        MessageEvent(text="/autoreset status", source=_source())
+    )
+    mutation = await runner._handle_autoreset_command(
+        MessageEvent(text="/autoreset on", source=_source())
+    )
+
+    assert status == (
+        "Automatic reset: disabled (safe fallback; thread policy state is invalid)."
+    )
+    assert mutation == ("Thread auto-reset state is invalid; no changes were made.")
+
+
+def test_daily_reset_boundary_uses_minute_precision(tmp_path, monkeypatch):
+    source = _source()
+    store = _store(tmp_path)
+    store.set_thread_reset_policy(
+        source,
+        SessionResetPolicy(mode="daily", at_hour=4, at_minute=30),
+    )
+    entry = _entry(source, datetime(2026, 7, 28, 4, 31))
+
+    monkeypatch.setattr(
+        "gateway.session._now", lambda: datetime(2026, 7, 29, 4, 29, 59)
+    )
+    assert store._is_session_expired(entry) is False
+    assert store._should_reset(entry, source) is None
+
+    monkeypatch.setattr("gateway.session._now", lambda: datetime(2026, 7, 29, 4, 30))
+    assert store._is_session_expired(entry) is True
+    assert store._should_reset(entry, source) == "daily"
+
+    monkeypatch.setattr("gateway.session._now", lambda: datetime(2026, 7, 29, 4, 31))
+    assert store._is_session_expired(entry) is True
+
+
+def test_watcher_due_selection_and_active_process_safeguard_are_preserved(
+    tmp_path, monkeypatch
+):
+    now = datetime(2026, 7, 29, 10, 0)
+    monkeypatch.setattr("gateway.session._now", lambda: now)
+    store = _store(tmp_path)
+    due = _source(thread_id="due")
+    later = _source(thread_id="later")
+    store.set_thread_reset_policy(
+        due, SessionResetPolicy(mode="daily", at_hour=9, at_minute=30)
+    )
+    store.set_thread_reset_policy(
+        later, SessionResetPolicy(mode="daily", at_hour=10, at_minute=30)
+    )
+    entries = [
+        _entry(due, now - timedelta(hours=2)),
+        _entry(later, now - timedelta(hours=2)),
+    ]
+
+    selected = [
+        entry.origin.thread_id for entry in entries if store._is_session_expired(entry)
+    ]
+    assert selected == ["due"]
+
+    monkeypatch.setattr(store, "_has_active_processes_safe", lambda *_a, **_k: True)
+    assert store._is_session_expired(entries[0]) is False
+    assert store._should_reset(entries[0], due) is None
+
+
+def test_manual_reset_rotates_session_and_preserves_thread_policy(tmp_path):
+    store = _store(tmp_path)
+    source = _source()
+    store.set_thread_reset_policy(
+        source,
+        SessionResetPolicy(mode="daily", at_hour=12, at_minute=34),
+    )
+    original = store.get_or_create_session(source)
+
+    reset = store.reset_session(original.session_key)
+
+    assert reset is not None
+    assert reset.session_id != original.session_id
+    assert reset.is_fresh_reset is True
+    policy, resolution = store.get_effective_reset_policy(source=source)
+    assert (policy.at_hour, policy.at_minute, resolution) == (12, 34, "override")
+
+
+def test_registry_surfaces_telegram_and_discord_but_not_native_slack():
+    assert "autoreset" in {name for name, _description in telegram_bot_commands()}
+    command = resolve_command("autoreset")
+    assert command is not None and command.gateway_only is True
+    assert "autoreset" not in {
+        name for name, _description, _hint in slack_native_slashes()
+    }
+    assert "start" in {name for name, _description, _hint in slack_native_slashes()}

--- a/tests/gateway/test_thread_autoreset.py
+++ b/tests/gateway/test_thread_autoreset.py
@@ -1,0 +1,538 @@
+"""Per-thread automatic reset policy tests."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, SessionResetPolicy
+from gateway.platforms.base import MessageEvent
+from gateway.session import AsyncSessionStore, SessionEntry, SessionSource, SessionStore
+from gateway.slash_commands import GatewaySlashCommandsMixin
+from gateway.thread_reset_policy import ThreadResetPolicyStateError
+from hermes_cli.commands import (
+    resolve_command,
+    slack_native_slashes,
+    telegram_bot_commands,
+)
+
+
+def _source(
+    thread_id: str | None = "10",
+    *,
+    chat_id: str = "-1001",
+    chat_type: str | None = None,
+    user_id: str = "user-a",
+    platform: Platform = Platform.TELEGRAM,
+    profile: str | None = None,
+) -> SessionSource:
+    if chat_type is None:
+        chat_type = {
+            Platform.TELEGRAM: "forum",
+            Platform.DISCORD: "thread",
+            Platform.SLACK: "group",
+        }.get(platform, "group")
+    return SessionSource(
+        platform=platform,
+        chat_id=chat_id,
+        chat_type=chat_type,
+        thread_id=thread_id,
+        user_id=user_id,
+        profile=profile,
+    )
+
+
+def _store(tmp_path, config: GatewayConfig | None = None) -> SessionStore:
+    config = config or GatewayConfig()
+    config.sessions_dir = tmp_path
+    store = SessionStore(tmp_path, config)
+    store._db = None
+    return store
+
+
+def _entry(
+    source: SessionSource,
+    updated_at: datetime,
+    *,
+    session_id: str | None = None,
+) -> SessionEntry:
+    return SessionEntry(
+        session_key="route",
+        session_id=session_id or f"session-{source.thread_id}",
+        created_at=updated_at,
+        updated_at=updated_at,
+        origin=source,
+        platform=source.platform,
+        chat_type=source.chat_type,
+    )
+
+
+def _runner(store: SessionStore, *, slack_prefix: bool = False):
+    runner = GatewaySlashCommandsMixin()
+    runner.session_store = store
+    runner.async_session_store = AsyncSessionStore(store)
+    runner.adapters = (
+        {Platform.SLACK: SimpleNamespace(typed_command_prefix="!")}
+        if slack_prefix
+        else {}
+    )
+    return runner
+
+
+def test_thread_identity_isolates_profile_platform_chat_and_thread_not_user_or_session(
+    tmp_path,
+):
+    store = _store(tmp_path, GatewayConfig(multiplex_profiles=True))
+    source = _source(profile="work")
+    store.set_thread_reset_policy(
+        source,
+        SessionResetPolicy(mode="daily", at_hour=6, at_minute=15),
+    )
+
+    same_route_other_user = _source(user_id="user-b", profile="work")
+    same_route_other_session = _entry(
+        same_route_other_user,
+        datetime(2026, 7, 29),
+        session_id="completely-unrelated-session-id",
+    )
+    isolated = (
+        _source(thread_id="11", profile="work"),
+        _source(chat_id="-1002", profile="work"),
+        _source(profile="personal"),
+        _source(platform=Platform.DISCORD, profile="work"),
+        _source(platform=Platform.SLACK, profile="work"),
+    )
+
+    policy, resolution = store.get_effective_reset_policy(
+        entry=same_route_other_session
+    )
+    assert (policy.at_hour, policy.at_minute, resolution) == (6, 15, "override")
+    assert all(
+        store.get_effective_reset_policy(source=other)[1] == "inherited"
+        for other in isolated
+    )
+
+
+def test_explicit_policy_persists_in_versioned_generic_state(tmp_path):
+    source = _source()
+    first = _store(tmp_path)
+    first.set_thread_reset_policy(
+        source,
+        SessionResetPolicy(mode="daily", at_hour=23, at_minute=59),
+    )
+
+    state_path = tmp_path / "thread_reset_policies.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["version"] == 1
+    assert list(state) == ["version", "threads"]
+    assert list(state["threads"].values()) == [
+        {"mode": "daily", "at_hour": 23, "at_minute": 59}
+    ]
+    assert not (tmp_path / "telegram_topic_reset_policies.json").exists()
+
+    reloaded = _store(tmp_path)
+    policy, resolution = reloaded.get_effective_reset_policy(source=source)
+    assert (policy.mode, policy.at_hour, policy.at_minute, resolution) == (
+        "daily",
+        23,
+        59,
+        "override",
+    )
+
+    reloaded.set_thread_reset_policy(source, SessionResetPolicy(mode="none"))
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert list(state["threads"].values()) == [{"mode": "none"}]
+
+
+def test_failed_atomic_write_keeps_last_known_policy(tmp_path, monkeypatch):
+    source = _source()
+    store = _store(tmp_path)
+    store.set_thread_reset_policy(source, SessionResetPolicy(mode="none"))
+
+    def fail_write(*_args, **_kwargs):
+        raise OSError("disk unavailable")
+
+    monkeypatch.setattr(
+        "gateway.thread_reset_policy.atomic_json_write",
+        fail_write,
+    )
+    with pytest.raises(OSError, match="disk unavailable"):
+        store.set_thread_reset_policy(
+            source,
+            SessionResetPolicy(mode="daily", at_hour=4, at_minute=30),
+        )
+
+    assert store.get_effective_reset_policy(source=source)[0].mode == "none"
+    assert _store(tmp_path).get_effective_reset_policy(source=source)[0].mode == "none"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "not json",
+        '{"version": 2, "threads": {}}',
+        '{"version": 1, "threads": {}, "extra": true}',
+        '{"version": 1, "threads": []}',
+        '{"version": 1, "threads": {"route": "off"}}',
+        '{"version": 1, "threads": {"route": {"mode": "none", "at_hour": 4}}}',
+        '{"version": 1, "threads": {"route": {"mode": "daily", "at_hour": 4}}}',
+        '{"version": 1, "threads": {"route": {"mode": "daily", "at_hour": true, "at_minute": 0}}}',
+        '{"version": 1, "threads": {"route": {"mode": "daily", "at_hour": 4, "at_minute": 60}}}',
+        '{"version": 1, "threads": {"route": {"mode": "idle"}}}',
+    ],
+)
+def test_malformed_persistence_fails_closed_and_preserves_evidence(
+    tmp_path, caplog, raw
+):
+    state_path = tmp_path / "thread_reset_policies.json"
+    state_path.write_text(raw, encoding="utf-8")
+    config = GatewayConfig(
+        default_reset_policy=SessionResetPolicy(
+            mode="daily", at_hour=4, at_minute=30
+        )
+    )
+
+    with caplog.at_level("WARNING"):
+        store = _store(tmp_path, config)
+
+    policy, resolution = store.get_effective_reset_policy(source=_source())
+    assert (policy.mode, resolution) == ("none", "invalid")
+    assert "Malformed thread auto-reset state" in caplog.text
+    with pytest.raises(ThreadResetPolicyStateError):
+        store.set_thread_reset_policy(_source(), SessionResetPolicy(mode="none"))
+    assert state_path.read_text(encoding="utf-8") == raw
+
+
+def test_invalid_in_memory_policy_is_rejected_without_losing_last_known_good(tmp_path):
+    source = _source()
+    store = _store(tmp_path)
+    store.set_thread_reset_policy(source, SessionResetPolicy(mode="none"))
+
+    with pytest.raises(ValueError, match="mode"):
+        store.set_thread_reset_policy(
+            source,
+            SessionResetPolicy(mode="idle", idle_minutes=10),
+        )
+    with pytest.raises(ValueError, match="at_minute"):
+        store.set_thread_reset_policy(
+            source,
+            SessionResetPolicy(mode="daily", at_hour=4, at_minute=60),
+        )
+
+    assert store.get_effective_reset_policy(source=source)[0].mode == "none"
+
+
+def test_thread_policy_precedes_platform_then_type_then_global(tmp_path):
+    config = GatewayConfig(
+        default_reset_policy=SessionResetPolicy(mode="idle", idle_minutes=30),
+        reset_by_type={
+            "forum": SessionResetPolicy(
+                mode="both", at_hour=7, at_minute=20, idle_minutes=45
+            ),
+            "thread": SessionResetPolicy(
+                mode="daily", at_hour=6, at_minute=25
+            ),
+        },
+        reset_by_platform={
+            Platform.TELEGRAM: SessionResetPolicy(
+                mode="daily", at_hour=9, at_minute=15
+            )
+        },
+    )
+    store = _store(tmp_path, config)
+    source = _source()
+
+    inherited, resolution = store.get_effective_reset_policy(source=source)
+    assert (
+        inherited.mode,
+        inherited.at_hour,
+        inherited.at_minute,
+        resolution,
+    ) == ("daily", 9, 15, "inherited")
+
+    store.set_thread_reset_policy(
+        source,
+        SessionResetPolicy(mode="daily", at_hour=5, at_minute=40),
+    )
+    overridden, resolution = store.get_effective_reset_policy(source=source)
+    assert (
+        overridden.mode,
+        overridden.at_hour,
+        overridden.at_minute,
+        resolution,
+    ) == ("daily", 5, 40, "override")
+
+    store.set_thread_reset_policy(source, None)
+    restored, resolution = store.get_effective_reset_policy(source=source)
+    assert (
+        restored.mode,
+        restored.at_hour,
+        restored.at_minute,
+        resolution,
+    ) == ("daily", 9, 15, "inherited")
+
+    discord = _source(platform=Platform.DISCORD)
+    by_type, resolution = store.get_effective_reset_policy(source=discord)
+    assert (
+        by_type.mode,
+        by_type.at_hour,
+        by_type.at_minute,
+        resolution,
+    ) == ("daily", 6, 25, "inherited")
+
+
+def test_two_threads_can_hold_different_daily_policies(tmp_path):
+    store = _store(tmp_path)
+    early = _source(thread_id="early")
+    late = _source(thread_id="late")
+    store.set_thread_reset_policy(
+        early, SessionResetPolicy(mode="daily", at_hour=4, at_minute=5)
+    )
+    store.set_thread_reset_policy(
+        late, SessionResetPolicy(mode="daily", at_hour=22, at_minute=55)
+    )
+
+    early_policy = store.get_effective_reset_policy(source=early)[0]
+    late_policy = store.get_effective_reset_policy(source=late)[0]
+    assert (early_policy.at_hour, early_policy.at_minute) == (4, 5)
+    assert (late_policy.at_hour, late_policy.at_minute) == (22, 55)
+
+
+@pytest.mark.asyncio
+async def test_autoreset_command_on_daily_off_inherit_and_status(tmp_path):
+    store = _store(tmp_path)
+    runner = _runner(store)
+    source = _source()
+
+    assert resolve_command("autoreset").name == "autoreset"
+    assert await runner._handle_autoreset_command(
+        MessageEvent(text="/autoreset", source=source)
+    ) == "Automatic reset: disabled (inherited policy)."
+    assert await runner._handle_autoreset_command(
+        MessageEvent(text="/autoreset on", source=source)
+    ) == "Automatic reset: daily at 04:00 (thread override)."
+    assert await runner._handle_autoreset_command(
+        MessageEvent(text="/autoreset daily 17:43", source=source)
+    ) == "Automatic reset: daily at 17:43 (thread override)."
+    assert await runner._handle_autoreset_command(
+        MessageEvent(text="/autoreset status", source=source)
+    ) == "Automatic reset: daily at 17:43 (thread override)."
+    assert await runner._handle_autoreset_command(
+        MessageEvent(text="/autoreset off", source=source)
+    ) == "Automatic reset: disabled (thread override)."
+    assert await runner._handle_autoreset_command(
+        MessageEvent(text="/autoreset inherit", source=source)
+    ) == "Automatic reset: disabled (inherited policy)."
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "args",
+    [
+        "daily",
+        "daily ",
+        "daily 4:00",
+        "daily 04:0",
+        "daily 24:00",
+        "daily 23:60",
+        "daily 12:30 extra",
+        "maybe",
+    ],
+)
+async def test_autoreset_command_rejects_invalid_times_without_rounding(tmp_path, args):
+    store = _store(tmp_path)
+    result = await _runner(store)._handle_autoreset_command(
+        MessageEvent(text=f"/autoreset {args}", source=_source())
+    )
+    assert result == (
+        "Usage: /autoreset [status|on|daily HH:MM|off|inherit]"
+    )
+    assert not (tmp_path / "thread_reset_policies.json").exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("platform", "chat_type"),
+    [
+        (Platform.TELEGRAM, "forum"),
+        (Platform.DISCORD, "thread"),
+        (Platform.SLACK, "group"),
+        (Platform.TELEGRAM, "dm"),
+        (Platform.DISCORD, "dm"),
+        (Platform.SLACK, "dm"),
+    ],
+)
+async def test_autoreset_accepts_supported_thread_sources(
+    tmp_path, platform, chat_type
+):
+    store = _store(tmp_path)
+    source = _source(platform=platform, chat_type=chat_type)
+    result = await _runner(
+        store, slack_prefix=platform == Platform.SLACK
+    )._handle_autoreset_command(
+        MessageEvent(
+            text="/autoreset daily 08:07",
+            source=source,
+        )
+    )
+
+    assert result == "Automatic reset: daily at 08:07 (thread override)."
+    assert store.get_effective_reset_policy(source=source)[1] == "override"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "source",
+    [
+        _source(platform=Platform.TELEGRAM, thread_id=None, chat_type="dm"),
+        _source(platform=Platform.DISCORD, thread_id=None, chat_type="group"),
+        _source(platform=Platform.SLACK, thread_id=None),
+        _source(platform=Platform.SLACK, chat_id=" "),
+        _source(platform=Platform.SLACK, thread_id=" "),
+    ],
+)
+async def test_autoreset_rejects_root_and_non_thread_sources(tmp_path, source):
+    store = _store(tmp_path)
+    runner = _runner(store, slack_prefix=source.platform == Platform.SLACK)
+    result = await runner._handle_autoreset_command(
+        MessageEvent(text="/autoreset on", source=source)
+    )
+
+    prefix = "!" if source.platform == Platform.SLACK else "/"
+    assert result == (
+        f"Run {prefix}autoreset inside the thread you want to configure "
+        "(not a root conversation or parent channel)."
+    )
+    assert not (tmp_path / "thread_reset_policies.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_autoreset_rejects_unsupported_platform(tmp_path):
+    result = await _runner(_store(tmp_path))._handle_autoreset_command(
+        MessageEvent(
+            text="/autoreset on",
+            source=_source(platform=Platform.MATRIX),
+        )
+    )
+    assert result == (
+        "/autoreset is only available in Telegram, Discord, and Slack threads."
+    )
+
+
+@pytest.mark.asyncio
+async def test_malformed_state_command_fails_safely(tmp_path):
+    (tmp_path / "thread_reset_policies.json").write_text(
+        "not json",
+        encoding="utf-8",
+    )
+    store = _store(
+        tmp_path,
+        GatewayConfig(default_reset_policy=SessionResetPolicy(mode="daily")),
+    )
+    runner = _runner(store)
+
+    status = await runner._handle_autoreset_command(
+        MessageEvent(text="/autoreset status", source=_source())
+    )
+    mutation = await runner._handle_autoreset_command(
+        MessageEvent(text="/autoreset on", source=_source())
+    )
+
+    assert status == (
+        "Automatic reset: disabled "
+        "(safe fallback; thread policy state is invalid)."
+    )
+    assert mutation == (
+        "Thread auto-reset state is invalid; no changes were made."
+    )
+
+
+def test_daily_reset_boundary_uses_minute_precision(tmp_path, monkeypatch):
+    source = _source()
+    store = _store(tmp_path)
+    store.set_thread_reset_policy(
+        source,
+        SessionResetPolicy(mode="daily", at_hour=4, at_minute=30),
+    )
+    entry = _entry(source, datetime(2026, 7, 28, 4, 31))
+
+    monkeypatch.setattr(
+        "gateway.session._now", lambda: datetime(2026, 7, 29, 4, 29, 59)
+    )
+    assert store._is_session_expired(entry) is False
+    assert store._should_reset(entry, source) is None
+
+    monkeypatch.setattr(
+        "gateway.session._now", lambda: datetime(2026, 7, 29, 4, 30)
+    )
+    assert store._is_session_expired(entry) is True
+    assert store._should_reset(entry, source) == "daily"
+
+    monkeypatch.setattr(
+        "gateway.session._now", lambda: datetime(2026, 7, 29, 4, 31)
+    )
+    assert store._is_session_expired(entry) is True
+
+
+def test_watcher_due_selection_and_active_process_safeguard_are_preserved(
+    tmp_path, monkeypatch
+):
+    now = datetime(2026, 7, 29, 10, 0)
+    monkeypatch.setattr("gateway.session._now", lambda: now)
+    store = _store(tmp_path)
+    due = _source(thread_id="due")
+    later = _source(thread_id="later")
+    store.set_thread_reset_policy(
+        due, SessionResetPolicy(mode="daily", at_hour=9, at_minute=30)
+    )
+    store.set_thread_reset_policy(
+        later, SessionResetPolicy(mode="daily", at_hour=10, at_minute=30)
+    )
+    entries = [
+        _entry(due, now - timedelta(hours=2)),
+        _entry(later, now - timedelta(hours=2)),
+    ]
+
+    selected = [
+        entry.origin.thread_id
+        for entry in entries
+        if store._is_session_expired(entry)
+    ]
+    assert selected == ["due"]
+
+    monkeypatch.setattr(store, "_has_active_processes_safe", lambda *_a, **_k: True)
+    assert store._is_session_expired(entries[0]) is False
+    assert store._should_reset(entries[0], due) is None
+
+
+def test_manual_reset_rotates_session_and_preserves_thread_policy(tmp_path):
+    store = _store(tmp_path)
+    source = _source()
+    store.set_thread_reset_policy(
+        source,
+        SessionResetPolicy(mode="daily", at_hour=12, at_minute=34),
+    )
+    original = store.get_or_create_session(source)
+
+    reset = store.reset_session(original.session_key)
+
+    assert reset is not None
+    assert reset.session_id != original.session_id
+    assert reset.is_fresh_reset is True
+    policy, resolution = store.get_effective_reset_policy(source=source)
+    assert (policy.at_hour, policy.at_minute, resolution) == (12, 34, "override")
+
+
+def test_registry_surfaces_telegram_and_discord_but_not_native_slack():
+    assert "autoreset" in {name for name, _description in telegram_bot_commands()}
+    command = resolve_command("autoreset")
+    assert command is not None and command.gateway_only is True
+    assert "autoreset" not in {
+        name for name, _description, _hint in slack_native_slashes()
+    }
+    assert "start" in {
+        name for name, _description, _hint in slack_native_slashes()
+    }

--- a/tests/hermes_cli/test_setup_agent_settings.py
+++ b/tests/hermes_cli/test_setup_agent_settings.py
@@ -76,3 +76,38 @@ def test_setup_agent_settings_prefers_config_over_stale_env(tmp_path, monkeypatc
     assert "Press Enter to keep 60." not in out
     # And the stale .env entry gets cleaned up
     assert "HERMES_MAX_ITERATIONS" in removed_keys
+
+
+def test_setup_agent_settings_accepts_minute_precision_daily_time(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = {
+        "agent": {"max_turns": 90},
+        "display": {"tool_progress": "all"},
+        "compression": {"threshold": 0.50},
+        "session_reset": {"mode": "daily", "at_hour": 4},
+    }
+    prompt_answers = iter(["90", "all", "0.5", "17:43"])
+
+    monkeypatch.setattr(
+        "hermes_cli.setup.prompt",
+        lambda *args, **kwargs: next(prompt_answers),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.setup.prompt_choice",
+        lambda *args, **kwargs: 2,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.setup.remove_env_value",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.setup.save_config",
+        lambda *args, **kwargs: None,
+    )
+
+    setup_agent_settings(config)
+
+    assert config["session_reset"]["at_hour"] == 17
+    assert config["session_reset"]["at_minute"] == 43

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -191,6 +191,7 @@ platform network disconnect as an event-loop failure.
 | Command | Description |
 |---------|-------------|
 | `/new` or `/reset` | Start a fresh conversation |
+| `/autoreset [status\|on\|daily HH:MM\|off\|inherit]` | Configure automatic reset for the current Telegram, Discord, or Slack thread |
 | `/model [provider:model]` | Show or change the model (supports `provider:model` syntax) |
 | `/personality [name]` | Set a personality (`none` to reset) |
 | `/retry` | Retry the last message |
@@ -262,14 +263,37 @@ session_reset:
   mode: idle        # "idle", "daily", "both", or "none" (default)
   idle_minutes: 1440  # for idle/both: minutes of inactivity before reset
   at_hour: 4          # for daily/both: hour of day (0-23, local time)
+  at_minute: 0        # for daily/both: minute of hour (0-59, local time)
 ```
 
 | Mode | Description |
 |------|-------------|
 | `none` | Never auto-reset (default) |
-| `daily` | Reset at a specific hour each day |
+| `daily` | Reset at a specific local time each day |
 | `idle` | Reset after N minutes of inactivity |
 | `both` | Whichever triggers first |
+
+#### Per-thread automatic reset
+
+Private and public Telegram topics, Discord threads, and Slack threads can
+override the inherited reset policy without changing global configuration.
+Both private and public threads are supported when the platform supplies
+stable, non-empty chat and thread IDs. Run the command inside the thread you
+want to configure:
+
+```text
+/autoreset status       # show the effective policy and whether it is inherited
+/autoreset on           # daily reset at 04:00 local server time
+/autoreset daily 06:30  # daily reset at an exact local server time
+/autoreset off          # explicitly disable auto-reset for this thread
+/autoreset inherit      # remove the override and use inherited configuration
+```
+
+Slack does not allow native slash commands inside threads, so type
+`!autoreset ...` there instead. The override is stored by profile, platform,
+chat, and thread; it survives `/new`, `/reset`, and gateway restarts. Root DMs,
+parent channels, other non-thread conversations, and unsupported platforms are
+rejected.
 
 A live background process (started with `terminal(background=true)`) normally
 protects its session from resetting so output isn't lost. To stop a forgotten

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -191,6 +191,7 @@ platform network disconnect as an event-loop failure.
 | Command | Description |
 |---------|-------------|
 | `/new` or `/reset` | Start a fresh conversation |
+| `/autoreset [status\|on\|daily HH:MM\|off\|inherit]` | Configure automatic reset for the current Telegram, Discord, or Slack thread |
 | `/model [provider:model]` | Show or change the model (supports `provider:model` syntax) |
 | `/personality [name]` | Set a personality |
 | `/retry` | Retry the last message |
@@ -262,14 +263,37 @@ session_reset:
   mode: idle        # "idle", "daily", "both", or "none" (default)
   idle_minutes: 1440  # for idle/both: minutes of inactivity before reset
   at_hour: 4          # for daily/both: hour of day (0-23, local time)
+  at_minute: 0        # for daily/both: minute of hour (0-59, local time)
 ```
 
 | Mode | Description |
 |------|-------------|
 | `none` | Never auto-reset (default) |
-| `daily` | Reset at a specific hour each day |
+| `daily` | Reset at a specific local time each day |
 | `idle` | Reset after N minutes of inactivity |
 | `both` | Whichever triggers first |
+
+#### Per-thread automatic reset
+
+Private and public Telegram topics, Discord threads, and Slack threads can
+override the inherited reset policy without changing global configuration.
+Both private and public threads are supported when the platform supplies
+stable, non-empty chat and thread IDs. Run the command inside the thread you
+want to configure:
+
+```text
+/autoreset status       # show the effective policy and whether it is inherited
+/autoreset on           # daily reset at 04:00 local server time
+/autoreset daily 06:30  # daily reset at an exact local server time
+/autoreset off          # explicitly disable auto-reset for this thread
+/autoreset inherit      # remove the override and use inherited configuration
+```
+
+Slack does not allow native slash commands inside threads, so type
+`!autoreset ...` there instead. The override is stored by profile, platform,
+chat, and thread; it survives `/new`, `/reset`, and gateway restarts. Root DMs,
+parent channels, other non-thread conversations, and unsupported platforms are
+rejected.
 
 A live background process (started with `terminal(background=true)`) normally
 protects its session from resetting so output isn't lost. To stop a forgotten

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/index.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/index.md
@@ -130,6 +130,7 @@ hermes gateway status --system         # 仅 Linux：显式检查系统服务
 | 命令 | 说明 |
 |---------|-------------|
 | `/new` 或 `/reset` | 开始新对话 |
+| `/autoreset [status\|on\|daily HH:MM\|off\|inherit]` | 配置当前 Telegram、Discord 或 Slack 线程的自动重置策略 |
 | `/model [provider:model]` | 显示或切换模型（支持 `provider:model` 语法） |
 | `/personality [name]` | 设置人格 |
 | `/retry` | 重试上一条消息 |
@@ -168,7 +169,8 @@ hermes gateway status --system         # 仅 Linux：显式检查系统服务
 session_reset:
   mode: idle        # "idle"、"daily"、"both" 或 "none"（默认）
   idle_minutes: 1440  # idle/both 模式：空闲多少分钟后重置
-  at_hour: 4          # daily/both 模式：每天的重置时间（0-23，本地时间）
+  at_hour: 4          # daily/both 模式：每天的重置小时（0-23，本地时间）
+  at_minute: 0        # daily/both 模式：每天的重置分钟（0-59，本地时间）
 ```
 
 | 模式 | 说明 |
@@ -177,6 +179,25 @@ session_reset:
 | `daily` | 每天在指定时间重置 |
 | `idle` | 空闲 N 分钟后重置 |
 | `both` | 以先触发者为准 |
+
+#### 每个线程的自动重置
+
+Telegram、Discord 和 Slack 的私有及公开线程可以覆盖继承的重置策略，
+而无需修改全局配置。只要平台提供稳定且非空的聊天 ID 和线程 ID，
+私有和公开线程都受支持。请在线程内运行：
+
+```text
+/autoreset status       # 查看生效策略及其是否继承
+/autoreset on           # 每天服务器本地时间 04:00 重置
+/autoreset daily 06:30  # 每天在指定的服务器本地时间重置
+/autoreset off          # 为当前线程明确禁用自动重置
+/autoreset inherit      # 删除覆盖并恢复继承配置
+```
+
+Slack 不允许在线程中使用原生斜杠命令，因此请改用 `!autoreset ...`。
+覆盖按配置文件、平台、聊天和线程持久保存，并在 `/new`、`/reset` 和
+网关重启后继续生效。根私信、父频道、其他非线程对话及不受支持的平台
+会被拒绝。
 
 在 `~/.hermes/gateway.json` 中配置各平台的覆盖设置：
 


### PR DESCRIPTION
## What does this PR do?

Adds durable per-thread automatic session-reset policies for threaded Telegram, Discord, and Slack conversations.

A thread can use `status`, `on`, `daily HH:MM`, `off`, or `inherit`. Policies are keyed by canonical route identity — profile, platform, workspace/guild scope where applicable, chat, and thread — rather than live session IDs, so they survive `/new`, `/reset`, gateway restarts, and do not cross workspace or guild boundaries.

Telegram and Discord expose `/autoreset`. Slack uses textual `!autoreset` because native Slack slash commands cannot be invoked from inside a thread and the generated app manifest is constrained by Slack's command limit.

## Current-main refresh

The feature has been semantically refreshed onto upstream `main` at `64a6f42cb38def7ad6524bdfe640a16997c88760`.

Current head: `baf749c07f8c7b14a1074d342119ceff63dc0440`.

The refresh preserves current-main command registry behavior, including newer `save`, `review`, and `platform` commands, while adding `autoreset` through the current registration and dispatch paths.

## Behavior

- Thread override precedence: thread → platform → session type → global.
- Daily schedules support exact server-local `HH:MM` precision.
- Policies persist atomically in versioned state and malformed state fails closed.
- `inherit` removes the thread override.
- Unsupported root/non-thread conversations are rejected.
- Slack workspace and Discord guild scopes are part of durable policy identity.
- Existing Slack key behavior remains compatible; non-Slack scoped platforms use a collision-safe encoded scope component.

## Verification on current head

- `357 passed, 0 failed` across:
  - `tests/gateway/test_thread_autoreset.py`
  - `tests/gateway/test_config.py`
  - `tests/gateway/test_slack.py`
  - `tests/gateway/test_discord_slash_commands.py`
  - `tests/hermes_cli/test_setup_agent_settings.py`
  - `tests/hermes_cli/test_commands.py`
  - `tests/gateway/test_gateway_command_dispatch_minimal.py`
- Ruff passed on every changed Python file.
- `git diff --check 64a6f42c..HEAD` passed.
- Production-path Slack tests exercise `!autoreset` rewrite and dispatch for `status`, `on`, `daily`, `off`, and `inherit`, retain workspace/channel/thread identity, persist the result, reload state, and prove isolation between two workspaces with identical channel/thread IDs.
- Persisted Discord regression coverage proves isolation between two guilds with identical chat/thread IDs.
- Native GPT-5.6 Luna review cycle 1 requested the Slack production-path tests; cycle 2 reviewed the amended full range and returned `APPROVE` with no remaining findings.

The complete repository matrix is delegated to GitHub CI.

## Documentation

Updates configuration examples, session lifecycle and messaging documentation, command surfaces, setup behavior, and locales.

## Non-goals

Automatic cleanup of policies for remote threads deleted on Telegram, Slack, or Discord is intentionally excluded.
