### PR TITLE
fix(desktop): sync pins across messaging session rows

### DIFF
--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -11,7 +11,7 @@ vi.mock('@/hermes', () => ({
 }))
 
 import { $pinnedSessionIds } from '@/store/layout'
-import { $sessions } from '@/store/session'
+import { $messagingSessions, $sessions } from '@/store/session'
 
 import { watchSessionPins } from './session-pin-sync'
 
@@ -29,12 +29,14 @@ beforeAll(() => {
 
 beforeEach(() => {
   $sessions.set([])
+  $messagingSessions.set([])
   $pinnedSessionIds.set([])
   patch.mockClear()
 })
 
 afterEach(() => {
   $sessions.set([])
+  $messagingSessions.set([])
   $pinnedSessionIds.set([])
 })
 
@@ -71,6 +73,18 @@ describe('watchSessionPins', () => {
     expect(patch).toHaveBeenCalledWith('c', true, 'p2')
   })
 
+  it('flushes a pending pin from a messaging row with its profile', async () => {
+    $pinnedSessionIds.set(['pending-message'])
+    await flush()
+    expect(patch).not.toHaveBeenCalled()
+
+    $messagingSessions.set([row('pending-message', { profile: 'chat-profile', source: 'telegram' })])
+    await flush()
+
+    expect(patch).toHaveBeenCalledTimes(1)
+    expect(patch).toHaveBeenCalledWith('pending-message', true, 'chat-profile')
+  })
+
   it('matches a pin id against the lineage root', async () => {
     // pin id is the lineage root; the live row carries it as _lineage_root_id.
     $sessions.set([row('tip', { _lineage_root_id: 'root' })])
@@ -92,9 +106,82 @@ describe('watchSessionPins', () => {
 
     expect(patch).not.toHaveBeenCalled()
   })
+
+  it('writes once when both stores represent the same durable conversation', async () => {
+    $sessions.set([row('local-tip', { _lineage_root_id: 'shared-pin' })])
+    $messagingSessions.set([row('message-tip', { _lineage_root_id: 'shared-pin', source: 'telegram' })])
+    $pinnedSessionIds.set(['shared-pin'])
+    await flush()
+
+    expect(patch).toHaveBeenCalledTimes(1)
+    expect(patch).toHaveBeenCalledWith('shared-pin', true, undefined)
+  })
+
+  it('resolves a pending tip id after its lineage is deduplicated', async () => {
+    $pinnedSessionIds.set(['legacy-tip'])
+    $sessions.set([row('legacy-root', { profile: 'root-profile' })])
+    $messagingSessions.set([
+      row('legacy-tip', {
+        _lineage_root_id: 'legacy-root',
+        profile: 'message-profile',
+        source: 'telegram'
+      })
+    ])
+    await flush()
+
+    expect(patch).toHaveBeenCalledTimes(1)
+    expect(patch).toHaveBeenCalledWith('legacy-tip', true, 'message-profile')
+  })
 })
 
 describe('watchSessionPins remote pull', () => {
+  it('adopts a messaging pin on its durable root without echoing a PATCH', async () => {
+    $messagingSessions.set([row('message-tip', { _lineage_root_id: 'message-root', pinned: true, source: 'telegram' })])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toEqual(['message-root'])
+    expect(patch).not.toHaveBeenCalled()
+  })
+
+  it('deduplicates a split lineage without discarding its authoritative pin', async () => {
+    $sessions.set([row('shared-root')])
+    $messagingSessions.set([row('shared-tip', { _lineage_root_id: 'shared-root', pinned: true, source: 'telegram' })])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toEqual(['shared-root'])
+    expect(patch).not.toHaveBeenCalled()
+  })
+
+  it('defers remote reconciliation when duplicate rows carry conflicting pin values', async () => {
+    $sessions.set([row('conflict-tip', { _lineage_root_id: 'conflict-root', pinned: true })])
+    $messagingSessions.set([row('conflict-root', { pinned: false, source: 'telegram' })])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toEqual(['conflict-root'])
+    expect(patch).not.toHaveBeenCalled()
+  })
+
+  it('leaves an unpinned renderer unpinned when conflicting rows arrive in reverse order', async () => {
+    $messagingSessions.set([row('reverse-root', { pinned: false, source: 'telegram' })])
+    $sessions.set([row('reverse-tip', { _lineage_root_id: 'reverse-root', pinned: true })])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toEqual([])
+    expect(patch).not.toHaveBeenCalled()
+  })
+
+  it('reconciles when either session slice updates', async () => {
+    $sessions.set([row('local-remote', { pinned: true })])
+    await flush()
+    expect($pinnedSessionIds.get()).toEqual(['local-remote'])
+
+    $messagingSessions.set([row('message-remote', { pinned: true, source: 'telegram' })])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toEqual(['local-remote', 'message-remote'])
+    expect(patch).not.toHaveBeenCalled()
+  })
+
   it('adopts a pin another app made', async () => {
     $sessions.set([row('remote', { pinned: true })])
     await flush()
@@ -164,5 +251,42 @@ describe('watchSessionPins remote pull', () => {
     await flush()
 
     expect($pinnedSessionIds.get()).not.toContain('race')
+  })
+
+  it('guards a messaging pin from a stale page while its write is in flight', async () => {
+    let settle: (v: { ok: boolean }) => void = () => {}
+
+    patch.mockImplementationOnce(() => new Promise(resolve => (settle = resolve)))
+
+    $messagingSessions.set([row('message-race-tip', { _lineage_root_id: 'message-race-root', source: 'telegram' })])
+    $pinnedSessionIds.set(['message-race-tip'])
+    await flush()
+    expect(patch).toHaveBeenCalledWith('message-race-tip', true, undefined)
+
+    $messagingSessions.set([
+      row('message-race-tip', {
+        _lineage_root_id: 'message-race-root',
+        pinned: false,
+        source: 'telegram'
+      })
+    ])
+    await flush()
+    expect($pinnedSessionIds.get()).toContain('message-race-tip')
+
+    settle({ ok: true })
+    await flush()
+    await flush()
+
+    $messagingSessions.set([
+      row('message-race-tip', {
+        _lineage_root_id: 'message-race-root',
+        pinned: false,
+        source: 'telegram'
+      }),
+      row('another-message', { source: 'telegram' })
+    ])
+    await flush()
+
+    expect($pinnedSessionIds.get()).not.toContain('message-race-tip')
   })
 })

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -22,7 +22,8 @@
 
 import { setSessionPinnedRemote } from '@/hermes'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
-import { $sessions, sessionMatchesStoredId, sessionPinId } from '@/store/session'
+import { $messagingSessions, $sessions, sessionMatchesStoredId, sessionPinId } from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
 
 // pin ids we've successfully PATCHed pinned=true this session.
 const mirrored = new Set<string>()
@@ -34,8 +35,56 @@ const pending = new Set<string>()
 // the request's own lifetime is the guard, so nothing can leave one open.
 const unconfirmed = new Map<string, boolean>()
 
-function profileFor(pinId: string): null | string | undefined {
-  return $sessions.get().find(row => sessionMatchesStoredId(row, pinId))?.profile
+interface PinSyncConversation {
+  pinId: string
+  representative: SessionInfo
+  rows: SessionInfo[]
+}
+
+/** One identity group per durable conversation across both sidebar slices. */
+function pinSyncConversations(): PinSyncConversation[] {
+  const byPinId = new Map<string, PinSyncConversation>()
+
+  for (const row of [...$sessions.get(), ...$messagingSessions.get()]) {
+    const pinId = sessionPinId(row)
+    const existing = byPinId.get(pinId)
+
+    if (!existing) {
+      byPinId.set(pinId, { pinId, representative: row, rows: [row] })
+
+      continue
+    }
+
+    existing.rows.push(row)
+
+    const existingHasPin = typeof existing.representative.pinned === 'boolean'
+    const rowHasPin = typeof row.pinned === 'boolean'
+
+    if (
+      (!existingHasPin && rowHasPin) ||
+      (existingHasPin === rowHasPin && row.id === pinId && existing.representative.id !== pinId)
+    ) {
+      existing.representative = row
+    }
+  }
+
+  return [...byPinId.values()]
+}
+
+function rowFor(conversations: PinSyncConversation[], storedId: string): SessionInfo | undefined {
+  for (const conversation of conversations) {
+    const row = conversation.rows.find(entry => sessionMatchesStoredId(entry, storedId))
+
+    if (row) {
+      return row
+    }
+  }
+
+  return undefined
+}
+
+function profileFor(conversations: PinSyncConversation[], pinId: string): null | string | undefined {
+  return rowFor(conversations, pinId)?.profile
 }
 
 /** PATCH the flag, guarding reads against pages that predate the write. */
@@ -60,10 +109,23 @@ function writePin(id: string, pinned: boolean, profile?: null | string): Promise
  * time we reconcile — it gets marked as mirrored rather than echoed straight
  * back as a redundant PATCH.
  */
-function pullRemotePins(): void {
+function pullRemotePins(conversations: PinSyncConversation[]): void {
   const local = new Set($pinnedSessionIds.get())
 
-  for (const row of $sessions.get()) {
+  for (const conversation of conversations) {
+    const { pinId, representative: row, rows } = conversation
+
+    const pinnedValues = new Set(
+      rows.map(entry => entry.pinned).filter((pinned): pinned is boolean => typeof pinned === 'boolean')
+    )
+
+    // Both slices are filtered views of the same backend data; neither is more
+    // authoritative. If overlapping rows disagree, preserve local state until
+    // a later refresh converges instead of choosing a synthetic winner.
+    if (pinnedValues.size > 1) {
+      continue
+    }
+
     // A backend without the flag has no opinion; never act on `undefined`.
     if (typeof row.pinned !== 'boolean') {
       continue
@@ -71,11 +133,12 @@ function pullRemotePins(): void {
 
     // Pins are keyed on the durable lineage root so they survive compression
     // tip rotation; the row may surface under either identity.
-    const pinId = sessionPinId(row)
-    const heldLocally = local.has(pinId) || local.has(row.id)
+    const heldId = local.has(pinId) ? pinId : rows.find(entry => local.has(entry.id))?.id
+    const heldLocally = heldId !== undefined
 
     // A write of ours the page hasn't caught up to yet is newer than the page.
-    const awaited = unconfirmed.has(pinId) ? unconfirmed.get(pinId) : unconfirmed.get(row.id)
+    const awaitedId = [pinId, ...rows.map(entry => entry.id)].find(id => unconfirmed.has(id))
+    const awaited = awaitedId === undefined ? undefined : unconfirmed.get(awaitedId)
 
     if (awaited !== undefined && awaited !== row.pinned) {
       continue
@@ -85,10 +148,13 @@ function pullRemotePins(): void {
       pinSession(pinId)
       // Already true server-side; record it so the push pass doesn't re-PATCH.
       mirrored.add(pinId)
-    } else if (!row.pinned && heldLocally) {
-      unpinSession(local.has(pinId) ? pinId : row.id)
+    } else if (!row.pinned && heldId !== undefined) {
+      unpinSession(heldId)
       mirrored.delete(pinId)
-      mirrored.delete(row.id)
+
+      for (const entry of rows) {
+        mirrored.delete(entry.id)
+      }
     }
   }
 }
@@ -99,7 +165,9 @@ function reconcile(): void {
     return
   }
 
-  pullRemotePins()
+  const conversations = pinSyncConversations()
+
+  pullRemotePins(conversations)
 
   const current = new Set($pinnedSessionIds.get())
 
@@ -108,7 +176,7 @@ function reconcile(): void {
     if (!current.has(id)) {
       mirrored.delete(id)
       pending.delete(id)
-      void writePin(id, false, profileFor(id)).catch(() => {})
+      void writePin(id, false, profileFor(conversations, id)).catch(() => {})
     }
   }
 
@@ -120,9 +188,9 @@ function reconcile(): void {
   }
 
   // Flush whatever we can resolve now; unresolved ids (row not loaded yet)
-  // retry on the next $sessions change.
+  // retry on the next session-list change.
   for (const id of [...pending]) {
-    const row = $sessions.get().find(entry => sessionMatchesStoredId(entry, id))
+    const row = rowFor(conversations, id)
 
     if (!row) {
       continue
@@ -143,4 +211,5 @@ export function watchSessionPins(): void {
   reconcile()
   $pinnedSessionIds.listen(reconcile)
   $sessions.listen(reconcile)
+  $messagingSessions.listen(reconcile)
 }


### PR DESCRIPTION
### Summary

- reconcile server-owned pins across both normal and messaging session slices
- deduplicate rows by durable lineage pin identity before pull/push reconciliation
- resolve profiles and pending pins from the same shared row projection
- subscribe pin reconciliation to updates from either session store

### Problem

PR #74234 made `sessions.pinned` authoritative across Desktop clients, but the renderer reconciliation path only reads and subscribes to `$sessions`. Messaging-source rows are intentionally fetched into the separate `$messagingSessions` store, so those rows cannot participate in remote pin adoption, profile lookup, or pending-pin flushing.

This leaves a server-pinned messaging conversation absent from another Desktop renderer's local pinned set even though its backend row is available in the messaging slice.

### Fix

Build one focused pin-sync identity projection from `$sessions` and `$messagingSessions`, keyed by `sessionPinId(row)`:

- keep one representative per durable conversation;
- retain member rows for legacy tip-ID and profile resolution;
- prefer an explicit backend `pinned` value over a row without an opinion when the explicit values agree;
- defer remote reconciliation when grouped rows carry conflicting explicit values, preserving current renderer state until a later refresh converges;
- use the exact lineage-root row only as a representative tie-breaker when values do not conflict;
- reuse the projection for remote pull, profile lookup, and pending-pin flush;
- reconcile when either source store changes.

The existing `unconfirmed` stale-page guard and lineage-root pin identity are preserved, with guard lookup extended across grouped row aliases.

### Regression coverage

The first regression test failed against current `origin/main`: a `pinned=true` row present only in `$messagingSessions` left `$pinnedSessionIds` empty. The completed suite covers:

- messaging-only remote pin adoption on the durable lineage root;
- no redundant PATCH when adopting authoritative server state;
- messaging-row profile resolution and pending-pin flushing;
- reconciliation triggered by either `$sessions` or `$messagingSessions`;
- at most one PATCH for a locally initiated pin when both stores represent the same durable conversation;
- deduplication without discarding the only explicit pin opinion;
- conflict deferral in both store-arrival orders, without selecting either slice as authoritative;
- pending legacy tip-ID resolution after lineage deduplication;
- preservation of the stale-page in-flight-write guard for alias-targeted messaging writes with distinct tip/root IDs.

### Validation

- `npx vitest run --project ui src/store/session-pin-sync.test.ts` — 20/20 passed
- `npm run test:ui` — 3,022/3,022 passed
- `npm run typecheck` — passed
- `npx eslint src/store/session-pin-sync.ts src/store/session-pin-sync.test.ts` — passed
- `git diff --check` — passed

### Scope

This PR addresses only pin reconciliation for the existing messaging session slice. It does not change session creation, resume routing, delegated-session discoverability, backend APIs, or database schema.

### Evidence boundary

A historical two-client observation occurred on a Desktop build released before #74234 merged. It is background context only and is not presented as a post-#74234 regression reproduction. The regression claim in this PR is based solely on the failing test executed against current `origin/main`.
