### PR TITLE
fix(delegation): enforce provider boundary and eager heartbeat

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -488,7 +488,13 @@ class TestDelegateTask(unittest.TestCase):
         parent.provider = "openai-codex"
         parent.api_mode = "codex_responses"
 
-        with patch("run_agent.AIAgent") as MockAgent:
+        # Isolate this parent-inheritance test from the operator's live
+        # delegation.provider setting; an explicit configured provider is
+        # intentionally authoritative and is covered by integration tests.
+        with (
+            patch("tools.delegate_tool._load_config", return_value={}),
+            patch("run_agent.AIAgent") as MockAgent,
+        ):
             mock_child = MagicMock()
             mock_child.run_conversation.return_value = {
                 "final_response": "ok",
@@ -3288,6 +3294,31 @@ class TestFallbackModelInheritance(unittest.TestCase):
 
         _, kwargs = MockAgent.call_args
         self.assertEqual(kwargs["fallback_model"], [fallback_entry])
+
+    def test_pinned_provider_does_not_inherit_parent_fallback_chain(self):
+        """An explicit delegated provider is a strict provider boundary."""
+        parent = _make_mock_parent(depth=0)
+        parent._fallback_chain = [
+            {"provider": "openrouter", "model": "deepseek/deepseek-v4-flash"}
+        ]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="test strict delegated provider",
+                context=None,
+                toolsets=None,
+                model="gpt-5.6-terra",
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                override_provider="openai-codex",
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["provider"], "openai-codex")
+        self.assertIsNone(kwargs["fallback_model"])
 
     def test_child_gets_no_fallback_when_parent_chain_empty(self):
         """When parent._fallback_chain is empty, fallback_model is None."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1454,11 +1454,15 @@ def _build_child_agent(
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
 
-    # Inherit the parent's fallback provider chain so subagents can recover
-    # from rate-limits and credential exhaustion exactly like the top-level
-    # agent does.  _fallback_chain is a list accepted by AIAgent's
-    # fallback_model parameter (which handles both list and dict forms).
-    parent_fallback = getattr(parent_agent, "_fallback_chain", None) or None
+    # Inherit the parent's fallback provider chain only when the child also
+    # inherits the parent's provider. An explicit delegation.provider is a
+    # strict provider boundary: passing the parent chain here could silently
+    # fail a pinned child over to a different provider.
+    parent_fallback = (
+        None
+        if override_provider
+        else (getattr(parent_agent, "_fallback_chain", None) or None)
+    )
 
     # Inherit the parent's OpenRouter provider-preference filters by default
     # (so subagents routed to the same provider honour the same routing
@@ -2009,11 +2013,18 @@ def _run_single_child(
     _stale_count = [0]
 
     def _heartbeat_loop():
-        while not _heartbeat_stop.wait(_HEARTBEAT_INTERVAL):
+        # Touch immediately, then wait between subsequent heartbeats. Starting
+        # with a wait creates a scheduler race for short child runs and leaves
+        # the parent falsely idle during the first interval.
+        while not _heartbeat_stop.is_set():
             if parent_agent is None:
+                if _heartbeat_stop.wait(_HEARTBEAT_INTERVAL):
+                    break
                 continue
             touch = getattr(parent_agent, "_touch_activity", None)
             if not touch:
+                if _heartbeat_stop.wait(_HEARTBEAT_INTERVAL):
+                    break
                 continue
             # Pull detail from the child's own activity tracker
             desc = f"delegate_task: subagent {task_index} working"
@@ -2076,6 +2087,8 @@ def _run_single_child(
                 touch(desc)
             except Exception:
                 pass
+            if _heartbeat_stop.wait(_HEARTBEAT_INTERVAL):
+                break
 
     _heartbeat_thread = threading.Thread(target=_heartbeat_loop, daemon=True)
 


### PR DESCRIPTION
## What does this PR do?

Fixes two delegation reliability bugs at their owning boundaries:

1. A child with an explicit `delegation.provider` could still inherit the parent agent's fallback chain. If the child request failed, fallback activation could move the child to a different provider despite the explicit provider pin. The child now inherits parent fallbacks only when it also inherits the parent provider.
2. The delegated-child heartbeat waited for one full interval before its first activity touch. Short or tool-bound child runs could therefore leave the parent falsely idle during that initial interval. The heartbeat now touches immediately, then waits between subsequent touches.

The change preserves existing fallback inheritance when no provider override is supplied and preserves the existing stop event as the heartbeat's interruptible wait.

## Related Issue

No matching open or merged PR was found for the provider-boundary or initial-heartbeat symptoms.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/delegate_tool.py`
  - Suppress parent fallback inheritance when `override_provider` is explicit.
  - Touch parent activity immediately when the child heartbeat starts.
  - Keep all heartbeat waits interruptible through `_heartbeat_stop`.
- `tests/tools/test_delegate.py`
  - Add regression coverage proving a pinned provider receives no parent fallback chain.
  - Isolate the existing runtime-credential inheritance test from an operator's live delegation configuration.
  - Retain existing heartbeat lifecycle and stale-detection coverage.

## How to Test

1. Run the full delegation module:
   ```bash
   python -m unittest -q tests.tools.test_delegate
   ```
   Result on the rebased branch: **161 tests passed**.
2. Repeat the changed provider-boundary and heartbeat behaviors:
   ```bash
   python -m unittest -q \
     tests.tools.test_delegate.TestFallbackModelInheritance.test_pinned_provider_does_not_inherit_parent_fallback_chain \
     tests.tools.test_delegate.TestDelegateHeartbeat.test_heartbeat_touches_parent_activity_during_child_run \
     tests.tools.test_delegate.TestDelegateHeartbeat.test_heartbeat_does_not_trip_idle_stale_while_inside_tool \
     tests.tools.test_delegate.TestDelegateHeartbeat.test_heartbeat_includes_child_activity_desc_when_no_tool
   ```
   Result: **4/4 passed across five consecutive runs**.
3. Run compilation and diff checks:
   ```bash
   python -m py_compile tools/delegate_tool.py tests/tools/test_delegate.py
   git diff --check main...HEAD
   ```

The repository-wide `scripts/run_tests.sh` was also attempted locally. The available editable-install venv lacks `pytest-asyncio`, so unrelated async suites failed with `PytestUnknownMarkWarning`/"async def functions are not natively supported"; the wrapper reached 67% before the 10-minute local ceiling. CI should provide the canonical dev dependency set.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — local full-suite environment lacks `pytest-asyncio`; focused module is 161/161
- [x] I've added tests for my changes
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] Documentation update — N/A; behavior and invariant are documented in code/tests
- [x] `cli-config.yaml.example` update — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; implementation uses existing `threading.Event` behavior
- [x] Tool descriptions/schemas update — N/A; model-facing schema is unchanged

## Screenshots / Logs

Focused verification:

```text
Ran 161 tests in 4.775s
OK

changed_behaviors_5x=passed
```
