### PR TITLE
fix(image_gen): sniff real image format from magic bytes

### DIFF
--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -236,19 +236,51 @@ def _images_cache_dir() -> Path:
     return path
 
 
+def _sniff_image_extension(raw: bytes) -> str:
+    """Sniff the real image format from magic bytes.
+
+    ponytail: 12 bytes is enough for all supported formats; no imghdr
+    dependency needed. Add when a new provider returns an exotic format.
+    """
+    if raw[:8] == b"\x89PNG\r\n\x1a\n":
+        return "png"
+    if raw[:3] == b"\xff\xd8\xff":
+        return "jpg"
+    if raw[:4] == b"RIFF" and raw[8:12] == b"WEBP":
+        return "webp"
+    if raw[:6] in (b"GIF87a", b"GIF89a"):
+        return "gif"
+    return "png"
+
+
 def save_b64_image(
     b64_data: str,
     *,
     prefix: str = "image",
-    extension: str = "png",
+    extension: str = "",
+    data_uri_mime: str = "",
 ) -> Path:
     """Decode base64 image data and write it under ``$HERMES_HOME/cache/images/``.
+
+    The actual extension is resolved in priority order:
+    1. Caller-supplied ``extension`` (explicit override).
+    2. ``data_uri_mime`` parsed from the ``data:image/...;base64`` prefix.
+    3. Magic-byte sniffing on the decoded bytes.
 
     Returns the absolute :class:`Path` to the saved file.
 
     Filename format: ``<prefix>_<YYYYMMDD_HHMMSS>_<short-uuid>.<ext>``.
     """
     raw = base64.b64decode(b64_data)
+    if not extension:
+        mime_map = {
+            "image/png": "png",
+            "image/jpeg": "jpg",
+            "image/jpg": "jpg",
+            "image/webp": "webp",
+            "image/gif": "gif",
+        }
+        extension = mime_map.get(data_uri_mime, "") or _sniff_image_extension(raw)
     ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     short = uuid.uuid4().hex[:8]
     path = _images_cache_dir() / f"{prefix}_{ts}_{short}.{extension}"

--- a/plugins/image_gen/openrouter/__init__.py
+++ b/plugins/image_gen/openrouter/__init__.py
@@ -450,8 +450,17 @@ class OpenRouterCompatImageProvider(ImageGenProvider):
             first = images[0]
             try:
                 if first.startswith("data:"):
+                    # Parse the MIME type from the data URI so save_b64_image
+                    # names the file with the correct extension.
+                    data_uri_mime = ""
+                    if first.startswith("data:") and ";" in first[:50]:
+                        mime_part = first[5 : first.index(";", 5)]
+                        if "/" in mime_part:
+                            data_uri_mime = mime_part
                     b64 = first.split(",", 1)[1] if "," in first else ""
-                    saved_path = save_b64_image(b64, prefix=f"{self._name}_gen")
+                    saved_path = save_b64_image(
+                        b64, prefix=f"{self._name}_gen", data_uri_mime=data_uri_mime,
+                    )
                 else:
                     saved_path = save_url_image(first, prefix=f"{self._name}_gen")
             except Exception as exc:  # noqa: BLE001


### PR DESCRIPTION
## Bug

`save_b64_image` hardcoded `extension="png"` and never sniffed the actual bytes. When a provider (OpenRouter, Gemini) returned JPEG data URIs, the file was saved as `.png` — magic bytes `ffd8 ffe0` inside a `.png` file. Downstream consumers (Discord adapter, Telegram send_photo, browser fetch) reject the mismatch.

## Fix

Two files, 43 lines:

1. **`agent/image_gen_provider.py`** — `save_b64_image` now resolves the extension in priority order:
   - Caller-supplied `extension` (explicit override, backwards-compatible)
   - `data_uri_mime` parsed from the `data:image/...;base64` prefix
   - Magic-byte sniffing on the decoded bytes (`_sniff_image_extension` — 12 bytes, no imghdr dependency)

2. **`plugins/image_gen/openrouter/__init__.py`** — parses the MIME type from the data URI header and passes it to `save_b64_image`.

## Impact

All providers that call `save_b64_image` without an explicit extension (xAI, DeepInfra, OpenAI, OpenAI-codex, OpenRouter) now get correct file extensions automatically via the magic-byte fallback, even if they don't parse the data URI.

## Verification

```bash
$ file ~/.hermes/profiles/commissar-dansk/cache/images/openrouter_gen_20260730_021652_*.png
JPEG image data, JFIF standard 1.01  # before fix: .png with JPEG bytes

# after fix: same generation saves as .jpg
```

No new tests — the magic-byte sniffer is trivial pure logic; the existing image_gen provider tests cover the save path.