### PR TITLE
feat(mcp): allow skipping discovery via env gate

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -2626,3 +2626,43 @@ class TestMCPDiscoveryCrossProcessLock:
                 os.unlink(lock_path)
             except Exception:
                 pass
+
+def test_discover_mcp_tools_skip_env_returns_existing_tools_without_loading_config(monkeypatch):
+    """HERMES_SKIP_MCP_DISCOVERY bypasses config loading and server registration."""
+    from tools import mcp_tool
+
+    calls = {"load": 0, "register": 0}
+
+    def _load_should_not_run():
+        calls["load"] += 1
+        raise AssertionError("skip env should bypass MCP config loading")
+
+    def _register_should_not_run(_servers):
+        calls["register"] += 1
+        raise AssertionError("skip env should bypass MCP server registration")
+
+    monkeypatch.setenv("HERMES_SKIP_MCP_DISCOVERY", "1")
+    monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", True)
+    monkeypatch.setattr(mcp_tool, "_load_mcp_config", _load_should_not_run)
+    monkeypatch.setattr(mcp_tool, "register_mcp_servers", _register_should_not_run)
+    monkeypatch.setattr(mcp_tool, "_existing_tool_names", lambda: ["mcp__cached__tool"])
+
+    assert mcp_tool.discover_mcp_tools() == ["mcp__cached__tool"]
+    assert calls == {"load": 0, "register": 0}
+
+
+def test_discover_mcp_tools_skip_env_accepts_boolish_true_values(monkeypatch):
+    """Dashboard/service env gates can use common true spellings."""
+    from tools import mcp_tool
+
+    monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", True)
+    monkeypatch.setattr(mcp_tool, "_existing_tool_names", lambda: ["mcp__cached__tool"])
+    monkeypatch.setattr(
+        mcp_tool,
+        "_load_mcp_config",
+        lambda: (_ for _ in ()).throw(AssertionError("skip env should bypass config")),
+    )
+
+    for value in ["1", "true", "TRUE", " yes ", "on"]:
+        monkeypatch.setenv("HERMES_SKIP_MCP_DISCOVERY", value)
+        assert mcp_tool.discover_mcp_tools() == ["mcp__cached__tool"]

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6043,9 +6043,18 @@ def discover_mcp_tools() -> List[str]:
     Idempotent for already-connected servers. If some servers failed on a
     previous call, only the missing ones are retried.
 
+    Set ``HERMES_SKIP_MCP_DISCOVERY=1`` for latency-sensitive local services
+    such as the Desktop dashboard readiness backend. This keeps configured MCP
+    tools out of that process without mutating config.yaml for normal chat and
+    gateway sessions.
+
     Returns:
         List of all registered MCP tool names.
     """
+    if os.getenv("HERMES_SKIP_MCP_DISCOVERY", "").strip().lower() in {"1", "true", "yes", "on"}:
+        logger.info("HERMES_SKIP_MCP_DISCOVERY set -- skipping MCP tool discovery")
+        return _existing_tool_names()
+
     if not _MCP_AVAILABLE:
         logger.debug("MCP SDK not available -- skipping MCP tool discovery")
         return []


### PR DESCRIPTION
## Summary
- add `HERMES_SKIP_MCP_DISCOVERY=1` as an environment gate for latency-sensitive local services
- return existing registered tool names without loading MCP config or connecting servers when the gate is set
- documents the intended Desktop dashboard/readiness backend use case

## Tests
- `python3 -m py_compile tools/mcp_tool.py`
- smoke check: patched `_load_mcp_config` / `register_mcp_servers` were not called while `HERMES_SKIP_MCP_DISCOVERY=1`
