### PR TITLE
fix(buzz): require explicit display-name mentions

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1120,7 +1120,7 @@ class BuzzAdapter(BasePlatformAdapter):
         if self._self_npub and self._self_npub in lowered:
             return True
         if self._display_name:
-            pattern = rf"(?<!\w)@?{re.escape(self._display_name.lower())}(?!\w)"
+            pattern = rf"(?<!\w)@{re.escape(self._display_name.lower())}(?!\w)"
             if re.search(pattern, lowered):
                 return True
         return False

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -243,6 +243,13 @@ class TestMentionGating:
         await self._poll_with(adapter, _event("e1", content="hey @Chip can you help?", created_at=10))
         assert len(adapter._dispatched) == 1
 
+    @pytest.mark.asyncio
+    async def test_plain_name_reference_ignored(self, adapter):
+        await self._poll_with(
+            adapter,
+            _event("e1", content="@Hermes did you see Chip's request?", created_at=10),
+        )
+        assert adapter._dispatched == []
 
     @pytest.mark.asyncio
     async def test_allowlist_blocks_unauthorized(self, adapter):


### PR DESCRIPTION
## Summary

- require an explicit `@` before the Buzz agent display name
- prevent ordinary references to an agent's name from waking it
- add a regression test for a message addressed to one agent that merely references another

## Root cause

The display-name matcher used `@?`, making the `@` optional even when `require_mention` was enabled. A message such as `@Hermes did you see Chip's request?` therefore dispatched to both Hermes and Chip.

## Verification

```text
python -m pytest tests/gateway/test_buzz_adapter.py -q
24 passed
```
