### PR TITLE
fix(kanban): normalize transient runtime outcomes

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -90,6 +90,11 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping, Optional
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
+from hermes_cli.runtime_outcomes import (
+    RuntimeOutcome,
+    outcome_for_launcher_exception,
+    outcome_for_worker_exit,
+)
 from toolsets import get_toolset_names
 
 _log = logging.getLogger(__name__)
@@ -6693,6 +6698,8 @@ class DispatchResult:
     (EX_TEMPFAIL sentinel exit) and were released back to ``ready`` WITHOUT
     counting a failure. These never trip the circuit breaker — a long quota
     window just makes the task bounce cheaply until the window clears."""
+    runtime_outcomes: list[dict[str, Any]] = field(default_factory=list)
+    """Typed runtime outcomes observed during this dispatch pass."""
     skipped_locked: bool = False
     """True when this tick was skipped because another process already held
     the board's dispatch lock (issue #35240). A losing dispatcher does no
@@ -6778,6 +6785,12 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
     except Exception:
         pass
     return ("unknown", None)
+
+
+def worker_exit_outcome(pid: int) -> RuntimeOutcome:
+    """Return the typed runtime outcome for a recently reaped worker."""
+    kind, code = _classify_worker_exit(pid)
+    return outcome_for_worker_exit(kind, code)
 
 
 def reap_worker_zombies() -> "list[int]":
@@ -7398,6 +7411,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     """
     crashed: list[str] = []
     rate_limited: list[str] = []
+    runtime_outcomes: list[dict[str, Any]] = []
     # Per-crash details collected inside the main txn, used after it
     # closes to run ``_record_task_failure`` (which needs its own
     # write_txn so can't nest). ``protocol_violation`` flags the
@@ -7430,8 +7444,15 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
 
             pid = int(row["worker_pid"])
             kind, code = _classify_worker_exit(pid)
+            runtime_outcome = worker_exit_outcome(pid)
             rate_limited_exit = False
             if kind == "clean_exit":
+                # A clean subprocess exit while the task is still running is
+                # not successful task completion: the worker violated the
+                # Kanban terminal-outcome protocol.
+                runtime_outcome = RuntimeOutcome.code_failure(
+                    reason="worker exited cleanly without terminal outcome"
+                )
                 # Worker subprocess returned 0 but its task is still
                 # ``running`` in the DB — it exited without calling
                 # ``kanban_complete`` / ``kanban_block``. Overwhelmingly the
@@ -7492,6 +7513,8 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     event_payload["exit_kind"] = kind
                     event_payload["exit_code"] = code
 
+            event_payload["runtime_outcome"] = runtime_outcome.to_dict()
+
             cur = conn.execute(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL "
@@ -7544,6 +7567,10 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                         (row["id"], pid, row["claim_lock"],
                          protocol_violation, error_text)
                     )
+                runtime_outcomes.append({
+                    "task_id": row["id"],
+                    **runtime_outcome.to_dict(),
+                })
     # Outside the main txn: account each crashed task and maybe trip the
     # breaker (the task transitions ready → blocked with a ``gave_up`` event
     # on top of the event we already emitted).
@@ -7635,6 +7662,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # Same side-channel for rate-limited requeues — these did NOT count a
     # failure and are NOT crashes, so they stay out of the ``crashed`` return.
     detect_crashed_workers._last_rate_limited = rate_limited  # type: ignore[attr-defined]
+    detect_crashed_workers._last_runtime_outcomes = runtime_outcomes  # type: ignore[attr-defined]
     return crashed
 
 
@@ -7643,7 +7671,7 @@ def _record_task_failure(
     task_id: str,
     error: str,
     *,
-    outcome: str,
+    outcome: str | RuntimeOutcome,
     failure_limit: int = None,
     force_trip: bool = False,
     release_claim: bool = False,
@@ -7695,6 +7723,42 @@ def _record_task_failure(
     """
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
+    typed_outcome = RuntimeOutcome.from_value(outcome)
+    if not typed_outcome.counts_against_failure_budget:
+        # Provider, transport, and temporary worker outcomes are operational
+        # events, not failures of the task. They may release a claim and close
+        # the run, but must never increment either breaker budget.
+        with write_txn(conn):
+            row = conn.execute(
+                "SELECT status FROM tasks WHERE id = ?", (task_id,)
+            ).fetchone()
+            if row is None:
+                return False
+            if release_claim:
+                conn.execute(
+                    "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                    "claim_expires = NULL, worker_pid = NULL "
+                    "WHERE id = ? AND status = 'running'",
+                    (task_id,),
+                )
+            run_id = None
+            if end_run:
+                run_id = _end_run(
+                    conn,
+                    task_id,
+                    outcome=typed_outcome.kind,
+                    status=typed_outcome.kind,
+                    error=error[:500],
+                    metadata=typed_outcome.to_dict(),
+                )
+            _append_event(
+                conn,
+                task_id,
+                typed_outcome.kind,
+                {"error": error[:500], **typed_outcome.to_dict()},
+                run_id=run_id,
+            )
+        return False
     blocked = False
     with write_txn(conn):
         row = conn.execute(
@@ -7747,7 +7811,7 @@ def _record_task_failure(
                     error=error[:500],
                     metadata={
                         "failures": failures,
-                        "trigger_outcome": outcome,
+                        "trigger_outcome": typed_outcome.kind,
                         "effective_limit": effective_limit,
                         "limit_source": limit_source,
                     },
@@ -7757,7 +7821,7 @@ def _record_task_failure(
                 "effective_limit": effective_limit,
                 "limit_source": limit_source,
                 "error": error[:500],
-                "trigger_outcome": outcome,
+                "trigger_outcome": typed_outcome.kind,
             }
             if event_payload_extra:
                 payload.update(event_payload_extra)
@@ -7788,13 +7852,17 @@ def _record_task_failure(
                 # Spawn path: close the open run with outcome.
                 run_id = _end_run(
                     conn, task_id,
-                    outcome=outcome, status=outcome,
+                    outcome=typed_outcome.kind, status=typed_outcome.kind,
                     error=error[:500],
                     metadata={"failures": failures},
                 )
                 _append_event(
-                    conn, task_id, outcome,
-                    {"error": error[:500], "failures": failures},
+                    conn, task_id, typed_outcome.kind,
+                    {
+                        "error": error[:500],
+                        "failures": failures,
+                        "kind": typed_outcome.kind,
+                    },
                     run_id=run_id,
                 )
             # Timeout/crash path's caller already emitted its own event.
@@ -8192,6 +8260,11 @@ def _dispatch_once_locked(
     )
     if _crash_rate_limited:
         result.rate_limited.extend(_crash_rate_limited)
+    _crash_runtime_outcomes = getattr(
+        detect_crashed_workers, "_last_runtime_outcomes", []
+    )
+    if _crash_runtime_outcomes:
+        result.runtime_outcomes.extend(_crash_runtime_outcomes)
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
 
@@ -8391,9 +8464,17 @@ def _dispatch_once_locked(
             else:
                 workspace = resolve_workspace(claimed, board=board)
         except Exception as exc:
-            auto = _record_spawn_failure(
+            runtime_outcome = outcome_for_launcher_exception(exc)
+            result.runtime_outcomes.append({
+                "task_id": claimed.id,
+                **runtime_outcome.to_dict(),
+            })
+            auto = _record_task_failure(
                 conn, claimed.id, f"workspace: {exc}",
+                outcome=runtime_outcome,
                 failure_limit=failure_limit,
+                release_claim=True,
+                end_run=True,
             )
             if auto:
                 result.auto_blocked.append(claimed.id)
@@ -8436,9 +8517,19 @@ def _dispatch_once_locked(
                     _per_profile_running.get(claimed.assignee, 0) + 1
                 )
         except Exception as exc:
-            auto = _record_spawn_failure(
-                conn, claimed.id, str(exc),
+            runtime_outcome = outcome_for_launcher_exception(exc)
+            result.runtime_outcomes.append({
+                "task_id": claimed.id,
+                **runtime_outcome.to_dict(),
+            })
+            auto = _record_task_failure(
+                conn,
+                claimed.id,
+                str(exc),
+                outcome=runtime_outcome,
                 failure_limit=failure_limit,
+                release_claim=True,
+                end_run=True,
             )
             if auto:
                 result.auto_blocked.append(claimed.id)
@@ -8483,9 +8574,17 @@ def _dispatch_once_locked(
             else:
                 workspace = resolve_workspace(claimed, board=board)
         except Exception as exc:
-            auto = _record_spawn_failure(
+            runtime_outcome = outcome_for_launcher_exception(exc)
+            result.runtime_outcomes.append({
+                "task_id": claimed.id,
+                **runtime_outcome.to_dict(),
+            })
+            auto = _record_task_failure(
                 conn, claimed.id, f"workspace: {exc}",
+                outcome=runtime_outcome,
                 failure_limit=failure_limit,
+                release_claim=True,
+                end_run=True,
             )
             if auto:
                 result.auto_blocked.append(claimed.id)
@@ -8517,9 +8616,17 @@ def _dispatch_once_locked(
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
             spawned += 1
         except Exception as exc:
-            auto = _record_spawn_failure(
+            runtime_outcome = outcome_for_launcher_exception(exc)
+            result.runtime_outcomes.append({
+                "task_id": claimed.id,
+                **runtime_outcome.to_dict(),
+            })
+            auto = _record_task_failure(
                 conn, claimed.id, str(exc),
+                outcome=runtime_outcome,
                 failure_limit=failure_limit,
+                release_claim=True,
+                end_run=True,
             )
             if auto:
                 result.auto_blocked.append(claimed.id)

--- a/hermes_cli/runtime_outcomes.py
+++ b/hermes_cli/runtime_outcomes.py
@@ -1,0 +1,109 @@
+"""Typed runtime outcomes shared by provider, launcher, worker, and goal paths."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RuntimeOutcome:
+    """Bounded execution result used for retry and budget accounting."""
+
+    kind: str
+    retryable: bool
+    counts_against_failure_budget: bool
+    reason: str = ""
+    source: str = ""
+
+    @property
+    def is_transient(self) -> bool:
+        return self.retryable and not self.counts_against_failure_budget
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "retryable": self.retryable,
+            "counts_against_failure_budget": self.counts_against_failure_budget,
+            "reason": self.reason,
+            "source": self.source,
+        }
+
+    @classmethod
+    def provider_overload(cls, reason: str = "provider overloaded") -> "RuntimeOutcome":
+        return cls("provider_overload", True, False, reason, "provider")
+
+    @classmethod
+    def launcher_transport_failure(
+        cls, reason: str = "launcher transport failure"
+    ) -> "RuntimeOutcome":
+        return cls("launcher_transport_failure", True, False, reason, "launcher")
+
+    @classmethod
+    def ex_tempfail(cls, reason: str = "worker exited EX_TEMPFAIL") -> "RuntimeOutcome":
+        return cls("ex_tempfail", True, False, reason, "worker")
+
+    @classmethod
+    def code_failure(cls, reason: str = "worker code failure") -> "RuntimeOutcome":
+        return cls("code_failure", False, True, reason, "worker")
+
+    @classmethod
+    def from_value(cls, value: Any) -> "RuntimeOutcome":
+        """Normalize legacy outcome/reason strings, failing closed."""
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, dict):
+            value = value.get("kind") or value.get("failure_reason")
+        raw = getattr(value, "value", value)
+        raw = str(raw or "").strip().lower()
+        if raw in {"overloaded", "upstream_rate_limit", "provider_overload"}:
+            return cls.provider_overload(reason=raw)
+        if raw in {"rate_limit", "billing"}:
+            return cls(raw, True, False, raw, "provider")
+        if raw in {"transport", "launcher_transport_failure", "judge_transport_failure"}:
+            return cls(raw, True, False, raw, "launcher" if raw != "judge_transport_failure" else "goal_judge")
+        if raw in {"rate_limited", "tempfail", "ex_tempfail"}:
+            return cls.ex_tempfail(reason=raw)
+        if raw in {"crashed", "code_failure", "failure", "spawn_failed", "timed_out"}:
+            return cls.code_failure(reason=raw)
+        if raw in {"completed", "success"}:
+            return cls("completed", False, False, raw, "worker")
+        return cls.code_failure(reason=raw or "unknown runtime failure")
+
+
+def outcome_for_provider_reason(reason: Any) -> RuntimeOutcome:
+    """Map the provider classifier's reason to runtime accounting."""
+    raw = getattr(reason, "value", reason)
+    raw = str(raw or "").strip().lower()
+    if raw in {"overloaded", "upstream_rate_limit"}:
+        return RuntimeOutcome.provider_overload(reason=raw)
+    if raw in {"rate_limit", "billing"}:
+        return RuntimeOutcome(raw, True, False, raw, "provider")
+    return RuntimeOutcome.code_failure(reason=raw or "unknown provider failure")
+
+
+def outcome_for_launcher_exception(exc: BaseException) -> RuntimeOutcome:
+    """Classify launcher transport failures without hiding code failures."""
+    if isinstance(exc, (ConnectionError, TimeoutError, BrokenPipeError, subprocess.TimeoutExpired)):
+        return RuntimeOutcome.launcher_transport_failure(
+            reason=str(exc) or exc.__class__.__name__
+        )
+    return RuntimeOutcome("spawn_failure", False, True, str(exc) or exc.__class__.__name__, "launcher")
+
+
+def outcome_for_worker_exit(kind: str, code: int | None) -> RuntimeOutcome:
+    """Map the existing worker-exit classifier to a typed outcome."""
+    if kind == "clean_exit":
+        return RuntimeOutcome("completed", False, False, "worker exited successfully", "worker")
+    if kind == "rate_limited" or code == 75:
+        return RuntimeOutcome.ex_tempfail(reason="worker exited EX_TEMPFAIL (75)")
+    return RuntimeOutcome.code_failure(reason=f"worker exit kind={kind}, code={code}")
+
+
+__all__ = [
+    "RuntimeOutcome",
+    "outcome_for_launcher_exception",
+    "outcome_for_provider_reason",
+    "outcome_for_worker_exit",
+]

--- a/tests/hermes_cli/test_kanban_runtime_outcomes.py
+++ b/tests/hermes_cli/test_kanban_runtime_outcomes.py
@@ -1,0 +1,194 @@
+"""Canonical runtime-outcome contract tests for Kanban execution paths."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from agent.error_classifier import FailoverReason
+from hermes_cli import kanban_db as kb
+from hermes_cli.runtime_outcomes import (
+    RuntimeOutcome,
+    outcome_for_provider_reason,
+)
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return home
+
+
+@pytest.mark.parametrize(
+    ("outcome", "counts_against_failure_budget"),
+    [
+        (RuntimeOutcome.provider_overload(), False),
+        (RuntimeOutcome.launcher_transport_failure(), False),
+        (RuntimeOutcome.ex_tempfail(), False),
+        (RuntimeOutcome.code_failure(), True),
+    ],
+)
+def test_runtime_outcome_contract_has_one_budget_policy(
+    outcome, counts_against_failure_budget
+):
+    assert outcome.counts_against_failure_budget is counts_against_failure_budget
+    assert outcome.is_transient is not counts_against_failure_budget
+
+
+def test_provider_overload_maps_to_transient_outcome():
+    outcome = outcome_for_provider_reason(FailoverReason.overloaded)
+    assert outcome.kind == "provider_overload"
+    assert outcome.is_transient
+
+
+@pytest.mark.parametrize(
+    "serialized",
+    [RuntimeOutcome.provider_overload().to_dict(), {"kind": "overloaded"}],
+)
+def test_serialized_provider_outcome_preserves_transient_policy(serialized):
+    outcome = RuntimeOutcome.from_value(serialized)
+    assert outcome.kind == "provider_overload"
+    assert outcome.is_transient
+
+
+def test_serialized_provider_rate_limit_preserves_transient_policy():
+    outcome = RuntimeOutcome.from_value({"kind": "rate_limit"})
+    assert outcome.kind == "rate_limit"
+    assert outcome.is_transient
+
+
+def test_provider_overload_does_not_increment_failure_or_block_recurrence(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="overloaded", assignee="worker")
+        assert kb.claim_task(conn, task_id) is not None
+
+        blocked = kb._record_task_failure(
+            conn,
+            task_id,
+            "provider overloaded",
+            outcome=RuntimeOutcome.provider_overload(),
+            failure_limit=1,
+            release_claim=True,
+            end_run=True,
+        )
+
+        task = kb.get_task(conn, task_id)
+        assert blocked is False
+        assert task.status == "ready"
+        assert task.consecutive_failures == 0
+        assert task.block_recurrences == 0
+
+
+def test_launcher_transport_does_not_increment_failure_or_block_recurrence(
+    kanban_home, monkeypatch
+):
+    import hermes_cli.profiles as profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _profile: True)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="transport", assignee="worker")
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                ConnectionError("launcher transport disconnected")
+            ),
+            failure_limit=1,
+        )
+
+        task = kb.get_task(conn, task_id)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 0
+        assert task.block_recurrences == 0
+        assert task_id not in result.auto_blocked
+        assert result.runtime_outcomes[0]["kind"] == "launcher_transport_failure"
+
+
+@pytest.mark.parametrize("status", ["ready", "review"])
+def test_launcher_code_failure_is_persisted_as_string_and_blocks_at_limit(
+    kanban_home, monkeypatch, status
+):
+    import hermes_cli.profiles as profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _profile: True)
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title=f"code-{status}", assignee="worker")
+        if status == "review":
+            conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (task_id,))
+            conn.commit()
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                RuntimeError("launcher code failure")
+            ),
+            failure_limit=1,
+        )
+
+        task = kb.get_task(conn, task_id)
+        assert task.status == "blocked"
+        assert task.consecutive_failures == 1
+        assert task_id in result.auto_blocked
+        assert result.runtime_outcomes[-1]["kind"] == "spawn_failure"
+        run = conn.execute(
+            "SELECT outcome FROM task_runs WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        assert run["outcome"] == "gave_up"
+
+
+def test_clean_exit_protocol_violation_is_counting_outcome(kanban_home, monkeypatch):
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="protocol", assignee="worker")
+        task = kb.claim_task(conn, task_id, claimer=f"{kb._claimer_id().split(':', 1)[0]}:worker")
+        assert task is not None
+        pid = 99124
+        conn.execute("UPDATE tasks SET worker_pid=? WHERE id=?", (pid, task_id))
+        conn.commit()
+        kb._record_worker_exit(pid, 0)
+
+        kb.detect_crashed_workers(conn)
+
+        event = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        assert '"kind": "code_failure"' in event["payload"]
+        outcome = kb.detect_crashed_workers._last_runtime_outcomes[-1]
+        assert outcome["kind"] == "code_failure"
+
+
+def test_ex_tempfail_is_transient_worker_exit():
+    pid = os.getpid()
+    kb._record_worker_exit(pid, kb.KANBAN_RATE_LIMIT_EXIT_CODE << 8)
+    outcome = kb.worker_exit_outcome(pid)
+    assert outcome.kind == "ex_tempfail"
+    assert outcome.is_transient
+
+
+def test_ordinary_worker_exit_still_counts_as_failure(kanban_home, monkeypatch):
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="crash", assignee="worker")
+        task = kb.claim_task(conn, task_id, claimer=f"{kb._claimer_id().split(':', 1)[0]}:worker")
+        assert task is not None
+        pid = 99123
+        conn.execute("UPDATE tasks SET worker_pid=? WHERE id=?", (pid, task_id))
+        conn.commit()
+        kb._record_worker_exit(pid, 1 << 8)
+
+        kb.detect_crashed_workers(conn)
+
+        task = kb.get_task(conn, task_id)
+        assert task.consecutive_failures == 1
+        assert task.status == "ready"


### PR DESCRIPTION
Fixes typed runtime outcome accounting across ready and review launcher paths. Transient provider overload, launcher transport failures, and EX_TEMPFAIL remain non-counting; ordinary launcher failures persist string outcome kinds and protocol violations count as failures. Focused canonical tests and ruff pass.