### PR TITLE
fix(whatsapp): render mention identities so the agent knows who was tagged

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -292,6 +292,41 @@ class WhatsAppBehaviorMixin:
             )
         return compiled
 
+    # Mention rendering ---------------------------------------------------
+    # WhatsApp bodies carry mentions as bare numeric ids (``@<lid>`` /
+    # ``@<phone>``); the human-readable identity never appears inline. These
+    # power _clean_bot_mention_text's symmetric rewrite.
+    _MENTION_TOKEN_RE = re.compile(r"@(\d{5,})\b")
+    _MENTION_SELF_LABEL = "@you"
+    _MENTION_OTHER_SUFFIX = " (another person)"
+
+    def _mention_name_map(self, data: Dict[str, Any]) -> Dict[str, str]:
+        """Map bare mention id -> display name, from bridge-supplied metadata.
+
+        The bridge may provide ``mentionedNames`` (id -> pushName/subject).
+        Falls back to the sender's own name so a self-referential tag in a DM
+        still resolves. Unknown ids are simply absent — the caller renders
+        those as an explicit "another person" instead of guessing.
+        """
+        mapping: Dict[str, str] = {}
+        raw = data.get("mentionedNames")
+        if isinstance(raw, dict):
+            for key, value in raw.items():
+                bare = self._normalize_whatsapp_id(key).split("@", 1)[0]
+                name = str(value or "").strip()
+                if bare and name:
+                    mapping[bare] = name
+        sender_id = self._normalize_whatsapp_id(data.get("senderId")).split("@", 1)[0]
+        sender_name = str(data.get("senderName") or "").strip()
+        if sender_id and sender_name and sender_id not in mapping:
+            mapping[sender_id] = sender_name
+        return mapping
+
+    def _lookup_mention_name(
+        self, bare_id: str, names: Dict[str, str]
+    ) -> Optional[str]:
+        return names.get(bare_id)
+
     def _bot_ids_from_message(self, data: Dict[str, Any]) -> set[str]:
         bot_ids = set()
         for candidate in data.get("botIds") or []:
@@ -333,17 +368,53 @@ class WhatsAppBehaviorMixin:
         return any(pattern.search(body) for pattern in self._mention_patterns)
 
     def _clean_bot_mention_text(self, text: str, data: Dict[str, Any]) -> str:
+        """Rewrite raw ``@<jid-or-lid>`` mention tokens into readable labels.
+
+        WhatsApp puts opaque numeric ids in the message body (``@142348...``)
+        and carries the real identities out-of-band in ``mentionedIds``. The
+        agent only ever sees the body, so it has to guess who a number is.
+
+        This used to strip *only the bot's own* mention and leave everyone
+        else's raw id in place, which inverted the signal: a message addressed
+        to the bot lost its marker entirely, while a message addressed to
+        another person kept a bare number that reads like "someone tagged
+        someone — possibly me". Confirmed in production: replies fired on 7/7
+        messages tagging other people and stayed silent on the one tagging the
+        bot.
+
+        Now every mention is resolved symmetrically — the bot becomes an
+        explicit self-marker and humans keep their display names — so
+        "addressed to me" and "addressed to someone else" are distinguishable
+        without guessing.
+        """
         if not text:
             return text
+
         bot_ids = self._bot_ids_from_message(data)
-        cleaned = text
-        for bot_id in bot_ids:
-            bare_id = bot_id.split("@", 1)[0]
-            if bare_id:
-                cleaned = re.sub(
-                    rf"@{re.escape(bare_id)}\b[,:\-]*\s*", "", cleaned
-                )
+        bot_bare = {bid.split("@", 1)[0] for bid in bot_ids if bid}
+        bot_bare.discard("")
+        names = self._mention_name_map(data)
+
+        def _label_for(bare_id: str) -> Optional[str]:
+            if bare_id in bot_bare:
+                return self._MENTION_SELF_LABEL
+            name = self._lookup_mention_name(bare_id, names)
+            if name:
+                return f"@{name}"
+            return None
+
+        def _replace(match: "re.Match[str]") -> str:
+            bare_id = match.group(1)
+            label = _label_for(bare_id)
+            if label is None:
+                # Unknown participant: keep the id but mark it as another
+                # person so it can never be mistaken for a self-mention.
+                return f"@{bare_id}{self._MENTION_OTHER_SUFFIX}"
+            return label
+
+        cleaned = self._MENTION_TOKEN_RE.sub(_replace, text)
         return cleaned.strip() or text
+
 
     def _should_process_message(self, data: Dict[str, Any]) -> bool:
         chat_id_raw = str(data.get("chatId") or "")

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -280,6 +280,47 @@ const recentlySentIds = createOutboundIdTracker(512);
 const recentlyProcessedPollUpdates = createOutboundIdTracker(512);
 const messageStore = createBoundedMessageStore(512);
 
+// Resolve mention ids -> display names so the agent can tell who was tagged.
+// Group metadata is a network round-trip, so cache per-chat with a short TTL:
+// membership changes rarely, and a stale name is far less harmful than
+// re-fetching metadata on every mention in a busy group.
+const MENTION_NAME_TTL_MS = 5 * 60 * 1000;
+const mentionNameCache = new Map();
+
+function cacheMentionNames(chatId, names) {
+  mentionNameCache.set(chatId, { names, expires: Date.now() + MENTION_NAME_TTL_MS });
+  // Bound the cache the same way the message store is bounded.
+  if (mentionNameCache.size > 64) {
+    const oldest = mentionNameCache.keys().next().value;
+    mentionNameCache.delete(oldest);
+  }
+}
+
+async function resolveMentionNames(mentionedIds, chatId) {
+  if (!chatId || !chatId.endsWith('@g.us') || !sock) return {};
+  let entry = mentionNameCache.get(chatId);
+  if (!entry || entry.expires < Date.now()) {
+    const metadata = await sock.groupMetadata(chatId);
+    const names = {};
+    for (const participant of metadata?.participants || []) {
+      // Prefer the group-scoped display name, then the contact notify name.
+      const label = participant.name || participant.notify || participant.subject || '';
+      for (const id of [participant.id, participant.jid, participant.lid]) {
+        const bare = normalizeWhatsAppId(id || '').split('@')[0];
+        if (bare && label) names[bare] = label;
+      }
+    }
+    entry = { names, expires: Date.now() + MENTION_NAME_TTL_MS };
+    cacheMentionNames(chatId, names);
+  }
+  const out = {};
+  for (const id of mentionedIds) {
+    const bare = String(id).split('@')[0];
+    if (entry.names[bare]) out[bare] = entry.names[bare];
+  }
+  return out;
+}
+
 function normalizePollUpdateOptions(aggregation, pollUpdateMessage, meId) {
   const selected = [];
   for (const option of aggregation || []) {
@@ -365,6 +406,7 @@ function enqueuePollUpdateEvent({ key, update, selectedOptions, aggregation }) {
     },
     mediaUrls: [],
     mentionedIds: [],
+    mentionedNames: {},
     quotedMessageId: pollId,
     quotedParticipant: '',
     quotedRemoteJid: chatId,
@@ -727,6 +769,7 @@ async function startSocket() {
           document: DOCUMENT_CACHE_DIR,
           audio: AUDIO_CACHE_DIR,
         },
+        resolveMentionNames,
       });
       event.fromOwner = fromOwner;
 

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -306,10 +306,24 @@ export async function extractBridgeEvent({
   downloadMedia,
   writeMediaFile,
   cacheDirs = {},
+  resolveMentionNames,
 }) {
   const messageContent = getMessageContent(msg);
   const contextInfo = getContextInfo(messageContent);
   const mentionedIds = Array.from(new Set((contextInfo?.mentionedJid || []).map(normalizeWhatsAppId).filter(Boolean)));
+  // Mentions arrive as opaque ids; the readable identity lives in group
+  // metadata. Resolve here so the agent can tell "tagged me" from "tagged
+  // someone else" instead of guessing from a bare number.
+  let mentionedNames = {};
+  if (mentionedIds.length && typeof resolveMentionNames === 'function') {
+    try {
+      const resolved = await resolveMentionNames(mentionedIds, chatId);
+      if (resolved && typeof resolved === 'object') mentionedNames = resolved;
+    } catch {
+      // Name resolution is best-effort: an unresolved mention degrades to
+      // "another person", which is still correct. Never drop the message.
+    }
+  }
   const quotedMessageId = contextInfo?.stanzaId || null;
   const quotedParticipant = normalizeWhatsAppId(contextInfo?.participant || '') || null;
   const quotedRemoteJid = normalizeWhatsAppId(contextInfo?.remoteJid || '') || null;
@@ -477,6 +491,7 @@ export async function extractBridgeEvent({
     nativeMetadata,
     mediaUrls,
     mentionedIds,
+    mentionedNames,
     quotedMessageId,
     quotedParticipant,
     quotedRemoteJid,

--- a/tests/gateway/test_whatsapp_mention_rendering.py
+++ b/tests/gateway/test_whatsapp_mention_rendering.py
@@ -1,0 +1,157 @@
+"""Mention rendering: the agent must be able to tell who was tagged.
+
+WhatsApp puts mentions in the body as opaque numeric ids and carries the
+identities out-of-band. The old behaviour stripped only the bot's own mention
+and left every other id as a bare number, which inverted the signal the agent
+reads: a message addressed to the bot lost its marker, while a message
+addressed to a human kept an ambiguous "@<digits>".
+
+Observed in production before this fix: in one group the agent replied to
+every message that tagged a third party and stayed silent on the one message
+that actually tagged it.
+
+These are behaviour contracts about the *relationship* between the mention
+metadata and the rendered text, not snapshots of exact wording.
+"""
+
+from unittest.mock import AsyncMock
+
+from gateway.config import Platform, PlatformConfig
+
+
+# Synthetic ids/names — shaped like real WhatsApp LIDs, tied to no real account.
+BOT_LID = "100000000000001"
+ALICE_LID = "100000000000002"
+BOB_LID = "100000000000003"
+GROUP_ID = "120363000000000000@g.us"
+
+
+def _make_adapter():
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    adapter = object.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = PlatformConfig(enabled=True, extra={})
+    adapter._message_handler = AsyncMock()
+    adapter._mention_patterns = []
+    return adapter
+
+
+def _msg(body, mentioned_ids=None, mentioned_names=None, **overrides):
+    data = {
+        "isGroup": True,
+        "body": body,
+        "chatId": GROUP_ID,
+        "senderId": f"{BOB_LID}@lid",
+        "senderName": "Bob",
+        "mentionedIds": list(mentioned_ids or []),
+        "mentionedNames": dict(mentioned_names or {}),
+        "botIds": [f"{BOT_LID}@lid", f"{BOT_LID}@s.whatsapp.net"],
+        "quotedParticipant": "",
+    }
+    data.update(overrides)
+    return data
+
+
+def test_tagging_another_person_is_not_rendered_as_self():
+    """The regression: Bob tags Alice, the agent must not read it as its own."""
+    adapter = _make_adapter()
+    data = _msg(
+        f"@{ALICE_LID} did you see this?",
+        mentioned_ids=[f"{ALICE_LID}@lid"],
+        mentioned_names={ALICE_LID: "Alice"},
+    )
+
+    rendered = adapter._clean_bot_mention_text(data["body"], data)
+
+    assert "Alice" in rendered
+    # The raw id must not survive — that is what the agent misread as "me".
+    assert ALICE_LID not in rendered
+    assert adapter._MENTION_SELF_LABEL not in rendered
+
+
+def test_tagging_the_bot_is_rendered_as_self():
+    adapter = _make_adapter()
+    data = _msg(f"@{BOT_LID} how many levels does it have?",
+                mentioned_ids=[f"{BOT_LID}@lid"])
+
+    rendered = adapter._clean_bot_mention_text(data["body"], data)
+
+    assert adapter._MENTION_SELF_LABEL in rendered
+    assert BOT_LID not in rendered
+
+
+def test_bot_and_human_tagged_together_keeps_both_distinguishable():
+    """Multi-tag: being tagged alongside someone must not erase either party."""
+    adapter = _make_adapter()
+    data = _msg(
+        f"@{BOT_LID} @{ALICE_LID} what time?",
+        mentioned_ids=[f"{BOT_LID}@lid", f"{ALICE_LID}@lid"],
+        mentioned_names={ALICE_LID: "Alice"},
+    )
+
+    rendered = adapter._clean_bot_mention_text(data["body"], data)
+
+    assert adapter._MENTION_SELF_LABEL in rendered
+    assert "Alice" in rendered
+    assert ALICE_LID not in rendered
+    assert BOT_LID not in rendered
+
+
+def test_unresolved_mention_is_marked_as_another_person():
+    """Name lookup can fail; it must degrade to 'not me', never to silence."""
+    adapter = _make_adapter()
+    unknown = "100000000000009"
+    data = _msg(f"@{unknown} coming?", mentioned_ids=[f"{unknown}@lid"])
+
+    rendered = adapter._clean_bot_mention_text(data["body"], data)
+
+    assert adapter._MENTION_OTHER_SUFFIX.strip() in rendered
+    assert adapter._MENTION_SELF_LABEL not in rendered
+
+
+def test_message_without_mentions_is_unchanged():
+    adapter = _make_adapter()
+    data = _msg("no mentions in this one")
+
+    assert adapter._clean_bot_mention_text(data["body"], data) == data["body"]
+
+
+def test_rendering_never_empties_a_mention_only_message():
+    """A body that is only a mention must stay non-empty.
+
+    Empty bodies are dropped upstream as 'no content', so a bare '@bot' ping
+    would vanish instead of waking the agent.
+    """
+    adapter = _make_adapter()
+    data = _msg(f"@{BOT_LID}", mentioned_ids=[f"{BOT_LID}@lid"])
+
+    rendered = adapter._clean_bot_mention_text(data["body"], data)
+
+    assert rendered.strip()
+
+
+def test_mention_detection_still_gates_on_bot_identity():
+    """The existing ingestion gate must keep working after the rewrite."""
+    adapter = _make_adapter()
+
+    tagged_bot = _msg("hi", mentioned_ids=[f"{BOT_LID}@lid"])
+    tagged_human = _msg("hi", mentioned_ids=[f"{ALICE_LID}@lid"])
+
+    assert adapter._message_mentions_bot(tagged_bot) is True
+    assert adapter._message_mentions_bot(tagged_human) is False
+
+
+def test_sender_name_resolves_a_self_referential_tag():
+    """Fallback path: no group metadata, but the sender tagged themselves."""
+    adapter = _make_adapter()
+    data = _msg(
+        f"@{BOB_LID} that's me",
+        mentioned_ids=[f"{BOB_LID}@lid"],
+        mentioned_names={},
+    )
+
+    rendered = adapter._clean_bot_mention_text(data["body"], data)
+
+    assert "Bob" in rendered
+    assert BOB_LID not in rendered


### PR DESCRIPTION
## What & why

WhatsApp carries mentions as opaque numeric ids in the message body (`@<numeric-id>`) and the real identities out-of-band in `contextInfo.mentionedJid`. The agent only ever sees the body, so it has to guess who a bare number refers to.

`_clean_bot_mention_text` made that guess systematically wrong. It stripped **only the bot's own** mention and left every other participant's raw id in place, which inverts the signal the agent reads:

- a message addressed **to the bot** lost its marker entirely (`@1423...` → ``), so nothing indicated it was addressed
- a message addressed **to a human** kept a bare `@1444...`, which reads like "someone was tagged — possibly me"

### Observed impact

In one group over a 17-day window, the agent replied to **7/7 messages that tagged other people** — twice answering over the human who was actually asked — and stayed **silent on the single message that tagged the bot**. A perfect inversion of intent.

`mentionedIds` already reached Python, but it had exactly one consumer: the boolean `_message_mentions_bot` ingestion gate. The identity behind each id was never surfaced to the model, so no prompt-level rule could recover it.

## The fix (symmetric in both directions)

- **bridge** (`bridge.js`, `bridge_helpers.js`): resolve mention ids → display names from group metadata and emit them as `mentionedNames`. Cached per-chat with a 5-minute TTL and a bounded map, so a busy group doesn't refetch metadata on every mention.
- **gateway** (`whatsapp_common.py`): rewrite *every* mention token instead of only the bot's. The bot becomes an explicit self-marker, humans keep their display names, and an unresolved id degrades to an explicit `(another person)` so it can never be misread as a self-mention.

Rendering on the real messages from the incident:

| body as received | rendered for the agent | gate |
|---|---|---|
| `@<alice-id> did you see this?` | `@Alice did you see this?` | not addressed |
| `@<bot-id>` | `@you` | addressed |
| `@<bot-id> @<alice-id> what time?` | `@you @Alice what time?` | addressed |

Name resolution is **best-effort**: a metadata failure degrades to the `(another person)` rendering and never drops the message. The ingestion gate is untouched and still keys off `botIds`.

## Relationship to existing work

- #67179 / #67227 ("focused WhatsApp-bridge mentions support") are **complementary, not duplicates**. Their inbound half adds a `mentioned` *boolean* — which is precisely the impoverished signal behind this bug: it says "the bot was tagged" but not *who else* was, so a message tagging three people including the bot is indistinguishable from one tagging the bot alone. This PR supplies the identities.
- #69634 (outbound `metadata["mentions"]` has no producer) is the opposite direction and is untouched here.

## How to test

```bash
scripts/run_tests.sh tests/gateway/test_whatsapp_mention_rendering.py
node --test scripts/whatsapp-bridge/*.test.mjs
```

Reproducing the original bug: in a group with `require_mention: false`, have someone `@`-tag a **third party** (not the bot). Before this change the body reaches the agent as a bare `@<digits>` and it answers as though addressed; after, it reads `@Name` and the message is correctly attributable to that person.

New tests are behaviour contracts on the metadata→rendering *relationship* rather than wording snapshots, and cover:

- tagging another person is never rendered as self (the regression)
- tagging the bot yields the self-marker
- **multi-tag**: bot tagged alongside a human keeps both parties distinguishable
- unresolved id degrades to "another person", never to silence
- a mention-only body never renders empty — empty bodies are dropped upstream, so a bare `@bot` ping would otherwise vanish
- the existing `_message_mentions_bot` gate still keys off bot identity

**Verified RED before GREEN:** 5 of the 8 new tests fail against the previous implementation, confirming they capture the defect rather than describing the new code.

## Validation

- `scripts/run_tests.sh` on `test_whatsapp_mention_rendering.py`, `test_whatsapp_group_gating.py`, `test_whatsapp_from_owner.py`, `test_whatsapp_allowlist_lid_resolution.py`, `test_whatsapp_native_delivery.py` → **27 passed, 0 failed** (on this branch, based on current `main`)
- `node --test scripts/whatsapp-bridge/*.test.mjs` → **29 passed, 0 failed**
- `node --check` on both modified JS files → clean
- `ruff check` on modified Python → `All checks passed!`
- `scripts/check-windows-footguns.py` on all modified files → no footguns
- `git diff --check` → clean
- Platform tested: **Linux** (aarch64, Python 3.11). No OS-specific code paths added — the change is string/dict handling plus a bridge HTTP call.
