### PR TITLE
fix(turn_finalizer): don't persist delivery-only reasoning excerpt as assistant message

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -311,7 +311,22 @@ def finalize_turn(
             except Exception:
                 _tail = None
             _tail_role = _tail.get("role") if isinstance(_tail, dict) else None
-            if _tail_role != "assistant":
+            # The empty-response terminal path sets final_response to a
+            # delivery-only labeled reasoning excerpt (e.g. "⚠️ The model
+            # produced only internal reasoning…").  It must NOT be appended
+            # as a new persisted assistant message — the excerpt is for the
+            # user's eyes only, not for transcript persistence.  Appending it
+            # makes future "continue" turns replay the reasoning as if it
+            # were a real response, causing empty-response loops.
+            #
+            # ``_drop_trailing_empty_response_scaffolding`` already stripped
+            # the ``(empty)`` sentinel, so the tail here is a prefill message,
+            # not the sentinel — without this guard the unconditional append
+            # would persist the excerpt as real assistant content.
+            _is_empty_response_exhausted = (
+                str(_turn_exit_reason) == "empty_response_exhausted"
+            )
+            if not _is_empty_response_exhausted and _tail_role != "assistant":
                 # Tail is not an assistant row — append the final response
                 # so the durable turn closes with the answer (#43849/#44100).
                 messages.append({"role": "assistant", "content": final_response})


### PR DESCRIPTION
When a reasoning-only model exhausts all retries, the labeled reasoning excerpt is delivery-only. Appending it as a persisted assistant message makes future 'continue' turns replay the reasoning as if it were a real response, causing empty-response loops.

## The bug

When `empty_response_exhausted` is the turn exit reason, `final_response` is a delivery-only labeled reasoning excerpt (e.g. `⚠️ The model produced only internal reasoning…`). The turn finalizer's persistence guard unconditionally appended `final_response` as a new assistant message when the tail didn't match. This persisted the excerpt as real assistant content, which then got replayed on `continue` turns, causing empty-response loops.

## The fix

Guard the append with a check: if `_turn_exit_reason == "empty_response_exhausted"`, skip the append. The excerpt is for the user's eyes only, not for transcript persistence.

The existing `_drop_trailing_empty_response_scaffolding()` already strips the `(empty)` sentinel before the finalizer runs, so the tail is a prefill message, not the sentinel — without this guard the unconditional append would persist the excerpt as real assistant content.

## Test

`tests/run_agent/test_empty_terminal_reasoning_surface.py` already asserts the excerpt is NOT persisted:

```python
assert not any(
    m.get("role") == "assistant"
    and "only internal reasoning" in (m.get("content") or "")
    for m in result["messages"]
)
```

All 3 tests in the file pass.

Fixes #58670 (make empty response retry count configurable — related)
Related to #58148 (surface reasoning as response — different approach)