### PR TITLE
fix: return nemo-relay to optional extra for musl/Alpine compatibility

### DIFF
--- a/docs/observability/relay-shared-metrics.md
+++ b/docs/observability/relay-shared-metrics.md
@@ -1,25 +1,28 @@
 # NeMo Relay Shared Metrics
 
-Hermes includes NeMo Relay as a normal runtime dependency on platforms for
-which Relay publishes a native wheel. The shared-metrics integration is built
-into Hermes and does not require `hermes plugins enable
-observability/nemo_relay`. Hermes remains importable without Relay on other
-native targets. Those targets use an explicit reduced-capability no-op host:
-Hermes execution remains available, while Relay scopes, middleware, plugins,
-and subscribers are unavailable. The `hermes-agent[nemo-relay]` extra remains
-as a no-op compatibility alias for existing installation commands.
+Hermes offers NeMo Relay as an optional extra on platforms for which Relay
+publishes a native wheel. The shared-metrics integration is built into Hermes
+and does not require `hermes plugins enable observability/nemo_relay`. Hermes
+remains importable without Relay — on unsupported platforms (including
+musl-based Linux such as Alpine) the runtime degrades gracefully to an
+explicit reduced-capability no-op host: Hermes execution remains available,
+while Relay scopes, middleware, plugins, and subscribers are unavailable.
+Install with `pip install hermes-agent[nemo-relay]` (or `uv pip install
+hermes-agent[nemo-relay]`) on platforms where Relay wheels are available.
 
 Hermes requires NeMo Relay 0.6.0 or later within the 0.6 release line. That
 release establishes the lossless provider-codec contract used for Anthropic
 Messages, OpenAI Chat Completions, and OpenAI Responses requests.
 
-## Runtime Dependency and Data Boundary
+## Optional Runtime Dependency and Data Boundary
 
 Hermes installs the platform-specific `nemo-relay` native wheel from the
-bounded `>=0.6.0,<0.7` dependency range. The published package is built from
-the [NVIDIA NeMo Relay repository](https://github.com/NVIDIA/NeMo-Relay).
-Unsupported platforms use the explicit no-op runtime described above rather
-than downloading a different implementation.
+bounded `>=0.6.0,<0.8` optional dependency range when the
+`hermes-agent[nemo-relay]` extra is selected. The published package is built
+from the [NVIDIA NeMo Relay repository](https://github.com/NVIDIA/NeMo-Relay).
+Platforms without available wheels (including musl-based Linux) skip the
+install and use the explicit no-op runtime described above rather than
+downloading a different implementation.
 
 When Relay managed execution is active, the provider request and response pass
 through that native module in the Hermes process so configured interceptors can

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,11 +137,6 @@ dependencies = [
   # Hence the ``sys_platform == 'win32'`` marker: the dep (and its portalocker
   # / pywin32 tree) ships only where it's actually used.
   "concurrent-log-handler==0.9.29; sys_platform == 'win32'",
-  # First-party lifecycle and shared-metrics runtime. Relay 0.6 is the minimum
-  # lossless provider-codec contract. Managed calls pass request/response data
-  # through this native module in-process; shared metrics installs no network
-  # exporter and consumes only its bounded projection.
-  "nemo-relay>=0.6.0,<0.7; (sys_platform == 'darwin' and platform_machine == 'arm64') or (sys_platform == 'linux' and platform_machine == 'x86_64') or (sys_platform == 'linux' and platform_machine == 'aarch64') or (sys_platform == 'win32' and platform_machine == 'AMD64') or (sys_platform == 'win32' and platform_machine == 'ARM64')",
 ]
 
 [project.optional-dependencies]
@@ -228,9 +223,12 @@ pty = []
 # extra that exposes a Starlette-backed server surface so pip/uv can't resolve
 # a vulnerable pre-1.0.1 transitive. Bump in lockstep with uv.lock.
 mcp = ["mcp==1.26.0", "starlette==1.3.1"]  # starlette: CVE-2026-48710
-# Backwards-compatible no-op alias. Relay is a core dependency on supported
-# wheel targets and intentionally unavailable on other platforms.
-nemo-relay = []
+# First-party lifecycle and shared-metrics runtime. Relay 0.6 is the minimum
+# lossless provider-codec contract. Optional: nemo-relay does not publish
+# musllinux wheels or sdists, so hosts on musl-based Linux (Alpine) install
+# without it and the runtime degrades gracefully to NoopRelayRuntime.
+# <0.8 per CONTRIBUTING pre-1.0 rule (<0.(current_minor + 2) at 0.6.x).
+nemo-relay = ["nemo-relay>=0.6.0,<0.8"]
 homeassistant = ["aiohttp==3.14.1"]
 sms = ["aiohttp==3.14.1"]
 teams = ["microsoft-teams-apps==2.0.13.4", "aiohttp==3.14.1"]  # aiohttp 3.14.1: CVE-2026-34993(RCE)/47265 + 34513/34518/34519/34520/34525


### PR DESCRIPTION
## Summary

PR #67607 moved `nemo-relay` from `[project.optional-dependencies]` into the base `dependencies` list. However, `nemo-relay` has **never published a musllinux wheel or sdist**, making it impossible to install or update Hermes on musl-based Linux (Alpine) since that merge.

This PR returns `nemo-relay` to `[project.optional-dependencies]` with the actual dependency specifier, restoring musl/Alpine install compatibility.

Fixes #74592

## Why this is safe

The runtime already handles the missing module gracefully:

- `NoopRelayRuntime` (agent/relay_runtime.py:368) provides a reduced-capability fallback
- `HOST_REGISTRY.for_profile()` wraps host creation in `try/except`, falling back to `NoopRelayRuntime` on import failure
- `get_runtime()` returns `None` for Noop hosts — all consumers no-op
- `emit_mark()` is documented as fail-open
- Tests use `pytest.importorskip('nemo_relay')` — they skip when the module is absent
- The plugin README still describes itself as an "optional Hermes plugin for NeMo Relay observability"

## Changes

### pyproject.toml
- Removed `nemo-relay>=0.6.0,<0.7` from base `dependencies` (with platform markers)
- Changed `nemo-relay = []` (empty no-op alias) to `nemo-relay = ["nemo-relay>=0.6.0,<0.8"]` in `[project.optional-dependencies]`
- Version bound widened to `<0.8` per CONTRIBUTING pre-1.0 rule (`<0.(current_minor + 2)` at 0.6.x)

### docs/observability/relay-shared-metrics.md
- Updated intro to describe Relay as an optional extra
- Updated "Runtime Dependency" section to "Optional Runtime Dependency"
- Noted musl/Alpine as a platform that uses the no-op fallback

## Test Plan

- [ ] `pip install -e .` succeeds on musl/Alpine without `nemo-relay` installed
- [ ] `pip install -e '.[nemo-relay]'` installs `nemo-relay` on platforms with wheels
- [ ] Runtime degrades to `NoopRelayRuntime` when `nemo-relay` is absent
- [ ] Existing relay tests still pass (they skip via `importorskip` when module absent)