### PR TITLE
fix: restart macos launchd gateway fleet

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1269,7 +1269,13 @@ def _parse_launchd_gateway_jobs_from_list_output(output: str) -> list[tuple[str,
     return jobs
 
 
-def _running_launchd_gateway_jobs() -> list[tuple[str, int]]:
+class LaunchdGatewayDiscoveryError(RuntimeError):
+    """Raised when running launchd gateways cannot be enumerated."""
+
+
+def _running_launchd_gateway_jobs(
+    *, require_success: bool = False
+) -> list[tuple[str, int]]:
     """Discover running launchd-managed Hermes gateways without starting jobs."""
     try:
         result = subprocess.run(
@@ -1278,16 +1284,35 @@ def _running_launchd_gateway_jobs() -> list[tuple[str, int]]:
             text=True, encoding='utf-8', errors='replace',
             timeout=5,
         )
-    except (subprocess.TimeoutExpired, FileNotFoundError):
+    except subprocess.TimeoutExpired as exc:
+        if require_success:
+            raise LaunchdGatewayDiscoveryError(
+                "launchctl list timed out"
+            ) from exc
+        return []
+    except FileNotFoundError as exc:
+        if require_success:
+            raise LaunchdGatewayDiscoveryError(
+                "launchctl executable was not found"
+            ) from exc
         return []
     if result.returncode != 0:
+        if require_success:
+            raise LaunchdGatewayDiscoveryError(
+                f"launchctl list exited with status {result.returncode}"
+            )
         return []
     return _parse_launchd_gateway_jobs_from_list_output(result.stdout or "")
 
 
-def running_launchd_gateway_labels() -> list[str]:
+def running_launchd_gateway_labels(*, require_success: bool = False) -> list[str]:
     """Return running Hermes launchd gateway labels, default and named profiles."""
-    return [label for label, _pid in _running_launchd_gateway_jobs()]
+    return [
+        label
+        for label, _pid in _running_launchd_gateway_jobs(
+            require_success=require_success
+        )
+    ]
 
 
 def _probe_launchd_service_running() -> bool:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -143,33 +143,8 @@ def _get_service_pids() -> set:
 
     # --- launchd (macOS) ---
     if is_macos():
-        try:
-            label = get_launchd_label()
-            result = subprocess.run(
-                ["launchctl", "list", label],
-                capture_output=True,
-                text=True, encoding='utf-8', errors='replace',
-                timeout=5,
-            )
-            if result.returncode == 0:
-                # Try plist format first (macOS 26+): "PID" = <N>;
-                pid = _parse_launchd_pid_from_list_output(result.stdout)
-                if pid is not None and pid > 0:
-                    pids.add(pid)
-                else:
-                    # Fall back to legacy tab-separated format:
-                    # "PID\tStatus\tLabel"
-                    for line in result.stdout.strip().splitlines():
-                        parts = line.split()
-                        if len(parts) >= 3 and parts[2] == label:
-                            try:
-                                pid = int(parts[0])
-                                if pid > 0:
-                                    pids.add(pid)
-                            except ValueError:
-                                pass
-        except (FileNotFoundError, subprocess.TimeoutExpired):
-            pass
+        for _label, _pid in _running_launchd_gateway_jobs():
+            pids.add(_pid)
 
     return pids
 
@@ -1270,6 +1245,49 @@ def _parse_launchd_pid_from_list_output(output: str) -> int | None:
                 except ValueError:
                     return None
     return None
+
+
+def _parse_launchd_gateway_jobs_from_list_output(output: str) -> list[tuple[str, int]]:
+    """Return running Hermes gateway jobs from ``launchctl list`` output."""
+    jobs: list[tuple[str, int]] = []
+    seen: set[str] = set()
+    for raw_line in output.splitlines():
+        parts = raw_line.split()
+        if len(parts) < 3:
+            continue
+        pid_text, _status, label = parts[0], parts[1], parts[2]
+        if label != "ai.hermes.gateway" and not label.startswith("ai.hermes.gateway-"):
+            continue
+        try:
+            pid = int(pid_text)
+        except ValueError:
+            continue
+        if pid <= 0 or label in seen:
+            continue
+        seen.add(label)
+        jobs.append((label, pid))
+    return jobs
+
+
+def _running_launchd_gateway_jobs() -> list[tuple[str, int]]:
+    """Discover running launchd-managed Hermes gateways without starting jobs."""
+    try:
+        result = subprocess.run(
+            ["launchctl", "list"],
+            capture_output=True,
+            text=True, encoding='utf-8', errors='replace',
+            timeout=5,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return []
+    if result.returncode != 0:
+        return []
+    return _parse_launchd_gateway_jobs_from_list_output(result.stdout or "")
+
+
+def running_launchd_gateway_labels() -> list[str]:
+    """Return running Hermes launchd gateway labels, default and named profiles."""
+    return [label for label, _pid in _running_launchd_gateway_jobs()]
 
 
 def _probe_launchd_service_running() -> bool:
@@ -4429,11 +4447,17 @@ def _wait_for_gateway_exit(
     return True
 
 
-def launchd_restart():
-    label = get_launchd_label()
+def launchd_restart(label: str | None = None):
+    label = label or get_launchd_label()
     target = f"{_launchd_domain()}/{label}"
     drain_timeout = _get_restart_drain_timeout()
     from gateway.status import get_running_pid
+
+    if label != get_launchd_label():
+        subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
+        print(f"✓ Service restarted ({label})")
+        _clear_launchd_unsupported_marker()
+        return
 
     try:
         pid = get_running_pid()

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4656,26 +4656,28 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 try:
                     from hermes_cli.gateway import (
                         launchd_restart,
-                        get_launchd_label,
-                        get_launchd_plist_path,
+                        running_launchd_gateway_labels,
                     )
 
-                    plist_path = get_launchd_plist_path()
-                    if plist_path.exists():
-                        check = subprocess.run(
-                            ["launchctl", "list", get_launchd_label()],
-                            capture_output=True,
-                            text=True, encoding="utf-8", errors="replace",
-                            timeout=5,
-                        )
-                        if check.returncode == 0:
-                            try:
-                                launchd_restart()
-                                restarted_services.append(get_launchd_label())
-                            except subprocess.CalledProcessError as e:
-                                stderr = (getattr(e, "stderr", "") or "").strip()
-                                print(f"  ⚠ Gateway restart failed: {stderr}")
-                except (FileNotFoundError, subprocess.TimeoutExpired, ImportError):
+                    for launchd_label in running_launchd_gateway_labels():
+                        try:
+                            launchd_restart(launchd_label)
+                            restarted_services.append(launchd_label)
+                        except subprocess.CalledProcessError as e:
+                            failed_or_stale_units.append(launchd_label)
+                            stderr = (getattr(e, "stderr", "") or "").strip()
+                            print(
+                                f"  ⚠ Gateway restart failed for {launchd_label}: "
+                                f"{stderr}"
+                            )
+                        except subprocess.TimeoutExpired as e:
+                            failed_or_stale_units.append(launchd_label)
+                            print(
+                                f"  ⚠ launchctl timed out restarting {launchd_label} "
+                                f"({e.cmd if e.cmd else 'unknown command'}); "
+                                f"continuing with remaining gateways"
+                            )
+                except (FileNotFoundError, ImportError):
                     pass
 
             # --- Manual (non-service) gateways ---

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4032,6 +4032,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # Never let the cron safety net break an otherwise-good update.
             logger.debug("Cron jobs auto-restore check failed: %s", exc)
 
+        try:
+            from hermes_cli.gateway import is_macos as _gateway_is_macos
+
+            defer_update_complete_message = _gateway_is_macos()
+        except Exception:
+            defer_update_complete_message = sys.platform == "darwin"
+
         print()
         if node_failures:
             print(
@@ -4040,7 +4047,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             )
             print("  Code and Python deps are updated, but the dashboard/TUI may")
             print("  be in a mixed state until the Node deps are rebuilt.")
-        else:
+        elif not defer_update_complete_message:
             print("✓ Update complete!")
 
         # Search-index optimization notice (v23). Existing installs keep their
@@ -4655,11 +4662,14 @@ def _cmd_update_impl(args, gateway_mode: bool):
             if is_macos():
                 try:
                     from hermes_cli.gateway import (
+                        LaunchdGatewayDiscoveryError,
                         launchd_restart,
                         running_launchd_gateway_labels,
                     )
 
-                    for launchd_label in running_launchd_gateway_labels():
+                    for launchd_label in running_launchd_gateway_labels(
+                        require_success=True
+                    ):
                         try:
                             launchd_restart(launchd_label)
                             restarted_services.append(launchd_label)
@@ -4677,6 +4687,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                 f"({e.cmd if e.cmd else 'unknown command'}); "
                                 f"continuing with remaining gateways"
                             )
+                except LaunchdGatewayDiscoveryError as e:
+                    discovery_name = "macOS launchd gateway discovery"
+                    failed_or_stale_units.append(discovery_name)
+                    print(
+                        f"  ⚠ {discovery_name} failed: {e}; "
+                        "running launchd gateways may still need restart"
+                    )
                 except (FileNotFoundError, ImportError):
                     pass
 
@@ -4873,6 +4890,14 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # Preserve the safety rule above: a failed Node refresh leaves the
         # currently running dashboard untouched.
         _finish_dashboard_update_cleanup(node_failures)
+
+        if (
+            defer_update_complete_message
+            and not node_failures
+            and not gateway_fleet_restart_incomplete
+        ):
+            print()
+            print("✓ Update complete!")
 
         print()
         print("Tip: You can now select a provider and model:")

--- a/tests/hermes_cli/test_update_macos_launchd_fleet_restart.py
+++ b/tests/hermes_cli/test_update_macos_launchd_fleet_restart.py
@@ -8,10 +8,24 @@ from types import SimpleNamespace
 import pytest
 
 
-def test_macos_update_restarts_running_launchd_gateway_fleet_once(
-    tmp_path, monkeypatch, capsys
+_DEFAULT_LAUNCHD_JOBS = {
+    "ai.hermes.gateway": 101,
+    "ai.hermes.gateway-builder": 201,
+    "ai.hermes.gateway-writer": 202,
+    "ai.hermes.gateway-dormant": None,
+    "com.example.unrelated": 303,
+}
+
+
+def _run_mocked_macos_update(
+    tmp_path,
+    monkeypatch,
+    capsys,
+    *,
+    launchd_jobs: dict[str, int | None] | None = None,
+    launchctl_list_failure: str | None = None,
+    restart_failure_label: str | None = "ai.hermes.gateway-writer",
 ):
-    """Post-update macOS refresh must cover every running Hermes launchd gateway."""
     from hermes_cli import gateway as gateway_cli
     from hermes_cli import main as hm
     import hermes_cli.config as config_cli
@@ -27,13 +41,7 @@ def test_macos_update_restarts_running_launchd_gateway_fleet_once(
     active_plist = tmp_path / "ai.hermes.gateway.plist"
     active_plist.write_text("<plist />", encoding="utf-8")
 
-    launchd_jobs = {
-        "ai.hermes.gateway": 101,
-        "ai.hermes.gateway-builder": 201,
-        "ai.hermes.gateway-writer": 202,
-        "ai.hermes.gateway-dormant": None,
-        "com.example.unrelated": 303,
-    }
+    jobs = dict(_DEFAULT_LAUNCHD_JOBS if launchd_jobs is None else launchd_jobs)
     restart_calls: list[str] = []
 
     def fake_run(cmd, **kwargs):
@@ -46,16 +54,28 @@ def test_macos_update_restarts_running_launchd_gateway_fleet_once(
         if cmd[:3] == ["git", "merge", "--ff-only"]:
             return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
         if cmd[:2] == ["launchctl", "list"] and len(cmd) == 2:
+            if launchctl_list_failure == "nonzero":
+                return subprocess.CompletedProcess(
+                    cmd,
+                    1,
+                    stdout="",
+                    stderr="launchctl could not enumerate jobs\n",
+                )
+            if launchctl_list_failure == "timeout":
+                raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 5))
+            if launchctl_list_failure == "missing":
+                raise FileNotFoundError("launchctl")
             rows = [
                 f"{pid if pid is not None else '-'}\t0\t{label}"
-                for label, pid in launchd_jobs.items()
+                for label, pid in jobs.items()
             ]
-            rows.append("202\t0\tai.hermes.gateway-writer")
+            if "ai.hermes.gateway-writer" in jobs:
+                rows.append("202\t0\tai.hermes.gateway-writer")
             return subprocess.CompletedProcess(
                 cmd, 0, stdout="\n".join(rows), stderr=""
             )
         if cmd[:2] == ["launchctl", "list"] and len(cmd) == 3:
-            pid = launchd_jobs.get(cmd[2])
+            pid = jobs.get(cmd[2])
             if pid is None:
                 return subprocess.CompletedProcess(
                     cmd, 0, stdout='"PID" = -1;\n', stderr=""
@@ -68,11 +88,11 @@ def test_macos_update_restarts_running_launchd_gateway_fleet_once(
     def fake_launchd_restart(label: str | None = None):
         restarted_label = label or gateway_cli.get_launchd_label()
         restart_calls.append(restarted_label)
-        if restarted_label == "ai.hermes.gateway-writer":
+        if restarted_label == restart_failure_label:
             raise subprocess.CalledProcessError(
                 75,
-                ["launchctl", "kickstart", "-k", "gui/501/ai.hermes.gateway-writer"],
-                stderr="writer failed to restart",
+                ["launchctl", "kickstart", "-k", f"gui/501/{restarted_label}"],
+                stderr=f"{restarted_label} failed to restart",
             )
 
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
@@ -118,7 +138,11 @@ def test_macos_update_restarts_running_launchd_gateway_fleet_once(
     monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
     monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: active_plist)
     monkeypatch.setattr(gateway_cli, "launchd_restart", fake_launchd_restart)
-    monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: {101, 201, 202, 303})
+    monkeypatch.setattr(
+        gateway_cli,
+        "_get_service_pids",
+        lambda: {pid for pid in jobs.values() if pid is not None},
+    )
     monkeypatch.setattr(
         gateway_cli,
         "find_gateway_pids",
@@ -149,11 +173,25 @@ def test_macos_update_restarts_running_launchd_gateway_fleet_once(
     monkeypatch.setattr("hermes_cli.config.get_missing_config_fields", lambda: [])
     monkeypatch.setattr("hermes_cli.config.check_config_version", lambda: (1, 1))
 
-    with pytest.raises(SystemExit) as excinfo:
-        hm._cmd_update_impl(
+    def run_update():
+        return hm._cmd_update_impl(
             SimpleNamespace(yes=True, force=False, force_venv=False),
             gateway_mode=False,
         )
+
+    return run_update, restart_calls
+
+
+def test_macos_update_restarts_running_launchd_gateway_fleet_once(
+    tmp_path, monkeypatch, capsys
+):
+    """Post-update macOS refresh must cover every running Hermes launchd gateway."""
+    run_update, restart_calls = _run_mocked_macos_update(
+        tmp_path, monkeypatch, capsys
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        run_update()
 
     assert excinfo.value.code == 1
     assert restart_calls == [
@@ -168,3 +206,45 @@ def test_macos_update_restarts_running_launchd_gateway_fleet_once(
     out = capsys.readouterr().out
     assert "ai.hermes.gateway-writer" in out
     assert "Update incomplete" in out
+
+
+@pytest.mark.parametrize("launchctl_list_failure", ["nonzero", "timeout", "missing"])
+def test_macos_update_fails_closed_when_launchd_fleet_discovery_fails(
+    tmp_path, monkeypatch, capsys, launchctl_list_failure
+):
+    run_update, restart_calls = _run_mocked_macos_update(
+        tmp_path,
+        monkeypatch,
+        capsys,
+        launchctl_list_failure=launchctl_list_failure,
+        restart_failure_label=None,
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        run_update()
+
+    assert excinfo.value.code == 1
+    assert restart_calls == []
+    out = capsys.readouterr().out
+    assert "macOS launchd gateway discovery" in out
+    assert "Update incomplete" in out
+    assert "\u2713 Update complete!" not in out
+
+
+def test_macos_update_treats_successful_empty_launchd_discovery_as_complete(
+    tmp_path, monkeypatch, capsys
+):
+    run_update, restart_calls = _run_mocked_macos_update(
+        tmp_path,
+        monkeypatch,
+        capsys,
+        launchd_jobs={},
+        restart_failure_label=None,
+    )
+
+    run_update()
+
+    assert restart_calls == []
+    out = capsys.readouterr().out
+    assert "macOS launchd gateway discovery" not in out
+    assert "\u2713 Update complete!" in out

--- a/tests/hermes_cli/test_update_macos_launchd_fleet_restart.py
+++ b/tests/hermes_cli/test_update_macos_launchd_fleet_restart.py
@@ -1,0 +1,170 @@
+"""macOS update restart coverage for launchd-managed profile gateways."""
+
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_macos_update_restarts_running_launchd_gateway_fleet_once(
+    tmp_path, monkeypatch, capsys
+):
+    """Post-update macOS refresh must cover every running Hermes launchd gateway."""
+    from hermes_cli import gateway as gateway_cli
+    from hermes_cli import main as hm
+    import hermes_cli.config as config_cli
+    import hermes_cli.managed_uv as managed_uv
+    import hermes_cli.profiles as profiles_cli
+    import tools.skills_sync as skills_sync
+
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    (checkout / ".git").mkdir()
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    active_plist = tmp_path / "ai.hermes.gateway.plist"
+    active_plist.write_text("<plist />", encoding="utf-8")
+
+    launchd_jobs = {
+        "ai.hermes.gateway": 101,
+        "ai.hermes.gateway-builder": 201,
+        "ai.hermes.gateway-writer": 202,
+        "ai.hermes.gateway-dormant": None,
+        "com.example.unrelated": 303,
+    }
+    restart_calls: list[str] = []
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ["git", "fetch", "origin"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[:3] == ["git", "rev-parse", "--abbrev-ref"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="main\n", stderr="")
+        if cmd[:2] == ["git", "rev-list"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="1\n", stderr="")
+        if cmd[:3] == ["git", "merge", "--ff-only"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[:2] == ["launchctl", "list"] and len(cmd) == 2:
+            rows = [
+                f"{pid if pid is not None else '-'}\t0\t{label}"
+                for label, pid in launchd_jobs.items()
+            ]
+            rows.append("202\t0\tai.hermes.gateway-writer")
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="\n".join(rows), stderr=""
+            )
+        if cmd[:2] == ["launchctl", "list"] and len(cmd) == 3:
+            pid = launchd_jobs.get(cmd[2])
+            if pid is None:
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout='"PID" = -1;\n', stderr=""
+                )
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=f'"PID" = {pid};\n', stderr=""
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    def fake_launchd_restart(label: str | None = None):
+        restarted_label = label or gateway_cli.get_launchd_label()
+        restart_calls.append(restarted_label)
+        if restarted_label == "ai.hermes.gateway-writer":
+            raise subprocess.CalledProcessError(
+                75,
+                ["launchctl", "kickstart", "-k", "gui/501/ai.hermes.gateway-writer"],
+                stderr="writer failed to restart",
+            )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(hm, "PROJECT_ROOT", checkout)
+    monkeypatch.setattr(config_cli, "PROJECT_ROOT", checkout, raising=False)
+    monkeypatch.setattr(hm, "_run_pre_update_backup", lambda args: None)
+    monkeypatch.setattr(hm, "_pause_windows_gateways_for_update", lambda: None)
+    monkeypatch.setattr(hm, "_resume_windows_gateways_after_update", lambda token: None)
+    monkeypatch.setattr(hm, "_is_windows", lambda: False)
+    monkeypatch.setattr(
+        hm,
+        "_get_origin_url",
+        lambda git_cmd, cwd: "git@github.com:NousResearch/hermes-agent.git",
+    )
+    monkeypatch.setattr(hm.shutil, "which", lambda command: None)
+    monkeypatch.setattr(hm, "_stash_local_changes_if_needed", lambda git_cmd, cwd: None)
+    monkeypatch.setattr(hm, "_capture_head_sha", lambda git_cmd, cwd: "pre-update-sha")
+    monkeypatch.setattr(
+        hm, "_validate_critical_files_syntax", lambda root: (True, None, None)
+    )
+    monkeypatch.setattr(hm, "_clear_bytecode_cache", lambda root: 0)
+    monkeypatch.setattr(hm, "_record_bytecode_fingerprint", lambda: None)
+    monkeypatch.setattr(hm, "_reload_updated_runtime_modules", lambda: None)
+    monkeypatch.setattr(
+        hm, "_upgrade_pip_before_lazy_refresh", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        hm, "_refresh_active_lazy_features", lambda *args, **kwargs: True
+    )
+    monkeypatch.setattr(hm, "_clear_lazy_refresh_incomplete_marker", lambda: None)
+    monkeypatch.setattr(hm, "_refresh_active_memory_provider_dependencies", lambda: None)
+    monkeypatch.setattr(hm, "_update_node_dependencies", lambda: [])
+    monkeypatch.setattr(hm, "_build_web_ui", lambda path: None)
+    monkeypatch.setattr(hm, "_desktop_packaged_executable", lambda path: None)
+    monkeypatch.setattr(hm, "_desktop_dist_exists", lambda path: False)
+    monkeypatch.setattr(hm, "_finish_dashboard_update_cleanup", lambda failures: None)
+    monkeypatch.setattr(hm, "_ensure_fhs_path_guard", lambda: None)
+    monkeypatch.setattr(hm, "_ensure_acp_launcher", lambda: None)
+    monkeypatch.setattr(hm, "_print_fts_optimize_available_notice", lambda: None)
+    monkeypatch.setattr(hm, "_print_curator_first_run_notice", lambda: None)
+    monkeypatch.setattr(hm, "_print_curator_recent_run_notice", lambda: None)
+    monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+    monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: active_plist)
+    monkeypatch.setattr(gateway_cli, "launchd_restart", fake_launchd_restart)
+    monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: {101, 201, 202, 303})
+    monkeypatch.setattr(
+        gateway_cli,
+        "find_gateway_pids",
+        lambda exclude_pids=None, all_profiles=False: [],
+    )
+    monkeypatch.setattr(
+        gateway_cli, "find_profile_gateway_processes", lambda exclude_pids=None: []
+    )
+    monkeypatch.setattr(gateway_cli, "has_legacy_hermes_units", lambda: False)
+    monkeypatch.setattr(managed_uv, "ensure_uv", lambda **kwargs: None)
+    monkeypatch.setattr(managed_uv, "update_managed_uv", lambda **kwargs: None)
+    monkeypatch.setattr(
+        skills_sync,
+        "sync_skills",
+        lambda quiet=True: {
+            "copied": [],
+            "updated": [],
+            "user_modified": [],
+            "cleaned": [],
+        },
+    )
+    monkeypatch.setattr(profiles_cli, "list_profiles", lambda: [])
+    monkeypatch.setattr(profiles_cli, "backfill_profile_envs", lambda quiet=True: [])
+    monkeypatch.setattr(hm.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        "hermes_cli.config.get_missing_env_vars", lambda required_only=True: []
+    )
+    monkeypatch.setattr("hermes_cli.config.get_missing_config_fields", lambda: [])
+    monkeypatch.setattr("hermes_cli.config.check_config_version", lambda: (1, 1))
+
+    with pytest.raises(SystemExit) as excinfo:
+        hm._cmd_update_impl(
+            SimpleNamespace(yes=True, force=False, force_venv=False),
+            gateway_mode=False,
+        )
+
+    assert excinfo.value.code == 1
+    assert restart_calls == [
+        "ai.hermes.gateway",
+        "ai.hermes.gateway-builder",
+        "ai.hermes.gateway-writer",
+    ]
+    assert restart_calls.count("ai.hermes.gateway-writer") == 1
+    assert "ai.hermes.gateway-dormant" not in restart_calls
+    assert "com.example.unrelated" not in restart_calls
+
+    out = capsys.readouterr().out
+    assert "ai.hermes.gateway-writer" in out
+    assert "Update incomplete" in out


### PR DESCRIPTION
## Summary
- discover every running macOS launchd Hermes gateway, including named profiles
- restart each running launchd gateway once while leaving dormant Hermes jobs and unrelated launchd jobs untouched
- keep post-restart service PID exclusion aligned with the discovered fleet
- fail closed and name per-label restart failures or timeouts
- distinguish successful empty discovery from systemic `launchctl list` failure, failing closed for nonzero, timeout or missing executable cases

## TDD evidence

Initial fleet regression:
- RED: `scripts/run_tests.sh tests/hermes_cli/test_update_macos_launchd_fleet_restart.py -q` exited 1 with `Failed: DID NOT RAISE <class 'SystemExit'>`; the old path restarted only the default label.
- GREEN: `1 tests passed, 0 failed`.

Independent-review remediation:
- RED before remediation: focused macOS file exited 1 with `3 failed, 2 passed`; each discovery-failure case still printed `✓ Update complete!` and did not raise `SystemExit`.
- GREEN: focused macOS file exited 0 with `5 tests passed, 0 failed`.
- Relevant suite: exited 0 with `74 tests passed, 0 failed` across the macOS fleet test, update timeout, command update and gateway restart-loop files.
- Launchd service subset: exited 0 with `9 tests passed, 0 failed`.
- Scanner: `✓ No Windows footguns found (3 file(s) scanned).`
- `git diff --check`: exit 0.

## Independent verification

Fresh `engineering-verifier` pass on exact head `9bc94c02e818e7247fb2d3858012c85d85aeeb49` returned **PASS**.

The verifier independently reproduced:
- default and named-profile exactly-once restart selection
- dormant and unrelated job exclusion
- duplicate-row de-duplication
- per-label failure and timeout continuation with fail-closed exit
- systemic discovery nonzero, timeout and missing-executable fail-closed behaviour with no success line
- successful empty discovery remaining a clean success
- named-profile launchd target construction under mocked subprocess
- read-only live fleet discovery matching the running Hermes launchd labels

No real `hermes update`, gateway restart or mutating `launchctl` command was run. This PR has not been merged or released.
