### PR TITLE
fix(terminal): exclude delegated-child marker from shared bash snapshot

### DIFF
--- a/tests/tools/test_snapshot_delegated_marker_leak.py
+++ b/tests/tools/test_snapshot_delegated_marker_leak.py
@@ -1,0 +1,57 @@
+"""Delegated-child marker leak via the shared bash snapshot.
+
+Regression coverage for the bug where a ``delegate_task`` child's terminal
+command dumped ``HERMES_DELEGATED_CHILD_CONTEXT=1`` (stamped onto its Popen env
+by ``_scrub_delegated_child_kanban_env``) into the shared session snapshot via
+``export -p``. Every later command from ANY session then ``source``d the marker,
+so the Kanban CLI/watchdog in a perfectly ordinary parent shell failed closed
+with "delegate_task child contexts cannot mutate Kanban tasks or boards"
+until the gateway restarted. Same bug class as the HERMES_SESSION_ID snapshot
+leak (see test_snapshot_session_id_leak.py); the marker is re-stamped fresh on
+every delegated command, so excluding it from the snapshot loses nothing.
+"""
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+from tools.environments.base import (
+    _SNAPSHOT_EXCLUDED_ENV_REGEX,
+    _export_dump_excluding_session_vars,
+)
+from agent.delegation_context import DELEGATED_CHILD_ENV_MARKER
+
+
+def test_regex_excludes_delegated_marker():
+    rx = re.compile(_SNAPSHOT_EXCLUDED_ENV_REGEX)
+    line = f'declare -x {DELEGATED_CHILD_ENV_MARKER}="1"'
+    assert rx.search(line), "delegated-child marker must be excluded from the snapshot"
+
+
+def test_export_snippet_unsets_delegated_marker():
+    snippet = _export_dump_excluding_session_vars("/tmp/snap.tmp.$BASHPID")
+    assert DELEGATED_CHILD_ENV_MARKER in snippet
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX bash snapshot path")
+def test_snapshot_dump_strips_delegated_marker():
+    """A delegated child's env dump must not persist the lineage marker."""
+    snap = tempfile.mktemp()
+    snippet = _export_dump_excluding_session_vars(snap)
+    env = dict(os.environ)
+    env[DELEGATED_CHILD_ENV_MARKER] = "1"
+    env["MY_USER_VAR"] = "keepme"
+    try:
+        subprocess.run(["bash", "-c", snippet], env=env, check=True)
+        with open(snap) as f:
+            content = f.read()
+        assert DELEGATED_CHILD_ENV_MARKER not in content
+        # User exports still persist — the exclusion is surgical.
+        assert "MY_USER_VAR" in content
+    finally:
+        if os.path.exists(snap):
+            os.unlink(snap)

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -401,7 +401,8 @@ def _cwd_marker(session_id: str) -> str:
 # as the Python-side contract for the exclusion set; the dump path unsets by
 # name/prefix instead of grepping declare lines (see below / issue #71296).
 _SNAPSHOT_EXCLUDED_ENV_REGEX = (
-    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_)"
+    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_"
+    "|HERMES_DELEGATED_CHILD_CONTEXT)"
 )
 
 
@@ -431,7 +432,7 @@ def _export_dump_excluding_session_vars(tmp_path: str) -> str:
     return (
         "{ ( "
         "unset ${!HERMES_SESSION_*} ${!HERMES_CRON_AUTO_DELIVER_*} "
-        "HERMES_UI_SESSION_ID 2>/dev/null; "
+        "HERMES_UI_SESSION_ID HERMES_DELEGATED_CHILD_CONTEXT 2>/dev/null; "
         "export -p; "
         ") || true; } "
         f"> {tmp_path}"


### PR DESCRIPTION
## Symptom

After any `delegate_task` child runs a terminal command, every subsequent `hermes kanban` invocation from ordinary sessions on the same backend fails with:

```
kanban: could not initialize database: delegate_task child contexts cannot mutate Kanban tasks or boards
```

The failure persists until the gateway restarts. Hit in production 2026-07-30: the kanban crash-watchdog cron was blind for hours because a parent-session shell inherited the marker.

## Root cause

`_scrub_delegated_child_kanban_env` stamps `HERMES_DELEGATED_CHILD_CONTEXT=1` onto delegated children's subprocess envs so the Kanban mutation guard survives the fork (correct). But the shared bash session snapshot (`export -p` re-dump in `BaseEnvironment`) persisted that marker, and a single long-lived backend serves many sessions — so every later command from ANY session `source`d the marker and was misidentified as a delegated child.

This is the same bug class as the `HERMES_SESSION_ID` snapshot leak (`test_snapshot_session_id_leak.py`): a per-command bridged var persisting into the shared snapshot.

## Fix

Add the marker to both exclusion sites in `tools/environments/base.py`:
- the `unset` list in `_export_dump_excluding_session_vars` (the actual dump path)
- `_SNAPSHOT_EXCLUDED_ENV_REGEX` (the Python-side contract used by tests)

Safe because the marker is re-stamped fresh on every delegated command by the env scrubbers — the snapshot never needs to carry it.

## Tests

`tests/tools/test_snapshot_delegated_marker_leak.py` — regex contract, snippet contract, and a real `bash` integration test proving the dump strips the marker while preserving user exports. Verified red (3 failed pre-fix) → green (25 passed incl. sibling snapshot + kanban isolation suites).