### PR TITLE
feat(slack): acknowledge all processed messages

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1546,6 +1546,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["reply_prefix"] = platform_cfg["reply_prefix"]
                 if "reply_in_thread" in platform_cfg:
                     bridged["reply_in_thread"] = platform_cfg["reply_in_thread"]
+                if plat == Platform.SLACK and "reaction_ack_scope" in platform_cfg:
+                    bridged["reaction_ack_scope"] = platform_cfg["reaction_ack_scope"]
                 if "cron_continuable_surface" in platform_cfg:
                     bridged["cron_continuable_surface"] = platform_cfg["cron_continuable_surface"]
                 if "require_mention" in platform_cfg:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5591,12 +5591,18 @@ class BasePlatformAdapter(ABC):
                 # (Registry-derived: busy_policy == "interrupt_then_dispatch".)
                 if cmd and is_interrupt_then_dispatch(cmd):
                     self._discard_text_debounce(session_key)
+                    _bypass_outcome = ProcessingOutcome.SUCCESS
                     try:
                         await self._dispatch_active_session_command(event, session_key, cmd)
                     except Exception as e:
+                        _bypass_outcome = ProcessingOutcome.FAILURE
                         logger.error(
                             "[%s] Command '/%s' dispatch failed: %s",
                             self.name, cmd, e, exc_info=True,
+                        )
+                    finally:
+                        await self._run_processing_hook(
+                            "on_processing_complete", event, _bypass_outcome
                         )
                     return
 
@@ -5607,6 +5613,7 @@ class BasePlatformAdapter(ABC):
                     "[%s] Command '/%s' bypassing active-session guard for %s",
                     self.name, cmd, session_key,
                 )
+                _bypass_outcome = ProcessingOutcome.SUCCESS
                 try:
                     _thread_meta = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
                     response = await self._message_handler(event)
@@ -5625,7 +5632,12 @@ class BasePlatformAdapter(ABC):
                                 ttl_seconds=_eph_ttl,
                             )
                 except Exception as e:
+                    _bypass_outcome = ProcessingOutcome.FAILURE
                     logger.error("[%s] Command '/%s' dispatch failed: %s", self.name, cmd, e, exc_info=True)
+                finally:
+                    await self._run_processing_hook(
+                        "on_processing_complete", event, _bypass_outcome
+                    )
                 return
 
             # Clarify reply bypass: if the agent is blocked on a

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -999,6 +999,10 @@ class SlackAdapter(BasePlatformAdapter):
         # exception between add and finalize would leak them — keep it bounded.
         self._reacting_message_ids: set = set()
         self._REACTING_MESSAGE_IDS_MAX = 5000
+        # ACK API calls are dispatched as soon as an accepted Slack message
+        # clears authorization/mention gates. Keep the task so completion can
+        # await it before swapping 👀 for ✅/❌, preventing an add/remove race.
+        self._reaction_ack_tasks: Dict[Any, asyncio.Task] = {}
         # Track active Assistant statuses by (team_id, channel_id, thread_ts)
         # so cleanup cannot clear an overlapping Slack Connect workspace.
         # Entries are popped when the status clears, but statuses abandoned
@@ -3743,6 +3747,52 @@ class SlackAdapter(BasePlatformAdapter):
         """Check if message reactions are enabled via config/env."""
         return os.getenv("SLACK_REACTIONS", "true").lower() not in {"false", "0", "no"}
 
+    def _reaction_ack_scope(self) -> str:
+        """Return which accepted Slack messages receive lifecycle reactions.
+
+        ``addressed`` is the backward-compatible default: only 1:1 DMs and
+        explicit @mentions. ``processed`` covers every message that survives
+        the adapter's authorization and mention gates. ``off`` disables ACK
+        reactions without changing the legacy ``SLACK_REACTIONS`` switch.
+        """
+        raw = str(self.config.extra.get("reaction_ack_scope", "addressed") or "addressed")
+        scope = raw.strip().lower()
+        return scope if scope in {"addressed", "processed", "off"} else "addressed"
+
+    def _should_ack_processed_message(
+        self, *, is_one_to_one_dm: bool, is_mentioned: bool
+    ) -> bool:
+        if not self._reactions_enabled():
+            return False
+        scope = self._reaction_ack_scope()
+        if scope == "off":
+            return False
+        if scope == "processed":
+            return True
+        # MPIMs remain shared surfaces under the default scope, so an
+        # unmentioned group-DM message does not create visible reaction noise.
+        return is_one_to_one_dm or is_mentioned
+
+    def _start_processing_ack(self, channel: str, timestamp: str, team_id: str = "") -> None:
+        """Dispatch the initial 👀 reaction without delaying message handling."""
+        marker = self._workspace_message_marker(team_id, timestamp)
+        if marker in self._reacting_message_ids:
+            return
+        self._reacting_message_ids.add(marker)
+        task = asyncio.create_task(self._add_reaction(channel, timestamp, "eyes", team_id))
+        self._reaction_ack_tasks[marker] = task
+        if len(self._reacting_message_ids) > self._REACTING_MESSAGE_IDS_MAX:
+            self._discard_oldest_slack_timestamps(
+                self._reacting_message_ids,
+                self._REACTING_MESSAGE_IDS_MAX // 2,
+            )
+            live_markers = self._reacting_message_ids
+            for stale in list(self._reaction_ack_tasks):
+                if stale not in live_markers:
+                    stale_task = self._reaction_ack_tasks.pop(stale)
+                    if not stale_task.done():
+                        stale_task.cancel()
+
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction when message processing begins."""
         if not self._reactions_enabled():
@@ -3752,6 +3802,8 @@ class SlackAdapter(BasePlatformAdapter):
         marker = self._workspace_message_marker(team_id, ts) if ts else None
         if not ts or marker not in self._reacting_message_ids:
             return
+        if marker in self._reaction_ack_tasks:
+            return  # Already dispatched before preprocessing/model work.
         channel_id = getattr(event.source, "chat_id", None)
         if channel_id:
             await self._add_reaction(channel_id, ts, "eyes", team_id)
@@ -3767,6 +3819,12 @@ class SlackAdapter(BasePlatformAdapter):
         marker = self._workspace_message_marker(team_id, ts) if ts else None
         if not ts or marker not in self._reacting_message_ids:
             return
+        ack_task = self._reaction_ack_tasks.pop(marker, None)
+        if ack_task is not None:
+            try:
+                await ack_task
+            except asyncio.CancelledError:
+                pass
         self._reacting_message_ids.discard(marker)
         channel_id = getattr(event.source, "chat_id", None)
         if not channel_id:
@@ -5753,6 +5811,17 @@ class SlackAdapter(BasePlatformAdapter):
             ):
                 self._register_mentioned_thread(thread_ts, team_id=team_id)
 
+        # Give immediate, non-blocking feedback before thread hydration, file
+        # downloads, or model work. ``addressed`` preserves the historical
+        # DM/@mention-only scope; ``processed`` also ACKs unmentioned messages
+        # that have passed the normal Slack gates (for free-response/project
+        # channels). Ignored messages return above and never receive an ACK.
+        if self._should_ack_processed_message(
+            is_one_to_one_dm=is_one_to_one_dm,
+            is_mentioned=is_mentioned,
+        ):
+            self._start_processing_ack(channel_id, ts, team_id)
+
         # Thread context rules:
         # - First message in a thread session (cold start): hydrate full
         #   context.
@@ -6294,24 +6363,6 @@ class SlackAdapter(BasePlatformAdapter):
                 "slack_thread_ts": thread_ts,
             },
         )
-
-        # Only react when bot is directly addressed (1:1 DM or @mention).
-        # MPIMs are shared surfaces: reacting to every group-DM message (even
-        # when unmentioned) is visible noise to the whole group, so they must
-        # be @mentioned to earn a reaction — same as any channel.
-        _should_react = (is_one_to_one_dm or is_mentioned) and self._reactions_enabled()
-        if _should_react:
-            self._reacting_message_ids.add(
-                self._workspace_message_marker(team_id, ts)
-            )
-            if len(self._reacting_message_ids) > self._REACTING_MESSAGE_IDS_MAX:
-                # Entries embed a Slack message ts (bare or workspace-scoped
-                # tuple) — evict oldest first by the embedded ts.
-                self._discard_oldest_slack_timestamps(
-                    self._reacting_message_ids,
-                    len(self._reacting_message_ids)
-                    - self._REACTING_MESSAGE_IDS_MAX // 2,
-                )
 
         # App-context is per-turn, user-controlled Slack UI state. Surface it
         # with the inbound user message rather than storing it on SessionSource:

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -13,11 +13,17 @@ the safety net in _run_agent discards leaked command text.
 """
 
 import asyncio
+from unittest.mock import AsyncMock
 
 import pytest
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    ProcessingOutcome,
+)
 from gateway.session import SessionSource, build_session_key
 
 
@@ -135,6 +141,20 @@ class TestCommandBypassActiveSession:
 
         assert sk not in adapter._pending_messages
         assert any("handled:approve" in r for r in adapter.sent_responses)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("command", ["/stop", "/status"])
+    async def test_bypass_commands_finalize_processing_lifecycle(self, command):
+        adapter = _make_adapter()
+        sk = _session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+        complete_hook = AsyncMock()
+        adapter.on_processing_complete = complete_hook
+        event = _make_event(command)
+
+        await adapter.handle_message(event)
+
+        complete_hook.assert_awaited_once_with(event, ProcessingOutcome.SUCCESS)
 
     @pytest.mark.asyncio
     async def test_deny_bypasses_guard(self):

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -27,6 +27,7 @@ from gateway.run import GatewayRunner
 from gateway.platforms.base import (
     MessageEvent,
     MessageType,
+    ProcessingOutcome,
     SendResult,
     SUPPORTED_VIDEO_TYPES,
     SendResult,
@@ -2550,6 +2551,7 @@ class TestReactions:
             "ts": "1234567890.000001",
         }
         await adapter._handle_slack_message(event)
+        await asyncio.sleep(0)  # initial ACK is intentionally fire-and-forget
 
         # _handle_slack_message should register the message for reactions
         assert "1234567890.000001" in adapter._reacting_message_ids
@@ -2590,6 +2592,128 @@ class TestReactions:
 
         # Message ID should be cleaned up
         assert "1234567890.000001" not in adapter._reacting_message_ids
+
+    @pytest.mark.asyncio
+    async def test_processed_scope_reacts_to_accepted_unmentioned_channel_message(
+        self, adapter
+    ):
+        adapter.config.extra.update(
+            {"require_mention": False, "reaction_ack_scope": "processed"}
+        )
+        adapter._app.client.reactions_add = AsyncMock()
+        adapter._app.client.reactions_remove = AsyncMock()
+        event = {
+            "text": "ordinary project-channel turn",
+            "user": "U_USER",
+            "channel": "C_PROJECT",
+            "channel_type": "channel",
+            "ts": "1234567890.000002",
+        }
+
+        await adapter._handle_slack_message(event)
+        await asyncio.sleep(0)
+
+        msg_event = adapter.handle_message.await_args.args[0]
+        adapter._app.client.reactions_add.assert_awaited_once_with(
+            channel="C_PROJECT",
+            timestamp="1234567890.000002",
+            name="eyes",
+        )
+        await adapter.on_processing_complete(msg_event, ProcessingOutcome.SUCCESS)
+        assert (
+            adapter._app.client.reactions_add.await_args_list[-1].kwargs["name"]
+            == "white_check_mark"
+        )
+        adapter._app.client.reactions_remove.assert_awaited_once_with(
+            channel="C_PROJECT",
+            timestamp="1234567890.000002",
+            name="eyes",
+        )
+
+    @pytest.mark.asyncio
+    async def test_default_scope_keeps_unmentioned_free_response_channel_quiet(
+        self, adapter
+    ):
+        adapter.config.extra["require_mention"] = False
+        adapter._app.client.reactions_add = AsyncMock()
+        await adapter._handle_slack_message(
+            {
+                "text": "accepted but not directly addressed",
+                "user": "U_USER",
+                "channel": "C_SHARED",
+                "channel_type": "channel",
+                "ts": "1234567890.000003",
+            }
+        )
+        await asyncio.sleep(0)
+
+        adapter.handle_message.assert_awaited_once()
+        adapter._app.client.reactions_add.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_processed_scope_does_not_react_to_message_rejected_by_gates(
+        self, adapter
+    ):
+        adapter.config.extra["reaction_ack_scope"] = "processed"
+        adapter._app.client.reactions_add = AsyncMock()
+        await adapter._handle_slack_message(
+            {
+                "text": "unmentioned in a mention-gated channel",
+                "user": "U_USER",
+                "channel": "C_GATED",
+                "channel_type": "channel",
+                "ts": "1234567890.000004",
+            }
+        )
+        await asyncio.sleep(0)
+
+        adapter.handle_message.assert_not_awaited()
+        adapter._app.client.reactions_add.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_processed_scope_dispatches_ack_before_slow_preprocessing(
+        self, adapter
+    ):
+        adapter.config.extra.update(
+            {"require_mention": False, "reaction_ack_scope": "processed"}
+        )
+        ack_seen = asyncio.Event()
+        release_preprocessing = asyncio.Event()
+
+        async def add_reaction(**kwargs):
+            ack_seen.set()
+
+        async def slow_user_lookup(*args, **kwargs):
+            await release_preprocessing.wait()
+            return "Test User"
+
+        adapter._app.client.reactions_add = AsyncMock(side_effect=add_reaction)
+        adapter._resolve_user_name = AsyncMock(side_effect=slow_user_lookup)
+        handler = asyncio.create_task(
+            adapter._handle_slack_message(
+                {
+                    "text": "please handle this project task",
+                    "user": "U_USER",
+                    "channel": "C_PROJECT",
+                    "channel_type": "channel",
+                    "ts": "1234567890.000005",
+                }
+            )
+        )
+
+        await asyncio.wait_for(ack_seen.wait(), timeout=1)
+        assert not handler.done()
+        release_preprocessing.set()
+        await handler
+
+    def test_reaction_ack_scope_normalization(self, adapter):
+        assert adapter._reaction_ack_scope() == "addressed"
+        adapter.config.extra["reaction_ack_scope"] = " PROCESSED "
+        assert adapter._reaction_ack_scope() == "processed"
+        adapter.config.extra["reaction_ack_scope"] = "off"
+        assert adapter._reaction_ack_scope() == "off"
+        adapter.config.extra["reaction_ack_scope"] = "unexpected"
+        assert adapter._reaction_ack_scope() == "addressed"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -255,20 +255,18 @@ def test_mpim_unmentioned_does_not_react():
 
 
 def test_reaction_guard_pinned_to_production_expression():
-    """Regression teeth for the reaction guard.
+    """Default reaction scope must retain the MPIM spam guard.
 
-    ``_reaction_guard`` mirrors the production expression at the
-    ``_should_react = (is_one_to_one_dm or is_mentioned) ...`` site in
-    ``adapter.py``. This test pins that source line so a revert of the fix
-    (back to ``is_dm or is_mentioned``, which reacts to unmentioned MPIMs)
-    fails here instead of silently passing a self-referential lambda.
+    ``processed`` deliberately expands ACKs only when configured. The default
+    ``addressed`` branch must continue to key off 1:1 IMs or explicit mentions,
+    never the broader ``is_dm`` value that also includes MPIMs.
     """
-    src = inspect.getsource(SlackAdapter._handle_slack_message)
-    assert "(is_one_to_one_dm or is_mentioned)" in src, (
-        "reaction guard no longer keys off is_one_to_one_dm — an unmentioned "
-        "MPIM would react again (regression of the group-DM fix)"
+    src = inspect.getsource(SlackAdapter._should_ack_processed_message)
+    assert "return is_one_to_one_dm or is_mentioned" in src, (
+        "default reaction scope no longer keys off is_one_to_one_dm — an "
+        "unmentioned MPIM would react again"
     )
-    assert "(is_dm or is_mentioned)" not in src, (
+    assert "return is_dm or is_mentioned" not in src, (
         "reaction guard reverted to is_dm — MPIMs would react when unmentioned"
     )
 

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -5,7 +5,6 @@ Follows the same pattern as test_whatsapp_group_gating.py.
 """
 
 import sys
-import inspect
 import logging
 from unittest.mock import AsyncMock, MagicMock
 
@@ -60,7 +59,7 @@ OTHER_CHANNEL_ID = "C9999999999"
 
 
 def _make_adapter(require_mention=None, strict_mention=None, free_response_channels=None,
-                  allowed_channels=None, mention_patterns=None):
+                  allowed_channels=None, mention_patterns=None, reaction_ack_scope=None):
     extra = {}
     if require_mention is not None:
         extra["require_mention"] = require_mention
@@ -72,6 +71,8 @@ def _make_adapter(require_mention=None, strict_mention=None, free_response_chann
         extra["allowed_channels"] = allowed_channels
     if mention_patterns is not None:
         extra["mention_patterns"] = mention_patterns
+    if reaction_ack_scope is not None:
+        extra["reaction_ack_scope"] = reaction_ack_scope
 
     adapter = object.__new__(SlackAdapter)
     adapter.platform = Platform.SLACK
@@ -254,20 +255,28 @@ def test_mpim_unmentioned_does_not_react():
     assert _reaction_guard("", False) is False         # channel, unmentioned
 
 
-def test_reaction_guard_pinned_to_production_expression():
-    """Default reaction scope must retain the MPIM spam guard.
-
-    ``processed`` deliberately expands ACKs only when configured. The default
-    ``addressed`` branch must continue to key off 1:1 IMs or explicit mentions,
-    never the broader ``is_dm`` value that also includes MPIMs.
-    """
-    src = inspect.getsource(SlackAdapter._should_ack_processed_message)
-    assert "return is_one_to_one_dm or is_mentioned" in src, (
-        "default reaction scope no longer keys off is_one_to_one_dm — an "
-        "unmentioned MPIM would react again"
-    )
-    assert "return is_dm or is_mentioned" not in src, (
-        "reaction guard reverted to is_dm — MPIMs would react when unmentioned"
+@pytest.mark.parametrize(
+    ("scope", "is_one_to_one_dm", "is_mentioned", "expected"),
+    [
+        ("addressed", False, False, False),  # unmentioned MPIM/channel
+        ("addressed", False, True, True),
+        ("addressed", True, False, True),
+        ("processed", False, False, True),
+        ("off", True, True, False),
+        ("invalid", False, False, False),  # fail back to addressed
+    ],
+)
+def test_reaction_ack_scope_runtime_behavior(
+    monkeypatch, scope, is_one_to_one_dm, is_mentioned, expected
+):
+    monkeypatch.setenv("SLACK_REACTIONS", "true")
+    adapter = _make_adapter(reaction_ack_scope=scope)
+    assert (
+        adapter._should_ack_processed_message(
+            is_one_to_one_dm=is_one_to_one_dm,
+            is_mentioned=is_mentioned,
+        )
+        is expected
     )
 
 
@@ -351,6 +360,26 @@ def test_config_bridges_slack_free_response_channels(monkeypatch, tmp_path):
     assert _os.environ["SLACK_FREE_RESPONSE_CHANNELS"] == "C0AQWDLHY9M,C9999999999"
     _os.environ.pop("SLACK_REQUIRE_MENTION", None)
     _os.environ.pop("SLACK_FREE_RESPONSE_CHANNELS", None)
+
+
+def test_config_bridges_slack_reaction_ack_scope(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "slack:\n"
+        "  reaction_ack_scope: processed\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    config = load_gateway_config()
+
+    slack_extra = config.platforms[Platform.SLACK].extra
+    assert slack_extra["reaction_ack_scope"] == "processed"
+    adapter = _make_adapter(reaction_ack_scope=slack_extra["reaction_ack_scope"])
+    assert adapter._reaction_ack_scope() == "processed"
 
 
 def test_top_level_slack_settings_do_not_disable_env_token_setup(monkeypatch, tmp_path):

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -546,6 +546,14 @@ slack:
   # must @mention the bot before Hermes will respond.
   strict_mention: false
 
+  # Processing reaction scope. "addressed" (default) preserves the existing
+  # behavior: 👀 → ✅/❌ only for 1:1 DMs and explicit @mentions. "processed"
+  # also reacts to unmentioned messages that pass the normal authorization and
+  # mention gates, which is useful for free-response/project channels. "off"
+  # disables lifecycle ACK reactions. The initial 👀 is dispatched before
+  # thread hydration, attachment downloads, and model work.
+  reaction_ack_scope: addressed
+
   # Ignore messages addressed to another user: when a channel or thread
   # message *opens* by @mentioning someone other than the bot (e.g.
   # "@rasha can you take this?"), stay silent unless the bot is also


### PR DESCRIPTION
## Summary

Extend Slack's existing processing-reaction lifecycle so free-response/project channels can opt in to ACKs for every message Hermes actually accepts.

- adds `reaction_ack_scope: addressed | processed | off`
- preserves the current DM/@mention-only behavior by default (`addressed`)
- dispatches the initial `:eyes:` reaction immediately after authorization/mention gates, before thread hydration, attachment downloads, and model work
- keeps ACK delivery non-blocking while ordering completion so `:eyes:` cannot race with `:white_check_mark:` / `:x:`
- never reacts to messages rejected by Slack's normal gates
- retains the unmentioned-MPIM spam guard in the default scope

## Motivation

Slack already has a `:eyes:` → `:white_check_mark:` / `:x:` processing lifecycle, but the current trigger is hard-coded to 1:1 DMs and explicit mentions. Free-response channels process ordinary unmentioned turns without any immediate feedback, which makes preprocessing and model latency look like radio silence.

`processed` fills that gap without changing the safe default or creating a second reaction system.

## Configuration

```yaml
slack:
  reaction_ack_scope: processed
```

- `addressed` (default): 1:1 DMs and explicit mentions only
- `processed`: every message accepted by authorization and mention gates
- `off`: disable lifecycle ACK reactions

The existing `SLACK_REACTIONS=false` compatibility switch still disables reactions globally.

## Validation

- Slack, relay, and progress suite: **379 passed**
- focused reaction tests: **8 passed**
- Ruff: passed
- `py_compile`: passed
- `git diff --check`: passed

No workspace IDs, tokens, logs, or private configuration are included.
