### PR TITLE
fix(computer_use): recover ended cua sessions once

### DIFF
--- a/tests/computer_use/test_cua_atexit_teardown.py
+++ b/tests/computer_use/test_cua_atexit_teardown.py
@@ -17,7 +17,8 @@ of ``atexit`` — not a snapshot of the module's source.
 """
 
 import atexit
-from unittest.mock import MagicMock, patch
+import json
+from unittest.mock import MagicMock, call, patch
 
 from tools.computer_use import tool as cu_tool
 
@@ -63,3 +64,75 @@ class TestAtexitTeardown:
         finally:
             atexit.unregister(cu_tool._shutdown_backend_atexit)
             atexit.register(cu_tool._shutdown_backend_atexit)
+
+
+class TestEndedSessionRecovery:
+    def test_ended_driver_session_is_released_then_retried_once(self):
+        """A stale cached cua-driver session gets one fresh-backend replay."""
+        stale = MagicMock()
+        fresh = MagicMock()
+        args = {"action": "list_apps"}
+        with patch.object(cu_tool, "_get_backend", side_effect=[stale, fresh]) as get, \
+             patch.object(cu_tool, "release_computer_use_session") as release, \
+             patch.object(
+                 cu_tool,
+                 "_dispatch",
+                 side_effect=[
+                     RuntimeError("session 'cua-123' has ended"),
+                     json.dumps({"apps": [], "count": 0}),
+                 ],
+             ) as dispatch, \
+             patch.object(cu_tool, "_backend_call_locks", {}):
+            result = cu_tool.handle_computer_use(args, session_id="run-123")
+
+        assert json.loads(result) == {"apps": [], "count": 0}
+        release.assert_called_once_with("run-123")
+        assert get.call_args_list == [
+            call(session_id="run-123"),
+            call(session_id="run-123"),
+        ]
+        assert dispatch.call_args_list == [
+            call(stale, "list_apps", args),
+            call(fresh, "list_apps", args),
+        ]
+
+    def test_unrelated_runtime_error_does_not_reset_or_retry(self):
+        """Only cua-driver's ended-session signature permits a replay."""
+        backend = MagicMock()
+        with patch.object(cu_tool, "_get_backend", return_value=backend) as get, \
+             patch.object(cu_tool, "release_computer_use_session") as release, \
+             patch.object(
+                 cu_tool,
+                 "_dispatch",
+                 side_effect=RuntimeError("driver connection dropped"),
+             ) as dispatch, \
+             patch.object(cu_tool, "_backend_call_locks", {}):
+            result = json.loads(
+                cu_tool.handle_computer_use({"action": "list_apps"}, session_id="run-123")
+            )
+
+        assert result["error"] == "list_apps failed: driver connection dropped"
+        release.assert_not_called()
+        assert get.call_count == 1
+        assert dispatch.call_count == 1
+
+    def test_ended_driver_session_failed_retry_is_not_repeated(self):
+        """A failed fresh-backend replay returns an error instead of looping."""
+        stale = MagicMock()
+        fresh = MagicMock()
+        with patch.object(cu_tool, "_get_backend", side_effect=[stale, fresh]) as get, \
+             patch.object(cu_tool, "release_computer_use_session") as release, \
+             patch.object(
+                 cu_tool,
+                 "_dispatch",
+                 side_effect=RuntimeError("session 'cua-123' has ended"),
+             ) as dispatch, \
+             patch.object(cu_tool, "_backend_call_locks", {}):
+            result = json.loads(
+                cu_tool.handle_computer_use({"action": "list_apps"}, session_id="run-123")
+            )
+
+        assert result["error"] == "list_apps failed: session 'cua-123' has ended"
+        release.assert_called_once_with("run-123")
+        assert get.call_count == 2
+        assert dispatch.call_count == 2

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -506,6 +506,27 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
             call_lock = _backend_call_locks.setdefault(session_id, threading.RLock())
         with call_lock:
             return _dispatch(backend, action, args)
+    except RuntimeError as e:
+        # cua-driver can end a cached session underneath Hermes. Reset only
+        # that exact, recognized failure through the normal lifecycle seam,
+        # then replay the original action once against a fresh backend.
+        if not re.search(r"\bsession\b.*\bhas ended\b", str(e), re.IGNORECASE):
+            logger.exception("computer_use %s failed", action)
+            return json.dumps({"error": f"{action} failed: {e}"})
+
+        logger.warning("cua-driver session ended; recreating it once")
+        try:
+            release_computer_use_session(session_id)
+            backend = _get_backend(session_id=session_id)
+            with _backend_lock:
+                call_lock = _backend_call_locks.setdefault(
+                    session_id, threading.RLock()
+                )
+            with call_lock:
+                return _dispatch(backend, action, args)
+        except Exception as retry_error:
+            logger.exception("computer_use %s recovery retry failed", action)
+            return json.dumps({"error": f"{action} failed: {retry_error}"})
     except Exception as e:
         logger.exception("computer_use %s failed", action)
         return json.dumps({"error": f"{action} failed: {e}"})


### PR DESCRIPTION
## Summary

Salvages only the reactive ended-session recovery from #74266 as a focused follow-up to the proactive computer-use lifecycle work merged in #74166.

When a cached cua-driver backend raises the specific runtime error `session … has ended`, Hermes now:

1. releases only that Hermes session's cached backend through `release_computer_use_session()`;
2. creates a fresh backend for the same session;
3. replays the original action exactly once.

Unrelated runtime errors keep the existing single-attempt behavior. A failed replay returns an error and does not loop.

## Scope

- `tools/computer_use/tool.py` — bounded, session-scoped recovery path
- `tests/computer_use/test_cua_atexit_teardown.py` — behavior contracts for successful recovery, unrelated failures, and failed retry

This intentionally excludes the gateway routing hook and skill-loading policy changes from #74266, which overlap separate design work identified during triage.

## Validation

- `scripts/run_tests.sh tests/computer_use/test_cua_atexit_teardown.py tests/tools/test_computer_use_cua_0_9.py tests/tools/test_computer_use_cua_0_10_permissions.py tests/tools/test_computer_use_approval_isolation.py tests/tools/test_computer_use_delivery_ladder.py` — **71 passed, 0 failed**
- `python -m compileall -q tools/computer_use/tool.py tests/computer_use/test_cua_atexit_teardown.py` — pass
- `git diff --check` — pass
- `gitleaks protect --staged --redact --no-banner --verbose` — no leaks found

## Notes

A pre-existing failure in `TestCaptureAppFilterNoMatch::test_linux_default_capture_skips_gnome_shell_helper` reproduces unchanged on the exact `origin/main` baseline and is outside this patch's files and behavior.
