### PR TITLE
fix(gateway): bridge api_server key/cors_origins/model_name from YAML top-level to extra

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1611,7 +1611,7 @@ def load_gateway_config() -> GatewayConfig:
                         if _bridge_key in platform_cfg and _bridge_key not in platform_cfg.get("extra", {}):
                             bridged[_bridge_key] = platform_cfg[_bridge_key]
                 if plat == Platform.API_SERVER:
-                    for _bridge_key in ("port", "host"):
+                    for _bridge_key in ("port", "host", "key", "cors_origins", "model_name"):
                         if _bridge_key in platform_cfg and _bridge_key not in platform_cfg.get("extra", {}):
                             bridged[_bridge_key] = platform_cfg[_bridge_key]
                 has_channel_overrides = "channel_overrides" in platform_cfg


### PR DESCRIPTION
## Description

Closes #74475

The `api_server` YAML config block at the top level (e.g. `api_server: {enabled: true, key: "...", host: "0.0.0.0", port: 9119}`) was not properly bridging all fields into the platform's `extra` dict. Only `port` and `host` were bridged; `key`, `cors_origins`, and `model_name` were silently dropped.

## Root Cause

In `gateway/config.py`, the `_shared_loop_targets` loop bridges top-level platform config keys into the platform's `extra` dict. For `Platform.API_SERVER`, only `port` and `host` were bridged (line 1614):

```python
if plat == Platform.API_SERVER:
    for _bridge_key in ("port", "host"):
```

Compare with `WEBHOOK`/`MSGRAPH_WEBHOOK` which bridge `port`, `host`, **and** `secret`.

Without `key` bridged to `extra`, `APIServerAdapter.__init__` reads `self._api_key` from `extra.get("key", os.getenv("API_SERVER_KEY", ""))` and gets an empty string. Then `connect()` fails at `_api_key_passes_startup_guard()` with:
> `Refusing to start: API_SERVER_KEY is required for the API server`

## Fix

Add `key`, `cors_origins`, and `model_name` to the bridge keys for `Platform.API_SERVER` — matching the fields that `_apply_env_overrides` also supports from env vars.

## Testing

- [x] Existing lint passes (ruff)
- Config path: top-level `api_server: {enabled: true, key: "xxx", host: "0.0.0.0", port: 9119}` → `key` now reaches `extra`
- Config path: `platforms.api_server.extra.key` → already worked via `_merge_platform_map`, still works
- Config path: env var `API_SERVER_KEY` → still works via `_apply_env_overrides`

## Related

PR #66630 previously added YAML loading for api_server but was later refactored, leaving the `key` bridge incomplete.