### PR TITLE
fix(gateway): stop session background delegations

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3341,7 +3341,7 @@ class BasePlatformAdapter(ABC):
         self,
         validator: Optional[Callable[[MessageEvent, str], bool]],
     ) -> None:
-        """Install the runner-owned durable completion admission validator."""
+        """Install the runner-owned synthetic completion admission validator."""
         self._completion_admission_validator = validator
 
     def _completion_admission_allowed(
@@ -3351,10 +3351,10 @@ class BasePlatformAdapter(ABC):
     ) -> bool:
         """Validate a tokenized completion at its real admission boundary.
 
-        Normal user messages and non-durable synthetic events carry no token
-        and remain unaffected. Tokenized events fail closed when the runner
-        validator is absent or raises, so a completion that never entered a
-        queue or task is not acknowledged as successfully admitted.
+        Normal user messages and untokenized synthetic events remain
+        unaffected. Tokenized events fail closed when the runner validator is
+        absent or raises, so a completion that never entered a queue or task is
+        not acknowledged as successfully admitted.
         """
         metadata = getattr(event, "metadata", None)
         if not isinstance(metadata, dict) or _COMPLETION_ADMISSION_TOKEN_KEY not in metadata:
@@ -3367,14 +3367,15 @@ class BasePlatformAdapter(ABC):
                 allowed = bool(validator(event, session_key))
             except Exception:
                 logger.warning(
-                    "[%s] Durable completion admission validation failed for %s",
+                    "[%s] Completion admission validation failed for %s",
                     self.name,
                     session_key,
                     exc_info=True,
                 )
         else:
             logger.warning(
-                "[%s] Rejecting durable completion for %s: no admission validator",
+                "[%s] Rejecting synthetic completion for %s: "
+                "no admission validator",
                 self.name,
                 session_key,
             )
@@ -3382,7 +3383,7 @@ class BasePlatformAdapter(ABC):
         if not allowed:
             metadata[_COMPLETION_ADMISSION_REJECTED_KEY] = True
             logger.info(
-                "[%s] Dropping stale durable completion admission for %s",
+                "[%s] Dropping stale synthetic completion admission for %s",
                 self.name,
                 session_key,
             )
@@ -5626,10 +5627,10 @@ class BasePlatformAdapter(ABC):
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
         )
 
-        # Durable completion claims are revalidated by GatewayRunner before
-        # this call, but topic recovery above is an await boundary.  Recheck
-        # the captured cancellation epoch here, after that boundary and before
-        # this event can enter any adapter queue or task.
+        # Synthetic completions are prepared by GatewayRunner before this call,
+        # but topic recovery above is an await boundary. Recheck the captured
+        # cancellation epoch here, after that boundary and before this event can
+        # enter any adapter queue or task.
         if not self._completion_admission_allowed(event, session_key):
             return
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -45,6 +45,8 @@ _AUDIO_EXTS = frozenset(_AUDIO_MIME_TYPES)
 _TELEGRAM_AUDIO_ATTACHMENT_EXTS = frozenset({'.mp3', '.m4a'})
 _TELEGRAM_VOICE_EXTS = frozenset({'.ogg', '.opus'})
 _POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS = 30.0
+_COMPLETION_ADMISSION_TOKEN_KEY = "_hermes_completion_admission"
+_COMPLETION_ADMISSION_REJECTED_KEY = "_hermes_completion_admission_rejected"
 
 
 def _platform_name(platform) -> str:
@@ -2807,6 +2809,14 @@ class BasePlatformAdapter(ABC):
         self._post_delivery_callbacks: Dict[str, Any] = {}
         self._expected_cancelled_tasks: set[asyncio.Task] = set()
         self._busy_session_handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]] = None
+        # GatewayRunner installs a validator for durable async-completion
+        # events.  The event carries the cancellation epoch captured before
+        # its final durable-claim revalidation; the adapter checks it at the
+        # actual queue/task admission boundary so /stop cannot slip through
+        # an earlier TOCTOU read.
+        self._completion_admission_validator: Optional[
+            Callable[[MessageEvent, str], bool]
+        ] = None
         # Optional authorization check, registered by GatewayRunner. Used by
         # adapters that fetch external context (e.g. Slack thread history) to
         # mark senders not on the allowlist as unverified in LLM context,
@@ -3326,6 +3336,57 @@ class BasePlatformAdapter(ABC):
     def set_busy_session_handler(self, handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]]) -> None:
         """Set an optional handler for messages arriving during active sessions."""
         self._busy_session_handler = handler
+
+    def set_completion_admission_validator(
+        self,
+        validator: Optional[Callable[[MessageEvent, str], bool]],
+    ) -> None:
+        """Install the runner-owned durable completion admission validator."""
+        self._completion_admission_validator = validator
+
+    def _completion_admission_allowed(
+        self,
+        event: MessageEvent,
+        session_key: str,
+    ) -> bool:
+        """Validate a tokenized completion at its real admission boundary.
+
+        Normal user messages and non-durable synthetic events carry no token
+        and remain unaffected. Tokenized events fail closed when the runner
+        validator is absent or raises, so a completion that never entered a
+        queue or task is not acknowledged as successfully admitted.
+        """
+        metadata = getattr(event, "metadata", None)
+        if not isinstance(metadata, dict) or _COMPLETION_ADMISSION_TOKEN_KEY not in metadata:
+            return True
+
+        validator = getattr(self, "_completion_admission_validator", None)
+        allowed = False
+        if callable(validator):
+            try:
+                allowed = bool(validator(event, session_key))
+            except Exception:
+                logger.warning(
+                    "[%s] Durable completion admission validation failed for %s",
+                    self.name,
+                    session_key,
+                    exc_info=True,
+                )
+        else:
+            logger.warning(
+                "[%s] Rejecting durable completion for %s: no admission validator",
+                self.name,
+                session_key,
+            )
+
+        if not allowed:
+            metadata[_COMPLETION_ADMISSION_REJECTED_KEY] = True
+            logger.info(
+                "[%s] Dropping stale durable completion admission for %s",
+                self.name,
+                session_key,
+            )
+        return allowed
 
     def set_reaction_handler(
         self, handler: Optional[Callable[[Dict[str, Any]], Awaitable[None]]]
@@ -5368,6 +5429,9 @@ class BasePlatformAdapter(ABC):
         False is returned so the caller isn't left holding a half-installed
         session lock.
         """
+        if not self._completion_admission_allowed(event, session_key):
+            return False
+
         guard = interrupt_event or asyncio.Event()
         self._active_sessions[session_key] = guard
 
@@ -5562,6 +5626,13 @@ class BasePlatformAdapter(ABC):
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
         )
 
+        # Durable completion claims are revalidated by GatewayRunner before
+        # this call, but topic recovery above is an await boundary.  Recheck
+        # the captured cancellation epoch here, after that boundary and before
+        # this event can enter any adapter queue or task.
+        if not self._completion_admission_allowed(event, session_key):
+            return
+
         # On-entry self-heal: if the adapter still has an _active_sessions
         # entry for this key but the owner task has already exited (done or
         # cancelled), the lock is stale.  Clear it and fall through to
@@ -5646,7 +5717,7 @@ class BasePlatformAdapter(ABC):
             # Same shape as the /approve deadlock fix (PR #4926) — both
             # cases are "agent thread blocked on Event.wait, message must
             # reach the resolver before being treated as a new turn."
-            if not cmd:
+            if not cmd and not getattr(event, "internal", False):
                 try:
                     from tools import clarify_gateway as _clarify_mod
                     _has_text_clarify = (
@@ -5695,6 +5766,12 @@ class BasePlatformAdapter(ABC):
                         return
                 except Exception as e:
                     logger.error("[%s] Busy-session handler failed: %s", self.name, e, exc_info=True)
+
+            # The busy handler is awaitable. Recheck after it returns so a
+            # /stop that advanced the session epoch while it ran wins before
+            # this completion reaches any pending queue.
+            if not self._completion_admission_allowed(event, session_key):
+                return
 
             # Special case: photo bursts/albums frequently arrive as multiple near-
             # simultaneous messages. Queue them without interrupting the active run,
@@ -6299,6 +6376,11 @@ class BasePlatformAdapter(ABC):
                 if _active is not None:
                     _active.clear()
                 await _stop_typing_task()
+                if not self._completion_admission_allowed(
+                    pending_event,
+                    session_key,
+                ):
+                    return
                 # Spawn a fresh task for the pending message instead of
                 # recursing.  Issue #17758: `await
                 # self._process_message_background(...)` here grew the
@@ -6408,6 +6490,14 @@ class BasePlatformAdapter(ABC):
             # active-session entry and the queued message would be silently
             # dropped (user never gets a reply).
             late_pending = self._pending_messages.pop(session_key, None)
+            if (
+                late_pending is not None
+                and not self._completion_admission_allowed(
+                    late_pending,
+                    session_key,
+                )
+            ):
+                late_pending = None
             if late_pending is not None:
                 current_task = asyncio.current_task()
                 existing_task = self._session_tasks.get(session_key)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2263,6 +2263,8 @@ from gateway.platforms.base import (
     EphemeralReply,
     MessageEvent,
     MessageType,
+    _COMPLETION_ADMISSION_REJECTED_KEY,
+    _COMPLETION_ADMISSION_TOKEN_KEY,
     _prefix_within_utf16_limit,
     _reply_anchor_for_event,
     build_auto_tts_output_path,
@@ -8585,6 +8587,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return True  # handled (silently dropped); do not fall through
 
+        # --- Internal synthetic events must never interrupt/steer ---
+        # Keep this before every awaitable busy-path branch. Durable completion
+        # admission is linearized by the base adapter immediately after this
+        # synchronous return; letting an internal event enter draining,
+        # approval, or clarify I/O would reopen a post-validation race.
+        if getattr(event, "internal", False):
+            return False
+
         # --- Draining case (gateway restarting/stopping) ---
         if self._draining:
             adapter = self._adapter_for_source(event.source)
@@ -8692,20 +8702,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         adapter = self._adapter_for_source(event.source)
         if not adapter:
             return False  # let default path handle it
-
-        # --- Internal synthetic events must never interrupt/steer ---
-        # Async-delegation completions (delegate_task(background=true)) and
-        # background-process completions (terminal notify_on_complete) re-enter
-        # the originating session as internal MessageEvents. When the session
-        # is busy, treating them like a user TEXT message means interrupt-mode
-        # (the default busy_text_mode) aborts the active turn AND sends a "⚡
-        # Interrupting current task" ack — exactly the opposite of the design
-        # invariant that a completion surfaces as a NEW turn only when idle and
-        # never splices into a running turn. Fall through to the base adapter,
-        # which queues internal events silently (no interrupt, no ack) so they
-        # cascade after the current turn finishes.
-        if getattr(event, "internal", False):
-            return False
 
         _busy_state = self._peek_session_state(session_key)
         running_agent = _busy_state.turn.agent if _busy_state else None
@@ -10841,6 +10837,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+            adapter.set_completion_admission_validator(
+                self._validate_completion_admission
+            )
             _set_reaction = getattr(adapter, "set_reaction_handler", None)
             if callable(_set_reaction):
                 _set_reaction(self._handle_reaction_event)
@@ -12213,6 +12212,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+                    adapter.set_completion_admission_validator(
+                        self._validate_completion_admission
+                    )
                     _set_reaction = getattr(adapter, "set_reaction_handler", None)
                     if callable(_set_reaction):
                         _set_reaction(self._handle_reaction_event)
@@ -13155,6 +13157,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         adapter.set_session_store(self.session_store)
         adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+        adapter.set_completion_admission_validator(
+            self._validate_completion_admission
+        )
         _set_reaction = getattr(adapter, "set_reaction_handler", None)
         if callable(_set_reaction):
             _set_reaction(self._handle_reaction_event)
@@ -21514,7 +21519,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
 
     async def _inject_watch_notification(
-        self, synth_text: str, evt: dict,
+        self,
+        synth_text: str,
+        evt: dict,
+        *,
+        completion_admission: Optional[Dict[str, Any]] = None,
     ) -> Optional[bool]:
         """Inject a watch/completion notification as a synthetic message event.
 
@@ -21606,6 +21615,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             parent_session_id = str(evt.get("parent_session_id") or "").strip()
             if parent_session_id:
                 metadata["gateway_session_id"] = parent_session_id
+            if completion_admission is not None:
+                metadata[_COMPLETION_ADMISSION_TOKEN_KEY] = completion_admission
             synth_event = MessageEvent(
                 text=synth_text,
                 message_type=MessageType.TEXT,
@@ -21621,6 +21632,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 source.thread_id,
             )
             await adapter.handle_message(synth_event)
+            if synth_event.metadata.get(_COMPLETION_ADMISSION_REJECTED_KEY):
+                return None
             return True
         except Exception as e:
             logger.error("Watch notification injection error: %s", e)
@@ -21784,8 +21797,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._completion_deliveries_inflight.add(identity)
 
         accepted = False
+        completion_admission = None
         try:
             if durable_claim_id:
+                # Capture immediately before the final durable-claim read.
+                # If /stop wins after that read but before the adapter's real
+                # queue/task boundary, its synchronous epoch bump makes this
+                # token stale and the adapter rejects the synthetic event.
+                completion_admission = self._capture_completion_admission(
+                    str(evt.get("session_key") or "").strip()
+                )
                 try:
                     from tools.async_delegation import (
                         is_completion_delivery_claim_active,
@@ -21803,7 +21824,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         exc,
                     )
                     return False
-            injection_result = await self._inject_watch_notification(synth_text, evt)
+            injection_result = await self._inject_watch_notification(
+                synth_text,
+                evt,
+                completion_admission=completion_admission,
+            )
             if injection_result is not True:
                 return injection_result
             accepted = True
@@ -22666,6 +22691,76 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         current = state.persistent.run_generation if state is not None else 0
         return int(current) == int(generation)
 
+    def _current_completion_admission_epoch(self, session_key: str) -> int:
+        """Return the cancellation epoch used by durable completion admission."""
+        if not session_key:
+            return 0
+        state = self._peek_session_state(session_key)
+        if state is None:
+            return 0
+        return int(state.persistent.completion_cancellation_epoch)
+
+    def _capture_completion_admission(
+        self,
+        session_key: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Capture a session epoch before the final durable-claim check."""
+        if not session_key:
+            return None
+        return {
+            "session_key": session_key,
+            "epoch": self._current_completion_admission_epoch(session_key),
+        }
+
+    def _invalidate_completion_admission_epoch(
+        self,
+        session_key: str,
+        *,
+        reason: str = "",
+    ) -> int:
+        """Invalidate synthetic completions not yet admitted for a session."""
+        if not session_key:
+            return 0
+        persistent = self._session_state(session_key).persistent
+        persistent.completion_cancellation_epoch = (
+            int(persistent.completion_cancellation_epoch) + 1
+        )
+        epoch = persistent.completion_cancellation_epoch
+        if reason:
+            logger.info(
+                "Invalidated completion admission epoch for %s → %d (%s)",
+                session_key,
+                epoch,
+                reason,
+            )
+        return epoch
+
+    def _validate_completion_admission(
+        self,
+        event: MessageEvent,
+        session_key: str,
+    ) -> bool:
+        """Validate an adapter-bound completion token against current state."""
+        metadata = getattr(event, "metadata", None)
+        token = (
+            metadata.get(_COMPLETION_ADMISSION_TOKEN_KEY)
+            if isinstance(metadata, dict)
+            else None
+        )
+        if not isinstance(token, dict):
+            return False
+        token_session_key = str(token.get("session_key") or "")
+        if not token_session_key or token_session_key != session_key:
+            return False
+        try:
+            expected_epoch = int(token["epoch"])
+        except (KeyError, TypeError, ValueError):
+            return False
+        return (
+            self._current_completion_admission_epoch(session_key)
+            == expected_epoch
+        )
+
     async def _cancel_session_background_work(
         self,
         session_key: str,
@@ -22682,6 +22777,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if not session_key:
             return 0
+
+        # Linearization point for /stop and /new versus synthetic completion
+        # admission. This is deliberately synchronous and happens before the
+        # durable cancellation write or any await below. A completion that
+        # already passed its claim read must still present the older epoch to
+        # the adapter and will be rejected at queue/task admission.
+        self._invalidate_completion_admission_epoch(
+            session_key,
+            reason=reason,
+        )
 
         cancelled = 0
         try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21785,6 +21785,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         accepted = False
         try:
+            if durable_claim_id:
+                try:
+                    from tools.async_delegation import (
+                        is_completion_delivery_claim_active,
+                    )
+
+                    if not is_completion_delivery_claim_active(
+                        durable_delegation_id,
+                        durable_claim_id,
+                    ):
+                        return None
+                except Exception as exc:
+                    logger.warning(
+                        "Could not revalidate durable async completion %s: %s",
+                        durable_delegation_id,
+                        exc,
+                    )
+                    return False
             injection_result = await self._inject_watch_notification(synth_text, evt)
             if injection_result is not True:
                 return injection_result
@@ -22648,6 +22666,56 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         current = state.persistent.run_generation if state is not None else 0
         return int(current) == int(generation)
 
+    async def _cancel_session_background_work(
+        self,
+        session_key: str,
+        *,
+        parent_session_id: str = "",
+        reason: str = "session_end",
+    ) -> int:
+        """Cancel detached delegations and stale restart recovery for a session.
+
+        ``delegate_task(background=true)`` is intentionally detached from the
+        foreground AIAgent, so ``running_agent.interrupt()`` cannot reach it.
+        Keep this as the single gateway cancellation funnel used by both the
+        active-run fast path and the idle /stop handler.
+        """
+        if not session_key:
+            return 0
+
+        cancelled = 0
+        try:
+            from tools.async_delegation import interrupt_for_session
+
+            cancelled = interrupt_for_session(
+                session_key=session_key,
+                parent_session_id=str(parent_session_id or ""),
+                reason=reason,
+            )
+        except Exception as exc:
+            # /stop must still release the foreground session even if the
+            # background registry or its durable DB is degraded.
+            logger.warning(
+                "Failed to cancel async delegations for %s (%s): %s",
+                session_key,
+                reason,
+                exc,
+            )
+
+        # An explicit /stop or /new is a terminal user decision, not a restart
+        # interruption. Leaving this marker set would synthesize an empty
+        # auto-resume event on the next gateway boot and restart work the user
+        # explicitly ended.
+        try:
+            await self.async_session_store.clear_resume_pending(session_key)
+        except Exception as exc:
+            logger.debug(
+                "Failed to clear resume_pending for stopped session %s: %s",
+                session_key,
+                exc,
+            )
+        return cancelled
+
     def _bind_adapter_run_generation(
         self,
         adapter: Any,
@@ -22672,14 +22740,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         interrupt_reason: str,
         invalidation_reason: str,
         release_running_state: bool = True,
-    ) -> None:
+    ) -> int:
         """Interrupt the current run and clear queued session state consistently."""
         if not session_key:
-            return
+            return 0
         _iac_state = self._peek_session_state(session_key)
         running_agent = _iac_state.turn.agent if _iac_state else None
         _process_task_id = ""
         _process_baseline = None
+        parent_session_id = (
+            str(getattr(running_agent, "session_id", "") or "")
+            if running_agent is not _AGENT_PENDING_SENTINEL
+            else ""
+        )
+        cancelled_background = await self._cancel_session_background_work(
+            session_key,
+            parent_session_id=parent_session_id,
+            reason=invalidation_reason,
+        )
         if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             request_hard_interrupt(running_agent, interrupt_reason)
             _process_task_id = getattr(
@@ -22747,6 +22825,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # object keeps its interrupt flag so a hung drain still dies
             # when it unblocks.
             self._evict_cached_agent(session_key)
+        return cancelled_background
 
     async def _refresh_agent_cache_message_count(
         self, session_key: str, session_id: Optional[str]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17526,7 +17526,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     synth_text = _format_gateway_process_notification(evt)
                     if synth_text:
                         try:
-                            await self._inject_watch_notification(synth_text, evt)
+                            await self._deliver_completion_notification(
+                                synth_text,
+                                evt,
+                            )
                         except Exception as e2:
                             logger.error("Watch notification injection error: %s", e2)
             except Exception as e:
@@ -21799,14 +21802,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         accepted = False
         completion_admission = None
         try:
-            if durable_claim_id:
-                # Capture immediately before the final durable-claim read.
-                # If /stop wins after that read but before the adapter's real
-                # queue/task boundary, its synchronous epoch bump makes this
-                # token stale and the adapter rejects the synthetic event.
-                completion_admission = self._capture_completion_admission(
-                    str(evt.get("session_key") or "").strip()
+            event_session_key = str(evt.get("session_key") or "").strip()
+            # Capture an admission epoch for every routed synthetic process
+            # event, not just durable async delegations. A /stop that wins after
+            # this point invalidates the token at the adapter's actual
+            # queue/task boundary.
+            completion_admission = self._capture_completion_admission(
+                event_session_key
+            )
+
+            if evt.get("type", "completion") in {
+                "completion",
+                "watch_match",
+                "watch_disabled",
+            }:
+                from tools.process_registry import process_registry
+
+                is_suppressed = getattr(
+                    process_registry,
+                    "is_completion_suppressed",
+                    None,
                 )
+                if callable(is_suppressed) and is_suppressed(
+                    str(evt.get("session_id") or "")
+                ):
+                    return None
+
+            if durable_claim_id:
+                # Revalidate after capturing the epoch and checking ordinary
+                # process suppression. If /stop wins after this final read but
+                # before the adapter's queue/task boundary, the older token is
+                # rejected there.
                 try:
                     from tools.async_delegation import (
                         is_completion_delivery_claim_active,
@@ -21970,15 +21996,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         message_id = str(watcher.get("message_id") or "").strip() or None
         agent_notify = watcher.get("notify_on_complete", False)
         notify_mode = self._load_background_notifications_mode()
+        is_completion_suppressed = getattr(
+            process_registry,
+            "is_completion_suppressed",
+            lambda _session_id: False,
+        )
 
         logger.debug("Process watcher started: %s (every %ss, notify=%s, agent_notify=%s)",
                       session_id, interval, notify_mode, agent_notify)
+
+        if is_completion_suppressed(session_id):
+            logger.debug("Process watcher suppressed by session stop: %s", session_id)
+            return
 
         if notify_mode == "off" and not agent_notify:
             # Still wait for the process to exit so we can log it, but don't
             # push any messages to the user.
             while True:
                 await asyncio.sleep(interval)
+                if is_completion_suppressed(session_id):
+                    break
                 session = process_registry.get(session_id)
                 if session is None or session.exited:
                     break
@@ -21988,6 +22025,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         last_output_len = 0
         while True:
             await asyncio.sleep(interval)
+
+            if is_completion_suppressed(session_id):
+                logger.debug(
+                    "Process watcher suppressed by session stop: %s",
+                    session_id,
+                )
+                break
 
             session = process_registry.get(session_id)
             if session is None:
@@ -22093,6 +22137,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             break
                     if adapter and chat_id:
                         try:
+                            if is_completion_suppressed(session_id):
+                                break
                             send_meta = {"thread_id": thread_id} if thread_id else None
                             await adapter.send(
                                 chat_id,
@@ -22123,6 +22169,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         break
                 if adapter and chat_id:
                     try:
+                        if is_completion_suppressed(session_id):
+                            break
                         send_meta = {"thread_id": thread_id} if thread_id else None
                         await adapter.send(
                             chat_id,
@@ -22768,10 +22816,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         parent_session_id: str = "",
         reason: str = "session_end",
     ) -> int:
-        """Cancel detached delegations and stale restart recovery for a session.
+        """Cancel detached work and stale restart recovery for a session.
 
         ``delegate_task(background=true)`` is intentionally detached from the
         foreground AIAgent, so ``running_agent.interrupt()`` cannot reach it.
+        The same is true of ``terminal(background=true)`` processes tracked by
+        the process registry.
         Keep this as the single gateway cancellation funnel used by both the
         active-run fast path and the idle /stop handler.
         """
@@ -22790,9 +22840,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         cancelled = 0
         try:
+            from tools.process_registry import process_registry
+
+            cancelled += process_registry.cancel_for_session(
+                session_key,
+                reason=reason,
+            )
+        except Exception as exc:
+            # Notification suppression and process termination are best-effort
+            # here so a degraded process backend cannot prevent the foreground
+            # session lock from being released.
+            logger.warning(
+                "Failed to cancel background processes for %s (%s): %s",
+                session_key,
+                reason,
+                exc,
+            )
+
+        try:
             from tools.async_delegation import interrupt_for_session
 
-            cancelled = interrupt_for_session(
+            cancelled += interrupt_for_session(
                 session_key=session_key,
                 parent_session_id=str(parent_session_id or ""),
                 reason=reason,

--- a/gateway/session_state.py
+++ b/gateway/session_state.py
@@ -24,8 +24,9 @@ Scopes (placement follows where each dict is CLEARED today):
 - ``SessionState.conversation`` — reset at conversation boundaries
   (/new, /resume, auto-reset, expiry, compression-exhausted reset).
 - ``SessionState.persistent`` — own lifecycles (approval resolution, update
-  prompt answer, native-image consumption); ``run_generation`` is monotonic
-  and NEVER reset (#28686).
+  prompt answer, native-image consumption); ``run_generation`` and the
+  durable-completion cancellation epoch are monotonic and NEVER reset
+  (#28686).
 
 Entries in ``GatewayRunner._sessions`` are never evicted (matching the old
 dicts, most of which also leaked empty/stale entries for dead sessions —
@@ -148,6 +149,10 @@ class PersistentState:
     # Monotonic run-generation counter (#28686).  NEVER reset: clearing it
     # would break stale-run detection.
     run_generation: int = 0
+    # Monotonic /stop-/new cancellation epoch for durable completion
+    # admission. Unlike run_generation this changes only at an explicit
+    # cancellation boundary, so normal queued turns do not stale a completion.
+    completion_cancellation_epoch: int = 0
 
 
 @dataclass

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1383,7 +1383,16 @@ class GatewaySlashCommandsMixin:
             )
             return EphemeralReply(t("gateway.stop.stopped"))
 
-        # No run under the caller's own session key.  In a per-user thread
+        # No foreground run under the caller's own session key. Detached
+        # delegate_task workers live outside _running_agents, so cancel them
+        # explicitly before looking for an authorized sibling run.
+        background_cancelled = await self._cancel_session_background_work(
+            session_key,
+            parent_session_id=str(getattr(session_entry, "session_id", "") or ""),
+            reason="stop_command_idle",
+        )
+
+        # In a per-user thread
         # (thread_sessions_per_user=True) each participant is isolated even
         # inside one shared thread, so a run another user started lives under
         # a different key.  Authorized users should still be able to /stop it
@@ -1403,6 +1412,15 @@ class GatewaySlashCommandsMixin:
                 session_key,
                 len(sibling_keys),
                 ", ".join(sibling_keys),
+            )
+            return EphemeralReply(t("gateway.stop.stopped"))
+
+        if background_cancelled:
+            logger.info(
+                "STOP (background-only) for session %s — cancelled %d "
+                "async delegation(s)",
+                session_key,
+                background_cancelled,
             )
             return EphemeralReply(t("gateway.stop.stopped"))
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -123,6 +123,13 @@ class GatewaySlashCommandsMixin:
         # Get existing session key
         session_key = self._session_key_for_source(source)
         self._invalidate_session_run_generation(session_key, reason="session_reset")
+        # Linearize /new against any durable completion that already passed
+        # its final claim read. This must happen before resource cleanup or any
+        # other await so the adapter rejects the old completion at admission.
+        self._invalidate_completion_admission_epoch(
+            session_key,
+            reason="session_reset",
+        )
         # Evict the running-agent slot now that the generation is bumped. The
         # in-flight run's own guarded release (run_generation=old) will return
         # False and leave its dead agent behind; clearing here keeps the slot

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1391,8 +1391,9 @@ class GatewaySlashCommandsMixin:
             return EphemeralReply(t("gateway.stop.stopped"))
 
         # No foreground run under the caller's own session key. Detached
-        # delegate_task workers live outside _running_agents, so cancel them
-        # explicitly before looking for an authorized sibling run.
+        # delegate_task workers and terminal background processes live outside
+        # _running_agents, so cancel them explicitly before looking for an
+        # authorized sibling run.
         background_cancelled = await self._cancel_session_background_work(
             session_key,
             parent_session_id=str(getattr(session_entry, "session_id", "") or ""),
@@ -1425,7 +1426,7 @@ class GatewaySlashCommandsMixin:
         if background_cancelled:
             logger.info(
                 "STOP (background-only) for session %s — cancelled %d "
-                "async delegation(s)",
+                "background job(s)",
                 session_key,
                 background_cancelled,
             )

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -121,6 +121,9 @@ class _SecondaryRecoveryAdapter:
     def set_busy_session_handler(self, handler):
         self.busy_session_handler = handler
 
+    def set_completion_admission_validator(self, handler):
+        self.completion_admission_validator = handler
+
     def set_topic_recovery_fn(self, handler):
         self.topic_recovery_fn = handler
 
@@ -493,5 +496,4 @@ class TestFeishuPortBindingConditional:
 
         connected = await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
         assert connected == 0  # no error, just nothing connected
-
 

--- a/tests/gateway/test_stop_async_delegation.py
+++ b/tests/gateway/test_stop_async_delegation.py
@@ -1,0 +1,310 @@
+"""Regression coverage for /stop and background async delegations.
+
+The gateway owns two independent execution lanes for one messaging session:
+the foreground AIAgent and detached ``delegate_task`` workers. ``/stop`` must
+cancel both lanes, drop an already-queued completion, and clear any restart
+auto-resume marker without affecting another thread.
+"""
+
+import queue
+import threading
+import time
+from collections import OrderedDict
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.platforms.base import MessageEvent, MessageType, Platform
+from gateway.run import GatewayRunner, _INTERRUPT_REASON_STOP
+from gateway.session import SessionSource, build_session_key
+from tools import async_delegation as ad
+from tools.process_registry import process_registry
+
+
+@pytest.fixture(autouse=True)
+def _clean_async_delegations():
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+    yield
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+
+class _SessionEntry:
+    def __init__(self, session_key, session_id, *, resume_pending=True):
+        self.session_key = session_key
+        self.session_id = session_id
+        self.resume_pending = resume_pending
+
+
+class _SessionStore:
+    def __init__(self, entry):
+        self.entry = entry
+        self.clear_calls = []
+
+    def get_or_create_session(self, _source):
+        return self.entry
+
+    def clear_resume_pending(self, session_key):
+        self.clear_calls.append(session_key)
+        changed = self.entry.resume_pending
+        self.entry.resume_pending = False
+        return changed
+
+
+def _source(thread_id):
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_type="forum",
+        chat_id="channel",
+        thread_id=thread_id,
+        user_id="user",
+    )
+
+
+def _wait_for_inactive(timeout=5):
+    deadline = time.monotonic() + timeout
+    while ad.active_count() and time.monotonic() < deadline:
+        time.sleep(0.02)
+
+
+def _delivery_runner():
+    runner = object.__new__(GatewayRunner)
+    runner._completion_delivery_lock = threading.Lock()
+    runner._completion_deliveries_inflight = set()
+    runner._completion_deliveries_delivered = OrderedDict()
+    runner._completion_delivery_retention = 16
+    runner._inject_watch_notification = AsyncMock(return_value=True)
+    session_db = MagicMock()
+    session_db.get_session = AsyncMock(
+        return_value={"id": "parent-a", "ended_at": None}
+    )
+    runner._session_db = session_db
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_interrupt_and_clear_session_cancels_foreground_and_background(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    source = _source("thread-a")
+    session_key = build_session_key(source)
+    entry = _SessionEntry(session_key, "parent-a")
+    store = _SessionStore(entry)
+
+    gate = threading.Event()
+    child_interrupted = MagicMock(side_effect=gate.set)
+
+    def background_runner():
+        gate.wait(timeout=60)
+        return {"status": "interrupted", "summary": None}
+
+    dispatched = ad.dispatch_async_delegation(
+        goal="background work",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key=session_key,
+        parent_session_id=entry.session_id,
+        runner=background_runner,
+        interrupt_fn=child_interrupted,
+    )
+
+    runner = object.__new__(GatewayRunner)
+    foreground = MagicMock()
+    foreground.session_id = entry.session_id
+    runner._running_agents = {session_key: foreground}
+    runner._session_run_generation = {}
+    runner._pending_messages = {}
+    runner.session_store = store
+    runner._adapter_for_source = lambda _source: None
+    runner._release_running_agent_state = lambda key: runner._running_agents.pop(
+        key, None
+    )
+    runner._evict_cached_agent = lambda _key: None
+
+    await runner._interrupt_and_clear_session(
+        session_key,
+        source,
+        interrupt_reason=_INTERRUPT_REASON_STOP,
+        invalidation_reason="stop_command",
+    )
+
+    foreground.interrupt.assert_called_once_with(_INTERRUPT_REASON_STOP)
+    child_interrupted.assert_called_once()
+    assert store.clear_calls == [session_key]
+    assert entry.resume_pending is False
+    assert session_key not in runner._running_agents
+
+    _wait_for_inactive()
+    assert ad.active_count() == 0
+    durable = ad.get_durable_delegation(dispatched["delegation_id"])
+    assert durable["state"] == "cancelled"
+    assert durable["delivery_state"] == "dropped"
+
+
+@pytest.mark.asyncio
+async def test_stop_with_only_background_work_is_scoped_and_idempotent(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    source_a = _source("thread-a")
+    source_b = _source("thread-b")
+    key_a = build_session_key(source_a)
+    key_b = build_session_key(source_b)
+    entry = _SessionEntry(key_a, "parent-a")
+    store = _SessionStore(entry)
+
+    gate_a = threading.Event()
+    gate_b = threading.Event()
+    interrupted_a = MagicMock(side_effect=gate_a.set)
+    interrupted_b = MagicMock(side_effect=gate_b.set)
+
+    def runner_a():
+        gate_a.wait(timeout=60)
+        return {"status": "interrupted", "summary": None}
+
+    def runner_b():
+        gate_b.wait(timeout=60)
+        return {"status": "completed", "summary": "other"}
+
+    mine = ad.dispatch_async_delegation(
+        goal="mine",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key=key_a,
+        parent_session_id="parent-a",
+        runner=runner_a,
+        interrupt_fn=interrupted_a,
+    )
+    other = ad.dispatch_async_delegation(
+        goal="other",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key=key_b,
+        parent_session_id="parent-b",
+        runner=runner_b,
+        interrupt_fn=interrupted_b,
+    )
+
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner.session_store = store
+    runner.adapters = {}
+    runner._is_user_authorized = lambda _source: True
+
+    event = MessageEvent(
+        text="/stop",
+        message_type=MessageType.TEXT,
+        source=source_a,
+    )
+    try:
+        first = await runner._handle_stop_command(event)
+        assert "no active" not in str(first).lower()
+        interrupted_a.assert_called_once()
+        interrupted_b.assert_not_called()
+        assert entry.resume_pending is False
+
+        second = await runner._handle_stop_command(event)
+        assert "no active" in str(second).lower()
+        interrupted_a.assert_called_once()
+
+        mine_row = ad.get_durable_delegation(mine["delegation_id"])
+        other_row = ad.get_durable_delegation(other["delegation_id"])
+        assert mine_row["state"] == "cancelled"
+        assert mine_row["delivery_state"] == "dropped"
+        assert other_row["state"] == "running"
+        assert other_row["delivery_state"] == "pending"
+    finally:
+        gate_b.set()
+
+
+@pytest.mark.asyncio
+async def test_gateway_drops_completion_cancelled_by_stop(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    dispatched = ad.dispatch_async_delegation(
+        goal="race",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key="discord-thread-a",
+        parent_session_id="parent-a",
+        runner=lambda: {"status": "completed", "summary": "must not re-enter"},
+    )
+    _wait_for_inactive()
+    assert ad.active_count() == 0
+    assert ad.interrupt_for_session(
+        session_key="discord-thread-a",
+        parent_session_id="parent-a",
+        reason="stop_command",
+    ) == 1
+
+    evt = None
+    while not process_registry.completion_queue.empty():
+        candidate = process_registry.completion_queue.get_nowait()
+        if candidate.get("delegation_id") == dispatched["delegation_id"]:
+            evt = candidate
+            break
+    assert evt is not None
+
+    runner = _delivery_runner()
+    assert await runner._deliver_completion_notification("synthetic", evt) is None
+    runner._inject_watch_notification.assert_not_awaited()
+    assert ad.restore_undelivered_completions(queue.Queue()) == 0
+
+
+@pytest.mark.asyncio
+async def test_gateway_revalidates_claim_when_stop_wins_delivery_race(
+    tmp_path, monkeypatch
+):
+    """A stop arriving just after claim must still block synthetic injection."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    dispatched = ad.dispatch_async_delegation(
+        goal="claim race",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key="discord-thread-a",
+        parent_session_id="parent-a",
+        runner=lambda: {"status": "completed", "summary": "must not re-enter"},
+    )
+    _wait_for_inactive()
+    assert ad.active_count() == 0
+
+    evt = None
+    while not process_registry.completion_queue.empty():
+        candidate = process_registry.completion_queue.get_nowait()
+        if candidate.get("delegation_id") == dispatched["delegation_id"]:
+            evt = candidate
+            break
+    assert evt is not None
+
+    real_claim = ad.claim_completion_delivery
+
+    def claim_then_stop(delegation_id, claim_id):
+        assert real_claim(delegation_id, claim_id) is True
+        assert ad.interrupt_for_session(
+            session_key="discord-thread-a",
+            parent_session_id="parent-a",
+            reason="stop_command",
+        ) == 1
+        return True
+
+    monkeypatch.setattr(ad, "claim_completion_delivery", claim_then_stop)
+
+    runner = _delivery_runner()
+    assert await runner._deliver_completion_notification("synthetic", evt) is None
+    runner._inject_watch_notification.assert_not_awaited()
+    durable = ad.get_durable_delegation(dispatched["delegation_id"])
+    assert durable["state"] == "cancelled"
+    assert durable["delivery_state"] == "dropped"

--- a/tests/gateway/test_stop_async_delegation.py
+++ b/tests/gateway/test_stop_async_delegation.py
@@ -28,16 +28,24 @@ from gateway.platforms.base import (
 from gateway.run import GatewayRunner, _INTERRUPT_REASON_STOP
 from gateway.session import SessionSource, build_session_key
 from tools import async_delegation as ad
-from tools.process_registry import process_registry
+from tools.process_registry import ProcessSession, process_registry
 
 
 @pytest.fixture(autouse=True)
 def _clean_async_delegations():
     ad._reset_for_tests()
+    with process_registry._lock:
+        process_registry._running.clear()
+        process_registry._finished.clear()
+    process_registry.pending_watchers = []
     while not process_registry.completion_queue.empty():
         process_registry.completion_queue.get_nowait()
     yield
     ad._reset_for_tests()
+    with process_registry._lock:
+        process_registry._running.clear()
+        process_registry._finished.clear()
+    process_registry.pending_watchers = []
     while not process_registry.completion_queue.empty():
         process_registry.completion_queue.get_nowait()
 
@@ -294,6 +302,145 @@ async def test_stop_with_only_background_work_is_scoped_and_idempotent(
 
 
 @pytest.mark.asyncio
+async def test_stop_cancels_terminal_process_and_drops_its_notifications(
+    tmp_path, monkeypatch
+):
+    """A stopped chat must not be revived by terminal notify_on_complete."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    source_a = _source("thread-a")
+    source_b = _source("thread-b")
+    key_a = build_session_key(source_a)
+    key_b = build_session_key(source_b)
+    entry = _SessionEntry(key_a, "parent-a")
+    store = _SessionStore(entry)
+
+    mine = ProcessSession(
+        id="proc_mine",
+        command="long-running-test",
+        session_key=key_a,
+        started_at=time.time(),
+        pid=1001,
+        process=MagicMock(pid=1001),
+        watcher_interval=5,
+        notify_on_complete=True,
+    )
+    other = ProcessSession(
+        id="proc_other",
+        command="other-session-test",
+        session_key=key_b,
+        started_at=time.time(),
+        pid=1002,
+        process=MagicMock(pid=1002),
+        watcher_interval=5,
+        notify_on_complete=True,
+    )
+    with process_registry._lock:
+        process_registry._running[mine.id] = mine
+        process_registry._running[other.id] = other
+    process_registry.pending_watchers = [
+        {"session_id": mine.id, "session_key": key_a},
+        {"session_id": other.id, "session_key": key_b},
+    ]
+    process_registry.completion_queue.put(
+        {
+            "type": "completion",
+            "session_id": mine.id,
+            "session_key": key_a,
+            "started_at": mine.started_at,
+        }
+    )
+    process_registry.completion_queue.put(
+        {
+            "type": "completion",
+            "session_id": other.id,
+            "session_key": key_b,
+            "started_at": other.started_at,
+        }
+    )
+    terminate = MagicMock()
+    monkeypatch.setattr(process_registry, "_terminate_host_pid", terminate)
+
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner.session_store = store
+    runner.adapters = {}
+    runner._is_user_authorized = lambda _source: True
+    event = MessageEvent(
+        text="/stop",
+        message_type=MessageType.TEXT,
+        source=source_a,
+    )
+
+    first = await runner._handle_stop_command(event)
+
+    assert "no active" not in str(first).lower()
+    assert mine.exited is True
+    assert mine.completion_reason == "killed"
+    assert other.exited is False
+    terminate.assert_called_once_with(1001, None)
+    assert process_registry.pending_watchers == [
+        {"session_id": other.id, "session_key": key_b}
+    ]
+    queued = []
+    while not process_registry.completion_queue.empty():
+        queued.append(process_registry.completion_queue.get_nowait())
+    assert [item["session_id"] for item in queued] == [other.id]
+
+    second = await runner._handle_stop_command(event)
+    assert "no active" in str(second).lower()
+    terminate.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_stop_drops_already_finished_terminal_completion(
+    tmp_path, monkeypatch
+):
+    """A queued completion remains cancellable after its process has exited."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    source = _source("thread-a")
+    session_key = build_session_key(source)
+    entry = _SessionEntry(session_key, "parent-a")
+    store = _SessionStore(entry)
+    finished = ProcessSession(
+        id="proc_finished",
+        command="already-done",
+        session_key=session_key,
+        started_at=time.time(),
+        exited=True,
+        exit_code=0,
+        notify_on_complete=True,
+    )
+    with process_registry._lock:
+        process_registry._finished[finished.id] = finished
+    process_registry.completion_queue.put(
+        {
+            "type": "completion",
+            "session_id": finished.id,
+            "session_key": session_key,
+            "started_at": finished.started_at,
+        }
+    )
+
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner.session_store = store
+    runner.adapters = {}
+    runner._is_user_authorized = lambda _source: True
+    event = MessageEvent(
+        text="/stop",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+
+    result = await runner._handle_stop_command(event)
+
+    assert "no active" not in str(result).lower()
+    assert finished.completion_suppressed is True
+    assert finished.notify_on_complete is False
+    assert process_registry.completion_queue.empty()
+
+
+@pytest.mark.asyncio
 async def test_gateway_drops_completion_cancelled_by_stop(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     dispatched = ad.dispatch_async_delegation(
@@ -445,6 +592,151 @@ async def test_stop_after_claim_revalidation_blocks_adapter_admission(
     durable = ad.get_durable_delegation(dispatched["delegation_id"])
     assert durable["state"] == "cancelled"
     assert durable["delivery_state"] == "dropped"
+
+
+@pytest.mark.asyncio
+async def test_terminal_completion_stop_race_blocks_adapter_admission(
+    tmp_path, monkeypatch
+):
+    """A terminal completion in Telegram topic recovery loses to /stop."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    source = _source(
+        "thread-a",
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    session_key = build_session_key(source)
+    finished = ProcessSession(
+        id="proc_admission_race",
+        command="race-test",
+        session_key=session_key,
+        started_at=time.time(),
+        exited=True,
+        exit_code=0,
+        notify_on_complete=True,
+    )
+    with process_registry._lock:
+        process_registry._finished[finished.id] = finished
+    evt = {
+        "type": "completion",
+        "session_id": finished.id,
+        "session_key": session_key,
+        "platform": source.platform.value,
+        "chat_type": source.chat_type,
+        "chat_id": source.chat_id,
+        "thread_id": source.thread_id,
+        "user_id": source.user_id,
+        "started_at": finished.started_at,
+        "command": finished.command,
+        "exit_code": 0,
+        "output": "done",
+    }
+
+    runner = _delivery_runner(mock_injection=False)
+    adapter, handler = _admission_adapter(runner, platform=Platform.TELEGRAM)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.session_store = SimpleNamespace(
+        _ensure_loaded=lambda: None,
+        _entries={session_key: SimpleNamespace(origin=source)},
+    )
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        clear_resume_pending=AsyncMock(return_value=False),
+    )
+
+    recovery_entered = threading.Event()
+    release_recovery = threading.Event()
+
+    def blocking_topic_recovery(_source):
+        recovery_entered.set()
+        release_recovery.wait(timeout=5)
+        return None
+
+    adapter.set_topic_recovery_fn(blocking_topic_recovery)
+    delivery_task = asyncio.create_task(
+        runner._deliver_completion_notification("synthetic", evt)
+    )
+
+    entered = await asyncio.wait_for(
+        asyncio.to_thread(recovery_entered.wait, 3),
+        timeout=4,
+    )
+    if entered:
+        try:
+            await runner._cancel_session_background_work(
+                session_key,
+                parent_session_id="parent-a",
+                reason="stop_command",
+            )
+        finally:
+            release_recovery.set()
+    else:
+        release_recovery.set()
+
+    result = await asyncio.wait_for(delivery_task, timeout=5)
+    await adapter.cancel_background_tasks()
+
+    assert entered is True
+    assert result is None
+    assert finished.completion_suppressed is True
+    handler.assert_not_awaited()
+    assert session_key not in adapter._active_sessions
+
+
+@pytest.mark.asyncio
+async def test_other_session_terminal_completion_is_admitted():
+    """An unrelated process completion keeps its own admission epoch."""
+    source = _source("thread-b")
+    session_key = build_session_key(source)
+    finished = ProcessSession(
+        id="proc_other_completion",
+        command="other-test",
+        session_key=session_key,
+        started_at=time.time(),
+        exited=True,
+        exit_code=0,
+        notify_on_complete=True,
+    )
+    with process_registry._lock:
+        process_registry._finished[finished.id] = finished
+    evt = {
+        "type": "completion",
+        "session_id": finished.id,
+        "session_key": session_key,
+        "platform": Platform.DISCORD.value,
+        "chat_type": source.chat_type,
+        "chat_id": source.chat_id,
+        "thread_id": source.thread_id,
+        "user_id": source.user_id,
+        "started_at": finished.started_at,
+        "command": finished.command,
+        "exit_code": 0,
+        "output": "done",
+    }
+
+    runner = _delivery_runner(mock_injection=False)
+    adapter, handler = _admission_adapter(runner)
+    runner.adapters = {Platform.DISCORD: adapter}
+    processed = asyncio.Event()
+
+    async def mark_processed(_event):
+        processed.set()
+
+    handler.side_effect = mark_processed
+
+    result = await runner._deliver_completion_notification("synthetic", evt)
+    await asyncio.wait_for(processed.wait(), timeout=2)
+    await adapter.cancel_background_tasks()
+
+    assert result is True
+    handler.assert_awaited_once()
+    delivered_event = handler.await_args.args[0]
+    admission = delivered_event.metadata[_COMPLETION_ADMISSION_TOKEN_KEY]
+    assert admission["session_key"] == session_key
+    assert admission["epoch"] == runner._current_completion_admission_epoch(
+        session_key
+    )
+    assert _COMPLETION_ADMISSION_REJECTED_KEY not in delivered_event.metadata
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_stop_async_delegation.py
+++ b/tests/gateway/test_stop_async_delegation.py
@@ -6,15 +6,25 @@ cancel both lanes, drop an already-queued completion, and clear any restart
 auto-resume marker without affecting another thread.
 """
 
+import asyncio
 import queue
 import threading
 import time
 from collections import OrderedDict
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.platforms.base import MessageEvent, MessageType, Platform
+from gateway.config import PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    Platform,
+    _COMPLETION_ADMISSION_REJECTED_KEY,
+    _COMPLETION_ADMISSION_TOKEN_KEY,
+)
 from gateway.run import GatewayRunner, _INTERRUPT_REASON_STOP
 from gateway.session import SessionSource, build_session_key
 from tools import async_delegation as ad
@@ -54,10 +64,29 @@ class _SessionStore:
         return changed
 
 
-def _source(thread_id):
+class _AdmissionAdapter(BasePlatformAdapter):
+    async def connect(self, *, is_reconnect: bool = False):
+        pass
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, content, **kwargs):
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+
+def _source(
+    thread_id,
+    *,
+    platform=Platform.DISCORD,
+    chat_type="forum",
+):
     return SessionSource(
-        platform=Platform.DISCORD,
-        chat_type="forum",
+        platform=platform,
+        chat_type=chat_type,
         chat_id="channel",
         thread_id=thread_id,
         user_id="user",
@@ -70,19 +99,56 @@ def _wait_for_inactive(timeout=5):
         time.sleep(0.02)
 
 
-def _delivery_runner():
+def _take_completion(delegation_id):
+    while not process_registry.completion_queue.empty():
+        candidate = process_registry.completion_queue.get_nowait()
+        if candidate.get("delegation_id") == delegation_id:
+            return candidate
+    return None
+
+
+def _delivery_runner(*, mock_injection=True):
     runner = object.__new__(GatewayRunner)
     runner._completion_delivery_lock = threading.Lock()
     runner._completion_deliveries_inflight = set()
     runner._completion_deliveries_delivered = OrderedDict()
     runner._completion_delivery_retention = 16
-    runner._inject_watch_notification = AsyncMock(return_value=True)
+    if mock_injection:
+        runner._inject_watch_notification = AsyncMock(return_value=True)
     session_db = MagicMock()
     session_db.get_session = AsyncMock(
         return_value={"id": "parent-a", "ended_at": None}
     )
     runner._session_db = session_db
     return runner
+
+
+def _admission_adapter(runner, *, platform=Platform.DISCORD):
+    adapter = _AdmissionAdapter(
+        PlatformConfig(enabled=True, token="test-token"),
+        platform,
+    )
+    handler = AsyncMock(return_value=None)
+    adapter.set_message_handler(handler)
+    adapter.set_completion_admission_validator(
+        runner._validate_completion_admission
+    )
+    return adapter, handler
+
+
+def _tokenized_completion(runner, source):
+    session_key = build_session_key(source)
+    return MessageEvent(
+        text="[SYSTEM: background delegation completed]",
+        message_type=MessageType.TEXT,
+        source=source,
+        internal=True,
+        metadata={
+            _COMPLETION_ADMISSION_TOKEN_KEY: (
+                runner._capture_completion_admission(session_key)
+            )
+        },
+    )
 
 
 @pytest.mark.asyncio
@@ -248,12 +314,7 @@ async def test_gateway_drops_completion_cancelled_by_stop(tmp_path, monkeypatch)
         reason="stop_command",
     ) == 1
 
-    evt = None
-    while not process_registry.completion_queue.empty():
-        candidate = process_registry.completion_queue.get_nowait()
-        if candidate.get("delegation_id") == dispatched["delegation_id"]:
-            evt = candidate
-            break
+    evt = _take_completion(dispatched["delegation_id"])
     assert evt is not None
 
     runner = _delivery_runner()
@@ -281,12 +342,7 @@ async def test_gateway_revalidates_claim_when_stop_wins_delivery_race(
     _wait_for_inactive()
     assert ad.active_count() == 0
 
-    evt = None
-    while not process_registry.completion_queue.empty():
-        candidate = process_registry.completion_queue.get_nowait()
-        if candidate.get("delegation_id") == dispatched["delegation_id"]:
-            evt = candidate
-            break
+    evt = _take_completion(dispatched["delegation_id"])
     assert evt is not None
 
     real_claim = ad.claim_completion_delivery
@@ -308,3 +364,143 @@ async def test_gateway_revalidates_claim_when_stop_wins_delivery_race(
     durable = ad.get_durable_delegation(dispatched["delegation_id"])
     assert durable["state"] == "cancelled"
     assert durable["delivery_state"] == "dropped"
+
+
+@pytest.mark.asyncio
+async def test_stop_after_claim_revalidation_blocks_adapter_admission(
+    tmp_path, monkeypatch
+):
+    """A stop during Telegram topic recovery wins after the final claim read."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    source = _source(
+        "thread-a",
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    session_key = build_session_key(source)
+    dispatched = ad.dispatch_async_delegation(
+        goal="post-claim race",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key=session_key,
+        parent_session_id="parent-a",
+        runner=lambda: {"status": "completed", "summary": "must not re-enter"},
+    )
+    _wait_for_inactive()
+    evt = _take_completion(dispatched["delegation_id"])
+    assert evt is not None
+
+    runner = _delivery_runner(mock_injection=False)
+    adapter, handler = _admission_adapter(runner, platform=Platform.TELEGRAM)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.session_store = SimpleNamespace(
+        _ensure_loaded=lambda: None,
+        _entries={session_key: SimpleNamespace(origin=source)},
+    )
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        clear_resume_pending=AsyncMock(return_value=False),
+    )
+
+    recovery_entered = threading.Event()
+    release_recovery = threading.Event()
+
+    def blocking_topic_recovery(_source):
+        recovery_entered.set()
+        release_recovery.wait(timeout=5)
+        return None
+
+    adapter.set_topic_recovery_fn(blocking_topic_recovery)
+    delivery_task = asyncio.create_task(
+        runner._deliver_completion_notification("synthetic", evt)
+    )
+
+    entered = await asyncio.wait_for(
+        asyncio.to_thread(recovery_entered.wait, 3),
+        timeout=4,
+    )
+    cancelled = -1
+    if entered:
+        try:
+            cancelled = await runner._cancel_session_background_work(
+                session_key,
+                parent_session_id="parent-a",
+                reason="stop_command",
+            )
+        finally:
+            release_recovery.set()
+    else:
+        release_recovery.set()
+
+    result = await asyncio.wait_for(delivery_task, timeout=5)
+    await adapter.cancel_background_tasks()
+
+    assert entered is True
+    assert cancelled == 1
+    assert result is None
+    handler.assert_not_awaited()
+    assert session_key not in adapter._active_sessions
+    durable = ad.get_durable_delegation(dispatched["delegation_id"])
+    assert durable["state"] == "cancelled"
+    assert durable["delivery_state"] == "dropped"
+
+
+@pytest.mark.asyncio
+async def test_stale_queued_completion_is_not_drained_after_stop_epoch():
+    runner = object.__new__(GatewayRunner)
+    source = _source("thread-a")
+    session_key = build_session_key(source)
+    adapter, handler = _admission_adapter(runner)
+    command_guard = asyncio.Event()
+    adapter._active_sessions[session_key] = command_guard
+    event = _tokenized_completion(runner, source)
+
+    await adapter.handle_message(event)
+    assert adapter._pending_messages[session_key] is event
+
+    runner._invalidate_completion_admission_epoch(
+        session_key,
+        reason="stop_command",
+    )
+    await adapter._drain_pending_after_session_command(
+        session_key,
+        command_guard,
+    )
+    await asyncio.sleep(0)
+
+    handler.assert_not_awaited()
+    assert event.metadata[_COMPLETION_ADMISSION_REJECTED_KEY] is True
+    assert session_key not in adapter._active_sessions
+    assert session_key not in adapter._session_tasks
+
+
+@pytest.mark.asyncio
+async def test_current_queued_completion_drains_normally():
+    runner = object.__new__(GatewayRunner)
+    source = _source("thread-a")
+    session_key = build_session_key(source)
+    adapter, handler = _admission_adapter(runner)
+    processed = asyncio.Event()
+
+    async def mark_processed(_event):
+        processed.set()
+
+    handler.side_effect = mark_processed
+    command_guard = asyncio.Event()
+    adapter._active_sessions[session_key] = command_guard
+    event = _tokenized_completion(runner, source)
+
+    await adapter.handle_message(event)
+    assert adapter._pending_messages[session_key] is event
+
+    await adapter._drain_pending_after_session_command(
+        session_key,
+        command_guard,
+    )
+    await asyncio.wait_for(processed.wait(), timeout=2)
+    await adapter.cancel_background_tasks()
+
+    handler.assert_awaited_once_with(event)
+    assert _COMPLETION_ADMISSION_REJECTED_KEY not in event.metadata

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -261,6 +261,103 @@ def test_interrupt_all_signals_running_children():
     assert evt["status"] == "interrupted"
 
 
+def test_interrupt_for_session_drops_completion_before_signalling_child(
+    tmp_path, monkeypatch
+):
+    """Session cancellation is durable before the child can finish.
+
+    Otherwise the child's interrupt handler can release the runner, whose
+    finalize path races the cancellation write and republishes a completion
+    that starts a fresh agent turn after /stop.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    gate = threading.Event()
+    durable_state_seen_by_interrupt = []
+
+    def runner():
+        gate.wait(timeout=60)
+        return {"status": "interrupted", "summary": None, "error": "cancelled"}
+
+    def interrupt_fn():
+        row = ad.get_durable_delegation(dispatched["delegation_id"])
+        durable_state_seen_by_interrupt.append(
+            (row["state"], row["delivery_state"])
+        )
+        gate.set()
+
+    dispatched = ad.dispatch_async_delegation(
+        goal="long session task",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key="discord-thread-a",
+        parent_session_id="parent-a",
+        runner=runner,
+        interrupt_fn=interrupt_fn,
+    )
+
+    assert ad.interrupt_for_session(
+        session_key="discord-thread-a",
+        parent_session_id="parent-a",
+        reason="stop_command",
+    ) == 1
+    assert durable_state_seen_by_interrupt == [("cancelled", "dropped")]
+    assert ad.interrupt_for_session(
+        session_key="discord-thread-a",
+        parent_session_id="parent-a",
+        reason="repeated_stop",
+    ) == 0
+
+    deadline = time.monotonic() + 5
+    while ad.active_count() and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert ad.active_count() == 0
+    assert _drain_for(dispatched["delegation_id"], timeout=0.25) is None
+
+    durable = ad.get_durable_delegation(dispatched["delegation_id"])
+    assert durable["state"] == "cancelled"
+    assert durable["delivery_state"] == "dropped"
+    assert ad.mark_completion_delivered(dispatched["delegation_id"]) is False
+    assert ad.restore_undelivered_completions(queue.Queue()) == 0
+
+
+def test_interrupt_for_session_drops_completion_already_on_queue(
+    tmp_path, monkeypatch
+):
+    """A /stop racing a completed worker must drop its queued event."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    dispatched = ad.dispatch_async_delegation(
+        goal="fast session task",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key="discord-thread-a",
+        parent_session_id="parent-a",
+        runner=lambda: {"status": "completed", "summary": "too late"},
+    )
+
+    deadline = time.monotonic() + 5
+    while ad.active_count() and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert ad.active_count() == 0
+
+    # The worker has published its event, but no consumer has claimed it yet.
+    assert ad.interrupt_for_session(
+        session_key="discord-thread-a",
+        parent_session_id="parent-a",
+        reason="stop_command",
+    ) == 1
+    evt = _drain_for(dispatched["delegation_id"])
+    assert evt is not None
+    assert ad.claim_event_delivery(evt, "late-consumer") is None
+    assert ad.restore_undelivered_completions(queue.Queue()) == 0
+    durable = ad.get_durable_delegation(dispatched["delegation_id"])
+    assert durable["state"] == "cancelled"
+    assert durable["delivery_state"] == "dropped"
+
+
 def _fast_stale_monitor(monkeypatch, *, idle=0.15, in_tool=0.3, grace=0.15):
     """Shrink the stale-monitor cadence so tests run in milliseconds."""
     monkeypatch.setattr(ad, "_STALE_CHECK_INTERVAL", 0.03)
@@ -623,6 +720,101 @@ def test_delegate_task_background_routes_async_and_does_not_block(monkeypatch):
     assert "the real task" in text
 
 
+def test_cancelled_background_batch_does_not_wait_for_uncooperative_children(
+    monkeypatch,
+):
+    """Cancelling the registry must release its batch runner promptly.
+
+    Child workers are daemon threads and may be stuck inside an uncooperative
+    provider. The registry must become terminal without joining those
+    workers; their late results remain dropped.
+    """
+    from unittest.mock import MagicMock
+
+    import tools.delegate_tool as dt
+    from tools.approval import reset_current_session_key, set_current_session_key
+
+    parent = MagicMock()
+    parent._delegate_depth = 0
+    parent.session_id = "parent-a"
+    parent._interrupt_requested = False
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+
+    children = []
+
+    def build_child(**_kwargs):
+        child = MagicMock()
+        child._delegate_role = "leaf"
+        child.get_activity_summary.return_value = {
+            "api_call_count": 0,
+            "current_tool": None,
+            "last_activity_ts": time.time(),
+        }
+        children.append(child)
+        return child
+
+    gate = threading.Event()
+
+    def uncooperative_child(task_index, goal, child=None, parent_agent=None, **_kw):
+        gate.wait(timeout=60)
+        return {
+            "task_index": task_index,
+            "status": "completed",
+            "summary": f"late: {goal}",
+            "api_calls": 1,
+            "duration_seconds": 60,
+            "model": "m",
+            "exit_reason": "completed",
+        }
+
+    creds = {
+        "model": "m",
+        "provider": None,
+        "base_url": None,
+        "api_key": None,
+        "api_mode": None,
+        "command": None,
+        "args": None,
+    }
+    monkeypatch.setattr(dt, "_build_child_agent", build_child)
+    monkeypatch.setattr(dt, "_run_single_child", uncooperative_child)
+    monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *a, **k: creds)
+
+    approval_token = set_current_session_key("discord-thread-a")
+    try:
+        out = dt.delegate_task(
+            tasks=[{"goal": "a"}, {"goal": "b"}],
+            background=True,
+            parent_agent=parent,
+        )
+    finally:
+        reset_current_session_key(approval_token)
+
+    parsed = json.loads(out)
+    assert parsed["status"] == "dispatched"
+    try:
+        assert ad.interrupt_for_session(
+            session_key="discord-thread-a",
+            parent_session_id="parent-a",
+            reason="stop_command",
+        ) == 1
+
+        deadline = time.monotonic() + 5
+        while ad.active_count() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert ad.active_count() == 0
+        assert _drain_for(parsed["delegation_id"], timeout=0.25) is None
+        durable = ad.get_durable_delegation(parsed["delegation_id"])
+        assert durable["state"] == "cancelled"
+        assert durable["delivery_state"] == "dropped"
+        assert all(child.interrupt.called for child in children)
+    finally:
+        # Let the abandoned daemon workers unwind before this test's patches
+        # and fixtures disappear.
+        gate.set()
+
+
 def test_delegate_task_background_uses_live_tui_agent_session_id(monkeypatch):
     """TUI async delegation must route to the live/compressed agent id.
 
@@ -760,4 +952,3 @@ def test_gateway_cli_origin_event_left_unrouted():
     evt = _make_async_evt(session_key="")
     runner._enrich_async_delegation_routing(evt)
     assert "platform" not in evt
-

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -867,6 +867,95 @@ class TestSpawnRewriteCompoundBackground:
 
 
 # =========================================================================
+# Session-scoped cancellation
+# =========================================================================
+
+class TestSessionCancellation:
+    def test_kill_failure_still_suppresses_all_notifications(
+        self, registry, monkeypatch
+    ):
+        session = _make_session(sid="proc_stop_failure")
+        session.session_key = "session-a"
+        session.process = MagicMock(pid=4242)
+        session.notify_on_complete = True
+        session.watcher_interval = 5
+        session.watch_patterns = ["READY"]
+        registry._running[session.id] = session
+        registry.pending_watchers = [
+            {"session_id": session.id, "session_key": "session-a"},
+            {"session_id": "proc_other", "session_key": "session-b"},
+        ]
+        registry.completion_queue.put(
+            {
+                "type": "watch_match",
+                "session_id": session.id,
+                "session_key": "session-a",
+            }
+        )
+        other_event = {
+            "type": "completion",
+            "session_id": "proc_other",
+            "session_key": "session-b",
+        }
+        registry.completion_queue.put(other_event)
+        monkeypatch.setattr(
+            registry,
+            "_terminate_host_pid",
+            MagicMock(side_effect=OSError("permission denied")),
+        )
+
+        with patch.object(registry, "_write_checkpoint"):
+            affected = registry.cancel_for_session(
+                "session-a",
+                reason="stop_command",
+            )
+
+            assert affected == 1
+            assert session.exited is False
+            assert session.completion_suppressed is True
+            assert session.notify_on_complete is False
+            assert session.watcher_interval == 0
+            assert session.watch_patterns == []
+            assert registry.pending_watchers == [
+                {"session_id": "proc_other", "session_key": "session-b"}
+            ]
+            assert registry.completion_queue.get_nowait() == other_event
+            assert registry.completion_queue.empty()
+
+            # Even if the backend exits later and a stale code path restores
+            # notify_on_complete, the authoritative suppression fence wins.
+            session.notify_on_complete = True
+            session.exited = True
+            session.exit_code = 1
+            registry._move_to_finished(session)
+            assert registry.completion_queue.empty()
+
+    def test_finished_process_with_pending_completion_counts_once(self, registry):
+        session = _make_session(
+            sid="proc_finished_pending",
+            exited=True,
+            exit_code=0,
+        )
+        session.session_key = "session-a"
+        session.notify_on_complete = True
+        registry._finished[session.id] = session
+        registry.completion_queue.put(
+            {
+                "type": "completion",
+                "session_id": session.id,
+                "session_key": "session-a",
+            }
+        )
+
+        with patch.object(registry, "_write_checkpoint"):
+            assert registry.cancel_for_session("session-a") == 1
+            assert registry.cancel_for_session("session-a") == 0
+
+        assert session.completion_suppressed is True
+        assert registry.completion_queue.empty()
+
+
+# =========================================================================
 # Checkpoint
 # =========================================================================
 
@@ -902,6 +991,48 @@ class TestCheckpoint:
 
             data = json.loads(checkpoint.read_text())
             assert data == []
+
+    def test_recovery_preserves_stop_suppression_without_replaying_watcher(
+        self, registry, tmp_path
+    ):
+        checkpoint = tmp_path / "procs.json"
+        checkpoint.write_text(json.dumps([{
+            "session_id": "proc_stopped_recovery",
+            "command": "sleep 999",
+            "pid": os.getpid(),
+            "pid_scope": "host",
+            "host_start_time": 123,
+            "task_id": "t1",
+            "session_key": "session-a",
+            "watcher_interval": 5,
+            "notify_on_complete": True,
+            "watch_patterns": ["READY"],
+            "completion_suppressed": True,
+        }]))
+
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint), \
+             patch.object(registry, "_host_pid_is_ours", return_value=True):
+            recovered = registry.recover_from_checkpoint()
+
+            assert recovered == 1
+            session = registry.get("proc_stopped_recovery")
+            assert session is not None
+            assert session.completion_suppressed is True
+            assert session.notify_on_complete is False
+            assert session.watcher_interval == 0
+            assert session.watch_patterns == []
+            assert registry.pending_watchers == []
+
+            persisted = json.loads(checkpoint.read_text())
+            assert persisted[0]["completion_suppressed"] is True
+            assert persisted[0]["notify_on_complete"] is False
+            assert persisted[0]["watcher_interval"] == 0
+            assert persisted[0]["watch_patterns"] == []
+
+            session.exited = True
+            session.exit_code = 0
+            registry._move_to_finished(session)
+            assert registry.completion_queue.empty()
 
 # =========================================================================
 # Kill process
@@ -1533,4 +1664,3 @@ class TestReaderLoopOrphanedPipe:
                 os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
             except (ProcessLookupError, PermissionError):
                 pass
-

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1046,6 +1046,30 @@ class TestKillProcess:
         assert result["status"] == "already_exited"
 
 
+    def test_kill_sandbox_process_uses_environment_tree_terminator(
+        self, registry, monkeypatch
+    ):
+        class FakeEnvironment:
+            def __init__(self):
+                self.calls = []
+
+            def terminate_process_tree(self, pid, *, timeout):
+                self.calls.append((pid, timeout))
+                return {"output": "", "returncode": 0}
+
+        env = FakeEnvironment()
+        s = _make_session(sid="proc_remote", command="sleep 999")
+        s.pid = 82477
+        s.pid_scope = "sandbox"
+        s.env_ref = env
+        registry._running[s.id] = s
+        monkeypatch.setattr(registry, "_write_checkpoint", lambda: None)
+
+        result = registry.kill_process(s.id)
+
+        assert result["status"] == "killed"
+        assert env.calls == [(82477, 5)]
+
     def test_kill_detached_session_uses_host_pid(self, registry):
         s = _make_session(sid="proc_detached", command="sleep 999")
         s.pid = 424242

--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -2,11 +2,16 @@
 
 import json
 import os
+import signal
 import subprocess
+import time
+import uuid
 from unittest.mock import MagicMock
 
+import psutil
 import pytest
 
+from tools.environments.base import _build_process_tree_kill_command
 from tools.environments.ssh import SSHEnvironment
 from tools.environments import ssh as ssh_env
 
@@ -31,6 +36,22 @@ def _run(command, task_id="ssh_test", **kwargs):
 def _cleanup(task_id="ssh_test"):
     from tools.terminal_tool import cleanup_vm
     cleanup_vm(task_id)
+
+
+def _wait_until(predicate, timeout=5.0, interval=0.05):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return bool(predicate())
+
+
+def _pid_is_live(pid):
+    try:
+        return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
+    except (psutil.NoSuchProcess, psutil.ZombieProcess):
+        return False
 
 
 class TestBuildSSHCommand:
@@ -172,6 +193,90 @@ class TestSSHPreflight:
         assert env.user == "alice"
 
 
+class TestSSHRemoteProcessCleanup:
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX process-tree semantics")
+    def test_tree_cleanup_command_leaves_no_live_orphan(self):
+        root = subprocess.Popen(
+            [
+                "/bin/bash",
+                "-c",
+                "trap 'wait; exit 0' TERM; sleep 60 & wait",
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        descendants = []
+        try:
+            def _capture_descendants():
+                try:
+                    descendants[:] = [
+                        child.pid
+                        for child in psutil.Process(root.pid).children(recursive=True)
+                    ]
+                except psutil.NoSuchProcess:
+                    descendants[:] = []
+                return bool(descendants)
+
+            assert _wait_until(_capture_descendants)
+
+            result = subprocess.run(
+                [
+                    "/bin/bash",
+                    "-c",
+                    _build_process_tree_kill_command(root_pid=root.pid),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+
+            assert result.returncode == 0, result.stderr
+            assert _wait_until(
+                lambda: root.poll() is not None
+                and all(not _pid_is_live(pid) for pid in descendants)
+            )
+        finally:
+            if root.poll() is None:
+                try:
+                    os.killpg(root.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+            try:
+                root.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+
+    def test_tracked_tree_termination_uses_ssh_connection(self, monkeypatch):
+        env = object.__new__(SSHEnvironment)
+        env._build_ssh_command = MagicMock(return_value=["ssh", "u@h"])
+        run = MagicMock(
+            return_value=subprocess.CompletedProcess([], 0, "", "")
+        )
+        monkeypatch.setattr(ssh_env.subprocess, "run", run)
+
+        result = env.terminate_process_tree(82477, timeout=3)
+
+        assert result == {"output": "", "returncode": 0}
+        env._build_ssh_command.assert_called_once_with()
+        tree_kill_calls = [
+            call
+            for call in run.call_args_list
+            if call.args
+            and call.args[0][:2] == ["ssh", "u@h"]
+            and "__hermes_root=82477" in call.args[0][-1]
+        ]
+        assert len(tree_kill_calls) == 1
+        tree_kill_call = tree_kill_calls[0]
+        remote_command = tree_kill_call.args[0][-1]
+        assert "__hermes_root=82477" in remote_command
+        assert "ps -eo pid=,ppid=" in remote_command
+        assert "kill -TERM" in remote_command
+        assert "kill -KILL" in remote_command
+        assert tree_kill_call.kwargs["timeout"] == 3
+
+
 def _setup_ssh_env(monkeypatch, persistent: bool):
     monkeypatch.setenv("TERMINAL_ENV", "ssh")
     monkeypatch.setenv("TERMINAL_SSH_HOST", _SSH_HOST)
@@ -223,6 +328,44 @@ class TestPersistentSSH:
         r = _run("echo $HERMES_PERSIST_TEST")
         assert r["output"].strip() == "works"
 
+
+    def test_background_registry_kill_kills_remote_child_tree(self):
+        from tools.process_registry import process_registry
+
+        marker = f"/tmp/hermes-background-child-{uuid.uuid4().hex}.pid"
+        session_id = ""
+        try:
+            started = _run(
+                f"sleep 999 & child=$!; echo $child > {marker}; wait $child",
+                background=True,
+            )
+            session_id = started["session_id"]
+            ready = _run(
+                f"for attempt in $(seq 1 50); do "
+                f"[ -s {marker} ] && exit 0; sleep 0.1; done; exit 1",
+                timeout=10,
+            )
+            assert ready["exit_code"] == 0
+
+            killed = process_registry.kill_process(session_id)
+            assert killed["status"] == "killed"
+
+            check = _run(
+                f"pid=$(cat {marker}); "
+                "state=$(ps -o stat= -p \"$pid\" 2>/dev/null); "
+                "case \"$state\" in ''|*Z*) echo dead ;; *) echo alive:$state ;; esac",
+                timeout=10,
+            )
+            assert check["output"].strip() == "dead"
+        finally:
+            if session_id:
+                process_registry.kill_process(session_id)
+            _run(
+                f"if [ -r {marker} ]; then "
+                f"pid=$(cat {marker}); kill -KILL \"$pid\" 2>/dev/null || true; fi; "
+                f"rm -f {marker}",
+                timeout=10,
+            )
 
     def test_large_output(self):
         r = _run("seq 1 1000")

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -270,16 +270,92 @@ def _prune_durable_records() -> None:
             )
 
 
-def _persist_completion(event: Dict[str, Any], result: Dict[str, Any]) -> None:
+def _persist_completion(event: Dict[str, Any], result: Dict[str, Any]) -> bool:
+    """Persist a terminal result unless the owning session cancelled it.
+
+    Returns ``False`` when a durable session cancellation won the race. A
+    missing row is treated as a legacy/non-durable event and remains
+    publishable for backward compatibility.
+    """
     now = time.time()
     with _DB_LOCK, _transaction() as conn:
-        conn.execute(
+        cur = conn.execute(
             """UPDATE async_delegations SET state=?, completed_at=?, updated_at=?,
                event_json=?, result_json=?, delivery_state='pending'
-               WHERE delegation_id=?""",
+               WHERE delegation_id=? AND state!='cancelled'
+                 AND delivery_state='pending'""",
             (event.get("status", "completed"), event.get("completed_at", now), now,
              json.dumps(event), json.dumps(result), event["delegation_id"]),
         )
+        if cur.rowcount == 1:
+            return True
+        row = conn.execute(
+            "SELECT state, delivery_state FROM async_delegations WHERE delegation_id=?",
+            (event["delegation_id"],),
+        ).fetchone()
+        return row is None
+
+
+def _cancel_durable_for_session(
+    *,
+    session_key: str = "",
+    origin_ui_session_id: str = "",
+    parent_session_id: str = "",
+    reason: str = "session_end",
+) -> set[str]:
+    """Durably cancel every undelivered delegation matching one session.
+
+    This write happens before child interrupt callbacks run. It covers both
+    still-running workers and the narrow race where a worker has already put
+    its completion on the shared queue but no consumer has delivered it yet.
+    """
+    selectors = []
+    params: List[Any] = []
+    if session_key:
+        selectors.append("origin_session=?")
+        params.append(session_key)
+    if origin_ui_session_id:
+        selectors.append("origin_ui_session_id=?")
+        params.append(origin_ui_session_id)
+    if parent_session_id:
+        selectors.append("parent_session_id=?")
+        params.append(parent_session_id)
+    if not selectors:
+        return set()
+
+    now = time.time()
+    selector_sql = " OR ".join(selectors)
+    try:
+        with _DB_LOCK, _transaction() as conn:
+            rows = conn.execute(
+                f"""SELECT delegation_id FROM async_delegations
+                    WHERE delivery_state='pending' AND ({selector_sql})""",
+                tuple(params),
+            ).fetchall()
+            delegation_ids = {str(row[0]) for row in rows}
+            if delegation_ids:
+                conn.execute(
+                    f"""UPDATE async_delegations
+                        SET state='cancelled',
+                            completed_at=COALESCE(completed_at, ?),
+                            updated_at=?,
+                            delivery_state='dropped',
+                            delivery_claim=NULL,
+                            delivery_claimed_at=NULL
+                        WHERE delivery_state='pending' AND ({selector_sql})""",
+                    (now, now, *params),
+                )
+            return delegation_ids
+    except Exception as exc:
+        # Session control must remain available even when durable state is
+        # degraded. The in-memory cancel_requested guard still prevents a
+        # same-process worker from publishing its result.
+        logger.warning(
+            "Could not durably cancel async delegations for session (%s): %s",
+            reason,
+            exc,
+        )
+        return set()
 
 
 def _note_delivery_attempt(delegation_id: str) -> None:
@@ -331,13 +407,14 @@ def recover_abandoned_delegations() -> int:
                 "dispatched_at": dispatched_at, "completed_at": now,
             }
             result = {"status": "unknown", "summary": None, "error": event["error"]}
-            conn.execute(
+            cur = conn.execute(
                 """UPDATE async_delegations SET state='unknown', completed_at=?,
                    updated_at=?, event_json=?, result_json=?, delivery_state='pending'
-                   WHERE delegation_id=?""",
+                   WHERE delegation_id=? AND state IN ('running','finalizing')
+                     AND delivery_state='pending'""",
                 (now, now, json.dumps(event), json.dumps(result), delegation_id),
             )
-            recovered += 1
+            recovered += cur.rowcount
     return recovered
 
 
@@ -374,7 +451,7 @@ def mark_completion_delivered(delegation_id: str) -> bool:
     with _DB_LOCK, _transaction() as conn:
         cur = conn.execute(
             """UPDATE async_delegations SET delivery_state='delivered', delivered_at=?, updated_at=?
-               WHERE delegation_id=? AND delivery_state!='delivered'""",
+               WHERE delegation_id=? AND delivery_state='pending'""",
             (now, now, delegation_id),
         )
         return cur.rowcount == 1
@@ -398,6 +475,26 @@ def claim_completion_delivery(delegation_id: str, claim_id: str) -> bool:
             (claim_id, now, now, delegation_id, now - 300),
         )
         return cur.rowcount == 1
+
+
+def is_completion_delivery_claim_active(
+    delegation_id: str, claim_id: str
+) -> bool:
+    """Revalidate a claim immediately before injecting its synthetic turn.
+
+    Session cancellation clears the claim and changes ``delivery_state`` to
+    ``dropped``. A missing row is a legacy non-durable event and remains
+    deliverable.
+    """
+    with _DB_LOCK, _transaction() as conn:
+        row = conn.execute(
+            """SELECT delivery_state, delivery_claim
+               FROM async_delegations WHERE delegation_id=?""",
+            (delegation_id,),
+        ).fetchone()
+    if row is None:
+        return True
+    return row[0] == "pending" and str(row[1] or "") == str(claim_id or "")
 
 
 def claim_event_delivery(evt: Dict[str, Any], consumer: str) -> Optional[str]:
@@ -839,6 +936,13 @@ def _begin_finalization(
         record = _records.get(delegation_id)
         if record is None or record.get("status") not in ("running", "stalling"):
             return
+        if record.get("cancel_requested"):
+            record["status"] = "cancelled"
+            record["completed_at"] = record.get("completed_at") or time.time()
+            record["interrupt_fn"] = None
+            record["progress_fn"] = None
+            _prune_completed_locked()
+            return
         # Stay active until durable persistence and queue publication finish;
         # otherwise process shutdown can kill this daemon worker in the narrow
         # gap after status flips but before SQLite is committed.
@@ -856,7 +960,9 @@ def _finish_finalization(delegation_id: str, status: str) -> None:
     with _records_lock:
         record = _records.get(delegation_id)
         if record is not None:
-            record["status"] = status
+            record["status"] = (
+                "cancelled" if record.get("cancel_requested") else status
+            )
         _prune_completed_locked()
 
 
@@ -918,7 +1024,12 @@ def _push_completion_event(
     ):
         if _k in result:
             evt[_k] = result[_k]
-    _persist_completion(evt, result)
+    if not _persist_completion(evt, result):
+        logger.info(
+            "Dropped completion for cancelled async delegation %s",
+            record.get("delegation_id"),
+        )
+        return
     try:
         process_registry.completion_queue.put(evt)
     except Exception as exc:  # pragma: no cover
@@ -1127,9 +1238,15 @@ def _push_batch_completion_event(
     ):
         if _k in combined:
             evt[_k] = combined[_k]
-    _persist_completion(evt, combined)
+    publish = _persist_completion(evt, combined)
     try:
-        process_registry.completion_queue.put(evt)
+        if publish:
+            process_registry.completion_queue.put(evt)
+        else:
+            logger.info(
+                "Dropped completion for cancelled async delegation batch %s",
+                event_record.get("delegation_id"),
+            )
     except Exception as exc:  # pragma: no cover
         logger.error(
             "Async delegation batch %s: failed to enqueue completion event; "
@@ -1423,6 +1540,7 @@ def interrupt_all(reason: str = "shutdown") -> int:
         targets = [
             r for r in _records.values()
             if r.get("status") in ("running", "stalling")
+            and not r.get("cancel_requested")
         ]
     for r in targets:
         fn = r.get("interrupt_fn")
@@ -1446,7 +1564,7 @@ def interrupt_for_session(
     parent_session_id: str = "",
     reason: str = "session_end",
 ) -> int:
-    """Signal running async delegations owned by ONE session to stop.
+    """Cancel async delegations owned by ONE session.
 
     A delegation's lifecycle is bound to the session that spawned it: when
     that session ends, its in-flight background subagents must end with it —
@@ -1462,36 +1580,81 @@ def interrupt_for_session(
       platform conversation key) SURVIVES a ``/new`` reset while the
       session id rotates.
 
-    Returns how many were interrupted.
+    Cancellation is recorded durably *before* child interrupt callbacks run.
+    A completion already waiting on the shared queue is therefore rejected by
+    its delivery claim, and a worker that finishes later cannot overwrite the
+    cancelled state or publish a new event.
+
+    Returns how many delegations were newly cancelled or dropped.
     """
     if not session_key and not origin_ui_session_id and not parent_session_id:
         return 0
-    count = 0
+
+    now = time.time()
     with _records_lock:
         targets = [
-            r for r in _records.values()
-            if r.get("status") in ("running", "stalling")
+            record
+            for record in _records.values()
+            if record.get("status") in {"running", "stalling", "finalizing"}
+            and not record.get("cancel_requested")
             and _matches_session_selectors(
-                r,
+                record,
                 session_key=session_key,
                 origin_ui_session_id=origin_ui_session_id,
                 parent_session_id=parent_session_id,
             )
         ]
+        memory_ids = {
+            str(record.get("delegation_id") or "")
+            for record in targets
+            if record.get("delegation_id")
+        }
+        for record in targets:
+            # Set this before releasing the lock so a racing finalize path
+            # cannot publish while durable cancellation is being written.
+            record["cancel_requested"] = True
+            record["cancel_reason"] = reason
+            record["cancel_requested_at"] = now
+
+    durable_ids = _cancel_durable_for_session(
+        session_key=session_key,
+        origin_ui_session_id=origin_ui_session_id,
+        parent_session_id=parent_session_id,
+        reason=reason,
+    )
+
+    # A worker may already be terminal in memory while its queued completion
+    # is still pending durably. Reflect the drop in status listings and make
+    # repeated session-control calls idempotent.
+    with _records_lock:
+        for delegation_id in durable_ids:
+            record = _records.get(delegation_id)
+            if record is None:
+                continue
+            record["cancel_requested"] = True
+            record["cancel_reason"] = reason
+            record["cancel_requested_at"] = now
+            if record.get("status") not in {"running", "stalling", "finalizing"}:
+                record["status"] = "cancelled"
+                record["completed_at"] = record.get("completed_at") or now
+                record["interrupt_fn"] = None
+                record["progress_fn"] = None
+        _prune_completed_locked()
+
     for r in targets:
         fn = r.get("interrupt_fn")
         if callable(fn):
             try:
                 fn()
-                count += 1
             except Exception as exc:
                 logger.debug(
                     "interrupt_for_session: %s interrupt failed: %s",
                     r.get("delegation_id"), exc,
                 )
+    count = len(memory_ids | durable_ids)
     if count:
         logger.info(
-            "Interrupted %d async delegation(s) for ending session (%s)",
+            "Cancelled %d async delegation(s) for ending session (%s)",
             count, reason,
         )
     return count

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2899,6 +2899,10 @@ def delegate_task(
 
     overall_start = time.monotonic()
     results = []
+    # Set by the async-delegation registry when its owning session ends.
+    # This is separate from parent_agent._interrupt_requested because a
+    # detached batch may outlive the foreground parent turn.
+    _batch_cancel_requested = threading.Event()
 
     n_tasks = len(task_list)
     # Track goal labels for progress display (truncated for readability)
@@ -2995,11 +2999,14 @@ def delegate_task(
             completed_count = 0
             spinner_ref = getattr(parent_agent, "_delegate_spinner", None)
 
-            # Daemon workers (tools.daemon_pool): the `with` block still joins
-            # normally, but if the parent is interrupted while a child is
-            # wedged, the abandoned worker must not block interpreter exit.
+            # Daemon workers (tools.daemon_pool) can be abandoned safely when
+            # interrupted. Do not use the executor as a context manager here:
+            # ThreadPoolExecutor.__exit__ calls shutdown(wait=True), which
+            # would turn the "abandon pending children" branch below into an
+            # unbounded join on an uncooperative child.
             from tools.daemon_pool import DaemonThreadPoolExecutor
-            with DaemonThreadPoolExecutor(max_workers=max_children) as executor:
+            executor = DaemonThreadPoolExecutor(max_workers=max_children)
+            try:
                 futures = {}
                 for i, t, child in children:
                     child_context = contextvars.copy_context()
@@ -3024,13 +3031,21 @@ def delegate_task(
 
                 pending = set(futures.keys())
                 while pending:
-                    if (
+                    parent_interrupted = (
                         honor_parent_interrupt
                         and getattr(parent_agent, "_interrupt_requested", False) is True
-                    ):
-                        # Parent interrupted — collect whatever finished and
-                        # abandon the rest.  Children already received the
-                        # interrupt signal; we just can't wait forever.
+                    )
+                    registry_cancelled = _batch_cancel_requested.is_set()
+                    if parent_interrupted or registry_cancelled:
+                        # Parent/session interrupted — collect whatever
+                        # finished and abandon the rest. Children already
+                        # received the interrupt signal; we cannot join an
+                        # uncooperative provider indefinitely.
+                        interruption_error = (
+                            "Async delegation cancelled — child did not finish in time"
+                            if registry_cancelled
+                            else "Parent agent interrupted — child did not finish in time"
+                        )
                         for f in pending:
                             idx = futures[f]
                             if f.done():
@@ -3049,11 +3064,12 @@ def delegate_task(
                                         ),
                                     }
                             else:
+                                f.cancel()
                                 entry = {
                                     "task_index": idx,
                                     "status": "interrupted",
                                     "summary": None,
-                                    "error": "Parent agent interrupted — child did not finish in time",
+                                    "error": interruption_error,
                                     "api_calls": 0,
                                     "duration_seconds": 0,
                                     "_child_role": getattr(
@@ -3114,6 +3130,11 @@ def delegate_task(
                                 )
                             except Exception as e:
                                 logger.debug("Spinner update_text failed: %s", e)
+            finally:
+                try:
+                    executor.shutdown(wait=False, cancel_futures=True)
+                except TypeError:  # pragma: no cover — Python < 3.9
+                    executor.shutdown(wait=False)
 
             # Sort by task_index so results match input order
             results.sort(key=lambda r: r["task_index"])
@@ -3274,6 +3295,7 @@ def delegate_task(
             return _execute_and_aggregate(honor_parent_interrupt=False)
 
         def _batch_interrupt():
+            _batch_cancel_requested.set()
             for _c in _child_agents:
                 try:
                     interrupted = request_hard_interrupt(_c, "Async delegation cancelled")

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -52,6 +52,46 @@ _activity_callback_local = threading.local()
 _UNBOUNDED_CAPTURE_CHARS = 2**63 - 1
 
 
+def _build_process_tree_kill_command(
+    *,
+    root_pid: int,
+) -> str:
+    """Build a Bash command that stops and terminates one POSIX process tree.
+
+    The root is stopped before descendants are enumerated, and each descendant
+    is stopped before its own children are inspected. This closes the fork
+    race that otherwise lets killing only the wrapper orphan a still-running
+    child under PID 1. The ``ps`` form works on both Linux and macOS.
+    """
+    try:
+        normalized_pid = int(root_pid)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("root_pid must be an integer") from exc
+    if normalized_pid <= 1:
+        raise ValueError("root_pid must be greater than 1")
+
+    return (
+        f"__hermes_root={normalized_pid}; "
+        "__hermes_children() { "
+        "ps -eo pid=,ppid= 2>/dev/null | "
+        "awk -v parent=\"$1\" '$2 == parent { print $1 }'; "
+        "}; "
+        "__hermes_collect() { "
+        "kill -STOP \"$1\" 2>/dev/null || true; "
+        "for __hermes_child in $(__hermes_children \"$1\"); do "
+        "__hermes_collect \"$__hermes_child\"; done; "
+        "printf '%s\\n' \"$1\"; "
+        "}; "
+        "__hermes_pids=$(__hermes_collect \"$__hermes_root\"); "
+        "if [ -n \"$__hermes_pids\" ]; then "
+        "kill -TERM $__hermes_pids 2>/dev/null || true; "
+        "kill -CONT $__hermes_pids 2>/dev/null || true; "
+        "sleep 0.5; "
+        "kill -KILL $__hermes_pids 2>/dev/null || true; "
+        "fi"
+    )
+
+
 class _BoundedOutputCollector:
     """Retain a bounded 40/60 head-tail window of streamed text.
 
@@ -1219,6 +1259,23 @@ class BaseEnvironment(ABC):
             proc.kill()
         except (ProcessLookupError, PermissionError, OSError):
             pass
+
+    def terminate_process_tree(self, pid: int, *, timeout: int = 5) -> dict:
+        """Terminate a tracked process and every descendant inside this backend."""
+        command = _build_process_tree_kill_command(root_pid=pid)
+        result = self.execute(
+            command,
+            timeout=timeout,
+            rewrite_compound_background=False,
+        )
+        returncode = result.get("returncode")
+        if returncode not in (None, 0):
+            detail = str(result.get("output") or "").strip()
+            raise RuntimeError(
+                f"process-tree termination failed (rc={returncode})"
+                + (f": {detail}" if detail else "")
+            )
+        return result
 
     # ------------------------------------------------------------------
     # CWD extraction

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -9,7 +9,11 @@ import subprocess
 import tempfile
 from pathlib import Path
 
-from tools.environments.base import BaseEnvironment, _popen_bash
+from tools.environments.base import (
+    BaseEnvironment,
+    _build_process_tree_kill_command,
+    _popen_bash,
+)
 from tools.environments.file_sync import (
     FileSyncManager,
     iter_sync_files,
@@ -339,6 +343,33 @@ class SSHEnvironment(BaseEnvironment):
     # ------------------------------------------------------------------
     # Execution
     # ------------------------------------------------------------------
+
+    def terminate_process_tree(self, pid: int, *, timeout: int = 5) -> dict:
+        """Terminate a tracked remote tree over this SSH connection."""
+        cmd = self._build_ssh_command()
+        cmd.extend(
+            [
+                "bash",
+                "-c",
+                shlex.quote(_build_process_tree_kill_command(root_pid=pid)),
+            ]
+        )
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            stdin=subprocess.DEVNULL,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip()
+            raise RuntimeError(
+                f"SSH process-tree termination failed (rc={result.returncode})"
+                + (f": {detail}" if detail else "")
+            )
+        return {"output": result.stdout, "returncode": result.returncode}
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -118,6 +118,7 @@ class ProcessSession:
     watcher_message_id: str = ""                # Triggering message id — reply anchor for topic routing
     watcher_interval: int = 0                   # 0 = no watcher configured
     notify_on_complete: bool = False             # Queue agent notification on exit
+    completion_suppressed: bool = False          # Explicit session stop: never notify/re-enter
     # Watch patterns — trigger agent notification when output matches any pattern
     watch_patterns: List[str] = field(default_factory=list)
     _watch_hits: int = field(default=0, repr=False)          # total matches delivered
@@ -156,6 +157,9 @@ class ProcessRegistry:
         "no job control in this shell",
         "cannot set terminal process group",
         "tcsetattr: Inappropriate ioctl for device",
+    )
+    _PROCESS_NOTIFICATION_TYPES = frozenset(
+        {"completion", "watch_match", "watch_disabled"}
     )
 
     def __init__(self):
@@ -233,6 +237,28 @@ class ProcessRegistry:
         except Exception:
             pass
 
+    def _queue_process_notification(
+        self,
+        session: ProcessSession,
+        event: Dict[str, Any],
+        *,
+        require_notify_on_complete: bool = False,
+    ) -> bool:
+        """Queue a process event unless an explicit session stop suppressed it.
+
+        ``cancel_for_session()`` and all process-owned producers share
+        ``self._lock`` as their notification admission boundary. This closes
+        the race where ``/stop`` drained the queue just before a reader thread
+        enqueued a late completion or watch event.
+        """
+        with self._lock:
+            if session.completion_suppressed:
+                return False
+            if require_notify_on_complete and not session.notify_on_complete:
+                return False
+            self.completion_queue.put(event)
+        return True
+
     def _check_watch_patterns(self, session: ProcessSession, new_text: str) -> None:
         """Scan new output for watch patterns and queue notifications.
 
@@ -246,7 +272,11 @@ class ProcessRegistry:
         notify_on_complete semantics — one notification when the process
         actually exits, no more mid-process spam.
         """
-        if not session.watch_patterns or session._watch_disabled:
+        if (
+            session.completion_suppressed
+            or not session.watch_patterns
+            or session._watch_disabled
+        ):
             return
         # Suppress-after-exit: once the reader loop has declared the process
         # exited, any late chunk we still see is post-exit noise. Dropping these
@@ -314,7 +344,7 @@ class ProcessRegistry:
             if should_disable:
                 # Emit exactly one "watch disabled, falling back to notify_on_complete"
                 # summary event so the agent/user sees why things went quiet.
-                self.completion_queue.put({
+                self._queue_process_notification(session, {
                     "session_id": session.id,
                     "session_key": session.session_key,
                     "command": session.command,
@@ -345,7 +375,7 @@ class ProcessRegistry:
         if not self._global_watch_admit(now):
             return
 
-        self.completion_queue.put({
+        self._queue_process_notification(session, {
             "session_id": session.id,
             "session_key": session.session_key,
             "command": session.command,
@@ -1194,29 +1224,41 @@ class ProcessRegistry:
         # Only enqueue completion notification on the FIRST move.  Without
         # this guard, kill_process() and the reader thread can both call
         # _move_to_finished(), producing duplicate [IMPORTANT: ...] messages.
-        if was_running and session.notify_on_complete:
+        if was_running:
             from tools.ansi_strip import strip_ansi
             output_tail = strip_ansi(session.output_buffer[-2000:]) if session.output_buffer else ""
-            self.completion_queue.put({
-                "type": "completion",
-                "session_id": session.id,
-                "session_key": session.session_key,
-                "command": session.command,
-                "exit_code": session.exit_code,
-                "completion_reason": session.completion_reason,
-                "termination_source": session.termination_source,
-                "output": output_tail,
-                # Stable producer identity across checkpoint recovery; unlike
-                # a consumer-observed completion timestamp, this does not vary
-                # based on which watcher notices exit first.
-                "started_at": session.started_at,
-            })
+            self._queue_process_notification(
+                session,
+                {
+                    "type": "completion",
+                    "session_id": session.id,
+                    "session_key": session.session_key,
+                    "command": session.command,
+                    "exit_code": session.exit_code,
+                    "completion_reason": session.completion_reason,
+                    "termination_source": session.termination_source,
+                    "output": output_tail,
+                    # Stable producer identity across checkpoint recovery;
+                    # unlike a consumer-observed completion timestamp, this
+                    # does not vary based on which watcher notices exit first.
+                    "started_at": session.started_at,
+                },
+                require_notify_on_complete=True,
+            )
 
     # ----- Query Methods -----
 
     def is_completion_consumed(self, session_id: str) -> bool:
         """Check if a completion notification was already consumed via wait/log."""
         return session_id in self._completion_consumed
+
+    def is_completion_suppressed(self, session_id: str) -> bool:
+        """Whether ``/stop`` permanently suppressed this process incarnation."""
+        if not session_id:
+            return False
+        with self._lock:
+            session = self._running.get(session_id) or self._finished.get(session_id)
+            return bool(session and session.completion_suppressed)
 
     def is_session_waiting(self, session_id: str) -> bool:
         """Whether a goal loop parked on this session should still be parked.
@@ -1346,6 +1388,11 @@ class ProcessRegistry:
             # session owns (or legacy ownerless ordinary events). Routing must
             # happen first so a foreign session cannot drop the owner's event.
             _evt_sid = evt.get("session_id", "")
+            if (
+                evt.get("type", "completion") in self._PROCESS_NOTIFICATION_TYPES
+                and self.is_completion_suppressed(_evt_sid)
+            ):
+                continue
             if evt.get("type") == "completion" and self._drain_should_skip(
                 _evt_sid, skip_poll_observed=skip_poll_observed
             ):
@@ -1890,6 +1937,122 @@ class ProcessRegistry:
 
     # ----- Session/Task Queries (for gateway integration) -----
 
+    def cancel_for_session(
+        self,
+        session_key: str,
+        reason: str = "session_stop",
+    ) -> int:
+        """Suppress notifications and terminate processes owned by one session.
+
+        Suppression is installed before any kill attempt. Therefore a failed
+        backend/OS termination cannot later revive the stopped conversation via
+        ``notify_on_complete``. Queued events and pending watcher registrations
+        for other sessions retain their order and remain untouched.
+
+        Returns the number of distinct active or pending process producers
+        affected. Repeating the call after a successful cancellation returns
+        zero.
+        """
+        session_key = str(session_key or "")
+        if not session_key:
+            return 0
+
+        affected_ids: set[str] = set()
+        kill_ids: list[str] = []
+        matched_sessions: Dict[str, ProcessSession] = {}
+
+        with self._lock:
+            for session in (
+                list(self._running.values()) + list(self._finished.values())
+            ):
+                if session.session_key == session_key:
+                    matched_sessions[session.id] = session
+
+            target_ids = set(matched_sessions)
+
+            retained_watchers = []
+            for watcher in self.pending_watchers:
+                watcher_id = str(watcher.get("session_id") or "")
+                if (
+                    watcher_id in target_ids
+                    or str(watcher.get("session_key") or "") == session_key
+                ):
+                    if watcher_id:
+                        affected_ids.add(watcher_id)
+                    continue
+                retained_watchers.append(watcher)
+            self.pending_watchers = retained_watchers
+
+            retained_events = []
+            while True:
+                try:
+                    event = self.completion_queue.get_nowait()
+                except Exception:
+                    break
+                event_type = (
+                    event.get("type", "completion")
+                    if isinstance(event, dict)
+                    else ""
+                )
+                event_id = (
+                    str(event.get("session_id") or "")
+                    if isinstance(event, dict)
+                    else ""
+                )
+                event_key = (
+                    str(event.get("session_key") or "")
+                    if isinstance(event, dict)
+                    else ""
+                )
+                if (
+                    event_type in self._PROCESS_NOTIFICATION_TYPES
+                    and (event_id in target_ids or event_key == session_key)
+                ):
+                    if event_id:
+                        affected_ids.add(event_id)
+                    continue
+                retained_events.append(event)
+            for event in retained_events:
+                self.completion_queue.put(event)
+
+            for session_id, session in matched_sessions.items():
+                if session_id in self._running and not session.exited:
+                    affected_ids.add(session_id)
+                    kill_ids.append(session_id)
+
+                # ``completion_suppressed`` is authoritative. Clear the legacy
+                # producer flags too so checkpoint recovery and already-running
+                # watcher tasks naturally stay quiet.
+                session.completion_suppressed = True
+                session.notify_on_complete = False
+                session.watcher_interval = 0
+                session.watch_patterns = []
+                session._watch_disabled = True
+
+        # Persist the suppression fence before touching the OS/backend. A kill
+        # can fail or the gateway can crash during it; neither may resurrect a
+        # completion on restart.
+        if matched_sessions:
+            self._write_checkpoint()
+
+        for session_id in kill_ids:
+            result = self.kill_process(
+                session_id,
+                source=reason,
+                consume_output=False,
+            )
+            if result.get("status") not in {"killed", "already_exited"}:
+                logger.warning(
+                    "Failed to terminate background process %s for session %s "
+                    "(%s): %s",
+                    session_id,
+                    session_key,
+                    reason,
+                    result.get("error") or result.get("status"),
+                )
+
+        return len(affected_ids)
+
     def has_active_processes(self, task_id: str) -> bool:
         """Check if there are active (running) processes for a task_id."""
         with self._lock:
@@ -2083,6 +2246,7 @@ class ProcessRegistry:
                             "watcher_message_id": s.watcher_message_id,
                             "watcher_interval": s.watcher_interval,
                             "notify_on_complete": s.notify_on_complete,
+                            "completion_suppressed": s.completion_suppressed,
                             "watch_patterns": s.watch_patterns,
                         })
             
@@ -2142,6 +2306,9 @@ class ProcessRegistry:
                     )
                 continue
 
+            completion_suppressed = bool(
+                entry.get("completion_suppressed", False)
+            )
             session = ProcessSession(
                 id=entry["session_id"],
                 command=entry.get("command", "unknown"),
@@ -2159,17 +2326,29 @@ class ProcessRegistry:
                 watcher_user_name=entry.get("watcher_user_name", ""),
                 watcher_thread_id=entry.get("watcher_thread_id", ""),
                 watcher_message_id=entry.get("watcher_message_id", ""),
-                watcher_interval=entry.get("watcher_interval", 0),
-                notify_on_complete=entry.get("notify_on_complete", False),
-                watch_patterns=entry.get("watch_patterns", []),
+                watcher_interval=(
+                    0 if completion_suppressed
+                    else entry.get("watcher_interval", 0)
+                ),
+                notify_on_complete=(
+                    False if completion_suppressed
+                    else entry.get("notify_on_complete", False)
+                ),
+                completion_suppressed=completion_suppressed,
+                watch_patterns=(
+                    [] if completion_suppressed
+                    else entry.get("watch_patterns", [])
+                ),
             )
+            if completion_suppressed:
+                session._watch_disabled = True
             with self._lock:
                 self._running[session.id] = session
             recovered += 1
             logger.info("Recovered detached process: %s (pid=%d)", session.command[:60], pid)
 
             # Re-enqueue watcher so gateway can resume notifications
-            if session.watcher_interval > 0:
+            if session.watcher_interval > 0 and not session.completion_suppressed:
                 self.pending_watchers.append({
                     "session_id": session.id,
                     "check_interval": session.watcher_interval,

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1727,8 +1727,23 @@ class ProcessRegistry:
                 # shell wrapper and leaves Git Bash descendants behind.
                 self._terminate_host_pid(session.process.pid, session.host_start_time)
             elif session.env_ref and session.pid:
-                # Non-local -- kill inside sandbox
-                session.env_ref.execute(f"kill {session.pid} 2>/dev/null", timeout=5)
+                # Non-local -- terminate descendants before their tracked root.
+                # Killing only the wrapper reparents its still-running children
+                # to PID 1, which is especially visible through the SSH backend.
+                terminate_tree = getattr(
+                    session.env_ref,
+                    "terminate_process_tree",
+                    None,
+                )
+                if callable(terminate_tree):
+                    terminate_tree(session.pid, timeout=5)
+                else:
+                    # Compatibility for third-party environments that do not yet
+                    # inherit the BaseEnvironment tree-termination primitive.
+                    session.env_ref.execute(
+                        f"kill {session.pid} 2>/dev/null",
+                        timeout=5,
+                    )
             elif session.detached and session.pid_scope == "host" and session.pid:
                 # Identity check, not bare liveness: if the PID is gone OR was
                 # recycled onto an unrelated process, treat our process as


### PR DESCRIPTION
## Root cause

`delegate_task(background=true)` runs outside the gateway's foreground
`_running_agents` registry. `/stop` only interrupted the foreground agent, so
detached work could continue and later publish a completion event that created
a new synthetic turn in the stopped Discord session.

## What changed

- cancel detached delegations through the same session lifecycle funnel used by
  `/stop` and session resets, including background-only sessions
- persist `cancelled` / `dropped` before signalling child workers, then
  revalidate delivery claims before injecting a completion
- clear stale `resume_pending` state so an explicit stop cannot restart work
  after a gateway reboot
- scope cancellation to the owning session so other Discord threads keep
  running
- avoid an unbounded executor join when an interrupted child does not cooperate

## Tests

- `scripts/run_tests.sh` on the full tree: 22,796 passed; 23 unrelated local
  macOS/environment failures
- the same 14 failing files were rerun on the unmodified upstream base and all
  failed there as well (21 identical baseline failures; the other 2 were
  0.1-second timeout flakes seen only under full parallel load)
- after rebasing onto the latest `upstream/main`, 158 directly related tests
  across 14 files passed with 0 failures
- `git diff --check upstream/main...HEAD`
