### PR TITLE
fix(desktop): sidebar labels truncate instead of pushing header icons out

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/chrome.tsx
+++ b/apps/desktop/src/app/chat/sidebar/chrome.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils'
 
 /** The muted slot beside a section label (loading glyph, status hint). */
 export function SidebarSectionMeta({ children }: { children: React.ReactNode }) {
-  return <span className="text-[0.6875rem] font-medium text-(--ui-text-quaternary)">{children}</span>
+  return <span className="shrink-0 text-[0.6875rem] font-medium text-(--ui-text-quaternary)">{children}</span>
 }
 
 // ── Row geometry (session row is canonical — everything composes these) ─────

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -135,7 +135,7 @@ export function SidebarCronJobsSection({
     <SidebarGroup className="shrink-0 p-0 pb-1">
       <div className="group/section flex shrink-0 items-center justify-between pb-1 pt-1.5">
         <button
-          className="group/section-label flex w-fit items-center gap-1 bg-transparent text-left leading-none"
+          className="group/section-label flex w-fit min-w-0 items-center gap-1 bg-transparent text-left leading-none"
           onClick={onToggle}
           type="button"
         >

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-header.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-header.tsx
@@ -24,7 +24,9 @@ function LaneLabel({ label, title }: { label: string; title?: string }) {
   const tail = label.slice(label.length - tailLen)
 
   return (
-    <span className="flex min-w-0" title={title}>
+    // overflow-hidden: the pinned tail is shrink-0, so at extreme narrow widths
+    // it must clip inside the label rather than push the trailing icons out.
+    <span className="flex min-w-0 overflow-hidden" title={title}>
       <span className="truncate">{head}</span>
       <span className="shrink-0 whitespace-pre">{tail}</span>
     </span>

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -64,7 +64,9 @@ function SidebarSectionHeader({
     <div className="group/section flex shrink-0 items-center justify-between gap-1 pb-1 pt-1.5">
       {collapsible ? (
         <button
-          className="group/section-label flex w-fit items-center gap-1 bg-transparent text-left leading-none"
+          // min-w-0 lets the label truncate at narrow sidebar widths instead of
+          // pushing the header's trailing action icons out of view.
+          className="group/section-label flex w-fit min-w-0 items-center gap-1 bg-transparent text-left leading-none"
           onClick={onToggle}
           type="button"
         >
@@ -75,7 +77,7 @@ function SidebarSectionHeader({
           />
         </button>
       ) : (
-        <div className="flex w-fit items-center gap-1 leading-none">{labelBody}</div>
+        <div className="flex w-fit min-w-0 items-center gap-1 leading-none">{labelBody}</div>
       )}
       {action}
     </div>

--- a/apps/desktop/src/app/settings/keybind-settings.tsx
+++ b/apps/desktop/src/app/settings/keybind-settings.tsx
@@ -173,11 +173,13 @@ export function KeybindSettings() {
 function CategoryHeader({ label, onToggle, open }: { label: string; onToggle: () => void; open: boolean }) {
   return (
     <button
-      className="group/kbd-cat flex w-fit items-center gap-1 px-2.5 pb-1 pt-3 text-left leading-none"
+      className="group/kbd-cat flex w-fit min-w-0 items-center gap-1 px-2.5 pb-1 pt-3 text-left leading-none"
       onClick={onToggle}
       type="button"
     >
-      <span className="text-[0.64rem] font-semibold uppercase tracking-[0.12em] text-muted-foreground/70">{label}</span>
+      <span className="min-w-0 truncate text-[0.64rem] font-semibold uppercase tracking-[0.12em] text-muted-foreground/70">
+        {label}
+      </span>
       <DisclosureCaret
         className="text-(--ui-text-tertiary) opacity-0 transition group-hover/kbd-cat:opacity-100"
         open={open}

--- a/apps/desktop/src/components/ui/disclosure-caret.tsx
+++ b/apps/desktop/src/components/ui/disclosure-caret.tsx
@@ -11,7 +11,7 @@ interface DisclosureCaretProps extends Omit<CodiconProps, 'name'> {
 export function DisclosureCaret({ className, open, size = '0.75rem', ...props }: DisclosureCaretProps) {
   return (
     <Codicon
-      className={cn('transition-transform duration-150', open && 'rotate-90', className)}
+      className={cn('shrink-0 transition-transform duration-150', open && 'rotate-90', className)}
       name="chevron-right"
       size={size}
       {...props}


### PR DESCRIPTION
## Summary

At narrow sidebar widths a long project title (or lane/section label) refused to shrink — flex's default `min-width: auto` on the label containers meant the label won the space fight and shoved the header's trailing action icons (disclosure caret, +, kebab, git-branch) past the sidebar edge.

This makes the rule global: labels give way, icons never do.

- `min-w-0` on the section-header label containers (sessions, cron, keybind categories) so each label's `truncate` can actually engage
- `shrink-0` on `DisclosureCaret` at the primitive, so every collapsible header keeps its caret for free
- `shrink-0` on `SidebarSectionMeta` (the loading-glyph slot)
- `overflow-hidden` on `LaneLabel`, whose pinned branch-suffix tail is `shrink-0` and could still overflow at extreme widths

All trailing action buttons in these headers were already `shrink-0`, so with the labels now shrinkable the icons hold at any width.

## Test plan

- [ ] Enter a project with a long name, drag the sidebar to minimum width: title ellipsizes, caret/+/kebab stay visible
- [ ] Same for repo/worktree lanes (branch tail stays pinned, clips instead of overflowing) and the cron section header