### PR TITLE
fix(gateway): stop multiplexed session recovery adopting a sibling profile's row

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1550,10 +1550,14 @@ class SessionStore:
         requested_session_key: str,
         recovered: Dict[str, Any],
     ) -> bool:
-        """Prevent non-multiplexed gateways from reviving another profile's row."""
-        if getattr(self.config, "multiplex_profiles", False):
-            return True
+        """Prevent a gateway from reviving another profile's row.
 
+        The durable peer fallback in ``find_latest_gateway_session_for_peer``
+        drops ``session_key`` and matches only the peer tuple, which for a DM is
+        byte-identical across profiles (``chat_id == user_id``, no thread). Both
+        configurations therefore have to check the recovered row's namespace;
+        they differ only in what counts as ours (#74285).
+        """
         recovered_key = str(recovered.get("session_key") or "")
         if not recovered_key or recovered_key == requested_session_key:
             return True
@@ -1561,6 +1565,18 @@ class SessionStore:
         recovered_profile = self._profile_from_session_key(recovered_key)
         if recovered_profile is None:
             return True
+
+        if getattr(self.config, "multiplex_profiles", False):
+            # Multiplexed: the requested key carries the profile this message
+            # was routed to, and that is what owns the turn. The process-wide
+            # active profile is meaningless here — several profiles serve
+            # traffic concurrently, so comparing against it would let a DM
+            # addressed to one bot resume a sibling profile's transcript and
+            # run with that profile's credentials and filesystem scope.
+            requested_profile = self._profile_from_session_key(requested_session_key)
+            if requested_profile is None:
+                return True
+            return recovered_profile == requested_profile
 
         return recovered_profile == self._active_profile_name()
 
@@ -1742,9 +1758,8 @@ class SessionStore:
             recovered=recovered,
         ):
             logger.warning(
-                "Gateway session DB recovery ignored %s for %s because "
-                "multiplex_profiles is disabled and the row belongs to a "
-                "different profile",
+                "Gateway session DB recovery ignored %s for %s because the row "
+                "belongs to a different profile",
                 recovered.get("session_key"),
                 session_key,
             )
@@ -1802,9 +1817,8 @@ class SessionStore:
             recovered=recovered,
         ):
             logger.warning(
-                "Gateway session DB recovery ignored %s for %s because "
-                "multiplex_profiles is disabled and the row belongs to a "
-                "different profile",
+                "Gateway session DB recovery ignored %s for %s because the row "
+                "belongs to a different profile",
                 recovered.get("session_key"),
                 session_key,
             )

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1536,6 +1536,22 @@ class SessionStore:
         namespace = parts[1] or "main"
         return "default" if namespace == "main" else namespace
 
+    def _peer_fallback_key_prefix(self, session_key: Optional[str]) -> Optional[str]:
+        """Namespace the durable peer fallback must stay inside, or None.
+
+        Only multiplexed gateways constrain it — a single-profile gateway owns
+        every row the peer tuple can reach, and narrowing the query there would
+        drop rows written under an earlier profile name. Derived from the
+        requested key rather than the config so it matches the namespace the
+        key was actually built with.
+        """
+        if not getattr(self.config, "multiplex_profiles", False):
+            return None
+        parts = str(session_key or "").split(":")
+        if len(parts) < 2 or parts[0] != "agent" or not parts[1]:
+            return None
+        return f"{parts[0]}:{parts[1]}:"
+
     @staticmethod
     def _active_profile_name() -> str:
         try:
@@ -1556,26 +1572,33 @@ class SessionStore:
         drops ``session_key`` and matches only the peer tuple, which for a DM is
         byte-identical across profiles (``chat_id == user_id``, no thread). Both
         configurations therefore have to check the recovered row's namespace;
-        they differ only in what counts as ours (#74285).
+        they differ in what counts as ours, and in whether a row that names no
+        profile at all may be adopted (#74285).
         """
+        multiplexed = bool(getattr(self.config, "multiplex_profiles", False))
+
         recovered_key = str(recovered.get("session_key") or "")
-        if not recovered_key or recovered_key == requested_session_key:
+        if recovered_key and recovered_key == requested_session_key:
             return True
 
         recovered_profile = self._profile_from_session_key(recovered_key)
-        if recovered_profile is None:
-            return True
+        requested_profile = self._profile_from_session_key(requested_session_key)
+        if recovered_profile is None or (multiplexed and requested_profile is None):
+            # Nothing on the row establishes ownership. A single-profile gateway
+            # adopts it anyway: there is only one claimant, and rows written
+            # before key namespacing have to stay recoverable. A multiplexed one
+            # must not — the peer tuple carries no profile discriminator, so an
+            # unnamespaced row is just as likely to be a sibling's, and adopting
+            # it would run that sibling's transcript under this profile's
+            # credentials and filesystem scope. Fail closed and start fresh.
+            return not multiplexed
 
-        if getattr(self.config, "multiplex_profiles", False):
-            # Multiplexed: the requested key carries the profile this message
-            # was routed to, and that is what owns the turn. The process-wide
-            # active profile is meaningless here — several profiles serve
-            # traffic concurrently, so comparing against it would let a DM
-            # addressed to one bot resume a sibling profile's transcript and
-            # run with that profile's credentials and filesystem scope.
-            requested_profile = self._profile_from_session_key(requested_session_key)
-            if requested_profile is None:
-                return True
+        if multiplexed:
+            # The requested key carries the profile this message was routed to,
+            # and that is what owns the turn. The process-wide active profile is
+            # meaningless here — several profiles serve traffic concurrently, so
+            # comparing against it would let a DM addressed to one bot resume a
+            # sibling profile's transcript.
             return recovered_profile == requested_profile
 
         return recovered_profile == self._active_profile_name()
@@ -1695,12 +1718,23 @@ class SessionStore:
         that tuple does not contain a workspace id and could therefore revive
         another team's session. The caller performs one explicit exact lookup
         of the old unscoped key instead.
+
+        When multiplexing, the peer fallback is additionally scoped to this
+        profile's key namespace. Without that, one query orders every profile's
+        rows together and returns the newest — so a sibling that spoke more
+        recently both loses us our own recoverable row and gets rejected by the
+        profile guard, ending in a needless fresh session (#74285).
         """
         if not self._db:
             return None
         finder = getattr(self._db, "find_latest_gateway_session_for_peer", None)
         if not callable(finder):
             return None
+        extra: Dict[str, Any] = {}
+        if allow_peer_fallback:
+            prefix = self._peer_fallback_key_prefix(session_key)
+            if prefix:
+                extra["session_key_prefix"] = prefix
         try:
             return finder(
                 source=source.platform.value,
@@ -1709,6 +1743,7 @@ class SessionStore:
                 chat_id=source.chat_id if allow_peer_fallback else None,
                 chat_type=source.chat_type if allow_peer_fallback else None,
                 thread_id=source.thread_id,
+                **extra,
             )
         except Exception as exc:
             logger.debug(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3017,6 +3017,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         chat_id: Optional[str] = None,
         chat_type: Optional[str] = None,
         thread_id: Optional[str] = None,
+        session_key_prefix: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Find the latest recoverable gateway session for a routing peer.
 
@@ -3028,6 +3029,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         (dashboard viewer disconnect before #60609) are treated as recoverable;
         explicit conversation boundaries such as /new, /resume switches, and
         compression splits are not.
+
+        ``session_key_prefix`` constrains the peer-tuple fallback to one key
+        namespace. A multiplexed gateway needs it: several profiles serve the
+        same peer tuple, so ordering all their rows together and taking the
+        newest hands back whichever profile spoke last. Filtering before
+        ``LIMIT 1`` picks the caller's own most recent row instead of dropping
+        recovery the moment a sibling is newer (#74285).
         """
         if not session_key:
             return None
@@ -3054,22 +3062,31 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # tuple so we never cross chats/threads/users.
             if chat_id is None or chat_type is None:
                 return None
+            params: List[Any] = [source, user_id, chat_id, chat_type, thread_id]
+            prefix_clause = ""
+            if session_key_prefix:
+                # substr() rather than LIKE: LIKE folds ASCII case and would
+                # read ``_`` / ``%`` in a profile name as wildcards.
+                prefix_clause = (
+                    "                  AND substr(COALESCE(session_key, ''), 1, ?) = ?\n"
+                )
+                params.extend([len(session_key_prefix), session_key_prefix])
             row = self._conn.execute(
-                """
+                f"""
                 SELECT * FROM sessions
                 WHERE source = ?
                   AND COALESCE(user_id, '') = COALESCE(?, '')
                   AND COALESCE(chat_id, '') = COALESCE(?, '')
                   AND COALESCE(chat_type, '') = COALESCE(?, '')
                   AND COALESCE(thread_id, '') = COALESCE(?, '')
-                  AND (ended_at IS NULL OR end_reason IN ('agent_close', 'ws_orphan_reap'))
+{prefix_clause}                  AND (ended_at IS NULL OR end_reason IN ('agent_close', 'ws_orphan_reap'))
                   AND (COALESCE(message_count, 0) > 0 OR EXISTS (
                       SELECT 1 FROM messages WHERE messages.session_id = sessions.id LIMIT 1
                   ))
                 ORDER BY started_at DESC
                 LIMIT 1
                 """,
-                (source, user_id, chat_id, chat_type, thread_id),
+                params,
             ).fetchone()
         return dict(row) if row else None
 

--- a/tests/gateway/test_multiplex_peer_fallback_profile.py
+++ b/tests/gateway/test_multiplex_peer_fallback_profile.py
@@ -16,7 +16,16 @@ this is a privilege boundary, not a session-list display detail.
 
 The requested key already carries the routed profile, so the multiplexed case
 has the information it needs to compare profiles rather than wave the row
-through.
+through. Two consequences the guard alone does not cover:
+
+* the fallback query has to be namespaced too. It orders every profile's rows
+  together under one ``LIMIT 1``, so a sibling that spoke more recently is the
+  only candidate the guard ever sees — our own older row is never offered, and
+  recovery ends in a needless fresh session.
+* a row whose key names no profile cannot be adopted while multiplexing. The
+  peer tuple has no profile discriminator, so nothing distinguishes it from a
+  sibling's row. A single-profile gateway still adopts it — there is only one
+  claimant, and pre-namespace rows have to stay recoverable.
 """
 
 from __future__ import annotations
@@ -96,14 +105,27 @@ class TestMultiplexedPeerFallbackProfileBoundary:
         )
         assert allowed is True
 
-    def test_row_without_profile_namespace_is_allowed(self, tmp_path):
-        """Rows whose key carries no parseable profile stay recoverable."""
+    def test_row_without_profile_namespace_is_rejected(self, tmp_path):
+        """An unnamespaced row proves nothing, and here that has to be fatal.
+
+        The peer tuple has no profile discriminator, so a row whose key names
+        no profile is exactly as likely to belong to a sibling as to us.
+        """
         store = _store(tmp_path, _db(), multiplex=True)
         allowed = store._recovered_row_allowed_for_active_profile(
             requested_session_key=store._generate_session_key(_dm_source("restricted")),
             recovered={"id": "sid_legacy", "session_key": "legacy-unnamespaced-key"},
         )
-        assert allowed is True
+        assert allowed is False
+
+    def test_row_without_any_session_key_is_rejected(self, tmp_path):
+        """Same reasoning for a row that carries no key at all."""
+        store = _store(tmp_path, _db(), multiplex=True)
+        allowed = store._recovered_row_allowed_for_active_profile(
+            requested_session_key=store._generate_session_key(_dm_source("restricted")),
+            recovered={"id": "sid_keyless"},
+        )
+        assert allowed is False
 
     def test_recovery_does_not_reuse_sibling_profile_session_id(self, tmp_path):
         """End to end: a DM routed to one profile never lands on another's session."""
@@ -121,8 +143,127 @@ class TestMultiplexedPeerFallbackProfileBoundary:
         ) != store._generate_session_key(_dm_source("admin"))
 
 
+class TestPeerFallbackIsScopedToTheProfile:
+    """The query must not hand back a sibling's row for the guard to reject.
+
+    Rejecting is only half the fix: one ``LIMIT 1`` orders every profile's rows
+    together, so a sibling that spoke more recently hides our own recoverable
+    row and recovery ends in a needless fresh session.
+    """
+
+    def test_lookup_is_namespaced_when_multiplexing(self, tmp_path):
+        db = _db()
+        store = _store(tmp_path, db, multiplex=True)
+
+        store.get_or_create_session(_dm_source("restricted"))
+
+        kwargs = db.find_latest_gateway_session_for_peer.call_args.kwargs
+        assert kwargs["session_key_prefix"] == "agent:restricted:"
+
+    def test_lookup_is_unconstrained_without_multiplexing(self, tmp_path):
+        """A single-profile gateway owns every row the peer tuple reaches."""
+        db = _db()
+        store = _store(tmp_path, db, multiplex=False)
+
+        store.get_or_create_session(_dm_source(None))
+
+        kwargs = db.find_latest_gateway_session_for_peer.call_args.kwargs
+        assert "session_key_prefix" not in kwargs
+
+    def test_older_same_profile_row_survives_a_newer_sibling(self, tmp_path):
+        """Real SessionDB: the newest row is a sibling's, ours is older."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            peer = dict(
+                source="telegram",
+                user_id="8494508720",
+                chat_id="8494508720",
+                chat_type="dm",
+                thread_id=None,
+            )
+            db.create_session(
+                "sid_restricted",
+                session_key="agent:restricted:telegram:dm:8494508720",
+                **peer,
+            )
+            db.append_message("sid_restricted", "user", "mine")
+            db.create_session(
+                "sid_admin",
+                session_key="agent:admin:telegram:dm:8494508720",
+                **peer,
+            )
+            db.append_message("sid_admin", "user", "the sibling's")
+            # The sibling spoke last — without the namespace filter it is the
+            # only candidate the fallback ever considers.
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ? WHERE id = ?",
+                (1_700_000_000.0, "sid_restricted"),
+            )
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ? WHERE id = ?",
+                (1_700_000_900.0, "sid_admin"),
+            )
+            db._conn.commit()
+
+            unscoped = db.find_latest_gateway_session_for_peer(
+                session_key="agent:restricted:telegram:dm:missing", **peer
+            )
+            scoped = db.find_latest_gateway_session_for_peer(
+                session_key="agent:restricted:telegram:dm:missing",
+                session_key_prefix="agent:restricted:",
+                **peer,
+            )
+
+            assert unscoped["id"] == "sid_admin"
+            assert scoped["id"] == "sid_restricted"
+        finally:
+            db.close()
+
+    def test_prefix_matching_is_exact(self, tmp_path):
+        """``restricted-2`` is a different profile, not a longer ``restricted``."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            peer = dict(
+                source="telegram",
+                user_id="8494508720",
+                chat_id="8494508720",
+                chat_type="dm",
+                thread_id=None,
+            )
+            db.create_session(
+                "sid_other",
+                session_key="agent:restricted-2:telegram:dm:8494508720",
+                **peer,
+            )
+            db.append_message("sid_other", "user", "hi")
+
+            found = db.find_latest_gateway_session_for_peer(
+                session_key="agent:restricted:telegram:dm:missing",
+                session_key_prefix="agent:restricted:",
+                **peer,
+            )
+
+            assert found is None
+        finally:
+            db.close()
+
+
 class TestNonMultiplexedGuardUnchanged:
     """Multiplexing off: keep comparing against the process-wide active profile."""
+
+    def test_unnamespaced_row_stays_recoverable(self, tmp_path):
+        """Pre-namespace rows must not become unrecoverable for the one profile."""
+        store = _store(tmp_path, _db(), multiplex=False)
+        with patch.object(SessionStore, "_active_profile_name", staticmethod(lambda: "default")):
+            allowed = store._recovered_row_allowed_for_active_profile(
+                requested_session_key="agent:main:telegram:dm:8494508720",
+                recovered={"id": "sid_legacy", "session_key": "legacy-unnamespaced-key"},
+            )
+        assert allowed is True
 
     def test_other_profile_row_still_rejected(self, tmp_path):
         store = _store(tmp_path, _db(), multiplex=False)

--- a/tests/gateway/test_multiplex_peer_fallback_profile.py
+++ b/tests/gateway/test_multiplex_peer_fallback_profile.py
@@ -1,0 +1,149 @@
+"""A multiplexed gateway must not revive a sibling profile's session (#74285).
+
+``SessionDB.find_latest_gateway_session_for_peer`` falls back to matching only
+the peer tuple ``(source, user_id, chat_id, chat_type, thread_id)`` when the
+exact ``session_key`` is missing. For a Telegram DM that tuple is
+byte-identical across profiles — ``chat_id == user_id`` and ``thread_id IS
+NULL`` for every bot — so the fallback can hand back a row owned by a sibling
+profile.
+
+``SessionStore._recovered_row_allowed_for_active_profile`` exists to stop
+exactly that, but it returned early whenever ``multiplex_profiles`` was
+enabled: precisely the configuration in which several profiles each own a bot
+token and can serve the same allowlisted user. The sibling profile was then
+actually executed — its persona, tools, credentials and filesystem scope — so
+this is a privilege boundary, not a session-list display detail.
+
+The requested key already carries the routed profile, so the multiplexed case
+has the information it needs to compare profiles rather than wave the row
+through.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+from gateway.config import GatewayConfig, Platform, SessionResetPolicy
+from gateway.session import SessionSource, SessionStore
+
+
+def _db() -> MagicMock:
+    """SessionDB mock: no routing state, recovery finds nothing by default."""
+    db = MagicMock()
+    db.get_session.return_value = None
+    db.find_latest_gateway_session_for_peer.return_value = None
+    db.reopen_session.return_value = None
+    db.create_session.return_value = None
+    # Mirror the real get_compression_tip identity for uncompressed sessions;
+    # a bare Mock would be assigned as the session_id by the routing heal.
+    db.get_compression_tip.side_effect = lambda sid: sid
+    return db
+
+
+def _store(tmp_path, db_mock: MagicMock, *, multiplex: bool) -> SessionStore:
+    """Build a SessionStore with a mock SessionDB, bypassing disk load."""
+    config = GatewayConfig(
+        default_reset_policy=SessionResetPolicy(mode="none"),
+        multiplex_profiles=multiplex,
+    )
+    with patch("gateway.session.SessionStore._ensure_loaded"):
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+    store._db = db_mock
+    store._loaded = True
+    return store
+
+
+def _dm_source(profile: Optional[str]) -> SessionSource:
+    """A Telegram DM from one user — same peer tuple whichever bot received it."""
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="8494508720",
+        chat_type="dm",
+        user_id="8494508720",
+        profile=profile,
+    )
+
+
+def _row_owned_by(store: SessionStore, profile: Optional[str], session_id: str) -> dict:
+    """A durable row the peer fallback would return, owned by ``profile``."""
+    return {
+        "id": session_id,
+        "session_key": store._generate_session_key(_dm_source(profile)),
+        "started_at": (datetime.now() - timedelta(hours=2)).timestamp(),
+    }
+
+
+class TestMultiplexedPeerFallbackProfileBoundary:
+    """Multiplexing on: the routed profile in the requested key is authoritative."""
+
+    def test_sibling_profile_row_is_rejected(self, tmp_path):
+        """A row owned by ``admin`` must not be adopted for ``restricted``."""
+        store = _store(tmp_path, _db(), multiplex=True)
+        allowed = store._recovered_row_allowed_for_active_profile(
+            requested_session_key=store._generate_session_key(_dm_source("restricted")),
+            recovered=_row_owned_by(store, "admin", "sid_admin"),
+        )
+        assert allowed is False
+
+    def test_same_profile_row_is_allowed(self, tmp_path):
+        """Recovery within one profile keeps working."""
+        store = _store(tmp_path, _db(), multiplex=True)
+        allowed = store._recovered_row_allowed_for_active_profile(
+            requested_session_key=store._generate_session_key(_dm_source("restricted")),
+            recovered=_row_owned_by(store, "restricted", "sid_restricted"),
+        )
+        assert allowed is True
+
+    def test_row_without_profile_namespace_is_allowed(self, tmp_path):
+        """Rows whose key carries no parseable profile stay recoverable."""
+        store = _store(tmp_path, _db(), multiplex=True)
+        allowed = store._recovered_row_allowed_for_active_profile(
+            requested_session_key=store._generate_session_key(_dm_source("restricted")),
+            recovered={"id": "sid_legacy", "session_key": "legacy-unnamespaced-key"},
+        )
+        assert allowed is True
+
+    def test_recovery_does_not_reuse_sibling_profile_session_id(self, tmp_path):
+        """End to end: a DM routed to one profile never lands on another's session."""
+        db = _db()
+        store = _store(tmp_path, db, multiplex=True)
+        db.find_latest_gateway_session_for_peer.return_value = _row_owned_by(
+            store, "admin", "sid_admin"
+        )
+
+        entry = store.get_or_create_session(_dm_source("restricted"))
+
+        assert entry.session_id != "sid_admin"
+        assert store._generate_session_key(
+            _dm_source("restricted")
+        ) != store._generate_session_key(_dm_source("admin"))
+
+
+class TestNonMultiplexedGuardUnchanged:
+    """Multiplexing off: keep comparing against the process-wide active profile."""
+
+    def test_other_profile_row_still_rejected(self, tmp_path):
+        store = _store(tmp_path, _db(), multiplex=False)
+        with patch.object(SessionStore, "_active_profile_name", staticmethod(lambda: "default")):
+            allowed = store._recovered_row_allowed_for_active_profile(
+                requested_session_key="agent:main:telegram:dm:8494508720",
+                recovered={
+                    "id": "sid_other",
+                    "session_key": "agent:coder:telegram:dm:8494508720",
+                },
+            )
+        assert allowed is False
+
+    def test_active_profile_row_allowed(self, tmp_path):
+        store = _store(tmp_path, _db(), multiplex=False)
+        with patch.object(SessionStore, "_active_profile_name", staticmethod(lambda: "coder")):
+            allowed = store._recovered_row_allowed_for_active_profile(
+                requested_session_key="agent:main:telegram:dm:8494508720",
+                recovered={
+                    "id": "sid_coder",
+                    "session_key": "agent:coder:telegram:dm:8494508720",
+                },
+            )
+        assert allowed is True


### PR DESCRIPTION
## What does this PR do?

On a multiplexed gateway (`GATEWAY_MULTIPLEX_PROFILES=1`) where several profiles each own their own bot token, a user allowlisted on two or more of those bots had every DM session collapsed onto whichever profile created a session first. Subsequent messages to *any* of the bots were then handled by that one profile — its persona, tools, credentials and filesystem scope. Because the wrong profile is actually **executed**, this is a privilege boundary, not a session-list display detail.

The collapse comes from the durable peer fallback. `SessionDB.find_latest_gateway_session_for_peer` first matches the exact, profile-namespaced `session_key`; when that misses it falls back to the peer tuple `(source, user_id, chat_id, chat_type, thread_id)`. For a Telegram DM that tuple is byte-identical across profiles — `chat_id == user_id` and `thread_id IS NULL` for every bot — so the fallback returns a sibling profile's row.

`SessionStore` already has a guard for exactly this, called on both recovery paths (`_recover_session_from_db` and `_query_recoverable_session`) right after the fallback. It just opted out of the multiplexed case:

```python
def _recovered_row_allowed_for_active_profile(self, *, requested_session_key, recovered):
    """Prevent non-multiplexed gateways from reviving another profile's row."""
    if getattr(self.config, "multiplex_profiles", False):
        return True          # ← the one configuration where several profiles serve one user
```

So the guard was disabled precisely where cross-profile collision is possible. This PR makes the multiplexed path compare profiles instead of waving the row through: the requested key carries the profile the inbound message was routed to, which is authoritative per-message, so it is compared against the recovered row's namespace via the existing `_profile_from_session_key` helper. The non-multiplexed branch keeps comparing against the process-wide active profile, unchanged.

Before / after, `restricted` asking while `admin` owns the row:

| | recovered row | result |
|---|---|---|
| before | `agent:admin:telegram:dm:<uid>` | adopted — `agent:restricted:...` key returns `session_id=sid_admin` |
| after | `agent:admin:telegram:dm:<uid>` | rejected — `restricted` gets its own session |

Exact-key matches, same-profile rows, and rows whose key carries no parseable profile stay recoverable, so this only removes the cross-profile case.

## Follow-up after review

Both review points were real; second commit covers them.

**The guard only ever saw one candidate.** `find_latest_gateway_session_for_peer` orders every profile's rows for the peer tuple under a single `LIMIT 1`, so whenever a sibling spoke more recently it is the only row the guard is offered — rejecting it then loses our own older recoverable row and recovery ends in a needless fresh session. `find_latest_gateway_session_for_peer` now takes an optional `session_key_prefix` and filters *before* `LIMIT 1`, so a multiplexed gateway selects its own most recent row. `substr()` rather than `LIKE`: `LIKE` folds ASCII case and reads `_` / `%` in a profile name as wildcards. Only multiplexed callers pass it — a single-profile gateway owns every row the peer tuple can reach and must keep seeing rows written under an earlier profile name.

**Unnamespaced rows now fail closed while multiplexing.** The peer tuple has no profile discriminator, so a row whose key names no profile is exactly as likely to be a sibling's; adopting it runs that transcript under this profile's credentials and filesystem scope. Same for a row carrying no `session_key` at all. Single-profile gateways still adopt both — one claimant, and pre-namespace rows have to stay recoverable. The test that required the old behavior is inverted, with the non-multiplexed case pinned separately.

Fallback selection is now covered against a real `SessionDB` (newer sibling row + older same-profile row, and `restricted-2` not matching `restricted`) rather than a mocked finder.

## Related Issue

Fixes #74285

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `gateway/session.py` — `_recovered_row_allowed_for_active_profile` now checks the recovered row's profile in both configurations, differing only in what counts as "ours": the requested key's profile when multiplexing, the active profile otherwise. Docstring records why the peer tuple can't distinguish profiles for a DM.
- `gateway/session.py` — the two recovery-path warnings no longer claim "multiplex_profiles is disabled" as the reason, which is no longer the only case that rejects a row.
- `tests/gateway/test_multiplex_peer_fallback_profile.py` — new file, 6 tests. This guard previously had **no test coverage** anywhere in `tests/`.

## How to Test

On `main` the two multiplexed tests fail, and the end-to-end one prints the exact collapse from the issue — a key namespaced to one profile holding another's `session_id`:

```
AssertionError: assert 'sid_admin' != 'sid_admin'
 +  where 'sid_admin' = SessionEntry(session_key='agent:restricted:telegram:dm:8494508720',
                                     session_id='sid_admin', ...).session_id
```

```bash
pytest tests/gateway/test_multiplex_peer_fallback_profile.py -q
```

Regression sweep over the gateway suite (CI parity, per-file isolation):

```bash
scripts/run_tests.sh tests/gateway/ -q
```

Manual: two profiles each with their own `TELEGRAM_BOT_TOKEN`, the same user ID in both `TELEGRAM_ALLOWED_USERS`, one gateway with `GATEWAY_MULTIPLEX_PROFILES=1`. DM bot A, then bot B, and ask each to identify itself — each now answers as its own profile.

## A note on the suggested fix

The issue proposes fixing this in SQL — adding `AND COALESCE(profile_name,'') = COALESCE(?,'')` to the fallback predicate plus `profile_name` in `idx_sessions_gateway_peer`. I went with the gateway-layer guard instead, for three reasons:

1. The guard for this class of bug already exists on both recovery paths and already resolves the profile; it only needed to stop opting out. That is a smaller, more idiomatic change than a new DB parameter threaded through every caller plus an index change on a shared table.
2. `sessions.profile_name` is nullable and is written by several unrelated paths (`run_agent.py`, `tui_gateway/server.py`, `agent/conversation_compression.py`) that each supply their own value. A strict `COALESCE` equality would silently stop recovering rows whose `profile_name` is NULL — including rows written before the column was populated — which changes behavior for single-profile users who are not affected by this bug.
3. The session key already encodes the profile authoritatively (`agent:<profile>:…`) and is what the exact-match query uses, so comparing on it keeps one source of truth.

Happy to add the DB-level predicate as defense-in-depth on top of this if you'd prefer belt-and-braces — say the word and I'll push it here rather than open a second PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 24.5.0, arm64), Python 3.13.14
- [ ] I've run `pytest tests/ -q` and all tests pass — see note below

**Note on the full suite:** I ran `scripts/run_tests.sh tests/gateway/ -q` (CI parity, per-file isolation) rather than the whole tree, plus `ruff check` on both touched files and `ty check gateway/session.py`. `ty` reports 16 diagnostics on `gateway/session.py`, but that is the **pre-existing** count — I verified it is identical with my changes stashed, so this PR adds none. I didn't claim a full-tree pass because this checkout has baseline failures unrelated to this change (e.g. #74358 — `tests/hermes_cli/` exits early via `os._exit`) and some suites need optional extras I don't have installed. Happy to run anything else you'd like.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — docstring now explains why the peer tuple can't distinguish profiles; the stale warning text was corrected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure string/dict logic, no platform-dependent behavior)

