### PR TITLE
fix(desktop): keep the composer's focus and insert buses alive while the gateway is connecting

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
@@ -2,10 +2,16 @@ import { act, cleanup, render } from '@testing-library/react'
 import { useLayoutEffect } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { type ComposerAttachment, mainComposerScope, stashSessionDraft } from '@/store/composer'
+import { clearSessionDraft, type ComposerAttachment, mainComposerScope, stashSessionDraft } from '@/store/composer'
 
 import type { QueueEditState } from '../composer-utils'
-import { type ComposerTarget, getActiveComposer, markActiveComposer } from '../focus'
+import {
+  type ComposerTarget,
+  getActiveComposer,
+  markActiveComposer,
+  requestComposerFocus,
+  requestComposerInsert
+} from '../focus'
 import { type ComposerScope, ComposerScopeProvider, MAIN_COMPOSER_SCOPE } from '../scope'
 
 import { useComposerDraft } from './use-composer-draft'
@@ -173,5 +179,122 @@ describe('useComposerDraft — a closing composer hands the focus-bus key back',
     unmount()
 
     expect(getActiveComposer()).toBe('tile:other')
+  })
+})
+
+const CONNECTING_SESSION = 'session-connecting'
+
+interface ConnectingHarnessProps {
+  inputDisabled: boolean
+}
+
+/**
+ * A composer with a real contentEditable bound to the hook's `editorRef`, so the
+ * focus/insert buses can be observed end to end: `paintDraft` renders into this
+ * element and `focusInput` focuses it. `ProbeHarness` above renders `null` (and
+ * hardcodes `inputDisabled: false`) because it probes the attachment-scope swap;
+ * these cases need the editor and need `inputDisabled` to be a prop they can flip.
+ */
+function ConnectingHarness({ inputDisabled }: ConnectingHarnessProps) {
+  const { editorRef } = useComposerDraft({
+    activeQueueSessionKey: CONNECTING_SESSION,
+    focusKey: null,
+    inputDisabled,
+    queueEditRef: { current: null as QueueEditState | null },
+    sessionId: CONNECTING_SESSION
+  })
+
+  return (
+    <div>
+      <div contentEditable={!inputDisabled} data-testid="editor" ref={editorRef} suppressContentEditableWarning />
+      <button data-testid="elsewhere" type="button" />
+    </div>
+  )
+}
+
+describe('useComposerDraft — the focus/insert buses survive a connecting gateway', () => {
+  afterEach(() => {
+    // cleanup() unmounts, and the hook's scope-swap cleanup stashes whatever is
+    // in the editor under CONNECTING_SESSION — drop it so the next mount's
+    // takeSessionDraft() doesn't rehydrate the previous case's text.
+    cleanup()
+    clearSessionDraft(CONNECTING_SESSION)
+    mainComposerScope.clear()
+    markActiveComposer('main')
+    mockComposerApi.setText.mockClear()
+  })
+
+  // `focus.ts`'s `dispatch` defers to a macrotask (`setTimeout(…, 0)`) so
+  // synchronous click/keydown handlers finish first. Without draining it every
+  // assertion below would pass vacuously — the event would never be delivered at
+  // all, so "the draft is empty" and "the editor is not focused" would both hold
+  // for the wrong reason.
+  const flushBus = async () => {
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+  }
+
+  const editorOf = (container: HTMLElement) => container.querySelector<HTMLElement>('[data-testid="editor"]')!
+
+  it('lands a type-to-focus keystroke in the draft while the gateway is connecting', async () => {
+    const { container } = render(<ConnectingHarness inputDisabled />)
+    const editor = editorOf(container)
+
+    requestComposerFocus('main', { typeChar: 'h' })
+    await flushBus()
+
+    // The keybind layer already called preventDefault() before dispatching, so
+    // this character has nowhere else to go.
+    expect(editor.textContent).toBe('h')
+    expect(mockComposerApi.setText).toHaveBeenCalledWith('h')
+
+    // …but the editor is not contentEditable yet, so it must NOT be focused.
+    expect(document.activeElement).not.toBe(editor)
+  })
+
+  it('lands an external insert in the draft while the gateway is connecting', async () => {
+    const { container } = render(<ConnectingHarness inputDisabled />)
+    const editor = editorOf(container)
+
+    requestComposerInsert('pasted while connecting', { target: 'main' })
+    await flushBus()
+
+    expect(editor.textContent).toBe('pasted while connecting')
+  })
+
+  it('keeps the mid-connect keystroke and focuses the editor once the gateway opens', async () => {
+    const { container, rerender } = render(<ConnectingHarness inputDisabled />)
+    const editor = editorOf(container)
+
+    requestComposerFocus('main', { typeChar: 'h' })
+    await flushBus()
+    expect(editor.textContent).toBe('h')
+
+    // gatewayState 'connecting' → 'open' flips inputDisabled, which re-runs the
+    // hook's focus effect — the deferral this fix relies on instead of dropping
+    // the keystroke outright.
+    await act(async () => {
+      rerender(<ConnectingHarness inputDisabled={false} />)
+    })
+
+    expect(editor.textContent).toBe('h')
+    expect(document.activeElement).toBe(editor)
+  })
+
+  it('still appends and focuses when the gateway is already open', async () => {
+    const { container } = render(<ConnectingHarness inputDisabled={false} />)
+    const editor = editorOf(container)
+
+    // Mount focuses the composer; move focus away so the assertion below is
+    // about the bus, not the mount.
+    container.querySelector<HTMLElement>('[data-testid="elsewhere"]')!.focus()
+    expect(document.activeElement).not.toBe(editor)
+
+    requestComposerFocus('main', { typeChar: 'x' })
+    await flushBus()
+
+    expect(editor.textContent).toBe('x')
+    expect(document.activeElement).toBe(editor)
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -163,11 +163,16 @@ export function useComposerDraft({
   // stays mounted behind the front tab; this covers true unmounts.)
   useEffect(() => () => releaseActiveComposer(target), [target])
 
+  // Stays subscribed while `inputDisabled` (i.e. `gatewayState === 'connecting'`).
+  // The publishers never stop publishing and the keybind layer has already
+  // consumed the keystroke — use-keybinds.ts calls `preventDefault()` *before*
+  // `requestComposerFocus`, so unsubscribing here does not defer the character,
+  // it destroys it. The composer is still mounted and visible at that point
+  // (gateway-connecting-overlay.tsx only covers the very first cold boot, by
+  // design), so this is a live input silently eating what the user types. The
+  // sibling `onComposerInsertRefsRequest` subscription below has always been
+  // unconditional for the same reason.
   useEffect(() => {
-    if (inputDisabled) {
-      return undefined
-    }
-
     const offFocus = onComposerFocusRequest(({ target: requested, typeChar }) => {
       if (requested !== target) {
         return
@@ -175,7 +180,10 @@ export function useComposerDraft({
 
       // Type-to-focus appends at end; bare Enter just focuses.
       if (typeChar) {
-        paintDraft(`${draftRef.current}${typeChar}`, true)
+        // Mid-connect the editor is not contentEditable (`index.tsx`), so don't
+        // ask for focus: the `!inputDisabled` effect above owns that and re-runs
+        // the moment the gateway opens. The text still lands now.
+        paintDraft(`${draftRef.current}${typeChar}`, !inputDisabled)
 
         return
       }


### PR DESCRIPTION
## This is a sibling follow-up to #73881 (`f12e6526a`)

- **What #73881 covered:** it healed `'active'` onto the *visible* chat surface, so a type-to-focus request can no longer be routed to a composer buried behind a keep-alive tab.
- **What it did not touch:** the case where the correctly-routed composer has **unsubscribed**. `use-composer-draft.ts` returned early while `inputDisabled`, and `targetIsReachable()` still reports that surface live because the composer is mounted and stamps `data-composer-target` — so healing resolves to a live surface with a dead subscriber.
- **What this adds:** the focus and insert buses stay subscribed while the gateway is connecting, so the keystroke is deferred until the gateway opens instead of being dropped.

## What does this PR do?

`useComposerDraft`'s bus effect opened with an early return that unsubscribed **both** `onComposerFocusRequest` and `onComposerInsertRequest` whenever `inputDisabled` was true:

```ts
useEffect(() => {
  if (inputDisabled) {
    return undefined          // <- unsubscribes both buses
  }
  const offFocus = onComposerFocusRequest(...)
  const offInsert = onComposerInsertRequest(...)
  return () => { offFocus(); offInsert() }
}, [appendExternalText, inputDisabled, paintDraft, target])
```

`inputDisabled` is `disabled && !reconnecting` where `disabled = !gatewayOpen` and `reconnecting = gatewayState === 'closed' || gatewayState === 'error'` (`composer/index.tsx`, `chat/index.tsx`). So it is true **exactly while `gatewayState === 'connecting'`** — every cold boot, every reconnect attempt (`closed → connecting → open`), and every profile / gateway switch.

Nothing on the publishing side pauses during that window, and the keybind layer has already committed to the keystroke — `app/hooks/use-keybinds.ts` calls `event.preventDefault()` and *then* `requestComposerFocus('active', { typeChar })` (same for the soft `/`). With no subscriber the character is not deferred, it is **destroyed**. External inserts (`use-composer-actions.ts`, `right-rail/preview-file.tsx`, `use-desktop-integrations.ts`, `clarify-tool.tsx`) are dropped the same way.

This is user-visible rather than a hidden edge case: `components/gateway-connecting-overlay.tsx` only shows its blocking overlay while `!coldBootDoneRef.current && !gatewaySwitching && initialBootActive`, and its comment states the intent outright — after a healthy boot *"Do not cover the chat then — users should still be able to type drafts"*. So on every reconnect after the first boot the user faces a mounted, visible composer showing the "connecting" placeholder, types into it, and the text vanishes.

**The gate was accidental, not deliberate.** The sibling `onComposerInsertRefsRequest` subscription in this same hook has always been unconditional, so ref-chip inserts already survived the connecting window while plain text and keystrokes did not — same hook, same file, same bus family, opposite policy. And `composer/focus.ts`'s `resolveActive` docstring already names this exact symptom in main's own words: *"with no subscriber on the visible surface, every type-to-focus keystroke is preventDefault'd and dropped."*

**Why stay subscribed rather than defer `preventDefault()` on the keybind side.** The deferral machinery already exists and is already correct — `useEffect(() => { if (!inputDisabled) { focusInput() } }, [focusInput, focusKey, focusRequestId, inputDisabled])` lists `inputDisabled` in its deps, so it re-runs the moment the gateway opens and focus lands then. Keeping the fix inside this one hook also leaves `contentEditable={!inputDisabled}` and the deliberate submit gate in `use-composer-submit.ts` untouched, so #45488's split of *editability* from *submit availability* is preserved.

`paintDraft` is passed `!inputDisabled` instead of a hardcoded `true` so a mid-connect keystroke does not raise a focus request against an editor that is not yet `contentEditable`; the effect above is the single focus authority. (Note for the reviewer: this argument is defensive/documentary — because that effect is itself gated on `!inputDisabled`, a hardcoded `true` produces the same end state, minus a redundant `focusRequestId` bump and re-render per mid-connect keystroke, which this file's design notes explicitly try to avoid. The behavioural fix is the removal of the early return, and that is what the tests pin.)

### Sibling-site sweep

`onComposerFocusRequest` / `onComposerInsertRequest` / `onComposerInsertRefsRequest` / `onComposerSubmitRequest` / `onComposerVoiceToggleRequest` and every `inputDisabled` reference under `apps/desktop/src`:

| Site | Verdict |
|---|---|
| `use-composer-draft.ts` bus effect (gates **both** focus + insert) | **the site — fixed here** |
| `use-composer-draft.ts` `onComposerInsertRefsRequest` | already unconditional; evidence the gate was accidental — nothing to change |
| `use-composer-submit.ts` `onComposerSubmitRequest` + inner `!inputDisabled` | subscribed unconditionally; the inner gate is the deliberate #45488 split — excluded |
| `use-composer-voice.ts` `onComposerVoiceToggleRequest` | unconditional — not a site |
| `user-edit-composer.tsx` focus + insert subscriptions | unconditional, no disabled flag — not a site |
| `use-composer-draft.ts` `if (!inputDisabled) focusInput()` | deliberate; this fix *depends* on it — excluded |
| `composer/index.tsx` `aria-disabled` / `contentEditable={!inputDisabled}` | deliberate DOM state — excluded |

One site, two buses. No other subscription in the tree shares this root cause.

## Related Issue

No filed issue — this was found by tracing the `preventDefault()`-then-dispatch path that `focus.ts`'s `resolveActive` docstring describes. Context instead:

- #45488 (merged) established the intent: the composer stays *visible and editable* while the gateway is down; only submit is gated.
- #73881 (merged) fixed the stale-`'active'`-claim half of the dropped-keystroke problem; this is the no-subscriber half.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts` — dropped the `if (inputDisabled) { return undefined }` early return so the focus and insert buses stay subscribed while the gateway is connecting; pass `!inputDisabled` as `paintDraft`'s `focus` argument; comment recording why the subscription must outlive `inputDisabled`.
- `apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx` — new `describe` with 4 cases and a `ConnectingHarness` that binds a real `contentEditable` to the hook's `editorRef` and takes `inputDisabled` as a prop. The existing `ProbeHarness` is untouched (it renders `null` and hardcodes `inputDisabled: false` for the #59305 attachment-scope test).

## How to Test

Automated:

```
cd apps/desktop
npx vitest run --project ui src/app/chat/composer/hooks/use-composer-draft.test.tsx
```

`8 passed (8)` — 4 new, 4 pre-existing. The whole composer directory is `28 files / 219 passed`, and the full desktop `ui` project is `339 files / 3017 passed`.

**Fails before the fix (verified both ways, not assumed).** Restoring `if (inputDisabled) { return undefined }` turns exactly the three new behavioural cases red and leaves the fourth (the gateway-already-open guard) green:

```
× lands a type-to-focus keystroke in the draft while the gateway is connecting
    AssertionError: expected '' to be 'h'
× lands an external insert in the draft while the gateway is connecting
    AssertionError: expected '' to be 'pasted while connecting'
× keeps the mid-connect keystroke and focuses the editor once the gateway opens
    AssertionError: expected '' to be 'h'
✓ still appends and focuses when the gateway is already open
  Tests  3 failed | 5 passed (8)
```

The empty-string results are the point: without a subscriber the dispatched event reaches nobody and the draft never receives the character.

One trap worth flagging for anyone extending these tests: `focus.ts`'s `dispatch` defers through `window.setTimeout(…, 0)`, and no pre-existing test in this file exercises that path (they all use the synchronous `markActiveComposer` / `getActiveComposer` helpers). Without draining the macrotask the assertions pass **vacuously** — "the draft is empty" would hold because the event was never delivered at all. The new cases go through a `flushBus()` helper, and the red-before run above is what proves they are not vacuous.

Manual:

1. Launch the desktop app and let it finish its cold boot (the connecting overlay must be gone).
2. Kill or restart the gateway so the app goes `closed → connecting`. The composer stays visible with the "connecting" placeholder.
3. While it reads "connecting", type a few characters with the composer unfocused (type-to-focus), or use a sidebar "insert into composer" action.
4. Before: the characters/text are silently discarded. After: they land in the draft, and the composer takes focus by itself once the gateway reaches `open`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, this is desktop TypeScript; the vitest runs above are the equivalent gate. (Heads-up unrelated to this PR: `Python tests / Run tests slice 8/8` and the aggregate `All required checks pass` gate are currently red on clean `origin/main` itself.)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4) — not verified on Windows or Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the changed behaviour is documented in-file at the subscription
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific code; renderer-only React/DOM
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

Two other open PRs touch `use-composer-draft.ts`. Neither is a duplicate of this one, and I'd rather name them than let a reviewer find them:

- **#62586** (`prevent composer draft leak on new session`) — disjoint. Its hunks are at the import block and the per-session stash path; its only `inputDisabled` occurrence is a test-harness prop.
- **#62579** (`discard draft on explicit new session`) — **edits this exact effect, for a different bug.** It adds a third subscription, `onComposerClearRequest`, *inside* the same effect, with `offClear()` in the cleanup. It does not remove the early return, so it neither duplicates nor supersedes this change — but it is worth noting that **its new subscription lands inside the very gate this PR removes, and therefore inherits this same defect**: a clear request published while the gateway is connecting would find no subscriber. Removing the early return here makes that pending subscription correct too. The textual overlap is a few lines and this diff was deliberately kept minimal so either order of merging resolves trivially.

I deliberately did **not** touch `app/hooks/use-keybinds.ts` or `composer/focus.ts`, even though the `preventDefault()` call and the `resolveActive` docstring both live there — #74545, #73948, #72959 and #74406 are actively reworking those two files, and this bug is fixable entirely on the subscriber side.
