### PR TITLE
fix(usage): support dict-shaped usage objects in normalize_usage (#74314)

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -987,6 +987,19 @@ def _to_int(value: Any) -> int:
         return 0
 
 
+def _usage_get(obj: Any, name: str, default: Any = 0) -> Any:
+    """Read a field from a usage object that may be a dict or an attribute object.
+
+    The Responses API can return usage as either a typed SDK object (accessible
+    via ``getattr``) or a plain ``dict`` (from JSON deserialisation).  Using
+    ``getattr`` on a dict silently yields the default, zeroing out all token
+    counts.  This helper normalises access so both shapes work transparently.
+    """
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
 def resolve_billing_route(
     model_name: str,
     provider: Optional[str] = None,
@@ -1226,32 +1239,32 @@ def normalize_usage(
     mode = (api_mode or "").strip().lower()
 
     if mode == "anthropic_messages" or provider_name == "anthropic":
-        input_tokens = _to_int(getattr(response_usage, "input_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "output_tokens", 0))
-        cache_read_tokens = _to_int(getattr(response_usage, "cache_read_input_tokens", 0))
-        cache_write_tokens = _to_int(getattr(response_usage, "cache_creation_input_tokens", 0))
+        input_tokens = _to_int(_usage_get(response_usage, "input_tokens", 0))
+        output_tokens = _to_int(_usage_get(response_usage, "output_tokens", 0))
+        cache_read_tokens = _to_int(_usage_get(response_usage, "cache_read_input_tokens", 0))
+        cache_write_tokens = _to_int(_usage_get(response_usage, "cache_creation_input_tokens", 0))
     elif mode == "codex_responses":
-        input_total = _to_int(getattr(response_usage, "input_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "output_tokens", 0))
-        details = getattr(response_usage, "input_tokens_details", None)
-        cache_read_tokens = _to_int(getattr(details, "cached_tokens", 0) if details else 0)
+        input_total = _to_int(_usage_get(response_usage, "input_tokens", 0))
+        output_tokens = _to_int(_usage_get(response_usage, "output_tokens", 0))
+        details = _usage_get(response_usage, "input_tokens_details", None)
+        cache_read_tokens = _to_int(_usage_get(details, "cached_tokens", 0) if details else 0)
         cache_write_tokens = _to_int(
-            getattr(details, "cache_creation_tokens", 0) if details else 0
+            _usage_get(details, "cache_creation_tokens", 0) if details else 0
         )
         input_tokens = max(0, input_total - cache_read_tokens - cache_write_tokens)
     else:
-        prompt_total = _to_int(getattr(response_usage, "prompt_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "completion_tokens", 0))
-        details = getattr(response_usage, "prompt_tokens_details", None)
+        prompt_total = _to_int(_usage_get(response_usage, "prompt_tokens", 0))
+        output_tokens = _to_int(_usage_get(response_usage, "completion_tokens", 0))
+        details = _usage_get(response_usage, "prompt_tokens_details", None)
         # Primary: OpenAI-style prompt_tokens_details. Fallback: Anthropic-style
         # top-level fields that some OpenAI-compatible proxies (OpenRouter, Vercel
         # AI Gateway, Cline) expose when routing Claude models — without this
         # fallback, cache writes are undercounted as 0 and cache reads can be
         # missed when the proxy only surfaces them at the top level.
         # Port of cline/cline#10266.
-        cache_read_tokens = _to_int(getattr(details, "cached_tokens", 0) if details else 0)
+        cache_read_tokens = _to_int(_usage_get(details, "cached_tokens", 0) if details else 0)
         if not cache_read_tokens:
-            cache_read_tokens = _to_int(getattr(response_usage, "cache_read_input_tokens", 0))
+            cache_read_tokens = _to_int(_usage_get(response_usage, "cache_read_input_tokens", 0))
         if not cache_read_tokens:
             # DeepSeek's native API (api.deepseek.com) reports context-cache
             # hits as top-level prompt_cache_hit_tokens (+ the complementary
@@ -1259,14 +1272,14 @@ def normalize_usage(
             # OpenAI nested shape. Without this, direct DeepSeek sessions
             # always showed 0 cache-hit tokens (#61871).
             cache_read_tokens = _to_int(
-                getattr(response_usage, "prompt_cache_hit_tokens", 0)
+                _usage_get(response_usage, "prompt_cache_hit_tokens", 0)
             )
         cache_write_tokens = _to_int(
-            getattr(details, "cache_write_tokens", 0) if details else 0
+            _usage_get(details, "cache_write_tokens", 0) if details else 0
         )
         if not cache_write_tokens:
             cache_write_tokens = _to_int(
-                getattr(response_usage, "cache_creation_input_tokens", 0)
+                _usage_get(response_usage, "cache_creation_input_tokens", 0)
             )
         input_tokens = max(0, prompt_total - cache_read_tokens - cache_write_tokens)
 
@@ -1278,14 +1291,14 @@ def normalize_usage(
     # hidden thinking was invisible in session accounting even though it
     # dominates output spend on models like deepseek-v4-flash (measured:
     # single calls burning 21K reasoning tokens to emit 500 visible tokens).
-    output_details = getattr(response_usage, "output_tokens_details", None)
+    output_details = _usage_get(response_usage, "output_tokens_details", None)
     if output_details:
-        reasoning_tokens = _to_int(getattr(output_details, "reasoning_tokens", 0))
+        reasoning_tokens = _to_int(_usage_get(output_details, "reasoning_tokens", 0))
     if not reasoning_tokens:
-        completion_details = getattr(response_usage, "completion_tokens_details", None)
+        completion_details = _usage_get(response_usage, "completion_tokens_details", None)
         if completion_details:
             reasoning_tokens = _to_int(
-                getattr(completion_details, "reasoning_tokens", 0)
+                _usage_get(completion_details, "reasoning_tokens", 0)
             )
 
     return CanonicalUsage(

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -312,3 +312,55 @@ def test_vertex_default_model_estimates_cached_usage(monkeypatch):
 
     assert result.status == "estimated"
     assert result.amount_usd is not None and result.amount_usd > 0
+
+
+def test_normalize_usage_handles_dict_shaped_usage():
+    """Regression test for #74314: when the Responses API returns usage as a
+    plain dict (e.g. from a middleware/proxy that deserialises JSON to dict
+    instead of a typed SDK object), normalize_usage() must read the same
+    token counts as it would from an attribute-style object.
+
+    Before this fix, getattr() on a dict silently returned 0 for every field,
+    so token counts and cost appeared as zero for dict-shaped usage.
+    """
+    # Same payload as both a dict and a SimpleNamespace
+    payload = {
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "input_tokens_details": {"cached_tokens": 60, "cache_creation_tokens": 10},
+    }
+    ns = SimpleNamespace(
+        input_tokens=100,
+        output_tokens=20,
+        input_tokens_details=SimpleNamespace(cached_tokens=60, cache_creation_tokens=10),
+    )
+
+    dict_result = normalize_usage(payload, api_mode="codex_responses")
+    ns_result = normalize_usage(ns, api_mode="codex_responses")
+
+    assert dict_result.input_tokens == ns_result.input_tokens, f"input_tokens: dict={dict_result.input_tokens} vs ns={ns_result.input_tokens}"
+    assert dict_result.output_tokens == ns_result.output_tokens, f"output_tokens: dict={dict_result.output_tokens} vs ns={ns_result.output_tokens}"
+    assert dict_result.cache_read_tokens == ns_result.cache_read_tokens, f"cache_read: dict={dict_result.cache_read_tokens} vs ns={ns_result.cache_read_tokens}"
+    assert dict_result.cache_write_tokens == ns_result.cache_write_tokens, f"cache_write: dict={dict_result.cache_write_tokens} vs ns={ns_result.cache_write_tokens}"
+    # Sanity: values must be non-zero (the whole point of the bug)
+    assert dict_result.input_tokens > 0
+    assert dict_result.cache_read_tokens > 0
+
+
+def test_normalize_usage_handles_dict_openai_chat_completions():
+    """Dict-shaped usage must also work in the default (OpenAI chat-completions)
+    branch, not just the codex_responses branch.
+    """
+    payload = {
+        "prompt_tokens": 500,
+        "completion_tokens": 100,
+        "prompt_tokens_details": {"cached_tokens": 200},
+        "completion_tokens_details": {"reasoning_tokens": 30},
+    }
+
+    result = normalize_usage(payload, api_mode="chat_completions")
+
+    assert result.output_tokens == 100
+    assert result.cache_read_tokens == 200
+    assert result.input_tokens == 500 - 200  # prompt_total - cache_read
+    assert result.reasoning_tokens == 30


### PR DESCRIPTION
## fix(usage): support dict-shaped usage objects in normalize_usage

### Root Cause
When the Responses API returns usage as a plain `dict` (e.g. from a middleware or proxy that deserialises JSON to dict instead of a typed SDK object), `normalize_usage()` in `agent/usage_pricing.py` used `getattr()` exclusively. Since dicts don't have attributes like `input_tokens`, `getattr()` silently returned the default (`0`) for every field.

### Impact
- Token counts and cost appear as zero whenever the backend returns plain JSON (dict) instead of a typed SDK object
- Cache hit-rate metrics become incorrect
- `ContextCompressor.update_from_response()` receives zeroed usage, delaying compression
- Any post-request hook relying on usage gets false metrics

### Fix
Added `_usage_get()` helper that reads via `.get()` for dicts and `getattr()` for attribute-style objects. All accessor sites in `normalize_usage()` now use this helper, so token counts and cost are correct regardless of the usage object's type.

### Changes
- `agent/usage_pricing.py`: Added `_usage_get()` helper; replaced all `getattr()` calls in `normalize_usage()` with `_usage_get()`
- `tests/agent/test_usage_pricing.py`: Two regression tests feeding the same payload as both dict and SimpleNamespace through codex_responses and chat_completions branches

### Tests
All 13 tests in `tests/agent/test_usage_pricing.py` pass (11 existing + 2 new).
