### PR TITLE
Add typed, mechanically inert Grover runtime release path

### DIFF
--- a/grover_runtime/README.md
+++ b/grover_runtime/README.md
@@ -1,0 +1,70 @@
+# Grover pinned runtime integration
+
+This package is private to the Grizzly pinned Hermes release. It adds one narrow
+Telegram callback route: opaque `od:` tokens are resolved by the owner-only
+loopback action service, and the server-issued SHADOW receipt is edited into the
+same bot-owned card. The callback contains no action, decision ID, destination,
+or authority. `act:` text is never treated as an executable callback.
+
+## Mac profile preparation
+
+On the Mac mini, from the reviewed pinned checkout:
+
+```bash
+python -m grover_runtime.profile_preparation prepare --dry-run
+python -m grover_runtime.profile_preparation prepare
+```
+
+Preparation creates clean `grover-prod` and `grover-shadow` profile homes
+without cloning `.env`, tokens, sessions, or state. Both Telegram adapters are
+explicitly disabled. The production Telegram credential and the action-service
+bridge token must be provisioned separately through the owner-only credential
+lane; do not put either value in Git, command arguments, or this package.
+
+Hermes profiles are runtime/configuration grouping, not a security boundary.
+The two Mac runtimes therefore also require separate runtime directories,
+least-privilege filesystem ownership, and the typed action-service capability
+boundary; profile names alone provide no isolation.
+
+`grover-shadow` is mechanically external-effect-free even if credentials are
+accidentally injected: its Telegram adapter denies connect, polling, webhook,
+send, callback answer/edit, and standalone-send paths, while the enabled
+`grover-shadow-guard` plugin blocks LLM and tool execution. Missing credentials
+and disabled Telegram configuration are defense-in-depth, not the boundary.
+The callback client itself can only call the allowlisted SHADOW
+callback/receipt routes; it cannot call the Control Plane execute API or
+provider APIs.
+
+## Cutover gate
+
+Before cutover, verify all of the following:
+
+1. the pinned checkout SHA and clean worktree;
+2. focused callback and fail-closed authorization tests pass;
+3. action service is loopback-only and its bridge token is an owner-only regular
+   file under the `grover-prod` profile home;
+4. the old Telegram consumer is stopped and polling is quiescent;
+5. `grover-shadow` still resolves `gateway.platforms.telegram.enabled=false`.
+
+Profile preparation intentionally exposes no cutover command. Cutover must use
+`grover_runtime.operations.execute_cutover` with reviewed fixed-argv commands.
+That gate proves exactly one known old consumer, transitions through zero
+consumers, starts exactly one pinned new consumer, verifies release-bound
+health and a provider-native Telegram delivery receipt, and invokes the
+fail-closed rollback sequence on any post-stop failure. Do not start both
+runtimes against the same bot token.
+
+## Rollback
+
+1. Disable `grover-prod` Telegram config and stop its gateway.
+2. Keep both action-service ledger and receipt state for audit; never delete or
+   rewrite receipts.
+3. Restore the previous pinned release and previous production profile backup.
+4. Start exactly one previous Telegram consumer.
+5. Verify one inbound update, one ordinary outbound reply, and absence of
+   duplicate polling before declaring rollback complete.
+
+A failed action-service resolution is consumed and reports that nothing was
+executed. If the SHADOW decision commits but Telegram receipt editing fails,
+the buttons are removed and the durable receipt remains pending for the
+supervised mirror retry; it does not replay the action.

--- a/grover_runtime/__init__.py
+++ b/grover_runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Private Grizzly runtime integration carried by the pinned Hermes build."""

--- a/grover_runtime/action_service_client.py
+++ b/grover_runtime/action_service_client.py
@@ -1,0 +1,338 @@
+"""Owner-token-authenticated loopback client for Grizzly action receipts."""
+
+from __future__ import annotations
+
+import html
+import json
+import os
+import re
+import stat
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+_BASE_URL = "http://127.0.0.1:8791"
+_MAX_RESPONSE_BYTES = 256_000
+_CALLBACK_RE = re.compile(r"^od:[A-Za-z0-9_-]{16,60}$")
+_CARD_REF_RE = re.compile(r"^TGC-[0-9a-f]{16}$")
+_RECEIPT_RE = re.compile(r"^ACT-[0-9a-f]{12}$")
+_TELEGRAM_ID_RE = re.compile(r"^-?[0-9]{1,24}$")
+_MESSAGE_ID_RE = re.compile(r"^[0-9]{1,24}$")
+_ACTION_LABELS = {
+    "approve": "Approved",
+    "reject": "Rejected",
+    "request_changes": "Changes requested",
+}
+
+
+class ActionServiceError(RuntimeError):
+    """A content-minimal bridge failure safe to log without response bodies."""
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _reject_non_finite(value: str) -> None:
+    raise ValueError(f"non-finite JSON value: {value}")
+
+
+def _read_owner_token(path: Path) -> str:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    if os.name != "nt":
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+    path_info_before = None
+    try:
+        # Windows lacks O_NOFOLLOW. Bind the fallback checks to the opened
+        # descriptor and compare file identity before/after the open so a
+        # reparse-point or path replacement cannot silently redirect the read.
+        if os.name == "nt":
+            path_info_before = os.lstat(path)
+            if stat.S_ISLNK(path_info_before.st_mode):
+                raise ActionServiceError(
+                    "action bridge token path must not be a symlink"
+                )
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise ActionServiceError("action bridge token is unavailable") from exc
+    try:
+        opened_info = os.fstat(descriptor)
+        if not stat.S_ISREG(opened_info.st_mode):
+            raise ActionServiceError("action bridge token is not a regular file")
+        if os.name != "nt":
+            expected_uid = getattr(os, "getuid", lambda: 0)()
+            if opened_info.st_uid != expected_uid:
+                raise ActionServiceError("action bridge token owner mismatch")
+            if stat.S_IMODE(opened_info.st_mode) & 0o077:
+                raise ActionServiceError("action bridge token is not owner-only")
+        if os.name == "nt":
+            path_info_after = os.lstat(path)
+            opened_identity = (
+                int(opened_info.st_dev),
+                int(opened_info.st_ino),
+            )
+            if (
+                path_info_before is None
+                or stat.S_ISLNK(path_info_after.st_mode)
+                or (int(path_info_before.st_dev), int(path_info_before.st_ino))
+                != opened_identity
+                or (int(path_info_after.st_dev), int(path_info_after.st_ino))
+                != opened_identity
+            ):
+                raise ActionServiceError(
+                    "action bridge token changed while it was opened"
+                )
+        raw_token = os.read(descriptor, 257)
+        if len(raw_token) != int(opened_info.st_size):
+            raise ActionServiceError("action bridge token changed while it was read")
+        token = raw_token.decode("utf-8").strip()
+    except UnicodeError as exc:
+        raise ActionServiceError("action bridge token is unreadable") from exc
+    finally:
+        os.close(descriptor)
+    if not 43 <= len(token) <= 256 or any(character.isspace() for character in token):
+        raise ActionServiceError("action bridge token is malformed")
+    return token
+
+
+def _decode(raw: bytes) -> dict[str, Any]:
+    if len(raw) > _MAX_RESPONSE_BYTES:
+        raise ActionServiceError("action service response is too large")
+    try:
+        payload = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_non_finite,
+        )
+    except (UnicodeError, ValueError) as exc:
+        raise ActionServiceError("action service response is invalid") from exc
+    if not isinstance(payload, dict):
+        raise ActionServiceError("action service response is not an object")
+    return payload
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+class ActionServiceClient:
+    """Narrow client for callback resolution and receipt mirror acknowledgement."""
+
+    def __init__(
+        self,
+        *,
+        token_path: Path | None = None,
+        timeout: float = 5.0,
+        opener: Any | None = None,
+    ) -> None:
+        self.token_path = token_path or (
+            get_hermes_home() / "state" / "action-service" / "bridge-token"
+        )
+        self.timeout = max(0.5, min(float(timeout), 20.0))
+        self.opener = opener or urllib.request.build_opener(
+            urllib.request.ProxyHandler({}), _NoRedirect()
+        )
+
+    def _read_owner_token(self) -> str:
+        """Read the bridge token from one validated file descriptor."""
+        return _read_owner_token(self.token_path)
+
+    def _request(
+        self, method: str, path: str, body: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        if method not in {"GET", "POST"} or path not in {
+            "/api/v1/telegram/resolve",
+            "/api/v1/telegram/pending",
+            "/api/v1/telegram/mirrored",
+        }:
+            raise ActionServiceError("action bridge request is outside its allowlist")
+        encoded = None
+        headers = {
+            "Accept": "application/json",
+            "Cache-Control": "no-store",
+            "X-Action-Bridge-Token": _read_owner_token(self.token_path),
+        }
+        if body is not None:
+            encoded = json.dumps(
+                body, ensure_ascii=False, separators=(",", ":"), allow_nan=False
+            ).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        request = urllib.request.Request(
+            _BASE_URL + path,
+            data=encoded,
+            headers=headers,
+            method=method,
+        )
+        try:
+            response = self.opener.open(request, timeout=self.timeout)
+            if response.geturl() != request.full_url:
+                raise ActionServiceError(
+                    "action service responded from an unexpected endpoint"
+                )
+            raw = response.read(_MAX_RESPONSE_BYTES + 1)
+        except urllib.error.HTTPError as exc:
+            # Preserve only status; response bodies may contain internal detail.
+            exc.read(_MAX_RESPONSE_BYTES + 1)
+            raise ActionServiceError(
+                f"action service rejected the request (HTTP {int(exc.code)})"
+            ) from None
+        except (OSError, urllib.error.URLError) as exc:
+            raise ActionServiceError("action service is unavailable") from exc
+        return _decode(raw)
+
+    def resolve_callback(
+        self,
+        callback: str,
+        chat_id: str,
+        message_id: str,
+        telegram_user_id: str,
+        actor_label: str,
+    ) -> dict[str, Any]:
+        if (
+            not _CALLBACK_RE.fullmatch(callback)
+            or not _TELEGRAM_ID_RE.fullmatch(chat_id)
+            or not _MESSAGE_ID_RE.fullmatch(message_id)
+            or not _TELEGRAM_ID_RE.fullmatch(telegram_user_id)
+        ):
+            raise ActionServiceError("Telegram callback context is malformed")
+        payload = self._request(
+            "POST",
+            "/api/v1/telegram/resolve",
+            {
+                "callback": callback,
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "telegram_user_id": telegram_user_id,
+                "actor_label": " ".join(actor_label.split())[:60],
+            },
+        )
+        if (
+            payload.get("mode") != "shadow"
+            or not _CARD_REF_RE.fullmatch(str(payload.get("card_ref") or ""))
+            or not _RECEIPT_RE.fullmatch(str(payload.get("receipt_id") or ""))
+            or payload.get("action") not in _ACTION_LABELS
+        ):
+            raise ActionServiceError("action service receipt is invalid")
+        return payload
+
+    def pending(self) -> list[dict[str, Any]]:
+        payload = self._request("GET", "/api/v1/telegram/pending")
+        items = payload.get("items")
+        if (
+            payload.get("mode") != "shadow"
+            or not isinstance(items, list)
+            or len(items) > 100
+        ):
+            raise ActionServiceError("pending receipt response is invalid")
+        for item in items:
+            _validate_pending(item)
+        return items
+
+    def pending_card(
+        self,
+        card_ref: str,
+        *,
+        chat_id: str,
+        thread_id: str | None,
+        message_id: str,
+        receipt_id: str,
+        action: str,
+    ) -> dict[str, Any] | None:
+        if not _CARD_REF_RE.fullmatch(card_ref):
+            raise ActionServiceError("card reference is malformed")
+        item = next(
+            (row for row in self.pending() if row["card_ref"] == card_ref), None
+        )
+        if item is None:
+            return None
+        binding = item["binding"]
+        resolution = item["resolution"]
+        binding_thread_id = binding["thread_id"]
+        thread_matches = (
+            binding_thread_id is None
+            and thread_id is None
+            or binding_thread_id is not None
+            and thread_id is not None
+            and str(binding_thread_id) == str(thread_id)
+        )
+        if (
+            str(binding["chat_id"]) != str(chat_id)
+            or not thread_matches
+            or str(binding["message_id"]) != str(message_id)
+            or str(resolution["receipt_id"]) != str(receipt_id)
+            or resolution["action"] != action
+        ):
+            raise ActionServiceError(
+                "pending receipt does not match its callback route"
+            )
+        return item
+
+    def mirrored(self, card_ref: str, receipt_id: str) -> dict[str, Any]:
+        if not _CARD_REF_RE.fullmatch(card_ref) or not _RECEIPT_RE.fullmatch(
+            receipt_id
+        ):
+            raise ActionServiceError("receipt acknowledgement is malformed")
+        payload = self._request(
+            "POST",
+            "/api/v1/telegram/mirrored",
+            {"card_ref": card_ref, "receipt_id": receipt_id},
+        )
+        if payload.get("mirrored") is not True or payload.get("card_ref") != card_ref:
+            raise ActionServiceError("receipt acknowledgement was not confirmed")
+        return payload
+
+
+def _validate_pending(item: Any) -> None:
+    binding = item.get("binding") if isinstance(item, dict) else None
+    resolution = item.get("resolution") if isinstance(item, dict) else None
+    if (
+        not isinstance(item, dict)
+        or not _CARD_REF_RE.fullmatch(str(item.get("card_ref") or ""))
+        or not isinstance(binding, dict)
+        or not _TELEGRAM_ID_RE.fullmatch(str(binding.get("chat_id") or ""))
+        or "thread_id" not in binding
+        or (
+            binding["thread_id"] is not None
+            and not _MESSAGE_ID_RE.fullmatch(str(binding["thread_id"]))
+        )
+        or not _MESSAGE_ID_RE.fullmatch(str(binding.get("message_id") or ""))
+        or not isinstance(binding.get("card_html"), str)
+        or not binding["card_html"].strip()
+        or len(binding["card_html"]) > 8_000
+        or not isinstance(resolution, dict)
+        or resolution.get("mode") != "shadow"
+        or resolution.get("action") not in _ACTION_LABELS
+        or not _RECEIPT_RE.fullmatch(str(resolution.get("receipt_id") or ""))
+    ):
+        raise ActionServiceError("pending receipt item is invalid")
+
+
+def render_shadow_card(item: dict[str, Any]) -> str:
+    """Render one compact escaped SHADOW receipt into the original card."""
+
+    _validate_pending(item)
+    binding = item["binding"]
+    resolution = item["resolution"]
+    actor = " ".join(str(resolution.get("actor_label") or "Principal").split())[:60]
+    rendered = (
+        binding["card_html"].rstrip()
+        + "\n\n<b>SHADOW RECEIPT</b>\n"
+        + html.escape(actor)
+        + " selected <b>"
+        + html.escape(_ACTION_LABELS[resolution["action"]])
+        + "</b>.\nRecorded only — nothing was executed.\n<code>"
+        + html.escape(resolution["receipt_id"])
+        + "</code>"
+    )
+    if len(rendered) > 10_000:
+        raise ActionServiceError("rendered receipt is too large")
+    return rendered

--- a/grover_runtime/migration_inventory.py
+++ b/grover_runtime/migration_inventory.py
@@ -1,0 +1,214 @@
+"""Read-only inventory of a dirty checkout and exported migration patches."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shlex
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+_MAX_GIT_OUTPUT_BYTES = 8 * 1024 * 1024
+_MAX_PATCH_BYTES = 64 * 1024 * 1024
+_MAX_INVENTORY_PATHS = 100_000
+_GIT_STATUS_ARGV = (
+    "git",
+    "-c",
+    "core.fsmonitor=false",
+    "-c",
+    "core.untrackedCache=false",
+    "status",
+    "--porcelain=v1",
+    "-z",
+    "--untracked-files=all",
+)
+
+
+def build_migration_inventory(
+    repository: Path,
+    *,
+    patch_files: Sequence[Path] = (),
+) -> dict[str, Any]:
+    """Return path/hash metadata without modifying or exposing file content."""
+
+    repo = Path(repository)
+    if not repo.exists() or not repo.is_dir():
+        raise ValueError("migration repository must be an existing directory")
+
+    status_rows = _read_git_status(repo)
+    checkout_paths = sorted({row["path"] for row in status_rows})
+    checkout_categories = _group_categories(checkout_paths)
+
+    patch_rows = [_inventory_patch(Path(path)) for path in patch_files]
+    return {
+        "checkout": {
+            "categories": checkout_categories,
+            "dirty": bool(status_rows),
+            "paths": status_rows,
+        },
+        "exported_patches": patch_rows,
+        "schema_version": "grover.migration-inventory.v1",
+    }
+
+
+def _read_git_status(repository: Path) -> list[dict[str, str]]:
+    environment = _git_environment()
+    try:
+        completed = subprocess.run(
+            _GIT_STATUS_ARGV,
+            cwd=repository,
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError("read-only git status command failed") from exc
+
+    if (
+        len(completed.stdout) > _MAX_GIT_OUTPUT_BYTES
+        or len(completed.stderr) > _MAX_GIT_OUTPUT_BYTES
+    ):
+        raise RuntimeError("git status output exceeded the inventory limit")
+    if completed.returncode != 0:
+        raise ValueError("migration repository is not a readable Git checkout")
+    return _parse_porcelain_status(completed.stdout)
+
+
+def _git_environment() -> dict[str, str]:
+    environment: dict[str, str] = {
+        "GIT_OPTIONAL_LOCKS": "0",
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+    }
+    for name in ("PATH", "PATHEXT", "SYSTEMROOT", "WINDIR"):
+        value = os.environ.get(name)
+        if value:
+            environment[name] = value
+    return environment
+
+
+def _parse_porcelain_status(payload: bytes) -> list[dict[str, str]]:
+    tokens = payload.split(b"\x00")
+    rows: list[dict[str, str]] = []
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        index += 1
+        if not token:
+            continue
+        if len(token) < 4 or token[2:3] != b" ":
+            raise RuntimeError("git status returned malformed porcelain output")
+        try:
+            status = token[:2].decode("ascii")
+            path = token[3:].decode("utf-8", errors="strict")
+        except UnicodeError as exc:
+            raise RuntimeError("git status returned a non-UTF-8 path") from exc
+        path = _normalize_inventory_path(path)
+        row = {
+            "category": _category_for_path(path),
+            "path": path,
+            "status": status,
+        }
+
+        if "R" in status or "C" in status:
+            if index >= len(tokens) or not tokens[index]:
+                raise RuntimeError("git status returned an incomplete rename record")
+            try:
+                previous = tokens[index].decode("utf-8", errors="strict")
+            except UnicodeError as exc:
+                raise RuntimeError("git status returned a non-UTF-8 path") from exc
+            index += 1
+            row["previous_path"] = _normalize_inventory_path(previous)
+
+        rows.append(row)
+        if len(rows) > _MAX_INVENTORY_PATHS:
+            raise RuntimeError("checkout inventory contains too many paths")
+
+    rows.sort(key=lambda row: (row["path"], row["status"]))
+    return rows
+
+
+def _inventory_patch(patch_file: Path) -> dict[str, Any]:
+    if patch_file.is_symlink() or not patch_file.is_file():
+        raise ValueError("exported patch must be a regular file")
+    try:
+        size = patch_file.stat().st_size
+    except OSError as exc:
+        raise ValueError("cannot inspect exported patch") from exc
+    if size > _MAX_PATCH_BYTES:
+        raise ValueError("exported patch exceeds the inventory size limit")
+    try:
+        payload = patch_file.read_bytes()
+    except OSError as exc:
+        raise ValueError("cannot read exported patch") from exc
+    if len(payload) != size or len(payload) > _MAX_PATCH_BYTES:
+        raise ValueError("exported patch changed while being read")
+
+    paths = _patch_paths(payload)
+    return {
+        "categories": _group_categories(paths),
+        "path": patch_file.name,
+        "paths": paths,
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "size_bytes": len(payload),
+    }
+
+
+def _patch_paths(payload: bytes) -> list[str]:
+    paths: set[str] = set()
+    for raw_line in payload.splitlines():
+        if not raw_line.startswith(b"diff --git "):
+            continue
+        try:
+            line = raw_line.decode("utf-8", errors="strict")
+            fields = shlex.split(line, posix=True)
+        except (UnicodeError, ValueError) as exc:
+            raise ValueError("exported patch has an invalid diff header") from exc
+        if len(fields) != 4 or fields[:2] != ["diff", "--git"]:
+            raise ValueError("exported patch has an invalid diff header")
+        target = fields[3]
+        if target.startswith("b/"):
+            target = target[2:]
+        paths.add(_normalize_inventory_path(target))
+        if len(paths) > _MAX_INVENTORY_PATHS:
+            raise ValueError("exported patch contains too many paths")
+    return sorted(paths)
+
+
+def _normalize_inventory_path(raw_path: str) -> str:
+    if (
+        not isinstance(raw_path, str)
+        or not raw_path
+        or "\x00" in raw_path
+        or "\\" in raw_path
+    ):
+        raise ValueError("inventory path is invalid")
+    path = PurePosixPath(raw_path)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError("inventory path is not repository-relative")
+    normalized = path.as_posix()
+    if normalized != raw_path:
+        raise ValueError("inventory path is not canonical")
+    return normalized
+
+
+def _group_categories(paths: Sequence[str]) -> dict[str, list[str]]:
+    grouped: dict[str, list[str]] = {}
+    for path in sorted(set(paths)):
+        grouped.setdefault(_category_for_path(path), []).append(path)
+    return {name: grouped[name] for name in sorted(grouped)}
+
+
+def _category_for_path(path: str) -> str:
+    if path == "plugins/platforms/telegram/adapter.py":
+        return "upstreamable_adapter"
+    if path.startswith("grover_runtime/") or path.startswith(
+        "plugins/grover_shadow_guard/"
+    ):
+        return "grizzly_specific"
+    return "unclassified"

--- a/grover_runtime/operations.py
+++ b/grover_runtime/operations.py
@@ -1,0 +1,589 @@
+"""Fail-closed runtime layout validation and Telegram cutover orchestration.
+
+The module deliberately does not spawn processes.  Every command is a fixed
+``tuple[str, ...]`` supplied in :class:`CutoverCommands` and is executed only
+through the runner injected by the caller.  Command output is bounded and JSON
+is decoded with duplicate-key and non-finite-number rejection.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+_MAX_ARGV_ITEMS = 32
+_MAX_ARG_BYTES = 4096
+_MAX_ARGV_BYTES = 32 * 1024
+_MAX_COMMAND_OUTPUT_BYTES = 128 * 1024
+_MAX_ENV_VALUE_BYTES = 32 * 1024
+_MAX_SHADOW_CREDENTIAL_FILE_BYTES = 64 * 1024
+
+_SAFE_INHERITED_ENVIRONMENT = frozenset({
+    "COMSPEC",
+    "LANG",
+    "LC_ALL",
+    "PATH",
+    "PATHEXT",
+    "PYTHONIOENCODING",
+    "PYTHONUTF8",
+    "SYSTEMROOT",
+    "TEMP",
+    "TMP",
+    "TZ",
+    "WINDIR",
+})
+
+
+class SafetyViolation(RuntimeError):
+    """Raised when a runtime safety invariant cannot be established."""
+
+
+class CutoverRolledBack(SafetyViolation):
+    """Raised after a failed cutover has been verified back on the old runtime."""
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """Bounded, shell-free command result returned by an injected runner."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+class CommandRunner(Protocol):
+    def __call__(
+        self,
+        argv: tuple[str, ...],
+        *,
+        env: Mapping[str, str],
+    ) -> CommandResult: ...
+
+
+@dataclass(frozen=True)
+class CutoverCommands:
+    """Operator-reviewed command vectors used by :func:`execute_cutover`."""
+
+    probe: tuple[str, ...]
+    disable_new: tuple[str, ...]
+    stop_old: tuple[str, ...]
+    enable_new: tuple[str, ...]
+    start_new: tuple[str, ...]
+    stop_new: tuple[str, ...]
+    start_old: tuple[str, ...]
+    health_new: tuple[str, ...]
+    health_old: tuple[str, ...]
+    receipt: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CutoverSpec:
+    release_id: str
+    old_consumer_id: str
+    new_consumer_id: str
+    commands: CutoverCommands
+    prod_home: Path
+
+
+@dataclass(frozen=True)
+class CutoverResult:
+    release_id: str
+    consumer_id: str
+    provider: str
+    provider_message_id: str
+    already_active: bool
+
+
+@dataclass(frozen=True)
+class RuntimeLayout:
+    prod_home: Path
+    shadow_home: Path
+    release_root: Path
+
+
+def sanitize_runtime_environment(
+    base_environment: Mapping[str, str],
+    *,
+    profile: str,
+    home: Path,
+    role: str,
+) -> dict[str, str]:
+    """Build a minimal runtime environment without inherited credentials.
+
+    An allowlist is used rather than trying to enumerate secret variable names.
+    ``HOME`` and ``HERMES_HOME`` are always replaced by the selected clean
+    profile home.
+    """
+
+    if not isinstance(base_environment, Mapping):
+        raise SafetyViolation("base environment must be a mapping")
+    _validate_identifier(profile, "profile")
+    if role not in {"prod", "shadow"}:
+        raise SafetyViolation("runtime role must be 'prod' or 'shadow'")
+
+    home_text = str(Path(home))
+    _validate_environment_value(home_text, "runtime home")
+
+    environment: dict[str, str] = {}
+    for key in sorted(_SAFE_INHERITED_ENVIRONMENT):
+        value = base_environment.get(key)
+        if value is None:
+            continue
+        if not isinstance(value, str):
+            raise SafetyViolation(f"environment value for {key} must be text")
+        _validate_environment_value(value, key)
+        environment[key] = value
+
+    environment.update({
+        "GROVER_RUNTIME_ROLE": role,
+        "HERMES_HOME": home_text,
+        "HERMES_PROFILE": profile,
+        "HOME": home_text,
+    })
+    return environment
+
+
+def validate_runtime_layout(layout: RuntimeLayout) -> None:
+    """Verify that production, shadow, and release storage are disjoint.
+
+    The shadow profile may contain an absent, blank, or comment-only ``.env``;
+    any credential-bearing content fails closed.
+    """
+
+    if not isinstance(layout, RuntimeLayout):
+        raise SafetyViolation("runtime layout has the wrong type")
+
+    labelled_paths = {
+        "production profile home": Path(layout.prod_home),
+        "shadow profile home": Path(layout.shadow_home),
+        "release root": Path(layout.release_root),
+    }
+    resolved = {
+        label: path.resolve(strict=False) for label, path in labelled_paths.items()
+    }
+
+    items = list(resolved.items())
+    for index, (left_label, left) in enumerate(items):
+        for right_label, right in items[index + 1 :]:
+            if left == right or left in right.parents or right in left.parents:
+                raise SafetyViolation(
+                    "runtime paths must be disjoint: "
+                    f"{left_label} and {right_label} overlap"
+                )
+
+    for label, path in labelled_paths.items():
+        if not path.exists() or not path.is_dir():
+            raise SafetyViolation(f"{label} must be an existing directory")
+
+    shadow_home = labelled_paths["shadow profile home"]
+    for credential_name in (".env", "auth.json", "credentials.json"):
+        credential_file = shadow_home / credential_name
+        if not credential_file.exists():
+            continue
+        if credential_file.is_symlink() or not credential_file.is_file():
+            raise SafetyViolation(
+                f"shadow credential file is not empty: {credential_name}"
+            )
+        try:
+            size = credential_file.stat().st_size
+        except OSError as exc:
+            raise SafetyViolation("cannot inspect shadow credential file") from exc
+        if size > _MAX_SHADOW_CREDENTIAL_FILE_BYTES:
+            raise SafetyViolation(
+                f"shadow credential file is not empty: {credential_name}"
+            )
+        try:
+            text = credential_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            raise SafetyViolation("cannot read shadow credential file safely") from exc
+
+        if credential_name == ".env":
+            has_content = any(
+                line.strip() and not line.lstrip().startswith("#")
+                for line in text.splitlines()
+            )
+        else:
+            has_content = bool(text.strip())
+        if has_content:
+            raise SafetyViolation(
+                f"shadow credential file is not empty: {credential_name}"
+            )
+
+
+def execute_cutover(
+    spec: CutoverSpec,
+    runner: CommandRunner,
+    *,
+    base_environment: Mapping[str, str],
+) -> CutoverResult:
+    """Move one Telegram consumer from the old runtime to the pinned release.
+
+    The normal transition is deliberately explicit: one old consumer, then
+    zero consumers, then one new consumer.  Once stopping the old runtime has
+    been attempted, every failure invokes the exact rollback sequence encoded
+    in :func:`_rollback`.
+    """
+
+    _validate_cutover_spec(spec)
+    if not callable(runner):
+        raise SafetyViolation("command runner must be callable")
+
+    environment = sanitize_runtime_environment(
+        base_environment,
+        profile="grover-prod",
+        home=spec.prod_home,
+        role="prod",
+    )
+
+    active_consumer = _probe_consumers(
+        spec,
+        runner,
+        environment,
+        expected="one-known",
+    )
+    if active_consumer == spec.new_consumer_id:
+        _verify_health(
+            spec,
+            runner,
+            environment,
+            command=spec.commands.health_new,
+            expected_consumer=spec.new_consumer_id,
+            expected_release=spec.release_id,
+            label="new runtime",
+        )
+        receipt = _verify_receipt(spec, runner, environment)
+        return _cutover_result(spec, receipt, already_active=True)
+
+    if active_consumer != spec.old_consumer_id:  # defensive; probe already gates
+        raise SafetyViolation("probe must report exactly one known Telegram consumer")
+
+    rollback_required = False
+    try:
+        _run_command(
+            "disable new runtime", spec.commands.disable_new, runner, environment
+        )
+        _probe_consumers(
+            spec,
+            runner,
+            environment,
+            expected=(spec.old_consumer_id,),
+        )
+
+        # A command can mutate state before reporting a failure, so arm rollback
+        # immediately before attempting to stop the old consumer.
+        rollback_required = True
+        _run_command("stop old runtime", spec.commands.stop_old, runner, environment)
+        _probe_consumers(spec, runner, environment, expected=())
+
+        _run_command(
+            "enable new runtime", spec.commands.enable_new, runner, environment
+        )
+        _run_command("start new runtime", spec.commands.start_new, runner, environment)
+        _probe_consumers(
+            spec,
+            runner,
+            environment,
+            expected=(spec.new_consumer_id,),
+        )
+        _verify_health(
+            spec,
+            runner,
+            environment,
+            command=spec.commands.health_new,
+            expected_consumer=spec.new_consumer_id,
+            expected_release=spec.release_id,
+            label="new runtime",
+        )
+        receipt = _verify_receipt(spec, runner, environment)
+    except SafetyViolation as failure:
+        if not rollback_required:
+            raise
+        try:
+            _rollback(spec, runner, environment)
+        except SafetyViolation as rollback_failure:
+            raise SafetyViolation(
+                "cutover failed and rollback could not be verified"
+            ) from rollback_failure
+        raise CutoverRolledBack(str(failure)) from failure
+
+    return _cutover_result(spec, receipt, already_active=False)
+
+
+def _cutover_result(
+    spec: CutoverSpec,
+    receipt: dict[str, Any],
+    *,
+    already_active: bool,
+) -> CutoverResult:
+    return CutoverResult(
+        release_id=spec.release_id,
+        consumer_id=spec.new_consumer_id,
+        provider=receipt["provider"],
+        provider_message_id=receipt["provider_message_id"],
+        already_active=already_active,
+    )
+
+
+def _rollback(
+    spec: CutoverSpec,
+    runner: CommandRunner,
+    environment: Mapping[str, str],
+) -> None:
+    """Restore the old consumer using the non-negotiable rollback order."""
+
+    # Stop/disable commands may mutate state and then report failure. Continue
+    # through both attempts and trust only the subsequent independent consumer
+    # probe. Never restart the old consumer unless that probe proves zero.
+    for label, command in (
+        ("stop new runtime", spec.commands.stop_new),
+        ("disable new runtime", spec.commands.disable_new),
+    ):
+        try:
+            _run_command(label, command, runner, environment)
+        except SafetyViolation:
+            pass
+    _probe_consumers(spec, runner, environment, expected=())
+    _run_command("start old runtime", spec.commands.start_old, runner, environment)
+    _probe_consumers(
+        spec,
+        runner,
+        environment,
+        expected=(spec.old_consumer_id,),
+    )
+    _verify_health(
+        spec,
+        runner,
+        environment,
+        command=spec.commands.health_old,
+        expected_consumer=spec.old_consumer_id,
+        expected_release=None,
+        label="old runtime",
+    )
+
+
+def _probe_consumers(
+    spec: CutoverSpec,
+    runner: CommandRunner,
+    environment: Mapping[str, str],
+    *,
+    expected: str | tuple[str, ...],
+) -> str | None:
+    result = _run_command(
+        "Telegram consumer probe", spec.commands.probe, runner, environment
+    )
+    payload = _strict_json_object(result.stdout, "Telegram consumer probe")
+    pollers = payload.get("pollers")
+    if not isinstance(pollers, list) or any(
+        not isinstance(item, str) or not item for item in pollers
+    ):
+        raise SafetyViolation("Telegram consumer probe returned an invalid poller list")
+    if len(pollers) != len(set(pollers)):
+        raise SafetyViolation("probe must report exactly one known Telegram consumer")
+
+    known = {spec.old_consumer_id, spec.new_consumer_id}
+    if any(item not in known for item in pollers):
+        raise SafetyViolation("probe must report exactly one known Telegram consumer")
+
+    if expected == "one-known":
+        if len(pollers) != 1:
+            raise SafetyViolation(
+                "probe must report exactly one known Telegram consumer"
+            )
+        return pollers[0]
+
+    if len(pollers) != len(expected) or set(pollers) != set(expected):
+        if not expected:
+            raise SafetyViolation("Telegram consumer probe must report zero consumers")
+        raise SafetyViolation(
+            "probe must report exactly one known Telegram consumer: " + expected[0]
+        )
+    return pollers[0] if pollers else None
+
+
+def _verify_health(
+    spec: CutoverSpec,
+    runner: CommandRunner,
+    environment: Mapping[str, str],
+    *,
+    command: tuple[str, ...],
+    expected_consumer: str,
+    expected_release: str | None,
+    label: str,
+) -> None:
+    result = _run_command(f"{label} health", command, runner, environment)
+    try:
+        payload = _strict_json_object(result.stdout, f"{label} health")
+    except SafetyViolation as exc:
+        raise SafetyViolation(f"{label} health gate failed: {exc}") from exc
+
+    healthy = payload.get("healthy") is True
+    consumer_matches = payload.get("consumer_id") == expected_consumer
+    release_matches = (
+        expected_release is None or payload.get("release_id") == expected_release
+    )
+    if not (healthy and consumer_matches and release_matches):
+        raise SafetyViolation(f"{label} health gate failed")
+
+
+def _verify_receipt(
+    spec: CutoverSpec,
+    runner: CommandRunner,
+    environment: Mapping[str, str],
+) -> dict[str, Any]:
+    result = _run_command(
+        "provider delivery receipt", spec.commands.receipt, runner, environment
+    )
+    try:
+        payload = _strict_json_object(result.stdout, "provider delivery receipt")
+    except SafetyViolation as exc:
+        raise SafetyViolation(f"provider delivery receipt gate failed: {exc}") from exc
+
+    if payload.get("delivered") is not True:
+        raise SafetyViolation("provider delivery receipt gate failed")
+    if payload.get("release_id") != spec.release_id:
+        raise SafetyViolation("provider delivery receipt release gate failed")
+
+    provider = payload.get("provider")
+    identity_source = payload.get("identity_source")
+    provider_message_id = payload.get("provider_message_id")
+    if (
+        provider != "telegram"
+        or identity_source != "provider"
+        or not isinstance(provider_message_id, str)
+        or not provider_message_id.strip()
+    ):
+        raise SafetyViolation(
+            "delivery receipt is missing provider-native message identity"
+        )
+    return payload
+
+
+def _run_command(
+    label: str,
+    argv: tuple[str, ...],
+    runner: CommandRunner,
+    environment: Mapping[str, str],
+) -> CommandResult:
+    _validate_argv(argv, label)
+    try:
+        result = runner(argv, env=dict(environment))
+    except Exception as exc:
+        raise SafetyViolation(f"{label} command runner failed") from exc
+
+    if not isinstance(result, CommandResult):
+        raise SafetyViolation(f"{label} command returned an invalid result")
+    if isinstance(result.returncode, bool) or not isinstance(result.returncode, int):
+        raise SafetyViolation(f"{label} command returned an invalid exit code")
+    for stream_name, stream in (("stdout", result.stdout), ("stderr", result.stderr)):
+        if not isinstance(stream, str):
+            raise SafetyViolation(f"{label} command returned non-text {stream_name}")
+        if len(stream.encode("utf-8")) > _MAX_COMMAND_OUTPUT_BYTES:
+            raise SafetyViolation(f"{label} command {stream_name} exceeded the limit")
+    if result.returncode != 0:
+        raise SafetyViolation(
+            f"{label} command failed with exit code {result.returncode}"
+        )
+    return result
+
+
+def _strict_json_object(text: str, label: str) -> dict[str, Any]:
+    if not isinstance(text, str):
+        raise SafetyViolation(f"{label} did not return text JSON")
+    if len(text.encode("utf-8")) > _MAX_COMMAND_OUTPUT_BYTES:
+        raise SafetyViolation(f"{label} JSON exceeded the limit")
+
+    def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate JSON key: {key}")
+            result[key] = value
+        return result
+
+    def reject_constant(value: str) -> Any:
+        raise ValueError(f"non-finite JSON number: {value}")
+
+    def finite_float(value: str) -> float:
+        parsed = float(value)
+        if not math.isfinite(parsed):
+            raise ValueError("non-finite JSON number")
+        return parsed
+
+    try:
+        payload = json.loads(
+            text,
+            object_pairs_hook=reject_duplicate_keys,
+            parse_constant=reject_constant,
+            parse_float=finite_float,
+        )
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise SafetyViolation(f"{label} returned invalid strict JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise SafetyViolation(f"{label} JSON must be an object")
+    return payload
+
+
+def _validate_cutover_spec(spec: CutoverSpec) -> None:
+    if not isinstance(spec, CutoverSpec):
+        raise SafetyViolation("cutover spec has the wrong type")
+    _validate_identifier(spec.release_id, "release id")
+    _validate_identifier(spec.old_consumer_id, "old consumer id")
+    _validate_identifier(spec.new_consumer_id, "new consumer id")
+    if spec.old_consumer_id == spec.new_consumer_id:
+        raise SafetyViolation("old and new consumer ids must be different")
+    prod_home = Path(spec.prod_home)
+    if not prod_home.is_absolute():
+        raise SafetyViolation("production runtime home must be absolute")
+    _validate_environment_value(str(prod_home), "production runtime home")
+    if not isinstance(spec.commands, CutoverCommands):
+        raise SafetyViolation("cutover commands have the wrong type")
+    for name in (
+        "probe",
+        "disable_new",
+        "stop_old",
+        "enable_new",
+        "start_new",
+        "stop_new",
+        "start_old",
+        "health_new",
+        "health_old",
+        "receipt",
+    ):
+        _validate_argv(getattr(spec.commands, name), name)
+
+
+def _validate_argv(argv: tuple[str, ...], label: str) -> None:
+    if not isinstance(argv, tuple) or not argv:
+        raise SafetyViolation(f"{label} must be a non-empty fixed argv tuple")
+    if len(argv) > _MAX_ARGV_ITEMS:
+        raise SafetyViolation(f"{label} argv has too many items")
+    total = 0
+    for argument in argv:
+        if not isinstance(argument, str) or not argument or "\x00" in argument:
+            raise SafetyViolation(f"{label} argv contains an invalid argument")
+        size = len(argument.encode("utf-8"))
+        if size > _MAX_ARG_BYTES:
+            raise SafetyViolation(f"{label} argv argument exceeded the limit")
+        total += size + 1
+    if total > _MAX_ARGV_BYTES:
+        raise SafetyViolation(f"{label} argv exceeded the limit")
+
+
+def _validate_identifier(value: str, label: str) -> None:
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or value != value.strip()
+        or len(value.encode("utf-8")) > 256
+        or any(ord(character) < 32 for character in value)
+    ):
+        raise SafetyViolation(f"{label} is invalid")
+
+
+def _validate_environment_value(value: str, label: str) -> None:
+    if "\x00" in value or len(value.encode("utf-8")) > _MAX_ENV_VALUE_BYTES:
+        raise SafetyViolation(f"{label} environment value is invalid")

--- a/grover_runtime/profile_preparation.py
+++ b/grover_runtime/profile_preparation.py
@@ -1,0 +1,110 @@
+"""Credential-free preparation of the Mac Grover runtime profiles."""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import shlex
+import subprocess
+from collections.abc import Sequence
+
+
+_PREPARE = (
+    ("hermes", "profile", "create", "grover-prod", "--no-alias", "--no-skills"),
+    ("hermes", "profile", "create", "grover-shadow", "--no-alias", "--no-skills"),
+    (
+        "hermes",
+        "-p",
+        "grover-prod",
+        "config",
+        "set",
+        "gateway.platforms.telegram.enabled",
+        "false",
+    ),
+    (
+        "hermes",
+        "-p",
+        "grover-shadow",
+        "config",
+        "set",
+        "gateway.platforms.telegram.enabled",
+        "false",
+    ),
+    (
+        "hermes",
+        "-p",
+        "grover-shadow",
+        "config",
+        "set",
+        "gateway.platforms.telegram.extra.external_effects",
+        "false",
+    ),
+    (
+        "hermes",
+        "-p",
+        "grover-shadow",
+        "plugins",
+        "enable",
+        "grover-shadow-guard",
+        "--no-allow-tool-override",
+    ),
+)
+
+
+def build_profile_commands(operation: str) -> list[list[str]]:
+    """Return the reviewed command sequence without reading or copying secrets."""
+
+    if operation == "prepare":
+        commands = _PREPARE
+    elif operation == "cutover-prod":
+        raise ValueError(
+            "cutover requires grover_runtime.operations health and receipt gates"
+        )
+    else:
+        raise ValueError(f"unknown profile operation: {operation}")
+    return [list(command) for command in commands]
+
+
+def run_profile_commands(commands: Sequence[Sequence[str]]) -> None:
+    """Run a reviewed sequence on macOS without reusing existing profiles."""
+
+    if platform.system() != "Darwin":
+        raise RuntimeError(
+            "Grover runtime profiles may only be prepared on the Mac mini"
+        )
+    for command in commands:
+        completed = subprocess.run(
+            list(command),
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        if completed.returncode == 0:
+            continue
+        output = " ".join((completed.stdout, completed.stderr)).casefold()
+        if (
+            tuple(command[:3]) == ("hermes", "profile", "create")
+            and "already exists" in output
+        ):
+            raise RuntimeError(
+                "profile already exists; refusing to reuse existing credential state"
+            )
+        raise RuntimeError(f"profile command failed: {shlex.join(command)}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=("prepare",))
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+    commands = build_profile_commands(args.operation)
+    if args.dry_run:
+        for command in commands:
+            print(shlex.join(command))
+        return 0
+    run_profile_commands(commands)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/grover_runtime/release.py
+++ b/grover_runtime/release.py
@@ -1,0 +1,384 @@
+"""Deterministic, credential-free Grover release artifact construction."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import re
+import shutil
+import stat
+import tarfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+_COMMIT_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+_RELEASE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_MAX_RELEASE_FILE_BYTES = 64 * 1024 * 1024
+_MAX_RELEASE_BYTES = 256 * 1024 * 1024
+
+_MUTABLE_DIRECTORY_NAMES = frozenset({
+    ".git",
+    ".pytest_cache",
+    "__pycache__",
+    "browser_cache",
+    "cache",
+    "logs",
+    "sessions",
+})
+_MUTABLE_FILE_NAMES = frozenset({
+    ".env",
+    "auth.json",
+    "credentials.json",
+    "state.db",
+    "state.db-shm",
+    "state.db-wal",
+})
+
+
+@dataclass(frozen=True)
+class ReleaseSpec:
+    release_id: str
+    source_tree: Path
+    patch_file: Path
+    output_dir: Path
+    upstream_commit: str
+    rollback_target: str
+    required_paths: tuple[str, ...]
+    dependency_lock: str = "uv.lock"
+
+
+@dataclass(frozen=True)
+class ReleaseResult:
+    artifact: Path
+    manifest: Path
+    evidence: Path
+
+
+def create_release(spec: ReleaseSpec) -> ReleaseResult:
+    """Create a deterministic allowlisted tar plus manifest and evidence.
+
+    Inputs are fully validated and snapshotted before the exclusive output
+    directory is created.  No source path outside ``required_paths`` and the
+    dependency lock can enter the tar.
+    """
+
+    if not isinstance(spec, ReleaseSpec):
+        raise TypeError("release spec has the wrong type")
+    if not isinstance(spec.release_id, str) or not _RELEASE_ID_RE.fullmatch(
+        spec.release_id
+    ):
+        raise ValueError("release id is not a safe artifact name")
+    _validate_commit(spec.upstream_commit, "upstream commit")
+    _validate_commit(spec.rollback_target, "rollback target")
+
+    source_tree = Path(spec.source_tree)
+    patch_file = Path(spec.patch_file)
+    output_dir = Path(spec.output_dir)
+    if not source_tree.exists() or not source_tree.is_dir():
+        raise ValueError("release source tree is missing")
+    if patch_file.is_symlink() or not patch_file.is_file():
+        raise ValueError("release patch file is missing or not a regular file")
+    if output_dir.exists():
+        raise FileExistsError(str(output_dir))
+
+    required_paths = _normalize_required_paths(spec.required_paths)
+    lock_path = _normalize_relative_path(spec.dependency_lock, "dependency lock")
+    if _is_mutable_path(lock_path):
+        raise ValueError("dependency lock path is not release-safe")
+
+    source_root = source_tree.resolve(strict=True)
+    included_names = tuple(sorted(set(required_paths) | {lock_path}))
+    included_bytes: dict[str, bytes] = {}
+    total_bytes = 0
+    for relative_name in included_names:
+        purpose = (
+            "dependency lock" if relative_name == lock_path else "required release path"
+        )
+        source_file = _resolve_regular_source_file(
+            source_root,
+            relative_name,
+            purpose=purpose,
+        )
+        data = _bounded_read(source_file, purpose)
+        total_bytes += len(data)
+        if total_bytes > _MAX_RELEASE_BYTES:
+            raise ValueError("release allowlist exceeds the total size limit")
+        included_bytes[relative_name] = data
+
+    patch_bytes = _bounded_read(patch_file, "release patch")
+    patch_sha256 = _sha256_bytes(patch_bytes)
+    artifact_bytes = _build_deterministic_tar(included_bytes)
+    artifact_sha256 = _sha256_bytes(artifact_bytes)
+
+    files_manifest = {
+        name: {
+            "sha256": _sha256_bytes(data),
+            "size_bytes": len(data),
+        }
+        for name, data in sorted(included_bytes.items())
+    }
+    manifest_data: dict[str, Any] = {
+        "artifact": {
+            "format": "tar",
+            "path": "artifact.tar",
+            "sha256": artifact_sha256,
+        },
+        "artifact_sha256": artifact_sha256,
+        "dependency_lock": {
+            "path": lock_path,
+            "sha256": _sha256_bytes(included_bytes[lock_path]),
+            "size_bytes": len(included_bytes[lock_path]),
+        },
+        "files": files_manifest,
+        "patch": {
+            "path": patch_file.name,
+            "sha256": patch_sha256,
+            "size_bytes": len(patch_bytes),
+        },
+        "patch_sha256": patch_sha256,
+        "release_id": spec.release_id,
+        "required_paths": list(required_paths),
+        "rollback_target": spec.rollback_target.lower(),
+        "schema_version": "grover.release.v1",
+        "upstream_commit": spec.upstream_commit.lower(),
+    }
+    manifest_bytes = _canonical_json_bytes(manifest_data)
+    manifest_sha256 = _sha256_bytes(manifest_bytes)
+
+    all_source_files = _inventory_source_paths(source_root)
+    included_set = set(included_names)
+    evidence_data: dict[str, Any] = {
+        "artifact_sha256": artifact_sha256,
+        "excluded_paths": sorted(all_source_files - included_set),
+        "included_paths": list(included_names),
+        "manifest_sha256": manifest_sha256,
+        "patch_sha256": patch_sha256,
+        "release_id": spec.release_id,
+        "schema_version": "grover.release-evidence.v1",
+    }
+    evidence_bytes = _canonical_json_bytes(evidence_data)
+
+    artifact_path = output_dir / "artifact.tar"
+    manifest_path = output_dir / "manifest.json"
+    evidence_path = output_dir / "evidence.json"
+    try:
+        output_dir.mkdir(parents=True, exist_ok=False)
+        _exclusive_write(artifact_path, artifact_bytes)
+        _exclusive_write(manifest_path, manifest_bytes)
+        _exclusive_write(evidence_path, evidence_bytes)
+        for path in (artifact_path, manifest_path, evidence_path):
+            os.chmod(path, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+    except BaseException:
+        if output_dir.exists():
+            for path in (artifact_path, manifest_path, evidence_path):
+                try:
+                    os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+                except OSError:
+                    pass
+            shutil.rmtree(output_dir, ignore_errors=True)
+        raise
+
+    return ReleaseResult(
+        artifact=artifact_path,
+        manifest=manifest_path,
+        evidence=evidence_path,
+    )
+
+
+def verify_wheel_modules(
+    wheel: Path,
+    *,
+    required_modules: tuple[str, ...],
+) -> None:
+    """Verify exact, safe module members in a wheel without extracting it."""
+
+    wheel_path = Path(wheel)
+    if wheel_path.is_symlink() or not wheel_path.is_file():
+        raise ValueError("wheel is missing or not a regular file")
+    required = _normalize_required_paths(required_modules, reject_mutable=False)
+
+    try:
+        with zipfile.ZipFile(wheel_path, "r") as archive:
+            infos = archive.infolist()
+    except (OSError, zipfile.BadZipFile) as exc:
+        raise ValueError("wheel is not a valid zip archive") from exc
+
+    names: set[str] = set()
+    for info in infos:
+        raw_name = info.filename
+        candidate = (
+            raw_name[:-1] if info.is_dir() and raw_name.endswith("/") else raw_name
+        )
+        normalized = _normalize_relative_path(candidate, "wheel member")
+        if normalized in names:
+            raise ValueError("wheel contains duplicate members")
+        names.add(normalized)
+
+    missing = sorted(module for module in required if module not in names)
+    if missing:
+        raise ValueError("wheel is missing required modules: " + ", ".join(missing))
+
+
+def _validate_commit(value: str, label: str) -> None:
+    if not isinstance(value, str) or not _COMMIT_RE.fullmatch(value):
+        raise ValueError(f"{label} must be a 40-character commit hash")
+
+
+def _normalize_required_paths(
+    paths: tuple[str, ...],
+    *,
+    reject_mutable: bool = True,
+) -> tuple[str, ...]:
+    if not isinstance(paths, tuple) or not paths:
+        raise ValueError("required release paths must be a non-empty tuple")
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw_path in paths:
+        relative_name = _normalize_relative_path(raw_path, "required release path")
+        if relative_name in seen:
+            raise ValueError(f"duplicate required release path: {relative_name}")
+        if reject_mutable and _is_mutable_path(relative_name):
+            raise ValueError(
+                f"required release path is mutable or credential-bearing: {relative_name}"
+            )
+        seen.add(relative_name)
+        normalized.append(relative_name)
+    return tuple(sorted(normalized))
+
+
+def _normalize_relative_path(raw_path: str, label: str) -> str:
+    if (
+        not isinstance(raw_path, str)
+        or not raw_path
+        or raw_path != raw_path.strip()
+        or "\x00" in raw_path
+        or "\\" in raw_path
+        or len(raw_path.encode("utf-8")) > 4096
+    ):
+        raise ValueError(f"{label} is not a safe relative path")
+    path = PurePosixPath(raw_path)
+    if path.is_absolute() or re.match(r"^[A-Za-z]:", raw_path):
+        raise ValueError(f"{label} is not a safe relative path")
+    if any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"{label} is not a safe relative path")
+    normalized = path.as_posix()
+    if normalized != raw_path:
+        raise ValueError(f"{label} is not a canonical relative path")
+    return normalized
+
+
+def _is_mutable_path(relative_name: str) -> bool:
+    parts = PurePosixPath(relative_name).parts
+    lowered_parts = tuple(part.lower() for part in parts)
+    name = lowered_parts[-1]
+    if any(part in _MUTABLE_DIRECTORY_NAMES for part in lowered_parts[:-1]):
+        return True
+    if name in _MUTABLE_FILE_NAMES or name.startswith(".env."):
+        return True
+    return (
+        name.endswith(".db")
+        or name.endswith(".db-shm")
+        or name.endswith(".db-wal")
+        or name.endswith(".log")
+        or name.endswith(".pyc")
+        or name.endswith(".sqlite")
+        or name.endswith(".sqlite3")
+    )
+
+
+def _resolve_regular_source_file(
+    source_root: Path,
+    relative_name: str,
+    *,
+    purpose: str,
+) -> Path:
+    candidate = source_root.joinpath(*PurePosixPath(relative_name).parts)
+    cursor = source_root
+    for part in PurePosixPath(relative_name).parts:
+        cursor = cursor / part
+        if cursor.is_symlink():
+            if purpose == "required release path":
+                raise ValueError(
+                    f"required release path is not a regular file: {relative_name}"
+                )
+            raise ValueError(f"{purpose} is not a regular file: {relative_name}")
+    if not candidate.exists():
+        if purpose == "required release path":
+            raise ValueError(f"required release path is missing: {relative_name}")
+        raise ValueError(f"{purpose} is missing: {relative_name}")
+    try:
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(source_root)
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"{purpose} escapes the source tree: {relative_name}") from exc
+    if not resolved.is_file():
+        raise ValueError(f"{purpose} is not a regular file: {relative_name}")
+    return resolved
+
+
+def _bounded_read(path: Path, label: str) -> bytes:
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        raise ValueError(f"cannot inspect {label}") from exc
+    if size > _MAX_RELEASE_FILE_BYTES:
+        raise ValueError(f"{label} exceeds the file size limit")
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        raise ValueError(f"cannot read {label}") from exc
+    if len(data) != size or len(data) > _MAX_RELEASE_FILE_BYTES:
+        raise ValueError(f"{label} changed while being read")
+    return data
+
+
+def _build_deterministic_tar(files: dict[str, bytes]) -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w", format=tarfile.USTAR_FORMAT) as archive:
+        for name, data in sorted(files.items()):
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            info.mode = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
+            info.mtime = 0
+            info.uid = 0
+            info.gid = 0
+            info.uname = ""
+            info.gname = ""
+            archive.addfile(info, io.BytesIO(data))
+    return buffer.getvalue()
+
+
+def _inventory_source_paths(source_root: Path) -> set[str]:
+    paths: set[str] = set()
+    for path in source_root.rglob("*"):
+        if path.is_file() or path.is_symlink():
+            paths.add(path.relative_to(source_root).as_posix())
+    return paths
+
+
+def _canonical_json_bytes(value: dict[str, Any]) -> bytes:
+    return (
+        json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _exclusive_write(path: Path, data: bytes) -> None:
+    with path.open("xb") as handle:
+        handle.write(data)
+        handle.flush()
+        os.fsync(handle.fileno())

--- a/grover_runtime/release.py
+++ b/grover_runtime/release.py
@@ -56,6 +56,7 @@ class ReleaseResult:
     artifact: Path
     manifest: Path
     evidence: Path
+    patch: Path
 
 
 def create_release(spec: ReleaseSpec) -> ReleaseResult:
@@ -84,6 +85,9 @@ def create_release(spec: ReleaseSpec) -> ReleaseResult:
         raise ValueError("release patch file is missing or not a regular file")
     if output_dir.exists():
         raise FileExistsError(str(output_dir))
+    patch_name = _normalize_relative_path(patch_file.name, "release patch name")
+    if patch_name in {"artifact.tar", "manifest.json", "evidence.json"}:
+        raise ValueError("release patch name collides with a reserved artifact")
 
     required_paths = _normalize_required_paths(spec.required_paths)
     lock_path = _normalize_relative_path(spec.dependency_lock, "dependency lock")
@@ -135,7 +139,7 @@ def create_release(spec: ReleaseSpec) -> ReleaseResult:
         },
         "files": files_manifest,
         "patch": {
-            "path": patch_file.name,
+            "path": patch_name,
             "sha256": patch_sha256,
             "size_bytes": len(patch_bytes),
         },
@@ -165,16 +169,18 @@ def create_release(spec: ReleaseSpec) -> ReleaseResult:
     artifact_path = output_dir / "artifact.tar"
     manifest_path = output_dir / "manifest.json"
     evidence_path = output_dir / "evidence.json"
+    patch_path = output_dir / patch_name
     try:
         output_dir.mkdir(parents=True, exist_ok=False)
         _exclusive_write(artifact_path, artifact_bytes)
+        _exclusive_write(patch_path, patch_bytes)
         _exclusive_write(manifest_path, manifest_bytes)
         _exclusive_write(evidence_path, evidence_bytes)
-        for path in (artifact_path, manifest_path, evidence_path):
+        for path in (artifact_path, manifest_path, evidence_path, patch_path):
             os.chmod(path, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
     except BaseException:
         if output_dir.exists():
-            for path in (artifact_path, manifest_path, evidence_path):
+            for path in (artifact_path, manifest_path, evidence_path, patch_path):
                 try:
                     os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
                 except OSError:
@@ -186,6 +192,7 @@ def create_release(spec: ReleaseSpec) -> ReleaseResult:
         artifact=artifact_path,
         manifest=manifest_path,
         evidence=evidence_path,
+        patch=patch_path,
     )
 
 

--- a/grover_runtime/telegram_callbacks.py
+++ b/grover_runtime/telegram_callbacks.py
@@ -1,0 +1,156 @@
+"""Grizzly's narrow Telegram-to-Control-Plane callback bridge.
+
+Only opaque ``od:`` callbacks are consumed.  The callback contains no action,
+decision, or authorization data: the loopback action service resolves it
+against its server-owned, message-bound registry and returns the receipt that
+is mirrored into the same bot-owned Telegram card.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+_CALLBACK_RE = re.compile(r"^od:[A-Za-z0-9_-]{16,60}$")
+_CARD_REF_RE = re.compile(r"^TGC-[0-9a-f]{16}$")
+_RECEIPT_RE = re.compile(r"^ACT-[0-9a-f]{12}$")
+_ACTIONS = frozenset({"approve", "reject", "request_changes"})
+
+
+def _default_dependencies() -> tuple[Callable[[], Any], Callable[[dict], str]]:
+    from grover_runtime.action_service_client import (
+        ActionServiceClient,
+        render_shadow_card,
+    )
+
+    return ActionServiceClient, render_shadow_card
+
+
+async def _answer(query: Any, text: str) -> None:
+    try:
+        await query.answer(text=text, show_alert=True)
+    except Exception:
+        logger.debug("Telegram typed-action alert failed", exc_info=True)
+
+
+async def handle_typed_action_callback(
+    query: Any,
+    *,
+    is_authorized: Callable[..., bool],
+    client_factory: Callable[[], Any] | None = None,
+    render_receipt: Callable[[dict], str] | None = None,
+) -> bool:
+    """Resolve one opaque typed callback; return whether it was consumed.
+
+    ``act:`` and all other model-authored callback text deliberately return
+    ``False``.  Once an ``od:`` prefix is observed, every malformed,
+    unauthorized, unavailable, or invalid path is consumed and fails closed so
+    it can never fall through to generic model dispatch.
+    """
+
+    data = str(getattr(query, "data", "") or "")
+    if not data.startswith("od:"):
+        return False
+
+    message = getattr(query, "message", None)
+    user = getattr(query, "from_user", None)
+    chat = getattr(message, "chat", None)
+    chat_id = getattr(message, "chat_id", None)
+    message_id = getattr(message, "message_id", None)
+    thread_id = getattr(message, "message_thread_id", None)
+    user_id = str(getattr(user, "id", "") or "")
+    user_label = " ".join(
+        str(getattr(user, "first_name", None) or "Principal").split()
+    )[:60]
+
+    if not _CALLBACK_RE.fullmatch(data):
+        await _answer(query, "Could not record this decision. Nothing was executed.")
+        return True
+
+    try:
+        authorized = is_authorized(
+            user_id,
+            chat_id=chat_id,
+            chat_type=str(getattr(chat, "type", "") or "") or None,
+            thread_id=str(thread_id) if thread_id is not None else None,
+            user_name=getattr(user, "first_name", None),
+        )
+    except Exception:
+        logger.exception("Telegram typed-action authorization check failed closed")
+        await _answer(query, "Could not verify authorization. Nothing was executed.")
+        return True
+    if not authorized:
+        await _answer(query, "You are not authorized to resolve this action.")
+        return True
+
+    decision_recorded = False
+    try:
+        if client_factory is None or render_receipt is None:
+            default_factory, default_renderer = _default_dependencies()
+            client_factory = client_factory or default_factory
+            render_receipt = render_receipt or default_renderer
+        if chat_id is None or message_id is None or not user_id:
+            raise RuntimeError("typed callback is not bound to a Telegram message")
+
+        client = client_factory()
+        result = await asyncio.to_thread(
+            client.resolve_callback,
+            data,
+            str(chat_id),
+            str(message_id),
+            user_id,
+            user_label,
+        )
+        card_ref = str(result.get("card_ref") or "")
+        receipt_id = str(result.get("receipt_id") or "")
+        if (
+            result.get("mode") != "shadow"
+            or result.get("action") not in _ACTIONS
+            or not _CARD_REF_RE.fullmatch(card_ref)
+            or not _RECEIPT_RE.fullmatch(receipt_id)
+        ):
+            raise RuntimeError("typed action service returned an invalid receipt")
+        decision_recorded = True
+
+        pending_card = await asyncio.to_thread(
+            client.pending_card,
+            card_ref,
+            chat_id=str(chat_id),
+            thread_id=str(thread_id) if thread_id is not None else None,
+            message_id=str(message_id),
+            receipt_id=receipt_id,
+            action=str(result["action"]),
+        )
+        if pending_card is None:
+            raise RuntimeError("typed action receipt projection is pending")
+        receipt_html = render_receipt(pending_card)
+        await query.edit_message_text(
+            text=receipt_html,
+            parse_mode="HTML",
+            disable_web_page_preview=True,
+            reply_markup=None,
+        )
+        await asyncio.to_thread(client.mirrored, card_ref, receipt_id)
+        await _answer(query, "Recorded in SHADOW. Nothing was executed.")
+    except Exception:
+        logger.exception("Telegram typed-action callback failed closed")
+        if decision_recorded:
+            try:
+                await query.edit_message_reply_markup(reply_markup=None)
+            except Exception:
+                logger.debug(
+                    "Committed typed-action buttons need cleanup", exc_info=True
+                )
+            await _answer(
+                query,
+                "Recorded in SHADOW; receipt sync pending. Nothing was executed.",
+            )
+        else:
+            await _answer(
+                query, "Could not record this decision. Nothing was executed."
+            )
+    return True

--- a/plugins/grover_shadow_guard/__init__.py
+++ b/plugins/grover_shadow_guard/__init__.py
@@ -1,0 +1,84 @@
+"""Mechanical external-effect guard for the clean Grover shadow runtime."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from functools import partial
+from typing import Any
+
+_BLOCK_MESSAGE = "grover-shadow is mechanically external-effect-free"
+_EXECUTION_ERROR = {"error": "grover-shadow external effects disabled"}
+
+
+def _is_shadow_runtime() -> bool:
+    return (
+        os.environ.get("HERMES_PROFILE", "").strip().lower() == "grover-shadow"
+        or os.environ.get("GROVER_RUNTIME_ROLE", "").strip().lower() == "shadow"
+    )
+
+
+def _on_pre_tool_call(
+    tool_name: str = "",
+    args: Any = None,
+    *,
+    _force_shadow: bool = False,
+    **_: Any,
+) -> dict[str, str] | None:
+    """Block every tool at the policy boundary in the shadow runtime."""
+
+    del tool_name, args
+    if not (_force_shadow or _is_shadow_runtime()):
+        return None
+    return {"action": "block", "message": _BLOCK_MESSAGE}
+
+
+def _on_llm_execution(
+    request: dict[str, Any],
+    next_call: Callable[[dict[str, Any]], Any],
+    *,
+    _force_shadow: bool = False,
+    **_: Any,
+) -> Any:
+    """Stop provider execution before ``next_call`` in shadow mode."""
+
+    if _force_shadow or _is_shadow_runtime():
+        return dict(_EXECUTION_ERROR)
+    return next_call(request)
+
+
+def _on_tool_execution(
+    tool_name: str,
+    args: dict[str, Any],
+    next_call: Callable[[dict[str, Any]], Any],
+    *,
+    _force_shadow: bool = False,
+    **_: Any,
+) -> Any:
+    """Stop tool execution before ``next_call`` in shadow mode."""
+
+    del tool_name
+    if _force_shadow or _is_shadow_runtime():
+        return dict(_EXECUTION_ERROR)
+    return next_call(args)
+
+
+def register(context: Any) -> None:
+    """Register both the policy hook and behavior-changing execution guards."""
+
+    profile_name = getattr(context, "profile_name", None)
+    if not isinstance(profile_name, str) or profile_name.casefold() != "grover-shadow":
+        raise RuntimeError("grover-shadow-guard may only be enabled for grover-shadow")
+
+    context.register_hook(
+        "pre_tool_call",
+        partial(_on_pre_tool_call, _force_shadow=True),
+    )
+    context.register_middleware(
+        "llm_execution",
+        partial(_on_llm_execution, _force_shadow=True),
+    )
+    context.register_middleware(
+        "tool_execution",
+        partial(_on_tool_execution, _force_shadow=True),
+    )

--- a/plugins/grover_shadow_guard/plugin.yaml
+++ b/plugins/grover_shadow_guard/plugin.yaml
@@ -1,0 +1,10 @@
+name: grover-shadow-guard
+version: "0.1.0"
+description: "Mechanically blocks LLM and tool external effects in the Grover shadow runtime."
+author: "Grizzly"
+kind: standalone
+hooks:
+  - pre_tool_call
+middleware:
+  - llm_execution
+  - tool_execution

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -22,6 +22,11 @@ from contextvars import ContextVar
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
 
+from grover_runtime.telegram_callbacks import handle_typed_action_callback
+
+# Backward-compatible integration name used by the Grover shadow guard.
+handle_typed_telegram_callback = handle_typed_action_callback
+
 logger = logging.getLogger(__name__)
 
 
@@ -861,6 +866,20 @@ class TelegramAdapter(BasePlatformAdapter):
         # API call (e.g. a set_my_commands stall for certain tokens) cannot
         # blow the gateway's connect timeout (#46298).
         self._post_connect_task: Optional[asyncio.Task] = None
+
+    @property
+    def external_effects_allowed(self) -> bool:
+        """Return whether this runtime may call Telegram at all.
+
+        The value must be the literal boolean ``True``. Missing configuration
+        preserves the normal adapter default; malformed or explicit false
+        values fail closed. This is an effect boundary, not an authorization
+        hint, and is checked again on every outbound or polling entry point.
+        """
+        extra = getattr(getattr(self, "config", None), "extra", None)
+        if not isinstance(extra, dict) or "external_effects" not in extra:
+            return True
+        return extra["external_effects"] is True
 
     def _mark_connected(self) -> None:
         self._drop_delayed_deliveries = False
@@ -2349,6 +2368,18 @@ class TelegramAdapter(BasePlatformAdapter):
                 return False
             raise
 
+    def _drop_pending_updates(self, *, is_reconnect: bool) -> bool:
+        """Choose whether startup may discard Telegram's pending update queue."""
+        if is_reconnect:
+            return False
+        extra = getattr(self.config, "extra", None)
+        if (
+            isinstance(extra, dict)
+            and extra.get("preserve_pending_updates_on_start") is True
+        ):
+            return False
+        return True
+
     async def _start_polling_resilient(
         self,
         *,
@@ -3597,6 +3628,15 @@ class TelegramAdapter(BasePlatformAdapter):
                                     all interfaces IPv4+IPv6)
             TELEGRAM_WEBHOOK_SECRET Secret token for update verification
         """
+        if not self.external_effects_allowed:
+            logger.error("[%s] Telegram external effects are mechanically disabled", self.name)
+            self._set_fatal_error(
+                "external_effects_disabled",
+                "Telegram external effects are mechanically disabled",
+                retryable=False,
+            )
+            return False
+
         # Explicit connect() is the only operation allowed to reopen polling
         # after a completed, serialized teardown. Background recovery never
         # clears this fence.
@@ -3985,7 +4025,9 @@ class TelegramAdapter(BasePlatformAdapter):
                     # server-side getUpdates queue, so this flag is a no-op
                     # in practice. Mirror the polling path's reconnect
                     # semantics for consistency.
-                    drop_pending_updates=not is_reconnect,
+                    drop_pending_updates=self._drop_pending_updates(
+                        is_reconnect=is_reconnect
+                    ),
                 )
                 self._webhook_mode = True
                 self._polling_progress_accepting = False
@@ -4042,7 +4084,9 @@ class TelegramAdapter(BasePlatformAdapter):
                     # On a cold first boot drop the stale Bot API queue; on a
                     # watcher reconnect after an outage preserve it so messages
                     # sent while the bot was offline are delivered (#46621).
-                    drop_pending_updates=not is_reconnect,
+                    drop_pending_updates=self._drop_pending_updates(
+                        is_reconnect=is_reconnect
+                    ),
                     error_callback=_polling_error_callback,
                     require_progress=not is_reconnect,
                 )
@@ -4326,6 +4370,11 @@ class TelegramAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None
     ) -> SendResult:
         """Send a message to a Telegram chat."""
+        if not self.external_effects_allowed:
+            return SendResult(
+                success=False,
+                error="external_effects_disabled",
+            )
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
@@ -6203,6 +6252,8 @@ class TelegramAdapter(BasePlatformAdapter):
         query = update.callback_query
         if not query or not query.data:
             return
+        if not self.external_effects_allowed:
+            return
         data = query.data
         query_message = getattr(query, "message", None)
         query_chat_id = getattr(query_message, "chat_id", None)
@@ -6210,6 +6261,16 @@ class TelegramAdapter(BasePlatformAdapter):
         query_chat_type = getattr(query_chat, "type", None)
         query_thread_id = getattr(query_message, "message_thread_id", None)
         query_user_name = getattr(query.from_user, "first_name", None)
+
+        # Grizzly shared-decision buttons carry only an opaque, one-card token.
+        # Resolve them before any built-in callback dispatch so they can never
+        # fall through as model-authored action text.  The bridge consumes every
+        # ``od:`` failure and fails closed; unrelated callbacks return False.
+        if await handle_typed_action_callback(
+            query,
+            is_authorized=self._is_callback_user_authorized,
+        ):
+            return
 
         # --- Model picker callbacks ---
         if data.startswith(("mp:", "mpg:", "mpv:", "mm:", "mc:", "mb", "mx", "mg:")):
@@ -9842,6 +9903,10 @@ async def _standalone_send(
     parse-mode fallback). Implements the standalone_sender_fn contract so
     deliver=telegram cron jobs succeed when cron runs separately from the
     gateway."""
+    extra = getattr(pconfig, "extra", None)
+    if isinstance(extra, dict) and "external_effects" in extra:
+        if extra["external_effects"] is not True:
+            return {"error": "external_effects_disabled"}
     token = getattr(pconfig, "token", None) or os.getenv("TELEGRAM_BOT_TOKEN", "")
     disable_link_previews = bool(
         getattr(pconfig, "extra", {}) and pconfig.extra.get("disable_link_previews")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -349,10 +349,11 @@ hermes-acp = "acp_adapter.entry:main"
 py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "utils", "mcp_serve"]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*", "grover_runtime", "grover_runtime.*"]
 
 [tool.setuptools.package-data]
 hermes_cli = ["observability/schemas/*.json"]
+"plugins.grover_shadow_guard" = ["plugin.yaml"]
 # gateway/assets/ ships status_phrases.yaml and the Telegram BotFather
 # screenshot. Without this, sealed venvs (uv2nix) silently lose both —
 # status phrases fall back to the tiny hardcoded set and the Telegram

--- a/tests/gateway/test_grizzly_shadow_inert.py
+++ b/tests/gateway/test_grizzly_shadow_inert.py
@@ -1,0 +1,146 @@
+"""Mechanical no-effect guarantees for the credential-free shadow runtime."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+os.environ.setdefault("LOCALAPPDATA", os.getcwd())
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
+
+
+@pytest.fixture
+def telegram_module():
+    return importlib.import_module("plugins.platforms.telegram.adapter")
+
+
+def _config(*, external_effects=...):
+    extra = {}
+    if external_effects is not ...:
+        extra["external_effects"] = external_effects
+    return PlatformConfig(enabled=True, token="x", extra=extra)
+
+
+def test_shadow_policy_is_explicit_fail_closed_and_prod_default_is_unchanged(
+    telegram_module,
+):
+    adapter_type = telegram_module.TelegramAdapter
+
+    assert adapter_type(_config()).external_effects_allowed is True
+    assert (
+        adapter_type(_config(external_effects=False)).external_effects_allowed is False
+    )
+    assert (
+        adapter_type(_config(external_effects="not-a-boolean")).external_effects_allowed
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_shadow_connect_never_builds_application_or_starts_polling(
+    telegram_module, monkeypatch
+):
+    adapter = telegram_module.TelegramAdapter(_config(external_effects=False))
+    builder = Mock(
+        side_effect=AssertionError(
+            "Telegram application construction is an external path"
+        )
+    )
+    monkeypatch.setattr(
+        telegram_module, "Application", SimpleNamespace(builder=builder)
+    )
+
+    connected = await adapter.connect()
+
+    assert connected is False
+    builder.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_shadow_direct_send_is_denied_before_any_bot_call(
+    telegram_module, monkeypatch
+):
+    adapter = telegram_module.TelegramAdapter(_config(external_effects=False))
+    adapter._bot = object()
+    low_level_send = AsyncMock(
+        return_value=(SimpleNamespace(message_id=777), None, None)
+    )
+    monkeypatch.setattr(adapter, "_send_message_with_thread_fallback", low_level_send)
+
+    result = await adapter.send("123", "must not leave shadow")
+
+    assert isinstance(result, SendResult)
+    assert result.success is False
+    assert result.error == "external_effects_disabled"
+    low_level_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shadow_callback_neither_resolves_answers_nor_edits(
+    telegram_module, monkeypatch
+):
+    adapter = telegram_module.TelegramAdapter(_config(external_effects=False))
+    query = SimpleNamespace(
+        data="od:" + "A" * 20 + ":approve",
+        answer=AsyncMock(),
+        edit_message_text=AsyncMock(),
+        message=SimpleNamespace(chat_id=123, message_id=456),
+        from_user=SimpleNamespace(id=789),
+    )
+    bridge = AsyncMock(
+        side_effect=AssertionError("shadow callback reached Control Plane")
+    )
+    monkeypatch.setattr(telegram_module, "handle_typed_telegram_callback", bridge)
+
+    await adapter._handle_callback_query(SimpleNamespace(callback_query=query), None)
+
+    bridge.assert_not_awaited()
+    query.answer.assert_not_awaited()
+    query.edit_message_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shadow_standalone_send_is_denied_before_provider_call(
+    telegram_module, monkeypatch
+):
+    provider_send = AsyncMock(
+        side_effect=AssertionError("shadow reached Telegram provider")
+    )
+    monkeypatch.setattr("tools.send_message_tool._send_telegram", provider_send)
+
+    result = await telegram_module._standalone_send(
+        _config(external_effects=False),
+        "123",
+        "must not leave shadow",
+    )
+
+    assert result == {"error": "external_effects_disabled"}
+    provider_send.assert_not_awaited()
+
+
+def test_cutover_profile_can_preserve_updates_queued_during_single_consumer_handoff(
+    telegram_module,
+):
+    adapter = telegram_module.TelegramAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="token",
+            extra={"preserve_pending_updates_on_start": True},
+        )
+    )
+
+    assert adapter._drop_pending_updates(is_reconnect=False) is False
+    assert adapter._drop_pending_updates(is_reconnect=True) is False
+
+
+def test_normal_prod_start_keeps_upstream_drop_pending_default(telegram_module):
+    adapter = telegram_module.TelegramAdapter(_config())
+
+    assert adapter._drop_pending_updates(is_reconnect=False) is True
+    assert adapter._drop_pending_updates(is_reconnect=True) is False

--- a/tests/gateway/test_grizzly_typed_telegram_callback.py
+++ b/tests/gateway/test_grizzly_typed_telegram_callback.py
@@ -1,0 +1,262 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from grover_runtime.telegram_callbacks import (
+    _default_dependencies,
+    handle_typed_action_callback,
+)
+
+
+CALLBACK = "od:" + "A" * 24
+CARD_REF = "TGC-0123456789abcdef"
+RECEIPT_ID = "ACT-0123456789ab"
+
+
+def test_default_bridge_dependencies_are_carried_by_the_pinned_runtime():
+    factory, renderer = _default_dependencies()
+
+    assert factory.__module__ == "grover_runtime.action_service_client"
+    assert renderer.__module__ == "grover_runtime.action_service_client"
+
+
+def _query(data=CALLBACK):
+    return SimpleNamespace(
+        data=data,
+        from_user=SimpleNamespace(id=123456, first_name="Kevin"),
+        message=SimpleNamespace(
+            chat_id=-1004474237403,
+            message_id=321,
+            message_thread_id=91,
+            text="Decision",
+            chat=SimpleNamespace(type="supergroup"),
+        ),
+        answer=AsyncMock(),
+        edit_message_text=AsyncMock(),
+        edit_message_reply_markup=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_opaque_callback_resolves_server_action_and_mirrors_exact_receipt():
+    query = _query()
+    client = Mock()
+    client.resolve_callback.return_value = {
+        "card_ref": CARD_REF,
+        "receipt_id": RECEIPT_ID,
+        "action": "approve",
+        "mode": "shadow",
+    }
+    pending = {
+        "card_ref": CARD_REF,
+        "binding": {
+            "chat_id": "-1004474237403",
+            "thread_id": "91",
+            "message_id": "321",
+            "card_html": "<b>Decision</b>",
+        },
+        "resolution": {
+            "receipt_id": RECEIPT_ID,
+            "action": "approve",
+            "actor_label": "Kevin",
+            "mode": "shadow",
+        },
+    }
+    client.pending_card.return_value = pending
+    render = Mock(return_value="<b>Decision</b>\n\n<b>SHADOW RECEIPT</b>")
+
+    handled = await handle_typed_action_callback(
+        query,
+        is_authorized=lambda *_args, **_kwargs: True,
+        client_factory=lambda: client,
+        render_receipt=render,
+    )
+
+    assert handled is True
+    client.resolve_callback.assert_called_once_with(
+        CALLBACK, "-1004474237403", "321", "123456", "Kevin"
+    )
+    client.pending_card.assert_called_once_with(
+        CARD_REF,
+        chat_id="-1004474237403",
+        thread_id="91",
+        message_id="321",
+        receipt_id=RECEIPT_ID,
+        action="approve",
+    )
+    client.mirrored.assert_called_once_with(CARD_REF, RECEIPT_ID)
+    query.edit_message_text.assert_awaited_once_with(
+        text="<b>Decision</b>\n\n<b>SHADOW RECEIPT</b>",
+        parse_mode="HTML",
+        disable_web_page_preview=True,
+        reply_markup=None,
+    )
+    query.answer.assert_awaited_once_with(
+        text="Recorded in SHADOW. Nothing was executed.", show_alert=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_arbitrary_act_text_is_not_a_typed_callback():
+    query = _query("act:approve this arbitrary request")
+
+    handled = await handle_typed_action_callback(
+        query,
+        is_authorized=lambda *_args, **_kwargs: True,
+        client_factory=Mock(),
+        render_receipt=Mock(),
+    )
+
+    assert handled is False
+    query.answer.assert_not_awaited()
+    query.edit_message_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_opaque_callback_fails_closed_before_server_resolution():
+    query = _query()
+    client_factory = Mock()
+
+    handled = await handle_typed_action_callback(
+        query,
+        is_authorized=lambda *_args, **_kwargs: False,
+        client_factory=client_factory,
+        render_receipt=Mock(),
+    )
+
+    assert handled is True
+    client_factory.assert_not_called()
+    query.answer.assert_awaited_once_with(
+        text="You are not authorized to resolve this action.", show_alert=True
+    )
+    query.edit_message_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_authorization_failure_is_consumed_and_fails_closed():
+    query = _query()
+    client_factory = Mock()
+
+    def broken_authorization(*_args, **_kwargs):
+        raise RuntimeError("authorization backend unavailable")
+
+    handled = await handle_typed_action_callback(
+        query,
+        is_authorized=broken_authorization,
+        client_factory=client_factory,
+        render_receipt=Mock(),
+    )
+
+    assert handled is True
+    client_factory.assert_not_called()
+    query.edit_message_text.assert_not_awaited()
+    query.answer.assert_awaited_once_with(
+        text="Could not verify authorization. Nothing was executed.", show_alert=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_malformed_or_unknown_opaque_callback_fails_closed_without_receipt():
+    for data in ("od:short", CALLBACK):
+        query = _query(data)
+        client = Mock()
+        client.resolve_callback.side_effect = RuntimeError("secret server detail")
+
+        handled = await handle_typed_action_callback(
+            query,
+            is_authorized=lambda *_args, **_kwargs: True,
+            client_factory=lambda: client,
+            render_receipt=Mock(),
+        )
+
+        assert handled is True
+        query.edit_message_text.assert_not_awaited()
+        query.answer.assert_awaited_once_with(
+            text="Could not record this decision. Nothing was executed.",
+            show_alert=True,
+        )
+        assert "secret server detail" not in query.answer.await_args.kwargs["text"]
+
+
+@pytest.mark.asyncio
+async def test_expired_callback_fails_closed_without_edit_or_mirror():
+    query = _query()
+    client = Mock()
+    client.resolve_callback.side_effect = RuntimeError("HTTP 404 expired")
+
+    handled = await handle_typed_action_callback(
+        query,
+        is_authorized=lambda *_args, **_kwargs: True,
+        client_factory=lambda: client,
+        render_receipt=Mock(),
+    )
+
+    assert handled is True
+    client.pending_card.assert_not_called()
+    client.mirrored.assert_not_called()
+    query.edit_message_text.assert_not_awaited()
+    query.answer.assert_awaited_once_with(
+        text="Could not record this decision. Nothing was executed.", show_alert=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_wrong_thread_or_tampered_receipt_stays_pending_and_removes_buttons():
+    query = _query()
+    client = Mock()
+    client.resolve_callback.return_value = {
+        "card_ref": CARD_REF,
+        "receipt_id": RECEIPT_ID,
+        "action": "approve",
+        "mode": "shadow",
+    }
+    client.pending_card.side_effect = RuntimeError(
+        "pending receipt does not match callback"
+    )
+
+    handled = await handle_typed_action_callback(
+        query,
+        is_authorized=lambda *_args, **_kwargs: True,
+        client_factory=lambda: client,
+        render_receipt=Mock(),
+    )
+
+    assert handled is True
+    client.pending_card.assert_called_once_with(
+        CARD_REF,
+        chat_id="-1004474237403",
+        thread_id="91",
+        message_id="321",
+        receipt_id=RECEIPT_ID,
+        action="approve",
+    )
+    client.mirrored.assert_not_called()
+    query.edit_message_text.assert_not_awaited()
+    query.edit_message_reply_markup.assert_awaited_once_with(reply_markup=None)
+    query.answer.assert_awaited_once_with(
+        text="Recorded in SHADOW; receipt sync pending. Nothing was executed.",
+        show_alert=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_telegram_adapter_routes_opaque_callback_before_builtin_dispatch(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+    from plugins.platforms.telegram import adapter as telegram_adapter
+
+    bridge = AsyncMock(return_value=True)
+    monkeypatch.setattr(telegram_adapter, "handle_typed_action_callback", bridge)
+    adapter = object.__new__(telegram_adapter.TelegramAdapter)
+    adapter._is_callback_user_authorized = Mock(return_value=True)
+    query = _query()
+    update = SimpleNamespace(callback_query=query)
+
+    await adapter._handle_callback_query(update, SimpleNamespace())
+
+    bridge.assert_awaited_once_with(
+        query,
+        is_authorized=adapter._is_callback_user_authorized,
+    )

--- a/tests/test_grover_action_service_client.py
+++ b/tests/test_grover_action_service_client.py
@@ -1,0 +1,334 @@
+import io
+import json
+import os
+import stat
+import urllib.error
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import grover_runtime.action_service_client as action_service_client
+from grover_runtime.action_service_client import (
+    ActionServiceClient,
+    ActionServiceError,
+    render_shadow_card,
+)
+
+
+class RecordingOpener:
+    def __init__(self, payload):
+        self.payload = payload
+        self.request = None
+        self.timeout = None
+
+    def open(self, request, timeout):
+        self.request = request
+        self.timeout = timeout
+        return SimpleNamespace(
+            read=lambda _limit: json.dumps(self.payload).encode(),
+            geturl=lambda: request.full_url,
+        )
+
+
+class RawResponseOpener:
+    def __init__(self, body: bytes):
+        self.body = body
+
+    def open(self, request, timeout):
+        return SimpleNamespace(
+            read=lambda _limit: self.body,
+            geturl=lambda: request.full_url,
+        )
+
+
+def _token(tmp_path):
+    path = tmp_path / "bridge-token"
+    path.write_text("T" * 48, encoding="utf-8")
+    path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    return path
+
+
+def test_resolve_uses_owner_token_and_typed_message_context(tmp_path):
+    payload = {
+        "card_ref": "TGC-0123456789abcdef",
+        "receipt_id": "ACT-0123456789ab",
+        "action": "approve",
+        "mode": "shadow",
+    }
+    opener = RecordingOpener(payload)
+    client = ActionServiceClient(token_path=_token(tmp_path), opener=opener)
+
+    assert (
+        client.resolve_callback(
+            "od:" + "A" * 24, "-1004474237403", "321", "123456", "Kevin"
+        )
+        == payload
+    )
+
+    assert opener.request.full_url == "http://127.0.0.1:8791/api/v1/telegram/resolve"
+    assert opener.request.get_header("X-action-bridge-token") == "T" * 48
+    assert json.loads(opener.request.data) == {
+        "callback": "od:" + "A" * 24,
+        "chat_id": "-1004474237403",
+        "message_id": "321",
+        "telegram_user_id": "123456",
+        "actor_label": "Kevin",
+    }
+
+
+def test_world_readable_bridge_token_is_rejected_before_network(tmp_path):
+    if os.name == "nt":
+        pytest.skip("Windows does not expose POSIX owner-only mode bits")
+    token_path = _token(tmp_path)
+    token_path.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IROTH)
+    opener = RecordingOpener({})
+    client = ActionServiceClient(token_path=token_path, opener=opener)
+
+    with pytest.raises(ActionServiceError, match="owner-only"):
+        client.pending()
+
+    assert opener.request is None
+
+
+def test_secure_token_loader_reads_from_one_descriptor_without_path_toctou(
+    tmp_path, monkeypatch
+):
+    token_path = _token(tmp_path)
+    original = "T" * 48
+    replacement = "A" * 48
+    real_stat = Path.stat
+    swapped = False
+
+    def swapping_stat(path, *args, **kwargs):
+        nonlocal swapped
+        result = real_stat(path, *args, **kwargs)
+        if path == token_path and not swapped:
+            swapped = True
+            token_path.unlink()
+            token_path.write_text(replacement, encoding="utf-8")
+        return result
+
+    monkeypatch.setattr(Path, "stat", swapping_stat)
+
+    assert ActionServiceClient(token_path=token_path)._read_owner_token() == original
+    assert swapped is False, "secure descriptor reads must not stat then reopen by path"
+
+
+def test_secure_token_loader_validates_the_open_descriptor_not_a_path_snapshot(
+    tmp_path, monkeypatch
+):
+    token_path = _token(tmp_path)
+    real_fstat = action_service_client.os.fstat
+
+    def insecure_fstat(fd):
+        current = real_fstat(fd)
+        return SimpleNamespace(
+            st_uid=getattr(current, "st_uid", 0) + 1,
+            st_mode=stat.S_IFREG | 0o644,
+            st_size=current.st_size,
+        )
+
+    monkeypatch.setattr(action_service_client.os, "name", "posix")
+    monkeypatch.setattr(action_service_client.os, "fstat", insecure_fstat)
+
+    with pytest.raises(ActionServiceError, match="owner mismatch"):
+        ActionServiceClient(token_path=token_path)._read_owner_token()
+
+
+def test_http_error_body_is_not_exposed(tmp_path):
+    class FailingOpener:
+        def open(self, _request, timeout):
+            raise urllib.error.HTTPError(
+                "http://127.0.0.1:8791/api/v1/telegram/pending",
+                500,
+                "failed",
+                {},
+                io.BytesIO(b"private service detail"),
+            )
+
+    client = ActionServiceClient(token_path=_token(tmp_path), opener=FailingOpener())
+
+    with pytest.raises(ActionServiceError) as caught:
+        client.pending()
+
+    assert "HTTP 500" in str(caught.value)
+    assert "private service detail" not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        b'{"mode":"prod","mode":"shadow","items":[]}',
+        b'{"mode":"shadow","items":[],"score":NaN}',
+        b'{"mode":"shadow","items":[],"score":Infinity}',
+    ],
+)
+def test_ambiguous_or_non_finite_service_json_is_rejected(tmp_path, body):
+    client = ActionServiceClient(
+        token_path=_token(tmp_path), opener=RawResponseOpener(body)
+    )
+
+    with pytest.raises(ActionServiceError, match="response is invalid"):
+        client.pending()
+
+
+@pytest.mark.parametrize(
+    "response_url",
+    [
+        "http://attacker.example/api/v1/telegram/pending",
+        "http://127.0.0.1:8791/api/v1/telegram/mirrored",
+        "http://localhost:8791/api/v1/telegram/pending",
+    ],
+)
+def test_redirected_or_non_exact_loopback_response_is_rejected(tmp_path, response_url):
+    class RedirectingOpener:
+        def open(self, request, timeout):
+            return SimpleNamespace(
+                read=lambda _limit: b'{"mode":"shadow","items":[]}',
+                geturl=lambda: response_url,
+            )
+
+    client = ActionServiceClient(
+        token_path=_token(tmp_path), opener=RedirectingOpener()
+    )
+
+    with pytest.raises(ActionServiceError, match="unexpected endpoint"):
+        client.pending()
+
+
+def test_default_transport_ignores_environment_proxies_and_redirects(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HTTP_PROXY", "http://attacker.example:8080")
+    monkeypatch.setenv("HTTPS_PROXY", "http://attacker.example:8080")
+
+    client = ActionServiceClient(token_path=_token(tmp_path))
+
+    proxy_handlers = [
+        handler
+        for handler in client.opener.handlers
+        if isinstance(handler, urllib.request.ProxyHandler)
+    ]
+    # build_opener intentionally omits an empty ProxyHandler from its final
+    # chain. Its absence proves urllib did not install the environment-backed
+    # default handler.
+    assert proxy_handlers == []
+    assert any(
+        handler.__class__.__name__ == "_NoRedirect"
+        for handler in client.opener.handlers
+    )
+
+
+def _pending_item():
+    return {
+        "card_ref": "TGC-0123456789abcdef",
+        "binding": {
+            "chat_id": "-1004474237403",
+            "thread_id": "91",
+            "message_id": "321",
+            "card_html": "<b>Decision</b>",
+        },
+        "resolution": {
+            "receipt_id": "ACT-0123456789ab",
+            "action": "approve",
+            "actor_label": "Kevin",
+            "surface": "telegram",
+            "mode": "shadow",
+        },
+    }
+
+
+def test_pending_card_is_bound_to_exact_route_and_receipt(tmp_path):
+    pending = _pending_item()
+    client = ActionServiceClient(
+        token_path=_token(tmp_path),
+        opener=RecordingOpener({"mode": "shadow", "items": [pending]}),
+    )
+
+    assert (
+        client.pending_card(
+            "TGC-0123456789abcdef",
+            chat_id="-1004474237403",
+            thread_id="91",
+            message_id="321",
+            receipt_id="ACT-0123456789ab",
+            action="approve",
+        )
+        == pending
+    )
+
+
+def test_pending_card_accepts_a_bound_non_topic_message(tmp_path):
+    pending = _pending_item()
+    pending["binding"]["thread_id"] = None
+    client = ActionServiceClient(
+        token_path=_token(tmp_path),
+        opener=RecordingOpener({"mode": "shadow", "items": [pending]}),
+    )
+
+    assert (
+        client.pending_card(
+            "TGC-0123456789abcdef",
+            chat_id="-1004474237403",
+            thread_id=None,
+            message_id="321",
+            receipt_id="ACT-0123456789ab",
+            action="approve",
+        )
+        == pending
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("chat_id", "-1009999999999"),
+        ("thread_id", "92"),
+        ("message_id", "322"),
+        ("receipt_id", "ACT-ffffffffffff"),
+        ("action", "reject"),
+    ],
+)
+def test_pending_card_rejects_tampered_route_or_receipt(tmp_path, field, value):
+    pending = _pending_item()
+    client = ActionServiceClient(
+        token_path=_token(tmp_path),
+        opener=RecordingOpener({"mode": "shadow", "items": [pending]}),
+    )
+    expected = {
+        "chat_id": "-1004474237403",
+        "thread_id": "91",
+        "message_id": "321",
+        "receipt_id": "ACT-0123456789ab",
+        "action": "approve",
+    }
+    expected[field] = value
+
+    with pytest.raises(ActionServiceError, match="does not match"):
+        client.pending_card("TGC-0123456789abcdef", **expected)
+
+
+def test_receipt_renderer_escapes_actor_and_preserves_shadow_honesty():
+    item = {
+        "card_ref": "TGC-0123456789abcdef",
+        "binding": {
+            "chat_id": "-1004474237403",
+            "thread_id": "91",
+            "message_id": "321",
+            "card_html": "<b>Decision</b>",
+        },
+        "resolution": {
+            "receipt_id": "ACT-0123456789ab",
+            "action": "reject",
+            "actor_label": "<Kevin>",
+            "mode": "shadow",
+        },
+    }
+
+    rendered = render_shadow_card(item)
+
+    assert "&lt;Kevin&gt;" in rendered
+    assert "<Kevin>" not in rendered
+    assert "Recorded only — nothing was executed." in rendered
+    assert "ACT-0123456789ab" in rendered

--- a/tests/test_grover_migration_inventory.py
+++ b/tests/test_grover_migration_inventory.py
@@ -1,0 +1,94 @@
+"""Read-only dirty-checkout and exported-patch migration inventory tests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+from grover_runtime.migration_inventory import build_migration_inventory
+
+
+def _snapshot(root: Path) -> dict[str, str]:
+    result = {}
+    for path in root.rglob("*"):
+        if path.is_file() and ".git" not in path.parts:
+            result[path.relative_to(root).as_posix()] = hashlib.sha256(
+                path.read_bytes()
+            ).hexdigest()
+    return result
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_inventory_is_read_only_by_default_and_reports_dirty_checkout(tmp_path: Path):
+    repo = tmp_path / "dirty"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "fixture@example.invalid")
+    _git(repo, "config", "user.name", "Fixture")
+    adapter = repo / "plugins" / "platforms" / "telegram" / "adapter.py"
+    adapter.parent.mkdir(parents=True)
+    adapter.write_text("BASE = True\n", encoding="utf-8")
+    _git(repo, "add", "plugins/platforms/telegram/adapter.py")
+    _git(repo, "commit", "-q", "-m", "fixture")
+    adapter.write_text("BASE = False\n", encoding="utf-8")
+    plugin = repo / "grover_runtime" / "service.py"
+    plugin.parent.mkdir()
+    plugin.write_text("PRIVATE = True\n", encoding="utf-8")
+    before = _snapshot(repo)
+
+    inventory = build_migration_inventory(repo, patch_files=())
+
+    assert _snapshot(repo) == before
+    assert inventory["checkout"]["dirty"] is True
+    categories = inventory["checkout"]["categories"]
+    assert categories["upstreamable_adapter"] == [
+        "plugins/platforms/telegram/adapter.py"
+    ]
+    assert categories["grizzly_specific"] == ["grover_runtime/service.py"]
+    assert not (repo / "migration-inventory.json").exists()
+
+
+def test_exported_patch_inventory_separates_mixed_upstream_and_private_paths(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    patch = tmp_path / "custom.patch"
+    patch.write_text(
+        """diff --git a/plugins/platforms/telegram/adapter.py b/plugins/platforms/telegram/adapter.py
+--- a/plugins/platforms/telegram/adapter.py
++++ b/plugins/platforms/telegram/adapter.py
+@@ -1 +1 @@
+-old
++new
+diff --git a/grover_runtime/action_service_client.py b/grover_runtime/action_service_client.py
+new file mode 100644
+--- /dev/null
++++ b/grover_runtime/action_service_client.py
+@@ -0,0 +1 @@
++private
+""",
+        encoding="utf-8",
+    )
+
+    inventory = build_migration_inventory(repo, patch_files=(patch,))
+
+    patch_row = inventory["exported_patches"][0]
+    assert patch_row["sha256"] == hashlib.sha256(patch.read_bytes()).hexdigest()
+    assert patch_row["categories"] == {
+        "grizzly_specific": ["grover_runtime/action_service_client.py"],
+        "upstreamable_adapter": ["plugins/platforms/telegram/adapter.py"],
+    }
+    json.dumps(inventory, allow_nan=False)

--- a/tests/test_grover_operations.py
+++ b/tests/test_grover_operations.py
@@ -1,0 +1,258 @@
+"""Fail-closed, exact-order runtime preparation and cutover tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from grover_runtime.operations import (
+    CommandResult,
+    CutoverCommands,
+    CutoverRolledBack,
+    CutoverSpec,
+    RuntimeLayout,
+    SafetyViolation,
+    execute_cutover,
+    sanitize_runtime_environment,
+    validate_runtime_layout,
+)
+
+
+def _commands() -> CutoverCommands:
+    return CutoverCommands(
+        probe=("probe",),
+        disable_new=("disable-new",),
+        stop_old=("stop-old",),
+        enable_new=("enable-new",),
+        start_new=("start-new",),
+        stop_new=("stop-new",),
+        start_old=("start-old",),
+        health_new=("health-new",),
+        health_old=("health-old",),
+        receipt=("receipt",),
+    )
+
+
+class StatefulRunner:
+    def __init__(
+        self, *, state: str = "old", fail_health_new: bool = False, receipt=None
+    ):
+        self.state = state
+        self.fail_health_new = fail_health_new
+        self.receipt = receipt or {
+            "delivered": True,
+            "provider": "telegram",
+            "provider_message_id": "777",
+            "identity_source": "provider",
+            "release_id": "release-1",
+        }
+        self.events: list[str] = []
+        self.environments: list[dict[str, str]] = []
+
+    def __call__(self, argv, *, env):
+        op = argv[0]
+        self.events.append(op)
+        self.environments.append(dict(env))
+        if op == "probe":
+            ids = {
+                "old": ["legacy"],
+                "new": ["grover-prod"],
+                "none": [],
+                "duplicate": ["legacy", "grover-prod"],
+            }[self.state]
+            return CommandResult(0, json.dumps({"pollers": ids}), "")
+        if op == "disable-new":
+            return CommandResult(0, "", "")
+        if op == "stop-old":
+            self.state = "none"
+            return CommandResult(0, "", "")
+        if op == "enable-new":
+            return CommandResult(0, "", "")
+        if op == "start-new":
+            self.state = "new"
+            return CommandResult(0, "", "")
+        if op == "stop-new":
+            self.state = "none"
+            return CommandResult(0, "", "")
+        if op == "start-old":
+            self.state = "old"
+            return CommandResult(0, "", "")
+        if op == "health-new":
+            payload = {
+                "healthy": not self.fail_health_new,
+                "consumer_id": "grover-prod",
+                "release_id": "release-1",
+            }
+            return CommandResult(0, json.dumps(payload), "")
+        if op == "health-old":
+            return CommandResult(
+                0,
+                json.dumps({"healthy": True, "consumer_id": "legacy"}),
+                "",
+            )
+        if op == "receipt":
+            return CommandResult(0, json.dumps(self.receipt), "")
+        raise AssertionError(op)
+
+
+def _spec() -> CutoverSpec:
+    return CutoverSpec(
+        release_id="release-1",
+        old_consumer_id="legacy",
+        new_consumer_id="grover-prod",
+        commands=_commands(),
+        prod_home=Path.cwd() / ".test-grover-prod",
+    )
+
+
+def test_cutover_has_explicit_zero_then_one_consumer_order_and_receipt_gate():
+    runner = StatefulRunner()
+
+    result = execute_cutover(_spec(), runner, base_environment={"PATH": "safe"})
+
+    assert result.already_active is False
+    assert result.provider_message_id == "777"
+    assert runner.state == "new"
+    assert all(
+        environment["HERMES_HOME"] == str(_spec().prod_home)
+        for environment in runner.environments
+    )
+    assert runner.events == [
+        "probe",
+        "disable-new",
+        "probe",
+        "stop-old",
+        "probe",
+        "enable-new",
+        "start-new",
+        "probe",
+        "health-new",
+        "receipt",
+    ]
+
+
+def test_cutover_is_idempotent_when_exact_new_consumer_is_already_healthy():
+    runner = StatefulRunner(state="new")
+
+    result = execute_cutover(_spec(), runner, base_environment={})
+
+    assert result.already_active is True
+    assert runner.events == ["probe", "health-new", "receipt"]
+
+
+def test_health_failure_rolls_back_only_after_new_is_stopped_and_disabled():
+    runner = StatefulRunner(fail_health_new=True)
+
+    with pytest.raises(CutoverRolledBack, match="new runtime health gate failed"):
+        execute_cutover(_spec(), runner, base_environment={})
+
+    assert runner.state == "old"
+    assert runner.events[-6:] == [
+        "stop-new",
+        "disable-new",
+        "probe",
+        "start-old",
+        "probe",
+        "health-old",
+    ]
+
+
+def test_rollback_recovers_when_stop_new_mutates_state_then_reports_failure():
+    class MutatingFailureRunner(StatefulRunner):
+        def __call__(self, argv, *, env):
+            if argv[0] == "stop-new":
+                self.events.append("stop-new")
+                self.state = "none"
+                return CommandResult(1, "", "reported failure after stop")
+            return super().__call__(argv, env=env)
+
+    runner = MutatingFailureRunner(fail_health_new=True)
+
+    with pytest.raises(CutoverRolledBack, match="new runtime health gate failed"):
+        execute_cutover(_spec(), runner, base_environment={})
+
+    assert runner.state == "old"
+    assert runner.events[-6:] == [
+        "stop-new",
+        "disable-new",
+        "probe",
+        "start-old",
+        "probe",
+        "health-old",
+    ]
+
+
+def test_missing_provider_native_identity_fails_and_rolls_back():
+    runner = StatefulRunner(
+        receipt={
+            "delivered": True,
+            "provider": "telegram",
+            "identity_source": "provider",
+            "release_id": "release-1",
+        }
+    )
+
+    with pytest.raises(CutoverRolledBack, match="provider-native message identity"):
+        execute_cutover(_spec(), runner, base_environment={})
+
+    assert runner.state == "old"
+
+
+def test_duplicate_pollers_fail_before_any_mutating_command():
+    runner = StatefulRunner(state="duplicate")
+
+    with pytest.raises(SafetyViolation, match="exactly one known Telegram consumer"):
+        execute_cutover(_spec(), runner, base_environment={})
+
+    assert runner.events == ["probe"]
+
+
+def test_runtime_layout_separates_profiles_credentials_and_release(tmp_path: Path):
+    prod = tmp_path / "profiles" / "grover-prod"
+    shadow = tmp_path / "profiles" / "grover-shadow"
+    release = tmp_path / "releases"
+    prod.mkdir(parents=True)
+    shadow.mkdir(parents=True)
+    release.mkdir()
+    (shadow / ".env").write_text("# deliberately empty\n", encoding="utf-8")
+
+    layout = RuntimeLayout(prod_home=prod, shadow_home=shadow, release_root=release)
+    validate_runtime_layout(layout)
+
+    (shadow / ".env").write_text("TELEGRAM_BOT_TOKEN=accidental\n", encoding="utf-8")
+    with pytest.raises(SafetyViolation, match="shadow credential file is not empty"):
+        validate_runtime_layout(layout)
+
+
+def test_runtime_layout_rejects_shared_or_nested_homes(tmp_path: Path):
+    prod = tmp_path / "same"
+    prod.mkdir()
+    with pytest.raises(SafetyViolation, match="must be disjoint"):
+        validate_runtime_layout(
+            RuntimeLayout(prod_home=prod, shadow_home=prod, release_root=tmp_path / "r")
+        )
+
+
+def test_runtime_environment_does_not_inherit_credentials(tmp_path: Path):
+    env = sanitize_runtime_environment(
+        {
+            "PATH": "safe-path",
+            "HOME": "safe-home",
+            "TELEGRAM_BOT_TOKEN": "secret",
+            "OPENAI_API_KEY": "secret",
+            "AWS_SESSION_TOKEN": "secret",
+            "UNRELATED_SECRET": "secret",
+        },
+        profile="grover-shadow",
+        home=tmp_path / "shadow",
+        role="shadow",
+    )
+
+    assert env["PATH"] == "safe-path"
+    assert env["HERMES_PROFILE"] == "grover-shadow"
+    assert env["GROVER_RUNTIME_ROLE"] == "shadow"
+    assert not any(
+        marker in key.upper() for key in env for marker in ("TOKEN", "KEY", "SECRET")
+    )

--- a/tests/test_grover_profile_preparation.py
+++ b/tests/test_grover_profile_preparation.py
@@ -1,0 +1,66 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from grover_runtime.profile_preparation import (
+    build_profile_commands,
+    run_profile_commands,
+)
+
+
+def test_prepare_commands_create_both_profiles_without_cloning_credentials():
+    commands = build_profile_commands("prepare")
+
+    rendered = [" ".join(command) for command in commands]
+    assert rendered[:2] == [
+        "hermes profile create grover-prod --no-alias --no-skills",
+        "hermes profile create grover-shadow --no-alias --no-skills",
+    ]
+    assert all("--clone" not in command for command in rendered)
+    assert all(".env" not in command for command in rendered)
+    assert (
+        "hermes -p grover-prod config set gateway.platforms.telegram.enabled false"
+        in rendered
+    )
+    assert (
+        "hermes -p grover-shadow config set gateway.platforms.telegram.enabled false"
+        in rendered
+    )
+    assert (
+        "hermes -p grover-shadow config set "
+        "gateway.platforms.telegram.extra.external_effects false" in rendered
+    )
+    assert (
+        "hermes -p grover-shadow plugins enable grover-shadow-guard "
+        "--no-allow-tool-override" in rendered
+    )
+
+
+def test_profile_preparation_cannot_bypass_cutover_health_and_receipt_gates():
+    with pytest.raises(ValueError, match="cutover requires grover_runtime.operations"):
+        build_profile_commands("cutover-prod")
+
+
+def test_unknown_profile_operation_fails_closed():
+    with pytest.raises(ValueError, match="unknown profile operation"):
+        build_profile_commands("deploy-everywhere")
+
+
+def test_existing_profile_aborts_instead_of_reusing_credential_state(monkeypatch):
+    monkeypatch.setattr(
+        "grover_runtime.profile_preparation.platform.system", lambda: "Darwin"
+    )
+    run = Mock(
+        return_value=SimpleNamespace(
+            returncode=1,
+            stdout="profile already exists",
+            stderr="",
+        )
+    )
+    monkeypatch.setattr("grover_runtime.profile_preparation.subprocess.run", run)
+
+    with pytest.raises(RuntimeError, match="profile already exists"):
+        run_profile_commands(build_profile_commands("prepare"))
+
+    assert run.call_count == 1

--- a/tests/test_grover_release.py
+++ b/tests/test_grover_release.py
@@ -1,0 +1,170 @@
+"""Immutable, credential-free release artifact and evidence tests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import stat
+import tarfile
+import tomllib
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from grover_runtime.release import (
+    ReleaseSpec,
+    create_release,
+    verify_wheel_modules,
+)
+
+
+UPSTREAM = "1" * 40
+ROLLBACK = "2" * 40
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _source_tree(root: Path) -> Path:
+    source = root / "source"
+    (source / "grover_runtime").mkdir(parents=True)
+    (source / "grover_runtime" / "__init__.py").write_text(
+        "VALUE = 1\n", encoding="utf-8"
+    )
+    (source / "grover_runtime" / "operations.py").write_text(
+        "VALUE = 2\n", encoding="utf-8"
+    )
+    (source / "uv.lock").write_text("lock-version = 1\n", encoding="utf-8")
+
+    # Mutable state, credentials, and browser/session caches must never enter a release.
+    (source / ".env").write_text("TOKEN=do-not-package\n", encoding="utf-8")
+    (source / "credentials.json").write_text("{}", encoding="utf-8")
+    (source / "state.db").write_bytes(b"db")
+    (source / "state.db-wal").write_bytes(b"wal")
+    (source / "state.db-shm").write_bytes(b"shm")
+    (source / "runtime.log").write_text("log", encoding="utf-8")
+    (source / "sessions").mkdir()
+    (source / "sessions" / "one.json").write_text("{}", encoding="utf-8")
+    (source / "browser_cache").mkdir()
+    (source / "browser_cache" / "cookies").write_text("cookie", encoding="utf-8")
+    return source
+
+
+def _spec(root: Path, source: Path, output_name: str) -> ReleaseSpec:
+    patch = root / "candidate.patch"
+    patch.write_text("diff --git a/x b/x\n", encoding="utf-8")
+    return ReleaseSpec(
+        release_id="grover-test-release",
+        source_tree=source,
+        patch_file=patch,
+        output_dir=root / output_name,
+        upstream_commit=UPSTREAM,
+        rollback_target=ROLLBACK,
+        required_paths=(
+            "grover_runtime/__init__.py",
+            "grover_runtime/operations.py",
+        ),
+    )
+
+
+def test_release_manifest_pins_every_required_hash_and_excludes_mutable_data(
+    tmp_path: Path,
+):
+    source = _source_tree(tmp_path)
+
+    result = create_release(_spec(tmp_path, source, "out"))
+
+    manifest = json.loads(result.manifest.read_text(encoding="utf-8"))
+    evidence = json.loads(result.evidence.read_text(encoding="utf-8"))
+    assert manifest["upstream_commit"] == UPSTREAM
+    assert manifest["rollback_target"] == ROLLBACK
+    assert manifest["patch_sha256"] == _sha256(tmp_path / "candidate.patch")
+    assert manifest["dependency_lock"]["path"] == "uv.lock"
+    assert manifest["dependency_lock"]["sha256"] == _sha256(source / "uv.lock")
+    assert manifest["artifact_sha256"] == _sha256(result.artifact)
+    assert evidence["manifest_sha256"] == _sha256(result.manifest)
+
+    with tarfile.open(result.artifact, "r") as archive:
+        names = archive.getnames()
+    assert "grover_runtime/operations.py" in names
+    for forbidden in (
+        ".env",
+        "credentials.json",
+        "state.db",
+        "state.db-wal",
+        "state.db-shm",
+        "runtime.log",
+        "sessions/one.json",
+        "browser_cache/cookies",
+    ):
+        assert forbidden not in names
+    assert set(evidence["excluded_paths"]) >= {
+        ".env",
+        "credentials.json",
+        "state.db",
+        "state.db-wal",
+        "state.db-shm",
+        "runtime.log",
+        "sessions/one.json",
+        "browser_cache/cookies",
+    }
+
+
+def test_release_is_deterministic_exclusive_and_read_only(tmp_path: Path):
+    source = _source_tree(tmp_path)
+    first = create_release(_spec(tmp_path, source, "out-1"))
+    second = create_release(_spec(tmp_path, source, "out-2"))
+
+    assert _sha256(first.artifact) == _sha256(second.artifact)
+    assert _sha256(first.manifest) == _sha256(second.manifest)
+    assert not first.artifact.stat().st_mode & stat.S_IWUSR
+    assert not first.manifest.stat().st_mode & stat.S_IWUSR
+    assert not first.evidence.stat().st_mode & stat.S_IWUSR
+
+    with pytest.raises(FileExistsError):
+        create_release(_spec(tmp_path, source, "out-1"))
+
+
+def test_release_refuses_missing_runtime_modules_and_bad_commit_pins(tmp_path: Path):
+    source = _source_tree(tmp_path)
+    spec = _spec(tmp_path, source, "out")
+    spec = ReleaseSpec(**{
+        **spec.__dict__,
+        "required_paths": ("grover_runtime/missing.py",),
+    })
+    with pytest.raises(ValueError, match="required release path is missing"):
+        create_release(spec)
+
+    bad = ReleaseSpec(**{**spec.__dict__, "upstream_commit": "main"})
+    with pytest.raises(ValueError, match="40-character commit"):
+        create_release(bad)
+
+
+def test_wheel_verification_requires_every_runtime_module(tmp_path: Path):
+    wheel = tmp_path / "candidate.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr("grover_runtime/__init__.py", "")
+        archive.writestr("grover_runtime/operations.py", "")
+
+    verify_wheel_modules(
+        wheel,
+        required_modules=(
+            "grover_runtime/__init__.py",
+            "grover_runtime/operations.py",
+        ),
+    )
+    with pytest.raises(ValueError, match="wheel is missing required modules"):
+        verify_wheel_modules(
+            wheel,
+            required_modules=("grover_runtime/action_service_client.py",),
+        )
+
+
+def test_project_packaging_includes_shadow_guard_manifest():
+    project = Path(__file__).resolve().parents[1]
+    config = tomllib.loads((project / "pyproject.toml").read_text(encoding="utf-8"))
+
+    package_data = config["tool"]["setuptools"]["package-data"]
+    assert "plugin.yaml" in package_data["plugins.grover_shadow_guard"]

--- a/tests/test_grover_release.py
+++ b/tests/test_grover_release.py
@@ -78,9 +78,12 @@ def test_release_manifest_pins_every_required_hash_and_excludes_mutable_data(
 
     manifest = json.loads(result.manifest.read_text(encoding="utf-8"))
     evidence = json.loads(result.evidence.read_text(encoding="utf-8"))
+    assert result.patch == result.manifest.parent / "candidate.patch"
+    assert result.patch.read_bytes() == (tmp_path / "candidate.patch").read_bytes()
     assert manifest["upstream_commit"] == UPSTREAM
     assert manifest["rollback_target"] == ROLLBACK
     assert manifest["patch_sha256"] == _sha256(tmp_path / "candidate.patch")
+    assert manifest["patch"]["sha256"] == _sha256(result.patch)
     assert manifest["dependency_lock"]["path"] == "uv.lock"
     assert manifest["dependency_lock"]["sha256"] == _sha256(source / "uv.lock")
     assert manifest["artifact_sha256"] == _sha256(result.artifact)
@@ -122,6 +125,8 @@ def test_release_is_deterministic_exclusive_and_read_only(tmp_path: Path):
     assert not first.artifact.stat().st_mode & stat.S_IWUSR
     assert not first.manifest.stat().st_mode & stat.S_IWUSR
     assert not first.evidence.stat().st_mode & stat.S_IWUSR
+    assert not first.patch.stat().st_mode & stat.S_IWUSR
+    assert _sha256(first.patch) == _sha256(second.patch)
 
     with pytest.raises(FileExistsError):
         create_release(_spec(tmp_path, source, "out-1"))
@@ -140,6 +145,16 @@ def test_release_refuses_missing_runtime_modules_and_bad_commit_pins(tmp_path: P
     bad = ReleaseSpec(**{**spec.__dict__, "upstream_commit": "main"})
     with pytest.raises(ValueError, match="40-character commit"):
         create_release(bad)
+
+    reserved_patch = tmp_path / "manifest.json"
+    reserved_patch.write_text("review patch\n", encoding="utf-8")
+    collision = ReleaseSpec(**{
+        **_spec(tmp_path, source, "reserved-output").__dict__,
+        "patch_file": reserved_patch,
+    })
+    with pytest.raises(ValueError, match="collides with a reserved artifact"):
+        create_release(collision)
+    assert not collision.output_dir.exists()
 
 
 def test_wheel_verification_requires_every_runtime_module(tmp_path: Path):

--- a/tests/test_grover_shadow_guard_plugin.py
+++ b/tests/test_grover_shadow_guard_plugin.py
@@ -1,0 +1,88 @@
+"""The shadow guard blocks agent/tool side effects without changing prod."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+
+def test_shadow_profile_blocks_every_tool_call(monkeypatch):
+    from plugins.grover_shadow_guard import _on_pre_tool_call
+
+    monkeypatch.setenv("HERMES_PROFILE", "grover-shadow")
+    directive = _on_pre_tool_call(tool_name="terminal", args={"command": "anything"})
+
+    assert directive == {
+        "action": "block",
+        "message": "grover-shadow is mechanically external-effect-free",
+    }
+
+
+def test_shadow_role_blocks_llm_and_tool_execution_without_calling_downstream(
+    monkeypatch,
+):
+    from plugins.grover_shadow_guard import (
+        _on_llm_execution,
+        _on_tool_execution,
+    )
+
+    monkeypatch.setenv("GROVER_RUNTIME_ROLE", "shadow")
+    downstream = Mock(side_effect=AssertionError("downstream external effect ran"))
+
+    assert _on_llm_execution(request={}, next_call=downstream) == {
+        "error": "grover-shadow external effects disabled"
+    }
+    assert _on_tool_execution(
+        tool_name="send_message", args={}, next_call=downstream
+    ) == {"error": "grover-shadow external effects disabled"}
+    downstream.assert_not_called()
+
+
+def test_guard_does_not_weaken_production(monkeypatch):
+    from plugins.grover_shadow_guard import (
+        _on_llm_execution,
+        _on_pre_tool_call,
+        _on_tool_execution,
+    )
+
+    monkeypatch.setenv("HERMES_PROFILE", "grover-prod")
+    monkeypatch.setenv("GROVER_RUNTIME_ROLE", "prod")
+    downstream = Mock(return_value={"ok": True})
+
+    assert _on_pre_tool_call(tool_name="terminal", args={}) is None
+    assert _on_llm_execution(request={"x": 1}, next_call=downstream) == {"ok": True}
+    assert _on_tool_execution(
+        tool_name="terminal", args={"x": 1}, next_call=downstream
+    ) == {"ok": True}
+    assert downstream.call_count == 2
+
+
+def test_guard_registers_profile_bound_policy_and_execution_boundaries(monkeypatch):
+    from plugins.grover_shadow_guard import register
+
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    monkeypatch.delenv("GROVER_RUNTIME_ROLE", raising=False)
+    context = Mock(profile_name="grover-shadow")
+    register(context)
+
+    hook_names = [call.args[0] for call in context.register_hook.call_args_list]
+    middleware_names = [
+        call.args[0] for call in context.register_middleware.call_args_list
+    ]
+    assert hook_names == ["pre_tool_call"]
+    assert middleware_names == ["llm_execution", "tool_execution"]
+
+    downstream = Mock(side_effect=AssertionError("profile-bound guard was bypassed"))
+    llm_guard = context.register_middleware.call_args_list[0].args[1]
+    tool_guard = context.register_middleware.call_args_list[1].args[1]
+    assert llm_guard(request={}, next_call=downstream)["error"]
+    assert tool_guard(tool_name="terminal", args={}, next_call=downstream)["error"]
+    downstream.assert_not_called()
+
+
+def test_guard_refuses_registration_outside_shadow_profile():
+    from plugins.grover_shadow_guard import register
+
+    with pytest.raises(RuntimeError, match="only be enabled for grover-shadow"):
+        register(Mock(profile_name="grover-prod"))


### PR DESCRIPTION
## Summary
- add typed opaque Telegram callbacks and exact owner/thread authorization
- add mechanically inert grover-shadow boundaries and fixed-argv operations
- add read-only migration inventory and separated profile preparation
- add deterministic credential-free release artifacts with exact patch evidence

## Verification
- focused Grizzly runtime: 60 passed, 1 Windows capability skip
- canonical process-isolated Telegram matrix: 56 files, 522 passed
- compilation, diff checks, source Gitleaks, and bundle Gitleaks passed
- deterministic twin candidate artifacts are byte-identical and read-only

## Safety boundary
This draft PR does not authorize deployment, profile activation, a second Telegram consumer, production cutover, or any external effect. A fresh independent identity-binding review is still required before readiness/merge, and a post-merge immutable release must be rebuilt from the exact merged commit.