### PR TITLE
feat(slack): add per-channel reply modes

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -985,6 +985,14 @@ platform_toolsets:
 #         priority_mode: prepend
 #         priority:
 #           - my_plugin_command
+#   slack:
+#     extra:
+#       reply_in_thread: true
+#       # Optional per-channel override for top-level messages. Existing Slack
+#       # threads always remain thread-scoped.
+#       channel_reply_modes:
+#         C0123456789: channel  # Flat replies + one shared channel session
+#         C9876543210: thread   # Thread-per-message
 #   webhook:
 #     extra:
 #       # Route scripts default to a 30 second timeout. Scripts must live under

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -367,9 +367,27 @@ class RelayAdapter(BasePlatformAdapter):
             return raw
         return str(raw).strip().lower() in {"1", "true", "yes", "on"}
 
-    def _effective_reply_in_thread(self) -> bool:
-        """Resolve the thread-per-message vs flat-DM mode for fronted Slack."""
+    def _slack_channel_reply_modes(self) -> Dict[str, bool]:
+        """Return relay-fronted Slack per-channel placement overrides."""
+        raw = self._relay_slack_extra().get("channel_reply_modes")
+        if not isinstance(raw, dict):
+            return {}
+        modes: Dict[str, bool] = {}
+        for channel_id, mode in raw.items():
+            normalized_id = str(channel_id).strip()
+            normalized_mode = str(mode).strip().lower()
+            if not normalized_id or normalized_mode not in {"thread", "channel"}:
+                continue
+            modes[normalized_id] = normalized_mode == "thread"
+        return modes
+
+    def _effective_reply_in_thread(self, chat_id: Optional[str] = None) -> bool:
+        """Resolve global/per-channel reply mode for relay-fronted Slack."""
         try:
+            if chat_id:
+                override = self._slack_channel_reply_modes().get(str(chat_id))
+                if override is not None:
+                    return override
             return self._coerce_flag(
                 self._relay_slack_extra().get("reply_in_thread"), True
             )
@@ -427,7 +445,7 @@ class RelayAdapter(BasePlatformAdapter):
             )
             if not message_id:
                 return
-            if not self._effective_reply_in_thread():
+            if not self._effective_reply_in_thread(getattr(src, "chat_id", None)):
                 return
             if not self._dm_top_level_threads_as_sessions():
                 return  # opt-out: threaded replies, one rolling session
@@ -1021,12 +1039,16 @@ class RelayAdapter(BasePlatformAdapter):
             return None
         if self._platform_by_chat.get(str(chat_id)) != Platform.SLACK.value:
             return reply_to
-        if self._chat_type_by_chat.get(str(chat_id)) != "dm":
-            return reply_to
         md = metadata or {}
         if md.get("thread_id") or md.get("thread_ts"):
-            # A real thread was resolved by run.py — honour it.
+            # A real thread was resolved by run.py — honour it regardless of
+            # the top-level channel policy.
             return reply_to
+        if self._chat_type_by_chat.get(str(chat_id)) != "dm":
+            # For a top-level channel turn, reply_to is the triggering message
+            # ts. Keep it only when this channel's effective policy requests a
+            # thread; a real in-thread turn was handled above.
+            return reply_to if self._effective_reply_in_thread(chat_id) else None
         # Mode gate (native _resolve_thread_ts parity). The final-reply lane
         # (gateway/platforms/base.py) builds metadata from source.thread_id
         # ONLY — for a top-level DM that is None, so in thread-per-message
@@ -1036,7 +1058,7 @@ class RelayAdapter(BasePlatformAdapter):
         # message to the DM root while progress stayed threaded (2026-07-27
         # report, same class as the prompt-placement bug). Native SlackAdapter only
         # suppresses the anchor when reply_in_thread=false; mirror that.
-        reply_in_thread = self._effective_reply_in_thread()
+        reply_in_thread = self._effective_reply_in_thread(chat_id)
         if reply_in_thread:
             # Thread-per-message: the triggering ts is the thread anchor.
             return reply_to

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -677,7 +677,12 @@ def _slack_reply_in_thread_for_progress(adapter: Any, chat_id: Any) -> bool:
 
         relay_mode = getattr(adapter, "_effective_reply_in_thread", None)
         if callable(relay_mode):
-            return bool(relay_mode())
+            try:
+                return bool(relay_mode(chat_id))
+            except TypeError:
+                # Compatibility with relay/plugin adapters that implemented
+                # the historical zero-argument resolver.
+                return bool(relay_mode())
 
         return bool(adapter.config.extra.get("reply_in_thread", True))
     except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -666,6 +666,24 @@ def _resolve_progress_thread_id(
     return None
 
 
+def _slack_reply_in_thread_for_progress(adapter: Any, chat_id: Any) -> bool:
+    """Resolve native/relay Slack reply mode for progress/status delivery."""
+    if adapter is None:
+        return True
+    try:
+        channel_mode = getattr(adapter, "_reply_in_thread_for_channel", None)
+        if callable(channel_mode):
+            return bool(channel_mode(chat_id))
+
+        relay_mode = getattr(adapter, "_effective_reply_in_thread", None)
+        if callable(relay_mode):
+            return bool(relay_mode())
+
+        return bool(adapter.config.extra.get("reply_in_thread", True))
+    except Exception:
+        return True
+
+
 def _has_platform_display_override(user_config: dict, platform_key: str, setting: str) -> bool:
     """Return True when display.platforms.<platform> explicitly sets setting."""
     display = user_config.get("display") if isinstance(user_config, dict) else None
@@ -23433,26 +23451,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _progress_reply_in_thread = True
         if source.platform == Platform.SLACK:
             _slack_adapter_for_progress = self._adapter_for_source(source)
-            if _slack_adapter_for_progress is not None:
-                try:
-                    # Relay lane: the adapter owns mode resolution (nested
-                    # platforms.relay.extra.slack subset with flat-key
-                    # fallback). Native lane: read the flat extra as before.
-                    _mode_fn = getattr(
-                        _slack_adapter_for_progress,
-                        "_effective_reply_in_thread",
-                        None,
-                    )
-                    if callable(_mode_fn):
-                        _progress_reply_in_thread = bool(_mode_fn())
-                    else:
-                        _progress_reply_in_thread = bool(
-                            _slack_adapter_for_progress.config.extra.get(
-                                "reply_in_thread", True
-                            )
-                        )
-                except Exception:
-                    _progress_reply_in_thread = True
+            _progress_reply_in_thread = _slack_reply_in_thread_for_progress(
+                _slack_adapter_for_progress,
+                source.chat_id,
+            )
         _progress_thread_id = _resolve_progress_thread_id(
             source.platform, source.thread_id, event_message_id,
             reply_in_thread=_progress_reply_in_thread,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2524,7 +2524,7 @@ class SlackAdapter(BasePlatformAdapter):
             # Split long messages, preserving code block boundaries
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
 
-            thread_ts = self._resolve_thread_ts(reply_to, metadata)
+            thread_ts = self._resolve_thread_ts(reply_to, metadata, chat_id=chat_id)
             last_result = None
 
             # reply_broadcast: also post thread replies to the main channel.
@@ -2642,7 +2642,7 @@ class SlackAdapter(BasePlatformAdapter):
 
         try:
             formatted = self.format_message(content)
-            thread_ts = self._resolve_thread_ts(reply_to, metadata)
+            thread_ts = self._resolve_thread_ts(reply_to, metadata, chat_id=chat_id)
             kwargs = {
                 "channel": chat_id,
                 "user": user_id,
@@ -2683,7 +2683,7 @@ class SlackAdapter(BasePlatformAdapter):
         edit fails (message deleted, too old, ...) the cached ts is dropped
         and a fresh message is sent.
         """
-        thread_ts = self._resolve_thread_ts(None, metadata) or ""
+        thread_ts = self._resolve_thread_ts(None, metadata, chat_id=chat_id) or ""
         key = (str(chat_id), str(thread_ts), str(status_key))
         cached_id = self._status_message_ids.get(key)
         if cached_id is not None:
@@ -2870,6 +2870,7 @@ class SlackAdapter(BasePlatformAdapter):
             thread_ts = self._resolve_thread_ts(
                 reply_to=metadata.get("message_id"),
                 metadata=metadata,
+                chat_id=chat_id,
             )
 
         if not thread_ts:
@@ -3124,6 +3125,8 @@ class SlackAdapter(BasePlatformAdapter):
         self,
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        *,
+        chat_id: Optional[str] = None,
     ) -> Optional[str]:
         """Resolve the correct thread_ts for a Slack API call.
 
@@ -3144,7 +3147,7 @@ class SlackAdapter(BasePlatformAdapter):
         # top-level message. reply_to is the incoming message's own id, so
         # when thread_id == reply_to the "thread" is synthetic and we reply
         # directly in the channel instead.
-        if not self.config.extra.get("reply_in_thread", True):
+        if not self._reply_in_thread_for_channel(chat_id):
             md = metadata or {}
             existing_thread = md.get("thread_id") or md.get("thread_ts")
             if existing_thread and reply_to and existing_thread == reply_to:
@@ -3182,7 +3185,7 @@ class SlackAdapter(BasePlatformAdapter):
         chat_id = await self._ensure_dm_conversation(
             chat_id, team_id=self._metadata_team_id(metadata)
         )
-        thread_ts = self._resolve_thread_ts(reply_to, metadata)
+        thread_ts = self._resolve_thread_ts(reply_to, metadata, chat_id=chat_id)
         last_exc = None
         for attempt in range(3):
             try:
@@ -3252,7 +3255,7 @@ class SlackAdapter(BasePlatformAdapter):
             await super().send_multiple_images(chat_id, images, metadata, human_delay)
             return
 
-        thread_ts = self._resolve_thread_ts(None, metadata)
+        thread_ts = self._resolve_thread_ts(None, metadata, chat_id=chat_id)
 
         CHUNK = 10
         chunks = [images[i : i + CHUNK] for i in range(0, len(images), CHUNK)]
@@ -4067,7 +4070,7 @@ class SlackAdapter(BasePlatformAdapter):
                 response = await client.get(image_url)
                 response.raise_for_status()
 
-            thread_ts = self._resolve_thread_ts(reply_to, metadata)
+            thread_ts = self._resolve_thread_ts(reply_to, metadata, chat_id=chat_id)
             chat_id = await self._ensure_dm_conversation(
                 chat_id, team_id=self._metadata_team_id(metadata)
             )
@@ -4148,7 +4151,7 @@ class SlackAdapter(BasePlatformAdapter):
             chat_id, team_id=self._metadata_team_id(metadata)
         )
         try:
-            thread_ts = self._resolve_thread_ts(reply_to, metadata)
+            thread_ts = self._resolve_thread_ts(reply_to, metadata, chat_id=chat_id)
             last_exc = None
             for attempt in range(3):
                 try:
@@ -4208,7 +4211,7 @@ class SlackAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=f"File not found: {file_path}")
 
         display_name = file_name or os.path.basename(file_path)
-        thread_ts = self._resolve_thread_ts(reply_to, metadata)
+        thread_ts = self._resolve_thread_ts(reply_to, metadata, chat_id=chat_id)
         chat_id = await self._ensure_dm_conversation(
             chat_id, team_id=self._metadata_team_id(metadata)
         )
@@ -5573,7 +5576,7 @@ class SlackAdapter(BasePlatformAdapter):
             # variants (Copilot on #15464).
             if event_thread_ts_raw and event_thread_ts_raw != ts:
                 thread_ts = event_thread_ts_raw
-            elif self.config.extra.get("reply_in_thread", True):
+            elif self._reply_in_thread_for_channel(channel_id):
                 # Legacy default: treat ts as a synthetic thread root so
                 # this top-level message gets its own session.
                 thread_ts = ts
@@ -6365,7 +6368,7 @@ class SlackAdapter(BasePlatformAdapter):
             chat_id, team_id=self._metadata_team_id(metadata)
         )
         try:
-            thread_ts = self._resolve_thread_ts(None, metadata)
+            thread_ts = self._resolve_thread_ts(None, metadata, chat_id=chat_id)
 
             # Slack hard-caps a section block's text at 3000 chars; an
             # oversized block fails the whole send with ``invalid_blocks``
@@ -6465,7 +6468,7 @@ class SlackAdapter(BasePlatformAdapter):
             chat_id, team_id=self._metadata_team_id(metadata)
         )
         try:
-            thread_ts = self._resolve_thread_ts(None, metadata)
+            thread_ts = self._resolve_thread_ts(None, metadata, chat_id=chat_id)
             # Same 3000-char section-block cap as send_exec_approval: budget
             # the body against the rendered title so the wrapper never pushes
             # the block over the limit (overflow → invalid_blocks → no buttons).
@@ -6572,7 +6575,7 @@ class SlackAdapter(BasePlatformAdapter):
             chat_id, team_id=self._metadata_team_id(metadata)
         )
         try:
-            thread_ts = self._resolve_thread_ts(None, metadata)
+            thread_ts = self._resolve_thread_ts(None, metadata, chat_id=chat_id)
 
             # Escape the Slack mrkdwn control chars (&, <, >) so a question
             # containing them renders literally instead of as markup/mentions.
@@ -8337,6 +8340,37 @@ class SlackAdapter(BasePlatformAdapter):
             re.search(rf"<@{re.escape(uid)}(?:\|[^>]*)?>", text)
             for uid in self_uids
         )
+
+    def _slack_channel_reply_modes(self) -> Dict[str, bool]:
+        """Return per-channel thread-placement overrides.
+
+        ``platforms.slack.extra.channel_reply_modes`` maps channel IDs to
+        ``"thread"`` or ``"channel"``. Invalid entries are ignored so the
+        global ``reply_in_thread`` setting remains the safe fallback.
+        """
+        raw = self.config.extra.get("channel_reply_modes")
+        if not isinstance(raw, dict):
+            return {}
+        modes: Dict[str, bool] = {}
+        for channel_id, mode in raw.items():
+            normalized_id = str(channel_id).strip()
+            normalized_mode = str(mode).strip().lower()
+            if not normalized_id or normalized_mode not in {"thread", "channel"}:
+                continue
+            modes[normalized_id] = normalized_mode == "thread"
+        return modes
+
+    def _reply_in_thread_for_channel(self, channel_id: Optional[str]) -> bool:
+        """Resolve Slack reply placement for one channel.
+
+        A configured channel override wins; otherwise preserve the historical
+        global ``reply_in_thread`` behavior.
+        """
+        if channel_id:
+            override = self._slack_channel_reply_modes().get(str(channel_id))
+            if override is not None:
+                return override
+        return bool(self.config.extra.get("reply_in_thread", True))
 
     def _slack_free_response_channels(self) -> set:
         """Return channel IDs where no @mention is required."""

--- a/tests/gateway/relay/test_relay_slack_dm_streaming.py
+++ b/tests/gateway/relay/test_relay_slack_dm_streaming.py
@@ -27,6 +27,7 @@ from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType
 from gateway.relay.adapter import RelayAdapter
 from gateway.relay.descriptor import CONTRACT_VERSION, CapabilityDescriptor
+from gateway.run import _slack_reply_in_thread_for_progress
 from gateway.session import SessionSource
 from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
 
@@ -131,6 +132,114 @@ async def test_slack_channel_top_level_reply_keeps_autothread_anchor():
     frame = stub.sent[0]
     assert frame["reply_to"] == "1700.0003"
     assert frame["metadata"]["thread_id"] == "1700.0003"
+
+
+def _wire_channel_modes():
+    desc = _slack_desc(supported_ops=("send", "send_media"))
+    stub = StubConnector(desc)
+    config = PlatformConfig(
+        extra={
+            "slack": {
+                "reply_in_thread": True,
+                "channel_reply_modes": {
+                    "C-flat": "channel",
+                    "C-thread": "thread",
+                    "C-invalid": "sideways",
+                },
+            }
+        }
+    )
+    adapter = RelayAdapter(config, desc, transport=stub)
+    for chat_id in ("C-flat", "C-thread", "C-fallback"):
+        adapter._capture_scope(
+            MessageEvent(
+                text="hi",
+                source=SessionSource(
+                    platform=Platform.SLACK,
+                    chat_id=chat_id,
+                    chat_type="channel",
+                    user_id="U1",
+                    scope_id="T1",
+                ),
+                message_type=MessageType.TEXT,
+            )
+        )
+    return adapter, stub
+
+
+def test_relay_slack_channel_modes_drive_session_scope_and_progress():
+    adapter, _ = _wire_channel_modes()
+
+    flat_source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C-flat",
+        chat_type="channel",
+        user_id="U1",
+    )
+    threaded_source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C-thread",
+        chat_type="channel",
+        user_id="U1",
+    )
+    flat_event = MessageEvent(
+        text="flat",
+        source=flat_source,
+        message_type=MessageType.TEXT,
+        message_id="1700.1000",
+    )
+    threaded_event = MessageEvent(
+        text="threaded",
+        source=threaded_source,
+        message_type=MessageType.TEXT,
+        message_id="1700.2000",
+    )
+
+    adapter._stamp_slack_session_thread(flat_event)
+    adapter._stamp_slack_session_thread(threaded_event)
+
+    assert flat_source.thread_id is None
+    assert threaded_source.thread_id == "1700.2000"
+    assert _slack_reply_in_thread_for_progress(adapter, "C-flat") is False
+    assert _slack_reply_in_thread_for_progress(adapter, "C-thread") is True
+    assert _slack_reply_in_thread_for_progress(adapter, "C-fallback") is True
+
+
+@pytest.mark.asyncio
+async def test_relay_slack_channel_modes_control_text_and_media_placement():
+    adapter, stub = _wire_channel_modes()
+
+    await adapter.send("C-flat", "flat", reply_to="1700.3000")
+    flat_text = stub.sent[-1]
+    assert flat_text["reply_to"] is None
+    assert "thread_id" not in (flat_text["metadata"] or {})
+
+    await adapter.send("C-thread", "threaded", reply_to="1700.4000")
+    threaded_text = stub.sent[-1]
+    assert threaded_text["reply_to"] == "1700.4000"
+    assert threaded_text["metadata"]["thread_id"] == "1700.4000"
+
+    await adapter.send_image(
+        "C-flat", "https://example.com/image.png", reply_to="1700.5000"
+    )
+    flat_media = stub.sent[-1]
+    assert flat_media["op"] == "send_media"
+    assert flat_media["reply_to"] is None
+    assert "thread_id" not in (flat_media["metadata"] or {})
+
+
+@pytest.mark.asyncio
+async def test_relay_slack_channel_mode_preserves_real_thread():
+    adapter, stub = _wire_channel_modes()
+    await adapter.send(
+        "C-flat",
+        "real thread",
+        reply_to="1700.6001",
+        metadata={"thread_id": "1700.6000"},
+    )
+    frame = stub.sent[-1]
+    assert frame["reply_to"] == "1700.6001"
+    assert frame["metadata"]["thread_id"] == "1700.6000"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1305,6 +1305,23 @@ async def test_consecutive_terminal_progress_collapses_headers(monkeypatch, tmp_
 class TestSlackReplyInThreadProgressRouting:
     """#18859: reply_in_thread=false must stop progress from creating threads."""
 
+    def test_per_channel_mode_is_used_for_progress(self):
+        from gateway.run import _slack_reply_in_thread_for_progress
+
+        seen = []
+        adapter = SimpleNamespace(
+            _reply_in_thread_for_channel=lambda chat_id: seen.append(chat_id) or False
+        )
+
+        assert _slack_reply_in_thread_for_progress(adapter, "C_PROJECT") is False
+        assert seen == ["C_PROJECT"]
+
+    def test_relay_mode_remains_the_fallback(self):
+        from gateway.run import _slack_reply_in_thread_for_progress
+
+        adapter = SimpleNamespace(_effective_reply_in_thread=lambda: False)
+        assert _slack_reply_in_thread_for_progress(adapter, "C_PROJECT") is False
+
     def test_slack_reply_in_thread_false_drops_synthetic_thread(self):
         from gateway.run import _resolve_progress_thread_id
 

--- a/tests/gateway/test_slack_channel_reply_modes.py
+++ b/tests/gateway/test_slack_channel_reply_modes.py
@@ -1,0 +1,82 @@
+"""Outbound regression coverage for per-channel Slack reply modes."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.slack.adapter import SlackAdapter
+
+
+@pytest.fixture
+def adapter():
+    config = PlatformConfig(enabled=True, token="«redacted:xox…»")
+    config.extra.update({
+        "reply_in_thread": True,
+        "channel_reply_modes": {
+            "C_FLAT": "channel",
+            "C_THREADED": "thread",
+        },
+    })
+    result = SlackAdapter(config)
+    result._app = MagicMock()
+    client = MagicMock()
+    client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "200.001"})
+    client.files_upload_v2 = AsyncMock(return_value={"ok": True, "ts": "200.002"})
+    result._get_client = MagicMock(return_value=client)
+    result._ensure_dm_conversation = AsyncMock(
+        side_effect=lambda chat_id, **_kwargs: chat_id
+    )
+    result.stop_typing = AsyncMock()
+    result._record_uploaded_file_thread = MagicMock()
+    return result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("chat_id", "metadata", "reply_to", "expected_thread"),
+    [
+        ("C_FLAT", None, "100.001", None),
+        ("C_THREADED", {"thread_id": "100.002"}, "100.002", "100.002"),
+        ("C_FLAT", {"thread_id": "100.003"}, "100.004", "100.003"),
+    ],
+)
+async def test_final_text_payload_uses_channel_mode(
+    adapter, chat_id, metadata, reply_to, expected_thread
+):
+    await adapter.send(chat_id, "done", reply_to=reply_to, metadata=metadata)
+
+    kwargs = adapter._get_client.return_value.chat_postMessage.await_args.kwargs
+    assert kwargs.get("thread_ts") == expected_thread
+
+
+@pytest.mark.asyncio
+async def test_flat_status_payload_has_no_thread_anchor(adapter):
+    await adapter.send_or_update_status("C_FLAT", "turn", "working", metadata=None)
+
+    kwargs = adapter._get_client.return_value.chat_postMessage.await_args.kwargs
+    assert "thread_ts" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_flat_attachment_payload_has_no_thread_anchor(adapter, tmp_path):
+    document = tmp_path / "report.txt"
+    document.write_text("report", encoding="utf-8")
+
+    await adapter.send_document("C_FLAT", str(document), metadata=None)
+
+    kwargs = adapter._get_client.return_value.files_upload_v2.await_args.kwargs
+    assert kwargs["thread_ts"] is None
+
+
+@pytest.mark.asyncio
+async def test_flat_interactive_prompt_payload_has_no_thread_anchor(adapter):
+    await adapter.send_exec_approval(
+        "C_FLAT",
+        command="true",
+        session_key="session",
+        metadata=None,
+    )
+
+    kwargs = adapter._get_client.return_value.chat_postMessage.await_args.kwargs
+    assert "thread_ts" not in kwargs

--- a/tests/gateway/test_slack_channel_session_scope.py
+++ b/tests/gateway/test_slack_channel_session_scope.py
@@ -162,3 +162,85 @@ class TestThreadReplyAlwaysScopesByThread:
             f"thread reply dropped with reply_in_thread={reply_in_thread}"
         )
         assert captured[0].source.thread_id == "1700000000.000009"
+
+
+class TestChannelReplyModeOverrides:
+    """Per-channel modes override the global default for both session scope
+    and outbound placement without affecting genuine Slack threads."""
+
+    @pytest.mark.asyncio
+    async def test_channel_mode_overrides_global_thread_default(self, adapter):
+        adapter.config.extra.update({
+            "reply_in_thread": True,
+            "channel_reply_modes": {"C_CHAN": "channel"},
+        })
+        captured = []
+        adapter.handle_message = AsyncMock(side_effect=lambda e: captured.append(e))
+
+        with patch.object(
+            adapter, "_resolve_user_name", new=AsyncMock(return_value="testuser")
+        ):
+            await adapter._handle_slack_message(
+                _channel_event("<@U_BOT> hello", ts="1700000000.000020")
+            )
+
+        assert captured[0].source.thread_id is None
+        assert adapter._resolve_thread_ts(
+            reply_to="1700000000.000020",
+            metadata={"thread_id": "1700000000.000020"},
+            chat_id="C_CHAN",
+        ) is None
+
+    @pytest.mark.asyncio
+    async def test_thread_mode_overrides_global_channel_default(self, adapter):
+        adapter.config.extra.update({
+            "reply_in_thread": False,
+            "channel_reply_modes": {"C_CHAN": "thread"},
+        })
+        captured = []
+        adapter.handle_message = AsyncMock(side_effect=lambda e: captured.append(e))
+
+        with patch.object(
+            adapter, "_resolve_user_name", new=AsyncMock(return_value="testuser")
+        ):
+            await adapter._handle_slack_message(
+                _channel_event("<@U_BOT> hello", ts="1700000000.000021")
+            )
+
+        assert captured[0].source.thread_id == "1700000000.000021"
+        assert adapter._resolve_thread_ts(
+            reply_to="1700000000.000021",
+            metadata={"thread_id": "1700000000.000021"},
+            chat_id="C_CHAN",
+        ) == "1700000000.000021"
+
+    @pytest.mark.asyncio
+    async def test_genuine_thread_survives_channel_mode(self, adapter):
+        adapter.config.extra["channel_reply_modes"] = {"C_CHAN": "channel"}
+        captured = []
+        adapter.handle_message = AsyncMock(side_effect=lambda e: captured.append(e))
+
+        with patch.object(
+            adapter, "_resolve_user_name", new=AsyncMock(return_value="testuser")
+        ):
+            await adapter._handle_slack_message(
+                _channel_event(
+                    "<@U_BOT> follow-up",
+                    ts="1700000000.000023",
+                    thread_ts="1700000000.000022",
+                )
+            )
+
+        assert captured[0].source.thread_id == "1700000000.000022"
+        assert adapter._resolve_thread_ts(
+            reply_to="1700000000.000023",
+            metadata={"thread_id": "1700000000.000022"},
+            chat_id="C_CHAN",
+        ) == "1700000000.000022"
+
+    def test_invalid_mode_falls_back_to_global(self, adapter):
+        adapter.config.extra.update({
+            "reply_in_thread": True,
+            "channel_reply_modes": {"C_CHAN": "sideways"},
+        })
+        assert adapter._reply_in_thread_for_channel("C_CHAN") is True

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -405,6 +405,13 @@ platforms:
       # of threads. Messages inside existing threads still reply in-thread.
       reply_in_thread: true
 
+      # Optional per-channel override. "channel" keeps top-level replies flat
+      # and shares one channel session; "thread" keeps thread-per-message mode.
+      # Genuine replies inside an existing Slack thread always stay there.
+      channel_reply_modes:
+        C0123456789: channel
+        C9876543210: thread
+
       # Also post thread replies to the main channel
       # (Slack's "Also send to channel" feature).
       # Only the first chunk of the first reply is broadcast.
@@ -451,6 +458,7 @@ platforms:
 |-----|---------|-------------|
 | `platforms.slack.reply_to_mode` | `"first"` | Threading mode for multi-part messages: `"off"`, `"first"`, or `"all"` |
 | `platforms.slack.extra.reply_in_thread` | `true` | When `false`, channel messages get direct replies instead of threads. Messages inside existing threads still reply in-thread. |
+| `platforms.slack.extra.channel_reply_modes` | `{}` | Optional map of Slack channel IDs to `"channel"` or `"thread"`. Per-channel values override `reply_in_thread` for top-level session scope, progress/status placement, prompts, attachments, and final replies. Existing threads remain thread-scoped. |
 | `platforms.slack.extra.reply_broadcast` | `false` | When `true`, thread replies are also posted to the main channel. Only the first chunk is broadcast. |
 | `platforms.slack.extra.rich_blocks` | `false` | When `true`, agent messages are rendered as [Block Kit](https://docs.slack.dev/block-kit/) blocks (headers, dividers, true nested lists, and native tables). A plain-text fallback is always sent. Tables over Slack's limits fall back to aligned monospace. No app reinstall required — it's a send-side change only. |
 | `platforms.slack.extra.feedback_buttons` | `false` | When `true` with `rich_blocks`, appends Slack-native feedback controls to final replies. |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/slack.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/slack.md
@@ -294,6 +294,12 @@ platforms:
       # 已在话题中的消息仍在话题中回复。
       reply_in_thread: true
 
+      # 可选的按频道覆盖。"channel" 让顶层消息平铺回复并共享频道会话；
+      # "thread" 保持每条顶层消息一个话题。真实话题中的回复始终留在话题内。
+      channel_reply_modes:
+        C0123456789: channel
+        C9876543210: thread
+
       # 同时将话题回复发布到主频道
       # （Slack 的"同时发送到频道"功能）。
       # 仅广播第一条回复的第一个分块。
@@ -319,6 +325,7 @@ platforms:
 |-----|---------|-------------|
 | `platforms.slack.reply_to_mode` | `"first"` | 多部分消息的话题模式：`"off"`、`"first"` 或 `"all"` |
 | `platforms.slack.extra.reply_in_thread` | `true` | 为 `false` 时，频道消息直接回复而非话题。已在话题中的消息仍在话题中回复。 |
+| `platforms.slack.extra.channel_reply_modes` | `{}` | 可选的 Slack 频道 ID 到 `"channel"` 或 `"thread"` 的映射。按频道设置会覆盖 `reply_in_thread`，并统一控制顶层会话范围、进度/状态、交互提示、附件和最终回复的位置；真实话题仍保持独立会话。 |
 | `platforms.slack.extra.reply_broadcast` | `false` | 为 `true` 时，话题回复也会发布到主频道。仅广播第一个分块。 |
 | `platforms.slack.extra.rich_blocks` | `false` | 为 `true` 时，Agent 消息会渲染为 [Block Kit](https://docs.slack.dev/block-kit/) 区块（标题、分隔线、真正的嵌套列表以及原生表格）。始终附带纯文本回退。超出 Slack 限制的表格会回退为对齐的等宽文本。无需重新安装应用——这仅是发送端的改动。 |
 | `platforms.slack.extra.cron_continuable_surface` | `"thread"` | [可继续 cron 任务](../features/cron.md)的投递方式。`"thread"` 为每次投递新建专用话题（默认）；`"in_channel"` 直接平铺投递到频道时间线。使用 `in_channel` 时需搭配 `reply_in_thread: false`（及 `require_mention: false`），纯文本回复即可继续任务。 |


### PR DESCRIPTION
## What does this PR do?

Adds deterministic per-channel Slack reply modes through `platforms.slack.extra.channel_reply_modes`.

A workspace can keep the historical global `reply_in_thread` default while selecting individual channels that should use either:

- `channel`: top-level messages share one channel-scoped session and all progress, prompts, attachments, and final replies stay in the channel timeline.
- `thread`: top-level messages keep the existing thread-per-message behavior.

Replies inside a genuine existing Slack thread always remain thread-scoped in either mode.

This addresses mixed Slack workspaces where long-running project channels need continuous top-level conversation while task-oriented channels should remain thread-isolated. The existing global boolean cannot express both behaviors at once.

This is distinct from #73070, which proposes adaptive per-message classification, and #73851, which changes per-channel mention gating rather than reply placement/session scope.

## Related Issue

No linked issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `SlackAdapter._reply_in_thread_for_channel()` with global fallback.
- Apply the resolved mode to inbound session scope and every Slack outbound thread resolver call path.
- Make progress/status routing use the same channel-aware decision.
- Preserve existing-thread isolation regardless of the configured top-level mode.
- Document the new YAML map in the config example and English/Chinese Slack guides.
- Add regression coverage for both override directions, genuine threads, invalid-value fallback, and progress routing.
- Assert actual Slack API payloads for final text, status, attachment, and interactive-prompt delivery.

## How to Test

1. Configure a flat project channel while keeping the global thread default:

   ```yaml
   platforms:
     slack:
       extra:
         reply_in_thread: true
         channel_reply_modes:
           C0123456789: channel
   ```

2. Send two top-level messages in `C0123456789`; confirm both use the same channel-scoped session and all progress/final output stays top-level.
3. Reply inside an existing thread in the same channel; confirm the response stays in that thread.
4. Configure another channel as `thread` with global `reply_in_thread: false`; confirm that channel still opens a thread per top-level message.
5. Run:

   ```bash
   pytest tests/gateway/test_slack*.py tests/gateway/test_run_progress_topics.py tests/gateway/relay/test_relay_slack*.py -q
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example`
- [x] CONTRIBUTING/AGENTS update: N/A
- [x] I've considered cross-platform impact: configuration and adapter logic are platform-independent Python
- [x] Tool descriptions/schemas update: N/A

## Verification

- Slack, relay, progress, and outbound-payload regression suite: **386 passed**.
- Focused per-channel routing and payload suite: **31 passed**.
- Ruff lint: passed.
- `git diff --check`: passed.
- Commit is GPG-signed.
