### PR TITLE
fix(gateway): queue retryable fatal platform BEFORE disconnect (#74494)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5520,12 +5520,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # the same object twice.
             self.adapters.pop(adapter.platform, None)
             self.delivery_router.adapters = self.adapters
-            # A half-closed transport can wedge an adapter's native close()
-            # indefinitely. Reuse the shutdown-path timeout so this runtime
-            # fatal handler always reaches the reconnect queue.
-            await self._safe_adapter_disconnect(adapter, adapter.platform)
 
-        # Queue retryable failures for background reconnection
+        # Queue retryable failures for background reconnection.
+        # IMPORTANT: queue BEFORE disconnect() so the reconnection intent
+        # survives any cancellation that disconnect() may trigger (#74494).
+        # _safe_adapter_disconnect runs adapter.disconnect() through
+        # ensure_future in _await_adapter_cleanup_with_timeout, which creates
+        # a wrapper task.  When an adapter's disconnect() uses the "is
+        # current_task" guard to avoid self-cancellation, the wrapper task
+        # is NOT the original polling task — so the guard is defeated and
+        # the original task gets cancelled.  If that happens before the
+        # queue block, the platform is silently stranded (observed:
+        # telegram popped from adapters but never queued after network
+        # outage).  Queueing first makes the intent immune.
         if adapter.fatal_error_retryable:
             platform_config = self.config.platforms.get(adapter.platform)
             if platform_config and adapter.platform not in self._failed_platforms:
@@ -5542,6 +5549,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # exhausting its restart budget), respawn it so queued platforms
                 # are not permanently stranded (#70344).
                 self._ensure_reconnect_watcher_running()
+
+        if existing is adapter:
+            # A half-closed transport can wedge an adapter's native close()
+            # indefinitely. Reuse the shutdown-path timeout so this runtime
+            # fatal handler always reaches the reconnect queue.
+            await self._safe_adapter_disconnect(adapter, adapter.platform)
 
         if not self.adapters and not self._failed_platforms:
             self._exit_reason = adapter.fatal_error_message or "All messaging adapters disconnected"


### PR DESCRIPTION
## Summary

Fixes #74494 (P1) — Gateway never queues a platform for reconnection after a retryable fatal error because `disconnect()` cancels the task running the fatal handler before it reaches the queue block.

## Root Cause

```
_handle_adapter_fatal_error_impl
  └─ await _safe_adapter_disconnect(adapter, ...)
       └─ _await_adapter_cleanup_with_timeout(adapter.disconnect(), timeout)
            └─ asyncio.ensure_future(adapter.disconnect())  ← wrapper task
                 └─ TelegramAdapter.disconnect()
                      └─ cancels _polling_error_task with "task is current_task" guard
                         ← BUT current_task is the wrapper, NOT the original polling task
                            → guard defeated, original task cancelled
                            → CancelledError silently kills handler
                            → queue block never reached
                            → platform stranded permanently
```

The `_safe_adapter_disconnect` → `_await_adapter_cleanup_with_timeout` path wraps `adapter.disconnect()` in `asyncio.ensure_future` to enable bounded waits with detached-result cleanup on timeout. This creates a wrapper task that defeats the `task is current_task` guard inside platform `disconnect()` methods (e.g. TelegramAdapter). The original polling task gets cancelled, the `CancelledError` propagates, and the queue block at the end of the handler is never reached.

## Fix

**Move the retryable-failure queue block BEFORE `_safe_adapter_disconnect`**, so the reconnection intent is recorded before any cancellation that `disconnect()` may trigger. The disconnect itself still runs afterward (only for the current adapter owner, as before).

This is the "Option A" approach from the issue: queue first makes the intent immune to cancellation during cleanup, regardless of the inner `ensure_future` wrapper behavior.

## Changes

| File | Change |
|------|--------|
| `gateway/run.py` | Move queue block before `_safe_adapter_disconnect` in `_handle_adapter_fatal_error_impl` (+18/-5) |

## Verification

All existing tests pass:
- `tests/gateway/test_runner_fatal_adapter.py` — 2 passed (covers retryable queuing + cancellation-swallowing disconnect)
- `tests/gateway/test_platform_reconnect.py` — 21 passed
- `tests/gateway/test_telegram_network_reconnect.py` — 14 passed
- `tests/plugins/platforms/photon/test_fatal_notify_self_cancel.py` — 4 passed