### PR TITLE
fix(session): batch transcript flush under lock pressure

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1739,21 +1739,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # legitimately held for multi-second stretches by sibling Hermes
     # processes: a TRUNCATE checkpoint at close on a large WAL, VACUUM after
     # an auto-prune, offline recovery, or an older still-running process
-    # whose FTS maintenance predates the bounded-merge protocol (every
-    # `hermes update` leaves mixed-version processes sharing the DB until
-    # the old ones exit).  An attempt-counted budget (~15s incidental worst
-    # case) silently loses that race and surfaces as
-    # session_persistence_failed — a destroyed turn — even though the store
-    # is healthy and merely busy (#74478).
-    #
-    # Two budgets: routine writes give up after _WRITE_PATIENCE_S so
-    # background/UI callers don't stall excessively, while transcript
-    # writes (append_message / session-row creation — the ones whose
-    # failure aborts the user's turn) ride out anything shorter than
-    # _TRANSCRIPT_WRITE_PATIENCE_S.  Jitter stays small for the first
-    # _WRITE_RETRY_SLOW_AFTER_S (fast reclaim on millisecond contention),
-    # then backs off so a long hold isn't hammered with BEGIN IMMEDIATE
-    # attempts.
+    # whose FTS maintenance predates the bounded-merge protocol.
     _WRITE_PATIENCE_S = 20.0
     _TRANSCRIPT_WRITE_PATIENCE_S = 60.0
     _WRITE_RETRY_MIN_S = 0.020   # 20ms
@@ -2396,6 +2382,29 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     ) from exc
                 # Non-lock error — propagate.
                 raise
+            except CompressionSessionBusyError as exc:
+                # In-place compression briefly owns a session-level lock while
+                # rewriting transcript rows. Treat that like SQLite write-lock
+                # pressure: back off with the same time-based patience budget
+                # rather than failing a turn on a transient owner overlap.
+                now = time.monotonic()
+                if now < deadline:
+                    elapsed = now - (deadline - patience_s)
+                    if elapsed >= self._WRITE_RETRY_SLOW_AFTER_S:
+                        jitter = random.uniform(
+                            self._WRITE_RETRY_SLOW_MIN_S,
+                            self._WRITE_RETRY_SLOW_MAX_S,
+                        )
+                    else:
+                        jitter = random.uniform(
+                            self._WRITE_RETRY_MIN_S,
+                            self._WRITE_RETRY_MAX_S,
+                        )
+                    time.sleep(min(jitter, max(deadline - now, 0.001)))
+                    continue
+                raise CompressionSessionBusyError(
+                    f"session compression lock held for over {patience_s:.0f}s"
+                ) from exc
             except sqlite3.DatabaseError as exc:
                 # Corrupt FTS shadow tables make every write raise the
                 # malformed/corrupt error class through the FTS sync triggers
@@ -5612,6 +5621,68 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         return self._execute_write(
             _do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S
         )
+
+    def append_messages(
+        self,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+        *,
+        compression_lock_holder: Optional[str] = None,
+    ) -> int:
+        """Append multiple transcript rows in one write transaction.
+
+        Turn-final persistence can contain many tool/result rows. Calling
+        :meth:`append_message` for each row acquires and releases SQLite's WAL
+        write lock repeatedly, which amplifies cross-process lock pressure on a
+        large shared ``state.db``.  This batch path performs the same
+        compression/session safety checks once, inserts every row atomically,
+        and updates session counters once.  No rows are marked durable by the
+        caller unless this method returns successfully.
+        """
+        if not messages:
+            return 0
+
+        def _do(conn):
+            active_lock = conn.execute(
+                "SELECT holder FROM compression_locks "
+                "WHERE session_id = ? AND expires_at > ?",
+                (session_id, time.time()),
+            ).fetchone()
+            if (
+                active_lock is not None
+                and active_lock["holder"] != compression_lock_holder
+            ):
+                raise CompressionSessionBusyError(
+                    f"Session {session_id!r} is being compressed by another writer"
+                )
+            session = conn.execute(
+                "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if (
+                session is not None
+                and session["ended_at"] is not None
+                and session["end_reason"] == "compression"
+            ):
+                raise CompressionSessionClosedError(session_id)
+
+            total_messages, total_tool_calls = self._insert_message_rows(
+                conn, session_id, messages
+            )
+            if total_tool_calls > 0:
+                conn.execute(
+                    """UPDATE sessions SET message_count = message_count + ?,
+                       tool_call_count = tool_call_count + ? WHERE id = ?""",
+                    (total_messages, total_tool_calls, session_id),
+                )
+            else:
+                conn.execute(
+                    "UPDATE sessions SET message_count = message_count + ? WHERE id = ?",
+                    (total_messages, session_id),
+                )
+            return total_messages
+
+        return self._execute_write(_do)
 
     def set_latest_matching_message_display_kind(
         self, session_id: str, *, role: str, content: str, display_kind: str,

--- a/run_agent.py
+++ b/run_agent.py
@@ -2032,6 +2032,9 @@ class AIAgent:
                 ):
                     _scan_start += 1
 
+            pending_db_rows = []
+            pending_live_messages = []
+
             for _msg_idx in range(_scan_start, len(messages)):
                 msg = messages[_msg_idx]
                 if not isinstance(msg, dict):
@@ -2150,33 +2153,42 @@ class AIAgent:
                     ]
                 elif isinstance(msg.get("tool_calls"), list):
                     tool_calls_data = msg["tool_calls"]
-                self._session_db.append_message(
-                    session_id=self.session_id,
-                    role=role,
-                    content=content,
-                    tool_name=msg.get("tool_name"),
-                    tool_calls=tool_calls_data,
-                    tool_call_id=msg.get("tool_call_id"),
-                    finish_reason=msg.get("finish_reason"),
-                    reasoning=msg.get("reasoning") if role == "assistant" else None,
-                    reasoning_content=msg.get("reasoning_content") if role == "assistant" else None,
-                    reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
-                    codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
-                    codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
-                    timestamp=_row_timestamp,
-                    api_content=_row_api_content,
-                    display_kind=(
-                        "hidden"
-                        if msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
-                        and not msg.get("_compressed_summary_has_user_turn")
-                        else msg.get("display_kind")
-                    ),
-                    display_metadata=msg.get("display_metadata"),
+                pending_db_rows.append(
+                    {
+                        "role": role,
+                        "content": content,
+                        "tool_name": msg.get("tool_name"),
+                        "tool_calls": tool_calls_data,
+                        "tool_call_id": msg.get("tool_call_id"),
+                        "finish_reason": msg.get("finish_reason"),
+                        "reasoning": msg.get("reasoning") if role == "assistant" else None,
+                        "reasoning_content": msg.get("reasoning_content") if role == "assistant" else None,
+                        "reasoning_details": msg.get("reasoning_details") if role == "assistant" else None,
+                        "codex_reasoning_items": msg.get("codex_reasoning_items") if role == "assistant" else None,
+                        "codex_message_items": msg.get("codex_message_items") if role == "assistant" else None,
+                        "timestamp": _row_timestamp,
+                        "api_content": _row_api_content,
+                        "display_kind": (
+                            "hidden"
+                            if msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
+                            and not msg.get("_compressed_summary_has_user_turn")
+                            else msg.get("display_kind")
+                        ),
+                        "display_metadata": msg.get("display_metadata"),
+                    }
+                )
+                pending_live_messages.append(msg)
+
+            if pending_db_rows:
+                self._session_db.append_messages(
+                    str(getattr(self, "session_id", "")),
+                    pending_db_rows,
                     compression_lock_holder=getattr(
                         self, "_active_compression_lock_holder", None
                     ),
                 )
-                msg[_DB_PERSISTED_MARKER] = True
+                for msg in pending_live_messages:
+                    msg[_DB_PERSISTED_MARKER] = True
             # The intrinsic markers are now the sole source of truth. Reset the
             # one-shot seed so no id() outlives this flush to alias a message
             # allocated next turn at a recycled address.

--- a/tests/state/test_session_db_batch_append.py
+++ b/tests/state/test_session_db_batch_append.py
@@ -1,0 +1,103 @@
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_state import CompressionSessionClosedError, SessionDB
+
+
+def test_append_messages_commits_rows_and_counters_in_one_transaction(tmp_path, monkeypatch):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("s1", source="test", model="m")
+
+    begin_count = {"n": 0}
+    original_execute = db._conn.execute
+
+    def counting_execute(sql, *args, **kwargs):
+        if isinstance(sql, str) and sql.strip().upper().startswith("BEGIN IMMEDIATE"):
+            begin_count["n"] += 1
+        return original_execute(sql, *args, **kwargs)
+
+    monkeypatch.setattr(db._conn, "execute", counting_execute)
+
+    written = db.append_messages(
+        "s1",
+        [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "checking", "tool_calls": [{"id": "c1"}]},
+            {"role": "tool", "content": "ok", "tool_call_id": "c1"},
+        ],
+    )
+
+    assert written == 3
+    assert begin_count["n"] == 1
+    session = db._conn.execute(
+        "SELECT message_count, tool_call_count FROM sessions WHERE id = ?",
+        ("s1",),
+    ).fetchone()
+    assert dict(session) == {"message_count": 3, "tool_call_count": 1}
+    roles = [
+        row[0]
+        for row in db._conn.execute(
+            "SELECT role FROM messages WHERE session_id = ? ORDER BY id",
+            ("s1",),
+        ).fetchall()
+    ]
+    assert roles == ["user", "assistant", "tool"]
+
+
+def test_append_messages_is_atomic_on_locked_retry_exhaustion(tmp_path, monkeypatch):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("s1", source="test", model="m")
+
+    attempts = {"n": 0}
+    original_execute = db._conn.execute
+
+    def flaky_execute(sql, *args, **kwargs):
+        if isinstance(sql, str) and sql.strip().upper().startswith("BEGIN IMMEDIATE"):
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                raise sqlite3.OperationalError("database is locked")
+        return original_execute(sql, *args, **kwargs)
+
+    monkeypatch.setattr(db._conn, "execute", flaky_execute)
+
+    assert db.append_messages("s1", [{"role": "user", "content": "after lock"}]) == 1
+    assert attempts["n"] == 2
+    count = db._conn.execute("SELECT COUNT(*) FROM messages WHERE session_id = 's1'").fetchone()[0]
+    assert count == 1
+
+
+def test_append_messages_retries_transient_compression_busy(tmp_path, monkeypatch):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("s1", source="test", model="m")
+
+    attempts = {"n": 0}
+    original_execute = db._conn.execute
+
+    def flaky_execute(sql, *args, **kwargs):
+        if isinstance(sql, str) and sql.startswith("SELECT holder FROM compression_locks"):
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                return SimpleNamespace(fetchone=lambda: {"holder": "other"})
+        return original_execute(sql, *args, **kwargs)
+
+    monkeypatch.setattr(db._conn, "execute", flaky_execute)
+    monkeypatch.setattr("hermes_state.time.sleep", lambda _seconds: None)
+
+    assert db.append_messages("s1", [{"role": "user", "content": "after compression"}]) == 1
+    assert attempts["n"] == 2
+
+
+def test_append_messages_respects_compression_closed_session(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("s1", source="test", model="m")
+    db._conn.execute(
+        "UPDATE sessions SET ended_at = 1, end_reason = 'compression' WHERE id = 's1'"
+    )
+
+    with pytest.raises(CompressionSessionClosedError):
+        db.append_messages("s1", [{"role": "user", "content": "blocked"}])
+
+    count = db._conn.execute("SELECT COUNT(*) FROM messages WHERE session_id = 's1'").fetchone()[0]
+    assert count == 0


### PR DESCRIPTION
## Summary
- batch transcript DB flushes into one `append_messages()` call where possible
- keep per-message durability markers after successful batch writes
- use time-based patience for transient SQLite/session-compression lock pressure

## Tests
- `python3 -m py_compile hermes_state.py run_agent.py tests/state/test_session_db_batch_append.py`
- `python3 -m pytest tests/state/test_session_db_batch_append.py -q` → 4 passed
