### PR TITLE
fix(tools): reject invalid search_files target values

### DIFF
--- a/tests/tools/test_search_invalid_target.py
+++ b/tests/tools/test_search_invalid_target.py
@@ -1,0 +1,101 @@
+"""Tests that search() rejects unknown `target` values instead of falling through.
+
+Regression for #74448: `search_files` declares `target` as an enum of
+("content", "files"), but nothing enforced it. `FileOperations.search()`
+branched on `target == "files"` and sent everything else to a *content*
+search, so an invalid value came back as a clean `{"total_count": 0}` with
+no error.
+
+`files_only` is the motivating mistake: `output_mode` on the same tool does
+accept `files_only`, so a caller reaching for "search filenames" naturally
+picks it for `target` too, then gets an empty result with no signal that
+`target` was the problem.
+
+Fix: validate `target` at the top of search() and return a SearchResult
+carrying an explanatory error.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.file_operations import ShellFileOperations
+
+
+@pytest.fixture()
+def ops():
+    env = MagicMock(cwd="/tmp/test")
+    env.execute.return_value = {"output": "exists", "returncode": 0}
+    return ShellFileOperations(env)
+
+
+class TestInvalidTargetIsRejected:
+    @pytest.mark.parametrize("target", ["files_only", "bogus", "FILES", "grep", "find", ""])
+    def test_invalid_target_returns_error(self, ops, target):
+        result = ops.search("pattern", path=".", target=target)
+
+        assert result.error is not None, f"target={target!r} should be rejected"
+        assert "Invalid target" in result.error
+        assert repr(target) in result.error
+        assert result.total_count == 0
+
+    def test_error_names_both_valid_targets(self, ops):
+        result = ops.search("pattern", path=".", target="files_only")
+
+        assert "'content'" in result.error
+        assert "'files'" in result.error
+
+    def test_error_points_files_only_at_output_mode(self, ops):
+        """The whole point: disambiguate target from output_mode='files_only'."""
+        result = ops.search("pattern", path=".", target="files_only")
+
+        assert "output_mode='files_only'" in result.error
+
+    def test_rejected_before_touching_the_filesystem(self, ops):
+        """Validation is argument-level, so it must not shell out first."""
+        ops.search("pattern", path=".", target="bogus")
+
+        ops.env.execute.assert_not_called()
+
+    def test_invalid_target_does_not_run_a_content_search(self, ops):
+        """The actual bug: the old code silently ran _search_content."""
+        called = []
+        ops._search_content = lambda *a, **k: called.append(a)
+        ops._search_files = lambda *a, **k: called.append(a)
+
+        ops.search("pattern", path=".", target="files_only")
+
+        assert called == []
+
+
+class TestValidTargetsStillWork:
+    def test_files_dispatches_to_search_files(self, ops):
+        sentinel = object()
+        ops._search_files = lambda *a, **k: sentinel
+
+        assert ops.search("*.py", path=".", target="files") is sentinel
+
+    def test_content_dispatches_to_search_content(self, ops):
+        sentinel = object()
+        ops._search_content = lambda *a, **k: sentinel
+
+        assert ops.search("pattern", path=".", target="content") is sentinel
+
+    def test_default_target_is_content(self, ops):
+        sentinel = object()
+        ops._search_content = lambda *a, **k: sentinel
+
+        assert ops.search("pattern", path=".") is sentinel
+
+
+class TestHandlerAliasesSurviveValidation:
+    """_handle_search_files maps grep->content and find->files before search()."""
+
+    @pytest.mark.parametrize(
+        ("raw_target", "expected"),
+        [("grep", "content"), ("find", "files"), ("content", "content"), ("files", "files")],
+    )
+    def test_alias_maps_to_valid_target(self, raw_target, expected):
+        target_map = {"grep": "content", "find": "files"}
+
+        assert target_map.get(raw_target, raw_target) == expected

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2069,6 +2069,21 @@ class ShellFileOperations(FileOperations):
         Returns:
             SearchResult with matches or file list
         """
+        # Reject unknown targets instead of falling through to a content
+        # search.  'files_only' is an easy mistake here because output_mode
+        # really does accept it, and the silent fallback returns a clean
+        # empty result that gives the caller no way to spot the error.
+        if target not in ("content", "files"):
+            return SearchResult(
+                error=(
+                    f"Invalid target: {target!r}. Use 'content' to search inside "
+                    "files, or 'files' to find files by name. To list only the "
+                    "paths of files whose contents match, use target='content' "
+                    "with output_mode='files_only'."
+                ),
+                total_count=0
+            )
+
         offset, limit = normalize_search_pagination(offset, limit)
 
         # Expand ~ and other shell paths


### PR DESCRIPTION
## What changed and why

`search_files` declares `target` as an enum of `("content", "files")`, but nothing enforced it. `ShellFileOperations.search()` branched on `target == "files"` and sent **everything else** to a content search:

```python
if target == "files":
    return self._search_files(...)
else:
    return self._search_content(...)
```

So any invalid `target` silently ran a content search. `files_only` is the motivating mistake, because `output_mode` on the very same tool really does accept `files_only` — a caller reaching for "search filenames" picks it for `target` too, gets `{"total_count": 0}` with no error, and has no signal that `target` was the problem. In practice that drives repeated identical calls until the unrelated loop-detection guard in `search_tool` trips at 4.

This validates `target` at the top of `search()` and returns a `SearchResult` carrying an explanatory error, reusing the same `SearchResult(error=...)` idiom that method already uses for path-not-found.

Fixes #74448

## How to test

Before (on `5c07ba2f3`), with a file matching by name but not by content:

```
target='files'        total_count=1   error=None
target='files_only'   total_count=0   error=None      <-- silently searched CONTENTS
target='bogus'        total_count=0   error=None
```

After:

```
target='files'        total_count=1   error=None
target='files_only'   total_count=0   error="Invalid target: 'files_only'. Use 'content' to
                                            search inside files, or 'files' to find files by
                                            name. To list only the paths of files whose
                                            contents match, use target='content' with
                                            output_mode='files_only'."
```

Regression tests in `tests/tools/test_search_invalid_target.py`. With `tools/file_operations.py` reverted, **10 of the 17 fail**; with the fix all 17 pass.

```
scripts/run_tests.sh tests/tools/test_search_invalid_target.py -q
# 17 passed
```

No regressions in the surrounding suites — same 6 files, run with and without the change:

| | passed | failed |
|---|---|---|
| baseline (no fix) | 95 | 3 |
| with fix | 112 | 3 |

The 3 failures are identical in both runs and pre-existing in my environment (`ModuleNotFoundError: No module named 'yaml'` — project deps not installed), in `test_search_hidden_dirs.py` and `test_tool_search.py`. Not related to this change.

`tests/tools/test_file_tools_live.py` also calls `ops.search()` directly, so I checked it separately: **20 failures both with and without this change** (verified against `HEAD~1`, not a stash). Pre-existing in my environment for the same missing-dependency reason.

Caveat on my environment: I could not install the pinned project dependencies, so a full `tests/tools/` run is dominated by collection errors and is not a useful signal either way. The comparisons above are all same-environment before/after, which is the part that isolates this change.

`ruff check` clean on both changed files (`PLW1514` is the only enabled rule).

## Platforms tested

Linux (CachyOS, kernel 7.1.1), Python 3.14.6, ripgrep present. The change is pure argument validation with no shell, path, or encoding involvement, so I don't expect platform variance — but I have **not** run it on macOS, WSL2, or without `rg` installed.

## Notes for review

Two deliberate choices worth a look, both easy to change if you'd rather go the other way:

1. **Validation lives in `search()`, not in `_handle_search_files`.** The issue offered either. I picked `search()` because it is the single choke point — `ShellFileOperations` is the only concrete implementation, and it covers the programmatic path in the issue's repro (`ops.search(target="files_only")`) as well as the tool path. It also sits before the `test -e` path check, so an invalid `target` reports the real problem instead of a path error. Happy to move it to the handler if you'd prefer the tool boundary to own schema enforcement.

2. **The handler aliases still work, but only through the handler.** `_handle_search_files` maps `grep`→`content` and `find`→`files` before calling `search()`, so those are unaffected. But `search(target="grep")` called *directly* now errors where it previously ran a content search. I verified `file_tools.py:1890` is the only production caller and no test passes the aliases straight to `search()`. Tell me if you'd rather `search()` accept the aliases itself.

Also intentionally left alone, to keep this focused:

- `output_mode` and `mode` on neighbouring tools have the same unenforced-enum shape. I did not touch them.
- The reporter noted the tag `v2026.7.20` and `__version__` `0.19.0` have diverged. Unrelated to this bug and not addressed here.
