### PR TITLE
fix(discord): schedule approval boxes on the gateway loop

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -884,6 +884,10 @@ class DiscordAdapter(BasePlatformAdapter):
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.DISCORD)
         self._client: Optional[commands.Bot] = None
+        # The Discord HTTP client is bound to the gateway's event loop. Sync
+        # tool handlers must schedule outbound work onto this loop rather than
+        # creating a private loop (aiohttp rejects that path).
+        self._event_loop: Optional[asyncio.AbstractEventLoop] = None
         self._ready_event = asyncio.Event()
         self._allowed_user_ids: set = set()  # For button approval authorization
         self._allowed_role_ids: set = set()  # For DISCORD_ALLOWED_ROLES filtering
@@ -1118,6 +1122,9 @@ class DiscordAdapter(BasePlatformAdapter):
             return False
 
         try:
+            # Preserve the gateway loop so sync tool handlers can schedule
+            # Discord HTTP work on the aiohttp session's owning loop.
+            self._event_loop = asyncio.get_running_loop()
             if not self._acquire_platform_lock('discord-bot-token', self.config.token, 'Discord bot token'):
                 return False
 
@@ -1679,6 +1686,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
         self._running = False
         self._client = None
+        self._event_loop = None
         self._ready_event.clear()
         self._post_connect_task = None
         self._liveness_task = None

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6601,6 +6601,51 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception as e:
             return SendResult(success=False, error=str(e))
 
+    async def send_deliverable_approval(
+        self,
+        chat_id: str,
+        title: str,
+        body: str,
+        drive_url: str,
+        approval_id: str,
+        metadata: Optional[dict] = None,
+    ) -> SendResult:
+        """Send Approve / Needs Work / Reject controls for a deliverable."""
+        if not self._client or not DISCORD_AVAILABLE:
+            return SendResult(success=False, error="Not connected")
+        try:
+            target_id = metadata.get("thread_id") if metadata and metadata.get("thread_id") else chat_id
+            channel = self._client.get_channel(int(target_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(target_id))
+            title_display = str(title or "Approval Required")[:256]
+            body_display = str(body or "")[:3500]
+            drive_display = str(drive_url or "").strip()[:1800]
+            content = self._self_contained_prompt_content(
+                f"📦 **Approval Required — {title_display}**",
+                body_display,
+                tail=(f"\n\n**Review file:** {drive_display}" if drive_display else "")
+                + "\n\nChoose **Approve**, **Needs Work**, or **Reject** below.",
+            )
+            embed = discord.Embed(
+                title=f"📦 Approval Required — {title_display}",
+                description=body_display or "No description provided.",
+                color=discord.Color.orange(),
+            )
+            if drive_display:
+                embed.add_field(name="Review file", value=drive_display, inline=False)
+            view = DeliverableApprovalView(
+                approval_id=approval_id,
+                allowed_user_ids=self._allowed_user_ids,
+                allowed_role_ids=self._allowed_role_ids,
+            )
+            msg = await channel.send(content=content, embed=embed, view=view)
+            view._message = msg
+            return SendResult(success=True, message_id=str(msg.id))
+        except Exception as exc:
+            logger.warning("[%s] send_deliverable_approval failed: %s", self.name, exc)
+            return SendResult(success=False, error=str(exc))
+
     async def send_slash_confirm(
         self, chat_id: str, title: str, message: str, session_key: str,
         confirm_id: str, metadata: Optional[dict] = None,
@@ -7825,7 +7870,7 @@ def _define_discord_view_classes() -> None:
     lazy install sets DISCORD_AVAILABLE=True but leaves the classes
     undefined, causing NameError on the first button interaction.
     """
-    global ExecApprovalView, SlashConfirmView, UpdatePromptView, ModelPickerView, ClarifyChoiceView, ChoicePickerView
+    global ExecApprovalView, DeliverableApprovalView, SlashConfirmView, UpdatePromptView, ModelPickerView, ClarifyChoiceView, ChoicePickerView
 
     class ExecApprovalView(discord.ui.View):
         """
@@ -7989,6 +8034,68 @@ def _define_discord_view_classes() -> None:
                     await msg.edit(embed=embed, view=self)
                 except Exception:
                     pass  # message deleted or too old to edit
+
+    class DeliverableApprovalView(discord.ui.View):
+        """Approve / Needs Work / Reject controls for external deliverables."""
+
+        def __init__(self, approval_id: str, allowed_user_ids: set, allowed_role_ids: Optional[set] = None):
+            super().__init__(timeout=_read_discord_prompt_timeout())
+            self.approval_id = approval_id
+            self.allowed_user_ids = allowed_user_ids
+            self.allowed_role_ids = allowed_role_ids or set()
+            self.resolved = False
+
+        async def _resolve(self, interaction: discord.Interaction, decision: str, color, label: str):
+            if self.resolved:
+                await interaction.response.send_message("This approval has already been resolved.", ephemeral=True)
+                return
+            if not _component_check_auth(interaction, self.allowed_user_ids, self.allowed_role_ids):
+                await interaction.response.send_message("You're not authorized to decide this approval.", ephemeral=True)
+                return
+            try:
+                from tools.discord_approval_box_tool import resolve_approval
+                record = resolve_approval(self.approval_id, decision, interaction.user.display_name)
+            except Exception as exc:
+                logger.error("Deliverable approval resolution failed: %s", exc)
+                record = None
+            if record is None:
+                await interaction.response.send_message("This approval is no longer pending.", ephemeral=True)
+                return
+            self.resolved = True
+            embed = interaction.message.embeds[0] if interaction.message.embeds else None
+            if embed:
+                embed.color = color
+                embed.set_footer(text=f"{label} by {interaction.user.display_name}")
+            for child in self.children:
+                child.disabled = True
+            await interaction.response.edit_message(embed=embed, view=self)
+
+        @discord.ui.button(label="Approve", style=discord.ButtonStyle.green)
+        async def approve(self, interaction: discord.Interaction, button: discord.ui.Button):
+            await self._resolve(interaction, "approved", discord.Color.green(), "Approved")
+
+        @discord.ui.button(label="Needs Work", style=discord.ButtonStyle.secondary)
+        async def needs_work(self, interaction: discord.Interaction, button: discord.ui.Button):
+            await self._resolve(interaction, "needs_work", discord.Color.orange(), "Needs work")
+
+        @discord.ui.button(label="Reject", style=discord.ButtonStyle.red)
+        async def reject(self, interaction: discord.Interaction, button: discord.ui.Button):
+            await self._resolve(interaction, "rejected", discord.Color.red(), "Rejected")
+
+        async def on_timeout(self):
+            self.resolved = True
+            for child in self.children:
+                child.disabled = True
+            msg = getattr(self, "_message", None)
+            if msg:
+                try:
+                    embed = msg.embeds[0] if msg.embeds else None
+                    if embed:
+                        embed.color = discord.Color.greyple()
+                        embed.set_footer(text="⏱ Approval expired — no action taken")
+                    await msg.edit(embed=embed, view=self)
+                except Exception:
+                    pass
 
     class SlashConfirmView(discord.ui.View):
         """Three-button view for generic slash-command confirmations.

--- a/tests/tools/test_discord_approval_box_tool.py
+++ b/tests/tools/test_discord_approval_box_tool.py
@@ -1,10 +1,11 @@
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
-from gateway.config import PlatformConfig
+from gateway.config import Platform, PlatformConfig
 from plugins.platforms.discord.adapter import DiscordAdapter
 from tools import discord_approval_box_tool as approval_tool
 
@@ -55,3 +56,42 @@ async def test_discord_deliverable_approval_has_exactly_three_review_controls():
     assert "Needs Work" in sent["content"]
     assert "Reject" in sent["content"]
     assert sent["view"] is not None
+
+
+def test_approval_tool_schedules_delivery_on_gateway_loop(tmp_path, monkeypatch):
+    """Approval cards must use Discord's owning event loop, not _run_async."""
+    monkeypatch.setattr(approval_tool, "get_hermes_home", lambda: Path(tmp_path))
+    gateway_loop = object()
+
+    class CompletedFuture:
+        def result(self, timeout):
+            assert timeout == 30
+            return SimpleNamespace(success=True, message_id="1234")
+
+    async def send_deliverable_approval(**_kwargs):
+        return None
+
+    adapter = SimpleNamespace(
+        _event_loop=gateway_loop,
+        send_deliverable_approval=send_deliverable_approval,
+    )
+    runner = SimpleNamespace(adapters={Platform.DISCORD: adapter})
+    monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: runner)
+
+    scheduled = {}
+
+    def fake_schedule(coro, loop):
+        scheduled["loop"] = loop
+        coro.close()
+        return CompletedFuture()
+
+    monkeypatch.setattr("agent.async_utils.safe_schedule_threadsafe", fake_schedule)
+    payload = json.loads(approval_tool.discord_approval_box_tool({
+        "title": "Review me",
+        "body": "Draft is ready.",
+        "channel_id": "discord",
+    }))
+
+    assert payload["success"] is True
+    assert payload["message_id"] == "1234"
+    assert scheduled["loop"] is gateway_loop

--- a/tests/tools/test_discord_approval_box_tool.py
+++ b/tests/tools/test_discord_approval_box_tool.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.discord.adapter import DiscordAdapter
+from tools import discord_approval_box_tool as approval_tool
+
+
+def test_first_resolution_wins_and_persists(tmp_path, monkeypatch):
+    monkeypatch.setattr(approval_tool, "get_hermes_home", lambda: Path(tmp_path))
+
+    record = approval_tool.create_approval_record(
+        title="Email draft",
+        body="Draft for client review.",
+        drive_url="https://drive.google.com/file/d/example/view",
+        channel_id="123",
+    )
+    resolved = approval_tool.resolve_approval(record["id"], "approved", "Willie")
+
+    assert resolved is not None
+    assert resolved["status"] == "approved"
+    assert resolved["resolved_by"] == "Willie"
+    assert approval_tool.resolve_approval(record["id"], "rejected", "Other") is None
+    assert approval_tool.get_approval_record(record["id"])["status"] == "approved"
+
+
+@pytest.mark.asyncio
+async def test_discord_deliverable_approval_has_exactly_three_review_controls():
+    sent = {}
+
+    async def fake_send(**kwargs):
+        sent.update(kwargs)
+        return SimpleNamespace(id=1234)
+
+    channel = SimpleNamespace(send=AsyncMock(side_effect=fake_send))
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send_deliverable_approval(
+        chat_id="555",
+        title="Ron article-email draft",
+        body="Prepared for review before release.",
+        drive_url="https://drive.google.com/file/d/example/view",
+        approval_id="abc123",
+    )
+
+    assert result.success is True
+    assert "Approve" in sent["content"]
+    assert "Needs Work" in sent["content"]
+    assert "Reject" in sent["content"]
+    assert sent["view"] is not None

--- a/tools/discord_approval_box_tool.py
+++ b/tools/discord_approval_box_tool.py
@@ -154,14 +154,19 @@ def discord_approval_box_tool(args: Dict[str, Any], **_kw: Any) -> str:
         title=title, body=body, drive_url=drive_url, channel_id=channel_id,
     )
     try:
-        from model_tools import _run_async
-        result = _run_async(adapter.send_deliverable_approval(
+        # discord.py owns an aiohttp session bound to the gateway's event
+        # loop. _run_async creates a private loop, which breaks channel.send.
+        from agent.async_utils import safe_schedule_threadsafe
+        future = safe_schedule_threadsafe(adapter.send_deliverable_approval(
             chat_id=channel_id,
             title=record["title"],
             body=record["body"],
             drive_url=record["drive_url"],
             approval_id=record["id"],
-        ))
+        ), getattr(adapter, "_event_loop", None))
+        if future is None:
+            raise RuntimeError("Discord gateway event loop is unavailable")
+        result = future.result(timeout=30)
     except Exception as exc:
         try:
             _record_path(record["id"]).unlink(missing_ok=True)

--- a/tools/discord_approval_box_tool.py
+++ b/tools/discord_approval_box_tool.py
@@ -1,0 +1,194 @@
+"""Interactive Discord approval boxes for outbound deliverables.
+
+The tool creates a durable approval record under ``HERMES_HOME/approval_boxes``
+and asks the live Discord adapter to render an Approve / Needs Work / Reject
+component view. A click is authorized by the adapter's normal user/role gate,
+then atomically finalizes the record and disables the controls.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from pathlib import Path
+from threading import Lock
+from typing import Any, Dict, Optional
+
+from hermes_constants import get_hermes_home
+from tools.registry import registry, tool_error, tool_result
+
+_RECORD_LOCK = Lock()
+_MAX_TITLE = 180
+_MAX_BODY = 6_000
+
+
+DISCORD_APPROVAL_BOX_SCHEMA = {
+    "name": "discord_approval_box",
+    "description": (
+        "Create an interactive Discord approval box for an external-facing "
+        "deliverable. The box has Approve, Needs Work, and Reject controls. "
+        "Use it before releasing public posts, client communications, or files. "
+        "For deliverables, provide the Google Drive URL so the reviewer can open it."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "title": {"type": "string", "description": "Short description of the action awaiting approval."},
+            "body": {"type": "string", "description": "What will be released, scope, and any material risk or limitation."},
+            "drive_url": {"type": "string", "description": "Google Drive URL for the deliverable. Required when a file is being reviewed."},
+            "channel_id": {"type": "string", "description": "Discord channel or thread ID. Omit to use the current Discord conversation."},
+        },
+        "required": ["title", "body"],
+    },
+}
+
+
+def _approval_dir() -> Path:
+    return get_hermes_home() / "approval_boxes"
+
+
+def _record_path(approval_id: str) -> Path:
+    return _approval_dir() / f"{approval_id}.json"
+
+
+def _safe_text(value: Any, limit: int) -> str:
+    text = str(value or "").strip()
+    return text[:limit]
+
+
+def _write_record(record: Dict[str, Any]) -> None:
+    directory = _approval_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    path = _record_path(record["id"])
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def create_approval_record(*, title: str, body: str, drive_url: str, channel_id: str) -> Dict[str, Any]:
+    """Persist a new pending approval record and return it."""
+    record = {
+        "id": uuid.uuid4().hex[:12],
+        "status": "pending",
+        "title": _safe_text(title, _MAX_TITLE),
+        "body": _safe_text(body, _MAX_BODY),
+        "drive_url": _safe_text(drive_url, 2_000),
+        "channel_id": str(channel_id),
+        "created_at": time.time(),
+        "resolved_at": None,
+        "resolved_by": None,
+    }
+    with _RECORD_LOCK:
+        _write_record(record)
+    return record
+
+
+def get_approval_record(approval_id: str) -> Optional[Dict[str, Any]]:
+    path = _record_path(str(approval_id))
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def resolve_approval(approval_id: str, decision: str, resolved_by: str) -> Optional[Dict[str, Any]]:
+    """Finalize a pending approval. First authorized decision wins."""
+    if decision not in {"approved", "needs_work", "rejected"}:
+        return None
+    with _RECORD_LOCK:
+        record = get_approval_record(approval_id)
+        if not record or record.get("status") != "pending":
+            return None
+        record["status"] = decision
+        record["resolved_at"] = time.time()
+        record["resolved_by"] = _safe_text(resolved_by, 200) or "authorized user"
+        _write_record(record)
+        return record
+
+
+def _current_target(args: Dict[str, Any]) -> str:
+    explicit = str(args.get("channel_id") or "").strip()
+    if explicit:
+        return explicit
+    try:
+        from gateway.session_context import get_session_env
+        thread_id = get_session_env("HERMES_SESSION_THREAD_ID", "").strip()
+        chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "").strip()
+        return thread_id or chat_id
+    except Exception:
+        return ""
+
+
+def check_discord_approval_box_requirements() -> bool:
+    """Expose only when this profile is configured with a Discord bot."""
+    return bool(os.getenv("DISCORD_BOT_TOKEN", "").strip())
+
+
+def discord_approval_box_tool(args: Dict[str, Any], **_kw: Any) -> str:
+    title = _safe_text(args.get("title"), _MAX_TITLE)
+    body = _safe_text(args.get("body"), _MAX_BODY)
+    drive_url = _safe_text(args.get("drive_url"), 2_000)
+    channel_id = _current_target(args)
+    if not title or not body:
+        return tool_error("Both title and body are required.")
+    if not channel_id:
+        return tool_error("No Discord channel could be resolved. Pass channel_id explicitly.")
+
+    try:
+        from gateway.run import _gateway_runner_ref
+        from gateway.config import Platform
+        runner = _gateway_runner_ref()
+        adapter = runner.adapters.get(Platform("discord")) if runner is not None else None
+    except Exception:
+        adapter = None
+    if adapter is None or not callable(getattr(adapter, "send_deliverable_approval", None)):
+        return tool_error(
+            "Interactive Discord approval boxes require the live Discord gateway adapter. "
+            "The current gateway has not loaded that capability."
+        )
+
+    record = create_approval_record(
+        title=title, body=body, drive_url=drive_url, channel_id=channel_id,
+    )
+    try:
+        from model_tools import _run_async
+        result = _run_async(adapter.send_deliverable_approval(
+            chat_id=channel_id,
+            title=record["title"],
+            body=record["body"],
+            drive_url=record["drive_url"],
+            approval_id=record["id"],
+        ))
+    except Exception as exc:
+        try:
+            _record_path(record["id"]).unlink(missing_ok=True)
+        except OSError:
+            pass
+        return tool_error(f"Could not deliver approval box: {exc}")
+    if not getattr(result, "success", False):
+        try:
+            _record_path(record["id"]).unlink(missing_ok=True)
+        except OSError:
+            pass
+        return tool_error(f"Could not deliver approval box: {getattr(result, 'error', 'unknown error')}")
+    return tool_result(
+        success=True,
+        approval_id=record["id"],
+        message_id=getattr(result, "message_id", None),
+        status="pending",
+    )
+
+
+registry.register(
+    name="discord_approval_box",
+    toolset="discord",
+    schema=DISCORD_APPROVAL_BOX_SCHEMA,
+    handler=discord_approval_box_tool,
+    check_fn=check_discord_approval_box_requirements,
+    requires_env=["DISCORD_BOT_TOKEN"],
+    description="Interactive Discord approval controls for outbound deliverables",
+    emoji="✅",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -78,6 +78,9 @@ _HERMES_CORE_TOOLS = [
     "kanban_attach", "kanban_attach_url", "kanban_attachments",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
+    # Approval-gated external delivery on Discord (available only when a
+    # Discord bot is configured; check_fn keeps it off other installations).
+    "discord_approval_box",
 ]
 
 # Webhook events may originate from untrusted third-party content (for example,


### PR DESCRIPTION
Closes #74470.

## What changed

- restores the Discord deliverable approval-box tool and three-button component view after the platform-plugin migration
- stores the Discord adapter's owning gateway event loop
- schedules approval delivery on that loop instead of `_run_async`'s private worker loop
- persists pending approval records and disables controls after the first authorized decision
- includes the Google Drive review URL in both plain content and the embed

## Root cause

`discord.py` owns an `aiohttp` session bound to the gateway event loop. The synchronous tool handler used `_run_async`, which ran `channel.send()` on a different event loop and produced `Timeout context manager should be used inside a task`.

## Verification

- `venv/bin/python -m py_compile tools/discord_approval_box_tool.py plugins/platforms/discord/adapter.py`
- `venv/bin/python -m pytest tests/tools/test_discord_approval_box_tool.py -o addopts='' -q` — 3 passed
- `venv/bin/python -m pytest tests/agent/test_async_utils.py -o addopts='' -q` — 6 passed

Live Discord verification will be recorded after the local gateway restart.
