### PR TITLE
fix(web): deliver learn seeds to persistent chat

### DIFF
--- a/web/src/lib/chat-learn-seed.test.ts
+++ b/web/src/lib/chat-learn-seed.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  OPEN_SOCKET_READY_STATE,
+  planChatLearnSeed,
+} from "./chat-learn-seed";
+
+function plan(
+  search: string,
+  overrides: Partial<Parameters<typeof planChatLearnSeed>[0]> = {},
+) {
+  return planChatLearnSeed({
+    isActive: true,
+    ptyState: "open",
+    searchParams: new URLSearchParams(search),
+    socketReadyState: OPEN_SOCKET_READY_STATE,
+    ...overrides,
+  });
+}
+
+describe("persistent chat learn seed delivery", () => {
+  it("plans a newly navigated learn seed without requiring a socket reopen", () => {
+    expect(plan("resume=session-id")).toBeNull();
+
+    const delivery = plan("learn=source%20text&resume=session-id");
+
+    expect(delivery?.command).toBe("/learn source text\r");
+    expect(delivery?.nextSearchParams.get("learn")).toBeNull();
+    expect(delivery?.nextSearchParams.get("resume")).toBe("session-id");
+  });
+
+  it("retains the seed until an active open PTY can accept it", () => {
+    const search = "learn=retry-me&resume=session-id";
+
+    expect(plan(search, { isActive: false })).toBeNull();
+    expect(plan(search, { ptyState: "connecting" })).toBeNull();
+    expect(plan(search, { socketReadyState: 3 })).toBeNull();
+    expect(new URLSearchParams(search).get("learn")).toBe("retry-me");
+  });
+});

--- a/web/src/lib/chat-learn-seed.ts
+++ b/web/src/lib/chat-learn-seed.ts
@@ -1,0 +1,41 @@
+import type { PtyConnectionState } from "@/lib/pty-reconnect";
+
+export const OPEN_SOCKET_READY_STATE = 1;
+
+export interface ChatLearnSeedPlan {
+  command: string;
+  nextSearchParams: URLSearchParams;
+}
+
+interface PlanChatLearnSeedInput {
+  isActive: boolean;
+  ptyState: PtyConnectionState;
+  socketReadyState: number | null;
+  searchParams: URLSearchParams;
+}
+
+export function planChatLearnSeed({
+  isActive,
+  ptyState,
+  socketReadyState,
+  searchParams,
+}: PlanChatLearnSeedInput): ChatLearnSeedPlan | null {
+  const learnSeed = searchParams.get("learn");
+
+  if (
+    !isActive ||
+    ptyState !== "open" ||
+    socketReadyState !== OPEN_SOCKET_READY_STATE ||
+    !learnSeed
+  ) {
+    return null;
+  }
+
+  const nextSearchParams = new URLSearchParams(searchParams);
+  nextSearchParams.delete("learn");
+
+  return {
+    command: `/learn ${learnSeed}`.trim() + "\r",
+    nextSearchParams,
+  };
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1223,7 +1223,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       socketReadyState: socket?.readyState ?? null,
     });
 
-    if (!plan || !learnSeed || pendingLearnSeedRef.current === learnSeed) {
+    if (!socket || !plan || !learnSeed || pendingLearnSeedRef.current === learnSeed) {
       return;
     }
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -36,6 +36,7 @@ import { usePageHeader } from "@/contexts/usePageHeader";
 import { useI18n } from "@/i18n";
 import { api } from "@/lib/api";
 import { latchChatActivation } from "@/lib/chat-activation";
+import { planChatLearnSeed } from "@/lib/chat-learn-seed";
 import { normalizeSessionTitle } from "@/lib/chat-title";
 import { PtyResumeSanitizer } from "@/lib/pty-resume-sanitizer";
 import {
@@ -193,6 +194,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const reconnectAttemptRef = useRef(0);
   const forceFreshPtyRef = useRef(false);
   const blockedInputNoticeRef = useRef(false);
+  const pendingLearnSeedRef = useRef<string | null>(null);
   const lastResumeReconnectAtRef = useRef(0);
   // True from the moment the connect effect begins until the socket resolves
   // (open or close). Guards the page-resume reconnect against firing during
@@ -307,6 +309,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // treat the current resume target as part of the PTY identity and rebuild the
   // terminal session when it changes.
   const resumeParam = searchParams.get("resume");
+  const learnSeed = searchParams.get("learn");
   // Profile-scoped chat: spawn the PTY under the globally selected
   // management profile. Changing it remounts the terminal (key below /
   // effect dep) so the user explicitly starts a fresh scoped session.
@@ -977,25 +980,6 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // follow up with the authoritative measurement — at worst Ink
       // reflows once after the PTY boots, which is imperceptible.
       ws.send(`\x1b[RESIZE:${term.cols};${term.rows}]`);
-      // One-shot: a ?learn=<text> param (set by the Skills page "Learn a
-      // skill" panel) is typed into the composer as a /learn command once the
-      // PTY is up. /learn resolves via command.dispatch → a normal agent turn,
-      // so this reuses the existing composer path — no special PTY protocol.
-      const learnSeed = searchParams.get("learn");
-      if (learnSeed) {
-        const next = new URLSearchParams(searchParams);
-        next.delete("learn");
-        setSearchParams(next, { replace: true });
-        const cmd = `/learn ${learnSeed}`.trim();
-        // Delay so Ink's composer has mounted and grabbed focus before input.
-        setTimeout(() => {
-          try {
-            wsRef.current?.send(cmd + "\r");
-          } catch {
-            /* PTY not ready / closed — user can retype */
-          }
-        }, 800);
-      }
     };
 
     // Session resume: Ink's two-pass virtual scroll floods the PTY with
@@ -1226,6 +1210,46 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     scopedProfile,
     reconnectNonce,
   ]);
+
+  // ChatPage stays mounted while the dashboard navigates, so a Skills-page
+  // `?learn=` handoff may arrive after this PTY's one and only `onopen`.
+  // Deliver it from URL state independently of the connection lifecycle.
+  useEffect(() => {
+    const socket = wsRef.current;
+    const plan = planChatLearnSeed({
+      isActive,
+      ptyState,
+      searchParams,
+      socketReadyState: socket?.readyState ?? null,
+    });
+
+    if (!plan || !learnSeed || pendingLearnSeedRef.current === learnSeed) {
+      return;
+    }
+
+    pendingLearnSeedRef.current = learnSeed;
+    const timer = window.setTimeout(() => {
+      if (wsRef.current !== socket || socket.readyState !== WebSocket.OPEN) {
+        pendingLearnSeedRef.current = null;
+        return;
+      }
+
+      try {
+        socket.send(plan.command);
+        setSearchParams(plan.nextSearchParams, { replace: true });
+      } catch {
+        // Keep `learn` in the URL so reconnect/reactivation can retry.
+        pendingLearnSeedRef.current = null;
+      }
+    }, 800);
+
+    return () => {
+      window.clearTimeout(timer);
+      if (pendingLearnSeedRef.current === learnSeed) {
+        pendingLearnSeedRef.current = null;
+      }
+    };
+  }, [isActive, learnSeed, ptyState, searchParams, setSearchParams]);
 
   // When the user returns to the chat tab (isActive: false → true), the
   // terminal host just transitioned from display:none to display:flex.


### PR DESCRIPTION
## What does this PR do?

Fixes the Skills-page “Learn” handoff when the persistent Chat page and PTY are already mounted. Previously, `?learn=` was consumed only inside the socket `onopen` callback, so later in-app navigation could leave the command unsent indefinitely.

Rebased onto upstream `main` at `8defb9fd60bebe2802eaab7c57fa2ee6a4ff6281`.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- moves learn-seed delivery out of the one-time WebSocket `onopen` callback
- watches URL, active-page, and PTY state independently of socket creation
- removes `learn` from the URL only after a successful send
- preserves unrelated query parameters such as `resume`
- retains the seed for retry if the page deactivates or the socket changes/closes
- adds focused regression tests for already-open PTY delivery and retry behavior
- guards the deferred production path when the socket is absent or replaced, a condition exposed by the current-upstream production build

## Verification after current-upstream rebase

- Web typecheck passed
- 21 test files / 137 tests passed
- focused Learn-navigation ring: 2 passed
- ESLint completed with zero errors; 25 upstream warnings
- production build passed
- `git diff --check` passed

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only this Web bug fix and its regression seam
- [x] I've added tests for my changes
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] README/docs — N/A; behavior remains the documented Skills-to-Chat handoff
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact was considered; browser APIs remain standard
- [x] Tool descriptions/schemas — N/A