### PR TITLE
Add profile-scoped ephemeral session mode

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -507,6 +507,7 @@ def init_agent(
     skip_context_files: bool = False,
     load_soul_identity: bool = False,
     skip_memory: bool = False,
+    persist_session: bool = True,
     session_db=None,
     parent_session_id: str = None,
     iteration_budget: "IterationBudget" = None,
@@ -1473,7 +1474,8 @@ def init_agent(
     # Session logs go into ~/.hermes/sessions/ alongside gateway sessions
     hermes_home = get_hermes_home()
     agent.logs_dir = hermes_home / "sessions"
-    agent.logs_dir.mkdir(parents=True, exist_ok=True)
+    if persist_session:
+        agent.logs_dir.mkdir(parents=True, exist_ok=True)
     # Per-session JSON snapshot writer (~/.hermes/sessions/session_{sid}.json)
     # is opt-in via sessions.write_json_snapshots (default False).  state.db
     # is canonical — the snapshot is only useful for external tooling that
@@ -1482,7 +1484,10 @@ def init_agent(
     try:
         from hermes_cli.config import load_config as _load_sess_cfg
         _sess_cfg = (_load_sess_cfg().get("sessions") or {})
-        agent._session_json_enabled = bool(_sess_cfg.get("write_json_snapshots", False))
+        agent._session_json_enabled = (
+            persist_session
+            and bool(_sess_cfg.get("write_json_snapshots", False))
+        )
     except Exception:
         pass
     # logs_dir is retained unconditionally for request_dump_*.json (debug
@@ -1538,7 +1543,7 @@ def init_agent(
     # (state.db) or the JSON snapshot, regardless of session_id. Set on the
     # background skill/memory review fork so its harness turn can't leak into
     # the user's real session and hijack the next live turn. Default False.
-    agent._persist_disabled = False
+    agent._persist_disabled = not persist_session
     agent._session_init_model_config = {
         "max_iterations": agent.max_iterations,
         "reasoning_config": reasoning_config,

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1716,6 +1716,9 @@ def dump_api_request_debug(
     like timeout). Intended for debugging provider-side 4xx failures where
     retries are not useful.
     """
+    if getattr(agent, "_persist_disabled", False):
+        return None
+
     try:
         body = copy.deepcopy(api_kwargs)
         body.pop("timeout", None)

--- a/cli.py
+++ b/cli.py
@@ -4159,6 +4159,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Initialize Rich console
         self.console = Console()
         self.config = CLI_CONFIG
+
+        from hermes_cli.config import resolve_session_persistence
+
+        self.persist_session = resolve_session_persistence(self.config)
+        if resume and not self.persist_session:
+            raise ValueError(
+                "cannot resume a session when sessions.persist is false"
+            )
+
         self.compact = compact if compact is not None else CLI_CONFIG["display"].get("compact", False)
         # tool_progress: "off", "new", "all", "verbose" (from config.yaml display section)
         # YAML 1.1 parses bare `off` as boolean False — normalise to string.
@@ -4463,8 +4472,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._session_db = None
         self._session_db_unavailable = False
         try:
-            from hermes_state import SessionDB
-            self._session_db = SessionDB()
+            if self.persist_session:
+                from hermes_state import SessionDB
+                self._session_db = SessionDB()
         except Exception as e:
             # #41386: a failed session store means the transcript is NOT
             # persisted to state.db — the live chat looks healthy but resume
@@ -4496,7 +4506,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # min_interval_hours, tracked via state_meta in state.db itself so
         # it's shared across all Hermes processes for this HERMES_HOME.
         # Never blocks startup on failure.
-        _run_state_db_auto_maintenance(self._session_db)
+        if self.persist_session:
+            _run_state_db_auto_maintenance(self._session_db)
 
         # Opportunistic shadow-repo cleanup — deletes orphan/stale
         # checkpoint repos under ~/.hermes/checkpoints/.  Opt-in via

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -616,6 +616,43 @@ When a session expires:
 
 ## Appendix: Key Configuration
 
+### Profile-scoped ephemeral sessions
+
+Hermes persists CLI and one-shot session transcripts by default. A restricted
+profile can disable that persistence explicitly:
+
+```yaml
+sessions:
+  persist: false
+```
+
+Or set it for one named profile:
+
+```bash
+hermes -p <profile> config set sessions.persist false
+```
+
+When `sessions.persist` is `false`, Hermes keeps the active transcript in
+memory for the lifetime of the process but does not create or update:
+
+- SQLite session rows, messages, tool calls, tool results, or FTS entries
+- per-session JSON transcript snapshots
+- API request-debug dump files containing prompt or context data
+- session-finalization records during shutdown
+
+Interactive and one-shot model inference and MCP tool calls continue to work.
+Session resume is rejected because no durable transcript exists.
+
+The setting defaults to `true`, so existing profiles retain their current
+persistent behavior. The value must be a YAML boolean; malformed values such
+as the string `"false"` are rejected rather than interpreted as truthy.
+
+This setting controls Hermes session-transcript persistence only. It does not
+disable unrelated terminal input history, ordinary application logs, tool-
+specific storage, or external memory providers. Restricted profiles should
+configure those features separately when their threat model requires it.
+
+
 | Config Key | Type | Default | Description |
 |---|---|---|---|
 | `group_sessions_per_user` | `bool` | `true` | Isolate group/channel sessions per user |

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -250,8 +250,8 @@ class CLIAgentSetupMixin:
 
         wait_for_mcp_discovery()
 
-        # Initialize SQLite session store for CLI sessions (if not already done in __init__)
-        if self._session_db is None:
+        # Initialize SQLite session storage only when profile persistence is enabled.
+        if self.persist_session and self._session_db is None:
             try:
                 from hermes_state import SessionDB
                 self._session_db = SessionDB()
@@ -388,6 +388,7 @@ class CLIAgentSetupMixin:
                 openrouter_min_coding_score=self._openrouter_min_coding_score,
                 session_id=self.session_id,
                 platform="cli",
+                persist_session=self.persist_session,
                 session_db=self._session_db,
                 clarify_callback=self._clarify_callback,
                 reasoning_callback=self._current_reasoning_callback(),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -42,6 +42,22 @@ logger = logging.getLogger(__name__)
 _CONFIG_PARSE_WARNED: set = set()
 
 
+def resolve_session_persistence(config: Dict[str, Any]) -> bool:
+    """Return the strict profile-scoped session persistence policy.
+
+    Persistence remains enabled by default for backward compatibility.
+    Only actual booleans are accepted so malformed security settings cannot
+    silently become truthy and enable storage.
+    """
+    sessions_config = config.get("sessions") or {}
+    value = sessions_config.get("persist", True)
+
+    if not isinstance(value, bool):
+        raise ValueError("sessions.persist must be a boolean")
+
+    return value
+
+
 def _backup_corrupt_config(config_path: Path) -> Optional[Path]:
     """Preserve a corrupted ``config.yaml`` by copying it to a timestamped ``.bak``.
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2520,6 +2520,10 @@ DEFAULT_CONFIG = {
     # reports 384MB+ databases with 68K+ messages, which slows down FTS5
     # inserts, /resume listing, and insights queries.
     "sessions": {
+        # Persist sessions, messages, tool calls, and tool results to state.db.
+        # Restricted profiles may explicitly disable this to keep session
+        # transcript content in memory for the lifetime of the process only.
+        "persist": True,
         # When true, prune ended sessions inactive for retention_days once
         # per (roughly) min_interval_hours at CLI/gateway/cron startup.
         # Activity is the latest message timestamp, falling back to creation

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -294,13 +294,16 @@ def run_oneshot(
     return 0
 
 
-def _create_session_db_for_oneshot():
+def _create_session_db_for_oneshot(persist_session: bool = True):
     """Best-effort SessionDB for ``hermes -z`` / oneshot mode.
 
     Oneshot bypasses ``HermesCLI._init_agent()``, so it must wire the SQLite
     session store itself. Without this, the ``session_search``/recall tool is
     advertised but every call returns "Session database not available.".
     """
+    if not persist_session:
+        return None
+
     try:
         from hermes_state import SessionDB
 
@@ -395,7 +398,12 @@ def _run_agent(
     if toolsets_list is None and use_config_toolsets:
         toolsets_list = sorted(_get_platform_tools(cfg, "cli"))
 
-    session_db = _create_session_db_for_oneshot()
+    from hermes_cli.config import resolve_session_persistence
+
+    persist_session = resolve_session_persistence(cfg)
+    session_db = _create_session_db_for_oneshot(
+        persist_session=persist_session
+    )
     # The try spans agent construction (not just ``chat``) so the SQLite store
     # opened above is always closed — including when ``AIAgent(...)`` itself
     # raises on a provider/config error. The one-shot exit path hard-exits via
@@ -417,6 +425,7 @@ def _run_agent(
             enabled_toolsets=toolsets_list,
             quiet_mode=True,
             platform="cli",
+            persist_session=persist_session,
             session_db=session_db,
             credential_pool=runtime.get("credential_pool"),
             fallback_model=_fb or None,

--- a/run_agent.py
+++ b/run_agent.py
@@ -489,6 +489,7 @@ class AIAgent:
         skip_context_files: bool = False,
         load_soul_identity: bool = False,
         skip_memory: bool = False,
+        persist_session: bool = True,
         session_db=None,
         parent_session_id: str = None,
         iteration_budget: "IterationBudget" = None,
@@ -567,6 +568,7 @@ class AIAgent:
             skip_context_files=skip_context_files,
             load_soul_identity=load_soul_identity,
             skip_memory=skip_memory,
+            persist_session=persist_session,
             session_db=session_db,
             parent_session_id=parent_session_id,
             iteration_budget=iteration_budget,
@@ -1821,6 +1823,9 @@ class AIAgent:
         never mutating the live message list used by the API call (#48677 is
         thus closed for every persist caller, not just this one).
         """
+        if getattr(self, "_persist_disabled", False):
+            return
+
         # Scaffolding removal mutates the live list (desired — ephemeral
         # retry/failure sentinels must not survive into the real transcript).
         # Close and turn-start persistence can run on separate CLI threads; the
@@ -3996,7 +4001,10 @@ class AIAgent:
         # an already-ended row, so this never clobbers a 'compression' /
         # 'cron_complete' / 'cli_close' reason set by an earlier terminal path.
         try:
-            if getattr(self, "_end_session_on_close", True):
+            if (
+                not getattr(self, "_persist_disabled", False)
+                and getattr(self, "_end_session_on_close", True)
+            ):
                 session_db = getattr(self, "_session_db", None)
                 session_id = getattr(self, "session_id", None)
                 if session_db and session_id:

--- a/tests/hermes_cli/test_ephemeral_session_mode.py
+++ b/tests/hermes_cli/test_ephemeral_session_mode.py
@@ -1,0 +1,293 @@
+"""Contract tests for profile-scoped ephemeral Hermes sessions."""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import hermes_state
+from agent.agent_init import init_agent
+from hermes_cli.config_defaults import DEFAULT_CONFIG
+from hermes_cli.oneshot import _create_session_db_for_oneshot
+from run_agent import AIAgent
+
+
+def test_session_persistence_defaults_to_enabled() -> None:
+    """Existing profiles must retain persistent sessions by default."""
+    assert DEFAULT_CONFIG["sessions"]["persist"] is True
+
+
+def test_aiagent_exposes_explicit_persist_session_argument() -> None:
+    """Callers must not overload session_db=None to mean two different things."""
+    parameter = inspect.signature(AIAgent.__init__).parameters["persist_session"]
+
+    assert parameter.default is True
+
+
+def test_init_agent_exposes_explicit_persist_session_argument() -> None:
+    """The constructor forwarder must propagate the persistence policy."""
+    parameter = inspect.signature(init_agent).parameters["persist_session"]
+
+    assert parameter.default is True
+
+
+def test_oneshot_does_not_open_session_db_when_persistence_disabled(
+    monkeypatch,
+) -> None:
+    """Ephemeral one-shot runs must avoid touching canonical state.db."""
+
+    def unexpected_session_db():
+        raise AssertionError("SessionDB must not be constructed")
+
+    monkeypatch.setattr(hermes_state, "SessionDB", unexpected_session_db)
+
+    assert _create_session_db_for_oneshot(persist_session=False) is None
+
+
+def test_oneshot_uses_profile_persistence_setting(monkeypatch) -> None:
+    """The profile setting must control DB creation and agent persistence."""
+    from hermes_cli import oneshot
+
+    captured: dict[str, object] = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.suppress_status_output = False
+            self.stream_delta_callback = object()
+            self.tool_gen_callback = object()
+            self._session_messages = []
+
+        def run_conversation(self, prompt):
+            return {"final_response": "ok"}
+
+        def shutdown_memory_provider(self, *args, **kwargs):
+            return None
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(
+        oneshot,
+        "load_config",
+        lambda: {
+            "sessions": {"persist": False},
+            "model": {"default": "test-model"},
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "sessions": {"persist": False},
+            "model": {"default": "test-model"},
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "test",
+            "base_url": "https://example.invalid",
+            "provider": "test",
+            "requested_provider": "test",
+            "api_mode": None,
+            "credential_pool": None,
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        lambda cfg, platform: set(),
+    )
+    monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+    monkeypatch.setattr(
+        oneshot,
+        "_create_session_db_for_oneshot",
+        lambda persist_session=True: captured.setdefault(
+            "db_persist_session", persist_session
+        ),
+    )
+
+    response, result = oneshot._run_agent("hello")
+
+    assert response == "ok"
+    assert result["final_response"] == "ok"
+    assert captured["db_persist_session"] is False
+    assert captured["persist_session"] is False
+    assert captured["session_db"] is False
+
+
+def test_agent_persistence_disabled_blocks_lazy_db_open(monkeypatch) -> None:
+    """An ephemeral agent must never lazily open canonical state.db."""
+    agent = object.__new__(AIAgent)
+    agent._persist_disabled = True
+    agent._session_db = None
+
+    def unexpected_session_db():
+        raise AssertionError("SessionDB must not be opened")
+
+    monkeypatch.setattr(hermes_state, "SessionDB", unexpected_session_db)
+
+    assert agent._get_session_db_for_recall() is None
+
+
+def test_agent_init_sets_persistence_disabled() -> None:
+    """The public constructor policy must activate the existing hard-stop."""
+    agent = object.__new__(AIAgent)
+
+    # init_agent has many unrelated setup dependencies, so verify the public
+    # AIAgent path using a minimal stub around the forwarder.
+    from unittest.mock import patch
+
+    with patch("agent.agent_init.init_agent") as mocked_init:
+        AIAgent.__init__(
+            agent,
+            model="test-model",
+            persist_session=False,
+        )
+
+    assert mocked_init.call_args.kwargs["persist_session"] is False
+
+
+def test_invalid_profile_persistence_value_must_not_enable_storage() -> None:
+    """A malformed security setting must fail closed, never become truthy."""
+    from hermes_cli.config import resolve_session_persistence
+
+    try:
+        resolve_session_persistence({"sessions": {"persist": "false"}})
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("invalid sessions.persist value must be rejected")
+
+
+def test_interactive_cli_does_not_open_session_db_when_ephemeral(
+    monkeypatch,
+) -> None:
+    """Interactive startup must not touch state.db for an ephemeral profile."""
+    import copy
+    import cli
+
+    config = copy.deepcopy(cli.CLI_CONFIG)
+    config.setdefault("sessions", {})["persist"] = False
+
+    def unexpected_session_db():
+        raise AssertionError("SessionDB must not be constructed")
+
+    monkeypatch.setattr(cli, "CLI_CONFIG", config)
+    monkeypatch.setattr(hermes_state, "SessionDB", unexpected_session_db)
+
+    hermes_cli = cli.HermesCLI(model="test-model")
+
+    assert hermes_cli.persist_session is False
+    assert hermes_cli._session_db is None
+    assert hermes_cli._session_db_unavailable is False
+
+
+def test_interactive_cli_rejects_resume_when_ephemeral(monkeypatch) -> None:
+    """Resume requires persisted state and must fail closed."""
+    import copy
+    import cli
+    import pytest
+
+    config = copy.deepcopy(cli.CLI_CONFIG)
+    config.setdefault("sessions", {})["persist"] = False
+    monkeypatch.setattr(cli, "CLI_CONFIG", config)
+
+    with pytest.raises(
+        ValueError,
+        match="cannot resume.*sessions.persist is false",
+    ):
+        cli.HermesCLI(model="test-model", resume="existing-session")
+
+
+def test_ephemeral_agent_persist_session_is_complete_noop(monkeypatch) -> None:
+    """Ephemeral persistence must skip JSON, SQLite, and accounting drains."""
+    agent = object.__new__(AIAgent)
+    agent._persist_disabled = True
+    agent._session_db = None
+    agent._session_persist_lock = None
+
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        agent,
+        "_drop_trailing_empty_response_scaffolding",
+        lambda messages: calls.append("drop"),
+    )
+    monkeypatch.setattr(
+        agent,
+        "_save_session_log",
+        lambda messages: calls.append("json"),
+    )
+    monkeypatch.setattr(
+        agent,
+        "_flush_messages_to_session_db",
+        lambda messages, history=None: calls.append("sqlite"),
+    )
+
+    agent._persist_session([{"role": "user", "content": "secret"}])
+
+    assert calls == []
+    assert not hasattr(agent, "_session_messages")
+
+
+def test_ephemeral_agent_close_never_ends_database_session() -> None:
+    """Close must not touch an injected database when persistence is disabled."""
+    calls: list[tuple[str, str]] = []
+
+    class RecordingDB:
+        def end_session(self, session_id, reason):
+            calls.append((session_id, reason))
+
+    agent = object.__new__(AIAgent)
+    agent._persist_disabled = True
+    agent._end_session_on_close = True
+    agent._session_db = RecordingDB()
+    agent.session_id = "ephemeral-test"
+    agent.client = None
+    agent._active_children_lock = __import__("threading").RLock()
+    agent._active_children = set()
+
+    # Resource cleanup is independently best-effort; this test targets only
+    # the final database-session write.
+    agent.close()
+
+    assert calls == []
+
+
+def test_ephemeral_agent_never_writes_api_request_debug_dump(
+    monkeypatch,
+) -> None:
+    """Debug failures must not persist prompts for ephemeral agents."""
+    from agent.agent_runtime_helpers import dump_api_request_debug
+
+    agent = object.__new__(AIAgent)
+    agent._persist_disabled = True
+    agent.verbose_logging = False
+    agent.session_id = "ephemeral-test"
+    agent.logs_dir = Path("/tmp")
+    agent.base_url = "https://example.invalid"
+    agent.api_mode = "chat_completions"
+    agent.client = None
+
+    writes: list[object] = []
+
+    def record_write(*args, **kwargs):
+        writes.append((args, kwargs))
+
+    monkeypatch.setattr(
+        "agent.agent_runtime_helpers.atomic_json_write",
+        record_write,
+    )
+
+    result = dump_api_request_debug(
+        agent,
+        {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "secret"}],
+        },
+        reason="test",
+    )
+
+    assert result is None
+    assert writes == []


### PR DESCRIPTION
## Summary

- add profile-scoped `sessions.persist` configuration, defaulting to `true`
- support ephemeral CLI and one-shot sessions without transcript persistence
- prevent SQLite session writes, JSON snapshots, request-debug dumps, lazy DB reopening, and shutdown finalization
- reject session resume when persistence is disabled
- document restricted-profile ephemeral sessions

## Validation

- 13 focused ephemeral-session tests passed
- 623 targeted regression tests passed
- Ruff checks passed
- Python compilation passed
- `git diff --check` passed
- disposable-profile model inference returned `ephemeral-ok`
- no session, message, tool-call, tool-result, or FTS tables were created
- resume failed closed when `sessions.persist` was `false`

## Compatibility

Existing profiles retain persistent sessions because the setting defaults to `true`. Non-boolean values are rejected rather than silently enabling storage.