### PR TITLE
fix(agent): step reasoning effort down the ladder instead of clamping to medium

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1335,6 +1335,13 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             openrouter_min_coding_score=agent.openrouter_min_coding_score,
             anthropic_max_output=_ant_max,
             supports_reasoning=agent._supports_reasoning_extra_body(),
+            # Resolved agent-side: only the agent holds the route's API key,
+            # and without it the catalog lookup can't see a Claude slot's
+            # effort list at all (#74295). Mirrors the LM Studio options the
+            # legacy path forwards below.
+            copilot_reasoning_efforts=(
+                agent._copilot_reasoning_efforts_cached() if _is_gh else None
+            ),
             qwen_session_metadata=_qwen_meta,
         )
 

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -324,6 +324,7 @@ class ChatCompletionsTransport(ProviderTransport):
             supports_reasoning: bool
             github_reasoning_extra: dict | None
             lmstudio_reasoning_options: list[str] | None  # raw allowed_options from /api/v1/models
+            copilot_reasoning_efforts: list[str] | None  # catalog effort levels, resolved agent-side
             # Claude on OpenRouter/Nous max output
             anthropic_max_output: int | None
             extra_body_additions: dict | None
@@ -588,6 +589,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 base_url=params.get("base_url"),
                 ollama_num_ctx=params.get("ollama_num_ctx"),
                 session_id=params.get("session_id"),
+                copilot_reasoning_efforts=params.get("copilot_reasoning_efforts"),
             )
         )
         api_kwargs.update(top_level_from_profile)

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import stat
 import sys
+from collections.abc import Sequence
 from contextvars import ContextVar, Token
 from pathlib import Path
 
@@ -842,6 +843,37 @@ def parse_reasoning_effort(effort) -> dict | None:
     if effort in VALID_REASONING_EFFORTS:
         return {"enabled": True, "effort": effort}
     return None
+
+
+def degrade_reasoning_effort(requested: str, supported: Sequence[str]) -> str:
+    """Map *requested* onto the closest level in a provider's *supported* set.
+
+    Providers advertise narrower effort vocabularies than
+    ``VALID_REASONING_EFFORTS`` — the Copilot catalog tops out at ``max`` and
+    lists no ``ultra`` for any model. Degradation walks Hermes' canonical
+    ladder rather than the provider's own ordering so the mapping stays
+    monotonic: a stronger request never resolves to a weaker level than a
+    lower request would. Clamping unsupported levels to a fixed ``medium``
+    inverts the ladder, which is what made ``ultra`` send less thinking than
+    ``high`` (#74295).
+
+    Levels outside the canonical ladder (e.g. ``none``, which disables
+    reasoning) are never selected as a degradation target. A request with
+    nothing weaker available takes the weakest supported level, since the
+    caller has already decided to send the field. Callers are expected to
+    skip the field entirely when *supported* is empty; that degenerate case
+    falls back to Hermes' own ``medium`` default rather than raising.
+    """
+    if not supported:
+        return "medium"
+    ladder = [effort for effort in VALID_REASONING_EFFORTS if effort in supported]
+    if requested not in VALID_REASONING_EFFORTS or not ladder:
+        return "medium" if "medium" in supported else supported[0]
+    rank = VALID_REASONING_EFFORTS.index(requested)
+    weaker_or_equal = [
+        effort for effort in ladder if VALID_REASONING_EFFORTS.index(effort) <= rank
+    ]
+    return weaker_or_equal[-1] if weaker_or_equal else ladder[0]
 
 
 def _canonical_model_variants(model: str) -> list[str]:

--- a/plugins/model-providers/copilot/__init__.py
+++ b/plugins/model-providers/copilot/__init__.py
@@ -12,6 +12,7 @@ Key quirks for the chat_completions subset:
 
 from typing import Any
 
+from hermes_constants import degrade_reasoning_effort
 from providers import register_provider
 from providers.base import ProviderProfile
 
@@ -39,21 +40,14 @@ class CopilotProfile(ProviderProfile):
                     # lists it as supported: gpt-5.5/gpt-5.4 DO support
                     # ``xhigh``. Only downgrade levels the catalog does NOT
                     # list (e.g. ``xhigh``/``max`` on models capped lower, or
-                    # ``minimal`` where unsupported), choosing the nearest
-                    # weaker supported level rather than forwarding verbatim.
+                    # ``minimal`` where unsupported), stepping down Hermes'
+                    # canonical ladder so the mapping stays monotonic.
                     #
                     # (Previously this unconditionally mapped xhigh->high, a
                     #  stale guard that silently capped models which do support
                     #  the higher level.)
                     if effort not in supported_efforts:
-                        if effort == "xhigh" and "high" in supported_efforts:
-                            effort = "high"
-                        elif effort == "minimal" and "low" in supported_efforts:
-                            effort = "low"
-                        elif "medium" in supported_efforts:
-                            effort = "medium"
-                        else:
-                            effort = supported_efforts[0]
+                        effort = degrade_reasoning_effort(effort, supported_efforts)
                     if effort in supported_efforts:
                         extra_body["reasoning"] = {"effort": effort}
                 elif supported_efforts:

--- a/plugins/model-providers/copilot/__init__.py
+++ b/plugins/model-providers/copilot/__init__.py
@@ -31,9 +31,16 @@ class CopilotProfile(ProviderProfile):
         extra_body: dict[str, Any] = {}
         if supports_reasoning and model:
             try:
-                from hermes_cli.models import github_model_reasoning_efforts
+                # The agent resolves the catalog's effort list once per
+                # (model, base_url) with the route's key in hand and forwards
+                # it here. Re-resolving locally would repeat that work without
+                # the key, and a keyless lookup only recognizes o-series and
+                # GPT-5 IDs — every Claude slot would come back empty (#74295).
+                supported_efforts = ctx.get("copilot_reasoning_efforts")
+                if supported_efforts is None:
+                    from hermes_cli.models import github_model_reasoning_efforts
 
-                supported_efforts = github_model_reasoning_efforts(model)
+                    supported_efforts = github_model_reasoning_efforts(model)
                 if supported_efforts and reasoning_config:
                     effort = reasoning_config.get("effort", "medium")
                     # Honor the requested level when the live Copilot catalog

--- a/run_agent.py
+++ b/run_agent.py
@@ -6443,12 +6443,7 @@ class AIAgent:
             base_url_host_matches(self._base_url_lower, "models.github.ai")
             or base_url_host_matches(self._base_url_lower, "githubcopilot.com")
         ):
-            try:
-                from hermes_cli.models import github_model_reasoning_efforts
-
-                return bool(github_model_reasoning_efforts(self.model))
-            except Exception:
-                return False
+            return bool(self._copilot_reasoning_efforts_cached())
         if (self.provider or "").strip().lower() == "lmstudio":
             opts = self._lmstudio_reasoning_options_cached()
             # "off-only" (or absent) means no real reasoning capability.
@@ -6543,6 +6538,57 @@ class AIAgent:
         cache[key] = (supported, _time.monotonic())
         return bool(supported)
 
+    def _copilot_reasoning_efforts_cached(self) -> list[str]:
+        """Resolve Copilot's advertised effort levels once per (model, base_url).
+
+        ``github_model_reasoning_efforts`` reads catalog capabilities only when
+        handed a catalog or an API key; without either, its fallback recognizes
+        just the o-series and GPT-5 IDs, so every Claude slot resolves to ``[]``
+        — the supports-reasoning gate goes False and the payload is dropped
+        before any effort mapping runs (#74295). Pass the route's key so the
+        live catalog is consulted.
+
+        The catalog is fetched here rather than handed down as an API key so
+        the lookup costs exactly one fetch: passing ``api_key`` instead makes
+        ``normalize_copilot_model_id`` and the capability read fetch it twice.
+        Only Copilot-hosted routes are worth a fetch — anything else keeps the
+        keyless heuristics, as does a failed fetch.
+
+        Caching mirrors the LM Studio / Ollama probes: a non-empty list is
+        permanent (catalog capabilities don't change mid-session), an empty one
+        carries a 60-second TTL so a transient catalog outage doesn't suppress
+        reasoning for the whole session yet also doesn't fetch every turn.
+        """
+        import time as _time
+
+        cache = getattr(self, "_copilot_efforts_cache", None)
+        if cache is None:
+            cache = self._copilot_efforts_cache = {}
+        key = (self.model, self.base_url)
+        cached = cache.get(key)
+        if cached is not None:
+            efforts, ts = cached
+            # Non-empty → permanent. Empty → 60s TTL.
+            if efforts or (_time.monotonic() - ts) < 60:
+                return efforts
+        try:
+            from hermes_cli.models import (
+                fetch_github_model_catalog,
+                github_model_reasoning_efforts,
+            )
+            catalog = None
+            if base_url_host_matches(
+                self._base_url_lower, "githubcopilot.com"
+            ) or base_url_host_matches(self._base_url_lower, "models.github.ai"):
+                catalog = fetch_github_model_catalog(
+                    api_key=getattr(self, "api_key", "") or None
+                )
+            efforts = github_model_reasoning_efforts(self.model, catalog=catalog)
+        except Exception:
+            efforts = []
+        cache[key] = (efforts, _time.monotonic())
+        return efforts
+
     def _resolve_lmstudio_summary_reasoning_effort(self) -> Optional[str]:
         """Resolve a safe top-level ``reasoning_effort`` for LM Studio.
 
@@ -6558,12 +6604,7 @@ class AIAgent:
 
     def _github_models_reasoning_extra_body(self) -> dict | None:
         """Format reasoning payload for GitHub Models/OpenAI-compatible routes."""
-        try:
-            from hermes_cli.models import github_model_reasoning_efforts
-        except Exception:
-            return None
-
-        supported_efforts = github_model_reasoning_efforts(self.model)
+        supported_efforts = self._copilot_reasoning_efforts_cached()
         if not supported_efforts:
             return None
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -63,7 +63,7 @@ from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 
-from hermes_constants import get_hermes_home
+from hermes_constants import degrade_reasoning_effort, get_hermes_home
 
 
 def _launch_cwd_for_session(source: str) -> Optional[str]:
@@ -6576,15 +6576,8 @@ class AIAgent:
         else:
             requested_effort = "medium"
 
-        if requested_effort == "xhigh" and "xhigh" not in supported_efforts and "high" in supported_efforts:
-            requested_effort = "high"
-        elif requested_effort not in supported_efforts:
-            if requested_effort == "minimal" and "low" in supported_efforts:
-                requested_effort = "low"
-            elif "medium" in supported_efforts:
-                requested_effort = "medium"
-            else:
-                requested_effort = supported_efforts[0]
+        if requested_effort not in supported_efforts:
+            requested_effort = degrade_reasoning_effort(requested_effort, supported_efforts)
 
         return {"effort": requested_effort}
 

--- a/tests/plugins/model_providers/test_copilot_profile.py
+++ b/tests/plugins/model_providers/test_copilot_profile.py
@@ -62,6 +62,40 @@ class TestCopilotReasoningEffortClamp:
         )
         assert extra_body["reasoning"] == {"effort": "high"}
 
+    def test_ultra_downgrades_to_max_not_medium(self, copilot_profile, monkeypatch):
+        """`ultra` steps down to `max` instead of collapsing to `medium`.
+
+        Regression for #74295: no Copilot catalog lists `ultra`, so the
+        strongest entry in the picker used to send `medium` — less thinking
+        than picking `high`.
+        """
+        _patch_efforts(monkeypatch, ["low", "medium", "high", "xhigh", "max"])
+        extra_body, _ = copilot_profile.build_api_kwargs_extras(
+            model="claude-opus-5",
+            reasoning_config={"effort": "ultra"},
+            supports_reasoning=True,
+        )
+        assert extra_body["reasoning"] == {"effort": "max"}
+
+    def test_effort_ladder_is_monotonic(self, copilot_profile, monkeypatch):
+        """Requesting a stronger effort never sends a weaker one (#74295)."""
+        from hermes_constants import VALID_REASONING_EFFORTS
+
+        supported = ["low", "medium", "high", "max"]
+        _patch_efforts(monkeypatch, supported)
+
+        sent = []
+        for effort in VALID_REASONING_EFFORTS:
+            extra_body, _ = copilot_profile.build_api_kwargs_extras(
+                model="claude-opus-4.6",
+                reasoning_config={"effort": effort},
+                supports_reasoning=True,
+            )
+            sent.append(extra_body["reasoning"]["effort"])
+
+        ranks = [supported.index(value) for value in sent]
+        assert ranks == sorted(ranks), dict(zip(VALID_REASONING_EFFORTS, sent))
+
     def test_minimal_downgrades_to_low_when_unsupported(self, copilot_profile, monkeypatch):
         _patch_efforts(monkeypatch, ["low", "medium", "high"])
         extra_body, _ = copilot_profile.build_api_kwargs_extras(

--- a/tests/plugins/model_providers/test_copilot_profile.py
+++ b/tests/plugins/model_providers/test_copilot_profile.py
@@ -37,7 +37,7 @@ def _patch_efforts(monkeypatch, efforts):
     """Stub the catalog lookup the profile calls for supported efforts."""
     import hermes_cli.models as models_mod
     monkeypatch.setattr(
-        models_mod, "github_model_reasoning_efforts", lambda model: list(efforts)
+        models_mod, "github_model_reasoning_efforts", lambda model, **_kw: list(efforts)
     )
 
 

--- a/tests/run_agent/test_copilot_claude_reasoning_effort.py
+++ b/tests/run_agent/test_copilot_claude_reasoning_effort.py
@@ -1,0 +1,151 @@
+"""Claude-on-Copilot reasoning effort, resolved the way production resolves it.
+
+The sibling tests in ``test_run_agent.py`` and ``test_copilot_profile.py`` stub
+``github_model_reasoning_efforts`` itself, so they pin the effort *mapping* but
+say nothing about whether a Claude slot ever reaches it. It did not: the runtime
+called that resolver with neither catalog nor API key, and its keyless fallback
+recognizes only o-series and GPT-5 IDs (``hermes_cli/models.py``
+``_github_reasoning_efforts_for_model_id``). Every ``claude-*`` model therefore
+resolved to ``[]``, the supports-reasoning gate went False, and the payload was
+dropped before any degradation ran — the exact route #74295 was filed against.
+
+These tests stub only the network boundary (``fetch_github_model_catalog``) and
+drive the real capability-resolution path from there: the agent's cached
+resolver, the supports-reasoning gate, and the request the chat_completions
+transport actually builds.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+# Live capabilities from the #74295 report, in the shape the Copilot
+# ``/models`` payload uses.
+_OPUS_5_EFFORTS = ["low", "medium", "high", "xhigh", "max"]
+_OPUS_46_EFFORTS = ["low", "medium", "high", "max"]
+
+
+def _catalog(*entries: tuple[str, list[str]]) -> list[dict]:
+    return [
+        {
+            "id": model_id,
+            "capabilities": {"supports": {"reasoning_effort": list(efforts)}},
+        }
+        for model_id, efforts in entries
+    ]
+
+
+@pytest.fixture
+def copilot_agent():
+    """An agent on the Copilot route, with tool loading and the client stubbed."""
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="ghu_test_copilot_token",
+            base_url="https://api.githubcopilot.com",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent.provider = "copilot"
+    agent.model = "claude-opus-5"
+    return agent
+
+
+@pytest.fixture
+def catalog_fetch(monkeypatch):
+    """Stub the one network call, and count it."""
+    import hermes_cli.models as models_mod
+
+    fetch = MagicMock(return_value=_catalog(
+        ("claude-opus-5", _OPUS_5_EFFORTS),
+        ("claude-opus-4.6", _OPUS_46_EFFORTS),
+    ))
+    monkeypatch.setattr(models_mod, "fetch_github_model_catalog", fetch)
+    return fetch
+
+
+class TestClaudeCopilotCapabilityResolution:
+    """The catalog reaches the runtime, so Claude slots resolve to real levels."""
+
+    def test_claude_slot_resolves_catalog_efforts(self, copilot_agent, catalog_fetch):
+        assert copilot_agent._copilot_reasoning_efforts_cached() == _OPUS_5_EFFORTS
+
+    def test_supports_reasoning_gate_opens_for_claude(self, copilot_agent, catalog_fetch):
+        """Without the catalog this gate was False and dropped the payload."""
+        assert copilot_agent._supports_reasoning_extra_body() is True
+
+    def test_catalog_is_fetched_once_per_model(self, copilot_agent, catalog_fetch):
+        """Recovering the capabilities must not cost a fetch per turn."""
+        for _ in range(3):
+            copilot_agent._copilot_reasoning_efforts_cached()
+        assert catalog_fetch.call_count == 1
+
+    def test_model_switch_refetches(self, copilot_agent, catalog_fetch):
+        """The cache is keyed on the model, so a ``/model`` swap re-resolves."""
+        copilot_agent._copilot_reasoning_efforts_cached()
+        copilot_agent.model = "claude-opus-4.6"
+        assert copilot_agent._copilot_reasoning_efforts_cached() == _OPUS_46_EFFORTS
+
+    def test_unavailable_catalog_falls_back_to_heuristics(self, copilot_agent, monkeypatch):
+        """A catalog outage degrades to the keyless behaviour, never raises."""
+        import hermes_cli.models as models_mod
+
+        monkeypatch.setattr(
+            models_mod, "fetch_github_model_catalog", lambda **_kw: None
+        )
+        assert copilot_agent._copilot_reasoning_efforts_cached() == []
+        assert copilot_agent._supports_reasoning_extra_body() is False
+
+    def test_non_copilot_route_does_not_fetch(self, copilot_agent, catalog_fetch):
+        """Only Copilot-hosted routes are worth a catalog round-trip."""
+        copilot_agent.base_url = "https://openrouter.ai/api/v1"
+        copilot_agent._base_url_lower = copilot_agent.base_url.lower()
+        copilot_agent.model = "anthropic/claude-opus-5"
+
+        assert copilot_agent._copilot_reasoning_efforts_cached() == []
+        assert catalog_fetch.call_count == 0
+
+
+class TestClaudeCopilotRequestBuilding:
+    """End to end: what the chat_completions transport puts on the wire."""
+
+    def _reasoning(self, agent, effort: str) -> dict | None:
+        agent.reasoning_config = {"enabled": True, "effort": effort}
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        return kwargs.get("extra_body", {}).get("reasoning")
+
+    def test_ultra_sends_max_not_medium(self, copilot_agent, catalog_fetch):
+        """#74295: the strongest picker entry used to send less than ``high``.
+
+        Pre-fix this assertion failed twice over — ``ultra`` mapped to
+        ``medium``, and before that the payload was omitted entirely.
+        """
+        assert self._reasoning(copilot_agent, "ultra") == {"effort": "max"}
+
+    def test_supported_effort_is_forwarded_verbatim(self, copilot_agent, catalog_fetch):
+        assert self._reasoning(copilot_agent, "xhigh") == {"effort": "xhigh"}
+
+    def test_capped_model_steps_down_one_rung(self, copilot_agent, catalog_fetch):
+        """opus-4.6 lists no ``xhigh``; the request lands on ``high``, not ``medium``."""
+        copilot_agent.model = "claude-opus-4.6"
+        assert self._reasoning(copilot_agent, "xhigh") == {"effort": "high"}
+
+    def test_request_ladder_is_monotonic(self, copilot_agent, catalog_fetch):
+        """A stronger request never puts a weaker effort on the wire."""
+        from hermes_constants import VALID_REASONING_EFFORTS
+
+        sent = [
+            self._reasoning(copilot_agent, effort)["effort"]
+            for effort in VALID_REASONING_EFFORTS
+        ]
+        ranks = [_OPUS_5_EFFORTS.index(value) for value in sent]
+        assert ranks == sorted(ranks), dict(zip(VALID_REASONING_EFFORTS, sent))

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1238,7 +1238,7 @@ class TestBuildApiKwargs:
         """The core GitHub Responses path must preserve a supported xhigh."""
         monkeypatch.setattr(
             "hermes_cli.models.github_model_reasoning_efforts",
-            lambda _model: ["none", "low", "medium", "high", "xhigh"],
+            lambda _model, **_kw: ["none", "low", "medium", "high", "xhigh"],
         )
         agent.model = "gpt-5.5"
         agent.reasoning_config = {"enabled": True, "effort": "xhigh"}
@@ -1254,7 +1254,7 @@ class TestBuildApiKwargs:
         """
         monkeypatch.setattr(
             "hermes_cli.models.github_model_reasoning_efforts",
-            lambda _model: ["low", "medium", "high", "xhigh", "max"],
+            lambda _model, **_kw: ["low", "medium", "high", "xhigh", "max"],
         )
         agent.model = "claude-opus-5"
         agent.reasoning_config = {"enabled": True, "effort": "ultra"}
@@ -1268,7 +1268,7 @@ class TestBuildApiKwargs:
         supported = ["low", "medium", "high", "max"]
         monkeypatch.setattr(
             "hermes_cli.models.github_model_reasoning_efforts",
-            lambda _model: supported,
+            lambda _model, **_kw: supported,
         )
         agent.model = "claude-opus-4.6"
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1245,6 +1245,41 @@ class TestBuildApiKwargs:
 
         assert agent._github_models_reasoning_extra_body() == {"effort": "xhigh"}
 
+    def test_core_responses_ultra_degrades_to_max(self, agent, monkeypatch):
+        """`ultra` steps down to the strongest supported level, not `medium`.
+
+        Regression for #74295: no Copilot catalog lists `ultra`, so selecting
+        the strongest level in the picker used to send `medium` — weaker than
+        selecting `high`.
+        """
+        monkeypatch.setattr(
+            "hermes_cli.models.github_model_reasoning_efforts",
+            lambda _model: ["low", "medium", "high", "xhigh", "max"],
+        )
+        agent.model = "claude-opus-5"
+        agent.reasoning_config = {"enabled": True, "effort": "ultra"}
+
+        assert agent._github_models_reasoning_extra_body() == {"effort": "max"}
+
+    def test_core_responses_effort_ladder_is_monotonic(self, agent, monkeypatch):
+        """Requesting a stronger effort never sends a weaker one (#74295)."""
+        from hermes_constants import VALID_REASONING_EFFORTS
+
+        supported = ["low", "medium", "high", "max"]
+        monkeypatch.setattr(
+            "hermes_cli.models.github_model_reasoning_efforts",
+            lambda _model: supported,
+        )
+        agent.model = "claude-opus-4.6"
+
+        sent = []
+        for effort in VALID_REASONING_EFFORTS:
+            agent.reasoning_config = {"enabled": True, "effort": effort}
+            sent.append(agent._github_models_reasoning_extra_body()["effort"])
+
+        ranks = [supported.index(value) for value in sent]
+        assert ranks == sorted(ranks), dict(zip(VALID_REASONING_EFFORTS, sent))
+
 
 
 

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -10,6 +10,7 @@ import hermes_constants
 from hermes_constants import (
     VALID_REASONING_EFFORTS,
     agent_browser_runnable,
+    degrade_reasoning_effort,
     find_hermes_node_executable,
     find_node_executable,
     find_node_executable_on_path,
@@ -279,6 +280,76 @@ class TestParseReasoningEffort:
         """
         documented = {"minimal", "low", "medium", "high", "xhigh", "max", "ultra"}
         assert documented.issubset(set(VALID_REASONING_EFFORTS))
+
+
+# Live Copilot catalog entries from #74295, weakest to strongest.
+_OPUS_5_EFFORTS = ["low", "medium", "high", "xhigh", "max"]
+_OPUS_46_EFFORTS = ["low", "medium", "high", "max"]
+
+
+class TestDegradeReasoningEffort:
+    """Tests for degrade_reasoning_effort() — mapping Hermes' canonical effort
+    ladder onto the narrower set a provider actually advertises.
+
+    Contract: the mapping stays monotonic. A stronger requested level may
+    resolve to an equal-or-stronger supported level, never a weaker one. The
+    effort picker is monotonic in the UI, so what lands on the wire must be
+    too. Mirrors the LM Studio contract in tests/agent/test_lmstudio_reasoning.
+    """
+
+    @pytest.mark.parametrize(
+        "supported", [_OPUS_5_EFFORTS, _OPUS_46_EFFORTS], ids=["opus-5", "opus-4.6"]
+    )
+    def test_ultra_degrades_to_nearest_weaker_level(self, supported):
+        """`ultra` steps down the ladder instead of clamping to `medium`.
+
+        Regression for #74295: `ultra` is in no Copilot catalog, so it fell
+        through to a hardcoded `medium`, making the strongest picker entry
+        send less thinking than `high`.
+        """
+        assert degrade_reasoning_effort("ultra", supported) == "max"
+
+    def test_xhigh_degrades_to_high_when_unsupported(self):
+        """Models capped below xhigh still step down to high."""
+        assert degrade_reasoning_effort("xhigh", _OPUS_46_EFFORTS) == "high"
+
+    def test_minimal_steps_up_when_nothing_weaker_is_supported(self):
+        """`minimal` has nothing below it, so it takes the weakest supported."""
+        assert degrade_reasoning_effort("minimal", _OPUS_5_EFFORTS) == "low"
+
+    @pytest.mark.parametrize(
+        "supported",
+        [_OPUS_5_EFFORTS, _OPUS_46_EFFORTS, ["medium"], ["low", "max"], ["high"]],
+    )
+    def test_ladder_is_monotonic(self, supported):
+        """Walking the canonical ladder never produces an inversion."""
+        resolved = [
+            degrade_reasoning_effort(effort, supported)
+            for effort in VALID_REASONING_EFFORTS
+        ]
+        ranks = [VALID_REASONING_EFFORTS.index(value) for value in resolved]
+        assert ranks == sorted(ranks), dict(zip(VALID_REASONING_EFFORTS, resolved))
+
+    @pytest.mark.parametrize("supported", [_OPUS_5_EFFORTS, ["medium"], ["high"]])
+    def test_result_is_always_a_supported_level(self, supported):
+        """Never invent a level the provider did not advertise."""
+        for effort in VALID_REASONING_EFFORTS:
+            assert degrade_reasoning_effort(effort, supported) in supported
+
+    def test_supported_level_is_returned_unchanged(self):
+        """A level the catalog lists is forwarded verbatim."""
+        for effort in _OPUS_5_EFFORTS:
+            assert degrade_reasoning_effort(effort, _OPUS_5_EFFORTS) == effort
+
+    def test_unknown_request_keeps_the_medium_default(self):
+        """An effort outside the canonical ladder falls back as before."""
+        assert degrade_reasoning_effort("bogus", _OPUS_5_EFFORTS) == "medium"
+        assert degrade_reasoning_effort("bogus", ["low", "high"]) == "low"
+
+    def test_non_canonical_supported_levels_are_never_selected(self):
+        """`none` disables reasoning, so degrading must not land on it."""
+        assert degrade_reasoning_effort("ultra", ["none", "low", "medium"]) == "medium"
+        assert degrade_reasoning_effort("minimal", ["none", "low"]) == "low"
 
 
 class TestResolvePerModelReasoningEffort:


### PR DESCRIPTION
## What does this PR do?

On the Copilot / GitHub Models route, an effort level the live catalog does not list was clamped to a hardcoded `medium`. Because no Copilot model advertises `ultra`, picking the *strongest* level in the Hermes effort picker sent **less** thinking than picking `high` — the ladder is monotonic in the UI but inverted on the wire.

Requested → sent, `claude-opus-5` (catalog: `low, medium, high, xhigh, max`):

| requested | before | after |
|---|---|---|
| medium | medium | medium |
| high | high | high |
| xhigh | xhigh | xhigh |
| max | max | max |
| **ultra** | **medium** ⬅ | **max** |

The clamp was duplicated in two places, both with the same inversion:

- `run_agent.py:6579` — `AIAgent._github_models_reasoning_extra_body()` (core Responses path)
- `plugins/model-providers/copilot/__init__.py:48` — `CopilotProfile.build_api_kwargs_extras()` (chat_completions path)

Rather than adding a third special case to each copy, both now call one shared helper that walks Hermes' canonical `VALID_REASONING_EFFORTS` ladder and picks the nearest **weaker-or-equal** supported level. That is what the Copilot plugin's own comment already claimed it did ("choosing the nearest weaker supported level"); the implementation just never covered levels above `xhigh`.

Walking the canonical ladder — rather than the provider's own list order — is what makes the result monotonic even when a provider advertises a sparse subset. This mirrors the contract already pinned for the LM Studio route in `tests/agent/test_lmstudio_reasoning.py::test_effort_ladder_is_monotonic`; the Copilot route had no equivalent guard, which is how the inversion survived.

Behavior for every level the old code handled explicitly is unchanged — `xhigh → high`, `minimal → low`, unknown → `medium`, and `medium`-less catalogs → weakest supported are all preserved and now covered by tests. Levels outside the canonical ladder (notably `none`, which *disables* reasoning) are never chosen as a degradation target.

## Follow-up after review

The review was right that the ladder fix alone never reached a Claude Copilot request. `github_model_reasoning_efforts()` reads catalog capabilities only when handed a catalog or an API key, and the runtime passed neither — its keyless fallback recognizes only o-series and GPT-5 IDs, so every `claude-*` model resolved to `[]`, `_supports_reasoning_extra_body()` went False, and the payload was dropped before any degradation ran. The route the issue was filed against was sending no reasoning field at all. (The ladder fix does reach the o-series and GPT-5 routes, whose keyless fallbacks are non-empty — `ultra` on `gpt-5.4` went to `medium`, below `high`.)

Second commit threads the catalog into runtime resolution, agent-side where the route's key lives:

- `run_agent.py` — `_copilot_reasoning_efforts_cached()` fetches the catalog once and caches per `(model, base_url)`, mirroring the LM Studio / Ollama probes (non-empty permanent, empty on a 60s TTL). No fetch per turn, and non-Copilot routes never fetch. The catalog is fetched here rather than passing `api_key` down because `api_key` makes `normalize_copilot_model_id()` and the capability read fetch it twice.
- Both request paths consume it: the core GitHub Responses body directly, and the chat_completions profile hook through a new `copilot_reasoning_efforts` context value, so the plugin no longer repeats a keyless lookup.
- `tests/run_agent/test_copilot_claude_reasoning_effort.py` — new, and stubs only the network boundary (`fetch_github_model_catalog`), driving the real resolution path from there: the gate opens for a Claude slot, the catalog is fetched once per model, an outage degrades to the keyless behavior, and the request the transport builds carries `{"effort": "max"}` for `ultra` on `claude-opus-5` and `high` for `xhigh` on `claude-opus-4.6`. All ten fail on the pre-fix branch.

## Related Issue

Fixes #74295

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_constants.py` — new `degrade_reasoning_effort(requested, supported)`; walks the canonical ladder to the nearest weaker-or-equal supported level, stepping up to the weakest supported level only when nothing weaker exists.
- `run_agent.py` — `_github_models_reasoning_extra_body()` delegates to the shared helper (removes the local `xhigh`/`minimal`/`medium` clamp chain).
- `plugins/model-providers/copilot/__init__.py` — same delegation for the chat_completions path.
- `tests/test_hermes_constants.py` — `TestDegradeReasoningEffort`: `ultra → max` on both live catalog shapes, preserved `xhigh`/`minimal`/unknown behavior, `none` never selected, result always within the supported set, and a monotonicity property test over the full ladder.
- `tests/run_agent/test_run_agent.py` — route-level regression + monotonicity for the core Responses path.
- `tests/plugins/model_providers/test_copilot_profile.py` — same two for the provider-profile path.

## How to Test

Reproduce the inversion on `main` (both new route tests fail, and the monotonicity assertion prints the reported rank sequence `[0, 0, 1, 2, 2, 3, 1]` — the last step drops):

```bash
pytest tests/run_agent/test_run_agent.py -k "ultra_degrades or ladder_is_monotonic" -q
```

Verify the fix and that nothing else in the reasoning path regressed:

```bash
pytest tests/test_hermes_constants.py \
       tests/plugins/model_providers/test_copilot_profile.py \
       tests/run_agent/test_run_agent.py \
       tests/agent/test_lmstudio_reasoning.py -q
```

Manual: with a Copilot provider configured, set `reasoning_effort: ultra` and confirm the request carries `{"effort": "max"}` instead of `{"effort": "medium"}`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.5.0, arm64), Python 3.13.14
- [ ] I've run `pytest tests/ -q` and all tests pass — see note below

**Note on the full suite:** I ran `scripts/run_tests.sh` over `tests/plugins/ tests/providers/ tests/run_agent/ tests/agent/ tests/test_hermes_constants.py` (CI parity, per-file isolation) rather than the whole tree, plus `ruff check` and `ty check` on every touched file — all clean. I did not claim a full-tree pass because this checkout has baseline failures unrelated to this change (e.g. #74358 — `tests/hermes_cli/` exits early via `os._exit`) and several suites need optional extras I don't have installed locally. Happy to run anything else you'd like.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring on the new helper explains the monotonicity contract; the now-inaccurate comment in the Copilot plugin was corrected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure string/list logic, no platform-dependent behavior)

