### PR TITLE
fix(desktop): refresh profiles when gateway becomes ready in global remote mode

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -41,6 +41,7 @@ import {
   $activeGatewayProfile,
   $freshSessionRequest,
   $profileScope,
+  $profiles,
   ensureGatewayProfile,
   newSessionInProfile,
   normalizeProfileKey,
@@ -499,6 +500,17 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     void refreshHermesConfig(true)
     void refreshActiveProfile()
   }, [activeGatewayProfile, refreshCurrentModel, refreshHermesConfig])
+
+  // When the gateway becomes ready (e.g. remote backend handshake completes),
+  // re-fetch the profile list. In global remote mode the first refreshActiveProfile
+  // call above may fire before the remote proxy is fully routed, silently failing
+  // and leaving $profiles empty (issue #70679). Only runs when the list is empty
+  // to avoid redundant refetches on reconnect.
+  useEffect(() => {
+    if (gatewayState === 'open' && $profiles.get().length === 0) {
+      void refreshActiveProfile()
+    }
+  }, [gatewayState])
 
   // New session anchored to a workspace. Seeds cwd + branch from the clicked
   // workspace; an explicit worktree path also drills the sidebar into that

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -40,8 +40,8 @@ import { $previewTarget } from '@/store/preview'
 import {
   $activeGatewayProfile,
   $freshSessionRequest,
-  $profileScope,
   $profiles,
+  $profileScope,
   ensureGatewayProfile,
   newSessionInProfile,
   normalizeProfileKey,

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -40,7 +40,6 @@ import { $previewTarget } from '@/store/preview'
 import {
   $activeGatewayProfile,
   $freshSessionRequest,
-  $profiles,
   $profileScope,
   ensureGatewayProfile,
   newSessionInProfile,
@@ -500,17 +499,6 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     void refreshHermesConfig(true)
     void refreshActiveProfile()
   }, [activeGatewayProfile, refreshCurrentModel, refreshHermesConfig])
-
-  // When the gateway becomes ready (e.g. remote backend handshake completes),
-  // re-fetch the profile list. In global remote mode the first refreshActiveProfile
-  // call above may fire before the remote proxy is fully routed, silently failing
-  // and leaving $profiles empty (issue #70679). Only runs when the list is empty
-  // to avoid redundant refetches on reconnect.
-  useEffect(() => {
-    if (gatewayState === 'open' && $profiles.get().length === 0) {
-      void refreshActiveProfile()
-    }
-  }, [gatewayState])
 
   // New session anchored to a workspace. Seeds cwd + branch from the clicked
   // workspace; an explicit worktree path also drills the sidebar into that

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -154,6 +154,15 @@ describe('prewarmProfileBackend (hover-intent pool spawn)', () => {
 })
 
 describe('refreshProfiles shared rail list (#49289)', () => {
+  beforeEach(() => {
+    vi.mocked(getProfiles).mockReset()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('removes a deleted profile from the shared $profiles cache after Manage Profiles refreshes', async () => {
     $profiles.set([profile('default', true), profile('test1')])
     vi.mocked(getProfiles).mockResolvedValueOnce({ profiles: [profile('default', true)] })
@@ -163,12 +172,36 @@ describe('refreshProfiles shared rail list (#49289)', () => {
     expect($profiles.get().map(profile => profile.name)).toEqual(['default'])
   })
 
-  it('leaves the shared $profiles cache intact when the refresh fails', async () => {
+  it('recovers from transient failures and writes the returned profile list (#70679)', async () => {
+    // Global remote mode: the refresh fires while the remote HTTP proxy is still
+    // routing, so the first attempts fail and a later one succeeds. The retry
+    // backoff is 500ms then 1000ms (refreshProfiles retries twice on failure).
+    $profiles.set([])
+    vi.mocked(getProfiles)
+      .mockRejectedValueOnce(new Error('backend unavailable'))
+      .mockRejectedValueOnce(new Error('backend unavailable'))
+      .mockResolvedValueOnce({ profiles: [profile('default', true), profile('healthops')] })
+
+    const refresh = refreshProfiles()
+    await vi.advanceTimersByTimeAsync(500)
+    await vi.advanceTimersByTimeAsync(1000)
+    await expect(refresh).resolves.toHaveLength(2)
+
+    expect(vi.mocked(getProfiles)).toHaveBeenCalledTimes(3)
+    expect($profiles.get().map(profile => profile.name)).toEqual(['default', 'healthops'])
+  })
+
+  it('leaves the shared $profiles cache intact when every retry fails', async () => {
     $profiles.set([profile('default', true), profile('test1')])
     vi.mocked(getProfiles).mockRejectedValue(new Error('backend unavailable'))
 
-    await expect(refreshProfiles()).rejects.toThrow('backend unavailable')
+    const refresh = refreshProfiles()
+    const rejection = expect(refresh).rejects.toThrow('backend unavailable')
+    await vi.advanceTimersByTimeAsync(500)
+    await vi.advanceTimersByTimeAsync(1000)
+    await rejection
 
+    expect(vi.mocked(getProfiles)).toHaveBeenCalledTimes(3)
     expect($profiles.get().map(profile => profile.name)).toEqual(['default', 'test1'])
   })
 })

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -165,7 +165,7 @@ describe('refreshProfiles shared rail list (#49289)', () => {
 
   it('leaves the shared $profiles cache intact when the refresh fails', async () => {
     $profiles.set([profile('default', true), profile('test1')])
-    vi.mocked(getProfiles).mockRejectedValueOnce(new Error('backend unavailable'))
+    vi.mocked(getProfiles).mockRejectedValue(new Error('backend unavailable'))
 
     await expect(refreshProfiles()).rejects.toThrow('backend unavailable')
 

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -160,6 +160,7 @@ describe('refreshProfiles shared rail list (#49289)', () => {
   })
 
   afterEach(() => {
+    vi.clearAllTimers()
     vi.useRealTimers()
   })
 
@@ -188,6 +189,24 @@ describe('refreshProfiles shared rail list (#49289)', () => {
     await expect(refresh).resolves.toHaveLength(2)
 
     expect(vi.mocked(getProfiles)).toHaveBeenCalledTimes(3)
+    expect($profiles.get().map(profile => profile.name)).toEqual(['default', 'healthops'])
+  })
+
+  it('shares one retry chain across concurrent callers (single-flight)', async () => {
+    // Gateway open fires both useBackgroundSync and the activeGatewayProfile
+    // effect at once; both callers must ride the same chain, not double it.
+    $profiles.set([])
+    vi.mocked(getProfiles)
+      .mockRejectedValueOnce(new Error('backend unavailable'))
+      .mockResolvedValueOnce({ profiles: [profile('default', true), profile('healthops')] })
+
+    const first = refreshProfiles()
+    const second = refreshProfiles()
+    await vi.advanceTimersByTimeAsync(500)
+    await expect(first).resolves.toHaveLength(2)
+    await expect(second).resolves.toHaveLength(2)
+
+    expect(vi.mocked(getProfiles)).toHaveBeenCalledTimes(2)
     expect($profiles.get().map(profile => profile.name)).toEqual(['default', 'healthops'])
   })
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -39,10 +39,31 @@ export function setActiveProfile(name: string): void {
 }
 
 export async function refreshProfiles(): Promise<ProfileInfo[]> {
-  const { profiles } = await getProfiles()
-  $profiles.set(profiles)
+  const MAX_RETRIES = 2
 
-  return profiles
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const { profiles } = await getProfiles()
+      $profiles.set(profiles)
+
+      return profiles
+    } catch (error) {
+      if (attempt === MAX_RETRIES) {
+        // Surface the failure so it's visible in the console — the prior silent
+        // catch in refreshActiveProfile() hid global-remote timing races (#70679).
+        console.error(`[profiles] refreshProfiles failed after ${MAX_RETRIES + 1} attempts:`, error)
+
+        throw error
+      }
+
+      // Back off before retrying: 500ms, then 1000ms. Gives the remote proxy a
+      // window to finish routing after WebSocket-ready but pre-HTTP-proxy states.
+      await new Promise(resolve => setTimeout(resolve, 500 * (attempt + 1)))
+    }
+  }
+
+  // Unreachable — satisfies TypeScript.
+  return []
 }
 
 // ── Rail order ─────────────────────────────────────────────────────────────

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -38,32 +38,48 @@ export function setActiveProfile(name: string): void {
   $activeProfile.set(name || 'default')
 }
 
-export async function refreshProfiles(): Promise<ProfileInfo[]> {
-  const MAX_RETRIES = 2
+// Single-flight guard: on gateway open both useBackgroundSync and the
+// activeGatewayProfile-change effect call refreshActiveProfile() at once, and
+// the Manage Profiles panel can join mid-flight. Dedupe so concurrent callers
+// share one retry chain instead of stampeding /api/profiles.
+let refreshInFlight: Promise<ProfileInfo[]> | null = null
 
-  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    try {
-      const { profiles } = await getProfiles()
-      $profiles.set(profiles)
-
-      return profiles
-    } catch (error) {
-      if (attempt === MAX_RETRIES) {
-        // Surface the failure so it's visible in the console — the prior silent
-        // catch in refreshActiveProfile() hid global-remote timing races (#70679).
-        console.error(`[profiles] refreshProfiles failed after ${MAX_RETRIES + 1} attempts:`, error)
-
-        throw error
-      }
-
-      // Back off before retrying: 500ms, then 1000ms. Gives the remote proxy a
-      // window to finish routing after WebSocket-ready but pre-HTTP-proxy states.
-      await new Promise(resolve => setTimeout(resolve, 500 * (attempt + 1)))
-    }
+export function refreshProfiles(): Promise<ProfileInfo[]> {
+  if (refreshInFlight) {
+    return refreshInFlight
   }
 
-  // Unreachable — satisfies TypeScript.
-  return []
+  refreshInFlight = (async () => {
+    const MAX_RETRIES = 2
+
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const { profiles } = await getProfiles()
+        $profiles.set(profiles)
+
+        return profiles
+      } catch (error) {
+        if (attempt === MAX_RETRIES) {
+          // Surface the failure so it's visible in the console — the prior silent
+          // catch in refreshActiveProfile() hid global-remote timing races (#70679).
+          console.error(`[profiles] refreshProfiles failed after ${MAX_RETRIES + 1} attempts:`, error)
+
+          throw error
+        }
+
+        // Back off before retrying: 500ms, then 1000ms. Gives the remote proxy a
+        // window to finish routing after WebSocket-ready but pre-HTTP-proxy states.
+        await new Promise(resolve => setTimeout(resolve, 500 * (attempt + 1)))
+      }
+    }
+
+    // Unreachable — satisfies TypeScript.
+    return []
+  })().finally(() => {
+    refreshInFlight = null
+  })
+
+  return refreshInFlight
 }
 
 // ── Rail order ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
# fix(desktop): retry profile refresh to cover the global-remote routing window

Refs #70679 — Desktop in global remote mode doesn't show the profile rail/dropdown even though the remote backend has multiple profiles.

## Root cause

The profile list (`$profiles`) is fetched when the gateway opens and when `activeGatewayProfile` changes. In global remote mode those events fire before the remote HTTP proxy is fully routed, so the `/api/profiles` fetch fails — and `refreshActiveProfile()` swallows the error, leaving `$profiles` empty. Since `ProfileRail` gates on `profiles.length > 1`, multi-profile remote users never saw the switcher.

## Changes

1. **`apps/desktop/src/store/profile.ts`** — `refreshProfiles()` now retries up to 2 times on failure (500ms, then 1s backoff). The existing on-connect refresh in `useBackgroundSync` therefore recovers on its own once the proxy finishes routing. Final failures are logged to the console so the timing gap is visible during debugging.
2. **`apps/desktop/src/store/profile.test.ts`** — fake-timer coverage: a transient-failure recovery test (two rejects, then a resolve; asserts the returned list lands in `$profiles` plus the call count) and a permanent-failure test (asserts all 3 attempts and that the cache is preserved).

## Verification

- `npx vitest run src/store/profile.test.ts` — 12/12 passed.
- `tsc -b` clean; eslint clean on changed files.
- Reporter verification (skillet07): with injected 503s on `/api/profiles` followed by recovery, the profile dropdown appeared with all 15 named profiles and profile switching reconnected the gateway — exactly the retry path this PR adds.

## Notes

- An earlier revision added a `ContribWiring` effect on `gatewayState === 'open'`; `useBackgroundSync` already performs that refresh ([`0f922002eb7`](https://github.com/NousResearch/hermes-agent/commit/0f922002eb7), which predates this PR's base), so the effect was removed during review — `wiring.tsx` is unchanged vs main.
