### PR TITLE
fix(search_files): reject invalid target values instead of silently passing through (#74448)

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2080,11 +2080,19 @@ def _handle_patch(args, **kw):
     )
 
 
+VALID_SEARCH_TARGETS = frozenset({"content", "files"})
+
 def _handle_search_files(args, **kw):
     tid = kw.get("task_id") or "default"
     target_map = {"grep": "content", "find": "files"}
     raw_target = args.get("target", "content")
     target = target_map.get(raw_target, raw_target)
+    if target not in VALID_SEARCH_TARGETS:
+        return tool_error(
+            f"search_files: invalid target '{raw_target}'. "
+            f"Must be one of: 'content' or 'files'. "
+            f"Re-emit the tool call with a valid target."
+        )
     return search_tool(
         pattern=args.get("pattern", ""), target=target, path=args.get("path", "."),
         file_glob=args.get("file_glob"), limit=args.get("limit", 50), offset=args.get("offset", 0),


### PR DESCRIPTION
**Fixes #74448**

## Problem

`search_files` declares `target` as `enum: ["content", "files"]` in its JSON schema, but the handler never validates this. If a model sends an invalid value like `grep`, `find`, or any other string, the handler passes it straight through to `search_tool()` via `target_map.get(raw_target, raw_target)` — silently accepting any value with no feedback.

## Fix

Added a validation check after the legacy alias map (`{grep→content, find→files}`). If the resolved target is neither `content` nor `files`, the handler returns a clear `tool_error` message telling the model which values are allowed and to re-emit with a valid target.

## Changes

**`tools/file_tools.py`** — `_handle_search_files()`:
- Added `VALID_SEARCH_TARGETS` frozenset constant
- Added `if target not in VALID_SEARCH_TARGETS:` guard that returns `tool_error(...)`

This matches the validation pattern already used by other tools in the same file (e.g. `_handle_write_file` validates required fields).