### PR TITLE
fix: add usedforsecurity=False to hashlib.md5 in context_compressor (#FIPS)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2620,7 +2620,7 @@ class ContextCompressor(ContextEngine):
                 continue
             if len(content) < 200:
                 continue
-            h = hashlib.md5(content.encode("utf-8", errors="replace")).hexdigest()[:12]
+            h = hashlib.md5(content.encode("utf-8", errors="replace"), usedforsecurity=False).hexdigest()[:12]
             if h in content_hashes:
                 # This is an older duplicate — replace with back-reference
                 result[i] = {**msg, "content": "[Duplicate tool output — same content as a more recent call]"}


### PR DESCRIPTION
## Summary

`agent/context_compressor.py` line 2623 uses `hashlib.md5()` without `usedforsecurity=False`. On FIPS-enabled systems (RHEL 8/9), this raises:

```
ValueError: EVP_DigestInit_ex disabled for FIPS
```

PR #56715 fixed the same pattern at line 1226 (different function — `_prune_old_tool_results` dedup), but this second call site in the same file was added later and was missed.

## Changes

- `agent/context_compressor.py:2623` — add `usedforsecurity=False` to `hashlib.md5()` call

## Context

- This is a non-security use (content dedup hashing for tool output compression)
- SHA-256 is FIPS-approved and doesn't need this parameter; only MD5 and SHA-1 crash on FIPS
- The fix is a single keyword argument addition with zero behavioral change

Fixes the same bug class as #56715 (context_compressor), #56716 (codex_responses_adapter), #56719 (gateway/platforms + skills_hub).