### PR TITLE
fix(cli): honor auto-TTS for wake-word turns

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15194,9 +15194,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         """Enable voice TTS when configured without overriding explicit state."""
         try:
             from hermes_cli.config import load_config
+            from utils import is_truthy_value
             _raw_voice = load_config().get("voice")
             voice_config = _raw_voice if isinstance(_raw_voice, dict) else {}
-            if voice_config.get("auto_tts", False):
+            if is_truthy_value(voice_config.get("auto_tts"), default=False):
                 with self._voice_lock:
                     self._voice_tts = True
         except Exception:

--- a/cli.py
+++ b/cli.py
@@ -15164,15 +15164,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         # Check config for auto_tts (shape-safe — malformed ``voice:`` YAML
         # leaves ``voice_config`` as a non-dict, so guard before .get()).
-        try:
-            from hermes_cli.config import load_config
-            _raw_voice = load_config().get("voice")
-            voice_config = _raw_voice if isinstance(_raw_voice, dict) else {}
-            if voice_config.get("auto_tts", False):
-                with self._voice_lock:
-                    self._voice_tts = True
-        except Exception:
-            pass
+        self._apply_voice_auto_tts_default()
 
         # Voice mode instruction is injected as a user message prefix (not a
         # system prompt change) to avoid invalidating the prompt cache.  See
@@ -15197,6 +15189,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             _cprint(f"  {_DIM}{_stop_hint}{_RST}")
         _cprint(f"  {_DIM}/voice tts  to toggle speech output{_RST}")
         _cprint(f"  {_DIM}/voice off  to disable voice mode{_RST}")
+
+    def _apply_voice_auto_tts_default(self) -> None:
+        """Enable voice TTS when configured without overriding explicit state."""
+        try:
+            from hermes_cli.config import load_config
+            _raw_voice = load_config().get("voice")
+            voice_config = _raw_voice if isinstance(_raw_voice, dict) else {}
+            if voice_config.get("auto_tts", False):
+                with self._voice_lock:
+                    self._voice_tts = True
+        except Exception:
+            pass
 
     def _typed_voice_stop(self, user_input) -> bool:
         """Typed bare stop phrase during an active voice chat ends the chat.
@@ -15406,6 +15410,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # VAD auto-stop transcribes and queues the transcript for process_loop.
         with self._voice_lock:
             self._voice_mode = True
+        self._apply_voice_auto_tts_default()
         self._voice_continuous = False
         try:
             self._voice_start_recording()

--- a/cli.py
+++ b/cli.py
@@ -12401,15 +12401,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         # Check config for auto_tts (shape-safe — malformed ``voice:`` YAML
         # leaves ``voice_config`` as a non-dict, so guard before .get()).
-        try:
-            from hermes_cli.config import load_config
-            _raw_voice = load_config().get("voice")
-            voice_config = _raw_voice if isinstance(_raw_voice, dict) else {}
-            if voice_config.get("auto_tts", False):
-                with self._voice_lock:
-                    self._voice_tts = True
-        except Exception:
-            pass
+        self._apply_voice_auto_tts_default()
 
         # Voice mode instruction is injected as a user message prefix (not a
         # system prompt change) to avoid invalidating the prompt cache.  See
@@ -12434,6 +12426,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             _cprint(f"  {_DIM}{_stop_hint}{_RST}")
         _cprint(f"  {_DIM}/voice tts  to toggle speech output{_RST}")
         _cprint(f"  {_DIM}/voice off  to disable voice mode{_RST}")
+
+    def _apply_voice_auto_tts_default(self) -> None:
+        """Enable voice TTS when configured without overriding explicit state."""
+        try:
+            from hermes_cli.config import load_config
+            _raw_voice = load_config().get("voice")
+            voice_config = _raw_voice if isinstance(_raw_voice, dict) else {}
+            if voice_config.get("auto_tts", False):
+                with self._voice_lock:
+                    self._voice_tts = True
+        except Exception:
+            pass
 
     def _typed_voice_stop(self, user_input) -> bool:
         """Typed bare stop phrase during an active voice chat ends the chat.
@@ -12643,6 +12647,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # VAD auto-stop transcribes and queues the transcript for process_loop.
         with self._voice_lock:
             self._voice_mode = True
+        self._apply_voice_auto_tts_default()
         self._voice_continuous = False
         try:
             self._voice_start_recording()

--- a/contributors/emails/2895359972@qq.com
+++ b/contributors/emails/2895359972@qq.com
@@ -1,0 +1,2 @@
+XRX193
+# PR #74637 salvage (wake-word auto-TTS)

--- a/contributors/emails/2895359972@qq.com
+++ b/contributors/emails/2895359972@qq.com
@@ -1,2 +1,2 @@
 XRX193
-# PR #74637 salvage (wake-word auto-TTS)
+# PR #72518 (Windows uv illegal-instruction fallback)

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -137,6 +137,32 @@ class TestEnableVoiceModeReal:
         assert cli._voice_mode is True
 
 
+class TestWakeWordAutoTts:
+    """Wake-triggered voice turns honor the global auto-TTS setting."""
+
+    def test_auto_tts_is_enabled_before_wake_recording(self, monkeypatch):
+        cli = _make_voice_cli(
+            _agent_running=False,
+            _wake_start_new_session=False,
+            _wake_word_active=True,
+            _wake_suspended=False,
+        )
+        cli._voice_start_recording = MagicMock()
+
+        monkeypatch.setattr("tools.wake_word.pause_listening", lambda owner: True)
+        monkeypatch.setattr("tools.wake_word.get_last_match", lambda: None)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"voice": {"auto_tts": True}},
+        )
+
+        with patch("cli._cprint"):
+            cli._on_wake_word()
+
+        assert cli._voice_tts is True
+        cli._voice_start_recording.assert_called_once_with()
+
+
 class TestVoiceBeepConfigReal:
     """Tests the CLI voice beep toggle."""
 

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -140,7 +140,18 @@ class TestEnableVoiceModeReal:
 class TestWakeWordAutoTts:
     """Wake-triggered voice turns honor the global auto-TTS setting."""
 
-    def test_auto_tts_is_enabled_before_wake_recording(self, monkeypatch):
+    @pytest.mark.parametrize(
+        ("yaml_value", "expected"),
+        [("true", True), ("false", False), ('"false"', False)],
+    )
+    def test_auto_tts_is_applied_before_wake_recording(
+        self, monkeypatch, tmp_path, yaml_value, expected
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            f"voice:\n  auto_tts: {yaml_value}\n",
+            encoding="utf-8",
+        )
         cli = _make_voice_cli(
             _agent_running=False,
             _wake_start_new_session=False,
@@ -151,15 +162,11 @@ class TestWakeWordAutoTts:
 
         monkeypatch.setattr("tools.wake_word.pause_listening", lambda owner: True)
         monkeypatch.setattr("tools.wake_word.get_last_match", lambda: None)
-        monkeypatch.setattr(
-            "hermes_cli.config.load_config",
-            lambda: {"voice": {"auto_tts": True}},
-        )
 
         with patch("cli._cprint"):
             cli._on_wake_word()
 
-        assert cli._voice_tts is True
+        assert cli._voice_tts is expected
         cli._voice_start_recording.assert_called_once_with()
 
 

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -134,6 +134,32 @@ class TestEnableVoiceModeReal:
         assert cli._voice_mode is True
 
 
+class TestWakeWordAutoTts:
+    """Wake-triggered voice turns honor the global auto-TTS setting."""
+
+    def test_auto_tts_is_enabled_before_wake_recording(self, monkeypatch):
+        cli = _make_voice_cli(
+            _agent_running=False,
+            _wake_start_new_session=False,
+            _wake_word_active=True,
+            _wake_suspended=False,
+        )
+        cli._voice_start_recording = MagicMock()
+
+        monkeypatch.setattr("tools.wake_word.pause_listening", lambda owner: True)
+        monkeypatch.setattr("tools.wake_word.get_last_match", lambda: None)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"voice": {"auto_tts": True}},
+        )
+
+        with patch("cli._cprint"):
+            cli._on_wake_word()
+
+        assert cli._voice_tts is True
+        cli._voice_start_recording.assert_called_once_with()
+
+
 class TestVoiceBeepConfigReal:
     """Tests the CLI voice beep toggle."""
 


### PR DESCRIPTION
## What does this PR do?

Wake-word captures now apply `voice.auto_tts` before recording, matching manual `/voice` entry. Previously `_on_wake_word()` only enabled voice mode; `_voice_tts` stayed at its default `False`, so both response-speech paths skipped playback.

The config lookup is extracted into a small helper shared by manual and wake-word entry. It only enables TTS when configured and preserves the existing exception-safe handling for malformed config.

## Related Issue

Fixes #74328

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Reuse one shape-safe auto-TTS config initializer from both voice entry paths in `cli.py`.
- Apply the auto-TTS default before wake-word recording begins.
- Add a behavioral regression test that calls the real `_on_wake_word()` path.

## How to Test

1. Set `wake_word.enabled: true` and `voice.auto_tts: true` in `config.yaml`.
2. Start Hermes and invoke a turn using the configured wake phrase.
3. Confirm the response is spoken without manually running `/voice tts`.

Automated test:

```bash
scripts/run_tests.sh tests/tools/test_voice_cli_integration.py -q -k "TestEnableVoiceModeReal or TestWakeWordAutoTts"
```

Result: `7 passed, 0 failed` on Windows 11.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched open and closed PRs for duplicates
- [x] My PR contains only changes related to this fix
- [ ] I've run the full test suite (focused voice integration tests were run)
- [x] I've added tests for my changes
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing behavior or config key changed
- [x] `cli-config.yaml.example`: N/A; no config key changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; this changes only in-memory state under the existing lock
- [x] Tool descriptions/schemas: N/A; no tool schema changed

## Screenshots / Logs

Not applicable; the regression is covered by the focused behavioral test above.