### PR TITLE
fix(kanban): type transient runtime outcomes

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -17895,6 +17895,12 @@ def main(
                         elif response:
                             print(response)
 
+                        from hermes_cli.runtime_outcomes import (
+                            outcome_for_worker_result as _outcome_for_worker_result,
+                            worker_exit_code_for_result as _worker_exit_code_for_result,
+                        )
+                        _worker_outcome = _outcome_for_worker_result(result)
+
                         # Kanban goal-loop mode: a worker spawned for a
                         # goal_mode card keeps working in THIS session until an
                         # auxiliary judge agrees the card is done, the worker
@@ -17902,7 +17908,10 @@ def main(
                         # out (→ sticky block). Gated on the env vars the
                         # dispatcher sets in `_default_spawn`; a no-op for every
                         # normal worker and every non-kanban `-q` run.
-                        if os.environ.get("HERMES_KANBAN_GOAL_MODE") == "1":
+                        if (
+                            os.environ.get("HERMES_KANBAN_GOAL_MODE") == "1"
+                            and _worker_outcome.counts_against_goal_budget
+                        ):
                             try:
                                 _run_kanban_goal_loop_q(cli, response)
                             except Exception as _goal_exc:
@@ -17923,19 +17932,10 @@ def main(
                         # 5-hour quota window can't trip the circuit breaker and
                         # permanently block the card. Non-kanban runs keep the
                         # plain 0/1 contract automation wrappers expect.
-                        _exit_code = 0
-                        if isinstance(result, dict) and result.get("failed"):
-                            _exit_code = 1
-                            if os.environ.get("HERMES_KANBAN_TASK") and result.get(
-                                "failure_reason"
-                            ) in ("rate_limit", "billing"):
-                                try:
-                                    from hermes_cli.kanban_db import (
-                                        KANBAN_RATE_LIMIT_EXIT_CODE as _RL_CODE,
-                                    )
-                                    _exit_code = _RL_CODE
-                                except Exception:
-                                    _exit_code = 1
+                        _exit_code = _worker_exit_code_for_result(
+                            result,
+                            kanban_task=bool(os.environ.get("HERMES_KANBAN_TASK")),
+                        )
                         sys.exit(_exit_code)
 
                 # Exit with error code if credentials or agent init fails

--- a/cli.py
+++ b/cli.py
@@ -17361,7 +17361,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 # Main Entry Point
 # ============================================================================
 
-def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
+def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str):
     """Drive a kanban goal_mode worker through the Ralph-style goal loop.
 
     Called from the quiet single-query path AFTER the worker's first turn,
@@ -17375,7 +17375,7 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
 
     task_id = (_os.environ.get("HERMES_KANBAN_TASK") or "").strip()
     if not task_id:
-        return
+        return None
 
     from hermes_cli import kanban_db as _kb
     from hermes_cli.goals import run_kanban_goal_loop as _run_loop, DEFAULT_MAX_TURNS as _DEF_TURNS
@@ -17391,18 +17391,20 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
         except Exception:
             pass
     if task is None:
-        return
+        return None
 
     goal_parts = [task.title or ""]
     if task.body:
         goal_parts.append(task.body)
     goal_text = "\n\n".join(p for p in goal_parts if p).strip()
     if not goal_text:
-        return
+        return None
 
     max_turns = task.goal_max_turns or _DEF_TURNS
 
-    def _run_turn(prompt: str) -> str:
+    def _run_turn(prompt: str):
+        from hermes_cli.runtime_outcomes import outcome_for_worker_result
+
         result = cli.agent.run_conversation(
             user_message=prompt,
             conversation_history=cli.conversation_history,
@@ -17413,6 +17415,10 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
             and cli.agent.session_id != cli.session_id
         ):
             cli.session_id = cli.agent.session_id
+        if isinstance(result, dict):
+            outcome = outcome_for_worker_result(result)
+            if outcome.is_transient:
+                return outcome
         resp = result.get("final_response", "") if isinstance(result, dict) else str(result)
         if resp:
             print(resp)
@@ -17439,7 +17445,7 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
             except Exception:
                 pass
 
-    _run_loop(
+    return _run_loop(
         task_id=task_id,
         goal_text=goal_text,
         run_turn=_run_turn,
@@ -17913,7 +17919,15 @@ def main(
                             and _worker_outcome.counts_against_goal_budget
                         ):
                             try:
-                                _run_kanban_goal_loop_q(cli, response)
+                                _goal_loop_result = _run_kanban_goal_loop_q(cli, response)
+                                if (
+                                    isinstance(_goal_loop_result, dict)
+                                    and _goal_loop_result.get("runtime_outcome") is not None
+                                ):
+                                    result = dict(result) if isinstance(result, dict) else {}
+                                    result["failed"] = True
+                                    result["runtime_outcome"] = _goal_loop_result["runtime_outcome"].to_dict()
+                                    result["failure_reason"] = _goal_loop_result["runtime_outcome"].kind
                             except Exception as _goal_exc:
                                 logger.debug("kanban goal loop failed: %s", _goal_exc)
 

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -37,6 +37,8 @@ from dataclasses import dataclass, field, asdict
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
+from hermes_cli.runtime_outcomes import RuntimeOutcome, outcome_for_worker_result
+
 logger = logging.getLogger(__name__)
 
 
@@ -1737,7 +1739,16 @@ def run_kanban_goal_loop(
         # The kanban worker loop has no wait-barrier concept (workers finish
         # via kanban_complete / kanban_block, not by parking), so a WAIT
         # verdict is treated as CONTINUE here.
-        verdict, reason, _parse_failed, _wait, _transport_failed = judge_goal(goal_text, last_response)
+        verdict, reason, _parse_failed, _wait, transport_failed = judge_goal(goal_text, last_response)
+        if transport_failed:
+            runtime_outcome = RuntimeOutcome.judge_transport_failure(reason)
+            _log(f"kanban goal loop: judge transport failure; deferring ({reason})")
+            return {
+                "outcome": "transient",
+                "turns_used": turns_used,
+                "reason": reason,
+                "runtime_outcome": runtime_outcome,
+            }
         if verdict == "wait":
             verdict = "continue"
         _log(f"kanban goal loop: turn {turns_used}/{max_turns} verdict={verdict} reason={_truncate(reason, 120)}")
@@ -1775,7 +1786,26 @@ def run_kanban_goal_loop(
 
         # Run another turn in the same session.
         try:
-            last_response = run_turn(prompt) or ""
+            turn_result = run_turn(prompt)
+            if isinstance(turn_result, RuntimeOutcome):
+                if turn_result.is_transient:
+                    return {
+                        "outcome": "transient",
+                        "turns_used": turns_used,
+                        "reason": turn_result.reason,
+                        "runtime_outcome": turn_result,
+                    }
+                last_response = ""
+            else:
+                turn_outcome = outcome_for_worker_result(turn_result)
+                if turn_outcome.is_transient:
+                    return {
+                        "outcome": "transient",
+                        "turns_used": turns_used,
+                        "reason": turn_outcome.reason,
+                        "runtime_outcome": turn_outcome,
+                    }
+                last_response = turn_result or ""
         except Exception as exc:
             _log(f"kanban goal loop: run_turn failed ({exc}); stopping")
             return {"outcome": "stopped", "turns_used": turns_used, "reason": f"run_turn error: {type(exc).__name__}"}

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -90,6 +90,12 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping, Optional
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
+from hermes_cli.runtime_outcomes import (
+    EX_TEMPFAIL_EXIT_CODE,
+    RuntimeOutcome,
+    outcome_for_launcher_exception,
+    outcome_for_worker_exit,
+)
 from toolsets import get_toolset_names
 
 _log = logging.getLogger(__name__)
@@ -255,7 +261,7 @@ DEFAULT_CRASH_GRACE_SECONDS = 30
 # transient throttle). 75 == BSD ``EX_TEMPFAIL`` (sysexits.h) — the
 # conventional "temporary failure, retry later" code, and well clear of the
 # 0/1/2 codes the worker uses for success / generic failure / usage error.
-KANBAN_RATE_LIMIT_EXIT_CODE = 75
+KANBAN_RATE_LIMIT_EXIT_CODE = EX_TEMPFAIL_EXIT_CODE
 
 
 def _resolve_crash_grace_seconds() -> int:
@@ -4184,7 +4190,12 @@ def claim_task(
         )
         _append_event(
             conn, task_id, "claimed",
-            {"lock": lock, "expires": expires, "run_id": run_id},
+            {
+                "lock": lock,
+                "expires": expires,
+                "run_id": run_id,
+                "source_status": "ready",
+            },
             run_id=run_id,
         )
         claimed = get_task(conn, task_id)
@@ -6693,6 +6704,8 @@ class DispatchResult:
     (EX_TEMPFAIL sentinel exit) and were released back to ``ready`` WITHOUT
     counting a failure. These never trip the circuit breaker — a long quota
     window just makes the task bounce cheaply until the window clears."""
+    runtime_outcomes: list[dict[str, Any]] = field(default_factory=list)
+    """Typed runtime outcomes observed during this dispatch pass."""
     skipped_locked: bool = False
     """True when this tick was skipped because another process already held
     the board's dispatch lock (issue #35240). A losing dispatcher does no
@@ -6778,6 +6791,12 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
     except Exception:
         pass
     return ("unknown", None)
+
+
+def worker_exit_outcome(pid: int) -> RuntimeOutcome:
+    """Return the typed runtime outcome for a recently reaped worker."""
+    kind, code = _classify_worker_exit(pid)
+    return outcome_for_worker_exit(kind, code)
 
 
 def reap_worker_zombies() -> "list[int]":
@@ -7368,6 +7387,60 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     return streak
 
 
+def _task_claim_source_status(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    run_id: Optional[int] = None,
+) -> str:
+    """Return the queue column from which the current run was claimed."""
+    run_id = run_id if run_id is not None else _current_run_id(conn, task_id)
+    if run_id is not None:
+        claimed_event = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND run_id = ? AND kind = 'claimed' "
+            "ORDER BY id DESC LIMIT 1",
+            (task_id, run_id),
+        ).fetchone()
+        if claimed_event and claimed_event["payload"]:
+            try:
+                source_status = json.loads(claimed_event["payload"]).get(
+                    "source_status"
+                )
+            except (TypeError, ValueError):
+                source_status = None
+            if source_status in {"ready", "review"}:
+                return source_status
+    return "ready"
+
+
+def _release_task_claim(
+    conn: sqlite3.Connection,
+    task_id: str,
+    outcome: RuntimeOutcome,
+    *,
+    worker_pid: Optional[int] = None,
+    claim_lock: Optional[str] = None,
+) -> sqlite3.Cursor:
+    """Release a claim, preserving its source column for transient outcomes."""
+    source_status = _task_claim_source_status(conn, task_id)
+    target_status = source_status if outcome.is_transient else "ready"
+    if worker_pid is not None:
+        return conn.execute(
+            "UPDATE tasks SET status = ?, claim_lock = NULL, "
+            "claim_expires = NULL, worker_pid = NULL "
+            "WHERE id = ? AND status = 'running' "
+            "  AND worker_pid = ? AND claim_lock IS ?",
+            (target_status, task_id, worker_pid, claim_lock),
+        )
+    return conn.execute(
+        "UPDATE tasks SET status = ?, claim_lock = NULL, "
+        "claim_expires = NULL, worker_pid = NULL "
+        "WHERE id = ? AND status = 'running'",
+        (target_status, task_id),
+    )
+
+
 def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
@@ -7398,6 +7471,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     """
     crashed: list[str] = []
     rate_limited: list[str] = []
+    runtime_outcomes: list[dict[str, Any]] = []
     # Per-crash details collected inside the main txn, used after it
     # closes to run ``_record_task_failure`` (which needs its own
     # write_txn so can't nest). ``protocol_violation`` flags the
@@ -7430,8 +7504,15 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
 
             pid = int(row["worker_pid"])
             kind, code = _classify_worker_exit(pid)
+            runtime_outcome = worker_exit_outcome(pid)
             rate_limited_exit = False
             if kind == "clean_exit":
+                # A clean subprocess exit while the task is still running is
+                # not successful task completion: the worker violated the
+                # Kanban terminal-outcome protocol.
+                runtime_outcome = RuntimeOutcome.code_failure(
+                    reason="worker exited cleanly without terminal outcome"
+                )
                 # Worker subprocess returned 0 but its task is still
                 # ``running`` in the DB — it exited without calling
                 # ``kanban_complete`` / ``kanban_block``. Overwhelmingly the
@@ -7492,12 +7573,14 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     event_payload["exit_kind"] = kind
                     event_payload["exit_code"] = code
 
-            cur = conn.execute(
-                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
-                "claim_expires = NULL, worker_pid = NULL "
-                "WHERE id = ? AND status = 'running' "
-                "  AND worker_pid = ? AND claim_lock IS ?",
-                (row["id"], pid, row["claim_lock"]),
+            event_payload["runtime_outcome"] = runtime_outcome.to_dict()
+
+            cur = _release_task_claim(
+                conn,
+                row["id"],
+                runtime_outcome,
+                worker_pid=pid,
+                claim_lock=row["claim_lock"],
             )
             if cur.rowcount == 1:
                 # Rate-limited requeues are a clean release, not a crash —
@@ -7544,6 +7627,10 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                         (row["id"], pid, row["claim_lock"],
                          protocol_violation, error_text)
                     )
+                runtime_outcomes.append({
+                    "task_id": row["id"],
+                    **runtime_outcome.to_dict(),
+                })
     # Outside the main txn: account each crashed task and maybe trip the
     # breaker (the task transitions ready → blocked with a ``gave_up`` event
     # on top of the event we already emitted).
@@ -7635,6 +7722,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # Same side-channel for rate-limited requeues — these did NOT count a
     # failure and are NOT crashes, so they stay out of the ``crashed`` return.
     detect_crashed_workers._last_rate_limited = rate_limited  # type: ignore[attr-defined]
+    detect_crashed_workers._last_runtime_outcomes = runtime_outcomes  # type: ignore[attr-defined]
     return crashed
 
 
@@ -7643,7 +7731,7 @@ def _record_task_failure(
     task_id: str,
     error: str,
     *,
-    outcome: str,
+    outcome: str | RuntimeOutcome,
     failure_limit: int = None,
     force_trip: bool = False,
     release_claim: bool = False,
@@ -7695,6 +7783,37 @@ def _record_task_failure(
     """
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
+    typed_outcome = RuntimeOutcome.from_value(outcome)
+    if not typed_outcome.counts_against_failure_budget:
+        # Provider, transport, and temporary worker outcomes are operational
+        # events, not failures of the task. They may release a claim and close
+        # the run, but must never increment either breaker budget.
+        with write_txn(conn):
+            row = conn.execute(
+                "SELECT status FROM tasks WHERE id = ?", (task_id,)
+            ).fetchone()
+            if row is None:
+                return False
+            if release_claim:
+                _release_task_claim(conn, task_id, typed_outcome)
+            run_id = None
+            if end_run:
+                run_id = _end_run(
+                    conn,
+                    task_id,
+                    outcome=typed_outcome.kind,
+                    status=typed_outcome.kind,
+                    error=error[:500],
+                    metadata=typed_outcome.to_dict(),
+                )
+            _append_event(
+                conn,
+                task_id,
+                typed_outcome.kind,
+                {"error": error[:500], **typed_outcome.to_dict()},
+                run_id=run_id,
+            )
+        return False
     blocked = False
     with write_txn(conn):
         row = conn.execute(
@@ -7747,7 +7866,7 @@ def _record_task_failure(
                     error=error[:500],
                     metadata={
                         "failures": failures,
-                        "trigger_outcome": outcome,
+                        "trigger_outcome": typed_outcome.kind,
                         "effective_limit": effective_limit,
                         "limit_source": limit_source,
                     },
@@ -7757,7 +7876,7 @@ def _record_task_failure(
                 "effective_limit": effective_limit,
                 "limit_source": limit_source,
                 "error": error[:500],
-                "trigger_outcome": outcome,
+                "trigger_outcome": typed_outcome.kind,
             }
             if event_payload_extra:
                 payload.update(event_payload_extra)
@@ -7788,13 +7907,17 @@ def _record_task_failure(
                 # Spawn path: close the open run with outcome.
                 run_id = _end_run(
                     conn, task_id,
-                    outcome=outcome, status=outcome,
+                    outcome=typed_outcome.kind, status=typed_outcome.kind,
                     error=error[:500],
                     metadata={"failures": failures},
                 )
                 _append_event(
-                    conn, task_id, outcome,
-                    {"error": error[:500], "failures": failures},
+                    conn, task_id, typed_outcome.kind,
+                    {
+                        "error": error[:500],
+                        "failures": failures,
+                        "kind": typed_outcome.kind,
+                    },
                     run_id=run_id,
                 )
             # Timeout/crash path's caller already emitted its own event.
@@ -8192,6 +8315,11 @@ def _dispatch_once_locked(
     )
     if _crash_rate_limited:
         result.rate_limited.extend(_crash_rate_limited)
+    _crash_runtime_outcomes = getattr(
+        detect_crashed_workers, "_last_runtime_outcomes", []
+    )
+    if _crash_runtime_outcomes:
+        result.runtime_outcomes.extend(_crash_runtime_outcomes)
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
 
@@ -8391,9 +8519,17 @@ def _dispatch_once_locked(
             else:
                 workspace = resolve_workspace(claimed, board=board)
         except Exception as exc:
-            auto = _record_spawn_failure(
+            runtime_outcome = outcome_for_launcher_exception(exc)
+            result.runtime_outcomes.append({
+                "task_id": claimed.id,
+                **runtime_outcome.to_dict(),
+            })
+            auto = _record_task_failure(
                 conn, claimed.id, f"workspace: {exc}",
+                outcome=runtime_outcome,
                 failure_limit=failure_limit,
+                release_claim=True,
+                end_run=True,
             )
             if auto:
                 result.auto_blocked.append(claimed.id)
@@ -8436,9 +8572,19 @@ def _dispatch_once_locked(
                     _per_profile_running.get(claimed.assignee, 0) + 1
                 )
         except Exception as exc:
-            auto = _record_spawn_failure(
-                conn, claimed.id, str(exc),
+            runtime_outcome = outcome_for_launcher_exception(exc)
+            result.runtime_outcomes.append({
+                "task_id": claimed.id,
+                **runtime_outcome.to_dict(),
+            })
+            auto = _record_task_failure(
+                conn,
+                claimed.id,
+                str(exc),
+                outcome=runtime_outcome,
                 failure_limit=failure_limit,
+                release_claim=True,
+                end_run=True,
             )
             if auto:
                 result.auto_blocked.append(claimed.id)
@@ -8483,9 +8629,17 @@ def _dispatch_once_locked(
             else:
                 workspace = resolve_workspace(claimed, board=board)
         except Exception as exc:
-            auto = _record_spawn_failure(
+            runtime_outcome = outcome_for_launcher_exception(exc)
+            result.runtime_outcomes.append({
+                "task_id": claimed.id,
+                **runtime_outcome.to_dict(),
+            })
+            auto = _record_task_failure(
                 conn, claimed.id, f"workspace: {exc}",
+                outcome=runtime_outcome,
                 failure_limit=failure_limit,
+                release_claim=True,
+                end_run=True,
             )
             if auto:
                 result.auto_blocked.append(claimed.id)
@@ -8517,9 +8671,17 @@ def _dispatch_once_locked(
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
             spawned += 1
         except Exception as exc:
-            auto = _record_spawn_failure(
+            runtime_outcome = outcome_for_launcher_exception(exc)
+            result.runtime_outcomes.append({
+                "task_id": claimed.id,
+                **runtime_outcome.to_dict(),
+            })
+            auto = _record_task_failure(
                 conn, claimed.id, str(exc),
+                outcome=runtime_outcome,
                 failure_limit=failure_limit,
+                release_claim=True,
+                end_run=True,
             )
             if auto:
                 result.auto_blocked.append(claimed.id)

--- a/hermes_cli/runtime_outcomes.py
+++ b/hermes_cli/runtime_outcomes.py
@@ -45,6 +45,12 @@ class RuntimeOutcome:
         return cls("launcher_transport_failure", True, False, reason, "launcher", False)
 
     @classmethod
+    def judge_transport_failure(
+        cls, reason: str = "goal judge transport failure"
+    ) -> "RuntimeOutcome":
+        return cls("judge_transport_failure", True, False, reason, "goal_judge", False)
+
+    @classmethod
     def ex_tempfail(cls, reason: str = "worker exited EX_TEMPFAIL") -> "RuntimeOutcome":
         return cls("ex_tempfail", True, False, reason, "worker", False)
 
@@ -96,6 +102,8 @@ def outcome_for_provider_reason(reason: Any) -> RuntimeOutcome:
 
 def outcome_for_worker_result(result: Any) -> RuntimeOutcome:
     """Normalize a quiet worker result before exit and goal-loop handling."""
+    if isinstance(result, dict) and result.get("runtime_outcome") is not None:
+        return RuntimeOutcome.from_value(result["runtime_outcome"])
     if not isinstance(result, dict) or not result.get("failed"):
         return RuntimeOutcome("completed", False, False, "completed", "worker")
     return outcome_for_provider_reason(result.get("failure_reason"))

--- a/hermes_cli/runtime_outcomes.py
+++ b/hermes_cli/runtime_outcomes.py
@@ -1,0 +1,139 @@
+"""Typed runtime outcomes shared by provider, launcher, worker, and goal paths."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from typing import Any
+
+EX_TEMPFAIL_EXIT_CODE = 75
+
+
+@dataclass(frozen=True)
+class RuntimeOutcome:
+    """Bounded execution result used for retry and budget accounting."""
+
+    kind: str
+    retryable: bool
+    counts_against_failure_budget: bool
+    reason: str = ""
+    source: str = ""
+    counts_against_goal_budget: bool = True
+
+    @property
+    def is_transient(self) -> bool:
+        return self.retryable and not self.counts_against_failure_budget
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "retryable": self.retryable,
+            "counts_against_failure_budget": self.counts_against_failure_budget,
+            "counts_against_goal_budget": self.counts_against_goal_budget,
+            "reason": self.reason,
+            "source": self.source,
+        }
+
+    @classmethod
+    def provider_overload(cls, reason: str = "provider overloaded") -> "RuntimeOutcome":
+        return cls("provider_overload", True, False, reason, "provider", False)
+
+    @classmethod
+    def launcher_transport_failure(
+        cls, reason: str = "launcher transport failure"
+    ) -> "RuntimeOutcome":
+        return cls("launcher_transport_failure", True, False, reason, "launcher", False)
+
+    @classmethod
+    def ex_tempfail(cls, reason: str = "worker exited EX_TEMPFAIL") -> "RuntimeOutcome":
+        return cls("ex_tempfail", True, False, reason, "worker", False)
+
+    @classmethod
+    def code_failure(cls, reason: str = "worker code failure") -> "RuntimeOutcome":
+        return cls("code_failure", False, True, reason, "worker")
+
+    @classmethod
+    def from_value(cls, value: Any) -> "RuntimeOutcome":
+        """Normalize legacy outcome/reason strings, failing closed."""
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, dict):
+            value = value.get("kind") or value.get("failure_reason")
+        raw = getattr(value, "value", value)
+        raw = str(raw or "").strip().lower()
+        if raw in {"overloaded", "upstream_rate_limit", "provider_overload"}:
+            return cls.provider_overload(reason=raw)
+        if raw in {"rate_limit", "billing"}:
+            return cls(raw, True, False, raw, "provider", False)
+        if raw in {"transport", "launcher_transport_failure", "judge_transport_failure"}:
+            return cls(
+                raw,
+                True,
+                False,
+                raw,
+                "launcher" if raw != "judge_transport_failure" else "goal_judge",
+                False,
+            )
+        if raw in {"rate_limited", "tempfail", "ex_tempfail"}:
+            return cls.ex_tempfail(reason=raw)
+        if raw in {"crashed", "code_failure", "failure", "spawn_failed", "timed_out"}:
+            return cls.code_failure(reason=raw)
+        if raw in {"completed", "success"}:
+            return cls("completed", False, False, raw, "worker")
+        return cls.code_failure(reason=raw or "unknown runtime failure")
+
+
+def outcome_for_provider_reason(reason: Any) -> RuntimeOutcome:
+    """Map the provider classifier's reason to runtime accounting."""
+    raw = getattr(reason, "value", reason)
+    raw = str(raw or "").strip().lower()
+    if raw in {"overloaded", "upstream_rate_limit"}:
+        return RuntimeOutcome.provider_overload(reason=raw)
+    if raw in {"rate_limit", "billing"}:
+        return RuntimeOutcome(raw, True, False, raw, "provider", False)
+    return RuntimeOutcome.code_failure(reason=raw or "unknown provider failure")
+
+
+def outcome_for_worker_result(result: Any) -> RuntimeOutcome:
+    """Normalize a quiet worker result before exit and goal-loop handling."""
+    if not isinstance(result, dict) or not result.get("failed"):
+        return RuntimeOutcome("completed", False, False, "completed", "worker")
+    return outcome_for_provider_reason(result.get("failure_reason"))
+
+
+def worker_exit_code_for_result(result: Any, *, kanban_task: bool) -> int:
+    """Return the quiet worker's process code for a normalized result."""
+    if not isinstance(result, dict) or not result.get("failed"):
+        return 0
+    if kanban_task and outcome_for_worker_result(result).is_transient:
+        return EX_TEMPFAIL_EXIT_CODE
+    return 1
+
+
+def outcome_for_launcher_exception(exc: BaseException) -> RuntimeOutcome:
+    """Classify launcher transport failures without hiding code failures."""
+    if isinstance(exc, (ConnectionError, TimeoutError, BrokenPipeError, subprocess.TimeoutExpired)):
+        return RuntimeOutcome.launcher_transport_failure(
+            reason=str(exc) or exc.__class__.__name__
+        )
+    return RuntimeOutcome("spawn_failure", False, True, str(exc) or exc.__class__.__name__, "launcher")
+
+
+def outcome_for_worker_exit(kind: str, code: int | None) -> RuntimeOutcome:
+    """Map the existing worker-exit classifier to a typed outcome."""
+    if kind == "clean_exit":
+        return RuntimeOutcome("completed", False, False, "worker exited successfully", "worker")
+    if kind == "rate_limited" or code == EX_TEMPFAIL_EXIT_CODE:
+        return RuntimeOutcome.ex_tempfail(reason="worker exited EX_TEMPFAIL (75)")
+    return RuntimeOutcome.code_failure(reason=f"worker exit kind={kind}, code={code}")
+
+
+__all__ = [
+    "EX_TEMPFAIL_EXIT_CODE",
+    "RuntimeOutcome",
+    "outcome_for_launcher_exception",
+    "outcome_for_provider_reason",
+    "outcome_for_worker_result",
+    "outcome_for_worker_exit",
+    "worker_exit_code_for_result",
+]

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 import cli
+from hermes_cli.runtime_outcomes import RuntimeOutcome
 
 
 @pytest.fixture(autouse=True)
@@ -201,3 +202,57 @@ def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatc
     assert ("claim", "cli", True) in calls
     assert ("run", "hello", []) in calls
     assert calls[-1] == ("finalize", "quiet-session")
+
+
+def test_quiet_kanban_goal_transient_outcome_exits_tempfail(monkeypatch):
+    calls = []
+
+    def run_conversation(*, user_message, conversation_history):
+        calls.append(("run", user_message))
+        return {"final_response": "partial", "failed": False}
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.provider = "test-provider"
+            self.model = "test-model"
+            self.session_id = "quiet-goal-session"
+            self.conversation_history = []
+            self._active_agent_route_signature = "same-route"
+            self.agent = SimpleNamespace(
+                session_id="quiet-goal-session",
+                platform="cli",
+                quiet_mode=False,
+                suppress_status_output=False,
+                stream_delta_callback=object(),
+                tool_gen_callback=object(),
+                run_conversation=run_conversation,
+            )
+
+        def _claim_active_session(self, surface, *, stderr=False):
+            return True
+
+        def _ensure_runtime_credentials(self):
+            return True
+
+        def _resolve_turn_agent_config(self, effective_query):
+            return {"signature": "same-route", "model": None, "runtime": None, "request_overrides": None}
+
+        def _init_agent(self, **kwargs):
+            return True
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-1")
+    monkeypatch.setenv("HERMES_KANBAN_GOAL_MODE", "1")
+    monkeypatch.setattr(cli, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli.atexit, "register", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli, "_finalize_single_query", lambda _cli: calls.append("finalize"))
+    monkeypatch.setattr(
+        cli,
+        "_run_kanban_goal_loop_q",
+        lambda *_args: {"runtime_outcome": RuntimeOutcome.judge_transport_failure("timeout")},
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(query="hello", quiet=True, toolsets="terminal")
+
+    assert exc_info.value.code == 75
+    assert calls[-1] == "finalize"

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -19,6 +19,7 @@ import pytest
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import goals
+from hermes_cli.runtime_outcomes import RuntimeOutcome
 
 
 @pytest.fixture
@@ -29,6 +30,75 @@ def kanban_home(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     return home
+
+
+# ---------------------------------------------------------------------------
+# Goal-loop runtime outcomes
+
+
+def _run_goal_loop(monkeypatch, *, judge_result, continuation_result=None, max_turns=1):
+    blocked = []
+    continuations = []
+    responses = iter([continuation_result] if continuation_result is not None else [])
+    monkeypatch.setattr(goals, "judge_goal", lambda *_args, **_kwargs: judge_result)
+
+    def run_turn(prompt):
+        continuations.append(prompt)
+        return next(responses)
+
+    result = goals.run_kanban_goal_loop(
+        task_id="t1",
+        goal_text="finish it",
+        run_turn=run_turn,
+        task_status_fn=lambda: "running",
+        block_fn=blocked.append,
+        max_turns=max_turns,
+        first_response="partial",
+    )
+    return result, blocked, continuations
+
+
+def test_goal_loop_judge_transport_is_typed_non_counting_and_does_not_block(monkeypatch):
+    result, blocked, continuations = _run_goal_loop(
+        monkeypatch,
+        judge_result=("continue", "judge unavailable", False, None, True),
+        max_turns=1,
+    )
+
+    assert result["turns_used"] == 1
+    assert result["runtime_outcome"].kind == "judge_transport_failure"
+    assert result["runtime_outcome"].is_transient
+    assert blocked == []
+    assert continuations == []
+
+
+def test_goal_loop_continuation_overload_is_typed_non_counting_and_does_not_block(monkeypatch):
+    result, blocked, continuations = _run_goal_loop(
+        monkeypatch,
+        judge_result=("continue", "keep working", False, None, False),
+        continuation_result=RuntimeOutcome.provider_overload(),
+        max_turns=2,
+    )
+
+    assert result["turns_used"] == 1
+    assert result["runtime_outcome"].kind == "provider_overload"
+    assert result["runtime_outcome"].is_transient
+    assert blocked == []
+    assert len(continuations) == 1
+
+
+def test_goal_loop_ordinary_continuation_failure_consumes_budget_and_blocks(monkeypatch):
+    result, blocked, continuations = _run_goal_loop(
+        monkeypatch,
+        judge_result=("continue", "keep working", False, None, False),
+        continuation_result={"final_response": "", "failed": True, "error": "boom"},
+        max_turns=2,
+    )
+
+    assert result["turns_used"] == 2
+    assert result["outcome"] == "blocked_budget"
+    assert len(blocked) == 1
+    assert len(continuations) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_runtime_outcomes.py
+++ b/tests/hermes_cli/test_kanban_runtime_outcomes.py
@@ -1,0 +1,295 @@
+"""Canonical runtime-outcome contract tests for Kanban execution paths."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from agent.error_classifier import FailoverReason
+from hermes_cli import kanban_db as kb
+from hermes_cli.runtime_outcomes import (
+    RuntimeOutcome,
+    outcome_for_provider_reason,
+    outcome_for_worker_result,
+    worker_exit_code_for_result,
+)
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return home
+
+
+@pytest.mark.parametrize(
+    ("outcome", "counts_against_failure_budget"),
+    [
+        (RuntimeOutcome.provider_overload(), False),
+        (RuntimeOutcome.launcher_transport_failure(), False),
+        (RuntimeOutcome.ex_tempfail(), False),
+        (RuntimeOutcome.code_failure(), True),
+    ],
+)
+def test_runtime_outcome_contract_has_one_budget_policy(
+    outcome, counts_against_failure_budget
+):
+    assert outcome.counts_against_failure_budget is counts_against_failure_budget
+    assert outcome.counts_against_goal_budget is counts_against_failure_budget
+    assert outcome.is_transient is not counts_against_failure_budget
+
+
+def test_provider_overload_maps_to_transient_outcome():
+    outcome = outcome_for_provider_reason(FailoverReason.overloaded)
+    assert outcome.kind == "provider_overload"
+    assert outcome.is_transient
+
+
+@pytest.mark.parametrize(
+    "serialized",
+    [RuntimeOutcome.provider_overload().to_dict(), {"kind": "overloaded"}],
+)
+def test_serialized_provider_outcome_preserves_transient_policy(serialized):
+    outcome = RuntimeOutcome.from_value(serialized)
+    assert outcome.kind == "provider_overload"
+    assert outcome.is_transient
+
+
+def test_serialized_provider_rate_limit_preserves_transient_policy():
+    outcome = RuntimeOutcome.from_value({"kind": "rate_limit"})
+    assert outcome.kind == "rate_limit"
+    assert outcome.is_transient
+
+
+def test_provider_overload_does_not_increment_failure_or_block_recurrence(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="overloaded", assignee="worker")
+        assert kb.claim_task(conn, task_id) is not None
+
+        blocked = kb._record_task_failure(
+            conn,
+            task_id,
+            "provider overloaded",
+            outcome=RuntimeOutcome.provider_overload(),
+            failure_limit=1,
+            release_claim=True,
+            end_run=True,
+        )
+
+        task = kb.get_task(conn, task_id)
+        assert blocked is False
+        assert task.status == "ready"
+        assert task.consecutive_failures == 0
+        assert task.block_recurrences == 0
+
+
+@pytest.mark.parametrize("status", ["ready", "review"])
+def test_launcher_transport_does_not_increment_failure_or_block_recurrence(
+    kanban_home, monkeypatch, status
+):
+    import hermes_cli.profiles as profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _profile: True)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="transport", assignee="worker")
+        if status == "review":
+            conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (task_id,))
+            conn.commit()
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                ConnectionError("launcher transport disconnected")
+            ),
+            failure_limit=1,
+        )
+
+        task = kb.get_task(conn, task_id)
+        assert task.status == status
+        assert task.consecutive_failures == 0
+        assert task.block_recurrences == 0
+        assert task_id not in result.auto_blocked
+        assert result.runtime_outcomes[0]["kind"] == "launcher_transport_failure"
+        run = conn.execute(
+            "SELECT outcome FROM task_runs WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        assert run["outcome"] == "launcher_transport_failure"
+
+        next_spawn = []
+        kb.dispatch_once(
+            conn,
+            spawn_fn=lambda task, *_args, **_kwargs: next_spawn.append(task.skills),
+            failure_limit=1,
+        )
+        assert next_spawn == ([["sdlc-review"]] if status == "review" else [None])
+
+
+@pytest.mark.parametrize("status", ["ready", "review"])
+def test_provider_overload_result_uses_tempfail_exit_and_requeues_without_failure(
+    kanban_home, monkeypatch, status
+):
+    import hermes_cli.profiles as profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _profile: True)
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    result = {"failed": True, "failure_reason": "overloaded"}
+
+    outcome = outcome_for_worker_result(result)
+    assert outcome.kind == "provider_overload"
+    assert not outcome.counts_against_goal_budget
+    exit_code = worker_exit_code_for_result(result, kanban_task=True)
+    assert exit_code == kb.KANBAN_RATE_LIMIT_EXIT_CODE
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="overload-result", assignee="worker")
+        if status == "review":
+            conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (task_id,))
+            conn.commit()
+            task = kb.claim_review_task(conn, task_id)
+        else:
+            task = kb.claim_task(conn, task_id)
+        assert task is not None
+        pid = 99125
+        conn.execute("UPDATE tasks SET worker_pid=? WHERE id=?", (pid, task_id))
+        conn.commit()
+        kb._record_worker_exit(pid, exit_code << 8)
+
+        dispatch_result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args, **_kwargs: None,
+            failure_limit=1,
+            max_spawn=0,
+        )
+
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == status
+        assert task.consecutive_failures == 0
+        assert task.block_recurrences == 0
+        assert any(
+            outcome["task_id"] == task_id
+            and outcome["kind"] == "ex_tempfail"
+            for outcome in dispatch_result.runtime_outcomes
+        )
+
+        next_spawn = []
+        kb.dispatch_once(
+            conn,
+            spawn_fn=lambda task, *_args, **_kwargs: next_spawn.append(task.skills),
+            failure_limit=1,
+        )
+        assert next_spawn == ([["sdlc-review"]] if status == "review" else [])
+
+
+@pytest.mark.parametrize(
+    ("result", "expected_exit", "counts_against_goal_budget"),
+    [
+        ({"failed": True, "failure_reason": "overloaded"}, 75, False),
+        ({"failed": True, "failure_reason": "unknown"}, 1, True),
+        ({"failed": False}, 0, True),
+    ],
+)
+def test_worker_result_exit_policy_keeps_ordinary_failures_counting(
+    result, expected_exit, counts_against_goal_budget
+):
+    outcome = outcome_for_worker_result(result)
+    assert outcome.counts_against_goal_budget is counts_against_goal_budget
+    assert worker_exit_code_for_result(result, kanban_task=True) == expected_exit
+
+
+@pytest.mark.parametrize("status", ["ready", "review"])
+def test_launcher_code_failure_is_persisted_as_string_and_blocks_at_limit(
+    kanban_home, monkeypatch, status
+):
+    import hermes_cli.profiles as profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _profile: True)
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title=f"code-{status}", assignee="worker")
+        if status == "review":
+            conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (task_id,))
+            conn.commit()
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                RuntimeError("launcher code failure")
+            ),
+            failure_limit=1,
+        )
+
+        task = kb.get_task(conn, task_id)
+        assert task.status == "blocked"
+        assert task.consecutive_failures == 1
+        assert task_id in result.auto_blocked
+        assert result.runtime_outcomes[-1]["kind"] == "spawn_failure"
+        run = conn.execute(
+            "SELECT outcome FROM task_runs WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        assert run["outcome"] == "gave_up"
+
+
+def test_clean_exit_protocol_violation_is_counting_outcome(kanban_home, monkeypatch):
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="protocol", assignee="worker")
+        task = kb.claim_task(conn, task_id, claimer=f"{kb._claimer_id().split(':', 1)[0]}:worker")
+        assert task is not None
+        pid = 99124
+        conn.execute("UPDATE tasks SET worker_pid=? WHERE id=?", (pid, task_id))
+        conn.commit()
+        kb._record_worker_exit(pid, 0)
+
+        kb.detect_crashed_workers(conn)
+
+        event = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        assert '"kind": "code_failure"' in event["payload"]
+        outcome = kb.detect_crashed_workers._last_runtime_outcomes[-1]
+        assert outcome["kind"] == "code_failure"
+        run = conn.execute(
+            "SELECT outcome, metadata FROM task_runs WHERE task_id = ? "
+            "ORDER BY id DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        assert run["outcome"] == "crashed"
+        assert '"kind": "code_failure"' in run["metadata"]
+
+
+def test_ex_tempfail_is_transient_worker_exit():
+    pid = os.getpid()
+    kb._record_worker_exit(pid, kb.KANBAN_RATE_LIMIT_EXIT_CODE << 8)
+    outcome = kb.worker_exit_outcome(pid)
+    assert outcome.kind == "ex_tempfail"
+    assert outcome.is_transient
+
+
+def test_ordinary_worker_exit_still_counts_as_failure(kanban_home, monkeypatch):
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="crash", assignee="worker")
+        task = kb.claim_task(conn, task_id, claimer=f"{kb._claimer_id().split(':', 1)[0]}:worker")
+        assert task is not None
+        pid = 99123
+        conn.execute("UPDATE tasks SET worker_pid=? WHERE id=?", (pid, task_id))
+        conn.commit()
+        kb._record_worker_exit(pid, 1 << 8)
+
+        kb.detect_crashed_workers(conn)
+
+        task = kb.get_task(conn, task_id)
+        assert task.consecutive_failures == 1
+        assert task.status == "ready"


### PR DESCRIPTION
## Summary
- Add a bounded RuntimeOutcome contract for provider overload, launcher transport failures, EX_TEMPFAIL, and ordinary code failures.
- Route dispatcher spawn/crash accounting through typed outcomes so transient infrastructure events do not increment failure budgets or auto-block tasks.
- Preserve legacy string outcome callers and expose typed runtime outcomes in DispatchResult/events.

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_runtime_outcomes.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_goals.py -q`
- `uv run ruff check hermes_cli/runtime_outcomes.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_runtime_outcomes.py`

Base: `8eb06e75b9dbf29dfad90683a8efef546e0058e0`
Head: `38315cdcbc87326e3bcc015756e3d8ce81e461e0`