### PR TITLE
feat(mcp): expose tool annotations in Desktop discovery

### DIFF
--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -34,6 +34,7 @@ import {
   type HermesGateway,
   installMcpCatalogEntry,
   type McpCatalogEntry,
+  type McpDiscoveredTool,
   type McpTestResult,
   saveMcpServers,
   testMcpServer
@@ -41,6 +42,7 @@ import {
 import { type Translations, useI18n } from '@/i18n'
 import { completeMcpDesktopOAuth } from '@/lib/mcp-dashboard-oauth'
 import { countEnabledTools, isToolEnabled, toggleToolInServer } from '@/lib/mcp-tool-filter'
+import { formatMcpToolDetails } from '@/lib/mcp-tool-metadata'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
@@ -53,6 +55,8 @@ import { DetailPane, ICON_BUTTON, MASTER_DETAIL_WIDE_COLS } from '../master-deta
 import { PanelAddButton, PanelEmpty } from '../overlays/panel'
 import { prettyName } from '../settings/helpers'
 import { useDeepLinkHighlight } from '../settings/use-deep-link-highlight'
+
+import { McpToolChip } from './mcp-tool-chip'
 
 type McpServers = Record<string, Record<string, unknown>>
 
@@ -137,6 +141,19 @@ const probeKey = (name: string, server: Record<string, unknown> | undefined): st
 type Probe = McpTestResult | 'probing'
 
 type ServerStatus = 'off' | 'probing' | 'ok' | 'needs-auth' | 'error' | 'unknown'
+
+function toolDetails(m: Translations['settings']['mcp'], tool: McpDiscoveredTool): string {
+  return formatMcpToolDetails(tool, {
+    additive: m.toolReportsAdditive,
+    closedWorld: m.toolReportsClosedWorld,
+    destructive: m.toolReportsDestructive,
+    idempotent: m.toolReportsIdempotent,
+    mayModify: m.toolReportsMayModify,
+    openWorld: m.toolReportsOpenWorld,
+    readOnly: m.toolReportsReadOnly,
+    repeatEffects: m.toolReportsRepeatEffects
+  })
+}
 
 function statusOf(server: Record<string, unknown>, probe: Probe | undefined): ServerStatus {
   if (!serverEnabled(server)) {
@@ -1221,23 +1238,19 @@ function ServerConfig({
               lists every tool regardless of the filter. */}
           {probe.tools.map(tool => {
             const on = isToolEnabled(entry, tool.name)
+            const action = on ? m.disableTool(tool.name) : m.enableTool(tool.name)
+            const details = toolDetails(m, tool)
 
             return (
-              <button
-                aria-pressed={on}
-                className={cn(
-                  'rounded-md px-1.5 py-0.5 font-mono text-[0.65rem] text-(--ui-text-tertiary) hover:text-foreground',
-                  saved ? 'cursor-pointer' : 'cursor-default',
-                  on ? 'bg-(--ui-bg-quinary)' : 'line-through opacity-70'
-                )}
-                disabled={!saved}
+              <McpToolChip
+                action={action}
+                details={details}
+                enabled={on}
                 key={tool.name}
-                onClick={() => onToggleTool(tool.name)}
-                title={on ? m.disableTool(tool.name) : m.enableTool(tool.name)}
-                type="button"
-              >
-                {tool.name}
-              </button>
+                onToggle={() => onToggleTool(tool.name)}
+                saved={saved}
+                toolName={tool.name}
+              />
             )
           })}
         </div>

--- a/apps/desktop/src/app/skills/mcp-tool-chip.test.tsx
+++ b/apps/desktop/src/app/skills/mcp-tool-chip.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { McpToolChip } from './mcp-tool-chip'
+
+afterEach(() => cleanup())
+
+describe('McpToolChip', () => {
+  it('exposes server-reported details when the chip receives keyboard focus', async () => {
+    render(
+      <McpToolChip
+        action="Disable read_page"
+        details={'Read a page\nServer reports read-only'}
+        enabled
+        onToggle={vi.fn()}
+        saved
+        toolName="read_page"
+      />
+    )
+
+    const chip = screen.getByRole('button', { name: 'Disable read_page' })
+    vi.spyOn(chip, 'matches').mockImplementation(selector => selector === ':focus-visible')
+
+    fireEvent.keyDown(chip, { key: 'Tab' })
+    fireEvent.focus(chip)
+
+    await waitFor(() => {
+      const tooltip = screen.getByRole('tooltip')
+
+      expect(tooltip.textContent).toContain('Read a page')
+      expect(tooltip.textContent).toContain('Server reports read-only')
+    })
+    expect(chip.hasAttribute('title')).toBe(false)
+  })
+
+  it('retains the existing toggle semantics', () => {
+    const onToggle = vi.fn()
+    render(<McpToolChip action="Disable read_page" details="" enabled onToggle={onToggle} saved toolName="read_page" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Disable read_page' }))
+
+    expect(onToggle).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/app/skills/mcp-tool-chip.tsx
+++ b/apps/desktop/src/app/skills/mcp-tool-chip.tsx
@@ -1,0 +1,34 @@
+import { Tip } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+interface McpToolChipProps {
+  action: string
+  details: string
+  enabled: boolean
+  onToggle: () => void
+  saved: boolean
+  toolName: string
+}
+
+export function McpToolChip({ action, details, enabled, onToggle, saved, toolName }: McpToolChipProps) {
+  const tooltip = details ? `${action}\n\n${details}` : action
+
+  return (
+    <Tip label={<span className="whitespace-pre-line">{tooltip}</span>}>
+      <button
+        aria-label={action}
+        aria-pressed={enabled}
+        className={cn(
+          'rounded-md px-1.5 py-0.5 font-mono text-[0.65rem] text-(--ui-text-tertiary) hover:text-foreground',
+          saved ? 'cursor-pointer' : 'cursor-default',
+          enabled ? 'bg-(--ui-bg-quinary)' : 'line-through opacity-70'
+        )}
+        disabled={!saved}
+        onClick={onToggle}
+        type="button"
+      >
+        {toolName}
+      </button>
+    </Tip>
+  )
+}

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -26,6 +26,7 @@ import type {
   HermesConfigRecord,
   LogsResponse,
   McpCatalogResponse,
+  McpDiscoveredTool,
   McpServerSummary,
   MemoryProviderConfig,
   MemoryProviderOAuthStatus,
@@ -163,8 +164,10 @@ export type {
   LogsResponse,
   McpCatalogEntry,
   McpCatalogResponse,
+  McpDiscoveredTool,
   McpServerSummary,
   McpServerTestResponse,
+  McpToolAnnotations,
   MemoryProviderConfig,
   MemoryProviderOAuthStatus,
   MemoryStatusResponse,
@@ -975,7 +978,7 @@ export function setSkillEnabled(
 export interface McpTestResult {
   ok: boolean
   error?: string
-  tools: { name: string; description: string }[]
+  tools: McpDiscoveredTool[]
   /** Capability counts (absent on older backends / failed probes). */
   prompts?: number
   resources?: number
@@ -987,7 +990,7 @@ export interface McpOAuthFlow {
   status: 'starting' | 'authorization_required' | 'approved' | 'error'
   authorization_url: string | null
   error: string | null
-  tools?: { name: string; description: string }[]
+  tools?: McpDiscoveredTool[]
 }
 
 /** Connect to the server, list its tools, disconnect. Slow (spawns/handshakes

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -799,6 +799,14 @@ export const en: Translations = {
       unsavedConnect: 'Unsaved — save mcp.json to connect.',
       enableTool: tool => `Enable ${tool}`,
       disableTool: tool => `Disable ${tool}`,
+      toolReportsReadOnly: 'Server reports read-only',
+      toolReportsMayModify: 'Server reports this may modify data',
+      toolReportsDestructive: 'Server reports this may be destructive',
+      toolReportsAdditive: 'Server reports additive updates only',
+      toolReportsIdempotent: 'Server reports repeat calls have no additional effect',
+      toolReportsRepeatEffects: 'Server reports repeat calls may have additional effects',
+      toolReportsOpenWorld: 'Server reports external-system access',
+      toolReportsClosedWorld: 'Server reports closed-world interaction',
       noOutput: 'No output yet.'
     },
     model: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -845,6 +845,14 @@ export const ja = defineLocale({
       unsavedConnect: '未保存 — 接続するには mcp.json を保存してください。',
       enableTool: tool => `${tool} を有効化`,
       disableTool: tool => `${tool} を無効化`,
+      toolReportsReadOnly: 'サーバーの申告: 読み取り専用',
+      toolReportsMayModify: 'サーバーの申告: データを変更する可能性があります',
+      toolReportsDestructive: 'サーバーの申告: 破壊的な変更の可能性があります',
+      toolReportsAdditive: 'サーバーの申告: 追加的な更新のみ',
+      toolReportsIdempotent: 'サーバーの申告: 再実行しても追加の影響はありません',
+      toolReportsRepeatEffects: 'サーバーの申告: 再実行により追加の影響が生じる可能性があります',
+      toolReportsOpenWorld: 'サーバーの申告: 外部システムにアクセスします',
+      toolReportsClosedWorld: 'サーバーの申告: 閉じた環境内で動作します',
       noOutput: 'まだ出力がありません。'
     },
     model: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -687,6 +687,14 @@ export interface Translations {
       unsavedConnect: string
       enableTool: (tool: string) => string
       disableTool: (tool: string) => string
+      toolReportsReadOnly: string
+      toolReportsMayModify: string
+      toolReportsDestructive: string
+      toolReportsAdditive: string
+      toolReportsIdempotent: string
+      toolReportsRepeatEffects: string
+      toolReportsOpenWorld: string
+      toolReportsClosedWorld: string
       noOutput: string
     }
     model: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -819,6 +819,14 @@ export const zhHant = defineLocale({
       unsavedConnect: '未儲存 — 儲存 mcp.json 以連線。',
       enableTool: tool => `啟用 ${tool}`,
       disableTool: tool => `停用 ${tool}`,
+      toolReportsReadOnly: '伺服器回報：唯讀',
+      toolReportsMayModify: '伺服器回報：可能修改資料',
+      toolReportsDestructive: '伺服器回報：可能執行破壞性變更',
+      toolReportsAdditive: '伺服器回報：僅執行增量更新',
+      toolReportsIdempotent: '伺服器回報：重複呼叫不會產生額外影響',
+      toolReportsRepeatEffects: '伺服器回報：重複呼叫可能產生額外影響',
+      toolReportsOpenWorld: '伺服器回報：存取外部系統',
+      toolReportsClosedWorld: '伺服器回報：僅在封閉環境中互動',
       noOutput: '尚無輸出。'
     },
     model: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1003,6 +1003,14 @@ export const zh: Translations = {
       unsavedConnect: '未保存 — 保存 mcp.json 以连接。',
       enableTool: tool => `启用 ${tool}`,
       disableTool: tool => `禁用 ${tool}`,
+      toolReportsReadOnly: '服务器报告：只读',
+      toolReportsMayModify: '服务器报告：可能修改数据',
+      toolReportsDestructive: '服务器报告：可能执行破坏性更改',
+      toolReportsAdditive: '服务器报告：仅执行增量更新',
+      toolReportsIdempotent: '服务器报告：重复调用不会产生额外影响',
+      toolReportsRepeatEffects: '服务器报告：重复调用可能产生额外影响',
+      toolReportsOpenWorld: '服务器报告：访问外部系统',
+      toolReportsClosedWorld: '服务器报告：仅在封闭环境中交互',
       noOutput: '暂无输出。'
     },
     model: {

--- a/apps/desktop/src/lib/mcp-dashboard-oauth.ts
+++ b/apps/desktop/src/lib/mcp-dashboard-oauth.ts
@@ -1,10 +1,12 @@
+import type { McpDiscoveredTool } from '@/hermes'
+
 export interface McpOAuthFlow {
   flow_id: string
   server_name: string
   status: 'starting' | 'authorization_required' | 'approved' | 'error'
   authorization_url: string | null
   error: string | null
-  tools?: Array<{ name: string; description: string }>
+  tools?: McpDiscoveredTool[]
 }
 
 interface CompleteOptions {

--- a/apps/desktop/src/lib/mcp-tool-metadata.test.ts
+++ b/apps/desktop/src/lib/mcp-tool-metadata.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatMcpToolDetails, type McpToolHintCopy } from './mcp-tool-metadata'
+
+const copy: McpToolHintCopy = {
+  additive: 'Server reports additive updates only',
+  closedWorld: 'Server reports closed-world interaction',
+  destructive: 'Server reports this may be destructive',
+  idempotent: 'Server reports repeat calls have no additional effect',
+  mayModify: 'Server reports this may modify data',
+  openWorld: 'Server reports external-system access',
+  readOnly: 'Server reports read-only',
+  repeatEffects: 'Server reports repeat calls may have additional effects'
+}
+
+describe('formatMcpToolDetails', () => {
+  it('supports older backend payloads without optional metadata', () => {
+    expect(formatMcpToolDetails({ description: 'Search pages', name: 'search_pages' }, copy)).toBe('Search pages')
+  })
+
+  it('uses top-level title before the legacy annotation title', () => {
+    expect(
+      formatMcpToolDetails(
+        {
+          annotations: { title: 'Legacy title' },
+          description: 'Moves a page to trash',
+          name: 'delete_page',
+          title: 'Delete a page'
+        },
+        copy
+      )
+    ).toBe('Delete a page\nMoves a page to trash')
+  })
+
+  it('describes true annotations as server reports rather than verified facts', () => {
+    expect(
+      formatMcpToolDetails(
+        {
+          annotations: {
+            destructiveHint: true,
+            idempotentHint: true,
+            openWorldHint: true,
+            readOnlyHint: false
+          },
+          description: '',
+          name: 'delete_page'
+        },
+        copy
+      )
+    ).toBe([copy.mayModify, copy.destructive, copy.idempotent, copy.openWorld].join('\n'))
+  })
+
+  it('preserves and explains explicit false annotations', () => {
+    expect(
+      formatMcpToolDetails(
+        {
+          annotations: {
+            destructiveHint: false,
+            idempotentHint: false,
+            openWorldHint: false,
+            readOnlyHint: false
+          },
+          description: '',
+          name: 'create_page'
+        },
+        copy
+      )
+    ).toBe([copy.mayModify, copy.additive, copy.repeatEffects, copy.closedWorld].join('\n'))
+  })
+
+  it('does not show write-only hints for a read-only tool', () => {
+    expect(
+      formatMcpToolDetails(
+        {
+          annotations: { destructiveHint: true, idempotentHint: false, readOnlyHint: true },
+          description: '',
+          name: 'read_page'
+        },
+        copy
+      )
+    ).toBe(copy.readOnly)
+  })
+})

--- a/apps/desktop/src/lib/mcp-tool-metadata.ts
+++ b/apps/desktop/src/lib/mcp-tool-metadata.ts
@@ -1,0 +1,46 @@
+import type { McpDiscoveredTool } from '@/hermes'
+
+export interface McpToolHintCopy {
+  additive: string
+  closedWorld: string
+  destructive: string
+  idempotent: string
+  mayModify: string
+  openWorld: string
+  readOnly: string
+  repeatEffects: string
+}
+
+/** Format server-reported MCP display metadata for a tool's hover details. */
+export function formatMcpToolDetails(tool: McpDiscoveredTool, copy: McpToolHintCopy): string {
+  const lines: string[] = []
+  const title = tool.title?.trim() || tool.annotations?.title?.trim()
+
+  if (title && title !== tool.name) {
+    lines.push(title)
+  }
+
+  if (tool.description.trim()) {
+    lines.push(tool.description.trim())
+  }
+
+  const annotations = tool.annotations
+
+  if (annotations?.readOnlyHint !== undefined) {
+    lines.push(annotations.readOnlyHint ? copy.readOnly : copy.mayModify)
+  }
+
+  if (annotations?.destructiveHint !== undefined && annotations.readOnlyHint !== true) {
+    lines.push(annotations.destructiveHint ? copy.destructive : copy.additive)
+  }
+
+  if (annotations?.idempotentHint !== undefined && annotations.readOnlyHint !== true) {
+    lines.push(annotations.idempotentHint ? copy.idempotent : copy.repeatEffects)
+  }
+
+  if (annotations?.openWorldHint !== undefined) {
+    lines.push(annotations.openWorldHint ? copy.openWorld : copy.closedWorld)
+  }
+
+  return lines.join('\n')
+}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1314,10 +1314,26 @@ export interface McpServerSummary {
   tools: string[] | null
 }
 
+export interface McpToolAnnotations {
+  title?: string
+  readOnlyHint?: boolean
+  destructiveHint?: boolean
+  idempotentHint?: boolean
+  openWorldHint?: boolean
+}
+
+export interface McpDiscoveredTool {
+  name: string
+  description: string
+  title?: string
+  /** Server-reported hints. They are not independently verified by Hermes. */
+  annotations?: McpToolAnnotations
+}
+
 export interface McpServerTestResponse {
   ok: boolean
   error?: string
-  tools: { name: string; description: string }[]
+  tools: McpDiscoveredTool[]
 }
 
 /** One Nous-approved MCP catalog entry from `GET /api/mcp/catalog`. */

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -275,6 +275,77 @@ def _resolve_mcp_server_config(config: dict) -> dict:
     return _interpolate_env_vars(config)
 
 
+_MCP_ANNOTATION_FIELDS = (
+    ("title", "title"),
+    ("readOnlyHint", "readOnlyHint", "read_only_hint"),
+    ("destructiveHint", "destructiveHint", "destructive_hint"),
+    ("idempotentHint", "idempotentHint", "idempotent_hint"),
+    ("openWorldHint", "openWorldHint", "open_world_hint"),
+)
+
+
+def _serialize_mcp_tool_metadata(tool: Any) -> Dict[str, Any]:
+    """Return lightweight, JSON-safe display metadata for an MCP tool.
+
+    MCP annotations are server-reported hints, not verified safety facts. Keep
+    them separate from provider-facing function schemas so a remote server
+    cannot smuggle non-provider fields into model tool definitions.
+
+    Attribute access deliberately supports MCP SDK v1's camelCase model fields,
+    SDK v2's snake_case model fields with camelCase wire aliases, and the simple
+    legacy/fake objects used by callers and tests.
+    """
+    payload: Dict[str, Any] = {
+        "name": str(getattr(tool, "name", "")),
+        "description": str(getattr(tool, "description", "") or ""),
+    }
+
+    title = getattr(tool, "title", None)
+    if isinstance(title, str) and title.strip():
+        payload["title"] = title
+
+    raw_annotations = getattr(tool, "annotations", None)
+    annotations: Dict[str, Any] = {}
+    for field, *attribute_names in _MCP_ANNOTATION_FIELDS:
+        if isinstance(raw_annotations, dict):
+            value = raw_annotations.get(field)
+            if value is None:
+                for attribute_name in attribute_names:
+                    value = raw_annotations.get(attribute_name)
+                    if value is not None:
+                        break
+        else:
+            value = None
+            for attribute_name in attribute_names:
+                value = getattr(raw_annotations, attribute_name, None)
+                if value is not None:
+                    break
+
+        if field == "title":
+            if isinstance(value, str) and value.strip():
+                annotations[field] = value
+        elif isinstance(value, bool):
+            # Preserve explicit false values; absence and false have different
+            # meanings in the MCP annotation contract.
+            annotations[field] = value
+
+    if annotations:
+        payload["annotations"] = annotations
+
+    return payload
+
+
+def _probe_tools_payload(
+    tools: List[Tuple[str, str]], details: Optional[dict]
+) -> List[Dict[str, Any]]:
+    """Return rich probe tools when available, otherwise the legacy tuples."""
+    if details:
+        rich_tools = details.get("tools")
+        if isinstance(rich_tools, list):
+            return rich_tools
+    return [{"name": name, "description": description} for name, description in tools]
+
+
 def _probe_single_server(
     name: str, config: dict, connect_timeout: Optional[float] = None, *, details: Optional[dict] = None
 ) -> List[Tuple[str, str]]:
@@ -309,6 +380,7 @@ def _probe_single_server(
 
     _ensure_mcp_loop()
     tools_found: List[Tuple[str, str]] = []
+    tool_metadata: List[Dict[str, Any]] = []
 
     async def _probe():
         server = await asyncio.wait_for(
@@ -316,12 +388,14 @@ def _probe_single_server(
         )
         try:
             for t in server._tools:
+                tool_metadata.append(_serialize_mcp_tool_metadata(t))
                 desc = getattr(t, "description", "") or ""
                 # Truncate long descriptions for display
                 if len(desc) > 80:
                     desc = desc[:77] + "..."
                 tools_found.append((t.name, desc))
             if details is not None:
+                details["tools"] = tool_metadata
                 # Gate the capability probes exactly like runtime utility-tool
                 # registration (tools.mcp_tool._select_utility_schemas):
                 #   1. honour the user's tools.prompts / tools.resources config

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -141,6 +141,7 @@ async def test_mcp_server(name: str, profile: Optional[str] = None):
         _get_mcp_servers,
         _oauth_tokens_present,
         _probe_single_server,
+        _probe_tools_payload,
     )
 
     with _profile_scope(profile):
@@ -188,7 +189,7 @@ async def test_mcp_server(name: str, profile: Optional[str] = None):
         }
     return {
         "ok": True,
-        "tools": [{"name": t, "description": d} for t, d in tools],
+        "tools": _probe_tools_payload(tools, details),
         "prompts": details.get("prompts", 0),
         "resources": details.get("resources", 0),
     }

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11907,6 +11907,7 @@ def _run_dashboard_mcp_oauth(flow, cfg: dict) -> None:
     from hermes_cli.mcp_config import (
         _oauth_tokens_present,
         _probe_single_server,
+        _probe_tools_payload,
         _save_mcp_server,
     )
     try:
@@ -11934,10 +11935,12 @@ def _run_dashboard_mcp_oauth(flow, cfg: dict) -> None:
                         flow.server_name,
                         hermes_home=flow.hermes_home,
                     )
+                    details: dict = {}
                     tools = _probe_single_server(
                         flow.server_name,
                         cfg,
                         connect_timeout=max(float(cfg.get("connect_timeout", 0) or 0), 315),
+                        details=details,
                     )
                     if not _oauth_tokens_present(flow.server_name):
                         raise RuntimeError(
@@ -11945,7 +11948,7 @@ def _run_dashboard_mcp_oauth(flow, cfg: dict) -> None:
                             "this provider may require a manually-registered OAuth client."
                         )
                     _save_mcp_server(flow.server_name, cfg)
-                    flow.tools = [{"name": t, "description": d} for t, d in tools]
+                    flow.tools = _probe_tools_payload(tools, details)
                     flow.mark_approved()
                     if flow.reconnect_live:
                         from tools.mcp_tool import reconnect_mcp_server

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -436,6 +436,162 @@ class TestProbeEnvResolution:
         assert seen["config"]["headers"]["Authorization"] == "Bearer jwt-token-xyz"
 
 
+class TestProbeToolMetadata:
+    def test_serializes_real_mcp_sdk_tool(self):
+        import pytest
+
+        from hermes_cli.mcp_config import _serialize_mcp_tool_metadata
+
+        mcp_types = pytest.importorskip("mcp.types")
+        tool = mcp_types.Tool(
+            name="read_page",
+            title="Read a page",
+            description="Read one page",
+            inputSchema={"type": "object", "properties": {}},
+            annotations=mcp_types.ToolAnnotations(
+                readOnlyHint=True,
+                destructiveHint=False,
+                idempotentHint=True,
+                openWorldHint=True,
+            ),
+        )
+
+        assert _serialize_mcp_tool_metadata(tool) == {
+            "name": "read_page",
+            "title": "Read a page",
+            "description": "Read one page",
+            "annotations": {
+                "readOnlyHint": True,
+                "destructiveHint": False,
+                "idempotentHint": True,
+                "openWorldHint": True,
+            },
+        }
+
+    def test_legacy_tool_keeps_historical_shape(self):
+        from types import SimpleNamespace
+
+        from hermes_cli.mcp_config import _serialize_mcp_tool_metadata
+
+        tool = SimpleNamespace(name="search_pages", description="Search pages")
+
+        assert _serialize_mcp_tool_metadata(tool) == {
+            "name": "search_pages",
+            "description": "Search pages",
+        }
+
+    def test_preserves_titles_and_explicit_false_annotations(self):
+        from types import SimpleNamespace
+
+        from hermes_cli.mcp_config import _serialize_mcp_tool_metadata
+
+        annotations = SimpleNamespace(
+            title="Legacy title",
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+            ignored="not part of ToolAnnotations",
+        )
+        tool = SimpleNamespace(
+            name="create_page",
+            title="Create a page",
+            description="Create a page in the workspace",
+            annotations=annotations,
+        )
+
+        assert _serialize_mcp_tool_metadata(tool) == {
+            "name": "create_page",
+            "title": "Create a page",
+            "description": "Create a page in the workspace",
+            "annotations": {
+                "title": "Legacy title",
+                "readOnlyHint": False,
+                "destructiveHint": False,
+                "idempotentHint": True,
+                "openWorldHint": False,
+            },
+        }
+
+    def test_supports_sdk_v2_snake_case_annotation_attributes(self):
+        from types import SimpleNamespace
+
+        from hermes_cli.mcp_config import _serialize_mcp_tool_metadata
+
+        tool = SimpleNamespace(
+            name="create_page",
+            description="Create a page",
+            annotations=SimpleNamespace(
+                read_only_hint=False,
+                destructive_hint=False,
+                idempotent_hint=True,
+                open_world_hint=True,
+            ),
+        )
+
+        assert _serialize_mcp_tool_metadata(tool)["annotations"] == {
+            "readOnlyHint": False,
+            "destructiveHint": False,
+            "idempotentHint": True,
+            "openWorldHint": True,
+        }
+
+    def test_probe_populates_rich_details_without_changing_tuple_return(
+        self, monkeypatch
+    ):
+        from types import SimpleNamespace
+
+        import hermes_cli.mcp_config as mc
+
+        description = "A" * 100
+        tool = SimpleNamespace(
+            name="delete_page",
+            title="Delete a page",
+            description=description,
+            annotations={"destructiveHint": True, "readOnlyHint": False},
+        )
+
+        class _FakeServer:
+            _tools = [tool]
+
+            async def shutdown(self):
+                return None
+
+        async def _fake_connect(name, config):
+            return _FakeServer()
+
+        monkeypatch.setattr("tools.mcp_tool._connect_server", _fake_connect)
+        details: dict = {}
+
+        tools = mc._probe_single_server(
+            "notion", {"url": "http://x/mcp"}, details=details
+        )
+
+        assert tools == [("delete_page", f"{'A' * 77}...")]
+        assert details["tools"] == [
+            {
+                "name": "delete_page",
+                "title": "Delete a page",
+                "description": description,
+                "annotations": {
+                    "readOnlyHint": False,
+                    "destructiveHint": True,
+                },
+            }
+        ]
+
+    def test_probe_payload_falls_back_for_legacy_callers(self):
+        from hermes_cli.mcp_config import _probe_tools_payload
+
+        legacy = [("search", "Search pages")]
+        assert _probe_tools_payload(legacy, None) == [
+            {"name": "search", "description": "Search pages"}
+        ]
+        assert _probe_tools_payload(legacy, {}) == [
+            {"name": "search", "description": "Search pages"}
+        ]
+
+
 class TestProbeCapabilityGating:
     """The ``details`` probe must not fire prompts/list or resources/list at
     servers that either disabled them in config or never advertised them.

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -136,11 +136,19 @@ class TestProfileScopedMcp:
             "mcp_servers:\n  oauth-srv:\n    url: http://x/sse\n    auth: oauth\n",
             encoding="utf-8",
         )
-        monkeypatch.setattr(
-            mcp_config,
-            "_probe_single_server",
-            lambda name, config, connect_timeout=30, details=None: [("tool-a", "desc")],
-        )
+        def fake_probe(name, config, connect_timeout=30, details=None):
+            if details is not None:
+                details["tools"] = [
+                    {
+                        "name": "tool-a",
+                        "description": "desc",
+                        "title": "Tool A",
+                        "annotations": {"readOnlyHint": True},
+                    }
+                ]
+            return [("tool-a", "desc")]
+
+        monkeypatch.setattr(mcp_config, "_probe_single_server", fake_probe)
         monkeypatch.setattr(mcp_config, "_oauth_tokens_present", lambda name: False)
 
         resp = client.post(
@@ -156,7 +164,16 @@ class TestProfileScopedMcp:
         resp = client.post(
             "/api/mcp/servers/oauth-srv/test", params={"profile": "worker_beta"}
         )
-        assert resp.json()["ok"] is True
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["tools"] == [
+            {
+                "name": "tool-a",
+                "description": "desc",
+                "title": "Tool A",
+                "annotations": {"readOnlyHint": True},
+            }
+        ]
 
 
 class TestProfileScopedModel:


### PR DESCRIPTION
## Summary

- preserve MCP tool titles and `ToolAnnotations` through server discovery and OAuth connection flows
- expose optional metadata in the Desktop API without changing the existing CLI probe tuple contract
- show server-reported tool behaviour hints in the existing Capabilities hover details
- support both MCP SDK v1 camelCase attributes and SDK v2 snake_case attributes with camelCase wire aliases

## Why

MCP servers already return display titles and behaviour annotations such as `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint`. Hermes retained the underlying SDK objects during connection, but flattened Desktop probe results to only `name` and a truncated `description`.

Preserving these fields gives users useful context when inspecting a connector's tools and establishes the discovery contract needed for later permission-policy work.

MCP annotations are untrusted server-reported hints. This change deliberately phrases them as reports, keeps them separate from provider-facing function schemas, and does not grant or enforce permissions.

## Compatibility

- annotation and title fields are optional and additive in the Desktop response
- older MCP servers and older Hermes backends continue to use the existing name/description shape
- `_probe_single_server()` retains its existing `List[Tuple[str, str]]` return contract for CLI callers
- explicit `false` annotation values are preserved rather than treated as absent
- the serializer recognises MCP Python SDK v1 and v2 field naming
- this PR does not upgrade Hermes to the MCP `2026-07-28` wire protocol

## Testing

- `PYTHONPATH="" uv run --extra mcp pytest tests/hermes_cli/test_mcp_*.py tests/tools/test_mcp_probe.py -q` (`75 passed`)
- `npm run typecheck`
- `npm run test:ui` (`341 files, 3020 tests passed`)
- focused keyboard-accessibility, metadata, and OAuth tests (`9 passed` after the final rebase)
- full Desktop ESLint (`0 errors`; existing warnings only)
- focused ESLint and Prettier checks on all changed Desktop files
- `uvx ruff check` on all changed Python files
- `git diff --check`

## Review

Independent backend review found no issues. Independent Desktop review identified inaccessible native tooltips, a duplicated OAuth response type, and formatting drift; all three findings are resolved in this revision. The tool chip now uses Desktop's keyboard-aware `Tip` component and has a component test covering keyboard focus.