### PR TITLE
fix(matrix): filter false localpart mentions

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -538,6 +538,8 @@ _STARTUP_GRACE_SECONDS = 5
 _OUTBOUND_MENTION_RE = re.compile(
     r"(?<![\w/])(@[0-9A-Za-z._=/-]+:[0-9A-Za-z.-]+(?::\d+)?)"
 )
+_MATRIX_TO_URL_RE = re.compile(r"https?://matrix\.to/#/\S+", re.IGNORECASE)
+_MATRIX_MXID_RE = re.compile(r"(?<![\w@])@[^\s:]+:[^\s]+")
 
 _E2EE_INSTALL_HINT = (
     "Install with: pip install 'mautrix[encryption]' asyncpg aiosqlite  "
@@ -1053,6 +1055,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
         # Mention/thread gating — parsed once from config.extra or env vars.
         self._require_mention: bool = self._parse_require_mention(config)
+        self._mention_mode: str = self._parse_mention_mode(config)
         self._thread_require_mention: bool = self._parse_thread_require_mention(config)
         free_rooms_raw = config.extra.get("free_response_rooms")
         if free_rooms_raw is None:
@@ -1203,6 +1206,19 @@ class MatrixAdapter(BasePlatformAdapter):
         return os.getenv(
             "MATRIX_REQUIRE_MENTION", "true"
         ).lower() not in {"false", "0", "no", "off"}
+
+    @staticmethod
+    def _parse_mention_mode(config) -> str:
+        """Parse the Matrix mention detector mode from config.yaml."""
+        configured = config.extra.get("mention_mode", "loose")
+        mode = str(configured).strip().lower()
+        if mode not in {"loose", "strict"}:
+            logger.warning(
+                "Matrix: invalid mention_mode %r; using loose",
+                configured,
+            )
+            return "loose"
+        return mode
 
     @staticmethod
     def _parse_thread_require_mention(config) -> bool:
@@ -1882,6 +1898,7 @@ class MatrixAdapter(BasePlatformAdapter):
                 "allowed_room_count": len(self._allowed_room_ids),
                 "ignored_user_pattern_count": len(self._ignored_user_patterns),
                 "require_mention": self._require_mention,
+                "mention_mode": self._mention_mode,
                 "free_response_room_count": len(self._free_rooms),
                 "allow_room_mentions": self._allow_room_mentions,
                 "process_notices": self._process_notices,
@@ -4470,12 +4487,11 @@ class MatrixAdapter(BasePlatformAdapter):
     ) -> bool:
         """Return True if the bot is mentioned in the message.
 
-        Per MSC3952, ``m.mentions.user_ids`` is the authoritative mention
-        signal in the Matrix spec.  When the sender's client populates that
-        field with the bot's user-id, we trust it — even when the visible
-        body text does not contain an explicit ``@bot`` string (some clients
-        only render mention "pills" in ``formatted_body`` or use display
-        names).
+        Structured mentions, the full bot MXID, and a bot pill are always
+        accepted. Strict mode additionally accepts an explicit ``@localpart``
+        token; loose mode retains the legacy bare-localpart fallback after
+        removing Matrix identifiers that can contain the localpart without
+        addressing the bot.
         """
         # m.mentions.user_ids — authoritative per MSC3952 / Matrix v1.7.
         if mention_user_ids and self._user_id and self._user_id in mention_user_ids:
@@ -4484,16 +4500,44 @@ class MatrixAdapter(BasePlatformAdapter):
             return False
         if self._user_id and self._user_id in body:
             return True
-        if self._user_id and ":" in self._user_id:
-            localpart = self._user_id.split(":")[0].lstrip("@")
-            if localpart and re.search(
-                r"\b" + re.escape(localpart) + r"\b", body, re.IGNORECASE
-            ):
-                return True
         if formatted_body and self._user_id:
             if f"matrix.to/#/{self._user_id}" in formatted_body:
                 return True
+        if self._user_id and ":" in self._user_id:
+            localpart = self._user_id.split(":")[0].lstrip("@")
+            fallback_body = self._mention_fallback_body(body)
+            if localpart and re.search(
+                r"(?<![\w@])@" + re.escape(localpart) + r"\b",
+                fallback_body,
+                re.IGNORECASE,
+            ):
+                return True
+            if (
+                self._mention_mode == "loose"
+                and localpart
+                and re.search(
+                    r"\b" + re.escape(localpart) + r"\b",
+                    fallback_body,
+                    re.IGNORECASE,
+                )
+            ):
+                return True
         return False
+
+    def _mention_fallback_body(self, body: str) -> str:
+        """Remove Matrix identifiers before localpart fallback matching."""
+        fallback_body = _MATRIX_TO_URL_RE.sub(" ", body)
+        fallback_body = _MATRIX_MXID_RE.sub(" ", fallback_body)
+        if self._user_id and ":" in self._user_id:
+            homeserver = self._user_id.split(":", 1)[1]
+            if homeserver:
+                fallback_body = re.sub(
+                    re.escape(homeserver),
+                    " ",
+                    fallback_body,
+                    flags=re.IGNORECASE,
+                )
+        return fallback_body
 
     def _strip_mention(self, body: str) -> str:
         """Remove explicit bot mentions from message body.
@@ -4913,9 +4957,13 @@ def _apply_yaml_config(yaml_cfg: dict, matrix_cfg: dict) -> dict | None:
     """Translate config.yaml matrix: keys into MATRIX_* env vars.
 
     Implements the apply_yaml_config_fn contract (#24849). Mirrors the legacy
-    matrix_cfg block from gateway/config.py::load_gateway_config(). Env vars
-    take precedence over YAML. Returns None — everything flows through env.
+    matrix_cfg block from gateway/config.py::load_gateway_config(). Existing
+    env-backed settings keep their precedence; config-only settings are seeded
+    into ``PlatformConfig.extra``.
     """
+    seeded: dict = {}
+    if "mention_mode" in matrix_cfg:
+        seeded["mention_mode"] = matrix_cfg["mention_mode"]
     if "require_mention" in matrix_cfg and not os.getenv("MATRIX_REQUIRE_MENTION"):
         os.environ["MATRIX_REQUIRE_MENTION"] = str(matrix_cfg["require_mention"]).lower()
     au = matrix_cfg.get("allowed_users")
@@ -4948,7 +4996,7 @@ def _apply_yaml_config(yaml_cfg: dict, matrix_cfg: dict) -> dict | None:
         os.environ["MATRIX_DM_MENTION_THREADS"] = str(matrix_cfg["dm_mention_threads"]).lower()
     if "max_message_length" in matrix_cfg and not os.getenv("MATRIX_MAX_MESSAGE_LENGTH"):
         os.environ["MATRIX_MAX_MESSAGE_LENGTH"] = str(matrix_cfg["max_message_length"])
-    return None
+    return seeded or None
 
 
 def _is_connected(config) -> bool:

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -350,6 +350,31 @@ class TestLoadGatewayConfig:
 
         assert os.getenv("SLACK_IGNORED_CHANNELS") == "C0123456789,C0987654321"
 
+    @pytest.mark.parametrize(
+        "yaml_text",
+        [
+            "matrix:\n  mention_mode: strict\n",
+            "platforms:\n  matrix:\n    mention_mode: strict\n",
+        ],
+    )
+    def test_matrix_mention_mode_seeds_platform_extra(
+        self,
+        tmp_path,
+        monkeypatch,
+        yaml_text,
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            yaml_text,
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.MATRIX].extra["mention_mode"] == "strict"
+
 
     def test_typing_status_text_from_nested_platforms_block(self, tmp_path, monkeypatch):
         """``platforms.slack.typing_status_text`` reaches PlatformConfig via

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -15,17 +15,19 @@ from gateway.config import PlatformConfig
 # needing real mautrix APIs mock them individually.
 
 
-def _make_adapter(tmp_path=None):
+def _make_adapter(**extra_overrides):
     """Create a MatrixAdapter with mocked config."""
     from plugins.platforms.matrix.adapter import MatrixAdapter
 
+    extra = {
+        "homeserver": "https://matrix.example.org",
+        "user_id": "@hermes:example.org",
+    }
+    extra.update(extra_overrides)
     config = PlatformConfig(
         enabled=True,
         token="syt_test_token",
-        extra={
-            "homeserver": "https://matrix.example.org",
-            "user_id": "@hermes:example.org",
-        },
+        extra=extra,
     )
     adapter = MatrixAdapter(config)
     adapter._text_batch_delay_seconds = 0  # disable batching for tests
@@ -92,6 +94,54 @@ class TestIsBotMentioned:
 
     def test_localpart_in_body(self):
         assert self.adapter._is_bot_mentioned("hermes can you help?")
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "@alice:example.com",
+            "https://matrix.to/#/@alice:example.com",
+            "please check example.com",
+        ],
+    )
+    def test_loose_mode_ignores_identifiers_from_same_named_homeserver(self, body):
+        adapter = _make_adapter(user_id="@example:example.com")
+
+        assert not adapter._is_bot_mentioned(body)
+
+    def test_loose_mode_still_accepts_bare_localpart(self):
+        adapter = _make_adapter(user_id="@example:example.com")
+
+        assert adapter._is_bot_mentioned("we should ask example about this")
+
+    def test_strict_mode_rejects_bare_localpart(self):
+        adapter = _make_adapter(
+            user_id="@example:example.com",
+            mention_mode="strict",
+        )
+
+        assert not adapter._is_bot_mentioned("we should ask example about this")
+
+    def test_strict_mode_accepts_explicit_localpart(self):
+        adapter = _make_adapter(
+            user_id="@example:example.com",
+            mention_mode="strict",
+        )
+
+        assert adapter._is_bot_mentioned("@example can you help?")
+
+    def test_strict_mode_accepts_structured_mention(self):
+        adapter = _make_adapter(mention_mode="strict")
+
+        assert adapter._is_bot_mentioned(
+            "please reply",
+            mention_user_ids=["@hermes:example.org"],
+        )
+
+    def test_invalid_mention_mode_falls_back_to_loose(self, caplog):
+        adapter = _make_adapter(mention_mode="typo")
+
+        assert adapter._is_bot_mentioned("hermes can you help?")
+        assert "invalid mention_mode" in caplog.text
 
 
     def test_matrix_pill_in_formatted_body(self):
@@ -213,6 +263,31 @@ async def test_require_mention_m_mentions_other_user_ignored(monkeypatch):
     )
 
     await adapter._on_room_message(event)
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_require_mention_ignores_other_user_on_same_named_homeserver(monkeypatch):
+    monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
+    adapter = _make_adapter(user_id="@example:example.com")
+    event = _make_event("@alice:example.com")
+
+    await adapter._on_room_message(event)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_require_mention_strict_mode_ignores_bare_localpart(monkeypatch):
+    monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
+    adapter = _make_adapter(
+        user_id="@example:example.com",
+        mention_mode="strict",
+    )
+    event = _make_event("we should ask example about this")
+
+    await adapter._on_room_message(event)
+
     adapter.handle_message.assert_not_awaited()
 
 
@@ -382,5 +457,3 @@ class TestMatrixConfigBridge:
             == "!room1:example.org,!room2:example.org"
         )
         assert os.getenv("MATRIX_AUTO_THREAD") == "false"
-
-

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -84,6 +84,7 @@ You can configure mention and auto-threading behavior via environment variables 
 ```yaml
 matrix:
   require_mention: true           # Require @mention in rooms (default: true)
+  mention_mode: loose             # loose accepts bare bot names; strict requires an explicit mention
   allowed_users:                  # Matrix users allowed to trigger agent turns
     - "@alice:matrix.org"
   allowed_rooms:                  # Matrix rooms allowed to trigger agent turns
@@ -115,6 +116,12 @@ MATRIX_DM_MENTION_THREADS=false
 MATRIX_REACTIONS=true          # default: true — emoji reactions during processing
 MATRIX_ALLOW_ROOM_MENTIONS=false
 ```
+
+`mention_mode` is intentionally config-only. The backward-compatible `loose`
+mode accepts a bare bot localpart such as `hermes`, while filtering Matrix URLs,
+other users' MXIDs, and the bot homeserver from that fallback. Set it to
+`strict` to accept only `m.mentions`, the bot's Matrix pill or full MXID, and an
+explicit `@localpart` token.
 
 :::tip Disabling reactions
 `MATRIX_REACTIONS=false` turns off the processing-lifecycle emoji reactions (👀/✅/❌) the bot posts on inbound messages. Useful for rooms where reaction events are noisy or aren't supported by all participating clients.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/matrix.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/matrix.md
@@ -59,6 +59,7 @@ group_sessions_per_user: false
 ```yaml
 matrix:
   require_mention: true           # 在房间中要求 @提及（默认：true）
+  mention_mode: loose             # loose 接受裸机器人名称；strict 要求显式提及
   free_response_rooms:            # 免除提及要求的房间
     - "!abc123:matrix.org"
   auto_thread: true               # 自动为响应创建线程（默认：true）
@@ -74,6 +75,11 @@ MATRIX_AUTO_THREAD=true
 MATRIX_DM_MENTION_THREADS=false
 MATRIX_REACTIONS=true          # 默认：true——处理过程中发送 emoji 反应
 ```
+
+`mention_mode` 仅通过配置文件设置。向后兼容的 `loose` 模式接受 `hermes`
+这样的裸机器人 localpart，但会先排除 Matrix 链接、其他用户的 MXID 和机器人
+homeserver。设为 `strict` 后，只接受 `m.mentions`、机器人的 Matrix pill 或完整
+MXID，以及显式的 `@localpart`。
 
 :::tip 禁用反应
 `MATRIX_REACTIONS=false` 会关闭机器人在收到消息时发布的处理生命周期 emoji 反应（👀/✅/❌）。适用于反应事件较为嘈杂或部分参与客户端不支持的房间。


### PR DESCRIPTION
## What does this PR do?

Prevents Matrix room messages from triggering the bot merely because its localpart appears inside a URL, another user's MXID, or the bot homeserver domain.

The existing bare-localpart behavior remains the default for compatibility. A new config-only `mention_mode` setting allows users to choose stricter matching without adding another environment variable:

- `loose` (default): accepts explicit Matrix mentions and the historical bare-localpart fallback after excluding known false-positive contexts.
- `strict`: accepts structured `m.mentions`, a bot Matrix pill, the full bot MXID, or explicit `@localpart` only.

Both `matrix.mention_mode` and `platforms.matrix.mention_mode` are supported. Invalid values emit a warning and fall back to `loose`.

## Related Issue

Fixes #74567

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Filter Matrix URLs, unrelated MXIDs, and the bot homeserver before applying loose bare-localpart matching in `plugins/platforms/matrix/adapter.py`.
- Add `loose` and `strict` mention modes, config resolution for both supported Matrix config paths, invalid-value fallback, and diagnostics output.
- Add regression coverage for false positives, valid mention forms, configuration paths, and fallback behavior.
- Document `mention_mode` in the English and Chinese Matrix guides.

## How to Test

1. Run the Matrix gateway suite:
   `uv run pytest tests/gateway/test_matrix.py tests/gateway/test_matrix_mention.py tests/gateway/test_matrix_plugin_setup.py tests/gateway/test_matrix_message_length.py tests/gateway/test_matrix_project_context_isolation.py tests/gateway/test_matrix_voice.py tests/gateway/test_matrix_exec_approval.py tests/gateway/test_matrix_approval_reaction_fail_closed.py tests/gateway/test_matrix_dm_invite_recording.py -q`
   Result: `143 passed, 1 skipped`.
2. Run the focused config and mention tests:
   `uv run pytest tests/gateway/test_config.py tests/gateway/test_matrix_mention.py -q`
   Result: `84 passed`.
3. Run lint:
   `.venv/bin/ruff check --no-cache plugins/platforms/matrix/adapter.py tests/gateway/test_matrix_mention.py tests/gateway/test_config.py`
   Result: passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (Matrix plugin configuration is documented in the Matrix guides)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; this changes Matrix mention matching and configuration behavior.
