### PR TITLE
fix(kanban): add fail-closed exact targeted dispatch

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -709,10 +709,20 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "dispatch",
         help="One dispatcher pass: reclaim stale, promote ready, spawn workers",
     )
+    p_disp.add_argument(
+        "--task-id",
+        dest="task_ids",
+        action="append",
+        default=None,
+        help=(
+            "Dispatch only this exact Ready task id (repeatable). Any explicit "
+            "target set fails closed and never falls back to generic selection"
+        ),
+    )
     p_disp.add_argument("--dry-run", action="store_true",
                         help="Don't actually spawn processes; just print what would happen")
     p_disp.add_argument("--max", type=int, default=None,
-                        help="Cap number of spawns this pass")
+                        help="Cap total Running workers across the board after this pass")
     p_disp.add_argument("--failure-limit", type=int,
                         default=kb.DEFAULT_SPAWN_FAILURE_LIMIT,
                         help=f"Auto-block a task after this many consecutive non-success attempts "
@@ -2480,9 +2490,17 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
+            task_ids=getattr(args, "task_ids", None),
         )
+    targeted_exit = (
+        0
+        if res.targeted
+        and bool(res.requested_outcomes)
+        and all(item.outcome == "spawned" for item in res.requested_outcomes)
+        else 1
+    )
     if getattr(args, "json", False):
-        print(json.dumps({
+        payload: dict[str, object] = {
             "reclaimed": res.reclaimed,
             "crashed": res.crashed,
             "timed_out": res.timed_out,
@@ -2500,8 +2518,30 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
                 for (tid, who, current) in res.skipped_per_profile_capped
             ],
             "auto_assigned_default": res.auto_assigned_default,
-        }, indent=2))
-        return 0
+        }
+        if res.targeted:
+            requested: list[dict[str, object]] = []
+            for item in res.requested_outcomes:
+                row: dict[str, object] = {
+                    "task_id": item.task_id,
+                    "outcome": item.outcome,
+                }
+                if item.assignee is not None:
+                    row["assignee"] = item.assignee
+                if item.workspace is not None:
+                    row["workspace"] = item.workspace
+                if item.detail is not None:
+                    row["detail"] = item.detail
+                if item.current is not None:
+                    row["current"] = item.current
+                requested.append(row)
+            payload.update({
+                "targeted": True,
+                "dry_run": bool(args.dry_run),
+                "requested": requested,
+            })
+        print(json.dumps(payload, indent=2))
+        return targeted_exit if res.targeted else 0
     print(f"Reclaimed:    {res.reclaimed}")
     print(f"Crashed:      {len(res.crashed)}")
     if res.crashed:
@@ -2537,6 +2577,23 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             f"Skipped (non-spawnable assignee — terminal lane, OK): "
             f"{', '.join(res.skipped_nonspawnable)}"
         )
+    if res.targeted:
+        print("Requested outcomes:")
+        if not res.requested_outcomes:
+            print("  (empty target set; no generic selection performed)")
+        for item in res.requested_outcomes:
+            details: list[str] = []
+            if item.assignee is not None:
+                details.append(f"assignee={item.assignee}")
+            if item.current is not None:
+                details.append(f"current={item.current}")
+            if item.detail is not None:
+                details.append(f"detail={item.detail}")
+            if item.workspace is not None:
+                details.append(f"workspace={item.workspace}")
+            suffix = f" ({', '.join(details)})" if details else ""
+            print(f"  - {item.task_id}: {item.outcome}{suffix}")
+        return targeted_exit
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -87,7 +87,7 @@ import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Optional
+from typing import Any, Iterable, Mapping, Optional, Sequence
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
 from toolsets import get_toolset_names
@@ -1480,9 +1480,11 @@ def _cross_process_init_lock(path: Path):
 def _dispatch_tick_lock(db_path: Path):
     """Non-blocking single-writer guard around one dispatcher tick.
 
-    Yields ``True`` when this process holds the board's dispatch lock and
-    may proceed with the tick, or ``False`` when another process already
-    holds it (the caller should skip the tick this round).
+    Yields ``True`` when this process holds the board's dispatch lock,
+    ``False`` when another process already holds it, or ``None`` when the
+    lock file cannot be opened. The tri-state result lets exact-target
+    callers fail closed on both contention and lock-mechanism failure while
+    preserving the legacy generic-dispatch fallback for unavailable locks.
 
     Motivation (issue #35240): a ``hermes gateway run --replace`` /
     ``gateway restart`` invoked from a shell on a systemd/launchd host can
@@ -1509,7 +1511,7 @@ def _dispatch_tick_lock(db_path: Path):
     """
     lock_path = db_path.with_name(db_path.name + ".dispatch.lock")
     handle = None
-    acquired = False
+    acquired: Optional[bool] = False
     try:
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         handle = lock_path.open("a+b")
@@ -1534,9 +1536,15 @@ def _dispatch_tick_lock(db_path: Path):
             except (BlockingIOError, OSError):
                 acquired = False
     except OSError:
-        # Could not even open the lock file (permissions, read-only FS).
-        # Degrade to a no-op so a probe failure never blocks dispatch.
-        acquired = True
+        # Lock unavailability is strictly less safe than contention: without
+        # a file handle we cannot know whether another dispatcher is active.
+        # Return a distinct state so exact-target callers can fail closed, and
+        # make the broken locking mechanism operator-visible.
+        _log.error(
+            "kanban dispatch lock unavailable: exclusive ownership cannot be "
+            "established; check permissions for the board data directory"
+        )
+        acquired = None
         handle = None
     try:
         yield acquired
@@ -4625,9 +4633,10 @@ def _verify_created_cards(
     return verified, phantom
 
 
-# Task-id pattern used both by ``kanban_create`` (``t_<12 hex>``) and
-# ``_new_task_id`` below. Kept permissive on length for forward compat:
-# accept 8+ hex chars after the ``t_`` prefix.
+# Task-id patterns used by ``kanban_create`` (``t_<8 hex>``), exact-target
+# dispatch, and the prose phantom-id guard below. Kept permissive on length for
+# forward compatibility: accept 8+ lowercase hex chars after the ``t_`` prefix.
+_TASK_ID_EXACT_RE = re.compile(r"t_[a-f0-9]{8,}")
 _TASK_ID_PROSE_RE = re.compile(r"\bt_[a-f0-9]{8,}\b")
 
 
@@ -6642,6 +6651,18 @@ _RESPAWN_GUARD_PR_URL_RE = re.compile(
 
 
 @dataclass
+class RequestedDispatchOutcome:
+    """Exact disposition of one id from a targeted dispatch request."""
+
+    task_id: str
+    outcome: str
+    assignee: Optional[str] = None
+    workspace: Optional[str] = None
+    detail: Optional[str] = None
+    current: Optional[int] = None
+
+
+@dataclass
 class DispatchResult:
     """Outcome of a single ``dispatch`` pass."""
 
@@ -6695,10 +6716,42 @@ class DispatchResult:
     window just makes the task bounce cheaply until the window clears."""
     skipped_locked: bool = False
     """True when this tick was skipped because another process already held
-    the board's dispatch lock (issue #35240). A losing dispatcher does no
-    DB writes this tick — the lock holder is making progress on the same
-    board. This is the steady-state signal that a single-writer guard is
-    actively preventing two dispatchers from racing on ``kanban.db``."""
+    the board's dispatch lock, or because an exact-target tick found the lock
+    mechanism unavailable (issue #35240). A skipped dispatcher does no DB writes
+    this tick. Lock-file open failures are logged as errors because no dispatcher
+    can safely prove exclusive ownership in that state."""
+    targeted: bool = False
+    """True when an explicit exact-task filter was supplied.
+
+    ``False`` means the legacy generic Ready/review selection path. ``True``
+    with an empty ``requested_outcomes`` list is intentionally meaningful: an
+    explicit empty target set fails closed and can never fall back to generic
+    queue selection."""
+    requested_outcomes: list[RequestedDispatchOutcome] = field(default_factory=list)
+    """One terminal outcome per distinct requested id, preserving request order."""
+
+
+def _unavailable_targeted_dispatch_result(
+    task_ids: Sequence[str],
+) -> DispatchResult:
+    """Fail an exact-target tick closed when its board lock is unavailable."""
+
+    result = DispatchResult(skipped_locked=True, targeted=True)
+    seen: set[str] = set()
+    for raw_task_id in task_ids:
+        task_id = raw_task_id if isinstance(raw_task_id, str) else str(raw_task_id)
+        if task_id in seen:
+            continue
+        seen.add(task_id)
+        outcome = (
+            "malformed"
+            if _TASK_ID_EXACT_RE.fullmatch(task_id) is None
+            else "locked"
+        )
+        result.requested_outcomes.append(
+            RequestedDispatchOutcome(task_id=task_id, outcome=outcome)
+        )
+    return result
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -8067,6 +8120,7 @@ def dispatch_once(
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
+    task_ids: Optional[Sequence[str]] = None,
 ) -> DispatchResult:
     """Run one dispatcher tick under the board's single-writer lock.
 
@@ -8075,20 +8129,30 @@ def dispatch_once(
     dispatchers pointed at the same ``kanban.db`` — e.g. the service-
     managed gateway and a shell-spawned orphan that escaped the service
     cgroup — can never run a reclaim/spawn/write tick concurrently and
-    race on WAL frames. The losing dispatcher returns an empty
-    ``DispatchResult`` with ``skipped_locked=True`` and does no DB writes;
-    the holder is already making progress on the same board.
+    race on WAL frames. A contender returns an empty ``DispatchResult`` with
+    ``skipped_locked=True`` and does no DB writes. Exact-target dispatch also
+    fails closed this way when the lock file cannot be opened; generic dispatch
+    retains its legacy degraded fallback. Lock-file open failures are logged as
+    errors because exclusive ownership cannot be established.
 
     The lock is keyed off the board's resolved DB path, so unrelated
     boards tick in parallel. See :func:`_dispatch_tick_lock` for the
     cross-process / cross-platform mechanics.
+
+    ``task_ids is None`` preserves generic Ready/review selection. Any explicit
+    sequence, including an empty one, enables exact-target mode. Exact-target
+    mode never falls back to generic selection and fails closed if the board
+    lock cannot be resolved or acquired.
     """
+    targeted = task_ids is not None
     try:
         db_path = kanban_db_path(board=board)
     except Exception:
-        # Path resolution should never fail, but if it somehow does we
-        # must not lose the tick — fall through to an unguarded dispatch
-        # rather than dropping work.
+        if task_ids is not None:
+            return _unavailable_targeted_dispatch_result(task_ids)
+        # Preserve the legacy generic fallback. Exact-target dispatch above
+        # cannot take this path because its filter must be enforced under the
+        # board-scoped lock.
         return _dispatch_once_locked(
             conn,
             spawn_fn=spawn_fn,
@@ -8101,10 +8165,33 @@ def dispatch_once(
             board=board,
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
+            task_ids=task_ids,
         )
     with _dispatch_tick_lock(db_path) as held:
-        if not held:
-            return DispatchResult(skipped_locked=True)
+        if held is not True:
+            if task_ids is not None:
+                return _unavailable_targeted_dispatch_result(task_ids)
+            if held is False:
+                return DispatchResult(skipped_locked=True)
+            # ``None`` means the lock mechanism itself is unavailable. Keep
+            # the pre-existing generic-dispatch fallback, including its
+            # successful-tick WAL hygiene.
+            result = _dispatch_once_locked(
+                conn,
+                spawn_fn=spawn_fn,
+                ttl_seconds=ttl_seconds,
+                dry_run=dry_run,
+                max_spawn=max_spawn,
+                max_in_progress=max_in_progress,
+                failure_limit=failure_limit,
+                stale_timeout_seconds=stale_timeout_seconds,
+                board=board,
+                default_assignee=default_assignee,
+                max_in_progress_per_profile=max_in_progress_per_profile,
+                task_ids=task_ids,
+            )
+            _maybe_checkpoint_wal(conn, db_path)
+            return result
         result = _dispatch_once_locked(
             conn,
             spawn_fn=spawn_fn,
@@ -8117,10 +8204,12 @@ def dispatch_once(
             board=board,
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
+            task_ids=task_ids,
         )
-        # Still under the dispatch lock: opportunistically truncate the WAL
-        # at a coarse interval so it cannot grow unbounded between restarts.
-        _maybe_checkpoint_wal(conn, db_path)
+        if not targeted:
+            # Preserve the official generic-tick WAL hygiene while keeping every
+            # exact-target call byte-invariant with respect to checkpointing.
+            _maybe_checkpoint_wal(conn, db_path)
         return result
 
 
@@ -8137,6 +8226,7 @@ def _dispatch_once_locked(
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
+    task_ids: Optional[Sequence[str]] = None,
 ) -> DispatchResult:
     """Run one dispatcher tick.
 
@@ -8166,34 +8256,104 @@ def _dispatch_once_locked(
     ``board`` pins workspace/log/db resolution for this tick to a specific
     board. When omitted, the current-board resolution chain is used.
     """
-    # Reap zombie children from previously spawned workers. See
-    # reap_worker_zombies() for the full rationale.
-    reap_worker_zombies()
+    targeted = task_ids is not None
+    read_only_target_preview = targeted and dry_run
 
-    result = DispatchResult()
-    result.reclaimed = release_stale_claims(conn)
-    result.stale = detect_stale_running(
-        conn, stale_timeout_seconds=stale_timeout_seconds,
-    )
-    result.crashed = detect_crashed_workers(conn)
-    # detect_crashed_workers stashes protocol-violation auto-blocks on
-    # itself so the public list-return stays stable. Pull them into the
-    # DispatchResult here so telemetry / tests see the trip.
-    _crash_auto_blocked = getattr(
-        detect_crashed_workers, "_last_auto_blocked", []
-    )
-    if _crash_auto_blocked:
-        result.auto_blocked.extend(_crash_auto_blocked)
-    # Rate-limited requeues (quota wall, no failure counted) — surface for
-    # telemetry / tests. These tasks went back to ``ready`` and the respawn
-    # guard will defer them until the quota window clears.
-    _crash_rate_limited = getattr(
-        detect_crashed_workers, "_last_rate_limited", []
-    )
-    if _crash_rate_limited:
-        result.rate_limited.extend(_crash_rate_limited)
-    result.timed_out = enforce_max_runtime(conn)
-    result.promoted = recompute_ready(conn, failure_limit=failure_limit)
+    # Targeted dry-runs are intentionally side-effect-free: no process reaping,
+    # reconciliation writes, claims, events, workspaces, or spawns. Real targeted
+    # ticks still run the same global reconciliation as generic ticks before the
+    # exact filter is applied under this board lock.
+    if not read_only_target_preview:
+        # Reap zombie children from previously spawned workers. See
+        # reap_worker_zombies() for the full rationale.
+        reap_worker_zombies()
+
+    result = DispatchResult(targeted=targeted)
+    if not read_only_target_preview:
+        result.reclaimed = release_stale_claims(conn)
+        result.stale = detect_stale_running(
+            conn, stale_timeout_seconds=stale_timeout_seconds,
+        )
+        result.crashed = detect_crashed_workers(conn)
+        # detect_crashed_workers stashes protocol-violation auto-blocks on
+        # itself so the public list-return stays stable. Pull them into the
+        # DispatchResult here so telemetry / tests see the trip.
+        _crash_auto_blocked = getattr(
+            detect_crashed_workers, "_last_auto_blocked", []
+        )
+        if _crash_auto_blocked:
+            result.auto_blocked.extend(_crash_auto_blocked)
+        # Rate-limited requeues (quota wall, no failure counted) — surface for
+        # telemetry / tests. These tasks went back to ``ready`` and the respawn
+        # guard will defer them until the quota window clears.
+        _crash_rate_limited = getattr(
+            detect_crashed_workers, "_last_rate_limited", []
+        )
+        if _crash_rate_limited:
+            result.rate_limited.extend(_crash_rate_limited)
+        result.timed_out = enforce_max_runtime(conn)
+        result.promoted = recompute_ready(conn, failure_limit=failure_limit)
+
+    requested_by_id: dict[str, RequestedDispatchOutcome] = {}
+    if targeted:
+        # Build the complete target disposition table while the board-scoped
+        # dispatch lock is held. ``None`` means generic selection; every actual
+        # sequence — even [] or an all-invalid list — stays on this fail-closed
+        # path and can never reach the unfiltered Ready query below.
+        seen: set[str] = set()
+        for raw_task_id in task_ids or ():
+            task_id = raw_task_id if isinstance(raw_task_id, str) else str(raw_task_id)
+            if task_id in seen:
+                continue
+            seen.add(task_id)
+            outcome = RequestedDispatchOutcome(task_id=task_id, outcome="pending")
+            requested_by_id[task_id] = outcome
+            result.requested_outcomes.append(outcome)
+            if _TASK_ID_EXACT_RE.fullmatch(task_id) is None:
+                outcome.outcome = "malformed"
+
+        ready_rows = []
+        for task_id, outcome in requested_by_id.items():
+            if outcome.outcome != "pending":
+                continue
+            row = conn.execute(
+                "SELECT id, assignee, status, claim_lock, priority, created_at "
+                "FROM tasks WHERE id = ?",
+                (task_id,),
+            ).fetchone()
+            if row is None:
+                outcome.outcome = "not_found"
+            elif row["claim_lock"] is not None:
+                outcome.outcome = "claimed"
+                outcome.assignee = row["assignee"]
+                outcome.detail = row["status"]
+            elif row["status"] != "ready":
+                outcome.outcome = "status_not_ready"
+                outcome.assignee = row["assignee"]
+                outcome.detail = row["status"]
+            else:
+                ready_rows.append(row)
+        ready_rows.sort(
+            key=lambda row: (
+                -int(row["priority"] or 0),
+                int(row["created_at"] or 0),
+            )
+        )
+        if any(
+            item.outcome == "malformed" for item in result.requested_outcomes
+        ):
+            # Syntax errors invalidate the whole target set. Report every id,
+            # but never partially execute the well-formed subset of a malformed
+            # operator request.
+            for row in ready_rows:
+                requested_by_id[row["id"]].outcome = "target_set_invalid"
+            return result
+    else:
+        ready_rows = conn.execute(
+            "SELECT id, assignee FROM tasks "
+            "WHERE status = 'ready' AND claim_lock IS NULL "
+            "ORDER BY priority DESC, created_at ASC"
+        ).fetchall()
 
     # Count tasks already running so max_spawn enforces concurrency rather
     # than a per-tick spawn budget. See the docstring above for the full
@@ -8209,12 +8369,6 @@ def _dispatch_once_locked(
                 "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
             ).fetchone()[0]
         )
-
-    ready_rows = conn.execute(
-        "SELECT id, assignee FROM tasks "
-        "WHERE status = 'ready' AND claim_lock IS NULL "
-        "ORDER BY priority DESC, created_at ASC"
-    ).fetchall()
     # Honour kanban.max_in_progress: if the board already has enough running
     # tasks, skip spawning this tick so slow workers (local LLMs,
     # resource-constrained hosts) can finish what they have before more tasks
@@ -8224,6 +8378,9 @@ def _dispatch_once_locked(
             "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
         ).fetchone()[0]
         if in_progress >= max_in_progress:
+            if targeted:
+                for row in ready_rows:
+                    requested_by_id[row["id"]].outcome = "ceiling_reached"
             return result
         # Only spawn enough to reach the cap, respecting max_spawn too.
         remaining = max_in_progress - in_progress
@@ -8268,6 +8425,9 @@ def _dispatch_once_locked(
             _default_assignee_resolved = True
     for row in ready_rows:
         if max_spawn is not None and running_count + spawned >= max_spawn:
+            if targeted:
+                requested_by_id[row["id"]].outcome = "ceiling_reached"
+                continue
             break
         row_assignee = row["assignee"]
         if not row_assignee:
@@ -8307,11 +8467,17 @@ def _dispatch_once_locked(
                             _default_assignee, row["id"], exc_info=True,
                         )
                         result.skipped_unassigned.append(row["id"])
+                        if targeted:
+                            outcome = requested_by_id[row["id"]]
+                            outcome.outcome = "unassigned"
+                            outcome.detail = "default_assignment_failed"
                         continue
                 row_assignee = _default_assignee
                 result.auto_assigned_default.append(row["id"])
             else:
                 result.skipped_unassigned.append(row["id"])
+                if targeted:
+                    requested_by_id[row["id"]].outcome = "unassigned"
                 continue
         # Skip ready tasks whose assignee is not a real Hermes profile.
         # `_default_spawn` invokes ``hermes -p <assignee>`` which fails
@@ -8335,6 +8501,10 @@ def _dispatch_once_locked(
             # multi-lane setups where the ready queue is steadily full
             # of human-pulled work.
             result.skipped_nonspawnable.append(row["id"])
+            if targeted:
+                outcome = requested_by_id[row["id"]]
+                outcome.outcome = "nonspawnable"
+                outcome.assignee = row_assignee
             continue
         # Per-profile concurrency cap (#21582): even if there's global
         # headroom, refuse to spawn for an assignee that's already at
@@ -8348,6 +8518,11 @@ def _dispatch_once_locked(
                 result.skipped_per_profile_capped.append(
                     (row["id"], row_assignee, current)
                 )
+                if targeted:
+                    outcome = requested_by_id[row["id"]]
+                    outcome.outcome = "profile_capped"
+                    outcome.assignee = row_assignee
+                    outcome.current = current
                 continue
         # Respawn guard: refuse to re-spawn when useful work is already
         # in-flight/recent, or when the last failure is a deterministic
@@ -8360,6 +8535,11 @@ def _dispatch_once_locked(
         guard_reason = check_respawn_guard(conn, row["id"])
         if guard_reason is not None:
             result.respawn_guarded.append((row["id"], guard_reason))
+            if targeted:
+                outcome = requested_by_id[row["id"]]
+                outcome.outcome = "respawn_guarded"
+                outcome.assignee = row_assignee
+                outcome.detail = guard_reason
             # Emit an event so operators can see why the task was
             # skipped when reading `hermes kanban tail` — without
             # this the task appears stuck in ready with no diagnosis.
@@ -8372,6 +8552,10 @@ def _dispatch_once_locked(
             continue
         if dry_run:
             result.spawned.append((row["id"], row_assignee, ""))
+            if targeted:
+                outcome = requested_by_id[row["id"]]
+                outcome.outcome = "spawned"
+                outcome.assignee = row_assignee
             # Increment per-profile counter even in dry_run so the cap
             # check sees the would-be spawn on subsequent iterations.
             # Without this, dry_run reports every task as spawnable and
@@ -8383,6 +8567,28 @@ def _dispatch_once_locked(
             continue
         claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
+            if targeted:
+                current = conn.execute(
+                    "SELECT status, claim_lock, assignee FROM tasks WHERE id = ?",
+                    (row["id"],),
+                ).fetchone()
+                outcome = requested_by_id[row["id"]]
+                outcome.assignee = (
+                    current["assignee"] if current is not None else row_assignee
+                )
+                if current is None:
+                    outcome.outcome = "not_found"
+                elif current["claim_lock"] is not None:
+                    outcome.outcome = "claimed"
+                    outcome.detail = current["status"]
+                elif current["status"] != "ready":
+                    outcome.outcome = "status_not_ready"
+                    outcome.detail = current["status"]
+                else:
+                    # A direct claimer can win the Ready CAS without using the
+                    # dispatch lock. Fail closed and expose the lost claim race.
+                    outcome.outcome = "claimed"
+                    outcome.detail = "claim_race"
             continue
         try:
             resolved_branch_name = None
@@ -8397,6 +8603,11 @@ def _dispatch_once_locked(
             )
             if auto:
                 result.auto_blocked.append(claimed.id)
+            if targeted:
+                outcome = requested_by_id[claimed.id]
+                outcome.outcome = "spawn_failed"
+                outcome.assignee = claimed.assignee
+                outcome.detail = f"workspace: {exc}"
             continue
         # Persist the resolved workspace path so the worker can cd there.
         set_workspace_path(conn, claimed.id, str(workspace))
@@ -8427,6 +8638,11 @@ def _dispatch_once_locked(
             # counter is cleared only on successful completion (see
             # complete_task).
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
+            if targeted:
+                outcome = requested_by_id[claimed.id]
+                outcome.outcome = "spawned"
+                outcome.assignee = claimed.assignee
+                outcome.workspace = str(workspace)
             spawned += 1
             # Track the new in-flight count for this profile so later
             # iterations in this same tick respect the per-profile cap
@@ -8442,6 +8658,16 @@ def _dispatch_once_locked(
             )
             if auto:
                 result.auto_blocked.append(claimed.id)
+            if targeted:
+                outcome = requested_by_id[claimed.id]
+                outcome.outcome = "spawn_failed"
+                outcome.assignee = claimed.assignee
+                outcome.detail = str(exc)
+
+    if targeted:
+        # Exact-target dispatch is Ready-only. In particular, an empty/all-bad
+        # target set must not fall through into the unfiltered review queue.
+        return result
 
     # ---- review column dispatch ----
     # Review tasks are tasks that a worker moved to 'review' after

--- a/tests/hermes_cli/test_kanban_targeted_dispatch.py
+++ b/tests/hermes_cli/test_kanban_targeted_dispatch.py
@@ -1,0 +1,518 @@
+"""Regression tests for fail-closed exact-task kanban dispatch."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kanban_cli
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def exact_dispatch_board(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    for profile in ("alpha", "beta", "default"):
+        (home / "profiles" / profile).mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_BROKER", "0")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = kb.kanban_db_path(board="default")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.init_db()
+    with kb.connect() as conn:
+        yield conn
+
+
+def _spawn_recorder(calls: list[str]):
+    def spawn(task, _workspace, board=None):
+        calls.append(task.id)
+        return 90001 + len(calls)
+
+    return spawn
+
+
+def _outcomes(result: kb.DispatchResult) -> dict[str, kb.RequestedDispatchOutcome]:
+    return {item.task_id: item for item in result.requested_outcomes}
+
+
+def _task(conn, task_id: str) -> kb.Task:
+    task = kb.get_task(conn, task_id)
+    assert task is not None
+    return task
+
+
+def _database_file_bytes() -> dict[str, bytes | None]:
+    """Snapshot the database and WAL/SHM sidecars without creating them."""
+    db_path = kb.kanban_db_path(board="default")
+    paths = (db_path, Path(f"{db_path}-wal"), Path(f"{db_path}-shm"))
+    return {path.name: path.read_bytes() if path.exists() else None for path in paths}
+
+
+def test_exact_target_does_not_spawn_higher_priority_unrequested_ready_task(
+    exact_dispatch_board,
+):
+    conn = exact_dispatch_board
+    heavy = kb.create_task(
+        conn,
+        title="heavy build",
+        assignee="alpha",
+        priority=1000,
+    )
+    target = kb.create_task(
+        conn,
+        title="low cpu read only",
+        assignee="beta",
+        priority=1,
+    )
+    calls: list[str] = []
+
+    result = kb.dispatch_once(
+        conn,
+        task_ids=[target],
+        spawn_fn=_spawn_recorder(calls),
+        max_spawn=4,
+    )
+
+    assert calls == [target]
+    assert [item[0] for item in result.spawned] == [target]
+    assert _outcomes(result)[target].outcome == "spawned"
+    assert _task(conn, heavy).status == "ready"
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM task_runs WHERE task_id = ?", (heavy,)
+        ).fetchone()[0]
+        == 0
+    )
+
+
+def test_recompute_can_promote_unrequested_task_without_dispatching_it(
+    exact_dispatch_board,
+):
+    conn = exact_dispatch_board
+    parent = kb.create_task(conn, title="parent", assignee="alpha")
+    child = kb.create_task(
+        conn,
+        title="newly promoted heavy child",
+        assignee="alpha",
+        priority=1000,
+        parents=[parent],
+    )
+    target = kb.create_task(
+        conn,
+        title="explicit safe target",
+        assignee="beta",
+        priority=1,
+    )
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status = 'done', claim_lock = NULL WHERE id = ?",
+            (parent,),
+        )
+    assert _task(conn, child).status == "todo"
+    calls: list[str] = []
+
+    result = kb.dispatch_once(
+        conn,
+        task_ids=[target],
+        spawn_fn=_spawn_recorder(calls),
+        max_spawn=4,
+    )
+
+    assert result.promoted == 1
+    assert calls == [target]
+    assert _task(conn, child).status == "ready"
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM task_runs WHERE task_id = ?", (child,)
+        ).fetchone()[0]
+        == 0
+    )
+
+
+def test_empty_unknown_and_malformed_target_sets_never_fall_back(
+    exact_dispatch_board,
+):
+    conn = exact_dispatch_board
+    heavy = kb.create_task(conn, title="generic heavy", assignee="alpha")
+    calls: list[str] = []
+    spawn = _spawn_recorder(calls)
+
+    empty = kb.dispatch_once(conn, task_ids=[], spawn_fn=spawn)
+    mixed = kb.dispatch_once(
+        conn,
+        task_ids=["t_deadbeef", "not-a-task"],
+        spawn_fn=spawn,
+    )
+    malformed_with_valid = kb.dispatch_once(
+        conn,
+        task_ids=[heavy, "BAD"],
+        spawn_fn=spawn,
+    )
+
+    assert empty.targeted is True
+    assert empty.requested_outcomes == []
+    assert [(item.task_id, item.outcome) for item in mixed.requested_outcomes] == [
+        ("t_deadbeef", "not_found"),
+        ("not-a-task", "malformed"),
+    ]
+    assert [
+        (item.task_id, item.outcome) for item in malformed_with_valid.requested_outcomes
+    ] == [
+        (heavy, "target_set_invalid"),
+        ("BAD", "malformed"),
+    ]
+    assert calls == []
+    assert _task(conn, heavy).status == "ready"
+
+
+def test_targeted_dry_run_has_no_database_writes_or_spawn_calls(
+    exact_dispatch_board,
+):
+    conn = exact_dispatch_board
+    target = kb.create_task(conn, title="target", assignee="alpha")
+    kb.create_task(conn, title="unrequested", assignee="beta", priority=100)
+    total_changes_before = conn.total_changes
+    dump_before = "\n".join(conn.iterdump())
+
+    def forbidden_spawn(*_args, **_kwargs):
+        raise AssertionError("dry-run must not invoke spawn_fn")
+
+    result = kb.dispatch_once(
+        conn,
+        task_ids=[target],
+        spawn_fn=forbidden_spawn,
+        dry_run=True,
+    )
+
+    assert _outcomes(result)[target].outcome == "spawned"
+    assert result.spawned == [(target, "alpha", "")]
+    assert conn.total_changes == total_changes_before
+    assert "\n".join(conn.iterdump()) == dump_before
+
+
+def test_targeted_dispatch_lock_contention_fails_closed_without_writes(
+    exact_dispatch_board,
+):
+    conn = exact_dispatch_board
+    target = kb.create_task(conn, title="target", assignee="alpha")
+    total_changes_before = conn.total_changes
+    dump_before = "\n".join(conn.iterdump())
+    calls: list[str] = []
+
+    with kb._dispatch_tick_lock(kb.kanban_db_path(board="default")) as held:
+        assert held is True
+        files_before = _database_file_bytes()
+        result = kb.dispatch_once(
+            conn,
+            task_ids=[target, "BAD"],
+            spawn_fn=_spawn_recorder(calls),
+        )
+        files_after = _database_file_bytes()
+
+    assert result.skipped_locked is True
+    assert result.targeted is True
+    assert [(item.task_id, item.outcome) for item in result.requested_outcomes] == [
+        (target, "locked"),
+        ("BAD", "malformed"),
+    ]
+    assert calls == []
+    assert files_after == files_before
+    assert conn.total_changes == total_changes_before
+    assert "\n".join(conn.iterdump()) == dump_before
+
+
+def test_targeted_dispatch_lock_open_failure_fails_closed_without_writes(
+    exact_dispatch_board,
+    monkeypatch,
+    caplog,
+):
+    conn = exact_dispatch_board
+    target = kb.create_task(conn, title="target", assignee="alpha")
+    total_changes_before = conn.total_changes
+    dump_before = "\n".join(conn.iterdump())
+    calls: list[str] = []
+    original_open = Path.open
+
+    def deny_dispatch_lock_open(path, *args, **kwargs):
+        if path.name.endswith(".dispatch.lock"):
+            raise PermissionError("adversarial dispatch-lock open denial")
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", deny_dispatch_lock_open)
+    with caplog.at_level(logging.ERROR, logger=kb.__name__):
+        files_before = _database_file_bytes()
+        result = kb.dispatch_once(
+            conn,
+            task_ids=[target, "BAD"],
+            spawn_fn=_spawn_recorder(calls),
+        )
+        files_after = _database_file_bytes()
+
+    assert result.skipped_locked is True
+    assert result.targeted is True
+    assert [(item.task_id, item.outcome) for item in result.requested_outcomes] == [
+        (target, "locked"),
+        ("BAD", "malformed"),
+    ]
+    assert result.spawned == []
+    assert calls == []
+    assert _task(conn, target).status == "ready"
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM task_runs WHERE task_id = ?", (target,)
+        ).fetchone()[0]
+        == 0
+    )
+    assert files_after == files_before
+    assert conn.total_changes == total_changes_before
+    assert "\n".join(conn.iterdump()) == dump_before
+    assert "dispatch lock unavailable" in caplog.text
+    assert "check permissions for the board data directory" in caplog.text
+    lock_path = kb.kanban_db_path(board="default").with_name(
+        kb.kanban_db_path(board="default").name + ".dispatch.lock"
+    )
+    assert str(lock_path) not in caplog.text
+    assert lock_path.name not in caplog.text
+    assert "adversarial dispatch-lock open denial" not in caplog.text
+    assert "PermissionError" not in caplog.text
+    assert "Traceback" not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
+
+
+@pytest.mark.parametrize(
+    "limit_kwargs",
+    [{"max_spawn": 1}, {"max_in_progress": 1}],
+    ids=["cli-max", "configured-max-in-progress"],
+)
+def test_targeted_dispatch_preserves_global_running_ceiling(
+    exact_dispatch_board,
+    limit_kwargs,
+):
+    conn = exact_dispatch_board
+    running = kb.create_task(conn, title="already running", assignee="alpha")
+    assert kb.claim_task(conn, running) is not None
+    target = kb.create_task(conn, title="target", assignee="beta")
+    calls: list[str] = []
+
+    result = kb.dispatch_once(
+        conn,
+        task_ids=[target],
+        spawn_fn=_spawn_recorder(calls),
+        **limit_kwargs,
+    )
+
+    assert calls == []
+    assert _outcomes(result)[target].outcome == "ceiling_reached"
+    assert _task(conn, target).status == "ready"
+    assert (
+        conn.execute("SELECT COUNT(*) FROM tasks WHERE status = 'running'").fetchone()[
+            0
+        ]
+        == 1
+    )
+
+
+def test_target_outcomes_cover_claimed_status_and_missing(exact_dispatch_board):
+    conn = exact_dispatch_board
+    claimed = kb.create_task(conn, title="claimed", assignee="alpha")
+    assert kb.claim_task(conn, claimed) is not None
+    not_ready = kb.create_task(conn, title="done", assignee="beta")
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (not_ready,))
+
+    result = kb.dispatch_once(
+        conn,
+        task_ids=[claimed, not_ready, "t_deadbeef", "BAD"],
+        spawn_fn=lambda *_args, **_kwargs: pytest.fail("nothing is spawnable"),
+    )
+
+    assert [(item.task_id, item.outcome) for item in result.requested_outcomes] == [
+        (claimed, "claimed"),
+        (not_ready, "status_not_ready"),
+        ("t_deadbeef", "not_found"),
+        ("BAD", "malformed"),
+    ]
+
+
+def test_target_outcome_profile_capped(exact_dispatch_board):
+    conn = exact_dispatch_board
+    running = kb.create_task(conn, title="running", assignee="alpha")
+    assert kb.claim_task(conn, running) is not None
+    target = kb.create_task(conn, title="target", assignee="alpha")
+
+    result = kb.dispatch_once(
+        conn,
+        task_ids=[target],
+        spawn_fn=lambda *_args, **_kwargs: pytest.fail("profile is capped"),
+        max_in_progress_per_profile=1,
+    )
+
+    outcome = _outcomes(result)[target]
+    assert (outcome.outcome, outcome.assignee, outcome.current) == (
+        "profile_capped",
+        "alpha",
+        1,
+    )
+
+
+def test_target_state_race_fails_closed(exact_dispatch_board, monkeypatch):
+    conn = exact_dispatch_board
+    target = kb.create_task(conn, title="racing target", assignee="alpha")
+
+    def lose_claim_race(race_conn, task_id, **_kwargs):
+        with kb.write_txn(race_conn):
+            race_conn.execute(
+                "UPDATE tasks SET status = 'done' WHERE id = ?",
+                (task_id,),
+            )
+        return None
+
+    monkeypatch.setattr(kb, "claim_task", lose_claim_race)
+    result = kb.dispatch_once(
+        conn,
+        task_ids=[target],
+        spawn_fn=lambda *_args, **_kwargs: pytest.fail("race loser must not spawn"),
+    )
+
+    outcome = _outcomes(result)[target]
+    assert (outcome.outcome, outcome.detail) == ("status_not_ready", "done")
+    assert _task(conn, target).status == "done"
+
+
+def test_target_outcome_nonspawnable(exact_dispatch_board):
+    conn = exact_dispatch_board
+    target = kb.create_task(conn, title="terminal lane", assignee="not-a-profile")
+
+    result = kb.dispatch_once(
+        conn,
+        task_ids=[target],
+        spawn_fn=lambda *_args, **_kwargs: pytest.fail("lane must not spawn"),
+    )
+
+    outcome = _outcomes(result)[target]
+    assert (outcome.outcome, outcome.assignee) == (
+        "nonspawnable",
+        "not-a-profile",
+    )
+
+
+def test_target_outcome_respawn_guarded(exact_dispatch_board, monkeypatch):
+    conn = exact_dispatch_board
+    target = kb.create_task(conn, title="guarded", assignee="alpha")
+    monkeypatch.setattr(
+        kb,
+        "check_respawn_guard",
+        lambda *_args, **_kwargs: "recent_success",
+    )
+
+    result = kb.dispatch_once(
+        conn,
+        task_ids=[target],
+        spawn_fn=lambda *_args, **_kwargs: pytest.fail("guarded task must not spawn"),
+    )
+
+    outcome = _outcomes(result)[target]
+    assert (outcome.outcome, outcome.detail) == (
+        "respawn_guarded",
+        "recent_success",
+    )
+
+
+def test_dispatch_parser_collects_repeatable_exact_task_ids():
+    root = argparse.ArgumentParser()
+    subparsers = root.add_subparsers(dest="command")
+    kanban_cli.build_parser(subparsers)
+
+    args = root.parse_args([
+        "kanban",
+        "dispatch",
+        "--task-id",
+        "t_deadbeef",
+        "--task-id",
+        "t_feedface",
+    ])
+
+    assert args.task_ids == ["t_deadbeef", "t_feedface"]
+
+
+@pytest.mark.parametrize("as_json", [False, True])
+def test_cli_reports_each_exact_requested_outcome(
+    exact_dispatch_board,
+    monkeypatch,
+    capsys,
+    as_json,
+):
+    outcomes = [
+        kb.RequestedDispatchOutcome("BAD", "malformed"),
+        kb.RequestedDispatchOutcome("t_deadbeef", "not_found"),
+        kb.RequestedDispatchOutcome("t_00000001", "status_not_ready", detail="todo"),
+        kb.RequestedDispatchOutcome("t_00000002", "claimed", detail="running"),
+        kb.RequestedDispatchOutcome(
+            "t_00000003", "profile_capped", assignee="alpha", current=1
+        ),
+        kb.RequestedDispatchOutcome(
+            "t_00000004", "nonspawnable", assignee="terminal-lane"
+        ),
+        kb.RequestedDispatchOutcome(
+            "t_00000005", "respawn_guarded", detail="recent_success"
+        ),
+        kb.RequestedDispatchOutcome("t_00000006", "ceiling_reached"),
+        kb.RequestedDispatchOutcome(
+            "t_00000007", "spawned", assignee="beta", workspace="/tmp/w"
+        ),
+    ]
+    fake_result = kb.DispatchResult(
+        targeted=True,
+        requested_outcomes=outcomes,
+        spawned=[("t_00000007", "beta", "/tmp/w")],
+    )
+    monkeypatch.setattr(kb, "dispatch_once", lambda *_args, **_kwargs: fake_result)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    args = argparse.Namespace(
+        dry_run=False,
+        max=None,
+        failure_limit=2,
+        json=as_json,
+        task_ids=[item.task_id for item in outcomes],
+    )
+
+    assert kanban_cli._cmd_dispatch(args) == 1
+    output = capsys.readouterr().out
+    if as_json:
+        payload = json.loads(output)
+        assert [(row["task_id"], row["outcome"]) for row in payload["requested"]] == [
+            (item.task_id, item.outcome) for item in outcomes
+        ]
+        assert payload["targeted"] is True
+    else:
+        for item in outcomes:
+            assert f"{item.task_id}: {item.outcome}" in output
+
+
+def test_cli_empty_target_result_is_nonzero_and_explicit(
+    exact_dispatch_board,
+    monkeypatch,
+    capsys,
+):
+    monkeypatch.setattr(
+        kb,
+        "dispatch_once",
+        lambda *_args, **_kwargs: kb.DispatchResult(targeted=True),
+    )
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    args = argparse.Namespace(
+        dry_run=False,
+        max=None,
+        failure_limit=2,
+        json=False,
+        task_ids=[],
+    )
+
+    assert kanban_cli._cmd_dispatch(args) == 1
+    assert "empty target set" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- add repeatable `hermes kanban dispatch --task-id t_...` exact Ready-task dispatch
- fail closed for explicit empty/malformed/missing/claimed/not-ready target sets and for targeted lock/path failures; never fall through to generic Ready or review selection
- expose one ordered per-id outcome in text/JSON (`spawned`, `locked`, `malformed`, `not_found`, `claimed`, `status_not_ready`, `ceiling_reached`, `profile_capped`, `nonspawnable`, `respawn_guarded`, `spawn_failed`, etc.)
- keep targeted dry-runs side-effect-free, including DB/WAL/SHM bytes and checkpoint hygiene
- preserve the official generic dispatcher path: reconciliation, Ready/review selection, concurrency caps, respawn guard, spawn flow, degraded lock fallback, and successful-tick WAL checkpoint behavior

This is a clean three-file transplant of the reviewed PR7 targeted-dispatch patch onto current official `main`; it supersedes the earlier partial approach in #53956 rather than importing the fork-only 13-commit dispatcher hardening stack.

## Reviewed-test adaptations

`tests/hermes_cli/test_kanban_targeted_dispatch.py` matches the reviewed 517-line test payload except for two mechanical adaptations required by current official APIs:

1. pass `max_in_progress_per_profile=1` in the profile-cap test because official `main` keeps that cap optional/configured
2. patch `check_respawn_guard` to return the official string reason instead of the fork-only `evaluate_respawn_guard` / `RespawnGuardDecision` API

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_kanban_targeted_dispatch.py tests/hermes_cli/test_kanban_dispatch_lock.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py tests/hermes_cli/test_kanban_db_repair.py -q`
  - 58 passed, 0 failed
- `.venv/bin/ruff check hermes_cli/kanban.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_targeted_dispatch.py`
  - passed
- `python3 -m py_compile ...`
  - passed
- `git diff --check origin/main...HEAD`
  - passed
- `graphify update .`
  - rebuilt 141,022 nodes / 270,017 edges / 4,752 communities; generated output was intentionally not committed
- complete canonical `scripts/run_tests.sh -j 16`
  - completed 20,431 discovered tests; 53 failures in unrelated optional/environment-sensitive areas, with no failure in any kanban path
  - replaying the exact failing-file set against a clean official-main worktree reproduced 53 failures and the same 10 ACP collection/import failures; isolated reruns showed the one-file WeCom/Honcho distribution is local-state/dependency-sensitive, not caused by this three-file diff

## Scope

Only:

- `hermes_cli/kanban.py`
- `hermes_cli/kanban_db.py`
- `tests/hermes_cli/test_kanban_targeted_dispatch.py`
