### PR TITLE
fix(update): unblock Desktop preflight and updater handoff

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2615,7 +2615,12 @@ def _detect_venv_python_processes(
 
     matches: list[tuple[int, str, str]] = []
     try:
-        proc_iter = psutil.process_iter(["pid", "exe", "name", "cmdline", "cwd"])
+        # On Windows, cmdline/cwd collection is dramatically more expensive
+        # than pid/name/exe (roughly 15s vs 4s on process-heavy desktops).  Take
+        # a cheap broad snapshot first so every executable under the venv is
+        # still covered, then load command details only for actual venv holders
+        # or Python/Hermes processes that could be base-interpreter trampolines.
+        proc_iter = psutil.process_iter(["pid", "name", "exe"])
     except Exception:
         return []
     for proc in proc_iter:
@@ -2631,13 +2636,24 @@ def _detect_venv_python_processes(
             exe_norm = str(Path(exe).resolve()).lower()
         except (OSError, ValueError):
             exe_norm = str(exe).lower()
-        cmdline_raw = " ".join(info.get("cmdline") or [])
+
+        name = info.get("name") or Path(exe).name
+        name_low = str(name).lower()
+        is_holder = exe_norm.startswith(venv_prefix)
+        could_be_trampoline = name_low.startswith("python") or name_low == "hermes.exe"
+        if not is_holder and not could_be_trampoline:
+            continue
+
+        try:
+            details = proc.as_dict(attrs=["cmdline", "cwd"])
+        except Exception:
+            details = {}
+        cmdline_raw = " ".join(details.get("cmdline") or [])
         cmdline_low = cmdline_raw.lower()
-        cwd_low = str(info.get("cwd") or "").lower().rstrip(os.sep) + os.sep
+        cwd_low = str(details.get("cwd") or "").lower().rstrip(os.sep) + os.sep
 
         # Primary match: the executable itself lives under this venv
         # (venv\Scripts\python(w).exe — the desktop backend / gateway case).
-        is_holder = exe_norm.startswith(venv_prefix)
         # Fallback: uv/base-interpreter trampolines run a python whose exe is
         # OUTSIDE the venv but which still imports from it and holds its .pyd
         # files. Catch those by what they're running: a cmdline that references
@@ -2650,7 +2666,6 @@ def _detect_venv_python_processes(
                 is_holder = True
         if not is_holder:
             continue
-        name = info.get("name") or Path(exe).name
         matches.append((int(pid), str(name), cmdline_raw[:120]))
     return matches
 

--- a/hermes_cli/update_lock.py
+++ b/hermes_cli/update_lock.py
@@ -138,6 +138,40 @@ def read_live_update(*, path: Path | None = None) -> UpdateHolder | None:
     return UpdateHolder(pid=pid, age_seconds=age)
 
 
+def _holder_is_packaged_updater_ancestor(
+    holder: UpdateHolder, *, marker_path: Path
+) -> bool:
+    """True only for the packaged updater's live ancestor-owned marker.
+
+    Windows venv/distlib shims can put one or more launcher processes between
+    ``Hermes-Setup`` and the Python process running ``hermes update``, so the
+    owner need not be our direct parent. Ancestry alone is insufficient,
+    though: an unrelated ancestor or an install-mode helper must never bypass
+    mutual exclusion. Require the marker owner to be the stable updater executable
+    beside the marker and to be running the internal ``--update`` mode. Fail
+    closed when process identity or arguments cannot be inspected.
+    """
+    updater_name = "hermes-setup.exe" if os.name == "nt" else "hermes-setup"
+    expected_exe = marker_path.parent / updater_name
+    try:
+        import psutil
+
+        owner = next(
+            (parent for parent in psutil.Process().parents() if parent.pid == holder.pid),
+            None,
+        )
+        if owner is None:
+            return False
+        actual_norm = os.path.normcase(str(Path(owner.exe()).resolve()))
+        expected_norm = os.path.normcase(str(expected_exe.resolve()))
+        identity_matches = actual_norm == expected_norm
+        update_mode = "--update" in owner.cmdline()[1:]
+        return identity_matches and update_mode
+    except Exception as exc:
+        logger.debug("Could not verify packaged updater ancestry: %s", exc)
+        return False
+
+
 def describe_holder(holder: UpdateHolder) -> str:
     """One-line, user-facing explanation of who holds the update lock."""
     minutes, seconds = divmod(int(max(holder.age_seconds, 0)), 60)
@@ -155,11 +189,14 @@ def describe_holder(holder: UpdateHolder) -> str:
 class UpdateLock:
     """Context manager owning the shared update marker for this process.
 
-    ``acquired`` is False when another live update already holds it — callers
-    decide whether that's a hard refusal (CLI/dashboard) or a wait. Releasing
-    only removes the marker when *we* still own it, so a marker rewritten by a
-    handoff partner (the Tauri updater overwrites it with its own pid) is never
-    deleted out from under its new owner.
+    ``acquired`` is True only when this process wrote and owns the marker. A
+    descendant of the live marker owner may borrow that ancestor-owned lock
+    (the Tauri updater → launcher shim → ``hermes update`` handoff); borrowing
+    returns True from :meth:`acquire` but leaves ``acquired`` False so the child
+    never removes the parent's marker before the rebuild stage. Every other
+    live owner is refused. Releasing only removes the marker when *we* still own
+    it, so a marker rewritten by a handoff partner is never deleted out from
+    under its new owner.
     """
 
     def __init__(self, *, path: Path | None = None) -> None:
@@ -171,6 +208,15 @@ class UpdateLock:
         """Claim the lock. Returns False (and sets ``holder``) if it's taken."""
         existing = read_live_update(path=self.path)
         if existing is not None:
+            if _holder_is_packaged_updater_ancestor(existing, marker_path=self.path):
+                # The packaged updater owns the cross-process marker while a
+                # descendant ``hermes update`` process mutates the checkout.
+                # Borrow without rewriting it: the ancestor must keep the
+                # Electron launch gate closed through the later rebuild stage.
+                logger.debug(
+                    "Borrowing update marker owned by ancestor pid %s", existing.pid
+                )
+                return True
             self.holder = existing
             return False
         try:

--- a/tests/hermes_cli/test_update_lock.py
+++ b/tests/hermes_cli/test_update_lock.py
@@ -17,10 +17,13 @@ disk.
 from __future__ import annotations
 
 import os
+import sys
 import time
+import types
 
 import pytest
 
+import hermes_cli.update_lock as update_lock_module
 from hermes_cli.update_lock import (
     UPDATE_MARKER_MAX_AGE_SECONDS,
     UpdateLock,
@@ -72,6 +75,80 @@ def test_second_acquire_is_refused_while_the_first_is_live(marker):
     assert second.holder is not None
     assert second.holder.pid == os.getpid()
     assert second.acquired is False
+
+
+def test_descendant_borrows_identified_updater_ancestor_marker(marker, monkeypatch):
+    """The identified updater owns the marker through launch shims and rebuild."""
+    started_at = int(time.time())
+    updater_pid = 220
+    updater_name = "hermes-setup.exe" if os.name == "nt" else "hermes-setup"
+    updater_exe = marker.parent / updater_name
+    launcher = types.SimpleNamespace(pid=110)
+    updater = types.SimpleNamespace(
+        pid=updater_pid,
+        exe=lambda: str(updater_exe),
+        cmdline=lambda: [str(updater_exe), "--update", "--branch", "main"],
+    )
+    current = types.SimpleNamespace(parents=lambda: [launcher, updater])
+    monkeypatch.setitem(
+        sys.modules, "psutil", types.SimpleNamespace(Process=lambda: current)
+    )
+    monkeypatch.setattr(
+        update_lock_module, "_pid_alive", lambda pid: pid == updater_pid
+    )
+    marker.write_text(f"{updater_pid}\n{started_at}\n", encoding="utf-8")
+
+    lock = UpdateLock(path=marker)
+
+    assert lock.acquire() is True
+    assert lock.acquired is False, "the child borrows rather than replaces the parent lock"
+    assert int(marker.read_text(encoding="utf-8").splitlines()[0]) == updater_pid
+
+    lock.release()
+    assert marker.exists(), "the parent owns the marker through the rebuild stage"
+
+
+def test_unrelated_ancestor_cannot_lend_update_marker(marker, monkeypatch):
+    started_at = int(time.time())
+    updater_pid = 220
+    unrelated = types.SimpleNamespace(
+        pid=updater_pid,
+        exe=lambda: str(marker.parent / "terminal.exe"),
+        cmdline=lambda: ["terminal.exe", "--update"],
+    )
+    current = types.SimpleNamespace(parents=lambda: [unrelated])
+    monkeypatch.setitem(
+        sys.modules, "psutil", types.SimpleNamespace(Process=lambda: current)
+    )
+    monkeypatch.setattr(update_lock_module, "_pid_alive", lambda _pid: True)
+    marker.write_text(f"{updater_pid}\n{started_at}\n", encoding="utf-8")
+
+    lock = UpdateLock(path=marker)
+
+    assert lock.acquire() is False
+    assert lock.holder is not None
+
+
+def test_install_mode_helper_cannot_lend_update_marker(marker, monkeypatch):
+    started_at = int(time.time())
+    updater_pid = 220
+    updater_name = "hermes-setup.exe" if os.name == "nt" else "hermes-setup"
+    install_mode = types.SimpleNamespace(
+        pid=updater_pid,
+        exe=lambda: str(marker.parent / updater_name),
+        cmdline=lambda: [str(marker.parent / updater_name)],
+    )
+    current = types.SimpleNamespace(parents=lambda: [install_mode])
+    monkeypatch.setitem(
+        sys.modules, "psutil", types.SimpleNamespace(Process=lambda: current)
+    )
+    monkeypatch.setattr(update_lock_module, "_pid_alive", lambda _pid: True)
+    marker.write_text(f"{updater_pid}\n{started_at}\n", encoding="utf-8")
+
+    lock = UpdateLock(path=marker)
+
+    assert lock.acquire() is False
+    assert lock.holder is not None
 
 
 def test_refused_lock_does_not_delete_the_live_owners_marker(marker):

--- a/tests/hermes_cli/test_update_venv_health.py
+++ b/tests/hermes_cli/test_update_venv_health.py
@@ -60,6 +60,70 @@ def _proc(pid: int, exe: str, name: str, cmdline: list[str] | None = None, cwd: 
     return proc
 
 
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_detect_venv_python_only_loads_expensive_details_for_python_candidates(_winp, tmp_path):
+    """Windows process snapshots must stay bounded on process-heavy desktops."""
+
+    class FakeProcess:
+        def __init__(self, *, pid, name, exe, cmdline, cwd=""):
+            self.all_info = {
+                "pid": pid,
+                "name": name,
+                "exe": exe,
+                "cmdline": cmdline,
+                "cwd": cwd,
+            }
+            self.info = {}
+            self.detail_calls = 0
+
+        def as_dict(self, attrs):
+            self.detail_calls += 1
+            return {attr: self.all_info.get(attr) for attr in attrs}
+
+    venv_py = str(tmp_path / "venv" / "Scripts" / "python.exe")
+    unrelated = FakeProcess(
+        pid=101,
+        name="chrome.exe",
+        exe="C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+        cmdline=["chrome.exe"],
+    )
+    candidate = FakeProcess(
+        pid=102,
+        name="python.exe",
+        exe=venv_py,
+        cmdline=[venv_py, "-m", "hermes_cli.main", "serve"],
+    )
+    venv_tool = FakeProcess(
+        pid=103,
+        name="custom-tool.exe",
+        exe=str(tmp_path / "venv" / "Scripts" / "custom-tool.exe"),
+        cmdline=["custom-tool.exe"],
+    )
+    requested_attrs = []
+
+    def process_iter(attrs):
+        requested_attrs.append(attrs)
+        for proc in (unrelated, candidate, venv_tool):
+            proc.info = {attr: proc.all_info.get(attr) for attr in attrs}
+        return iter((unrelated, candidate, venv_tool))
+
+    me = MagicMock()
+    me.parents.return_value = []
+    fake_psutil = types.SimpleNamespace(
+        process_iter=process_iter,
+        Process=lambda *a, **k: me,
+    )
+
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.dict(
+        sys.modules, {"psutil": fake_psutil}
+    ):
+        matches = cli_main._detect_venv_python_processes()
+
+    assert requested_attrs == [["pid", "name", "exe"]]
+    assert unrelated.detail_calls == 0
+    assert candidate.detail_calls == 1
+    assert venv_tool.detail_calls == 1
+    assert [match[0] for match in matches] == [102, 103]
 
 
 @patch.object(cli_main, "_is_windows", return_value=True)


### PR DESCRIPTION
## What does this PR do?

Fixes two independent failures in the same Desktop update path:

1. On process-heavy Windows hosts, `_detect_venv_python_processes()` collected `cmdline` and `cwd` for every process. The native scan took 14.7 seconds on the affected machine, colliding with Desktop's 15-second preflight timeout. Electron killed a healthy probe and surfaced `exit code -1`.
2. After preflight passed, the Tauri updater owned `.hermes-update-in-progress`, but its `hermes update` descendant treated that same live marker as a competing update. Windows venv/distlib launchers insert shim processes, so the Tauri owner is not always the Python process's immediate parent.

The venv scan now takes a cheap broad `pid`/`name`/`exe` snapshot and loads expensive command details only for executables already under the venv or Python/Hermes trampoline candidates. This keeps arbitrary venv executables detectable without paying the Windows process-query cost for unrelated applications.

The update lock now permits borrowing only when the live marker owner is in the process ancestry, resolves to the stable `HERMES_HOME/hermes-setup(.exe)` helper, and is running its internal `--update` mode. Borrowing does not rewrite or remove the marker: the Tauri updater retains ownership through repository update and Desktop rebuild, while unrelated live updaters still block.

This does not exclude or bypass genuine venv holders; actual gateway/other-process coordination remains a separate concern tracked in #74326.

## Related Issue

Fixes #74001
Fixes #74531

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/update_cmd.py`
  - Keep the broad Windows process scan limited to cheap metadata.
  - Defer `cmdline`/`cwd` collection to venv holders and Python/Hermes trampoline candidates.
- `hermes_cli/update_lock.py`
  - Recognize the stable packaged updater anywhere in the current process ancestry.
  - Require exact executable identity and internal `--update` mode; identity inspection fails closed.
  - Borrow ancestor-owned markers without transferring ownership or weakening exclusion for unrelated updaters.
- `tests/hermes_cli/test_update_venv_health.py`
  - Assert unrelated processes never incur expensive detail queries.
  - Preserve detection of Python and arbitrary executables under the venv.
- `tests/hermes_cli/test_update_lock.py`
  - Assert descendant borrowing, marker survival, and non-ownership on release.
  - Cover a Tauri owner above an intermediate launcher process, wrong-path ancestors, and install-mode helpers.

## How to Test

1. Run the focused regression suites:
   ```bash
   uv run --isolated --with pytest --with-editable . pytest \
     tests/hermes_cli/test_update_lock.py \
     tests/hermes_cli/test_update_venv_health.py -q
   ```
   Expected: `25 passed`.
2. Run focused lint:
   ```bash
   uv run --isolated --with ruff ruff check \
     hermes_cli/update_lock.py hermes_cli/update_cmd.py \
     tests/hermes_cli/test_update_lock.py \
     tests/hermes_cli/test_update_venv_health.py
   ```
3. On Windows, run `venv\Scripts\python.exe hermes_cli\_scan_venv_blockers.py`; verify it returns valid JSON comfortably inside Desktop's preflight timeout.
4. Trigger **Desktop → Update now** and verify the bootstrap log reaches successful update and rebuild stages, the updater exits, and Desktop relaunches automatically.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused updater suites pass; full matrix left to CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 native Desktop, with WSL used only to orchestrate diagnostics

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; implementation docstrings explain the process contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — stable helper naming follows the Rust updater's Windows/non-Windows contract and identity inspection fails closed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before optimization, native Windows profiling returned:

```text
import_hermes_cli_main_ms=128.2
detect_ms=14694.6
result=[]
```

After the fix and rebase onto current `main`:

```text
{"ok": true, "blocked": false, "processes": []}
exit=0
elapsed_ms=4891.6
```

The real packaged update path was exercised after both fixes. The observed process tree was:

```text
HERMES_HOME/hermes-setup.exe --update --branch main
  -> hermes.exe update --yes --gateway --force --branch main
    -> venv python.exe
      -> base python.exe
        -> uv.exe pip install -e .[all]
```

The bootstrap log recorded both update and Desktop rebuild as `Succeeded`; the updater exited, the update marker cleared, and the responsive Desktop relaunched automatically.
