### PR TITLE
fix(codex): handle completed auxiliary responses

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1216,11 +1216,19 @@ class _CodexCompletionsAdapter:
 
             event_stream = self._client.responses.create(**stream_kwargs)
             try:
-                final = _consume_codex_event_stream(
-                    event_stream,
-                    model=resp_kwargs.get("model"),
-                    on_event=_on_each_event,
-                )
+                # Some Codex-compatible hosts accept ``stream=True`` but return
+                # a completed Responses object instead of an SSE iterator. Do
+                # not hand that object to the event consumer: typed Responses
+                # (and compatibility shims such as SimpleNamespace) are not
+                # event streams and may not be iterable at all.
+                if hasattr(event_stream, "output"):
+                    final = event_stream
+                else:
+                    final = _consume_codex_event_stream(
+                        event_stream,
+                        model=str(resp_kwargs.get("model") or model),
+                        on_event=_on_each_event,
+                    )
             finally:
                 close_fn = getattr(event_stream, "close", None)
                 if callable(close_fn):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3301,6 +3301,43 @@ class TestCodexAuxiliaryAdapterNullOutputRecovery:
             codex_runtime._consume_codex_event_stream = original_consume
 
 
+class TestCodexAuxiliaryAdapterCompletedResponse:
+    def test_accepts_completed_response_when_stream_was_requested(self):
+        completed = SimpleNamespace(
+            status="completed",
+            id="resp_completed",
+            output=[SimpleNamespace(
+                type="message",
+                content=[SimpleNamespace(
+                    type="output_text",
+                    text="completed response",
+                )],
+            )],
+            usage=SimpleNamespace(
+                input_tokens=11,
+                output_tokens=3,
+                total_tokens=14,
+            ),
+        )
+
+        class FakeResponses:
+            def create(self, **kwargs):
+                assert kwargs["stream"] is True
+                return completed
+
+        fake_client = SimpleNamespace(responses=FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.6-terra")
+
+        response = adapter.create(
+            messages=[{"role": "user", "content": "review this"}],
+        )
+
+        assert response.choices[0].message.content == "completed response"
+        assert response.usage.prompt_tokens == 11
+        assert response.usage.completion_tokens == 3
+        assert response.usage.total_tokens == 14
+
+
 # ---------------------------------------------------------------------------
 # Issue #23432 — auxiliary timeout poisons cached client; later aux calls fail
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes the Codex auxiliary Responses adapter when a compatible endpoint accepts `stream=True` but returns a completed Responses object instead of an SSE iterator.

The adapter previously passed every return value to `_consume_codex_event_stream()`. A completed `SimpleNamespace` or typed Responses object therefore failed with:

```text
TypeError: 'types.SimpleNamespace' object is not iterable
```

The fix uses the Responses contract as the discriminator: objects with `output` are normalized as completed responses, while genuine event streams continue through the existing SSE consumer.

This also covers the official OpenAI SDK shape: typed `Response` objects expose `output` and are themselves iterable over fields, while the SDK `Stream` container is iterable but does not expose `output`. Checking generic iterability would therefore be incorrect.

This surfaced with an `openai-codex` GPT model as a MoA aggregator, but the adapter is shared by other Codex auxiliary tasks.

## Related Issue

Partially addresses #74532

> **Scope update (2026-07-31):** This PR fixes the inner `_CodexCompletionsAdapter` failure: a completed Responses object was incorrectly consumed as an SSE iterator. Independent end-to-end streamed-MoA verification found a second, outer Relay streaming-boundary defect after this normalization. **#74031** addresses that boundary; #74532 should remain open until the combined path (or an equivalent unified fix) is verified.

The inner adapter defect here is distinct from the earlier #55933 / #56713 guards. However, the full Codex-MoA streamed path also traverses the outer Relay seam covered by #74031, so both layers must be accounted for before the issue is closed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py`: distinguish completed Responses objects from SSE streams before event consumption.
- `tests/agent/test_auxiliary_client.py`: add regression coverage for completed-response content and token-usage normalization.

## How to Test

1. On unmodified current `main`, pass a completed `SimpleNamespace(output=[...])` from `responses.create(stream=True)` and confirm the exact baseline failure:
   ```text
   TypeError: 'types.SimpleNamespace' object is not iterable
   ```
2. Run the relevant CI-parity suite:
   ```bash
   scripts/run_tests.sh tests/agent/test_auxiliary_client.py tests/run_agent/test_moa_streaming.py tests/run_agent/test_streaming.py -q
   ```
   Result: 199 passed.
3. Run Ruff and whitespace validation:
   ```bash
   ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client.py
   git diff --check
   ```
4. Live smoke test: a prepared MoA aggregator call using `openai-codex` / `gpt-5.6-sol`, `stream=True`, and a dummy tool schema returned a completed chat response containing exactly `MOA_UPSTREAM_OK` with no tool call.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the project test wrapper and all relevant tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.3, Apple Silicon, Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation update: N/A, internal compatibility fix with no user-facing API change
- [x] `cli-config.yaml.example`: N/A, no config changes
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A, no architecture or workflow changes
- [x] Cross-platform impact considered: shape-based Python handling, no platform-specific behavior
- [x] Tool descriptions/schemas: N/A, no tool behavior changes

## Screenshots / Logs

Deterministic reproduction on unmodified current `main`:

```text
BASELINE_ERROR=TypeError: 'types.SimpleNamespace' object is not iterable
```

Same input after the fix:

```text
FIXED_CONTENT=ok
```

Independent pre-commit review passed with no security concerns, logic errors, suggestions, or requested changes. Static security scans were also clean.

