### PR TITLE
fix(update): handle UnicodeDecodeError in interactive update prompts

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -986,7 +986,15 @@ def _restore_stashed_changes(
         if input_fn is not None:
             response = input_fn("Restore local changes now? [Y/n]", "y")
         else:
-            response = input().strip().lower()
+            try:
+                response = input().strip().lower()
+            except (EOFError, UnicodeDecodeError):
+                # Mirror the config-migration prompt's fix: don't let a
+                # terminal-encoding issue or a closed stdin crash the
+                # update mid-restore. Falls through to the existing
+                # skip-restore path below, which already explains how to
+                # restore manually from git stash.
+                response = "n"
         if response not in {"", "y", "yes"}:
             print("Skipped restoring local changes.")
             print("Your changes are still preserved in git stash.")
@@ -1273,7 +1281,7 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
             response = (
                 input("Add official repo as 'upstream' remote? [Y/n]: ").strip().lower()
             )
-        except (EOFError, KeyboardInterrupt):
+        except (EOFError, KeyboardInterrupt, UnicodeDecodeError):
             print()
             response = "n"
 
@@ -3989,6 +3997,16 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         .lower()
                     )
                 except EOFError:
+                    response = "n"
+                except UnicodeDecodeError:
+                    # input() can raise this when the terminal encoding can't
+                    # decode the byte sequence (e.g. a non-UTF-8 locale, or an
+                    # embedded terminal). Without this, the exception escapes
+                    # here and crashes the update at this prompt.
+                    print(
+                        "  ⚠ Could not read input (encoding issue). Skipping. "
+                        "Run 'hermes config migrate' manually to configure."
+                    )
                     response = "n"
 
             if response in {"", "y", "yes", "auto"}:

--- a/tests/hermes_cli/test_update_yes_flag.py
+++ b/tests/hermes_cli/test_update_yes_flag.py
@@ -181,9 +181,7 @@ class TestUnicodeDecodeErrorInUpdatePrompts:
 
         out = capsys.readouterr().out
         assert "hermes config migrate" in out
-        assert mock_migrate.call_count == 0 or (
-            mock_migrate.call_args and mock_migrate.call_args.kwargs.get("interactive") is not True
-        )
+        mock_migrate.assert_not_called()
 
     def test_stash_restore_unicode_decode_error_falls_through_to_skip(self, tmp_path, capsys):
         from hermes_cli.update_cmd import _restore_stashed_changes

--- a/tests/hermes_cli/test_update_yes_flag.py
+++ b/tests/hermes_cli/test_update_yes_flag.py
@@ -135,3 +135,99 @@ class TestUpdateYesConfigMigration:
 class TestUpdateYesStashRestore:
     """--yes auto-restores the pre-update autostash without prompting."""
 
+
+
+class TestUnicodeDecodeErrorInUpdatePrompts:
+    """Regression tests (review of #68497): input() can raise
+    UnicodeDecodeError when the terminal encoding can't decode the byte
+    sequence (e.g. a non-UTF-8 locale, or an embedded terminal). Three
+    interactive update prompts call input() directly -- the config-
+    migration prompt, the stash-restore prompt, and the upstream-remote
+    prompt -- and each must fail safe (skip, don't crash) rather than let
+    the exception escape and crash `hermes update` mid-flight.
+    """
+
+    @patch("hermes_cli.config.migrate_config")
+    @patch("hermes_cli.config.check_config_version", return_value=(1, 2))
+    @patch("hermes_cli.config.get_missing_config_fields", return_value=[])
+    @patch("hermes_cli.config.get_missing_env_vars", return_value=["NEW_KEY"])
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_unicode_decode_error_in_tty_skips_and_prints_hint(
+        self,
+        mock_run,
+        _mock_which,
+        _mock_missing_env,
+        _mock_missing_cfg,
+        _mock_version,
+        mock_migrate,
+        capsys,
+    ):
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+        mock_migrate.return_value = {"env_added": [], "config_added": []}
+        args = SimpleNamespace(yes=False)
+
+        import sys as _sys
+
+        with patch(
+            "builtins.input",
+            side_effect=UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid byte"),
+        ), patch.object(_sys.stdin, "isatty", return_value=True), patch.object(
+            _sys.stdout, "isatty", return_value=True
+        ):
+            cmd_update(args)  # must not raise
+
+        out = capsys.readouterr().out
+        assert "hermes config migrate" in out
+        assert mock_migrate.call_count == 0 or (
+            mock_migrate.call_args and mock_migrate.call_args.kwargs.get("interactive") is not True
+        )
+
+    def test_stash_restore_unicode_decode_error_falls_through_to_skip(self, tmp_path, capsys):
+        from hermes_cli.update_cmd import _restore_stashed_changes
+
+        with patch(
+            "builtins.input",
+            side_effect=UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid byte"),
+        ):
+            result = _restore_stashed_changes(
+                ["git"], tmp_path, "stash@{0}", prompt_user=True, input_fn=None,
+            )  # must not raise
+
+        assert result is False
+        out = capsys.readouterr().out
+        assert "Skipped restoring local changes" in out
+        assert "git stash apply stash@{0}" in out
+
+    def test_stash_restore_eof_error_still_falls_through_to_skip(self, tmp_path):
+        """Sanity: this fix must not regress the pre-existing EOFError case,
+        which the raw input() path had no guard for at all before this fix."""
+        from hermes_cli.update_cmd import _restore_stashed_changes
+
+        with patch("builtins.input", side_effect=EOFError()):
+            result = _restore_stashed_changes(
+                ["git"], tmp_path, "stash@{0}", prompt_user=True, input_fn=None,
+            )  # must not raise
+
+        assert result is False
+
+    def test_upstream_remote_prompt_unicode_decode_error_falls_through_to_skip(
+        self, tmp_path
+    ):
+        from hermes_cli.update_cmd import _sync_with_upstream_if_needed
+
+        with patch(
+            "hermes_cli.update_cmd._has_upstream_remote", return_value=False
+        ), patch(
+            "hermes_cli.update_cmd._should_skip_upstream_prompt", return_value=False
+        ), patch(
+            "hermes_cli.update_cmd._add_upstream_remote"
+        ) as mock_add, patch(
+            "builtins.input",
+            side_effect=UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid byte"),
+        ):
+            _sync_with_upstream_if_needed(["git"], tmp_path)  # must not raise
+
+        mock_add.assert_not_called()


### PR DESCRIPTION
## Context

Supersedes #68497 per @teknium1's review -- the prior port targeted the pre-refactor `hermes_cli/main.py` location.

## Problem

`input()` can raise `UnicodeDecodeError` when the terminal encoding can't decode the byte sequence. The update pipeline moved to `hermes_cli/update_cmd.py` in 927463efcc.

## Fix

Per review, fixed all three interactive update prompts that call `input()` directly:

1. **Config-migration prompt**: extends the existing `except EOFError` to also catch `UnicodeDecodeError`, prints an actionable `hermes config migrate` hint.
2. **Stash-restore prompt** (`_restore_stashed_changes`): the raw `input()` call had NO exception guard at all. Added a try/except covering both `EOFError` and `UnicodeDecodeError`.
3. **Upstream-remote prompt** (`_sync_with_upstream_if_needed`): already caught `(EOFError, KeyboardInterrupt)` but not `UnicodeDecodeError` -- added it.

Also dropped the incorrect #12884 reference (an unrelated TUI report).

## Verification

4 new tests pass covering all three call sites; 6/6 in the full `tests/hermes_cli/test_update_yes_flag.py` file (no regression).