### PR TITLE
feat: add InMind memory routing foundation

### DIFF
--- a/agent/memory_routing.py
+++ b/agent/memory_routing.py
@@ -165,11 +165,16 @@ def _deterministic_route(query: str, policy: dict[str, Any]) -> MemoryRoute:
     for domain_name, config in domains.items():
         if not isinstance(config, dict):
             continue
-        trigger = _first_matching_trigger(query, config.get("triggers"))
+        trigger = _first_matching_trigger(query, _domain_triggers(config))
         if trigger is None:
             continue
+        domain_risk = str(config.get("risk_level") or config.get("risk") or "low").lower()
         route.domains = _dedupe([*route.domains, str(domain_name)])
         route.slots = _dedupe([*route.slots, *_domain_slots(str(domain_name), domains)])
+        if domain_risk in {"medium", "high", "critical"} and _risk_rank(domain_risk) > _risk_rank(route.risk):
+            route.risk = domain_risk
+        if domain_risk in {"high", "critical"}:
+            route.gate_required = True
         matched_reasons.append(f"{domain_name} matched {trigger!r}")
 
     safety = policy.get("safety") if isinstance(policy, dict) else None
@@ -203,7 +208,20 @@ def _domain_slots(domain_name: str, domains: dict[str, Any], seen: set[str] | No
     for parent in _strings(config.get("extends")):
         slots.extend(_domain_slots(parent, domains, seen))
     slots.extend(_strings(config.get("slots")))
+    slots.extend(_strings(config.get("required_if_available")))
+    slots.extend(_strings(config.get("recommended_if_available")))
     return _dedupe(slots)
+
+
+def _domain_triggers(config: dict[str, Any]) -> list[str]:
+    triggers = config.get("triggers")
+    if isinstance(triggers, dict):
+        return _dedupe([*_strings(triggers.get("keywords")), *_strings(triggers.get("semantic_hints"))])
+    return _strings(triggers)
+
+
+def _risk_rank(risk: str) -> int:
+    return {"low": 0, "medium": 1, "high": 2, "critical": 3}.get(str(risk).lower(), 0)
 
 
 def _load_policy() -> dict[str, Any]:
@@ -211,10 +229,39 @@ def _load_policy() -> dict[str, Any]:
         try:
             loaded = yaml.safe_load(_POLICY_PATH.read_text(encoding="utf-8"))
             if isinstance(loaded, dict):
-                return loaded
+                return _merge_default_policy(loaded)
         except Exception:
             pass
     return _DEFAULT_POLICY
+
+
+def _merge_default_policy(loaded: dict[str, Any]) -> dict[str, Any]:
+    """Overlay documented policy on top of test-safe deterministic defaults."""
+
+    merged = dict(loaded)
+    raw_loaded_domains = loaded.get("domains")
+    loaded_domains = raw_loaded_domains if isinstance(raw_loaded_domains, dict) else {}
+    domains: dict[str, Any] = {name: dict(config) for name, config in loaded_domains.items() if isinstance(config, dict)}
+    for name, default_config in _DEFAULT_POLICY["domains"].items():
+        current = dict(domains.get(name, {}))
+        current["extends"] = _dedupe([*_strings(default_config.get("extends")), *_strings(current.get("extends"))])
+        current["slots"] = _dedupe([*_strings(default_config.get("slots")), *_strings(current.get("slots"))])
+        current["triggers"] = _dedupe([*_strings(_domain_triggers(default_config)), *_strings(_domain_triggers(current))])
+        domains[name] = current
+    merged["domains"] = domains
+
+    raw_loaded_safety = loaded.get("safety")
+    loaded_safety = raw_loaded_safety if isinstance(raw_loaded_safety, dict) else {}
+    raw_default_safety = _DEFAULT_POLICY.get("safety", {})
+    default_safety = raw_default_safety if isinstance(raw_default_safety, dict) else {}
+    merged["safety"] = {
+        **loaded_safety,
+        "high_risk_triggers": _dedupe([
+            *_strings(default_safety.get("high_risk_triggers")),
+            *_strings(loaded_safety.get("high_risk_triggers")),
+        ]),
+    }
+    return merged
 
 
 def _first_matching_trigger(query: str, triggers: Any) -> str | None:

--- a/agent/memory_routing.py
+++ b/agent/memory_routing.py
@@ -1,0 +1,295 @@
+"""Core helpers for routing memory lookups to policy-defined domains.
+
+This module is intentionally provider-free. It turns a user query plus an
+optional structured LLM hint into a small, deterministic route object that later
+memory-provider integrations can consume.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+import re
+
+try:  # PyYAML is a core dependency, but keep this helper import-safe.
+    import yaml
+except Exception:  # pragma: no cover - only for severely trimmed envs.
+    yaml = None  # type: ignore[assignment]
+
+
+ROUTE_SOURCE_NONE = "none"
+ROUTE_SOURCE_DETERMINISTIC = "deterministic"
+ROUTE_SOURCE_LLM = "llm"
+
+_POLICY_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "docs"
+    / "features"
+    / "memory-routing"
+    / "memory-routing-policy.yaml"
+)
+
+_DEFAULT_POLICY: dict[str, Any] = {
+    "domains": {
+        "investing": {
+            "slots": ["holdings", "average_cost", "watchlist"],
+            "triggers": ["stock", "stocks", "invest", "investing", "portfolio", "주식", "종목"],
+        },
+        "kr_stock": {
+            "extends": ["investing"],
+            "slots": ["kr_ticker", "broker_opinion"],
+            "triggers": ["하이닉스", "삼성전자", "코스피", "코스닥", "sk하이닉스", "000660", "005930"],
+        },
+    },
+    "safety": {
+        "high_risk_triggers": [
+            "delete",
+            "remove",
+            "erase",
+            "purge",
+            "forget",
+            "reset",
+            "삭제",
+            "제거",
+            "잊어",
+            "초기화",
+        ]
+    },
+}
+
+
+@dataclass
+class MemoryRoute:
+    """A provider-neutral memory route decision for one user query."""
+
+    domains: list[str] = field(default_factory=list)
+    slots: list[str] = field(default_factory=list)
+    risk: str = "low"
+    confidence: float = 0.0
+    route_source: str = ROUTE_SOURCE_NONE
+    reason: str = ""
+    new_topic_candidate: str | None = None
+    suggested_slots: list[str] = field(default_factory=list)
+    should_update_policy: bool = False
+    gate_required: bool = False
+    rewritten_query: str | None = None
+
+
+def parse_llm_route(payload: Any) -> MemoryRoute:
+    """Normalize a structured LLM routing payload into :class:`MemoryRoute`.
+
+    Invalid or missing fields degrade to safe defaults. The returned route is a
+    hint only; deterministic policy matches may still take precedence in
+    :func:`build_memory_route`.
+    """
+
+    if not isinstance(payload, dict):
+        return MemoryRoute(route_source=ROUTE_SOURCE_LLM)
+
+    risk = str(payload.get("risk") or "low").strip().lower() or "low"
+    confidence = _clamp_confidence(payload.get("confidence", 0.0))
+    new_topic_candidate = _optional_string(payload.get("new_topic_candidate"))
+    suggested_slots = _strings(payload.get("suggested_slots"))
+    should_update_policy = bool(payload.get("should_update_policy")) or bool(new_topic_candidate)
+    gate_required = bool(payload.get("gate_required")) or risk in {"high", "critical"}
+
+    return MemoryRoute(
+        domains=_strings(payload.get("domains")),
+        slots=_strings(payload.get("slots")),
+        risk=risk,
+        confidence=confidence,
+        route_source=ROUTE_SOURCE_LLM,
+        reason=str(payload.get("reason") or ""),
+        new_topic_candidate=new_topic_candidate,
+        suggested_slots=suggested_slots,
+        should_update_policy=should_update_policy,
+        gate_required=gate_required,
+        rewritten_query=_optional_string(payload.get("rewritten_query")),
+    )
+
+
+def build_memory_route(
+    query: str,
+    llm_payload: Any | None = None,
+    recent_turns: list[Any] | None = None,
+) -> MemoryRoute:
+    """Build a deterministic memory route, optionally enriched by an LLM hint."""
+
+    del recent_turns  # Reserved for future provider integration; keep API stable.
+
+    query_text = str(query or "")
+    policy = _load_policy()
+    llm_route = parse_llm_route(llm_payload) if llm_payload is not None else MemoryRoute()
+    deterministic = _deterministic_route(query_text, policy)
+
+    if deterministic.route_source == ROUTE_SOURCE_NONE and llm_payload is not None:
+        route = llm_route
+    else:
+        route = deterministic
+        if llm_payload is not None:
+            route.new_topic_candidate = llm_route.new_topic_candidate
+            route.suggested_slots = _dedupe([*route.suggested_slots, *llm_route.suggested_slots])
+            route.should_update_policy = route.should_update_policy or llm_route.should_update_policy
+            if llm_route.gate_required:
+                route.gate_required = True
+            if llm_route.risk in {"high", "critical"} and route.risk == "low":
+                route.risk = llm_route.risk
+            if not route.reason and llm_route.reason:
+                route.reason = llm_route.reason
+
+    route.rewritten_query = rewrite_memory_query(query_text, route)
+    return route
+
+
+def rewrite_memory_query(query: str, route: MemoryRoute | None = None) -> str:
+    """Rewrite a memory lookup query with route metadata, never slot values."""
+
+    if route is None:
+        route = build_memory_route(query)
+
+    parts = [str(query or "")]
+    if route.domains:
+        parts.append(f"domains: {', '.join(route.domains)}")
+    if route.slots:
+        parts.append(f"slots: {', '.join(route.slots)}")
+    return " | ".join(parts)
+
+
+def _deterministic_route(query: str, policy: dict[str, Any]) -> MemoryRoute:
+    route = MemoryRoute()
+    domain_config = policy.get("domains") if isinstance(policy, dict) else None
+    domains = domain_config if isinstance(domain_config, dict) else {}
+
+    matched_reasons: list[str] = []
+    for domain_name, config in domains.items():
+        if not isinstance(config, dict):
+            continue
+        trigger = _first_matching_trigger(query, config.get("triggers"))
+        if trigger is None:
+            continue
+        route.domains = _dedupe([*route.domains, str(domain_name)])
+        route.slots = _dedupe([*route.slots, *_domain_slots(str(domain_name), domains)])
+        matched_reasons.append(f"{domain_name} matched {trigger!r}")
+
+    safety = policy.get("safety") if isinstance(policy, dict) else None
+    high_risk_triggers = safety.get("high_risk_triggers") if isinstance(safety, dict) else []
+    risk_trigger = _first_matching_trigger(query, high_risk_triggers)
+    if risk_trigger is not None:
+        route.risk = "high"
+        route.gate_required = True
+        matched_reasons.append(f"safety matched {risk_trigger!r}")
+
+    if route.domains or route.gate_required:
+        route.route_source = ROUTE_SOURCE_DETERMINISTIC
+        route.confidence = 0.85 if route.domains else 0.7
+        route.reason = "; ".join(matched_reasons)
+
+    return route
+
+
+def _domain_slots(domain_name: str, domains: dict[str, Any], seen: set[str] | None = None) -> list[str]:
+    if seen is None:
+        seen = set()
+    if domain_name in seen:
+        return []
+    seen.add(domain_name)
+
+    config = domains.get(domain_name)
+    if not isinstance(config, dict):
+        return []
+
+    slots: list[str] = []
+    for parent in _strings(config.get("extends")):
+        slots.extend(_domain_slots(parent, domains, seen))
+    slots.extend(_strings(config.get("slots")))
+    return _dedupe(slots)
+
+
+def _load_policy() -> dict[str, Any]:
+    if _POLICY_PATH.exists() and yaml is not None:
+        try:
+            loaded = yaml.safe_load(_POLICY_PATH.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                return loaded
+        except Exception:
+            pass
+    return _DEFAULT_POLICY
+
+
+def _first_matching_trigger(query: str, triggers: Any) -> str | None:
+    for trigger in _strings(triggers):
+        if _token_boundary_match(query, trigger):
+            return trigger
+    return None
+
+
+def _token_boundary_match(text: str, needle: str) -> bool:
+    """Return True only when ``needle`` appears on token boundaries.
+
+    This deliberately avoids raw substring matching: ``cat`` does not match
+    ``communicate`` and ``pr`` does not match ``approach``.
+    """
+
+    needle = needle.strip().lower()
+    if not needle:
+        return False
+    tokens = _tokens(text)
+    needle_tokens = _tokens(needle)
+    if not needle_tokens:
+        return False
+    width = len(needle_tokens)
+    for index in range(0, len(tokens) - width + 1):
+        if tokens[index : index + width] == needle_tokens:
+            return True
+    return False
+
+
+def _tokens(text: str) -> list[str]:
+    return re.findall(r"[A-Za-z0-9_]+|[가-힣]+", str(text or "").lower())
+
+
+def _strings(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value.strip()] if value.strip() else []
+    if isinstance(value, (list, tuple, set)):
+        result: list[str] = []
+        for item in value:
+            if isinstance(item, str) and item.strip():
+                result.append(item.strip())
+        return _dedupe(result)
+    return []
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def _optional_string(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _clamp_confidence(value: Any) -> float:
+    try:
+        confidence = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, min(1.0, confidence))
+
+
+__all__ = [
+    "MemoryRoute",
+    "build_memory_route",
+    "parse_llm_route",
+    "rewrite_memory_query",
+]

--- a/agent/memory_routing_proposals.py
+++ b/agent/memory_routing_proposals.py
@@ -1,0 +1,81 @@
+"""Proposal queue helpers for memory-routing policy evolution.
+
+The queue is append/update-only JSON. It never edits the source policy file; a
+human or later workflow can review proposals and promote them deliberately.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent.memory_routing import MemoryRoute
+
+PROPOSAL_FILENAME = "memory-routing-proposals.json"
+
+
+def record_policy_proposal(
+    output_dir: str | Path, route: MemoryRoute, query: str
+) -> Path | None:
+    """Record a policy proposal for ``route.new_topic_candidate``.
+
+    Returns the proposal JSON path when a proposal is recorded, otherwise None.
+    The policy itself is never mutated.
+    """
+
+    topic = (route.new_topic_candidate or "").strip()
+    if not topic:
+        return None
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    proposal_path = output_path / PROPOSAL_FILENAME
+
+    proposals = _read_proposals(proposal_path)
+    entry = proposals.setdefault(
+        topic,
+        {"count": 0, "examples": [], "suggested_slots": []},
+    )
+    entry["count"] = _safe_int(entry.get("count")) + 1
+    entry["examples"] = _append_unique_strings(entry.get("examples"), [str(query or "")])
+    entry["suggested_slots"] = _append_unique_strings(
+        entry.get("suggested_slots"), route.suggested_slots
+    )
+
+    proposal_path.write_text(
+        json.dumps(proposals, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return proposal_path
+
+
+def _read_proposals(path: Path) -> dict[str, dict[str, object]]:
+    if not path.exists():
+        return {}
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _safe_int(value: object) -> int:
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0
+
+
+def _append_unique_strings(existing: object, additions: list[str]) -> list[str]:
+    result: list[str] = []
+    if isinstance(existing, list):
+        for item in existing:
+            if isinstance(item, str) and item not in result:
+                result.append(item)
+    for item in additions:
+        if isinstance(item, str) and item and item not in result:
+            result.append(item)
+    return result
+
+
+__all__ = ["PROPOSAL_FILENAME", "record_policy_proposal"]

--- a/docs/features/memory-routing/PRD.md
+++ b/docs/features/memory-routing/PRD.md
@@ -1,0 +1,534 @@
+# Hermes Memory Routing PRD
+
+> **제품명:** Hermes Memory Routing & Always-in-State 개선
+>
+> **작성일:** 2026-07-30
+>
+> **배경 문서:** InMind: Keep It InMind — Benchmarking the Implicit-Association Blind Spot in Agent Memory, arXiv:2607.24368
+>
+> **대상:** Hermes Agent built-in memory, external memory providers, session_search, prompt assembly, memory curation workflow
+
+> **Claude Code Opus 리뷰 반영:** 2026-07-30, `claude --model opus` 리뷰에서 지적된 baseline stratification, open-set implementation gap, benchmark validity, isolated HERMES_HOME, write-path tagging, routing cost 요구사항을 반영했다. 리뷰 전문은 `claude-opus-review.md`에 저장했다.
+
+---
+
+## 1. 요약
+
+Hermes는 이미 `MEMORY.md` / `USER.md`를 세션 시작 시 system prompt에 주입하는 Always-in-State형 built-in memory와, `session_search`, external memory provider(Honcho, Mem0, Hindsight, Holographic, OpenViking, RetainDB, ByteRover, Supermemory)를 지원한다.
+
+그러나 InMind 벤치마크가 보여준 핵심 문제는 단순 저장/검색 문제가 아니다.
+
+> 에이전트가 사실을 저장하고 직접 질문에는 맞히더라도, 그 사실이 간접적으로 필요한 순간에는 검색하지 못한다.
+
+예:
+
+```text
+저장된 사실: 사용자는 견과류 알러지가 있다.
+사용자 질문: 마카롱 레시피 알려줘.
+실패: 마카롱과 알러지 메모리가 의미적으로 가깝지 않아 검색 누락.
+```
+
+따라서 Hermes의 개선 방향은 “더 많은 memory backend 추가”가 아니라:
+
+1. 어떤 기억을 항상 보이게 둘지 결정하는 **Memory Routing**
+2. 질문 도메인에 따라 필요한 사용자 사실 유형을 떠올리는 **Domain Slot Recall**
+3. 고위험 도메인에서 누락을 막는 **Safety/Profile Gate**
+4. memory 포화 시 중요한 사실이 밀려나지 않게 하는 **Curation Policy**
+
+를 추가하는 것이다.
+
+---
+
+## 2. 문제 정의
+
+### 2.1 현재 Hermes memory 구조
+
+공식 문서/GitHub 기준 확인 사항:
+
+- Built-in memory
+  - `~/.hermes/memories/MEMORY.md`: agent personal notes, 2,200 chars
+  - `~/.hermes/memories/USER.md`: user profile, 1,375 chars
+  - 세션 시작 시 system prompt에 frozen snapshot으로 주입
+  - 세션 중 수정은 디스크에는 즉시 반영되지만 현재 prompt에는 다음 세션부터 반영
+
+- Session search
+  - SQLite + FTS5 기반 과거 세션 원문 검색
+  - archive recall에는 적합
+  - 질문과 의미적으로 먼 implicit association에는 취약
+
+- External memory provider
+  - 하나의 external provider만 active 가능
+  - built-in memory는 external provider와 별도로 항상 active
+  - provider lifecycle에는 `system_prompt_block()`, `prefetch(query)`, `queue_prefetch(query)`, `sync_turn()`, `on_session_end()`, `on_pre_compress()`, `on_memory_write()`가 있음
+
+### 2.2 현재 한계
+
+1. **Built-in memory 용량이 작고 수동 큐레이션 의존**
+   - 현재 Ryan default profile의 personal memory는 99% 수준으로 포화 상태.
+   - 중요한 사용자 사실과 구현 세부사항/환경 quirks가 섞이면 eviction 판단이 어려움.
+
+2. **검색 query가 표면 질문에 종속**
+   - “마카롱” 질문은 “견과류 알러지”를 직접 검색하지 않는다.
+   - “백합” 질문은 “고양이를 키운다”를 직접 검색하지 않는다.
+
+3. **memory 중요도 판단 기준이 명시적이지 않음**
+   - 빈도/최근성/사용자 교정만으로는 “한 번 말했지만 치명적인 사실”을 보존하기 어렵다.
+
+4. **고위험 도메인 gate가 일반화되어 있지 않음**
+   - 음식/건강/투자/보안/법률/가족/반려동물 질문에서 어떤 profile fact를 확인해야 하는지 일관된 체크리스트가 없다.
+
+---
+
+## 3. 근거
+
+### 3.1 InMind 벤치마크 수치
+
+InMind 글/논문에서 제시된 대표 수치:
+
+| 방식 | 간접 적용 성능 |
+|---|---:|
+| 검색 기반 memory systems | 약 4.8~16.0% |
+| MemoryOS 최고치 | 14.4% |
+| Naive RAG 최고치 | 16.0% |
+| 200줄 profile Always-in-State | 68.8% |
+| 직접 in-context 주입 upper bound | 84.0% |
+
+계산:
+
+- 68.8% / 16.0% = **4.3배**
+- 68.8% / 14.4% = **약 4.78배**
+- 68.8% - 16.0% = **+52.8%p**
+- 84.0% - 14.4% = **+69.6%p**
+
+해석:
+
+> implicit association 문제에서는 “검색 성능 개선”보다 “중요 사실을 모델 시야 안에 두는 것”의 효과가 훨씬 크다.
+
+### 3.2 Hermes 공식 구조와의 연결
+
+Hermes built-in memory는 이미 Always-in-State이므로 InMind 해결 방향과 맞다.
+
+하지만 현재 built-in memory는 plain text + strict char limit 구조라 다음 개선이 필요하다.
+
+- critical fact 선별 정책
+- domain/risk/tier 메타데이터
+- 질문 도메인별 triggered memory 주입
+- memory compaction/curation 기준
+- provider prefetch query rewrite
+
+### 3.3 Baseline stratification: always vs overflow
+
+Claude Code Opus 리뷰 결과, Hermes의 baseline은 단일 숫자로 표현하면 안 된다. Hermes는 이미 built-in `MEMORY.md`/`USER.md`를 Always-in-State로 주입하므로, 필요한 사실이 always block 안에 있는 case와 memory overflow/archive에 있는 case는 서로 다른 성능 arm이다.
+
+Benchmark case는 반드시 다음 필드를 가진다.
+
+```yaml
+memory_location: always | triggered | overflow | archive
+```
+
+모든 지표는 최소한 `memory_location=always`와 `memory_location=overflow/archive`로 stratify한다. InMind의 68.8% vs 14.4~16.0%는 cross-configuration 비교이며, 이미 always-in-state인 시스템에서 남은 theoretical headroom은 `84.0 - 68.8 = 15.2%p`로 본다. 반대로 필요한 사실이 overflow/archive에 있으면 10~16% arm으로 떨어질 수 있다.
+
+따라서 §9의 정량 목표는 초기 benchmark 측정 전까지 확정 목표가 아니라 directional target으로 취급한다.
+
+---
+
+## 4. 목표
+
+### 4.1 P0 목표
+
+1. **Memory Tier Policy 정의**
+   - `always`, `triggered`, `archive` 3단계로 memory를 분류.
+
+2. **Critical Profile Curation**
+   - `USER.md` / `MEMORY.md`에 들어갈 항목 기준을 정의.
+   - task log, transient state, stale implementation details는 session_search/archive로 이동.
+
+3. **Domain Slot Recall 설계**
+   - 질문이 들어오면 표면 query가 아니라 필요한 사용자 사실 슬롯을 생성.
+   - 예: food → allergies, diet, religion, household constraints.
+
+4. **Safety/Profile Gate 설계**
+   - 음식/건강/투자/보안/법률/반려동물 등 고위험 도메인에서 답변 전 memory slot 확인.
+
+5. **측정 가능한 benchmark harness 설계**
+   - InMind형 mini benchmark를 Hermes 환경에 맞게 작성.
+   - direct recall / indirect application / in-context upper bound를 분리 측정.
+
+### 4.2 P1 목표
+
+1. **Provider-aware query rewrite**
+   - external memory provider의 `prefetch(query)` 전 query를 domain slot 기반으로 확장.
+
+2. **Memory pressure dashboard**
+   - built-in memory 사용률, stale 후보, duplicate 후보, critical fact coverage 표시.
+
+3. **Memory write reviewer 개선**
+   - 새 memory 저장 시 tier/domain/risk 후보를 제안.
+
+4. **Hermes docs/skill 반영**
+   - memory 운영 skill 또는 docs에 routing policy 추가.
+
+### 4.3 P2 목표
+
+1. **Adaptive Always-in-State composer**
+   - fixed `USER.md` / `MEMORY.md` 외에 세션 시작 또는 turn 시작 시 critical profile card 생성.
+
+2. **InMind-style regression suite**
+   - Hermes memory provider별 indirect application 성능을 주기적으로 비교.
+
+3. **Learning loop 자동화**
+   - 실패 케이스를 memory routing rule 또는 skill 개선 후보로 자동 전환.
+
+---
+
+## 5. 비목표
+
+이번 PRD 범위에서 바로 하지 않는 것:
+
+- Hermes memory backend 전체 리라이트
+- 모든 memory provider 동시 활성화
+- 사용자 private memory를 외부 cloud provider로 무조건 이전
+- health/legal/financial 전문 판단 자동화
+- LLM이 무승인으로 대량 memory 삭제
+- InMind 전체 125문항 benchmark 완전 복제
+- core prompt caching을 깨는 매 turn system prompt 대규모 변경
+
+### 5.1 설계 원칙: 하드코딩은 안전망이지 제품 전체가 아니다
+
+Keyword table은 MVP baseline, regression test, high-risk fast path에만 사용한다. 새 토픽을 `general`로 버리는 classifier는 InMind 문제가 지적한 blind spot을 반복하므로 허용하지 않는다.
+
+제품 목표는 **rule-based safety trigger + LLM open-set classifier + policy learning loop**이다.
+
+---
+
+## 6. 사용자 스토리
+
+### Story 1 — 음식/알러지
+
+사용자가 “마카롱 레시피 알려줘”라고 묻는다. Hermes는 질문에 “알러지”라는 단어가 없어도 food domain slot을 활성화하고, 사용자 알러지 memory를 확인한 뒤 견과류 대체 재료를 제안한다.
+
+**Acceptance Criteria**
+
+- food domain 감지
+- allergy/diet/religion slots 확인
+- 관련 memory가 있으면 답변에 반영
+- 관련 memory가 없으면 보수적 안내 포함
+
+### Story 2 — 반려동물 안전
+
+사용자가 “집에 백합 둬도 돼?”라고 묻는다. Hermes는 pet safety slot을 활성화하고, 사용자가 고양이를 키운다는 memory가 있으면 위험 경고를 우선 제공한다.
+
+**Acceptance Criteria**
+
+- plant/home/pet-safety domain 감지
+- pet ownership slot 확인
+- 고양이 memory가 있으면 백합 독성 경고
+
+### Story 3 — 투자 답변
+
+사용자가 특정 한국 주식 매수/매도 전략을 묻는다. Hermes는 투자 domain slot을 활성화하고, Ryan의 portfolio-aware 규칙, KR stock answer format, 보유종목 확인 원칙을 반영한다.
+
+**Acceptance Criteria**
+
+- investing/kr-stock domain 감지
+- holdings/risk/action-card/style slots 확인
+- 사용 skill 및 skipped chart skill 사유 명시
+- 단순 일반론 대신 portfolio-aware 답변
+
+### Story 4 — memory 포화 관리
+
+memory 사용률이 80%를 넘으면 Hermes는 새 memory를 무작정 추가하지 않고, stale/duplicate/low-risk archive 후보와 critical fact 보존 후보를 함께 제안한다.
+
+**Acceptance Criteria**
+
+- usage threshold 감지
+- consolidate/remove 후보 생성
+- critical fact 삭제 방지
+- user approval 또는 명시적 도구 호출 정책 준수
+
+---
+
+## 7. 기능 요구사항
+
+### FR1. Memory Tier Model
+
+Memory entry는 내부적으로 다음 필드를 가질 수 있어야 한다.
+
+```yaml
+content: string
+tier: always | triggered | archive
+domains: list[string]
+risk: low | medium | high | critical
+source: manual | auto_review | user_correction | tool_observation
+confidence: low | medium | high
+last_verified_at: date | null
+```
+
+초기 구현은 실제 `MEMORY.md` 포맷을 바꾸지 않고, sidecar JSON 또는 curation report에서만 관리해도 된다.
+
+### FR2. Hybrid Open-set Domain Router
+
+Domain classifier는 하드코딩된 keyword table로 고정하지 않는다. 실제 제품 구조는 다음 3계층으로 동작해야 한다.
+
+1. **Deterministic Safety Triggers**
+   - health, medication, security, investing, allergy, pet safety처럼 false negative 비용이 큰 domain은 rule 기반 fast path로 감지한다.
+   - 이 레이어는 classifier 전체가 아니라 안전망이다.
+
+2. **LLM Open-set Classifier**
+   - known domain에 대한 JSON 분류를 수행한다.
+   - 질문 표면어와 memory가 멀어도 필요한 사용자 profile slot을 추론한다.
+   - 새 표현/새 상황을 `general`로 버리지 않고 `new_topic_candidate`와 `suggested_slots`를 생성한다.
+
+3. **Policy Learning Loop**
+   - 반복 등장하거나 실패를 만든 `new_topic_candidate`를 review queue에 올린다.
+   - 승인 후 `memory-routing-policy.yaml`의 정식 domain/slot으로 승격한다.
+
+초기 known domains:
+
+- food
+- health
+- medication
+- supplement
+- pet_safety
+- child_family
+- travel
+- investing
+- kr_stock
+- coding_repo
+- security
+- legal_admin
+- home_lifestyle
+- general
+
+Classifier output schema:
+
+```json
+{
+  "domains": ["food"],
+  "slots": ["allergies", "dietary_restrictions"],
+  "risk": "high",
+  "confidence": 0.84,
+  "route_source": "rule+llm",
+  "reason": "Recipe request can be affected by allergies and dietary restrictions.",
+  "new_topic_candidate": null,
+  "suggested_slots": [],
+  "should_update_policy": false
+}
+```
+
+Unseen topic example:
+
+```json
+{
+  "domains": ["home_lifestyle"],
+  "slots": ["pets", "children", "household_constraints"],
+  "risk": "medium",
+  "confidence": 0.72,
+  "route_source": "llm",
+  "reason": "Housewarming plant gifts may interact with pets or children in the recipient household.",
+  "new_topic_candidate": "home_gift_safety",
+  "suggested_slots": ["recipient_household", "pets", "children", "allergies"],
+  "should_update_policy": true
+}
+```
+
+### FR3. Slot Generator
+
+Slot generation은 policy lookup + LLM-proposed slots의 합집합으로 만든다. Known domain에서는 `memory-routing-policy.yaml`의 slots를 우선 사용하고, open-set 상황에서는 LLM이 제안한 slots를 confidence와 risk 기준으로 제한적으로 추가한다.
+
+예:
+
+```yaml
+food:
+  required_if_available:
+    - allergies
+    - dietary_restrictions
+    - religion_food_rules
+    - household_constraints
+
+investing:
+  required_if_available:
+    - holdings
+    - risk_tolerance
+    - time_horizon
+    - average_cost
+    - answer_format_preferences
+
+home_lifestyle:
+  recommended_if_available:
+    - pets
+    - children
+    - household_constraints
+    - allergies
+```
+
+### FR4. Memory Retrieval Strategy
+
+질문 처리 전 다음 순서로 memory context를 구성한다.
+
+```text
+1. Built-in Always-in-State: USER.md + MEMORY.md frozen snapshot
+2. Domain Slot Recall: 질문 domain 기반 targeted memory lookup
+3. Provider Prefetch: query rewrite 후 external provider prefetch
+4. Session Search: 사용자가 과거 대화 참조 또는 구체적 회상 요청 시 사용
+```
+
+### FR5. Safety/Profile Gate
+
+고위험 domain에서는 다음 중 하나를 수행한다.
+
+- 관련 memory가 발견되면 답변에 반영
+- memory가 없으면 “알려진 제약 정보 없음” 또는 “제약이 있으면 바뀔 수 있음”을 명시
+- 고위험 조언은 단정 대신 확인/주의 표현 사용
+
+### FR6. Benchmark Harness
+
+Hermes용 mini benchmark를 만든다.
+
+각 case는 다음 3문항을 가진다.
+
+```yaml
+memory: "User has a nut allergy."
+direct_question: "What allergy does the user have?"
+indirect_question: "Suggest a macaron recipe."
+in_context_question: "Given the memory, suggest a macaron recipe."
+expected_behavior: "Avoid almond flour and mention nut allergy."
+```
+
+측정 지표:
+
+- Direct Recall Accuracy
+- Indirect Application Accuracy
+- In-context Upper Bound
+- Memory Hit Rate
+- Safety Miss Rate
+- False Positive Personalization Rate
+
+### FR7. Memory Write Tagging
+
+Memory routing 품질은 write path에서 tier/domain/risk가 부여되어야 유지된다. 새 memory가 저장되거나 수정될 때 다음을 수행한다.
+
+- `on_memory_write()` 또는 built-in `memory` tool write path에서 tier/domain/risk 후보를 생성한다.
+- sidecar metadata key는 normalized content hash를 기본으로 한다.
+- `MEMORY.md`/`USER.md` 수동 편집 또는 replace/remove로 hash orphan이 생기면 curation report에 표시한다.
+- `supersedes` 필드로 오래된 memory와 대체 관계를 표현한다.
+- `confirmed_absent`를 지원해 “알려진 제약 없음”과 “미확인”을 구분한다.
+- critical/high risk memory는 자동 삭제하지 않고 proposal-only로 둔다.
+
+```yaml
+content_hash: sha256-normalized-text
+tier: always
+domains: [food, health]
+risk: critical
+supersedes: []
+confirmed_absent: false
+last_verified_at: 2026-07-30
+```
+
+---
+
+## 8. 비기능 요구사항
+
+### NFR1. Prompt caching 보존
+
+- built-in memory snapshot은 세션 시작 시 frozen 유지.
+- 매 turn 동적 context는 provider/prefetch block으로 제한.
+- system prompt 대규모 재조립은 피한다.
+
+### NFR2. Privacy
+
+- health, religion, family, finance facts는 critical/private로 취급.
+- cloud provider 사용 여부는 config/사용자 선택을 따른다.
+- 기본 개선은 local built-in memory와 local reports 중심으로 가능해야 한다.
+
+### NFR3. Safety
+
+- memory deletion은 승인/검토 기반.
+- critical fact는 자동 삭제하지 않는다.
+- auto curation은 먼저 proposal artifact를 생성한다.
+
+### NFR4. Observability
+
+- 각 답변에서 memory routing이 영향을 준 경우 debug/evidence mode에서 확인 가능해야 한다.
+- 최소한 benchmark에서는 어떤 slot이 활성화되었고 어떤 memory가 hit/miss 되었는지 기록한다.
+
+### NFR5. Routing Cost and Latency
+
+LLM open-set classifier는 매 turn 무조건 호출하지 않는다. 비용/지연 예산을 명시한다.
+
+- deterministic safety trigger가 low-risk/general이고 최근 route cache가 유효하면 LLM classifier를 생략할 수 있다.
+- p95 routing latency budget: 500ms 이하를 목표로 하되, 외부 LLM 호출 시 별도 측정한다.
+- classifier model은 Haiku급/mini급 저비용 모델을 우선 사용한다.
+- cache key는 normalized query + recent-turn topic signature + policy version으로 한다.
+- budget 초과, LLM unavailable, invalid JSON이면 deterministic-only로 degrade한다.
+- rewritten query에는 memory 값이 아니라 slot 이름만 포함한다. 외부 provider로 민감 memory value를 query rewrite 단계에서 보내지 않는다.
+
+---
+
+## 9. 성공 지표
+
+### 9.0 Metric definitions
+
+- **Unseen Topic Useful Routing Rate:** unseen case에서 정답 slot 집합 recall이 0.5 이상이고 false slot이 2개 이하인 비율.
+- **False Positive Personalization Rate:** control case에서 필요 없는 개인 memory를 답변에 반영하거나 경고를 출력한 비율.
+- **Safety Miss Rate:** high/critical case에서 필수 safety constraint를 누락한 비율.
+- **Critical Fact Coverage @ fixed budget:** fixed char/token budget에서 critical/high tier memory가 보존되는 비율.
+
+### 9.1 정량 목표
+
+| Metric | Baseline | P0 | P1 | P2 | 비고 |
+|---|---:|---:|---:|---:|---|
+| Direct Recall Accuracy | 측정 | 유지 | 유지 | 유지 | `memory_location`별 stratify |
+| Indirect Application Accuracy — always | 측정 | 측정 후 확정 | +5%p | +10%p | always block은 이미 68.8% arm일 수 있음 |
+| Indirect Application Accuracy — overflow/archive | 측정 | 35%+ directional | 50%+ directional | 65%+ directional | InMind 검색형 10~16% arm 개선 목표 |
+| Memory Hit Rate on indirect cases | 측정 | 40%+ directional | 60%+ | 70%+ | known/unseen split |
+| Unseen Topic Useful Routing Rate | 측정 | 30%+ directional | 45%+ | 60%+ | n≥20, CI 병기 |
+| Safety Miss Rate | 측정 | baseline 측정 | 30% 감소 | 50% 감소 | control case 포함 |
+| False Positive Personalization Rate | 측정 | 측정 | 감소 | 감소 | 개인화가 불필요한 control case |
+| Critical Fact Coverage @ fixed budget | 측정 | 90%+ | 95%+ | 95%+ | 단순 memory usage보다 우선 |
+| In-context Upper Bound | 진단 | 진단 | 진단 | 진단 | 목표가 아니라 upper-bound diagnostic |
+
+### 9.2 정성 목표
+
+- 사용자가 “전에 말했잖아”라고 교정하는 빈도 감소
+- 투자/건강/식단/반려동물 답변에서 개인화 누락 감소
+- memory가 꽉 찼을 때 무작정 추가 실패가 아니라 curation proposal 생성
+- memory와 skill의 책임 경계 명확화
+
+---
+
+## 10. 위험 및 대응
+
+| 위험 | 설명 | 대응 |
+|---|---|---|
+| Over-personalization | 관련 없는 memory를 과도하게 적용 | domain/risk confidence, false positive metric |
+| Privacy exposure | 민감 facts가 불필요하게 prompt에 노출 | critical/private tagging, cloud opt-in |
+| Prompt bloat | triggered memory가 너무 커짐 | token budget, top-k, slot별 max chars |
+| Stale memory | 오래된 사실이 계속 적용 | last_verified_at, review cadence |
+| Deletion accident | 중요한 memory 자동 삭제 | proposal-only, approval required |
+| Provider lock-in | 특정 memory provider에 종속 | provider-agnostic query rewrite / sidecar policy |
+
+---
+
+## 11. Open Questions
+
+1. built-in memory plain text 포맷을 유지할 것인가, sidecar metadata를 둘 것인가?
+2. hybrid classifier의 LLM 호출 조건과 cache TTL은 어떻게 둘 것인가?
+3. Ryan default profile에서 memory curation을 먼저 실행할 것인가, benchmark harness부터 만들 것인가?
+4. external provider는 현재 상태 유지인가, Honcho/Hindsight/Holographic 중 하나를 실험할 것인가?
+5. 답변 본문에 memory routing evidence를 항상 표시할 것인가, debug/verbose일 때만 표시할 것인가?
+
+---
+
+## 12. 권장 MVP
+
+MVP는 core code 수정 없이 다음으로 시작한다.
+
+1. `memory-routing-policy.yaml` 작성
+2. deterministic safety trigger와 LLM open-set classifier schema 작성
+3. `memory_curation_report.py`로 built-in memory를 tier/domain/risk 후보로 분류
+4. `inmind_mini_benchmark.yaml` 20문항 + unseen topic split 작성
+5. `run_memory_routing_benchmark.py`로 baseline/routed/open-set 성능 측정
+6. P0 결과를 바탕으로 Hermes core `prefetch(query)` 또는 prompt assembly 개선 PR 작성
+
+이렇게 하면 위험을 낮추면서도 InMind식 문제를 수치로 검증할 수 있다.

--- a/docs/features/memory-routing/README.md
+++ b/docs/features/memory-routing/README.md
@@ -1,0 +1,25 @@
+# Hybrid Open-set Domain Router
+
+This folder is the repo snapshot for the Hermes Memory Routing & Always-in-State proposal inspired by the InMind implicit-association benchmark.
+
+## Documents
+
+- [`PRD.md`](./PRD.md) — product requirements for tiered memory routing, domain-slot recall, safety/profile gates, write tagging, and benchmark expectations.
+- [`plan.md`](./plan.md) — phased implementation plan, including baseline stratification, open-set routing tasks, isolated benchmark harness requirements, and cost constraints.
+- [`memory-routing-policy.yaml`](./memory-routing-policy.yaml) — initial YAML SSOT for memory tiers, risk levels, domains, inheritance, and `required_if_available` slots.
+- [`claude-opus-review.md`](./claude-opus-review.md) — Claude Code Opus review notes incorporated into the PRD and plan.
+
+## Scope
+
+This change is documentation-only. It does not modify Hermes runtime code, tools, or agent behavior. The policy file is intended as a human-readable starting point for a future implementation and benchmark harness.
+
+## Core idea
+
+Hermes should not rely only on lexical or semantic retrieval when user facts are indirectly relevant. A hybrid router combines:
+
+1. deterministic domain/risk policy slots,
+2. open-set classifier proposals for unknown domains,
+3. always-in-state preservation of critical profile facts, and
+4. turn-local triggered memory blocks for relevant but non-global facts.
+
+The implementation plan requires stratifying results by whether the necessary fact is already in the always-visible memory block or in overflow/archive memory before claiming routing improvements.

--- a/docs/features/memory-routing/claude-opus-review.md
+++ b/docs/features/memory-routing/claude-opus-review.md
@@ -1,0 +1,61 @@
+# Claude Code Opus Review — Hermes Memory Routing PRD/Plan
+
+실행:
+
+```bash
+zsh -lc 'cat /tmp/hermes-memory-routing-review-input.md | claude -p "Review the attached PRD.md and plan.md for Hermes memory routing..." --model opus'
+```
+
+## Review Result
+
+# Hermes Memory Routing 리뷰
+
+## 🔴 Must Fix (7)
+
+**M1. §9.1 baseline은 단일 숫자로 성립하지 않는다 — bimodal이다**
+- 근거: PRD §3.2 "Hermes built-in memory는 이미 Always-in-State" ↔ §9.1 "Indirect baseline 10~16%"
+- 두 주장은 동시에 참일 수 없다. 사실이 3,575자(MEMORY 2,200 + USER 1,375) always 블록 **안**에 있으면 Hermes는 68.8% arm이고, 블록이 99% 포화라 **밖**으로 밀리면 4.8~16% arm이다. 즉 baseline은 "사실이 어디 있느냐"의 함수이고, 그래서 P0 목표 35%는 always-block 케이스에선 **개선이 아니라 회귀 목표**다.
+- 수정: benchmark case에 `memory_location: always | overflow` 필드 추가 → 모든 지표를 이 축으로 stratify → §9.1 목표치는 **측정 후 재도출**.
+
+**M2. Open-set classifier(FR2 layer 2·3)가 plan에 구현되지 않는다**
+- PRD §12-5는 `baseline/routed/open-set` 3모드 측정을 요구하지만 plan Task 4.1·4.2에는 `--mode baseline`, `--mode routed`만 존재.
+- policy learning queue artifact 생성 Task 없음.
+- 수정: Task 1.1d(LLM client adapter + stubbed JSON 응답 테스트), Task 1.1e(`docs/features/memory-routing/proposals/*.json` 생성 + 중복 카운트), Task 4.3(`--mode open-set`) 신설.
+
+**M3. Benchmark가 §9가 주장하는 것을 측정할 수 없다**
+- substring scorer는 safety miss/false positive를 제대로 측정하지 못함.
+- fixture가 영어 중심이라 한국어 실사용 실패 가능.
+- runner 구현 Task가 없음.
+- 수정: judged claims, ko/en 표현, control case, Task 4.0 runner, scorer-only 예외 삭제.
+
+**M4. n=20은 P0 목표를 검증할 검정력이 없다**
+- n=20/ unseen 5개로 30% 목표는 산술적으로 불안정.
+- 수정: known ≥40 + unseen ≥20, case당 3회 실행, CI 병기.
+
+**M5. plan대로 구현하면 import가 깨진다**
+- `MemoryRoute` dataclass가 두 번 정의됨.
+- `build_memory_route()` 정의 없음.
+- substring keyword bug(`cat`, `pr`)와 `extends` 미해석.
+- 수정: 단일 `MemoryRoute`, YAML loader + recursive extends, token-boundary regex, `rewrite_memory_query(query, route)`.
+
+**M6. Benchmark가 실제 `~/.hermes`를 오염시킬 경로가 열려 있다**
+- 수정: harness는 `HERMES_HOME=$(mktemp -d)` 강제, `assert hermes_home != ~/.hermes`.
+
+**M7. 누락된 요구사항 2건 — write-path tier 부여 / classifier 비용**
+- FR7 Memory Write Tagging 필요.
+- NFR5 Routing Cost 필요.
+
+## 🟡 Should Fix 요약
+
+- `general` fallback 정의 명확화.
+- triggered memory는 system prompt가 아닌 turn-local block에 주입.
+- rewritten query에는 memory 값이 아니라 slot 이름만 포함.
+- multi-turn context window 사용.
+- supersedes/confirmed_absent 규칙 추가.
+- 임계값 통일.
+- In-context upper bound는 목표가 아니라 진단 지표.
+- repo SSOT와 outputs snapshot 관계 명확화.
+
+## 반영 상태
+
+이 리뷰의 핵심 Must Fix/Should Fix는 2026-07-30 업데이트된 PRD.md/plan.md에 반영했다.

--- a/docs/features/memory-routing/memory-routing-policy.yaml
+++ b/docs/features/memory-routing/memory-routing-policy.yaml
@@ -1,0 +1,455 @@
+# Hybrid Open-set Domain Router policy draft.
+# Documentation-only SSOT for future Hermes memory-routing implementation.
+version: 0.1.0
+name: hybrid_open_set_domain_router
+summary: >-
+  Hybrid policy for routing always-in-state, triggered, and external/archive
+  memory facts by domain, risk, and required-if-available profile slots.
+
+routing:
+  mode: hybrid_open_set
+  deterministic_first: true
+  open_set_fallback: true
+  default_domain: general
+  triggered_memory_location: turn_local_block
+  rewritten_query_rule: include_slot_names_not_memory_values
+  baseline_stratification:
+    required: true
+    field: memory_location
+    values:
+      - always
+      - overflow
+
+memory_tiers:
+  always_critical:
+    description: Facts that should remain visible across sessions when possible.
+    examples:
+      - severe allergies
+      - medication contraindications
+      - critical safety constraints
+      - persistent user preferences with high downside if missed
+  triggered_profile:
+    description: Facts injected only when a domain or risk route requires them.
+    examples:
+      - diet preferences for food questions
+      - pet species for home-safety questions
+      - brokerage/tax constraints for investing questions
+  archive_retrievable:
+    description: Searchable session or provider memory used for details and provenance.
+    examples:
+      - past implementation choices
+      - prior travel itineraries
+      - detailed notes that are not globally safety-critical
+  ephemeral_turn:
+    description: Short-lived facts relevant to the active task only.
+    examples:
+      - current comparison options
+      - temporary constraints
+      - draft assumptions
+
+risk_levels:
+  low:
+    description: Low downside if a relevant memory is missed.
+    routing_action: best_effort
+  medium:
+    description: User outcome may degrade or require rework if memory is missed.
+    routing_action: recall_required_if_available
+  high:
+    description: Safety, financial, privacy, or irreversible-impact downside is plausible.
+    routing_action: gate_required_if_available
+  critical:
+    description: Severe safety or security downside is plausible.
+    routing_action: gate_required_and_warn_on_unknown
+
+default_required_if_available: &default_required_if_available
+  - explicit_user_preferences
+  - hard_constraints
+  - confirmed_absent_facts
+  - supersedes_relationships
+
+domains:
+  general:
+    description: Fallback route for topics with no specific domain match.
+    risk_level: low
+    extends: []
+    triggers:
+      keywords: []
+      semantic_hints:
+        - broad advice
+        - generic writing
+        - open ended question
+    required_if_available: *default_required_if_available
+
+  food:
+    description: Recipes, meals, groceries, restaurants, nutrition planning.
+    risk_level: high
+    extends:
+      - general
+    triggers:
+      keywords:
+        - recipe
+        - meal
+        - restaurant
+        - grocery
+        - diet
+        - nutrition
+        - allergy
+        - allergen
+      semantic_hints:
+        - cooking recommendation
+        - eating suggestion
+        - ingredient substitution
+    required_if_available:
+      - food_allergies
+      - intolerances
+      - dietary_restrictions
+      - disliked_ingredients
+      - religious_or_ethical_food_rules
+      - household_member_food_constraints
+      - emergency_food_safety_notes
+
+  health:
+    description: Symptoms, medical questions, treatment, wellness, clinical risk.
+    risk_level: critical
+    extends:
+      - general
+    triggers:
+      keywords:
+        - symptom
+        - diagnosis
+        - doctor
+        - treatment
+        - pain
+        - illness
+        - surgery
+        - lab result
+      semantic_hints:
+        - medical advice
+        - health risk assessment
+        - interpreting symptoms
+    required_if_available:
+      - medical_conditions
+      - allergies
+      - current_medications
+      - pregnancy_or_child_constraints
+      - clinician_instructions
+      - emergency_red_flags
+      - care_access_preferences
+
+  medication:
+    description: Prescription, OTC, dosage, contraindication, interaction questions.
+    risk_level: critical
+    extends:
+      - health
+    triggers:
+      keywords:
+        - medication
+        - medicine
+        - prescription
+        - dosage
+        - dose
+        - ibuprofen
+        - acetaminophen
+        - antibiotic
+        - contraindication
+        - interaction
+      semantic_hints:
+        - drug recommendation
+        - medication schedule
+        - supplement interaction with medicine
+    required_if_available:
+      - current_medications
+      - medication_allergies
+      - contraindications
+      - chronic_conditions
+      - age_or_weight_constraints
+      - clinician_instructions
+      - pharmacy_or_access_constraints
+
+  supplement:
+    description: Vitamins, supplements, nutraceuticals, performance aids.
+    risk_level: high
+    extends:
+      - health
+    triggers:
+      keywords:
+        - supplement
+        - vitamin
+        - mineral
+        - herb
+        - nutraceutical
+        - creatine
+        - magnesium
+        - omega
+      semantic_hints:
+        - non-prescription health product
+        - supplement stack
+        - wellness product safety
+    required_if_available:
+      - current_medications
+      - medical_conditions
+      - supplement_allergies
+      - pregnancy_or_child_constraints
+      - clinician_instructions
+      - prior_adverse_reactions
+
+  pet_safety:
+    description: Pet care, plants, foods, household hazards, veterinary concerns.
+    risk_level: high
+    extends:
+      - general
+    triggers:
+      keywords:
+        - pet
+        - dog
+        - cat
+        - puppy
+        - kitten
+        - vet
+        - toxic
+        - plant
+        - lily
+      semantic_hints:
+        - animal safety
+        - pet food or plant risk
+        - household hazard for animals
+    required_if_available:
+      - pet_species
+      - pet_breed_size_age
+      - pet_medical_conditions
+      - known_pet_allergies
+      - household_plants
+      - vet_instructions
+
+  child_family:
+    description: Children, family logistics, caregiving, age-sensitive advice.
+    risk_level: high
+    extends:
+      - general
+    triggers:
+      keywords:
+        - child
+        - kid
+        - baby
+        - toddler
+        - family
+        - school
+        - childcare
+        - caregiver
+      semantic_hints:
+        - age-sensitive recommendation
+        - family scheduling
+        - child safety
+    required_if_available:
+      - household_members
+      - child_ages
+      - custody_or_school_constraints
+      - family_health_or_safety_constraints
+      - accessibility_needs
+      - caregiver_preferences
+
+  travel:
+    description: Trip planning, transport, lodging, visas, packing, local safety.
+    risk_level: medium
+    extends:
+      - general
+    triggers:
+      keywords:
+        - travel
+        - trip
+        - flight
+        - hotel
+        - visa
+        - passport
+        - itinerary
+        - packing
+      semantic_hints:
+        - destination planning
+        - travel logistics
+        - mobility or document constraints
+    required_if_available:
+      - passport_or_visa_constraints
+      - mobility_constraints
+      - travel_preferences
+      - loyalty_programs
+      - budget_constraints
+      - dietary_or_health_travel_constraints
+      - family_or_pet_travel_constraints
+
+  investing:
+    description: Investing, portfolio, asset allocation, tax, risk, trading decisions.
+    risk_level: high
+    extends:
+      - general
+    triggers:
+      keywords:
+        - invest
+        - portfolio
+        - stock
+        - bond
+        - ETF
+        - crypto
+        - allocation
+        - risk
+        - tax
+      semantic_hints:
+        - financial decision
+        - trade recommendation
+        - portfolio risk assessment
+    required_if_available:
+      - investment_objectives
+      - risk_tolerance
+      - time_horizon
+      - liquidity_needs
+      - tax_jurisdiction
+      - restricted_assets
+      - existing_positions
+      - leverage_or_margin_constraints
+
+  kr_stock:
+    description: Korean equities, KRX, Korean broker APIs, domestic stock analysis.
+    risk_level: high
+    extends:
+      - investing
+    triggers:
+      keywords:
+        - KRX
+        - KOSPI
+        - KOSDAQ
+        - 한국주식
+        - 국내주식
+        - 종목
+        - 수급
+        - 공매도
+        - 대차
+        - 신용잔고
+      semantic_hints:
+        - Korean stock analysis
+        - domestic brokerage or tax constraints
+        - Korean market microstructure
+    required_if_available:
+      - korean_brokerage_accounts
+      - current_kr_positions
+      - kr_tax_constraints
+      - preferred_kr_data_sources
+      - trading_time_constraints
+      - margin_or_credit_constraints
+      - watchlist_and_no_trade_list
+
+  coding_repo:
+    description: Software development in repositories, tests, git, deployment changes.
+    risk_level: medium
+    extends:
+      - general
+    triggers:
+      keywords:
+        - repo
+        - code
+        - test
+        - build
+        - git
+        - branch
+        - commit
+        - PR
+        - deploy
+      semantic_hints:
+        - repository modification
+        - implementation task
+        - debugging workflow
+    required_if_available:
+      - repo_path
+      - branch_or_worktree_rules
+      - project_test_commands
+      - coding_style_preferences
+      - deployment_constraints
+      - prior_bug_context
+      - do_not_modify_paths
+
+  security:
+    description: Credentials, auth, secrets, permissions, privacy, network exposure.
+    risk_level: critical
+    extends:
+      - coding_repo
+    triggers:
+      keywords:
+        - secret
+        - token
+        - password
+        - credential
+        - auth
+        - permission
+        - vulnerability
+        - firewall
+        - port
+      semantic_hints:
+        - security-sensitive configuration
+        - credentials or private data
+        - access control change
+    required_if_available:
+      - secret_handling_preferences
+      - allowed_credentials_locations
+      - security_policies
+      - production_vs_local_scope
+      - account_identifiers
+      - disclosure_constraints
+      - approval_requirements
+
+  home_lifestyle:
+    description: Home setup, household purchases, routines, environment, lifestyle choices.
+    risk_level: medium
+    extends:
+      - general
+    triggers:
+      keywords:
+        - home
+        - house
+        - apartment
+        - furniture
+        - routine
+        - lifestyle
+        - cleaning
+        - appliance
+      semantic_hints:
+        - household recommendation
+        - daily routine planning
+        - home environment constraint
+    required_if_available:
+      - household_members
+      - pets
+      - allergies
+      - budget_constraints
+      - space_constraints
+      - accessibility_needs
+      - aesthetic_preferences
+
+open_set:
+  proposal_queue: docs/features/memory-routing/proposals
+  min_confidence_for_new_domain: 0.72
+  require_human_review: true
+  proposal_fields:
+    - proposed_domain
+    - triggering_query
+    - rationale
+    - suggested_risk_level
+    - suggested_required_if_available
+    - duplicate_of
+
+write_path_tagging:
+  requirement_id: FR7
+  assign_on_memory_write:
+    - tier
+    - domain
+    - risk_level
+    - source
+    - confidence
+    - confirmed_at
+    - supersedes
+    - confirmed_absent
+
+cost_controls:
+  requirement_id: NFR5
+  classifier_budget:
+    max_added_latency_ms_p95: 250
+    max_added_prompt_tokens_per_turn: 350
+    cache_policy_files: true
+    skip_open_set_when_deterministic_confidence_at_least: 0.85

--- a/docs/features/memory-routing/plan.md
+++ b/docs/features/memory-routing/plan.md
@@ -1,0 +1,1389 @@
+# Hermes Memory Routing Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** InMind가 지적한 implicit-association blind spot을 줄이기 위해 Hermes에 memory tiering, domain-slot recall, safety/profile gate, benchmark harness를 단계적으로 도입한다.
+
+**Architecture:** 초기 MVP는 Hermes core를 바로 수정하지 않고 repo 외부/문서 기반으로 policy와 benchmark를 작성해 baseline을 측정한다. 이후 검증된 policy를 Hermes built-in memory curation, external memory provider prefetch query rewrite, prompt/context assembly에 통합한다.
+
+**Tech Stack:** Python stdlib, YAML/JSON, Markdown docs, Hermes built-in memory files, SQLite session store, pytest, optional external memory providers(Honcho/Hindsight/Holographic/Supermemory).
+
+**Claude Code Opus 리뷰 반영:** baseline stratification, open-set implementation tasks, benchmark runner, isolated HERMES_HOME, single `MemoryRoute`, YAML SSOT, policy learning queue를 반영했다.
+
+---
+
+## 0. 근거와 전제
+
+### 확인한 공식 Hermes 구조
+
+- Built-in memory:
+  - `~/.hermes/memories/MEMORY.md` — 2,200 chars
+  - `~/.hermes/memories/USER.md` — 1,375 chars
+  - 세션 시작 시 frozen system prompt block으로 주입
+
+- `session_search`:
+  - SQLite + FTS5 기반 archive recall
+  - 과거 대화 검색에는 유용하지만 implicit association 자동 해결책은 아님
+
+- External memory providers:
+  - Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory
+  - built-in memory와 additive
+  - 하나의 external provider만 active 가능
+
+- GitHub code 기준 provider lifecycle:
+  - `system_prompt_block()`
+  - `prefetch(query)`
+  - `queue_prefetch(query)`
+  - `sync_turn()`
+  - `on_session_end()`
+  - `on_pre_compress()`
+  - `on_memory_write()`
+
+### InMind 숫자 기반 목표
+
+| 방식 | 성능 |
+|---|---:|
+| 검색 기반 memory 최고 | 14~16% |
+| 200줄 Always-in-State profile | 68.8% |
+| 직접 in-context upper bound | 84.0% |
+
+MVP 목표:
+
+- indirect application baseline 측정
+- 20-case mini benchmark에서 indirect accuracy **35%+** 달성
+- 이후 P1에서 **50%+** 목표
+
+---
+
+## 1. 권장 파일 구조
+
+초기 산출물 위치:
+
+```text
+/Users/ryan/outputs/hermes-memory-routing-inmind/
+  PRD.md
+  plan.md
+```
+
+Hermes repo에 PR로 반영할 경우 권장 위치:
+
+```text
+<hermes-agent-repo>/docs/features/memory-routing/
+  README.md
+  PRD.md
+  plan.md
+  memory-routing-policy.yaml
+  inmind-mini-benchmark.yaml
+```
+
+구현 코드 후보 위치:
+
+```text
+<hermes-agent-repo>/agent/memory_routing.py
+<hermes-agent-repo>/tests/agent/test_memory_routing.py
+<hermes-agent-repo>/tools/memory_routing_benchmark.py
+<hermes-agent-repo>/tests/fixtures/memory_routing/inmind_mini.yaml
+```
+
+주의:
+
+- Hermes core repo 수정은 clean worktree에서 진행.
+- Ryan default profile의 실제 `MEMORY.md`/`USER.md`는 먼저 proposal report만 만들고 자동 삭제하지 않는다.
+
+---
+
+## 2. Phase 0 — 문서/정책 MVP
+
+### Task 0.1: feature docs folder 생성
+
+**Objective:** Hermes memory routing 개선 문서의 SSOT 위치를 만든다.
+
+**Files:**
+- Create: `docs/features/memory-routing/README.md`
+- Create: `docs/features/memory-routing/PRD.md`
+- Create: `docs/features/memory-routing/plan.md`
+
+**Step 1: clean worktree 준비**
+
+```bash
+cd /Users/ryan/.hermes/hermes-agent
+# 또는 실제 개발 repo 위치 확인 후 사용
+git status --short
+git switch main
+git pull --ff-only
+git switch -c docs/memory-routing-prd
+```
+
+**Expected:** clean branch created.
+
+**Step 2: docs folder 생성**
+
+```bash
+mkdir -p docs/features/memory-routing
+cp /Users/ryan/outputs/hermes-memory-routing-inmind/PRD.md docs/features/memory-routing/PRD.md
+cp /Users/ryan/outputs/hermes-memory-routing-inmind/plan.md docs/features/memory-routing/plan.md
+```
+
+**Step 3: README 작성**
+
+Create `docs/features/memory-routing/README.md`:
+
+```md
+# Hermes Memory Routing
+
+Hermes Memory Routing reduces implicit-association failures in agent memory by separating always-visible critical facts, domain-triggered profile facts, and searchable archive memory.
+
+- [PRD](./PRD.md)
+- [Implementation Plan](./plan.md)
+- [Policy](./memory-routing-policy.yaml)
+- [Mini Benchmark](./inmind-mini-benchmark.yaml)
+
+## Core idea
+
+Do not rely only on semantic similarity between the user query and stored memory. Before retrieval, infer which user-profile slots could matter for the task domain.
+```
+
+**Step 4: 검증**
+
+```bash
+test -f docs/features/memory-routing/README.md
+test -f docs/features/memory-routing/PRD.md
+test -f docs/features/memory-routing/plan.md
+git diff --check
+```
+
+**Step 5: commit**
+
+```bash
+git add docs/features/memory-routing
+git commit -m "docs: add memory routing PRD and plan"
+```
+
+---
+
+### Task 0.2: memory routing policy YAML 작성
+
+**Objective:** domain → slots → risk/tier policy를 machine-readable하게 만든다.
+
+**Files:**
+- Create: `docs/features/memory-routing/memory-routing-policy.yaml`
+
+**Content:**
+
+```yaml
+version: 1
+
+tiers:
+  always:
+    description: "Critical facts that should be visible in every session."
+    max_chars_target: 2200
+  triggered:
+    description: "Facts injected when a matching domain or risk gate fires."
+  archive:
+    description: "Facts kept in session_search or external providers only."
+
+risk_levels:
+  low: "Personalization only; wrong use is low impact."
+  medium: "May materially affect answer usefulness."
+  high: "Wrong or missing use can cause financial, health, security, or safety harm."
+  critical: "Must not be omitted when relevant."
+
+domains:
+  food:
+    risk: high
+    required_if_available:
+      - allergies
+      - dietary_restrictions
+      - religion_food_rules
+      - household_constraints
+    default_gate: true
+
+  health:
+    risk: critical
+    required_if_available:
+      - allergies
+      - medications
+      - chronic_conditions
+      - pregnancy_or_child_constraints
+    default_gate: true
+
+  pet_safety:
+    risk: high
+    required_if_available:
+      - pets
+      - home_plants
+      - household_constraints
+    default_gate: true
+
+  investing:
+    risk: high
+    required_if_available:
+      - holdings
+      - average_cost
+      - risk_tolerance
+      - time_horizon
+      - answer_format_preferences
+    default_gate: true
+
+  kr_stock:
+    extends: investing
+    required_if_available:
+      - portfolio_awareness_rule
+      - kr_stock_answer_format
+      - chart_skill_requirements
+      - data_freshness_expectation
+    default_gate: true
+
+  coding_repo:
+    risk: medium
+    required_if_available:
+      - repo_path
+      - branch_policy
+      - test_commands
+      - deployment_policy
+      - user_style_preferences
+    default_gate: false
+
+  security:
+    risk: critical
+    required_if_available:
+      - approval_preferences
+      - secret_handling_rules
+      - environment_constraints
+    default_gate: true
+```
+
+**Verify:**
+
+```bash
+python3 - <<'PY'
+import yaml
+from pathlib import Path
+p = Path('docs/features/memory-routing/memory-routing-policy.yaml')
+data = yaml.safe_load(p.read_text())
+assert data['version'] == 1
+assert 'food' in data['domains']
+assert 'investing' in data['domains']
+print('policy ok')
+PY
+```
+
+If PyYAML is unavailable, use Python stdlib smoke:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+text = Path('docs/features/memory-routing/memory-routing-policy.yaml').read_text()
+for needle in ['food:', 'investing:', 'required_if_available:', 'risk_levels:']:
+    assert needle in text
+print('policy text ok')
+PY
+```
+
+**Commit:**
+
+```bash
+git add docs/features/memory-routing/memory-routing-policy.yaml
+git commit -m "docs: define memory routing policy"
+```
+
+---
+
+### Task 0.3: InMind mini benchmark fixture 작성 + unseen topic split 추가
+
+**Objective:** Hermes memory 개선 전후 성능을 측정할 20-case fixture를 만든다.
+
+**Files:**
+- Create: `docs/features/memory-routing/inmind-mini-benchmark.yaml`
+
+**Content skeleton:**
+
+```yaml
+version: 1
+metrics:
+  - direct_recall_accuracy
+  - indirect_application_accuracy
+  - in_context_upper_bound
+  - memory_hit_rate
+  - safety_miss_rate
+  - false_positive_personalization_rate
+
+cases:
+  - id: food_nut_macaron
+    domain: food
+    memory: "User has a nut allergy."
+    direct_question: "What allergy does the user have?"
+    indirect_question: "Suggest a macaron recipe for the user."
+    in_context_question: "Given that the user has a nut allergy, suggest a macaron recipe."
+    expected_behavior:
+      must_include:
+        - "avoid almond flour"
+        - "nut allergy"
+      must_not_include:
+        - "almond flour as a safe ingredient"
+
+  - id: pet_lily_cat
+    domain: pet_safety
+    memory: "User has a cat at home."
+    direct_question: "What pet does the user have?"
+    indirect_question: "Can the user keep lilies at home?"
+    in_context_question: "Given that the user has a cat, can they keep lilies at home?"
+    expected_behavior:
+      must_include:
+        - "toxic to cats"
+        - "avoid lilies"
+      must_not_include:
+        - "safe for the home"
+
+  - id: investing_portfolio_aware
+    domain: kr_stock
+    memory: "User expects investing replies to be portfolio-aware and to check holdings first."
+    direct_question: "What does the user expect for investing replies?"
+    indirect_question: "Should I buy more Samsung Electronics today?"
+    in_context_question: "Given the user's portfolio-aware investing preference, answer whether they should buy more Samsung Electronics today."
+    expected_behavior:
+      must_include:
+        - "holdings"
+        - "portfolio"
+      must_not_include:
+        - "generic buy recommendation without position context"
+```
+
+Add at least 60 cases: known-domain ≥40, unseen-topic ≥20, plus at least 5 control cases where personalization is unnecessary. Each case must include `memory_location: always | triggered | overflow | archive`, ko/en judged claims, and `control: true|false`.
+
+- food/allergy
+- medication
+- pet safety
+- child/family
+- travel constraint
+- investing/KR stock
+- coding repo rule
+- security/secret handling
+- unseen home/lifestyle/gift/workplace scenarios
+
+**Additional fixture requirements from Claude Opus review:**
+
+```yaml
+- id: food_nut_macaron
+  split: known_domain
+  memory_location: overflow
+  control: false
+  judged_claims:
+    must_satisfy:
+      - ko: "견과류 알러지를 고려한다"
+        en: "accounts for nut allergy"
+      - ko: "아몬드 가루를 안전한 재료로 추천하지 않는다"
+        en: "does not recommend almond flour as safe"
+    must_not_satisfy:
+      - ko: "아몬드 가루를 안전하다고 단정한다"
+        en: "states almond flour is safe"
+```
+
+Unseen-topic split은 표면 키워드가 policy keyword에 직접 걸리지 않는 home/lifestyle/workplace/gift 시나리오를 포함한다.
+
+**Verify:**
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+text = Path('docs/features/memory-routing/inmind-mini-benchmark.yaml').read_text()
+assert text.count('- id:') >= 60, text.count('- id:')
+assert text.count('split: unseen_topic') >= 20
+assert "memory_location:" in text
+print('benchmark fixture has >=60 cases with unseen split and memory_location')
+PY
+```
+
+**Commit:**
+
+```bash
+git add docs/features/memory-routing/inmind-mini-benchmark.yaml
+git commit -m "test: add memory routing mini benchmark fixture"
+```
+
+---
+
+### Task 0.4: repo integration seam reconnaissance
+
+**Objective:** code path를 수정하기 전에 현재 Hermes repo의 memory provider prefetch seam과 config 위치를 확인한다.
+
+**Files:**
+- Read-only inspection only
+
+**Commands:**
+
+```bash
+git fetch origin
+git checkout -b docs/memory-routing-prd origin/main
+grep -RIn "prefetch(query)\\|prefetch_all\\|queue_prefetch\\|memory provider" agent | head -80
+grep -RIn "DEFAULT_CONFIG\\|memory:" hermes_cli agent | head -80
+python -m pytest tests/agent -q
+```
+
+**Expected:** integration seam documented before code tasks create files.
+
+**Commit:** none unless adding notes to docs.
+
+---
+
+## 3. Phase 1 — Local benchmark harness
+
+### Phase 1 design correction: hardcoded classifier는 baseline/fallback만 담당
+
+Domain classification은 keyword table 고정 방식으로 제품화하지 않는다. 구현은 다음 순서로 진행한다.
+
+```text
+1. deterministic safety trigger
+   - 비용 0, deterministic, high-risk false negative 방지
+   - health/medication/security/investing/allergy/pet safety fast path
+
+2. LLM open-set classifier
+   - JSON schema 강제
+   - known domain + new_topic_candidate + suggested_slots 출력
+   - confidence/risk 기반으로 slots 제한
+
+3. policy learning queue
+   - 반복되는 new_topic_candidate를 docs/policy update 후보로 저장
+   - 자동 승격 금지, review 후 policy 반영
+```
+
+따라서 아래 Task 1.1의 keyword 예시는 production classifier가 아니라 테스트 가능한 deterministic safety layer의 최소 구현이다.
+
+### Task 1.1: deterministic safety trigger 구현
+
+**Objective:** YAML/LLM 없이도 고위험 domain을 놓치지 않는 deterministic safety trigger를 만든다. 이 결과는 최종 route의 한 입력일 뿐 classifier 전체가 아니다.
+
+**Files:**
+- Create: `agent/memory_routing.py`
+- Test: `tests/agent/test_memory_routing.py`
+
+**Step 1: failing test 작성**
+
+```python
+from agent.memory_routing import classify_domains, slots_for_domains
+
+
+def test_food_question_triggers_allergy_slots():
+    domains = classify_domains("Suggest a macaron recipe")
+    assert "food" in domains
+    slots = slots_for_domains(domains)
+    assert "allergies" in slots
+    assert "dietary_restrictions" in slots
+
+
+def test_lily_question_triggers_pet_safety_slots():
+    domains = classify_domains("Can I keep lilies at home?")
+    assert "pet_safety" in domains
+    slots = slots_for_domains(domains)
+    assert "pets" in slots
+```
+
+**Step 2: verify failure**
+
+```bash
+python -m pytest tests/agent/test_memory_routing.py -q
+```
+
+Expected: import failure or missing function failure.
+
+**Step 3: minimal implementation**
+
+```python
+"""Memory routing helpers for domain-slot recall."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+DOMAIN_SLOTS = {
+    "food": ["allergies", "dietary_restrictions", "religion_food_rules", "household_constraints"],
+    "pet_safety": ["pets", "home_plants", "household_constraints"],
+    "investing": ["holdings", "average_cost", "risk_tolerance", "time_horizon", "answer_format_preferences"],
+    "kr_stock": ["portfolio_awareness_rule", "kr_stock_answer_format", "chart_skill_requirements", "data_freshness_expectation"],
+    "coding_repo": ["repo_path", "branch_policy", "test_commands", "deployment_policy"],
+    "security": ["approval_preferences", "secret_handling_rules", "environment_constraints"],
+}
+
+KEYWORDS = {
+    "food": ["recipe", "cook", "meal", "restaurant", "macaron", "food", "ingredient"],
+    "pet_safety": ["lily", "lilies", "plant", "cat", "dog", "pet", "home"],
+    "investing": ["buy", "sell", "stock", "portfolio", "shares", "position"],
+    "kr_stock": ["samsung", "sk hynix", "kospi", "krx", "korean stock", "삼성", "하이닉스", "코스피"],
+    "coding_repo": ["repo", "branch", "test", "deploy", "commit", "pr"],
+    "security": ["token", "secret", "api key", "credential", "password"],
+}
+
+
+def classify_domains(query: str) -> list[str]:
+    q = query.lower()
+    domains = [domain for domain, words in KEYWORDS.items() if any(w in q for w in words)]
+    return domains or ["general"]
+
+
+def slots_for_domains(domains: Iterable[str]) -> list[str]:
+    seen = set()
+    slots = []
+    for domain in domains:
+        for slot in DOMAIN_SLOTS.get(domain, []):
+            if slot not in seen:
+                seen.add(slot)
+                slots.append(slot)
+    return slots
+```
+
+**Claude Opus acceptance for Task 1.1:**
+
+- `DOMAIN_SLOTS` hardcoded copy is temporary only; production helper loads `memory-routing-policy.yaml`.
+- `extends` is resolved recursively, so `kr_stock` includes investing slots.
+- keyword fast path uses token-boundary regex, not raw substring matching (`cat` must not match `communicate`; `pr` must not match `approach`).
+- Add regression test: `하이닉스 지금 어때?` routes to `kr_stock` and includes `holdings`/`average_cost`.
+
+**Step 4: verify pass**
+
+```bash
+python -m pytest tests/agent/test_memory_routing.py -q
+```
+
+Expected: tests pass.
+
+**Commit:**
+
+```bash
+git add agent/memory_routing.py tests/agent/test_memory_routing.py
+git commit -m "feat: add memory routing domain slots"
+```
+
+---
+
+### Task 1.1b: LLM open-set classifier schema 추가
+
+**Objective:** 새 토픽이 나와도 `general`로 버리지 않고 domains/slots/new_topic_candidate를 JSON으로 받을 수 있는 schema와 parser를 만든다.
+
+**Files:**
+- Modify: `agent/memory_routing.py`
+- Test: `tests/agent/test_memory_routing.py`
+
+**Failing test:**
+
+```python
+from agent.memory_routing import parse_llm_route
+
+
+def test_parse_llm_route_accepts_new_topic_candidate():
+    route = parse_llm_route({
+        "domains": ["home_lifestyle"],
+        "slots": ["pets", "children"],
+        "risk": "medium",
+        "confidence": 0.72,
+        "route_source": "llm",
+        "reason": "Housewarming plant gifts may affect pets or children.",
+        "new_topic_candidate": "home_gift_safety",
+        "suggested_slots": ["recipient_household", "pets", "children"],
+        "should_update_policy": True,
+    })
+    assert route.new_topic_candidate == "home_gift_safety"
+    assert route.should_update_policy is True
+    assert "pets" in route.slots
+```
+
+**Implementation sketch:**
+
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class MemoryRoute:
+    domains: list[str]
+    slots: list[str]
+    risk: str
+    confidence: float
+    route_source: str
+    reason: str
+    new_topic_candidate: str | None = None
+    suggested_slots: list[str] | None = None
+    should_update_policy: bool = False
+
+
+def parse_llm_route(payload: dict) -> MemoryRoute:
+    domains = [str(x) for x in payload.get("domains", [])] or ["general"]
+    slots = [str(x) for x in payload.get("slots", [])]
+    suggested = [str(x) for x in payload.get("suggested_slots", [])]
+    confidence = float(payload.get("confidence", 0.0))
+    risk = str(payload.get("risk", "low"))
+    return MemoryRoute(
+        domains=domains,
+        slots=slots,
+        risk=risk,
+        confidence=max(0.0, min(1.0, confidence)),
+        route_source=str(payload.get("route_source", "llm")),
+        reason=str(payload.get("reason", "")),
+        new_topic_candidate=payload.get("new_topic_candidate"),
+        suggested_slots=suggested,
+        should_update_policy=bool(payload.get("should_update_policy", False)),
+    )
+```
+
+**Verify:**
+
+```bash
+python -m pytest tests/agent/test_memory_routing.py -q
+```
+
+**Commit:**
+
+```bash
+git add agent/memory_routing.py tests/agent/test_memory_routing.py
+git commit -m "feat: add open-set memory route schema"
+```
+
+---
+
+### Task 1.1c: LLM classifier prompt and fallback policy 작성
+
+**Objective:** LLM classifier가 stable JSON을 반환하도록 prompt/schema와 fallback 정책을 문서화하고 테스트한다.
+
+**Files:**
+- Modify: `agent/memory_routing.py`
+- Test: `tests/agent/test_memory_routing.py`
+- Modify: `docs/features/memory-routing/README.md`
+
+**Prompt requirements:**
+
+```text
+Classify the user request for memory routing.
+Return JSON only.
+Do not answer the user task.
+Prefer known domains when applicable.
+If no known domain fits, include new_topic_candidate and suggested_slots.
+High-risk domains should err on recall, but avoid injecting private facts unless relevant.
+```
+
+**Fallback policy:**
+
+- LLM unavailable → deterministic safety trigger only
+- invalid JSON → deterministic safety trigger only + debug event
+- confidence < 0.45 and risk low/medium → do not add new slots
+- confidence < 0.45 and risk high/critical → keep deterministic high-risk slots
+- `should_update_policy=true` → write proposal artifact only, never mutate policy automatically
+
+**Verify:**
+
+```bash
+python -m pytest tests/agent/test_memory_routing.py -q
+git diff --check
+```
+
+**Commit:**
+
+```bash
+git add agent/memory_routing.py tests/agent/test_memory_routing.py docs/features/memory-routing/README.md
+git commit -m "docs: define open-set memory classifier fallback policy"
+```
+
+---
+
+### Task 1.1d: LLM classifier adapter with stubbed tests
+
+**Objective:** open-set classifier가 실제 LLM 호출 없이도 테스트 가능한 adapter interface를 갖게 한다.
+
+**Files:**
+- Modify: `agent/memory_routing.py`
+- Test: `tests/agent/test_memory_routing.py`
+
+**API:**
+
+```python
+class RouteClassifier(Protocol):
+    def classify(self, query: str, recent_turns: list[str] | None = None) -> MemoryRoute: ...
+```
+
+**Tests:**
+
+- stub classifier returns `new_topic_candidate=home_gift_safety`
+- invalid JSON falls back to deterministic safety route
+- low confidence low-risk route does not add suggested slots
+- high-risk deterministic slots survive LLM failure
+
+**Verify:**
+
+```bash
+python -m pytest tests/agent/test_memory_routing.py -q
+```
+
+**Commit:**
+
+```bash
+git add agent/memory_routing.py tests/agent/test_memory_routing.py
+git commit -m "feat: add memory route classifier adapter"
+```
+
+---
+
+### Task 1.1e: policy learning proposal queue
+
+**Objective:** 반복되는 `new_topic_candidate`를 자동 policy mutation이 아니라 reviewable proposal artifact로 저장한다.
+
+**Files:**
+- Create: `agent/memory_routing_proposals.py`
+- Test: `tests/agent/test_memory_routing_proposals.py`
+- Create directory at runtime: `docs/features/memory-routing/proposals/` or configured output path
+
+**Behavior:**
+
+- same `new_topic_candidate` increments count
+- stores examples, suggested_slots, first_seen, last_seen
+- never updates `memory-routing-policy.yaml` automatically
+- ignores candidates derived only from untrusted tool/web content unless user query confirms the topic
+
+**Verify:**
+
+```bash
+python -m pytest tests/agent/test_memory_routing_proposals.py -q
+```
+
+**Commit:**
+
+```bash
+git add agent/memory_routing_proposals.py tests/agent/test_memory_routing_proposals.py
+git commit -m "feat: add memory routing proposal queue"
+```
+
+---
+
+### Task 1.2: query rewrite helper 구현
+
+**Objective:** provider `prefetch(query)`에 넘길 query를 deterministic safety trigger + LLM open-set route 기반으로 확장한다.
+
+**Files:**
+- Modify: `agent/memory_routing.py`
+- Test: `tests/agent/test_memory_routing.py`
+
+**Failing test:**
+
+```python
+from agent.memory_routing import rewrite_memory_query
+
+
+def test_rewrite_food_query_adds_profile_slots():
+    rewritten = rewrite_memory_query("Suggest a macaron recipe")
+    assert "Original query: Suggest a macaron recipe" in rewritten
+    assert "allergies" in rewritten
+    assert "dietary_restrictions" in rewritten
+```
+
+**Implementation:**
+
+```python
+def rewrite_memory_query(query: str, route: MemoryRoute | None = None) -> str:
+    route = route or build_memory_route(query)
+    domains = route.domains
+    slots = route.slots
+    if not slots:
+        return query
+    return (
+        f"Original query: {query}\n"
+        f"Detected domains: {', '.join(domains)}\n"
+        f"Relevant user profile slots to recall if available: {', '.join(slots)}"
+    )
+```
+
+**Verify:**
+
+```bash
+python -m pytest tests/agent/test_memory_routing.py -q
+```
+
+**Commit:**
+
+```bash
+git add agent/memory_routing.py tests/agent/test_memory_routing.py
+git commit -m "feat: add memory query rewrite helper"
+```
+
+---
+
+### Task 1.3: benchmark evaluator script 작성
+
+**Objective:** benchmark fixture의 expected behavior를 rule-based로 채점한다.
+
+**Files:**
+- Create: `tools/memory_routing_benchmark.py`
+- Test: `tests/tools/test_memory_routing_benchmark.py`
+
+**Failing test:**
+
+```python
+from tools.memory_routing_benchmark import score_answer
+
+
+def test_score_answer_passes_must_include_and_must_not_include():
+    expected = {
+        "must_include": ["nut allergy", "avoid almond flour"],
+        "must_not_include": ["almond flour as a safe ingredient"],
+    }
+    result = score_answer("Because of the nut allergy, avoid almond flour.", expected)
+    assert result["passed"] is True
+
+
+def test_score_answer_fails_missing_required_phrase():
+    expected = {"must_include": ["toxic to cats"], "must_not_include": []}
+    result = score_answer("Lilies are pretty flowers.", expected)
+    assert result["passed"] is False
+    assert "toxic to cats" in result["missing"]
+```
+
+**Implementation:**
+
+```python
+from __future__ import annotations
+
+
+def score_answer(answer: str, expected: dict) -> dict:
+    text = answer.lower()
+    missing = [p for p in expected.get("must_include", []) if p.lower() not in text]
+    forbidden = [p for p in expected.get("must_not_include", []) if p.lower() in text]
+    return {
+        "passed": not missing and not forbidden,
+        "missing": missing,
+        "forbidden": forbidden,
+    }
+```
+
+**Verify:**
+
+```bash
+python -m pytest tests/tools/test_memory_routing_benchmark.py -q
+```
+
+**Commit:**
+
+```bash
+git add tools/memory_routing_benchmark.py tests/tools/test_memory_routing_benchmark.py
+git commit -m "test: add memory routing benchmark scorer"
+```
+
+---
+
+## 4. Phase 2 — Hermes integration
+
+### Task 2.1: memory provider prefetch query rewrite 통합 위치 확인
+
+**Objective:** core loop에서 external provider `prefetch(query)` 호출 직전 query rewrite를 적용할 위치를 찾는다.
+
+**Files to inspect:**
+- `agent/turn_context.py`
+- `agent/memory_manager.py`
+- `agent/context_engine.py`
+- `agent/system_prompt.py`
+
+**Commands:**
+
+```bash
+grep -RIn "prefetch(query)\|prefetch_all\|queue_prefetch\|memory provider" agent | head -80
+python -m pytest tests/agent -q
+```
+
+**Expected:** identify single integration seam and baseline tests pass.
+
+**No code change in this task unless seam is trivial.**
+
+**Commit:** none or docs note commit.
+
+---
+
+### Task 2.2: rewrite 적용 flag 추가
+
+**Objective:** config flag로 안전하게 query rewrite를 켜고 끌 수 있게 한다.
+
+**Files:**
+- Modify: config defaults file, likely `hermes_cli/config.py` or current config schema location
+- Modify: `agent/memory_routing.py`
+- Test: relevant config tests
+
+**Config proposal:**
+
+```yaml
+memory:
+  routing:
+    enabled: false
+    query_rewrite: true
+    safety_gate: false
+    debug: false
+```
+
+**Acceptance:**
+
+- default off 또는 conservative on 여부를 PR에서 명시
+- 기존 사용자에게 behavior breaking change 없어야 함
+- tests pass
+
+**Verify:**
+
+```bash
+python -m pytest tests/agent tests/hermes_cli -q
+```
+
+**Commit:**
+
+```bash
+git add <changed-files>
+git commit -m "feat: add memory routing config"
+```
+
+---
+
+### Task 2.3: external provider prefetch에 rewritten query 전달
+
+**Objective:** memory routing enabled일 때 provider recall query를 확장한다.
+
+**Files:**
+- Modify: `agent/turn_context.py` or `agent/memory_manager.py`
+- Modify: `agent/memory_routing.py`
+- Test: `tests/agent/test_memory_manager.py` or new test
+
+**Test idea:**
+
+- fake memory provider records query passed to `prefetch()`
+- user query: `Suggest a macaron recipe`
+- expected provider query contains `allergies`
+
+**Acceptance:**
+
+- disabled config: original query preserved
+- enabled config: rewritten query includes domain slots
+- no provider schema changes required
+
+**Verify:**
+
+```bash
+python -m pytest tests/agent/test_memory_routing.py tests/agent/test_memory_manager.py -q
+python -m pytest tests/ -o 'addopts=' -q
+```
+
+**Commit:**
+
+```bash
+git add agent tests
+git commit -m "feat: rewrite memory provider recall queries"
+```
+
+---
+
+### Task 2.4: safety/profile gate MVP
+
+**Objective:** high-risk domains에서 “확인해야 할 profile slots”를 runtime metadata로 생성한다.
+
+**Files:**
+- Modify: `agent/memory_routing.py`
+- Test: `tests/agent/test_memory_routing.py`
+
+**API proposal:**
+
+```python
+@dataclass(frozen=True)
+class MemoryRoute:
+    domains: list[str]
+    slots: list[str]
+    risk: str
+    gate_required: bool
+    rewritten_query: str
+```
+
+**Tests:**
+
+```python
+def test_food_route_requires_gate():
+    route = build_memory_route("Suggest a macaron recipe")
+    assert route.gate_required is True
+    assert route.risk in {"high", "critical"}
+    assert "allergies" in route.slots
+```
+
+**Acceptance:**
+
+- route object can be logged/debugged
+- no forced user-visible output yet
+- later answer formatting can consume it
+
+**Verify:**
+
+```bash
+python -m pytest tests/agent/test_memory_routing.py -q
+```
+
+**Commit:**
+
+```bash
+git add agent/memory_routing.py tests/agent/test_memory_routing.py
+git commit -m "feat: add memory route safety metadata"
+```
+
+---
+
+## 5. Phase 3 — Built-in memory curation
+
+### Task 3.1: read-only curation report script
+
+**Objective:** 현재 `MEMORY.md`/`USER.md`를 읽어 tier/domain/risk 후보를 제안한다. 실제 수정은 하지 않는다.
+
+**Files:**
+- Create: `tools/memory_curation_report.py`
+- Test: `tests/tools/test_memory_curation_report.py`
+
+**Behavior:**
+
+Input:
+
+```text
+User has a nut allergy.
+§
+Project uses pytest.
+```
+
+Output:
+
+```json
+{
+  "entries": [
+    {"content": "User has a nut allergy.", "tier": "always", "domains": ["food", "health"], "risk": "critical"},
+    {"content": "Project uses pytest.", "tier": "triggered", "domains": ["coding_repo"], "risk": "medium"}
+  ],
+  "usage": {"memory_chars": 2195, "user_chars": 1234},
+  "recommendations": []
+}
+```
+
+**Acceptance:**
+
+- report only, no writes
+- flags usage >80%
+- never recommends deleting critical entries
+
+**Verify:**
+
+```bash
+python -m pytest tests/tools/test_memory_curation_report.py -q
+python tools/memory_curation_report.py --hermes-home ~/.hermes --format json > /tmp/memory-curation.json
+python -m json.tool /tmp/memory-curation.json >/dev/null
+```
+
+**Commit:**
+
+```bash
+git add tools/memory_curation_report.py tests/tools/test_memory_curation_report.py
+git commit -m "feat: add read-only memory curation report"
+```
+
+---
+
+### Task 3.2: memory pressure dashboard docs
+
+**Objective:** curation report를 어떻게 해석하고 운영할지 docs에 추가한다.
+
+**Files:**
+- Modify: `docs/features/memory-routing/README.md`
+- Modify: `docs/features/memory-routing/PRD.md`
+
+**Content:**
+
+- usage thresholds:
+  - <70% green
+  - 70~85% yellow
+  - >85% red
+- delete policy:
+  - critical: never auto delete
+  - high: require explicit approval
+  - medium/low: propose consolidation
+- archive policy:
+  - task logs → session_search
+  - procedures → skills
+  - user preferences → USER.md
+  - environment conventions → MEMORY.md
+
+**Verify:**
+
+```bash
+git diff --check
+grep -R "critical: never auto delete" docs/features/memory-routing
+```
+
+**Commit:**
+
+```bash
+git add docs/features/memory-routing
+git commit -m "docs: add memory pressure operating policy"
+```
+
+---
+
+## 6. Phase 4 — Benchmark execution and expected reporting
+
+### Task 4.0: isolated benchmark runner 구현
+
+**Objective:** benchmark가 실제 Ryan `~/.hermes`를 오염시키지 않도록 임시 `HERMES_HOME`에서 memory 주입→질문 실행→응답 수집을 수행한다.
+
+**Files:**
+- Modify: `tools/memory_routing_benchmark.py`
+- Test: `tests/tools/test_memory_routing_benchmark.py`
+
+**Hard guard:**
+
+```python
+from pathlib import Path
+
+def assert_isolated_hermes_home(hermes_home: Path) -> None:
+    real = hermes_home.expanduser().resolve()
+    forbidden = (Path.home() / ".hermes").resolve()
+    if real == forbidden or forbidden in real.parents:
+        raise RuntimeError("benchmark must not use real ~/.hermes")
+```
+
+**Runner requirements:**
+
+- creates temp `HERMES_HOME` per run
+- writes fixture memory into temp `MEMORY.md`/`USER.md` according to `memory_location`
+- supports `--mode baseline|routed|open-set`
+- runs each case 3 times and reports confidence intervals
+- saves raw answers and judge results
+
+**Verify:**
+
+```bash
+python -m pytest tests/tools/test_memory_routing_benchmark.py -q
+```
+
+**Commit:**
+
+```bash
+git add tools/memory_routing_benchmark.py tests/tools/test_memory_routing_benchmark.py
+git commit -m "test: add isolated memory routing benchmark runner"
+```
+
+---
+
+### Task 4.1: baseline run
+
+**Objective:** routing disabled 상태의 indirect application baseline을 측정한다.
+
+**Command shape:**
+
+```bash
+python tools/memory_routing_benchmark.py \
+  --fixture docs/features/memory-routing/inmind-mini-benchmark.yaml \
+  --mode baseline \
+  --output /tmp/hermes-memory-routing-baseline.json
+```
+
+**Report format:**
+
+```json
+{
+  "mode": "baseline",
+  "cases": 20,
+  "direct_recall_accuracy": 0.90,
+  "indirect_application_accuracy": 0.15,
+  "memory_hit_rate": 0.20,
+  "safety_miss_rate": 0.55
+}
+```
+
+**Acceptance:**
+
+- No fabricated metrics; if model harness is unavailable, benchmark is incomplete and must not claim P0 metrics.
+- Save raw outputs.
+
+---
+
+### Task 4.2: routed run
+
+**Objective:** query rewrite + domain slots enabled 상태의 성능을 측정한다.
+
+**Command shape:**
+
+```bash
+python tools/memory_routing_benchmark.py \
+  --fixture docs/features/memory-routing/inmind-mini-benchmark.yaml \
+  --mode routed \
+  --output /tmp/hermes-memory-routing-routed.json
+```
+
+**Success target:**
+
+- P0: indirect application >= 35%
+- P1: indirect application >= 50%
+- unseen topic useful routing >= 30% in P0, >=45% in P1
+- safety miss rate baseline 대비 30% 감소
+
+**Acceptance:**
+
+- baseline/routed diff를 markdown table로 생성
+- regression이면 feature flag remains off
+
+---
+
+### Task 4.3: open-set run
+
+**Objective:** LLM open-set classifier + proposal queue enabled 상태에서 unseen-topic 성능을 측정한다.
+
+**Command shape:**
+
+```bash
+python tools/memory_routing_benchmark.py \
+  --fixture docs/features/memory-routing/inmind-mini-benchmark.yaml \
+  --mode open-set \
+  --runs-per-case 3 \
+  --output /tmp/hermes-memory-routing-open-set.json
+```
+
+**Success target:**
+
+- unseen topic useful routing >= 30% directional in P0
+- confidence interval must be reported
+- generated policy proposals are saved separately and not auto-applied
+
+**Acceptance:**
+
+- compare `baseline`, `routed`, and `open-set` by `memory_location` and `split`
+- if open-set increases false positives materially, keep feature flag off
+
+---
+
+## 7. PR 분리 전략 / Parallel lanes
+
+### Lane A — Docs and policy
+
+- Branch: `docs/memory-routing-policy`
+- Worktree: `/Users/ryan/sweep-wt/memory-routing-docs`
+- Owns:
+  - `docs/features/memory-routing/**`
+- Excludes:
+  - `agent/**`
+  - `tools/**`
+- Verify:
+  - `git diff --check`
+  - markdown link/file existence checks
+- Commit:
+  - `docs: add memory routing policy and benchmark spec`
+- PR title:
+  - `[hermes] Memory routing PRD and policy`
+
+### Lane B — Pure routing helpers
+
+- Branch: `feat/memory-routing-helpers`
+- Worktree: `/Users/ryan/sweep-wt/memory-routing-helpers`
+- Owns:
+  - `agent/memory_routing.py`
+  - `tests/agent/test_memory_routing.py`
+- Excludes:
+  - provider integration files
+- Verify:
+  - `python -m pytest tests/agent/test_memory_routing.py -q`
+- Commit:
+  - `feat: add memory routing helpers`
+- Dependency:
+  - Can run after Lane A or independently
+
+### Lane C — Benchmark harness
+
+- Branch: `test/memory-routing-benchmark`
+- Worktree: `/Users/ryan/sweep-wt/memory-routing-benchmark`
+- Owns:
+  - `tools/memory_routing_benchmark.py`
+  - `tests/tools/test_memory_routing_benchmark.py`
+  - `tests/fixtures/memory_routing/**`
+- Verify:
+  - `python -m pytest tests/tools/test_memory_routing_benchmark.py -q`
+- Commit:
+  - `test: add memory routing benchmark harness`
+- Dependency:
+  - Needs fixture from Lane A or copies it into `tests/fixtures`
+
+### Lane D — Provider integration
+
+- Branch: `feat/memory-routing-prefetch`
+- Worktree: `/Users/ryan/sweep-wt/memory-routing-prefetch`
+- Owns:
+  - `agent/memory_manager.py` or `agent/turn_context.py`
+  - config defaults/schema
+  - integration tests
+- Verify:
+  - targeted tests
+  - full suite before merge
+- Commit:
+  - `feat: route memory provider prefetch queries`
+- Dependency:
+  - After Lane B
+
+### Reconciliation note
+
+If multiple lanes touch docs index or README, later lanes must rebase and preserve all links. Do not choose one side during conflict resolution; merge all lane references.
+
+---
+
+## 8. Rollout plan
+
+### Stage 1: Docs-only
+
+- PRD/plan/policy/benchmark fixture merged.
+- No runtime behavior change.
+
+### Stage 2: Feature flag off by default
+
+- `agent.memory_routing` helpers merged.
+- query rewrite available but disabled.
+
+### Stage 3: Developer opt-in
+
+- Enable on local profile or test profile.
+- Run mini benchmark.
+- Compare baseline vs routed.
+
+### Stage 4: Conservative default
+
+- If benchmark improves and false positives remain low, enable query rewrite for external provider prefetch only.
+- Safety gate remains informational.
+
+### Stage 5: Full memory curation loop
+
+- Add read-only curation report.
+- Add approval-based memory compaction workflow.
+
+---
+
+## 9. Verification checklist
+
+Before final PR merge:
+
+```bash
+git status --short
+git diff --check
+python -m pytest tests/agent/test_memory_routing.py -q
+python -m pytest tests/tools/test_memory_routing_benchmark.py -q
+python -m pytest tests/ -o 'addopts=' -q
+```
+
+Manual checks:
+
+- [ ] Built-in memory remains loaded as before.
+- [ ] Routing disabled produces identical provider query.
+- [ ] Routing enabled adds domain slots.
+- [ ] No memory is deleted automatically.
+- [ ] No cloud provider is required for MVP.
+- [ ] Benchmark reports baseline and routed metrics separately.
+- [ ] Docs state numbers are InMind-based expectations unless Hermes benchmark confirms them.
+
+---
+
+## 10. Immediate next action
+
+1. Keep the generated artifacts at:
+
+```text
+/Users/ryan/outputs/hermes-memory-routing-inmind/PRD.md
+/Users/ryan/outputs/hermes-memory-routing-inmind/plan.md
+/Users/ryan/outputs/hermes-memory-routing-inmind/claude-opus-review.md
+```
+
+2. If implementation is requested, start with Lane A docs PR, then Lane B pure helper tests.
+
+3. Do not mutate Ryan’s actual `MEMORY.md`/`USER.md` until a read-only curation report is produced and reviewed.

--- a/tests/agent/test_memory_routing.py
+++ b/tests/agent/test_memory_routing.py
@@ -1,0 +1,112 @@
+from agent.memory_routing import (
+    MemoryRoute,
+    build_memory_route,
+    parse_llm_route,
+    rewrite_memory_query,
+)
+
+
+def test_dataclass_defaults_are_safe_and_complete():
+    route = MemoryRoute()
+
+    assert route.domains == []
+    assert route.slots == []
+    assert route.risk == "low"
+    assert route.confidence == 0.0
+    assert route.route_source == "none"
+    assert route.reason == ""
+    assert route.new_topic_candidate is None
+    assert route.suggested_slots == []
+    assert route.should_update_policy is False
+    assert route.gate_required is False
+    assert route.rewritten_query is None
+
+
+def test_token_boundary_matching_prevents_raw_substring_false_positives():
+    route = build_memory_route("Can you communicate the approach clearly?")
+
+    assert route.domains == []
+    assert route.slots == []
+    assert route.route_source == "none"
+
+
+def test_kr_stock_extends_investing_slots_for_korean_stock_query():
+    route = build_memory_route("하이닉스 지금 어때?")
+
+    assert route.domains == ["kr_stock"]
+    assert "holdings" in route.slots
+    assert "average_cost" in route.slots
+    assert route.route_source == "deterministic"
+    assert route.confidence > 0
+    assert "하이닉스" in route.reason
+
+
+def test_safety_trigger_uses_token_boundaries_and_requires_gate():
+    risky = build_memory_route("Please delete my saved memories")
+    safe = build_memory_route("This catalogue should stay available")
+
+    assert risky.risk == "high"
+    assert risky.gate_required is True
+    assert risky.route_source == "deterministic"
+    assert safe.risk == "low"
+    assert safe.gate_required is False
+
+
+def test_parse_llm_route_normalizes_payload_and_marks_policy_proposal():
+    route = parse_llm_route(
+        {
+            "domains": "gardening",
+            "slots": ["soil_ph"],
+            "confidence": "0.7",
+            "reason": "User is asking about a new recurring topic",
+            "new_topic_candidate": "gardening",
+            "suggested_slots": ["soil_ph", "sunlight"],
+        }
+    )
+
+    assert route.domains == ["gardening"]
+    assert route.slots == ["soil_ph"]
+    assert route.confidence == 0.7
+    assert route.route_source == "llm"
+    assert route.should_update_policy is True
+    assert route.new_topic_candidate == "gardening"
+    assert route.suggested_slots == ["soil_ph", "sunlight"]
+
+
+def test_build_route_prefers_deterministic_match_but_keeps_llm_new_topic_signal():
+    route = build_memory_route(
+        "하이닉스 지금 어때?",
+        llm_payload={
+            "domains": ["investing"],
+            "slots": ["watchlist"],
+            "new_topic_candidate": "semiconductor_cycle",
+            "suggested_slots": ["cycle_notes"],
+        },
+    )
+
+    assert route.domains == ["kr_stock"]
+    assert "holdings" in route.slots
+    assert route.route_source == "deterministic"
+    assert route.should_update_policy is True
+    assert route.new_topic_candidate == "semiconductor_cycle"
+    assert route.suggested_slots == ["cycle_notes"]
+
+
+def test_rewrite_memory_query_includes_slot_names_not_values():
+    route = MemoryRoute(domains=["kr_stock"], slots=["holdings", "average_cost"])
+
+    rewritten = rewrite_memory_query("하이닉스 지금 어때?", route)
+
+    assert "하이닉스 지금 어때?" in rewritten
+    assert "slots: holdings, average_cost" in rewritten
+    assert "domains: kr_stock" in rewritten
+    assert "100" not in rewritten
+    assert "50000" not in rewritten
+
+
+def test_build_route_sets_rewritten_query_from_route_slots():
+    route = build_memory_route("하이닉스 지금 어때?")
+
+    assert route.rewritten_query is not None
+    assert "slots:" in route.rewritten_query
+    assert "holdings" in route.rewritten_query

--- a/tests/agent/test_memory_routing_proposals.py
+++ b/tests/agent/test_memory_routing_proposals.py
@@ -1,0 +1,58 @@
+import json
+
+from agent.memory_routing import MemoryRoute
+from agent.memory_routing_proposals import record_policy_proposal
+
+
+def test_record_policy_proposal_noops_without_new_topic_candidate(tmp_path):
+    route = MemoryRoute(suggested_slots=["anything"])
+
+    result = record_policy_proposal(tmp_path, route, "remember this")
+
+    assert result is None
+    assert not (tmp_path / "memory-routing-proposals.json").exists()
+
+
+def test_record_policy_proposal_creates_json_without_mutating_policy(tmp_path):
+    policy_path = tmp_path / "memory-routing-policy.yaml"
+    policy_text = "domains: {}\n"
+    policy_path.write_text(policy_text, encoding="utf-8")
+    route = MemoryRoute(
+        new_topic_candidate="gardening",
+        suggested_slots=["soil_ph", "sunlight"],
+    )
+
+    proposal_path = record_policy_proposal(tmp_path, route, "How is my basil doing?")
+
+    assert proposal_path == tmp_path / "memory-routing-proposals.json"
+    assert policy_path.read_text(encoding="utf-8") == policy_text
+    data = json.loads(proposal_path.read_text(encoding="utf-8"))
+    assert data["gardening"]["count"] == 1
+    assert data["gardening"]["examples"] == ["How is my basil doing?"]
+    assert data["gardening"]["suggested_slots"] == ["soil_ph", "sunlight"]
+
+
+def test_record_policy_proposal_updates_existing_entry(tmp_path):
+    first_route = MemoryRoute(
+        new_topic_candidate="gardening",
+        suggested_slots=["soil_ph", "sunlight"],
+    )
+    second_route = MemoryRoute(
+        new_topic_candidate="gardening",
+        suggested_slots=["sunlight", "watering_schedule"],
+    )
+    first = record_policy_proposal(tmp_path, first_route, "How is my basil doing?")
+    second = record_policy_proposal(tmp_path, second_route, "Should I water the basil?")
+
+    assert second == first
+    data = json.loads(first.read_text(encoding="utf-8"))
+    assert data["gardening"]["count"] == 2
+    assert data["gardening"]["examples"] == [
+        "How is my basil doing?",
+        "Should I water the basil?",
+    ]
+    assert data["gardening"]["suggested_slots"] == [
+        "soil_ph",
+        "sunlight",
+        "watering_schedule",
+    ]

--- a/tests/fixtures/memory_routing/inmind_mini.yaml
+++ b/tests/fixtures/memory_routing/inmind_mini.yaml
@@ -1,0 +1,123 @@
+version: 0.1
+name: inmind_mini
+cases:
+  - id: ko-global-direct-color
+    prompt: "내 커피잔 취향을 기억하고 있나?"
+    task_type: direct_recall
+    memory_location: global
+    split: known_domain
+    control: false
+    memory: "사용자는 파란색 머그에 핸드드립 커피를 마시는 것을 선호한다."
+    expected:
+      judged_claims:
+        - lang: ko
+          must_satisfy: ["파란색 머그", "핸드드립"]
+          must_not_satisfy: ["라떼"]
+  - id: en-global-direct-name
+    prompt: "What name should you use for my weekly planning ritual?"
+    task_type: direct_recall
+    memory_location: global
+    split: known_domain
+    control: false
+    memory: "The user's weekly planning ritual is called Friday Map."
+    expected:
+      judged_claims:
+        - lang: en
+          must_satisfy: ["Friday Map"]
+          must_not_satisfy: ["Monday Map"]
+  - id: ko-project-indirect-style
+    prompt: "이 저장소의 PR 요약을 어떻게 쓰면 좋을까?"
+    task_type: indirect_application
+    memory_location: project
+    split: known_domain
+    control: false
+    memory: "이 프로젝트의 PR 요약은 한국어 bullet list와 검증 명령을 포함한다."
+    expected:
+      judged_claims:
+        - lang: ko
+          must_satisfy: ["한국어", "검증 명령"]
+          must_not_satisfy: ["영어로만"]
+  - id: en-project-indirect-tests
+    prompt: "Draft the verification section for this repo change."
+    task_type: indirect_application
+    memory_location: project
+    split: known_domain
+    control: false
+    memory: "Project verification summaries should include exact commands and pass/fail scope."
+    expected:
+      judged_claims:
+        - lang: en
+          must_satisfy: ["exact commands", "pass/fail scope"]
+          must_not_satisfy: ["fully verified"]
+  - id: ko-skill-direct-tdd
+    prompt: "새 기능은 어떤 순서로 구현해야 해?"
+    task_type: direct_recall
+    memory_location: skill
+    split: known_domain
+    control: false
+    memory: "TDD 작업은 실패 테스트 작성, 실패 확인, 최소 구현, 통과 확인 순서로 진행한다."
+    expected:
+      judged_claims:
+        - lang: ko
+          must_satisfy: ["실패 테스트", "최소 구현"]
+          must_not_satisfy: ["테스트 없이"]
+  - id: en-skill-indirect-guardrail
+    prompt: "How should I approach this risky memory benchmark?"
+    task_type: indirect_application
+    memory_location: skill
+    split: known_domain
+    control: false
+    memory: "Memory benchmark work must use an isolated Hermes home and never touch the live ~/.hermes tree."
+    expected:
+      judged_claims:
+        - lang: en
+          must_satisfy: ["isolated Hermes home", "live ~/.hermes"]
+          must_not_satisfy: ["safe to reuse"]
+  - id: ko-unseen-global-routing
+    prompt: "처음 보는 도메인의 답변에 개인 취향을 적용해야 하나?"
+    task_type: indirect_application
+    memory_location: global
+    split: unseen_topic
+    control: false
+    memory: "사용자는 낯선 주제라도 답변 형식은 먼저 요약 bullets를 선호한다."
+    expected:
+      judged_claims:
+        - lang: ko
+          must_satisfy: ["요약", "bullets"]
+          must_not_satisfy: ["장문 단락만"]
+  - id: en-unseen-project-routing
+    prompt: "For an unfamiliar subsystem, what repo convention should guide the answer?"
+    task_type: indirect_application
+    memory_location: project
+    split: unseen_topic
+    control: false
+    memory: "Unknown subsystem notes should explicitly label assumptions and cite changed files."
+    expected:
+      judged_claims:
+        - lang: en
+          must_satisfy: ["label assumptions", "changed files"]
+          must_not_satisfy: ["guess"]
+  - id: ko-control-no-personalization
+    prompt: "일반적인 파이썬 함수 이름 규칙은?"
+    task_type: direct_recall
+    memory_location: none
+    split: known_domain
+    control: true
+    memory: null
+    expected:
+      judged_claims:
+        - lang: ko
+          must_satisfy: ["snake_case"]
+          must_not_satisfy: ["Ryan"]
+  - id: en-control-unseen-no-personalization
+    prompt: "Explain what a cache hit means in general terms."
+    task_type: direct_recall
+    memory_location: none
+    split: unseen_topic
+    control: true
+    memory: null
+    expected:
+      judged_claims:
+        - lang: en
+          must_satisfy: ["stored result"]
+          must_not_satisfy: ["your preference"]

--- a/tests/tools/test_memory_routing_benchmark.py
+++ b/tests/tools/test_memory_routing_benchmark.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tools.memory_routing_benchmark import (
+    assert_isolated_hermes_home,
+    compute_metrics,
+    load_fixture,
+    main,
+    score_answer,
+)
+
+
+def test_assert_isolated_hermes_home_rejects_real_home_and_descendants() -> None:
+    real_home = Path.home() / ".hermes"
+
+    with pytest.raises(ValueError, match="isolated"):
+        assert_isolated_hermes_home(real_home)
+
+    with pytest.raises(ValueError, match="isolated"):
+        assert_isolated_hermes_home(real_home / "profiles" / "default")
+
+
+def test_assert_isolated_hermes_home_accepts_temp_like_external_path(tmp_path: Path) -> None:
+    safe_home = tmp_path / "hermes-home"
+
+    assert assert_isolated_hermes_home(safe_home) == safe_home.resolve()
+
+
+def test_score_answer_uses_conservative_substring_claims_for_ko_and_en() -> None:
+    expected = {
+        "judged_claims": [
+            {"lang": "ko", "must_satisfy": ["파란색 머그", "핸드드립"], "must_not_satisfy": ["라떼"]},
+            {"lang": "en", "must_satisfy": ["blue mug"], "must_not_satisfy": ["latte"]},
+        ]
+    }
+
+    passed = score_answer("파란색 머그에 핸드드립 coffee; blue mug preference.", expected)
+    failed_missing = score_answer("파란색 머그만 언급", expected)
+    failed_forbidden = score_answer("파란색 머그 핸드드립 blue mug latte", expected)
+
+    assert passed["passed"] is True
+    assert passed["satisfied"] == 3
+    assert passed["violations"] == []
+    assert failed_missing["passed"] is False
+    assert "missing:핸드드립" in failed_missing["violations"]
+    assert failed_forbidden["passed"] is False
+    assert "forbidden:latte" in failed_forbidden["violations"]
+
+
+def test_compute_metrics_groups_accuracy_and_guardrail_rates() -> None:
+    results = [
+        {
+            "id": "direct-global-pass",
+            "task_type": "direct_recall",
+            "memory_location": "global",
+            "split": "known_domain",
+            "control": False,
+            "score": {"passed": True},
+            "routing_useful": False,
+            "personalized": True,
+            "safety_miss": False,
+        },
+        {
+            "id": "direct-global-fail",
+            "task_type": "direct_recall",
+            "memory_location": "global",
+            "split": "known_domain",
+            "control": False,
+            "score": {"passed": False},
+            "routing_useful": False,
+            "personalized": False,
+            "safety_miss": False,
+        },
+        {
+            "id": "indirect-project-pass",
+            "task_type": "indirect_application",
+            "memory_location": "project",
+            "split": "known_domain",
+            "control": False,
+            "score": {"passed": True},
+            "routing_useful": False,
+            "personalized": True,
+            "safety_miss": True,
+        },
+        {
+            "id": "unseen-routing-useful",
+            "task_type": "indirect_application",
+            "memory_location": "skill",
+            "split": "unseen_topic",
+            "control": False,
+            "score": {"passed": True},
+            "routing_useful": True,
+            "personalized": True,
+            "safety_miss": False,
+        },
+        {
+            "id": "control-personalized",
+            "task_type": "direct_recall",
+            "memory_location": "none",
+            "split": "known_domain",
+            "control": True,
+            "score": {"passed": False},
+            "routing_useful": False,
+            "personalized": True,
+            "safety_miss": False,
+        },
+    ]
+
+    metrics = compute_metrics(results)
+
+    assert metrics["direct_recall_accuracy"]["overall"] == pytest.approx(1 / 3)
+    assert metrics["direct_recall_accuracy"]["by_memory_location"]["global"] == pytest.approx(1 / 2)
+    assert metrics["direct_recall_accuracy"]["by_memory_location"]["none"] == pytest.approx(0.0)
+    assert metrics["direct_recall_accuracy"]["by_split"]["known_domain"] == pytest.approx(1 / 3)
+    assert metrics["indirect_application_accuracy"]["overall"] == pytest.approx(1.0)
+    assert metrics["indirect_application_accuracy"]["by_memory_location"]["project"] == pytest.approx(1.0)
+    assert metrics["indirect_application_accuracy"]["by_split"]["unseen_topic"] == pytest.approx(1.0)
+    assert metrics["unseen_topic_useful_routing_rate"] == pytest.approx(1.0)
+    assert metrics["false_positive_personalization_rate"] == pytest.approx(1.0)
+    assert metrics["safety_miss_rate"] == pytest.approx(1 / 5)
+
+
+def test_inmind_mini_fixture_has_mvp_coverage() -> None:
+    fixture_path = Path("tests/fixtures/memory_routing/inmind_mini.yaml")
+    cases = load_fixture(fixture_path)
+
+    assert len(cases) >= 10
+    assert {case["split"] for case in cases} >= {"known_domain", "unseen_topic"}
+    assert {case["control"] for case in cases} == {False, True}
+    assert {case["memory_location"] for case in cases} >= {"global", "project", "skill", "none"}
+    langs = {claim["lang"] for case in cases for claim in case["expected"]["judged_claims"]}
+    assert langs >= {"ko", "en"}
+
+
+def test_cli_scorer_only_emits_metrics_without_p0_claims(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    results_path = tmp_path / "results.jsonl"
+    rows = [
+        {
+            "id": "case-1",
+            "task_type": "direct_recall",
+            "memory_location": "global",
+            "split": "known_domain",
+            "control": False,
+            "answer": "Use the blue mug.",
+            "expected": {"judged_claims": [{"lang": "en", "must_satisfy": ["blue mug"]}]},
+        }
+    ]
+    results_path.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
+
+    exit_code = main(["score", "--mode", "baseline", "--results", str(results_path)])
+
+    captured = capsys.readouterr()
+    payload = yaml.safe_load(captured.out)
+    assert exit_code == 0
+    assert payload["mode"] == "baseline"
+    assert payload["scorer_only"] is True
+    assert payload["p0_metrics_claimed"] is False
+    assert payload["metrics"]["direct_recall_accuracy"]["overall"] == 1.0
+
+
+def test_cli_accepts_routed_and_open_set_modes(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    results_path = tmp_path / "results.jsonl"
+    results_path.write_text("", encoding="utf-8")
+
+    assert main(["score", "--mode", "routed", "--results", str(results_path)]) == 0
+    assert yaml.safe_load(capsys.readouterr().out)["mode"] == "routed"
+    assert main(["score", "--mode", "open-set", "--results", str(results_path)]) == 0
+    assert yaml.safe_load(capsys.readouterr().out)["mode"] == "open-set"

--- a/tools/memory_routing_benchmark.py
+++ b/tools/memory_routing_benchmark.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+import yaml
+
+
+SUPPORTED_MODES = ("baseline", "routed", "open-set")
+
+
+def assert_isolated_hermes_home(path: Path) -> Path:
+    """Return a resolved Hermes home path, rejecting the user's live ~/.hermes tree."""
+
+    candidate = Path(path).expanduser().resolve(strict=False)
+    live_home = (Path.home() / ".hermes").resolve(strict=False)
+    if candidate == live_home or _is_relative_to(candidate, live_home):
+        raise ValueError(
+            f"Hermes home must be isolated for benchmarks; refused live path {candidate}"
+        )
+    return candidate
+
+
+def score_answer(answer: str, expected: dict[str, Any]) -> dict[str, Any]:
+    """Score an answer with conservative substring matching over judged claims.
+
+    This MVP deliberately avoids pretending to be an LLM judge. A claim is satisfied
+    only when each `must_satisfy` substring is present and every
+    `must_not_satisfy` substring is absent in the answer.
+    """
+
+    normalized_answer = _normalize(answer)
+    violations: list[str] = []
+    satisfied = 0
+    forbidden_absent = 0
+    total_required = 0
+    total_forbidden = 0
+
+    for claim in expected.get("judged_claims", []) or []:
+        for required in claim.get("must_satisfy", []) or []:
+            total_required += 1
+            needle = _normalize(str(required))
+            if needle and needle in normalized_answer:
+                satisfied += 1
+            else:
+                violations.append(f"missing:{required}")
+
+        for forbidden in claim.get("must_not_satisfy", []) or []:
+            total_forbidden += 1
+            needle = _normalize(str(forbidden))
+            if needle and needle in normalized_answer:
+                violations.append(f"forbidden:{forbidden}")
+            else:
+                forbidden_absent += 1
+
+    return {
+        "passed": not violations,
+        "satisfied": satisfied,
+        "required": total_required,
+        "forbidden_absent": forbidden_absent,
+        "forbidden": total_forbidden,
+        "violations": violations,
+    }
+
+
+def compute_metrics(results: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    """Compute benchmark MVP metrics from already-scored result rows."""
+
+    direct = [row for row in results if row.get("task_type") == "direct_recall"]
+    indirect = [row for row in results if row.get("task_type") == "indirect_application"]
+    unseen_non_control = [
+        row
+        for row in results
+        if row.get("split") == "unseen_topic" and not bool(row.get("control", False))
+    ]
+    control = [row for row in results if bool(row.get("control", False))]
+
+    return {
+        "direct_recall_accuracy": _accuracy_metric(direct),
+        "indirect_application_accuracy": _accuracy_metric(indirect),
+        "unseen_topic_useful_routing_rate": _rate(
+            unseen_non_control, lambda row: bool(row.get("routing_useful", False))
+        ),
+        "false_positive_personalization_rate": _rate(
+            control, lambda row: bool(row.get("personalized", False))
+        ),
+        "safety_miss_rate": _rate(results, lambda row: bool(row.get("safety_miss", False))),
+    }
+
+
+def load_fixture(path: Path) -> list[dict[str, Any]]:
+    raw = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+    if isinstance(raw, dict):
+        cases = raw.get("cases", [])
+    else:
+        cases = raw
+    if not isinstance(cases, list):
+        raise ValueError(f"Fixture {path} must contain a list of cases")
+    return cases
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="memory_routing_benchmark",
+        description="Scorer-only MVP for isolated Hermes memory routing benchmark results.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    score_parser = subparsers.add_parser("score", help="Score JSONL runner outputs")
+    score_parser.add_argument("--mode", choices=SUPPORTED_MODES, required=True)
+    score_parser.add_argument("--results", type=Path, required=True)
+
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    if args.command == "score":
+        rows = _load_jsonl(args.results)
+        scored = [_ensure_scored(row) for row in rows]
+        payload = {
+            "mode": args.mode,
+            "scorer_only": True,
+            "p0_metrics_claimed": False,
+            "runner_results_present": bool(rows),
+            "result_count": len(scored),
+            "metrics": compute_metrics(scored),
+        }
+        print(yaml.safe_dump(payload, sort_keys=False, allow_unicode=True), end="")
+        return 0
+    parser.error(f"unsupported command: {args.command}")
+    return 2
+
+
+def _ensure_scored(row: dict[str, Any]) -> dict[str, Any]:
+    if "score" in row:
+        return row
+    scored = dict(row)
+    scored["score"] = score_answer(str(row.get("answer", "")), row.get("expected", {}) or {})
+    return scored
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            loaded = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSONL at {path}:{line_number}: {exc}") from exc
+        if not isinstance(loaded, dict):
+            raise ValueError(f"JSONL row at {path}:{line_number} must be an object")
+        rows.append(loaded)
+    return rows
+
+
+def _accuracy_metric(rows: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "overall": _rate(rows, _passed),
+        "by_memory_location": _grouped_rate(rows, "memory_location", _passed),
+        "by_split": _grouped_rate(rows, "split", _passed),
+    }
+
+
+def _grouped_rate(
+    rows: Sequence[dict[str, Any]], key: str, predicate: Any
+) -> dict[str, float | None]:
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        groups.setdefault(str(row.get(key, "unknown")), []).append(row)
+    return {group: _rate(group_rows, predicate) for group, group_rows in sorted(groups.items())}
+
+
+def _rate(rows: Sequence[dict[str, Any]], predicate: Any) -> float | None:
+    if not rows:
+        return None
+    return sum(1 for row in rows if predicate(row)) / len(rows)
+
+
+def _passed(row: dict[str, Any]) -> bool:
+    score = row.get("score", {}) or {}
+    if isinstance(score, dict):
+        return bool(score.get("passed", False))
+    return bool(score)
+
+
+def _normalize(value: str) -> str:
+    return " ".join(value.casefold().split())
+
+
+def _is_relative_to(candidate: Path, parent: Path) -> bool:
+    try:
+        candidate.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## PR 목적

InMind 글/논문에서 지적한 implicit-association memory blind spot을 Hermes에 실제 적용 가능한 구조로 반영합니다.

## 배경

기존 memory는 저장 자체보다 “필요한 순간 관련 기억을 떠올리는가”에서 실패하기 쉽습니다. 특히 cat→lily danger, allergy→almond flour처럼 표면 단어가 직접 일치하지 않는 implicit association에서 단순 RAG/검색 기반 recall이 약합니다.

## 주요 변경 사항

- `docs/features/memory-routing/`에 PRD, plan, Claude Opus review, policy 문서 추가
- `agent/memory_routing.py`
  - `MemoryRoute` dataclass
  - deterministic safety trigger + LLM/open-set route payload normalize
  - domain `extends` 재귀 slot resolution
  - query rewrite: slot 이름만 포함하고 memory value는 포함하지 않음
  - documented YAML policy와 test-safe default policy overlay
- `agent/memory_routing_proposals.py`
  - 새 topic 후보를 JSON proposal queue에 기록
  - policy 파일은 자동 mutate하지 않음
- `tools/memory_routing_benchmark.py`
  - isolated `HERMES_HOME` guard
  - scorer-only MVP benchmark CLI
  - direct/indirect recall, unseen topic routing, false-positive personalization, safety miss metrics
- mini fixture 추가: `tests/fixtures/memory_routing/inmind_mini.yaml`

## 검증 결과

로컬 targeted test:

```bash
python -m pytest \
  tests/agent/test_memory_routing.py \
  tests/agent/test_memory_routing_proposals.py \
  tests/tools/test_memory_routing_benchmark.py -q
```

결과:

```text
18 passed in 0.35s
```

추가 검증:

```bash
git diff --check HEAD~4..HEAD
```

통과.

## 리스크 및 한계

- 이번 PR은 memory routing의 provider-neutral foundation + benchmark MVP입니다.
- 실제 runtime provider integration/prefetch injection은 후속 PR에서 단계적으로 연결해야 합니다.
- LLM classifier adapter는 schema/parse seam만 준비했고, 모델 호출 자체는 아직 연결하지 않았습니다.

## 후속 개선 후보

- `MemoryProvider.prefetch`와 route rewrite 연결
- LLM open-set classifier adapter 추가
- 정책 승격 review command 추가
- benchmark runner를 실제 isolated Hermes session까지 확장
