### PR TITLE
fix(state): backfill user_id/source in session upsert conflict clause

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2363,6 +2363,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 )
                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                    ON CONFLICT(id) DO UPDATE SET
+                       user_id = COALESCE(sessions.user_id, excluded.user_id),
+                       -- Only backfill a placeholder source ('unknown', e.g.
+                       -- from the update_token_counts self-heal row); never
+                       -- overwrite a real one.
+                       source = COALESCE(NULLIF(sessions.source, 'unknown'), excluded.source),
                        model = COALESCE(sessions.model, excluded.model),
                        model_config = COALESCE(sessions.model_config, excluded.model_config),
                        system_prompt = COALESCE(sessions.system_prompt, excluded.system_prompt),

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -178,7 +178,41 @@ class TestSessionLifecycle:
             peer.close()
 
 
+class TestUpsertUserIdSourceBackfill:
+    """The _insert_session_row ON CONFLICT clause must backfill user_id and a
+    placeholder source ('unknown') left by the update_token_counts self-heal
+    row, without ever overwriting real values."""
 
+    def test_backfills_user_id_and_source_after_self_heal_row(self, db):
+        # Lock-contention self-heal: bare row (source='unknown', user_id=NULL)
+        db.update_token_counts("s1", input_tokens=5, model="gpt-x")
+        row = db.get_session("s1")
+        assert row["source"] == "unknown"
+        assert row["user_id"] is None
+
+        # Retried real create_session must enrich both columns
+        db.create_session(
+            session_id="s1", source="gateway", user_id="tg:12345",
+            model="gpt-x", session_key="gw:tg:12345",
+        )
+        row = db.get_session("s1")
+        assert row["source"] == "gateway"
+        assert row["user_id"] == "tg:12345"
+        assert row["session_key"] == "gw:tg:12345"
+
+    def test_never_clobbers_real_source_or_user_id(self, db):
+        db.create_session(session_id="s1", source="gateway", user_id="tg:12345")
+
+        db.create_session(session_id="s1", source="unknown", user_id=None)
+        row = db.get_session("s1")
+        assert row["source"] == "gateway"
+        assert row["user_id"] == "tg:12345"
+
+        # A later call with a *different* real user_id must not overwrite either
+        db.create_session(session_id="s1", source="cron", user_id="other")
+        row = db.get_session("s1")
+        assert row["source"] == "gateway"
+        assert row["user_id"] == "tg:12345"
 
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes sessions getting permanently stranded with `user_id = NULL` and `source = 'unknown'` in the SessionDB after a specific recovery path.

`update_token_counts` deliberately self-heals a missing session row with a bare insert (`source="unknown"`, `user_id=None`) for the case where the initial `create_session()` failed due to SQLite lock contention (its own comment describes this). When the real `create_session(..., user_id=..., source=...)` is subsequently retried, the `_insert_session_row` `ON CONFLICT(id) DO UPDATE` clause COALESCE-backfills a dozen columns — `model`, `model_config`, `system_prompt`, `session_key`, `chat_id`, `chat_type`, `thread_id`, `parent_session_id`, `cwd`, `profile_name`, `git_repo_root` — but **not `user_id` or `source`**. The enrichment is dropped on the floor and the placeholder values stick forever.

`user_id` is a filter column in gateway user-scoped queries, and `source='cron'` is the filter for cron run-history — so affected sessions silently vanish from per-user views and run history.

The fix adds two assignments to the conflict clause, matching the clause's existing fill-only-when-empty contract (documented in the method's docstring):

- `user_id = COALESCE(sessions.user_id, excluded.user_id)` — fills only when still NULL
- `source = COALESCE(NULLIF(sessions.source, 'unknown'), excluded.source)` — fills only when still the `'unknown'` placeholder; a real source is never overwritten

## Related Issue

No GitHub issue — discovered via code review and reproduced live (see below). Happy to file one first if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py`: `_insert_session_row` conflict clause gains `user_id`/`source` backfills (guarded as above), with an inline comment on the placeholder-source rule.
- `tests/test_hermes_state.py`: new `TestUpsertUserIdSourceBackfill` — one test that a self-heal row gets enriched by the retried `create_session`, one test that real `source`/`user_id` values are never clobbered by later bare *or* conflicting calls.

## How to Test

Reproduction (against pre-fix code):

```python
from hermes_state import SessionDB
db = SessionDB(...)                      # temp db
db.update_token_counts("sess1", input_tokens=5, model="gpt-x")   # self-heal bare row
db.create_session("sess1", "gateway", user_id="tg:12345", model="gpt-x", session_key="gw:tg:12345")
row = db.get_session("sess1")
# pre-fix: row["source"] == "unknown", row["user_id"] is None   (session_key IS backfilled — only these two columns dropped)
# post-fix: row["source"] == "gateway", row["user_id"] == "tg:12345"
```

Focused validation completed:

1. `bash scripts/run_tests.sh tests/test_hermes_state.py` — 134/134 pass.
2. Sabotage checks: stashing the `hermes_state.py` change → the backfill test fails (133 pass). Replacing the fix with the naive `excluded.*` overwrite → **both** new tests fail (132 pass) — the no-clobber test genuinely pins the guard, not just the happy path.
3. `bash scripts/run_tests.sh tests/hermes_state/ tests/test_hermes_state_compression_locks.py tests/test_hermes_state_readonly_preflight.py tests/test_hermes_state_wal_fallback.py tests/test_session_db_read_path_split.py` — 61/63 pass; the 2 failures in `test_hermes_state_readonly_preflight.py` fail identically on a clean `main` worktree on the same machine (WAL-sidecar fixtures; this environment's SQLite 3.45.1 forces `journal_mode=DELETE`), i.e. pre-existing and unrelated.
4. `uvx --from ruff==0.15.10 ruff check hermes_state.py tests/test_hermes_state.py` — clean.
5. `git diff --check` — clean.
6. Adversarial cases executed: later bare call (`source="unknown"`, `user_id=None`) does not clobber real values; later call with a *different real* `user_id`/`source` does not overwrite the originals; the docstring's gateway-bare-row → agent-enrichment scenario still backfills model metadata as before.

The full repo-wide suite was not run for this change; the SessionDB-related suites above cover the changed method's surface, and GitHub CI owns full-suite validation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full suite not run locally (see How to Test; all SessionDB-related suites pass except 2 failures proven pre-existing on clean main)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (the method docstring already documents the fill-only-when-empty contract this change implements)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — single SQLite DDL/DML clause, no platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Logs

Sabotage verification output:

```
# fix stashed (pre-fix behavior):
=== Summary: 1 files, 133 tests passed, 1 failed ===   (test_backfills_user_id_and_source_after_self_heal_row)
# naive overwrite variant (excluded.* instead of guarded COALESCE):
=== Summary: 1 files, 132 tests passed, 2 failed ===   (both new tests)
# real fix restored:
=== Summary: 1 files, 134 tests passed, 0 failed ===
```
