### PR TITLE
feat(oneshot): reuse warm hermes-serve backend for -z when untoolset-scoped

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -17,6 +17,16 @@ Model / provider selection mirrors `hermes chat`:
 
 Env var fallbacks (used when the corresponding arg is not passed):
     - HERMES_INFERENCE_MODEL
+
+Warm-backend reuse: when no explicit --toolsets was requested, this first
+tries the persistent `hermes serve` daemon (ws://127.0.0.1:9119/api/ws, see
+`hermes_cli/oneshot_warm.py`) before falling back to a cold, per-invocation
+AIAgent. The win is MCP servers already discovered on the warm daemon (e.g.
+`hostinger`, which takes ~4s to connect via npx) vs. the cold path racing a
+much shorter discovery bound from scratch every call. An explicit
+--toolsets/-t ALWAYS forces the cold path: `session.create` on the warm
+daemon has no per-session toolset-restriction equivalent, so a scoped call
+must never risk silently widening to the daemon's full default toolset.
 """
 
 from __future__ import annotations
@@ -216,6 +226,11 @@ def run_oneshot(
         return 2
     use_config_toolsets = _normalize_toolsets(toolsets) is None
 
+    # Warm-backend path is only safe when the caller did NOT restrict
+    # toolsets explicitly — see oneshot_warm.py's docstring for why an
+    # explicit -t must always take the cold path.
+    warm_eligible = use_config_toolsets
+
     # Auto-approve any shell / tool approvals.  Non-interactive by
     # definition — a prompt would hang forever.
     os.environ["HERMES_YOLO_MODE"] = "1"
@@ -242,13 +257,16 @@ def run_oneshot(
     try:
         with redirect_stdout(devnull), redirect_stderr(devnull):
             try:
-                response, result = _run_agent(
-                    prompt,
-                    model=model,
-                    provider=provider,
-                    toolsets=explicit_toolsets,
-                    use_config_toolsets=use_config_toolsets,
-                )
+                if warm_eligible:
+                    response, result = _try_warm_agent(prompt, model=model, provider=provider)
+                if response is None:
+                    response, result = _run_agent(
+                        prompt,
+                        model=model,
+                        provider=provider,
+                        toolsets=explicit_toolsets,
+                        use_config_toolsets=use_config_toolsets,
+                    )
             except BaseException as exc:  # noqa: BLE001
                 # Capture anything that escapes the agent (including OSError
                 # from prompt_toolkit/Vt100 when stdout is a non-TTY pipe,
@@ -292,6 +310,52 @@ def run_oneshot(
         return 1
 
     return 0
+
+
+def _try_warm_agent(
+    prompt: str,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
+) -> tuple[Optional[str], dict]:
+    """Attempt the warm `hermes serve` backend (see ``oneshot_warm.py``).
+
+    Returns ``(None, {})`` when it's safe to fall back to the cold path —
+    nothing ran server-side (backend unreachable, no token, RPC error before
+    ``prompt.submit`` was acked). Raises when the warm daemon accepted the
+    turn but it didn't finish successfully: the caller must NOT fall back to
+    the cold path in that case (the turn may have already run real tools
+    server-side, and retrying risks double-executing side effects) — letting
+    this propagate surfaces it as a normal oneshot failure instead.
+    """
+    from hermes_cli.oneshot_warm import try_warm_oneshot
+
+    warm = try_warm_oneshot(prompt, cwd=os.getcwd(), model=model, provider=provider)
+
+    if not warm.submitted:
+        return None, {}
+
+    if not warm.ok:
+        raise RuntimeError(f"warm backend: {warm.error}")
+
+    usage = warm.usage or {}
+    result = {
+        "final_response": warm.text,
+        "input_tokens": usage.get("input"),
+        "output_tokens": usage.get("output"),
+        "reasoning_tokens": usage.get("reasoning"),
+        "total_tokens": usage.get("total"),
+        "api_calls": usage.get("calls"),
+        "cache_read_tokens": None,
+        "cache_write_tokens": None,
+        "estimated_cost_usd": None,
+        "cost_status": "unavailable",
+        "cost_source": "warm_backend",
+        "model": usage.get("model") or model or "",
+        "provider": provider or "",
+        "completed": True,
+        "failed": False,
+    }
+    return warm.text, result
 
 
 def _create_session_db_for_oneshot():

--- a/hermes_cli/oneshot_warm.py
+++ b/hermes_cli/oneshot_warm.py
@@ -1,0 +1,213 @@
+"""Warm-backend client for ``hermes -z`` — reuse the persistent ``hermes serve``
+daemon (JSON-RPC over WebSocket, port 9119, ``hermes-serve.service``) instead
+of cold-building a brand new ``AIAgent`` per invocation.
+
+Port of Crucible's proven client (``hermesWarm.ts`` in the agent-os repo):
+connect to ``ws://127.0.0.1:9119/api/ws?token=...``, wait for
+``gateway.ready``, ``session.create`` (with ``close_on_disconnect=True`` so
+the throwaway session is reaped the instant we close the socket — no manual
+``session.close`` needed), ``config.set`` yolo=1, ``prompt.submit``, then wait
+for the ``message.complete`` event.
+
+The win: MCP servers (e.g. ``hostinger``, spawned via ``npx`` and taking
+~4s to connect) are already discovered process-wide on the warm daemon by the
+time this client connects — a fresh session on that daemon inherits them
+immediately. The cold path has to rediscover them from scratch every
+invocation, racing a ~1.5s discovery bound it can lose (see #<mcp_discovery
+timing bug>).
+
+Scope, by design (mirrors hermesWarm.ts's own documented limitation):
+``session.create`` has no per-session toolset-restriction equivalent to
+``-z``'s ``--toolsets``/``-t`` flag — a session always gets the profile's
+full default toolset. So this client must ONLY be used for oneshot calls
+that did NOT request an explicit toolset restriction; ``hermes_cli/oneshot.py``
+enforces that gate before importing this module. A toolset-scoped call (e.g.
+``-t hostinger``) must keep using the cold, per-invocation ``AIAgent`` path —
+routing it through a shared warm session would silently drop the restriction
+and grant the daemon's full default toolset instead.
+
+Safety contract (same as hermesWarm.ts): every failure resolves to a
+``WarmOneshotResult`` instead of raising.  ``submitted`` distinguishes two
+situations for the caller:
+  - ``submitted=False`` — failed before ``prompt.submit`` was acked
+    (connect/token/session-create/config-set). Nothing ran server-side —
+    safe to fall back to the cold path.
+  - ``submitted=True`` — the turn was accepted by the server and may have
+    already run real tools before we lost track of it (timeout/dropped
+    connection). The caller must NOT retry via the cold path in this case —
+    that risks double-executing side effects — surface the error instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Optional
+
+TOKEN_FILE = Path.home() / ".hermes" / "dashboard_session_token.env"
+WARM_HOST = "127.0.0.1"
+WARM_PORT = 9119
+
+# Mirrors hermesWarm.ts's SETUP_TIMEOUT_MS / SUBMIT_TIMEOUT_MS exactly, so the
+# two clients degrade the same way against the same daemon.
+SETUP_TIMEOUT = 8.0
+SUBMIT_TIMEOUT = 6 * 60.0
+
+
+class WarmOneshotResult:
+    __slots__ = ("ok", "text", "submitted", "error", "usage")
+
+    def __init__(
+        self,
+        ok: bool,
+        text: str,
+        submitted: bool,
+        error: Optional[str] = None,
+        usage: Optional[dict] = None,
+    ) -> None:
+        self.ok = ok
+        self.text = text
+        self.submitted = submitted
+        self.error = error
+        self.usage = usage or {}
+
+
+def _read_token() -> Optional[str]:
+    try:
+        for line in TOKEN_FILE.read_text(encoding="utf-8").splitlines():
+            if line.startswith("HERMES_DASHBOARD_SESSION_TOKEN="):
+                tok = line.split("=", 1)[1].strip()
+                return tok or None
+    except Exception:
+        return None
+    return None
+
+
+async def _run(
+    prompt: str,
+    cwd: str,
+    model: Optional[str],
+    provider: Optional[str],
+) -> WarmOneshotResult:
+    try:
+        import websockets
+    except Exception as exc:
+        return WarmOneshotResult(False, "", False, error=f"websockets not available: {exc}")
+
+    token = _read_token()
+    if not token:
+        return WarmOneshotResult(False, "", False, error=f"no warm token at {TOKEN_FILE}")
+
+    uri = f"ws://{WARM_HOST}:{WARM_PORT}/api/ws?token={token}"
+
+    try:
+        ws = await asyncio.wait_for(websockets.connect(uri), timeout=SETUP_TIMEOUT)
+    except Exception as exc:
+        return WarmOneshotResult(False, "", False, error=f"warm connect failed: {exc}")
+
+    submitted = False
+    session_id: Optional[str] = None
+    next_id = 1
+
+    async def call(method: str, params: dict, timeout: float) -> Any:
+        nonlocal next_id
+        rid = next_id
+        next_id += 1
+        await ws.send(json.dumps({"jsonrpc": "2.0", "id": rid, "method": method, "params": params}))
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(f"warm rpc timeout: {method}")
+            raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+            msg = json.loads(raw)
+            if msg.get("id") == rid:
+                if msg.get("error"):
+                    raise RuntimeError((msg["error"] or {}).get("message") or f"{method} rpc error")
+                return msg.get("result")
+            # Interleaved event frame (status.update, etc.) or a stale reply —
+            # not our turn's RPC reply. Keep waiting for the matching id.
+
+    try:
+        # Wait for gateway.ready before issuing any RPC — mirrors hermesWarm.ts's
+        # connect(): the socket is open but the gateway isn't accepting RPCs yet.
+        deadline = time.monotonic() + SETUP_TIMEOUT
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return WarmOneshotResult(False, "", False, error="warm connect timeout (waiting for gateway.ready)")
+            raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+            msg = json.loads(raw)
+            if msg.get("method") == "event" and (msg.get("params") or {}).get("type") == "gateway.ready":
+                break
+
+        title = f"cli-oneshot-{uuid.uuid4().hex[:8]}"
+        create_params: dict = {"cwd": cwd, "title": title, "close_on_disconnect": True}
+        if model:
+            create_params["model"] = model
+        if provider:
+            create_params["provider"] = provider
+
+        created = await call("session.create", create_params, SETUP_TIMEOUT)
+        session_id = (created or {}).get("session_id")
+        if not session_id:
+            return WarmOneshotResult(False, "", False, error="session.create returned no session_id")
+
+        # Session-scoped only (never touches global approvals.mode) — a headless
+        # oneshot call has no user to approve a dangerous-command prompt.
+        await call("config.set", {"session_id": session_id, "key": "yolo", "value": "1"}, SETUP_TIMEOUT)
+
+        await call("prompt.submit", {"session_id": session_id, "text": prompt}, SETUP_TIMEOUT)
+        submitted = True
+
+        # Past this point the turn is live server-side — any failure below
+        # means submitted=True, and the caller must not retry via the cold path.
+        deadline = time.monotonic() + SUBMIT_TIMEOUT
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return WarmOneshotResult(False, "", True, error="warm turn timeout")
+            raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+            msg = json.loads(raw)
+            if msg.get("method") != "event":
+                continue
+            params = msg.get("params") or {}
+            if params.get("session_id") != session_id:
+                continue
+            evt_type = params.get("type")
+            if evt_type == "message.complete":
+                payload = params.get("payload") or {}
+                text = str(payload.get("text") or "")
+                status = str(payload.get("status") or "complete")
+                usage = payload.get("usage") or {}
+                ok = status == "complete" and bool(text)
+                return WarmOneshotResult(
+                    ok, text, True, error=None if ok else f"warm status={status}", usage=usage
+                )
+            if evt_type == "error":
+                err = (params.get("payload") or {}).get("error") or "warm session error event"
+                return WarmOneshotResult(False, "", True, error=err)
+            # message.delta, tool.start, status.update, etc. — not needed here.
+    except Exception as exc:
+        return WarmOneshotResult(False, "", submitted, error=str(exc))
+    finally:
+        try:
+            await ws.close()
+        except Exception:
+            pass
+
+
+def try_warm_oneshot(
+    prompt: str,
+    cwd: str,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
+) -> WarmOneshotResult:
+    """Synchronous entry point for ``hermes_cli/oneshot.py``. Never raises."""
+    try:
+        return asyncio.run(_run(prompt, cwd, model, provider))
+    except Exception as exc:
+        return WarmOneshotResult(False, "", False, error=str(exc))


### PR DESCRIPTION
## Summary
- Cold `hermes -z` invocations race a ~1.5s `mcp_discovery_timeout` against MCP servers that take longer to connect (e.g. `hostinger`'s npx-spawned stdio server, ~4s) — the tools never make it into that turn's schema, so the model either honestly reports having no tools or, on weaker models, hallucinates a plausible-looking fake tool call/result.
- When no explicit `--toolsets`/`-t` is given, `-z` now tries the persistent `hermes serve` daemon (`ws://127.0.0.1:9119/api/ws`, same protocol as Crucible's `hermesWarm.ts`) before falling back to a cold `AIAgent` build. The daemon's MCP servers are already connected process-wide, so a new session on it has tools available immediately with no discovery race.
- An explicit `-t` always keeps the cold, per-invocation path: `session.create` has no per-session toolset-restriction equivalent, so a scoped call must never risk silently widening to the daemon's full default toolset (the same limitation `hermesWarm.ts`'s own callers already work around for `dogfood`/`yuanbao`/`computer-use`).

## Test plan
- [x] `py_compile` on both changed/new files
- [x] Verified live against a running `hermes-serve.service`: untoolset-scoped call dropped from ~28s cold to ~12s warm with a genuine 2-call tool-invocation round trip (was a 1-call hallucination before the fix)
- [x] Verified `-t hostinger` still takes the cold path unchanged (`cost_source: provider_models_api`, classic cold session-id format)
- [x] Confirmed no protocol drift against current `main` (`session.create` params, `_get_usage` fields, `/api/ws`, token env var) despite this branch being rebased onto a much newer base than the original dev clone