### PR TITLE
fix(tests): isolate Vercel sandbox SDK fixture

### DIFF
--- a/tests/tools/test_vercel_sandbox_environment.py
+++ b/tests/tools/test_vercel_sandbox_environment.py
@@ -219,6 +219,7 @@ def vercel_module(vercel_sdk, monkeypatch):
     monkeypatch.setattr("tools.credential_files.get_credential_file_mounts", lambda: [])
     monkeypatch.setattr("tools.credential_files.iter_skills_files", lambda **kwargs: [])
     monkeypatch.setattr("tools.credential_files.iter_cache_files", lambda **kwargs: [])
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda *args, **kwargs: None)
 
     module = importlib.import_module("tools.environments.vercel_sandbox")
     return importlib.reload(module)


### PR DESCRIPTION
## Problem

Current `main` fails all 16 Vercel sandbox environment tests when CI disables lazy installs.

The test fixture injects a fake `vercel` SDK into `sys.modules`, but the production lazy dependency loader still checks for the real installed distribution and raises before the fake SDK can be exercised.

## Fix

Stub `tools.lazy_deps.ensure` inside the fake-SDK fixture. Production dependency handling is unchanged.

## Verification

- Reproduced on pristine `main`: 16 failed
- Patched Vercel sandbox tests: 16 passed
- Vercel sandbox and related lazy dependency suites: 83 passed
- Ruff 0.15.10: clean
- `git diff --check`: clean
