### PR TITLE
fix(error_classifier): walk exception cause chain for structured error codes

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -633,7 +633,7 @@ def classify_api_error(
     if status_code is None and error_type == "RateLimitError":
         status_code = 429
     body = _extract_error_body(error)
-    error_code = _extract_error_code(body)
+    error_code = _extract_error_code_from_error(error)
 
     # Build a comprehensive error message string for pattern matching.
     # str(error) alone may not include the body message (e.g. OpenAI SDK's
@@ -688,6 +688,12 @@ def classify_api_error(
         }
         defaults.update(overrides)
         return ClassifiedError(**defaults)
+
+    # Some OpenAI-compatible providers report overload only through this
+    # structured code, without an overload status or human-readable message.
+    # The code is authoritative and must win before status classification.
+    if error_code == "server_is_overloaded":
+        return _result(FailoverReason.overloaded, retryable=True)
 
     # ── 1. Provider-specific patterns (highest priority) ────────────
 
@@ -1716,6 +1722,42 @@ def _extract_error_code(body: dict) -> str:
         if text and text != "400":
             return text
     return ""
+
+
+def _extract_error_code_from_error(error: Exception) -> str:
+    """Find a structured error code across an exception cause/context chain.
+
+    Wrapper exceptions commonly expose an empty or generic ``body`` while the
+    provider SDK exception carrying the authoritative code is attached as the
+    cause. Do not let the wrapper body mask that inner structured signal.
+    """
+    current = error
+    first_code = ""
+    for _ in range(5):  # Match the other exception-chain extractors.
+        body = getattr(current, "body", None)
+        if isinstance(body, dict):
+            code = _extract_error_code(body)
+            if code == "server_is_overloaded":
+                return code
+            first_code = first_code or code
+        response = getattr(current, "response", None)
+        if response is not None:
+            try:
+                json_body = response.json()
+            except Exception:
+                json_body = None
+            if isinstance(json_body, dict):
+                code = _extract_error_code(json_body)
+                if code == "server_is_overloaded":
+                    return code
+                first_code = first_code or code
+        cause = getattr(current, "__cause__", None) or getattr(
+            current, "__context__", None
+        )
+        if cause is None or cause is current:
+            break
+        current = cause
+    return first_code
 
 
 def _extract_message(error: Exception, body: dict) -> str:

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -274,6 +274,43 @@ class TestClassifyApiError:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.overloaded
 
+    def test_structured_server_overload_code_without_overload_status_or_text(self):
+        error = MockAPIError(
+            "Request rejected",
+            status_code=400,
+            body={"error": {"code": "server_is_overloaded"}},
+        )
+
+        result = classify_api_error(error, provider="sudo")
+
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_rotate_credential is False
+        assert result.should_compress is False
+        assert result.should_fallback is False
+
+    @pytest.mark.parametrize(
+        "outer_body",
+        [
+            {},
+            {"error": {"message": "wrapper rejected request"}},
+            {"error": {"code": "wrapper_error"}},
+        ],
+    )
+    def test_structured_server_overload_code_survives_wrapper_body(self, outer_body):
+        inner = MockAPIError(
+            "inner provider error",
+            status_code=400,
+            body={"error": {"code": "server_is_overloaded"}},
+        )
+        outer = MockAPIError("wrapper error", status_code=400, body=outer_body)
+        outer.__cause__ = inner
+
+        result = classify_api_error(outer, provider="sudo")
+
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_rotate_credential is False
 
     def test_408_request_timeout_is_retryable_timeout(self):
         """HTTP 408 Request Timeout is a transient timing failure the server


### PR DESCRIPTION
## Problem

`classify_api_error()` used `_extract_error_code(body)` which only inspected the top-level exception's body. When a wrapper exception (e.g. httpx transport error, SDK wrapper) exposes an empty or generic body but wraps an inner provider exception carrying the real structured error code, classification falls through to `FailoverReason.unknown` — so overload and other code-only signals never trigger failover.

## Fix

- **New `_extract_error_code_from_error(error)`** walks the `__cause__`/`__context__` chain (up to 5 levels) to find structured error codes, prioritizing `server_is_overloaded`. The inner provider SDK exception carrying the authoritative code may be wrapped by a generic outer exception whose body masks the real signal.
- **Early `server_is_overloaded` classification** before status-based classification. Some OpenAI-compatible providers report overload only through this structured code, without an overload HTTP status or human-readable message. The code is authoritative and must win before status-based heuristics.
- The existing `body` variable is still extracted (via `_extract_error_body`) for message-string pattern matching; only the code-extraction path changed.

## Scope

This changes **classification only**, not retry/backoff policy.

## Issues

- Fixes #70414 (code-only errors miss failover classification)
- Related to #68771 and #60761 (5xx / 529 overload not triggering fallback)

## Related

- PR #70686 addresses a similar area but is separate — this fix is more focused on the cause-chain traversal so a wrapper exception's empty body does not mask the inner structured code.

## Testing

- `scripts/run_tests.sh tests/agent/test_error_classifier.py -q` → 73 tests passed, 0 failed
- New tests:
  - `test_structured_server_overload_code_without_overload_status_or_text` — a 400 with `code: server_is_overloaded` classifies as `overloaded` (retryable)
  - `test_structured_server_overload_code_survives_wrapper_body` (parametrized ×3) — an outer wrapper exception with empty/generic/competing body still resolves to `overloaded` via the `__cause__` chain