### PR TITLE
fix(config): resolve model.key_env into model.api_key at load time

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2715,6 +2715,16 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
                 if isinstance(v, str) and v.strip():
                     model_api_key = v.strip()
                     break
+            # Resolve key_env / api_key_env when no inline api_key is present.
+            # Mirrors the fallback_providers path in chat_completion_helpers.py
+            # and the Desktop UI writer in web_server.py which writes
+            # model.key_env but was never consumed here.
+            if not model_api_key:
+                _key_env = str(
+                    model_cfg.get("key_env") or model_cfg.get("api_key_env") or ""
+                ).strip()
+                if _key_env:
+                    model_api_key = os.getenv(_key_env, "").strip()
             if model_provider == "custom" and model_base_url and model_api_key:
                 # Check if this model's base_url matches our custom provider
                 matched_key = get_custom_provider_pool_key(model_base_url)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3367,6 +3367,21 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
 
         normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
         expanded = _expand_env_vars(normalized)
+        # Resolve model.key_env / model.api_key_env into model.api_key so all
+        # downstream consumers (agent_init, credential_pool, gateway) see the
+        # resolved value without each needing independent key_env support.
+        # Mirrors the fallback_providers path in chat_completion_helpers.py.
+        _model_section = expanded.get("model")
+        if isinstance(_model_section, dict):
+            _existing_key = str(_model_section.get("api_key") or "").strip()
+            if not _existing_key:
+                _key_env_name = str(
+                    _model_section.get("key_env") or _model_section.get("api_key_env") or ""
+                ).strip()
+                if _key_env_name:
+                    _resolved = os.getenv(_key_env_name, "").strip()
+                    if _resolved:
+                        _model_section["api_key"] = _resolved
         # Managed scope wins at the leaf. Applied AFTER user expansion so a user
         # ${VAR} cannot shadow a managed literal: managed values are expanded only
         # against the process environment, never against user-config-defined refs.


### PR DESCRIPTION
## What does this PR do?

Resolves `model.key_env` / `model.api_key_env` into `model.api_key` at config load time, so custom providers configured with an environment variable reference in the top-level `model:` section no longer send requests with an empty API key (HTTP 401).

## Related Issue

Fixes #74561

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes Made

- **`hermes_cli/config.py`**: In `load_config()`, immediately after `_expand_env_vars()`, resolve `model.key_env` / `model.api_key_env` via `os.getenv()` into `model.api_key` when no inline key is present. This is the single chokepoint all downstream consumers read from.
- **`agent/credential_pool.py`**: In the model-config seed path (~L2717), add `key_env` / `api_key_env` resolution as defense-in-depth for the credential pool.

## How to Test

1. Configure a custom provider in `~/.hermes/config.yaml`:
   ```yaml
   model:
     default: qwen3.8-max-preview
     provider: custom
     base_url: https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic
     api_mode: anthropic_messages
     key_env: BAILIAN_API_KEY
   ```
2. Set `BAILIAN_API_KEY=sk-sp-...` in `~/.hermes/.env`
3. Start the gateway: `hermes gateway run`
4. Send a message and confirm no 401 errors in `~/.hermes/logs/errors.log`
5. Verify the response comes from the custom provider (check `agent.log` for `model=qwen3.8-max-preview provider=custom`)

## Checklist - Code

- [x] I have read the [Contributing Guide](../blob/main/CONTRIBUTING.md)
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
- [x] I have searched existing PRs to confirm this is not a duplicate
- [x] This PR contains only changes relevant to the fix
- [x] `pytest tests/ -q` passes locally
- [x] I have tested on my platform: Ubuntu 24.04 (WSL2), gateway multiplex mode with 7 Feishu profiles

## Checklist - Documentation & Housekeeping

- [x] N/A — no documentation changes needed (behavior now matches existing docs for `key_env`)
- [x] N/A — `cli-config.yaml.example` already documents `key_env`
- [x] N/A — no CONTRIBUTING.md/AGENTS.md changes
- [x] Cross-platform: fix uses `os.getenv()` which is platform-agnostic
- [x] N/A — no tool description/schema changes

## Logs

Before fix:
```
WARNING agent.conversation_loop: API call failed (attempt 1/3) error_type=AuthenticationError provider=custom model=qwen3.8-max-preview summary=HTTP 401: Invalid API-key provided
```

After fix:
```
INFO agent.conversation_loop: API call #1: model=qwen3.8-max-preview provider=custom in=60341 out=259 total=60600
INFO gateway.run: response ready: platform=feishu time=117.6s api_calls=3 response=718 chars
```
