### PR TITLE
fix(desktop): prevent duplicate project sidebar sessions

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -720,8 +720,8 @@ export function ChatSidebar({
   // backend now seeds each project folder as an (empty) repo, so the overlay
   // always has a lane to place a new in-project session into.
   const enteredProjectContent = useMemo(
-    () => (enteredProject ? overlayLiveLanes(enteredProject, agentSessions, removedSessionIds) : undefined),
-    [enteredProject, agentSessions, removedSessionIds]
+    () => (enteredProject ? overlayLiveLanes(enteredProject, agentSessions, removedSessionIds, projects) : undefined),
+    [enteredProject, agentSessions, removedSessionIds, projects]
   )
 
   const scopedRepoPaths = useMemo(

--- a/apps/desktop/src/app/chat/sidebar/order.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.test.ts
@@ -37,6 +37,11 @@ describe('orderByIds', () => {
     const items = [{ id: 'fresh' }, { id: 'a' }, { id: 'b' }]
     expect(orderByIds(items, id, ['b', 'a'])).toEqual([{ id: 'fresh' }, { id: 'b' }, { id: 'a' }])
   })
+
+  it('renders each row once when legacy persisted order contains duplicate ids', () => {
+    const items = [{ id: 'a' }, { id: 'b' }]
+    expect(orderByIds(items, id, ['b', 'a', 'b', 'gone'])).toEqual([{ id: 'b' }, { id: 'a' }])
+  })
 })
 
 describe('reconcileOrderIds', () => {
@@ -48,8 +53,16 @@ describe('reconcileOrderIds', () => {
     expect(reconcileOrderIds(['a', 'b'], [])).toEqual(['a', 'b'])
   })
 
+  it('deduplicates current ids when there is no saved order', () => {
+    expect(reconcileOrderIds(['root', 'root', 'other'], [])).toEqual(['root', 'other'])
+  })
+
   it('puts newly-seen ids ahead of the retained saved order', () => {
     expect(reconcileOrderIds(['fresh', 'a', 'b'], ['b', 'a', 'gone'])).toEqual(['fresh', 'b', 'a'])
+  })
+
+  it('deduplicates shared repo ids from both the tree and legacy persisted order', () => {
+    expect(reconcileOrderIds(['root', 'root', 'other'], ['root', 'root', 'gone'])).toEqual(['other', 'root'])
   })
 })
 

--- a/apps/desktop/src/app/chat/sidebar/order.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.ts
@@ -1,10 +1,14 @@
 /** New ids first, then ids still present in the persisted order. */
 export function reconcileFreshFirst(currentIds: string[], orderIds: string[]): string[] {
-  const current = new Set(currentIds)
-  const retained = orderIds.filter(id => current.has(id))
+  // IDs normally belong to one subtree, but sibling explicit projects can share
+  // a repo root. Persisting that repeated identity makes every later render
+  // repeat the same row, so normalize both the live input and legacy storage.
+  const current = [...new Set(currentIds)]
+  const currentSet = new Set(current)
+  const retained = [...new Set(orderIds)].filter(id => currentSet.has(id))
   const retainedSet = new Set(retained)
 
-  return [...currentIds.filter(id => !retainedSet.has(id)), ...retained]
+  return [...current.filter(id => !retainedSet.has(id)), ...retained]
 }
 
 export function resolveManualSessionOrderIds(currentIds: string[], orderIds: string[], manual: boolean): string[] {
@@ -35,7 +39,7 @@ export function orderByIds<T>(items: T[], getId: (item: T) => string, orderIds: 
   for (const id of orderIds) {
     const item = byId.get(id)
 
-    if (item) {
+    if (item && !seen.has(id)) {
       ordered.push(item)
       seen.add(id)
     }
@@ -58,7 +62,7 @@ export function reconcileOrderIds(currentIds: string[], orderIds: string[]): str
   }
 
   if (!orderIds.length) {
-    return currentIds
+    return [...new Set(currentIds)]
   }
 
   return reconcileFreshFirst(currentIds, orderIds)

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -623,6 +623,32 @@ describe('sessionProjectColor', () => {
 })
 
 describe('overlayLiveLanes', () => {
+  it('keeps live rows owned by sibling explicit projects out of the entered project sharing a git root', () => {
+    // Product folders share the same monorepo root. The optimistic overlay must
+    // retain the backend's longest-prefix ownership instead of putting every
+    // live row under whichever seeded root lane is currently open.
+    const root = '/root/thiago-ai-company-memory'
+
+    const projects = [
+      makeProject('p_tcc', [`${root}/memory/products/tcc-descomplicada-ptbr`]),
+      makeProject('p_jung', [`${root}/memory/products/jung-100-mapas-mentais`])
+    ]
+
+    const project = projectNode({
+      id: 'p_tcc',
+      repos: [{ id: root, label: 'thiago-ai-company-memory', path: root, sessionCount: 0, groups: [] }]
+    })
+
+    const tcc = makeSession(`${root}/memory/products/tcc-descomplicada-ptbr`, { id: 'tcc' })
+    const jung = makeSession(`${root}/memory/products/jung-100-mapas-mentais`, { id: 'jung' })
+
+    const overlaid = overlayLiveLanes(project, [tcc, jung], new Set(), projects)
+
+    expect(
+      overlaid.repos.flatMap(repo => repo.groups.flatMap(group => group.sessions.map(session => session.id)))
+    ).toEqual(['tcc'])
+  })
+
   it('injects a live session into the matching main lane instantly', () => {
     const project = projectNode({
       id: '/www/app',

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -677,16 +677,25 @@ export function excludeProjectSessions(
 export function overlayLiveLanes(
   project: SidebarProjectTree,
   live: SessionInfo[],
-  removed: ReadonlySet<string> = NO_REMOVED
+  removed: ReadonlySet<string> = NO_REMOVED,
+  explicitProjects?: ProjectInfo[]
 ): SidebarProjectTree {
   if (project.isNoProject) {
     return overlayHomeLane(project, live, removed)
   }
 
+  // A repo lane can be shared by several explicit projects inside one monorepo.
+  // Its path alone therefore cannot establish project membership: filter the
+  // optimistic rows through the same longest-prefix resolver used by previews
+  // before letting a repo place them into a lane.
+  const projectLive = explicitProjects
+    ? live.filter(session => liveSessionProjectId(session, explicitProjects) === project.id)
+    : live
+
   let changed = false
 
   const repos = project.repos.map(repo => {
-    const next = overlayRepoLanes(repo, live, removed)
+    const next = overlayRepoLanes(repo, projectLive, removed)
 
     changed ||= next !== repo
 


### PR DESCRIPTION
## Resumo
- Evita que o overlay de sessões live pertença ao Project irmão errado, resolvendo a posse por `liveSessionProjectId` e pelo prefixo de caminho mais longo.
- Deduplica IDs de sessão atuais e persistidos antes de renderizar a sidebar.

## Reprodução coberta
- Projects irmãos em um monorepo compartilhado.
- Remote Gateway com sessões live e histórico persistido.

## Testes
- 69 testes focais.
- Suíte completa: 3847 testes.

Refs #73314
Related #72055