### PR TITLE
fix(deps): keep nemo-relay opt-in so musl/Alpine installs resolve

### DIFF
--- a/docs/observability/relay-shared-metrics.md
+++ b/docs/observability/relay-shared-metrics.md
@@ -1,13 +1,18 @@
 # NeMo Relay Shared Metrics
 
-Hermes includes NeMo Relay as a normal runtime dependency on platforms for
-which Relay publishes a native wheel. The shared-metrics integration is built
-into Hermes and does not require `hermes plugins enable
+Hermes installs NeMo Relay through the `hermes-agent[nemo-relay]` extra on
+platforms for which Relay publishes a native wheel. The shared-metrics
+integration is built into Hermes and does not require `hermes plugins enable
 observability/nemo_relay`. Hermes remains importable without Relay on other
 native targets. Those targets use an explicit reduced-capability no-op host:
 Hermes execution remains available, while Relay scopes, middleware, plugins,
-and subscribers are unavailable. The `hermes-agent[nemo-relay]` extra remains
-as a no-op compatibility alias for existing installation commands.
+and subscribers are unavailable.
+
+Relay is an extra rather than a base dependency because PEP 508 markers cannot
+distinguish musl from glibc. A base-dependency marker of `sys_platform ==
+'linux' and platform_machine == 'x86_64'` also matches `musllinux_1_2_x86_64`,
+where Relay publishes no wheel or sdist, which would make Hermes itself
+unresolvable there instead of falling back to the no-op host.
 
 Hermes requires NeMo Relay 0.6.0 or later within the 0.6 release line. That
 release establishes the lossless provider-codec contract used for Anthropic
@@ -15,9 +20,15 @@ Messages, OpenAI Chat Completions, and OpenAI Responses requests.
 
 ## Runtime Dependency and Data Boundary
 
-Hermes installs the platform-specific `nemo-relay` native wheel from the
-bounded `>=0.6.0,<0.7` dependency range. The published package is built from
-the [NVIDIA NeMo Relay repository](https://github.com/NVIDIA/NeMo-Relay).
+The `nemo-relay` extra installs the platform-specific native wheel from the
+bounded `>=0.6.0,<0.7` dependency range:
+
+```bash
+uv pip install -e '.[nemo-relay]'
+```
+
+The published package is built from the
+[NVIDIA NeMo Relay repository](https://github.com/NVIDIA/NeMo-Relay).
 Unsupported platforms use the explicit no-op runtime described above rather
 than downloading a different implementation.
 

--- a/docs/observability/relay-shared-metrics.md
+++ b/docs/observability/relay-shared-metrics.md
@@ -1,12 +1,16 @@
 # NeMo Relay Shared Metrics
 
-Hermes installs NeMo Relay through the `hermes-agent[nemo-relay]` extra on
-platforms for which Relay publishes a native wheel. The shared-metrics
-integration is built into Hermes and does not require `hermes plugins enable
-observability/nemo_relay`. Hermes remains importable without Relay on other
-native targets. Those targets use an explicit reduced-capability no-op host:
-Hermes execution remains available, while Relay scopes, middleware, plugins,
-and subscribers are unavailable.
+NeMo Relay is available when Hermes is installed with the
+`hermes-agent[nemo-relay]` extra, on platforms for which Relay publishes a
+native wheel. It is not part of a plain base install: the extra must be
+requested explicitly. Once it is present, the shared-metrics integration is
+built into Hermes and does not require `hermes plugins enable
+observability/nemo_relay`.
+
+Hermes remains importable and fully usable without Relay — both on a base
+install and on native targets where no wheel exists. Those cases use an
+explicit reduced-capability no-op host: Hermes execution remains available,
+while Relay scopes, middleware, plugins, and subscribers are unavailable.
 
 Relay is an extra rather than a base dependency because PEP 508 markers cannot
 distinguish musl from glibc. A base-dependency marker of `sys_platform ==

--- a/plugins/observability/nemo_relay/README.md
+++ b/plugins/observability/nemo_relay/README.md
@@ -81,17 +81,18 @@ uv run hermes chat --query 'Reply exactly ok' --provider custom --model qwen3.6:
 
 To ship the updated CLI into another environment, build and install a fresh
 wheel from this checkout. On platforms for which Relay publishes a native
-wheel, Hermes installs its supported NeMo Relay runtime as a normal dependency:
+wheel, add the `nemo-relay` extra to pull in the supported runtime:
 
 ```bash
 uv build --wheel
 python -m pip install --force-reinstall dist/hermes_agent-*.whl
+python -m pip install 'hermes-agent[nemo-relay]'
 hermes plugins enable observability/nemo_relay
 ```
 
-The plugin remains opt-in even though the runtime dependency is installed by
-default. Enabling this plugin controls rich observability and adaptive
-behavior; it does not control Hermes shared client metrics.
+The plugin remains opt-in in addition to the runtime dependency. Enabling this
+plugin controls rich observability and adaptive behavior; it does not control
+Hermes shared client metrics.
 
 ## Export Configuration
 

--- a/plugins/observability/nemo_relay/README.md
+++ b/plugins/observability/nemo_relay/README.md
@@ -84,8 +84,9 @@ wheel from this checkout. On platforms for which Relay publishes a native
 wheel, add the `nemo-relay` extra to pull in the supported runtime:
 
 ```bash
-uv build --wheel
-WHEEL=$(ls dist/hermes_agent-*.whl)
+BUILD_DIR=$(mktemp -d)
+uv build --wheel --out-dir "$BUILD_DIR"
+WHEEL=$(echo "$BUILD_DIR"/hermes_agent-*.whl)
 python -m pip install --force-reinstall "${WHEEL}[nemo-relay]"
 hermes plugins enable observability/nemo_relay
 ```
@@ -93,6 +94,10 @@ hermes plugins enable observability/nemo_relay
 Requesting the extra against the built artifact keeps Hermes itself resolving
 from this checkout. `pip install 'hermes-agent[nemo-relay]'` would instead pull
 Hermes from PyPI and overwrite the wheel you just built.
+
+Building into a fresh directory keeps the glob unambiguous. Globbing a shared
+`dist/` can match several wheels from earlier builds, and `${WHEEL}` would then
+expand to multiple paths and install the wrong artifact — or nothing.
 
 The plugin remains opt-in in addition to the runtime dependency. Enabling this
 plugin controls rich observability and adaptive behavior; it does not control

--- a/plugins/observability/nemo_relay/README.md
+++ b/plugins/observability/nemo_relay/README.md
@@ -85,10 +85,14 @@ wheel, add the `nemo-relay` extra to pull in the supported runtime:
 
 ```bash
 uv build --wheel
-python -m pip install --force-reinstall dist/hermes_agent-*.whl
-python -m pip install 'hermes-agent[nemo-relay]'
+WHEEL=$(ls dist/hermes_agent-*.whl)
+python -m pip install --force-reinstall "${WHEEL}[nemo-relay]"
 hermes plugins enable observability/nemo_relay
 ```
+
+Requesting the extra against the built artifact keeps Hermes itself resolving
+from this checkout. `pip install 'hermes-agent[nemo-relay]'` would instead pull
+Hermes from PyPI and overwrite the wheel you just built.
 
 The plugin remains opt-in in addition to the runtime dependency. Enabling this
 plugin controls rich observability and adaptive behavior; it does not control

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,11 +137,6 @@ dependencies = [
   # Hence the ``sys_platform == 'win32'`` marker: the dep (and its portalocker
   # / pywin32 tree) ships only where it's actually used.
   "concurrent-log-handler==0.9.29; sys_platform == 'win32'",
-  # First-party lifecycle and shared-metrics runtime. Relay 0.6 is the minimum
-  # lossless provider-codec contract. Managed calls pass request/response data
-  # through this native module in-process; shared metrics installs no network
-  # exporter and consumes only its bounded projection.
-  "nemo-relay>=0.6.0,<0.7; (sys_platform == 'darwin' and platform_machine == 'arm64') or (sys_platform == 'linux' and platform_machine == 'x86_64') or (sys_platform == 'linux' and platform_machine == 'aarch64') or (sys_platform == 'win32' and platform_machine == 'AMD64') or (sys_platform == 'win32' and platform_machine == 'ARM64')",
 ]
 
 [project.optional-dependencies]
@@ -228,9 +223,22 @@ pty = []
 # extra that exposes a Starlette-backed server surface so pip/uv can't resolve
 # a vulnerable pre-1.0.1 transitive. Bump in lockstep with uv.lock.
 mcp = ["mcp==1.26.0", "starlette==1.3.1"]  # starlette: CVE-2026-48710
-# Backwards-compatible no-op alias. Relay is a core dependency on supported
-# wheel targets and intentionally unavailable on other platforms.
-nemo-relay = []
+# First-party lifecycle and shared-metrics runtime. Relay 0.6 is the minimum
+# lossless provider-codec contract. Managed calls pass request/response data
+# through this native module in-process; shared metrics installs no network
+# exporter and consumes only its bounded projection.
+#
+# Declared as an extra rather than a base dependency because PEP 508 markers
+# cannot distinguish musl from glibc. A base-dependency marker of
+# ``sys_platform == 'linux' and platform_machine == 'x86_64'`` also matches
+# ``musllinux_1_2_x86_64``, where no nemo-relay wheel or sdist is published, so
+# the resolver fails outright instead of treating the platform as unsupported.
+# The runtime already degrades cleanly on such targets via NoopRelayRuntime
+# ("Explicit reduced-capability host for platforms without Relay wheels"), and
+# the Relay tests already ``pytest.importorskip("nemo_relay")``. Keeping Relay
+# opt-in preserves the intended "core on supported wheel targets, unavailable
+# elsewhere" behaviour without making Hermes uninstallable on musl.
+nemo-relay = ["nemo-relay>=0.6.0,<0.7"]
 homeassistant = ["aiohttp==3.14.1"]
 sms = ["aiohttp==3.14.1"]
 teams = ["microsoft-teams-apps==2.0.13.4", "aiohttp==3.14.1"]  # aiohttp 3.14.1: CVE-2026-34993(RCE)/47265 + 34513/34518/34519/34520/34525

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -25,6 +25,23 @@ def _distribution_name(requirement: str) -> str:
     return spec.strip().lower()
 
 
+def _requested_extras(requirement: str) -> set[str]:
+    """Extract the extras a PEP 508 requirement asks for (``name[a,b]`` -> {a, b}).
+
+    ``_distribution_name`` deliberately *drops* extras, so it cannot answer
+    "does this aggregate extra pull in extra X?" -- ``hermes-agent[nemo-relay]``
+    reduces to ``hermes-agent`` there. This complements it for assertions about
+    self-referential extras like ``[all]``, without the false positives of a
+    plain substring match.
+    """
+    spec = requirement.split(";", 1)[0]  # drop environment markers
+    spec = spec.split("@", 1)[0]  # drop direct-reference URLs
+    if "[" not in spec:
+        return set()
+    inner = spec.split("[", 1)[1].split("]", 1)[0]
+    return {part.strip().lower() for part in inner.split(",") if part.strip()}
+
+
 def test_packaging_declared_as_core_dependency():
     """Regression for #40503.
 
@@ -79,13 +96,16 @@ def test_nemo_relay_is_not_a_base_dependency():
     )
 
     relay_extra = data["project"]["optional-dependencies"]["nemo-relay"]
-    assert any(dep.startswith("nemo-relay") for dep in relay_extra)
+    assert "nemo-relay" in {_distribution_name(dep) for dep in relay_extra}
 
     # scripts/install.sh installs '.[all]' on non-Termux platforms, so pulling
     # Relay in through [all] would reintroduce the Alpine install failure even
-    # with the base dependency removed.
+    # with the base dependency removed. [all] entries are self-referential
+    # (``hermes-agent[cron]``), so this checks requested *extras* --
+    # _distribution_name strips them and would always yield "hermes-agent".
     all_extra = data["project"]["optional-dependencies"]["all"]
-    assert not any("nemo-relay" in dep for dep in all_extra), (
+    pulled_extras = {extra for dep in all_extra for extra in _requested_extras(dep)}
+    assert "nemo-relay" not in pulled_extras, (
         "[all] must not pull nemo-relay: scripts/install.sh installs '.[all]' "
         "on non-Termux platforms, which would break musl installs again"
     )

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -56,6 +56,41 @@ def test_faster_whisper_is_not_a_base_dependency():
     assert any(dep.startswith("faster-whisper") for dep in voice_extra)
 
 
+def test_nemo_relay_is_not_a_base_dependency():
+    """Regression for #74592.
+
+    PEP 508 has no libc marker, so a base-dependency marker of
+    ``sys_platform == 'linux' and platform_machine == 'x86_64'`` also matches
+    ``musllinux_1_2_x86_64``. nemo-relay publishes no musllinux wheel and no
+    sdist for any release, so declaring it in ``[project.dependencies]`` makes
+    Hermes itself unresolvable on Alpine instead of degrading. The runtime
+    already handles absence via ``NoopRelayRuntime`` ("Explicit
+    reduced-capability host for platforms without Relay wheels") and the Relay
+    tests ``importorskip`` it, so Relay must stay opt-in.
+    """
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    deps = data["project"]["dependencies"]
+    names = {_distribution_name(dep) for dep in deps}
+
+    assert "nemo-relay" not in names, (
+        "nemo-relay must not be a base dependency: it publishes no musllinux "
+        "wheel or sdist, and PEP 508 markers cannot exclude musl, so a base "
+        "dependency makes Hermes uninstallable on Alpine — see #74592"
+    )
+
+    relay_extra = data["project"]["optional-dependencies"]["nemo-relay"]
+    assert any(dep.startswith("nemo-relay") for dep in relay_extra)
+
+    # scripts/install.sh installs '.[all]' on non-Termux platforms, so pulling
+    # Relay in through [all] would reintroduce the Alpine install failure even
+    # with the base dependency removed.
+    all_extra = data["project"]["optional-dependencies"]["all"]
+    assert not any("nemo-relay" in dep for dep in all_extra), (
+        "[all] must not pull nemo-relay: scripts/install.sh installs '.[all]' "
+        "on non-Termux platforms, which would break musl installs again"
+    )
+
+
 # Minimum non-vulnerable Starlette: CVE-2026-48710 ("BadHost") was fixed in
 # 1.0.1. Anything below that lets a malformed Host header desync
 # ``request.url.path`` from the dispatched ASGI path, bypassing path-based

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -100,14 +100,21 @@ def test_nemo_relay_is_not_a_base_dependency():
 
     # scripts/install.sh installs '.[all]' on non-Termux platforms, so pulling
     # Relay in through [all] would reintroduce the Alpine install failure even
-    # with the base dependency removed. [all] entries are self-referential
-    # (``hermes-agent[cron]``), so this checks requested *extras* --
-    # _distribution_name strips them and would always yield "hermes-agent".
+    # with the base dependency removed. Relay can reach [all] by two routes and
+    # neither matcher alone covers both:
+    #   - a self-referential extra (``hermes-agent[nemo-relay]``), which
+    #     _distribution_name reduces to "hermes-agent";
+    #   - a direct distribution entry (``nemo-relay>=...``), for which
+    #     _requested_extras returns no extras at all.
+    # Union both so either form fails the guard.
     all_extra = data["project"]["optional-dependencies"]["all"]
-    pulled_extras = {extra for dep in all_extra for extra in _requested_extras(dep)}
-    assert "nemo-relay" not in pulled_extras, (
-        "[all] must not pull nemo-relay: scripts/install.sh installs '.[all]' "
-        "on non-Termux platforms, which would break musl installs again"
+    reachable = {extra for dep in all_extra for extra in _requested_extras(dep)} | {
+        _distribution_name(dep) for dep in all_extra
+    }
+    assert "nemo-relay" not in reachable, (
+        "[all] must not pull nemo-relay, whether as an extra or as a direct "
+        "entry: scripts/install.sh installs '.[all]' on non-Termux platforms, "
+        "which would break musl installs again"
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1559,7 +1559,6 @@ dependencies = [
     { name = "httpx", extra = ["socks"] },
     { name = "jinja2" },
     { name = "markdown" },
-    { name = "nemo-relay", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'ARM64' and sys_platform == 'win32')" },
     { name = "openai" },
     { name = "packaging" },
     { name = "pathspec" },
@@ -1694,6 +1693,9 @@ mistral = [
 ]
 modal = [
     { name = "modal" },
+]
+nemo-relay = [
+    { name = "nemo-relay" },
 ]
 otlp = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
@@ -1852,7 +1854,7 @@ requires-dist = [
     { name = "microsoft-teams-apps", marker = "extra == 'teams'", specifier = "==2.0.13.4" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = "==2.4.8" },
     { name = "modal", marker = "extra == 'modal'", specifier = "==1.3.4" },
-    { name = "nemo-relay", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'ARM64' and sys_platform == 'win32')", specifier = ">=0.6.0,<0.7" },
+    { name = "nemo-relay", marker = "extra == 'nemo-relay'", specifier = ">=0.6.0,<0.7" },
     { name = "numpy", marker = "extra == 'voice'", specifier = "==2.4.3" },
     { name = "numpy", marker = "extra == 'wake'", specifier = "==2.4.3" },
     { name = "onnxruntime", marker = "extra == 'wake'", specifier = "==1.27.0" },


### PR DESCRIPTION
## What does this PR do?

Moves `nemo-relay` out of `[project.dependencies]` and back into the `nemo-relay` extra, so Hermes is installable on musl-based Linux again.

#67607 promoted `nemo-relay` to a base dependency. `nemo-relay` publishes no `musllinux` wheel and no sdist for any of its 10 releases, and PEP 508 has no libc marker — so the marker `sys_platform == 'linux' and platform_machine == 'x86_64'` also matches `musllinux_1_2_x86_64`. The resolver therefore treats Alpine as a *supported* target and fails outright instead of degrading.

That contradicts the design already in the tree. The intent is stated in `pyproject.toml` itself ("Relay is a core dependency on supported wheel targets and intentionally unavailable on other platforms"), and three separate mechanisms already implement it:

- `NoopRelayRuntime` — *"Explicit reduced-capability host for platforms without Relay wheels"*, with `available = False`
- `HOST_REGISTRY.for_profile()` catches host-creation failure and substitutes that Noop host; `get_runtime()` filters it to `None`
- `tests/agent/test_relay_llm.py` and `test_relay_tools.py` open with `pytest.importorskip("nemo_relay")`

Absence is therefore a first-class, tested state; it simply cannot be reached on musl because installation fails first. Making Relay opt-in again restores the documented behaviour without touching any runtime code.

This also restores the project's own degradation floor: `scripts/install.sh`'s Termux chain falls back `.[termux-all]` → `.[termux]` → **base install**, which only works while a plain base install resolves everywhere. `[all]` deliberately does **not** reference Relay, matching the 2026-05-12 `[all]` policy (the same reasoning applied to `matrix`/`python-olm` on Windows and macOS) and keeping `.[all]` — what `install.sh` uses on non-Termux platforms — resolvable on musl.

## Related Issue

Fixes #74592

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `pyproject.toml` — removed `nemo-relay` from `[project.dependencies]`; populated the previously no-op extra as `nemo-relay = ["nemo-relay>=0.6.0,<0.7"]`. The `>=0.6.0,<0.7` range is carried over unchanged so this PR stays a single logical change; the comment now records why it must not be a base dependency.
- `uv.lock` — regenerated with `uv lock --python 3.11` using **uv 0.9.28**, the version pinned in `tests.yml` and `uv-lockfile-check.yml`. Net change is 4 insertions / 2 deletions. (Regenerating with a newer uv additionally normalises unrelated `python_full_version` markers on `scipy` and `vercel-workers`; I used your pinned version specifically to keep that churn out of the diff.)
- `tests/test_packaging_metadata.py` — added `test_nemo_relay_is_not_a_base_dependency`, mirroring the existing `test_faster_whisper_is_not_a_base_dependency`. It asserts Relay is absent from base deps, present in its extra, and **not** reachable through `[all]` (that last assertion is what keeps `install.sh`'s `.[all]` path working on musl). Also adds a small `_requested_extras()` helper. The `[all]` check unions two matchers because neither covers both routes alone: `_distribution_name()` strips extras, reducing `hermes-agent[nemo-relay]` to `hermes-agent`, while `_requested_extras()` returns nothing for a bracket-free `nemo-relay>=...`. Either form now fails the guard.
- `docs/observability/relay-shared-metrics.md` — describes the extra as the install route rather than a no-op alias, states that it must be requested explicitly and that a base install remains fully usable without Relay, documents the musl/PEP 508 constraint, and adds the `uv pip install -e '.[nemo-relay]'` command.
- `plugins/observability/nemo_relay/README.md` — install snippet now requests the extra against the locally built wheel artifact (`"${WHEEL}[nemo-relay]"`) rather than `pip install 'hermes-agent[nemo-relay]'`, which would resolve Hermes from PyPI and overwrite the checkout-built wheel.

No runtime or `agent/` code is touched.

## How to Test

Reproduce the bug (on any musl/Alpine x86_64 host, before this change):

```sh
git checkout 2d4049424
uv pip install -e .
# error: Distribution `nemo-relay==0.6.0` can't be installed because it doesn't
#        have a source distribution or wheel for the current platform
```

Verify the fix:

```sh
uv lock --check --python 3.11                              # lockfile gate
uv sync --locked --python 3.11 --extra dev                 # base install
uv sync --locked --python 3.11 --extra all --extra dev     # .[all], as install.sh uses
python -m pytest -q tests/test_packaging_metadata.py
```

Confirm the runtime degrades rather than crashing, with `nemo_relay` not installed:

```sh
python -c "
import agent.relay_runtime as rr
print(rr.get_runtime(create=True))   # -> None; warning logged, NoopRelayRuntime substituted
"
```

The regression test was verified to actually guard, on every branch:

- with `nemo-relay` restored as a base dependency — fails
- with `hermes-agent[nemo-relay]` injected into `[all]` — fails
- with `nemo-relay>=0.6.0,<0.7` injected directly into `[all]` — fails
- with none of the above — passes

I also re-ran `uv lock --check` against a locally simulated merge with current `main` (`ba7d214b6`, 24 commits past this branch's base). It merges cleanly and the check passes, so the committed lockfile is still current — upstream's only `pyproject.toml` change in that range adds two `[tool.pytest.ini_options]` markers and doesn't affect resolution.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **partially; see note below**
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Alpine Linux 3.23.5, `musllinux_1_2_x86_64`, Python 3.11.15

**Note on the full suite:** I ran a targeted set rather than `pytest tests/ -q` — every test file referencing `nemo_relay`, plus `test_packaging_metadata.py`, `test_project_metadata.py` and `test_termux_all_extra_compat.py`: **52 passed, 6 skipped** (the skips are the `importorskip` ones, expected with Relay absent). `tests/e2e/` cannot collect in this environment because its `conftest.py` imports `aiohttp`, which is not in `[dev]`. `ruff check .` passes with exit 0. Full-suite coverage on glibc is left to CI; additional selections can be run locally on request.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] N/A — no config keys added or changed (`cli-config.yaml.example` untouched)
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A

Cross-platform notes: on every target where Relay publishes a wheel, behaviour is unchanged when installing with the extra, and identical to the pre-#67607 state otherwise. `termux-all` does not reference `[all]` or Relay, so Termux is unaffected. Windows and macOS arm64 wheels are unaffected by the move.

## One open question for maintainers

Should Relay remain installed by default on supported platforms, the alternative is adding `hermes-agent[nemo-relay]` to `[all]`. That was intentionally not done here: `install.sh` runs `.[all]` on non-Termux platforms, so it would reintroduce the Alpine failure, and unlike Termux there is currently no musl branch in `install.sh` to fall back on. Routing Relay through `LAZY_DEPS` may be the more idiomatic long-term home per the 2026-05-12 `[all]` policy, but that touches runtime paths and is out of scope for this change. Either direction can be accommodated.

Separately, the durable upstream fix is `musllinux_1_2_x86_64` wheels — and ideally an sdist — from [NVIDIA/NeMo-Relay](https://github.com/NVIDIA/NeMo-Relay), a build-matrix addition on their side. That will be filed upstream and cross-linked.
