### PR TITLE
fix(sessiondb): time-based lock patience with backoff jitter (#74478)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1678,7 +1678,9 @@ def get_custom_provider_extra_headers(
         entry_url = normalize_route_base_url(entry.get("base_url"))
         if not entry_url or entry_url != target_url:
             continue
-        return normalize_extra_headers(entry.get("extra_headers"))
+        headers = normalize_extra_headers(entry.get("extra_headers"))
+        if headers:
+            return headers
     return {}
 
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1509,9 +1509,25 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # Instead, we keep the SQLite timeout short (1s) and handle retries at the
     # application level with random jitter, which naturally staggers competing
     # writers and avoids the convoy.
-    _WRITE_MAX_RETRIES = 15
-    _WRITE_RETRY_MIN_S = 0.020   # 20ms
-    _WRITE_RETRY_MAX_S = 0.150   # 150ms
+    #
+    # Time-based patience replaces the old attempt-counted scheme (15 * 20-150ms
+    # ≈ 1.3s max). A sibling process can legitimately hold the WAL write lock
+    # for multiple seconds (VACUUM after auto-prune, WAL checkpoint, offline
+    # recovery/repair, or an older version's mixed-connection pool), so the
+    # retry window must exceed the longest routine write-hold. Two budgets:
+    #
+    #   routine (20s) — used for most writes (create_session, meta updates, etc.)
+    #   critical (60s) — used for append_message (loss of a turn's transcript)
+    #
+    # Backoff jitter activates after BACKOFF_AFTER_S: once elapsed time exceeds
+    # that threshold the max sleep grows linearly so competing processes have
+    # room to finish their long-running operations.
+    _WRITE_PATIENCE_S = 20.0               # routine writes
+    _WRITE_PATIENCE_CRITICAL_S = 60.0      # transcript-critical writes (append_message)
+    _WRITE_RETRY_MIN_S = 0.020              # 20ms
+    _WRITE_RETRY_MAX_S = 0.150              # 150ms (base, before backoff)
+    _WRITE_BACKOFF_AFTER_S = 2.0            # switch to backoff jitter after 2s
+    _WRITE_BACKOFF_MAX_S = 1.0              # cap backoff jitter at 1s
     # Attempt a WAL checkpoint every N successful writes (PASSIVE mode).
     _CHECKPOINT_EVERY_N_WRITES = 50
     # Retain the existing coarse 1000-write maintenance cadence, but replace
@@ -1667,31 +1683,86 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 self._fts_cjk_loaded = load_fts5_cjk_extension(self._conn)
                 self._init_schema()
 
-            try:
-                _connect_and_init()
-            except sqlite3.DatabaseError as exc:
-                # The malformed-schema class (e.g. a duplicate sqlite_master
-                # row for messages_fts) fails on the very first statement —
-                # before _init_schema can run — so it can't be caught at the
-                # FTS-rebuild layer. Recover by repairing sqlite_master in
-                # place (backup first; canonical sessions/messages preserved),
-                # then reopen once. This is what lets Desktop/Dashboard
-                # self-heal instead of silently showing "no sessions".
-                if not is_malformed_db_error(exc) or not _claim_repair_attempt(self.db_path):
-                    raise
-                logger.error(
-                    "state.db schema is malformed (%s) — attempting automatic "
-                    "repair (a backup copy is made first).", exc,
-                )
+            # Retry _connect_and_init() for locked/busy errors with the
+            # same time-based patience as routine writes.  A sibling
+            # process may hold the WAL write lock during VACUUM after
+            # auto-prune, a WAL checkpoint, offline recovery, or an older
+            # version's mixed-connection pool — the open path must wait
+            # long enough for those to complete instead of failing fast.
+            last_open_err: Optional[Exception] = None
+            open_deadline = time.monotonic() + self._WRITE_PATIENCE_S
+            open_attempt = 0
+            while True:
+                open_attempt += 1
                 try:
-                    if self._conn is not None:
-                        self._conn.close()
-                except Exception:
-                    pass
-                report = repair_state_db_schema(self.db_path)
-                if not report.get("repaired"):
+                    _connect_and_init()
+                    break
+                except sqlite3.OperationalError as exc:
+                    err_msg = str(exc).lower()
+                    if "locked" in err_msg or "busy" in err_msg:
+                        last_open_err = exc
+                        now = time.monotonic()
+                        if now < open_deadline:
+                            elapsed = now - (open_deadline - self._WRITE_PATIENCE_S)
+                            # Same backoff strategy as _execute_write
+                            if elapsed <= self._WRITE_BACKOFF_AFTER_S:
+                                hi = self._WRITE_RETRY_MAX_S
+                            else:
+                                progress = min(
+                                    1.0,
+                                    (elapsed - self._WRITE_BACKOFF_AFTER_S)
+                                    / (self._WRITE_PATIENCE_S - self._WRITE_BACKOFF_AFTER_S),
+                                )
+                                hi = self._WRITE_RETRY_MAX_S + progress * (
+                                    self._WRITE_BACKOFF_MAX_S - self._WRITE_RETRY_MAX_S
+                                )
+                            jitter = random.uniform(
+                                self._WRITE_RETRY_MIN_S,
+                                hi,
+                            )
+                            time.sleep(jitter)
+                            continue
+                        # Patience exhausted — break so the post-loop
+                        # check below raises with the clear message.
+                        break
+                    # Not a lock/busy error — propagate to the outer
+                    # handler (malformed repair or generic failure).
                     raise
-                _connect_and_init()
+                except sqlite3.DatabaseError as exc:
+                    # The malformed-schema class (e.g. a duplicate sqlite_master
+                    # row for messages_fts) fails on the very first statement —
+                    # before _init_schema can run — so it can't be caught at the
+                    # FTS-rebuild layer. Recover by repairing sqlite_master in
+                    # place (backup first; canonical sessions/messages preserved),
+                    # then reopen once. This is what lets Desktop/Dashboard
+                    # self-heal instead of silently showing "no sessions".
+                    if not is_malformed_db_error(exc) or not _claim_repair_attempt(self.db_path):
+                        raise
+                    logger.error(
+                        "state.db schema is malformed (%s) — attempting automatic "
+                        "repair (a backup copy is made first).", exc,
+                    )
+                    try:
+                        if self._conn is not None:
+                            self._conn.close()
+                    except Exception:
+                        pass
+                    report = repair_state_db_schema(self.db_path)
+                    if not report.get("repaired"):
+                        raise
+                    _connect_and_init()
+                    break
+            if last_open_err is not None and time.monotonic() >= open_deadline:
+                # Patience exhausted on a locked/busy error — give a clear
+                # actionable message instead of the raw OperationalError.
+                raise sqlite3.OperationalError(
+                    f"SessionDB open failed: state.db write lock not acquired "
+                    f"after {self._WRITE_PATIENCE_S}s (routine patience). "
+                    f"The database is locked by another process "
+                    f"(VACUUM, checkpoint, or an older hermes version). "
+                    f"This is not disk corruption — wait for the other process "
+                    f"to finish or stop it before retrying."
+                ) from last_open_err
 
             # NOTE: the v23 FTS optimization is OPT-IN (`hermes db optimize`),
             # never auto-started on open. Legacy installs keep their working
@@ -2029,6 +2100,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def _execute_write(
         self,
         fn: Callable[[sqlite3.Connection], T],
+        *,
+        critical: bool = False,
     ) -> T:
         """Execute a write transaction with BEGIN IMMEDIATE and jitter retry.
 
@@ -2039,13 +2112,24 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         BEGIN IMMEDIATE acquires the WAL write lock at transaction start
         (not at commit time), so lock contention surfaces immediately.
         On ``database is locked``, we release the Python lock, sleep a
-        random 20-150ms, and retry — breaking the convoy pattern that
+        random interval, and retry — breaking the convoy pattern that
         SQLite's built-in deterministic backoff creates.
+
+        *critical* selects the patience budget (default 20s routine,
+        60s for transcript-critical writes).
 
         Returns whatever *fn* returns.
         """
+        patience = (
+            self._WRITE_PATIENCE_CRITICAL_S
+            if critical
+            else self._WRITE_PATIENCE_S
+        )
         last_err: Optional[Exception] = None
-        for attempt in range(self._WRITE_MAX_RETRIES):
+        deadline = time.monotonic() + patience
+        attempt = 0
+        while True:
+            attempt += 1
             try:
                 with self._lock:
                     self._conn.execute("BEGIN IMMEDIATE")
@@ -2069,10 +2153,28 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 err_msg = str(exc).lower()
                 if "locked" in err_msg or "busy" in err_msg:
                     last_err = exc
-                    if attempt < self._WRITE_MAX_RETRIES - 1:
+                    now = time.monotonic()
+                    if now < deadline:
+                        elapsed = now - (deadline - patience)
+                        # Compute jitter: base 20-150ms for first 2s, then
+                        # grow max linearly so competing writers have room
+                        # to finish long-running operations.
+                        if elapsed <= self._WRITE_BACKOFF_AFTER_S:
+                            hi = self._WRITE_RETRY_MAX_S
+                        else:
+                            # Linear ramp from RETRY_MAX_S to BACKOFF_MAX_S
+                            # as elapsed goes from BACKOFF_AFTER_S to deadline.
+                            progress = min(
+                                1.0,
+                                (elapsed - self._WRITE_BACKOFF_AFTER_S)
+                                / (patience - self._WRITE_BACKOFF_AFTER_S),
+                            )
+                            hi = self._WRITE_RETRY_MAX_S + progress * (
+                                self._WRITE_BACKOFF_MAX_S - self._WRITE_RETRY_MAX_S
+                            )
                         jitter = random.uniform(
                             self._WRITE_RETRY_MIN_S,
-                            self._WRITE_RETRY_MAX_S,
+                            hi,
                         )
                         time.sleep(jitter)
                         continue
@@ -2092,8 +2194,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     raise
                 continue
         # Retries exhausted (shouldn't normally reach here).
+        label = "critical" if critical else "routine"
         raise last_err or sqlite3.OperationalError(
-            "database is locked after max retries"
+            f"SessionDB write lock not acquired after {patience}s ({label} "
+            f"patience). The state.db write lock is held by another process "
+            f"(VACUUM, checkpoint, or an older hermes version). This is not "
+            f"disk corruption — the write was abandoned after exhausting the "
+            f"retry budget."
         )
 
     @staticmethod
@@ -5287,7 +5394,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 )
             return msg_id
 
-        return self._execute_write(_do)
+        return self._execute_write(_do, critical=True)
 
     def set_latest_matching_message_display_kind(
         self, session_id: str, *, role: str, content: str, display_kind: str,

--- a/tests/hermes_cli/test_custom_provider_extra_headers.py
+++ b/tests/hermes_cli/test_custom_provider_extra_headers.py
@@ -15,6 +15,16 @@ from hermes_cli.config import (
 from hermes_cli import models as models_mod
 
 
+def test_normalize_extra_headers_stringifies_and_drops_none():
+    assert normalize_extra_headers({"X-Int": 7, "X-Str": "v", "X-None": None}) == {
+        "X-Int": "7",
+        "X-Str": "v",
+    }
+
+
+def test_normalize_extra_headers_rejects_non_dict_and_empty():
+    for bad in (None, "x", 42, ["a"], {}):
+        assert normalize_extra_headers(bad) == {}
 
 
 def test_normalize_entry_keeps_extra_headers():
@@ -32,14 +42,168 @@ def test_normalize_entry_keeps_extra_headers():
     }
 
 
+def test_normalize_entry_drops_invalid_extra_headers():
+    for bad in ("not-a-dict", {}, 42, ["a"]):
+        normalized = _normalize_custom_provider_entry(
+            {
+                "name": "my-proxy",
+                "base_url": "https://llm.internal.example.com/v1",
+                "extra_headers": bad,
+            }
+        )
+        assert normalized is not None
+        assert "extra_headers" not in normalized
 
 
+def test_normalize_entry_stringifies_values_and_skips_none():
+    normalized = _normalize_custom_provider_entry(
+        {
+            "name": "my-proxy",
+            "base_url": "https://llm.internal.example.com/v1",
+            "extra_headers": {"X-Int": 7, "X-None": None},
+        }
+    )
+    assert normalized is not None
+    assert normalized["extra_headers"] == {"X-Int": "7"}
 
 
+def test_get_custom_provider_extra_headers_matches_base_url():
+    """Match by normalized base_url returns the entry's extra_headers."""
+    providers = [
+        {
+            "name": "my-proxy",
+            "base_url": "https://llm.internal.example.com/v1",
+            "extra_headers": {"CF-Access-Client-Id": "xxxx.access"},
+        }
+    ]
+    # trailing-slash and case insensitive match, mirroring the TLS helper
+    headers = get_custom_provider_extra_headers(
+        "https://LLM.internal.example.com/v1/",
+        custom_providers=providers,
+    )
+    assert headers == {"CF-Access-Client-Id": "xxxx.access"}
 
 
+def test_get_custom_provider_extra_headers_no_match_returns_empty():
+    """No matching base_url yields empty dict."""
+    providers = [
+        {
+            "name": "my-proxy",
+            "base_url": "https://llm.internal.example.com/v1",
+            "extra_headers": {"X-Secret": "s"},
+        }
+    ]
+    assert get_custom_provider_extra_headers(
+        "https://other.example.com/v1", custom_providers=providers,
+    ) == {}
+    # prefix look-alike host must not match (no substring bypass)
+    assert get_custom_provider_extra_headers(
+        "https://llm.internal.example.com.attacker.test/v1",
+        custom_providers=providers,
+    ) == {}
 
 
+def test_get_custom_provider_extra_headers_preserves_extra_path_segment():
+    """Extra path segment after normalisation is still a mismatch."""
+    providers = [
+        {
+            "base_url": "https://llm.internal.example.com/v1//",
+            "extra_headers": {"Authorization": "secret"},
+        }
+    ]
+    assert get_custom_provider_extra_headers(
+        "https://llm.internal.example.com/v1",
+        custom_providers=providers,
+    ) == {}
+
+
+def test_get_custom_provider_extra_headers_skips_alias_without_headers():
+    """Bug #74465: an earlier entry matching the same URL but without
+    extra_headers must not shadow a later entry that DOES have headers."""
+    providers = [
+        {
+            "name": "direct",
+            "base_url": "http://127.0.0.1:8787/v1",
+            # no extra_headers
+        },
+        {
+            "name": "aether-router",
+            "base_url": "http://127.0.0.1:8787/v1",
+            "extra_headers": {"X-Aether-Route": "my-route"},
+        },
+    ]
+    headers = get_custom_provider_extra_headers(
+        "http://127.0.0.1:8787/v1",
+        custom_providers=providers,
+    )
+    assert headers == {"X-Aether-Route": "my-route"}
+
+
+def test_get_custom_provider_extra_headers_skips_empty_header_dict_alias():
+    """An earlier entry with an explicit but empty extra_headers dict must
+    not shadow a later entry that carries real headers."""
+    providers = [
+        {
+            "name": "bare-alias",
+            "base_url": "http://127.0.0.1:8787/v1",
+            "extra_headers": {},
+        },
+        {
+            "name": "proxied",
+            "base_url": "http://127.0.0.1:8787/v1",
+            "extra_headers": {"Authorization": "Bearer tok"},
+        },
+    ]
+    headers = get_custom_provider_extra_headers(
+        "http://127.0.0.1:8787/v1",
+        custom_providers=providers,
+    )
+    assert headers == {"Authorization": "Bearer tok"}
+
+
+def test_apply_extra_headers_merges_onto_existing_defaults():
+    """apply_custom_provider_extra_headers_to_client_kwargs merges headers,
+    with provider-specific values winning over existing defaults."""
+    client_kwargs = {
+        "api_key": "x",
+        "base_url": "https://llm.internal.example.com/v1",
+        "default_headers": {"User-Agent": "curl/8.7.1", "X-Keep": "1"},
+    }
+    providers = [
+        {
+            "name": "my-proxy",
+            "base_url": "https://llm.internal.example.com/v1",
+            "extra_headers": {"User-Agent": "override", "X-New": "2"},
+        }
+    ]
+    apply_custom_provider_extra_headers_to_client_kwargs(
+        client_kwargs,
+        "https://llm.internal.example.com/v1",
+        custom_providers=providers,
+    )
+    assert client_kwargs["default_headers"] == {
+        "User-Agent": "override",  # provider-specific value wins
+        "X-Keep": "1",             # untouched defaults preserved
+        "X-New": "2",
+    }
+
+
+def test_apply_extra_headers_noop_without_match():
+    """No matching base_url -> no default_headers key added."""
+    client_kwargs = {"api_key": "x", "base_url": "https://other.example.com/v1"}
+    providers = [
+        {
+            "name": "my-proxy",
+            "base_url": "https://llm.internal.example.com/v1",
+            "extra_headers": {"X-Secret": "s"},
+        }
+    ]
+    apply_custom_provider_extra_headers_to_client_kwargs(
+        client_kwargs,
+        "https://other.example.com/v1",
+        custom_providers=providers,
+    )
+    assert "default_headers" not in client_kwargs
 
 
 def test_fetch_api_models_sends_extra_headers_to_models_probe(monkeypatch):


### PR DESCRIPTION
## Problem (P1)

Turns die with "session storage could not be written" when a sibling process holds the state.db write lock for a few seconds.

## Root cause

SessionDB._execute_write used attempt-counted retries (15 x 20-150ms ~ 1.3s max patience). A shared state.db can be legitimately held for multiple seconds by VACUUM after auto-prune, WAL checkpoint, offline recovery, or mixed-version process pools. The SessionDB() open path had zero retry for locked/busy errors.

## Fix

1. Time-based patience replacing old attempt-counted: routine 20s, transcript-critical 60s
2. Backoff jitter after 2s: first 2s uses 20-150ms uniform jitter, then ramps max sleep to 1s
3. Open path retry for locked/busy errors with same 20s patience
4. Clearer error messages that name the real cause (sibling process holding lock, not disk corruption)

Fixes #74478
