### PR TITLE
fix(buzz): replace assert with ImportError in nostr_auth loader

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -104,7 +104,8 @@ def _load_nostr_auth():
 
         path = Path(__file__).with_name("nostr_auth.py")
         spec = importlib.util.spec_from_file_location("plugin_adapter_buzz_nostr_auth", path)
-        assert spec is not None and spec.loader is not None
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot load nostr_auth module from {path}")
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
         return module


### PR DESCRIPTION
## Summary

Replace `assert spec is not None and spec.loader is not None` in `plugins/platforms/buzz/adapter.py:107` with a proper `ImportError` raise.

## Problem

The `assert` statement at `_load_nostr_auth()` line 107 is stripped by `python -O`, silently removing the guard. If `spec` or `spec.loader` is `None`, the subsequent `spec.loader.exec_module(module)` would crash with `AttributeError: 'NoneType' object has no attribute 'exec_module'` — a confusing error with no indication of the real cause.

## Fix

Replace the bare `assert` with an explicit `if/raise ImportError` that:
- Survives `python -O` (not stripped)
- Provides the failing path for debugging
- Matches the existing `except ImportError` handler at line 102 (the caller already handles ImportError)

## Files Changed

- `plugins/platforms/buzz/adapter.py` — 1 line changed (assert → if/raise)