### PR TITLE
fix(buzz): keep native presence alive

### DIFF
--- a/contributors/emails/68875027+bbamnesia@users.noreply.github.com
+++ b/contributors/emails/68875027+bbamnesia@users.noreply.github.com
@@ -1,0 +1,2 @@
+bbamnesia
+# Buzz native presence lifecycle

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -76,6 +76,26 @@ _DEFAULT_POLL_INTERVAL = 4.0
 _MIN_POLL_INTERVAL = 1.0
 _CLI_TIMEOUT = 30.0
 
+# Presence: ``buzz users set-presence`` publishes an ephemeral kind-20001
+# event that the relay stores with a 90-second TTL (buzz-pubsub
+# PRESENCE_TTL_SECS, documented upstream as "3x the 30s heartbeat interval"),
+# so clients age an agent to offline unless its presence is refreshed.
+_PRESENCE_RELAY_TTL = 90.0
+# Heartbeat at the relay's expected 30s cadence: a single missed or failed
+# refresh never flaps the agent offline.  The legacy buzz-acp workers
+# refreshed at 60s, where one miss already expires presence.
+_PRESENCE_HEARTBEAT_INTERVAL = 30.0
+# Presence publishes are bounded well below the heartbeat interval so a hung
+# CLI call cannot stretch the gap between successful refreshes past the relay
+# TTL.  Worst case after one failed refresh (fixed-rate cadence): the failed
+# attempt burns one interval, the next succeeds within interval + timeout —
+# 2*30 + 10 = 70s < 90s.  The generic _CLI_TIMEOUT of 30s would instead allow
+# a 30s hang + 30s sleep to land the retry exactly at the TTL boundary.
+_PRESENCE_PUBLISH_TIMEOUT = 10.0
+# Tighter bound for the best-effort offline publish so a hung relay cannot
+# stall gateway shutdown.
+_PRESENCE_DISCONNECT_TIMEOUT = 5.0
+
 # WebSocket transport (NIP-42 authenticated Nostr subscription).
 # kind 44100 is Buzz's channel-membership event — used for live DM discovery.
 _WS_AUTH_TIMEOUT = 20.0
@@ -286,6 +306,16 @@ async def _exec_buzz(
         proc.kill()
         await proc.wait()
         return 124, "", json.dumps({"error": "timeout", "message": f"buzz {args[0] if args else ''} timed out after {timeout}s"})
+    except asyncio.CancelledError:
+        # Don't leave the CLI running detached: a cancelled call (e.g. the
+        # presence heartbeat during disconnect) must not publish after the
+        # adapter has moved on.
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+        await proc.wait()
+        raise
     return (
         proc.returncode if proc.returncode is not None else 4,
         stdout.decode("utf-8", errors="replace"),
@@ -399,6 +429,7 @@ class BuzzAdapter(BasePlatformAdapter):
 
         # Runtime state
         self._poll_task: Optional[asyncio.Task] = None
+        self._presence_task: Optional[asyncio.Task] = None
         self._ws_task: Optional[asyncio.Task] = None
         self._ws_ready: Optional[asyncio.Event] = None
         self._ws_active = False  # True while the WS loop owns inbound delivery
@@ -419,7 +450,13 @@ class BuzzAdapter(BasePlatformAdapter):
 
     # ── buzz-cli plumbing ─────────────────────────────────────────────────
 
-    async def _run_cli(self, args: List[str], *, input_text: Optional[str] = None) -> Tuple[int, str, str]:
+    async def _run_cli(
+        self,
+        args: List[str],
+        *,
+        input_text: Optional[str] = None,
+        timeout: float = _CLI_TIMEOUT,
+    ) -> Tuple[int, str, str]:
         if not self._private_key:
             self._private_key = _resolve_private_key(self._extra)
         return await _exec_buzz(
@@ -428,12 +465,88 @@ class BuzzAdapter(BasePlatformAdapter):
             relay_url=self.relay_url,
             private_key=self._private_key,
             input_text=input_text,
+            timeout=timeout,
         )
+
+    # ── Presence ──────────────────────────────────────────────────────────
+    #
+    # The legacy buzz-acp workers published presence; without it the relay's
+    # 90s Redis TTL expires and every client shows the agent offline even
+    # while the gateway is healthy and answering messages.
+
+    async def _publish_presence(self, status: str, *, timeout: float) -> bool:
+        """Publish presence via ``buzz users set-presence`` (best-effort).
+
+        Presence is cosmetic: failures are logged and swallowed so they can
+        never fail a healthy connect, heartbeat sweep, or shutdown.
+        """
+        if not self.cli_path:
+            return False
+        try:
+            code, _out, err = await self._run_cli(
+                ["users", "set-presence", "--status", status], timeout=timeout
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("Buzz: failed to publish '%s' presence", status, exc_info=True)
+            return False
+        if code != 0:
+            logger.warning(
+                "Buzz: failed to publish '%s' presence — %s", status, _cli_error_message(err, code)
+            )
+            return False
+        return True
+
+    async def _presence_heartbeat_loop(self) -> None:
+        """Publish online presence at a fixed cadence until cancelled.
+
+        All presence I/O lives here — including the FIRST publish — so a slow
+        or hung CLI can never delay connect() (the gateway bounds adapter
+        connects with an overall timeout), and an in-flight publish is always
+        cancellable through this task.  The sleep subtracts the time the
+        publish took (fixed-rate cadence, floored to avoid a tight spin), so
+        a slow or failed refresh cannot stretch the gap between successful
+        refreshes past the relay's presence TTL.
+        """
+        clock = asyncio.get_running_loop().time
+        while True:
+            started = clock()
+            await self._publish_presence("online", timeout=_PRESENCE_PUBLISH_TIMEOUT)
+            elapsed = clock() - started
+            await asyncio.sleep(
+                max(_PRESENCE_HEARTBEAT_INTERVAL - elapsed, _PRESENCE_HEARTBEAT_INTERVAL / 2)
+            )
+
+    async def _start_presence(self) -> None:
+        """(Re)start the presence heartbeat.
+
+        Stops any previous heartbeat first so repeated connect() calls never
+        stack loops.  Deliberately performs no CLI work inline — the online
+        publish happens inside the task, so a transient relay error
+        self-heals on a later refresh and connect() latency stays decoupled
+        from the presence CLI.
+        """
+        await self._stop_presence_task()
+        self._presence_task = asyncio.create_task(self._presence_heartbeat_loop())
+
+    async def _stop_presence_task(self) -> None:
+        task, self._presence_task = self._presence_task, None
+        if task is None:
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception:  # pragma: no cover — never leak an unretrieved error
+            logger.debug("Buzz: presence heartbeat ended with error", exc_info=True)
 
     # ── Connection lifecycle ──────────────────────────────────────────────
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
-        """Verify relay credentials, seed high-water marks, start polling."""
+        """Verify relay credentials, seed high-water marks, start the inbound
+        transport, and publish online presence."""
         if not self.relay_url:
             logger.error("Buzz: relay URL must be configured")
             self._set_fatal_error("config_missing", "BUZZ_RELAY_URL must be set", retryable=False)
@@ -533,6 +646,7 @@ class BuzzAdapter(BasePlatformAdapter):
         if transport_used == "poll":
             self._poll_task = asyncio.create_task(self._poll_loop())
         self._mark_connected()
+        await self._start_presence()
         logger.info(
             "Buzz: connected to %s as %s, watching %d channel(s) via %s%s",
             self.relay_url,
@@ -546,6 +660,10 @@ class BuzzAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Stop the inbound transport and drop runtime state."""
         self._mark_disconnected()
+        # Stop the heartbeat before anything else so no online refresh can
+        # land after the offline publish below.
+        had_presence = self._presence_task is not None
+        await self._stop_presence_task()
         lock_key = getattr(self, "_lock_key", None)
         if lock_key:
             try:
@@ -570,6 +688,10 @@ class BuzzAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
         self._poll_task = None
+        if had_presence:
+            # Graceful goodbye — clients show offline immediately instead of
+            # waiting out the relay's presence TTL.
+            await self._publish_presence("offline", timeout=_PRESENCE_DISCONNECT_TIMEOUT)
         self._channel_state = {}
         self._poll_count = 0
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import time
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
@@ -86,13 +87,15 @@ class _ScriptedCli:
     def __init__(self):
         self.responses = {}  # (group, cmd) -> list of (code, stdout, stderr)
         self.calls = []
+        self.timeouts = []  # (args, timeout kwarg) per call
 
     def script(self, group, cmd, payload, code=0, stderr=""):
         stdout = payload if isinstance(payload, str) else json.dumps(payload)
         self.responses.setdefault((group, cmd), []).append((code, stdout, stderr))
 
-    async def __call__(self, args, *, input_text=None):
+    async def __call__(self, args, *, input_text=None, timeout=None):
         self.calls.append((list(args), input_text))
+        self.timeouts.append((list(args), timeout))
         queue = self.responses.get((args[0], args[1]), [])
         if len(queue) > 1:
             return queue.pop(0)
@@ -464,6 +467,256 @@ class TestBuzzAdapterLifecycle:
         adapter._run_cli = cli
         assert await adapter.connect() is False
         assert adapter._lock_key is None
+        assert adapter._presence_task is None
+        assert _presence_calls(cli, "online") == []
+
+
+# ── Presence lifecycle ────────────────────────────────────────────────────
+#
+# The Buzz relay stores presence (ephemeral kind-20001, published via
+# ``buzz users set-presence``) in Redis with a 90-second TTL — documented
+# upstream as 3x the expected 30s client heartbeat — so an agent that never
+# refreshes its presence ages to offline even while the gateway is connected.
+# The adapter must publish
+# online on connect, refresh on a heartbeat, and best-effort publish offline
+# on graceful disconnect; presence failures are cosmetic and must never take
+# down an otherwise healthy adapter.
+
+
+def _presence_calls(cli, status):
+    return [
+        args for args, _ in cli.calls
+        if args[:2] == ["users", "set-presence"] and args[-1] == status
+    ]
+
+
+async def _wait_until(predicate, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        await asyncio.sleep(0.005)
+    return False
+
+
+def _connect_cli():
+    """Scripted CLI covering the full connect() conversation."""
+    cli = _ScriptedCli()
+    cli.script("users", "get", [{"pubkey": SELF_PUBKEY, "display_name": "Chip"}])
+    cli.script("channels", "list", [
+        {"channel_id": CHANNEL, "name": "general", "description": "General chat."},
+    ])
+    # messages get / dms list / users set-presence fall through to (0, "[]", "")
+    return cli
+
+
+class TestPresenceLifecycle:
+
+    @pytest.fixture
+    def connected(self, monkeypatch):
+        """Adapter wired for a full connect() with a scripted CLI."""
+        import gateway.status as gateway_status
+
+        monkeypatch.setattr(gateway_status, "acquire_scoped_lock", lambda p, k: True)
+        monkeypatch.setattr(gateway_status, "release_scoped_lock", lambda p, k: None)
+        monkeypatch.setattr(_buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1test")
+        adapter = _make_adapter({"transport": "poll", "channels": [CHANNEL]})
+        adapter.cli_path = "/fake/buzz"
+        cli = _connect_cli()
+        adapter._run_cli = cli
+        return adapter, cli
+
+    @pytest.mark.asyncio
+    async def test_connect_publishes_online_and_starts_heartbeat(self, connected):
+        adapter, cli = connected
+        try:
+            assert await adapter.connect() is True
+            assert await _wait_until(lambda: len(_presence_calls(cli, "online")) == 1)
+            online = _presence_calls(cli, "online")
+            assert online == [["users", "set-presence", "--status", "online"]]
+            # The private key must never be part of argv
+            assert all("nsec" not in arg for arg in online[0])
+            assert adapter._presence_task is not None
+            assert not adapter._presence_task.done()
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_connect_does_not_wait_for_presence_and_disconnect_cancels_it(self, connected):
+        """Cosmetic presence must not consume the gateway connect timeout.
+
+        The heartbeat task owns the first publish. Teardown can therefore
+        cancel an in-flight online write before publishing offline, with no
+        late online write after disconnect returns.
+        """
+        adapter, cli = connected
+        online_started = asyncio.Event()
+        release_online = asyncio.Event()
+        online_completed = []
+
+        async def blocking_cli(args, *, input_text=None, timeout=None):
+            if args[:2] == ["users", "set-presence"] and args[-1] == "online":
+                cli.calls.append((list(args), input_text))
+                cli.timeouts.append((list(args), timeout))
+                online_started.set()
+                await release_online.wait()
+                online_completed.append(True)
+                return 0, "[]", ""
+            return await cli(args, input_text=input_text, timeout=timeout)
+
+        adapter._run_cli = blocking_cli
+        assert await asyncio.wait_for(adapter.connect(), timeout=0.5) is True
+        assert await asyncio.wait_for(online_started.wait(), timeout=0.5) is True
+        presence_task = adapter._presence_task
+        assert presence_task is not None and not presence_task.done()
+        assert cli.timeouts[-1][1] == _buzz_mod._PRESENCE_PUBLISH_TIMEOUT
+        assert (
+            2 * _buzz_mod._PRESENCE_HEARTBEAT_INTERVAL
+            + _buzz_mod._PRESENCE_PUBLISH_TIMEOUT
+            < _buzz_mod._PRESENCE_RELAY_TTL
+        )
+
+        await asyncio.wait_for(adapter.disconnect(), timeout=0.5)
+        assert presence_task.done()
+        assert online_completed == []
+        assert len(_presence_calls(cli, "offline")) == 1
+
+        release_online.set()
+        await asyncio.sleep(0)
+        assert online_completed == []
+        assert len(_presence_calls(cli, "offline")) == 1
+
+    @pytest.mark.asyncio
+    async def test_online_presence_failure_does_not_fail_connect(self, connected):
+        adapter, cli = connected
+        cli.script(
+            "users", "set-presence", "",
+            code=2, stderr='{"error":"relay_error","message":"presence down"}',
+        )
+        try:
+            assert await adapter.connect() is True
+            assert await _wait_until(lambda: len(_presence_calls(cli, "online")) == 1)
+            assert adapter.is_connected
+            # The heartbeat still starts so a transient failure self-heals.
+            assert adapter._presence_task is not None
+            assert not adapter._presence_task.done()
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_refreshes_online_presence(self, monkeypatch):
+        monkeypatch.setattr(_buzz_mod, "_PRESENCE_HEARTBEAT_INTERVAL", 0.01)
+        adapter = _make_adapter()
+        adapter.cli_path = "/fake/buzz"
+        cli = _ScriptedCli()
+        adapter._run_cli = cli
+        try:
+            await adapter._start_presence()
+            # Initial publish plus at least one heartbeat refresh.
+            assert await _wait_until(lambda: len(_presence_calls(cli, "online")) >= 2)
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_stops_heartbeat_and_publishes_offline(self, monkeypatch):
+        monkeypatch.setattr(_buzz_mod, "_PRESENCE_HEARTBEAT_INTERVAL", 0.01)
+        adapter = _make_adapter()
+        adapter.cli_path = "/fake/buzz"
+        cli = _ScriptedCli()
+        adapter._run_cli = cli
+        await adapter._start_presence()
+        task = adapter._presence_task
+        await adapter.disconnect()
+
+        assert adapter._presence_task is None
+        assert task.done()
+        assert len(_presence_calls(cli, "offline")) == 1
+        # No late writes: the heartbeat task is finished, so no further
+        # presence publish can happen after disconnect returns.
+        count = len(cli.calls)
+        await asyncio.sleep(0.05)
+        assert len(cli.calls) == count
+
+        # A second disconnect is a no-op — no duplicate offline publish.
+        await adapter.disconnect()
+        assert len(_presence_calls(cli, "offline")) == 1
+
+    @pytest.mark.asyncio
+    async def test_offline_publish_failure_does_not_break_disconnect(self):
+        adapter = _make_adapter()
+        adapter.cli_path = "/fake/buzz"
+        cli = _ScriptedCli()
+        cli.script(
+            "users", "set-presence", "",
+            code=2, stderr='{"error":"relay_error","message":"gone"}',
+        )
+        adapter._run_cli = cli
+        await adapter._start_presence()
+        await adapter.disconnect()  # must not raise
+        assert adapter._presence_task is None
+
+    @pytest.mark.asyncio
+    async def test_presence_exception_does_not_break_lifecycle(self):
+        """A CLI that cannot even launch must not take down the adapter."""
+        adapter = _make_adapter()
+        adapter.cli_path = "/fake/buzz"
+        attempts = []
+
+        async def broken_cli(args, *, input_text=None, timeout=None):
+            attempts.append(list(args))
+            raise OSError("no such binary")
+
+        adapter._run_cli = broken_cli
+        await adapter._start_presence()  # online publish fails — swallowed
+        assert await _wait_until(lambda: len(attempts) == 1)
+        await adapter.disconnect()  # offline publish fails — swallowed
+        assert adapter._presence_task is None
+        assert [args[-1] for args in attempts] == ["online", "offline"]
+
+    @pytest.mark.asyncio
+    async def test_repeated_start_does_not_duplicate_heartbeat(self):
+        adapter = _make_adapter()
+        adapter.cli_path = "/fake/buzz"
+        cli = _ScriptedCli()
+        adapter._run_cli = cli
+        try:
+            await adapter._start_presence()
+            first = adapter._presence_task
+            await adapter._start_presence()
+            second = adapter._presence_task
+            assert first is not second
+            assert first.done()  # the old loop was stopped, not leaked
+            assert not second.done()
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_reconnect_lifecycle_single_heartbeat(self, connected):
+        """connect → disconnect → connect must end with exactly one live
+        heartbeat task and an offline publish per disconnect."""
+        adapter, cli = connected
+        try:
+            assert await adapter.connect() is True
+            assert await _wait_until(lambda: len(_presence_calls(cli, "online")) == 1)
+            await adapter.disconnect()
+            assert len(_presence_calls(cli, "offline")) == 1
+            assert await adapter.connect(is_reconnect=True) is True
+            assert await _wait_until(lambda: len(_presence_calls(cli, "online")) == 2)
+            assert len(_presence_calls(cli, "online")) == 2
+            assert adapter._presence_task is not None
+            assert not adapter._presence_task.done()
+        finally:
+            await adapter.disconnect()
+        assert len(_presence_calls(cli, "offline")) == 2
+
+    @pytest.mark.asyncio
+    async def test_disconnect_without_presence_publishes_nothing(self):
+        """An adapter that never went online must not shell out on teardown."""
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        adapter._run_cli = cli
+        await adapter.disconnect()
+        assert cli.calls == []
 
 
 # ── Credentials / requirements ────────────────────────────────────────────

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -120,4 +120,5 @@ Check status with `hermes gateway status` — Buzz connection state is reported 
 - **Inbound is polled, not streamed.** The `buzz` CLI is request/response, so the adapter polls `buzz messages get` per watched channel every `poll_interval` seconds (default 4). Expect up to one interval of latency on inbound messages. A future optimization is a websocket transport (the Buzz repo ships `buzz-ws-client` for true streaming).
 - On (re)connect the adapter seeds its high-water mark from the newest events, so channel history is never replayed into the agent.
 - New DM conversations are discovered automatically (every few poll sweeps).
+- **Presence is automatic.** On connect the agent publishes online presence and refreshes it every 30 seconds (the relay expires presence 90 seconds after the last refresh); on graceful shutdown it publishes offline. Presence failures are logged but never interrupt messaging.
 - The private key is passed to the CLI via the subprocess environment — it never appears in argv or logs.


### PR DESCRIPTION
## Summary

- publish native Buzz `online` presence after a successful adapter connection and refresh it on the relay's 30-second heartbeat cadence
- keep all presence I/O background-only and best-effort so a slow or failed CLI call cannot delay or fail gateway connect
- cancel in-flight heartbeats before a bounded best-effort `offline` publish on graceful disconnect
- prevent duplicate heartbeat tasks across reconnects and document the lifecycle behavior

## Why

Buzz presence is stored with a 90-second relay TTL. The native Hermes Buzz adapter currently never publishes or refreshes presence, so connected agents can appear offline even while they are receiving and answering messages.

The first online write deliberately runs inside the heartbeat task rather than inline in `connect()`. Presence is cosmetic and must not consume the gateway's adapter-connect timeout.

## Tests

- `scripts/run_tests.sh tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py -q` — 37 passed
- `.venv/bin/ruff check plugins/platforms/buzz/adapter.py tests/gateway/test_buzz_adapter.py` — passed
- `git diff --check` — passed
- `scripts/run_tests.sh tests/gateway -q` — 4,436 passed, 3 failed; the same 3 failures reproduce on untouched base and are unrelated to Buzz:
  - `test_complete_path_at_filter.py` is blocked by the local Git identity guard when its fixture commits as `test@example.com`
  - two `test_wecom_callback.py` cases lack the optional XML dependency (`ET is None`)
