### PR TITLE
fix(skill-commands): suppress self-claim dedup warnings (#74574)

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -448,11 +448,15 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     # preserves local-before-external precedence.
                     cmd_key = f"/{cmd_name}"
                     if cmd_key in _skill_commands:
-                        logger.warning(
-                            "Skill %r maps to slash command %s already claimed "
-                            "by %r; keeping the first and skipping this one.",
-                            name, cmd_key, _skill_commands[cmd_key]["name"],
-                        )
+                        # Silent skip when the same skill name claims its own
+                        # command (e.g. skill present in both local and external
+                        # dirs, or scan_skill_commands called more than once).
+                        if _skill_commands[cmd_key]["name"] != name:
+                            logger.warning(
+                                "Skill %r maps to slash command %s already claimed "
+                                "by %r; keeping the first and skipping this one.",
+                                name, cmd_key, _skill_commands[cmd_key]["name"],
+                            )
                         continue
                     _skill_commands[cmd_key] = {
                         "name": name,


### PR DESCRIPTION
## fix(skill-commands): suppress self-claim dedup warnings

### Root Cause
When `scan_skill_commands()` processes the same skill name from multiple directories (local + external) or is called more than once, the dedup check at line 450 fires a WARNING even though the claiming skill has the same name as the current one. This produces 101+ spurious warnings per startup.

### Impact
- ~101 WARNING lines per session startup bloating `errors.log`
- No functional impact (first registration wins, dedup is correct)
- Noise makes real conflicts harder to spot

### Fix
Skip the warning when the claiming skill has the same name as the current skill (`_skill_commands[cmd_key]["name"] != name`). Only warn when a **different** skill name claims the same slash command slug (the intended use case for the dedup check).

### Changes
- `agent/skill_commands.py`: Added conditional check before logging the dedup warning

### Tests
All 22 tests in `tests/agent/test_skill_commands.py` pass.
