### PR TITLE
fix(acp): pass disabled_toolsets from config to ACP agent (#74582)

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -620,12 +620,18 @@ class SessionManager:
             if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
         ]
 
+        agent_cfg = config.get("agent") or {}
+        disabled_toolsets = (
+            agent_cfg.get("disabled_toolsets") if isinstance(agent_cfg, dict) else None
+        ) or None
+
         kwargs = {
             "platform": "acp",
             "enabled_toolsets": _expand_acp_enabled_toolsets(
                 ["hermes-acp"],
                 mcp_server_names=configured_mcp_servers,
             ),
+            "disabled_toolsets": disabled_toolsets,
             "quiet_mode": True,
             "session_id": session_id,
             "session_db": self._get_db(),


### PR DESCRIPTION
## fix(acp): pass disabled_toolsets from config to ACP agent

### Root Cause
`SessionManager._make_agent` in `acp_adapter/session.py` builds the agent with `enabled_toolsets` but never reads or passes `agent.disabled_toolsets` from config. The gateway runner (`gateway/run.py`) correctly reads this setting and passes it to `AIAgent`, but the ACP path omits it entirely.

### Impact
- Tools cannot be disabled for ACP sessions (including Buzz-run agents whose harness is `hermes-acp`)
- The `agent.disabled_toolsets` config knob is silently dropped on ACP while working everywhere else

### Fix
Read `disabled_toolsets` from `config["agent"]["disabled_toolsets"]` and pass it to the `AIAgent` constructor kwargs, matching the pattern used in `gateway/run.py:18538`.

### Changes
- `acp_adapter/session.py`: Added 6 lines to read and pass `disabled_toolsets`
