### PR TITLE
test: round-2 stability closeout — log-leak sandbox, order-dependence fix, write-guard hardening

### DIFF
--- a/contributors/emails/mehmet.kar@std.yildiz.edu.tr
+++ b/contributors/emails/mehmet.kar@std.yildiz.edu.tr
@@ -1,0 +1,1 @@
+mehmetkr-31

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,0 +1,50 @@
+"""Shared fixtures for CLI tests.
+
+prompt_toolkit / capsys isolation
+---------------------------------
+``cli._cprint`` renders through ``prompt_toolkit.print_formatted_text``,
+which — when called with no explicit ``output=`` — lazily creates an
+``Output`` from ``sys.stdout`` **and caches it on the process-global default
+``AppSession``** (``prompt_toolkit.application.current._current_app_session``,
+a ``ContextVar`` with a module-level default). The cache is keyed to nothing
+and never re-reads ``sys.stdout``.
+
+Under pytest, ``capsys`` swaps ``sys.stdout`` for a fresh buffer per test.
+So the first CLI test that emits through ``_cprint`` (e.g. one exercising
+``/queue``, which prints a "Queued: …" line) locks prompt_toolkit's cached
+output onto *its* captured stdout. Every later ``capsys`` test that asserts
+on ``_cprint`` output then reads an empty buffer, because the render went to
+the first test's now-dead capture target. That is the mechanism behind the
+order-dependent ``test_resume_quiet_stderr`` failure: it passes in isolation
+and in its own file, but fails in a full ``tests/cli`` run.
+
+Reset the cached output before every CLI test so each one re-creates a fresh
+prompt_toolkit ``Output`` bound to its own ``sys.stdout`` on first use. This
+is a no-op when prompt_toolkit isn't importable and cheap otherwise (the
+property re-creates lazily).
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_prompt_toolkit_output_cache():
+    """Clear prompt_toolkit's cached AppSession output around each CLI test.
+
+    See the module docstring for the capsys/prompt_toolkit interaction this
+    guards against.
+    """
+
+    def _clear() -> None:
+        try:
+            from prompt_toolkit.application.current import get_app_session
+
+            get_app_session()._output = None
+        except Exception:
+            # prompt_toolkit not importable / internal shape changed — the
+            # tests that rely on this simply keep their prior behavior.
+            pass
+
+    _clear()
+    yield
+    _clear()

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -44,13 +44,28 @@ def _make_cli(env_overrides=None, config_overrides=None, **kwargs):
         "prompt_toolkit.formatted_text": MagicMock(),
         "prompt_toolkit.auto_suggest": MagicMock(),
     }
-    with patch.dict(sys.modules, prompt_toolkit_stubs), \
-         patch.dict("os.environ", clean_env, clear=False):
-        import cli as _cli_mod
-        _cli_mod = importlib.reload(_cli_mod)
-        with patch.object(_cli_mod, "get_tool_definitions", return_value=[]), \
-             patch.dict(_cli_mod.__dict__, {"CLI_CONFIG": _clean_config}):
-            return _cli_mod.HermesCLI(**kwargs)
+    try:
+        with patch.dict(sys.modules, prompt_toolkit_stubs), \
+             patch.dict("os.environ", clean_env, clear=False):
+            import cli as _cli_mod
+            _cli_mod = importlib.reload(_cli_mod)
+            with patch.object(_cli_mod, "get_tool_definitions", return_value=[]), \
+                 patch.dict(_cli_mod.__dict__, {"CLI_CONFIG": _clean_config}):
+                return _cli_mod.HermesCLI(**kwargs)
+    finally:
+        # The reload above re-executed cli.py while prompt_toolkit was stubbed
+        # with MagicMocks, permanently rebinding cli's module globals
+        # (``_pt_print``, ``_PT_ANSI``, …) to those mocks. ``patch.dict``
+        # restores ``sys.modules`` on exit, but NOT the names the reloaded
+        # module already bound — so ``sys.modules["cli"]`` is left with a
+        # mock ``_pt_print``, and ``cli._cprint`` then silently no-ops for
+        # every later test (one half of the order-dependent
+        # ``test_resume_quiet_stderr`` full-suite failure; the other half is
+        # the prompt_toolkit output cache reset in this dir's conftest).
+        # Reload once more with the real modules visible so cli's globals
+        # rebind cleanly.
+        import cli as _cli_restore
+        importlib.reload(_cli_restore)
 
 
 class TestMaxTurnsResolution:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -594,7 +594,15 @@ def _kanban_write_guard(_hermetic_environment, monkeypatch):
     if _kdb is None:
         return
 
-    _orig_connect = _kdb.connect
+    # The sys.modules probe can observe the module MID-IMPORT: a fixture
+    # boundary firing while another test's lazy `import hermes_cli.kanban_db`
+    # is still executing sees a partially initialized module whose `connect`
+    # doesn't exist yet (AttributeError flake, caught in a full-suite run).
+    # A half-imported module has no callers yet either — nothing to guard
+    # this round; the next test's fixture will patch the completed module.
+    _orig_connect = getattr(_kdb, "connect", None)
+    if _orig_connect is None:
+        return
 
     def _guarded_connect(db_path=None, *args, **kwargs):
         if db_path is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,9 +20,12 @@ test runner at ``scripts/run_tests.sh``.
 """
 
 import asyncio
+import atexit
 import os
+import shutil
 import sqlite3
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -31,6 +34,42 @@ import pytest
 PROJECT_ROOT = Path(__file__).parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
+
+
+# ── Sandbox HERMES_HOME before ANY test module is imported ──────────────────
+# `hermes_cli/main.py` calls `setup_logging()` at MODULE level, which resolves
+# `get_hermes_home()` and attaches rotating file handlers to the ROOT logger.
+# So merely importing it - which many test modules do, directly or
+# transitively - points the whole pytest session's logging at the operator's
+# real `~/.hermes/logs/agent.log` and `errors.log`.
+#
+# The `_isolate_env` fixture below also sandboxes HERMES_HOME, but fixtures run
+# AFTER collection imports test modules, by which point the handler already
+# holds an absolute path to the real log. Measured on a live install: 126
+# warnings in the operator's agent.log came from test runs, not the gateway -
+# enough noise to make genuine warnings hard to find.
+#
+# conftest is imported before any test module, so setting it here closes that
+# window. The per-test fixture still applies for everything after import.
+#
+# ORDER MATTERS: the kanban write guard's deny-list (further down) must know
+# the REAL Hermes root — capture it BEFORE the sandbox rewires HERMES_HOME,
+# otherwise the deny-list would point at the throwaway tempdir and the guard
+# would silently stop protecting the operator's actual ~/.hermes (#69385).
+_PRE_SANDBOX_KANBAN_OVERRIDE = os.environ.get("HERMES_KANBAN_HOME", "").strip()
+_PRE_SANDBOX_HERMES_HOME = os.environ.get("HERMES_HOME", "")
+if not os.environ.get("HERMES_HOME"):
+    _SESSION_HERMES_HOME = tempfile.mkdtemp(prefix="hermes-test-home-")
+    os.environ["HERMES_HOME"] = _SESSION_HERMES_HOME
+    atexit.register(shutil.rmtree, _SESSION_HERMES_HOME, True)
+
+#: HERMES_HOME as it stood when conftest was imported - i.e. before any test
+#: module could import code that configures logging. Recorded so the guard in
+#: tests/test_log_isolation.py can assert the sandbox existed AT THAT MOMENT.
+#: Reading os.environ from inside a test is useless here: the per-test
+#: `_isolate_env` fixture has sandboxed it by then, so the check would pass
+#: even with this block removed.
+HERMES_HOME_AT_CONFTEST_IMPORT = os.environ.get("HERMES_HOME", "")
 
 
 # ── Per-file process isolation ──────────────────────────────────────────────
@@ -513,16 +552,23 @@ def _neutralize_macos_keychain_creds(request, monkeypatch):
 def _capture_real_kanban_root() -> Path:
     """Resolve the REAL kanban root from the pre-test environment.
 
-    Runs at conftest import time, before any fixture rewires HERMES_HOME.
-    Mirrors ``kanban_db.kanban_home()`` resolution order:
+    Uses the pre-sandbox environment snapshot taken at the very top of this
+    file (before the session HERMES_HOME sandbox rewired the env), so the
+    deny-list keeps pointing at the operator's actual root. Mirrors
+    ``kanban_db.kanban_home()`` resolution order:
     1. ``HERMES_KANBAN_HOME`` env var when set and non-empty
-    2. ``get_default_hermes_root()`` otherwise
+    2. the real (pre-sandbox) Hermes root otherwise
     """
-    override = os.environ.get("HERMES_KANBAN_HOME", "").strip()
-    if override:
-        return Path(override).expanduser().resolve()
-    from hermes_constants import get_default_hermes_root
-    return get_default_hermes_root().resolve()
+    if _PRE_SANDBOX_KANBAN_OVERRIDE:
+        return Path(_PRE_SANDBOX_KANBAN_OVERRIDE).expanduser().resolve()
+    if _PRE_SANDBOX_HERMES_HOME:
+        # HERMES_HOME was genuinely set before the sandbox — honor it via the
+        # normal resolver (it may be a profile dir whose root matters).
+        from hermes_constants import get_default_hermes_root
+        return get_default_hermes_root().resolve()
+    # No pre-existing HERMES_HOME: the real root is the platform default,
+    # NOT the sandbox tempdir now sitting in the env.
+    return (Path.home() / ".hermes").resolve()
 
 
 _REAL_KANBAN_ROOT = _capture_real_kanban_root()

--- a/tests/test_log_isolation.py
+++ b/tests/test_log_isolation.py
@@ -1,0 +1,88 @@
+"""The test suite must never write into the operator's real Hermes logs.
+
+`hermes_cli/main.py` calls `setup_logging()` at module scope, which resolves
+`get_hermes_home()` and attaches rotating file handlers to the ROOT logger.
+Importing it - which many test modules do, directly or transitively - wires
+the whole pytest session's logging to `<HERMES_HOME>/logs/agent.log`.
+
+If HERMES_HOME is not already sandboxed at that moment, that is the
+operator's real log. Measured on a live install, 126 warnings in a personal
+`agent.log` came from test runs rather than the running gateway: phantom
+`FakeTree` Discord failures and `rejected invalid API key` entries from
+`test_api_server_runs.py`. Noise like that makes genuine warnings hard to
+find precisely when someone is debugging.
+
+The per-test env fixture cannot close this: fixtures run after collection has
+imported the test modules, and by then the handler holds an absolute path.
+`tests/conftest.py` sets HERMES_HOME at module scope for that reason - this
+guards the property so a refactor cannot quietly undo it.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+import pytest
+
+
+def _real_hermes_home() -> Path:
+    """Where the operator's logs live, ignoring any test sandboxing."""
+    return Path.home() / ".hermes"
+
+
+def _all_file_destinations() -> list[str]:
+    """Every file path the root logger can reach, including via a QueueHandler.
+
+    Logging is routed through a queue, so the file handlers hang off the
+    listener rather than the root logger - checking `root.handlers` alone
+    reports nothing and looks falsely clean.
+    """
+    seen: list[str] = []
+
+    def collect(handlers) -> None:
+        for handler in handlers or ():
+            path = getattr(handler, "baseFilename", None)
+            if path:
+                seen.append(str(path))
+            listener = getattr(handler, "listener", None)
+            if listener is not None:
+                collect(getattr(listener, "handlers", ()))
+
+    collect(logging.getLogger().handlers)
+
+    try:
+        import hermes_logging
+
+        listener = getattr(hermes_logging, "_queue_listener", None)
+        if listener is not None:
+            collect(getattr(listener, "handlers", ()))
+    except Exception:
+        pass
+
+    return seen
+
+
+class TestLogIsolation:
+    def test_hermes_home_is_sandboxed_before_imports(self):
+        # Deliberately NOT os.environ: by test time the per-test `_isolate_env`
+        # fixture has sandboxed HERMES_HOME, so reading it here would pass even
+        # with the conftest block deleted. Assert the value captured at conftest
+        # import, which is the moment that actually matters.
+        from tests.conftest import HERMES_HOME_AT_CONFTEST_IMPORT as home
+
+        assert home, "conftest must set HERMES_HOME before test modules import"
+        assert Path(home).resolve() != _real_hermes_home().resolve(), (
+            f"HERMES_HOME pointed at the operator's real home ({home}) when "
+            "conftest loaded; import-time setup_logging() writes to their agent.log"
+        )
+
+    def test_importing_the_cli_does_not_target_the_real_logs(self):
+        pytest.importorskip("hermes_cli.main")
+
+        real_logs = str(_real_hermes_home() / "logs")
+        offenders = [p for p in _all_file_destinations() if p.startswith(real_logs)]
+
+        assert offenders == [], (
+            "the test session is writing into the operator's real Hermes logs:\n  "
+            + "\n  ".join(offenders)
+        )


### PR DESCRIPTION
## Summary
Closes out the test-stability backlog: the last 2 real fixes salvaged (log-file leak at collection time, order-dependent CLI flake), plus a hardening of the kanban write-guard merged in #74517 whose sys.modules probe raced lazy imports.

## Changes
- **#71271** (@joelbrilliant) — session-level HERMES_HOME sandbox at the top of tests/conftest.py: module-level `import hermes_cli.main` in any test file wired root logging to the operator's real `~/.hermes/logs/agent.log` before fixtures could run (126 warnings in a live log traced to test runs). Adapted to preserve the #69385 kanban deny-list: the real root is snapshotted pre-sandbox, so the guard keeps protecting the actual `~/.hermes` (probe-verified).
- **#68872** (@mehmetkr-31) — order-dependent `test_resume_quiet_stderr` flake fixed at the source (stale mock globals after `cli` reload + prompt_toolkit AppSession output cache pinned to a dead capsys buffer). Reproduced both orders pre-fix; 723/723 tests/cli green post-fix. AUTHOR_MAP hunk rerouted to contributors/emails/.
- **write-guard hardening** — the #74517 kanban guard's `sys.modules.get()` can observe `hermes_cli.kanban_db` mid-import on a fixture boundary (no `.connect` yet → AttributeError, flagged FLAKY 1/2460 in the verification run). Half-imported modules have no callers to guard; skip that round.

Also closed as covered by #74517 (verified empirically): #50699/#50681 (call-time db path), #43344 + #58612/#58609 (suite-wide Keychain guard).

## Validation
| Gate | Result |
|---|---|
| Full suite (CI-parity runner) | 2,460 files, 22,601 passed, 0 failed, 0 flaky |
| tests/cli both orders + full dir | 27 + 723 green |
| Log-isolation + guard + kanban suites | green ×3 |
| Kanban deny-list under sandbox | points at real ~/.hermes (probe) |

## Infographic

![round 2 infographic](https://v3b.fal.media/files/b/0aa445ce/9CiMU8mtLsLxNHvZHpsLF_HQWQ7oCr.png)
