### PR TITLE
fix(packaging): add missing hermes_state_* modules to py-modules list (#74287)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -345,7 +345,7 @@ hermes-acp = "acp_adapter.entry:main"
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's
 # sealed venv is missing hermes_constants, run_agent, etc.
-py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "utils", "mcp_serve"]
+py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_state_common", "hermes_state_portability", "hermes_state_schema", "hermes_state_search", "hermes_time", "hermes_logging", "utils", "mcp_serve"]
 
 [tool.setuptools.packages.find]
 include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]


### PR DESCRIPTION
## Summary

`hermes_state.py` imports four sibling top-level modules that are not listed in `[tool.setuptools] py-modules`, so they are never packaged in wheel/sdist builds. Any install built from `pyproject.toml` (pip/uv wheel, nix, distro packaging) silently disables the SQLite session store because the modules are missing from the distribution.

Git installs are unaffected since they run from the repo tree where the files are present.

## Root Cause

`hermes_state.py` imports:
- `hermes_state_common` (line 46, re-exported for back-compat)
- `hermes_state_portability` (line 70, `SessionPortabilityMixin`)
- `hermes_state_schema` (line 71, `SessionSchemaMixin`)
- `hermes_state_search` (line 72, `SessionSearchMixin`)

But `pyproject.toml` line 348 only lists `hermes_state` — the four dependencies are absent.

## Fix

Add the four missing modules to the `py-modules` list in `pyproject.toml`.

## Testing

- All 4 existing packaging tests pass (`tests/test_packaging_build_guard.py`)
- Verified the modules exist in the repo root
- Verified the imports in `hermes_state.py` match the added module names

Fixes #74287