### PR TITLE
fix(prompt): apply root policy to named profiles

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -13,7 +13,12 @@ import contextvars
 from collections import OrderedDict
 from pathlib import Path
 
-from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
+from hermes_constants import (
+    get_default_hermes_root,
+    get_hermes_home,
+    get_skills_dir,
+    is_wsl,
+)
 from typing import Optional
 
 from agent.runtime_cwd import resolve_agent_cwd
@@ -2009,6 +2014,49 @@ def load_soul_md(context_length: Optional[int] = None) -> Optional[str]:
         return content
     except Exception as e:
         logger.debug("Could not read SOUL.md from %s: %s", soul_path, e)
+        return None
+
+
+def load_universal_policy_md(context_length: Optional[int] = None) -> Optional[str]:
+    """Load the root universal policy for a named profile, if configured.
+
+    ``<root>/AGENTS.md`` is intentionally *not* part of ordinary project-context
+    discovery: ``AGENTS.md`` remains cwd-only so portable project instructions
+    never leak across workspaces.  The root file is instead an explicit,
+    profile-wide policy source for named profiles.  Returning the body without
+    a project-context wrapper lets the system-prompt builder keep it separate
+    and avoid a duplicate when the root directory is deliberately the cwd.
+
+    The default profile already owns the root and does not receive a second
+    copy.  ``--ignore-rules`` is enforced by the caller, alongside SOUL and
+    project-context loading.
+    """
+    profile_home = get_hermes_home()
+    root_home = get_default_hermes_root()
+    try:
+        if profile_home.resolve() == root_home.resolve():
+            return None
+    except OSError:
+        # A path that cannot be resolved is not a safe basis for cross-profile
+        # policy inheritance; preserve the profile's normal isolated prompt.
+        return None
+
+    policy_path = root_home / "AGENTS.md"
+    if not policy_path.is_file():
+        return None
+    try:
+        content = policy_path.read_text(encoding="utf-8").strip()
+        if not content:
+            return None
+        content = _scan_context_content(content, "universal AGENTS.md")
+        return _truncate_content(
+            content,
+            "universal AGENTS.md",
+            context_length=context_length,
+            read_path=str(policy_path),
+        )
+    except Exception as e:
+        logger.debug("Could not read universal policy from %s: %s", policy_path, e)
         return None
 
 

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -497,6 +497,19 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         if context_files_prompt:
             context_parts.append(context_files_prompt)
 
+        # Root AGENTS.md is a deliberate universal-policy source for named
+        # profiles, not cwd-local project context. Keep it in the stable tier
+        # and suppress it if an explicit root cwd already loaded the same body
+        # through the ordinary AGENTS.md contract.
+        universal_policy = _r.load_universal_policy_md(_ctx_len)
+        if universal_policy and universal_policy not in context_files_prompt:
+            stable_parts.append(
+                "# Universal Profile Policy\n\n"
+                "The following policy comes from the Hermes root AGENTS.md and "
+                "applies to named profiles. It is not project-cwd context.\n\n"
+                + universal_policy
+            )
+
     # ── Volatile tier (changes per session/turn — never cached) ───
     volatile_parts: List[str] = []
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -168,6 +168,7 @@ from agent.prompt_builder import (  # noqa: F401  # re-exported via _ra() / mock
     build_environment_hints,
     build_nous_subscription_prompt,
     load_soul_md,
+    load_universal_policy_md,
 )
 from agent.process_bootstrap import _get_proxy_from_env  # noqa: F401
 from agent.message_sanitization import (  # noqa: F401

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -18,6 +18,7 @@ from agent.prompt_builder import (
     build_skills_system_prompt,
     build_nous_subscription_prompt,
     build_context_files_prompt,
+    load_universal_policy_md,
     CONTEXT_FILE_MAX_CHARS,
     _dynamic_context_file_max_chars,
     _get_context_file_max_chars,
@@ -516,6 +517,29 @@ class TestBuildContextFilesPrompt:
 
 
 
+
+
+class TestUniversalProfilePolicy:
+    def test_named_profile_loads_root_policy_without_changing_cwd_discovery(
+        self, tmp_path, monkeypatch
+    ):
+        root = tmp_path / "hermes"
+        profile = root / "profiles" / "specialist"
+        profile.mkdir(parents=True)
+        (root / "AGENTS.md").write_text("Universal SoLoRecall policy.")
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+
+        assert load_universal_policy_md() == "Universal SoLoRecall policy."
+
+    def test_default_profile_does_not_load_its_root_policy_twice(
+        self, tmp_path, monkeypatch
+    ):
+        root = tmp_path / "hermes"
+        root.mkdir()
+        (root / "AGENTS.md").write_text("Universal SoLoRecall policy.")
+        monkeypatch.setenv("HERMES_HOME", str(root))
+
+        assert load_universal_policy_md() is None
 
 
 # =========================================================================

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -62,12 +62,90 @@ class TestContextFileCwd:
         assert _captured_context_cwd(_make_agent()) == tmp_path
 
 
+class TestUniversalProfilePolicy:
+    def test_named_profile_injects_root_policy_and_keeps_cwd_agents_local(
+        self, tmp_path, monkeypatch
+    ):
+        """Exercise the real profile, policy, and cwd context-file loaders."""
+        root = tmp_path / "hermes"
+        profile = root / "profiles" / "recall-specialist"
+        project = tmp_path / "project"
+        profile.mkdir(parents=True)
+        project.mkdir()
+        (root / "AGENTS.md").write_text(
+            "# SoLo Briefs / SoLoRecall Agent Hub\n\n"
+            "Universal reporting policy.\n\n"
+            "# SoLoRecall Deliverable Persistence Rule\n\n"
+            "Persist deliverables in SoLoRecall.\n",
+            encoding="utf-8",
+        )
+        (project / "AGENTS.md").write_text(
+            "CWD_LOCAL_AGENTS_POLICY", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+        monkeypatch.setenv("TERMINAL_CWD", str(project))
+
+        parts = build_system_prompt_parts(_make_agent())
+
+        assert "SoLo Briefs / SoLoRecall Agent Hub" in parts["stable"]
+        assert "SoLoRecall Deliverable Persistence Rule" in parts["stable"]
+        assert "CWD_LOCAL_AGENTS_POLICY" not in parts["stable"]
+        assert "CWD_LOCAL_AGENTS_POLICY" in parts["context"]
+        assert "SoLo Briefs / SoLoRecall Agent Hub" not in parts["context"]
+
+    def test_named_profile_policy_is_stable_and_not_project_context(self):
+        agent = _make_agent()
+        marker = "UNIVERSAL_SOLORECALL_POLICY_MARKER"
+        with (
+            patch("run_agent.load_soul_md", return_value=""),
+            patch("run_agent.build_nous_subscription_prompt", return_value=""),
+            patch("run_agent.build_environment_hints", return_value=""),
+            patch("run_agent.build_context_files_prompt", return_value=""),
+            patch("run_agent.load_universal_policy_md", return_value=marker),
+        ):
+            parts = build_system_prompt_parts(agent)
+
+        assert marker in parts["stable"]
+        assert "Universal Profile Policy" in parts["stable"]
+        assert marker not in parts["context"]
+
+    def test_policy_is_not_injected_twice_when_root_cwd_loaded_it(self):
+        agent = _make_agent()
+        marker = "UNIVERSAL_SOLORECALL_POLICY_MARKER"
+        root_context = f"# Project Context\n\n## AGENTS.md\n\n{marker}"
+        with (
+            patch("run_agent.load_soul_md", return_value=""),
+            patch("run_agent.build_nous_subscription_prompt", return_value=""),
+            patch("run_agent.build_environment_hints", return_value=""),
+            patch("run_agent.build_context_files_prompt", return_value=root_context),
+            patch("run_agent.load_universal_policy_md", return_value=marker),
+        ):
+            parts = build_system_prompt_parts(agent)
+
+        assert marker not in parts["stable"]
+        assert parts["context"].count(marker) == 1
+
+    def test_ignore_rules_skips_universal_policy(self):
+        agent = _make_agent(skip_context_files=True)
+        with (
+            patch("run_agent.load_soul_md", return_value=""),
+            patch("run_agent.build_nous_subscription_prompt", return_value=""),
+            patch("run_agent.build_environment_hints", return_value=""),
+            patch("run_agent.load_universal_policy_md", return_value="policy") as policy_loader,
+        ):
+            parts = build_system_prompt_parts(agent)
+
+        policy_loader.assert_not_called()
+        assert "policy" not in parts["stable"]
+
+
 def _stable_prompt(agent):
     with (
         patch("run_agent.load_soul_md", return_value=""),
         patch("run_agent.build_nous_subscription_prompt", return_value=""),
         patch("run_agent.build_environment_hints", return_value=""),
         patch("run_agent.build_context_files_prompt", return_value=""),
+        patch("run_agent.load_universal_policy_md", return_value=""),
     ):
         return build_system_prompt_parts(agent)["stable"]
 


### PR DESCRIPTION
## Summary
- Load the default Hermes root `AGENTS.md` as an explicitly labelled stable universal-policy tier for named profiles.
- Keep ordinary `AGENTS.md` discovery cwd-local, skip default-profile duplication, and suppress duplicate injection when root policy is already loaded from cwd context.
- Add hermetic prompt-builder/system-prompt regression coverage.

## Committed files
- `agent/prompt_builder.py`
- `agent/system_prompt.py`
- `run_agent.py`
- `tests/agent/test_prompt_builder.py`
- `tests/agent/test_system_prompt.py`

Pre-existing unrelated changes intentionally excluded:
- `hermes_cli/gateway.py`
- `tests/hermes_cli/test_gateway_service.py`

## Verification
- `scripts/run_tests.sh tests/agent/test_system_prompt.py tests/agent/test_prompt_builder.py -q -k UniversalProfilePolicy` — blocked locally because `.venv/bin/python` has no `pytest`.
- `env -i PATH="$PATH" HOME="$HOME" TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONHASHSEED=0 venv/bin/python scripts/run_tests_parallel.py tests/agent/test_system_prompt.py tests/agent/test_prompt_builder.py -q -k UniversalProfilePolicy` — passed: 6 tests, 0 failures (2 files, 1.3s).

## Closeout
- Branch: `agent/universal-profile-policy-pr`
- Commit: `ebb21543c`
