### PR TITLE
fix: resolve lazy-refresh startup warning in Docker images

### DIFF
--- a/COMMIT_MSG.txt
+++ b/COMMIT_MSG.txt
@@ -1,0 +1,19 @@
+fix: resolve lazy-refresh startup warning in Docker images
+
+The import-probe recovery for lazy-backend refresh produces a
+"Import probes unavailable" warning on every Docker container
+startup, caused by two bugs:
+
+1. Wrong Docker detection in _recover_from_interrupted_install():
+   The guard checked `not (PROJECT_ROOT / "pyproject.toml").is_file()`,
+   but Docker images DO ship pyproject.toml, so the Docker skip
+   never fired. Fixed by using detect_install_method() which reads
+   the baked /opt/hermes/.install_method stamp.
+
+2. Hardcoded venv path in three call sites: uv sync creates .venv/
+   (dot-prefixed) by default, but the recovery code hardcoded
+   PROJECT_ROOT / "venv" (no dot). The import-probe subprocess
+   couldn't find a Python at the wrong path, returned None, and
+   the marker was never cleared. Fixed by adding a shared
+   _detect_venv_path() helper that probes both .venv and venv,
+   and using it in all three call sites.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7588,9 +7588,20 @@ def _recover_from_interrupted_install() -> None:
     if not core_marker and not lazy_marker:
         return
 
-    # Skip in managed/Docker installs and on PyPI installs with no git checkout:
-    # those don't run the source-tree update path, so a stray marker is not ours
-    # to act on. Just clear it.
+    # Skip in Docker installs: the venv is baked into an immutable image,
+    # lazy-backend refresh is disabled, and the marker (if present) can't
+    # be deleted by the runtime hermes user. A stray marker is not ours
+    # to act on — just try to clear it and return.
+    # Also skip on PyPI installs with no git checkout (same rationale).
+    try:
+        from hermes_cli.config import detect_install_method
+
+        if detect_install_method(PROJECT_ROOT) in ("docker",):
+            _clear_update_incomplete_marker()
+            _clear_lazy_refresh_incomplete_marker()
+            return
+    except Exception:
+        pass
     if not (PROJECT_ROOT / "pyproject.toml").is_file():
         _clear_update_incomplete_marker()
         _clear_lazy_refresh_incomplete_marker()
@@ -7724,7 +7735,7 @@ def _recover_core_update_marker_locked() -> None:
 
         uv_bin = ensure_uv()
         if uv_bin:
-            uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+            uv_env = {**os.environ, "VIRTUAL_ENV": str(_detect_venv_path())}
             if _is_termux_env(uv_env):
                 uv_env.pop("PYTHONPATH", None)
                 uv_env.pop("PYTHONHOME", None)
@@ -7798,6 +7809,20 @@ def _windows_running_hermes_launcher_locked() -> bool:
     return False
 
 
+def _detect_venv_path() -> Path:
+    """Detect the actual project venv directory, preferring .venv over venv.
+
+    ``uv sync`` creates ``.venv/`` by default, while older install scripts
+    and managed-uv helpers historically used ``venv/``.  Probe both so the
+    update-recovery import probes work regardless of which layout is in use.
+    """
+    for candidate in (".venv", "venv"):
+        p = PROJECT_ROOT / candidate
+        if p.is_dir():
+            return p
+    return PROJECT_ROOT / ".venv"
+
+
 def _default_venv_install_target() -> tuple[list[str], dict[str, str] | None]:
     """Return ``(install_cmd_prefix, env)`` for the project venv when possible."""
     try:
@@ -7807,7 +7832,7 @@ def _default_venv_install_target() -> tuple[list[str], dict[str, str] | None]:
     except Exception:
         uv_bin = None
     if uv_bin:
-        env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+        env = {**os.environ, "VIRTUAL_ENV": str(_detect_venv_path())}
         if _is_termux_env(env):
             env.pop("PYTHONPATH", None)
             env.pop("PYTHONHOME", None)
@@ -7860,11 +7885,13 @@ def _is_windows() -> bool:
 
 def _venv_scripts_dir() -> Path | None:
     """Return the venv Scripts directory if we're running inside the project venv."""
-    venv_dir = PROJECT_ROOT / "venv"
-    if not venv_dir.is_dir():
-        return None
-    scripts = venv_dir / ("Scripts" if _is_windows() else "bin")
-    return scripts if scripts.is_dir() else None
+    for venv_candidate in (".venv", "venv"):
+        venv_dir = PROJECT_ROOT / venv_candidate
+        if venv_dir.is_dir():
+            scripts = venv_dir / ("Scripts" if _is_windows() else "bin")
+            if scripts.is_dir():
+                return scripts
+    return None
 
 
 def _hermes_exe_shims(scripts_dir: Path) -> list[Path]:


### PR DESCRIPTION
The import-probe recovery for lazy-backend refresh produces a "Import probes unavailable" warning on every Docker container startup, caused by two bugs:

1. Wrong Docker detection in _recover_from_interrupted_install(): The guard checked `not (PROJECT_ROOT / "pyproject.toml").is_file()`, but Docker images DO ship pyproject.toml, so the Docker skip never fired. Fixed by using detect_install_method() which reads the baked /opt/hermes/.install_method stamp.

2. Hardcoded venv path in three call sites: uv sync creates .venv/ (dot-prefixed) by default, but the recovery code hardcoded PROJECT_ROOT / "venv" (no dot). The import-probe subprocess couldn't find a Python at the wrong path, returned None, and the marker was never cleared. Fixed by adding a shared _detect_venv_path() helper that probes both .venv and venv, and using it in all three call sites.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

