### PR TITLE
fix(desktop): refresh messaging session tiles at runtime

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -127,6 +127,9 @@ Before changing the app, read:
   transport, performance, and testing rules.
 - [`DESIGN.md`](./DESIGN.md): visual system, information architecture, motion,
   direct manipulation, and keyboard behavior.
+- [`docs/messaging-tile-runtime-refresh-incident.md`](./docs/messaging-tile-runtime-refresh-incident.md):
+  why background-written messaging transcripts must resolve every open surface,
+  not only the primary selected session.
 
 ### Connections, projects, and switching
 

--- a/apps/desktop/docs/messaging-tile-runtime-refresh-incident.md
+++ b/apps/desktop/docs/messaging-tile-runtime-refresh-incident.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Resolved and validated in a packaged Windows Desktop build.
+Resolved. The primary runtime-refresh path was validated in a packaged Windows Desktop build; subsequent review hardening for pagination, lineage rotation, reconnect busy state, and asynchronous races was validated by focused tests, type checking, lint, and a production build.
 
 This was a **Desktop renderer bug**, not a missing messaging capability and not a QQBot ingestion failure. Hermes already had runtime background synchronization for messaging conversations, but its transcript refresh target was limited to the primary chat surface. Messaging conversations opened as session tiles were omitted.
 
@@ -17,7 +17,7 @@ The bug was caused by a state-scope mismatch:
 - therefore, a messaging session visible in a tile could be absent from the refresh target set;
 - the refresh callback also used the primary runtime and its global busy guard instead of resolving the target tile's runtime and busy state.
 
-The fix makes open messaging transcripts explicit: collect messaging sessions from both the primary chat and all open session tiles, resolve each stored session to its own runtime and profile, skip only the target runtime when it is busy, and update that runtime's renderer cache.
+The fix makes open messaging transcripts explicit: collect direct runtime bindings from both the primary chat and all open session tiles, resolve each surface's stored-session metadata and profile, skip only target runtimes whose authoritative state is busy, and update each matching renderer cache. Exact metadata fallback, lineage grouping, and post-request revalidation cover restored or compressed sessions that are not represented by the current sidebar page.
 
 ## User-visible symptoms
 
@@ -163,32 +163,35 @@ A session tile is deliberately isolated from the primary chat atoms. Focusing or
 
 ## Fix design
 
-### 1. Resolve all open messaging stored sessions
+### 1. Enumerate open renderer surfaces directly
 
-`resolveOpenMessagingStoredSessionIds()` builds a deduplicated target list from:
+`resolveOpenTranscriptSurfaces()` collects:
 
-- the primary selected stored session;
-- every open `$sessionTiles` entry.
+- the primary selected stored session together with its active runtime ID;
+- every open `$sessionTiles` entry together with that tile's own runtime ID.
 
-It retains only rows whose source is recognized as messaging.
+It deduplicates identical runtime bindings and does not infer a tile runtime through the stored-to-runtime reverse map. This matters after compression, when a durable tile can retain the lineage-root ID while its live runtime has rotated to a continuation-tip ID.
 
-### 2. Resolve each target independently
+`resolveOpenMessagingCandidateIds()` is the lightweight poll gate. It checks both the capped messaging page and the known session cache, excludes sessions already known to be local, and retains only known messaging rows or unresolved open candidates for exact metadata resolution.
 
-`resolveMessagingTranscriptTarget()` maps each stored session to:
+### 2. Resolve metadata and lineage independently
 
-- its owning profile;
-- its bound runtime session ID;
-- its target runtime's busy state.
+`resolveMessagingTranscriptTargets()` reads each target runtime's current stored ID, checks the current session caches, and falls back to the existing exact-ID `resolveStoredSession()` path for restored, search-opened, project-opened, or older sessions outside the sidebar's recent window. It then:
 
-An unrelated busy primary runtime no longer blocks an idle messaging tile.
+- keeps only sources recognized as messaging;
+- preserves the owning profile;
+- canonicalizes the live stored-session tip;
+- groups root/tip aliases by profile and lineage root while preserving every renderer runtime that must be updated.
 
-### 3. Refresh each transcript into its own cache entry
+### 3. Use authoritative busy state and revalidate after I/O
 
-The wiring callback fetches all eligible open messaging transcripts and commits each result with `updateSessionState(runtimeSessionId, ..., storedSessionId)`. This preserves the Desktop invariant that background work updates its own cache without stealing the foreground.
+The wiring reads `$sessionStates` before the cache ref because reconnect hydration publishes the authoritative busy snapshot to that atom. An unrelated busy primary runtime no longer blocks an idle messaging tile, while a target runtime restored as busy is not polled.
 
-### 4. Keep signatures scoped per stored session
+After each stored-message read, `refreshMessagingTranscriptTarget()` rechecks request generation, open-surface membership, runtime identity, and busy state. A delayed response therefore cannot overwrite a newer poll, a running turn, a closed tile, or a runtime rebound to another session.
 
-The no-change signature remains keyed by profile and stored-session ID. Multiple open messaging tiles cannot suppress each other's updates.
+### 4. Refresh every renderer runtime without cross-suppression
+
+One canonical transcript read can update every renderer runtime displaying that lineage. No-change signatures are scoped per runtime ID, so a current primary view cannot suppress a stale tile (or vice versa). The commit uses the authoritative full session state as the cache-update base before calling `updateSessionState(runtimeSessionId, ..., storedSessionId)`.
 
 ### 5. Preserve the existing synchronization mechanism
 
@@ -197,24 +200,29 @@ The fix does not add another timer, websocket path, global store, or transport-s
 ## Changed files
 
 - `apps/desktop/src/app/contrib/hooks/refresh-messaging-transcript.ts`
-  - resolves open messaging stored sessions;
-  - resolves each stored session to its own runtime/profile target.
+  - enumerates direct primary/tile runtime surfaces;
+  - resolves paginated metadata and canonical lineage targets;
+  - guards asynchronous commits and per-runtime signatures.
 - `apps/desktop/src/app/contrib/hooks/refresh-messaging-transcript.test.ts`
-  - covers a messaging tile while the primary view is non-messaging;
-  - covers per-runtime busy selection;
-  - covers deduplication.
+  - covers capped-sidebar misses and exact metadata fallback;
+  - covers direct runtime binding and root/tip alias grouping;
+  - covers authoritative busy state, stale-response suppression, and per-runtime signatures.
 - `apps/desktop/src/app/contrib/wiring.tsx`
   - includes `$sessionTiles` in the background-refresh target set;
-  - refreshes and commits each target independently.
+  - reads authoritative runtime state and commits each still-valid target independently.
 
 ## Regression tests
 
 The focused behavior tests assert these contracts:
 
-1. A messaging tile remains a refresh target while the primary view is a non-messaging session.
-2. The target messaging runtime is refreshed even when an unrelated primary runtime is busy.
-3. The same stored session is not refreshed twice when represented in both the primary view and a tile.
-4. Existing background-sync and route-resume behavior remains green.
+1. A messaging tile remains a refresh candidate while the primary view is a non-messaging session.
+2. An open tile outside the capped messaging sidebar page is resolved by exact stored-session ID.
+3. Primary and tile surfaces use their direct runtime bindings instead of a rotation-sensitive reverse lookup.
+4. Root/tip aliases are grouped by lineage while every renderer runtime remains an update destination.
+5. A target published as busy is not resolved or fetched, and a runtime that becomes busy during I/O rejects the response.
+6. A delayed older response cannot overwrite a newer response.
+7. Transcript signatures are independent per renderer runtime.
+8. Existing background-sync and session-state behavior remains green.
 
 The verification commands are:
 
@@ -223,7 +231,8 @@ cd apps/desktop
 npx vitest run \
   src/app/contrib/hooks/refresh-messaging-transcript.test.ts \
   src/app/contrib/hooks/use-background-sync.test.ts \
-  src/app/session/hooks/use-route-resume.test.tsx
+  src/app/session/hooks/use-route-resume.test.tsx \
+  src/store/session-states.test.ts
 npm run typecheck
 npx eslint \
   src/app/contrib/wiring.tsx \
@@ -232,9 +241,18 @@ npx eslint \
 npm run build
 ```
 
+Current follow-up verification results:
+
+- focused Vitest selection: 4 files, 49 tests passed;
+- Desktop type checking: passed;
+- targeted ESLint: passed with no warnings;
+- full Desktop lint: exit code 0, with 67 pre-existing warnings outside the changed files;
+- production build: passed, including renderer, Electron main/preload, native dependency staging, and dist assertion;
+- complete Desktop Vitest run: 3,890 passed, 22 failed, and 3 skipped. The failures match the previously reproduced unchanged Windows/MSYS baseline: 19 platform/environment cases plus one locale-dependent time label and two Billing copy assertions. No changed or newly added test file failed.
+
 ## Production end-to-end validation
 
-The final acceptance test used the normal production Windows Desktop profile and one continuously running formal Desktop instance.
+The primary runtime-refresh acceptance test used the normal production Windows Desktop profile and one continuously running formal Desktop instance.
 
 Conditions:
 
@@ -254,20 +272,22 @@ Result:
 
 Before that validation, the packaged renderer artifact was checked against the tested build by SHA-256. The packaged `app.asar` renderer entry matched the build output.
 
+After that acceptance, an independent review identified additional edge cases involving the capped messaging sidebar page, root/tip alias rotation, reconnect-published busy state, and overlapping asynchronous polls. Those follow-up guards were verified with dedicated RED/GREEN regression tests, Desktop type checking, targeted and full lint, and a fresh production build. The continuously running formal Desktop instance was intentionally not reinstalled or restarted solely to repeat the already-passed primary acceptance sequence.
+
 All credentials, pairing codes, user identifiers, connection details, local paths, and real session IDs are intentionally omitted or represented as `[REDACTED]`.
 
 ## Risk assessment
 
 The change is narrow:
 
-- it runs only while at least one messaging transcript is open;
+- it runs only while at least one known messaging transcript or unresolved open candidate exists;
 - it reuses the existing cadence and invalidation events;
 - it skips busy target runtimes;
-- it signature-gates unchanged transcripts;
-- it deduplicates sessions represented in more than one surface;
+- it signature-gates unchanged transcripts per renderer runtime;
+- it groups root/tip aliases while preserving all visible renderer destinations;
 - errors remain non-fatal and retry on the next existing refresh opportunity.
 
-The only expected increase is one stored-message read per distinct open, idle messaging transcript on a refresh tick.
+The only expected increase is one stored-message read per distinct open, idle messaging lineage on a refresh tick. An uncached open surface may also perform the existing exact-ID metadata lookup once before source filtering.
 
 ## Follow-up recommendations
 

--- a/apps/desktop/docs/messaging-tile-runtime-refresh-incident.md
+++ b/apps/desktop/docs/messaging-tile-runtime-refresh-incident.md
@@ -17,7 +17,7 @@ The bug was caused by a state-scope mismatch:
 - therefore, a messaging session visible in a tile could be absent from the refresh target set;
 - the refresh callback also used the primary runtime and its global busy guard instead of resolving the target tile's runtime and busy state.
 
-The fix makes open messaging transcripts explicit: collect direct runtime bindings from both the primary chat and all open session tiles, resolve each surface's stored-session metadata and profile, skip only target runtimes whose authoritative state is busy, and update each matching renderer cache. Exact metadata fallback, lineage grouping, and post-request revalidation cover restored or compressed sessions that are not represented by the current sidebar page.
+The fix makes open messaging transcripts explicit: collect direct runtime bindings from both the primary chat and all open session tiles, resolve each surface's stored-session metadata within its owning profile, skip only target runtimes whose authoritative state is busy, and update each matching renderer cache. Exact metadata fallback, lineage grouping, profile-qualified matching, and post-request revalidation cover restored or compressed sessions that are not represented by the current sidebar page.
 
 ## User-visible symptoms
 
@@ -176,7 +176,7 @@ It deduplicates identical runtime bindings and does not infer a tile runtime thr
 
 ### 2. Resolve metadata and lineage independently
 
-`resolveMessagingTranscriptTargets()` reads each target runtime's current stored ID, checks the current session caches, and falls back to the existing exact-ID `resolveStoredSession()` path for restored, search-opened, project-opened, or older sessions outside the sidebar's recent window. It then:
+`resolveMessagingTranscriptTargets()` reads each target runtime's current stored ID, checks the current session caches within the surface's owning profile, and falls back to the profile-scoped exact-ID `getSession(id, profile)` path for restored, search-opened, project-opened, or older sessions outside the sidebar's recent window. The production adapter treats that scoped transport as authoritative and stamps the normalized requested profile on its result; alternate adapters must return metadata for the same profile before source or lineage processing. It then:
 
 - keeps only sources recognized as messaging;
 - preserves the owning profile;
@@ -187,7 +187,7 @@ It deduplicates identical runtime bindings and does not infer a tile runtime thr
 
 The wiring reads `$sessionStates` before the cache ref because reconnect hydration publishes the authoritative busy snapshot to that atom. An unrelated busy primary runtime no longer blocks an idle messaging tile, while a target runtime restored as busy is not polled.
 
-After each stored-message read, `refreshMessagingTranscriptTarget()` rechecks request generation, open-surface membership, runtime identity, and busy state. A delayed response therefore cannot overwrite a newer poll, a running turn, a closed tile, or a runtime rebound to another session.
+After each stored-message read, `refreshMessagingTranscriptTarget()` rechecks request generation, active-profile ownership, a monotonic profile epoch, open-surface membership, runtime identity, and busy state. A delayed response therefore cannot overwrite a newer poll, a running turn, a closed tile, a Profile switch (including an `A -> B -> A` round trip), or a runtime rebound to another session.
 
 ### 4. Refresh every renderer runtime without cross-suppression
 
@@ -206,10 +206,11 @@ The fix does not add another timer, websocket path, global store, or transport-s
 - `apps/desktop/src/app/contrib/hooks/refresh-messaging-transcript.test.ts`
   - covers capped-sidebar misses and exact metadata fallback;
   - covers direct runtime binding and root/tip alias grouping;
-  - covers authoritative busy state, stale-response suppression, and per-runtime signatures.
+  - covers authoritative busy state, stale-response suppression, and per-runtime signatures;
+  - covers same-ID collisions, wrong-profile exact-resolution responses, and the profile-scoped production RPC adapter.
 - `apps/desktop/src/app/contrib/wiring.tsx`
   - includes `$sessionTiles` in the background-refresh target set;
-  - reads authoritative runtime state and commits each still-valid target independently.
+  - resolves metadata through the target profile and commits each still-valid target independently.
 
 ## Regression tests
 
@@ -222,7 +223,10 @@ The focused behavior tests assert these contracts:
 5. A target published as busy is not resolved or fetched, and a runtime that becomes busy during I/O rejects the response.
 6. A delayed older response cannot overwrite a newer response.
 7. Transcript signatures are independent per renderer runtime.
-8. Existing background-sync and session-state behavior remains green.
+8. A same-ID session from another profile cannot classify or hydrate an open surface.
+9. A response started before a Profile round trip cannot commit after the original Profile becomes active again.
+10. The production exact-session adapter queries and stamps the normalized target profile.
+11. Existing background-sync and session-state behavior remains green.
 
 The verification commands are:
 
@@ -243,12 +247,12 @@ npm run build
 
 Current follow-up verification results:
 
-- focused Vitest selection: 4 files, 49 tests passed;
+- focused Vitest selection: 4 files, 54 tests passed;
 - Desktop type checking: passed;
 - targeted ESLint: passed with no warnings;
 - full Desktop lint: exit code 0, with 67 pre-existing warnings outside the changed files;
 - production build: passed, including renderer, Electron main/preload, native dependency staging, and dist assertion;
-- complete Desktop Vitest run: 3,890 passed, 22 failed, and 3 skipped. The failures match the previously reproduced unchanged Windows/MSYS baseline: 19 platform/environment cases plus one locale-dependent time label and two Billing copy assertions. No changed or newly added test file failed.
+- earlier complete Desktop Vitest baseline run: 3,890 passed, 22 failed, and 3 skipped. The failures matched the previously reproduced unchanged Windows/MSYS baseline: 19 platform/environment cases plus one locale-dependent time label and two Billing copy assertions. No changed or newly added test file failed; the profile-hardening changes above were subsequently covered by the fresh focused selection.
 
 ## Production end-to-end validation
 
@@ -272,9 +276,27 @@ Result:
 
 Before that validation, the packaged renderer artifact was checked against the tested build by SHA-256. The packaged `app.asar` renderer entry matched the build output.
 
-After that acceptance, an independent review identified additional edge cases involving the capped messaging sidebar page, root/tip alias rotation, reconnect-published busy state, and overlapping asynchronous polls. Those follow-up guards were verified with dedicated RED/GREEN regression tests, Desktop type checking, targeted and full lint, and a fresh production build. The continuously running formal Desktop instance was intentionally not reinstalled or restarted solely to repeat the already-passed primary acceptance sequence.
+After that acceptance, an independent review identified additional edge cases involving the capped messaging sidebar page, root/tip alias rotation, reconnect-published busy state, overlapping asynchronous polls, and same-ID sessions across independent profiles. Those follow-up guards were verified with dedicated RED/GREEN regression tests, Desktop type checking, targeted and full lint, and a fresh production build. The continuously running formal Desktop instance was intentionally not reinstalled or restarted solely to repeat the already-passed primary acceptance sequence.
 
 All credentials, pairing codes, user identifiers, connection details, local paths, and real session IDs are intentionally omitted or represented as `[REDACTED]`.
+
+## Related but separate incident: updater blocked by a sibling gateway process
+
+The same investigation also captured a distinct Desktop update failure. It did **not** cause the messaging transcript refresh gap and is not fixed by the renderer changes in this PR.
+
+The Desktop log records the following order:
+
+1. the updater verified `state.db` and created its emergency backup;
+2. Desktop terminated its headless backend;
+3. the `update-in-flight` gate deferred any backend restart;
+4. the venv blocker scan found one remaining process using the installation;
+5. the update aborted and identified that process as `python.exe -m hermes_cli.main gateway run` from the same managed venv.
+
+Repeated attempts reported the same sibling gateway process. This distinguishes the observed blocker from the older self-respawn failure class documented in `electron/update-gate.ts`: the Desktop backend did not respawn inside the update critical section, but the separately running messaging gateway continued to hold the managed runtime.
+
+The abort was therefore a safety response to a real install-tree owner, not evidence that the messaging database was corrupt or that the Gateway had stopped writing messages. A separate updater follow-up should coordinate the lifecycle of eligible local gateway siblings—or offer an explicit stop/update/restart flow—without terminating remote or independently managed services. The UI should also distinguish a Desktop backend from a messaging gateway when reporting blockers.
+
+This PR deliberately keeps that updater lifecycle work out of the messaging refresh fix.
 
 ## Risk assessment
 
@@ -283,6 +305,7 @@ The change is narrow:
 - it runs only while at least one known messaging transcript or unresolved open candidate exists;
 - it reuses the existing cadence and invalidation events;
 - it skips busy target runtimes;
+- it scopes cache, exact metadata, lineage grouping, and commits to the target profile;
 - it signature-gates unchanged transcripts per renderer runtime;
 - it groups root/tip aliases while preserving all visible renderer destinations;
 - errors remain non-fatal and retry on the next existing refresh opportunity.

--- a/apps/desktop/docs/messaging-tile-runtime-refresh-incident.md
+++ b/apps/desktop/docs/messaging-tile-runtime-refresh-incident.md
@@ -1,0 +1,278 @@
+# Incident report: messaging session tiles did not refresh at runtime
+
+## Status
+
+Resolved and validated in a packaged Windows Desktop build.
+
+This was a **Desktop renderer bug**, not a missing messaging capability and not a QQBot ingestion failure. Hermes already had runtime background synchronization for messaging conversations, but its transcript refresh target was limited to the primary chat surface. Messaging conversations opened as session tiles were omitted.
+
+## Summary
+
+Inbound QQBot messages reached the gateway and were persisted successfully, but an already-running Hermes Desktop window did not display them in an open QQBot session tile. Switching sessions or returning to the tile did not help. The messages appeared only after restarting Desktop because startup hydration read the latest persisted transcript from the database.
+
+The bug was caused by a state-scope mismatch:
+
+- messaging background refresh was gated by the primary chat's `selectedStoredSessionId`;
+- session tiles intentionally do not mutate the primary chat's selection or runtime atoms;
+- therefore, a messaging session visible in a tile could be absent from the refresh target set;
+- the refresh callback also used the primary runtime and its global busy guard instead of resolving the target tile's runtime and busy state.
+
+The fix makes open messaging transcripts explicit: collect messaging sessions from both the primary chat and all open session tiles, resolve each stored session to its own runtime and profile, skip only the target runtime when it is busy, and update that runtime's renderer cache.
+
+## User-visible symptoms
+
+The affected state had all of the following properties:
+
+1. QQBot pairing and gateway connectivity were healthy.
+2. New inbound messages reached the gateway.
+3. The gateway persisted those messages to `state.db`.
+4. SQLite integrity checks completed successfully.
+5. The open Desktop window did not read or render the new messages.
+6. Switching to another session and back to the QQBot tile did not refresh it.
+7. There was no reliable runtime history catch-up.
+8. Restarting the entire Desktop process made the messages appear.
+
+The last point was misleading: it proved only that startup hydration worked. It did not prove that runtime synchronization worked.
+
+## Impact
+
+The production report involved QQBot, but the defect was not QQBot-specific. Any messaging-backed conversation opened as a session tile could be affected, including Telegram, Discord, WeChat, and other sources recognized by `isMessagingSource()`.
+
+Primary-chat messaging transcripts could continue to refresh because they populated the atoms used by the old gate. The failure depended on presentation topology, not the transport used to ingest the message.
+
+## Expected data flow
+
+```text
+Messaging platform
+  -> gateway ingestion
+  -> state.db persistence
+  -> sessions.changed / visible polling
+  -> resolve every open messaging transcript
+  -> fetch stored messages for each transcript
+  -> update the matching runtime session state
+  -> render the new messages in its surface
+```
+
+## Broken data flow
+
+```text
+QQBot
+  -> gateway ingestion                         OK
+  -> state.db persistence                      OK
+  -> Desktop background synchronization       running
+  -> primary selected-session messaging gate  false
+  -> QQBot tile target resolution              omitted
+  -> tile runtime session-state update         never executed
+  -> visible tile transcript                   stale
+
+Desktop restart
+  -> startup hydration
+  -> read current state.db transcript
+  -> messages become visible
+```
+
+## Why this is a bug, not an unimplemented feature
+
+Hermes Desktop already contained all of the required mechanisms:
+
+- messaging-session discovery;
+- `sessions.changed` invalidation and compatibility polling;
+- stored-message retrieval;
+- runtime-to-stored-session mappings;
+- per-runtime renderer session-state caches;
+- startup transcript hydration.
+
+`useBackgroundSync()` explicitly describes messaging turns written by background gateways and polls the open transcript because those turns do not arrive over the Desktop websocket. This establishes the intended behavior.
+
+The missing piece was coverage for another existing presentation surface. `useSessionTileDelegate()` intentionally keeps tile activity out of the primary view:
+
+```text
+$activeSessionId and $messages remain the primary thread's state
+```
+
+That isolation is correct. The bug was assuming that primary-view state also described every transcript that was open on screen.
+
+## Investigation
+
+### 1. Verify ingestion before touching the renderer
+
+The investigation first confirmed that pairing, gateway receipt, and database persistence were working. The persisted state passed SQLite integrity checks. This ruled out QQBot delivery loss, pairing failure, and database corruption.
+
+### 2. Separate startup hydration from runtime refresh
+
+Restarting Desktop loaded the messages, which localized the failure:
+
+- the persisted transcript was valid;
+- the startup load path could read it;
+- the long-lived renderer state was not being reconciled after new writes.
+
+### 3. Reject UI-only success signals
+
+The following were treated as insufficient evidence:
+
+- pairing succeeded;
+- the database contained the message;
+- a unit test passed;
+- a newly built package was installed;
+- messages appeared after restart.
+
+The acceptance criterion remained: at least two consecutive, unique inbound messages must appear in the same production Desktop instance without a restart, reload, or tab switch.
+
+### 4. Test the route/runtime mismatch hypothesis
+
+An initial investigation found a real route/runtime mismatch: a routed stored session could be selected while the active runtime still belonged to another session. That path was corrected and tested separately.
+
+A packaged build containing that correction still failed four consecutive runtime message probes. This was useful negative evidence: route resumption was not the complete root cause.
+
+The latest upstream `main` already contains the route/runtime self-healing behavior, so this change does not duplicate it.
+
+### 5. Trace the tile state boundary
+
+The decisive source trace compared:
+
+- `useBackgroundSync()` and its active-messaging gate;
+- the transcript refresh callback in `contrib/wiring.tsx`;
+- `$sessionTiles` and the per-runtime state cache;
+- `useSessionTileDelegate()`, which intentionally avoids mutating the primary view.
+
+The old gate and refresh callback were both derived from primary-view refs:
+
+```text
+selectedStoredSessionIdRef.current
+activeSessionIdRef.current
+busyRef.current
+```
+
+A QQBot session displayed in a tile could have its own valid stored-session ID, runtime binding, and cached renderer state while none of those primary refs described it. As a result, the background tick existed but had no eligible target.
+
+## Root cause
+
+The root cause was incomplete refresh-target resolution.
+
+### Primary cause
+
+The `activeIsMessaging` gate checked only the primary selected stored session. If the primary chat was a normal local session and QQBot was open in a tile, the gate was false and `useBackgroundSync()` did not poll a messaging transcript at all.
+
+### Secondary cause
+
+Even when the refresh callback ran, it used the primary active runtime and global primary busy state. A busy unrelated chat could suppress a messaging refresh, and a tile's own runtime was not selected explicitly.
+
+### Why switching tabs did not repair the state
+
+A session tile is deliberately isolated from the primary chat atoms. Focusing or revisiting it does not make it the primary selected session. Therefore, tab switching did not repair the target set and no dependable historical catch-up occurred.
+
+## Fix design
+
+### 1. Resolve all open messaging stored sessions
+
+`resolveOpenMessagingStoredSessionIds()` builds a deduplicated target list from:
+
+- the primary selected stored session;
+- every open `$sessionTiles` entry.
+
+It retains only rows whose source is recognized as messaging.
+
+### 2. Resolve each target independently
+
+`resolveMessagingTranscriptTarget()` maps each stored session to:
+
+- its owning profile;
+- its bound runtime session ID;
+- its target runtime's busy state.
+
+An unrelated busy primary runtime no longer blocks an idle messaging tile.
+
+### 3. Refresh each transcript into its own cache entry
+
+The wiring callback fetches all eligible open messaging transcripts and commits each result with `updateSessionState(runtimeSessionId, ..., storedSessionId)`. This preserves the Desktop invariant that background work updates its own cache without stealing the foreground.
+
+### 4. Keep signatures scoped per stored session
+
+The no-change signature remains keyed by profile and stored-session ID. Multiple open messaging tiles cannot suppress each other's updates.
+
+### 5. Preserve the existing synchronization mechanism
+
+The fix does not add another timer, websocket path, global store, or transport-specific QQBot special case. It extends the existing `sessions.changed` / visible-poll refresh path with correct target resolution.
+
+## Changed files
+
+- `apps/desktop/src/app/contrib/hooks/refresh-messaging-transcript.ts`
+  - resolves open messaging stored sessions;
+  - resolves each stored session to its own runtime/profile target.
+- `apps/desktop/src/app/contrib/hooks/refresh-messaging-transcript.test.ts`
+  - covers a messaging tile while the primary view is non-messaging;
+  - covers per-runtime busy selection;
+  - covers deduplication.
+- `apps/desktop/src/app/contrib/wiring.tsx`
+  - includes `$sessionTiles` in the background-refresh target set;
+  - refreshes and commits each target independently.
+
+## Regression tests
+
+The focused behavior tests assert these contracts:
+
+1. A messaging tile remains a refresh target while the primary view is a non-messaging session.
+2. The target messaging runtime is refreshed even when an unrelated primary runtime is busy.
+3. The same stored session is not refreshed twice when represented in both the primary view and a tile.
+4. Existing background-sync and route-resume behavior remains green.
+
+The verification commands are:
+
+```bash
+cd apps/desktop
+npx vitest run \
+  src/app/contrib/hooks/refresh-messaging-transcript.test.ts \
+  src/app/contrib/hooks/use-background-sync.test.ts \
+  src/app/session/hooks/use-route-resume.test.tsx
+npm run typecheck
+npx eslint \
+  src/app/contrib/wiring.tsx \
+  src/app/contrib/hooks/refresh-messaging-transcript.ts \
+  src/app/contrib/hooks/refresh-messaging-transcript.test.ts
+npm run build
+```
+
+## Production end-to-end validation
+
+The final acceptance test used the normal production Windows Desktop profile and one continuously running formal Desktop instance.
+
+Conditions:
+
+- no diagnostic Electron profile;
+- no secondary Desktop instance;
+- no restart between inbound messages;
+- no reload;
+- no tab switch used as a refresh trigger;
+- at least two unique consecutive QQBot messages.
+
+Result:
+
+- each message was ingested and persisted;
+- each message appeared automatically in the already-open QQBot transcript;
+- the Desktop process remained the same for the runtime message sequence;
+- the user confirmed that all probes appeared in real time.
+
+Before that validation, the packaged renderer artifact was checked against the tested build by SHA-256. The packaged `app.asar` renderer entry matched the build output.
+
+All credentials, pairing codes, user identifiers, connection details, local paths, and real session IDs are intentionally omitted or represented as `[REDACTED]`.
+
+## Risk assessment
+
+The change is narrow:
+
+- it runs only while at least one messaging transcript is open;
+- it reuses the existing cadence and invalidation events;
+- it skips busy target runtimes;
+- it signature-gates unchanged transcripts;
+- it deduplicates sessions represented in more than one surface;
+- errors remain non-fatal and retry on the next existing refresh opportunity.
+
+The only expected increase is one stored-message read per distinct open, idle messaging transcript on a refresh tick.
+
+## Follow-up recommendations
+
+1. Add an Electron end-to-end scenario with a non-messaging primary chat and a messaging session tile receiving two external database updates.
+2. Treat “visible/open session” as an explicit target set in future background synchronization code; do not infer it from the primary selection atom.
+3. Keep busy, runtime, profile, and signature state scoped to the target session.
+4. Do not accept restart hydration as evidence of runtime synchronization.
+5. Apply the same topology test to every background-written surface introduced later.

--- a/apps/desktop/src/app/contrib/hooks/refresh-messaging-transcript.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/refresh-messaging-transcript.test.ts
@@ -1,14 +1,70 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import {
+  isTranscriptRefreshScopeCurrent,
   refreshMessagingTranscriptTarget,
   resolveAuthoritativeRuntimeState,
   resolveMessagingTranscriptTargets,
   resolveOpenMessagingCandidateIds,
-  resolveOpenTranscriptSurfaces
+  resolveOpenTranscriptSurfaces,
+  resolveProfileScopedStoredSession
 } from './refresh-messaging-transcript'
 
-const session = (id: string, source: null | string = null) => ({ id, profile: 'default', source })
+const session = (id: string, source: null | string = null, profile = 'default') => ({
+  _lineage_root_id: null,
+  id,
+  profile,
+  source
+})
+
+describe('isTranscriptRefreshScopeCurrent', () => {
+  const surfaces = [
+    {
+      profile: 'default',
+      runtimeSessionId: 'runtime-a',
+      storedSessionId: 'stored-a'
+    }
+  ]
+
+  it('rejects an old response after an A -> B -> A profile round trip', () => {
+    expect(
+      isTranscriptRefreshScopeCurrent({
+        activeProfile: 'default',
+        capturedProfileEpoch: 1,
+        currentProfileEpoch: 3,
+        profile: 'default',
+        runtimeSessionId: 'runtime-a',
+        surfaces
+      })
+    ).toBe(false)
+
+    expect(
+      isTranscriptRefreshScopeCurrent({
+        activeProfile: 'default',
+        capturedProfileEpoch: 3,
+        currentProfileEpoch: 3,
+        profile: 'default',
+        runtimeSessionId: 'runtime-a',
+        surfaces
+      })
+    ).toBe(true)
+  })
+})
+
+describe('resolveProfileScopedStoredSession', () => {
+  it('queries and stamps the target profile at the production adapter boundary', async () => {
+    const getSession = vi.fn().mockResolvedValue(session('shared-id', 'qqbot', 'default'))
+
+    await expect(
+      resolveProfileScopedStoredSession({
+        getSession,
+        profile: ' work ',
+        storedSessionId: 'shared-id'
+      })
+    ).resolves.toMatchObject({ id: 'shared-id', profile: 'work', source: 'qqbot' })
+    expect(getSession).toHaveBeenCalledWith('shared-id', 'work')
+  })
+})
 
 describe('resolveAuthoritativeRuntimeState', () => {
   it('prefers reconnect-published state over a stale cache entry', () => {
@@ -20,6 +76,18 @@ describe('resolveAuthoritativeRuntimeState', () => {
 })
 
 describe('resolveOpenMessagingCandidateIds', () => {
+  it('does not let another profile session with the same id classify the active surface', () => {
+    expect(
+      resolveOpenMessagingCandidateIds({
+        knownSessions: [session('shared-id', null, 'work')],
+        messagingSessions: [session('shared-id', 'qqbot', 'default')],
+        profile: 'work',
+        selectedStoredSessionId: 'shared-id',
+        sessionTiles: []
+      })
+    ).toEqual([])
+  })
+
   it('does not keep a known local session as an unresolved messaging candidate', () => {
     const primary = session('stored-primary')
 
@@ -27,6 +95,7 @@ describe('resolveOpenMessagingCandidateIds', () => {
       resolveOpenMessagingCandidateIds({
         knownSessions: [primary],
         messagingSessions: [],
+        profile: 'default',
         selectedStoredSessionId: primary.id,
         sessionTiles: []
       })
@@ -38,6 +107,7 @@ describe('resolveOpenMessagingCandidateIds', () => {
       resolveOpenMessagingCandidateIds({
         knownSessions: [],
         messagingSessions: [],
+        profile: 'default',
         selectedStoredSessionId: null,
         sessionTiles: [{ storedSessionId: 'stored-outside-sidebar-page' }]
       })
@@ -52,6 +122,7 @@ describe('resolveOpenMessagingCandidateIds', () => {
       resolveOpenMessagingCandidateIds({
         knownSessions: [primary],
         messagingSessions: [messaging],
+        profile: 'default',
         selectedStoredSessionId: primary.id,
         sessionTiles: [{ storedSessionId: messaging.id }]
       })
@@ -65,6 +136,7 @@ describe('resolveOpenMessagingCandidateIds', () => {
       resolveOpenMessagingCandidateIds({
         knownSessions: [],
         messagingSessions: [messaging],
+        profile: 'default',
         selectedStoredSessionId: messaging.id,
         sessionTiles: [{ storedSessionId: messaging.id }]
       })
@@ -83,6 +155,7 @@ describe('resolveOpenMessagingCandidateIds', () => {
       resolveOpenMessagingCandidateIds({
         knownSessions: [],
         messagingSessions: [messaging],
+        profile: 'default',
         selectedStoredSessionId: 'stored-root',
         sessionTiles: [{ storedSessionId: 'stored-tip' }]
       })
@@ -95,6 +168,7 @@ describe('resolveOpenTranscriptSurfaces', () => {
     expect(
       resolveOpenTranscriptSurfaces({
         activeRuntimeSessionId: 'runtime-primary',
+        profile: 'work',
         selectedStoredSessionId: 'stored-primary-root',
         sessionTiles: [
           {
@@ -104,8 +178,8 @@ describe('resolveOpenTranscriptSurfaces', () => {
         ]
       })
     ).toEqual([
-      { runtimeSessionId: 'runtime-primary', storedSessionId: 'stored-primary-root' },
-      { runtimeSessionId: 'runtime-tile', storedSessionId: 'stored-tile-root' }
+      { profile: 'work', runtimeSessionId: 'runtime-primary', storedSessionId: 'stored-primary-root' },
+      { profile: 'work', runtimeSessionId: 'runtime-tile', storedSessionId: 'stored-tile-root' }
     ])
   })
 })
@@ -125,10 +199,10 @@ describe('resolveMessagingTranscriptTargets', () => {
       getRuntimeState: () => ({ busy: false, storedSessionId: 'stored-tip' }),
       resolveStoredSession,
       sessionRows: [],
-      surfaces: [{ runtimeSessionId: 'runtime-tile', storedSessionId: 'stored-root' }]
+      surfaces: [{ profile: 'work', runtimeSessionId: 'runtime-tile', storedSessionId: 'stored-root' }]
     })
 
-    expect(resolveStoredSession).toHaveBeenCalledWith('stored-tip')
+    expect(resolveStoredSession).toHaveBeenCalledWith('stored-tip', 'work')
     expect(targets).toEqual([
       {
         key: 'work:stored-root',
@@ -138,6 +212,44 @@ describe('resolveMessagingTranscriptTargets', () => {
         storedSessionId: 'stored-tip'
       }
     ])
+  })
+
+  it('selects only the row owned by the open surface profile when stored ids collide', async () => {
+    const defaultRow = session('shared-id', 'qqbot', 'default')
+    const workRow = session('shared-id', 'qqbot', 'work')
+    const resolveStoredSession = vi.fn()
+
+    const targets = await resolveMessagingTranscriptTargets({
+      getRuntimeState: () => ({ busy: false, storedSessionId: 'shared-id' }),
+      resolveStoredSession,
+      sessionRows: [defaultRow, workRow],
+      surfaces: [{ profile: 'work', runtimeSessionId: 'runtime-work', storedSessionId: 'shared-id' }]
+    })
+
+    expect(resolveStoredSession).not.toHaveBeenCalled()
+    expect(targets).toEqual([
+      {
+        key: 'work:shared-id',
+        profile: 'work',
+        runtimeSessionIds: ['runtime-work'],
+        session: workRow,
+        storedSessionId: 'shared-id'
+      }
+    ])
+  })
+
+  it('rejects exact metadata returned from another profile', async () => {
+    const resolveStoredSession = vi.fn(async () => session('shared-id', 'qqbot', 'default'))
+
+    const targets = await resolveMessagingTranscriptTargets({
+      getRuntimeState: () => ({ busy: false, storedSessionId: 'shared-id' }),
+      resolveStoredSession,
+      sessionRows: [],
+      surfaces: [{ profile: 'work', runtimeSessionId: 'runtime-work', storedSessionId: 'shared-id' }]
+    })
+
+    expect(resolveStoredSession).toHaveBeenCalledWith('shared-id', 'work')
+    expect(targets).toEqual([])
   })
 
   it('prefers the runtime-published live tip over a stale durable-root cache hit', async () => {
@@ -155,10 +267,10 @@ describe('resolveMessagingTranscriptTargets', () => {
       getRuntimeState: () => ({ busy: false, storedSessionId: 'stored-live-tip' }),
       resolveStoredSession,
       sessionRows: [stale],
-      surfaces: [{ runtimeSessionId: 'runtime-tile', storedSessionId: 'stored-root' }]
+      surfaces: [{ profile: 'default', runtimeSessionId: 'runtime-tile', storedSessionId: 'stored-root' }]
     })
 
-    expect(resolveStoredSession).toHaveBeenCalledWith('stored-live-tip')
+    expect(resolveStoredSession).toHaveBeenCalledWith('stored-live-tip', 'default')
     expect(targets[0]?.storedSessionId).toBe('stored-live-tip')
   })
 
@@ -174,7 +286,7 @@ describe('resolveMessagingTranscriptTargets', () => {
       getRuntimeState: () => ({ busy: false, storedSessionId: 'stored-live-tip' }),
       resolveStoredSession: vi.fn(),
       sessionRows: [live],
-      surfaces: [{ runtimeSessionId: 'runtime-tile', storedSessionId: 'stored-intermediate-tip' }]
+      surfaces: [{ profile: 'default', runtimeSessionId: 'runtime-tile', storedSessionId: 'stored-intermediate-tip' }]
     })
 
     expect(targets[0]?.runtimeSessionIds).toEqual(['runtime-tile'])
@@ -197,8 +309,8 @@ describe('resolveMessagingTranscriptTargets', () => {
       resolveStoredSession: vi.fn(),
       sessionRows: [resolved],
       surfaces: [
-        { runtimeSessionId: 'runtime-root', storedSessionId: 'stored-root' },
-        { runtimeSessionId: 'runtime-tip', storedSessionId: 'stored-tip' }
+        { profile: 'default', runtimeSessionId: 'runtime-root', storedSessionId: 'stored-root' },
+        { profile: 'default', runtimeSessionId: 'runtime-tip', storedSessionId: 'stored-tip' }
       ]
     })
 
@@ -214,7 +326,7 @@ describe('resolveMessagingTranscriptTargets', () => {
       getRuntimeState: () => ({ busy: true, storedSessionId: 'stored-messaging' }),
       resolveStoredSession,
       sessionRows: [],
-      surfaces: [{ runtimeSessionId: 'runtime-busy', storedSessionId: 'stored-messaging' }]
+      surfaces: [{ profile: 'default', runtimeSessionId: 'runtime-busy', storedSessionId: 'stored-messaging' }]
     })
 
     expect(targets).toEqual([])

--- a/apps/desktop/src/app/contrib/hooks/refresh-messaging-transcript.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/refresh-messaging-transcript.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  resolveMessagingTranscriptTarget,
+  resolveOpenMessagingStoredSessionIds
+} from './refresh-messaging-transcript'
+
+const session = (id: string, source: null | string = null) => ({ id, profile: 'default', source })
+
+describe('resolveMessagingTranscriptTarget', () => {
+  it('uses the target runtime state instead of an unrelated busy primary runtime', () => {
+    const busyByRuntimeId = new Map([
+      ['runtime-primary', true],
+      ['runtime-messaging', false]
+    ])
+
+    const isRuntimeBusy = vi.fn((runtimeId: string) => busyByRuntimeId.get(runtimeId) ?? false)
+
+    const target = resolveMessagingTranscriptTarget({
+      getRuntimeIdForStoredSession: storedId => (storedId === 'stored-messaging' ? 'runtime-messaging' : null),
+      isRuntimeBusy,
+      messagingSessions: [{ id: 'stored-messaging', profile: 'default', source: 'qqbot' }],
+      selectedStoredSessionId: 'stored-messaging'
+    })
+
+    expect(target).toEqual({
+      profile: 'default',
+      runtimeSessionId: 'runtime-messaging',
+      storedSessionId: 'stored-messaging'
+    })
+    expect(isRuntimeBusy).toHaveBeenCalledWith('runtime-messaging')
+    expect(isRuntimeBusy).not.toHaveBeenCalledWith('runtime-primary')
+  })
+})
+
+describe('resolveOpenMessagingStoredSessionIds', () => {
+  it('includes a messaging tile when the primary view is a non-messaging session', () => {
+    const primary = session('stored-primary')
+    const messaging = session('stored-messaging', 'qqbot')
+
+    expect(
+      resolveOpenMessagingStoredSessionIds({
+        messagingSessions: [messaging],
+        selectedStoredSessionId: primary.id,
+        sessionTiles: [{ storedSessionId: messaging.id }]
+      })
+    ).toEqual([messaging.id])
+  })
+
+  it('deduplicates a messaging session shown in both the primary view and a tile', () => {
+    const messaging = session('stored-messaging', 'qqbot')
+
+    expect(
+      resolveOpenMessagingStoredSessionIds({
+        messagingSessions: [messaging],
+        selectedStoredSessionId: messaging.id,
+        sessionTiles: [{ storedSessionId: messaging.id }]
+      })
+    ).toEqual([messaging.id])
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/refresh-messaging-transcript.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/refresh-messaging-transcript.test.ts
@@ -1,45 +1,56 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import {
-  resolveMessagingTranscriptTarget,
-  resolveOpenMessagingStoredSessionIds
+  refreshMessagingTranscriptTarget,
+  resolveAuthoritativeRuntimeState,
+  resolveMessagingTranscriptTargets,
+  resolveOpenMessagingCandidateIds,
+  resolveOpenTranscriptSurfaces
 } from './refresh-messaging-transcript'
 
 const session = (id: string, source: null | string = null) => ({ id, profile: 'default', source })
 
-describe('resolveMessagingTranscriptTarget', () => {
-  it('uses the target runtime state instead of an unrelated busy primary runtime', () => {
-    const busyByRuntimeId = new Map([
-      ['runtime-primary', true],
-      ['runtime-messaging', false]
-    ])
+describe('resolveAuthoritativeRuntimeState', () => {
+  it('prefers reconnect-published state over a stale cache entry', () => {
+    const published = { 'runtime-messaging': { busy: true } }
+    const cached = new Map([['runtime-messaging', { busy: false }]])
 
-    const isRuntimeBusy = vi.fn((runtimeId: string) => busyByRuntimeId.get(runtimeId) ?? false)
-
-    const target = resolveMessagingTranscriptTarget({
-      getRuntimeIdForStoredSession: storedId => (storedId === 'stored-messaging' ? 'runtime-messaging' : null),
-      isRuntimeBusy,
-      messagingSessions: [{ id: 'stored-messaging', profile: 'default', source: 'qqbot' }],
-      selectedStoredSessionId: 'stored-messaging'
-    })
-
-    expect(target).toEqual({
-      profile: 'default',
-      runtimeSessionId: 'runtime-messaging',
-      storedSessionId: 'stored-messaging'
-    })
-    expect(isRuntimeBusy).toHaveBeenCalledWith('runtime-messaging')
-    expect(isRuntimeBusy).not.toHaveBeenCalledWith('runtime-primary')
+    expect(resolveAuthoritativeRuntimeState('runtime-messaging', published, cached)).toEqual({ busy: true })
   })
 })
 
-describe('resolveOpenMessagingStoredSessionIds', () => {
+describe('resolveOpenMessagingCandidateIds', () => {
+  it('does not keep a known local session as an unresolved messaging candidate', () => {
+    const primary = session('stored-primary')
+
+    expect(
+      resolveOpenMessagingCandidateIds({
+        knownSessions: [primary],
+        messagingSessions: [],
+        selectedStoredSessionId: primary.id,
+        sessionTiles: []
+      })
+    ).toEqual([])
+  })
+
+  it('keeps an open tile as a refresh candidate when its metadata is outside the capped sidebar slice', () => {
+    expect(
+      resolveOpenMessagingCandidateIds({
+        knownSessions: [],
+        messagingSessions: [],
+        selectedStoredSessionId: null,
+        sessionTiles: [{ storedSessionId: 'stored-outside-sidebar-page' }]
+      })
+    ).toEqual(['stored-outside-sidebar-page'])
+  })
+
   it('includes a messaging tile when the primary view is a non-messaging session', () => {
     const primary = session('stored-primary')
     const messaging = session('stored-messaging', 'qqbot')
 
     expect(
-      resolveOpenMessagingStoredSessionIds({
+      resolveOpenMessagingCandidateIds({
+        knownSessions: [primary],
         messagingSessions: [messaging],
         selectedStoredSessionId: primary.id,
         sessionTiles: [{ storedSessionId: messaging.id }]
@@ -51,11 +62,288 @@ describe('resolveOpenMessagingStoredSessionIds', () => {
     const messaging = session('stored-messaging', 'qqbot')
 
     expect(
-      resolveOpenMessagingStoredSessionIds({
+      resolveOpenMessagingCandidateIds({
+        knownSessions: [],
         messagingSessions: [messaging],
         selectedStoredSessionId: messaging.id,
         sessionTiles: [{ storedSessionId: messaging.id }]
       })
     ).toEqual([messaging.id])
+  })
+
+  it('deduplicates lineage-root and live-tip aliases to the live stored id', () => {
+    const messaging = {
+      _lineage_root_id: 'stored-root',
+      id: 'stored-tip',
+      profile: 'default',
+      source: 'qqbot'
+    }
+
+    expect(
+      resolveOpenMessagingCandidateIds({
+        knownSessions: [],
+        messagingSessions: [messaging],
+        selectedStoredSessionId: 'stored-root',
+        sessionTiles: [{ storedSessionId: 'stored-tip' }]
+      })
+    ).toEqual(['stored-tip'])
+  })
+})
+
+describe('resolveOpenTranscriptSurfaces', () => {
+  it('uses direct primary and tile runtime bindings without a stored-id reverse lookup', () => {
+    expect(
+      resolveOpenTranscriptSurfaces({
+        activeRuntimeSessionId: 'runtime-primary',
+        selectedStoredSessionId: 'stored-primary-root',
+        sessionTiles: [
+          {
+            runtimeId: 'runtime-tile',
+            storedSessionId: 'stored-tile-root'
+          }
+        ]
+      })
+    ).toEqual([
+      { runtimeSessionId: 'runtime-primary', storedSessionId: 'stored-primary-root' },
+      { runtimeSessionId: 'runtime-tile', storedSessionId: 'stored-tile-root' }
+    ])
+  })
+})
+
+describe('resolveMessagingTranscriptTargets', () => {
+  it('resolves an open messaging tile whose metadata is outside the capped sidebar slice', async () => {
+    const resolved = {
+      _lineage_root_id: 'stored-root',
+      id: 'stored-tip',
+      profile: 'work',
+      source: 'qqbot'
+    }
+
+    const resolveStoredSession = vi.fn(async () => resolved)
+
+    const targets = await resolveMessagingTranscriptTargets({
+      getRuntimeState: () => ({ busy: false, storedSessionId: 'stored-tip' }),
+      resolveStoredSession,
+      sessionRows: [],
+      surfaces: [{ runtimeSessionId: 'runtime-tile', storedSessionId: 'stored-root' }]
+    })
+
+    expect(resolveStoredSession).toHaveBeenCalledWith('stored-tip')
+    expect(targets).toEqual([
+      {
+        key: 'work:stored-root',
+        profile: 'work',
+        runtimeSessionIds: ['runtime-tile'],
+        session: resolved,
+        storedSessionId: 'stored-tip'
+      }
+    ])
+  })
+
+  it('prefers the runtime-published live tip over a stale durable-root cache hit', async () => {
+    const stale = {
+      _lineage_root_id: 'stored-root',
+      id: 'stored-old-tip',
+      profile: 'default',
+      source: 'qqbot'
+    }
+
+    const live = { ...stale, id: 'stored-live-tip' }
+    const resolveStoredSession = vi.fn(async () => live)
+
+    const targets = await resolveMessagingTranscriptTargets({
+      getRuntimeState: () => ({ busy: false, storedSessionId: 'stored-live-tip' }),
+      resolveStoredSession,
+      sessionRows: [stale],
+      surfaces: [{ runtimeSessionId: 'runtime-tile', storedSessionId: 'stored-root' }]
+    })
+
+    expect(resolveStoredSession).toHaveBeenCalledWith('stored-live-tip')
+    expect(targets[0]?.storedSessionId).toBe('stored-live-tip')
+  })
+
+  it('keeps refreshing when a tile retains an intermediate continuation tip', async () => {
+    const live = {
+      _lineage_root_id: 'stored-root',
+      id: 'stored-live-tip',
+      profile: 'default',
+      source: 'qqbot'
+    }
+
+    const targets = await resolveMessagingTranscriptTargets({
+      getRuntimeState: () => ({ busy: false, storedSessionId: 'stored-live-tip' }),
+      resolveStoredSession: vi.fn(),
+      sessionRows: [live],
+      surfaces: [{ runtimeSessionId: 'runtime-tile', storedSessionId: 'stored-intermediate-tip' }]
+    })
+
+    expect(targets[0]?.runtimeSessionIds).toEqual(['runtime-tile'])
+    expect(targets[0]?.storedSessionId).toBe('stored-live-tip')
+  })
+
+  it('groups root/tip aliases while preserving every renderer runtime', async () => {
+    const resolved = {
+      _lineage_root_id: 'stored-root',
+      id: 'stored-tip',
+      profile: 'default',
+      source: 'qqbot'
+    }
+
+    const targets = await resolveMessagingTranscriptTargets({
+      getRuntimeState: runtimeSessionId => ({
+        busy: false,
+        storedSessionId: runtimeSessionId === 'runtime-root' ? 'stored-root' : 'stored-tip'
+      }),
+      resolveStoredSession: vi.fn(),
+      sessionRows: [resolved],
+      surfaces: [
+        { runtimeSessionId: 'runtime-root', storedSessionId: 'stored-root' },
+        { runtimeSessionId: 'runtime-tip', storedSessionId: 'stored-tip' }
+      ]
+    })
+
+    expect(targets).toHaveLength(1)
+    expect(targets[0]?.runtimeSessionIds).toEqual(['runtime-root', 'runtime-tip'])
+    expect(targets[0]?.storedSessionId).toBe('stored-tip')
+  })
+
+  it('does not resolve metadata for a runtime published as busy', async () => {
+    const resolveStoredSession = vi.fn()
+
+    const targets = await resolveMessagingTranscriptTargets({
+      getRuntimeState: () => ({ busy: true, storedSessionId: 'stored-messaging' }),
+      resolveStoredSession,
+      sessionRows: [],
+      surfaces: [{ runtimeSessionId: 'runtime-busy', storedSessionId: 'stored-messaging' }]
+    })
+
+    expect(targets).toEqual([])
+    expect(resolveStoredSession).not.toHaveBeenCalled()
+  })
+})
+
+describe('refreshMessagingTranscriptTarget', () => {
+  const target = {
+    key: 'default:stored-root',
+    profile: 'default',
+    runtimeSessionIds: ['runtime-messaging'],
+    session: {
+      _lineage_root_id: 'stored-root',
+      id: 'stored-tip',
+      profile: 'default',
+      source: 'qqbot'
+    },
+    storedSessionId: 'stored-tip'
+  }
+
+  function deferred<T>() {
+    let resolve!: (value: T) => void
+
+    const promise = new Promise<T>(next => {
+      resolve = next
+    })
+
+    return { promise, resolve }
+  }
+
+  it('drops a response when the authoritative runtime becomes busy during the request', async () => {
+    const response = deferred<{ signature: string }>()
+    const state = { busy: false, storedSessionId: 'stored-tip' }
+    const commit = vi.fn()
+
+    const refresh = refreshMessagingTranscriptTarget({
+      commit,
+      generationByTarget: new Map(),
+      getCurrentRuntimeState: () => state,
+      getSignature: value => value.signature,
+      isRuntimeOpen: () => true,
+      loadTranscript: () => response.promise,
+      signatureByRuntimeId: new Map(),
+      target
+    })
+
+    state.busy = true
+    response.resolve({ signature: 'new' })
+    await refresh
+
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('allows only the latest overlapping response to commit', async () => {
+    const firstResponse = deferred<{ signature: string }>()
+    const secondResponse = deferred<{ signature: string }>()
+
+    const loadTranscript = vi
+      .fn<() => Promise<{ signature: string }>>()
+      .mockImplementationOnce(() => firstResponse.promise)
+      .mockImplementationOnce(() => secondResponse.promise)
+
+    const commit = vi.fn()
+
+    const options = {
+      commit,
+      generationByTarget: new Map<string, number>(),
+      getCurrentRuntimeState: () => ({ busy: false, storedSessionId: 'stored-tip' }),
+      getSignature: (value: { signature: string }) => value.signature,
+      isRuntimeOpen: () => true,
+      loadTranscript,
+      signatureByRuntimeId: new Map<string, string>(),
+      target
+    }
+
+    const first = refreshMessagingTranscriptTarget(options)
+    const second = refreshMessagingTranscriptTarget(options)
+
+    secondResponse.resolve({ signature: 'new' })
+    await second
+    firstResponse.resolve({ signature: 'old' })
+    await first
+
+    expect(commit).toHaveBeenCalledTimes(1)
+    expect(commit).toHaveBeenCalledWith(
+      'runtime-messaging',
+      { busy: false, storedSessionId: 'stored-tip' },
+      { signature: 'new' }
+    )
+  })
+
+  it('tracks transcript signatures independently for each renderer runtime', async () => {
+    const twoRuntimeTarget = { ...target, runtimeSessionIds: ['runtime-current', 'runtime-stale'] }
+    const commit = vi.fn()
+
+    await refreshMessagingTranscriptTarget({
+      commit,
+      generationByTarget: new Map(),
+      getCurrentRuntimeState: () => ({ busy: false, storedSessionId: 'stored-tip' }),
+      getSignature: value => value.signature,
+      isRuntimeOpen: () => true,
+      loadTranscript: async () => ({ signature: 'same-server-transcript' }),
+      signatureByRuntimeId: new Map([['default:stored-root:runtime-current', 'same-server-transcript']]),
+      target: twoRuntimeTarget
+    })
+
+    expect(commit).toHaveBeenCalledTimes(1)
+    expect(commit).toHaveBeenCalledWith(
+      'runtime-stale',
+      { busy: false, storedSessionId: 'stored-tip' },
+      { signature: 'same-server-transcript' }
+    )
+  })
+
+  it('does not reuse a signature when the same runtime is rebound to another lineage', async () => {
+    const commit = vi.fn()
+
+    await refreshMessagingTranscriptTarget({
+      commit,
+      generationByTarget: new Map(),
+      getCurrentRuntimeState: () => ({ busy: false, storedSessionId: 'stored-tip' }),
+      getSignature: value => value.signature,
+      isRuntimeOpen: () => true,
+      loadTranscript: async () => ({ signature: 'same-server-transcript' }),
+      signatureByRuntimeId: new Map([['runtime-messaging', 'same-server-transcript']]),
+      target
+    })
+
+    expect(commit).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/desktop/src/app/contrib/hooks/refresh-messaging-transcript.ts
+++ b/apps/desktop/src/app/contrib/hooks/refresh-messaging-transcript.ts
@@ -1,74 +1,253 @@
 import { isMessagingSource } from '@/lib/session-source'
-import { sessionMatchesStoredId } from '@/store/session'
+import { sessionMatchesStoredId, sessionPinId } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
 type MessagingSessionRow = Pick<SessionInfo, '_lineage_root_id' | 'id' | 'profile' | 'source'>
 
-interface ResolveMessagingTranscriptTargetOptions {
-  getRuntimeIdForStoredSession: (storedSessionId: string) => null | string
-  isRuntimeBusy: (runtimeSessionId: string) => boolean
-  messagingSessions: MessagingSessionRow[]
-  selectedStoredSessionId: null | string
-}
-
-interface ResolveOpenMessagingStoredSessionIdsOptions {
+interface ResolveOpenMessagingCandidateIdsOptions {
+  knownSessions: MessagingSessionRow[]
   messagingSessions: MessagingSessionRow[]
   selectedStoredSessionId: null | string
   sessionTiles: ReadonlyArray<{ storedSessionId: string }>
 }
 
-export interface MessagingTranscriptTarget {
-  profile?: null | string
+interface ResolveOpenTranscriptSurfacesOptions {
+  activeRuntimeSessionId: null | string
+  selectedStoredSessionId: null | string
+  sessionTiles: ReadonlyArray<{ runtimeId?: null | string; storedSessionId: string }>
+}
+
+export interface OpenTranscriptSurface {
   runtimeSessionId: string
   storedSessionId: string
 }
 
+export function resolveAuthoritativeRuntimeState<TState>(
+  runtimeSessionId: string,
+  publishedStates: Readonly<Record<string, TState | undefined>>,
+  cachedStates: ReadonlyMap<string, TState>
+): TState | undefined {
+  return publishedStates[runtimeSessionId] ?? cachedStates.get(runtimeSessionId)
+}
+
+export interface MessagingTranscriptRuntimeState {
+  busy: boolean
+  storedSessionId: null | string
+}
+
+export interface ResolvedMessagingTranscriptTarget {
+  key: string
+  profile?: null | string
+  runtimeSessionIds: string[]
+  session: MessagingSessionRow
+  storedSessionId: string
+}
+
+interface ResolveMessagingTranscriptTargetsOptions {
+  getRuntimeState: (runtimeSessionId: string) => MessagingTranscriptRuntimeState | undefined
+  resolveStoredSession: (storedSessionId: string) => Promise<MessagingSessionRow | undefined>
+  sessionRows: MessagingSessionRow[]
+  surfaces: OpenTranscriptSurface[]
+}
+
+interface RefreshMessagingTranscriptTargetOptions<TTranscript> {
+  commit: (
+    runtimeSessionId: string,
+    currentState: MessagingTranscriptRuntimeState,
+    transcript: TTranscript
+  ) => void
+  generationByTarget: Map<string, number>
+  getCurrentRuntimeState: (runtimeSessionId: string) => MessagingTranscriptRuntimeState | undefined
+  getSignature: (transcript: TTranscript) => string
+  isRuntimeOpen: (runtimeSessionId: string) => boolean
+  loadTranscript: () => Promise<TTranscript>
+  signatureByRuntimeId: Map<string, string>
+  target: ResolvedMessagingTranscriptTarget
+}
+
+export function resolveOpenTranscriptSurfaces(
+  options: ResolveOpenTranscriptSurfacesOptions
+): OpenTranscriptSurface[] {
+  const surfaces: OpenTranscriptSurface[] = []
+  const runtimeIds = new Set<string>()
+
+  const add = (runtimeSessionId: null | string | undefined, storedSessionId: null | string) => {
+    if (!runtimeSessionId || !storedSessionId || runtimeIds.has(runtimeSessionId)) {
+      return
+    }
+
+    runtimeIds.add(runtimeSessionId)
+    surfaces.push({ runtimeSessionId, storedSessionId })
+  }
+
+  add(options.activeRuntimeSessionId, options.selectedStoredSessionId)
+
+  for (const tile of options.sessionTiles) {
+    add(tile.runtimeId, tile.storedSessionId)
+  }
+
+  return surfaces
+}
+
 /**
- * Returns messaging sessions currently open in either the primary chat or a
- * session tile. Tiles deliberately do not mutate the primary session atoms, so
- * deriving this list from selectedStoredSessionId alone silently excludes
- * tiled messaging transcripts from background refreshes.
+ * Returns known messaging sessions plus unresolved open candidates from both
+ * the primary surface and independent session tiles. Exact metadata resolution
+ * later filters non-messaging candidates without treating the capped sidebar
+ * slice as authoritative.
  */
-export function resolveOpenMessagingStoredSessionIds(
-  options: ResolveOpenMessagingStoredSessionIdsOptions
+export function resolveOpenMessagingCandidateIds(
+  options: ResolveOpenMessagingCandidateIdsOptions
 ): string[] {
   const openIds = [options.selectedStoredSessionId, ...options.sessionTiles.map(tile => tile.storedSessionId)]
-  const result: string[] = []
+  const result = new Set<string>()
 
   for (const storedSessionId of openIds) {
-    if (!storedSessionId || result.includes(storedSessionId)) {
+    if (!storedSessionId) {
       continue
     }
 
-    const stored = options.messagingSessions.find(session => sessionMatchesStoredId(session, storedSessionId))
+    const stored =
+      options.messagingSessions.find(session => sessionMatchesStoredId(session, storedSessionId)) ??
+      options.knownSessions.find(session => sessionMatchesStoredId(session, storedSessionId))
 
     if (stored && isMessagingSource(stored.source)) {
-      result.push(storedSessionId)
+      // A durable tile may still carry the lineage root after compression while
+      // the fresh sidebar row carries the live continuation tip. Normalize to
+      // the live id so root/tip aliases do not schedule duplicate reads.
+      result.add(stored.id)
+    } else if (!stored) {
+      // The messaging sidebar is a capped page. Keep unknown open surfaces as
+      // candidates so the caller can resolve their metadata by exact id rather
+      // than treating absence from that page as proof they are local sessions.
+      result.add(storedSessionId)
     }
   }
 
-  return result
+  return [...result]
 }
 
-export function resolveMessagingTranscriptTarget(
-  options: ResolveMessagingTranscriptTargetOptions
-): MessagingTranscriptTarget | null {
-  const storedSessionId = options.selectedStoredSessionId
+/**
+ * Resolves the open renderer surfaces to transport-agnostic messaging targets.
+ * A surface owns its runtime id directly; the durable stored id is only the
+ * lookup fallback because compression may already have rotated the live state
+ * to a continuation tip. Unknown ids are resolved exactly instead of being
+ * discarded merely because the messaging sidebar's capped page omitted them.
+ */
+export async function resolveMessagingTranscriptTargets(
+  options: ResolveMessagingTranscriptTargetsOptions
+): Promise<ResolvedMessagingTranscriptTarget[]> {
+  const grouped = new Map<string, ResolvedMessagingTranscriptTarget>()
 
-  if (!storedSessionId) {
-    return null
+  for (const surface of options.surfaces) {
+    const runtimeState = options.getRuntimeState(surface.runtimeSessionId)
+
+    if (!runtimeState || runtimeState.busy) {
+      continue
+    }
+
+    const liveStoredSessionId = runtimeState.storedSessionId ?? surface.storedSessionId
+
+    let stored = options.sessionRows.find(session => sessionMatchesStoredId(session, liveStoredSessionId))
+
+    stored ??= await options.resolveStoredSession(liveStoredSessionId)
+
+    if (!stored && liveStoredSessionId !== surface.storedSessionId) {
+      stored =
+        options.sessionRows.find(session => sessionMatchesStoredId(session, surface.storedSessionId)) ??
+        (await options.resolveStoredSession(surface.storedSessionId))
+    }
+
+    if (!stored || !isMessagingSource(stored.source)) {
+      continue
+    }
+
+    const profile = stored.profile?.trim() || 'default'
+    const lineageRoot = sessionPinId(stored)
+    const key = `${profile}:${lineageRoot}`
+    const existing = grouped.get(key)
+
+    if (existing) {
+      if (!existing.runtimeSessionIds.includes(surface.runtimeSessionId)) {
+        existing.runtimeSessionIds.push(surface.runtimeSessionId)
+      }
+
+      // Prefer a live continuation tip over a durable lineage root when two
+      // aliases for the same transcript are simultaneously open.
+      if (existing.storedSessionId === lineageRoot && stored.id !== lineageRoot) {
+        existing.session = stored
+        existing.storedSessionId = stored.id
+      }
+
+      continue
+    }
+
+    grouped.set(key, {
+      key,
+      profile: stored.profile,
+      runtimeSessionIds: [surface.runtimeSessionId],
+      session: stored,
+      storedSessionId: stored.id
+    })
   }
 
-  const stored = options.messagingSessions.find(session => sessionMatchesStoredId(session, storedSessionId))
-  const runtimeSessionId = options.getRuntimeIdForStoredSession(storedSessionId)
+  return [...grouped.values()]
+}
 
-  if (!stored || !isMessagingSource(stored.source) || !runtimeSessionId || options.isRuntimeBusy(runtimeSessionId)) {
-    return null
+/**
+ * Loads one canonical transcript and commits it to every still-open renderer
+ * runtime for that lineage. Generation, membership, identity, and authoritative
+ * busy state are rechecked after the await so a slow poll cannot overwrite a
+ * newer response, a running turn, a closed tile, or a rebound runtime.
+ */
+export async function refreshMessagingTranscriptTarget<TTranscript>(
+  options: RefreshMessagingTranscriptTargetOptions<TTranscript>
+): Promise<void> {
+  const hasIdleRuntime = options.target.runtimeSessionIds.some(runtimeSessionId => {
+    const state = options.getCurrentRuntimeState(runtimeSessionId)
+
+    return Boolean(
+      state &&
+        !state.busy &&
+        sessionMatchesStoredId(
+          options.target.session,
+          state.storedSessionId ?? options.target.storedSessionId
+        )
+    )
+  })
+
+  if (!hasIdleRuntime) {
+    return
   }
 
-  return {
-    profile: stored.profile,
-    runtimeSessionId,
-    storedSessionId
+  const generation = (options.generationByTarget.get(options.target.key) ?? 0) + 1
+  options.generationByTarget.set(options.target.key, generation)
+
+  const transcript = await options.loadTranscript()
+
+  if (options.generationByTarget.get(options.target.key) !== generation) {
+    return
+  }
+
+  const signature = options.getSignature(transcript)
+
+  for (const runtimeSessionId of options.target.runtimeSessionIds) {
+    const currentState = options.getCurrentRuntimeState(runtimeSessionId)
+    const signatureKey = `${options.target.key}:${runtimeSessionId}`
+
+    if (
+      !currentState ||
+      currentState.busy ||
+      !options.isRuntimeOpen(runtimeSessionId) ||
+      !sessionMatchesStoredId(
+        options.target.session,
+        currentState.storedSessionId ?? options.target.storedSessionId
+      ) ||
+      options.signatureByRuntimeId.get(signatureKey) === signature
+    ) {
+      continue
+    }
+
+    options.commit(runtimeSessionId, currentState, transcript)
+    options.signatureByRuntimeId.set(signatureKey, signature)
   }
 }

--- a/apps/desktop/src/app/contrib/hooks/refresh-messaging-transcript.ts
+++ b/apps/desktop/src/app/contrib/hooks/refresh-messaging-transcript.ts
@@ -7,18 +7,36 @@ type MessagingSessionRow = Pick<SessionInfo, '_lineage_root_id' | 'id' | 'profil
 interface ResolveOpenMessagingCandidateIdsOptions {
   knownSessions: MessagingSessionRow[]
   messagingSessions: MessagingSessionRow[]
+  profile: string
   selectedStoredSessionId: null | string
   sessionTiles: ReadonlyArray<{ storedSessionId: string }>
 }
 
 interface ResolveOpenTranscriptSurfacesOptions {
   activeRuntimeSessionId: null | string
+  profile: string
   selectedStoredSessionId: null | string
   sessionTiles: ReadonlyArray<{ runtimeId?: null | string; storedSessionId: string }>
 }
 
 export interface OpenTranscriptSurface {
   runtimeSessionId: string
+  storedSessionId: string
+  profile: string
+}
+
+interface IsTranscriptRefreshScopeCurrentOptions {
+  activeProfile: null | string | undefined
+  capturedProfileEpoch: number
+  currentProfileEpoch: number
+  profile: null | string | undefined
+  runtimeSessionId: string
+  surfaces: OpenTranscriptSurface[]
+}
+
+interface ResolveProfileScopedStoredSessionOptions {
+  getSession: (storedSessionId: string, profile: string) => Promise<MessagingSessionRow>
+  profile: string
   storedSessionId: string
 }
 
@@ -45,10 +63,46 @@ export interface ResolvedMessagingTranscriptTarget {
 
 interface ResolveMessagingTranscriptTargetsOptions {
   getRuntimeState: (runtimeSessionId: string) => MessagingTranscriptRuntimeState | undefined
-  resolveStoredSession: (storedSessionId: string) => Promise<MessagingSessionRow | undefined>
+  resolveStoredSession: (storedSessionId: string, profile: string) => Promise<MessagingSessionRow | undefined>
   sessionRows: MessagingSessionRow[]
   surfaces: OpenTranscriptSurface[]
 }
+
+const profileKey = (profile: null | string | undefined) => profile?.trim() || 'default'
+
+export async function resolveProfileScopedStoredSession(
+  options: ResolveProfileScopedStoredSessionOptions
+): Promise<MessagingSessionRow> {
+  const profile = profileKey(options.profile)
+
+  return {
+    ...(await options.getSession(options.storedSessionId, profile)),
+    profile
+  }
+}
+
+export function isTranscriptRefreshScopeCurrent(
+  options: IsTranscriptRefreshScopeCurrentOptions
+): boolean {
+  if (options.capturedProfileEpoch !== options.currentProfileEpoch) {
+    return false
+  }
+
+  const profile = profileKey(options.profile)
+
+  if (profileKey(options.activeProfile) !== profile) {
+    return false
+  }
+
+  return options.surfaces.some(
+    surface => surface.runtimeSessionId === options.runtimeSessionId && surface.profile === profile
+  )
+}
+
+const findSessionInProfile = (sessions: MessagingSessionRow[], storedSessionId: string, profile: string) =>
+  sessions.find(
+    session => profileKey(session.profile) === profile && sessionMatchesStoredId(session, storedSessionId)
+  )
 
 interface RefreshMessagingTranscriptTargetOptions<TTranscript> {
   commit: (
@@ -70,6 +124,7 @@ export function resolveOpenTranscriptSurfaces(
 ): OpenTranscriptSurface[] {
   const surfaces: OpenTranscriptSurface[] = []
   const runtimeIds = new Set<string>()
+  const profile = profileKey(options.profile)
 
   const add = (runtimeSessionId: null | string | undefined, storedSessionId: null | string) => {
     if (!runtimeSessionId || !storedSessionId || runtimeIds.has(runtimeSessionId)) {
@@ -77,7 +132,7 @@ export function resolveOpenTranscriptSurfaces(
     }
 
     runtimeIds.add(runtimeSessionId)
-    surfaces.push({ runtimeSessionId, storedSessionId })
+    surfaces.push({ profile, runtimeSessionId, storedSessionId })
   }
 
   add(options.activeRuntimeSessionId, options.selectedStoredSessionId)
@@ -99,6 +154,7 @@ export function resolveOpenMessagingCandidateIds(
   options: ResolveOpenMessagingCandidateIdsOptions
 ): string[] {
   const openIds = [options.selectedStoredSessionId, ...options.sessionTiles.map(tile => tile.storedSessionId)]
+  const profile = profileKey(options.profile)
   const result = new Set<string>()
 
   for (const storedSessionId of openIds) {
@@ -107,8 +163,8 @@ export function resolveOpenMessagingCandidateIds(
     }
 
     const stored =
-      options.messagingSessions.find(session => sessionMatchesStoredId(session, storedSessionId)) ??
-      options.knownSessions.find(session => sessionMatchesStoredId(session, storedSessionId))
+      findSessionInProfile(options.messagingSessions, storedSessionId, profile) ??
+      findSessionInProfile(options.knownSessions, storedSessionId, profile)
 
     if (stored && isMessagingSource(stored.source)) {
       // A durable tile may still carry the lineage root after compression while
@@ -138,7 +194,18 @@ export async function resolveMessagingTranscriptTargets(
 ): Promise<ResolvedMessagingTranscriptTarget[]> {
   const grouped = new Map<string, ResolvedMessagingTranscriptTarget>()
 
+  const resolveForProfile = async (storedSessionId: string, profile: string) => {
+    try {
+      const resolved = await options.resolveStoredSession(storedSessionId, profile)
+
+      return resolved && profileKey(resolved.profile) === profile ? resolved : undefined
+    } catch {
+      return undefined
+    }
+  }
+
   for (const surface of options.surfaces) {
+    const profile = profileKey(surface.profile)
     const runtimeState = options.getRuntimeState(surface.runtimeSessionId)
 
     if (!runtimeState || runtimeState.busy) {
@@ -147,21 +214,20 @@ export async function resolveMessagingTranscriptTargets(
 
     const liveStoredSessionId = runtimeState.storedSessionId ?? surface.storedSessionId
 
-    let stored = options.sessionRows.find(session => sessionMatchesStoredId(session, liveStoredSessionId))
+    let stored = findSessionInProfile(options.sessionRows, liveStoredSessionId, profile)
 
-    stored ??= await options.resolveStoredSession(liveStoredSessionId)
+    stored ??= await resolveForProfile(liveStoredSessionId, profile)
 
     if (!stored && liveStoredSessionId !== surface.storedSessionId) {
       stored =
-        options.sessionRows.find(session => sessionMatchesStoredId(session, surface.storedSessionId)) ??
-        (await options.resolveStoredSession(surface.storedSessionId))
+        findSessionInProfile(options.sessionRows, surface.storedSessionId, profile) ??
+        (await resolveForProfile(surface.storedSessionId, profile))
     }
 
     if (!stored || !isMessagingSource(stored.source)) {
       continue
     }
 
-    const profile = stored.profile?.trim() || 'default'
     const lineageRoot = sessionPinId(stored)
     const key = `${profile}:${lineageRoot}`
     const existing = grouped.get(key)
@@ -183,7 +249,7 @@ export async function resolveMessagingTranscriptTargets(
 
     grouped.set(key, {
       key,
-      profile: stored.profile,
+      profile,
       runtimeSessionIds: [surface.runtimeSessionId],
       session: stored,
       storedSessionId: stored.id

--- a/apps/desktop/src/app/contrib/hooks/refresh-messaging-transcript.ts
+++ b/apps/desktop/src/app/contrib/hooks/refresh-messaging-transcript.ts
@@ -1,0 +1,74 @@
+import { isMessagingSource } from '@/lib/session-source'
+import { sessionMatchesStoredId } from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
+
+type MessagingSessionRow = Pick<SessionInfo, '_lineage_root_id' | 'id' | 'profile' | 'source'>
+
+interface ResolveMessagingTranscriptTargetOptions {
+  getRuntimeIdForStoredSession: (storedSessionId: string) => null | string
+  isRuntimeBusy: (runtimeSessionId: string) => boolean
+  messagingSessions: MessagingSessionRow[]
+  selectedStoredSessionId: null | string
+}
+
+interface ResolveOpenMessagingStoredSessionIdsOptions {
+  messagingSessions: MessagingSessionRow[]
+  selectedStoredSessionId: null | string
+  sessionTiles: ReadonlyArray<{ storedSessionId: string }>
+}
+
+export interface MessagingTranscriptTarget {
+  profile?: null | string
+  runtimeSessionId: string
+  storedSessionId: string
+}
+
+/**
+ * Returns messaging sessions currently open in either the primary chat or a
+ * session tile. Tiles deliberately do not mutate the primary session atoms, so
+ * deriving this list from selectedStoredSessionId alone silently excludes
+ * tiled messaging transcripts from background refreshes.
+ */
+export function resolveOpenMessagingStoredSessionIds(
+  options: ResolveOpenMessagingStoredSessionIdsOptions
+): string[] {
+  const openIds = [options.selectedStoredSessionId, ...options.sessionTiles.map(tile => tile.storedSessionId)]
+  const result: string[] = []
+
+  for (const storedSessionId of openIds) {
+    if (!storedSessionId || result.includes(storedSessionId)) {
+      continue
+    }
+
+    const stored = options.messagingSessions.find(session => sessionMatchesStoredId(session, storedSessionId))
+
+    if (stored && isMessagingSource(stored.source)) {
+      result.push(storedSessionId)
+    }
+  }
+
+  return result
+}
+
+export function resolveMessagingTranscriptTarget(
+  options: ResolveMessagingTranscriptTargetOptions
+): MessagingTranscriptTarget | null {
+  const storedSessionId = options.selectedStoredSessionId
+
+  if (!storedSessionId) {
+    return null
+  }
+
+  const stored = options.messagingSessions.find(session => sessionMatchesStoredId(session, storedSessionId))
+  const runtimeSessionId = options.getRuntimeIdForStoredSession(storedSessionId)
+
+  if (!stored || !isMessagingSource(stored.source) || !runtimeSessionId || options.isRuntimeBusy(runtimeSessionId)) {
+    return null
+  }
+
+  return {
+    profile: stored.profile,
+    runtimeSessionId,
+    storedSessionId
+  }
+}

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -27,7 +27,6 @@ import { emitGatewayEvent } from '@/contrib/events'
 import { getSessionMessages, triggerCronJob } from '@/hermes'
 import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
 import { sessionMessagesSignature } from '@/lib/session-signatures'
-import { isMessagingSource } from '@/lib/session-source'
 import { latestSessionTodos } from '@/lib/todos'
 import { playWakeSound } from '@/lib/wake-sound'
 import { $billingSettingsRequest } from '@/store/billing-block'
@@ -63,6 +62,7 @@ import {
   setBusy,
   setMessages
 } from '@/store/session'
+import { $sessionTiles } from '@/store/session-states'
 import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
 import { armWakeWord } from '@/store/wake-word'
 import { isSecondaryWindow } from '@/store/windows'
@@ -106,6 +106,10 @@ import { TitlebarControls } from '../shell/titlebar-controls'
 import { UpdatesOverlay } from '../updates-overlay'
 
 import { ContribWiringContext } from './context'
+import {
+  resolveMessagingTranscriptTarget,
+  resolveOpenMessagingStoredSessionIds
+} from './hooks/refresh-messaging-transcript'
 import { useBackgroundSync } from './hooks/use-background-sync'
 import { useDesktopIntegrations } from './hooks/use-desktop-integrations'
 import { usePetBridge } from './hooks/use-pet-bridge'
@@ -169,6 +173,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const resumeExhaustedSessionId = useStore($resumeExhaustedSessionId)
   const selectedStoredSessionId = useStore($selectedStoredSessionId)
   const messagingSessions = useStore($messagingSessions)
+  const sessionTiles = useStore($sessionTiles)
   const activeGatewayProfile = useStore($activeGatewayProfile)
   const profileScope = useStore($profileScope)
 
@@ -347,44 +352,57 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     [activeSessionIdRef, selectedStoredSessionIdRef, updateSessionState]
   )
 
-  // Refresh the open messaging transcript (inbound platform turns arrive via
-  // the background gateway, not the desktop websocket). Signature-gated so a
-  // no-change poll doesn't churn the thread.
-  const refreshActiveMessagingTranscript = useCallback(async () => {
-    const storedSessionId = selectedStoredSessionIdRef.current
-    const runtimeSessionId = activeSessionIdRef.current
+  // Refresh every open messaging transcript (primary view + session tiles).
+  // Inbound platform turns arrive via the background gateway, not the desktop
+  // websocket. Signatures are keyed per stored session so multiple open
+  // messaging tiles cannot suppress one another.
+  const refreshOpenMessagingTranscripts = useCallback(async () => {
+    const currentMessagingSessions = $messagingSessions.get()
 
-    if (!storedSessionId || !runtimeSessionId || busyRef.current) {
-      return
-    }
+    const openStoredSessionIds = resolveOpenMessagingStoredSessionIds({
+      messagingSessions: currentMessagingSessions,
+      selectedStoredSessionId: selectedStoredSessionIdRef.current,
+      sessionTiles: $sessionTiles.get()
+    })
 
-    const stored = $messagingSessions.get().find(s => sessionMatchesStoredId(s, storedSessionId))
+    await Promise.all(
+      openStoredSessionIds.map(async selectedSessionId => {
+        const target = resolveMessagingTranscriptTarget({
+          getRuntimeIdForStoredSession,
+          isRuntimeBusy: runtimeSessionId => Boolean(sessionStateByRuntimeIdRef.current.get(runtimeSessionId)?.busy),
+          messagingSessions: currentMessagingSessions,
+          selectedStoredSessionId: selectedSessionId
+        })
 
-    if (!stored || !isMessagingSource(stored.source)) {
-      return
-    }
+        if (!target) {
+          return
+        }
 
-    try {
-      const latest = await getSessionMessages(storedSessionId, stored.profile)
-      const signatureKey = `${stored.profile ?? 'default'}:${storedSessionId}`
-      const sig = sessionMessagesSignature(latest.messages)
+        const { profile, runtimeSessionId, storedSessionId } = target
 
-      if (messagingTranscriptSignatureRef.current.get(signatureKey) === sig) {
-        return
-      }
+        try {
+          const latest = await getSessionMessages(storedSessionId, profile)
+          const signatureKey = `${profile ?? 'default'}:${storedSessionId}`
+          const sig = sessionMessagesSignature(latest.messages)
 
-      messagingTranscriptSignatureRef.current.set(signatureKey, sig)
-      const messages = toChatMessages(latest.messages)
+          if (messagingTranscriptSignatureRef.current.get(signatureKey) === sig) {
+            return
+          }
 
-      updateSessionState(
-        runtimeSessionId,
-        state => ({ ...state, messages: preserveLocalAssistantErrors(messages, state.messages) }),
-        storedSessionId
-      )
-    } catch {
-      // Non-fatal: next poll or manual refresh can hydrate.
-    }
-  }, [activeSessionIdRef, busyRef, selectedStoredSessionIdRef, updateSessionState])
+          messagingTranscriptSignatureRef.current.set(signatureKey, sig)
+          const messages = toChatMessages(latest.messages)
+
+          updateSessionState(
+            runtimeSessionId,
+            state => ({ ...state, messages: preserveLocalAssistantErrors(messages, state.messages) }),
+            storedSessionId
+          )
+        } catch {
+          // Non-fatal: next poll or manual refresh can hydrate.
+        }
+      })
+    )
+  }, [getRuntimeIdForStoredSession, selectedStoredSessionIdRef, sessionStateByRuntimeIdRef, updateSessionState])
 
   const { handleGatewayEvent } = useMessageStream({
     activeGatewayProfile,
@@ -734,11 +752,11 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     }
   }, [gatewayState, requestGateway])
 
-  // Only the open messaging transcript needs its own poll — local chats are
-  // live over the websocket already.
+  // Only open messaging transcripts need their own poll — local chats are live
+  // over the websocket already. Session tiles intentionally don't update the
+  // primary selected-session atom, so include them explicitly.
   const activeIsMessaging =
-    !!selectedStoredSessionId &&
-    isMessagingSource(messagingSessions.find(s => sessionMatchesStoredId(s, selectedStoredSessionId))?.source)
+    resolveOpenMessagingStoredSessionIds({ messagingSessions, selectedStoredSessionId, sessionTiles }).length > 0
 
   // Keep app data live while the gateway is open (on-connect reseed + the
   // cron / messaging / transcript visibility polls + fresh-draft reseed).
@@ -748,7 +766,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     activeSessionId,
     freshDraftReady,
     gatewayState,
-    refreshActiveMessagingTranscript,
+    refreshActiveMessagingTranscript: refreshOpenMessagingTranscripts,
     refreshCronJobs,
     refreshCurrentModel,
     refreshHermesConfig,

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -24,7 +24,7 @@ import { $newSessionTabAction } from '@/components/pane-shell/tree/store'
 import { FloatingPet } from '@/components/pet/floating-pet'
 import { RemoteDisplayBanner } from '@/components/remote-display-banner'
 import { emitGatewayEvent } from '@/contrib/events'
-import { getSessionMessages, triggerCronJob } from '@/hermes'
+import { getSession, getSessionMessages, triggerCronJob } from '@/hermes'
 import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
 import { sessionMessagesSignature } from '@/lib/session-signatures'
 import { latestSessionTodos } from '@/lib/todos'
@@ -96,7 +96,6 @@ import { usePreviewRouting } from '../session/hooks/use-preview-routing'
 import { usePromptActions } from '../session/hooks/use-prompt-actions'
 import { useRouteResume } from '../session/hooks/use-route-resume'
 import { useSessionActions } from '../session/hooks/use-session-actions'
-import { resolveStoredSession } from '../session/hooks/use-session-actions/utils'
 import { useSessionListActions } from '../session/hooks/use-session-list-actions'
 import { useSessionStateCache } from '../session/hooks/use-session-state-cache'
 import { startWorkspaceSession } from '../session/workspace-session-target'
@@ -108,11 +107,13 @@ import { UpdatesOverlay } from '../updates-overlay'
 
 import { ContribWiringContext } from './context'
 import {
+  isTranscriptRefreshScopeCurrent,
   refreshMessagingTranscriptTarget,
   resolveAuthoritativeRuntimeState,
   resolveMessagingTranscriptTargets,
   resolveOpenMessagingCandidateIds,
-  resolveOpenTranscriptSurfaces
+  resolveOpenTranscriptSurfaces,
+  resolveProfileScopedStoredSession
 } from './hooks/refresh-messaging-transcript'
 import { useBackgroundSync } from './hooks/use-background-sync'
 import { useDesktopIntegrations } from './hooks/use-desktop-integrations'
@@ -357,6 +358,16 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     [activeSessionIdRef, selectedStoredSessionIdRef, updateSessionState]
   )
 
+  const messagingRefreshProfileEpochRef = useRef(0)
+
+  useEffect(
+    () =>
+      $activeGatewayProfile.subscribe(() => {
+        messagingRefreshProfileEpochRef.current += 1
+      }),
+    []
+  )
+
   // Messaging sessions are written by background gateway adapters rather than
   // this renderer's stream, so reconcile every open messaging transcript from
   // storage. Tiles own independent renderer state and never select the primary
@@ -364,6 +375,9 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // sidebar is capped), then guard each async commit against lineage rotation,
   // reconnect busy state, tile closure/rebind, and newer overlapping polls.
   const refreshOpenMessagingTranscripts = useCallback(async () => {
+    const profile = normalizeProfileKey($activeGatewayProfile.get())
+    const profileEpoch = messagingRefreshProfileEpochRef.current
+
     const getCurrentRuntimeState = (runtimeSessionId: string) =>
       resolveAuthoritativeRuntimeState(
         runtimeSessionId,
@@ -374,13 +388,15 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     const getOpenSurfaces = () =>
       resolveOpenTranscriptSurfaces({
         activeRuntimeSessionId: activeSessionIdRef.current,
+        profile,
         selectedStoredSessionId: selectedStoredSessionIdRef.current,
         sessionTiles: $sessionTiles.get()
       })
 
     const targets = await resolveMessagingTranscriptTargets({
       getRuntimeState: getCurrentRuntimeState,
-      resolveStoredSession,
+      resolveStoredSession: (storedSessionId, targetProfile) =>
+        resolveProfileScopedStoredSession({ getSession, profile: targetProfile, storedSessionId }),
       sessionRows: [...$messagingSessions.get(), ...$sessions.get()],
       surfaces: getOpenSurfaces()
     })
@@ -411,7 +427,14 @@ export function ContribWiring({ children }: { children: ReactNode }) {
             getCurrentRuntimeState,
             getSignature: latest => sessionMessagesSignature(latest.messages),
             isRuntimeOpen: runtimeSessionId =>
-              getOpenSurfaces().some(surface => surface.runtimeSessionId === runtimeSessionId),
+              isTranscriptRefreshScopeCurrent({
+                activeProfile: normalizeProfileKey($activeGatewayProfile.get()),
+                capturedProfileEpoch: profileEpoch,
+                currentProfileEpoch: messagingRefreshProfileEpochRef.current,
+                profile: target.profile,
+                runtimeSessionId,
+                surfaces: getOpenSurfaces()
+              }),
             loadTranscript: () => getSessionMessages(target.storedSessionId, target.profile),
             signatureByRuntimeId: messagingTranscriptSignatureByRuntimeRef.current,
             target
@@ -778,6 +801,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     resolveOpenMessagingCandidateIds({
       knownSessions: $sessions.get(),
       messagingSessions,
+      profile: normalizeProfileKey(activeGatewayProfile),
       selectedStoredSessionId,
       sessionTiles
     }).length > 0

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -62,7 +62,7 @@ import {
   setBusy,
   setMessages
 } from '@/store/session'
-import { $sessionTiles } from '@/store/session-states'
+import { $sessionStates, $sessionTiles } from '@/store/session-states'
 import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
 import { armWakeWord } from '@/store/wake-word'
 import { isSecondaryWindow } from '@/store/windows'
@@ -96,6 +96,7 @@ import { usePreviewRouting } from '../session/hooks/use-preview-routing'
 import { usePromptActions } from '../session/hooks/use-prompt-actions'
 import { useRouteResume } from '../session/hooks/use-route-resume'
 import { useSessionActions } from '../session/hooks/use-session-actions'
+import { resolveStoredSession } from '../session/hooks/use-session-actions/utils'
 import { useSessionListActions } from '../session/hooks/use-session-list-actions'
 import { useSessionStateCache } from '../session/hooks/use-session-state-cache'
 import { startWorkspaceSession } from '../session/workspace-session-target'
@@ -107,8 +108,11 @@ import { UpdatesOverlay } from '../updates-overlay'
 
 import { ContribWiringContext } from './context'
 import {
-  resolveMessagingTranscriptTarget,
-  resolveOpenMessagingStoredSessionIds
+  refreshMessagingTranscriptTarget,
+  resolveAuthoritativeRuntimeState,
+  resolveMessagingTranscriptTargets,
+  resolveOpenMessagingCandidateIds,
+  resolveOpenTranscriptSurfaces
 } from './hooks/refresh-messaging-transcript'
 import { useBackgroundSync } from './hooks/use-background-sync'
 import { useDesktopIntegrations } from './hooks/use-desktop-integrations'
@@ -146,7 +150,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // context (the sticky toast). The shell owns `navigate`, so it consumes the
   // intent counter here; the ref skips the initial mount value.
   const billingSettingsSeenRef = useRef(0)
-  const messagingTranscriptSignatureRef = useRef(new Map<string, string>())
+  const messagingTranscriptGenerationRef = useRef(new Map<string, number>())
+  const messagingTranscriptSignatureByRuntimeRef = useRef(new Map<string, string>())
   // Stable identity for the whole callback surface (see WiringActions). Mutated
   // in place each render so memoized surfaces never re-render on churn.
   const actionsRef = useRef<WiringActions | null>(null)
@@ -352,57 +357,71 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     [activeSessionIdRef, selectedStoredSessionIdRef, updateSessionState]
   )
 
-  // Refresh every open messaging transcript (primary view + session tiles).
-  // Inbound platform turns arrive via the background gateway, not the desktop
-  // websocket. Signatures are keyed per stored session so multiple open
-  // messaging tiles cannot suppress one another.
+  // Messaging sessions are written by background gateway adapters rather than
+  // this renderer's stream, so reconcile every open messaging transcript from
+  // storage. Tiles own independent renderer state and never select the primary
+  // session. Resolve their direct runtime bindings and exact metadata (the
+  // sidebar is capped), then guard each async commit against lineage rotation,
+  // reconnect busy state, tile closure/rebind, and newer overlapping polls.
   const refreshOpenMessagingTranscripts = useCallback(async () => {
-    const currentMessagingSessions = $messagingSessions.get()
+    const getCurrentRuntimeState = (runtimeSessionId: string) =>
+      resolveAuthoritativeRuntimeState(
+        runtimeSessionId,
+        $sessionStates.get(),
+        sessionStateByRuntimeIdRef.current
+      )
 
-    const openStoredSessionIds = resolveOpenMessagingStoredSessionIds({
-      messagingSessions: currentMessagingSessions,
-      selectedStoredSessionId: selectedStoredSessionIdRef.current,
-      sessionTiles: $sessionTiles.get()
+    const getOpenSurfaces = () =>
+      resolveOpenTranscriptSurfaces({
+        activeRuntimeSessionId: activeSessionIdRef.current,
+        selectedStoredSessionId: selectedStoredSessionIdRef.current,
+        sessionTiles: $sessionTiles.get()
+      })
+
+    const targets = await resolveMessagingTranscriptTargets({
+      getRuntimeState: getCurrentRuntimeState,
+      resolveStoredSession,
+      sessionRows: [...$messagingSessions.get(), ...$sessions.get()],
+      surfaces: getOpenSurfaces()
     })
 
     await Promise.all(
-      openStoredSessionIds.map(async selectedSessionId => {
-        const target = resolveMessagingTranscriptTarget({
-          getRuntimeIdForStoredSession,
-          isRuntimeBusy: runtimeSessionId => Boolean(sessionStateByRuntimeIdRef.current.get(runtimeSessionId)?.busy),
-          messagingSessions: currentMessagingSessions,
-          selectedStoredSessionId: selectedSessionId
-        })
-
-        if (!target) {
-          return
-        }
-
-        const { profile, runtimeSessionId, storedSessionId } = target
-
+      targets.map(async target => {
         try {
-          const latest = await getSessionMessages(storedSessionId, profile)
-          const signatureKey = `${profile ?? 'default'}:${storedSessionId}`
-          const sig = sessionMessagesSignature(latest.messages)
+          await refreshMessagingTranscriptTarget({
+            commit: (runtimeSessionId, _checkedState, latest) => {
+              // Reconnect hydration publishes authoritative state directly to
+              // the atom. Use that full snapshot as the cache-update base so a
+              // stale ref cannot re-publish obsolete busy/transcript state.
+              const currentState = getCurrentRuntimeState(runtimeSessionId)
 
-          if (messagingTranscriptSignatureRef.current.get(signatureKey) === sig) {
-            return
-          }
+              if (!currentState) {
+                return
+              }
 
-          messagingTranscriptSignatureRef.current.set(signatureKey, sig)
-          const messages = toChatMessages(latest.messages)
+              const messages = toChatMessages(latest.messages)
 
-          updateSessionState(
-            runtimeSessionId,
-            state => ({ ...state, messages: preserveLocalAssistantErrors(messages, state.messages) }),
-            storedSessionId
-          )
+              updateSessionState(
+                runtimeSessionId,
+                () => ({ ...currentState, messages: preserveLocalAssistantErrors(messages, currentState.messages) }),
+                target.storedSessionId
+              )
+            },
+            generationByTarget: messagingTranscriptGenerationRef.current,
+            getCurrentRuntimeState,
+            getSignature: latest => sessionMessagesSignature(latest.messages),
+            isRuntimeOpen: runtimeSessionId =>
+              getOpenSurfaces().some(surface => surface.runtimeSessionId === runtimeSessionId),
+            loadTranscript: () => getSessionMessages(target.storedSessionId, target.profile),
+            signatureByRuntimeId: messagingTranscriptSignatureByRuntimeRef.current,
+            target
+          })
         } catch {
           // Non-fatal: next poll or manual refresh can hydrate.
         }
       })
     )
-  }, [getRuntimeIdForStoredSession, selectedStoredSessionIdRef, sessionStateByRuntimeIdRef, updateSessionState])
+  }, [activeSessionIdRef, selectedStoredSessionIdRef, sessionStateByRuntimeIdRef, updateSessionState])
 
   const { handleGatewayEvent } = useMessageStream({
     activeGatewayProfile,
@@ -755,14 +774,19 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // Only open messaging transcripts need their own poll — local chats are live
   // over the websocket already. Session tiles intentionally don't update the
   // primary selected-session atom, so include them explicitly.
-  const activeIsMessaging =
-    resolveOpenMessagingStoredSessionIds({ messagingSessions, selectedStoredSessionId, sessionTiles }).length > 0
+  const hasMessagingRefreshCandidate =
+    resolveOpenMessagingCandidateIds({
+      knownSessions: $sessions.get(),
+      messagingSessions,
+      selectedStoredSessionId,
+      sessionTiles
+    }).length > 0
 
   // Keep app data live while the gateway is open (on-connect reseed + the
   // cron / messaging / transcript visibility polls + fresh-draft reseed).
   useBackgroundSync({
     activeGatewayProfile,
-    activeIsMessaging,
+    activeIsMessaging: hasMessagingRefreshCandidate,
     activeSessionId,
     freshDraftReady,
     gatewayState,


### PR DESCRIPTION
## Summary

- Fix runtime transcript refresh for messaging conversations opened as Desktop session tiles.
- Resolve each open messaging transcript against its own stored session, runtime, profile, busy state, and signature.
- Add focused regression coverage and a complete incident report.

## Root cause

The existing background synchronization path was gated by the primary chat selection. Session tiles intentionally do not mutate that primary selection, so a QQBot transcript opened in a tile could be omitted from runtime refresh. Restarting Desktop appeared to fix it only because startup hydration reread the persisted database transcript.

## Validation

- Focused Vitest: 19/19 passed.
- TypeScript typecheck: passed (renderer, Electron, and E2E configs).
- Targeted ESLint: passed.
- Production Desktop build: passed, including Electron main/preload bundling and native dependency staging.
- Full lint: exit 0 with pre-existing warnings only.
- Full UI suite: 3028/3031 passed; the same 3 locale/Billing failures reproduce on unmodified `main`.
- Desktop platform suite: the Windows/MSYS baseline failures reproduce without this change.
- Production end-to-end validation: two consecutive unique QQBot messages appeared in the same running Desktop instance without restart, reload, or tab switching.

The incident report intentionally omits credentials, pairing codes, user identifiers, connection details, local paths, and real session IDs.