### PR TITLE
fix(update): unbrick desktop updates on gateway-enabled Windows installs

### DIFF
--- a/hermes_cli/_scan_venv_blockers.py
+++ b/hermes_cli/_scan_venv_blockers.py
@@ -92,6 +92,35 @@ def _redact_sensitive_cmdline(cmdline: str) -> str:
     return cmdline
 
 
+def _is_pausable_gateway(cmdline: str) -> bool:
+    """Return True when *cmdline* is a gateway process the updater can pause.
+
+    A running gateway shows up in the venv-holder scan as one or both halves
+    of its launcher/worker chain (``venv\\Scripts\\python.exe -m
+    hermes_cli.main gateway run`` and the uv-side interpreter re-running the
+    same argv). Reporting those as blockers dead-ends the Desktop update:
+    the preflight aborts with ``venv-blocked`` *before* spawning
+    ``hermes-setup``, so the CLI updater's own
+    ``_pause_windows_gateways_for_update()`` — which exists precisely to
+    stop these processes (and is always active: ``hermes-setup`` invokes
+    ``hermes update --yes --gateway``) — never gets the chance to run.
+
+    Only gateway invocations are exempted. Anything else running from the
+    venv (an operator's REPL, a stray script, a ``serve`` backend that
+    survived the desktop's own teardown) has no pause machinery downstream
+    and must keep blocking the handoff.
+    """
+    lowered = cmdline.lower()
+    if "hermes_cli.main" not in lowered:
+        return False
+    try:
+        tokens = [t for t in lowered.split() if t]
+        idx = tokens.index("gateway")
+    except ValueError:
+        return False
+    return len(tokens) > idx + 1 and tokens[idx + 1] == "run"
+
+
 def main() -> None:
     """Entry point.  Prints one JSON doc to stdout.  Exits 0 for valid scan."""
     try:
@@ -113,8 +142,17 @@ def main() -> None:
             "cmdline": _redact_sensitive_cmdline(cmdline),
         }
         for pid, name, cmdline in matches
+        if not _is_pausable_gateway(cmdline)
     ]
-    data = {"ok": True, "blocked": bool(processes), "processes": processes}
+    exempted = sum(1 for _pid, _name, cmdline in matches if _is_pausable_gateway(cmdline))
+    data = {
+        "ok": True,
+        "blocked": bool(processes),
+        "processes": processes,
+        # Diagnostic only: gateway processes present but not counted as
+        # blockers because the downstream updater pauses them itself.
+        "pausable_gateways": exempted,
+    }
     print(json.dumps(data))
     sys.exit(0)
 

--- a/hermes_cli/_scan_venv_blockers.py
+++ b/hermes_cli/_scan_venv_blockers.py
@@ -109,16 +109,21 @@ def _is_pausable_gateway(cmdline: str) -> bool:
     venv (an operator's REPL, a stray script, a ``serve`` backend that
     survived the desktop's own teardown) has no pause machinery downstream
     and must keep blocking the handoff.
+
+    Delegates to ``gateway.status.looks_like_gateway_command_line`` — the
+    canonical ``gateway run`` matcher (profile-selector aware, shlex
+    tokenization, ``run``-only) — so this exemption, the pause discovery,
+    and the updater's guard fallback all share one parser. A hand-rolled
+    token scan here regressed ``--profile gateway gateway run``: the profile
+    *value* shadowed the subcommand token. An import failure counts as
+    not-pausable — the scan then reports the process as a blocker, which is
+    exactly the pre-exemption behavior.
     """
-    lowered = cmdline.lower()
-    if "hermes_cli.main" not in lowered:
-        return False
     try:
-        tokens = [t for t in lowered.split() if t]
-        idx = tokens.index("gateway")
-    except ValueError:
+        from gateway.status import looks_like_gateway_command_line  # noqa: PLC0415
+    except Exception:
         return False
-    return len(tokens) > idx + 1 and tokens[idx + 1] == "run"
+    return looks_like_gateway_command_line(cmdline)
 
 
 def main() -> None:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5046,6 +5046,7 @@ from hermes_cli.update_cmd import (  # noqa: F401
     _upgrade_pip_before_lazy_refresh,
     _validate_critical_files_syntax,
     _venv_core_imports_healthy,
+    _venv_launcher_ancestors,
     _wait_for_windows_update_gateway_exit,
     _warn_incomplete_gateway_fleet_restart,
     _web_build_toolchain_ready,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5014,6 +5014,7 @@ from hermes_cli.update_cmd import (  # noqa: F401
     _invalidate_update_cache,
     _is_android_python,
     _is_fork,
+    _leftover_pausable_gateway_pids,
     _log_only_write,
     _mark_skip_upstream_prompt,
     _npm_bin_exists,

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2680,6 +2680,72 @@ def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> 
     lines.append("  (or use `hermes update --force-venv` to proceed anyway at your own risk)")
     return "\n".join(lines)
 
+def _venv_launcher_ancestors(pids: list[int]) -> list[int]:
+    """Return venv-interpreter ancestors of *pids* that hold the install open.
+
+    On Windows a gateway started through the venv shim is a **two-process
+    chain**: ``venv\\Scripts\\python.exe`` (the launcher, which keeps native
+    ``.pyd`` files from the venv mapped) spawns the actual interpreter from
+    uv's managed CPython directory (``AppData\\Roaming\\uv\\python\\...``).
+    The gateway writes its PID file from the *child*, so
+    ``find_gateway_pids()`` — and therefore this module's pause set — only
+    ever sees the uv-side worker.
+
+    ``_detect_venv_python_processes()`` matches on the venv path prefix, so
+    the guard downstream of the pause sees the *launcher* instead. The two
+    sets are disjoint, which meant a paused gateway still tripped the
+    venv-holder guard and aborted the update every time (the Desktop
+    "venv-blocked: N process(es) hold the install" dead-end, where the
+    reported holder is a gateway the updater believes it already stopped).
+
+    Walking one hop up from each mapped gateway PID and keeping ancestors
+    that live under the project venv closes the gap. Only the venv-side
+    parent is returned — unrelated ancestors (the Scheduled Task's
+    ``cmd.exe``, an operator's shell) are ignored so we never widen the
+    blast radius beyond the gateway's own launcher. Never raises.
+    """
+    if not _m()._is_windows() or not pids:
+        return []
+    try:
+        import psutil
+    except Exception:
+        return []
+
+    venv_dir = _m().PROJECT_ROOT / "venv"
+    try:
+        venv_prefix = str(venv_dir.resolve()).lower().rstrip(os.sep) + os.sep
+    except OSError:
+        venv_prefix = str(venv_dir).lower().rstrip(os.sep) + os.sep
+
+    # Never return ourselves or our own ancestry: a CLI ``hermes update``
+    # runs from the venv python and would otherwise nominate itself.
+    skip: set[int] = {os.getpid()}
+    try:
+        for anc in psutil.Process().parents():
+            skip.add(int(anc.pid))
+    except Exception:
+        pass
+
+    found: list[int] = []
+    for pid in pids:
+        try:
+            parent = psutil.Process(int(pid)).parent()
+        except Exception:
+            continue
+        if parent is None:
+            continue
+        ppid = int(parent.pid)
+        if ppid in skip or ppid in found or ppid in set(pids):
+            continue
+        try:
+            exe = (parent.exe() or "").lower()
+        except Exception:
+            continue
+        if exe.startswith(venv_prefix):
+            found.append(ppid)
+    return found
+
+
 def _pause_windows_gateways_for_update() -> dict | None:
     """Stop running Windows gateways before mutating the checkout or venv.
 
@@ -2780,8 +2846,18 @@ def _pause_windows_gateways_for_update() -> dict | None:
             logger.debug("Could not capture argv for unmapped gateway %s: %s", pid, exc)
         unmapped.append({"pid": int(pid), "argv": argv})
 
+    # A gateway's graceful drain above targets the PID that wrote the PID file
+    # (the uv-side worker). On Windows that worker's parent is usually the
+    # venv-side ``python.exe`` launcher, which keeps venv ``.pyd`` files mapped
+    # and is what ``_detect_venv_python_processes()`` reports downstream. Left
+    # alive, it trips the venv-holder guard and aborts the update even though
+    # the gateway itself is stopped. Force-kill those launchers alongside the
+    # survivors; ``terminate_pid(force=True)`` is a tree kill, so a launcher
+    # that outlived its worker takes any stragglers with it.
+    launcher_pids = _m()._venv_launcher_ancestors(mapped_pids)
+
     force_killed = []
-    for pid in sorted(set(survivors).union(unmapped_pids)):
+    for pid in sorted(set(survivors).union(unmapped_pids).union(launcher_pids)):
         try:
             terminate_pid(int(pid), force=True)
             force_killed.append(int(pid))

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2866,6 +2866,20 @@ def _pause_windows_gateways_for_update() -> dict | None:
         mapped_pids.append(int(pid))
         _write_update_planned_stop_marker(Path(proc.path), int(pid))
 
+    # Resolve each mapped worker's venv-side launcher BEFORE draining: the
+    # drain stops tracking a PID exactly when it dies, so a gracefully
+    # drained worker is gone by the time the wait returns — and a dead pid's
+    # parent cannot be recovered (psutil raises NoSuchProcess). The snapshot
+    # is stopped after the drain alongside the survivors.
+    #
+    # Why launchers matter: the drain targets the PID that wrote the PID
+    # file (the uv-side worker). On Windows that worker's parent is usually
+    # the venv-side ``python.exe`` launcher, which keeps venv ``.pyd`` files
+    # mapped and is what ``_detect_venv_python_processes()`` reports
+    # downstream. Left alive, it trips the venv-holder guard and aborts the
+    # update even though the gateway itself is stopped.
+    launcher_pids = _m()._venv_launcher_ancestors(mapped_pids)
+
     print("→ Stopping Windows gateway process(es) before updating Hermes...")
     try:
         drain_timeout = max(float(_get_restart_drain_timeout()), 1.0)
@@ -2892,16 +2906,11 @@ def _pause_windows_gateways_for_update() -> dict | None:
             logger.debug("Could not capture argv for unmapped gateway %s: %s", pid, exc)
         unmapped.append({"pid": int(pid), "argv": argv})
 
-    # A gateway's graceful drain above targets the PID that wrote the PID file
-    # (the uv-side worker). On Windows that worker's parent is usually the
-    # venv-side ``python.exe`` launcher, which keeps venv ``.pyd`` files mapped
-    # and is what ``_detect_venv_python_processes()`` reports downstream. Left
-    # alive, it trips the venv-holder guard and aborts the update even though
-    # the gateway itself is stopped. Force-kill those launchers alongside the
-    # survivors; ``terminate_pid(force=True)`` is a tree kill, so a launcher
-    # that outlived its worker takes any stragglers with it.
-    launcher_pids = _m()._venv_launcher_ancestors(mapped_pids)
-
+    # Stop drain survivors, unmapped gateways, and the pre-drain launcher
+    # snapshot. ``terminate_pid(force=True)`` is a tree kill, so a launcher
+    # that outlived its worker takes any stragglers with it; a launcher that
+    # already exited with its drained worker raises ProcessLookupError below
+    # and is skipped.
     force_killed = []
     for pid in sorted(set(survivors).union(unmapped_pids).union(launcher_pids)):
         try:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2746,6 +2746,52 @@ def _venv_launcher_ancestors(pids: list[int]) -> list[int]:
     return found
 
 
+def _leftover_pausable_gateway_pids(
+    matches: list[tuple[int, str, str]],
+) -> list[int] | None:
+    """PIDs from *matches* when every remaining venv holder is a pausable gateway.
+
+    ``_pause_windows_gateways_for_update()`` stops every gateway its discovery
+    finds, but the venv-holder guard downstream sees the process table as it
+    is *now*: a gateway respawned by its supervisor (Scheduled Task, login
+    watchdog) inside the pause→guard window, or one started through a spawn
+    path the discovery does not map, still holds venv ``.pyd`` files and
+    would dead-end the update — an abort pointed at exactly the kind of
+    process the pause machinery exists to stop.
+
+    Holders are classified with the same matcher the Desktop preflight uses
+    to exempt them (``_is_pausable_gateway``), so the preflight's exemption
+    and this guard's tolerance cannot drift apart — matcher drift between
+    two views of the same process table is what produced the launcher/worker
+    dead-end fixed above. The scan captures only a 120-char cmdline prefix,
+    so the live argv is re-read where psutil allows; an unreadable argv
+    falls back to the captured prefix.
+
+    Returns ``None`` when any holder is not a pausable gateway — an operator
+    REPL, a stray script, or the Desktop backend has no pause machinery
+    downstream, and the guard must keep refusing exactly as before.
+    """
+    from hermes_cli._scan_venv_blockers import _is_pausable_gateway
+
+    try:
+        import psutil  # type: ignore
+    except Exception:
+        psutil = None
+
+    pids: list[int] = []
+    for pid, _name, cmdline in matches:
+        argv = cmdline
+        if psutil is not None:
+            try:
+                argv = " ".join(psutil.Process(int(pid)).cmdline()) or cmdline
+            except Exception:
+                pass
+        if not _is_pausable_gateway(argv):
+            return None
+        pids.append(int(pid))
+    return pids
+
+
 def _pause_windows_gateways_for_update() -> dict | None:
     """Stop running Windows gateways before mutating the checkout or venv.
 
@@ -3199,6 +3245,30 @@ def _cmd_update_impl(args, gateway_mode: bool):
     # --force-venv is the explicit escape hatch.
     if _m()._is_windows() and not getattr(args, "force_venv", False):
         _venv_holders = _m()._detect_venv_python_processes()
+        if _venv_holders:
+            _gateway_holders = _m()._leftover_pausable_gateway_pids(_venv_holders)
+            if _gateway_holders is not None:
+                # Every remaining holder is a gateway the pause machinery
+                # already owns — respawned by its supervisor inside the
+                # pause→guard window, or up through a spawn path discovery
+                # does not map. Stop them and re-check instead of
+                # dead-ending; the post-update resume (and the supervisor
+                # that respawned them) brings gateways back afterwards.
+                from gateway.status import terminate_pid
+
+                print(
+                    f"  ⚠ {len(_gateway_holders)} gateway process(es) still "
+                    "hold the venv after the pause; stopping them"
+                )
+                for _pid in _gateway_holders:
+                    try:
+                        terminate_pid(int(_pid), force=True)
+                    except Exception as exc:
+                        logger.debug(
+                            "Could not stop leftover gateway %s: %s", _pid, exc
+                        )
+                _time.sleep(1.0)
+                _venv_holders = _m()._detect_venv_python_processes()
         if _venv_holders:
             print(_format_venv_python_holders_message(_venv_holders))
             _m()._resume_windows_gateways_after_update(_windows_gateway_resume)

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -2,7 +2,6 @@
 
 import argparse
 import os
-import pty
 import signal
 import subprocess
 import sys
@@ -111,6 +110,13 @@ def test_gateway_run_subprocess_preserves_daemon_exit_codes(
     master_fd = slave_fd = None
     try:
         if stdin_is_tty:
+            # Imported here, not at module scope: ``pty`` pulls in ``termios``,
+            # which does not exist on Windows, so a top-level import raises
+            # ModuleNotFoundError during *collection* — before the skipif above
+            # can take effect — and takes the whole module's Windows-viable
+            # tests down with it.
+            import pty
+
             master_fd, slave_fd = pty.openpty()
             stdin = slave_fd
         else:
@@ -219,6 +225,10 @@ class TestContainerSystemdSupport:
 
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="systemd user-linger is Linux-only (drives os.getuid())",
+)
 def test_systemd_install_checks_linger_status(monkeypatch, tmp_path, capsys):
     unit_path = tmp_path / "systemd" / "user" / "hermes-gateway.service"
 

--- a/tests/hermes_cli/test_scan_venv_blockers.py
+++ b/tests/hermes_cli/test_scan_venv_blockers.py
@@ -17,6 +17,7 @@ import pytest
 
 import agent.redact as redact_module
 from hermes_cli._scan_venv_blockers import (
+    _is_pausable_gateway,
     _redact_sensitive_cmdline,
     main,
 )
@@ -93,3 +94,117 @@ def test_redact_short_flags_not_redacted() -> None:
     raw = "python.exe -m hermes_cli.main serve -t web -p default -k somearg"
     result = _redact_sensitive_cmdline(raw)
     assert result == raw  # short flags pass through unchanged
+
+
+# ---------------------------------------------------------------------------
+# _is_pausable_gateway — the gateway exemption
+#
+# `hermes-setup` always invokes `hermes update --yes --gateway`, whose
+# `_pause_windows_gateways_for_update()` stops running gateways itself. The
+# Desktop preflight must therefore not report gateway launcher/worker chains
+# as blockers — doing so aborts the handoff before the component that can
+# handle them ever runs.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cmdline",
+    [
+        # venv-side launcher, exactly as the scheduled task spawns it
+        r"C:\Users\u\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe"
+        " -m hermes_cli.main gateway run --replace",
+        # uv-side worker re-running the same argv (quoted exe, double space)
+        r'"C:\Users\u\AppData\Roaming\uv\python\cpython-3.11-windows-x86_64-none\python.exe"'
+        "  -m hermes_cli.main gateway run --replace",
+        # profile-scoped gateway
+        "python.exe -m hermes_cli.main --profile work gateway run",
+        # case variations survive
+        "PYTHON.EXE -m hermes_cli.main GATEWAY RUN",
+    ],
+)
+def test_is_pausable_gateway_accepts_gateway_run_chains(cmdline: str) -> None:
+    assert _is_pausable_gateway(cmdline) is True
+
+
+@pytest.mark.parametrize(
+    "cmdline",
+    [
+        # desktop backend: no pause machinery downstream, must keep blocking
+        "python.exe -m hermes_cli.main serve --host 127.0.0.1 --port 8756",
+        # other gateway subcommands are not running gateways
+        "python.exe -m hermes_cli.main gateway stop",
+        "python.exe -m hermes_cli.main gateway status",
+        "python.exe -m hermes_cli.main gateway install",
+        # operator REPL / stray script
+        "python.exe",
+        "python.exe myscript.py gateway run",  # not a hermes_cli.main invocation
+        # 'gateway' as a trailing word with nothing after it
+        "python.exe -m hermes_cli.main gateway",
+        "",
+    ],
+)
+def test_is_pausable_gateway_rejects_everything_else(cmdline: str) -> None:
+    assert _is_pausable_gateway(cmdline) is False
+
+
+def _run_main_with_detector(monkeypatch, capsys, matches):
+    """Run main() with the process detector patched to return *matches*."""
+    for name, mod in _psutil_fake().items():
+        monkeypatch.setitem(sys.modules, name, mod)
+    import hermes_cli.main as cli_main
+
+    monkeypatch.setattr(cli_main, "_detect_venv_python_processes", lambda: matches)
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    out = capsys.readouterr().out
+    return excinfo.value.code, json.loads(out)
+
+
+def test_main_exempts_gateway_chain_but_keeps_other_holders(monkeypatch, capsys):
+    """A gateway launcher/worker pair alone must scan clear; a non-gateway
+    holder alongside it must still block (and be the only reported PID)."""
+    gateway_launcher = (
+        12,
+        "python.exe",
+        r"C:\x\venv\Scripts\python.exe -m hermes_cli.main gateway run --replace",
+    )
+    gateway_worker = (
+        34,
+        "python.exe",
+        r'"C:\u\uv\python\python.exe"  -m hermes_cli.main gateway run --replace',
+    )
+    stray_repl = (56, "python.exe", r"C:\x\venv\Scripts\python.exe")
+
+    # Gateway chain only → clear
+    code, data = _run_main_with_detector(
+        monkeypatch, capsys, [gateway_launcher, gateway_worker]
+    )
+    assert code == 0
+    assert data["ok"] is True
+    assert data["blocked"] is False
+    assert data["processes"] == []
+    assert data["pausable_gateways"] == 2
+
+    # Gateway chain + stray REPL → blocked, reporting only the REPL
+    code, data = _run_main_with_detector(
+        monkeypatch, capsys, [gateway_launcher, gateway_worker, stray_repl]
+    )
+    assert code == 0
+    assert data["blocked"] is True
+    assert [p["pid"] for p in data["processes"]] == [56]
+    assert data["pausable_gateways"] == 2
+
+
+def test_main_desktop_serve_backend_still_blocks(monkeypatch, capsys):
+    """The desktop's own `serve` backend has no downstream pause — it must
+    keep blocking exactly as before the exemption."""
+    serve = (
+        78,
+        "python.exe",
+        r"C:\x\venv\Scripts\python.exe -m hermes_cli.main serve --host 127.0.0.1",
+    )
+    code, data = _run_main_with_detector(monkeypatch, capsys, [serve])
+    assert code == 0
+    assert data["blocked"] is True
+    assert [p["pid"] for p in data["processes"]] == [78]
+    assert data["pausable_gateways"] == 0

--- a/tests/hermes_cli/test_scan_venv_blockers.py
+++ b/tests/hermes_cli/test_scan_venv_blockers.py
@@ -118,6 +118,12 @@ def test_redact_short_flags_not_redacted() -> None:
         "  -m hermes_cli.main gateway run --replace",
         # profile-scoped gateway
         "python.exe -m hermes_cli.main --profile work gateway run",
+        # a profile literally NAMED "gateway" — the profile value must not
+        # shadow the subcommand token (the hand-rolled matcher regressed this)
+        "python.exe -m hermes_cli.main --profile gateway gateway run",
+        "python.exe -m hermes_cli.main -p gateway gateway run",
+        # bare `gateway` defaults to `run` (mirrors the canonical matcher)
+        "python.exe -m hermes_cli.main gateway",
         # case variations survive
         "PYTHON.EXE -m hermes_cli.main GATEWAY RUN",
     ],
@@ -138,8 +144,6 @@ def test_is_pausable_gateway_accepts_gateway_run_chains(cmdline: str) -> None:
         # operator REPL / stray script
         "python.exe",
         "python.exe myscript.py gateway run",  # not a hermes_cli.main invocation
-        # 'gateway' as a trailing word with nothing after it
-        "python.exe -m hermes_cli.main gateway",
         "",
     ],
 )

--- a/tests/hermes_cli/test_update_concurrent_quarantine.py
+++ b/tests/hermes_cli/test_update_concurrent_quarantine.py
@@ -283,16 +283,23 @@ def test_pause_windows_gateways_for_update_stops_profile_and_unmapped_pids(
 # ---------------------------------------------------------------------------
 
 
-def _fake_psutil_tree(tree, venv_exe, worker_exe):
+def _fake_psutil_tree(tree, venv_exe, worker_exe, dead=None):
     """Build a psutil stand-in where ``tree`` maps worker pid -> parent pid.
 
     Parents whose pid is even are venv-side (``venv_exe``); odd parents are
-    unrelated ancestors (``worker_exe``) that must NOT be returned.
+    unrelated ancestors (``worker_exe``) that must NOT be returned. Pids in
+    ``dead`` (a live reference — later additions count) are uninspectable:
+    construction raises, exactly like psutil.NoSuchProcess for an exited
+    process.
     """
+
+    dead_set = dead if dead is not None else set()
 
     class FakeProc:
         def __init__(self, pid):
             self.pid = pid
+            if pid in dead_set:
+                raise ValueError(f"process {pid} has exited")
             if pid not in tree and pid not in tree.values():
                 raise ValueError(f"no such pid {pid}")
 
@@ -375,13 +382,26 @@ def test_pause_kill_set_covers_venv_guard_abort_set(
         gateway_mod, "find_profile_gateway_processes", lambda **_k: [profile_proc]
     )
     monkeypatch.setattr(gateway_mod, "_get_restart_drain_timeout", lambda: 0.1)
-    # Graceful drain succeeds: the worker exits, leaving zero survivors. This is
+    # Graceful drain succeeds: the worker exits, leaving zero survivors — and
+    # an exited worker is UNINSPECTABLE afterwards, exactly like the real
+    # process table. Resolving the launcher after this point is impossible,
+    # so the pause must snapshot launcher ancestors before draining. This is
     # precisely the case that used to leave the launcher alive and abort.
+    drained_dead: set[int] = set()
+
+    def _drain_marks_workers_dead(pids, *, timeout):
+        drained_dead.update(int(p) for p in pids)
+        return set()
+
     monkeypatch.setattr(
-        cli_main, "_wait_for_windows_update_gateway_exit", lambda pids, *, timeout: set()
+        cli_main,
+        "_wait_for_windows_update_gateway_exit",
+        _drain_marks_workers_dead,
     )
 
-    fake = _fake_psutil_tree({worker_pid: launcher_pid}, venv_exe, worker_exe)
+    fake = _fake_psutil_tree(
+        {worker_pid: launcher_pid}, venv_exe, worker_exe, dead=drained_dead
+    )
     monkeypatch.setitem(sys.modules, "psutil", fake)
 
     terminated = []

--- a/tests/hermes_cli/test_update_concurrent_quarantine.py
+++ b/tests/hermes_cli/test_update_concurrent_quarantine.py
@@ -401,6 +401,95 @@ def test_pause_kill_set_covers_venv_guard_abort_set(
     )
 
 
+# ---------------------------------------------------------------------------
+# _leftover_pausable_gateway_pids (the guard-level gateway fallback)
+#
+# The pause stops every gateway discovery finds, but the venv-holder guard
+# sees the process table as it is NOW. A supervisor (Scheduled Task, login
+# watchdog) can respawn a gateway inside the pause→guard window, and some
+# spawn paths never register in discovery at all. Those holders are exactly
+# what the pause machinery exists to stop — the guard nominates them for a
+# stop-and-recheck instead of dead-ending, and refuses the moment any
+# non-gateway holder is present.
+# ---------------------------------------------------------------------------
+
+
+GATEWAY_ARGV = [
+    r"C:\x\venv\Scripts\python.exe",
+    "-m",
+    "hermes_cli.main",
+    "gateway",
+    "run",
+]
+
+
+def _fake_psutil_cmdlines(argv_by_pid):
+    """psutil stand-in serving live argv per pid; unknown pids raise."""
+
+    class FakeProc:
+        def __init__(self, pid):
+            if pid not in argv_by_pid:
+                raise ValueError(f"no such pid {pid}")
+            self._argv = argv_by_pid[pid]
+
+        def cmdline(self):
+            return self._argv
+
+    return types.SimpleNamespace(Process=FakeProc)
+
+
+def test_leftover_holders_that_are_all_gateways_are_nominated(monkeypatch):
+    """Respawned/unmapped gateway holders get stopped, not dead-ended on."""
+    monkeypatch.setitem(
+        sys.modules,
+        "psutil",
+        _fake_psutil_cmdlines({300: GATEWAY_ARGV, 301: GATEWAY_ARGV}),
+    )
+    matches = [
+        (300, "python.exe", "truncated..."),
+        (301, "python.exe", "truncated..."),
+    ]
+
+    assert cli_main._leftover_pausable_gateway_pids(matches) == [300, 301]
+
+
+def test_one_non_gateway_holder_keeps_the_hard_refusal(monkeypatch):
+    """A REPL/backend holder means the guard must abort exactly as before."""
+    monkeypatch.setitem(
+        sys.modules,
+        "psutil",
+        _fake_psutil_cmdlines(
+            {300: GATEWAY_ARGV, 400: [r"C:\x\venv\Scripts\python.exe", "-i"]}
+        ),
+    )
+    matches = [(300, "python.exe", "..."), (400, "python.exe", "...")]
+
+    assert cli_main._leftover_pausable_gateway_pids(matches) is None
+
+
+def test_unreadable_argv_falls_back_to_the_captured_prefix(monkeypatch):
+    """psutil failure degrades to the scan's captured cmdline, not a crash.
+
+    The captured prefix decides: a gateway invocation still qualifies, and
+    anything else still refuses.
+    """
+    monkeypatch.setitem(sys.modules, "psutil", _fake_psutil_cmdlines({}))
+    gateway_prefix = r"venv\Scripts\python.exe -m hermes_cli.main gateway run"
+
+    assert cli_main._leftover_pausable_gateway_pids(
+        [(300, "python.exe", gateway_prefix)]
+    ) == [300]
+    assert (
+        cli_main._leftover_pausable_gateway_pids(
+            [
+                (300, "python.exe", gateway_prefix),
+                (400, "python.exe", "python.exe -i"),
+            ]
+        )
+        is None
+    )
+
+
 
 
 

--- a/tests/hermes_cli/test_update_concurrent_quarantine.py
+++ b/tests/hermes_cli/test_update_concurrent_quarantine.py
@@ -270,6 +270,138 @@ def test_pause_windows_gateways_for_update_stops_profile_and_unmapped_pids(
     assert "Restart manually after update" not in captured
 
 
+# ---------------------------------------------------------------------------
+# venv-side launcher ancestors (the uv launcher/worker split)
+#
+# A gateway started through the venv shim is two processes:
+#   venv\Scripts\python.exe (launcher)  ->  uv\python\...\python.exe (worker)
+# The gateway's PID file records the WORKER, so find_gateway_pids() (and the
+# pause set built from it) only ever sees the worker. The venv-holder guard
+# matches on the venv path prefix, so it only ever sees the LAUNCHER. The two
+# sets were disjoint: a gateway the updater had just stopped still tripped the
+# guard, aborting every update ("venv-blocked: N process(es) hold the install").
+# ---------------------------------------------------------------------------
+
+
+def _fake_psutil_tree(tree, venv_exe, worker_exe):
+    """Build a psutil stand-in where ``tree`` maps worker pid -> parent pid.
+
+    Parents whose pid is even are venv-side (``venv_exe``); odd parents are
+    unrelated ancestors (``worker_exe``) that must NOT be returned.
+    """
+
+    class FakeProc:
+        def __init__(self, pid):
+            self.pid = pid
+            if pid not in tree and pid not in tree.values():
+                raise ValueError(f"no such pid {pid}")
+
+        def parent(self):
+            ppid = tree.get(self.pid)
+            return FakeProc(ppid) if ppid else None
+
+        def parents(self):
+            return []
+
+        def exe(self):
+            # Parents of workers are the launchers under test.
+            return venv_exe if self.pid % 2 == 0 else worker_exe
+
+    mod = types.SimpleNamespace(Process=FakeProc)
+    return mod
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_venv_launcher_ancestors_returns_venv_side_parent(_winp, monkeypatch):
+    """The worker's venv-side parent is reported so the guard set is covered."""
+    venv_exe = str(cli_main.PROJECT_ROOT / "venv" / "Scripts" / "python.exe")
+    worker_exe = r"C:\Users\x\AppData\Roaming\uv\python\cpython-3.11\python.exe"
+
+    # worker 200 -> launcher 100 (even == venv-side)
+    fake = _fake_psutil_tree({200: 100}, venv_exe, worker_exe)
+    monkeypatch.setitem(sys.modules, "psutil", fake)
+
+    assert cli_main._venv_launcher_ancestors([200]) == [100]
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_venv_launcher_ancestors_ignores_non_venv_parents(_winp, monkeypatch):
+    """A Scheduled Task's cmd.exe / an operator shell is not a venv holder."""
+    venv_exe = str(cli_main.PROJECT_ROOT / "venv" / "Scripts" / "python.exe")
+    worker_exe = r"C:\Windows\System32\cmd.exe"
+
+    # worker 200 -> parent 101 (odd == NOT venv-side)
+    fake = _fake_psutil_tree({200: 101}, venv_exe, worker_exe)
+    monkeypatch.setitem(sys.modules, "psutil", fake)
+
+    assert cli_main._venv_launcher_ancestors([200]) == []
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_venv_launcher_ancestors_is_empty_without_pids(_winp):
+    """No mapped gateways means nothing to walk up from."""
+    assert cli_main._venv_launcher_ancestors([]) == []
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_pause_kill_set_covers_venv_guard_abort_set(
+    _winp,
+    monkeypatch,
+    tmp_path,
+):
+    """INVARIANT: whatever the venv guard would abort on must be stopped.
+
+    This is the contract the two PID-resolution paths must satisfy. Before the
+    launcher walk existed, ``terminated`` held only the uv-side worker while
+    the guard reported the venv-side launcher, so the update aborted forever
+    despite a "successful" pause.
+    """
+    import hermes_cli.gateway as gateway_mod
+    import gateway.status as status_mod
+
+    venv_exe = str(cli_main.PROJECT_ROOT / "venv" / "Scripts" / "python.exe")
+    worker_exe = r"C:\Users\x\AppData\Roaming\uv\python\cpython-3.11\python.exe"
+
+    profile_home = tmp_path / "profiles" / "default"
+    profile_home.mkdir(parents=True)
+    # The PID file records the WORKER (even-numbered parent 400 is its launcher).
+    worker_pid, launcher_pid = 500, 400
+    profile_proc = SimpleNamespace(
+        profile="default", path=profile_home, pid=worker_pid
+    )
+
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda **_k: [worker_pid])
+    monkeypatch.setattr(
+        gateway_mod, "find_profile_gateway_processes", lambda **_k: [profile_proc]
+    )
+    monkeypatch.setattr(gateway_mod, "_get_restart_drain_timeout", lambda: 0.1)
+    # Graceful drain succeeds: the worker exits, leaving zero survivors. This is
+    # precisely the case that used to leave the launcher alive and abort.
+    monkeypatch.setattr(
+        cli_main, "_wait_for_windows_update_gateway_exit", lambda pids, *, timeout: set()
+    )
+
+    fake = _fake_psutil_tree({worker_pid: launcher_pid}, venv_exe, worker_exe)
+    monkeypatch.setitem(sys.modules, "psutil", fake)
+
+    terminated = []
+    monkeypatch.setattr(
+        status_mod,
+        "terminate_pid",
+        lambda pid, force=False: terminated.append(int(pid)),
+    )
+
+    cli_main._pause_windows_gateways_for_update()
+
+    # What the downstream venv-holder guard would report as blocking.
+    guard_would_abort_on = {launcher_pid}
+    assert guard_would_abort_on.issubset(set(terminated)), (
+        f"pause stopped {sorted(terminated)} but the venv guard aborts on "
+        f"{sorted(guard_would_abort_on)} — disjoint sets abort the update"
+    )
+
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes #74326: a Windows install with a running gateway can never complete a desktop-button update, because three different views of the same gateway disagree. Three fixes, smallest possible surface:

1. **Desktop preflight veto** — `_scan_venv_blockers` reported the gateway's venv processes as blockers and aborted before `hermes-setup` (and the CLI's own `_pause_windows_gateways_for_update`) ever got the chance to run. `_is_pausable_gateway()` now exempts `hermes_cli.main … gateway run` invocations — both halves of the venv-shim launcher/worker chain match, since the uv-side worker re-runs the same argv. Everything else keeps blocking: `serve` backends, other `gateway` subcommands, REPLs, stray scripts. The JSON gains a diagnostic `pausable_gateways` count; the TS consumer validates only `ok`/`blocked`/`processes` and ignores unknown keys, so old and new desktop builds both accept the new document.

2. **Pause set and guard set were disjoint** — the gateway PID file records the uv-side *worker*, so the pause only ever stopped the worker; the venv-holder guard matches on the venv path prefix, so it only ever saw the venv-side *launcher* (`venv\Scripts\python.exe`), which keeps native `.pyd` files mapped. A "successfully paused" gateway therefore still tripped the guard and aborted every update. `_venv_launcher_ancestors()` walks one hop up from each mapped gateway PID and stops launchers living under the project venv. Unrelated ancestors — a Scheduled Task's `cmd.exe`, an operator's shell — are never touched.

3. **Guard-level fallback** — a supervisor (Scheduled Task, login watchdog) can respawn a gateway inside the pause→guard window, and some spawn paths never register in discovery (#74326's "Defect 2"). When every remaining holder classifies as a pausable gateway, the guard stops them and re-scans once instead of dead-ending. Classification reuses the exact `_is_pausable_gateway` matcher the preflight uses, so the preflight's exemption and the guard's tolerance cannot drift apart — matcher drift between two views of one process table is what caused failure mode 2. Any non-gateway holder keeps the hard refusal unchanged, and a survivor after the stop still aborts before any `.pyd` mutation.

**The fix reaches already-bricked installs.** The preflight exemption lives in repo Python that the *existing* Electron build invokes fresh on every scan — no desktop rebuild is required for the update path to start working. Verified end-to-end on an affected machine (Windows 11, Scheduled-Task-supervised gateway, every desktop update failing for weeks): after these changes the first desktop-button update completed — preflight passed, gateway drained and resumed, `update stage state=Succeeded`.

Relationship to in-flight work: complementary to #74599 (the updater→CLI lock handoff — the affected machine needed that fix too; this PR does not touch `update_lock.py`). Alternative to #74419's Electron-side layers: this PR keeps gateway coordination in the CLI where the pause/resume machinery already lives, adds no Electron↔CLI env-token contract, duplicates no process-classification logic into TypeScript, and — because the Electron-side layers of #74419 only activate after a desktop rebuild that must itself arrive via an update — is deployable to installs that are currently stuck.

## Related Issue

Fixes #74326
Refs #74386

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/_scan_venv_blockers.py`
  - `_is_pausable_gateway()`: exempt gateway invocations from the blocker report; add `pausable_gateways` diagnostic count to the JSON.
- `hermes_cli/update_cmd.py`
  - `_venv_launcher_ancestors()`: nominate the venv-side launcher of each paused gateway for the stop set.
  - `_leftover_pausable_gateway_pids()` + guard fallback: stop gateway-only leftovers at the venv-holder guard and re-scan once; refuse on any non-gateway holder.
- `hermes_cli/main.py`: re-export the two new helpers.
- `tests/`: 13 new scanner cases (plus an assertion added to a previously assertion-less test), launcher-ancestor cases including the pause/guard set-cover invariant, and guard-fallback classification cases. `test_gateway` made collectable on Windows.

## How to Test

1. Focused suites:
   ```bash
   uv run --isolated --with pytest --with-editable . pytest \
     tests/hermes_cli/test_scan_venv_blockers.py \
     tests/hermes_cli/test_update_concurrent_quarantine.py \
     tests/hermes_cli/test_update_lock.py
   ```
2. Manual, on a gateway-enabled Windows install: with `hermes gateway` running, click the desktop's Update button. Before: `[updates] venv-blocked: N process(es) hold the install` and the "Update didn't finish" screen. After: preflight passes (`pausable_gateways` ≥ 1, `blocked: false`), the CLI updater pauses the gateway (launcher and worker both gone), the update completes, and the gateway resumes.
