### PR TITLE
feat: add host-enforced turn gate extension point

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -23,6 +23,7 @@ import random
 import re
 import ssl
 import time
+import uuid
 from typing import Any, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
@@ -1081,7 +1082,7 @@ def _notify_context_engine_turn_complete(
         )
 
 
-def run_conversation(
+def _run_conversation_unleased(
     agent,
     user_message: Any,
     system_message: str = None,
@@ -7031,4 +7032,72 @@ def run_conversation(
 
 
 
-__all__ = ["run_conversation"]
+def run_conversation(
+    agent,
+    user_message: Any,
+    system_message: str = None,
+    conversation_history: List[Dict[str, Any]] = None,
+    task_id: str = None,
+    stream_callback: Optional[callable] = None,
+    persist_user_message: Optional[Any] = None,
+    persist_user_timestamp: Optional[float] = None,
+    persist_user_display_kind: Optional[str] = None,
+    persist_user_display_metadata: Optional[Dict[str, Any]] = None,
+    moa_config: Optional[dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Run one conversation inside the host-owned outer-turn lease.
+
+    The large conversation body remains independently testable as
+    ``_run_conversation_unleased``.  This wrapper is deliberately the only
+    public conversation entrypoint: it constructs the runtime identity before
+    any prompt, persistence, or tool setup and keeps the lease alive through
+    the final response.
+    """
+    from agent.turn_gate import (
+        TurnGateRequest,
+        acquire_outer_turn,
+        build_runtime_identity,
+        guard_output_callback,
+        enforce_output_allowed,
+    )
+
+    session_id = str(getattr(agent, "session_id", "") or "session")
+    turn_id = f"{session_id}:{task_id or 'task'}:{uuid.uuid4().hex[:8]}"
+    identity = build_runtime_identity(
+        surface="conversation",
+        session_scope=session_id,
+        turn_id=turn_id,
+    )
+    request = TurnGateRequest(
+        entrypoint="conversation",
+        purpose="business",
+        task_id=task_id,
+        identity=identity,
+    )
+    guarded_callback = guard_output_callback(stream_callback)
+    with acquire_outer_turn(request):
+        result = _run_conversation_unleased(
+            agent,
+            user_message,
+            system_message=system_message,
+            conversation_history=conversation_history,
+            task_id=task_id,
+            stream_callback=guarded_callback,
+            persist_user_message=persist_user_message,
+            persist_user_timestamp=persist_user_timestamp,
+            persist_user_display_kind=persist_user_display_kind,
+            persist_user_display_metadata=persist_user_display_metadata,
+            moa_config=moa_config,
+        )
+        # Final assembly is an output boundary even when no streaming callback
+        # was installed (for example, a CLI or a test double).
+        enforce_output_allowed()
+        return result
+
+
+# Preserve source-introspection compatibility for diagnostics and existing
+# regression tests while keeping the host-owned outer wrapper public.
+run_conversation.__wrapped__ = _run_conversation_unleased  # type: ignore[attr-defined]
+
+
+__all__ = ["run_conversation", "_run_conversation_unleased"]

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -32,6 +32,8 @@ from agent.display import (
     redact_tool_args_for_display as _redact_tool_args_for_display,
     _detect_tool_failure,
 )
+from agent.tool_guardrails import ToolGuardrailDecision
+from agent.turn_gate import tool_block_message
 from agent.tool_dispatch_helpers import (
     _is_destructive_command,
     _is_multimodal_tool_result,
@@ -51,6 +53,11 @@ from tools.tool_result_storage import (
 from tools.budget_config import BudgetConfig, DEFAULT_BUDGET, budget_for_context_window
 
 logger = logging.getLogger(__name__)
+
+
+def _host_gate_block_message(function_name: str) -> str | None:
+    """Return a host-enforced block reason before hooks or middleware run."""
+    return tool_block_message(function_name)
 
 
 def _ensure_file_checkpoint(
@@ -366,6 +373,27 @@ def _run_agent_tool_execution_middleware(
     authorization_gate: _ConcurrentToolAuthorizationGate | None = None,
 ) -> _ManagedToolResult:
     """Run Relay rewrites before Hermes policy and dispatch exactly once."""
+    host_gate_block = _host_gate_block_message(function_name)
+    if host_gate_block is not None:
+        trace = list(middleware_trace or [])
+        result = json.dumps(
+            {"error": host_gate_block, "error_type": "turn_gate_block"},
+            ensure_ascii=False,
+        )
+        _emit_terminal_post_tool_call(
+            agent,
+            function_name=function_name,
+            function_args=dict(function_args),
+            result=result,
+            effective_task_id=effective_task_id,
+            tool_call_id=tool_call_id,
+            status="blocked",
+            error_type="turn_gate_block",
+            error_message=host_gate_block,
+            middleware_trace=trace,
+        )
+        return _ManagedToolResult(result, dict(function_args), trace, True)
+
     from agent import relay_tools
     from hermes_cli.middleware import (
         apply_tool_request_middleware,

--- a/agent/turn_gate.py
+++ b/agent/turn_gate.py
@@ -1,0 +1,759 @@
+"""Policy-neutral host-enforced outer-turn gate.
+
+Providers decide admission and generation; Hermes owns lease lifetime and
+revalidates before consequential tool, output, and child-process boundaries.
+The core deliberately contains no product-, platform-, or provider-specific
+approval policy.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import inspect
+import json
+import os
+import re
+import threading
+import uuid
+from contextlib import contextmanager
+from contextvars import Context, ContextVar
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Iterator, Mapping, Protocol, cast
+
+
+_ENVIRONMENT_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_ALLOWED_PURPOSES = frozenset({"business", "reload"})
+
+
+class GateState(str, Enum):
+    OPEN = "OPEN"
+    CLOSED_DRAINING = "CLOSED_DRAINING"
+    RELOAD_ONLY = "RELOAD_ONLY"
+
+
+class TurnGateBlocked(RuntimeError):
+    """The configured host gate could not safely admit or continue a turn."""
+
+
+class _TurnPoison:
+    """Mutable poison cell shared by copied ContextVar contexts."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._reason: str | None = None
+
+    def set(self, reason: str) -> None:
+        with self._lock:
+            if self._reason is None:
+                self._reason = reason
+
+    def get(self) -> str | None:
+        with self._lock:
+            return self._reason
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeIdentity:
+    machine_id: str
+    profile: str
+    surface: str
+    session_instance_id: str
+    gateway_instance_id: str
+    turn_id: str
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "machine_id",
+            "profile",
+            "surface",
+            "session_instance_id",
+            "gateway_instance_id",
+            "turn_id",
+        ):
+            value = getattr(self, field_name)
+            if type(value) is not str or not value.strip() or "\x00" in value:
+                raise ValueError(
+                    f"runtime identity {field_name} must be non-empty text"
+                )
+
+
+@dataclass(frozen=True, slots=True)
+class TurnGateRequest:
+    entrypoint: str
+    purpose: str
+    identity: RuntimeIdentity | None
+    task_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if type(self.entrypoint) is not str or not self.entrypoint.strip():
+            raise ValueError("turn gate entrypoint must be non-empty text")
+        if type(self.purpose) is not str or self.purpose not in _ALLOWED_PURPOSES:
+            raise ValueError("turn gate purpose is unsupported")
+        if self.identity is not None and not isinstance(
+            self.identity, RuntimeIdentity
+        ):
+            raise ValueError("turn gate identity must be a RuntimeIdentity")
+        if self.task_id is not None and (
+            type(self.task_id) is not str or not self.task_id.strip()
+        ):
+            raise ValueError("turn gate task_id must be non-empty text")
+
+
+@dataclass(frozen=True, slots=True)
+class GateDecision:
+    provider_id: str
+    state: GateState
+    lease_id: str
+    generation: int
+    allowed_tools: tuple[str, ...] = ()
+    child_environment: tuple[tuple[str, str], ...] = ()
+
+    def __post_init__(self) -> None:
+        for field_name in ("provider_id", "lease_id"):
+            value = getattr(self, field_name)
+            if type(value) is not str or not value.strip() or "\x00" in value:
+                raise ValueError(f"gate decision {field_name} is invalid")
+        if not isinstance(self.state, GateState):
+            raise ValueError("gate state must be a GateState")
+        if type(self.generation) is not int or self.generation < 0:
+            raise ValueError("gate generation must be a non-negative integer")
+        if type(self.allowed_tools) is not tuple or any(
+            type(name) is not str or not name.strip() or "\x00" in name
+            for name in self.allowed_tools
+        ):
+            raise ValueError("allowed_tools must be a tuple of non-empty names")
+        if len(self.allowed_tools) != len(set(self.allowed_tools)):
+            raise ValueError("allowed_tools must not contain duplicates")
+        if type(self.child_environment) is not tuple:
+            raise ValueError("child_environment must be a tuple")
+        seen_environment: set[str] = set()
+        for item in self.child_environment:
+            if type(item) is not tuple or len(item) != 2:
+                raise ValueError("child_environment entries must be pairs")
+            name, value = item
+            if (
+                type(name) is not str
+                or _ENVIRONMENT_NAME.fullmatch(name) is None
+                or name in seen_environment
+            ):
+                raise ValueError("child_environment variable name is invalid")
+            if type(value) is not str or "\x00" in value:
+                raise ValueError("child_environment variable value is invalid")
+            seen_environment.add(name)
+
+
+class TurnGateProvider(Protocol):
+    def acquire(self, request: TurnGateRequest) -> GateDecision: ...
+
+    def validate(self, decision: GateDecision, checkpoint: str) -> GateDecision: ...
+
+    def release(self, decision: GateDecision) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _ProviderRegistration:
+    owner_id: str
+    provider: TurnGateProvider
+
+
+_registry_lock = threading.RLock()
+_providers: dict[str, _ProviderRegistration] = {}
+_required_provider_id: str | None = None
+_allowed_child_environment: frozenset[str] = frozenset()
+_runtime_machine_id: str | None = None
+_configuration_error: str | None = None
+_configuration_loaded = False
+_gateway_instance_id = str(uuid.uuid4())
+_session_identity_key = os.urandom(32)
+_current_decision: ContextVar[GateDecision | None] = ContextVar(
+    "hermes_turn_gate_decision", default=None
+)
+_current_request: ContextVar[TurnGateRequest | None] = ContextVar(
+    "hermes_turn_gate_request", default=None
+)
+_current_poison: ContextVar[_TurnPoison | None] = ContextVar(
+    "hermes_turn_gate_poison", default=None
+)
+
+
+def create_detached_task(coro, *, name: str | None = None) -> asyncio.Task:
+    """Create an asyncio task with an empty context instead of copied leases."""
+    if name is None:
+        return Context().run(asyncio.create_task, coro)
+    return Context().run(asyncio.create_task, coro, name=name)
+
+
+def register_turn_gate_provider(
+    provider_id: str,
+    provider: TurnGateProvider,
+    *,
+    owner_id: str,
+    replace: bool = False,
+) -> None:
+    """Register a provider owned by the plugin with the same manifest key."""
+    if type(provider_id) is not str or not provider_id.strip():
+        raise ValueError("turn gate provider id must be non-empty text")
+    if type(owner_id) is not str or owner_id != provider_id:
+        raise ValueError("turn gate provider id must match its plugin manifest owner")
+    methods = tuple(getattr(provider, method, None) for method in (
+        "acquire",
+        "validate",
+        "release",
+    ))
+    if not all(callable(method) for method in methods):
+        raise ValueError("turn gate provider does not implement the contract")
+    if any(inspect.iscoroutinefunction(method) for method in methods):
+        raise ValueError("turn gate provider methods must be synchronous")
+    with _registry_lock:
+        existing = _providers.get(provider_id)
+        if existing is not None and existing.provider is not provider and not replace:
+            raise ValueError(f"turn gate provider already registered: {provider_id}")
+        _providers[provider_id] = _ProviderRegistration(owner_id, provider)
+
+
+def unregister_turn_gate_providers_by_owner(owner_id: str) -> None:
+    if type(owner_id) is not str or not owner_id.strip():
+        raise ValueError("turn gate provider owner must be non-empty text")
+    with _registry_lock:
+        for provider_id in tuple(_providers):
+            if _providers[provider_id].owner_id == owner_id:
+                _providers.pop(provider_id, None)
+
+
+def snapshot_turn_gate_providers() -> dict[str, _ProviderRegistration]:
+    with _registry_lock:
+        return dict(_providers)
+
+
+def restore_turn_gate_providers(
+    snapshot: Mapping[str, _ProviderRegistration],
+) -> None:
+    if not isinstance(snapshot, Mapping):
+        raise ValueError("turn gate provider snapshot must be a mapping")
+    restored = dict(snapshot)
+    if any(
+        type(provider_id) is not str
+        or not isinstance(registration, _ProviderRegistration)
+        or registration.owner_id != provider_id
+        for provider_id, registration in restored.items()
+    ):
+        raise ValueError("turn gate provider snapshot is invalid")
+    with _registry_lock:
+        _providers.clear()
+        _providers.update(restored)
+
+
+def _latch_configuration_error(reason: str) -> None:
+    global _configuration_error, _configuration_loaded
+    with _registry_lock:
+        _configuration_error = reason
+        _configuration_loaded = True
+
+
+def mark_turn_gate_configuration_error(reason: str) -> None:
+    """Latch an external configuration-load failure for fail-closed admission."""
+    if type(reason) is not str or not reason.strip():
+        raise ValueError("turn gate configuration error must be non-empty text")
+    _latch_configuration_error(reason.strip())
+
+
+def configure_turn_gate_from_config(config: object) -> None:
+    """Load the opt-in gate contract from config.yaml data.
+
+    A malformed configured gate latches a fail-closed error. A later complete,
+    valid configuration replaces that latch; removing the section disables the
+    optional extension point and restores Hermes' default behavior.
+    """
+    global _required_provider_id, _allowed_child_environment
+    global _runtime_machine_id, _configuration_error, _configuration_loaded
+
+    agent_config = (
+        cast(Mapping[str, Any], config).get("agent")
+        if isinstance(config, Mapping)
+        else None
+    )
+    gate_config = (
+        cast(Mapping[str, Any], agent_config).get("turn_gate")
+        if isinstance(agent_config, Mapping)
+        else None
+    )
+    if gate_config is None:
+        with _registry_lock:
+            _required_provider_id = None
+            _allowed_child_environment = frozenset()
+            _runtime_machine_id = None
+            _configuration_error = None
+            _configuration_loaded = True
+        return
+    if not isinstance(gate_config, Mapping):
+        reason = "agent.turn_gate must be a mapping"
+        _latch_configuration_error(reason)
+        raise TurnGateBlocked(reason)
+
+    gate_mapping = cast(Mapping[str, Any], gate_config)
+    required = gate_mapping.get("required_provider")
+    if type(required) is not str or not required.strip():
+        reason = "agent.turn_gate.required_provider must be non-empty text"
+        _latch_configuration_error(reason)
+        raise TurnGateBlocked(reason)
+
+    runtime_identity = gate_mapping.get("runtime_identity")
+    machine_id = (
+        cast(Mapping[str, Any], runtime_identity).get("machine_id")
+        if isinstance(runtime_identity, Mapping)
+        else None
+    )
+    if type(machine_id) is not str or not machine_id.strip() or "\x00" in machine_id:
+        reason = (
+            "agent.turn_gate.runtime_identity.machine_id must be non-empty text"
+        )
+        _latch_configuration_error(reason)
+        raise TurnGateBlocked(reason)
+
+    raw_allowlist = gate_mapping.get("allowed_child_environment", [])
+    if type(raw_allowlist) is not list or any(
+        type(name) is not str or _ENVIRONMENT_NAME.fullmatch(name) is None
+        for name in raw_allowlist
+    ) or len(raw_allowlist) != len(set(raw_allowlist)):
+        reason = (
+            "agent.turn_gate.allowed_child_environment must be a unique list "
+            "of environment variable names"
+        )
+        _latch_configuration_error(reason)
+        raise TurnGateBlocked(reason)
+
+    with _registry_lock:
+        _required_provider_id = required.strip()
+        _allowed_child_environment = frozenset(raw_allowlist)
+        _runtime_machine_id = machine_id.strip()
+        _configuration_error = None
+        _configuration_loaded = True
+
+
+def clear_turn_gate_registry_for_testing() -> None:
+    global _required_provider_id, _allowed_child_environment
+    global _runtime_machine_id, _configuration_error, _configuration_loaded
+    global _gateway_instance_id, _session_identity_key
+    with _registry_lock:
+        _providers.clear()
+        _required_provider_id = None
+        _allowed_child_environment = frozenset()
+        _runtime_machine_id = None
+        _configuration_error = None
+        _configuration_loaded = False
+        _gateway_instance_id = str(uuid.uuid4())
+        _session_identity_key = os.urandom(32)
+    _current_decision.set(None)
+    _current_request.set(None)
+    _current_poison.set(None)
+
+
+def build_runtime_identity(
+    *,
+    surface: str,
+    session_scope: str,
+    turn_id: str,
+) -> RuntimeIdentity | None:
+    """Build host-owned identity without exposing raw platform chat IDs."""
+    for field_name, value in (
+        ("surface", surface),
+        ("session_scope", session_scope),
+        ("turn_id", turn_id),
+    ):
+        if type(value) is not str or not value.strip() or "\x00" in value:
+            raise ValueError(f"runtime {field_name} must be non-empty text")
+    with _registry_lock:
+        machine_id = _runtime_machine_id
+        gateway_instance_id = _gateway_instance_id
+        identity_key = _session_identity_key
+    if machine_id is None:
+        return None
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        profile = get_active_profile_name()
+    except Exception as exc:
+        raise TurnGateBlocked("runtime profile identity is unavailable") from exc
+    if type(profile) is not str or not profile.strip():
+        raise TurnGateBlocked("runtime profile identity is unavailable")
+    digest = hmac.new(
+        identity_key,
+        session_scope.encode("utf-8", errors="strict"),
+        hashlib.sha256,
+    ).hexdigest()
+    return RuntimeIdentity(
+        machine_id=machine_id,
+        profile=profile,
+        surface=surface,
+        session_instance_id=f"session-{digest}",
+        gateway_instance_id=gateway_instance_id,
+        turn_id=turn_id,
+    )
+
+
+def current_turn_gate_decision() -> GateDecision | None:
+    return _current_decision.get()
+
+
+def current_turn_gate_request() -> TurnGateRequest | None:
+    return _current_request.get()
+
+
+def _required_provider() -> tuple[str, TurnGateProvider] | None:
+    with _registry_lock:
+        required = _required_provider_id
+        configuration_error = _configuration_error
+        registration = _providers.get(required) if required is not None else None
+    if configuration_error is not None:
+        raise TurnGateBlocked(
+            f"mandatory turn gate configuration is invalid: {configuration_error}"
+        )
+    if required is None:
+        return None
+    if registration is None:
+        raise TurnGateBlocked(f"required provider is not registered: {required}")
+    return required, registration.provider
+
+
+def _validate_decision(required_id: str, decision: Any) -> GateDecision:
+    if not isinstance(decision, GateDecision):
+        raise TurnGateBlocked("turn gate provider returned an invalid decision")
+    if decision.provider_id != required_id:
+        raise TurnGateBlocked("turn gate provider identity mismatch")
+    return decision
+
+
+def _require_synchronous_provider_result(result: Any, stage: str) -> Any:
+    if not inspect.isawaitable(result):
+        return result
+    close = getattr(result, "close", None)
+    if callable(close):
+        close()
+    else:
+        cancel = getattr(result, "cancel", None)
+        if callable(cancel):
+            cancel()
+    raise TurnGateBlocked(
+        f"mandatory turn gate provider returned async work during {stage}"
+    )
+
+
+def _poison_current(reason: str) -> None:
+    poison = _current_poison.get()
+    if poison is not None:
+        poison.set(reason)
+
+
+def _revalidate_current(checkpoint: str) -> GateDecision | None:
+    poison = _current_poison.get()
+    poisoned_reason = poison.get() if poison is not None else None
+    if poisoned_reason is not None:
+        raise TurnGateBlocked(f"outer-turn lease is poisoned: {poisoned_reason}")
+
+    decision = _current_decision.get()
+    if decision is None:
+        if _required_provider() is not None:
+            raise TurnGateBlocked(
+                "mandatory turn gate requires an active outer-turn lease"
+            )
+        return None
+
+    with _registry_lock:
+        registration = _providers.get(decision.provider_id)
+    if registration is None:
+        reason = "mandatory turn gate provider disappeared"
+        _poison_current(reason)
+        raise TurnGateBlocked(reason)
+    try:
+        refreshed = _validate_decision(
+            decision.provider_id,
+            _require_synchronous_provider_result(
+                registration.provider.validate(decision, checkpoint),
+                "validate",
+            ),
+        )
+    except TurnGateBlocked as exc:
+        _poison_current(str(exc))
+        raise
+    except Exception as exc:
+        reason = f"mandatory turn gate revalidation failed at {checkpoint}"
+        _poison_current(reason)
+        raise TurnGateBlocked(reason) from exc
+
+    drift_checks = (
+        ("lease", refreshed.lease_id, decision.lease_id),
+        ("generation", refreshed.generation, decision.generation),
+        ("state", refreshed.state, decision.state),
+        ("tool policy", refreshed.allowed_tools, decision.allowed_tools),
+        (
+            "child environment",
+            refreshed.child_environment,
+            decision.child_environment,
+        ),
+    )
+    for label, actual, expected in drift_checks:
+        if actual != expected:
+            reason = f"turn gate {label} changed during outer turn"
+            _poison_current(reason)
+            raise TurnGateBlocked(reason)
+    _current_decision.set(refreshed)
+    return refreshed
+
+
+def _enforce_entry_state(decision: GateDecision, request: TurnGateRequest) -> None:
+    if decision.state is GateState.CLOSED_DRAINING:
+        raise TurnGateBlocked("turn blocked by CLOSED_DRAINING fence")
+    if decision.state is GateState.RELOAD_ONLY and request.purpose != "reload":
+        raise TurnGateBlocked("business turn blocked by RELOAD_ONLY fence")
+
+
+@contextmanager
+def acquire_outer_turn(
+    request: TurnGateRequest,
+) -> Iterator[GateDecision | None]:
+    """Acquire once at the public outer-turn boundary and release exactly once."""
+    if not isinstance(request, TurnGateRequest):
+        raise ValueError("outer turn requires a TurnGateRequest")
+    current = _current_decision.get()
+    current_request = _current_request.get()
+    if current is not None:
+        if (
+            current.state is GateState.RELOAD_ONLY
+            and current_request is not None
+            and current_request.purpose == "reload"
+            and request.purpose != "reload"
+        ):
+            raise TurnGateBlocked("nested turn cannot elevate a RELOAD_ONLY lease")
+        _enforce_entry_state(current, request)
+        yield current
+        return
+
+    required = _required_provider()
+    if required is None:
+        request_token = _current_request.set(request)
+        try:
+            yield None
+        finally:
+            _current_request.reset(request_token)
+        return
+    required_id, provider = required
+    if request.identity is None:
+        raise TurnGateBlocked(
+            "mandatory turn gate requires host-owned runtime identity"
+        )
+    try:
+        decision = _validate_decision(
+            required_id,
+            _require_synchronous_provider_result(provider.acquire(request), "acquire"),
+        )
+    except TurnGateBlocked:
+        raise
+    except Exception as exc:
+        raise TurnGateBlocked("mandatory turn gate failed during acquire") from exc
+
+    decision_token = _current_decision.set(decision)
+    request_token = _current_request.set(request)
+    poison_token = _current_poison.set(_TurnPoison())
+    try:
+        _enforce_entry_state(decision, request)
+        yield decision
+    finally:
+        _current_request.reset(request_token)
+        _current_decision.reset(decision_token)
+        _current_poison.reset(poison_token)
+        try:
+            _require_synchronous_provider_result(provider.release(decision), "release")
+        except Exception as exc:
+            raise TurnGateBlocked("mandatory turn gate failed during release") from exc
+
+
+def enforce_tool_allowed(tool_name: str) -> None:
+    if type(tool_name) is not str or not tool_name.strip():
+        raise ValueError("tool name must be non-empty text")
+    decision = _revalidate_current(f"tool:{tool_name}")
+    if decision is None:
+        return
+    if decision.state is GateState.CLOSED_DRAINING:
+        reason = f"tool is blocked by CLOSED_DRAINING fence: {tool_name}"
+    elif decision.state is GateState.RELOAD_ONLY and tool_name not in decision.allowed_tools:
+        reason = f"tool is blocked by RELOAD_ONLY fence: {tool_name}"
+    elif decision.allowed_tools and tool_name not in decision.allowed_tools:
+        reason = f"tool is outside the exact gate allowlist: {tool_name}"
+    else:
+        return
+    _poison_current(reason)
+    raise TurnGateBlocked(reason)
+
+
+def enforce_output_allowed() -> None:
+    decision = _revalidate_current("output")
+    if decision is None:
+        return
+    if decision.state is GateState.OPEN:
+        return
+    reason = f"output is blocked by {decision.state.value} fence"
+    _poison_current(reason)
+    raise TurnGateBlocked(reason)
+
+
+def record_tool_observation(
+    *,
+    tool_name: str,
+    tool_args: dict[str, Any],
+    tool_call_id: str,
+    result: Any,
+) -> None:
+    """Record a host-observed successful main ``skill_view`` invocation."""
+    if tool_name != "skill_view":
+        return
+    decision = _revalidate_current("tool-observation")
+    if decision is None:
+        return
+    try:
+        if not tool_call_id:
+            raise ValueError("skill observation requires tool_call_id")
+        if (
+            not isinstance(tool_args, dict)
+            or not isinstance(tool_args.get("name"), str)
+            or not tool_args["name"]
+        ):
+            raise ValueError("skill observation requires a skill name")
+        if tool_args.get("file_path") not in (None, ""):
+            raise ValueError("linked skill files cannot satisfy reload observation")
+        if not isinstance(result, str):
+            raise ValueError("skill observation result must be JSON text")
+        payload = json.loads(result)
+        if (
+            not isinstance(payload, dict)
+            or payload.get("success") is not True
+            or payload.get("name") != tool_args["name"]
+            or not isinstance(payload.get("skill_dir"), str)
+            or not os.path.isabs(payload["skill_dir"])
+            or payload.get("file_path") not in (None, "")
+        ):
+            raise ValueError(
+                "skill observation result is not a successful main skill load"
+            )
+    except Exception as exc:
+        reason = "skill observation evidence is invalid"
+        _poison_current(reason)
+        raise TurnGateBlocked(reason) from exc
+
+    required = _required_provider()
+    if required is None:
+        return
+    provider_id, provider = required
+    recorder = getattr(provider, "record_tool_observation", None)
+    if not callable(recorder):
+        if decision.state is GateState.RELOAD_ONLY:
+            reason = "required provider cannot record reload observations"
+            _poison_current(reason)
+            raise TurnGateBlocked(reason)
+        return
+    request = _current_request.get()
+    if request is None:
+        reason = "tool observation has no outer-turn identity"
+        _poison_current(reason)
+        raise TurnGateBlocked(reason)
+    try:
+        _require_synchronous_provider_result(
+            recorder(
+                decision,
+                request,
+                tool_name,
+                tool_args,
+                tool_call_id,
+                result,
+            ),
+            "record_tool_observation",
+        )
+    except Exception as exc:
+        reason = f"required provider observation failed closed: {provider_id}"
+        _poison_current(reason)
+        raise TurnGateBlocked(reason) from exc
+
+
+def inject_turn_gate_child_environment(
+    base: Mapping[str, str],
+) -> dict[str, str]:
+    """Strip caller copies, revalidate, then inject provider-owned values."""
+    if not isinstance(base, Mapping) or any(
+        type(name) is not str for name in base
+    ):
+        raise ValueError("child environment base must use text names")
+    with _registry_lock:
+        allowed = _allowed_child_environment
+    child = dict(base)
+    for name in allowed:
+        child.pop(name, None)
+
+    if _current_decision.get() is None:
+        with _registry_lock:
+            configuration_error = _configuration_error
+        if configuration_error is not None:
+            raise TurnGateBlocked(
+                f"mandatory turn gate configuration is invalid: {configuration_error}"
+            )
+        return child
+
+    decision = _revalidate_current("child-environment")
+    assert decision is not None
+    for name, value in decision.child_environment:
+        if name not in allowed:
+            reason = "provider child environment is outside the host allowlist"
+            _poison_current(reason)
+            raise TurnGateBlocked(reason)
+        child[name] = value
+    return child
+
+
+def tool_block_message(tool_name: str) -> str | None:
+    try:
+        enforce_tool_allowed(tool_name)
+    except TurnGateBlocked as exc:
+        decision = _current_decision.get()
+        generation = decision.generation if decision is not None else "unknown"
+        return f"{exc}; generation={generation}"
+    return None
+
+
+def guard_output_callback(callback):
+    if callback is None:
+        return None
+
+    def guarded(value, *args, **kwargs):
+        if value not in (None, ""):
+            enforce_output_allowed()
+        return callback(value, *args, **kwargs)
+
+    return guarded
+
+
+__all__ = [
+    "GateDecision",
+    "GateState",
+    "RuntimeIdentity",
+    "TurnGateBlocked",
+    "TurnGateProvider",
+    "TurnGateRequest",
+    "acquire_outer_turn",
+    "build_runtime_identity",
+    "clear_turn_gate_registry_for_testing",
+    "configure_turn_gate_from_config",
+    "create_detached_task",
+    "current_turn_gate_decision",
+    "current_turn_gate_request",
+    "enforce_output_allowed",
+    "enforce_tool_allowed",
+    "guard_output_callback",
+    "inject_turn_gate_child_environment",
+    "mark_turn_gate_configuration_error",
+    "record_tool_observation",
+    "register_turn_gate_provider",
+    "restore_turn_gate_providers",
+    "snapshot_turn_gate_providers",
+    "tool_block_message",
+    "unregister_turn_gate_providers_by_owner",
+]

--- a/agent/turn_gate.py
+++ b/agent/turn_gate.py
@@ -11,7 +11,6 @@ import asyncio
 import hashlib
 import hmac
 import inspect
-import json
 import os
 import re
 import threading
@@ -25,6 +24,7 @@ from typing import Any, Iterator, Mapping, Protocol, cast
 
 _ENVIRONMENT_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _ALLOWED_PURPOSES = frozenset({"business", "reload"})
+TURN_GATE_API_VERSION = 1
 
 
 class GateState(str, Enum):
@@ -190,6 +190,7 @@ def register_turn_gate_provider(
     provider: TurnGateProvider,
     *,
     owner_id: str,
+    api_version: int = TURN_GATE_API_VERSION,
     replace: bool = False,
 ) -> None:
     """Register a provider owned by the plugin with the same manifest key."""
@@ -197,6 +198,11 @@ def register_turn_gate_provider(
         raise ValueError("turn gate provider id must be non-empty text")
     if type(owner_id) is not str or owner_id != provider_id:
         raise ValueError("turn gate provider id must match its plugin manifest owner")
+    if type(api_version) is not int or api_version != TURN_GATE_API_VERSION:
+        raise ValueError(
+            "turn gate provider API version mismatch: "
+            f"expected {TURN_GATE_API_VERSION}, got {api_version!r}"
+        )
     methods = tuple(getattr(provider, method, None) for method in (
         "acquire",
         "validate",
@@ -605,39 +611,25 @@ def record_tool_observation(
     tool_call_id: str,
     result: Any,
 ) -> None:
-    """Record a host-observed successful main ``skill_view`` invocation."""
-    if tool_name != "skill_view":
-        return
+    """Forward a host-observed tool result to the configured provider.
+
+    Hermes validates only the policy-neutral event envelope.  The provider
+    owns every semantic decision about which tool/result can satisfy its gate.
+    """
     decision = _revalidate_current("tool-observation")
     if decision is None:
         return
     try:
-        if not tool_call_id:
-            raise ValueError("skill observation requires tool_call_id")
+        if type(tool_name) is not str or not tool_name.strip():
+            raise ValueError("tool observation requires a tool name")
+        if type(tool_call_id) is not str or not tool_call_id.strip():
+            raise ValueError("tool observation requires tool_call_id")
         if (
             not isinstance(tool_args, dict)
-            or not isinstance(tool_args.get("name"), str)
-            or not tool_args["name"]
         ):
-            raise ValueError("skill observation requires a skill name")
-        if tool_args.get("file_path") not in (None, ""):
-            raise ValueError("linked skill files cannot satisfy reload observation")
-        if not isinstance(result, str):
-            raise ValueError("skill observation result must be JSON text")
-        payload = json.loads(result)
-        if (
-            not isinstance(payload, dict)
-            or payload.get("success") is not True
-            or payload.get("name") != tool_args["name"]
-            or not isinstance(payload.get("skill_dir"), str)
-            or not os.path.isabs(payload["skill_dir"])
-            or payload.get("file_path") not in (None, "")
-        ):
-            raise ValueError(
-                "skill observation result is not a successful main skill load"
-            )
+            raise ValueError("tool observation requires a tool argument mapping")
     except Exception as exc:
-        reason = "skill observation evidence is invalid"
+        reason = "tool observation envelope is invalid"
         _poison_current(reason)
         raise TurnGateBlocked(reason) from exc
 
@@ -647,10 +639,6 @@ def record_tool_observation(
     provider_id, provider = required
     recorder = getattr(provider, "record_tool_observation", None)
     if not callable(recorder):
-        if decision.state is GateState.RELOAD_ONLY:
-            reason = "required provider cannot record reload observations"
-            _poison_current(reason)
-            raise TurnGateBlocked(reason)
         return
     request = _current_request.get()
     if request is None:
@@ -738,6 +726,7 @@ __all__ = [
     "TurnGateBlocked",
     "TurnGateProvider",
     "TurnGateRequest",
+    "TURN_GATE_API_VERSION",
     "acquire_outer_turn",
     "build_runtime_identity",
     "clear_turn_gate_registry_for_testing",

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -799,6 +799,18 @@ agent:
   # Recommended: 20-30 for focused tasks, 50-100 for open exploration
   max_turns: 500
 
+  # Optional host-enforced outer-turn gate. A plugin must register a provider
+  # under the same manifest key/name as `required_provider`. When configured,
+  # malformed settings or a missing provider fail closed before the turn body.
+  # See docs/turn-gate/README.md for the provider contract.
+  # turn_gate:
+  #   required_provider: example-gate
+  #   runtime_identity:
+  #     machine_id: workstation-01
+  #   allowed_child_environment:
+  #     - EXAMPLE_TURN_LEASE_ID
+  #     - EXAMPLE_COORDINATOR_SOCKET
+
   # Inactivity timeout for gateway agent runs (seconds, 0 = unlimited).
   # The agent can run indefinitely when actively calling tools or receiving
   # API responses.  Only fires after the agent has been idle for this duration.

--- a/docs/turn-gate/README.md
+++ b/docs/turn-gate/README.md
@@ -1,0 +1,88 @@
+# Host Turn-Gate Provider Contract
+
+Hermes exposes an opt-in, host-enforced outer-turn gate for deployments that
+must pause, drain, or restrict agent work while a runtime policy changes. The
+core is policy-neutral: a plugin decides admission and generation, while Hermes
+owns lease lifetime and revalidates before tool execution, platform output, and
+child-process environment injection.
+
+When `agent.turn_gate` is absent, the extension point is disabled and Hermes
+keeps its default behavior. When the section is present, malformed
+configuration or a missing required provider fails closed before a turn body or
+side effect begins.
+
+## Configuration
+
+```yaml
+agent:
+  turn_gate:
+    required_provider: example-gate
+    runtime_identity:
+      machine_id: workstation-01
+    allowed_child_environment:
+      - EXAMPLE_TURN_LEASE_ID
+      - EXAMPLE_COORDINATOR_SOCKET
+```
+
+- `required_provider` must match the registering plugin manifest key or name.
+- `runtime_identity.machine_id` is host-owned. Hermes combines it with the
+  active profile, gateway instance, turn ID, and an HMAC-derived session
+  instance ID; raw platform chat IDs are not exposed to providers.
+- `allowed_child_environment` is the complete host allowlist. Caller-controlled
+  values with these names are stripped outside an admitted turn. Inside an
+  admitted turn, only provider-returned values from this list are injected.
+
+## Provider API
+
+A plugin registers one provider under its own manifest identity:
+
+```python
+from agent.turn_gate import GateDecision, GateState
+
+
+class ExampleGate:
+    def acquire(self, request):
+        return GateDecision(
+            provider_id="example-gate",
+            state=GateState.OPEN,
+            lease_id="opaque-lease-id",
+            generation=1,
+            child_environment=(
+                ("EXAMPLE_TURN_LEASE_ID", "opaque-lease-id"),
+            ),
+        )
+
+    def validate(self, decision, checkpoint):
+        return decision
+
+    def release(self, decision):
+        return None
+
+
+def register(ctx):
+    ctx.register_turn_gate_provider(ExampleGate())
+```
+
+`acquire(request)` returns a `GateDecision`. `validate(decision, checkpoint)`
+is called again at consequential boundaries and must return the current
+decision. Hermes rejects provider identity mismatches, lease changes,
+generation changes, state downgrades, widened tool permissions, and changed
+child-environment contributions. `release(decision)` runs in `finally` after the
+outer turn.
+
+Provider exceptions and async provider methods fail closed. A provider may
+implement `record_tool_observation(...)` when `RELOAD_ONLY` turns require a
+host-observed successful main `skill_view`; invalid or unrecordable evidence
+poisons the turn.
+
+## Gate states
+
+- `OPEN`: tools and output are admitted, subject to revalidation.
+- `CLOSED_DRAINING`: new work, tools, and output are blocked.
+- `RELOAD_ONLY`: only the exact `allowed_tools` tuple is admitted; output remains
+  blocked until a later turn is admitted as `OPEN`.
+
+Detached background tasks are created without inheriting the parent turn's
+context. Any later side effect must acquire its own fresh outer-turn lease.
+Plugin force reload snapshots and restores provider ownership transactionally,
+so a failed reload cannot silently remove or replace a required provider.

--- a/docs/turn-gate/README.md
+++ b/docs/turn-gate/README.md
@@ -60,7 +60,7 @@ class ExampleGate:
 
 
 def register(ctx):
-    ctx.register_turn_gate_provider(ExampleGate())
+    ctx.register_turn_gate_provider(ExampleGate(), api_version=1)
 ```
 
 `acquire(request)` returns a `GateDecision`. `validate(decision, checkpoint)`
@@ -70,10 +70,15 @@ generation changes, state downgrades, widened tool permissions, and changed
 child-environment contributions. `release(decision)` runs in `finally` after the
 outer turn.
 
-Provider exceptions and async provider methods fail closed. A provider may
-implement `record_tool_observation(...)` when `RELOAD_ONLY` turns require a
-host-observed successful main `skill_view`; invalid or unrecordable evidence
-poisons the turn.
+Provider exceptions and async provider methods fail closed. A plugin must
+declare the exact host contract version when registering; this document defines
+`api_version=1`, and mismatches are rejected before the provider can replace a
+live registration. A provider may implement `record_tool_observation(...)` to
+interpret the generic `(tool_name, tool_args, tool_call_id, result)` envelope.
+Hermes does not recognize policy-specific tools or result fields. A provider
+rejection or exception poisons the turn; a provider without an observation
+callback leaves the gate state unchanged, so `RELOAD_ONLY` still cannot emit
+business output.
 
 ## Gate states
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6,6 +6,7 @@ and implement the required methods.
 """
 
 import asyncio
+import functools
 import inspect
 import ipaddress
 import logging
@@ -23,6 +24,14 @@ from abc import ABC, abstractmethod
 from urllib.parse import urlsplit
 
 from utils import normalize_proxy_url
+from agent.turn_gate import (
+    TurnGateRequest,
+    acquire_outer_turn,
+    build_runtime_identity,
+    create_detached_task,
+    current_turn_gate_request,
+    enforce_output_allowed,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -2634,6 +2643,136 @@ class BasePlatformAdapter(ABC):
     - Handling media
     """
 
+    _GATE_GUARDED_OUTPUT_METHODS = frozenset(
+        {
+            "send",
+            "send_animation",
+            "send_approval_request",
+            "send_audio",
+            "send_biz_request",
+            "send_c2c_message",
+            "send_c2c_msg_body",
+            "send_clarify",
+            "send_direct",
+            "send_dm",
+            "send_document",
+            "send_draft",
+            "send_exec_approval",
+            "send_file",
+            "send_group_message",
+            "send_group_msg_body",
+            "send_heartbeat_once",
+            "send_image",
+            "send_image_file",
+            "send_media",
+            "send_multiple_images",
+            "send_private_notice",
+            "send_reaction",
+            "send_slash_confirm",
+            "send_sticker",
+            "send_text",
+            "send_text_chunk",
+            "send_typing",
+            "send_update_prompt",
+            "send_video",
+            "send_voice",
+            "send_weixin_direct",
+            "send_with_keyboard",
+            "send_yuanbao_direct",
+            "edit_message",
+            "update_message",
+            "delete",
+            "delete_message",
+            "add_reaction",
+            "remove_reaction",
+            "stop_typing",
+            "mark_read",
+            "react",
+            "reply",
+            "on_processing_start",
+            "on_processing_complete",
+            # Thread/topic/room lifecycle, membership, presence, read receipts,
+            # and redaction perform real platform mutations but do NOT match the
+            # send/edit/update/delete/react prefixes. Enumerated explicitly (by
+            # name, auditable) so the host gate wraps every subclass override of
+            # them before the side effect — rather than widening a prefix that
+            # could also catch pure-query helpers.
+            "create_handoff_thread",
+            "create_room",
+            "invite_user",
+            "rename_thread",
+            "rename_dm_topic",
+            "send_read_receipt",
+            "redact_message",
+            "set_presence",
+        }
+    )
+    _GATE_GUARDED_OUTPUT_PREFIXES = (
+        "send",
+        "edit",
+        "update",
+        "delete",
+        "add_reaction",
+        "remove_reaction",
+        "set_reaction",
+        "reaction",
+        "react",
+        "reply",
+        "start_typing",
+        "stop_typing",
+        "set_typing",
+        "mark_read",
+        "mark_message_read",
+    )
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """Gate every platform-visible subclass override at the host boundary.
+
+        Call sites are intentionally not the security boundary: background,
+        fallback, streaming, and legacy paths may call adapter methods directly.
+        Wrapping subclass implementations here keeps the checkpoint immediately
+        adjacent to the actual platform operation.
+        """
+        super().__init_subclass__(**kwargs)
+        for method_name, implementation in tuple(cls.__dict__.items()):
+            if not (
+                method_name in cls._GATE_GUARDED_OUTPUT_METHODS
+                or method_name.startswith(cls._GATE_GUARDED_OUTPUT_PREFIXES)
+            ):
+                continue
+            if getattr(implementation, "_hermes_output_gate_wrapped", False):
+                continue
+            if not callable(implementation):
+                continue
+
+            if inspect.iscoroutinefunction(implementation):
+                @functools.wraps(implementation)
+                async def guarded_async_output_method(
+                    self,
+                    *args: Any,
+                    __implementation=implementation,
+                    **method_kwargs: Any,
+                ):
+                    enforce_output_allowed()
+                    return await __implementation(self, *args, **method_kwargs)
+
+                guarded_output_method = guarded_async_output_method
+            else:
+                @functools.wraps(implementation)
+                def guarded_sync_output_method(
+                    self,
+                    *args: Any,
+                    __implementation=implementation,
+                    **method_kwargs: Any,
+                ):
+                    enforce_output_allowed()
+                    return __implementation(self, *args, **method_kwargs)
+
+                guarded_output_method = guarded_sync_output_method
+
+            setattr(guarded_output_method, "_hermes_output_gate_wrapped", True)
+            setattr(cls, method_name, guarded_output_method)
+
     # Whether this platform renders triple-backtick fenced code blocks (i.e.
     # ``format_message`` translates/preserves markdown fences into a real code
     # block).  Capability flag for markdown-aware presentation choices.
@@ -3620,7 +3759,28 @@ class BasePlatformAdapter(ABC):
         async def _run_delete() -> None:
             try:
                 await asyncio.sleep(max(1, int(ttl_seconds)))
-                await self.delete_message(chat_id=chat_id, message_id=message_id)
+                # This runs AFTER the originating outer turn released its lease.
+                # The task was created with an empty ContextVar context (below)
+                # precisely so it does NOT inherit that dead lease. Take a fresh,
+                # independent host-owned outer turn dedicated to the cleanup so
+                # the gate-wrapped delete_message sees a live authorization.
+                # Identity/task ids are random opaque UUIDs — never the
+                # chat_id/message_id being deleted.
+                turn_id = str(uuid.uuid4())
+                session_id = str(uuid.uuid4())
+                identity = build_runtime_identity(
+                    surface="gateway-ephemeral-delete",
+                    session_scope=session_id,
+                    turn_id=turn_id,
+                )
+                request = TurnGateRequest(
+                    entrypoint="gateway-ephemeral-delete",
+                    purpose="business",
+                    task_id=session_id,
+                    identity=identity,
+                )
+                with acquire_outer_turn(request):
+                    await self.delete_message(chat_id=chat_id, message_id=message_id)
             except asyncio.CancelledError:
                 raise
             except Exception as e:
@@ -3631,7 +3791,10 @@ class BasePlatformAdapter(ABC):
 
         coro = _run_delete()
         try:
-            asyncio.create_task(coro)
+            # Schedule the task from a fresh, empty ContextVar context so it can
+            # never inherit the scheduling turn's about-to-be-released gate
+            # lease (asyncio copies the context active at create_task time).
+            create_detached_task(coro)
         except RuntimeError:
             # No running loop (e.g. unit tests that never reach the async
             # path).  Close the coroutine cleanly so Python doesn't warn
@@ -5038,6 +5201,8 @@ class BasePlatformAdapter(ABC):
         know to retry rather than waiting indefinitely.
         """
 
+        if content:
+            enforce_output_allowed()
         result = await self.send(
             chat_id=chat_id,
             content=content,
@@ -5072,6 +5237,8 @@ class BasePlatformAdapter(ABC):
                     self.name, attempt, max_retries, delay, error_str,
                 )
                 await asyncio.sleep(delay)
+                if content:
+                    enforce_output_allowed()
                 result = await self.send(
                     chat_id=chat_id,
                     content=content,
@@ -5094,6 +5261,7 @@ class BasePlatformAdapter(ABC):
                     "Please try again \u2014 your request was processed but the response could not be sent."
                 )
                 try:
+                    enforce_output_allowed()
                     await self.send(chat_id=chat_id, content=notice, reply_to=reply_to, metadata=metadata)
                 except Exception as notify_err:
                     logger.debug("[%s] Could not send delivery-failure notice: %s", self.name, notify_err)
@@ -5101,6 +5269,7 @@ class BasePlatformAdapter(ABC):
 
         # Non-network / post-retry formatting failure: try plain text as fallback
         logger.warning("[%s] Send failed: %s — trying plain-text fallback", self.name, error_str)
+        enforce_output_allowed()
         fallback_result = await self.send(
             chat_id=chat_id,
             content=f"(Response formatting failed, plain text:)\n\n{content[:3500]}",
@@ -5371,7 +5540,9 @@ class BasePlatformAdapter(ABC):
         guard = interrupt_event or asyncio.Event()
         self._active_sessions[session_key] = guard
 
-        task = asyncio.create_task(self._process_message_background(event, session_key))
+        task = create_detached_task(
+            self._process_message_background(event, session_key)
+        )
         self._session_tasks[session_key] = task
         try:
             self._background_tasks.add(task)
@@ -5760,6 +5931,40 @@ class BasePlatformAdapter(ABC):
         return random.uniform(min_ms / 1000.0, max_ms / 1000.0)
 
     async def _process_message_background(self, event: MessageEvent, session_key: str) -> None:
+        """Hold the outer-turn lease through final platform delivery."""
+        # The delegated body keeps the established auto-TTS contract:
+        # ``play_tts`` runs inside a try/finally, and the finally block calls
+        # ``os.remove`` for every generated temporary audio path.
+        inherited = current_turn_gate_request()
+        purpose = inherited.purpose if inherited is not None else "business"
+        session_instances = getattr(self, "_turn_gate_session_instances", None)
+        if session_instances is None:
+            session_instances = {}
+            setattr(self, "_turn_gate_session_instances", session_instances)
+        session_scope = session_instances.get(session_key)
+        if session_scope is None:
+            session_scope = str(uuid.uuid4())
+            session_instances[session_key] = session_scope
+        turn_id = (
+            inherited.identity.turn_id
+            if inherited is not None and inherited.identity is not None
+            else f"{session_scope}:{uuid.uuid4().hex}"
+        )
+        identity = build_runtime_identity(
+            surface=getattr(self, "name", None) or "gateway",
+            session_scope=session_scope,
+            turn_id=turn_id,
+        )
+        request = TurnGateRequest(
+            entrypoint="gateway-delivery",
+            purpose=purpose,
+            task_id=session_scope,
+            identity=identity,
+        )
+        with acquire_outer_turn(request):
+            return await self._process_message_background_unleased(event, session_key)
+
+    async def _process_message_background_unleased(self, event: MessageEvent, session_key: str) -> None:
         """Background task that actually processes the message."""
         # Track delivery outcomes for the processing-complete hook
         delivery_attempted = False
@@ -6302,7 +6507,7 @@ class BasePlatformAdapter(ABC):
                 # exhaust at ~2000 frames and SIGSEGV the process.
                 # Mirror the late-arrival drain pattern below: hand off
                 # to a new task and return so this frame can unwind.
-                drain_task = asyncio.create_task(
+                drain_task = create_detached_task(
                     self._process_message_background(pending_event, session_key)
                 )
                 # Hand ownership of the session to the drain task so
@@ -6427,7 +6632,7 @@ class BasePlatformAdapter(ABC):
                     _active = self._active_sessions.get(session_key)
                     if _active is not None:
                         _active.clear()
-                    drain_task = asyncio.create_task(
+                    drain_task = create_detached_task(
                         self._process_message_background(late_pending, session_key)
                     )
                     # Hand ownership of the session to the drain task so stale-lock

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -40,6 +40,7 @@ import sys
 import signal
 import threading
 import time
+import uuid
 from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
@@ -18475,18 +18476,51 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         resolve from that profile's secret scope. Mirrors the pattern in
         ``_run_agent``.
         """
-        if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
-            return await self._run_background_task_inner(
-                prompt, source, task_id, event_message_id, media_urls, media_types,
-            )
+        from agent.turn_gate import (
+            TurnGateRequest,
+            acquire_outer_turn,
+            build_runtime_identity,
+        )
 
-        profile_home = self._resolve_profile_home_for_source(source)
-        with _profile_runtime_scope(profile_home):
-            return await self._run_background_task_inner(
-                prompt, source, task_id, event_message_id, media_urls, media_types,
-            )
+        turn_id = f"{task_id}:{uuid.uuid4().hex[:8]}"
+        identity = build_runtime_identity(
+            surface="gateway-background",
+            session_scope=task_id,
+            turn_id=turn_id,
+        )
+        request = TurnGateRequest(
+            entrypoint="gateway-background",
+            purpose="business",
+            task_id=task_id,
+            identity=identity,
+        )
+        with acquire_outer_turn(request):
+            if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
+                return await self._run_background_task_inner(
+                    prompt, source, task_id, event_message_id, media_urls, media_types,
+                )
+
+            profile_home = self._resolve_profile_home_for_source(source)
+            with _profile_runtime_scope(profile_home):
+                return await self._run_background_task_inner(
+                    prompt, source, task_id, event_message_id, media_urls, media_types,
+                )
 
     async def _run_background_task_inner(
+        self,
+        prompt: str,
+        source: "SessionSource",
+        task_id: str,
+        event_message_id: Optional[str] = None,
+        media_urls: Optional[List[str]] = None,
+        media_types: Optional[List[str]] = None,
+    ) -> None:
+        """Compatibility seam that remains below the host-owned lease."""
+        return await self._run_background_task_unleased(
+            prompt, source, task_id, event_message_id, media_urls, media_types,
+        )
+
+    async def _run_background_task_unleased(
         self,
         prompt: str,
         source: "SessionSource",
@@ -23003,6 +23037,56 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 message_type=message_type,
             )
 
+    async def _run_agent_inner(
+        self,
+        message: str,
+        context_prompt: str,
+        history: List[Dict[str, Any]],
+        source: SessionSource,
+        session_id: str,
+        session_key: str = None,
+        run_generation: Optional[int] = None,
+        _interrupt_depth: int = 0,
+        event_message_id: Optional[str] = None,
+        channel_prompt: Optional[str] = None,
+        moa_config: Optional[dict] = None,
+        persist_user_message: Optional[Any] = None,
+        persist_user_timestamp: Optional[float] = None,
+        message_type: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Acquire the host lease before entering the real gateway turn."""
+        from agent.turn_gate import (
+            TurnGateRequest,
+            acquire_outer_turn,
+            build_runtime_identity,
+            enforce_output_allowed,
+        )
+
+        turn_id = f"{session_id}:{uuid.uuid4().hex[:8]}"
+        identity = build_runtime_identity(
+            surface="gateway",
+            session_scope=session_id,
+            turn_id=turn_id,
+        )
+        request = TurnGateRequest(
+            entrypoint="gateway",
+            purpose="business",
+            task_id=session_id,
+            identity=identity,
+        )
+        with acquire_outer_turn(request):
+            result = await self._run_agent_inner_unleased(
+                message, context_prompt, history, source, session_id,
+                session_key=session_key, run_generation=run_generation,
+                _interrupt_depth=_interrupt_depth, event_message_id=event_message_id,
+                channel_prompt=channel_prompt, moa_config=moa_config,
+                persist_user_message=persist_user_message,
+                persist_user_timestamp=persist_user_timestamp,
+                message_type=message_type,
+            )
+            enforce_output_allowed()
+            return result
+
     def _profile_name_for_source(self, source: SessionSource) -> Optional[str]:
         """Resolve the profile name for an inbound source via configured routes.
 
@@ -23107,7 +23191,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return get_hermes_home()
 
-    async def _run_agent_inner(
+    async def _run_agent_inner_unleased(
         self,
         message: str,
         context_prompt: str,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -32,6 +32,7 @@ from typing import Any, Optional, Union
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.i18n import t
 from agent.turn_context import extract_api_content_sidecar
+from agent.turn_gate import create_detached_task
 from gateway.config import HomeChannel, Platform, PlatformConfig, persist_home_channel
 from gateway.platforms.base import EphemeralReply, MessageEvent, MessageType
 from gateway.session import (
@@ -3163,7 +3164,7 @@ class GatewaySlashCommandsMixin:
         media_types = list(event.media_types) if event.media_types else []
 
         # Fire-and-forget the background task
-        _task = asyncio.create_task(
+        _task = create_detached_task(
             self._run_background_task(
                 prompt,
                 source,

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -34,6 +34,7 @@ so plugin-defined tools appear alongside the built-in tools.
 from __future__ import annotations
 
 import asyncio
+import importlib
 import importlib.metadata
 import importlib.util
 import inspect
@@ -1174,6 +1175,24 @@ class PluginContext:
             display_name,
         )
 
+    def register_turn_gate_provider(self, provider: Any) -> None:
+        """Register this plugin as a host-enforced outer-turn gate provider."""
+        from agent.turn_gate import register_turn_gate_provider
+
+        provider_id = self.manifest.key or self.manifest.name
+        register_turn_gate_provider(
+            provider_id,
+            provider,
+            owner_id=provider_id,
+            replace=True,
+        )
+        self._manager._turn_gate_provider_ids.add(provider_id)
+        logger.debug(
+            "Plugin %s registered mandatory turn gate provider: %s",
+            self.manifest.name,
+            provider_id,
+        )
+
     def register_hook(self, hook_name: str, callback: Callable) -> None:
         """Register a lifecycle hook callback.
 
@@ -1273,6 +1292,22 @@ class PluginManager:
         self._middleware: Dict[str, List[Callable]] = {}
         self._plugin_tool_names: Set[str] = set()
         self._plugin_platform_names: Set[str] = set()
+        self._turn_gate_provider_ids: Set[str] = set()
+        # Set to the failing plugin's error text when a plugin that touched the
+        # mandatory turn-gate registry raised during its own load. _load_plugin
+        # swallows that exception (so other plugins still load) and rolls back
+        # its own gate registration, but a force reload must NOT commit a round
+        # in which the mandatory gate silently failed to (re)register after the
+        # up-front teardown already removed the previously-live provider. Reset
+        # per discovery round; consulted only by the force path.
+        self._gate_provider_load_error: Optional[str] = None
+        # Ephemeral transaction context for failures that happen before a
+        # same-ID plugin can call register(). Cleared whenever the round exits.
+        self._force_reload_prior_gate_provider_ids: frozenset[str] = frozenset()
+        # Any plugin import/load/register failure aborts a force round. Non-force
+        # discovery keeps the historical best-effort, per-plugin error behavior.
+        self._force_reload_error: Optional[str] = None
+        self._force_reload_active: bool = False
         self._cli_commands: Dict[str, dict] = {}
         self._context_engine = None  # Set by a plugin via register_context_engine()
         self._plugin_commands: Dict[str, dict] = {}  # Slash commands registered by plugins
@@ -1304,11 +1339,34 @@ class PluginManager:
         """
         if self._discovered and not force:
             return
-        if env_var_enabled("HERMES_SAFE_MODE"):
-            logger.info("HERMES_SAFE_MODE=1 — plugin discovery skipped")
-            self._discovered = True
-            return
+        # force=True is transactional: the teardown below unregisters the live
+        # turn-gate providers and wipes discovery state up front, but a plugin's
+        # register() can register a same-id replacement and then fail mid-round.
+        # Snapshot the exact prior providers and discovery state BEFORE any
+        # teardown so any BaseException from the round restores them precisely
+        # (a per-plugin _load_plugin snapshot cannot — the old objects are
+        # already gone by the time it runs). A successful clean (including
+        # SAFE_MODE) commits.
+        _gate_registry_snapshot = None
+        _discovery_snapshot = None
+        _host_registry_snapshot = None
+        self._force_reload_prior_gate_provider_ids = (
+            frozenset(self._turn_gate_provider_ids) if force else frozenset()
+        )
         if force:
+            from agent.turn_gate import (
+                snapshot_turn_gate_providers,
+                unregister_turn_gate_providers_by_owner,
+            )
+
+            _gate_registry_snapshot = snapshot_turn_gate_providers()
+            _discovery_snapshot = self._snapshot_discovery_state()
+            _host_registry_snapshot = self._snapshot_force_reload_host_state()
+            self._force_reload_active = True
+
+            for provider_id in tuple(self._turn_gate_provider_ids):
+                unregister_turn_gate_providers_by_owner(provider_id)
+            self._turn_gate_provider_ids.clear()
             self._plugins.clear()
             self._hooks.clear()
             self._middleware.clear()
@@ -1320,6 +1378,17 @@ class PluginManager:
             self._aux_tasks.clear()
             self._slack_action_handlers.clear()
             self._context_engine = None
+        # Fresh per round: _load_plugin records here when a gate-registering
+        # plugin fails its own load. The force path treats such a failure as a
+        # failed round even though _load_plugin itself swallowed the exception.
+        self._gate_provider_load_error = None
+        self._force_reload_error = None
+        if env_var_enabled("HERMES_SAFE_MODE"):
+            logger.info("HERMES_SAFE_MODE=1 — plugin discovery skipped")
+            self._discovered = True
+            self._force_reload_prior_gate_provider_ids = frozenset()
+            self._force_reload_active = False
+            return
         # Set the flag up front as a re-entrancy guard (a plugin's register()
         # can transitively trigger discovery again), but reset it if the sweep
         # raises so a failed scan is NOT cached as "discovered with an empty
@@ -1329,9 +1398,224 @@ class PluginManager:
         self._discovered = True
         try:
             self._discover_and_load_inner()
+            if force and self._gate_provider_load_error is not None:
+                # A plugin registered a turn-gate provider (same-id replacement
+                # of a torn-down live provider, or a fresh one) and then raised.
+                # _load_plugin swallowed that and only recorded loaded.error, so
+                # _discover_and_load_inner returned "successfully" — but the
+                # mandatory gate is now missing the provider the up-front
+                # teardown removed. Fail the round closed so the except below
+                # restores the exact previous provider object and manager state.
+                from agent.turn_gate import TurnGateBlocked
+
+                raise TurnGateBlocked(
+                    "force reload failed to re-establish a mandatory turn gate "
+                    f"provider and rolled back: {self._gate_provider_load_error}"
+                )
+            if force and self._force_reload_error is not None:
+                raise RuntimeError(
+                    "force plugin discovery failed and rolled back: "
+                    f"{self._force_reload_error}"
+                )
         except BaseException:
-            self._discovered = False
+            try:
+                if force:
+                    # Roll the whole round back to the exact pre-teardown state:
+                    # provider objects, tracking, and every cleared discovery map.
+                    from agent.turn_gate import restore_turn_gate_providers
+
+                    restore_turn_gate_providers(_gate_registry_snapshot)
+                    assert _host_registry_snapshot is not None
+                    self._restore_force_reload_host_state(_host_registry_snapshot)
+                    self._restore_discovery_state(_discovery_snapshot)
+                else:
+                    self._discovered = False
+            finally:
+                self._force_reload_prior_gate_provider_ids = frozenset()
+                self._force_reload_active = False
             raise
+        self._force_reload_prior_gate_provider_ids = frozenset()
+        self._force_reload_active = False
+
+    def _snapshot_discovery_state(self) -> dict:
+        """Capture the manager discovery state that a force-reload tears down.
+
+        Shallow per-container copies are enough to restore the exact prior
+        objects: the force teardown ``clear()``s each container in place, so the
+        round populates fresh containers/lists and never mutates the snapshot's.
+        """
+        return {
+            "plugins": dict(self._plugins),
+            "hooks": {name: list(cbs) for name, cbs in self._hooks.items()},
+            "middleware": {
+                kind: list(cbs) for kind, cbs in self._middleware.items()
+            },
+            "plugin_tool_names": set(self._plugin_tool_names),
+            "plugin_platform_names": set(self._plugin_platform_names),
+            "turn_gate_provider_ids": set(self._turn_gate_provider_ids),
+            "gate_provider_load_error": self._gate_provider_load_error,
+            "force_reload_error": self._force_reload_error,
+            "cli_commands": dict(self._cli_commands),
+            "plugin_commands": dict(self._plugin_commands),
+            "plugin_skills": dict(self._plugin_skills),
+            "aux_tasks": dict(self._aux_tasks),
+            "slack_action_handlers": list(self._slack_action_handlers),
+            "context_engine": self._context_engine,
+            "discovered": self._discovered,
+        }
+
+    def _restore_discovery_state(self, snapshot: dict) -> None:
+        """Restore state captured by :meth:`_snapshot_discovery_state`, in place."""
+        self._plugins.clear()
+        self._plugins.update(snapshot["plugins"])
+        self._hooks.clear()
+        self._hooks.update(snapshot["hooks"])
+        self._middleware.clear()
+        self._middleware.update(snapshot["middleware"])
+        self._plugin_tool_names.clear()
+        self._plugin_tool_names.update(snapshot["plugin_tool_names"])
+        self._plugin_platform_names.clear()
+        self._plugin_platform_names.update(snapshot["plugin_platform_names"])
+        self._turn_gate_provider_ids.clear()
+        self._turn_gate_provider_ids.update(snapshot["turn_gate_provider_ids"])
+        self._gate_provider_load_error = snapshot["gate_provider_load_error"]
+        self._force_reload_error = snapshot["force_reload_error"]
+        self._cli_commands.clear()
+        self._cli_commands.update(snapshot["cli_commands"])
+        self._plugin_commands.clear()
+        self._plugin_commands.update(snapshot["plugin_commands"])
+        self._plugin_skills.clear()
+        self._plugin_skills.update(snapshot["plugin_skills"])
+        self._aux_tasks.clear()
+        self._aux_tasks.update(snapshot["aux_tasks"])
+        self._slack_action_handlers[:] = snapshot["slack_action_handlers"]
+        self._context_engine = snapshot["context_engine"]
+        self._discovered = snapshot["discovered"]
+
+    @staticmethod
+    def _snapshot_force_reload_host_state() -> dict:
+        """Snapshot every host registry exposed through ``PluginContext``.
+
+        A force round may replace providers or register tools/platforms before a
+        later plugin fails. The manager-local snapshot cannot undo those global
+        writes, so capture their exact object mappings and the plugin namespace
+        modules as one transaction boundary.
+        """
+        browser_registry = importlib.import_module("agent.browser_registry")
+        dashboard_auth_registry = importlib.import_module(
+            "hermes_cli.dashboard_auth.registry"
+        )
+        image_gen_registry = importlib.import_module("agent.image_gen_registry")
+        transcription_registry = importlib.import_module(
+            "agent.transcription_registry"
+        )
+        tts_registry = importlib.import_module("agent.tts_registry")
+        video_gen_registry = importlib.import_module("agent.video_gen_registry")
+        web_search_registry = importlib.import_module("agent.web_search_registry")
+        secret_source_registry = importlib.import_module(
+            "agent.secret_sources.registry"
+        )
+        platform_registry = importlib.import_module(
+            "gateway.platform_registry"
+        ).platform_registry
+        tool_registry = importlib.import_module("tools.registry").registry
+
+        provider_registries = []
+        for registry_module in (
+            browser_registry,
+            dashboard_auth_registry,
+            image_gen_registry,
+            transcription_registry,
+            tts_registry,
+            video_gen_registry,
+            web_search_registry,
+        ):
+            lock = getattr(registry_module, "_lock")
+            providers = getattr(registry_module, "_providers")
+            with lock:
+                provider_registries.append((registry_module, dict(providers)))
+
+        tool_lock = getattr(tool_registry, "_lock")
+        with tool_lock:
+            tool_state = {
+                "tools": dict(getattr(tool_registry, "_tools")),
+                "plugin_override_policy": dict(
+                    getattr(tool_registry, "_plugin_override_policy")
+                ),
+                "toolset_checks": dict(getattr(tool_registry, "_toolset_checks")),
+                "toolset_aliases": dict(getattr(tool_registry, "_toolset_aliases")),
+                "generation": getattr(tool_registry, "_generation"),
+            }
+
+        return {
+            "tool_registry": tool_registry,
+            "tool_state": tool_state,
+            "platform_registry": platform_registry,
+            "platform_entries": dict(getattr(platform_registry, "_entries")),
+            "platform_deferred": dict(getattr(platform_registry, "_deferred")),
+            "provider_registries": provider_registries,
+            "secret_source_registry": secret_source_registry,
+            "secret_sources": dict(getattr(secret_source_registry, "_SOURCES")),
+            "secret_builtins_loaded": getattr(
+                secret_source_registry, "_BUILTINS_LOADED"
+            ),
+            "plugin_modules": {
+                name: module
+                for name, module in sys.modules.items()
+                if name == _NS_PARENT or name.startswith(f"{_NS_PARENT}.")
+            },
+        }
+
+    @staticmethod
+    def _restore_force_reload_host_state(snapshot: dict) -> None:
+        """Restore the host registries captured for a failed force round."""
+        tool_registry = snapshot["tool_registry"]
+        tool_state = snapshot["tool_state"]
+        tool_lock = getattr(tool_registry, "_lock")
+        with tool_lock:
+            for attr, key in (
+                ("_tools", "tools"),
+                ("_plugin_override_policy", "plugin_override_policy"),
+                ("_toolset_checks", "toolset_checks"),
+                ("_toolset_aliases", "toolset_aliases"),
+            ):
+                target = getattr(tool_registry, attr)
+                target.clear()
+                target.update(tool_state[key])
+            setattr(tool_registry, "_generation", tool_state["generation"])
+
+        platform_registry = snapshot["platform_registry"]
+        entries = getattr(platform_registry, "_entries")
+        entries.clear()
+        entries.update(snapshot["platform_entries"])
+        deferred = getattr(platform_registry, "_deferred")
+        deferred.clear()
+        deferred.update(snapshot["platform_deferred"])
+
+        for registry_module, providers_before in snapshot["provider_registries"]:
+            lock = getattr(registry_module, "_lock")
+            providers = getattr(registry_module, "_providers")
+            with lock:
+                providers.clear()
+                providers.update(providers_before)
+
+        secret_source_registry = snapshot["secret_source_registry"]
+        sources = getattr(secret_source_registry, "_SOURCES")
+        sources.clear()
+        sources.update(snapshot["secret_sources"])
+        setattr(
+            secret_source_registry,
+            "_BUILTINS_LOADED",
+            snapshot["secret_builtins_loaded"],
+        )
+
+        modules_before = snapshot["plugin_modules"]
+        for name in tuple(sys.modules):
+            if (
+                name == _NS_PARENT or name.startswith(f"{_NS_PARENT}.")
+            ) and name not in modules_before:
+                sys.modules.pop(name, None)
+        sys.modules.update(modules_before)
 
     def _discover_and_load_inner(self) -> None:
         """The actual discovery sweep — see :meth:`discover_and_load`."""
@@ -1773,7 +2057,11 @@ class PluginManager:
         )
 
         from tools.registry import registry as _registry
+        from agent.turn_gate import snapshot_turn_gate_providers
+
         _plugin_id = manifest.key or manifest.name
+        _gate_ids_before = set(self._turn_gate_provider_ids)
+        _gate_registry_before = snapshot_turn_gate_providers()
         _slug = _plugin_id.replace("/", "__").replace("-", "_")
         _registry.register_plugin_override_policy(
             f"{_NS_PARENT}.{_slug}",
@@ -1791,6 +2079,11 @@ class PluginManager:
             register_fn = getattr(module, "register", None)
             if register_fn is None:
                 loaded.error = "no register() function"
+                if (
+                    self._force_reload_active
+                    and self._force_reload_error is None
+                ):
+                    self._force_reload_error = f"{_plugin_id}: {loaded.error}"
                 logger.warning("Plugin '%s' has no register() function", manifest.name)
             else:
                 ctx = PluginContext(manifest, self)
@@ -1840,7 +2133,41 @@ class PluginManager:
                     ),
                 )
 
+            if (
+                _plugin_id in self._force_reload_prior_gate_provider_ids
+                and _plugin_id not in self._turn_gate_provider_ids
+            ):
+                self._gate_provider_load_error = (
+                    f"{_plugin_id}: previously-live turn gate provider was not re-registered"
+                )
+
         except Exception as exc:
+            from agent.turn_gate import restore_turn_gate_providers
+
+            # Detect BEFORE rollback whether this plugin's register() touched
+            # the mandatory turn-gate registry (registered/replaced a provider)
+            # before it raised. If so, record it so a force reload can judge the
+            # whole round failed — swallowing here would otherwise silently drop
+            # a gate provider the force teardown already removed up front.
+            _gate_registry_after = snapshot_turn_gate_providers()
+            _gate_touched = (
+                set(_gate_registry_after) != set(_gate_registry_before)
+                or any(
+                    _gate_registry_after.get(provider_id) is not provider
+                    for provider_id, provider in _gate_registry_before.items()
+                )
+                or set(self._turn_gate_provider_ids) != _gate_ids_before
+            )
+            restore_turn_gate_providers(_gate_registry_before)
+            self._turn_gate_provider_ids.clear()
+            self._turn_gate_provider_ids.update(_gate_ids_before)
+            if (
+                _gate_touched
+                or _plugin_id in self._force_reload_prior_gate_provider_ids
+            ):
+                self._gate_provider_load_error = f"{_plugin_id}: {exc}"
+            if self._force_reload_active and self._force_reload_error is None:
+                self._force_reload_error = f"{_plugin_id}: {exc}"
             loaded.error = str(exc)
             logger.warning(
                 "Failed to load plugin '%s': %s",
@@ -2057,12 +2384,25 @@ def get_plugin_manager() -> PluginManager:
 
 
 def discover_plugins(force: bool = False) -> None:
-    """Discover and load all plugins.
+    """Discover plugins and bind any mandatory host turn gate from config.yaml."""
+    manager = get_plugin_manager()
+    try:
+        manager.discover_and_load(force=force)
+    finally:
+        try:
+            from agent.turn_gate import configure_turn_gate_from_config
+            from hermes_cli.config import load_config
 
-    Default behavior is idempotent. Pass ``force=True`` to rescan plugin
-    manifests and reload state in the current process.
-    """
-    get_plugin_manager().discover_and_load(force=force)
+            configure_turn_gate_from_config(load_config() or {})
+        except Exception as exc:
+            try:
+                from agent.turn_gate import mark_turn_gate_configuration_error
+
+                mark_turn_gate_configuration_error(str(exc))
+            except Exception:
+                pass
+            logger.error("mandatory turn gate configuration failed", exc_info=True)
+            raise
 
 
 def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
@@ -2351,9 +2691,8 @@ def _ensure_plugins_discovered(force: bool = False) -> PluginManager:
 
     Pass ``force=True`` to rescan in the current process.
     """
-    manager = get_plugin_manager()
-    manager.discover_and_load(force=force)
-    return manager
+    discover_plugins(force=force)
+    return get_plugin_manager()
 
 
 def get_plugin_context_engine():

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1175,15 +1175,30 @@ class PluginContext:
             display_name,
         )
 
-    def register_turn_gate_provider(self, provider: Any) -> None:
+    def register_turn_gate_provider(
+        self,
+        provider: Any,
+        *,
+        api_version: int | None = None,
+    ) -> None:
         """Register this plugin as a host-enforced outer-turn gate provider."""
-        from agent.turn_gate import register_turn_gate_provider
+        from agent.turn_gate import (
+            TURN_GATE_API_VERSION,
+            register_turn_gate_provider,
+        )
+
+        if type(api_version) is not int or api_version != TURN_GATE_API_VERSION:
+            raise ValueError(
+                "turn gate provider API version mismatch: "
+                f"expected {TURN_GATE_API_VERSION}, got {api_version!r}"
+            )
 
         provider_id = self.manifest.key or self.manifest.name
         register_turn_gate_provider(
             provider_id,
             provider,
             owner_id=provider_id,
+            api_version=api_version,
             replace=True,
         )
         self._manager._turn_gate_provider_ids.add(provider_id)
@@ -2198,6 +2213,17 @@ class PluginManager:
         key = manifest.key or manifest.name
         slug = key.replace("/", "__").replace("-", "_")
         module_name = f"{_NS_PARENT}.{slug}"
+        if self._force_reload_active:
+            # A package plugin may import policy and provider code from relative
+            # submodules. Replacing only ``__init__`` leaves those modules in
+            # ``sys.modules`` and silently reuses old code during an upgrade.
+            # The force-round host snapshot restores these exact objects if any
+            # later load or registration step fails.
+            for loaded_name in tuple(sys.modules):
+                if loaded_name == module_name or loaded_name.startswith(
+                    f"{module_name}."
+                ):
+                    sys.modules.pop(loaded_name, None)
         spec = importlib.util.spec_from_file_location(
             module_name,
             init_file,

--- a/model_tools.py
+++ b/model_tools.py
@@ -1341,18 +1341,16 @@ def handle_function_call(
                         enabled_tools=sandbox_enabled,
                         _hermes_tool_call_id=tool_call_id or "",
                     )
-                    # Only the host-side registry handler may satisfy a
-                    # reload observation.  Keeping this immediately after
-                    # registry.dispatch means execution middleware that does
-                    # not invoke its callback cannot forge evidence.
-                    if function_name == "skill_view":
-                        from agent.turn_gate import record_tool_observation
-                        record_tool_observation(
-                            tool_name=function_name,
-                            tool_args=dict(next_args),
-                            tool_call_id=tool_call_id or "",
-                            result=result,
-                        )
+                    # Only the host-side registry handler may emit an
+                    # observation. Providers — not Hermes core — decide which
+                    # tool/result has policy meaning.
+                    from agent.turn_gate import record_tool_observation
+                    record_tool_observation(
+                        tool_name=function_name,
+                        tool_args=dict(next_args),
+                        tool_call_id=tool_call_id or "",
+                        result=result,
+                    )
                     return result
             else:
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
@@ -1365,14 +1363,13 @@ def handle_function_call(
                     )
                     # See the execute_code branch above: observation evidence
                     # is recorded only after the real registry handler returns.
-                    if function_name == "skill_view":
-                        from agent.turn_gate import record_tool_observation
-                        record_tool_observation(
-                            tool_name=function_name,
-                            tool_args=dict(next_args),
-                            tool_call_id=tool_call_id or "",
-                            result=result,
-                        )
+                    from agent.turn_gate import record_tool_observation
+                    record_tool_observation(
+                        tool_name=function_name,
+                        tool_args=dict(next_args),
+                        tool_call_id=tool_call_id or "",
+                        result=result,
+                    )
                     return result
             if skip_tool_execution_middleware:
                 result = _dispatch(function_args)

--- a/model_tools.py
+++ b/model_tools.py
@@ -31,6 +31,7 @@ from typing import Dict, Any, List, Optional, Tuple
 
 from tools.registry import discover_builtin_tools, registry, tool_error
 from toolsets import resolve_toolset, validate_toolset
+from agent.turn_gate import tool_block_message
 
 logger = logging.getLogger(__name__)
 
@@ -1122,6 +1123,13 @@ def handle_function_call(
     Returns:
         Function result as a JSON string.
     """
+    _host_gate_block = tool_block_message(function_name)
+    if _host_gate_block is not None:
+        return json.dumps(
+            {"error": _host_gate_block, "error_type": "turn_gate_block"},
+            ensure_ascii=False,
+        )
+
     # Coerce string arguments to their schema-declared types (e.g. "42"→42)
     function_args = coerce_tool_args(function_name, function_args)
     if not isinstance(function_args, dict):
@@ -1326,20 +1334,46 @@ def handle_function_call(
                 # the parent's tool set via the process-global.
                 sandbox_enabled = enabled_tools if enabled_tools is not None else _last_resolved_tool_names
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
-                    return registry.dispatch(
+                    result = registry.dispatch(
                         function_name, next_args,
                         task_id=task_id,
                         session_id=session_id,
                         enabled_tools=sandbox_enabled,
+                        _hermes_tool_call_id=tool_call_id or "",
                     )
+                    # Only the host-side registry handler may satisfy a
+                    # reload observation.  Keeping this immediately after
+                    # registry.dispatch means execution middleware that does
+                    # not invoke its callback cannot forge evidence.
+                    if function_name == "skill_view":
+                        from agent.turn_gate import record_tool_observation
+                        record_tool_observation(
+                            tool_name=function_name,
+                            tool_args=dict(next_args),
+                            tool_call_id=tool_call_id or "",
+                            result=result,
+                        )
+                    return result
             else:
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
-                    return registry.dispatch(
+                    result = registry.dispatch(
                         function_name, next_args,
                         task_id=task_id,
                         session_id=session_id,
                         user_task=user_task,
+                        _hermes_tool_call_id=tool_call_id or "",
                     )
+                    # See the execute_code branch above: observation evidence
+                    # is recorded only after the real registry handler returns.
+                    if function_name == "skill_view":
+                        from agent.turn_gate import record_tool_observation
+                        record_tool_observation(
+                            tool_name=function_name,
+                            tool_args=dict(next_args),
+                            tool_call_id=tool_call_id or "",
+                            result=result,
+                        )
+                    return result
             if skip_tool_execution_middleware:
                 result = _dispatch(function_args)
             else:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -62,13 +62,14 @@ import shutil
 import subprocess
 import sys
 import time
+import uuid
 from urllib.parse import urljoin, urlsplit, urlunsplit
 from dataclasses import dataclass, field
 
 from html import escape as _html_escape
 from html.parser import HTMLParser
 from pathlib import Path
-from typing import Any, Dict, Optional, Set
+from typing import Any, Awaitable, Callable, Dict, Optional, Set
 
 try:
     from mautrix.types import (
@@ -136,6 +137,12 @@ from gateway.platforms.base import (
     _ssrf_redirect_guard,
 )
 from gateway.platforms.helpers import ThreadParticipationTracker
+from agent.turn_gate import (
+    TurnGateRequest,
+    acquire_outer_turn,
+    build_runtime_identity,
+    create_detached_task,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -3486,6 +3493,27 @@ class MatrixAdapter(BasePlatformAdapter):
         """Remove a reaction by redacting its event."""
         return await self.redact_message(room_id, reaction_event_id, reason)
 
+    async def _run_deferred_platform_side_effect(
+        self,
+        entrypoint: str,
+        operation: Callable[[], Awaitable[Any]],
+    ) -> Any:
+        """Run detached Matrix output under a fresh host-owned outer turn."""
+        turn_id = str(uuid.uuid4())
+        session_id = str(uuid.uuid4())
+        identity = build_runtime_identity(
+            surface=entrypoint,
+            session_scope=session_id,
+            turn_id=turn_id,
+        )
+        request = TurnGateRequest(
+            entrypoint=entrypoint,
+            purpose="business",
+            identity=identity,
+        )
+        with acquire_outer_turn(request):
+            return await operation()
+
     def _schedule_reaction_redaction(
         self,
         room_id: str,
@@ -3498,20 +3526,27 @@ class MatrixAdapter(BasePlatformAdapter):
             try:
                 if self._reaction_redaction_delay_seconds:
                     await asyncio.sleep(self._reaction_redaction_delay_seconds)
-                if not await self._redact_reaction(room_id, reaction_event_id, reason):
+                if not await self._run_deferred_platform_side_effect(
+                    "matrix-reaction-redaction",
+                    lambda: self._redact_reaction(
+                        room_id, reaction_event_id, reason
+                    ),
+                ):
                     logger.debug(
                         "Matrix: failed to redact reaction %s", reaction_event_id
                     )
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
-                logger.debug(
+                logger.warning(
                     "Matrix: delayed reaction redaction failed for %s: %s",
                     reaction_event_id,
                     exc,
                 )
 
-        task = asyncio.create_task(_redact_later())
+        # A Task copies the current ContextVars. Schedule from an empty Context
+        # so a delayed output cannot inherit the caller's soon-to-expire lease.
+        task = create_detached_task(_redact_later())
         self._reaction_redaction_tasks.add(task)
         task.add_done_callback(self._reaction_redaction_tasks.discard)
 
@@ -3886,11 +3921,16 @@ class MatrixAdapter(BasePlatformAdapter):
 
         async def _send() -> None:
             try:
-                await self.send_read_receipt(room_id, event_id)
+                await self._run_deferred_platform_side_effect(
+                    "matrix-read-receipt",
+                    lambda: self.send_read_receipt(room_id, event_id),
+                )
             except Exception as exc:  # pragma: no cover — defensive
-                logger.debug("Matrix: background read receipt failed: %s", exc)
+                logger.warning("Matrix: background read receipt failed: %s", exc)
 
-        asyncio.ensure_future(_send())
+        # Read receipts are detached from message parsing. Never inherit an
+        # outer-turn lease from a future caller that happens to schedule one.
+        create_detached_task(_send())
 
     async def send_read_receipt(self, room_id: str, event_id: str) -> bool:
         """Send a read receipt (m.read) for an event."""

--- a/tests/agent/test_conversation_reload_gate.py
+++ b/tests/agent/test_conversation_reload_gate.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import agent.conversation_loop as conversation_loop
+from agent.turn_gate import (
+    GateDecision,
+    GateState,
+    TurnGateBlocked,
+    clear_turn_gate_registry_for_testing,
+    configure_turn_gate_from_config,
+    current_turn_gate_decision,
+    register_turn_gate_provider as _register_turn_gate_provider,
+)
+
+
+def _configure_gate(provider_id: str) -> None:
+    configure_turn_gate_from_config(
+        {
+            "agent": {
+                "turn_gate": {
+                    "required_provider": provider_id,
+                    "runtime_identity": {"machine_id": "test-machine"},
+                }
+            }
+        }
+    )
+
+
+def register_turn_gate_provider(provider_id: str, provider) -> None:
+    _register_turn_gate_provider(
+        provider_id,
+        provider,
+        owner_id=provider_id,
+    )
+
+
+class RecordingProvider:
+    def __init__(self, events):
+        self.events = events
+        self.requests = []
+
+    def acquire(self, request):
+        self.requests.append(request)
+        self.events.append(("acquire", request.entrypoint, request.purpose))
+        return GateDecision(
+            provider_id="test-gate",
+            state=GateState.OPEN,
+            lease_id="lease-conversation",
+            generation=26,
+            allowed_tools=(),
+        )
+
+    def validate(self, decision, checkpoint):
+        return decision
+
+    def release(self, decision):
+        self.events.append(("release", decision.lease_id))
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    clear_turn_gate_registry_for_testing()
+    yield
+    clear_turn_gate_registry_for_testing()
+
+
+def test_run_conversation_acquires_gate_before_body_and_releases_after_return(monkeypatch):
+    events = []
+    provider = RecordingProvider(events)
+    register_turn_gate_provider("test-gate", provider)
+    _configure_gate("test-gate")
+
+    def fake_body(*args, **kwargs):
+        decision = current_turn_gate_decision()
+        assert decision is not None
+        events.append(("body", decision.lease_id))
+        return {"final_response": "ok"}
+
+    monkeypatch.setattr(conversation_loop, "_run_conversation_unleased", fake_body)
+    agent = SimpleNamespace(stream_delta_callback=None, session_id="session-1")
+    result = conversation_loop.run_conversation(
+        agent, "hello", task_id="task-1"
+    )
+
+    assert result == {"final_response": "ok"}
+    assert provider.requests[0].task_id == "task-1"
+    assert provider.requests[0].identity is not None
+    assert provider.requests[0].identity.surface == "conversation"
+    assert provider.requests[0].identity.turn_id.startswith("session-1:task-1:")
+    assert events == [
+        ("acquire", "conversation", "business"),
+        ("body", "lease-conversation"),
+        ("release", "lease-conversation"),
+    ]
+
+
+def test_run_conversation_releases_gate_when_body_raises(monkeypatch):
+    events = []
+    provider = RecordingProvider(events)
+    register_turn_gate_provider("test-gate", provider)
+    _configure_gate("test-gate")
+
+    def fail_body(*args, **kwargs):
+        events.append(("body", current_turn_gate_decision().lease_id))
+        raise RuntimeError("body failed")
+
+    monkeypatch.setattr(conversation_loop, "_run_conversation_unleased", fail_body)
+    with pytest.raises(RuntimeError, match="body failed"):
+        conversation_loop.run_conversation(SimpleNamespace(stream_delta_callback=None), "hello")
+
+    assert events == [
+        ("acquire", "conversation", "business"),
+        ("body", "lease-conversation"),
+        ("release", "lease-conversation"),
+    ]
+
+
+def test_required_gate_missing_blocks_before_conversation_body(monkeypatch):
+    _configure_gate("missing-gate")
+    called = False
+
+    def fake_body(*args, **kwargs):
+        nonlocal called
+        called = True
+        return {}
+
+    monkeypatch.setattr(conversation_loop, "_run_conversation_unleased", fake_body)
+    with pytest.raises(TurnGateBlocked, match="required provider"):
+        conversation_loop.run_conversation(SimpleNamespace(stream_delta_callback=None), "hello")
+    assert called is False

--- a/tests/agent/test_host_tool_env_bridge.py
+++ b/tests/agent/test_host_tool_env_bridge.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import pytest
+
+from agent.turn_gate import (
+    GateDecision,
+    GateState,
+    TurnGateRequest,
+    acquire_outer_turn,
+    build_runtime_identity,
+    clear_turn_gate_registry_for_testing,
+    configure_turn_gate_from_config,
+    register_turn_gate_provider,
+)
+from tools.environments.local import build_subprocess_env
+
+
+_ALLOWED_ENV = (
+    "EXAMPLE_TURN_LEASE_ID",
+    "EXAMPLE_COORDINATOR_SOCKET",
+    "EXAMPLE_REQUEST_ID",
+)
+
+
+class _EnvironmentProvider:
+    def acquire(self, request: TurnGateRequest) -> GateDecision:
+        return GateDecision(
+            provider_id="example-gate",
+            state=GateState.OPEN,
+            lease_id="example-lease",
+            generation=1,
+            child_environment=(
+                ("EXAMPLE_TURN_LEASE_ID", "lease-from-host"),
+                ("EXAMPLE_COORDINATOR_SOCKET", "/tmp/example-coordinator.sock"),
+                ("EXAMPLE_REQUEST_ID", "request-123"),
+            ),
+        )
+
+    def validate(self, decision: GateDecision, checkpoint: str) -> GateDecision:
+        return decision
+
+    def release(self, decision: GateDecision) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _configured_gate():
+    clear_turn_gate_registry_for_testing()
+    configure_turn_gate_from_config(
+        {
+            "agent": {
+                "turn_gate": {
+                    "required_provider": "example-gate",
+                    "runtime_identity": {"machine_id": "test-machine"},
+                    "allowed_child_environment": list(_ALLOWED_ENV),
+                }
+            }
+        }
+    )
+    register_turn_gate_provider(
+        "example-gate",
+        _EnvironmentProvider(),
+        owner_id="example-gate",
+    )
+    try:
+        yield
+    finally:
+        clear_turn_gate_registry_for_testing()
+
+
+def _request() -> TurnGateRequest:
+    identity = build_runtime_identity(
+        surface="test",
+        session_scope="session-1",
+        turn_id="turn-1",
+    )
+    return TurnGateRequest(
+        entrypoint="test",
+        purpose="business",
+        task_id="task-1",
+        identity=identity,
+    )
+
+
+def test_host_environment_is_injected_only_inside_outer_turn(monkeypatch):
+    monkeypatch.setenv("EXAMPLE_TURN_LEASE_ID", "caller-controlled")
+    monkeypatch.setenv("EXAMPLE_REQUEST_ID", "caller-request")
+
+    outside = build_subprocess_env(
+        base={"PATH": "/usr/bin", "EXAMPLE_TURN_LEASE_ID": "caller-controlled"},
+        inherit_profile_home=False,
+        scrub_secrets=False,
+    )
+    assert all(name not in outside for name in _ALLOWED_ENV)
+
+    with acquire_outer_turn(_request()):
+        inside = build_subprocess_env(
+            base={"PATH": "/usr/bin", "EXAMPLE_TURN_LEASE_ID": "caller-controlled"},
+            inherit_profile_home=False,
+            scrub_secrets=False,
+        )
+
+    assert inside["EXAMPLE_TURN_LEASE_ID"] == "lease-from-host"
+    assert inside["EXAMPLE_COORDINATOR_SOCKET"] == "/tmp/example-coordinator.sock"
+    assert inside["EXAMPLE_REQUEST_ID"] == "request-123"
+
+
+def test_host_environment_is_removed_after_outer_turn():
+    with acquire_outer_turn(_request()):
+        pass
+
+    after = build_subprocess_env(
+        base={"PATH": "/usr/bin", "EXAMPLE_REQUEST_ID": "spoofed"},
+        inherit_profile_home=False,
+        scrub_secrets=False,
+    )
+    assert all(name not in after for name in _ALLOWED_ENV)

--- a/tests/agent/test_tool_executor_reload_gate.py
+++ b/tests/agent/test_tool_executor_reload_gate.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 
+import agent.turn_gate as turn_gate
 import model_tools
 from agent.tool_executor import _host_gate_block_message
 from agent.turn_gate import (
@@ -119,3 +120,31 @@ def test_direct_tool_dispatch_without_required_outer_lease_fails_closed(monkeypa
     payload = json.loads(result)
     assert payload["error_type"] == "turn_gate_block"
     assert "outer-turn lease" in payload["error"]
+
+
+def test_direct_registry_dispatch_fails_closed_when_gate_check_raises(monkeypatch):
+    entry = model_tools.registry.get_entry("skill_view")
+    assert entry is not None
+    executed = []
+    monkeypatch.setattr(
+        entry,
+        "handler",
+        lambda args, **kwargs: executed.append(True) or json.dumps({"executed": True}),
+    )
+    monkeypatch.setattr(
+        turn_gate,
+        "tool_block_message",
+        lambda name: (_ for _ in ()).throw(RuntimeError("gate unavailable")),
+    )
+
+    result = model_tools.registry.dispatch(
+        "skill_view",
+        {"name": "must-not-run"},
+        task_id="task-direct-registry",
+    )
+
+    assert isinstance(result, str)
+    payload = json.loads(result)
+    assert executed == []
+    assert payload["error_type"] == "turn_gate_block"
+    assert "failed closed" in payload["error"]

--- a/tests/agent/test_tool_executor_reload_gate.py
+++ b/tests/agent/test_tool_executor_reload_gate.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import model_tools
+from agent.tool_executor import _host_gate_block_message
+from agent.turn_gate import (
+    GateDecision,
+    GateState,
+    RuntimeIdentity,
+    TurnGateRequest,
+    acquire_outer_turn,
+    clear_turn_gate_registry_for_testing,
+    configure_turn_gate_from_config,
+    register_turn_gate_provider as _register_turn_gate_provider,
+)
+
+
+def _configure_gate(provider_id: str) -> None:
+    configure_turn_gate_from_config(
+        {
+            "agent": {
+                "turn_gate": {
+                    "required_provider": provider_id,
+                    "runtime_identity": {"machine_id": "test-machine"},
+                }
+            }
+        }
+    )
+
+
+def register_turn_gate_provider(provider_id: str, provider) -> None:
+    _register_turn_gate_provider(
+        provider_id,
+        provider,
+        owner_id=provider_id,
+    )
+
+
+class ReloadOnlyProvider:
+    def acquire(self, request):
+        return GateDecision(
+            provider_id="test-gate",
+            state=GateState.RELOAD_ONLY,
+            lease_id="lease-reload",
+            generation=26,
+            allowed_tools=("skill_view",),
+        )
+
+    def validate(self, decision, checkpoint):
+        return decision
+
+    def release(self, decision):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def gate():
+    clear_turn_gate_registry_for_testing()
+    register_turn_gate_provider("test-gate", ReloadOnlyProvider())
+    _configure_gate("test-gate")
+    yield
+    clear_turn_gate_registry_for_testing()
+
+
+def reload_request() -> TurnGateRequest:
+    identity = RuntimeIdentity(
+        machine_id="test-machine",
+        profile="default",
+        surface="gateway",
+        session_instance_id="test-session",
+        gateway_instance_id="test-gateway",
+        turn_id="test-turn",
+    )
+    return TurnGateRequest(
+        entrypoint="gateway",
+        purpose="reload",
+        identity=identity,
+    )
+
+
+def test_tool_executor_host_gate_allows_only_exact_reload_tool():
+    with acquire_outer_turn(reload_request()):
+        assert _host_gate_block_message("skill_view") is None
+        blocked = _host_gate_block_message("terminal")
+    assert "RELOAD_ONLY" in blocked
+    assert "generation=26" in blocked
+    assert "terminal" in blocked
+
+
+def test_registry_dispatch_is_blocked_before_argument_coercion(monkeypatch):
+    def forbidden_coercion(*args, **kwargs):
+        raise AssertionError("host gate must run before argument coercion or dispatch")
+
+    monkeypatch.setattr(model_tools, "coerce_tool_args", forbidden_coercion)
+    with acquire_outer_turn(reload_request()):
+        result = model_tools.handle_function_call(
+            "terminal",
+            {"command": "must-not-run"},
+            task_id="task-1",
+        )
+    payload = json.loads(result)
+    assert payload["error_type"] == "turn_gate_block"
+    assert "RELOAD_ONLY" in payload["error"]
+
+
+def test_direct_tool_dispatch_without_required_outer_lease_fails_closed(monkeypatch):
+    def forbidden_coercion(*args, **kwargs):
+        raise AssertionError("dispatch must not begin without an outer lease")
+
+    monkeypatch.setattr(model_tools, "coerce_tool_args", forbidden_coercion)
+    result = model_tools.handle_function_call(
+        "terminal",
+        {"command": "must-not-run"},
+        task_id="task-direct",
+    )
+    payload = json.loads(result)
+    assert payload["error_type"] == "turn_gate_block"
+    assert "outer-turn lease" in payload["error"]

--- a/tests/agent/test_tool_observation_dispatch.py
+++ b/tests/agent/test_tool_observation_dispatch.py
@@ -34,6 +34,26 @@ class _ReloadProvider:
     def release(self, decision):
         return None
 
+    def record_tool_observation(
+        self,
+        decision,
+        request,
+        tool_name,
+        tool_args,
+        tool_call_id,
+        result,
+    ):
+        if tool_name != "skill_view":
+            return
+        payload = json.loads(result)
+        if (
+            payload.get("success") is not True
+            or payload.get("name") != tool_args.get("name")
+            or not payload.get("skill_dir")
+            or tool_args.get("file_path") not in (None, "")
+        ):
+            raise ValueError("provider rejected reload observation")
+
 
 def _reload_request():
     identity = turn_gate.RuntimeIdentity(
@@ -106,6 +126,40 @@ def test_real_registry_handler_records_successful_skill_view_observation(monkeyp
             "tool_name": "skill_view",
             "tool_args": {"name": "example-skill"},
             "tool_call_id": "call-observation",
+            "result": json.dumps(payload),
+        }
+    ]
+
+
+def test_real_registry_handler_reports_policy_neutral_tool_observation(monkeypatch):
+    observed = []
+    payload = {"bytes": 17, "content": "opaque result"}
+    entry = model_tools.registry.get_entry("read_file")
+    assert entry is not None
+    monkeypatch.setattr(entry, "handler", lambda args, **kwargs: json.dumps(payload))
+    monkeypatch.setattr(
+        turn_gate,
+        "record_tool_observation",
+        lambda **kwargs: observed.append(kwargs),
+    )
+
+    result = model_tools.handle_function_call(
+        "read_file",
+        {"path": "/tmp/policy-neutral"},
+        task_id="task-observation",
+        session_id="session-observation",
+        turn_id="turn-observation",
+        tool_call_id="call-policy-neutral",
+        skip_pre_tool_call_hook=True,
+        skip_tool_request_middleware=True,
+    )
+
+    assert json.loads(result) == payload
+    assert observed == [
+        {
+            "tool_name": "read_file",
+            "tool_args": {"path": "/tmp/policy-neutral"},
+            "tool_call_id": "call-policy-neutral",
             "result": json.dumps(payload),
         }
     ]

--- a/tests/agent/test_tool_observation_dispatch.py
+++ b/tests/agent/test_tool_observation_dispatch.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import agent.turn_gate as turn_gate
+import hermes_cli.middleware as middleware
+import model_tools
+
+
+def _payload():
+    return {
+        "success": True,
+        "name": "example-skill",
+        "skill_dir": "/tmp/simulated-skill-dir",
+        "content": "loaded",
+    }
+
+
+class _ReloadProvider:
+    def acquire(self, request):
+        return turn_gate.GateDecision(
+            provider_id="test-gate",
+            state=turn_gate.GateState.RELOAD_ONLY,
+            lease_id="reload-lease",
+            generation=26,
+            allowed_tools=("skill_view",),
+        )
+
+    def validate(self, decision, checkpoint):
+        return decision
+
+    def release(self, decision):
+        return None
+
+
+def _reload_request():
+    identity = turn_gate.RuntimeIdentity(
+        machine_id="test-machine",
+        profile="default",
+        surface="conversation",
+        session_instance_id="reload-session",
+        gateway_instance_id="reload-gateway",
+        turn_id="reload-turn",
+    )
+    return turn_gate.TurnGateRequest(
+        entrypoint="conversation",
+        purpose="reload",
+        identity=identity,
+    )
+
+
+def _configure_reload_gate() -> None:
+    turn_gate.configure_turn_gate_from_config(
+        {
+            "agent": {
+                "turn_gate": {
+                    "required_provider": "test-gate",
+                    "runtime_identity": {"machine_id": "test-machine"},
+                }
+            }
+        }
+    )
+
+
+def _dispatch_skill_view(tool_call_id: str):
+    return model_tools.handle_function_call(
+        "skill_view",
+        {"name": "example-skill"},
+        task_id="task-observation",
+        session_id="reload-session",
+        turn_id="reload-turn",
+        tool_call_id=tool_call_id,
+        skip_pre_tool_call_hook=True,
+        skip_tool_request_middleware=True,
+    )
+
+
+def test_real_registry_handler_records_successful_skill_view_observation(monkeypatch):
+    observed = []
+    payload = _payload()
+    entry = model_tools.registry.get_entry("skill_view")
+    assert entry is not None
+    monkeypatch.setattr(entry, "handler", lambda args, **kwargs: json.dumps(payload))
+    monkeypatch.setattr(
+        turn_gate,
+        "record_tool_observation",
+        lambda **kwargs: observed.append(kwargs),
+    )
+
+    result = model_tools.handle_function_call(
+        "skill_view",
+        {"name": "example-skill"},
+        task_id="task-observation",
+        session_id="session-observation",
+        turn_id="turn-observation",
+        tool_call_id="call-observation",
+        skip_pre_tool_call_hook=True,
+        skip_tool_request_middleware=True,
+    )
+
+    assert json.loads(result) == payload
+    assert observed == [
+        {
+            "tool_name": "skill_view",
+            "tool_args": {"name": "example-skill"},
+            "tool_call_id": "call-observation",
+            "result": json.dumps(payload),
+        }
+    ]
+
+
+def test_empty_tool_call_id_poisons_reload_turn_after_real_handler(monkeypatch):
+    entry = model_tools.registry.get_entry("skill_view")
+    assert entry is not None
+    monkeypatch.setattr(entry, "handler", lambda args, **kwargs: json.dumps(_payload()))
+    turn_gate.clear_turn_gate_registry_for_testing()
+    turn_gate.register_turn_gate_provider(
+        "test-gate",
+        _ReloadProvider(),
+        owner_id="test-gate",
+    )
+    _configure_reload_gate()
+    try:
+        with turn_gate.acquire_outer_turn(_reload_request()):
+            result = json.loads(_dispatch_skill_view(""))
+            assert "error" in result
+            with pytest.raises(turn_gate.TurnGateBlocked, match="poisoned"):
+                turn_gate.enforce_tool_allowed("skill_view")
+    finally:
+        turn_gate.clear_turn_gate_registry_for_testing()
+
+
+def test_handler_exception_poisons_reload_turn(monkeypatch):
+    entry = model_tools.registry.get_entry("skill_view")
+    assert entry is not None
+
+    def fail_handler(args, **kwargs):
+        raise RuntimeError("handler failed")
+
+    monkeypatch.setattr(entry, "handler", fail_handler)
+    turn_gate.clear_turn_gate_registry_for_testing()
+    turn_gate.register_turn_gate_provider(
+        "test-gate",
+        _ReloadProvider(),
+        owner_id="test-gate",
+    )
+    _configure_reload_gate()
+    try:
+        with turn_gate.acquire_outer_turn(_reload_request()):
+            result = json.loads(_dispatch_skill_view("call-failed"))
+            assert "error" in result
+            with pytest.raises(turn_gate.TurnGateBlocked, match="poisoned"):
+                turn_gate.enforce_tool_allowed("skill_view")
+    finally:
+        turn_gate.clear_turn_gate_registry_for_testing()
+
+
+def test_execution_middleware_cannot_forge_skill_observation(monkeypatch):
+    observed = []
+    payload = _payload()
+    monkeypatch.setattr(
+        middleware,
+        "run_tool_execution_middleware",
+        lambda *args, **kwargs: json.dumps(payload),
+    )
+    monkeypatch.setattr(
+        turn_gate,
+        "record_tool_observation",
+        lambda **kwargs: observed.append(kwargs),
+    )
+
+    result = model_tools.handle_function_call(
+        "skill_view",
+        {"name": "example-skill"},
+        task_id="task-observation",
+        session_id="session-observation",
+        turn_id="turn-observation",
+        tool_call_id="call-observation",
+        skip_pre_tool_call_hook=True,
+        skip_tool_request_middleware=True,
+    )
+
+    assert json.loads(result) == payload
+    assert observed == []

--- a/tests/agent/test_turn_gate.py
+++ b/tests/agent/test_turn_gate.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+from typing import Any, Iterator
+
+import asyncio
+from dataclasses import replace
+
+import pytest
+
+from agent.turn_gate import (
+    GateDecision,
+    GateState,
+    RuntimeIdentity,
+    TurnGateBlocked,
+    TurnGateRequest,
+    acquire_outer_turn,
+    build_runtime_identity,
+    clear_turn_gate_registry_for_testing,
+    configure_turn_gate_from_config,
+    create_detached_task,
+    current_turn_gate_decision,
+    enforce_output_allowed,
+    enforce_tool_allowed,
+    inject_turn_gate_child_environment,
+    register_turn_gate_provider,
+)
+
+
+class FakeProvider:
+    def __init__(self, decision: GateDecision) -> None:
+        self.decision = decision
+        self.acquire_calls = 0
+        self.validate_calls: list[str] = []
+        self.release_calls = 0
+
+    def acquire(self, request: TurnGateRequest) -> GateDecision:
+        self.acquire_calls += 1
+        return self.decision
+
+    def validate(self, decision: GateDecision, checkpoint: str) -> GateDecision:
+        self.validate_calls.append(checkpoint)
+        return self.decision
+
+    def release(self, decision: GateDecision) -> None:
+        self.release_calls += 1
+
+
+@pytest.mark.parametrize("method_name", ["acquire", "validate", "release"])
+def test_async_provider_methods_are_rejected_at_registration(method_name: str) -> None:
+    class AsyncProvider(FakeProvider):
+        pass
+
+    async def async_method(*args, **kwargs):
+        return None
+
+    setattr(AsyncProvider, method_name, async_method)
+    provider = AsyncProvider(_decision())
+
+    with pytest.raises(ValueError, match="synchronous"):
+        register_turn_gate_provider(
+            "example-gate",
+            provider,
+            owner_id="example-gate",
+        )
+
+
+def _coroutine_returning(value: object) -> Any:
+    async def work():
+        return value
+
+    return work()
+
+
+def test_sync_wrapper_returning_async_acquire_fails_closed() -> None:
+    class Provider(FakeProvider):
+        def acquire(self, request: TurnGateRequest) -> Any:
+            return _coroutine_returning(self.decision)
+
+    _configure()
+    _register(Provider(_decision()))
+    with pytest.raises(TurnGateBlocked, match="async work during acquire"):
+        with acquire_outer_turn(_request()):
+            pass
+
+
+def test_sync_wrapper_returning_async_validate_fails_closed() -> None:
+    class Provider(FakeProvider):
+        def validate(self, decision: GateDecision, checkpoint: str) -> Any:
+            return _coroutine_returning(self.decision)
+
+    _configure()
+    _register(Provider(_decision()))
+    with acquire_outer_turn(_request()):
+        with pytest.raises(TurnGateBlocked, match="async work during validate"):
+            enforce_tool_allowed("terminal")
+
+
+def test_sync_wrapper_returning_async_release_fails_closed() -> None:
+    class Provider(FakeProvider):
+        def release(self, decision: GateDecision) -> Any:
+            return _coroutine_returning(None)
+
+    _configure()
+    _register(Provider(_decision()))
+    with pytest.raises(TurnGateBlocked, match="failed during release"):
+        with acquire_outer_turn(_request()):
+            pass
+
+
+@pytest.fixture(autouse=True)
+def _clear_gate() -> Iterator[None]:
+    clear_turn_gate_registry_for_testing()
+    yield
+    clear_turn_gate_registry_for_testing()
+
+
+def _identity() -> RuntimeIdentity:
+    return RuntimeIdentity(
+        machine_id="machine-1",
+        profile="default",
+        surface="test",
+        session_instance_id="session-instance-1",
+        gateway_instance_id="gateway-instance-1",
+        turn_id="turn-1",
+    )
+
+
+def _request(*, purpose: str = "business") -> TurnGateRequest:
+    return TurnGateRequest(
+        entrypoint="test",
+        purpose=purpose,
+        task_id="task-1",
+        identity=_identity(),
+    )
+
+
+def _decision(
+    *,
+    state: GateState = GateState.OPEN,
+    generation: int = 7,
+    allowed_tools: tuple[str, ...] = (),
+    child_environment: tuple[tuple[str, str], ...] = (),
+) -> GateDecision:
+    return GateDecision(
+        provider_id="example-gate",
+        state=state,
+        lease_id="lease-1",
+        generation=generation,
+        allowed_tools=allowed_tools,
+        child_environment=child_environment,
+    )
+
+
+def _configure(*, allowed_child_environment: list[str] | None = None) -> None:
+    gate: dict[str, object] = {
+        "required_provider": "example-gate",
+        "runtime_identity": {"machine_id": "machine-1"},
+    }
+    if allowed_child_environment is not None:
+        gate["allowed_child_environment"] = allowed_child_environment
+    configure_turn_gate_from_config({"agent": {"turn_gate": gate}})
+
+
+def _register(provider: FakeProvider) -> None:
+    register_turn_gate_provider(
+        "example-gate",
+        provider,
+        owner_id="example-gate",
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("provider_id", 1),
+        ("lease_id", object()),
+        ("state", "OPEN"),
+        ("generation", True),
+        ("generation", 1.5),
+        ("allowed_tools", ["skill_view"]),
+        ("allowed_tools", ("skill_view", "skill_view")),
+        ("child_environment", [("LEASE_ID", "lease-1")]),
+        ("child_environment", (("BAD-NAME", "value"),)),
+        ("child_environment", (("LEASE_ID", "value\x00tail"),)),
+    ],
+)
+def test_gate_decision_rejects_truthy_wrong_types(field: str, value: object) -> None:
+    kwargs: dict[str, Any] = {
+        "provider_id": "example-gate",
+        "state": GateState.OPEN,
+        "lease_id": "lease-1",
+        "generation": 1,
+        "allowed_tools": (),
+        "child_environment": (),
+    }
+    kwargs[field] = value
+    with pytest.raises(ValueError):
+        GateDecision(**kwargs)
+
+
+def test_required_provider_missing_fails_closed_before_body() -> None:
+    _configure()
+    body_ran = False
+
+    with pytest.raises(TurnGateBlocked, match="not registered"):
+        with acquire_outer_turn(_request()):
+            body_ran = True
+
+    assert body_ran is False
+
+
+def test_outer_turn_reuses_one_lease_and_releases_once() -> None:
+    _configure()
+    provider = FakeProvider(_decision())
+    _register(provider)
+
+    with acquire_outer_turn(_request()) as outer:
+        with acquire_outer_turn(_request()) as nested:
+            assert nested is outer
+            enforce_tool_allowed("terminal")
+            enforce_output_allowed()
+
+    assert provider.acquire_calls == 1
+    assert provider.release_calls == 1
+    assert provider.validate_calls == ["tool:terminal", "output"]
+
+
+def test_reload_only_uses_exact_tool_allowlist_and_blocks_output() -> None:
+    _configure()
+    provider = FakeProvider(
+        _decision(state=GateState.RELOAD_ONLY, allowed_tools=("skill_view",))
+    )
+    _register(provider)
+
+    with acquire_outer_turn(_request(purpose="reload")):
+        enforce_tool_allowed("skill_view")
+        with pytest.raises(TurnGateBlocked, match="RELOAD_ONLY"):
+            enforce_tool_allowed("read_file")
+        with pytest.raises(TurnGateBlocked, match="poisoned"):
+            enforce_output_allowed()
+
+
+def test_checkpoint_drift_poison_survives_provider_recovery() -> None:
+    _configure()
+    provider = FakeProvider(_decision())
+    _register(provider)
+
+    with acquire_outer_turn(_request()):
+        provider.decision = replace(provider.decision, generation=8)
+        with pytest.raises(TurnGateBlocked, match="generation changed"):
+            enforce_tool_allowed("terminal")
+        provider.decision = replace(provider.decision, generation=7)
+        with pytest.raises(TurnGateBlocked, match="poisoned"):
+            enforce_output_allowed()
+
+
+def test_direct_tool_and_output_without_required_outer_lease_fail_closed() -> None:
+    _configure()
+    _register(FakeProvider(_decision()))
+
+    with pytest.raises(TurnGateBlocked, match="active outer-turn lease"):
+        enforce_tool_allowed("terminal")
+    with pytest.raises(TurnGateBlocked, match="active outer-turn lease"):
+        enforce_output_allowed()
+
+
+def test_child_environment_is_provider_owned_allowlisted_and_spoof_resistant() -> None:
+    _configure(allowed_child_environment=["LEASE_ID", "EIP_ID"])
+    provider = FakeProvider(
+        _decision(child_environment=(("LEASE_ID", "lease-value"),))
+    )
+    _register(provider)
+    base = {"LEASE_ID": "spoofed", "EIP_ID": "spoofed", "PATH": "/usr/bin"}
+
+    with acquire_outer_turn(_request()):
+        child = inject_turn_gate_child_environment(base)
+
+    assert child == {"LEASE_ID": "lease-value", "PATH": "/usr/bin"}
+    assert base["LEASE_ID"] == "spoofed"
+    assert provider.validate_calls == ["child-environment"]
+
+
+def test_provider_environment_outside_host_allowlist_fails_closed() -> None:
+    _configure(allowed_child_environment=["LEASE_ID"])
+    provider = FakeProvider(_decision(child_environment=(("EIP_ID", "eip-1"),)))
+    _register(provider)
+
+    with acquire_outer_turn(_request()):
+        with pytest.raises(TurnGateBlocked, match="allowlist"):
+            inject_turn_gate_child_environment({})
+
+
+def test_child_environment_preserves_legacy_values_but_rejects_non_text_keys() -> None:
+    _configure(allowed_child_environment=["LEASE_ID"])
+    sentinel = object()
+
+    legacy_base: Any = {"LEASE_ID": "spoofed", "LEGACY_VALUE": sentinel}
+    child = inject_turn_gate_child_environment(legacy_base)
+
+    assert "LEASE_ID" not in child
+    assert child["LEGACY_VALUE"] is sentinel
+    with pytest.raises(ValueError, match="text names"):
+        inject_turn_gate_child_environment({1: "invalid"})  # type: ignore[dict-item]
+
+
+@pytest.mark.asyncio
+async def test_detached_task_does_not_inherit_outer_turn_context() -> None:
+    _configure()
+    provider = FakeProvider(_decision())
+    _register(provider)
+
+    async def probe() -> GateDecision | None:
+        await asyncio.sleep(0)
+        return current_turn_gate_decision()
+
+    with acquire_outer_turn(_request()):
+        result = await create_detached_task(probe())
+
+    assert result is None
+
+
+def test_malformed_config_latches_fail_closed_until_valid_reload() -> None:
+    with pytest.raises(TurnGateBlocked, match="required_provider"):
+        configure_turn_gate_from_config(
+            {"agent": {"turn_gate": {"required_provider": True}}}
+        )
+
+    with pytest.raises(TurnGateBlocked, match="configuration"):
+        enforce_output_allowed()
+
+    _configure()
+    provider = FakeProvider(_decision())
+    _register(provider)
+    with acquire_outer_turn(_request()):
+        enforce_output_allowed()
+
+
+def test_provider_identity_must_match_plugin_manifest_owner() -> None:
+    with pytest.raises(ValueError, match="manifest owner"):
+        register_turn_gate_provider(
+            "example-gate",
+            FakeProvider(_decision()),
+            owner_id="different-plugin",
+        )
+
+
+def test_host_identity_builder_uses_configured_machine_and_opaque_session() -> None:
+    _configure()
+
+    first = build_runtime_identity(
+        surface="gateway",
+        session_scope="raw-chat:123",
+        turn_id="turn-a",
+    )
+    second = build_runtime_identity(
+        surface="gateway",
+        session_scope="raw-chat:123",
+        turn_id="turn-b",
+    )
+
+    assert first is not None and second is not None
+    assert first.machine_id == "machine-1"
+    assert first.profile == "default"
+    assert first.session_instance_id == second.session_instance_id
+    assert first.session_instance_id != "raw-chat:123"
+    assert first.gateway_instance_id == second.gateway_instance_id
+    assert first.turn_id == "turn-a"
+    assert second.turn_id == "turn-b"

--- a/tests/agent/test_turn_gate.py
+++ b/tests/agent/test_turn_gate.py
@@ -22,6 +22,7 @@ from agent.turn_gate import (
     enforce_output_allowed,
     enforce_tool_allowed,
     inject_turn_gate_child_environment,
+    record_tool_observation,
     register_turn_gate_provider,
 )
 
@@ -223,6 +224,48 @@ def test_outer_turn_reuses_one_lease_and_releases_once() -> None:
     assert provider.acquire_calls == 1
     assert provider.release_calls == 1
     assert provider.validate_calls == ["tool:terminal", "output"]
+
+
+def test_tool_observation_is_policy_neutral_and_forwarded_to_provider() -> None:
+    class ObservingProvider(FakeProvider):
+        def __init__(self, decision: GateDecision) -> None:
+            super().__init__(decision)
+            self.observations: list[tuple[object, ...]] = []
+
+        def record_tool_observation(
+            self,
+            decision,
+            request,
+            tool_name,
+            tool_args,
+            tool_call_id,
+            result,
+        ) -> None:
+            self.observations.append(
+                (decision, request, tool_name, tool_args, tool_call_id, result)
+            )
+
+    _configure()
+    provider = ObservingProvider(_decision())
+    _register(provider)
+    opaque_result = object()
+
+    with acquire_outer_turn(_request()):
+        record_tool_observation(
+            tool_name="provider-owned-tool",
+            tool_args={"provider_owned": True},
+            tool_call_id="provider-owned-call",
+            result=opaque_result,
+        )
+
+    assert len(provider.observations) == 1
+    observation = provider.observations[0]
+    assert observation[2:] == (
+        "provider-owned-tool",
+        {"provider_owned": True},
+        "provider-owned-call",
+        opaque_result,
+    )
 
 
 def test_reload_only_uses_exact_tool_allowlist_and_blocks_output() -> None:

--- a/tests/gateway/test_reload_turn_gate.py
+++ b/tests/gateway/test_reload_turn_gate.py
@@ -1,0 +1,511 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent.turn_gate import (
+    GateDecision,
+    GateState,
+    TurnGateBlocked,
+    TurnGateRequest,
+    acquire_outer_turn,
+    build_runtime_identity,
+    clear_turn_gate_registry_for_testing,
+    configure_turn_gate_from_config,
+    current_turn_gate_request,
+    register_turn_gate_provider as _register_turn_gate_provider,
+)
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.run import GatewayRunner
+
+
+def _configure_gate(provider_id: str) -> None:
+    configure_turn_gate_from_config(
+        {
+            "agent": {
+                "turn_gate": {
+                    "required_provider": provider_id,
+                    "runtime_identity": {"machine_id": "test-machine"},
+                }
+            }
+        }
+    )
+
+
+def register_turn_gate_provider(provider_id: str, provider) -> None:
+    _register_turn_gate_provider(
+        provider_id,
+        provider,
+        owner_id=provider_id,
+    )
+
+
+class DirectSendAdapter(BasePlatformAdapter):
+    platform_name = "test-direct"
+
+    def __init__(self):
+        self.network_calls = 0
+        self.follow_up_calls = 0
+        self.named_output_calls = 0
+        self.sync_output_calls = 0
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: str | None = None,
+        metadata: dict | None = None,
+    ) -> SendResult:
+        self.network_calls += 1
+        return SendResult(success=True)
+
+    async def send_follow_up(self, chat_id: str, content: str) -> SendResult:
+        self.follow_up_calls += 1
+        return SendResult(success=True)
+
+    async def set_typing(self, chat_id: str) -> None:
+        self.named_output_calls += 1
+
+    async def mark_message_read(self, chat_id: str) -> None:
+        self.named_output_calls += 1
+
+    async def set_reaction(self, chat_id: str) -> None:
+        self.named_output_calls += 1
+
+    def send_sync_notice(self, chat_id: str) -> SendResult:
+        self.sync_output_calls += 1
+        return SendResult(success=True)
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+
+class RecordingProvider:
+    def __init__(self, events):
+        self.events = events
+        self.requests = []
+        self.validation_decision: GateDecision | None = None
+        self.validation_error: Exception | None = None
+
+    def acquire(self, request):
+        self.requests.append(request)
+        self.events.append(("acquire", request.entrypoint, request.task_id))
+        return GateDecision(
+            provider_id="test-gate",
+            state=GateState.OPEN,
+            lease_id=f"lease-{request.entrypoint}",
+            generation=26,
+        )
+
+    def validate(self, decision, checkpoint):
+        if self.validation_error is not None:
+            raise self.validation_error
+        return self.validation_decision or decision
+
+    def release(self, decision):
+        self.events.append(("release", decision.lease_id))
+
+
+@pytest.fixture(autouse=True)
+def reset_gate():
+    clear_turn_gate_registry_for_testing()
+    yield
+    clear_turn_gate_registry_for_testing()
+
+
+@pytest.mark.asyncio
+async def test_gateway_main_turn_acquires_before_any_inner_processing(monkeypatch):
+    events = []
+    register_turn_gate_provider("test-gate", RecordingProvider(events))
+    _configure_gate("test-gate")
+
+    async def fake_inner(self, *args, **kwargs):
+        request = current_turn_gate_request()
+        events.append(("body", request.entrypoint, request.task_id))
+        return {"final_response": "ok"}
+
+    monkeypatch.setattr(GatewayRunner, "_run_agent_inner_unleased", fake_inner)
+    runner = object.__new__(GatewayRunner)
+    result = await runner._run_agent_inner(
+        "hello",
+        "context",
+        [],
+        SimpleNamespace(platform="feishu"),
+        "session-1",
+        session_key="raw-key-not-persisted",
+    )
+    assert result == {"final_response": "ok"}
+    assert events == [
+        ("acquire", "gateway", "session-1"),
+        ("body", "gateway", "session-1"),
+        ("release", "lease-gateway"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gateway_background_turn_uses_same_outer_gate(monkeypatch):
+    events = []
+    register_turn_gate_provider("test-gate", RecordingProvider(events))
+    _configure_gate("test-gate")
+
+    async def fake_background(self, *args, **kwargs):
+        request = current_turn_gate_request()
+        events.append(("body", request.entrypoint, request.task_id))
+        return None
+
+    monkeypatch.setattr(GatewayRunner, "_run_background_task_unleased", fake_background)
+    runner = object.__new__(GatewayRunner)
+    await runner._run_background_task(
+        "summarize",
+        SimpleNamespace(platform="feishu"),
+        "bg-1",
+    )
+    assert events == [
+        ("acquire", "gateway-background", "bg-1"),
+        ("body", "gateway-background", "bg-1"),
+        ("release", "lease-gateway-background"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gateway_required_provider_missing_blocks_before_body(monkeypatch):
+    _configure_gate("missing-gate")
+    called = False
+
+    async def fake_inner(self, *args, **kwargs):
+        nonlocal called
+        called = True
+        return {}
+
+    monkeypatch.setattr(GatewayRunner, "_run_agent_inner_unleased", fake_inner)
+    runner = object.__new__(GatewayRunner)
+    with pytest.raises(TurnGateBlocked, match="required provider"):
+        await runner._run_agent_inner(
+            "hello",
+            "context",
+            [],
+            SimpleNamespace(platform="feishu"),
+            "session-1",
+        )
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_adapter_holds_lease_through_final_delivery():
+    events = []
+    provider = RecordingProvider(events)
+    register_turn_gate_provider("test-gate", provider)
+    _configure_gate("test-gate")
+
+    async def fake_unleased(event, session_key):
+        request = current_turn_gate_request()
+        events.append(("handler", request.entrypoint))
+        events.append(("send", request.entrypoint))
+
+    adapter = SimpleNamespace(
+        _process_message_background_unleased=fake_unleased,
+    )
+    await BasePlatformAdapter._process_message_background(
+        adapter,
+        SimpleNamespace(),
+        "raw-session-key",
+    )
+    assert events[0][0:2] == ("acquire", "gateway-delivery")
+    assert len(events[0][2]) == 36 and events[0][2].count("-") == 4
+    assert "raw-session-key" not in events[0][2]
+    assert events[1:] == [
+        ("handler", "gateway-delivery"),
+        ("send", "gateway-delivery"),
+        ("release", "lease-gateway-delivery"),
+    ]
+    request = provider.requests[0]
+    assert request.identity is not None
+    assert request.identity.session_instance_id != "raw-session-key"
+    assert request.identity.turn_id.startswith(f"{request.task_id}:")
+
+
+@pytest.mark.asyncio
+async def test_direct_adapter_output_without_outer_lease_fails_closed():
+    events = []
+    register_turn_gate_provider("test-gate", RecordingProvider(events))
+    _configure_gate("test-gate")
+    adapter = DirectSendAdapter()
+
+    with pytest.raises(TurnGateBlocked, match="outer-turn lease"):
+        await adapter.send("chat", "must not leak")
+
+    assert adapter.network_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_typing_read_and_reaction_outputs_without_lease_fail_closed():
+    register_turn_gate_provider("test-gate", RecordingProvider([]))
+    _configure_gate("test-gate")
+    adapter = DirectSendAdapter()
+
+    for method in (
+        adapter.set_typing,
+        adapter.mark_message_read,
+        adapter.set_reaction,
+    ):
+        with pytest.raises(TurnGateBlocked, match="outer-turn lease"):
+            await method("chat")
+    with pytest.raises(TurnGateBlocked, match="outer-turn lease"):
+        adapter.send_sync_notice("chat")
+
+    assert adapter.named_output_calls == 0
+    assert adapter.sync_output_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_future_send_named_method_is_automatically_host_gated():
+    events = []
+    provider = RecordingProvider(events)
+    register_turn_gate_provider("test-gate", provider)
+    _configure_gate("test-gate")
+    adapter = DirectSendAdapter()
+    identity = build_runtime_identity(
+        surface="gateway-delivery",
+        session_scope="follow-up-session",
+        turn_id="follow-up-turn",
+    )
+    assert identity is not None
+
+    with acquire_outer_turn(
+        TurnGateRequest(
+            entrypoint="gateway-delivery",
+            purpose="business",
+            identity=identity,
+        )
+    ):
+        provider.validation_decision = GateDecision(
+            provider_id="test-gate",
+            state=GateState.OPEN,
+            lease_id="lease-gateway-delivery",
+            generation=27,
+        )
+        with pytest.raises(TurnGateBlocked, match="generation changed"):
+            await adapter.send_follow_up("chat", "must not leak")
+
+    assert adapter.follow_up_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_direct_adapter_send_is_host_gated_before_network_call():
+    events = []
+    provider = RecordingProvider(events)
+    register_turn_gate_provider("test-gate", provider)
+    _configure_gate("test-gate")
+    adapter = DirectSendAdapter()
+    identity = build_runtime_identity(
+        surface="gateway-delivery",
+        session_scope="direct-session",
+        turn_id="direct-turn",
+    )
+    assert identity is not None
+
+    with acquire_outer_turn(
+        TurnGateRequest(
+            entrypoint="gateway-delivery",
+            purpose="business",
+            identity=identity,
+        )
+    ):
+        provider.validation_decision = GateDecision(
+            provider_id="test-gate",
+            state=GateState.OPEN,
+            lease_id="lease-gateway-delivery",
+            generation=27,
+        )
+        with pytest.raises(TurnGateBlocked, match="generation changed"):
+            await adapter.send("chat", "must not leak")
+
+    assert adapter.network_calls == 0
+
+
+class SideEffectAdapter(BasePlatformAdapter):
+    """Adapter overriding real platform side-effect entrypoints that are NOT
+    covered by the ``send``/``edit``/``delete`` prefix set: thread handoff,
+    thread/topic rename, and redaction. Each records a real underlying-effect
+    counter so the host gate can be proven to run (or fail to run) before them.
+    """
+
+    platform_name = "test-side-effect"
+
+    def __init__(self):
+        self.handoff_calls = 0
+        self.create_room_calls = 0
+        self.invite_user_calls = 0
+        self.rename_thread_calls = 0
+        self.rename_dm_topic_calls = 0
+        self.read_receipt_calls = 0
+        self.redact_calls = 0
+        self.presence_calls = 0
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: str | None = None,
+        metadata: dict | None = None,
+    ) -> SendResult:
+        return SendResult(success=True)
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+    async def create_handoff_thread(self, parent_chat_id: str, name: str):
+        self.handoff_calls += 1
+        return "thread-1"
+
+    async def create_room(self, name: str = ""):
+        self.create_room_calls += 1
+        return "room-1"
+
+    async def invite_user(self, room_id: str, user_id: str) -> bool:
+        self.invite_user_calls += 1
+        return True
+
+    async def rename_thread(self, chat_id: str, thread_id: str, name: str) -> bool:
+        self.rename_thread_calls += 1
+        return True
+
+    async def rename_dm_topic(self, chat_id: str, topic_id: str, name: str) -> bool:
+        self.rename_dm_topic_calls += 1
+        return True
+
+    async def send_read_receipt(self, chat_id: str, message_id: str) -> bool:
+        self.read_receipt_calls += 1
+        return True
+
+    async def redact_message(self, chat_id: str, message_id: str) -> bool:
+        self.redact_calls += 1
+        return True
+
+    async def set_presence(self, state: str = "online") -> bool:
+        self.presence_calls += 1
+        return True
+
+
+@pytest.mark.asyncio
+async def test_create_handoff_thread_without_outer_lease_has_no_side_effect():
+    register_turn_gate_provider("test-gate", RecordingProvider([]))
+    _configure_gate("test-gate")
+    adapter = SideEffectAdapter()
+
+    # A required provider with no active outer lease MUST fail closed before
+    # the platform side effect — the new thread must never be created.
+    with pytest.raises(TurnGateBlocked, match="outer-turn lease"):
+        await adapter.create_handoff_thread("parent-chat", "handoff")
+
+    assert adapter.handoff_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_generation_change_blocks_create_rename_and_redact_side_effects():
+    provider = RecordingProvider([])
+    register_turn_gate_provider("test-gate", provider)
+    _configure_gate("test-gate")
+    adapter = SideEffectAdapter()
+    identity = build_runtime_identity(
+        surface="gateway-delivery",
+        session_scope="handoff-session",
+        turn_id="handoff-turn",
+    )
+    assert identity is not None
+
+    with acquire_outer_turn(
+        TurnGateRequest(
+            entrypoint="gateway-delivery",
+            purpose="business",
+            identity=identity,
+        )
+    ):
+        # The generation moves under the running turn; every representative
+        # create/rename/redact entrypoint must revalidate and fail closed.
+        provider.validation_decision = GateDecision(
+            provider_id="test-gate",
+            state=GateState.OPEN,
+            lease_id="lease-gateway-delivery",
+            generation=27,
+        )
+        with pytest.raises(TurnGateBlocked, match="generation changed"):
+            await adapter.create_handoff_thread("parent-chat", "handoff")
+        with pytest.raises(TurnGateBlocked):
+            await adapter.create_room("room")
+        with pytest.raises(TurnGateBlocked):
+            await adapter.invite_user("room-1", "user-1")
+        with pytest.raises(TurnGateBlocked):
+            await adapter.rename_thread("chat", "thread-1", "renamed")
+        with pytest.raises(TurnGateBlocked):
+            await adapter.rename_dm_topic("chat", "topic-1", "renamed")
+        with pytest.raises(TurnGateBlocked):
+            await adapter.send_read_receipt("chat", "m-1")
+        with pytest.raises(TurnGateBlocked):
+            await adapter.redact_message("chat", "m-1")
+        with pytest.raises(TurnGateBlocked):
+            await adapter.set_presence("online")
+
+    assert adapter.handoff_calls == 0
+    assert adapter.create_room_calls == 0
+    assert adapter.invite_user_calls == 0
+    assert adapter.rename_thread_calls == 0
+    assert adapter.rename_dm_topic_calls == 0
+    assert adapter.read_receipt_calls == 0
+    assert adapter.redact_calls == 0
+    assert adapter.presence_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_platform_send_revalidates_generation_before_network_call():
+    events = []
+    provider = RecordingProvider(events)
+    register_turn_gate_provider("test-gate", provider)
+    _configure_gate("test-gate")
+    send_calls = 0
+
+    async def send(**kwargs):
+        nonlocal send_calls
+        send_calls += 1
+        return SimpleNamespace(success=True)
+
+    adapter = SimpleNamespace(send=send)
+    identity = build_runtime_identity(
+        surface="gateway-delivery",
+        session_scope="delivery-session",
+        turn_id="delivery-turn",
+    )
+    assert identity is not None
+    with acquire_outer_turn(
+        TurnGateRequest(
+            entrypoint="gateway-delivery",
+            purpose="business",
+            identity=identity,
+        )
+    ):
+        provider.validation_decision = GateDecision(
+            provider_id="test-gate",
+            state=GateState.OPEN,
+            lease_id="lease-gateway-delivery",
+            generation=27,
+        )
+        with pytest.raises(TurnGateBlocked, match="generation changed"):
+            await BasePlatformAdapter._send_with_retry(
+                adapter,
+                chat_id="chat",
+                content="must not leak",
+            )
+    assert send_calls == 0

--- a/tests/hermes_cli/test_turn_gate_plugin.py
+++ b/tests/hermes_cli/test_turn_gate_plugin.py
@@ -78,18 +78,36 @@ def test_plugin_context_registers_provider_under_its_own_manifest_id():
     manager = PluginManager()
     manifest = PluginManifest(name="secure-gate", key="secure-gate", source="user")
     context = PluginContext(manifest, manager)
-    context.register_turn_gate_provider(PluginGateProvider("secure-gate"))
+    context.register_turn_gate_provider(
+        PluginGateProvider("secure-gate"), api_version=1
+    )
     _configure_gate("secure-gate")
 
     with acquire_outer_turn(gate_request()) as lease:
         assert lease.provider_id == "secure-gate"
 
 
+def test_plugin_provider_must_declare_exact_turn_gate_api_version():
+    manager = PluginManager()
+    manifest = PluginManifest(name="secure-gate", key="secure-gate", source="user")
+    context = PluginContext(manifest, manager)
+
+    with pytest.raises(ValueError, match="API version"):
+        context.register_turn_gate_provider(PluginGateProvider("secure-gate"))
+    with pytest.raises(ValueError, match="API version"):
+        context.register_turn_gate_provider(
+            PluginGateProvider("secure-gate"),
+            api_version=2,
+        )
+
+
 def test_plugin_provider_identity_mismatch_fails_closed():
     manager = PluginManager()
     manifest = PluginManifest(name="secure-gate", key="secure-gate", source="user")
     context = PluginContext(manifest, manager)
-    context.register_turn_gate_provider(PluginGateProvider("impersonated-gate"))
+    context.register_turn_gate_provider(
+        PluginGateProvider("impersonated-gate"), api_version=1
+    )
     _configure_gate("secure-gate")
 
     with pytest.raises(TurnGateBlocked, match="identity mismatch"):
@@ -101,7 +119,9 @@ def test_force_reload_unregisters_stale_provider_even_in_safe_mode(monkeypatch):
     manager = PluginManager()
     manifest = PluginManifest(name="secure-gate", key="secure-gate", source="user")
     context = PluginContext(manifest, manager)
-    context.register_turn_gate_provider(PluginGateProvider("secure-gate"))
+    context.register_turn_gate_provider(
+        PluginGateProvider("secure-gate"), api_version=1
+    )
     _configure_gate("secure-gate")
     manager._discovered = True
     monkeypatch.setenv("HERMES_SAFE_MODE", "1")
@@ -126,7 +146,7 @@ def test_failed_plugin_load_rolls_back_registered_gate_provider(tmp_path):
         "    def release(self, decision):\n"
         "        return None\n\n"
         "def register(ctx):\n"
-        "    ctx.register_turn_gate_provider(Provider())\n"
+        "    ctx.register_turn_gate_provider(Provider(), api_version=1)\n"
         "    raise RuntimeError('replacement failed after registration')\n",
         encoding="utf-8",
     )
@@ -152,7 +172,7 @@ def test_failed_same_id_replacement_restores_previous_gate_provider(tmp_path):
     manager = PluginManager()
     manifest = PluginManifest(name="secure-gate", key="secure-gate", source="user")
     PluginContext(manifest, manager).register_turn_gate_provider(
-        PluginGateProvider("secure-gate")
+        PluginGateProvider("secure-gate"), api_version=1
     )
 
     plugin_dir = tmp_path / "replacement-gate"
@@ -165,7 +185,7 @@ def test_failed_same_id_replacement_restores_previous_gate_provider(tmp_path):
         "    def validate(self, decision, checkpoint): return decision\n"
         "    def release(self, decision): return None\n\n"
         "def register(ctx):\n"
-        "    ctx.register_turn_gate_provider(Replacement())\n"
+        "    ctx.register_turn_gate_provider(Replacement(), api_version=1)\n"
         "    raise RuntimeError('same-id replacement failed')\n",
         encoding="utf-8",
     )
@@ -204,7 +224,9 @@ def test_force_full_round_failure_restores_previous_gate_provider_and_state(
     manager = PluginManager()
     manifest = PluginManifest(name="secure-gate", key="secure-gate", source="user")
     old_provider = PluginGateProvider("secure-gate")
-    PluginContext(manifest, manager).register_turn_gate_provider(old_provider)
+    PluginContext(manifest, manager).register_turn_gate_provider(
+        old_provider, api_version=1
+    )
 
     # Other pre-existing manager state that force-reload wipes before the round.
     sentinel_plugin = object()
@@ -227,7 +249,7 @@ def test_force_full_round_failure_restores_previous_gate_provider_and_state(
             "    def validate(self, decision, checkpoint): return decision\n"
             "    def release(self, decision): return None\n\n"
             "def register(ctx):\n"
-            "    ctx.register_turn_gate_provider(Replacement())\n"
+            "    ctx.register_turn_gate_provider(Replacement(), api_version=1)\n"
             "    raise RuntimeError('same-id replacement failed mid-round')\n"
         )
     (plugin_dir / "__init__.py").write_text(module_source, encoding="utf-8")
@@ -276,7 +298,9 @@ def test_force_round_rolls_back_unrelated_plugin_failure_after_gate_replacement(
     manager = PluginManager()
     manifest = PluginManifest(name="secure-gate", key="secure-gate", source="user")
     old_provider = PluginGateProvider("secure-gate")
-    PluginContext(manifest, manager).register_turn_gate_provider(old_provider)
+    PluginContext(manifest, manager).register_turn_gate_provider(
+        old_provider, api_version=1
+    )
 
     sentinel_plugin = object()
     sentinel_hook = lambda **_: None
@@ -296,7 +320,7 @@ def test_force_round_rolls_back_unrelated_plugin_failure_after_gate_replacement(
         "    def validate(self, decision, checkpoint): return decision\n"
         "    def release(self, decision): return None\n\n"
         "def register(ctx):\n"
-        "    ctx.register_turn_gate_provider(Replacement())\n",
+        "    ctx.register_turn_gate_provider(Replacement(), api_version=1)\n",
         encoding="utf-8",
     )
     replacement_manifest = PluginManifest(
@@ -423,7 +447,7 @@ def test_temp_hermes_home_discovers_required_gate_end_to_end(tmp_path, monkeypat
         "    def release(self, decision):\n"
         "        return None\n\n"
         "def register(ctx):\n"
-        "    ctx.register_turn_gate_provider(Provider())\n",
+        "    ctx.register_turn_gate_provider(Provider(), api_version=1)\n",
         encoding="utf-8",
     )
     (home / "config.yaml").write_text(
@@ -447,3 +471,56 @@ def test_temp_hermes_home_discovers_required_gate_end_to_end(tmp_path, monkeypat
     with acquire_outer_turn(gate_request()) as lease:
         assert lease.provider_id == "secure-gate"
         assert lease.lease_id == "e2e"
+
+
+def test_force_reload_refreshes_plugin_relative_submodules(tmp_path, monkeypatch):
+    import importlib
+    import shutil
+
+    monkeypatch.delenv("HERMES_SAFE_MODE", raising=False)
+    plugin_dir = tmp_path / "submodule-gate"
+    plugin_dir.mkdir()
+    (plugin_dir / "__init__.py").write_text(
+        "from .provider import Provider\n\n"
+        "def register(ctx):\n"
+        "    ctx.register_turn_gate_provider(Provider(), api_version=1)\n",
+        encoding="utf-8",
+    )
+    provider_file = plugin_dir / "provider.py"
+
+    def write_provider(generation: int) -> None:
+        provider_file.write_text(
+            "from agent.turn_gate import GateDecision, GateState\n\n"
+            "class Provider:\n"
+            "    def acquire(self, request):\n"
+            f"        return GateDecision(provider_id='submodule-gate', state=GateState.OPEN, lease_id='submodule', generation={generation})\n"
+            "    def validate(self, decision, checkpoint): return self.acquire(None)\n"
+            "    def release(self, decision): return None\n",
+            encoding="utf-8",
+        )
+        shutil.rmtree(plugin_dir / "__pycache__", ignore_errors=True)
+        importlib.invalidate_caches()
+
+    write_provider(1)
+    manifest = PluginManifest(
+        name="submodule-gate",
+        key="submodule-gate",
+        source="user",
+        path=str(plugin_dir),
+    )
+    manager = PluginManager()
+    manager._load_plugin(manifest)
+    _configure_gate("submodule-gate")
+    with acquire_outer_turn(gate_request()) as lease:
+        assert lease.generation == 1
+
+    write_provider(2)
+    monkeypatch.setattr(
+        manager,
+        "_discover_and_load_inner",
+        lambda: manager._load_plugin(manifest),
+    )
+    manager.discover_and_load(force=True)
+    _configure_gate("submodule-gate")
+    with acquire_outer_turn(gate_request()) as lease:
+        assert lease.generation == 2

--- a/tests/hermes_cli/test_turn_gate_plugin.py
+++ b/tests/hermes_cli/test_turn_gate_plugin.py
@@ -1,0 +1,449 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+import yaml
+
+from agent.turn_gate import (
+    GateDecision,
+    GateState,
+    RuntimeIdentity,
+    TurnGateBlocked,
+    TurnGateRequest,
+    acquire_outer_turn,
+    clear_turn_gate_registry_for_testing,
+    configure_turn_gate_from_config,
+    snapshot_turn_gate_providers,
+)
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+
+def _configure_gate(provider_id: str) -> None:
+    configure_turn_gate_from_config(
+        {
+            "agent": {
+                "turn_gate": {
+                    "required_provider": provider_id,
+                    "runtime_identity": {"machine_id": "test-machine"},
+                }
+            }
+        }
+    )
+
+
+class PluginGateProvider:
+    def __init__(self, provider_id: str):
+        self.provider_id = provider_id
+
+    def acquire(self, request):
+        return GateDecision(
+            provider_id=self.provider_id,
+            state=GateState.OPEN,
+            lease_id="lease-plugin",
+            generation=26,
+        )
+
+    def validate(self, decision, checkpoint):
+        return decision
+
+    def release(self, decision):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def reset_gate():
+    clear_turn_gate_registry_for_testing()
+    yield
+    clear_turn_gate_registry_for_testing()
+
+
+def gate_request() -> TurnGateRequest:
+    identity = RuntimeIdentity(
+        machine_id="test-machine",
+        profile="default",
+        surface="gateway",
+        session_instance_id="test-session",
+        gateway_instance_id="test-gateway",
+        turn_id="test-turn",
+    )
+    return TurnGateRequest(
+        entrypoint="gateway",
+        purpose="business",
+        identity=identity,
+    )
+
+
+def test_plugin_context_registers_provider_under_its_own_manifest_id():
+    manager = PluginManager()
+    manifest = PluginManifest(name="secure-gate", key="secure-gate", source="user")
+    context = PluginContext(manifest, manager)
+    context.register_turn_gate_provider(PluginGateProvider("secure-gate"))
+    _configure_gate("secure-gate")
+
+    with acquire_outer_turn(gate_request()) as lease:
+        assert lease.provider_id == "secure-gate"
+
+
+def test_plugin_provider_identity_mismatch_fails_closed():
+    manager = PluginManager()
+    manifest = PluginManifest(name="secure-gate", key="secure-gate", source="user")
+    context = PluginContext(manifest, manager)
+    context.register_turn_gate_provider(PluginGateProvider("impersonated-gate"))
+    _configure_gate("secure-gate")
+
+    with pytest.raises(TurnGateBlocked, match="identity mismatch"):
+        with acquire_outer_turn(gate_request()):
+            pass
+
+
+def test_force_reload_unregisters_stale_provider_even_in_safe_mode(monkeypatch):
+    manager = PluginManager()
+    manifest = PluginManifest(name="secure-gate", key="secure-gate", source="user")
+    context = PluginContext(manifest, manager)
+    context.register_turn_gate_provider(PluginGateProvider("secure-gate"))
+    _configure_gate("secure-gate")
+    manager._discovered = True
+    monkeypatch.setenv("HERMES_SAFE_MODE", "1")
+
+    manager.discover_and_load(force=True)
+
+    with pytest.raises(TurnGateBlocked, match="required provider"):
+        with acquire_outer_turn(gate_request()):
+            pass
+
+
+def test_failed_plugin_load_rolls_back_registered_gate_provider(tmp_path):
+    plugin_dir = tmp_path / "failed-gate"
+    plugin_dir.mkdir()
+    (plugin_dir / "__init__.py").write_text(
+        "from agent.turn_gate import GateDecision, GateState\n\n"
+        "class Provider:\n"
+        "    def acquire(self, request):\n"
+        "        return GateDecision(provider_id='failed-gate', state=GateState.OPEN, lease_id='failed-plugin-lease', generation=26)\n"
+        "    def validate(self, decision, checkpoint):\n"
+        "        return decision\n"
+        "    def release(self, decision):\n"
+        "        return None\n\n"
+        "def register(ctx):\n"
+        "    ctx.register_turn_gate_provider(Provider())\n"
+        "    raise RuntimeError('replacement failed after registration')\n",
+        encoding="utf-8",
+    )
+    manager = PluginManager()
+    manifest = PluginManifest(
+        name="failed-gate",
+        key="failed-gate",
+        source="user",
+        path=str(plugin_dir),
+    )
+
+    manager._load_plugin(manifest)
+    _configure_gate("failed-gate")
+
+    assert manager._plugins["failed-gate"].enabled is False
+    assert "replacement failed" in (manager._plugins["failed-gate"].error or "")
+    with pytest.raises(TurnGateBlocked, match="required provider"):
+        with acquire_outer_turn(gate_request()):
+            pass
+
+
+def test_failed_same_id_replacement_restores_previous_gate_provider(tmp_path):
+    manager = PluginManager()
+    manifest = PluginManifest(name="secure-gate", key="secure-gate", source="user")
+    PluginContext(manifest, manager).register_turn_gate_provider(
+        PluginGateProvider("secure-gate")
+    )
+
+    plugin_dir = tmp_path / "replacement-gate"
+    plugin_dir.mkdir()
+    (plugin_dir / "__init__.py").write_text(
+        "from agent.turn_gate import GateDecision, GateState\n\n"
+        "class Replacement:\n"
+        "    def acquire(self, request):\n"
+        "        return GateDecision(provider_id='secure-gate', state=GateState.OPEN, lease_id='partial-replacement', generation=26)\n"
+        "    def validate(self, decision, checkpoint): return decision\n"
+        "    def release(self, decision): return None\n\n"
+        "def register(ctx):\n"
+        "    ctx.register_turn_gate_provider(Replacement())\n"
+        "    raise RuntimeError('same-id replacement failed')\n",
+        encoding="utf-8",
+    )
+    replacement_manifest = PluginManifest(
+        name="secure-gate",
+        key="secure-gate",
+        source="user",
+        path=str(plugin_dir),
+    )
+
+    manager._load_plugin(replacement_manifest)
+    _configure_gate("secure-gate")
+
+    assert manager._plugins["secure-gate"].enabled is False
+    with acquire_outer_turn(gate_request()) as lease:
+        assert lease is not None
+        assert lease.lease_id == "lease-plugin"
+
+
+@pytest.mark.parametrize("failure_before_registration", [False, True])
+def test_force_full_round_failure_restores_previous_gate_provider_and_state(
+    tmp_path, monkeypatch, failure_before_registration
+):
+    """A ``force=True`` reload clears the live provider set up front, then runs
+    the whole discovery round via the REAL ``_load_plugin``. If a plugin's
+    ``register(ctx)`` registers a same-ID replacement provider and THEN raises,
+    ``_load_plugin`` swallows the exception and only records ``loaded.error`` —
+    so ``_discover_and_load_inner`` returns "successfully". The force round must
+    still be judged failed: the previously-active provider object, the manager's
+    provider tracking, and the other manager state cleared up front must all be
+    restored exactly — not left holding an empty/half-applied gate registry that
+    the up-front teardown already stripped of the live provider.
+    """
+    monkeypatch.delenv("HERMES_SAFE_MODE", raising=False)
+
+    manager = PluginManager()
+    manifest = PluginManifest(name="secure-gate", key="secure-gate", source="user")
+    old_provider = PluginGateProvider("secure-gate")
+    PluginContext(manifest, manager).register_turn_gate_provider(old_provider)
+
+    # Other pre-existing manager state that force-reload wipes before the round.
+    sentinel_plugin = object()
+    manager._plugins["pre-existing"] = sentinel_plugin
+    manager._discovered = True
+
+    # Exercise both real swallowed-error paths for the same-ID plugin: failure
+    # during module import before registration, and failure after registering a
+    # replacement provider. Either one must fail the whole force round.
+    plugin_dir = tmp_path / "replacement-gate"
+    plugin_dir.mkdir()
+    if failure_before_registration:
+        module_source = "raise RuntimeError('same-id replacement failed mid-round')\n"
+    else:
+        module_source = (
+            "from agent.turn_gate import GateDecision, GateState\n\n"
+            "class Replacement:\n"
+            "    def acquire(self, request):\n"
+            "        return GateDecision(provider_id='secure-gate', state=GateState.OPEN, lease_id='lease-replacement', generation=26)\n"
+            "    def validate(self, decision, checkpoint): return decision\n"
+            "    def release(self, decision): return None\n\n"
+            "def register(ctx):\n"
+            "    ctx.register_turn_gate_provider(Replacement())\n"
+            "    raise RuntimeError('same-id replacement failed mid-round')\n"
+        )
+    (plugin_dir / "__init__.py").write_text(module_source, encoding="utf-8")
+    replacement_manifest = PluginManifest(
+        name="secure-gate",
+        key="secure-gate",
+        source="user",
+        path=str(plugin_dir),
+    )
+
+    def fake_inner():
+        # The real round runs _load_plugin, which swallows either import or
+        # post-registration RuntimeError and only records loaded.error.
+        manager._load_plugin(replacement_manifest)
+        loaded = manager._plugins["secure-gate"]
+        assert loaded.enabled is False
+        assert "same-id replacement failed" in (loaded.error or "")
+
+    monkeypatch.setattr(manager, "_discover_and_load_inner", fake_inner)
+
+    with pytest.raises(TurnGateBlocked, match="same-id replacement failed"):
+        manager.discover_and_load(force=True)
+
+    _configure_gate("secure-gate")
+
+    # The exact previous provider object, its tracking, and other manager state
+    # must be restored after the failed force round.
+    restored = snapshot_turn_gate_providers().get("secure-gate")
+    assert restored is not None
+    assert restored.provider is old_provider
+    assert "secure-gate" in manager._turn_gate_provider_ids
+    assert manager._plugins.get("pre-existing") is sentinel_plugin
+    with acquire_outer_turn(gate_request()) as lease:
+        assert lease is not None
+        assert lease.lease_id == "lease-plugin"
+
+
+@pytest.mark.parametrize("failure_stage", ["register", "import"])
+def test_force_round_rolls_back_unrelated_plugin_failure_after_gate_replacement(
+    tmp_path, monkeypatch, failure_stage
+):
+    """Any later plugin failure aborts every host-owned mutation in the force round."""
+    from tools.registry import registry
+
+    monkeypatch.delenv("HERMES_SAFE_MODE", raising=False)
+    manager = PluginManager()
+    manifest = PluginManifest(name="secure-gate", key="secure-gate", source="user")
+    old_provider = PluginGateProvider("secure-gate")
+    PluginContext(manifest, manager).register_turn_gate_provider(old_provider)
+
+    sentinel_plugin = object()
+    sentinel_hook = lambda **_: None
+    manager._plugins["pre-existing"] = sentinel_plugin  # type: ignore[assignment]
+    manager._hooks["pre_tool_call"] = [sentinel_hook]
+    manager._cli_commands["pre-cli"] = {"plugin": "pre-existing"}
+    manager._plugin_commands["pre-command"] = {"plugin": "pre-existing"}
+    manager._discovered = True
+
+    replacement_dir = tmp_path / "replacement-gate"
+    replacement_dir.mkdir()
+    (replacement_dir / "__init__.py").write_text(
+        "from agent.turn_gate import GateDecision, GateState\n\n"
+        "class Replacement:\n"
+        "    def acquire(self, request):\n"
+        "        return GateDecision(provider_id='secure-gate', state=GateState.OPEN, lease_id='replacement', generation=26)\n"
+        "    def validate(self, decision, checkpoint): return decision\n"
+        "    def release(self, decision): return None\n\n"
+        "def register(ctx):\n"
+        "    ctx.register_turn_gate_provider(Replacement())\n",
+        encoding="utf-8",
+    )
+    replacement_manifest = PluginManifest(
+        name="secure-gate",
+        key="secure-gate",
+        source="user",
+        path=str(replacement_dir),
+    )
+
+    broken_dir = tmp_path / "broken-plugin"
+    broken_dir.mkdir()
+    if failure_stage == "import":
+        broken_source = "raise RuntimeError('unrelated plugin failed during import')\n"
+    else:
+        broken_source = (
+            "def partial_tool(args, **kwargs): return 'partial'\n"
+            "def register(ctx):\n"
+            "    ctx.register_hook('post_tool_call', lambda **kwargs: None)\n"
+            "    ctx.register_tool(\n"
+            "        name='force_partial_tool', toolset='force-partial',\n"
+            "        schema={'name': 'force_partial_tool', 'description': 'partial', 'parameters': {'type': 'object', 'properties': {}}},\n"
+            "        handler=partial_tool,\n"
+            "    )\n"
+            "    ctx.register_command('force-partial-command', lambda args: 'partial')\n"
+            "    ctx.register_cli_command('force-partial-cli', 'partial', lambda parser: None)\n"
+            "    raise RuntimeError('unrelated plugin failed during register')\n"
+        )
+    (broken_dir / "__init__.py").write_text(broken_source, encoding="utf-8")
+    broken_manifest = PluginManifest(
+        name="broken-plugin",
+        key="broken-plugin",
+        source="user",
+        path=str(broken_dir),
+    )
+
+    with registry._lock:
+        tool_state_before = {
+            "tools": dict(registry._tools),
+            "plugin_override_policy": dict(registry._plugin_override_policy),
+            "toolset_checks": dict(registry._toolset_checks),
+            "toolset_aliases": dict(registry._toolset_aliases),
+            "generation": registry._generation,
+        }
+    modules_before = {
+        name: module
+        for name, module in sys.modules.items()
+        if name == "hermes_plugins" or name.startswith("hermes_plugins.")
+    }
+
+    def fake_inner():
+        manager._load_plugin(replacement_manifest)
+        assert manager._plugins["secure-gate"].enabled is True
+        manager._load_plugin(broken_manifest)
+
+    monkeypatch.setattr(manager, "_discover_and_load_inner", fake_inner)
+
+    try:
+        with pytest.raises(RuntimeError, match="unrelated plugin failed"):
+            manager.discover_and_load(force=True)
+
+        restored = snapshot_turn_gate_providers().get("secure-gate")
+        assert restored is not None
+        assert restored.provider is old_provider
+        assert manager._plugins == {"pre-existing": sentinel_plugin}
+        assert manager._hooks == {"pre_tool_call": [sentinel_hook]}
+        assert manager._cli_commands == {"pre-cli": {"plugin": "pre-existing"}}
+        assert manager._plugin_commands == {
+            "pre-command": {"plugin": "pre-existing"}
+        }
+        assert registry.get_entry("force_partial_tool") is None
+        with registry._lock:
+            assert registry._tools == tool_state_before["tools"]
+            assert registry._plugin_override_policy == tool_state_before[
+                "plugin_override_policy"
+            ]
+            assert registry._toolset_checks == tool_state_before["toolset_checks"]
+            assert registry._toolset_aliases == tool_state_before["toolset_aliases"]
+            assert registry._generation == tool_state_before["generation"]
+        modules_after = {
+            name: module
+            for name, module in sys.modules.items()
+            if name == "hermes_plugins" or name.startswith("hermes_plugins.")
+        }
+        assert modules_after == modules_before
+    finally:
+        # Keep the RED run hermetic even before rollback exists in production.
+        with registry._lock:
+            registry._tools.clear()
+            registry._tools.update(tool_state_before["tools"])
+            registry._plugin_override_policy.clear()
+            registry._plugin_override_policy.update(
+                tool_state_before["plugin_override_policy"]
+            )
+            registry._toolset_checks.clear()
+            registry._toolset_checks.update(tool_state_before["toolset_checks"])
+            registry._toolset_aliases.clear()
+            registry._toolset_aliases.update(tool_state_before["toolset_aliases"])
+            registry._generation = tool_state_before["generation"]
+        for name in tuple(sys.modules):
+            if (
+                name == "hermes_plugins" or name.startswith("hermes_plugins.")
+            ) and name not in modules_before:
+                sys.modules.pop(name, None)
+        sys.modules.update(modules_before)
+
+
+def test_temp_hermes_home_discovers_required_gate_end_to_end(tmp_path, monkeypatch):
+    from hermes_cli import plugins as plugins_mod
+
+    home = tmp_path / "hermes-home"
+    plugin_dir = home / "plugins" / "secure-gate"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        yaml.safe_dump({"name": "secure-gate", "version": "0.1.0"}),
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        "from agent.turn_gate import GateDecision, GateState\n\n"
+        "class Provider:\n"
+        "    def acquire(self, request):\n"
+        "        return GateDecision(provider_id='secure-gate', state=GateState.OPEN, lease_id='e2e', generation=26)\n"
+        "    def validate(self, decision, checkpoint):\n"
+        "        return decision\n"
+        "    def release(self, decision):\n"
+        "        return None\n\n"
+        "def register(ctx):\n"
+        "    ctx.register_turn_gate_provider(Provider())\n",
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "plugins": {"enabled": ["secure-gate"]},
+                "agent": {
+                    "turn_gate": {
+                        "required_provider": "secure-gate",
+                        "runtime_identity": {"machine_id": "test-machine"},
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", PluginManager())
+
+    plugins_mod.discover_plugins()
+    with acquire_outer_turn(gate_request()) as lease:
+        assert lease.provider_id == "secure-gate"
+        assert lease.lease_id == "e2e"

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -449,6 +449,17 @@ def _inject_session_context_env(env: dict) -> None:
             env.pop(var_name, None)
 
 
+def _inject_turn_gate_env(env: dict[str, str]) -> None:
+    """Apply the generic host-owned child-environment contribution contract."""
+    try:
+        from agent.turn_gate import inject_turn_gate_child_environment
+    except ImportError:
+        return
+    sanitized = inject_turn_gate_child_environment(env)
+    env.clear()
+    env.update(sanitized)
+
+
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
     """Filter Hermes-managed secrets from a subprocess environment."""
     try:
@@ -485,6 +496,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     # Same cross-session leak guard as _make_run_env, for the background/PTY
     # spawn path (process_registry.spawn_local builds env via this function).
     _inject_session_context_env(sanitized)
+    _inject_turn_gate_env(sanitized)
 
     for _marker in _ACTIVE_VENV_MARKER_VARS:
         sanitized.pop(_marker, None)
@@ -629,6 +641,7 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
     # session's identity. Strip _UNSET session vars when engaged so that can't
     # happen; single uniform policy across every spawn surface.
     _inject_session_context_env(env)
+    _inject_turn_gate_env(env)
 
     # Non-terminal subprocess helpers (browser, lazy-deps, TUI/ACP hosts, etc.)
     # also need the delegate_task child lineage marker.  Otherwise a child
@@ -699,6 +712,7 @@ def build_subprocess_env(
         apply_subprocess_home_env(env)
     if extra:
         env.update(extra)
+    _inject_turn_gate_env(env)
     return env
 
 
@@ -1255,6 +1269,7 @@ def _make_run_env(env: dict) -> dict:
     # cross-session leak guard — strips _UNSET vars when a concurrent host is
     # engaged so a sibling session's os.environ mirror can't leak in).
     _inject_session_context_env(run_env)
+    _inject_turn_gate_env(run_env)
 
     for _marker in _ACTIVE_VENV_MARKER_VARS:
         run_env.pop(_marker, None)

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -687,7 +687,11 @@ class ToolRegistry:
             from agent.turn_gate import tool_block_message
             block_message = tool_block_message(name)
         except Exception:
-            block_message = None
+            return tool_error(
+                "mandatory turn gate check failed closed",
+                error_type="turn_gate_block",
+                tool=name,
+            )
         if block_message is not None:
             return tool_error(
                 block_message,

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -683,6 +683,18 @@ class ToolRegistry:
         * All exceptions are caught and returned as ``{"error": "..."}``
           for consistent error format.
         """
+        try:
+            from agent.turn_gate import tool_block_message
+            block_message = tool_block_message(name)
+        except Exception:
+            block_message = None
+        if block_message is not None:
+            return tool_error(
+                block_message,
+                error_type="turn_gate_block",
+                tool=name,
+            )
+
         entry = self.get_entry(name)
         if not entry:
             return tool_error(f"Unknown tool: {name}")


### PR DESCRIPTION
## Summary

- add an opt-in, host-enforced outer-turn gate with plugin-owned provider registration and fail-closed configuration
- enforce the acquired lease across conversation, gateway, delivery, output, tool execution, observation, and child-environment boundaries
- make plugin force-reload transactional for gate providers and clear inherited gate context from detached tasks
- document the provider/configuration contract and keep the default (unconfigured) path behavior-compatible

## Design notes

- Core owns runtime identity, lease lifetime, state/generation revalidation, poisoning, and the child-environment allowlist.
- Providers remain policy-only and must be synchronous. Native async methods and sync wrappers that return awaitables fail closed.
- `RELOAD_ONLY` permits only explicitly allowlisted tools and blocks output until the provider reports `OPEN`.
- Provider registration is bound to the plugin manifest owner. A required missing/malformed provider blocks before the gated body executes.
- The diff contains no deployment-specific policy, Feishu integration, or live transport.

## Verification

- `scripts/run_tests.sh` on the seven host-gate test files: **61 passed**
- existing compatibility regression matrix (OAuth source introspection, Matrix deferred cleanup, slash worker profile home, subprocess encoding): **106 passed**
- current-main restart/approval/slash regression matrix: **38 passed**
- `ruff check .`: passed
- `ty check agent/turn_gate.py`: passed
- `git diff --check origin/main...HEAD`: passed
- `cli-config.yaml.example`: YAML parse passed

### Full-suite context

The full per-file suite is not green on this macOS host on clean `origin/main` (Linux/systemd, worktree, external-network/tool, TUI/voice, and SQLite timing failures). A base/candidate diagnostic run exposed six real compatibility regressions; all six were fixed and the affected matrices above are green. The only residual candidate-only full-run file was `tests/state/test_write_lock_patience.py`, and it reproduced identically on the base (`1 failed / 5 passed`). CI remains authoritative.

## Scope boundary

This PR is source-only. It does **not** install a provider, modify a live profile, restart a gateway, deploy, tag, release, or perform external writes.
