### PR TITLE
fix(patch): anchor V4A Begin/End Patch markers to full lines

### DIFF
--- a/tests/tools/test_patch_parser.py
+++ b/tests/tools/test_patch_parser.py
@@ -106,6 +106,61 @@ class TestParseMoveFile:
         assert ops[0].new_path == "new/path.py"
 
 
+class TestBoundaryMarkersInContent:
+    """Patch boundary markers inside content lines must not be treated as
+    real boundaries (docs about the patch format, nested patch text, etc.)."""
+
+    def test_end_patch_marker_in_add_content_does_not_truncate(self):
+        patch = """\
+*** Begin Patch
+*** Add File: notes.md
++doc line one
++*** End Patch
++content after the marker mention
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        assert len(ops) == 1
+        contents = [l.content for l in ops[0].hunks[0].lines if l.prefix == "+"]
+        assert contents == [
+            "doc line one",
+            "*** End Patch",
+            "content after the marker mention",
+        ]
+
+    def test_begin_patch_marker_in_content_does_not_discard_operations(self):
+        patch = """\
+*** Begin Patch
+*** Add File: first.md
++first file content
+*** Add File: second.md
++*** Begin Patch
++second file content
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        assert [(op.operation, op.file_path) for op in ops] == [
+            (OperationType.ADD, "first.md"),
+            (OperationType.ADD, "second.md"),
+        ]
+
+    def test_context_line_end_patch_marker_does_not_truncate(self):
+        patch = """\
+*** Begin Patch
+*** Update File: guide.md
+@@ section @@
+ old line
+ *** End Patch
++new line
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        assert len(ops) == 1
+        hunk_lines = [(l.prefix, l.content) for l in ops[0].hunks[0].lines]
+        assert (" ", "*** End Patch") in hunk_lines
+        assert ("+", "new line") in hunk_lines
+
+
 class TestParseInvalidPatch:
     def test_empty_patch_returns_empty_ops(self):
         ops, err = parse_v4a_patch("")

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -80,15 +80,19 @@ def parse_v4a_patch(patch_content: str) -> Tuple[List[PatchOperation], Optional[
     """
     lines = patch_content.split('\n')
     operations: List[PatchOperation] = []
-    
-    # Find patch boundaries
+
+    # Find patch boundaries. Markers must occupy the whole line at column 0:
+    # content lines like "+*** End Patch" or " *** End Patch" (e.g. docs
+    # about the patch format) must not truncate the patch or reset the
+    # start boundary.
     start_idx = None
     end_idx = None
-    
+    begin_marker = re.compile(r'^\*\*\*\s*Begin\s+Patch\s*$')
+    end_marker = re.compile(r'^\*\*\*\s*End\s+Patch\s*$')
     for i, line in enumerate(lines):
-        if '*** Begin Patch' in line or '***Begin Patch' in line:
+        if begin_marker.match(line):
             start_idx = i
-        elif '*** End Patch' in line or '***End Patch' in line:
+        elif end_marker.match(line):
             end_idx = i
             break
     


### PR DESCRIPTION
## What does this PR do?

Fixes silent data loss in `parse_v4a_patch` (`tools/patch_parser.py`) when a patch's *content* mentions the V4A boundary markers.

The boundary scan used substring matching on every line:

- A content line like `+*** End Patch` (e.g. a docs file documenting the patch format, or nested patch text) was treated as the real end boundary. Everything after it was silently dropped from the parsed operation — and since the truncated operation list still validates, the apply phase reports **success** with partial content written.
- A content line like `+*** Begin Patch` reset the start boundary, discarding all already-parsed operations. A two-file patch could parse to **zero operations with no error** — a silent no-op.

The file-operation headers (`*** Update File:` etc.) already used anchored regexes; only the Begin/End markers used unanchored substring tests. This PR anchors them the same way: markers must occupy the whole line at column 0, which patch content lines never do (they carry a `+`/`-`/space prefix). The no-space `***Begin Patch` tolerance is preserved.

## Related Issue

No GitHub issue — discovered via code review and reproduced live (see below). Happy to file one first if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/patch_parser.py`: boundary scan now matches `^\*\*\*\s*Begin\s+Patch\s*$` / `^\*\*\*\s*End\s+Patch\s*$` (whole line, column 0) instead of substring tests.
- `tests/tools/test_patch_parser.py`: new `TestBoundaryMarkersInContent` class — 3 regression tests: End-marker in Add content does not truncate, Begin-marker in content does not discard operations, context-line (` ` prefix) End-marker does not truncate.

## How to Test

Reproduction of the original bug (run against pre-fix code):

```python
from tools.patch_parser import parse_v4a_patch
patch = "*** Begin Patch\n*** Add File: notes.md\n+doc line one\n+*** End Patch\n+content after the marker mention\n*** End Patch"
ops, err = parse_v4a_patch(patch)
# pre-fix: content == ['doc line one']  (trailing lines silently dropped, err=None)
# post-fix: content == ['doc line one', '*** End Patch', 'content after the marker mention']
```

Focused validation completed:

1. `bash scripts/run_tests.sh tests/tools/test_patch_parser.py` — 31/31 pass.
2. Sabotage check: stashing the `tools/patch_parser.py` change makes exactly the 3 new tests fail (28 pass); restoring it returns to 31/31 — the tests genuinely pin the fix.
3. Full repo-wide suite, `bash scripts/run_tests.sh` (branch): 45,297 pass / 4,612 fail. Baseline on clean `origin/main`, same machine: 20,448 pass / 1,888 fail. The failures are environment-dependent lanes (browser/MCP/vision/ACP/LSP, no API keys or services locally) plus tests broken at this branch point and since fixed upstream. Diffing the failing-file lists: every file failing on the branch but not on baseline was verified to (a) not import `patch_parser`/`file_operations`/`file_tools`, and (b) have been touched by upstream fix commits after this branch point. The parser's full dependency surface passes in the branch run: `test_patch_parser.py` 31✓, `test_file_operations.py` 94✓, `test_file_tools.py` 51✓, `test_patch_failure_tracking.py` 5✓.
4. `uvx --from ruff==0.15.10 ruff check tools/patch_parser.py tests/tools/test_patch_parser.py` — clean.
5. `git diff --check` — clean.
6. Adversarial edge cases verified: trailing-whitespace markers still bound, no-Begin fallback intact, no-End parses to EOF, case-sensitivity unchanged, junk after the real End marker still ignored, context-line `*** Begin Patch` no longer resets the boundary.
7. End-to-end: a patch whose Add File content contains a literal `*** End Patch` line round-trips through `parse_v4a_patch` → `apply_v4a_operations` — apply reports success and the written file preserves all content lines.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full suite run locally via `scripts/run_tests.sh`; failures are pre-existing/environment-dependent and verified unrelated to this change (see How to Test, item 3)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (parser behavior now matches its documented contract)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python regex change, no platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no schema change; parser now accepts what the format spec already implies)

## Logs

Parser-level fix with no UI surface. Sabotage verification output:

```
# fix stashed:
=== Summary: 1 files, 28 tests passed, 3 failed ===   (the 3 new regression tests)
# fix restored:
=== Summary: 1 files, 31 tests passed, 0 failed ===
```
