### PR TITLE
fix(mcp): do not trip server breaker on tool-level errors

### DIFF
--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -101,6 +101,45 @@ def _cleanup(mcp_tool_module, name: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_tool_level_errors_do_not_trip_server_breaker(monkeypatch, tmp_path):
+    """A completed MCP round-trip with ``isError=True`` proves transport health.
+
+    Validation/domain errors belong to the request or tool, not to the server
+    connection. Repeating them must preserve the actionable tool error without
+    opening the server-level circuit breaker.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    call_count = {"n": 0}
+
+    async def _call_tool_validation_error(*a, **kw):
+        call_count["n"] += 1
+        result = MagicMock()
+        result.isError = True
+        block = MagicMock()
+        block.text = "REQUEST_INVALID: type 'solution' is not allowed"
+        result.content = [block]
+        result.structuredContent = None
+        return result
+
+    _install_stub_server(mcp_tool, "srv-semantic", _call_tool_validation_error)
+    mcp_tool._ensure_mcp_loop()
+
+    try:
+        handler = _make_tool_handler("srv-semantic", "note_create", 10.0)
+        for _ in range(mcp_tool._CIRCUIT_BREAKER_THRESHOLD + 1):
+            parsed = json.loads(handler({"type": "solution"}))
+            assert "REQUEST_INVALID" in parsed.get("error", ""), parsed
+
+        assert call_count["n"] == mcp_tool._CIRCUIT_BREAKER_THRESHOLD + 1
+        assert mcp_tool._server_error_counts.get("srv-semantic", 0) == 0
+    finally:
+        _cleanup(mcp_tool, "srv-semantic")
+
+
 def test_circuit_breaker_half_opens_after_cooldown(monkeypatch, tmp_path):
     """After a tripped breaker's cooldown elapses, the *next* call must
     actually execute against the session (half-open probe). When the

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4894,15 +4894,11 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
 
         try:
             result = _call_once()
-            # Check if the MCP tool itself returned an error
-            try:
-                parsed = json.loads(result)
-                if "error" in parsed:
-                    _bump_server_error(server_name)
-                else:
-                    _reset_server_error(server_name)  # success — reset
-            except (json.JSONDecodeError, TypeError):
-                _reset_server_error(server_name)  # non-JSON = success
+            # Any CallToolResult — including ``isError=True`` — proves that the
+            # MCP transport completed a healthy RPC round-trip. Tool-level
+            # validation/domain errors belong to the request or tool and must
+            # not open the server-level circuit breaker.
+            _reset_server_error(server_name)
             return result
         except InterruptedError:
             return _interrupted_call_result()


### PR DESCRIPTION
## Problem
A completed MCP `tools/call` with `CallToolResult.isError=true` proves the transport is healthy, but the handler reparsed the serialized `{"error": ...}` result and incremented the server circuit breaker. Three validation/domain errors therefore produced a false `MCP server ... is unreachable` message.

## Fix
Reset the server breaker after every completed `CallToolResult`, including tool-level errors. Only exceptions/no-session paths continue to increment it.

## Regression test
Adds a test that returns four consecutive `isError=true` validation results and verifies that all reach the tool and the server error count remains zero. Existing transport-failure breaker tests remain intact.

## Verification
`uv run --extra dev pytest -q tests/tools/test_mcp_circuit_breaker.py tests/tools/test_mcp_failure_classification.py`

Result: `22 passed`.