### PR TITLE
fix(apps): stop Desktop sleep/wake from wiring primary chat to the wrong profile backend

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -2,7 +2,9 @@ import { act, cleanup, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $desktopBoot } from '@/store/boot'
-import { $gatewayState } from '@/store/session'
+import { closeSecondaryGateways, isActivePrimary } from '@/store/gateway'
+import { $activeGatewayProfile, ensureGatewayProfile } from '@/store/profile'
+import { $connection, $gatewayState } from '@/store/session'
 
 import { takeGatewaySurvivor } from './gateway-hmr-survivor'
 import { useGatewayBoot } from './use-gateway-boot'
@@ -76,18 +78,30 @@ class FakeWebSocket {
   }
 }
 
-function fakeDesktop() {
-  const conn = {
-    authMode: 'token' as const,
-    baseUrl: 'https://vps.example.com',
-    profile: 'default',
-    token: 't',
-    wsUrl: 'wss://vps.example.com/api/ws?token=t'
-  }
+const primaryConn = {
+  authMode: 'token' as const,
+  baseUrl: 'https://vps.example.com',
+  profile: 'default',
+  token: 't',
+  wsUrl: 'wss://vps.example.com/api/ws?token=t'
+}
 
+const coderConn = {
+  authMode: 'token' as const,
+  baseUrl: 'https://coder.example.com',
+  profile: 'coder',
+  token: 'c',
+  wsUrl: 'wss://coder.example.com/api/ws?token=c'
+}
+
+function fakeDesktop() {
   return {
-    getConnection: vi.fn(async () => conn),
-    getGatewayWsUrl: vi.fn(async () => conn.wsUrl),
+    getConnection: vi.fn(async (profile?: null | string) => {
+      const key = (profile ?? '').trim()
+
+      return !key || key === 'default' ? primaryConn : coderConn
+    }),
+    getGatewayWsUrl: vi.fn(async (conn?: { wsUrl?: string }) => conn?.wsUrl ?? primaryConn.wsUrl),
     getBootProgress: vi.fn(async () => ({
       error: null,
       fakeMode: false,
@@ -143,6 +157,9 @@ beforeEach(() => {
     }
   }
 
+  closeSecondaryGateways()
+  $activeGatewayProfile.set('default')
+  $connection.set(null)
   vi.useFakeTimers()
   FakeWebSocket.mode = 'open'
   FakeWebSocket.instances = []
@@ -177,6 +194,9 @@ afterEach(() => {
     }
   }
 
+  closeSecondaryGateways()
+  $activeGatewayProfile.set('default')
+  $connection.set(null)
   vi.useRealTimers()
   ;(globalThis as { WebSocket: unknown }).WebSocket = originalWebSocket
   delete (window as { hermesDesktop?: unknown }).hermesDesktop
@@ -336,5 +356,46 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect($desktopBoot.get().error).toBeNull()
     expect($desktopBoot.get().visible).toBe(false)
     expect($desktopBoot.get().phase).toBe('renderer.ready')
+  })
+
+  it('FIX: primary sleep/wake reconnect dials the window backend, not the active secondary profile', async () => {
+    const desktop = fakeDesktop()
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    expect(FakeWebSocket.instances[0].url).toBe(primaryConn.wsUrl)
+
+    // Profile swap opens a secondary WS; briefly use real timers so that
+    // handshake isn't wedged behind the suite's fake clock.
+    vi.useRealTimers()
+    await ensureGatewayProfile('coder')
+    vi.useFakeTimers()
+
+    expect(isActivePrimary()).toBe(false)
+    expect($activeGatewayProfile.get()).toBe('coder')
+    expect($connection.get()?.profile).toBe('coder')
+    expect($connection.get()?.baseUrl).toBe(coderConn.baseUrl)
+
+    const callsBeforeDrop = desktop.getConnection.mock.calls.length
+    const socketsBeforeDrop = FakeWebSocket.instances.length
+    const primarySocket = FakeWebSocket.instances[0]
+
+    act(() => primarySocket.drop())
+    await flushAsync()
+    await advanceBackoff()
+
+    const reconnectCalls = desktop.getConnection.mock.calls.slice(callsBeforeDrop)
+    expect(reconnectCalls.some(args => (args[0] ?? '').trim() === 'coder')).toBe(false)
+    expect(reconnectCalls.some(args => args.length === 0 || args[0] == null || args[0] === '')).toBe(true)
+
+    const primaryReconnectSockets = FakeWebSocket.instances
+      .slice(socketsBeforeDrop)
+      .filter(socket => socket.url === primaryConn.wsUrl)
+    expect(primaryReconnectSockets.length).toBeGreaterThan(0)
+    expect($connection.get()?.profile).toBe('coder')
+    expect($connection.get()?.baseUrl).toBe(coderConn.baseUrl)
   })
 })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -17,6 +17,7 @@ import {
   closeSecondaryGateways,
   configureGatewayRegistry,
   ensureGatewayForProfile,
+  isActivePrimary,
   pruneSecondaryGateways,
   reconnectSecondaryGateways,
   reportPrimaryGatewayState,
@@ -150,13 +151,23 @@ export function useGatewayBoot({
         // "Starting Hermes…". The probe is a no-op for a healthy or local backend.
         await desktop.revalidateConnection?.().catch(() => undefined)
 
-        const conn = await desktop.getConnection($activeGatewayProfile.get())
+        // Primary sleep/wake reconnect must dial the WINDOW-owned primary backend
+        // (same as boot/softSwitch). Passing $activeGatewayProfile would retarget
+        // this primary socket at a secondary profile's backend after a live swap.
+        // Secondaries reconnect via reconnectSecondaryGateways().
+        const conn = await desktop.getConnection()
 
         if (cancelled) {
           return
         }
 
-        publish(conn)
+        // Only publish the primary descriptor when the primary is active.
+        // Otherwise a background-profile view would inherit the primary's
+        // mode/baseUrl and break image.attach / fs / media routing (#46651).
+        if (isActivePrimary()) {
+          publish(conn)
+        }
+
         // Re-mint the WS URL before reconnecting. OAuth tickets are single-use
         // with a short TTL, so the ticket baked into the cached conn.wsUrl is
         // dead on every reconnect after the initial boot — reusing it surfaces


### PR DESCRIPTION
## What does this PR do?

Fixes Desktop sleep/wake (and other primary WebSocket drop) reconnect so the window-owned primary gateway always redials the primary backend, not whichever profile is currently active in the sidebar. After concurrent primary+secondary sockets landed, the old single-socket reconnect still passed `$activeGatewayProfile` into `getConnection()`, which could wire the primary socket (and `$connection`) to a secondary backend.

### Bug Cause

`attemptReconnect` in `use-gateway-boot.ts` called `desktop.getConnection($activeGatewayProfile.get())` and then `connect`/`publish` on the effect-local primary `HermesGateway`. That was correct under the old single swapping socket model, but wrong after multi-profile concurrent sockets: primary reconnect must match boot/softSwitch (no-arg `getConnection()`), while secondaries reconnect via `reconnectSecondaryGateways()`.

### Reproduction Steps

1. Boot Desktop on the window primary profile (typically `default`).
2. Switch the sidebar to another profile (e.g. `coder`) with its own backend so a secondary socket is active.
3. Sleep/wake the machine, or drop the primary WebSocket while still on `coder`.
4. Observe primary reconnect using the active profile's descriptor; switching back to `default` can keep talking to the wrong backend.

Expected: primary reconnect dials only the window backend; secondaries reconnect on their own sockets; `$connection` / active socket / `primaryProfile` agree.
Before fix: primary socket and `publish()` can target the secondary backend.

### Fix

- `attemptReconnect` uses no-arg `getConnection()` (same as boot/softSwitch).
- `publish()` only when `isActivePrimary()`, so a background-profile view does not inherit the primary descriptor (#46651).
- Secondary profiles keep reconnecting through the existing registry path.
- Added a vitest covering live secondary swap then primary drop/reconnect.

## Related Issue

Fixes #74551

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts` - primary sleep/wake reconnect dials the window backend; gate `publish` on `isActivePrimary()`
- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx` - assert primary reconnect ignores the active secondary profile and preserves `$connection`

## How to Test

1. Manual: multi-profile Desktop, switch to a secondary profile, sleep/wake (or drop primary WS), confirm primary stays on the window backend and the secondary still reconnects on its own socket.
2. Automated (already run locally, 7 passed):

```bash
npm run test --workspace apps/desktop -- src/app/gateway/hooks/use-gateway-boot.test.tsx
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant desktop vitest file and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A
