### PR TITLE
feat(skills): separate managed content from runtime state

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -21,7 +21,10 @@ REFERENCE_PATTERN = re.compile(
 TRAILING_PUNCTUATION = ",.;!?"
 _NEEDS_QUOTING = re.compile(r"""[\s()\[\]{}<>"'`]""")
 _SENSITIVE_HOME_DIRS = (".ssh", ".aws", ".gnupg", ".kube", ".docker", ".azure", ".config/gh")
-_SENSITIVE_HERMES_DIRS = (Path("skills") / ".hub",)
+_SENSITIVE_HERMES_DIRS = (
+    Path("state") / "skills" / "hub",
+    Path("skills") / ".hub",
+)
 _SENSITIVE_HOME_FILES = (
     Path(".ssh") / "authorized_keys",
     Path(".ssh") / "id_rsa",

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -10,7 +10,7 @@ Responsibilities:
   - Auto-transition lifecycle states based on derived skill activity timestamps
   - Spawn a background review agent that can pin / archive / consolidate /
     patch agent-created skills via skill_manage
-  - Persist curator state (last_run_at, paused, etc.) in .curator_state
+  - Persist curator state (last_run_at, paused, etc.) outside skill discovery
 
 Strict invariants:
   - Only touches agent-created skills (see tools/skill_usage.is_agent_created)
@@ -30,7 +30,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, get_skills_state_dir
 from tools import skill_usage
 from utils import atomic_json_write
 
@@ -79,10 +79,17 @@ DEFAULT_CONSOLIDATE = False
 
 
 # ---------------------------------------------------------------------------
-# .curator_state — persistent scheduler + status
+# External curator state — persistent scheduler + status
 # ---------------------------------------------------------------------------
 
 def _state_file() -> Path:
+    return get_skills_state_dir() / "curator-state.json"
+
+
+def _state_read_file() -> Path:
+    path = _state_file()
+    if path.exists():
+        return path
     return get_hermes_home() / "skills" / ".curator_state"
 
 
@@ -99,7 +106,7 @@ def _default_state() -> Dict[str, Any]:
 
 
 def load_state() -> Dict[str, Any]:
-    path = _state_file()
+    path = _state_read_file()
     if not path.exists():
         return _default_state()
     try:
@@ -116,7 +123,17 @@ def load_state() -> Dict[str, Any]:
 def save_state(data: Dict[str, Any]) -> None:
     path = _state_file()
     try:
+        from tools.skills_policy import (
+            note_legacy_state_write,
+            prepare_legacy_state_write,
+        )
+
+        migration = prepare_legacy_state_write(
+            path,
+            get_hermes_home() / "skills" / ".curator_state",
+        )
         atomic_json_write(path, data, indent=2, sort_keys=True)
+        note_legacy_state_write(migration)
     except Exception as e:
         logger.debug("Failed to save curator state: %s", e, exc_info=True)
 
@@ -1527,6 +1544,33 @@ def run_curator_review(
     *consolidate*: when consolidation is off, the preview only reports the
     deterministic prune candidates.
     """
+    if not dry_run:
+        from tools.skills_policy import (
+            SkillsContentPolicyError,
+            require_skills_content_writable,
+        )
+
+        try:
+            require_skills_content_writable("run curator skill maintenance")
+        except SkillsContentPolicyError as exc:
+            message = str(exc)
+            if on_summary:
+                try:
+                    on_summary(f"curator: {message}")
+                except Exception:
+                    pass
+            return {
+                "started_at": None,
+                "auto_transitions": {
+                    "checked": 0,
+                    "marked_stale": 0,
+                    "archived": 0,
+                    "reactivated": 0,
+                },
+                "summary_so_far": message,
+                "refused": True,
+            }
+
     if consolidate is None:
         consolidate = get_consolidate()
     start = datetime.now(timezone.utc)

--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -596,11 +596,14 @@ def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]
 
     Returns ``(ok, message, snapshot_path)``.
     """
-    from tools.skills_policy import require_skills_content_writable
+    from tools.skills_policy import (
+        SkillsContentPolicyError,
+        require_skills_content_writable,
+    )
 
     try:
         require_skills_content_writable("rollback curator skill snapshot")
-    except RuntimeError as exc:
+    except SkillsContentPolicyError as exc:
         return False, str(exc), None
 
     target = _resolve_backup(backup_id)

--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -1,28 +1,26 @@
 """Curator snapshot + rollback.
 
-A pre-run snapshot of ``~/.hermes/skills/`` (excluding ``.curator_backups/``
-itself) is taken before any mutating curator pass. Snapshots are tar.gz
-files under ``~/.hermes/skills/.curator_backups/<utc-iso>/`` with a
+A pre-run snapshot of ``~/.hermes/skills/`` is taken before any mutating
+curator pass. Snapshots are tar.gz files under
+``~/.hermes/state/skills/curator-backups/<utc-iso>/`` with a
 companion ``manifest.json`` describing the snapshot (reason, time, size,
 counted skill files). Rollback picks a snapshot, moves the current
 ``skills/`` tree aside into another snapshot so even the rollback itself
 is undoable, then extracts the chosen snapshot into place.
 
 The snapshot does NOT include:
-  - ``.curator_backups/`` (would recurse)
+  - legacy ``.curator_backups/`` (would recurse)
   - ``.hub/`` (hub-installed skills — managed by the hub, not us)
 
 It DOES include:
   - all SKILL.md files + their directories (``scripts/``, ``references/``,
     ``templates/``, ``assets/``)
-  - ``.usage.json`` (usage telemetry — needed to rehydrate state cleanly)
   - ``.archive/`` (so rollback restores previously-archived skills too)
-  - ``.curator_state`` (so rolling back also restores the last-run-at
-    pointer — otherwise the curator would immediately re-fire on the next
-    tick)
-  - ``.bundled_manifest`` (so protection markers stay consistent)
-  - ``.curator_suppressed`` (so rollback restores the set of pruned built-ins
-    the re-seeder must leave archived)
+
+Writable usage, curator, bundled-sync, and hub metadata lives outside this
+content snapshot under ``state/skills/``. Legacy discovery-root metadata may
+still be present in an old profile and is preserved as inert compatibility
+data, but it is not the post-migration write authority.
 
 Alongside the skills tarball, each snapshot also captures a copy of
 ``~/.hermes/cron/jobs.json`` as ``cron-jobs.json`` when it exists. Cron
@@ -44,11 +42,12 @@ import logging
 import re
 import shutil
 import tarfile
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, get_skills_state_dir
 from agent.skill_utils import is_excluded_skill_path
 
 logger = logging.getLogger(__name__)
@@ -68,7 +67,47 @@ _ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z(-\d{2})?$")
 
 
 def _backups_dir() -> Path:
+    return get_skills_state_dir() / "curator-backups"
+
+
+def _backups_read_dir() -> Path:
+    path = _backups_dir()
+    if path.exists():
+        return path
     return get_hermes_home() / "skills" / ".curator_backups"
+
+
+def _prepare_backups_dir_for_write() -> Path:
+    """Preserve legacy snapshots before the first external-state snapshot."""
+    backups = _backups_dir()
+    legacy = get_hermes_home() / "skills" / ".curator_backups"
+    if backups.exists() or not legacy.is_dir():
+        return backups
+
+    backups.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(
+        tempfile.mkdtemp(
+            dir=str(backups.parent),
+            prefix=f".{backups.name}.migration-",
+        )
+    )
+    staging.rmdir()
+    try:
+        shutil.copytree(legacy, staging, symlinks=True)
+        try:
+            staging.replace(backups)
+        except OSError:
+            if not backups.exists():
+                raise
+            shutil.rmtree(staging, ignore_errors=True)
+        else:
+            from tools.skills_policy import warn_legacy_state_migrated
+
+            warn_legacy_state_migrated(legacy)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    return backups
 
 
 def _skills_dir() -> Path:
@@ -234,7 +273,7 @@ def snapshot_skills(reason: str = "manual", *, protect_ids: Optional[Set[str]] =
         logger.debug("No ~/.hermes/skills/ directory — nothing to back up")
         return None
 
-    backups = _backups_dir()
+    backups = _prepare_backups_dir_for_write()
     try:
         backups.mkdir(parents=True, exist_ok=True)
     except OSError as e:
@@ -352,7 +391,7 @@ def list_backups() -> List[Dict[str, Any]]:
     real ``skills.tar.gz`` tarball are listed — transient
     ``.rollback-staging-*`` directories created mid-rollback are
     implementation detail and not shown."""
-    backups = _backups_dir()
+    backups = _backups_read_dir()
     if not backups.exists():
         return []
     out: List[Dict[str, Any]] = []
@@ -379,7 +418,7 @@ def list_backups() -> List[Dict[str, Any]]:
 def _resolve_backup(backup_id: Optional[str]) -> Optional[Path]:
     """Return the path of the requested backup, or the newest one if
     *backup_id* is None. Returns None if no match."""
-    backups = _backups_dir()
+    backups = _backups_read_dir()
     if not backups.exists():
         return None
     if backup_id:
@@ -557,6 +596,13 @@ def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]
 
     Returns ``(ok, message, snapshot_path)``.
     """
+    from tools.skills_policy import require_skills_content_writable
+
+    try:
+        require_skills_content_writable("rollback curator skill snapshot")
+    except RuntimeError as exc:
+        return False, str(exc), None
+
     target = _resolve_backup(backup_id)
     if target is None:
         return (

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -196,7 +196,8 @@ def get_read_block_error(path: str) -> Optional[str]:
 
     Three categories are blocked:
 
-      * Internal Hermes cache files under ``HERMES_HOME/skills/.hub`` —
+      * Internal Hermes cache files under ``HERMES_HOME/state/skills/hub``
+        (plus the legacy ``HERMES_HOME/skills/.hub`` compatibility path) —
         readable metadata that an attacker could use as a prompt-injection
         carrier.
       * Credential / secret stores under HERMES_HOME and the global Hermes
@@ -252,9 +253,12 @@ def get_read_block_error(path: str) -> Optional[str]:
         except Exception:
             continue
 
-    # Skills .hub: prompt-injection carriers.
+    # Skills hub state and its legacy discovery location: prompt-injection
+    # carriers. Keep the denial as a union during metadata compatibility.
     for hd in hermes_dirs:
         blocked_dirs = [
+            hd / "state" / "skills" / "hub" / "index-cache",
+            hd / "state" / "skills" / "hub",
             hd / "skills" / ".hub" / "index-cache",
             hd / "skills" / ".hub",
         ]

--- a/agent/learning_graph.py
+++ b/agent/learning_graph.py
@@ -87,11 +87,7 @@ def _load_usage() -> dict[str, dict[str, Any]]:
 
         return load_usage()
     except Exception:
-        path = get_hermes_home() / "skills" / ".usage.json"
-        try:
-            return json.loads(path.read_text(encoding="utf-8"))
-        except Exception:
-            return {}
+        return {}
 
 
 def _to_int_ts(value: Any) -> Optional[int]:

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -21,13 +21,14 @@ from agent.skill_utils import (
     EXCLUDED_SKILL_DIRS,
     ORG_ACTIVE_MARKER,
     ORG_MIRROR_DIR_NAME,
-    ORG_PROVENANCE_FILE,
     SKILL_SUPPORT_DIRS,
     extract_skill_conditions,
     extract_skill_description,
     get_all_skills_dirs,
     get_disabled_skill_names,
     iter_skill_index_files,
+    org_active_marker_path,
+    org_provenance_path,
     org_id_of_path,
     parse_frontmatter,
     read_active_org_id,
@@ -1378,7 +1379,7 @@ def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
     prefix_len = len(base)
     active_org = read_active_org_id(skills_dir)
     org_root = os.path.join(skills_dir_str, ORG_MIRROR_DIR_NAME)
-    marker_path = os.path.join(org_root, ORG_ACTIVE_MARKER)
+    marker_path = str(org_active_marker_path(skills_dir))
     try:
         st = os.stat(marker_path)
         manifest[ORG_MIRROR_DIR_NAME + "/" + ORG_ACTIVE_MARKER] = [
@@ -1491,9 +1492,7 @@ def _build_snapshot_entry(
         try:
             import json as _json
 
-            prov_path = (
-                skills_dir / ORG_MIRROR_DIR_NAME / org_id / ORG_PROVENANCE_FILE
-            )
+            prov_path = org_provenance_path(skills_dir, org_id)
             prov = _json.loads(prov_path.read_text(encoding="utf-8"))
             device = str(prov.get("author_device") or "")
             entry["org_author"] = device or str(prov.get("author_user_id") or "")

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -12,7 +12,12 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from hermes_constants import get_config_path, get_skills_dir, is_termux
+from hermes_constants import (
+    get_config_path,
+    get_skills_dir,
+    get_skills_state_dir,
+    is_termux,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -67,16 +72,54 @@ ORG_PROVENANCE_FILE = ".org-provenance.json"
 ORG_BASELINE_FILE = ".org-baseline.json"
 
 
+def _skills_state_root_for(skills_dir: Path) -> Path:
+    """Resolve profile state without leaking real-profile state into test roots."""
+    try:
+        is_active_root = (
+            Path(skills_dir).resolve(strict=False)
+            == get_skills_dir().resolve(strict=False)
+        )
+    except OSError:
+        is_active_root = Path(skills_dir).absolute() == get_skills_dir().absolute()
+    if is_active_root:
+        return get_skills_state_dir()
+    # Explicit discovery roots are used by embedders and isolated behavior
+    # tests. Preserve the same HERMES_HOME-relative layout for those roots.
+    return Path(skills_dir).parent / "state" / "skills"
+
+
+def org_active_marker_path(skills_dir: Path) -> Path:
+    """Prefer the external active-org marker, then its legacy mirror path."""
+    path = _skills_state_root_for(skills_dir) / "sync" / "org" / "active-org"
+    if path.exists():
+        return path
+    return skills_dir / ORG_MIRROR_DIR_NAME / ORG_ACTIVE_MARKER
+
+
 def read_active_org_id(skills_dir: Path) -> Optional[str]:
     """The org id whose mirror may resolve, or None (no org skills load)."""
     try:
-        marker = skills_dir / ORG_MIRROR_DIR_NAME / ORG_ACTIVE_MARKER
+        marker = org_active_marker_path(skills_dir)
         if not marker.exists():
             return None
         val = marker.read_text(encoding="utf-8").strip()
         return val or None
     except OSError:
         return None
+
+
+def org_provenance_path(skills_dir: Path, org_id: str) -> Path:
+    """Prefer external org provenance, then its legacy mirror sidecar."""
+    path = (
+        _skills_state_root_for(skills_dir)
+        / "sync"
+        / "org"
+        / org_id
+        / "provenance.json"
+    )
+    if path.exists():
+        return path
+    return skills_dir / ORG_MIRROR_DIR_NAME / org_id / ORG_PROVENANCE_FILE
 
 
 def is_org_mirror_path(path, skills_dir: Path) -> bool:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -760,6 +760,13 @@ streaming:
 # also create new skills after completing complex tasks.
 #
 skills:
+  # Whether Hermes may create, update, archive, restore, or remove skill
+  # discovery content. Managed deployments can set this to read_only while
+  # Hermes keeps mutable runtime metadata under ~/.hermes/state/skills/.
+  # read_only protects the discovery tree only; HERMES_HOME/state must remain
+  # writable for normal runtime metadata.
+  content_mode: writable  # writable | read_only
+
   # Nudge the agent to create skills after complex tasks.
   # Every N tool-calling iterations, remind the model to consider saving a skill.
   # Set to 0 to disable.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1668,6 +1668,10 @@ DEFAULT_CONFIG = {
     # always goes to ~/.hermes/skills/.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        # Whether Hermes may mutate skill discovery content. Managed
+        # deployments set read_only and keep mutable metadata under
+        # HERMES_HOME/state/skills instead.
+        "content_mode": "writable",  # writable | read_only
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
         # content with the absolute skill directory and the active session id
         # before the agent sees it.  Lets skill authors reference bundled
@@ -1749,7 +1753,7 @@ DEFAULT_CONFIG = {
         "prune_builtins": True,
         # Pre-run backup: before every real curator pass (dry-run is
         # skipped), snapshot ~/.hermes/skills/ into
-        # ~/.hermes/skills/.curator_backups/<utc-iso>/skills.tar.gz so the
+        # ~/.hermes/state/skills/curator-backups/<utc-iso>/skills.tar.gz so the
         # user can roll back with `hermes curator rollback`.
         "backup": {
             "enabled": True,

--- a/hermes_cli/curator.py
+++ b/hermes_cli/curator.py
@@ -524,7 +524,10 @@ def _cmd_backup(args) -> int:
     if snap is None:
         print("curator: snapshot failed — check logs (backup disabled or IO error)")
         return 1
-    print(f"curator: snapshot created at ~/.hermes/skills/.curator_backups/{snap.name}")
+    print(
+        "curator: snapshot created at "
+        f"~/.hermes/state/skills/curator-backups/{snap.name}"
+    )
     return 0
 
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2488,7 +2488,12 @@ def run_doctor(args):
         check_warn("Could not check tool availability", f"({e})")
     
     _section("Skills Hub")
-    hub_dir = HERMES_HOME / "skills" / ".hub"
+    active_home = get_hermes_home()
+    hub_dir = active_home / "state" / "skills" / "hub"
+    if not hub_dir.exists():
+        legacy_hub_dir = active_home / "skills" / ".hub"
+        if legacy_hub_dir.exists():
+            hub_dir = legacy_hub_dir
     if hub_dir.exists():
         check_ok("Skills Hub directory exists")
         lock_file = hub_dir / "lock.json"
@@ -2505,7 +2510,7 @@ def run_doctor(args):
         if q_count > 0:
             check_warn(f"{q_count} skill(s) in quarantine", "(pending review)")
     else:
-        check_warn("Skills Hub directory not initialized", "(run: hermes skills list)")
+        check_ok("Skills Hub state not initialized (no persisted hub state)")
 
     from hermes_cli.config import get_env_value
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -887,6 +887,13 @@ def _termux_bundled_skills_fingerprint() -> str:
 
 
 def _termux_bundled_skills_stamp_path() -> Path:
+    return get_hermes_home() / "state" / "skills" / "termux-bundled-sync-stamp"
+
+
+def _termux_bundled_skills_stamp_read_path() -> Path:
+    stamp = _termux_bundled_skills_stamp_path()
+    if stamp.exists():
+        return stamp
     return get_hermes_home() / "skills" / ".termux_bundled_sync_stamp"
 
 
@@ -896,7 +903,7 @@ def _termux_bundled_skills_sync_needed() -> bool:
     if os.environ.get("HERMES_TERMUX_FORCE_SKILLS_SYNC") == "1":
         return True
     try:
-        stamp = _termux_bundled_skills_stamp_path()
+        stamp = _termux_bundled_skills_stamp_read_path()
         return stamp.read_text(encoding="utf-8").strip() != _termux_bundled_skills_fingerprint()
     except OSError:
         return True
@@ -907,8 +914,19 @@ def _mark_termux_bundled_skills_synced() -> None:
         return
     try:
         stamp = _termux_bundled_skills_stamp_path()
-        stamp.parent.mkdir(parents=True, exist_ok=True)
-        stamp.write_text(_termux_bundled_skills_fingerprint() + "\n", encoding="utf-8")
+        legacy = get_hermes_home() / "skills" / ".termux_bundled_sync_stamp"
+        from tools.skills_policy import (
+            note_legacy_state_write,
+            prepare_legacy_state_write,
+        )
+        from utils import atomic_write_text
+
+        migration = prepare_legacy_state_write(stamp, legacy)
+        atomic_write_text(
+            stamp,
+            _termux_bundled_skills_fingerprint() + "\n",
+        )
+        note_legacy_state_write(migration)
     except OSError:
         pass
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11001,7 +11001,7 @@ def cmd_skills(args):
     else:
         from hermes_cli.skills_hub import skills_command
 
-        skills_command(args)
+        return skills_command(args)
 
 
 def cmd_pairing(args):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -170,6 +170,7 @@ def _run_and_exit_oneshot(
     model: object = None,
     provider: object = None,
     toolsets: object = None,
+    skills: object = None,
     usage_file: object = None,
 ) -> None:
     try:
@@ -180,6 +181,7 @@ def _run_and_exit_oneshot(
             model=model,
             provider=provider,
             toolsets=toolsets,
+            skills=skills,
             usage_file=usage_file,
         )
     except KeyboardInterrupt:
@@ -10760,6 +10762,7 @@ def _try_termux_fast_cli_launch() -> bool:
             model=getattr(args, "model", None),
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
+            skills=getattr(args, "skills", None),
             usage_file=getattr(args, "usage_file", None),
         )
 
@@ -12364,6 +12367,7 @@ def main():
             model=getattr(args, "model", None),
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
+            skills=getattr(args, "skills", None),
             usage_file=getattr(args, "usage_file", None),
         )
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -50,6 +50,26 @@ def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
     return [item for item in normalized if item] or None
 
 
+def _normalize_skills(skills: object = None) -> list[str] | None:
+    """Normalize repeated/comma-separated ``--skills`` values."""
+    if not skills:
+        return None
+
+    raw_items = [skills] if isinstance(skills, str) else skills
+    if not isinstance(raw_items, (list, tuple)):
+        raw_items = [raw_items]
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for item in raw_items:
+        for value in str(item).split(","):
+            identifier = value.strip()
+            if identifier and identifier not in seen:
+                normalized.append(identifier)
+                seen.add(identifier)
+    return normalized or None
+
+
 def _validate_explicit_toolsets(toolsets: object = None) -> tuple[list[str] | None, str | None]:
     normalized = _normalize_toolsets(toolsets)
     if normalized is None:
@@ -172,6 +192,7 @@ def run_oneshot(
     model: Optional[str] = None,
     provider: Optional[str] = None,
     toolsets: object = None,
+    skills: object = None,
     usage_file: Optional[str] = None,
 ) -> int:
     """Execute a single prompt and print only the final content block.
@@ -183,6 +204,7 @@ def run_oneshot(
         provider: Optional provider override. Falls back to config.yaml's
             model.provider, then "auto".
         toolsets: Optional comma-separated string or iterable of toolsets.
+        skills: Optional repeated/comma-separated skill identifiers to preload.
         usage_file: Optional path; when set, a JSON usage report (estimated
             cost, token counts, model, api_calls) is written there after the
             run — even when the run fails — so pipelines can account for
@@ -248,6 +270,7 @@ def run_oneshot(
                     provider=provider,
                     toolsets=explicit_toolsets,
                     use_config_toolsets=use_config_toolsets,
+                    skills=_normalize_skills(skills),
                 )
             except BaseException as exc:  # noqa: BLE001
                 # Capture anything that escapes the agent (including OSError
@@ -316,6 +339,7 @@ def _run_agent(
     provider: Optional[str] = None,
     toolsets: object = None,
     use_config_toolsets: bool = True,
+    skills: object = None,
 ) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn would, then
     run a single conversation.  Returns ``(final_response, run_result)``."""
@@ -395,6 +419,23 @@ def _run_agent(
     if toolsets_list is None and use_config_toolsets:
         toolsets_list = sorted(_get_platform_tools(cfg, "cli"))
 
+    skills_prompt = None
+    skill_identifiers = _normalize_skills(skills)
+    if skill_identifiers:
+        from agent.skill_commands import build_preloaded_skills_prompt
+
+        skills_prompt, loaded_skills, missing_skills = (
+            build_preloaded_skills_prompt(skill_identifiers)
+        )
+        if missing_skills and not loaded_skills:
+            raise ValueError(f"Unknown skill(s): {', '.join(missing_skills)}")
+        if missing_skills:
+            logging.warning(
+                "Unknown skill(s) requested, skipping: %s. Continuing with: %s",
+                ", ".join(missing_skills),
+                ", ".join(loaded_skills),
+            )
+
     session_db = _create_session_db_for_oneshot()
     # The try spans agent construction (not just ``chat``) so the SQLite store
     # opened above is always closed — including when ``AIAgent(...)`` itself
@@ -417,6 +458,7 @@ def _run_agent(
             enabled_toolsets=toolsets_list,
             quiet_mode=True,
             platform="cli",
+            ephemeral_system_prompt=skills_prompt,
             session_db=session_db,
             credential_pool=runtime.get("credential_pool"),
             fallback_model=_fb or None,

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1081,19 +1081,22 @@ def do_check(name: Optional[str] = None, console: Optional[Console] = None) -> N
     c.print(f"[dim]{update_count} update(s) available across {len(results)} checked skill(s)[/]\n")
 
 
-def do_update(name: Optional[str] = None, console: Optional[Console] = None) -> None:
-    """Update hub-installed skills with upstream changes."""
+def do_update(
+    name: Optional[str] = None,
+    console: Optional[Console] = None,
+) -> bool:
+    """Update hub-installed skills, returning False on a policy refusal."""
     from tools.skills_hub import HubLockFile, check_for_skill_updates
 
     c = console or _console
     target = name if name is not None else "all installed skills"
     if _content_write_refused(f"update {target}", c):
-        return
+        return False
     lock = HubLockFile()
     updates = [entry for entry in check_for_skill_updates(name=name) if entry.get("status") == "update_available"]
     if not updates:
         c.print("[dim]No updates available.[/]\n")
-        return
+        return True
 
     for entry in updates:
         installed = lock.get_installed(entry["name"])
@@ -1115,6 +1118,7 @@ def do_update(name: Optional[str] = None, console: Optional[Console] = None) -> 
         )
 
     c.print(f"[bold green]Updated {len(updates)} skill(s).[/]\n")
+    return True
 
 
 def do_audit(name: Optional[str] = None, console: Optional[Console] = None,
@@ -1768,7 +1772,7 @@ def do_snapshot_import(input_path: str, force: bool = False,
 # CLI argparse entry point
 # ---------------------------------------------------------------------------
 
-def skills_command(args) -> None:
+def skills_command(args) -> Optional[int]:
     """Router for `hermes skills <subcommand>` — called from hermes_cli/main.py."""
     action = getattr(args, "skills_action", None)
 
@@ -1791,7 +1795,8 @@ def skills_command(args) -> None:
     elif action == "check":
         do_check(name=getattr(args, "name", None))
     elif action == "update":
-        do_update(name=getattr(args, "name", None))
+        if not do_update(name=getattr(args, "name", None)):
+            return 2
     elif action == "audit":
         do_audit(name=getattr(args, "name", None),
                  deep=getattr(args, "deep", False))

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1772,7 +1772,7 @@ def do_snapshot_import(input_path: str, force: bool = False,
 # CLI argparse entry point
 # ---------------------------------------------------------------------------
 
-def skills_command(args) -> Optional[int]:
+def skills_command(args) -> int:
     """Router for `hermes skills <subcommand>` — called from hermes_cli/main.py."""
     action = getattr(args, "skills_action", None)
 
@@ -1836,11 +1836,12 @@ def skills_command(args) -> Optional[int]:
         repo = getattr(args, "repo", "") or getattr(args, "name", "")
         if not tap_action:
             _console.print("Usage: hermes skills tap [list|add|remove]\n")
-            return
+            return 0
         do_tap(tap_action, repo=repo)
     else:
         _console.print("Usage: hermes skills [browse|search|install|inspect|list|list-modified|diff|check|update|audit|uninstall|reset|opt-out|opt-in|publish|snapshot|tap]\n")
         _console.print("Run 'hermes skills <command> --help' for details.\n")
+    return 0
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -28,6 +28,21 @@ from agent.skill_utils import is_excluded_skill_path
 _console = Console()
 
 
+def _content_write_refused(operation: str, console: Console) -> bool:
+    """Print a stable refusal and return True when content is managed."""
+    from tools.skills_policy import (
+        SkillsContentPolicyError,
+        require_skills_content_writable,
+    )
+
+    try:
+        require_skills_content_writable(operation)
+    except SkillsContentPolicyError as exc:
+        console.print(f"[bold red]Error:[/] {exc}\n")
+        return True
+    return False
+
+
 def _display_source(r) -> str:
     """Human-facing source label for a result row.
 
@@ -520,6 +535,10 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     registry. Skill names are not namespaced across registries, so an
     unconstrained resolve can silently change a skill's provenance.
     """
+    c = console or _console
+    if _content_write_refused(f"install skill {identifier!r}", c):
+        return
+
     from tools.skills_hub import (
         GitHubAuth, create_source_router, ensure_hub_dirs,
         quarantine_bundle, install_from_quarantine, HubLockFile,
@@ -527,7 +546,6 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     )
     from tools.skills_guard import scan_skill_cached, should_allow_install, format_scan_report
 
-    c = console or _console
     ensure_hub_dirs()
 
     # Resolve which source adapter handles this identifier
@@ -956,13 +974,12 @@ def do_list(source_filter: str = "all",
     ``skills.disabled`` list because ``-p`` swaps ``HERMES_HOME`` at process
     start.  No explicit profile flag needed here.
     """
-    from tools.skills_hub import HubLockFile, ensure_hub_dirs
+    from tools.skills_hub import HubLockFile
     from tools.skills_sync import _read_manifest
     from tools.skills_tool import _find_all_skills
     from agent.skill_utils import get_disabled_skill_names
 
     c = console or _console
-    ensure_hub_dirs()
     lock = HubLockFile()
     hub_installed = {e["name"]: e for e in lock.list_installed()}
     builtin_names = set(_read_manifest())
@@ -1069,6 +1086,9 @@ def do_update(name: Optional[str] = None, console: Optional[Console] = None) -> 
     from tools.skills_hub import HubLockFile, check_for_skill_updates
 
     c = console or _console
+    target = name if name is not None else "all installed skills"
+    if _content_write_refused(f"update {target}", c):
+        return
     lock = HubLockFile()
     updates = [entry for entry in check_for_skill_updates(name=name) if entry.get("status") == "update_available"]
     if not updates:
@@ -1186,6 +1206,8 @@ def do_reset(name: str, restore: bool = False,
     from tools.skills_sync import reset_bundled_skill
 
     c = console or _console
+    if _content_write_refused(f"reset bundled skill {name!r}", c):
+        return
 
     if not skip_confirm and restore:
         c.print(f"\n[bold]Restore '{name}' from bundled source?[/]")
@@ -1307,6 +1329,8 @@ def do_opt_out(remove: bool = False,
     )
 
     c = console or _console
+    if remove and _content_write_refused("remove pristine bundled skills", c):
+        return
 
     # Write the marker first (the always-safe part).
     res = set_bundled_skills_opt_out(True)
@@ -1380,8 +1404,11 @@ def do_opt_in(sync: bool = False,
 
     if sync:
         synced = sync_skills(quiet=True)
-        copied = len(synced.get("copied", []))
-        c.print(f"[dim]Re-seeded {copied} bundled skill(s).[/]")
+        if synced.get("skipped_read_only"):
+            c.print("[dim]Bundled sync skipped: skills.content_mode is read_only.[/]")
+        else:
+            copied = len(synced.get("copied", []))
+            c.print(f"[dim]Re-seeded {copied} bundled skill(s).[/]")
         if invalidate_cache:
             try:
                 from agent.prompt_builder import clear_skills_system_prompt_cache
@@ -1399,6 +1426,11 @@ def do_repair_official(name: str, restore: bool = False,
     from tools.skills_sync import restore_official_optional_skill
 
     c = console or _console
+    if restore and _content_write_refused(
+        f"restore official optional skill {name!r}",
+        c,
+    ):
+        return
     if restore and not skip_confirm:
         c.print(f"\n[bold]Restore official optional skill '{name}' from repo source?[/]")
         c.print("[dim]Existing matching active copies will be moved to a restore backup before copying the official source.[/]")
@@ -1689,6 +1721,8 @@ def do_snapshot_import(input_path: str, force: bool = False,
     from tools.skills_hub import TapsManager
 
     c = console or _console
+    if _content_write_refused("import skill snapshot", c):
+        return
     inp = Path(input_path)
     if not inp.exists():
         c.print(f"[bold red]Error:[/] File not found: {inp}\n")

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -161,7 +161,7 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         "reset",
         help="Reset a bundled skill — clears 'user-modified' tracking so updates work again",
         description=(
-            "Clear a bundled skill's entry from the sync manifest (~/.hermes/skills/.bundled_manifest) "
+            "Clear a bundled skill's entry from external bundled state "
             "so future 'hermes update' runs stop marking it as user-modified. Pass --restore to also "
             "replace the current copy with the bundled version."
         ),

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -296,7 +296,7 @@ TIPS = [
     "agent.api_max_retries (default 3) controls how many times the agent retries a failed API call before surfacing the error — lower it for fast fallback.",
     "The gateway caches AIAgent instances per session — destroying this cache breaks Anthropic prompt caching.",
     "Any website can expose skills via /.well-known/skills/index.json — the skills hub discovers them automatically.",
-    "The skills audit log at ~/.hermes/skills/.hub/audit.log tracks every install and removal operation.",
+    "The skills audit log at ~/.hermes/state/skills/hub/audit.log tracks every install and removal operation.",
     "Stale git worktrees are auto-cleaned on startup: clean, fully-merged trees get pruned; dirty or unpushed work is always preserved.",
     "Profiles scope Hermes state via HERMES_HOME; host tool subprocesses keep your real HOME unless terminal.home_mode is profile.",
     "HERMES_HOME_MODE env var (octal, e.g. 0701) sets custom directory permissions for web server traversal.",
@@ -336,7 +336,7 @@ TIPS = [
     "Each MCP server gets its own toolset (mcp-servername) that can be toggled independently via hermes tools.",
     "MCP ${ENV_VAR} placeholders in config are resolved at server spawn — including vars from ~/.hermes/.env.",
     "Skills from trusted repos (NousResearch) get a 'trusted' security level; community skills get extra scanning.",
-    "The skills quarantine at ~/.hermes/skills/.hub/quarantine/ holds skills pending security review.",
+    "The skills quarantine at ~/.hermes/state/skills/hub/quarantine/ holds skills pending security review.",
 
     # --- Advanced Slash Commands ---
     '/steer <prompt> injects a note after the next tool call — nudge direction mid-task without interrupting.',
@@ -366,7 +366,7 @@ TIPS = [
     # --- Curator ---
     'hermes curator run --dry-run previews what the curator would archive or consolidate without mutating anything.',
     "hermes curator pin <skill> hard-fences a skill against both auto-archival and the agent's skill_manage tool.",
-    'hermes curator rollback restores skills from a pre-run snapshot — backups live under skills/.curator_backups/.',
+    'hermes curator rollback restores skills from a pre-run snapshot — backups live under state/skills/curator-backups/.',
 
     # --- Credential Pools & Routing ---
     'hermes auth reset <provider> clears all cooldowns and exhaustion flags on a credential pool.',

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12993,7 +12993,7 @@ def _installed_hub_identifiers(profile: Optional[str] = None) -> dict:
     """Map identifier -> installed lock entry for hub-installed skills.
 
     Lets the UI mark search results that are already installed.  Scoped to
-    ``profile``'s skills/.hub/lock.json when provided (HubLockFile takes an
+    ``profile``'s state/skills/hub/lock.json when provided (HubLockFile takes an
     explicit path, sidestepping the import-time LOCK_FILE binding).
     Best-effort: returns an empty dict if the lock file can't be read.
     """
@@ -13003,7 +13003,10 @@ def _installed_hub_identifiers(profile: Optional[str] = None) -> dict:
         requested = (profile or "").strip()
         if requested and requested.lower() != "current":
             profile_dir = _resolve_profile_dir(requested)
-            lock = HubLockFile(profile_dir / "skills" / ".hub" / "lock.json")
+            lock_path = profile_dir / "state" / "skills" / "hub" / "lock.json"
+            if not lock_path.exists():
+                lock_path = profile_dir / "skills" / ".hub" / "lock.json"
+            lock = HubLockFile(lock_path)
         else:
             lock = HubLockFile()
         out = {}

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1177,6 +1177,15 @@ def get_skills_dir() -> Path:
     return get_hermes_home() / "skills"
 
 
+def get_skills_state_dir() -> Path:
+    """Return the profile-scoped writable state directory for skills.
+
+    Skill discovery content and mutable runtime metadata intentionally have
+    different roots.  This helper only computes a path; it never creates it.
+    """
+    return get_hermes_home() / "state" / "skills"
+
+
 
 def get_env_path() -> Path:
     """Return the path to the ``.env`` file under HERMES_HOME."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   "httpx[socks]==0.28.1",
   "rich==14.3.3",
   "tenacity==9.1.4",
-  "pyyaml==6.0.3",
+  "pyyaml==6.0.3",  # config parsing + side-effect-free skills content policy
   "ruamel.yaml==0.18.17",
   "requests==2.33.0",  # CVE-2026-25645
   "jinja2==3.1.6",

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -387,6 +387,54 @@ def test_state_atomic_write_no_tmp_leftovers(curator_env):
     assert tmp_files == []
 
 
+def test_managed_read_only_refuses_curator_before_snapshot_or_llm(
+    curator_env,
+    monkeypatch,
+):
+    c = curator_env["curator"]
+    calls = {"policy": 0, "snapshot": 0, "llm": 0}
+
+    def refuse_curator(operation):
+        from tools.skills_policy import (
+            SKILLS_CONTENT_READ_ONLY,
+            SkillsContentPolicyError,
+        )
+
+        calls["policy"] += 1
+        raise SkillsContentPolicyError(
+            SKILLS_CONTENT_READ_ONLY,
+            f"{operation} is disabled for this test",
+        )
+
+    def count_snapshot(**_kwargs):
+        calls["snapshot"] += 1
+        return None
+
+    def count_llm(_prompt):
+        calls["llm"] += 1
+        return "unexpected"
+
+    monkeypatch.setattr(
+        "tools.skills_policy.require_skills_content_writable",
+        refuse_curator,
+    )
+    monkeypatch.setattr(
+        "agent.curator_backup.snapshot_skills",
+        count_snapshot,
+    )
+    monkeypatch.setattr(
+        c,
+        "_run_llm_review",
+        count_llm,
+    )
+
+    result = c.run_curator_review(synchronous=True, consolidate=True)
+
+    assert result["refused"] is True
+    assert "SKILLS_CONTENT_READ_ONLY" in result["summary_so_far"]
+    assert calls == {"policy": 1, "snapshot": 0, "llm": 0}
+
+
 
 
 
@@ -697,5 +745,3 @@ def test_review_fork_uses_runtime_model_and_output_cap(curator_env, monkeypatch)
     assert result["error"] is None
     assert captured["model"] == "real-model-id"
     assert captured["max_tokens"] == 1234
-
-

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -77,7 +77,12 @@ def test_snapshot_prunes_to_keep_count(backup_env, monkeypatch):
         monkeypatch.setattr(cb, "_utc_id", lambda now=None, _f=fid: _f)
         cb.snapshot_skills(reason=f"n{i}")
 
-    remaining = sorted(p.name for p in (backup_env["skills"] / ".curator_backups").iterdir())
+    remaining = sorted(
+        p.name
+        for p in (
+            backup_env["skills"].parent / "state" / "skills" / "curator-backups"
+        ).iterdir()
+    )
     # Newest 3 kept (lex order == date order for this id format)
     assert remaining == ids[2:], f"expected newest 3, got {remaining}"
 
@@ -128,11 +133,45 @@ def test_rollback_is_itself_undoable(backup_env):
         f"{[(r.get('id'), r.get('reason')) for r in rows]}"
     )
     # And the transient staging dir must be gone (it's implementation detail)
-    backups_dir = skills / ".curator_backups"
+    backups_dir = skills.parent / "state" / "skills" / "curator-backups"
     staging_dirs = [p for p in backups_dir.iterdir() if p.name.startswith(".rollback-staging-")]
     assert staging_dirs == [], (
         f"staging dir should be cleaned up on success, got: {staging_dirs}"
     )
+
+
+def test_rollback_refuses_managed_content_before_snapshot_or_move(
+    backup_env,
+    monkeypatch,
+):
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+    original = _write_skill(skills, "managed-skill")
+    cb.snapshot_skills(reason="managed-baseline")
+    before = {
+        path.relative_to(skills).as_posix(): path.read_bytes()
+        for path in skills.rglob("*")
+        if path.is_file()
+    }
+    backup_count = len(cb.list_backups())
+    monkeypatch.setattr(
+        "tools.skills_policy.skills_content_mode",
+        lambda: "read_only",
+    )
+
+    ok, message, snapshot = cb.rollback()
+
+    assert ok is False
+    assert "SKILLS_CONTENT_READ_ONLY" in message
+    assert snapshot is None
+    assert original.exists()
+    assert len(cb.list_backups()) == backup_count
+    after = {
+        path.relative_to(skills).as_posix(): path.read_bytes()
+        for path in skills.rglob("*")
+        if path.is_file()
+    }
+    assert after == before
 
 
 
@@ -388,7 +427,5 @@ def _three_ordered_snapshots(cb, skills, monkeypatch):
         assert cb.snapshot_skills(reason=snap_id) is not None
     monkeypatch.setattr(cb, "_utc_id", lambda now=None: "2026-05-09T00-00-00Z")
     return "2026-05-01T00-00-00Z"
-
-
 
 

--- a/tests/hermes_cli/test_main_skills_sync.py
+++ b/tests/hermes_cli/test_main_skills_sync.py
@@ -1,6 +1,7 @@
 """Startup behavior at the managed read-only skills boundary."""
 
 from pathlib import Path
+from types import SimpleNamespace
 import sys
 
 import pytest
@@ -135,6 +136,28 @@ def test_main_oneshot_routes_preloaded_nested_skill(monkeypatch):
 
     assert captured["prompt"] == "Return the loaded skill name only."
     assert captured["skills"] == ["planning/ticket-decomposition"]
+
+
+def test_cmd_skills_propagates_policy_refusal_status(tmp_path, monkeypatch):
+    from hermes_cli import main as main_mod
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "skills:\n  content_mode: read_only\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    assert (
+        main_mod.cmd_skills(
+            SimpleNamespace(
+                skills_action="update",
+                name="planning/ticket-decomposition",
+            )
+        )
+        == 2
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_main_skills_sync.py
+++ b/tests/hermes_cli/test_main_skills_sync.py
@@ -1,6 +1,7 @@
 """Startup behavior at the managed read-only skills boundary."""
 
 from pathlib import Path
+import sys
 
 import pytest
 
@@ -87,6 +88,53 @@ def test_invalid_config_still_reaches_read_only_discovery(
     )
     assert _census(skills) == before
     assert not (home / "state").exists()
+
+
+def test_main_oneshot_routes_preloaded_nested_skill(monkeypatch):
+    from hermes_cli import main as main_mod
+
+    class RoutedOneshot(Exception):
+        pass
+
+    captured = {}
+
+    def capture_oneshot(prompt, **kwargs):
+        captured["prompt"] = prompt
+        captured.update(kwargs)
+        raise RoutedOneshot
+
+    monkeypatch.setattr(main_mod, "_set_process_title", lambda: None)
+    monkeypatch.setattr(
+        main_mod,
+        "_sweep_stale_bytecode_if_checkout_changed",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "_recover_from_interrupted_install",
+        lambda: None,
+    )
+    monkeypatch.setattr(main_mod, "_try_termux_fast_tui_launch", lambda: False)
+    monkeypatch.setattr(main_mod, "_try_termux_fast_cli_launch", lambda: False)
+    monkeypatch.setattr(main_mod, "_prepare_agent_startup", lambda _args: None)
+    monkeypatch.setattr(main_mod, "_run_and_exit_oneshot", capture_oneshot)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hermes",
+            "--skills",
+            "planning/ticket-decomposition",
+            "--oneshot",
+            "Return the loaded skill name only.",
+        ],
+    )
+
+    with pytest.raises(RoutedOneshot):
+        main_mod.main()
+
+    assert captured["prompt"] == "Return the loaded skill name only."
+    assert captured["skills"] == ["planning/ticket-decomposition"]
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_main_skills_sync.py
+++ b/tests/hermes_cli/test_main_skills_sync.py
@@ -1,0 +1,150 @@
+"""Startup behavior at the managed read-only skills boundary."""
+
+from pathlib import Path
+
+import pytest
+
+
+def _write_managed_skill(home: Path) -> Path:
+    skill = home / "skills" / "planning" / "ticket-decomposition"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text(
+        "---\n"
+        "name: ticket-decomposition\n"
+        "description: Split work into durable tickets.\n"
+        "---\n\n"
+        "# Ticket decomposition\n",
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(
+        "skills:\n  content_mode: read_only\n",
+        encoding="utf-8",
+    )
+    return home / "skills"
+
+
+def _census(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+def test_cli_startup_skips_sync_and_reaches_nested_discovery(
+    tmp_path,
+    monkeypatch,
+):
+    from hermes_cli import config
+    from hermes_cli import main as main_mod
+    from tools import skills_tool
+
+    home = tmp_path / ".hermes"
+    skills = _write_managed_skill(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    config._LOAD_CONFIG_CACHE.clear()
+    config._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+    before = _census(skills)
+
+    main_mod._sync_bundled_skills_quietly()
+    discovered = skills_tool._find_all_skills(skip_disabled=True)
+
+    assert any(
+        skill["name"] == "ticket-decomposition"
+        and skill["category"] == "planning"
+        for skill in discovered
+    )
+    assert _census(skills) == before
+    assert not (skills / ".bundled_manifest").exists()
+    assert not (home / "state").exists()
+
+
+def test_invalid_config_still_reaches_read_only_discovery(
+    tmp_path,
+    monkeypatch,
+):
+    from hermes_cli import config
+    from hermes_cli import main as main_mod
+    from tools import skills_tool
+
+    home = tmp_path / ".hermes"
+    skills = _write_managed_skill(home)
+    (home / "config.yaml").write_text(
+        "skills: [unterminated\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    config._LOAD_CONFIG_CACHE.clear()
+    config._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+    before = _census(skills)
+
+    main_mod._sync_bundled_skills_quietly()
+    discovered = skills_tool._find_all_skills(skip_disabled=True)
+
+    assert any(
+        skill["name"] == "ticket-decomposition"
+        for skill in discovered
+    )
+    assert _census(skills) == before
+    assert not (home / "state").exists()
+
+
+@pytest.mark.asyncio
+async def test_gateway_startup_skips_sync_and_reaches_nested_discovery(
+    tmp_path,
+    monkeypatch,
+):
+    from gateway.config import GatewayConfig
+    from gateway.run import start_gateway
+    from hermes_cli import config
+    from tools import skills_tool
+
+    home = tmp_path / ".hermes"
+    skills = _write_managed_skill(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    config._LOAD_CONFIG_CACHE.clear()
+    config._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+    before = _census(skills)
+    reached = []
+
+    class _CleanExitRunner:
+        def __init__(self, gateway_config):
+            self.config = gateway_config
+            self.should_exit_cleanly = True
+            self.exit_reason = None
+            self.exit_code = None
+            self.adapters = {}
+
+        async def start(self):
+            assert self._platform_lock_takeover_on_start is False
+            reached.extend(
+                skill["name"]
+                for skill in skills_tool._find_all_skills(skip_disabled=True)
+            )
+            return True
+
+        async def stop(self):
+            return None
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr(
+        "hermes_logging.setup_logging",
+        lambda hermes_home, mode: tmp_path,
+    )
+    monkeypatch.setattr(
+        "hermes_logging._add_rotating_handler",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr("gateway.run.GatewayRunner", _CleanExitRunner)
+
+    assert (
+        await start_gateway(
+            config=GatewayConfig(),
+            replace=False,
+            verbosity=1,
+        )
+        is True
+    )
+    assert "ticket-decomposition" in reached
+    assert _census(skills) == before
+    assert not (skills / ".bundled_manifest").exists()

--- a/tests/hermes_cli/test_oneshot_usage_file.py
+++ b/tests/hermes_cli/test_oneshot_usage_file.py
@@ -2,6 +2,7 @@
 
 import json
 
+from hermes_cli import oneshot
 from hermes_cli.oneshot import _write_usage_file
 
 
@@ -54,4 +55,36 @@ class TestWriteUsageFile:
         # Missing result fields serialize as null, not KeyError.
         assert report["estimated_cost_usd"] is None
 
+
+def test_run_oneshot_passes_normalized_preloaded_skills(monkeypatch, capsys):
+    captured = {}
+
+    def fake_run_agent(prompt, **kwargs):
+        captured["prompt"] = prompt
+        captured.update(kwargs)
+        return "ticket-decomposition", {
+            "final_response": "ticket-decomposition",
+            "failed": False,
+            "partial": False,
+        }
+
+    monkeypatch.setattr(oneshot, "_run_agent", fake_run_agent)
+
+    assert (
+        oneshot.run_oneshot(
+            "Return the loaded skill name only.",
+            skills=[
+                "planning/ticket-decomposition, github-auth",
+                "planning/ticket-decomposition",
+            ],
+        )
+        == 0
+    )
+
+    output = capsys.readouterr()
+    assert output.out == "ticket-decomposition\n"
+    assert captured["skills"] == [
+        "planning/ticket-decomposition",
+        "github-auth",
+    ]
 

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -123,8 +123,12 @@ def test_nested_update_refuses_before_remote_check(monkeypatch, tmp_path):
 
     sink = StringIO()
     console = Console(file=sink, force_terminal=False, color_system=None)
-    do_update(name="planning/ticket-decomposition", console=console)
+    result = do_update(
+        name="planning/ticket-decomposition",
+        console=console,
+    )
 
+    assert result is False
     assert "SKILLS_CONTENT_READ_ONLY" in sink.getvalue()
     after = {
         path.relative_to(home / "skills").as_posix(): path.read_bytes()

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -80,6 +80,61 @@ def _capture_check(monkeypatch, results, name=None) -> str:
     return sink.getvalue()
 
 
+def test_list_does_not_initialize_hub_state(three_source_env):
+    assert not three_source_env.exists()
+    _capture()
+    assert not three_source_env.exists()
+
+
+def test_check_does_not_initialize_hub_state(monkeypatch, hub_env):
+    output = _capture_check(monkeypatch, [])
+
+    assert "No hub-installed skills" in output
+    assert not hub_env.exists()
+
+
+def test_nested_update_refuses_before_remote_check(monkeypatch, tmp_path):
+    import tools.skills_hub as hub
+
+    home = tmp_path / ".hermes"
+    skill = home / "skills" / "planning" / "ticket-decomposition"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text(
+        "---\nname: ticket-decomposition\ndescription: Split tickets.\n---\n",
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(
+        "skills:\n  content_mode: read_only\n",
+        encoding="utf-8",
+    )
+    before = {
+        path.relative_to(home / "skills").as_posix(): path.read_bytes()
+        for path in (home / "skills").rglob("*")
+        if path.is_file()
+    }
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(
+        hub,
+        "check_for_skill_updates",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("update check must not run after policy refusal")
+        ),
+    )
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    do_update(name="planning/ticket-decomposition", console=console)
+
+    assert "SKILLS_CONTENT_READ_ONLY" in sink.getvalue()
+    after = {
+        path.relative_to(home / "skills").as_posix(): path.read_bytes()
+        for path in (home / "skills").rglob("*")
+        if path.is_file()
+    }
+    assert after == before
+    assert not (home / "state").exists()
+
+
 def _capture_update(monkeypatch, results) -> tuple[str, list[tuple[str, str, bool]]]:
     import tools.skills_hub as hub
     import hermes_cli.skills_hub as cli_hub
@@ -312,4 +367,3 @@ def test_do_search_json_flag_emits_full_identifiers(capsys):
     assert payload[0]["source"] == "browse-sh"
     # Table render must be suppressed — sink should be empty (no "Searching for:" header).
     assert "Searching for:" not in sink.getvalue()
-

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -68,6 +68,33 @@ def test_termux_skips_bundled_skill_sync_when_stamp_fresh(monkeypatch, tmp_path,
     assert calls == []
 
 
+def test_termux_stamp_reads_legacy_then_writes_external_state(
+    monkeypatch,
+    tmp_path,
+    main_mod,
+):
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setattr(main_mod, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        main_mod,
+        "_termux_bundled_skills_fingerprint",
+        lambda: "legacy-fp",
+    )
+    legacy = tmp_path / "skills" / ".termux_bundled_sync_stamp"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text("legacy-fp\n", encoding="utf-8")
+
+    assert main_mod._termux_bundled_skills_sync_needed() is False
+    assert not (tmp_path / "state").exists()
+
+    main_mod._mark_termux_bundled_skills_synced()
+
+    assert legacy.read_text(encoding="utf-8") == "legacy-fp\n"
+    assert (
+        tmp_path / "state" / "skills" / "termux-bundled-sync-stamp"
+    ).read_text(encoding="utf-8") == "legacy-fp\n"
+
+
 
 
 
@@ -282,7 +309,6 @@ def test_make_tui_argv_dev_prebuilds_hermes_ink(monkeypatch, main_mod, tmp_path)
     assert argv == [str(tsx), "src/entry.tsx"]
     assert cwd == tui_dir
     assert calls == [(["/usr/bin/npm", "run", "build"], str(ink_dir))]
-
 
 
 

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -234,12 +234,31 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
         "hermes_cli.tools_config",
         mod("hermes_cli.tools_config", _get_platform_tools=lambda *_args, **_kwargs: {"session_search"}),
     )
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.skill_commands",
+        mod(
+            "agent.skill_commands",
+            build_preloaded_skills_prompt=lambda skills: (
+                f"preloaded:{','.join(skills)}",
+                ["ticket-decomposition"],
+                [],
+            ),
+        ),
+    )
 
-    text, result = _run_agent("recall this")
+    text, result = _run_agent(
+        "recall this",
+        skills=["planning/ticket-decomposition"],
+    )
     assert text == "ok"
     assert not result.get("failed")
     assert captured["session_db"] is sentinel_db
     assert captured["enabled_toolsets"] == ["session_search"]
+    assert (
+        captured["ephemeral_system_prompt"]
+        == "preloaded:planning/ticket-decomposition"
+    )
     assert captured["prompt"] == "recall this"
 
 
@@ -309,6 +328,5 @@ def test_make_tui_argv_dev_prebuilds_hermes_ink(monkeypatch, main_mod, tmp_path)
     assert argv == [str(tsx), "src/entry.tsx"]
     assert cwd == tui_dir
     assert calls == [(["/usr/bin/npm", "run", "build"], str(ink_dir))]
-
 
 

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -1,6 +1,8 @@
 """Tests for hermes_constants module."""
 
 import os
+import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -17,6 +19,7 @@ from hermes_constants import (
     get_hermes_dir,
     get_hermes_home,
     get_process_hermes_home,
+    get_skills_state_dir,
     heal_hermes_managed_node,
     hermes_managed_node_tree_present,
     iter_hermes_node_dirs,
@@ -79,6 +82,38 @@ class TestGetHermesHome:
         monkeypatch.setattr(hermes_constants, "_profile_fallback_warned", False)
 
         assert get_hermes_home() == local_appdata / "hermes"
+
+    def test_skills_state_dir_tracks_context_override_without_io(self, tmp_path):
+        profile = tmp_path / "profile-a"
+        token = set_hermes_home_override(profile)
+        try:
+            assert get_skills_state_dir() == profile / "state" / "skills"
+            assert not profile.exists()
+        finally:
+            reset_hermes_home_override(token)
+
+    def test_skills_state_dir_fresh_import_is_side_effect_free(self, tmp_path):
+        profile = tmp_path / "fresh-profile"
+        env = {**os.environ, "HERMES_HOME": str(profile)}
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "from hermes_constants import get_skills_state_dir; "
+                    "print(get_skills_state_dir())"
+                ),
+            ],
+            cwd=Path(__file__).resolve().parents[1],
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.stdout.strip() == str(profile / "state" / "skills")
+        assert not profile.exists()
 
 
 class TestGetProcessHermesHome:

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -52,7 +53,10 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        mock_ops.write_file.assert_called_once_with(
+            str(Path("/tmp/out.txt").resolve()),
+            "hello world!\n",
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -143,7 +147,12 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once_with(
+            str(Path("/tmp/f.py").resolve()),
+            "foo",
+            "bar",
+            False,
+        )
 
 
     @patch("tools.file_tools._get_file_ops")

--- a/tests/tools/test_patch_parser.py
+++ b/tests/tools/test_patch_parser.py
@@ -5,8 +5,31 @@ from types import SimpleNamespace
 from tools.patch_parser import (
     OperationType,
     apply_v4a_operations,
+    extract_v4a_target_paths,
     parse_v4a_patch,
 )
+
+
+def test_target_extractor_uses_parser_boundaries_and_includes_move_endpoints():
+    patch = """\
+ignored before begin
+*** Delete File: ignored-before.txt
+*** Begin Patch
+***Update File: src/main.py
+*** Add File: src/new.py
+*** Delete File: src/old.py
+*** Move File: src/from.py -> src/to.py
+*** End Patch
+*** Delete File: ignored-after.txt
+"""
+
+    assert extract_v4a_target_paths(patch) == [
+        "src/main.py",
+        "src/new.py",
+        "src/old.py",
+        "src/from.py",
+        "src/to.py",
+    ]
 
 
 class TestParseUpdateFile:

--- a/tests/tools/test_skill_bundle_provenance.py
+++ b/tests/tools/test_skill_bundle_provenance.py
@@ -159,7 +159,11 @@ def test_real_temp_repo_and_home_install_e2e(served_repo, monkeypatch, tmp_path)
     assert (installed / "examples" / "endpoint-inventory.md").is_file()
     assert not (installed / "examples" / "not-installed.md").exists()
     assert (installed / "assets" / "logo.png").read_bytes() == b"\x89PNG\r\n\x1a\n\x00\xff"
-    entry = json.loads((home / "skills" / ".hub" / "lock.json").read_text())["installed"]["demo-bundle"]
+    entry = json.loads(
+        (
+            home / "state" / "skills" / "hub" / "lock.json"
+        ).read_text()
+    )["installed"]["demo-bundle"]
     assert entry["scan_provenance"]["source_url"] == url
     assert entry["scan_provenance"]["fresh"] is True
     assert "Scan provenance: fresh" in sink.getvalue()

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -175,6 +175,23 @@ class TestCreateSkill:
         assert "Invalid category '../escape'" in result["error"]
         assert not (tmp_path / "escape").exists()
 
+    def test_managed_read_only_refuses_before_creating_root(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        skills_dir = tmp_path / "skills"
+        monkeypatch.setattr(
+            "tools.skills_policy.skills_content_mode",
+            lambda: "read_only",
+        )
+        with _skill_dir(skills_dir):
+            result = _create_skill("managed-skill", VALID_SKILL_CONTENT)
+
+        assert result["success"] is False
+        assert "SKILLS_CONTENT_READ_ONLY" in result["error"]
+        assert not skills_dir.exists()
+
 
     def test_edit_long_desc_still_allowed_with_preview(self, tmp_path):
         """Edit/patch paths stay permissive so existing over-limit skills

--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -88,8 +88,39 @@ def test_get_record_missing_returns_empty_record(skills_home):
 
 def test_load_usage_handles_corrupt_file(skills_home):
     from tools.skill_usage import load_usage, _usage_file
+    _usage_file().parent.mkdir(parents=True, exist_ok=True)
     _usage_file().write_text("{ not json }", encoding="utf-8")
     assert load_usage() == {}
+
+
+def test_usage_writes_external_state_and_reads_legacy(skills_home):
+    from tools.skill_usage import load_usage, save_usage
+
+    legacy = skills_home / "skills" / ".usage.json"
+    legacy.write_text('{"legacy": {"use_count": 1}}', encoding="utf-8")
+    assert load_usage()["legacy"]["use_count"] == 1
+    assert not (skills_home / "state").exists()
+
+    save_usage({"new": {"use_count": 2}})
+    state_file = skills_home / "state" / "skills" / "usage.json"
+    assert state_file.exists()
+    assert load_usage()["new"]["use_count"] == 2
+
+
+def test_archive_refuses_before_content_mutation(skills_home, monkeypatch):
+    from tools import skill_usage
+
+    skill = _write_skill(skills_home / "skills", "managed-skill")
+    monkeypatch.setattr(
+        "tools.skills_policy.skills_content_mode",
+        lambda: "read_only",
+    )
+
+    ok, message = skill_usage.archive_skill("managed-skill")
+
+    assert ok is False
+    assert "SKILLS_CONTENT_READ_ONLY" in message
+    assert skill.exists()
 
 
 # ---------------------------------------------------------------------------
@@ -363,4 +394,3 @@ def test_adopt_rejects_empty_name(skills_home):
     from tools.skill_usage import adopt_skill
 
     assert adopt_skill("")[0] is False
-

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -27,6 +27,7 @@ from tools.skills_hub import (
     parallel_search_sources,
     unified_search,
     append_audit_log,
+    ensure_hub_dirs,
     quarantine_bundle,
 )
 
@@ -879,6 +880,143 @@ class TestQuarantineBundleBinaryAssets:
                 quarantine_bundle(bundle)
 
         assert not absolute_target.exists()
+
+
+def test_ensure_hub_dirs_migrates_legacy_state_without_modifying_source(
+    tmp_path,
+    monkeypatch,
+):
+    import tools.skills_hub as hub
+
+    skills = tmp_path / "skills"
+    legacy = skills / ".hub"
+    state = tmp_path / "state" / "skills" / "hub"
+    (legacy / "quarantine" / "pending").mkdir(parents=True)
+    (legacy / "index-cache").mkdir()
+    (legacy / "lock.json").write_text(
+        '{"version": 1, "installed": {"kept": {"install_path": "kept"}}}\n',
+        encoding="utf-8",
+    )
+    (legacy / "taps.json").write_text(
+        '{"taps": [{"repo": "owner/repo", "path": "skills/"}]}\n',
+        encoding="utf-8",
+    )
+    (legacy / "audit.log").write_text("legacy audit\n", encoding="utf-8")
+    (legacy / "quarantine" / "pending" / "SKILL.md").write_text(
+        "---\nname: pending\n---\n",
+        encoding="utf-8",
+    )
+    (legacy / "index-cache" / "cached.json").write_text(
+        '{"cached": true}\n',
+        encoding="utf-8",
+    )
+    before = {
+        path.relative_to(legacy).as_posix(): path.read_bytes()
+        for path in legacy.rglob("*")
+        if path.is_file()
+    }
+    monkeypatch.setattr(hub, "SKILLS_DIR", skills)
+    monkeypatch.setattr(hub, "HUB_DIR", state)
+    monkeypatch.setattr(hub, "LOCK_FILE", state / "lock.json")
+    monkeypatch.setattr(hub, "QUARANTINE_DIR", state / "quarantine")
+    monkeypatch.setattr(hub, "AUDIT_LOG", state / "audit.log")
+    monkeypatch.setattr(hub, "TAPS_FILE", state / "taps.json")
+    monkeypatch.setattr(hub, "INDEX_CACHE_DIR", state / "index-cache")
+
+    ensure_hub_dirs()
+
+    assert HubLockFile(state / "lock.json").get_installed("kept") is not None
+    assert TapsManager(state / "taps.json").list_taps() == [
+        {"repo": "owner/repo", "path": "skills/"}
+    ]
+    assert (state / "audit.log").read_text(encoding="utf-8") == "legacy audit\n"
+    assert (state / "quarantine" / "pending" / "SKILL.md").exists()
+    assert (state / "index-cache" / "cached.json").exists()
+    after = {
+        path.relative_to(legacy).as_posix(): path.read_bytes()
+        for path in legacy.rglob("*")
+        if path.is_file()
+    }
+    assert after == before
+
+
+def test_audit_append_preserves_legacy_log_before_first_external_write(
+    tmp_path,
+    monkeypatch,
+):
+    import tools.skills_hub as hub
+
+    skills = tmp_path / "skills"
+    legacy = skills / ".hub" / "audit.log"
+    state = tmp_path / "state" / "skills" / "hub"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text("legacy audit\n", encoding="utf-8")
+    monkeypatch.setattr(hub, "SKILLS_DIR", skills)
+    monkeypatch.setattr(hub, "HUB_DIR", state)
+    monkeypatch.setattr(hub, "AUDIT_LOG", state / "audit.log")
+
+    hub.append_audit_log(
+        "UNINSTALL",
+        "example",
+        "official",
+        "trusted",
+        "n/a",
+    )
+
+    assert legacy.read_text(encoding="utf-8") == "legacy audit\n"
+    external = (state / "audit.log").read_text(encoding="utf-8")
+    assert external.startswith("legacy audit\n")
+    assert "UNINSTALL example official:trusted n/a" in external
+
+
+def test_install_from_quarantine_refuses_managed_content_before_move(
+    tmp_path,
+    monkeypatch,
+):
+    import tools.skills_hub as hub
+    from tools.skills_guard import ScanResult
+
+    skills_dir = tmp_path / "skills"
+    quarantine_root = tmp_path / "state" / "skills" / "hub" / "quarantine"
+    pending = quarantine_root / "pending"
+    pending.mkdir(parents=True)
+    (pending / "SKILL.md").write_text(
+        "---\nname: managed-skill\ndescription: managed\n---\n",
+        encoding="utf-8",
+    )
+    bundle = SkillBundle(
+        name="managed-skill",
+        files={"SKILL.md": "---\nname: managed-skill\n---\n"},
+        source="official",
+        identifier="official/managed-skill",
+        trust_level="builtin",
+    )
+    result = ScanResult(
+        skill_name="managed-skill",
+        source="official",
+        trust_level="builtin",
+        verdict="safe",
+    )
+    monkeypatch.setattr(
+        "tools.skills_policy.skills_content_mode",
+        lambda: "read_only",
+    )
+
+    with (
+        patch.object(hub, "SKILLS_DIR", skills_dir),
+        patch.object(hub, "QUARANTINE_DIR", quarantine_root),
+        pytest.raises(RuntimeError, match="SKILLS_CONTENT_READ_ONLY"),
+    ):
+        hub.install_from_quarantine(
+            pending,
+            "managed-skill",
+            "",
+            bundle,
+            result,
+        )
+
+    assert pending.exists()
+    assert not (skills_dir / "managed-skill").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_skills_policy.py
+++ b/tests/tools/test_skills_policy.py
@@ -1,0 +1,236 @@
+"""Behavior tests for managed read-only skill content and external state."""
+
+from pathlib import Path
+
+import pytest
+
+
+def test_state_root_is_profile_scoped_and_side_effect_free(tmp_path, monkeypatch):
+    from hermes_constants import get_skills_dir, get_skills_state_dir
+
+    first = tmp_path / "profiles" / "first"
+    second = tmp_path / "profiles" / "second"
+
+    monkeypatch.setenv("HERMES_HOME", str(first))
+    assert get_skills_dir() == first / "skills"
+    assert get_skills_state_dir() == first / "state" / "skills"
+    assert not first.exists()
+
+    monkeypatch.setenv("HERMES_HOME", str(second))
+    assert get_skills_dir() == second / "skills"
+    assert get_skills_state_dir() == second / "state" / "skills"
+    assert not second.exists()
+
+
+def test_all_metadata_resolvers_follow_active_profile_without_io(
+    tmp_path,
+    monkeypatch,
+):
+    from agent import curator, curator_backup
+    from tools import skill_usage, skills_hub, skills_sync, skills_sync_client
+
+    for profile_name in ("alpha", "beta"):
+        home = tmp_path / "profiles" / profile_name
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        assert skills_hub._hub_dir() == home / "state" / "skills" / "hub"
+        assert skill_usage._usage_file() == home / "state" / "skills" / "usage.json"
+        assert skills_sync._manifest_file() == (
+            home / "state" / "skills" / "bundled-manifest"
+        )
+        assert skills_sync_client._sync_state_path() == (
+            home / "state" / "skills" / "sync" / "state.json"
+        )
+        assert curator._state_file() == (
+            home / "state" / "skills" / "curator-state.json"
+        )
+        assert curator_backup._backups_dir() == (
+            home / "state" / "skills" / "curator-backups"
+        )
+        assert not home.exists()
+
+
+def test_read_only_config_refuses_content_mutation(tmp_path, monkeypatch):
+    from tools.skills_policy import (
+        SKILLS_CONTENT_READ_ONLY,
+        SkillsContentPolicyError,
+        require_skills_content_writable,
+    )
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "skills:\n  content_mode: read_only\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    with pytest.raises(SkillsContentPolicyError, match=SKILLS_CONTENT_READ_ONLY):
+        require_skills_content_writable("test mutation")
+
+
+def test_missing_config_preserves_writable_default(tmp_path, monkeypatch):
+    from tools.skills_policy import skills_content_mode
+
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    assert skills_content_mode() == "writable"
+    # A policy read may resolve a path but must not initialize discovery or
+    # state. The normal writable mutator creates what it needs later.
+    assert not home.exists()
+
+
+def test_invalid_config_fails_closed_for_content_mutation(tmp_path, monkeypatch):
+    from tools.skills_policy import (
+        SKILLS_CONFIG_UNAVAILABLE,
+        SkillsContentPolicyError,
+        require_skills_content_writable,
+    )
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("skills: [unterminated\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    with pytest.raises(SkillsContentPolicyError, match=SKILLS_CONFIG_UNAVAILABLE):
+        require_skills_content_writable("test mutation")
+
+
+def test_unreadable_existing_config_fails_closed(tmp_path, monkeypatch):
+    from tools import skills_policy
+    from tools.skills_policy import (
+        SKILLS_CONFIG_UNAVAILABLE,
+        SkillsContentPolicyError,
+        require_skills_content_writable,
+    )
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    config_path = home / "config.yaml"
+    config_path.write_text(
+        "skills:\n  content_mode: writable\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(
+        skills_policy,
+        "_read_raw_policy_config",
+        lambda path: (_ for _ in ()).throw(PermissionError(str(path))),
+    )
+
+    with pytest.raises(SkillsContentPolicyError, match=SKILLS_CONFIG_UNAVAILABLE):
+        require_skills_content_writable("test mutation")
+
+    assert config_path.read_text(encoding="utf-8").endswith("writable\n")
+    assert not (home / "state").exists()
+
+
+def test_valid_config_on_read_only_filesystem_needs_no_policy_write(
+    tmp_path,
+    monkeypatch,
+):
+    from tools.skills_policy import skills_content_mode
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    config_path = home / "config.yaml"
+    config_path.write_text(
+        "skills:\n  content_mode: read_only\n",
+        encoding="utf-8",
+    )
+    config_path.chmod(0o444)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    assert skills_content_mode() == "read_only"
+    assert config_path.stat().st_mode & 0o222 == 0
+    assert not (home / "state").exists()
+
+
+def test_unrecognized_content_mode_fails_closed(tmp_path, monkeypatch):
+    from tools.skills_policy import (
+        SKILLS_CONFIG_UNAVAILABLE,
+        SkillsContentPolicyError,
+        require_skills_content_writable,
+    )
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "skills:\n  content_mode: sometimes\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    with pytest.raises(SkillsContentPolicyError, match=SKILLS_CONFIG_UNAVAILABLE):
+        require_skills_content_writable("test mutation")
+
+
+def test_state_reader_falls_back_without_migrating(tmp_path, monkeypatch):
+    from tools.skills_policy import state_read_path
+
+    home = tmp_path / ".hermes"
+    legacy = home / "skills" / ".usage.json"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    selected = state_read_path(("usage.json",), (".usage.json",))
+
+    assert selected == legacy
+    assert not (home / "state").exists()
+
+
+def test_legacy_migration_warning_is_once_per_source(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    from tools import skills_policy
+
+    home = tmp_path / ".hermes"
+    legacy = home / "skills" / ".usage.json"
+    state = home / "state" / "skills" / "usage.json"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    skills_policy._warned_legacy_sources.clear()
+
+    migration = skills_policy.prepare_legacy_state_write(state, legacy)
+    state.parent.mkdir(parents=True)
+    state.write_text("{}", encoding="utf-8")
+
+    with caplog.at_level("WARNING", logger="hermes.skills_state"):
+        skills_policy.note_legacy_state_write(migration)
+        skills_policy.note_legacy_state_write(migration)
+
+    messages = [
+        record.message
+        for record in caplog.records
+        if "Migrated legacy skills runtime metadata" in record.message
+    ]
+    assert len(messages) == 1
+    assert str(legacy) in messages[0]
+
+
+def test_legacy_migration_selects_first_existing_variadic_source(
+    tmp_path,
+    monkeypatch,
+):
+    from tools import skills_policy
+
+    home = tmp_path / ".hermes"
+    state = home / "state" / "skills" / "sync" / "state.json"
+    missing = home / "skills" / ".sync_state"
+    oldest = home / "skills" / ".sync_manifest"
+    oldest.parent.mkdir(parents=True)
+    oldest.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    migration = skills_policy.prepare_legacy_state_write(
+        state,
+        missing,
+        oldest,
+    )
+
+    assert migration == oldest

--- a/tests/tools/test_skills_policy.py
+++ b/tests/tools/test_skills_policy.py
@@ -1,6 +1,13 @@
-"""Behavior tests for managed read-only skill content and external state."""
+"""Behavior tests for managed read-only skill content and external state.
 
+The generic-writer cases intentionally use the real ``ShellFileOperations``
+backend. Mocking ``_get_file_ops`` would bypass the backend policy boundary
+these tests are required to prove.
+"""
+
+import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -67,6 +74,353 @@ def test_read_only_config_refuses_content_mutation(tmp_path, monkeypatch):
 
     with pytest.raises(SkillsContentPolicyError, match=SKILLS_CONTENT_READ_ONLY):
         require_skills_content_writable("test mutation")
+
+
+@pytest.fixture
+def read_only_skill_content(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    skill = home / "skills" / "planning" / "ticket-decomposition"
+    skill.mkdir(parents=True)
+    target = skill / "SKILL.md"
+    target.write_text("original\n", encoding="utf-8")
+    (home / "config.yaml").write_text(
+        "skills:\n  content_mode: read_only\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home, target
+
+
+def _assert_read_only_tool_result(result_json: str) -> None:
+    from tools.skills_policy import SKILLS_CONTENT_READ_ONLY
+
+    result = json.loads(result_json)
+    assert SKILLS_CONTENT_READ_ONLY in result["error"]
+
+
+def test_generic_write_file_refuses_managed_content_before_mutation(
+    read_only_skill_content,
+):
+    from tools.file_tools import write_file_tool
+
+    _home, target = read_only_skill_content
+    before = target.read_bytes()
+
+    _assert_read_only_tool_result(write_file_tool(str(target), "overwritten\n"))
+
+    assert target.read_bytes() == before
+
+
+def test_generic_write_policy_precedes_backend_dispatch(
+    read_only_skill_content,
+):
+    from tools.file_tools import write_file_tool
+
+    _home, target = read_only_skill_content
+    with patch("tools.file_tools._get_file_ops") as get_file_ops:
+        _assert_read_only_tool_result(
+            write_file_tool(str(target), "overwritten\n")
+        )
+
+    get_file_ops.assert_not_called()
+    assert target.read_text(encoding="utf-8") == "original\n"
+
+
+def test_generic_write_absolute_fallback_policy_precedes_backend_dispatch(
+    read_only_skill_content,
+):
+    from tools.file_tools import write_file_tool
+
+    _home, target = read_only_skill_content
+    with (
+        patch(
+            "tools.file_tools._resolve_path_for_task",
+            side_effect=PermissionError("resolver unavailable"),
+        ),
+        patch("tools.file_tools._get_file_ops") as get_file_ops,
+    ):
+        _assert_read_only_tool_result(
+            write_file_tool(str(target), "overwritten\n")
+        )
+
+    get_file_ops.assert_not_called()
+    assert target.read_text(encoding="utf-8") == "original\n"
+
+
+def test_generic_patch_replace_refuses_managed_content_before_mutation(
+    read_only_skill_content,
+):
+    from tools.file_tools import patch_tool
+
+    _home, target = read_only_skill_content
+    before = target.read_bytes()
+
+    _assert_read_only_tool_result(
+        patch_tool(
+            mode="replace",
+            path=str(target),
+            old_string="original",
+            new_string="overwritten",
+        )
+    )
+
+    assert target.read_bytes() == before
+
+
+@pytest.mark.parametrize("mode", ["replace", "patch"])
+def test_generic_patch_policy_precedes_backend_dispatch(
+    read_only_skill_content,
+    mode,
+):
+    from tools.file_tools import patch_tool
+
+    _home, target = read_only_skill_content
+    kwargs = (
+        {
+            "mode": "replace",
+            "path": str(target),
+            "old_string": "original",
+            "new_string": "overwritten",
+        }
+        if mode == "replace"
+        else {
+            "mode": "patch",
+            "patch": (
+                "*** Begin Patch\n"
+                f"*** Update File: {target}\n"
+                "@@\n"
+                "-original\n"
+                "+overwritten\n"
+                "*** End Patch\n"
+            ),
+        }
+    )
+    with patch("tools.file_tools._get_file_ops") as get_file_ops:
+        _assert_read_only_tool_result(patch_tool(**kwargs))
+
+    get_file_ops.assert_not_called()
+    assert target.read_text(encoding="utf-8") == "original\n"
+
+
+@pytest.mark.parametrize(
+    "operation",
+    ["update", "add", "delete", "move_source", "move_destination"],
+)
+def test_generic_v4a_refuses_every_operation_type_before_mutation(
+    read_only_skill_content,
+    tmp_path,
+    operation,
+):
+    from tools.file_tools import patch_tool
+
+    home, target = read_only_skill_content
+    added = home / "skills" / "added.md"
+    outside = tmp_path / "outside.md"
+    outside.write_text("outside\n", encoding="utf-8")
+    if operation == "update":
+        body = (
+            f"*** Update File: {target}\n"
+            "@@\n"
+            "-original\n"
+            "+overwritten\n"
+        )
+    elif operation == "add":
+        body = f"*** Add File: {added}\n+added\n"
+    elif operation == "delete":
+        body = f"*** Delete File: {target}\n"
+    elif operation == "move_source":
+        body = f"*** Move File: {target} -> {outside}\n"
+    else:
+        body = f"*** Move File: {outside} -> {added}\n"
+    patch = f"*** Begin Patch\n{body}*** End Patch\n"
+    target_before = target.read_bytes()
+    outside_before = outside.read_bytes()
+
+    _assert_read_only_tool_result(patch_tool(mode="patch", patch=patch))
+
+    assert target.read_bytes() == target_before
+    assert outside.read_bytes() == outside_before
+    assert not added.exists()
+
+
+def test_generic_v4a_preflights_all_targets_before_any_mutation(
+    read_only_skill_content,
+    tmp_path,
+):
+    from tools.file_tools import patch_tool
+
+    _home, target = read_only_skill_content
+    outside = tmp_path / "outside-created.md"
+    target_before = target.read_bytes()
+    patch = (
+        "*** Begin Patch\n"
+        f"*** Add File: {outside}\n"
+        "+outside\n"
+        f"*** Update File: {target}\n"
+        "@@\n"
+        "-original\n"
+        "+overwritten\n"
+        "*** End Patch\n"
+    )
+
+    _assert_read_only_tool_result(patch_tool(mode="patch", patch=patch))
+
+    assert not outside.exists()
+    assert target.read_bytes() == target_before
+
+
+def test_backend_v4a_policy_runs_before_parser(
+    read_only_skill_content,
+):
+    from tools.environments.local import LocalEnvironment
+    from tools.file_operations import ShellFileOperations
+    from tools.skills_policy import SKILLS_CONTENT_READ_ONLY
+
+    home, target = read_only_skill_content
+    operations = ShellFileOperations(LocalEnvironment(cwd=str(home)))
+    patch_text = (
+        "*** Begin Patch\n"
+        f"*** Update File: {target}\n"
+        "@@\n"
+        "-original\n"
+        "+overwritten\n"
+        "*** End Patch\n"
+    )
+    with patch(
+        "tools.patch_parser.parse_v4a_patch",
+        side_effect=AssertionError("parser must not run before policy"),
+    ) as parser:
+        result = operations.patch_v4a(patch_text)
+
+    assert SKILLS_CONTENT_READ_ONLY in result.error
+    parser.assert_not_called()
+    assert target.read_text(encoding="utf-8") == "original\n"
+
+
+def test_generic_write_refuses_resolved_alias_into_managed_content(
+    read_only_skill_content,
+    tmp_path,
+):
+    from tools.file_tools import write_file_tool
+
+    home, _target = read_only_skill_content
+    alias = tmp_path / "skills-alias"
+    try:
+        alias.symlink_to(home / "skills", target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlink unavailable: {exc}")
+    target = alias / "alias-created.md"
+
+    _assert_read_only_tool_result(write_file_tool(str(target), "blocked\n"))
+
+    assert not target.exists()
+
+
+def test_generic_write_allows_relocated_runtime_state_via_normalized_path(
+    read_only_skill_content,
+):
+    from tools.file_tools import write_file_tool
+
+    home, _target = read_only_skill_content
+    state = home / "skills" / ".." / "state" / "skills" / "runtime.txt"
+
+    result = json.loads(write_file_tool(str(state), "runtime\n"))
+
+    assert not result.get("error"), result
+    assert (
+        home / "state" / "skills" / "runtime.txt"
+    ).read_text(encoding="utf-8") == "runtime\n"
+
+
+def test_relative_backend_path_uses_backend_cwd_for_policy(
+    read_only_skill_content,
+):
+    from tools.environments.local import LocalEnvironment
+    from tools.file_operations import ShellFileOperations
+    from tools.skills_policy import SKILLS_CONTENT_READ_ONLY
+
+    home, target = read_only_skill_content
+    before = target.read_bytes()
+    operations = ShellFileOperations(
+        LocalEnvironment(cwd=str(home)),
+        cwd=str(home),
+    )
+
+    result = operations.write_file(
+        "skills/planning/ticket-decomposition/SKILL.md",
+        "overwritten\n",
+    )
+
+    assert SKILLS_CONTENT_READ_ONLY in result.error
+    assert target.read_bytes() == before
+
+
+def test_backend_delete_refuses_managed_content(
+    read_only_skill_content,
+):
+    from tools.environments.local import LocalEnvironment
+    from tools.file_operations import ShellFileOperations
+    from tools.skills_policy import SKILLS_CONTENT_READ_ONLY
+
+    home, target = read_only_skill_content
+    operations = ShellFileOperations(LocalEnvironment(cwd=str(home)))
+    before = target.read_bytes()
+
+    result = operations.delete_file(str(target))
+
+    assert SKILLS_CONTENT_READ_ONLY in result.error
+    assert target.read_bytes() == before
+
+
+@pytest.mark.parametrize("managed_endpoint", ["source", "destination"])
+def test_backend_move_refuses_each_managed_endpoint(
+    read_only_skill_content,
+    tmp_path,
+    managed_endpoint,
+):
+    from tools.environments.local import LocalEnvironment
+    from tools.file_operations import ShellFileOperations
+    from tools.skills_policy import SKILLS_CONTENT_READ_ONLY
+
+    home, managed = read_only_skill_content
+    outside = tmp_path / "outside.md"
+    outside.write_text("outside\n", encoding="utf-8")
+    operations = ShellFileOperations(LocalEnvironment(cwd=str(home)))
+    source, destination = (
+        (managed, outside)
+        if managed_endpoint == "source"
+        else (outside, home / "skills" / "moved.md")
+    )
+    managed_before = managed.read_bytes()
+    outside_before = outside.read_bytes()
+
+    result = operations.move_file(str(source), str(destination))
+
+    assert SKILLS_CONTENT_READ_ONLY in result.error
+    assert managed.read_bytes() == managed_before
+    assert outside.read_bytes() == outside_before
+    assert not (home / "skills" / "moved.md").exists()
+
+
+def test_generic_write_file_preserves_writable_skill_content(
+    tmp_path,
+    monkeypatch,
+):
+    from tools.file_tools import write_file_tool
+
+    home = tmp_path / ".hermes"
+    target = home / "skills" / "local" / "SKILL.md"
+    target.parent.mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        "skills:\n  content_mode: writable\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = json.loads(write_file_tool(str(target), "writable\n"))
+
+    assert not result.get("error"), result
+    assert target.read_text(encoding="utf-8") == "writable\n"
 
 
 def test_missing_config_preserves_writable_default(tmp_path, monkeypatch):

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -50,6 +50,41 @@ class TestReadWriteManifest:
         assert result == {"old-skill": "", "new-skill": "abc123"}
 
 
+def test_sync_read_only_skips_before_creating_content(tmp_path):
+    skills_dir = tmp_path / "skills"
+    with (
+        patch("tools.skills_sync.SKILLS_DIR", skills_dir),
+        patch("tools.skills_sync.HERMES_HOME", tmp_path),
+        patch("tools.skills_policy.skills_content_mode", return_value="read_only"),
+    ):
+        result = sync_skills(quiet=True)
+
+    assert result["skipped_read_only"] is True
+    assert not skills_dir.exists()
+
+
+def test_restore_backup_state_preserves_legacy_directory(tmp_path):
+    from tools import skills_sync
+
+    skills = tmp_path / "skills"
+    state = tmp_path / "state" / "skills"
+    legacy_file = skills / ".restore-backups" / "old" / "SKILL.md"
+    legacy_file.parent.mkdir(parents=True)
+    legacy_file.write_text("legacy backup\n", encoding="utf-8")
+
+    with (
+        patch("tools.skills_sync.SKILLS_DIR", skills),
+        patch("tools.skills_sync.get_skills_state_dir", return_value=state),
+    ):
+        destination = skills_sync._prepare_restore_backups_dir()
+
+    assert destination == state / "restore-backups"
+    assert (
+        destination / "old" / "SKILL.md"
+    ).read_text(encoding="utf-8") == "legacy backup\n"
+    assert legacy_file.read_text(encoding="utf-8") == "legacy backup\n"
+
+
 class TestDirHash:
     def test_hash_reflects_content_only(self, tmp_path):
         dir_a = tmp_path / "a"

--- a/tests/tools/test_skills_sync_client.py
+++ b/tests/tools/test_skills_sync_client.py
@@ -24,6 +24,98 @@ import pytest
 import tools.skills_sync_client as ssc
 
 
+def test_pull_refuses_managed_content_before_network_or_root_creation(
+    tmp_path,
+    monkeypatch,
+):
+    skills = tmp_path / "skills"
+
+    class _ClientMustNotRun:
+        def capabilities(self):
+            raise AssertionError("read-only refusal must precede network access")
+
+    monkeypatch.setattr(ssc, "_skills_dir", lambda: skills)
+    monkeypatch.setattr(
+        "tools.skills_policy.skills_content_mode",
+        lambda: "read_only",
+    )
+
+    with pytest.raises(RuntimeError, match="SKILLS_CONTENT_READ_ONLY"):
+        ssc.pull_skills(
+            _ClientMustNotRun(),
+            identity={"owner": "managed", "api_key": "unused"},
+        )
+
+    assert not skills.exists()
+
+
+def test_materialize_tree_cannot_bypass_managed_content_policy(
+    tmp_path,
+    monkeypatch,
+):
+    destination = tmp_path / "skills" / "managed"
+
+    class _ClientMustNotRun:
+        def get_tree_json(self, _tree_hash):
+            raise AssertionError("materialization must refuse before tree fetch")
+
+    monkeypatch.setattr(
+        "tools.skills_policy.skills_content_mode",
+        lambda: "read_only",
+    )
+
+    with pytest.raises(RuntimeError, match="SKILLS_CONTENT_READ_ONLY"):
+        ssc.materialize_tree(_ClientMustNotRun(), "sha256:unused", destination)
+
+    assert not destination.exists()
+
+
+def test_legacy_sync_state_reads_without_migration_then_writes_external_state(
+    tmp_path,
+    monkeypatch,
+):
+    skills = tmp_path / "skills"
+    state = tmp_path / "state" / "skills"
+    skills.mkdir()
+    legacy = skills / ".sync_manifest"
+    legacy.write_text(
+        '{"head": "sha256:legacy", "skills": {"alpha": {"tree": "t"}}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ssc, "_skills_dir", lambda: skills)
+    monkeypatch.setattr(ssc, "_skills_state_dir", lambda: state)
+
+    loaded = ssc.read_sync_state()
+
+    assert loaded["head"] == "sha256:legacy"
+    assert not state.exists()
+    ssc.write_sync_state({**loaded, "head": "sha256:new"})
+
+    assert legacy.exists()
+    assert (state / "sync" / "manifest.json").exists()
+    assert json.loads((state / "sync" / "state.json").read_text())["head"] == (
+        "sha256:new"
+    )
+
+
+def test_external_empty_org_marker_masks_legacy_marker(tmp_path, monkeypatch):
+    from agent.skill_utils import ORG_ACTIVE_MARKER, read_active_org_id
+
+    skills = tmp_path / "skills"
+    state = tmp_path / "state" / "skills"
+    legacy_marker = skills / ssc.ORG_DIR_NAME / ORG_ACTIVE_MARKER
+    legacy_marker.parent.mkdir(parents=True)
+    legacy_marker.write_text("old-org", encoding="utf-8")
+    monkeypatch.setattr(ssc, "_skills_dir", lambda: skills)
+    monkeypatch.setattr(ssc, "_skills_state_dir", lambda: state)
+
+    assert read_active_org_id(skills) == "old-org"
+    ssc._clear_active_org_marker()
+
+    assert legacy_marker.read_text(encoding="utf-8") == "old-org"
+    assert read_active_org_id(skills) is None
+
+
 # ---------------------------------------------------------------------------
 # In-process mock sync server (read + write endpoints)
 # ---------------------------------------------------------------------------
@@ -785,6 +877,7 @@ class TestEnvConfig:
 class TestDeviceName:
     def test_default_is_hostname_seeded(self, tmp_path, monkeypatch):
         monkeypatch.setattr(ssc, "_skills_dir", lambda: tmp_path)
+        monkeypatch.setattr(ssc, "_skills_state_dir", lambda: tmp_path)
         monkeypatch.delenv("HERMES_SYNC_DEVICE_NAME", raising=False)
         monkeypatch.setattr(
             "socket.gethostname", lambda: "bens-macbook.local", raising=False
@@ -794,7 +887,7 @@ class TestDeviceName:
         assert val.startswith("bens-macbook-")
         assert val != "bens-macbook-"
         # persisted + stable across calls
-        assert (tmp_path / ".sync_device_id").read_text() == val
+        assert (tmp_path / "sync" / "device-id").read_text() == val
         assert ssc.stable_device_id() == val
 
     def test_existing_file_wins_over_default_and_env(self, tmp_path, monkeypatch):
@@ -806,10 +899,11 @@ class TestDeviceName:
     def test_env_seeds_first_use(self, tmp_path, monkeypatch):
         # Hermes Cloud path: HERMES_SYNC_DEVICE_NAME seeds the first-use label.
         monkeypatch.setattr(ssc, "_skills_dir", lambda: tmp_path)
+        monkeypatch.setattr(ssc, "_skills_state_dir", lambda: tmp_path)
         monkeypatch.setenv("HERMES_SYNC_DEVICE_NAME", "hermes-cloud-ben-1")
         assert ssc.stable_device_id() == "hermes-cloud-ben-1"
         # persisted so it stays stable even if the env later changes
-        assert (tmp_path / ".sync_device_id").read_text() == "hermes-cloud-ben-1"
+        assert (tmp_path / "sync" / "device-id").read_text() == "hermes-cloud-ben-1"
         monkeypatch.setenv("HERMES_SYNC_DEVICE_NAME", "changed")
         assert ssc.stable_device_id() == "hermes-cloud-ben-1"
 

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -258,14 +258,14 @@ class TestFindAllSkills:
 
 
 class TestSkillsList:
-    def test_empty_creates_directory(self, tmp_path):
+    def test_empty_does_not_create_directory(self, tmp_path):
         skills_dir = tmp_path / "skills"
         with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
             raw = skills_list()
         result = json.loads(raw)
         assert result["success"] is True
         assert result["skills"] == []
-        assert skills_dir.exists()
+        assert not skills_dir.exists()
 
     def test_category_filter(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
@@ -277,6 +277,37 @@ class TestSkillsList:
         assert all_result["count"] == 2
         assert filtered["count"] == 1
         assert filtered["skills"][0]["name"] == "skill-a"
+
+    def test_lists_nested_ticket_decomposition_without_mutation(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        nested = skills_dir / "planning" / "ticket-decomposition"
+        nested.mkdir(parents=True)
+        (nested / "SKILL.md").write_text(
+            "---\n"
+            "name: ticket-decomposition\n"
+            "description: Split work into tickets.\n"
+            "---\n",
+            encoding="utf-8",
+        )
+        before = {
+            path.relative_to(skills_dir).as_posix(): path.read_bytes()
+            for path in skills_dir.rglob("*")
+            if path.is_file()
+        }
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            result = json.loads(skills_list())
+
+        assert [skill["name"] for skill in result["skills"]] == [
+            "ticket-decomposition"
+        ]
+        assert result["skills"][0]["category"] == "planning"
+        after = {
+            path.relative_to(skills_dir).as_posix(): path.read_bytes()
+            for path in skills_dir.rglob("*")
+            if path.is_file()
+        }
+        assert after == before
 
     def test_category_filter_finds_symlinked_category(self, tmp_path):
         external_root = tmp_path / "repo"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -957,6 +957,43 @@ class ShellFileOperations(FileOperations):
                         return user_home + suffix
         
         return path
+
+    def _mutation_policy_error(
+        self,
+        path: str,
+        operation: str,
+        *,
+        verb: str = "Write",
+    ) -> Optional[str]:
+        """Run every path-level refusal shared by backend mutators.
+
+        Generic file tools and V4A operations all converge on this backend,
+        so enforcing the policy here also covers future callers that reuse the
+        existing file-operation interface. Every implementation of a new
+        write-capable ``FileOperations`` method must enter through this
+        preflight before its first mutation.
+        """
+        from tools.skills_policy import (
+            SkillsContentPolicyError,
+            require_skills_path_writable,
+        )
+
+        policy_path = self._expand_path(path) if path.startswith("~") else path
+        denied = get_write_denied_error(policy_path, verb=verb)
+        if denied:
+            return denied
+
+        if not os.path.isabs(policy_path):
+            effective_cwd = getattr(self.env, "cwd", None) or self.cwd
+            effective_cwd = os.path.abspath(os.path.expanduser(effective_cwd))
+            policy_path = os.path.normpath(
+                os.path.join(effective_cwd, policy_path)
+            )
+        try:
+            require_skills_path_writable(policy_path, operation)
+        except SkillsContentPolicyError as exc:
+            return str(exc)
+        return None
     
     def _escape_shell_arg(self, arg: str) -> str:
         """Escape a string for safe use in shell commands.
@@ -1290,9 +1327,13 @@ class ShellFileOperations(FileOperations):
 
     def _python_delete(self, path: str, recursive: bool) -> WriteResult:
         path = self._expand_path(path)
-        denied = get_write_denied_error(path, verb="Delete")
-        if denied:
-            return WriteResult(error=denied)
+        policy_error = self._mutation_policy_error(
+            path,
+            "delete",
+            verb="Delete",
+        )
+        if policy_error:
+            return WriteResult(error=policy_error)
 
         # We can't shell out to ``rm`` here — it doesn't exist on Windows
         # ``cmd.exe`` or PowerShell, so this code path is what's left when
@@ -1337,9 +1378,13 @@ class ShellFileOperations(FileOperations):
         src = self._expand_path(src)
         dst = self._expand_path(dst)
         for p in (src, dst):
-            denied = get_write_denied_error(p, verb="Move")
-            if denied:
-                return WriteResult(error=denied)
+            policy_error = self._mutation_policy_error(
+                p,
+                "move",
+                verb="Move",
+            )
+            if policy_error:
+                return WriteResult(error=policy_error)
         result = self._exec(
             f"mv {self._escape_shell_arg(src)} {self._escape_shell_arg(dst)}"
         )
@@ -1385,10 +1430,9 @@ class ShellFileOperations(FileOperations):
         # Expand ~ and other shell paths
         path = self._expand_path(path)
 
-        # Block writes to sensitive paths
-        denied = get_write_denied_error(path)
-        if denied:
-            return WriteResult(error=denied)
+        policy_error = self._mutation_policy_error(path, "write_file")
+        if policy_error:
+            return WriteResult(error=policy_error)
 
         # ── Fail-closed pre-write syntax gate ───────────────────────────
         # Validate the CANDIDATE content BEFORE any bytes touch disk —
@@ -1569,10 +1613,9 @@ class ShellFileOperations(FileOperations):
         # Expand ~ and other shell paths
         path = self._expand_path(path)
 
-        # Block writes to sensitive paths
-        denied = get_write_denied_error(path)
-        if denied:
-            return PatchResult(error=denied)
+        policy_error = self._mutation_policy_error(path, "patch")
+        if policy_error:
+            return PatchResult(error=policy_error)
 
         # Read current content
         read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
@@ -1695,9 +1738,20 @@ class ShellFileOperations(FileOperations):
         Returns:
             PatchResult with changes made
         """
-        # Import patch parser
-        from tools.patch_parser import parse_v4a_patch, apply_v4a_operations
-        
+        # Preflight targets with the parser's shared pure extractor before
+        # parsing or applying anything. This preserves all-target atomicity
+        # even if a future parser path performs setup before returning ops.
+        from tools.patch_parser import (
+            apply_v4a_operations,
+            extract_v4a_target_paths,
+            parse_v4a_patch,
+        )
+
+        for target in extract_v4a_target_paths(patch_content):
+            policy_error = self._mutation_policy_error(target, "patch")
+            if policy_error:
+                return PatchResult(error=policy_error)
+
         operations, parse_error = parse_v4a_patch(patch_content)
         if parse_error:
             return PatchResult(error=f"Failed to parse patch: {parse_error}")

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -726,6 +726,49 @@ def _is_expected_write_exception(exc: Exception) -> bool:
     return False
 
 
+def _check_skills_content_write(
+    path: str,
+    task_id: str,
+    operation: str,
+) -> str | None:
+    """Preflight managed content before dispatch to any file backend."""
+    from tools.skills_policy import (
+        SkillsContentPolicyError,
+        require_skills_path_writable,
+    )
+
+    try:
+        resolved = str(_resolve_path_for_task(path, task_id))
+    except Exception:
+        # An absolute caller path still carries enough identity for the policy
+        # even when task/workspace resolution fails. Only unresolved relative
+        # paths must defer to the backend, which has the live environment cwd
+        # and repeats this same check before mutation.
+        candidate = _expand_tilde(path)
+        if _uses_container_paths(task_id):
+            if not posixpath.isabs(candidate):
+                return None
+            resolved = posixpath.normpath(candidate)
+        elif sys.platform == "win32":
+            import ntpath
+
+            from tools.environments.local import _msys_to_windows_path
+
+            candidate = _msys_to_windows_path(candidate)
+            if not ntpath.isabs(candidate):
+                return None
+            resolved = ntpath.normpath(candidate)
+        else:
+            if not os.path.isabs(candidate):
+                return None
+            resolved = os.path.normpath(candidate)
+    try:
+        require_skills_path_writable(resolved, operation)
+    except SkillsContentPolicyError as exc:
+        return str(exc)
+    return None
+
+
 _file_ops_lock = threading.Lock()
 _file_ops_cache: dict = {}
 
@@ -1594,6 +1637,14 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
         except Exception:
             _resolved = None
 
+        policy_error = _check_skills_content_write(
+            _resolved or path,
+            task_id,
+            "write_file",
+        )
+        if policy_error:
+            return tool_error(policy_error)
+
         if _resolved is None:
             stale_warning = _check_file_staleness(path, task_id)
             file_ops = _get_file_ops(task_id)
@@ -1659,8 +1710,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
     if path:
         _paths_to_check.append(path)
     if mode == "patch" and patch:
-        import re as _re
+        from tools.patch_parser import extract_v4a_target_paths
         from tools.path_security import has_traversal_component
+
         def _reject_v4a_traversal(v4a_path: str) -> str | None:
             # V4A path headers come from patch CONTENT, not the explicit
             # ``path=`` arg — so they're more attacker-influenceable (skill
@@ -1679,26 +1731,11 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 )
             return None
 
-        # ``\s*`` (not ``\s+``) after ``***`` matches patch_parser leniency:
-        # it accepts ``***Update File:`` with no space after the asterisks
-        # (patch_parser.py uses ``\*\*\*\s*Update\s+File:``). Requiring a space
-        # here let a no-space header parse + apply while skipping this check.
-        for _m in _re.finditer(r'^\*\*\*\s*(?:Update|Add|Delete)\s+File:\s*(.+)$', patch, _re.MULTILINE):
-            v4a_path = _m.group(1).strip()
+        for v4a_path in extract_v4a_target_paths(patch):
             _err = _reject_v4a_traversal(v4a_path)
             if _err:
                 return _err
             _paths_to_check.append(v4a_path)
-        # ``*** Move File: src -> dst`` is a valid V4A op (patch_parser.py:114)
-        # but was never extracted, so a Move targeting /etc/crontab skipped the
-        # sensitive-path pre-check. Check BOTH endpoints, and run them through
-        # the same ``..`` traversal rejection as the other headers.
-        for _m in _re.finditer(r'^\*\*\*\s*Move\s+File:\s*(.+?)\s*->\s*(.+)$', patch, _re.MULTILINE):
-            for v4a_path in (_m.group(1).strip(), _m.group(2).strip()):
-                _err = _reject_v4a_traversal(v4a_path)
-                if _err:
-                    return _err
-                _paths_to_check.append(v4a_path)
     for _p in _paths_to_check:
         sensitive_err = _check_sensitive_path(_p, task_id)
         if sensitive_err:
@@ -1712,12 +1749,21 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         # callers lock in the same order — prevents deadlock on overlapping
         # multi-file V4A patches.
         _resolved_paths: list[str] = []
+        _path_to_resolved: dict[str, str | None] = {}
         _seen: set[str] = set()
         for _p in _paths_to_check:
             try:
                 _r = str(_resolve_path_for_task(_p, task_id))
             except Exception:
                 _r = None
+            _path_to_resolved[_p] = _r
+            policy_error = _check_skills_content_write(
+                _r or _p,
+                task_id,
+                "patch",
+            )
+            if policy_error:
+                return tool_error(policy_error)
             if _r and _r not in _seen:
                 _resolved_paths.append(_r)
                 _seen.add(_r)
@@ -1734,13 +1780,8 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             # Collect warnings — cross-agent registry first (names sibling),
             # then per-task tracker as a fallback.
             stale_warnings: list[str] = []
-            _path_to_resolved: dict[str, str] = {}
             for _p in _paths_to_check:
-                try:
-                    _r = str(_resolve_path_for_task(_p, task_id))
-                except Exception:
-                    _r = None
-                _path_to_resolved[_p] = _r
+                _r = _path_to_resolved[_p]
                 _cross = file_state.check_stale(task_id, _r) if _r else None
                 _sw = _cross or _check_file_staleness(_p, task_id)
                 if not _sw and _r:

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -35,6 +35,14 @@ from typing import List, Optional, Tuple, Any
 from enum import Enum
 
 
+_UPDATE_FILE_PATTERN = re.compile(r'\*\*\*\s*Update\s+File:\s*(.+)')
+_ADD_FILE_PATTERN = re.compile(r'\*\*\*\s*Add\s+File:\s*(.+)')
+_DELETE_FILE_PATTERN = re.compile(r'\*\*\*\s*Delete\s+File:\s*(.+)')
+_MOVE_FILE_PATTERN = re.compile(
+    r'\*\*\*\s*Move\s+File:\s*(.+?)\s*->\s*(.+)'
+)
+
+
 class OperationType(Enum):
     ADD = "add"
     UPDATE = "update"
@@ -66,6 +74,57 @@ class PatchOperation:
     content: Optional[str] = None  # For add file operations
 
 
+def _patch_bounds(lines: List[str]) -> Tuple[int, int]:
+    """Return the parser's inclusive-start/exclusive-end patch boundaries."""
+    start_idx = None
+    end_idx = None
+    for i, line in enumerate(lines):
+        if '*** Begin Patch' in line or '***Begin Patch' in line:
+            start_idx = i
+        elif '*** End Patch' in line or '***End Patch' in line:
+            end_idx = i
+            break
+    return (
+        -1 if start_idx is None else start_idx,
+        len(lines) if end_idx is None else end_idx,
+    )
+
+
+def extract_v4a_target_paths(patch_content: str) -> List[str]:
+    """Extract every mutation target without parsing or touching the filesystem.
+
+    This intentionally shares marker patterns and boundaries with
+    :func:`parse_v4a_patch` so policy callers can preflight every target before
+    parser work or the first mutation. Move operations contribute both their
+    source and destination.
+    """
+    lines = patch_content.split('\n')
+    start_idx, end_idx = _patch_bounds(lines)
+    targets: List[str] = []
+
+    for line in lines[start_idx + 1:end_idx]:
+        move_match = _MOVE_FILE_PATTERN.match(line)
+        if move_match:
+            targets.extend(
+                [
+                    move_match.group(1).strip(),
+                    move_match.group(2).strip(),
+                ]
+            )
+            continue
+        for pattern in (
+            _UPDATE_FILE_PATTERN,
+            _ADD_FILE_PATTERN,
+            _DELETE_FILE_PATTERN,
+        ):
+            match = pattern.match(line)
+            if match:
+                targets.append(match.group(1).strip())
+                break
+
+    return targets
+
+
 def parse_v4a_patch(patch_content: str) -> Tuple[List[PatchOperation], Optional[str]]:
     """
     Parse a V4A format patch.
@@ -81,23 +140,7 @@ def parse_v4a_patch(patch_content: str) -> Tuple[List[PatchOperation], Optional[
     lines = patch_content.split('\n')
     operations: List[PatchOperation] = []
     
-    # Find patch boundaries
-    start_idx = None
-    end_idx = None
-    
-    for i, line in enumerate(lines):
-        if '*** Begin Patch' in line or '***Begin Patch' in line:
-            start_idx = i
-        elif '*** End Patch' in line or '***End Patch' in line:
-            end_idx = i
-            break
-    
-    if start_idx is None:
-        # Try to parse without explicit begin marker
-        start_idx = -1
-    
-    if end_idx is None:
-        end_idx = len(lines)
+    start_idx, end_idx = _patch_bounds(lines)
     
     # Parse operations between boundaries
     i = start_idx + 1
@@ -108,10 +151,10 @@ def parse_v4a_patch(patch_content: str) -> Tuple[List[PatchOperation], Optional[
         line = lines[i]
         
         # Check for file operation markers
-        update_match = re.match(r'\*\*\*\s*Update\s+File:\s*(.+)', line)
-        add_match = re.match(r'\*\*\*\s*Add\s+File:\s*(.+)', line)
-        delete_match = re.match(r'\*\*\*\s*Delete\s+File:\s*(.+)', line)
-        move_match = re.match(r'\*\*\*\s*Move\s+File:\s*(.+?)\s*->\s*(.+)', line)
+        update_match = _UPDATE_FILE_PATTERN.match(line)
+        add_match = _ADD_FILE_PATTERN.match(line)
+        delete_match = _DELETE_FILE_PATTERN.match(line)
+        move_match = _MOVE_FILE_PATTERN.match(line)
         
         if update_match:
             # Save previous operation

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -907,11 +907,14 @@ def _add_description_prompt_preview(result: Dict[str, Any], content: str) -> Non
 
 def _content_write_refusal(operation: str) -> Optional[Dict[str, Any]]:
     """Return a stable tool error when discovery content is managed read-only."""
-    from tools.skills_policy import require_skills_content_writable
+    from tools.skills_policy import (
+        SkillsContentPolicyError,
+        require_skills_content_writable,
+    )
 
     try:
         require_skills_content_writable(operation)
-    except RuntimeError as exc:
+    except SkillsContentPolicyError as exc:
         return {"success": False, "error": str(exc)}
     return None
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -905,8 +905,22 @@ def _add_description_prompt_preview(result: Dict[str, Any], content: str) -> Non
         )
 
 
+def _content_write_refusal(operation: str) -> Optional[Dict[str, Any]]:
+    """Return a stable tool error when discovery content is managed read-only."""
+    from tools.skills_policy import require_skills_content_writable
+
+    try:
+        require_skills_content_writable(operation)
+    except RuntimeError as exc:
+        return {"success": False, "error": str(exc)}
+    return None
+
+
 def _create_skill(name: str, content: str, category: str = None) -> Dict[str, Any]:
     """Create a new user skill with SKILL.md content."""
+    refusal = _content_write_refusal(f"create skill {name!r}")
+    if refusal:
+        return refusal
     # Validate name
     err = _validate_name(name)
     if err:
@@ -976,6 +990,9 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
 
 def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     """Replace the SKILL.md of any existing skill (full rewrite)."""
+    refusal = _content_write_refusal(f"edit skill {name!r}")
+    if refusal:
+        return refusal
     err = _validate_frontmatter(content)
     if err:
         return {"success": False, "error": err}
@@ -1048,6 +1065,9 @@ def _patch_skill(
     Defaults to SKILL.md. Use file_path to patch a supporting file instead.
     Requires a unique match unless replace_all is True.
     """
+    refusal = _content_write_refusal(f"patch skill {name!r}")
+    if refusal:
+        return refusal
     if not old_string:
         return {"success": False, "error": "old_string is required for 'patch'."}
     if new_string is None:
@@ -1168,6 +1188,10 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
         target must exist on disk. Validated here so the model can't claim an
         umbrella that doesn't exist.
     """
+    refusal = _content_write_refusal(f"delete skill {name!r}")
+    if refusal:
+        return refusal
+
     existing = _find_skill(name)
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name)}
@@ -1266,6 +1290,9 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
 
 def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     """Add or overwrite a supporting file within any skill directory."""
+    refusal = _content_write_refusal(f"write file in skill {name!r}")
+    if refusal:
+        return refusal
     err = _validate_file_path(file_path)
     if err:
         return {"success": False, "error": err}
@@ -1336,6 +1363,9 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
 
 def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     """Remove a supporting file from any skill directory."""
+    refusal = _content_write_refusal(f"remove file from skill {name!r}")
+    if refusal:
+        return refusal
     err = _validate_file_path(file_path)
     if err:
         return {"success": False, "error": err}

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -1,6 +1,6 @@
 """Skill usage telemetry + provenance tracking for the Curator feature.
 
-Tracks per-skill usage metadata in a sidecar JSON file (~/.hermes/skills/.usage.json)
+Tracks per-skill usage metadata in ``~/.hermes/state/skills/usage.json``
 keyed by skill name. Counters are bumped by the existing skill tools (skill_view,
 skill_manage); the curator orchestrator reads the derived activity timestamp to
 decide lifecycle transitions.
@@ -8,7 +8,7 @@ decide lifecycle transitions.
 Design notes:
   - Sidecar, not frontmatter. Keeps operational telemetry out of user-authored
     SKILL.md content and avoids conflict pressure for bundled/hub skills.
-  - Atomic writes via tempfile + os.replace (same pattern as .bundled_manifest).
+  - Atomic writes via tempfile + os.replace (same pattern as bundled state).
   - All counter bumps are best-effort: failures log at DEBUG and return silently.
     A broken sidecar never breaks the underlying tool call.
   - Provenance filter: curator-managed skills are explicitly marked when
@@ -33,8 +33,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, get_skills_state_dir
 from agent.skill_utils import is_excluded_skill_path, is_external_skill_path
+from utils import atomic_json_write, atomic_write_text
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +84,13 @@ def _skills_dir() -> Path:
 
 
 def _usage_file() -> Path:
+    return get_skills_state_dir() / "usage.json"
+
+
+def _usage_read_file() -> Path:
+    path = _usage_file()
+    if path.exists():
+        return path
     return _skills_dir() / ".usage.json"
 
 
@@ -181,10 +189,12 @@ def activity_count(record: Dict[str, Any]) -> int:
 def _read_bundled_manifest_names() -> Set[str]:
     """Return the set of skill names that were seeded from the bundled repo.
 
-    Reads ~/.hermes/skills/.bundled_manifest (format: "name:hash" per line).
+    Reads external bundled state, with legacy discovery fallback.
     Returns empty set if the file is missing or unreadable.
     """
-    manifest = _skills_dir() / ".bundled_manifest"
+    manifest = get_skills_state_dir() / "bundled-manifest"
+    if not manifest.exists():
+        manifest = _skills_dir() / ".bundled_manifest"
     if not manifest.exists():
         return set()
     names: Set[str] = set()
@@ -204,9 +214,11 @@ def _read_bundled_manifest_names() -> Set[str]:
 def _read_hub_installed_names() -> Set[str]:
     """Return the set of skill names installed via the Skills Hub.
 
-    Reads ~/.hermes/skills/.hub/lock.json (see tools/skills_hub.py :: HubLockFile).
+    Reads external hub state, with legacy discovery fallback.
     """
-    lock_path = _skills_dir() / ".hub" / "lock.json"
+    lock_path = get_skills_state_dir() / "hub" / "lock.json"
+    if not lock_path.exists():
+        lock_path = _skills_dir() / ".hub" / "lock.json"
     if not lock_path.exists():
         return set()
     try:
@@ -269,17 +281,24 @@ def _prune_builtins_enabled() -> bool:
 
 
 def _suppressed_file() -> Path:
+    return get_skills_state_dir() / "curator-suppressed"
+
+
+def _suppressed_read_file() -> Path:
+    path = _suppressed_file()
+    if path.exists():
+        return path
     return _skills_dir() / ".curator_suppressed"
 
 
 def read_suppressed_names() -> Set[str]:
     """Built-in skills the curator pruned — the re-seeder must leave archived.
 
-    One skill name per line in ``~/.hermes/skills/.curator_suppressed``. This is
+    One skill name per line in external curator state (with legacy fallback). This is
     what makes pruning a built-in durable: without it, ``hermes update`` would
     re-copy the bundled skill on the next sync.
     """
-    path = _suppressed_file()
+    path = _suppressed_read_file()
     if not path.exists():
         return set()
     names: Set[str] = set()
@@ -296,21 +315,18 @@ def read_suppressed_names() -> Set[str]:
 def _write_suppressed_names(names: Set[str]) -> None:
     path = _suppressed_file()
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
+        from tools.skills_policy import (
+            note_legacy_state_write,
+            prepare_legacy_state_write,
+        )
+
+        migration = prepare_legacy_state_write(
+            path,
+            _skills_dir() / ".curator_suppressed",
+        )
         data = "\n".join(sorted(names)) + ("\n" if names else "")
-        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".curator_suppressed_", suffix=".tmp")
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(data)
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(tmp, path)
-        except BaseException:
-            try:
-                os.unlink(tmp)
-            except OSError:
-                pass
-            raise
+        atomic_write_text(path, data, tmp_prefix=".curator_suppressed_")
+        note_legacy_state_write(migration)
     except Exception as e:
         logger.debug("Failed to write curator suppression list: %s", e, exc_info=True)
 
@@ -659,7 +675,7 @@ def _empty_record() -> Dict[str, Any]:
 
 def load_usage() -> Dict[str, Dict[str, Any]]:
     """Read the entire .usage.json map. Returns empty dict on missing/corrupt."""
-    path = _usage_file()
+    path = _usage_read_file()
     if not path.exists():
         return {}
     try:
@@ -681,22 +697,17 @@ def save_usage(data: Dict[str, Dict[str, Any]]) -> None:
     """Write the usage map atomically. Best-effort — errors are logged, not raised."""
     path = _usage_file()
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp_path = tempfile.mkstemp(
-            dir=str(path.parent), prefix=".usage_", suffix=".tmp"
+        from tools.skills_policy import (
+            note_legacy_state_write,
+            prepare_legacy_state_write,
         )
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2, sort_keys=True, ensure_ascii=False)
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(tmp_path, path)
-        except BaseException:
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-            raise
+
+        migration = prepare_legacy_state_write(
+            path,
+            _skills_dir() / ".usage.json",
+        )
+        atomic_json_write(path, data, indent=2, sort_keys=True)
+        note_legacy_state_write(migration)
     except Exception as e:
         logger.debug("Failed to write %s: %s", path, e, exc_info=True)
 
@@ -881,6 +892,13 @@ def archive_skill(skill_name: str) -> Tuple[bool, str]:
     when one is archived, its name is added to the suppression list so the
     update-time re-seeder leaves it archived instead of restoring it.
     """
+    from tools.skills_policy import require_skills_content_writable
+
+    try:
+        require_skills_content_writable(f"archive skill {skill_name!r}")
+    except RuntimeError as exc:
+        return False, str(exc)
+
     local_skill_dir = _find_skill_dir(skill_name)
     if local_skill_dir is None and _find_external_skill_dir(skill_name) is not None:
         return False, _external_read_only_message(skill_name)
@@ -945,6 +963,13 @@ def restore_skill(skill_name: str) -> Tuple[bool, str]:
     way to lift a prune). Restoring clears any suppression entry so future
     updates may re-seed the built-in again.
     """
+    from tools.skills_policy import require_skills_content_writable
+
+    try:
+        require_skills_content_writable(f"restore skill {skill_name!r}")
+    except RuntimeError as exc:
+        return False, str(exc)
+
     # Hub skills always have an external upstream owner — never shadow them.
     if is_hub_installed(skill_name):
         return False, (

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -892,11 +892,14 @@ def archive_skill(skill_name: str) -> Tuple[bool, str]:
     when one is archived, its name is added to the suppression list so the
     update-time re-seeder leaves it archived instead of restoring it.
     """
-    from tools.skills_policy import require_skills_content_writable
+    from tools.skills_policy import (
+        SkillsContentPolicyError,
+        require_skills_content_writable,
+    )
 
     try:
         require_skills_content_writable(f"archive skill {skill_name!r}")
-    except RuntimeError as exc:
+    except SkillsContentPolicyError as exc:
         return False, str(exc)
 
     local_skill_dir = _find_skill_dir(skill_name)
@@ -963,11 +966,14 @@ def restore_skill(skill_name: str) -> Tuple[bool, str]:
     way to lift a prune). Restoring clears any suppression entry so future
     updates may re-seed the built-in again.
     """
-    from tools.skills_policy import require_skills_content_writable
+    from tools.skills_policy import (
+        SkillsContentPolicyError,
+        require_skills_content_writable,
+    )
 
     try:
         require_skills_content_writable(f"restore skill {skill_name!r}")
-    except RuntimeError as exc:
+    except SkillsContentPolicyError as exc:
         return False, str(exc)
 
     # Hub skills always have an external upstream owner — never shadow them.

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3774,11 +3774,14 @@ def install_from_quarantine(
 
 def uninstall_skill(skill_name: str) -> Tuple[bool, str]:
     """Remove a hub-installed skill. Refuses to remove builtins."""
-    from tools.skills_policy import require_skills_content_writable
+    from tools.skills_policy import (
+        SkillsContentPolicyError,
+        require_skills_content_writable,
+    )
 
     try:
         require_skills_content_writable(f"uninstall skill {skill_name!r}")
-    except RuntimeError as exc:
+    except SkillsContentPolicyError as exc:
         return False, str(exc)
     lock = HubLockFile()
     entry = lock.get_installed(skill_name)

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -20,12 +20,13 @@ import os
 import re
 import shutil
 import subprocess
+import tempfile
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, get_skills_state_dir
 from hermes_cli._subprocess_compat import windows_hide_flags
 from agent.skill_utils import is_excluded_skill_path
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -71,7 +72,7 @@ def _skills_dir() -> Path:
 
 def _hub_dir() -> Path:
     forced = _override("HUB_DIR")
-    return Path(forced) if forced is not None else _skills_dir() / ".hub"
+    return Path(forced) if forced is not None else get_skills_state_dir() / "hub"
 
 
 def _lock_file() -> Path:
@@ -97,6 +98,17 @@ def _taps_file() -> Path:
 def _index_cache_dir() -> Path:
     forced = _override("INDEX_CACHE_DIR")
     return Path(forced) if forced is not None else _hub_dir() / "index-cache"
+
+
+def _legacy_hub_dir() -> Path:
+    return _skills_dir() / ".hub"
+
+
+def _index_cache_read_file(key: str) -> Path:
+    path = _index_cache_dir() / f"{key}.json"
+    if path.exists():
+        return path
+    return _legacy_hub_dir() / "index-cache" / f"{key}.json"
 
 
 _DYNAMIC_PATH_RESOLVERS = {
@@ -1137,7 +1149,7 @@ class GitHubSource(SkillSource):
 
     def _read_cache(self, key: str) -> Optional[list]:
         """Read cached index if not expired."""
-        cache_file = _index_cache_dir() / f"{key}.json"
+        cache_file = _index_cache_read_file(key)
         if not cache_file.exists():
             return None
         try:
@@ -1151,10 +1163,19 @@ class GitHubSource(SkillSource):
     def _write_cache(self, key: str, data: list) -> None:
         """Write index data to cache."""
         index_cache_dir = _index_cache_dir()
-        index_cache_dir.mkdir(parents=True, exist_ok=True)
         cache_file = index_cache_dir / f"{key}.json"
+        from tools.skills_policy import (
+            note_legacy_state_write,
+            prepare_legacy_state_write,
+        )
+
+        migration = prepare_legacy_state_write(
+            cache_file,
+            _legacy_hub_dir() / "index-cache" / f"{key}.json",
+        )
         try:
-            cache_file.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+            _atomic_hub_json(cache_file, data)
+            note_legacy_state_write(migration)
         except OSError as e:
             logger.debug("Could not write cache: %s", e)
 
@@ -3248,7 +3269,7 @@ class OptionalSkillSource(SkillSource):
 
 def _read_index_cache(key: str) -> Optional[Any]:
     """Read cached data if not expired."""
-    cache_file = _index_cache_dir() / f"{key}.json"
+    cache_file = _index_cache_read_file(key)
     if not cache_file.exists():
         return None
     try:
@@ -3263,6 +3284,16 @@ def _read_index_cache(key: str) -> Optional[Any]:
 def _write_index_cache(key: str, data: Any) -> None:
     """Write data to cache."""
     index_cache_dir = _index_cache_dir()
+    cache_file = index_cache_dir / f"{key}.json"
+    from tools.skills_policy import (
+        note_legacy_state_write,
+        prepare_legacy_state_write,
+    )
+
+    migration = prepare_legacy_state_write(
+        cache_file,
+        _legacy_hub_dir() / "index-cache" / f"{key}.json",
+    )
     index_cache_dir.mkdir(parents=True, exist_ok=True)
     # Ensure .ignore exists so ripgrep (and tools respecting .ignore) skip
     # this directory.  Cache files contain unvetted community content that
@@ -3273,9 +3304,9 @@ def _write_index_cache(key: str, data: Any) -> None:
             ignore_file.write_text("# Exclude hub internals from search tools\n*\n", encoding="utf-8")
         except OSError:
             pass
-    cache_file = index_cache_dir / f"{key}.json"
     try:
-        cache_file.write_text(json.dumps(data, ensure_ascii=False, default=str), encoding="utf-8")
+        _atomic_hub_json(cache_file, data, default=str)
+        note_legacy_state_write(migration)
     except OSError as e:
         logger.debug("Could not write cache: %s", e)
 
@@ -3300,22 +3331,38 @@ def _skill_meta_to_dict(meta: SkillMeta) -> dict:
 # ---------------------------------------------------------------------------
 
 class HubLockFile:
-    """Manages skills/.hub/lock.json — tracks provenance of installed hub skills."""
+    """Manage profile-scoped hub provenance outside skill discovery."""
 
     def __init__(self, path: Optional[Path] = None):
         self.path = path if path is not None else _lock_file()
 
     def load(self) -> dict:
-        if not self.path.exists():
+        path = self.path
+        if not path.exists() and path == _lock_file():
+            legacy = _skills_dir() / ".hub" / "lock.json"
+            if legacy.exists():
+                path = legacy
+        if not path.exists():
             return {"version": 1, "installed": {}}
         try:
-            return json.loads(self.path.read_text(encoding="utf-8"))
+            return json.loads(path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             return {"version": 1, "installed": {}}
 
     def save(self, data: dict) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        migration = None
+        if self.path == _lock_file():
+            from tools.skills_policy import prepare_legacy_state_write
+
+            migration = prepare_legacy_state_write(
+                self.path,
+                _legacy_hub_dir() / "lock.json",
+            )
+        _atomic_hub_json(self.path, data)
+        if migration is not None:
+            from tools.skills_policy import note_legacy_state_write
+
+            note_legacy_state_write(migration)
 
     def record_install(
         self,
@@ -3380,17 +3427,33 @@ class TapsManager:
         self.path = path if path is not None else _taps_file()
 
     def load(self) -> List[dict]:
-        if not self.path.exists():
+        path = self.path
+        if not path.exists() and path == _taps_file():
+            legacy = _skills_dir() / ".hub" / "taps.json"
+            if legacy.exists():
+                path = legacy
+        if not path.exists():
             return []
         try:
-            data = json.loads(self.path.read_text(encoding="utf-8"))
+            data = json.loads(path.read_text(encoding="utf-8"))
             return data.get("taps", [])
         except (json.JSONDecodeError, OSError):
             return []
 
     def save(self, taps: List[dict]) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps({"taps": taps}, indent=2) + "\n", encoding="utf-8")
+        migration = None
+        if self.path == _taps_file():
+            from tools.skills_policy import prepare_legacy_state_write
+
+            migration = prepare_legacy_state_write(
+                self.path,
+                _legacy_hub_dir() / "taps.json",
+            )
+        _atomic_hub_json(self.path, {"taps": taps})
+        if migration is not None:
+            from tools.skills_policy import note_legacy_state_write
+
+            note_legacy_state_write(migration)
 
     def add(self, repo: str, path: str = "skills/") -> bool:
         """Add a tap. Returns False if already exists."""
@@ -3422,7 +3485,11 @@ def append_audit_log(action: str, skill_name: str, source: str,
                      trust_level: str, verdict: str, extra: str = "") -> None:
     """Append a line to the audit log."""
     audit_log = _audit_log()
-    audit_log.parent.mkdir(parents=True, exist_ok=True)
+    if not audit_log.exists():
+        _initialize_hub_audit_log(
+            audit_log,
+            _legacy_hub_dir() / "audit.log",
+        )
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     parts = [timestamp, action, skill_name, f"{source}:{trust_level}", verdict]
     if extra:
@@ -3439,21 +3506,155 @@ def append_audit_log(action: str, skill_name: str, source: str,
 # Hub operations (high-level)
 # ---------------------------------------------------------------------------
 
+def _initialize_hub_json(
+    destination: Path,
+    legacy: Path,
+    default: dict,
+) -> None:
+    """Atomically seed a state file from valid legacy JSON or a default."""
+    if destination.exists():
+        return
+    data = default
+    migrated = False
+    if legacy != destination and legacy.exists():
+        try:
+            candidate = json.loads(legacy.read_text(encoding="utf-8"))
+            if isinstance(candidate, dict):
+                data = candidate
+                migrated = True
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    _atomic_hub_json(destination, data)
+    if migrated:
+        from tools.skills_policy import warn_legacy_state_migrated
+
+        warn_legacy_state_migrated(legacy)
+
+
+def _atomic_hub_json(
+    destination: Path,
+    data: Any,
+    *,
+    default: Optional[Any] = None,
+) -> None:
+    """Write one hub JSON state file with replace-after-fsync semantics."""
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(
+        dir=str(destination.parent),
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            dump_kwargs = {"default": default} if default is not None else {}
+            json.dump(
+                data,
+                stream,
+                indent=2,
+                ensure_ascii=False,
+                **dump_kwargs,
+            )
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(tmp, destination)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _initialize_hub_directory(destination: Path, legacy: Path) -> None:
+    """Atomically preserve a legacy hub directory before first state write."""
+    if destination.exists():
+        return
+    if legacy == destination or not legacy.is_dir():
+        destination.mkdir(parents=True, exist_ok=True)
+        return
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(
+        tempfile.mkdtemp(
+            dir=str(destination.parent),
+            prefix=f".{destination.name}.migration-",
+        )
+    )
+    staging.rmdir()
+    try:
+        shutil.copytree(legacy, staging, symlinks=True)
+        try:
+            staging.replace(destination)
+        except OSError:
+            if not destination.exists():
+                raise
+            shutil.rmtree(staging, ignore_errors=True)
+        else:
+            from tools.skills_policy import warn_legacy_state_migrated
+
+            warn_legacy_state_migrated(legacy)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+
+def _initialize_hub_audit_log(destination: Path, legacy: Path) -> None:
+    """Preserve the append-only legacy audit log without editing its source."""
+    if destination.exists():
+        return
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if legacy != destination and legacy.is_file():
+        fd, tmp = tempfile.mkstemp(
+            dir=str(destination.parent),
+            prefix=".audit.",
+            suffix=".tmp",
+        )
+        os.close(fd)
+        try:
+            shutil.copyfile(legacy, tmp)
+            os.replace(tmp, destination)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+        from tools.skills_policy import warn_legacy_state_migrated
+
+        warn_legacy_state_migrated(legacy)
+        return
+    destination.touch()
+
+
 def ensure_hub_dirs() -> None:
-    """Create the .hub directory structure if it doesn't exist."""
+    """Create external hub state, preserving valid legacy state on first use."""
     hub_dir = _hub_dir()
     lock_file = _lock_file()
     audit_log = _audit_log()
     taps_file = _taps_file()
     hub_dir.mkdir(parents=True, exist_ok=True)
-    _quarantine_dir().mkdir(exist_ok=True)
-    _index_cache_dir().mkdir(exist_ok=True)
-    if not lock_file.exists():
-        lock_file.write_text('{"version": 1, "installed": {}}\n', encoding="utf-8")
-    if not audit_log.exists():
-        audit_log.touch()
-    if not taps_file.exists():
-        taps_file.write_text('{"taps": []}\n', encoding="utf-8")
+    legacy_hub = _legacy_hub_dir()
+    _initialize_hub_directory(
+        _quarantine_dir(),
+        legacy_hub / "quarantine",
+    )
+    _initialize_hub_directory(
+        _index_cache_dir(),
+        legacy_hub / "index-cache",
+    )
+    _initialize_hub_json(
+        lock_file,
+        legacy_hub / "lock.json",
+        {"version": 1, "installed": {}},
+    )
+    _initialize_hub_audit_log(audit_log, legacy_hub / "audit.log")
+    _initialize_hub_json(
+        taps_file,
+        legacy_hub / "taps.json",
+        {"taps": []},
+    )
 
 
 def quarantine_bundle(bundle: SkillBundle) -> Path:
@@ -3490,6 +3691,9 @@ def install_from_quarantine(
     scan_provenance: Optional[Dict[str, Any]] = None,
 ) -> Path:
     """Move a scanned skill from quarantine into the skills directory."""
+    from tools.skills_policy import require_skills_content_writable
+
+    require_skills_content_writable(f"install skill {skill_name!r}")
     safe_skill_name = _validate_skill_name(skill_name)
     safe_category = _validate_install_parent_path(category) if category else ""
     quarantine_resolved = quarantine_path.resolve()
@@ -3570,6 +3774,12 @@ def install_from_quarantine(
 
 def uninstall_skill(skill_name: str) -> Tuple[bool, str]:
     """Remove a hub-installed skill. Refuses to remove builtins."""
+    from tools.skills_policy import require_skills_content_writable
+
+    try:
+        require_skills_content_writable(f"uninstall skill {skill_name!r}")
+    except RuntimeError as exc:
+        return False, str(exc)
     lock = HubLockFile()
     entry = lock.get_installed(skill_name)
     if not entry:
@@ -3705,6 +3915,13 @@ def _hermes_index_cache_file() -> Path:
     return _index_cache_dir() / "hermes-index.json"
 
 
+def _hermes_index_cache_read_file() -> Path:
+    path = _hermes_index_cache_file()
+    if path.exists():
+        return path
+    return _legacy_hub_dir() / "index-cache" / "hermes-index.json"
+
+
 def _load_hermes_index() -> Optional[dict]:
     """Fetch the centralized skills index, with local cache.
 
@@ -3713,7 +3930,7 @@ def _load_hermes_index() -> Optional[dict]:
     downloads within a session.
     """
     # Check local cache
-    hermes_index_cache_file = _hermes_index_cache_file()
+    hermes_index_cache_file = _hermes_index_cache_read_file()
     if hermes_index_cache_file.exists():
         try:
             age = time.time() - hermes_index_cache_file.stat().st_mtime
@@ -3771,8 +3988,18 @@ def _load_hermes_index() -> Optional[dict]:
 
     # Cache locally
     try:
-        hermes_index_cache_file.parent.mkdir(parents=True, exist_ok=True)
-        hermes_index_cache_file.write_text(json.dumps(data), encoding="utf-8")
+        write_path = _hermes_index_cache_file()
+        from tools.skills_policy import (
+            note_legacy_state_write,
+            prepare_legacy_state_write,
+        )
+
+        migration = prepare_legacy_state_write(
+            write_path,
+            _legacy_hub_dir() / "index-cache" / "hermes-index.json",
+        )
+        _atomic_hub_json(write_path, data)
+        note_legacy_state_write(migration)
     except OSError:
         pass
 
@@ -3781,7 +4008,7 @@ def _load_hermes_index() -> Optional[dict]:
 
 def _load_stale_index_cache() -> Optional[dict]:
     """Fall back to stale cache when the network fetch fails."""
-    hermes_index_cache_file = _hermes_index_cache_file()
+    hermes_index_cache_file = _hermes_index_cache_read_file()
     if hermes_index_cache_file.exists():
         try:
             return json.loads(hermes_index_cache_file.read_text(encoding="utf-8"))

--- a/tools/skills_policy.py
+++ b/tools/skills_policy.py
@@ -1,0 +1,170 @@
+"""Skill content ownership and profile-scoped runtime-state helpers."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from hermes_constants import get_config_path, get_skills_dir, get_skills_state_dir
+
+
+SKILLS_CONTENT_READ_ONLY = "SKILLS_CONTENT_READ_ONLY"
+SKILLS_CONFIG_UNAVAILABLE = "SKILLS_CONFIG_UNAVAILABLE"
+# Keep legacy discovery-root metadata readers for the first two upstream
+# releases containing this module. Remove them only after both releases have
+# shipped and the review-bound migration follow-up has been completed.
+LEGACY_SKILLS_STATE_COMPAT_RELEASES = 2
+
+_VALID_CONTENT_MODES = {"writable", "read_only"}
+_warned_legacy_sources: set[str] = set()
+logger = logging.getLogger("hermes.skills_state")
+
+
+class SkillsContentPolicyError(RuntimeError):
+    """Base class for stable skill-content policy refusals."""
+
+    reason_code: str
+
+    def __init__(self, reason_code: str, detail: str) -> None:
+        self.reason_code = reason_code
+        super().__init__(f"{reason_code}: {detail}")
+
+
+def _read_raw_policy_config(config_path: Path) -> dict:
+    """Read only the user-authored YAML without importing the CLI layer."""
+    try:
+        with config_path.open(encoding="utf-8") as stream:
+            data = yaml.safe_load(stream) or {}
+    except FileNotFoundError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _strict_user_config_validation() -> Optional[SkillsContentPolicyError]:
+    """Validate an existing user config before trusting a mutation policy."""
+    config_path = get_config_path()
+    try:
+        config_path.stat()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        return SkillsContentPolicyError(
+            SKILLS_CONFIG_UNAVAILABLE,
+            f"cannot access skills content policy in {config_path}: {exc}",
+        )
+
+    try:
+        _read_raw_policy_config(config_path)
+    except Exception as exc:
+        return SkillsContentPolicyError(
+            SKILLS_CONFIG_UNAVAILABLE,
+            f"cannot read skills content policy in {config_path}: {exc}",
+        )
+    return None
+
+
+def skills_content_mode() -> str:
+    """Return the configured content mode, failing closed on invalid policy."""
+    validation_error = _strict_user_config_validation()
+    if validation_error is not None:
+        raise validation_error
+
+    try:
+        # Do not use the CLI config layer here: a low-level policy gate must be
+        # usable by gateway, packaged-agent, and headless tool runtimes without
+        # importing CLI-only dependencies or initializing the profile.
+        config = _read_raw_policy_config(get_config_path())
+    except Exception as exc:
+        raise SkillsContentPolicyError(
+            SKILLS_CONFIG_UNAVAILABLE,
+            f"cannot load skills content policy: {exc}",
+        ) from exc
+
+    skills = config.get("skills", {}) if isinstance(config, dict) else {}
+    if not isinstance(skills, dict):
+        raise SkillsContentPolicyError(
+            SKILLS_CONFIG_UNAVAILABLE,
+            "skills must be a mapping when skills.content_mode is configured",
+        )
+    mode = skills.get("content_mode", "writable")
+    if not isinstance(mode, str) or mode not in _VALID_CONTENT_MODES:
+        raise SkillsContentPolicyError(
+            SKILLS_CONFIG_UNAVAILABLE,
+            f"skills.content_mode must be one of {sorted(_VALID_CONTENT_MODES)}",
+        )
+    return mode
+
+
+def require_skills_content_writable(operation: str) -> None:
+    """Refuse *operation* before its first skill-content mutation."""
+    if skills_content_mode() == "read_only":
+        raise SkillsContentPolicyError(
+            SKILLS_CONTENT_READ_ONLY,
+            f"{operation} is disabled because skills.content_mode is read_only",
+        )
+
+
+def skills_state_path(*parts: str) -> Path:
+    """Return a path below the profile-aware writable skills state root."""
+    return get_skills_state_dir().joinpath(*parts)
+
+
+def legacy_skills_path(*parts: str) -> Path:
+    """Return a legacy metadata path below the discovery root."""
+    return get_skills_dir().joinpath(*parts)
+
+
+def state_read_path(
+    state_parts: tuple[str, ...],
+    legacy_parts: tuple[str, ...],
+) -> Path:
+    """Prefer external state, then legacy metadata, without creating either."""
+    state_path = skills_state_path(*state_parts)
+    if state_path.exists():
+        return state_path
+    return legacy_skills_path(*legacy_parts)
+
+
+def prepare_legacy_state_write(
+    state_path: Path,
+    *legacy_paths: Path,
+) -> Optional[Path]:
+    """Return the legacy source that a successful first state write migrates.
+
+    Callers capture this immediately before an atomic write and pass the
+    returned path to :func:`note_legacy_state_write` only after the write
+    succeeds. The legacy source remains untouched for the compatibility
+    window.
+    """
+    if state_path.exists():
+        return None
+    for legacy_path in legacy_paths:
+        if legacy_path.exists():
+            return legacy_path
+    return None
+
+
+def note_legacy_state_write(legacy_source: Optional[Path]) -> None:
+    """Emit the once-per-source warning after a migration write succeeds."""
+    if legacy_source is not None:
+        warn_legacy_state_migrated(legacy_source)
+
+
+def warn_legacy_state_migrated(path: Path) -> None:
+    """Warn once per canonical legacy source in this process."""
+    try:
+        key = str(path.resolve())
+    except OSError:
+        key = str(path.absolute())
+    if key in _warned_legacy_sources:
+        return
+    _warned_legacy_sources.add(key)
+    logger.warning(
+        "Migrated legacy skills runtime metadata from %s; compatibility "
+        "fallback remains for %d releases",
+        path,
+        LEGACY_SKILLS_STATE_COMPAT_RELEASES,
+    )

--- a/tools/skills_policy.py
+++ b/tools/skills_policy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 from typing import Optional
 
@@ -105,6 +106,52 @@ def require_skills_content_writable(operation: str) -> None:
             SKILLS_CONTENT_READ_ONLY,
             f"{operation} is disabled because skills.content_mode is read_only",
         )
+
+
+def _is_within(candidate: Path, root: Path) -> bool:
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _targets_skills_content(path: str | Path) -> bool:
+    """Return whether *path* names content below the active discovery root.
+
+    Check both the lexical and resolved forms. The lexical check refuses a
+    path entered through the discovery root even when an internal symlink
+    points out of it; the resolved check catches aliases outside the discovery
+    tree that point back into managed content.
+    """
+    candidate = Path(path).expanduser()
+    root = get_skills_dir().expanduser()
+    lexical_candidate = Path(
+        os.path.normpath(os.path.abspath(os.fspath(candidate)))
+    )
+    lexical_root = Path(os.path.normpath(os.path.abspath(os.fspath(root))))
+    if _is_within(lexical_candidate, lexical_root):
+        return True
+
+    try:
+        resolved_candidate = candidate.resolve(strict=False)
+        resolved_root = root.resolve(strict=False)
+    except OSError:
+        return False
+    return _is_within(resolved_candidate, resolved_root)
+
+
+def require_skills_path_writable(path: str | Path, operation: str) -> None:
+    """Refuse a generic mutation that targets the discovery/content root.
+
+    This policy is intentionally narrower than ``HERMES_HOME``: relocated
+    runtime metadata under ``HERMES_HOME/state/skills`` must remain writable
+    in read-only content mode.
+    """
+    if not os.path.isabs(os.fspath(path)):
+        raise ValueError("skills content policy requires an absolute path")
+    if _targets_skills_content(path):
+        require_skills_content_writable(operation)
 
 
 def skills_state_path(*parts: str) -> Path:

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -19,7 +19,8 @@ Update logic:
   - DELETED by user (in manifest, absent from user dir): respected, not re-added.
   - REMOVED from bundled (in manifest, gone from repo): cleaned from manifest.
 
-The manifest lives at ~/.hermes/skills/.bundled_manifest.
+The manifest lives at ~/.hermes/state/skills/bundled-manifest. The legacy
+discovery-root manifest remains readable during the compatibility window.
 """
 
 import hashlib
@@ -28,6 +29,7 @@ import logging
 import os
 import shutil
 import sys
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 
@@ -45,7 +47,13 @@ for _stream in (sys.stdout, sys.stderr):
             _stream.reconfigure(encoding="utf-8", errors="replace")
         except (ValueError, TypeError):
             pass
-from hermes_constants import get_bundled_skills_dir, get_hermes_home, get_optional_skills_dir
+from hermes_constants import (
+    get_bundled_skills_dir,
+    get_hermes_home,
+    get_optional_skills_dir,
+    get_skills_dir,
+    get_skills_state_dir,
+)
 from agent.skill_utils import is_excluded_skill_path
 from typing import Dict, List, Optional, Set, Tuple
 from utils import atomic_replace
@@ -54,8 +62,11 @@ logger = logging.getLogger(__name__)
 
 
 HERMES_HOME = get_hermes_home()
-SKILLS_DIR = HERMES_HOME / "skills"
-MANIFEST_FILE = SKILLS_DIR / ".bundled_manifest"
+SKILLS_DIR = get_skills_dir()
+MANIFEST_FILE = get_skills_state_dir() / "bundled-manifest"
+_DEFAULT_HERMES_HOME = HERMES_HOME
+_DEFAULT_SKILLS_DIR = SKILLS_DIR
+_DEFAULT_MANIFEST_FILE = MANIFEST_FILE
 
 # Marker file written by `hermes profile create --no-skills` (named profiles)
 # and by the installer's `--no-skills` flag (the default ~/.hermes profile).
@@ -65,6 +76,34 @@ MANIFEST_FILE = SKILLS_DIR / ".bundled_manifest"
 # hermes_cli.profiles.NO_BUNDLED_SKILLS_MARKER (kept as a literal here to
 # avoid importing the CLI layer into this low-level sync module).
 NO_BUNDLED_SKILLS_MARKER = ".no-bundled-skills"
+
+
+def _hermes_home() -> Path:
+    forced = globals().get("HERMES_HOME")
+    if forced is not None and Path(forced) != _DEFAULT_HERMES_HOME:
+        return Path(forced)
+    return get_hermes_home()
+
+
+def _skills_dir() -> Path:
+    forced = globals().get("SKILLS_DIR")
+    if forced is not None and Path(forced) != _DEFAULT_SKILLS_DIR:
+        return Path(forced)
+    return get_skills_dir()
+
+
+def _manifest_file() -> Path:
+    forced = globals().get("MANIFEST_FILE")
+    if forced is not None and Path(forced) != _DEFAULT_MANIFEST_FILE:
+        return Path(forced)
+    return get_skills_state_dir() / "bundled-manifest"
+
+
+def _manifest_read_file() -> Path:
+    current = _manifest_file()
+    if current.exists():
+        return current
+    return _skills_dir() / ".bundled_manifest"
 
 
 def _get_bundled_dir() -> Path:
@@ -117,11 +156,12 @@ def _read_manifest() -> Dict[str, str]:
     Handles both v1 (plain names) and v2 (name:hash) formats.
     v1 entries get an empty hash string which triggers migration on next sync.
     """
-    if not MANIFEST_FILE.exists():
+    manifest_file = _manifest_read_file()
+    if not manifest_file.exists():
         return {}
     try:
         result = {}
-        for line in MANIFEST_FILE.read_text(encoding="utf-8").splitlines():
+        for line in manifest_file.read_text(encoding="utf-8").splitlines():
             line = line.strip()
             if not line:
                 continue
@@ -141,15 +181,17 @@ def _read_suppressed_names() -> set:
     """Built-in skills the curator pruned — must NOT be re-seeded on sync.
 
     Delegates to ``tools.skill_usage`` (single source of truth) and falls back
-    to reading ``~/.hermes/skills/.curator_suppressed`` directly if that import
-    is unavailable in a packaged/update context.
+    to the same external-first compatibility read if that import is
+    unavailable in a packaged/update context.
     """
     try:
         from tools.skill_usage import read_suppressed_names
 
         return read_suppressed_names()
     except Exception:
-        path = SKILLS_DIR / ".curator_suppressed"
+        path = get_skills_state_dir() / "curator-suppressed"
+        if not path.exists():
+            path = _skills_dir() / ".curator_suppressed"
         if not path.exists():
             return set()
         names = set()
@@ -170,13 +212,22 @@ def _write_manifest(entries: Dict[str, str]):
     crashes or is interrupted mid-write.
     """
     import tempfile
+    from tools.skills_policy import (
+        note_legacy_state_write,
+        prepare_legacy_state_write,
+    )
 
-    MANIFEST_FILE.parent.mkdir(parents=True, exist_ok=True)
+    manifest_file = _manifest_file()
+    migration = prepare_legacy_state_write(
+        manifest_file,
+        _skills_dir() / ".bundled_manifest",
+    )
+    manifest_file.parent.mkdir(parents=True, exist_ok=True)
     data = "\n".join(f"{name}:{hash_val}" for name, hash_val in sorted(entries.items())) + "\n"
 
     try:
         fd, tmp_path = tempfile.mkstemp(
-            dir=str(MANIFEST_FILE.parent),
+            dir=str(manifest_file.parent),
             prefix=".bundled_manifest_",
             suffix=".tmp",
         )
@@ -185,7 +236,8 @@ def _write_manifest(entries: Dict[str, str]):
                 f.write(data)
                 f.flush()
                 os.fsync(f.fileno())
-            atomic_replace(tmp_path, MANIFEST_FILE)
+            atomic_replace(tmp_path, manifest_file)
+            note_legacy_state_write(migration)
         except BaseException:
             try:
                 os.unlink(tmp_path)
@@ -193,7 +245,7 @@ def _write_manifest(entries: Dict[str, str]):
                 pass
             raise
     except Exception as e:
-        logger.debug("Failed to write skills manifest %s: %s", MANIFEST_FILE, e, exc_info=True)
+        logger.debug("Failed to write skills manifest %s: %s", manifest_file, e, exc_info=True)
 
 
 def _read_skill_name(skill_md: Path, fallback: str) -> str:
@@ -248,7 +300,7 @@ def _compute_relative_dest(skill_dir: Path, bundled_dir: Path) -> Path:
     e.g., bundled/skills/mlops/axolotl -> ~/.hermes/skills/mlops/axolotl
     """
     rel = skill_dir.relative_to(bundled_dir)
-    return SKILLS_DIR / rel
+    return _skills_dir() / rel
 
 
 def _dir_hash(directory: Path) -> str:
@@ -328,7 +380,7 @@ def _optional_skill_index() -> Dict[str, Tuple[str, str, Path]]:
 
 def _move_to_restore_backup(path: Path, backup_root: Path) -> str:
     """Move an existing skill directory into a restore backup, preserving rel path."""
-    rel = path.relative_to(SKILLS_DIR)
+    rel = path.relative_to(_skills_dir())
     target = backup_root / rel
     target.parent.mkdir(parents=True, exist_ok=True)
     if target.exists():
@@ -340,6 +392,39 @@ def _move_to_restore_backup(path: Path, backup_root: Path) -> str:
     return rel.as_posix()
 
 
+def _prepare_restore_backups_dir() -> Path:
+    """Preserve legacy restore backups before the first external-state write."""
+    destination = get_skills_state_dir() / "restore-backups"
+    legacy = _skills_dir() / ".restore-backups"
+    if destination.exists() or not legacy.is_dir():
+        return destination
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(
+        tempfile.mkdtemp(
+            dir=str(destination.parent),
+            prefix=".restore-backups.migration-",
+        )
+    )
+    staging.rmdir()
+    try:
+        shutil.copytree(legacy, staging, symlinks=True)
+        try:
+            staging.replace(destination)
+        except OSError:
+            if not destination.exists():
+                raise
+            shutil.rmtree(staging, ignore_errors=True)
+        else:
+            from tools.skills_policy import warn_legacy_state_migrated
+
+            warn_legacy_state_migrated(legacy)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    return destination
+
+
 def restore_official_optional_skill(name: str, *, restore: bool = False) -> dict:
     """Restore one or all official optional skills from repo source.
 
@@ -347,6 +432,11 @@ def restore_official_optional_skill(name: str, *, restore: bool = False) -> dict
     repairs already-mutated/reorganized skills by backing up matching active
     copies and copying the official optional source into its canonical path.
     """
+    if restore:
+        from tools.skills_policy import require_skills_content_writable
+
+        require_skills_content_writable("restore official optional skill")
+
     index = _optional_skill_index()
     if not index:
         return {"ok": False, "message": "No official optional skills directory found.", "restored": [], "backfilled": [], "backed_up": []}
@@ -361,10 +451,13 @@ def restore_official_optional_skill(name: str, *, restore: bool = False) -> dict
     restored: List[str] = []
     backed_up: List[str] = []
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
-    backup_root = SKILLS_DIR / ".restore-backups" / f"official-optional-{timestamp}"
+    backup_root = (
+        _prepare_restore_backups_dir()
+        / f"official-optional-{timestamp}"
+    )
 
     for folder_name, install_path, src in targets:
-        dest = SKILLS_DIR / Path(*install_path.split("/"))
+        dest = _skills_dir() / Path(*install_path.split("/"))
         src_hash = _dir_hash(src)
         canonical_ok = dest.exists() and _dir_hash(dest) == src_hash
 
@@ -372,13 +465,13 @@ def restore_official_optional_skill(name: str, *, restore: bool = False) -> dict
         # or folder slug, even if curator moved it into another category.
         src_frontmatter = _read_skill_name(src / "SKILL.md", folder_name)
         matches: List[Path] = []
-        if SKILLS_DIR.exists():
-            for skill_md in sorted(SKILLS_DIR.rglob("SKILL.md")):
+        if _skills_dir().exists():
+            for skill_md in sorted(_skills_dir().rglob("SKILL.md")):
                 if is_excluded_skill_path(skill_md):
                     continue
                 candidate = skill_md.parent
                 try:
-                    candidate.relative_to(SKILLS_DIR)
+                    candidate.relative_to(_skills_dir())
                 except ValueError:
                     continue
                 candidate_name = _read_skill_name(skill_md, candidate.name)
@@ -414,15 +507,15 @@ def restore_official_optional_skill(name: str, *, restore: bool = False) -> dict
 def _index_installed_skill_dirs_by_name() -> Dict[str, List[Path]]:
     """Index installed skills by directory name with one active-tree scan."""
     index: Dict[str, List[Path]] = {}
-    if not SKILLS_DIR.exists():
+    if not _skills_dir().exists():
         return index
-    for skill_md in SKILLS_DIR.rglob("SKILL.md"):
+    for skill_md in _skills_dir().rglob("SKILL.md"):
         if is_excluded_skill_path(skill_md):
             continue
         candidate = skill_md.parent
         # Never reach outside the skills tree (symlinked/external dirs).
         try:
-            candidate.resolve().relative_to(SKILLS_DIR.resolve())
+            candidate.resolve().relative_to(_skills_dir().resolve())
         except (OSError, ValueError):
             continue
         index.setdefault(candidate.name, []).append(candidate)
@@ -442,7 +535,7 @@ def _find_installed_skill_dir_by_name(
     would write provenance onto the wrong skill. The caller still verifies a
     byte-identical content hash before recording anything.
     """
-    if not skill_dir_name or not SKILLS_DIR.exists():
+    if not skill_dir_name or not _skills_dir().exists():
         return None
     if installed_index is None:
         installed_index = _index_installed_skill_dirs_by_name()
@@ -465,9 +558,11 @@ def _backfill_optional_provenance(quiet: bool = False) -> List[str]:
     if not optional_dir.exists():
         return []
 
-    lock_path = SKILLS_DIR / ".hub" / "lock.json"
+    lock_path = get_skills_state_dir() / "hub" / "lock.json"
+    legacy_lock_path = _skills_dir() / ".hub" / "lock.json"
+    read_lock_path = lock_path if lock_path.exists() else legacy_lock_path
     try:
-        data = json.loads(lock_path.read_text(encoding="utf-8")) if lock_path.exists() else {"version": 1, "installed": {}}
+        data = json.loads(read_lock_path.read_text(encoding="utf-8")) if read_lock_path.exists() else {"version": 1, "installed": {}}
     except (json.JSONDecodeError, OSError):
         data = {"version": 1, "installed": {}}
     installed = data.setdefault("installed", {})
@@ -492,7 +587,7 @@ def _backfill_optional_provenance(quiet: bool = False) -> List[str]:
         lock_name = src.name
         if lock_name in installed or install_path in existing_paths:
             continue
-        dest = SKILLS_DIR / Path(*install_path.split("/"))
+        dest = _skills_dir() / Path(*install_path.split("/"))
         if not dest.exists() or not dest.is_dir():
             # The active tree may hold the same skill under a DIFFERENT
             # category path than the repo uses — categories get reorganized
@@ -508,7 +603,7 @@ def _backfill_optional_provenance(quiet: bool = False) -> List[str]:
             if dest is None:
                 continue
             try:
-                install_path = _safe_rel_install_path(dest, SKILLS_DIR)
+                install_path = _safe_rel_install_path(dest, _skills_dir())
             except ValueError as e:
                 logger.debug("Skipping relocated optional skill %s: %s", dest, e)
                 continue
@@ -537,6 +632,12 @@ def _backfill_optional_provenance(quiet: bool = False) -> List[str]:
             print(f"  = {lock_name} (official optional provenance backfilled)")
 
     if changed:
+        from tools.skills_policy import (
+            note_legacy_state_write,
+            prepare_legacy_state_write,
+        )
+
+        migration = prepare_legacy_state_write(lock_path, legacy_lock_path)
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         # Atomic write so a crash mid-write can't silently wipe all provenance
         # via the JSONDecodeError fallback above (which resets `installed` to
@@ -555,6 +656,7 @@ def _backfill_optional_provenance(quiet: bool = False) -> List[str]:
                 f.flush()
                 os.fsync(f.fileno())
             atomic_replace(tmp_path, lock_path)
+            note_legacy_state_write(migration)
         except BaseException:
             try:
                 os.unlink(tmp_path)
@@ -572,7 +674,9 @@ def _read_hub_install_paths() -> Set[str]:
     content happens to match a bundled origin hash, or the lock's
     ``install_path`` would point at a directory that no longer exists.
     """
-    lock_path = SKILLS_DIR / ".hub" / "lock.json"
+    lock_path = get_skills_state_dir() / "hub" / "lock.json"
+    if not lock_path.exists():
+        lock_path = _skills_dir() / ".hub" / "lock.json"
     if not lock_path.exists():
         return set()
     try:
@@ -595,9 +699,9 @@ def _index_active_skills() -> Dict[str, List[Path]]:
     locate a bundled skill that upstream moved to a new category/directory.
     """
     index: Dict[str, List[Path]] = {}
-    if not SKILLS_DIR.exists():
+    if not _skills_dir().exists():
         return index
-    for skill_md in SKILLS_DIR.rglob("SKILL.md"):
+    for skill_md in _skills_dir().rglob("SKILL.md"):
         if is_excluded_skill_path(skill_md):
             continue
         skill_dir = skill_md.parent
@@ -637,7 +741,7 @@ def _recover_renamed_skill(
         if candidate == dest or not candidate.is_dir():
             continue
         try:
-            rel = candidate.relative_to(SKILLS_DIR).as_posix()
+            rel = candidate.relative_to(_skills_dir()).as_posix()
         except ValueError:
             continue
         # Never relocate a hub-installed skill — the hub owns its path.
@@ -650,7 +754,7 @@ def _recover_renamed_skill(
             if not quiet:
                 print(
                     f"  ⚠ {skill_name}: upstream moved this skill to "
-                    f"{dest.relative_to(SKILLS_DIR).as_posix()}, but your "
+                    f"{dest.relative_to(_skills_dir()).as_posix()}, but your "
                     f"modified copy at {rel} was kept — it will not receive "
                     f"updates. Run `hermes skills reset {skill_name} --restore` "
                     f"to move to the new location."
@@ -667,7 +771,7 @@ def _recover_renamed_skill(
             return None
         logger.info("Relocated renamed bundled skill: %s -> %s", candidate, dest)
         if not quiet:
-            print(f"  → {skill_name} (moved {rel} → {dest.relative_to(SKILLS_DIR).as_posix()})")
+            print(f"  → {skill_name} (moved {rel} → {dest.relative_to(_skills_dir()).as_posix()})")
         return rel
     return None
 
@@ -685,13 +789,25 @@ def sync_skills(quiet: bool = False) -> dict:
     # empty-result shape with skipped_opt_out lets callers report "opted out"
     # instead of "synced 0 / failed". This is the default-profile counterpart
     # to seed_profile_skills()'s marker check for named profiles.
-    if (HERMES_HOME / NO_BUNDLED_SKILLS_MARKER).exists():
+    if (_hermes_home() / NO_BUNDLED_SKILLS_MARKER).exists():
         if not quiet:
             print("  (skipped — profile opted out of bundled skills via .no-bundled-skills)")
         return {
             "copied": [], "updated": [], "skipped": 0,
             "user_modified": [], "cleaned": [], "total_bundled": 0,
             "optional_provenance_backfilled": [], "skipped_opt_out": True,
+        }
+
+    from tools.skills_policy import skills_content_mode
+
+    if skills_content_mode() == "read_only":
+        if not quiet:
+            print("  (skipped — skills.content_mode is read_only)")
+        return {
+            "copied": [], "updated": [], "skipped": 0,
+            "user_modified": [], "cleaned": [], "suppressed": [],
+            "total_bundled": 0, "optional_provenance_backfilled": [],
+            "skipped_read_only": True,
         }
 
     bundled_dir = _get_bundled_dir()
@@ -702,7 +818,7 @@ def sync_skills(quiet: bool = False) -> dict:
             "optional_provenance_backfilled": [],
         }
 
-    SKILLS_DIR.mkdir(parents=True, exist_ok=True)
+    _skills_dir().mkdir(parents=True, exist_ok=True)
     manifest = _read_manifest()
     bundled_skills = _discover_bundled_skills(bundled_dir)
     bundled_names = {name for name, _ in bundled_skills}
@@ -923,7 +1039,7 @@ def sync_skills(quiet: bool = False) -> dict:
     # Also copy DESCRIPTION.md files for categories (if not already present)
     for desc_md in bundled_dir.rglob("DESCRIPTION.md"):
         rel = desc_md.relative_to(bundled_dir)
-        dest_desc = SKILLS_DIR / rel
+        dest_desc = _skills_dir() / rel
         if not dest_desc.exists():
             try:
                 dest_desc.parent.mkdir(parents=True, exist_ok=True)
@@ -969,7 +1085,7 @@ def _rmtree_writable(path: Path) -> None:
     # ``shutil.rmtree(~/.hermes)`` into a loud, recoverable ``ValueError``
     # instead of silently destroying the user's install.
     target = Path(path).resolve()
-    skills_root = SKILLS_DIR.resolve()
+    skills_root = _skills_dir().resolve()
     # Every legitimate caller passes a skill directory or its ``.bak``
     # sibling — always a strict child of the skills root. The skills root
     # itself must never be removed: a ``dest`` that collapses to
@@ -1021,6 +1137,9 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
           - message: human-readable description
           - synced: dict from sync_skills() if a sync was triggered, else None
     """
+    from tools.skills_policy import require_skills_content_writable
+
+    require_skills_content_writable(f"reset bundled skill {name!r}")
     manifest = _read_manifest()
     bundled_dir = _get_bundled_dir()
     bundled_skills = _discover_bundled_skills(bundled_dir)
@@ -1277,11 +1396,12 @@ def set_bundled_skills_opt_out(enabled: bool) -> dict:
         dict with keys: ok (bool), changed (bool), marker (str path),
                         message (str).
     """
-    marker = HERMES_HOME / NO_BUNDLED_SKILLS_MARKER
+    hermes_home = _hermes_home()
+    marker = hermes_home / NO_BUNDLED_SKILLS_MARKER
     existed = marker.exists()
     try:
         if enabled:
-            HERMES_HOME.mkdir(parents=True, exist_ok=True)
+            hermes_home.mkdir(parents=True, exist_ok=True)
             marker.write_text(
                 "This profile opted out of bundled-skill seeding "
                 "(`hermes skills opt-out`).\n"
@@ -1315,7 +1435,7 @@ def set_bundled_skills_opt_out(enabled: bool) -> dict:
 
 def is_bundled_skills_opt_out() -> bool:
     """Return True if the active profile carries the opt-out marker."""
-    return (HERMES_HOME / NO_BUNDLED_SKILLS_MARKER).exists()
+    return (_hermes_home() / NO_BUNDLED_SKILLS_MARKER).exists()
 
 
 def remove_pristine_bundled_skills(dry_run: bool = False) -> dict:
@@ -1341,6 +1461,10 @@ def remove_pristine_bundled_skills(dry_run: bool = False) -> dict:
                         skipped (list[dict]) where each dict is
                         {name, reason}, dry_run (bool), message (str).
     """
+    if not dry_run:
+        from tools.skills_policy import require_skills_content_writable
+
+        require_skills_content_writable("remove pristine bundled skills")
     manifest = _read_manifest()
     bundled_dir = _get_bundled_dir()
     bundled_by_name = dict(_discover_bundled_skills(bundled_dir))

--- a/tools/skills_sync_client.py
+++ b/tools/skills_sync_client.py
@@ -65,6 +65,8 @@ from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from utils import atomic_json_write, atomic_write_text
+
 logger = logging.getLogger(__name__)
 
 # Sync protocol constants
@@ -444,9 +446,15 @@ def sync_default_opt_in() -> bool:
 # ---------------------------------------------------------------------------
 
 def _skills_dir() -> Path:
-    from hermes_constants import get_hermes_home
+    from hermes_constants import get_skills_dir
 
-    return get_hermes_home() / "skills"
+    return get_skills_dir()
+
+
+def _skills_state_dir() -> Path:
+    from hermes_constants import get_skills_state_dir
+
+    return get_skills_state_dir()
 
 
 def is_sync_eligible(skill_name: str) -> bool:
@@ -675,7 +683,7 @@ def _default_device_label() -> str:
 def stable_device_id() -> str:
     """Return a stable per-device label for commit ``author.device`` (contract
      -- advisory, never an auth input). Persisted under
-    ~/.hermes/skills/.sync_device_id.
+    ~/.hermes/state/skills/sync/device-id.
 
     New devices are seeded with a HUMAN-FRIENDLY default (short hostname + a
     short random suffix, e.g. ``bens-macbook-a1b2c3``) so the sync console shows
@@ -683,10 +691,12 @@ def stable_device_id() -> str:
     files are honored verbatim (backward-compatible — a machine keeps its id).
     Use ``set_device_name()`` / ``hermes sync device --name`` to set an explicit
     label."""
-    path = _skills_dir() / ".sync_device_id"
+    path = _skills_state_dir() / "sync" / "device-id"
+    legacy_path = _skills_dir() / ".sync_device_id"
+    read_path = path if path.exists() else legacy_path
     try:
-        if path.exists():
-            val = path.read_text(encoding="utf-8").strip()
+        if read_path.exists():
+            val = read_path.read_text(encoding="utf-8").strip()
             if val:
                 return val
     except OSError:
@@ -703,8 +713,14 @@ def stable_device_id() -> str:
     env_name = (os.environ.get("HERMES_SYNC_DEVICE_NAME") or "").strip()
     val = env_name if env_name else _default_device_label()
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(val, encoding="utf-8")
+        from tools.skills_policy import (
+            note_legacy_state_write,
+            prepare_legacy_state_write,
+        )
+
+        migration = prepare_legacy_state_write(path, legacy_path)
+        atomic_write_text(path, val)
+        note_legacy_state_write(migration)
     except OSError as e:
         logger.debug("skills_sync_client: could not persist device id: %s", e)
     return val
@@ -713,7 +729,7 @@ def stable_device_id() -> str:
 def set_device_name(name: str) -> str:
     """Set the human-friendly device label used for commit ``author.device``.
 
-    Writes the (trimmed) name to ~/.hermes/skills/.sync_device_id, overwriting
+    Writes the (trimmed) name to external profile-scoped skills state, overwriting
     any previous value. The label is advisory metadata only — never an auth
     input (contract §2.4) — so any non-empty string is accepted. Returns the
     stored value. Raises ValueError on an empty name.
@@ -721,9 +737,18 @@ def set_device_name(name: str) -> str:
     cleaned = (name or "").strip()
     if not cleaned:
         raise ValueError("device name must be a non-empty string")
-    path = _skills_dir() / ".sync_device_id"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(cleaned, encoding="utf-8")
+    path = _skills_state_dir() / "sync" / "device-id"
+    from tools.skills_policy import (
+        note_legacy_state_write,
+        prepare_legacy_state_write,
+    )
+
+    migration = prepare_legacy_state_write(
+        path,
+        _skills_dir() / ".sync_device_id",
+    )
+    atomic_write_text(path, cleaned)
+    note_legacy_state_write(migration)
     return cleaned
 
 
@@ -901,7 +926,7 @@ class SyncClient:
 # (skills_sync.py, truncated local content_hash namespace) AND from the
 # `sync-manifest` OBJECT in the sync plane (the per-skill opt-in content). This
 # is purely local reconciliation bookkeeping. Lives at
-# ~/.hermes/skills/.sync_state as JSON.
+# ~/.hermes/state/skills/sync/state.json as JSON.
 #
 # NOTE: renamed from `.sync_manifest` -> `.sync_state` to remove the collision
 # with the  plane `sync-manifest`. `read_sync_state` migrates an existing
@@ -909,11 +934,46 @@ class SyncClient:
 # ---------------------------------------------------------------------------
 
 def _sync_state_path() -> Path:
-    return _skills_dir() / ".sync_state"
+    return _skills_state_dir() / "sync" / "state.json"
 
 
 def _legacy_sync_state_path() -> Path:
+    return _skills_dir() / ".sync_state"
+
+
+def _oldest_sync_state_path() -> Path:
     return _skills_dir() / ".sync_manifest"
+
+
+def _external_legacy_sync_state_path() -> Path:
+    """External compatibility destination for the oldest local state name."""
+    return _skills_state_dir() / "sync" / "manifest.json"
+
+
+def _preserve_oldest_sync_state() -> None:
+    """Copy valid `.sync_manifest` JSON to its exact external state path."""
+    source = _oldest_sync_state_path()
+    destination = _external_legacy_sync_state_path()
+    if destination.exists() or not source.exists():
+        return
+    try:
+        data = json.loads(source.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return
+        atomic_json_write(
+            destination,
+            data,
+            indent=2,
+            sort_keys=True,
+        )
+        from tools.skills_policy import warn_legacy_state_migrated
+
+        warn_legacy_state_migrated(source)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.debug(
+            "skills_sync_client: oldest sync state preservation failed: %s",
+            exc,
+        )
 
 
 def read_sync_state() -> Dict[str, Any]:
@@ -922,24 +982,29 @@ def read_sync_state() -> Dict[str, Any]:
     Shape: ``{"head": "sha256:...|null", "skills": {name: {tree, commit}}}``.
     ``head`` is the last profile-root HEAD commit we reconciled with.
 
-    Migrates a legacy ``.sync_manifest`` file (pre-rename) transparently: if the
-    new ``.sync_state`` is absent but the legacy file exists, it is read and
-    rewritten to the new path so an existing device keeps its head record.
+    Reads legacy discovery metadata when external state is absent. Read-only
+    calls never migrate or remove the legacy copy.
     """
     path = _sync_state_path()
     if not path.exists():
-        legacy = _legacy_sync_state_path()
-        if legacy.exists():
+        legacy = next(
+            (
+                candidate
+                for candidate in (
+                    _external_legacy_sync_state_path(),
+                    _legacy_sync_state_path(),
+                    _oldest_sync_state_path(),
+                )
+                if candidate.exists()
+            ),
+            None,
+        )
+        if legacy is not None:
             try:
                 data = json.loads(legacy.read_text(encoding="utf-8"))
                 if isinstance(data, dict):
                     data.setdefault("head", None)
                     data.setdefault("skills", {})
-                    write_sync_state(data)  # migrate to the new path
-                    try:
-                        legacy.unlink()
-                    except OSError:
-                        pass
                     return data
             except (OSError, json.JSONDecodeError) as e:
                 logger.debug("skills_sync_client: legacy sync state migrate failed: %s", e)
@@ -957,24 +1022,26 @@ def read_sync_state() -> Dict[str, Any]:
 
 def write_sync_state(data: Dict[str, Any]) -> None:
     """Write the local sync state atomically. Best-effort."""
-    import tempfile
-
     path = _sync_state_path()
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".sync_state_", suffix=".tmp")
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2, sort_keys=True, ensure_ascii=False)
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(tmp, path)
-        except BaseException:
-            try:
-                os.unlink(tmp)
-            except OSError:
-                pass
-            raise
+        from tools.skills_policy import (
+            note_legacy_state_write,
+            prepare_legacy_state_write,
+        )
+
+        migration = prepare_legacy_state_write(
+            path,
+            _legacy_sync_state_path(),
+            _oldest_sync_state_path(),
+        )
+        _preserve_oldest_sync_state()
+        atomic_json_write(
+            path,
+            data,
+            indent=2,
+            sort_keys=True,
+        )
+        note_legacy_state_write(migration)
     except Exception as e:
         logger.debug("skills_sync_client: sync state write failed: %s", e)
 
@@ -990,6 +1057,9 @@ def materialize_tree(client: SyncClient, tree_hash: str, dest: Path) -> None:
     become subdirectories. Does NOT delete files absent from the tree -- the
     caller decides removal semantics. Refuses path traversal via entry names.
     """
+    from tools.skills_policy import require_skills_content_writable
+
+    require_skills_content_writable("materialize synchronized skill content")
     dest.mkdir(parents=True, exist_ok=True)
     tree = client.get_tree_json(tree_hash)
     for entry in tree.get("entries", []):
@@ -1464,6 +1534,9 @@ def pull_skills(
     materialized, so a pull never resurrects a skill the user hasn't chosen.
     Best-effort; returns a result dict.
     """
+    from tools.skills_policy import require_skills_content_writable
+
+    require_skills_content_writable("pull synchronized skills")
     if identity is None:
         identity = resolve_identity()
     owner = identity["owner"]
@@ -1740,6 +1813,9 @@ def pull_org_skills(
     is `propose_skill` (the fork lives in their personal skills, not _org/).
     Returns {ok, org_id, head, updated} (updated = skill rel-paths written).
     """
+    from tools.skills_policy import require_skills_content_writable
+
+    require_skills_content_writable("pull organization skills")
     identity = identity or resolve_org_identity()
     if "org_id" not in identity:
         raise SyncInertError("no organisation context available")
@@ -1862,14 +1938,17 @@ def _skill_dir_fingerprint(path: Path) -> str:
 
 def _org_baseline_path(org_id: str) -> Path:
     """Sidecar recording the upstream fingerprint of each mirrored skill."""
-    from agent.skill_utils import ORG_BASELINE_FILE
-
-    return _org_dir() / org_id / ORG_BASELINE_FILE
+    return _skills_state_dir() / "sync" / "org" / org_id / "baseline.json"
 
 
 def _read_org_baseline(org_id: str) -> Dict[str, Any]:
+    path = _org_baseline_path(org_id)
+    if not path.exists():
+        from agent.skill_utils import ORG_BASELINE_FILE
+
+        path = _org_dir() / org_id / ORG_BASELINE_FILE
     try:
-        return json.loads(_org_baseline_path(org_id).read_text(encoding="utf-8"))
+        return json.loads(path.read_text(encoding="utf-8"))
     except Exception:
         return {}
 
@@ -1877,8 +1956,18 @@ def _read_org_baseline(org_id: str) -> Dict[str, Any]:
 def _write_org_baseline(org_id: str, baseline: Dict[str, Any]) -> None:
     try:
         p = _org_baseline_path(org_id)
-        p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(json.dumps(baseline, indent=2, sort_keys=True), encoding="utf-8")
+        from agent.skill_utils import ORG_BASELINE_FILE
+        from tools.skills_policy import (
+            note_legacy_state_write,
+            prepare_legacy_state_write,
+        )
+
+        migration = prepare_legacy_state_write(
+            p,
+            _org_dir() / org_id / ORG_BASELINE_FILE,
+        )
+        atomic_json_write(p, baseline, indent=2, sort_keys=True)
+        note_legacy_state_write(migration)
     except Exception as e:
         logger.debug("skills_sync_client: baseline write failed: %s", e)
 
@@ -1917,11 +2006,20 @@ def list_locally_modified_org_skills(org_id: Optional[str] = None) -> List[str]:
 def _write_active_org_marker(org_id: str) -> None:
     """Record which org's mirror may resolve (best-effort, never raises)."""
     try:
+        root = _skills_state_dir() / "sync" / "org"
         from agent.skill_utils import ORG_ACTIVE_MARKER
+        from tools.skills_policy import (
+            note_legacy_state_write,
+            prepare_legacy_state_write,
+        )
 
-        root = _org_dir()
-        root.mkdir(parents=True, exist_ok=True)
-        (root / ORG_ACTIVE_MARKER).write_text(org_id, encoding="utf-8")
+        marker = root / "active-org"
+        migration = prepare_legacy_state_write(
+            marker,
+            _org_dir() / ORG_ACTIVE_MARKER,
+        )
+        atomic_write_text(marker, org_id)
+        note_legacy_state_write(migration)
     except Exception as e:
         logger.debug("skills_sync_client: active-org marker write failed: %s", e)
 
@@ -1929,13 +2027,20 @@ def _write_active_org_marker(org_id: str) -> None:
 def _write_org_provenance(org_id: str, data: Dict[str, Any]) -> None:
     """Persist the org HEAD provenance sidecar (best-effort, never raises)."""
     try:
+        dest = _skills_state_dir() / "sync" / "org" / org_id
         from agent.skill_utils import ORG_PROVENANCE_FILE
-
-        dest = _org_dir() / org_id
-        dest.mkdir(parents=True, exist_ok=True)
-        (dest / ORG_PROVENANCE_FILE).write_text(
-            json.dumps(data, indent=2), encoding="utf-8"
+        from tools.skills_policy import (
+            note_legacy_state_write,
+            prepare_legacy_state_write,
         )
+
+        path = dest / "provenance.json"
+        migration = prepare_legacy_state_write(
+            path,
+            _org_dir() / org_id / ORG_PROVENANCE_FILE,
+        )
+        atomic_json_write(path, data, indent=2)
+        note_legacy_state_write(migration)
     except Exception as e:
         logger.debug("skills_sync_client: org provenance write failed: %s", e)
 
@@ -2078,16 +2183,24 @@ def maybe_pull_org_skills() -> Optional[Dict[str, Any]]:
 
 
 def _clear_active_org_marker() -> None:
-    """Remove the active-org marker (org skills stop resolving)."""
+    """Mask any active-org marker without modifying its legacy copy."""
     try:
         from agent.skill_utils import ORG_ACTIVE_MARKER
+        from tools.skills_policy import (
+            note_legacy_state_write,
+            prepare_legacy_state_write,
+        )
 
-        marker = _org_dir() / ORG_ACTIVE_MARKER
-        if marker.exists():
-            marker.unlink()
-            logger.info(
-                "skills_sync_client: cleared active-org marker "
-                "(token has no org workflow); org skills no longer resolve"
-            )
+        marker = _skills_state_dir() / "sync" / "org" / "active-org"
+        migration = prepare_legacy_state_write(
+            marker,
+            _org_dir() / ORG_ACTIVE_MARKER,
+        )
+        atomic_write_text(marker, "")
+        note_legacy_state_write(migration)
+        logger.info(
+            "skills_sync_client: cleared active-org marker "
+            "(token has no org workflow); org skills no longer resolve"
+        )
     except Exception as e:
         logger.debug("skills_sync_client: marker clear failed: %s", e)

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -799,13 +799,12 @@ def skills_list(category: str = None, task_id: str = None) -> str:
     try:
         active_skills_dir = _skills_dir()
         if not active_skills_dir.exists():
-            active_skills_dir.mkdir(parents=True, exist_ok=True)
             return json.dumps(
                 {
                     "success": True,
                     "skills": [],
                     "categories": [],
-                    "message": f"No skills found. Skills directory created at {display_hermes_home()}/skills/",
+                    "message": f"No skills found at {display_hermes_home()}/skills/.",
                 },
                 ensure_ascii=False,
             )
@@ -1572,8 +1571,8 @@ def skill_view(
         if skill_dir:
             try:
                 from agent.skill_utils import (
-                    ORG_PROVENANCE_FILE,
                     is_org_mirror_path,
+                    org_provenance_path,
                     org_id_of_path,
                 )
 
@@ -1584,11 +1583,8 @@ def skill_view(
                     if prov_org:
                         try:
                             prov = json.loads(
-                                (
-                                    active_skills_dir
-                                    / "_org"
-                                    / prov_org
-                                    / ORG_PROVENANCE_FILE
+                                org_provenance_path(
+                                    active_skills_dir, prov_org
                                 ).read_text(encoding="utf-8")
                             )
                             author = str(


### PR DESCRIPTION
## What does this PR do?

Separates skill discovery content from mutable Hermes runtime metadata so a
managed or immutable `HERMES_HOME/skills` tree remains usable.

`skills.content_mode: read_only` now refuses content mutations with the stable
`SKILLS_CONTENT_READ_ONLY` reason, while list/check/startup discovery continues.
Hub, bundled-sync, usage, curator, sync-client, and organization metadata move
to profile-scoped `HERMES_HOME/state/skills`. Legacy metadata remains readable
for a two-release compatibility window and is never migrated by read-only
operations.

## Related Issue

External tracker: https://github.com/Bad-Robots/Workforce/issues/724

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add a profile-aware, side-effect-free skills state root
- add `skills.content_mode` with writable compatibility default
- move all inventoried skill runtime metadata outside discovery
- guard hub, bundled-sync, sync-client, skill-manager, curator, and rollback
  content mutations before their first write
- retain external-first legacy readers for two releases with atomic first-write
  migration and once-per-source warnings
- make list and startup discovery zero-write and preserve nested skill discovery
- extend read-block protection to new and legacy hub-state locations

## How to Test

1. Run the ticket-targeted command through `scripts/run_tests.sh` (20 files,
   570 tests).
2. Run `scripts/run_tests.sh tests/tools tests/agent tests/hermes_cli`.
3. Configure `skills.content_mode: read_only`, point `HERMES_HOME/skills` at a
   read-only nested tree, and verify list/check/startup work while update,
   install, sync, curator, and rollback mutations refuse before content delta.

Local macOS validation:

- ticket-targeted: 570 passed, 0 failed
- policy/hub/curator/config: 162 passed, 0 failed
- config-read guard plus hub regression: 58 passed, 0 failed
- Ruff, compileall, and diff checks passed
- the broader command completed; 17 remaining failures are
  platform/environment-sensitive tests outside this change. The two affected
  broader files were rerun after the final fix and pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run the entire test tree with zero local platform failures
- [x] I've added tests for my changes
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation and docstrings
- [x] I've updated `cli-config.yaml.example`
- [x] Architecture/workflow docs are N/A
- [x] I've considered cross-platform impact
- [x] Tool descriptions/schemas are N/A
