### PR TITLE
fix(buzz): publish presence and preserve DM reply topology

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1187,7 +1187,7 @@ platform_toolsets:
 #       script_timeout_seconds: 30
 #   buzz:
 #     extra:
-#       presence: true  # Advertise online while connected; refreshes the 90-second Buzz lease
+#       presence: true  # Advertise online while connected; refreshes the 180-second Buzz lease
 #
 # Discord-specific settings (config.yaml top-level, not under platforms:):
 #

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1185,6 +1185,9 @@ platform_toolsets:
 #       # Route scripts default to a 30 second timeout. Scripts must live under
 #       # the active profile's scripts directory and receive webhook JSON on stdin.
 #       script_timeout_seconds: 30
+#   buzz:
+#     extra:
+#       presence: true  # Advertise online while connected; refreshes the 90-second Buzz lease
 #
 # Discord-specific settings (config.yaml top-level, not under platforms:):
 #

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -991,6 +991,9 @@ platform_toolsets:
 #       # Route scripts default to a 30 second timeout. Scripts must live under
 #       # the active profile's scripts directory and receive webhook JSON on stdin.
 #       script_timeout_seconds: 30
+#   buzz:
+#     extra:
+#       presence: true  # Advertise online while connected; refreshes the 90-second Buzz lease
 #
 # Discord-specific settings (config.yaml top-level, not under platforms:):
 #

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -993,7 +993,7 @@ platform_toolsets:
 #       script_timeout_seconds: 30
 #   buzz:
 #     extra:
-#       presence: true  # Advertise online while connected; refreshes the 90-second Buzz lease
+#       presence: true  # Advertise online while connected; refreshes the 180-second Buzz lease
 #
 # Discord-specific settings (config.yaml top-level, not under platforms:):
 #

--- a/contributors/emails/carrion256@proton.me
+++ b/contributors/emails/carrion256@proton.me
@@ -1,0 +1,2 @@
+carrion256
+# PR #74507 salvage of #74185

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -22,6 +22,7 @@ Configuration in config.yaml::
               - ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd
             home_channel: ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd
             poll_interval: 4           # seconds between poll sweeps
+            presence: true             # advertise online status while connected
             cli_path: ""               # path to the buzz binary (default: PATH, then ~/bin/buzz)
             credentials_file: ""       # JSON file holding the nsec (fallback for BUZZ_PRIVATE_KEY)
             allowed_users: []          # empty = allow all; entries are hex pubkeys or npubs
@@ -99,6 +100,15 @@ _DM_DISCOVERY_EVERY = 5
 _DEFAULT_POLL_INTERVAL = 4.0
 _MIN_POLL_INTERVAL = 1.0
 _CLI_TIMEOUT = 30.0
+
+# Buzz presence is a 90-second relay lease, defined upstream as three
+# 30-second heartbeats so one missed refresh does not make a healthy agent
+# appear offline. Keep each publish bounded so the next fixed-rate attempt
+# still lands before the lease expires.
+_PRESENCE_RELAY_TTL = 90.0
+_PRESENCE_HEARTBEAT_INTERVAL = 30.0
+_PRESENCE_CLI_TIMEOUT = 10.0
+_PRESENCE_OFFLINE_TIMEOUT = 2.0
 
 # WebSocket transport (NIP-42 authenticated Nostr subscription).
 # kind 44100 is Buzz's channel-membership event — used for live DM discovery.
@@ -310,6 +320,13 @@ async def _exec_buzz(
         proc.kill()
         await proc.wait()
         return 124, "", json.dumps({"error": "timeout", "message": f"buzz {args[0] if args else ''} timed out after {timeout}s"})
+    except asyncio.CancelledError:
+        # Presence heartbeats are cancelled during gateway shutdown. Do not
+        # leave their buzz subprocess running after the adapter has stopped.
+        if proc.returncode is None:
+            proc.kill()
+            await proc.wait()
+        raise
     return (
         proc.returncode if proc.returncode is not None else 4,
         stdout.decode("utf-8", errors="replace"),
@@ -381,6 +398,17 @@ class BuzzAdapter(BasePlatformAdapter):
             interval = _DEFAULT_POLL_INTERVAL
         self.poll_interval = max(_MIN_POLL_INTERVAL, interval)
 
+        # Advertise this gateway identity as online while its inbound
+        # transport is active. This is config-only because it is not a secret
+        # and new settings belong in config.yaml.
+        _presence_cfg = extra.get("presence", True)
+        self.presence_enabled = str(_presence_cfg).strip().lower() not in (
+            "false",
+            "0",
+            "no",
+            "off",
+        )
+
         # Whether channel messages must @mention the agent to get a response.
         # Defaults to True (respond only when addressed). Set False to make the
         # agent respond to every message in a watched channel. DMs always
@@ -424,6 +452,7 @@ class BuzzAdapter(BasePlatformAdapter):
         # Runtime state
         self._poll_task: Optional[asyncio.Task] = None
         self._ws_task: Optional[asyncio.Task] = None
+        self._presence_task: Optional[asyncio.Task] = None
         self._ws_ready: Optional[asyncio.Event] = None
         self._ws_active = False  # True while the WS loop owns inbound delivery
         self._membership_since = 0
@@ -443,7 +472,13 @@ class BuzzAdapter(BasePlatformAdapter):
 
     # ── buzz-cli plumbing ─────────────────────────────────────────────────
 
-    async def _run_cli(self, args: List[str], *, input_text: Optional[str] = None) -> Tuple[int, str, str]:
+    async def _run_cli(
+        self,
+        args: List[str],
+        *,
+        input_text: Optional[str] = None,
+        timeout: float = _CLI_TIMEOUT,
+    ) -> Tuple[int, str, str]:
         if not self._private_key:
             self._private_key = _resolve_private_key(self._extra)
         return await _exec_buzz(
@@ -452,9 +487,78 @@ class BuzzAdapter(BasePlatformAdapter):
             relay_url=self.relay_url,
             private_key=self._private_key,
             input_text=input_text,
+            timeout=timeout,
         )
 
     # ── Connection lifecycle ──────────────────────────────────────────────
+
+    async def _set_presence(self, status: str, *, timeout: float) -> bool:
+        """Publish one best-effort Buzz presence update."""
+        try:
+            code, out, err = await self._run_cli(
+                ["users", "set-presence", "--status", status],
+                timeout=timeout,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning("Buzz: failed to publish %s presence — %s", status, exc)
+            return False
+        if code != 0:
+            logger.warning(
+                "Buzz: failed to publish %s presence — %s",
+                status,
+                _cli_error_message(err, code),
+            )
+            return False
+        try:
+            response = json.loads(out or "{}")
+        except ValueError:
+            response = {}
+        if not isinstance(response, dict) or response.get("accepted") is not True:
+            logger.warning("Buzz: relay did not accept %s presence", status)
+            return False
+        return True
+
+    async def _presence_loop(self) -> None:
+        """Publish and refresh the online lease on a fixed cadence."""
+        loop = asyncio.get_running_loop()
+        next_refresh = loop.time()
+        while True:
+            await asyncio.sleep(max(0.0, next_refresh - loop.time()))
+            next_refresh += _PRESENCE_HEARTBEAT_INTERVAL
+            await self._set_presence("online", timeout=_PRESENCE_CLI_TIMEOUT)
+
+    async def _cancel_presence_task(self) -> bool:
+        """Cancel the heartbeat without publishing a presence transition."""
+        task = self._presence_task
+        self._presence_task = None
+        if task is None:
+            return False
+        if not task.done():
+            task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            logger.warning("Buzz: presence heartbeat stopped unexpectedly — %s", exc)
+        return True
+
+    async def _start_presence(self) -> None:
+        """Start one background presence task without delaying connect."""
+        if not self.presence_enabled:
+            return
+        # Presence is advisory. Keep the first publish in the task so a slow
+        # relay cannot consume the gateway's adapter-connect timeout.
+        await self._cancel_presence_task()
+        self._presence_task = asyncio.create_task(self._presence_loop())
+
+    async def _stop_presence(self) -> None:
+        """Stop refreshes, then best-effort publish a clean offline state."""
+        if not await self._cancel_presence_task():
+            return
+        await self._set_presence("offline", timeout=_PRESENCE_OFFLINE_TIMEOUT)
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Verify relay credentials, seed high-water marks, start polling."""
@@ -557,6 +661,7 @@ class BuzzAdapter(BasePlatformAdapter):
         if transport_used == "poll":
             self._poll_task = asyncio.create_task(self._poll_loop())
         self._mark_connected()
+        await self._start_presence()
         logger.info(
             "Buzz: connected to %s as %s, watching %d channel(s) via %s%s",
             self.relay_url,
@@ -570,6 +675,7 @@ class BuzzAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Stop the inbound transport and drop runtime state."""
         self._mark_disconnected()
+        await self._stop_presence()
         lock_key = getattr(self, "_lock_key", None)
         if lock_key:
             try:

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -705,19 +705,6 @@ class BuzzAdapter(BasePlatformAdapter):
 
     # ── Sending ───────────────────────────────────────────────────────────
 
-    def _reply_target_for_chat(self, chat_id: str, reply_target: Optional[str]) -> Optional[str]:
-        """Keep direct-message conversations flat while preserving channel replies.
-
-        Buzz renders ``--reply-to`` as a nested reply-tree edge.  A DM is
-        already its own conversation, so anchoring every Hermes response to
-        the triggering message creates an ever-deepening tree instead of the
-        expected linear exchange.
-        """
-        state = self._channel_state.get(str(chat_id))
-        if state and state.get("chat_type") == "dm":
-            return None
-        return reply_target
-
     async def send(
         self,
         chat_id: str,
@@ -728,12 +715,9 @@ class BuzzAdapter(BasePlatformAdapter):
         if not content:
             return SendResult(success=False, error="Empty message")
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
-        reply_target = self._reply_target_for_chat(
-            chat_id,
-            reply_to or (metadata or {}).get("thread_id"),
-        )
+        reply_target = self._reply_target(chat_id, reply_to, metadata)
         if reply_target:
-            args += ["--reply-to", str(reply_target)]
+            args += ["--reply-to", reply_target]
         code, out, err = await self._run_cli(args, input_text=content)
         if code != 0:
             return SendResult(
@@ -755,6 +739,28 @@ class BuzzAdapter(BasePlatformAdapter):
             message_id=str(event_id) if event_id else None,
             raw_response=data,
         )
+
+    def _reply_target(
+        self,
+        chat_id: str,
+        reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[str]:
+        """Resolve Buzz threading without turning every DM response into one.
+
+        The gateway supplies the triggering message ID as ``reply_to`` for
+        most platforms. In Buzz, that creates a thread and removes the response
+        from the main DM timeline. A real inbound Buzz thread is represented by
+        ``metadata.thread_id``; only that explicit thread marker may thread a
+        DM response. Shared channels retain the gateway's existing reply
+        behavior.
+        """
+        thread_id = (metadata or {}).get("thread_id")
+        state = self._channel_state.get(str(chat_id))
+        if state and state.get("chat_type") == "dm":
+            return str(thread_id) if thread_id else None
+        target = reply_to or thread_id
+        return str(target) if target else None
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Buzz has no typing indicator API — no-op."""
@@ -803,9 +809,9 @@ class BuzzAdapter(BasePlatformAdapter):
                 "--file", str(local),
                 "--content", "-",
             ]
-            reply_target = self._reply_target_for_chat(chat_id, reply_to)
+            reply_target = self._reply_target(chat_id, reply_to, metadata)
             if reply_target:
-                args += ["--reply-to", str(reply_target)]
+                args += ["--reply-to", reply_target]
             code, out, err = await self._run_cli(args, input_text=caption or "")
             if code != 0:
                 return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)
@@ -1170,6 +1176,7 @@ class BuzzAdapter(BasePlatformAdapter):
         # open with "@Chip" even though no mention is required there, so the
         # strip applies to both chat types.
         dispatch_text = self._strip_mention(content)
+        thread_id = self._thread_id_from_event(event)
 
         await self._dispatch_message(
             text=dispatch_text,
@@ -1179,6 +1186,7 @@ class BuzzAdapter(BasePlatformAdapter):
             user_name=await self._resolve_user_name(pubkey),
             message_id=event_id,
             created_at=created_at,
+            thread_id=thread_id,
         )
 
     # ── DM classification (issue #68871) ──────────────────────────────────
@@ -1258,6 +1266,30 @@ class BuzzAdapter(BasePlatformAdapter):
         state["chat_type"] = "dm"
         self._channel_names.setdefault(channel_id, "DM")
         logger.info("Buzz: conversation %s reclassified as DM (message p-tagged to self)", channel_id)
+
+    @staticmethod
+    def _thread_id_from_event(event: dict) -> Optional[str]:
+        """Return the root of a real Buzz reply thread, if present.
+
+        Buzz uses NIP-10 ``e`` tags with ``root`` and ``reply`` markers. A
+        top-level message has no marked ``e`` tag. Prefer the root marker so
+        every message in a nested thread shares one Hermes session; fall back
+        to the immediate reply target when the event has no explicit root.
+        """
+        root_id = None
+        reply_id = None
+        for tag in event.get("tags") or []:
+            if not isinstance(tag, list) or len(tag) < 4 or tag[0] != "e":
+                continue
+            event_id = str(tag[1] or "")
+            if not event_id:
+                continue
+            marker = str(tag[3] or "").lower()
+            if marker == "root":
+                root_id = event_id
+            elif marker == "reply":
+                reply_id = event_id
+        return root_id or reply_id
 
     def _is_mentioned(self, content: str) -> bool:
         """True when the message addresses this agent (npub, hex, or name)."""
@@ -1342,6 +1374,7 @@ class BuzzAdapter(BasePlatformAdapter):
         user_name: str,
         message_id: str,
         created_at: int,
+        thread_id: Optional[str] = None,
     ) -> None:
         """Build a MessageEvent and hand it to the base class handler."""
         if not self._message_handler:
@@ -1353,6 +1386,9 @@ class BuzzAdapter(BasePlatformAdapter):
             chat_type=chat_type,
             user_id=user_id,
             user_name=user_name,
+            thread_id=thread_id,
+            parent_chat_id=chat_id if thread_id else None,
+            message_id=message_id,
         )
 
         event = MessageEvent(

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -705,6 +705,19 @@ class BuzzAdapter(BasePlatformAdapter):
 
     # ── Sending ───────────────────────────────────────────────────────────
 
+    def _reply_target_for_chat(self, chat_id: str, reply_target: Optional[str]) -> Optional[str]:
+        """Keep direct-message conversations flat while preserving channel replies.
+
+        Buzz renders ``--reply-to`` as a nested reply-tree edge.  A DM is
+        already its own conversation, so anchoring every Hermes response to
+        the triggering message creates an ever-deepening tree instead of the
+        expected linear exchange.
+        """
+        state = self._channel_state.get(str(chat_id))
+        if state and state.get("chat_type") == "dm":
+            return None
+        return reply_target
+
     async def send(
         self,
         chat_id: str,
@@ -715,7 +728,10 @@ class BuzzAdapter(BasePlatformAdapter):
         if not content:
             return SendResult(success=False, error="Empty message")
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
-        reply_target = reply_to or (metadata or {}).get("thread_id")
+        reply_target = self._reply_target_for_chat(
+            chat_id,
+            reply_to or (metadata or {}).get("thread_id"),
+        )
         if reply_target:
             args += ["--reply-to", str(reply_target)]
         code, out, err = await self._run_cli(args, input_text=content)
@@ -787,8 +803,9 @@ class BuzzAdapter(BasePlatformAdapter):
                 "--file", str(local),
                 "--content", "-",
             ]
-            if reply_to:
-                args += ["--reply-to", str(reply_to)]
+            reply_target = self._reply_target_for_chat(chat_id, reply_to)
+            if reply_target:
+                args += ["--reply-to", str(reply_target)]
             code, out, err = await self._run_cli(args, input_text=caption or "")
             if code != 0:
                 return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -101,12 +101,12 @@ _DEFAULT_POLL_INTERVAL = 4.0
 _MIN_POLL_INTERVAL = 1.0
 _CLI_TIMEOUT = 30.0
 
-# Buzz presence is a 90-second relay lease, defined upstream as three
-# 30-second heartbeats so one missed refresh does not make a healthy agent
+# Buzz presence is a 180-second relay lease, defined upstream as three
+# 60-second heartbeats so one missed refresh does not make a healthy agent
 # appear offline. Keep each publish bounded so the next fixed-rate attempt
 # still lands before the lease expires.
-_PRESENCE_RELAY_TTL = 90.0
-_PRESENCE_HEARTBEAT_INTERVAL = 30.0
+_PRESENCE_RELAY_TTL = 180.0
+_PRESENCE_HEARTBEAT_INTERVAL = 60.0
 _PRESENCE_CLI_TIMEOUT = 10.0
 _PRESENCE_OFFLINE_TIMEOUT = 2.0
 

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -22,6 +22,7 @@ Configuration in config.yaml::
               - ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd
             home_channel: ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd
             poll_interval: 4           # seconds between poll sweeps
+            presence: true             # advertise online status while connected
             cli_path: ""               # path to the buzz binary (default: PATH, then ~/bin/buzz)
             credentials_file: ""       # JSON file holding the nsec (fallback for BUZZ_PRIVATE_KEY)
             allowed_users: []          # empty = allow all; entries are hex pubkeys or npubs
@@ -75,6 +76,15 @@ _DM_DISCOVERY_EVERY = 5
 _DEFAULT_POLL_INTERVAL = 4.0
 _MIN_POLL_INTERVAL = 1.0
 _CLI_TIMEOUT = 30.0
+
+# Buzz presence is a 90-second relay lease, defined upstream as three
+# 30-second heartbeats so one missed refresh does not make a healthy agent
+# appear offline. Keep each publish bounded so the next fixed-rate attempt
+# still lands before the lease expires.
+_PRESENCE_RELAY_TTL = 90.0
+_PRESENCE_HEARTBEAT_INTERVAL = 30.0
+_PRESENCE_CLI_TIMEOUT = 10.0
+_PRESENCE_OFFLINE_TIMEOUT = 2.0
 
 # WebSocket transport (NIP-42 authenticated Nostr subscription).
 # kind 44100 is Buzz's channel-membership event — used for live DM discovery.
@@ -286,6 +296,13 @@ async def _exec_buzz(
         proc.kill()
         await proc.wait()
         return 124, "", json.dumps({"error": "timeout", "message": f"buzz {args[0] if args else ''} timed out after {timeout}s"})
+    except asyncio.CancelledError:
+        # Presence heartbeats are cancelled during gateway shutdown. Do not
+        # leave their buzz subprocess running after the adapter has stopped.
+        if proc.returncode is None:
+            proc.kill()
+            await proc.wait()
+        raise
     return (
         proc.returncode if proc.returncode is not None else 4,
         stdout.decode("utf-8", errors="replace"),
@@ -357,6 +374,17 @@ class BuzzAdapter(BasePlatformAdapter):
             interval = _DEFAULT_POLL_INTERVAL
         self.poll_interval = max(_MIN_POLL_INTERVAL, interval)
 
+        # Advertise this gateway identity as online while its inbound
+        # transport is active. This is config-only because it is not a secret
+        # and new settings belong in config.yaml.
+        _presence_cfg = extra.get("presence", True)
+        self.presence_enabled = str(_presence_cfg).strip().lower() not in (
+            "false",
+            "0",
+            "no",
+            "off",
+        )
+
         # Whether channel messages must @mention the agent to get a response.
         # Defaults to True (respond only when addressed). Set False to make the
         # agent respond to every message in a watched channel. DMs always
@@ -400,6 +428,7 @@ class BuzzAdapter(BasePlatformAdapter):
         # Runtime state
         self._poll_task: Optional[asyncio.Task] = None
         self._ws_task: Optional[asyncio.Task] = None
+        self._presence_task: Optional[asyncio.Task] = None
         self._ws_ready: Optional[asyncio.Event] = None
         self._ws_active = False  # True while the WS loop owns inbound delivery
         self._membership_since = 0
@@ -419,7 +448,13 @@ class BuzzAdapter(BasePlatformAdapter):
 
     # ── buzz-cli plumbing ─────────────────────────────────────────────────
 
-    async def _run_cli(self, args: List[str], *, input_text: Optional[str] = None) -> Tuple[int, str, str]:
+    async def _run_cli(
+        self,
+        args: List[str],
+        *,
+        input_text: Optional[str] = None,
+        timeout: float = _CLI_TIMEOUT,
+    ) -> Tuple[int, str, str]:
         if not self._private_key:
             self._private_key = _resolve_private_key(self._extra)
         return await _exec_buzz(
@@ -428,9 +463,78 @@ class BuzzAdapter(BasePlatformAdapter):
             relay_url=self.relay_url,
             private_key=self._private_key,
             input_text=input_text,
+            timeout=timeout,
         )
 
     # ── Connection lifecycle ──────────────────────────────────────────────
+
+    async def _set_presence(self, status: str, *, timeout: float) -> bool:
+        """Publish one best-effort Buzz presence update."""
+        try:
+            code, out, err = await self._run_cli(
+                ["users", "set-presence", "--status", status],
+                timeout=timeout,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning("Buzz: failed to publish %s presence — %s", status, exc)
+            return False
+        if code != 0:
+            logger.warning(
+                "Buzz: failed to publish %s presence — %s",
+                status,
+                _cli_error_message(err, code),
+            )
+            return False
+        try:
+            response = json.loads(out or "{}")
+        except ValueError:
+            response = {}
+        if not isinstance(response, dict) or response.get("accepted") is not True:
+            logger.warning("Buzz: relay did not accept %s presence", status)
+            return False
+        return True
+
+    async def _presence_loop(self) -> None:
+        """Publish and refresh the online lease on a fixed cadence."""
+        loop = asyncio.get_running_loop()
+        next_refresh = loop.time()
+        while True:
+            await asyncio.sleep(max(0.0, next_refresh - loop.time()))
+            next_refresh += _PRESENCE_HEARTBEAT_INTERVAL
+            await self._set_presence("online", timeout=_PRESENCE_CLI_TIMEOUT)
+
+    async def _cancel_presence_task(self) -> bool:
+        """Cancel the heartbeat without publishing a presence transition."""
+        task = self._presence_task
+        self._presence_task = None
+        if task is None:
+            return False
+        if not task.done():
+            task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            logger.warning("Buzz: presence heartbeat stopped unexpectedly — %s", exc)
+        return True
+
+    async def _start_presence(self) -> None:
+        """Start one background presence task without delaying connect."""
+        if not self.presence_enabled:
+            return
+        # Presence is advisory. Keep the first publish in the task so a slow
+        # relay cannot consume the gateway's adapter-connect timeout.
+        await self._cancel_presence_task()
+        self._presence_task = asyncio.create_task(self._presence_loop())
+
+    async def _stop_presence(self) -> None:
+        """Stop refreshes, then best-effort publish a clean offline state."""
+        if not await self._cancel_presence_task():
+            return
+        await self._set_presence("offline", timeout=_PRESENCE_OFFLINE_TIMEOUT)
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Verify relay credentials, seed high-water marks, start polling."""
@@ -533,6 +637,7 @@ class BuzzAdapter(BasePlatformAdapter):
         if transport_used == "poll":
             self._poll_task = asyncio.create_task(self._poll_loop())
         self._mark_connected()
+        await self._start_presence()
         logger.info(
             "Buzz: connected to %s as %s, watching %d channel(s) via %s%s",
             self.relay_url,
@@ -546,6 +651,7 @@ class BuzzAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Stop the inbound transport and drop runtime state."""
         self._mark_disconnected()
+        await self._stop_presence()
         lock_key = getattr(self, "_lock_key", None)
         if lock_key:
             try:

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -681,6 +681,19 @@ class BuzzAdapter(BasePlatformAdapter):
 
     # ── Sending ───────────────────────────────────────────────────────────
 
+    def _reply_target_for_chat(self, chat_id: str, reply_target: Optional[str]) -> Optional[str]:
+        """Keep direct-message conversations flat while preserving channel replies.
+
+        Buzz renders ``--reply-to`` as a nested reply-tree edge.  A DM is
+        already its own conversation, so anchoring every Hermes response to
+        the triggering message creates an ever-deepening tree instead of the
+        expected linear exchange.
+        """
+        state = self._channel_state.get(str(chat_id))
+        if state and state.get("chat_type") == "dm":
+            return None
+        return reply_target
+
     async def send(
         self,
         chat_id: str,
@@ -691,7 +704,10 @@ class BuzzAdapter(BasePlatformAdapter):
         if not content:
             return SendResult(success=False, error="Empty message")
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
-        reply_target = reply_to or (metadata or {}).get("thread_id")
+        reply_target = self._reply_target_for_chat(
+            chat_id,
+            reply_to or (metadata or {}).get("thread_id"),
+        )
         if reply_target:
             args += ["--reply-to", str(reply_target)]
         code, out, err = await self._run_cli(args, input_text=content)
@@ -763,8 +779,9 @@ class BuzzAdapter(BasePlatformAdapter):
                 "--file", str(local),
                 "--content", "-",
             ]
-            if reply_to:
-                args += ["--reply-to", str(reply_to)]
+            reply_target = self._reply_target_for_chat(chat_id, reply_to)
+            if reply_target:
+                args += ["--reply-to", str(reply_target)]
             code, out, err = await self._run_cli(args, input_text=caption or "")
             if code != 0:
                 return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -77,12 +77,12 @@ _DEFAULT_POLL_INTERVAL = 4.0
 _MIN_POLL_INTERVAL = 1.0
 _CLI_TIMEOUT = 30.0
 
-# Buzz presence is a 90-second relay lease, defined upstream as three
-# 30-second heartbeats so one missed refresh does not make a healthy agent
+# Buzz presence is a 180-second relay lease, defined upstream as three
+# 60-second heartbeats so one missed refresh does not make a healthy agent
 # appear offline. Keep each publish bounded so the next fixed-rate attempt
 # still lands before the lease expires.
-_PRESENCE_RELAY_TTL = 90.0
-_PRESENCE_HEARTBEAT_INTERVAL = 30.0
+_PRESENCE_RELAY_TTL = 180.0
+_PRESENCE_HEARTBEAT_INTERVAL = 60.0
 _PRESENCE_CLI_TIMEOUT = 10.0
 _PRESENCE_OFFLINE_TIMEOUT = 2.0
 

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -681,19 +681,6 @@ class BuzzAdapter(BasePlatformAdapter):
 
     # ── Sending ───────────────────────────────────────────────────────────
 
-    def _reply_target_for_chat(self, chat_id: str, reply_target: Optional[str]) -> Optional[str]:
-        """Keep direct-message conversations flat while preserving channel replies.
-
-        Buzz renders ``--reply-to`` as a nested reply-tree edge.  A DM is
-        already its own conversation, so anchoring every Hermes response to
-        the triggering message creates an ever-deepening tree instead of the
-        expected linear exchange.
-        """
-        state = self._channel_state.get(str(chat_id))
-        if state and state.get("chat_type") == "dm":
-            return None
-        return reply_target
-
     async def send(
         self,
         chat_id: str,
@@ -704,12 +691,9 @@ class BuzzAdapter(BasePlatformAdapter):
         if not content:
             return SendResult(success=False, error="Empty message")
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
-        reply_target = self._reply_target_for_chat(
-            chat_id,
-            reply_to or (metadata or {}).get("thread_id"),
-        )
+        reply_target = self._reply_target(chat_id, reply_to, metadata)
         if reply_target:
-            args += ["--reply-to", str(reply_target)]
+            args += ["--reply-to", reply_target]
         code, out, err = await self._run_cli(args, input_text=content)
         if code != 0:
             return SendResult(
@@ -731,6 +715,28 @@ class BuzzAdapter(BasePlatformAdapter):
             message_id=str(event_id) if event_id else None,
             raw_response=data,
         )
+
+    def _reply_target(
+        self,
+        chat_id: str,
+        reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[str]:
+        """Resolve Buzz threading without turning every DM response into one.
+
+        The gateway supplies the triggering message ID as ``reply_to`` for
+        most platforms. In Buzz, that creates a thread and removes the response
+        from the main DM timeline. A real inbound Buzz thread is represented by
+        ``metadata.thread_id``; only that explicit thread marker may thread a
+        DM response. Shared channels retain the gateway's existing reply
+        behavior.
+        """
+        thread_id = (metadata or {}).get("thread_id")
+        state = self._channel_state.get(str(chat_id))
+        if state and state.get("chat_type") == "dm":
+            return str(thread_id) if thread_id else None
+        target = reply_to or thread_id
+        return str(target) if target else None
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Buzz has no typing indicator API — no-op."""
@@ -779,9 +785,9 @@ class BuzzAdapter(BasePlatformAdapter):
                 "--file", str(local),
                 "--content", "-",
             ]
-            reply_target = self._reply_target_for_chat(chat_id, reply_to)
+            reply_target = self._reply_target(chat_id, reply_to, metadata)
             if reply_target:
-                args += ["--reply-to", str(reply_target)]
+                args += ["--reply-to", reply_target]
             code, out, err = await self._run_cli(args, input_text=caption or "")
             if code != 0:
                 return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)
@@ -1146,6 +1152,7 @@ class BuzzAdapter(BasePlatformAdapter):
         # open with "@Chip" even though no mention is required there, so the
         # strip applies to both chat types.
         dispatch_text = self._strip_mention(content)
+        thread_id = self._thread_id_from_event(event)
 
         await self._dispatch_message(
             text=dispatch_text,
@@ -1155,6 +1162,7 @@ class BuzzAdapter(BasePlatformAdapter):
             user_name=await self._resolve_user_name(pubkey),
             message_id=event_id,
             created_at=created_at,
+            thread_id=thread_id,
         )
 
     # ── DM classification (issue #68871) ──────────────────────────────────
@@ -1234,6 +1242,30 @@ class BuzzAdapter(BasePlatformAdapter):
         state["chat_type"] = "dm"
         self._channel_names.setdefault(channel_id, "DM")
         logger.info("Buzz: conversation %s reclassified as DM (message p-tagged to self)", channel_id)
+
+    @staticmethod
+    def _thread_id_from_event(event: dict) -> Optional[str]:
+        """Return the root of a real Buzz reply thread, if present.
+
+        Buzz uses NIP-10 ``e`` tags with ``root`` and ``reply`` markers. A
+        top-level message has no marked ``e`` tag. Prefer the root marker so
+        every message in a nested thread shares one Hermes session; fall back
+        to the immediate reply target when the event has no explicit root.
+        """
+        root_id = None
+        reply_id = None
+        for tag in event.get("tags") or []:
+            if not isinstance(tag, list) or len(tag) < 4 or tag[0] != "e":
+                continue
+            event_id = str(tag[1] or "")
+            if not event_id:
+                continue
+            marker = str(tag[3] or "").lower()
+            if marker == "root":
+                root_id = event_id
+            elif marker == "reply":
+                reply_id = event_id
+        return root_id or reply_id
 
     def _is_mentioned(self, content: str) -> bool:
         """True when the message addresses this agent (npub, hex, or name)."""
@@ -1318,6 +1350,7 @@ class BuzzAdapter(BasePlatformAdapter):
         user_name: str,
         message_id: str,
         created_at: int,
+        thread_id: Optional[str] = None,
     ) -> None:
         """Build a MessageEvent and hand it to the base class handler."""
         if not self._message_handler:
@@ -1329,6 +1362,9 @@ class BuzzAdapter(BasePlatformAdapter):
             chat_type=chat_type,
             user_id=user_id,
             user_name=user_name,
+            thread_id=thread_id,
+            parent_chat_id=chat_id if thread_id else None,
+            message_id=message_id,
         )
 
         event = MessageEvent(

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -462,6 +462,29 @@ class TestBuzzAdapterSend:
         # Our own event id is marked seen for echo suppression
         assert "evt123" in adapter._channel_state[CHANNEL]["seen"]
 
+    @pytest.mark.asyncio
+    async def test_send_reply_to(self):
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt124", "message": ""})
+        adapter._run_cli = cli
+        await adapter.send(CHANNEL, "threaded", reply_to="root-event")
+        args, _stdin = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == "root-event"
+
+    @pytest.mark.asyncio
+    async def test_send_dm_does_not_create_reply_tree(self):
+        adapter = _make_adapter()
+        adapter._channel_state[DM_CHANNEL] = {"chat_type": "dm", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-dm", "message": ""})
+        adapter._run_cli = cli
+
+        await adapter.send(DM_CHANNEL, "flat reply", reply_to="user-event")
+
+        args, _stdin = cli.calls[0]
+        assert "--reply-to" not in args
 
     @pytest.mark.asyncio
     async def test_send_image_local_file_uses_file_flag(self, tmp_path):
@@ -475,6 +498,21 @@ class TestBuzzAdapterSend:
         assert result.success is True
         args, _stdin = cli.calls[0]
         assert args[args.index("--file") + 1] == str(img)
+
+    @pytest.mark.asyncio
+    async def test_send_image_in_dm_does_not_create_reply_tree(self, tmp_path):
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG fake")
+        adapter = _make_adapter()
+        adapter._channel_state[DM_CHANNEL] = {"chat_type": "dm", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-dm-image", "message": ""})
+        adapter._run_cli = cli
+
+        await adapter.send_image(DM_CHANNEL, str(img), reply_to="user-event")
+
+        args, _stdin = cli.calls[0]
+        assert "--reply-to" not in args
 
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -376,6 +376,25 @@ class TestDmClassification:
         assert adapter._channel_state[DM_CHANNEL]["chat_type"] == "dm"
         assert [d["message_id"] for d in adapter._dispatched] == ["e1"]
         assert adapter._dispatched[0]["chat_type"] == "dm"
+        assert adapter._dispatched[0]["thread_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_dm_reply_preserves_explicit_thread_root(self, adapter):
+        """A real inbound thread reply carries its root into SessionSource."""
+        adapter._channel_state[DM_CHANNEL]["chat_type"] = "dm"
+        event = _tagged_event(
+            "e2",
+            DM_CHANNEL,
+            content="reply in a thread",
+            p=SELF_PUBKEY,
+            reply_to="immediate-parent",
+        )
+        event["tags"].insert(1, ["e", "thread-root", "", "root"])
+
+        await self._poll_with(adapter, DM_CHANNEL, event)
+
+        assert len(adapter._dispatched) == 1
+        assert adapter._dispatched[0]["thread_id"] == "thread-root"
 
 
     @pytest.mark.asyncio
@@ -463,28 +482,60 @@ class TestBuzzAdapterSend:
         assert "evt123" in adapter._channel_state[CHANNEL]["seen"]
 
     @pytest.mark.asyncio
-    async def test_send_reply_to(self):
-        adapter = _make_adapter()
-        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
-        cli = _ScriptedCli()
-        cli.script("messages", "send", {"accepted": True, "event_id": "evt124", "message": ""})
-        adapter._run_cli = cli
-        await adapter.send(CHANNEL, "threaded", reply_to="root-event")
-        args, _stdin = cli.calls[0]
-        assert args[args.index("--reply-to") + 1] == "root-event"
-
-    @pytest.mark.asyncio
-    async def test_send_dm_does_not_create_reply_tree(self):
+    async def test_top_level_dm_ignores_gateway_reply_anchor(self):
+        """A generic reply anchor must not hide a DM response in a thread."""
         adapter = _make_adapter()
         adapter._channel_state[DM_CHANNEL] = {"chat_type": "dm", "last_ts": 0, "seen": {}}
         cli = _ScriptedCli()
-        cli.script("messages", "send", {"accepted": True, "event_id": "evt-dm", "message": ""})
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt124"})
         adapter._run_cli = cli
 
-        await adapter.send(DM_CHANNEL, "flat reply", reply_to="user-event")
+        result = await adapter.send(
+            DM_CHANNEL,
+            "visible in the main DM",
+            reply_to="triggering-message",
+        )
 
+        assert result.success is True
         args, _stdin = cli.calls[0]
         assert "--reply-to" not in args
+
+    @pytest.mark.asyncio
+    async def test_threaded_dm_uses_explicit_thread_root(self):
+        adapter = _make_adapter()
+        adapter._channel_state[DM_CHANNEL] = {"chat_type": "dm", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt125"})
+        adapter._run_cli = cli
+
+        result = await adapter.send(
+            DM_CHANNEL,
+            "stays in the real thread",
+            reply_to="triggering-message",
+            metadata={"thread_id": "thread-root"},
+        )
+
+        assert result.success is True
+        args, _stdin = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == "thread-root"
+
+    @pytest.mark.asyncio
+    async def test_channel_keeps_gateway_reply_anchor(self):
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt126"})
+        adapter._run_cli = cli
+
+        result = await adapter.send(
+            CHANNEL,
+            "channel reply",
+            reply_to="triggering-message",
+        )
+
+        assert result.success is True
+        args, _stdin = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == "triggering-message"
 
     @pytest.mark.asyncio
     async def test_send_image_local_file_uses_file_flag(self, tmp_path):
@@ -500,19 +551,55 @@ class TestBuzzAdapterSend:
         assert args[args.index("--file") + 1] == str(img)
 
     @pytest.mark.asyncio
-    async def test_send_image_in_dm_does_not_create_reply_tree(self, tmp_path):
+    async def test_top_level_dm_image_ignores_gateway_reply_anchor(self, tmp_path):
         img = tmp_path / "shot.png"
         img.write_bytes(b"\x89PNG fake")
         adapter = _make_adapter()
         adapter._channel_state[DM_CHANNEL] = {"chat_type": "dm", "last_ts": 0, "seen": {}}
         cli = _ScriptedCli()
-        cli.script("messages", "send", {"accepted": True, "event_id": "evt-dm-image", "message": ""})
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt127"})
         adapter._run_cli = cli
 
-        await adapter.send_image(DM_CHANNEL, str(img), reply_to="user-event")
+        result = await adapter.send_image(
+            DM_CHANNEL,
+            str(img),
+            caption="visible image",
+            reply_to="triggering-message",
+        )
 
+        assert result.success is True
         args, _stdin = cli.calls[0]
         assert "--reply-to" not in args
+
+
+# ── Inbound thread source ─────────────────────────────────────────────────
+
+
+class TestBuzzAdapterDispatch:
+
+    @pytest.mark.asyncio
+    async def test_dispatch_stamps_real_thread_on_session_source(self):
+        adapter = _make_adapter()
+        adapter._message_handler = AsyncMock()
+        adapter.handle_message = AsyncMock()
+        adapter.send_reaction = AsyncMock(return_value=True)
+
+        await adapter._dispatch_message(
+            text="inside thread",
+            chat_id=DM_CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Chris",
+            message_id="reply-event",
+            created_at=1000,
+            thread_id="thread-root",
+        )
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.message_id == "reply-event"
+        assert event.source.message_id == "reply-event"
+        assert event.source.thread_id == "thread-root"
+        assert event.source.parent_chat_id == DM_CHANNEL
 
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 from tests.gateway._plugin_adapter_loader import load_plugin_adapter
 
@@ -18,6 +18,7 @@ hex_to_npub = _buzz_mod.hex_to_npub
 npub_to_hex = _buzz_mod.npub_to_hex
 _normalize_user_ref = _buzz_mod._normalize_user_ref
 _cli_error_message = _buzz_mod._cli_error_message
+_exec_buzz = _buzz_mod._exec_buzz
 _resolve_private_key = _buzz_mod._resolve_private_key
 check_requirements = _buzz_mod.check_requirements
 validate_config = _buzz_mod.validate_config
@@ -86,13 +87,15 @@ class _ScriptedCli:
     def __init__(self):
         self.responses = {}  # (group, cmd) -> list of (code, stdout, stderr)
         self.calls = []
+        self.timeouts = []
 
     def script(self, group, cmd, payload, code=0, stderr=""):
         stdout = payload if isinstance(payload, str) else json.dumps(payload)
         self.responses.setdefault((group, cmd), []).append((code, stdout, stderr))
 
-    async def __call__(self, args, *, input_text=None):
+    async def __call__(self, args, *, input_text=None, timeout=30.0):
         self.calls.append((list(args), input_text))
+        self.timeouts.append(timeout)
         queue = self.responses.get((args[0], args[1]), [])
         if len(queue) > 1:
             return queue.pop(0)
@@ -135,6 +138,12 @@ class TestBuzzAdapterInit:
         assert adapter.channels == ["ccc"]
         assert adapter.poll_interval == 2.0
         assert adapter.home_channel == "ccc"
+        assert adapter.presence_enabled is True
+
+    @pytest.mark.parametrize("value", [False, "false", "0", "no", "off"])
+    def test_presence_can_be_disabled_in_config(self, value):
+        adapter = _make_adapter({"presence": value})
+        assert adapter.presence_enabled is False
 
     def test_env_overrides_config(self, monkeypatch):
         monkeypatch.setenv("BUZZ_RELAY_URL", "https://env.relay")
@@ -151,6 +160,52 @@ class TestCliErrorContract:
     def test_parses_json_error(self):
         msg = _cli_error_message('{"error":"relay_error","message":"boom","retryable":false}', 2)
         assert "relay_error" in msg and "boom" in msg and "exit 2" in msg
+
+
+class TestCliExecution:
+
+    @pytest.mark.asyncio
+    async def test_cancellation_kills_the_cli_subprocess(self, monkeypatch):
+        communicate_started = asyncio.Event()
+
+        class FakeProcess:
+            returncode = None
+            killed = False
+            waited = False
+
+            async def communicate(self, input_bytes):
+                communicate_started.set()
+                await asyncio.Event().wait()
+
+            def kill(self):
+                self.killed = True
+                self.returncode = -9
+
+            async def wait(self):
+                self.waited = True
+                return self.returncode
+
+        process = FakeProcess()
+
+        async def create_subprocess(*args, **kwargs):
+            return process
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", create_subprocess)
+        task = asyncio.create_task(
+            _exec_buzz(
+                "/fake/buzz",
+                ["users", "set-presence", "--status", "online"],
+                relay_url="https://test.relay",
+                private_key="nsec1test",
+            )
+        )
+        await asyncio.wait_for(communicate_started.wait(), timeout=1)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert process.killed is True
+        assert process.waited is True
 
 
 # ── Seeding / high-water mark / de-dupe ───────────────────────────────────
@@ -427,6 +482,186 @@ class TestBuzzAdapterSend:
 
 class TestBuzzAdapterLifecycle:
 
+    @pytest.mark.asyncio
+    async def test_presence_lifecycle_publishes_online_then_offline(self):
+        adapter = _make_adapter()
+        online_started = asyncio.Event()
+
+        async def publish(status, *, timeout):
+            if status == "online":
+                online_started.set()
+            return True
+
+        adapter._set_presence = AsyncMock(side_effect=publish)
+
+        await adapter._start_presence()
+        assert adapter._presence_task is not None
+        await asyncio.wait_for(online_started.wait(), timeout=0.1)
+        adapter._set_presence.assert_awaited_once_with(
+            "online", timeout=_buzz_mod._PRESENCE_CLI_TIMEOUT
+        )
+
+        await adapter._stop_presence()
+        assert adapter._presence_task is None
+        assert adapter._set_presence.await_args_list == [
+            call("online", timeout=_buzz_mod._PRESENCE_CLI_TIMEOUT),
+            call("offline", timeout=_buzz_mod._PRESENCE_OFFLINE_TIMEOUT),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_presence_refreshes_after_initial_publish_failure(self, monkeypatch):
+        """Presence is advisory and later heartbeats recover a transient failure."""
+        adapter = _make_adapter()
+        refreshed = asyncio.Event()
+        online_attempts = 0
+
+        async def publish(status, *, timeout):
+            nonlocal online_attempts
+            if status != "online":
+                return True
+            online_attempts += 1
+            if online_attempts == 1:
+                return False
+            refreshed.set()
+            return True
+
+        adapter._set_presence = AsyncMock(side_effect=publish)
+        monkeypatch.setattr(_buzz_mod, "_PRESENCE_HEARTBEAT_INTERVAL", 0.001)
+
+        await adapter._start_presence()
+        await asyncio.wait_for(refreshed.wait(), timeout=1)
+        await adapter._stop_presence()
+
+        online_calls = [
+            call for call in adapter._set_presence.await_args_list
+            if call.args == ("online",)
+        ]
+        assert len(online_calls) >= 2
+
+    def test_presence_cadence_tolerates_one_failed_heartbeat(self):
+        """One failed refresh must leave time for the next bounded attempt."""
+        assert (
+            2 * _buzz_mod._PRESENCE_HEARTBEAT_INTERVAL
+            + _buzz_mod._PRESENCE_CLI_TIMEOUT
+            < _buzz_mod._PRESENCE_RELAY_TTL
+        )
+
+    @pytest.mark.asyncio
+    async def test_initial_presence_publish_does_not_delay_start(self):
+        adapter = _make_adapter()
+        online_started = asyncio.Event()
+        release_online = asyncio.Event()
+        online_completed = False
+
+        async def publish(status, *, timeout):
+            nonlocal online_completed
+            if status == "online":
+                online_started.set()
+                await release_online.wait()
+                online_completed = True
+            return True
+
+        adapter._set_presence = AsyncMock(side_effect=publish)
+
+        await asyncio.wait_for(adapter._start_presence(), timeout=0.1)
+        await asyncio.wait_for(online_started.wait(), timeout=0.1)
+        assert online_completed is False
+
+        await asyncio.wait_for(adapter._stop_presence(), timeout=0.1)
+        assert online_completed is False
+        release_online.set()
+
+    @pytest.mark.asyncio
+    async def test_repeated_start_keeps_only_one_heartbeat(self):
+        adapter = _make_adapter()
+        adapter._set_presence = AsyncMock(return_value=True)
+
+        await adapter._start_presence()
+        first_task = adapter._presence_task
+        await adapter._start_presence()
+        second_task = adapter._presence_task
+
+        assert first_task is not None and first_task.done()
+        assert second_task is not None and second_task is not first_task
+        await adapter._stop_presence()
+
+    @pytest.mark.asyncio
+    async def test_disabled_presence_does_not_publish(self):
+        adapter = _make_adapter({"presence": False})
+        adapter._set_presence = AsyncMock()
+
+        await adapter._start_presence()
+        await adapter._stop_presence()
+
+        adapter._set_presence.assert_not_awaited()
+        assert adapter._presence_task is None
+
+    @pytest.mark.asyncio
+    async def test_presence_reject_and_cli_failure_are_nonfatal(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("users", "set-presence", {"accepted": False})
+        adapter._run_cli = cli
+        assert await adapter._set_presence("online", timeout=10) is False
+
+        cli.responses.clear()
+        cli.script(
+            "users",
+            "set-presence",
+            "",
+            code=2,
+            stderr='{"error":"relay_error","message":"unavailable"}',
+        )
+        assert await adapter._set_presence("online", timeout=10) is False
+
+        assert cli.calls == [
+            (["users", "set-presence", "--status", "online"], None),
+            (["users", "set-presence", "--status", "online"], None),
+        ]
+        assert cli.timeouts == [10, 10]
+
+        adapter._run_cli = AsyncMock(side_effect=OSError("spawn failed"))
+        assert await adapter._set_presence("online", timeout=10) is False
+
+    @pytest.mark.asyncio
+    async def test_connect_starts_presence_after_transport_is_ready(self, monkeypatch):
+        import gateway.status as gateway_status
+
+        monkeypatch.setattr(
+            gateway_status, "acquire_scoped_lock", lambda platform, key: True
+        )
+        monkeypatch.setattr(
+            gateway_status, "release_scoped_lock", lambda platform, key: None
+        )
+        monkeypatch.setattr(
+            _buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1test"
+        )
+        adapter = _make_adapter({"transport": "poll"})
+        adapter.cli_path = "/fake/buzz"
+        cli = _ScriptedCli()
+        cli.script(
+            "users",
+            "get",
+            [{"pubkey": SELF_PUBKEY, "display_name": "Chip"}],
+        )
+        cli.script(
+            "channels",
+            "list",
+            [{"channel_id": CHANNEL, "name": "general", "description": ""}],
+        )
+        cli.script("messages", "get", [])
+        cli.script("dms", "list", [])
+        adapter._run_cli = cli
+        presence_start_states = []
+
+        async def record_presence_start():
+            presence_start_states.append(adapter.is_connected)
+
+        adapter._start_presence = record_presence_start
+
+        assert await adapter.connect() is True
+        assert presence_start_states == [True]
+        await adapter.disconnect()
 
     @pytest.mark.asyncio
     async def test_disconnect_releases_scoped_lock(self, monkeypatch):
@@ -536,5 +771,3 @@ class TestStandaloneSend:
         assert captured["input_text"] == "cron says hi"
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
-
-

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -76,6 +76,7 @@ gateway:
           - ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd
         home_channel: ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd
         poll_interval: 4                  # seconds between inbound poll sweeps (default 4 — balances latency vs. relay load)
+        presence: true                    # show the agent online while its gateway is connected
         cli_path: ""                      # buzz binary (default: PATH, then ~/bin/buzz)
         credentials_file: ""              # JSON file with the nsec (BUZZ_PRIVATE_KEY fallback)
         allowed_users: []                 # empty = allow all if allow_all_users is true; otherwise restrict to listed npubs/hex pubkeys
@@ -88,6 +89,7 @@ gateway:
 - `interim_assistant_messages: false` — prevents intermediate tool results, reasoning comments, and progress updates from being posted as separate messages to the channel. Only the final response goes to the channel.
 - `tool_progress: off` — suppresses tool progress bubbles (e.g., "Running terminal command...", "Reading file..."). Keeps the channel focused on actual results, not process.
 - `poll_interval: 4` — balances inbound latency (up to 4s delay) against relay load. Lower values increase polling frequency; higher values reduce it.
+- `presence: true` — publishes `online` in the background after the inbound transport is ready and refreshes it every 30 seconds. The 90-second lease tolerates one missed refresh without showing a healthy agent offline. A clean shutdown publishes `offline`; after a crash, Buzz expires the lease. Set this to `false` if another process owns presence for the same identity.
 - `allowed_users: []` + `allow_all_users: false` — private mode by default. Only listed users can interact. Set `allow_all_users: true` for community mode where everyone can chat (admin tier still restricted to the owner).
 - `require_mention: true` — in channels, the agent only responds when addressed. DMs always dispatch regardless of this setting.
 

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -89,7 +89,7 @@ gateway:
 - `interim_assistant_messages: false` — prevents intermediate tool results, reasoning comments, and progress updates from being posted as separate messages to the channel. Only the final response goes to the channel.
 - `tool_progress: off` — suppresses tool progress bubbles (e.g., "Running terminal command...", "Reading file..."). Keeps the channel focused on actual results, not process.
 - `poll_interval: 4` — balances inbound latency (up to 4s delay) against relay load. Lower values increase polling frequency; higher values reduce it.
-- `presence: true` — publishes `online` in the background after the inbound transport is ready and refreshes it every 30 seconds. The 90-second lease tolerates one missed refresh without showing a healthy agent offline. A clean shutdown publishes `offline`; after a crash, Buzz expires the lease. Set this to `false` if another process owns presence for the same identity.
+- `presence: true` — publishes `online` in the background after the inbound transport is ready and refreshes it every 60 seconds. The 180-second relay lease tolerates one missed refresh without showing a healthy agent offline. A clean shutdown publishes `offline`; after a crash, Buzz expires the lease. Set this to `false` if another process owns presence for the same identity.
 - `allowed_users: []` + `allow_all_users: false` — private mode by default. Only listed users can interact. Set `allow_all_users: true` for community mode where everyone can chat (admin tier still restricted to the owner).
 - `require_mention: true` — in channels, the agent only responds when addressed. DMs always dispatch regardless of this setting.
 


### PR DESCRIPTION
## What does this PR do?

A healthy remote Hermes Buzz gateway currently appears offline because the native adapter never publishes Buzz presence. Messaging still works, but Buzz has no active presence lease to distinguish the running agent from a stopped one.

The same adapter also passes the gateway's generic triggering-message anchor to every top-level DM response. Buzz correctly stores those responses as thread replies, which removes them from the main DM timeline. The agent receives the message and generates a response, but the user appears to get no reply unless they open the hidden thread.

This change starts a background presence task only after the inbound transport is ready, publishes `online` immediately from that task, refreshes the 180-second Buzz lease every 60 seconds, and publishes `offline` on a clean shutdown. The first publish cannot delay adapter connection. Presence is best-effort so a transient presence failure cannot take down messaging. Operators can set `gateway.platforms.buzz.extra.presence: false` when another process owns presence for the same identity.

The 60-second cadence matches current Buzz Desktop. With the bounded 10-second CLI timeout, one failed heartbeat still leaves time for the next attempt before the 180-second relay lease expires.

The reply fix distinguishes top-level messages from real Buzz threads using the inbound NIP-10 `e` tags. Top-level DMs now remain flat. Genuine DM threads retain their root and session scope. Shared-channel reply behavior is unchanged.

Both fixes stay inside the bundled Buzz plugin. Presence uses the existing `buzz users set-presence` CLI contract, and reply routing uses the existing `buzz messages send --reply-to` contract only when an inbound Buzz thread actually exists. The PR does not add a Buzz special case to the gateway core.

Operationally, the 180-second relay lease is the quiet version of “Stayin' Alive”: Hermes refreshes status without generating chat traffic.

## Related Issue

Follow-up to #68871.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/buzz/adapter.py`
  - Add a background initial online event, fixed-rate 60-second heartbeat, and clean offline event.
  - Bound heartbeat and shutdown CLI calls so presence cannot stall the gateway lifecycle.
  - Kill a `buzz` subprocess when its asyncio caller is cancelled so heartbeat shutdown cannot leave an orphan process.
  - Keep exactly one heartbeat task across repeated starts.
  - Add the config-only `presence` switch, enabled by default.
  - Preserve the root ID from genuine inbound Buzz thread events.
  - Ignore the gateway's synthetic reply anchor for top-level DMs so responses remain in the main timeline.
  - Preserve existing reply behavior for genuine DM threads, shared channels, and local-image sends.
- `tests/gateway/test_buzz_adapter.py`
  - Cover the default and opt-out config contracts.
  - Cover online, heartbeat recovery after a real failed attempt, lease timing, non-blocking startup, single-task ownership, offline, relay rejection, CLI failure, cancellation cleanup, and transport-ready ordering.
  - Cover top-level DM text and image responses, genuine DM thread roots, shared-channel replies, and `SessionSource` thread metadata.
- `website/docs/user-guide/messaging/buzz.md` and `cli-config.yaml.example`
  - Document the lifecycle, lease timing, and opt-out.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_buzz_adapter.py -q`.
2. Start a Buzz gateway and query `buzz users presence --pubkeys <agent-pubkey>`. The identity should become `online`, and `updated_at` should advance on the 60-second heartbeat.
3. Stop the gateway cleanly. Presence should clear immediately. Restart it and confirm it returns `online`.
4. Send a top-level Buzz DM. The response event must not contain an NIP-10 thread `e` tag and must appear in the main DM timeline.
5. Send a message inside a real Buzz thread. The response must preserve the thread root and remain inside that thread.

Validation performed. The first two bullets are on the current rebased head; remaining bullets are historical validation before the cadence-only rebase:

- Current rebase to main c9de69c6d plus merged Buzz #3783 cadence: canonical Buzz suites passed, 47 total (43 adapter and 4 native WebSocket).
- Current rebase: Ruff for the changed adapter and tests, plus git diff --check, passed. Full Linux CI for head 88d70de4e is in progress.
- Full gateway suite on macOS: 4,457 passed and 3 unrelated baseline tests failed. The same three failures reproduce on clean current `origin/main` (`0bd82a8a8`): two stale readiness fixtures expect a July gateway to accept an April/early-July status timestamp, and Linux abstract Unix sockets are unavailable on macOS.
- Prior combined PR head 871e5d0d0: Linux CI passed all 8 Python test slices, E2E, Ruff, Windows footguns, docs, Playwright, and amd64/arm64 Docker builds.
- Ruff: `ruff check plugins/platforms/buzz/adapter.py tests/gateway/test_buzz_adapter.py`.
- Windows scan: `scripts/check-windows-footguns.py plugins/platforms/buzz/adapter.py tests/gateway/test_buzz_adapter.py`.
- Fly.io Ubuntu 24.04 amd64 with Buzz v0.5.2 and the exact adapter source in this commit:
  - initial online readback succeeded;
  - the presence timestamp advanced from `1785376517` to `1785376564` without inbound traffic;
  - a top-level DM received exactly one exact-marker reply with zero thread tags;
  - Buzz mobile displayed that reply directly in the main Fly conversation;
  - a genuine threaded DM received exactly one exact-marker reply and preserved the expected root;
  - a clean machine stop cleared presence immediately;
  - restart returned the identity online without an inbound message or manual repair.

## Contributor Credit

The core top-level DM reply fix originated in @carrion256's earlier PR #74185. Commit `1825f938b` preserves carrion256 as the author of that implementation. Commit `c722fcce9` adds the thread-aware follow-up coverage and routing hardening found during combined Fly testing. The contributor registry now maps `carrion256@proton.me` to `carrion256`, as required by Hermes's release tooling.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1 arm64 and Fly.io Ubuntu 24.04 amd64

The owner also reported a clean full test-suite run. In my separate macOS gateway run, the only three failures reproduced unchanged in a clean worktree at the then-current origin/main; the Buzz suites were green. The current head's full Linux CI is still running, so this PR does not yet claim a completed CI run for 88d70de4e.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (no architecture or workflow change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no tool behavior change)

## Screenshots / Logs

Live Fly validation used the same remote-gateway shape that exposed the bug. No credentials or private message content are included in this PR.
