### PR TITLE
fix(cron): keep scheduler jobs outside child context

### DIFF
--- a/agent/delegation_context.py
+++ b/agent/delegation_context.py
@@ -40,6 +40,23 @@ def delegated_child_context() -> Iterator[None]:
         _DELEGATED_CHILD_CONTEXT.reset(token)
 
 
+@contextmanager
+def cron_parent_context() -> Iterator[None]:
+    """Run a scheduler-owned cron job outside a caller's child lineage.
+
+    ``cron.scheduler.tick`` copies ContextVars into its worker threads so
+    per-request state remains available.  A cron execution is nevertheless a
+    scheduler parent: it must not inherit a surrounding ``delegate_task``
+    child's no-Kanban-mutation authority.  This only resets the ContextVar;
+    an explicit process environment marker remains a hard child boundary.
+    """
+    token = _DELEGATED_CHILD_CONTEXT.set(False)
+    try:
+        yield
+    finally:
+        _DELEGATED_CHILD_CONTEXT.reset(token)
+
+
 def is_delegated_child_context() -> bool:
     """Return True while code is running for a delegate_task child."""
     return bool(_DELEGATED_CHILD_CONTEXT.get())

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4237,7 +4237,20 @@ def tick(
 
             def _run_and_release(j=dispatched_job, ctx=_ctx):
                 try:
-                    return ctx.run(_process_job, j)
+                    # A scheduled job is a scheduler parent, never a
+                    # ``delegate_task`` child.  ``copy_context`` preserves
+                    # useful per-tick state, but it also used to propagate a
+                    # caller's delegated-child marker into the cron agent and
+                    # its terminal subprocesses, denying its Kanban closure
+                    # authority.  Retain the copied context while explicitly
+                    # resetting only that child-local marker for this job.
+                    def _run_as_cron_parent():
+                        from agent.delegation_context import cron_parent_context
+
+                        with cron_parent_context():
+                            return _process_job(j)
+
+                    return ctx.run(_run_as_cron_parent)
                 finally:
                     with _running_lock:
                         _running_job_ids.discard(j["id"])

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -54,6 +54,39 @@ def test_tick_process_job_sequence(monkeypatch):
     assert calls[-1] == ("mark", "j1", True)
 
 
+def test_tick_does_not_propagate_delegated_child_context_to_cron_parent(monkeypatch):
+    """A scheduler-owned cron run must retain Kanban authority.
+
+    ``tick`` uses ``copy_context`` to bridge request-local state into a worker
+    thread. A caller can itself be a delegated child, but a scheduled job is a
+    scheduler parent, not that child's descendant. Propagating the child marker
+    made every Kanban operation fail closed inside PM cron jobs.
+    """
+    from agent.delegation_context import (
+        delegated_child_context,
+        is_delegated_child_process_context,
+    )
+
+    # The test runner itself may be a delegated child. The regression is about
+    # copied *ContextVar* state, so remove any inherited process marker before
+    # establishing the test's child scope.
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+
+    seen = []
+    monkeypatch.setattr(s, "get_due_jobs", lambda: [{"id": "j-context", "name": "t"}])
+    monkeypatch.setattr(s, "advance_next_run", lambda _: True)
+    monkeypatch.setattr(
+        s,
+        "run_one_job",
+        lambda *args, **kwargs: seen.append(is_delegated_child_process_context()) or True,
+    )
+
+    with delegated_child_context():
+        s.tick(verbose=False, sync=True)
+
+    assert seen == [False]
+
+
 def test_run_one_job_success_sequence(monkeypatch):
     """The extracted helper runs the same execute→save→deliver→mark sequence
     for a successful job."""


### PR DESCRIPTION
## Summary
- prevent `tick()` from propagating a delegated-child ContextVar into scheduler-owned cron jobs
- preserve the hard child-process environment marker guard
- add a regression test covering a delegated caller firing a cron parent

## Verification
- `python3 -m pytest -q tests/cron/test_run_one_job.py` (4 passed)
- `python3 -m py_compile agent/delegation_context.py cron/scheduler.py`
- `git diff --check`

This fixes PM cron Kanban closure being denied solely because `contextvars.copy_context()` carried a surrounding `delegate_task` child marker into the scheduler worker.