### PR TITLE
fix(meet): constrain websockets version to match project pin

### DIFF
--- a/plugins/google_meet/cli.py
+++ b/plugins/google_meet/cli.py
@@ -247,7 +247,7 @@ def _cmd_install(*, realtime: bool, assume_yes: bool) -> int:
     print("-------------------")
 
     # 1) pip deps — always safe, venv-scoped.
-    pip_pkgs = ["playwright", "websockets"]
+    pip_pkgs = ["playwright", "websockets>=15.0.1,<16"]
     print(f"\n[1/3] pip install: {' '.join(pip_pkgs)}")
     try:
         from hermes_cli.tools_config import _pip_install


### PR DESCRIPTION
## Summary

`hermes meet install` runs `pip install --upgrade playwright websockets` with no version constraint on `websockets`. Since `websockets` is pinned in `pyproject.toml` (`==15.0.1`), the unconstrained `--upgrade` installs the latest release (currently 17.0), which removed its legacy API in 14.0 and is incompatible with code written against 15.0.1.

## Root cause

In `plugins/google_meet/cli.py:250`, the pip package list has no version constraint:
```python
pip_pkgs = ["playwright", "websockets"]
```

Combined with `--upgrade` on line 255, this forces pip to install the latest `websockets`, overriding the project's own pin. The gateway and platform adapters that import `websockets` then break on their next restart.

## Fix

Constrain `websockets` to `>=15.0.1,<16`:
```python
pip_pkgs = ["playwright", "websockets>=15.0.1,<16"]
```

This respects the project's dependency pin while still allowing patch-level updates within the 15.x range.

## Changes

- `plugins/google_meet/cli.py`: Add version constraint to websockets in `_cmd_install()` pip package list

Fixes #74345