### PR TITLE
fix(profile): respect distribution_owned in _copy_dist_payload

### DIFF
--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -557,8 +557,15 @@ def _copy_dist_payload(
     ``preserve_config`` is False (fresh install or ``--force-config`` update).
     ``.env.template`` is renamed to ``.env.EXAMPLE`` in the target to avoid
     shadowing a real ``.env``.
+
+    When the manifest declares ``distribution_owned``, only those paths (plus
+    always-distributed infra like ``.env.template``) are copied.  When the
+    field is unset the entire staged tree (minus user-owned exclusions) is
+    copied — matching the legacy behaviour for manifests that predate the
+    field.
     """
     target.mkdir(parents=True, exist_ok=True)
+    owned = set(manifest.owned_paths()) if manifest.distribution_owned else None
 
     for entry in staged.iterdir():
         name = entry.name
@@ -567,6 +574,8 @@ def _copy_dist_payload(
             continue
         if name == ENV_TEMPLATE_FILENAME:
             shutil.copy2(entry, target / ENV_EXAMPLE_FILENAME)
+            continue
+        if owned is not None and name not in owned:
             continue
         if name == "config.yaml" and preserve_config and (target / "config.yaml").exists():
             # Leave user's config.yaml alone on update


### PR DESCRIPTION
## Summary

When a manifest declares `distribution_owned`, `_copy_dist_payload()` still iterated every staged entry and copied it unless its name was in `USER_OWNED_EXCLUDE`. An explicit manifest like `distribution_owned: [SOUL.md]` still installed unlisted entries (`.github/`, `docs/`, `ops/`, tests, plugins). On update, staged directories replaced the complete destination directory, deleting target-only children.

## Root cause

`_copy_dist_payload()` (line 563) iterates `staged.iterdir()` and filters only by `USER_OWNED_EXCLUDE`. It never consults `manifest.owned_paths()` to see which paths are actually distribution-owned.

## Fix

When the manifest has an explicit `distribution_owned` list, filter the copy loop to only copy entries whose names appear in `owned_paths()`. When `distribution_owned` is unset, preserve the legacy behaviour of copying the entire staged tree (minus user-owned exclusions).

The `.env.template` special case and `write_manifest()` are unaffected — `.env.template` is handled before the owned filter, and `write_manifest()` runs after the loop.

## Changes

- `hermes_cli/profile_distribution.py`: Add `owned` set from `manifest.owned_paths()` when `distribution_owned` is set; skip entries not in `owned`

## Test plan

- [x] All 43 existing tests pass (`tests/hermes_cli/test_profile_distribution.py`)
- [ ] Fresh install with explicit `distribution_owned` only copies listed paths
- [ ] Fresh install without `distribution_owned` copies everything (legacy)
- [ ] Update with explicit `distribution_owned` preserves target-only children

Fixes #74373