### PR TITLE
fix(gateway): prefix all busy-ack messages with [System], including the priority-path drain gate

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8374,9 +8374,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
             if self._queue_during_drain_enabled():
                 self._queue_or_replace_pending_event(session_key, event)
-                message = f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
+                message = f"[System] ⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
             else:
-                message = f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
+                message = f"[System] ⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
 
             await adapter._send_with_retry(
                 chat_id=event.source.chat_id,
@@ -8768,6 +8768,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 mark_seen(_hermes_home / "config.yaml", BUSY_INPUT_FLAG)
         except Exception as _onb_err:
             logger.debug("Failed to apply busy-input onboarding hint: %s", _onb_err)
+
+        # Prefix all busy-ack messages with [System] so the user and the
+        # agent can distinguish automated gateway notices from agent replies.
+        # Applied after the final message is selected (including onboarding hint
+        # append) so every busy mode -- steer, queue, interrupt, subagent, and
+        # compression demotion -- is uniformly prefixed. LINE's
+        # _is_system_bypass() strips this prefix before matching its known
+        # emoji prefixes, so the bypass contract for interrupt/queue/steer
+        # acks continues to work (see plugins/platforms/line/adapter.py).
+        message = "[System] " + message
 
         reply_anchor = self._reply_anchor_for_event(event)
         thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
@@ -14879,7 +14889,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _quick_key,
             )
             return (
-                "⏳ This agent is draining for a maintenance action and isn't "
+                "[System] ⏳ This agent is draining for a maintenance action and isn't "
                 "accepting new turns right now. It'll be back in a moment — "
                 "please resend shortly."
             )

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -640,6 +640,12 @@ _SYSTEM_BYPASS_PREFIXES: Tuple[str, ...] = (
 def _is_system_bypass(content: str) -> bool:
     if not content:
         return False
+    # All gateway busy-ack and drain-ack messages are now wrapped with a
+    # "[System] " prefix for user/agent legibility (gateway/run.py). Strip
+    # it before checking so the bypass contract keeps matching regardless
+    # of the wrapper.
+    if content.startswith("[System] "):
+        content = content[len("[System] "):]
     return any(content.startswith(p) for p in _SYSTEM_BYPASS_PREFIXES)
 
 

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -403,6 +403,169 @@ class TestBusySessionAck:
         assert "10 min" in content  # elapsed
 
 
+class TestBusyAckSystemPrefix:
+    """All busy-ack and drain-ack messages must carry a '[System] ' prefix
+    so users/the agent can distinguish automated gateway notices from agent
+    replies, and so LINE's postback-bypass detection (which strips this
+    prefix before matching) keeps working across every mode."""
+
+    def _content_of(self, adapter):
+        call_kwargs = adapter._send_with_retry.call_args
+        return call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
+
+    @pytest.mark.asyncio
+    async def test_interrupt_mode_prefixed(self):
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+        event = _make_event(text="hi")
+        sk = build_session_key(event.source)
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {}
+        runner._running_agents[sk] = agent
+        runner.adapters[event.source.platform] = adapter
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        content = self._content_of(adapter)
+        assert content.startswith("[System] "), content
+        assert "Interrupting" in content
+
+    @pytest.mark.asyncio
+    async def test_queue_mode_prefixed(self):
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+        event = _make_event(text="hi")
+        sk = build_session_key(event.source)
+        runner._running_agents[sk] = MagicMock()
+        runner.adapters[event.source.platform] = adapter
+
+        with patch("gateway.run.merge_pending_message_event"):
+            await runner._handle_active_session_busy_message(event, sk)
+
+        content = self._content_of(adapter)
+        assert content.startswith("[System] "), content
+        assert "Queued for the next turn" in content
+
+    @pytest.mark.asyncio
+    async def test_steer_mode_prefixed(self, monkeypatch):
+        import gateway.run as _gr
+
+        monkeypatch.delenv("HERMES_GATEWAY_BUSY_STEER_ACK_ENABLED", raising=False)
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+        event = _make_event(text="steer this")
+        sk = build_session_key(event.source)
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+        runner.adapters[event.source.platform] = adapter
+
+        with patch("gateway.run.merge_pending_message_event"):
+            await runner._handle_active_session_busy_message(event, sk)
+
+        content = self._content_of(adapter)
+        assert content.startswith("[System] "), content
+        assert "Steered" in content
+
+    @pytest.mark.asyncio
+    async def test_subagent_demotion_prefixed(self, monkeypatch):
+        """interrupt demoted to queue because the running agent has active
+        subagents (#30170) — a distinct message branch from plain queue."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+        event = _make_event(text="hi")
+        sk = build_session_key(event.source)
+        runner._running_agents[sk] = MagicMock()
+        runner.adapters[event.source.platform] = adapter
+        monkeypatch.setattr(
+            type(runner), "_agent_has_active_subagents", staticmethod(lambda _agent: True)
+        )
+
+        with patch("gateway.run.merge_pending_message_event"):
+            await runner._handle_active_session_busy_message(event, sk)
+
+        content = self._content_of(adapter)
+        assert content.startswith("[System] "), content
+        assert "Subagent working" in content
+
+    @pytest.mark.asyncio
+    async def test_compression_demotion_prefixed(self, monkeypatch):
+        """interrupt demoted to queue because compression is in flight (#56391)."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+        event = _make_event(text="hi")
+        sk = build_session_key(event.source)
+        runner._running_agents[sk] = MagicMock()
+        runner.adapters[event.source.platform] = adapter
+        monkeypatch.setattr(
+            type(runner), "_agent_has_active_subagents", staticmethod(lambda _agent: False)
+        )
+
+        async def _compression_in_flight(_sk):
+            return True
+
+        runner._session_has_compression_in_flight = _compression_in_flight
+
+        with patch("gateway.run.merge_pending_message_event"):
+            await runner._handle_active_session_busy_message(event, sk)
+
+        content = self._content_of(adapter)
+        assert content.startswith("[System] "), content
+        assert "Compressing context" in content
+
+    @pytest.mark.asyncio
+    async def test_draining_case_prefixed(self):
+        """The draining-case ack is a separate early-return branch from the
+        busy-mode message selection above; it must also carry the prefix."""
+        runner, sentinel = _make_runner()
+        runner._draining = True
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+        event = _make_event(text="hello")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+        runner._queue_during_drain_enabled = lambda: True
+        runner._status_action_gerund = lambda: "restarting"
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        content = self._content_of(adapter)
+        assert content.startswith("[System] "), content
+        assert "restarting" in content
+
+    def test_priority_path_external_drain_ack_prefixed(self):
+        """Regression (review of #68501): a SEPARATE priority-path fast
+        route (the external-drain new-turn gate, checked before a new
+        turn's session slot is even claimed) returns its own bare drain
+        acknowledgement string directly -- it does not go through
+        _handle_active_session_busy_message()'s message-selection/prefix
+        logic tested above at all. This is a plain string constant, so
+        importing the module source and checking it directly is more
+        robust than reconstructing the full external-drain gate state
+        (is_internal, _external_drain_active, session claiming) needed to
+        actually execute that code path end to end."""
+        import inspect
+        import gateway.run as _gr
+
+        src = inspect.getsource(_gr)
+        assert (
+            '"[System] \u23f3 This agent is draining for a maintenance action'
+            in src
+        ), (
+            "The external-drain new-turn gate's acknowledgement must also "
+            "carry the [System] prefix -- this is a separate return path "
+            "from the main busy-ack selection logic and was not covered "
+            "by the original all-busy-ack-prefixed guarantee"
+        )
+
+
 class TestBusySessionOnboardingHint:
     """First-touch hint appended to the busy-ack the first time it fires."""
 

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -243,6 +243,16 @@ class TestSendRouting:
         assert not _is_system_bypass("Hello world")
         assert not _is_system_bypass("")
 
+    def test_system_bypass_recognized_with_system_prefix(self):
+        """gateway/run.py wraps all busy-ack messages with a '[System] '
+        prefix; the bypass check must strip it before matching the known
+        emoji prefixes, or every busy-ack silently stops bypassing the
+        postback cache on LINE."""
+        assert _is_system_bypass("[System] ⚡ Interrupting current run")
+        assert _is_system_bypass("[System] ⏳ Queued — agent is busy")
+        assert _is_system_bypass("[System] ⏩ Steered toward new task")
+        assert not _is_system_bypass("[System] Hello world")
+
 
     def test_send_caps_messages_per_call_at_five(self, adapter):
         # Build a payload that would naturally split into more than 5 LINE


### PR DESCRIPTION
## Context

Supersedes #68501 per @teknium1's review.

## Problem

The original port prefixed all busy-ack messages routed through `_handle_active_session_busy_message()`'s message-selection logic (5 modes + the draining-case early return), and updated LINE's `_is_system_bypass()` to strip the prefix. But a SEPARATE priority-path fast route -- the external-drain new-turn gate, checked before a new turn's session slot is even claimed -- returns its own bare drain acknowledgement string directly, bypassing that logic entirely. This path remained unprefixed despite the stated all-busy-ack guarantee.

## Fix

Applied the same `[System] ` prefix to the priority-path gate's return value.

## Verification

Added a regression test for the priority-path gate (source-inspection, since fully exercising the gate's real state end to end is disproportionate for a single string-constant check) plus the full ported test suite for the other 6 busy-ack modes and the LINE bypass-with-prefix cases.

7/7 in `TestBusyAckSystemPrefix` (including the new priority-path test), 2/2 LINE bypass tests; 48 passed / 1 pre-existing skip across the full test files (no regression).