### PR TITLE
fix: reclaim compression lock from dead-PID holder in append_message

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6072,7 +6072,11 @@ def run_conversation(
                     # run side-effecting tools from state that exists only in
                     # this process. Breaking also avoids retrying the same
                     # unpersisted turn until the iteration budget is exhausted.
-                    _turn_exit_reason = "session_persistence_failed"
+                    _turn_exit_reason = (
+                        "session_persistence_failed:lock_busy"
+                        if getattr(agent, "_last_flush_was_compression_busy", False)
+                        else "session_persistence_failed"
+                    )
                     final_response = ""
                     failed = True
                     break
@@ -6101,7 +6105,11 @@ def run_conversation(
                     # A tool result could not be made canonical. Do not send
                     # the in-memory result back to the model or project any
                     # later events from this turn.
-                    _turn_exit_reason = "session_persistence_failed"
+                    _turn_exit_reason = (
+                        "session_persistence_failed:lock_busy"
+                        if getattr(agent, "_last_flush_was_compression_busy", False)
+                        else "session_persistence_failed"
+                    )
                     final_response = ""
                     failed = True
                     break

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5545,9 +5545,23 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 active_lock is not None
                 and active_lock["holder"] != compression_lock_holder
             ):
-                raise CompressionSessionBusyError(
-                    f"Session {session_id!r} is being compressed by another writer"
-                )
+                # A compressor that self-restarted (or was killed) without
+                # releasing its lease otherwise blocks every append for the
+                # rest of the TTL, surfacing to the user as a misleading
+                # "session storage could not be written" turn failure.
+                # Mirror try_acquire_compression_lock's reclaim-first check:
+                # only a kernel-confirmed-dead holder PID is reclaimed here,
+                # so a live compressor is never interrupted.
+                if _compression_lock_holder_process_is_dead(active_lock["holder"]):
+                    conn.execute(
+                        "DELETE FROM compression_locks "
+                        "WHERE session_id = ? AND holder = ?",
+                        (session_id, active_lock["holder"]),
+                    )
+                else:
+                    raise CompressionSessionBusyError(
+                        f"Session {session_id!r} is being compressed by another writer"
+                    )
             session = conn.execute(
                 "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
                 (session_id,),

--- a/run_agent.py
+++ b/run_agent.py
@@ -2191,6 +2191,14 @@ class AIAgent:
             # leaves messages with mixed dispositions.
             self._db_flush_scan_prefix = None
             logger.warning("Session DB append_message failed: %s", e)
+            # Let the turn-exit-reason formatter distinguish a live writer
+            # holding the compression lease (transient, self-resolves within
+            # the lease TTL) from an actual disk/permission failure, instead
+            # of blaming disk space for both (#session_persistence_failed).
+            from hermes_state import CompressionSessionBusyError
+            self._last_flush_was_compression_busy = isinstance(
+                e, CompressionSessionBusyError
+            )
             return False
 
     def _get_messages_up_to_last_assistant(self, messages: List[Dict]) -> List[Dict]:
@@ -3509,6 +3517,14 @@ class AIAgent:
                 + "the turn stopped while a tool result was still pending and "
                 "the model produced no follow-up text. Send `continue` to "
                 "let it summarize."
+            )
+        if reason == "session_persistence_failed:lock_busy":
+            return (
+                prefix
+                + "the turn was stopped because another Hermes process is "
+                "still compressing this session's history (its lease "
+                "expires within a few minutes). This resolves on its own — "
+                "wait a moment, then send your message again."
             )
         if reason == "session_persistence_failed":
             return (

--- a/tests/run_agent/test_tool_call_incremental_persistence.py
+++ b/tests/run_agent/test_tool_call_incremental_persistence.py
@@ -243,6 +243,30 @@ def test_failed_assistant_persist_blocks_ui_projection_and_tool_side_effects():
     assert result["turn_exit_reason"] == "session_persistence_failed"
 
 
+def test_failed_assistant_persist_from_compression_busy_gets_distinct_reason():
+    """A still-live compressor's lease must not be reported as a disk/
+    permission failure (#session_persistence_failed): the turn-exit reason
+    carries a ``:lock_busy`` suffix so the user sees an accurate, actionable
+    message instead of being told to check disk space for a healthy DB.
+    """
+    agent = _make_agent()
+    tool_call = _mock_tool_call(call_id="must-not-run")
+    agent.client.chat.completions.create.return_value = _mock_response(
+        content="I'll inspect the repository now.",
+        finish_reason="tool_calls",
+        tool_calls=[tool_call],
+    )
+    agent._flush_messages_to_session_db = MagicMock(return_value=False)
+    agent._last_flush_was_compression_busy = True
+    agent.interim_assistant_callback = MagicMock()
+    agent._execute_tool_calls = MagicMock()
+
+    result = agent.run_conversation("inspect the repository")
+
+    assert result["failed"] is True
+    assert result["turn_exit_reason"] == "session_persistence_failed:lock_busy"
+
+
 # ---------------------------------------------------------------------------
 # Contract 2: the SEQUENTIAL path flushes each tool result immediately, BEFORE
 # the next tool dispatches.  Dispatch goes through run_agent.handle_function_call

--- a/tests/run_agent/test_turn_completion_explainer.py
+++ b/tests/run_agent/test_turn_completion_explainer.py
@@ -81,6 +81,25 @@ def test_explanation_quiet_for_empty_reason():
 
 
 
+def test_explanation_distinguishes_lock_busy_from_disk_permission_failure():
+    """``session_persistence_failed:lock_busy`` must not blame disk space.
+
+    A live compressor holding the lease is a transient, self-resolving
+    condition — the message must say so instead of pointing the user at
+    disk/permission checks for a database that isn't actually broken.
+    """
+    generic = AIAgent._format_turn_completion_explanation(
+        "session_persistence_failed"
+    )
+    assert "disk space" in generic.lower()
+
+    lock_busy = AIAgent._format_turn_completion_explanation(
+        "session_persistence_failed:lock_busy"
+    )
+    assert "disk space" not in lock_busy.lower()
+    assert "compress" in lock_busy.lower()
+
+
 def test_explanation_for_max_iterations_reached_prefix_match():
     """``max_iterations_reached(...)`` carries a parenthetical suffix."""
     out = AIAgent._format_turn_completion_explanation(

--- a/tests/test_hermes_state_compression_locks.py
+++ b/tests/test_hermes_state_compression_locks.py
@@ -153,6 +153,54 @@ def test_non_expired_lock_from_live_pid_is_not_reclaimed(db: SessionDB) -> None:
 
 
 
+def test_append_message_reclaims_lock_from_dead_pid(
+    db: SessionDB, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A writer must not be blocked for the full TTL by a lease whose
+    holder process is confirmed gone (#session_persistence_failed).
+
+    Regression for a gateway self-restart mid-compression: the old
+    process's lease outlived it, and every append to that session raised
+    ``CompressionSessionBusyError`` — surfaced to the user as a bogus
+    "session storage could not be written" failure — until the TTL
+    (minutes) elapsed on its own.
+    """
+    monkeypatch.setattr(hermes_state.os, "name", "posix")
+    db.create_session("sess1", "cli")
+    dead_holder = "pid=424242:tid=1:agent=abc:nonce=deadbeef"
+    assert db.try_acquire_compression_lock(
+        "sess1", dead_holder, ttl_seconds=300
+    ) is True
+
+    monkeypatch.setattr(
+        hermes_state, "psutil", SimpleNamespace(pid_exists=lambda _pid: False)
+    )
+
+    # Appending as a different holder must reclaim the dead lease rather
+    # than raise, and the stale row must be gone afterwards.
+    msg_id = db.append_message(
+        "sess1", "user", content="hello", compression_lock_holder="someone-else"
+    )
+    assert isinstance(msg_id, int)
+    assert db.get_compression_lock_holder("sess1") is None
+
+
+def test_append_message_still_blocked_by_live_holder(
+    db: SessionDB, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A live compressor's lease must still block concurrent appends."""
+    db.create_session("sess1", "cli")
+    live_holder = f"pid={os.getpid()}:tid=1:agent=abc:nonce=live"
+    assert db.try_acquire_compression_lock(
+        "sess1", live_holder, ttl_seconds=300
+    ) is True
+
+    with pytest.raises(hermes_state.CompressionSessionBusyError):
+        db.append_message(
+            "sess1", "user", content="hello", compression_lock_holder="someone-else"
+        )
+
+
 def test_unstructured_holder_waits_for_ttl(
     db: SessionDB, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Fixes #74568

## Problem

A gateway process that self-restarts or is killed mid-compression leaves its `compression_locks` row in place — only a graceful release deletes it. `try_acquire_compression_lock` already reclaims a non-expired lock once the kernel confirms its holder PID is gone (`_compression_lock_holder_process_is_dead`), but `append_message`'s busy-check only looked at `expires_at`, so every append to that session raised `CompressionSessionBusyError` for the rest of the lease TTL (minutes) after a routine restart.

That surfaced to the user as:

```
⚠️ No reply: the turn was stopped because session storage could not be
written (the transcript would have been lost on restart). Check disk
space / permissions for the state DB, then send your message again.
```

— misleading, since the DB is healthy and the actual cause is contention with a process that no longer exists.

## Fix

- `hermes_state.py`: `append_message`'s busy-check now reclaims (deletes) a lock whose holder PID is kernel-confirmed dead, mirroring `try_acquire_compression_lock`'s existing reclaim-first logic. A lock held by a *live* process still blocks appends, unchanged.
- `run_agent.py` / `agent/conversation_loop.py`: when persistence still fails because a live process holds the lease, `turn_exit_reason` is tagged `session_persistence_failed:lock_busy` so `_format_turn_completion_explanation` can tell the user the lease will clear on its own, instead of pointing at disk space/permissions.

## Test plan

- [x] New: `tests/test_hermes_state_compression_locks.py::test_append_message_reclaims_lock_from_dead_pid` — dead-PID holder is reclaimed and the row is removed.
- [x] New: `tests/test_hermes_state_compression_locks.py::test_append_message_still_blocked_by_live_holder` — a live holder's lease still blocks, unchanged.
- [x] New: `tests/run_agent/test_tool_call_incremental_persistence.py::test_failed_assistant_persist_from_compression_busy_gets_distinct_reason` — the `:lock_busy` tag flows through `run_conversation`'s result.
- [x] New: `tests/run_agent/test_turn_completion_explainer.py::test_explanation_distinguishes_lock_busy_from_disk_permission_failure` — message text no longer mentions disk space for the lock-busy case.
- [x] Full run of `tests/test_hermes_state_compression_locks.py`, `tests/test_hermes_state.py`, `tests/state/test_write_lock_patience.py`, `tests/run_agent/test_tool_call_incremental_persistence.py`, `tests/run_agent/test_turn_completion_explainer.py` (174 tests) — all pass.
- [x] `ruff check` on all changed files — clean.