### PR TITLE
fix(billing): account usage from invalid responses before retry/fallback (#74313)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2445,7 +2445,40 @@ def run_conversation(
                     # Invalid response — could be rate limiting, provider timeout,
                     # upstream server error, or malformed response.
                     retry_count += 1
-                    
+
+                    # --- Fix #74313: account for usage even on invalid responses ---
+                    # A response that fails output validation can still carry a
+                    # valid usage block for the API call that already happened
+                    # and was billed.  Without this, retry/fallback paths jump
+                    # past the accounting at the bottom of the loop, so the
+                    # billed attempt silently vanishes from token/cost tracking.
+                    if hasattr(response, 'usage') and response.usage:
+                        try:
+                            _invalid_usage = normalize_usage(
+                                response.usage,
+                                provider=agent.provider,
+                                api_mode=agent.api_mode,
+                            )
+                            agent.session_prompt_tokens += _invalid_usage.prompt_tokens
+                            agent.session_completion_tokens += _invalid_usage.output_tokens
+                            agent.session_total_tokens += _invalid_usage.total_tokens
+                            agent.session_api_calls += 1
+                            agent.session_input_tokens += _invalid_usage.input_tokens
+                            agent.session_output_tokens += _invalid_usage.output_tokens
+                            agent.session_cache_read_tokens += _invalid_usage.cache_read_tokens
+                            agent.session_cache_write_tokens += _invalid_usage.cache_write_tokens
+                            agent.session_reasoning_tokens += _invalid_usage.reasoning_tokens
+                            logger.debug(
+                                "Accounted usage from invalid response: "
+                                "input=%d output=%d total=%d",
+                                _invalid_usage.input_tokens,
+                                _invalid_usage.output_tokens,
+                                _invalid_usage.total_tokens,
+                            )
+                        except Exception:
+                            logger.debug("Failed to account usage from invalid response", exc_info=True)
+                    # --- end fix #74313 ---
+
                     # Eager fallback: empty/malformed responses are a common
                     # rate-limit symptom.  Switch to fallback immediately
                     # rather than retrying with extended backoff.

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -987,6 +987,19 @@ def _to_int(value: Any) -> int:
         return 0
 
 
+def _usage_get(obj: Any, name: str, default: Any = 0) -> Any:
+    """Read a field from a usage object that may be a dict or an attribute object.
+
+    The Responses API can return usage as either a typed SDK object (accessible
+    via ``getattr``) or a plain ``dict`` (from JSON deserialisation).  Using
+    ``getattr`` on a dict silently yields the default, zeroing out all token
+    counts.  This helper normalises access so both shapes work transparently.
+    """
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
 def resolve_billing_route(
     model_name: str,
     provider: Optional[str] = None,
@@ -1226,32 +1239,32 @@ def normalize_usage(
     mode = (api_mode or "").strip().lower()
 
     if mode == "anthropic_messages" or provider_name == "anthropic":
-        input_tokens = _to_int(getattr(response_usage, "input_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "output_tokens", 0))
-        cache_read_tokens = _to_int(getattr(response_usage, "cache_read_input_tokens", 0))
-        cache_write_tokens = _to_int(getattr(response_usage, "cache_creation_input_tokens", 0))
+        input_tokens = _to_int(_usage_get(response_usage, "input_tokens", 0))
+        output_tokens = _to_int(_usage_get(response_usage, "output_tokens", 0))
+        cache_read_tokens = _to_int(_usage_get(response_usage, "cache_read_input_tokens", 0))
+        cache_write_tokens = _to_int(_usage_get(response_usage, "cache_creation_input_tokens", 0))
     elif mode == "codex_responses":
-        input_total = _to_int(getattr(response_usage, "input_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "output_tokens", 0))
-        details = getattr(response_usage, "input_tokens_details", None)
-        cache_read_tokens = _to_int(getattr(details, "cached_tokens", 0) if details else 0)
+        input_total = _to_int(_usage_get(response_usage, "input_tokens", 0))
+        output_tokens = _to_int(_usage_get(response_usage, "output_tokens", 0))
+        details = _usage_get(response_usage, "input_tokens_details", None)
+        cache_read_tokens = _to_int(_usage_get(details, "cached_tokens", 0) if details else 0)
         cache_write_tokens = _to_int(
-            getattr(details, "cache_creation_tokens", 0) if details else 0
+            _usage_get(details, "cache_creation_tokens", 0) if details else 0
         )
         input_tokens = max(0, input_total - cache_read_tokens - cache_write_tokens)
     else:
-        prompt_total = _to_int(getattr(response_usage, "prompt_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "completion_tokens", 0))
-        details = getattr(response_usage, "prompt_tokens_details", None)
+        prompt_total = _to_int(_usage_get(response_usage, "prompt_tokens", 0))
+        output_tokens = _to_int(_usage_get(response_usage, "completion_tokens", 0))
+        details = _usage_get(response_usage, "prompt_tokens_details", None)
         # Primary: OpenAI-style prompt_tokens_details. Fallback: Anthropic-style
         # top-level fields that some OpenAI-compatible proxies (OpenRouter, Vercel
         # AI Gateway, Cline) expose when routing Claude models — without this
         # fallback, cache writes are undercounted as 0 and cache reads can be
         # missed when the proxy only surfaces them at the top level.
         # Port of cline/cline#10266.
-        cache_read_tokens = _to_int(getattr(details, "cached_tokens", 0) if details else 0)
+        cache_read_tokens = _to_int(_usage_get(details, "cached_tokens", 0) if details else 0)
         if not cache_read_tokens:
-            cache_read_tokens = _to_int(getattr(response_usage, "cache_read_input_tokens", 0))
+            cache_read_tokens = _to_int(_usage_get(response_usage, "cache_read_input_tokens", 0))
         if not cache_read_tokens:
             # DeepSeek's native API (api.deepseek.com) reports context-cache
             # hits as top-level prompt_cache_hit_tokens (+ the complementary
@@ -1259,14 +1272,14 @@ def normalize_usage(
             # OpenAI nested shape. Without this, direct DeepSeek sessions
             # always showed 0 cache-hit tokens (#61871).
             cache_read_tokens = _to_int(
-                getattr(response_usage, "prompt_cache_hit_tokens", 0)
+                _usage_get(response_usage, "prompt_cache_hit_tokens", 0)
             )
         cache_write_tokens = _to_int(
-            getattr(details, "cache_write_tokens", 0) if details else 0
+            _usage_get(details, "cache_write_tokens", 0) if details else 0
         )
         if not cache_write_tokens:
             cache_write_tokens = _to_int(
-                getattr(response_usage, "cache_creation_input_tokens", 0)
+                _usage_get(response_usage, "cache_creation_input_tokens", 0)
             )
         input_tokens = max(0, prompt_total - cache_read_tokens - cache_write_tokens)
 
@@ -1278,14 +1291,14 @@ def normalize_usage(
     # hidden thinking was invisible in session accounting even though it
     # dominates output spend on models like deepseek-v4-flash (measured:
     # single calls burning 21K reasoning tokens to emit 500 visible tokens).
-    output_details = getattr(response_usage, "output_tokens_details", None)
+    output_details = _usage_get(response_usage, "output_tokens_details", None)
     if output_details:
-        reasoning_tokens = _to_int(getattr(output_details, "reasoning_tokens", 0))
+        reasoning_tokens = _to_int(_usage_get(output_details, "reasoning_tokens", 0))
     if not reasoning_tokens:
-        completion_details = getattr(response_usage, "completion_tokens_details", None)
+        completion_details = _usage_get(response_usage, "completion_tokens_details", None)
         if completion_details:
             reasoning_tokens = _to_int(
-                getattr(completion_details, "reasoning_tokens", 0)
+                _usage_get(completion_details, "reasoning_tokens", 0)
             )
 
     return CanonicalUsage(

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -312,3 +312,55 @@ def test_vertex_default_model_estimates_cached_usage(monkeypatch):
 
     assert result.status == "estimated"
     assert result.amount_usd is not None and result.amount_usd > 0
+
+
+def test_normalize_usage_handles_dict_shaped_usage():
+    """Regression test for #74314: when the Responses API returns usage as a
+    plain dict (e.g. from a middleware/proxy that deserialises JSON to dict
+    instead of a typed SDK object), normalize_usage() must read the same
+    token counts as it would from an attribute-style object.
+
+    Before this fix, getattr() on a dict silently returned 0 for every field,
+    so token counts and cost appeared as zero for dict-shaped usage.
+    """
+    # Same payload as both a dict and a SimpleNamespace
+    payload = {
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "input_tokens_details": {"cached_tokens": 60, "cache_creation_tokens": 10},
+    }
+    ns = SimpleNamespace(
+        input_tokens=100,
+        output_tokens=20,
+        input_tokens_details=SimpleNamespace(cached_tokens=60, cache_creation_tokens=10),
+    )
+
+    dict_result = normalize_usage(payload, api_mode="codex_responses")
+    ns_result = normalize_usage(ns, api_mode="codex_responses")
+
+    assert dict_result.input_tokens == ns_result.input_tokens, f"input_tokens: dict={dict_result.input_tokens} vs ns={ns_result.input_tokens}"
+    assert dict_result.output_tokens == ns_result.output_tokens, f"output_tokens: dict={dict_result.output_tokens} vs ns={ns_result.output_tokens}"
+    assert dict_result.cache_read_tokens == ns_result.cache_read_tokens, f"cache_read: dict={dict_result.cache_read_tokens} vs ns={ns_result.cache_read_tokens}"
+    assert dict_result.cache_write_tokens == ns_result.cache_write_tokens, f"cache_write: dict={dict_result.cache_write_tokens} vs ns={ns_result.cache_write_tokens}"
+    # Sanity: values must be non-zero (the whole point of the bug)
+    assert dict_result.input_tokens > 0
+    assert dict_result.cache_read_tokens > 0
+
+
+def test_normalize_usage_handles_dict_openai_chat_completions():
+    """Dict-shaped usage must also work in the default (OpenAI chat-completions)
+    branch, not just the codex_responses branch.
+    """
+    payload = {
+        "prompt_tokens": 500,
+        "completion_tokens": 100,
+        "prompt_tokens_details": {"cached_tokens": 200},
+        "completion_tokens_details": {"reasoning_tokens": 30},
+    }
+
+    result = normalize_usage(payload, api_mode="chat_completions")
+
+    assert result.output_tokens == 100
+    assert result.cache_read_tokens == 200
+    assert result.input_tokens == 500 - 200  # prompt_total - cache_read
+    assert result.reasoning_tokens == 30


### PR DESCRIPTION
## Summary

A response that fails output validation (empty/malformed) can still carry a valid `usage` block for the API call that already happened and was billed. The retry/fallback loop jumped straight to the next attempt (via `continue`) before that usage was accounted, so the billed attempt silently vanished from token/cost tracking.

## Root cause

In `agent/conversation_loop.py`, when `response_invalid` is true (~line 2421):
1. `retry_count` is incremented (line 2447)
2. The code tries fallback activation — if it succeeds, `continue` (line 2460) skips to the next iteration
3. Otherwise, backoff + `continue` (line 2593) retries the API call
4. The normal usage accounting at ~line 3072 is **never reached** for invalid responses

Any attempt with usage but unusable output (e.g. empty-content-but-usage-bearing response) is never counted.

## Fix

Extract and record usage from the response **immediately after** incrementing `retry_count`, before any `continue` path can skip past the normal accounting. Uses the same `normalize_usage()` call and session counter pattern as the success path.

All paths from `if response_invalid:` either `continue` or `return` — there is no risk of double-counting with the normal success path accounting.

## Changes

- `agent/conversation_loop.py`: Added usage extraction and session counter updates after `retry_count += 1` in the invalid-response handler, wrapped in try/except to avoid masking the original error.

## Test plan

- [x] Syntax check passes (`ast.parse`)
- [ ] Existing conversation loop tests pass
- [ ] Manual verification: invalid response with usage now appears in `/usage` output

Fixes #74313