### PR TITLE
fix(credential-pool): write-through to root self-disables after first refresh (#74339)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1055,12 +1055,21 @@ class CredentialPool:
                     "openai-codex": "openai-codex",
                     "xai-oauth": "xai-oauth",
                 }.get(self.provider)
-                write_through_to_root = bool(_wt_provider_id) and not (
-                    isinstance(auth_store.get("providers"), dict)
-                    and isinstance(
-                        auth_store["providers"].get(_wt_provider_id), dict
-                    )
+                # Check whether the profile has its own providers.<id> block
+                # that was NOT created by a previous write-through.  A
+                # write-through-created block carries a sentinel so that
+                # subsequent calls still propagate rotated tokens to root.
+                _profile_has_own_block = False
+                _wt_profile_block = (
+                    auth_store.get("providers", {}).get(_wt_provider_id)
+                    if isinstance(auth_store.get("providers"), dict)
+                    else None
                 )
+                if isinstance(_wt_profile_block, dict) and not _wt_profile_block.get(
+                    "_synced_from_root"
+                ):
+                    _profile_has_own_block = True
+                write_through_to_root = bool(_wt_provider_id) and not _profile_has_own_block
                 if self.provider == "nous":
                     state = _load_provider_state(auth_store, "nous")
                     if state is None:
@@ -1114,6 +1123,13 @@ class CredentialPool:
 
                 else:
                     return
+
+                # Tag the profile's provider block so subsequent calls
+                # know it was created by write-through, not by the user.
+                if write_through_to_root and _wt_provider_id:
+                    _pb = auth_store.get("providers", {}).get(_wt_provider_id)
+                    if isinstance(_pb, dict):
+                        _pb["_synced_from_root"] = True
 
                 _save_auth_store(auth_store)
                 if write_through_to_root and _wt_provider_id:

--- a/tests/agent/test_credential_pool_oauth_writethrough.py
+++ b/tests/agent/test_credential_pool_oauth_writethrough.py
@@ -233,3 +233,68 @@ def test_codex_pool_refresh_holds_auth_store_lock_across_post(monkeypatch, tmp_p
     # The invariant: the single-use token POST ran inside the auth-store lock.
     assert lock_held["during_post"] is True
 
+
+
+def test_write_through_to_root_survives_successive_refreshes(
+    profile_and_root,
+):
+    """Write-through must fire on every refresh, not just the first.
+
+    Regression test for #74339: the first call creates ``providers.<id>``
+    in the profile auth store (via ``_store_provider_state``), which made
+    the subsequent call's ``write_through_to_root`` check see the block
+    and skip the write-through.  Rotated single-use refresh tokens would
+    then never reach root, causing ``refresh_token_reused`` for every
+    other profile reading the stale root grant.
+    """
+    profile_path, root_path = profile_and_root
+    # Root has the initial grant; profile has no own block.
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "root-AT-v1",
+                        "refresh_token": "root-RT-v1",
+                    }
+                }
+            },
+        },
+    )
+    _write_store(profile_path, {"version": 1})
+
+    def _make_pool(access_token, refresh_token):
+        entry = _entry(
+            "openai-codex",
+            id="codex-1",
+            access_token=access_token,
+            refresh_token=refresh_token,
+        )
+        pool = CredentialPool("openai-codex", [entry])
+        return pool, entry
+
+    # --- First refresh: profile has no providers block ---
+    pool, entry = _make_pool("AT-v1", "RT-v1")
+    entry.access_token = "AT-v2"
+    entry.refresh_token = "RT-v2"
+    pool._sync_device_code_entry_to_auth_store(entry)
+
+    root_store = _read_store(root_path)
+    assert (
+        root_store["providers"]["openai-codex"]["tokens"]["access_token"] == "AT-v2"
+    ), "first refresh must write rotated tokens to root"
+
+    # --- Second refresh: profile NOW has providers.openai-codex ---
+    entry.access_token = "AT-v3"
+    entry.refresh_token = "RT-v3"
+    pool._sync_device_code_entry_to_auth_store(entry)
+
+    root_store = _read_store(root_path)
+    assert (
+        root_store["providers"]["openai-codex"]["tokens"]["access_token"] == "AT-v3"
+    ), "second refresh must still write through to root (#74339 regression)"
+    assert (
+        root_store["providers"]["openai-codex"]["tokens"]["refresh_token"] == "RT-v3"
+    ), "refresh token must propagate to root on every rotation"


### PR DESCRIPTION
## Summary

`CredentialPool._sync_device_code_entry_to_auth_store` checks whether the profile has its own `providers.<id>` block to decide if write-through to root is needed. But `_store_provider_state` creates that block unconditionally on the first call, so every subsequent call sees it and skips write-through.

**Result:** Rotated single-use refresh tokens never reach root after the first refresh. Other profiles reading the stale root grant hit `refresh_token_reused` / `invalid_grant` once their access token expires.

## Root Cause

1. First call: profile has no `providers.openai-codex` -> `write_through_to_root = True` -> writes to root AND creates block in profile via `_store_provider_state`
2. Second call: profile NOW has `providers.openai-codex` (created in step 1) -> `write_through_to_root = False` -> write-through skipped permanently

## Fix

Tag write-through-created profile blocks with a `_synced_from_root` sentinel. The write-through check now ignores tagged blocks so that write-through fires on every refresh, not just the first.

A genuinely independent per-profile block (no sentinel) is still respected and does not trigger write-through.

## Testing

- 2 existing tests pass unchanged
- New regression test `test_write_through_to_root_survives_successive_refreshes` exercises two successive refreshes and verifies rotated tokens reach root both times

Fixes #74339