### PR TITLE
feat(telegram): allow concurrent update processing via extra.concurrent_updates

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3624,6 +3624,28 @@ class TelegramAdapter(BasePlatformAdapter):
 
             # Build the application
             builder = Application.builder().token(self.config.token)
+            # PTB processes updates sequentially unless told otherwise: the next
+            # update is only picked up after the previous handler returns. In a
+            # forum group, where every topic is a separate conversation, this
+            # serialises unrelated chats — a turn started in one topic blocks the
+            # start of a turn in another. Opt-in via
+            # ``platforms.<name>.extra.concurrent_updates``; the default of 1
+            # keeps the current behaviour unchanged.
+            concurrent_updates_raw = self.config.extra.get("concurrent_updates", 1)
+            try:
+                concurrent_updates = int(concurrent_updates_raw)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "[%s] Ignoring non-numeric concurrent_updates=%r, using 1",
+                    self.name, concurrent_updates_raw,
+                )
+                concurrent_updates = 1
+            if concurrent_updates > 1:
+                builder = builder.concurrent_updates(concurrent_updates)
+                logger.info(
+                    "[%s] Telegram concurrent_updates=%s",
+                    self.name, concurrent_updates,
+                )
             custom_base_url = self.config.extra.get("base_url")
             if custom_base_url:
                 builder = builder.base_url(custom_base_url)


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in setting that lets the Telegram adapter process updates
concurrently instead of one at a time.

`Application.builder()` is used without `.concurrent_updates()`, so
python-telegram-bot keeps its default of **sequential** update processing: the
next update is dispatched only after the previous handler returns. For a bot
where one chat equals one conversation that is a sane default. For a **forum
group**, where each topic is an independent conversation with its own session, it
means unrelated topics block each other.

## Why it matters

Measured on a production forum group (10 topics, agent turns taking tens of
seconds), messages sent 2 s apart into two different topics:

| | Before | After (`concurrent_updates: 4`) |
|---|---|---|
| Second topic's turn starts | **+10 s** after the first topic's turn | within the same second |
| `database is locked` | 0 | 0 |
| `409 Conflict` | 0 | 0 |
| Dropped / dead-letter updates | 0 | 0 |

The delay is not CPU-bound — it is the dispatcher waiting for the previous
handler to return.

## The change

One insertion in `start()`, right after the builder is created:

```python
concurrent_updates_raw = self.config.extra.get("concurrent_updates", 1)
try:
    concurrent_updates = int(concurrent_updates_raw)
except (TypeError, ValueError):
    logger.warning(...)
    concurrent_updates = 1
if concurrent_updates > 1:
    builder = builder.concurrent_updates(concurrent_updates)
    logger.info(...)
```

Configuration:

```yaml
platforms:
  telegram:
    extra:
      concurrent_updates: 4   # default 1 = current sequential behaviour
```

## Design notes

* **Default is 1.** Nothing changes for existing installations; the feature has
  to be switched on deliberately, and rolling back is a config edit rather than a
  code change.
* **Non-numeric values are ignored with a warning**, not fatal: a typo in a
  config file should not stop a bot from starting.
* **`0` and `1` behave the same** (sequential), so `concurrent_updates: 0` reads
  naturally as "off".
* **Per-chat ordering is unchanged.** PTB's concurrency is per-update and each
  topic keeps its own session key, so this does not interleave turns *within* one
  conversation — it stops different conversations from queueing behind each other.
* The setting lives in `extra`, next to `base_url` and `local_mode`, so no schema
  change is needed.

## Risk

Handlers that assume they are the only one running would now overlap. Per-topic
state is keyed by session and the storage layer is already reached from multiple
tasks; a full working day on the deployment above produced no locking or conflict
errors. The opt-in default means the risk is only taken by someone who asks for
it.

## Testing

Verified on a live deployment for a working day (10 topics, concurrent turns,
documents and voice messages): no `database is locked`, no `409 Conflict`, no lost
updates, replies delivered to the correct topics. Patch is written against current
`main`.

Not run: the upstream `pytest` suite — the deployment host has no pytest
installed. Happy to add a unit test for the parsing branch (non-numeric →
warning + fallback to 1) if you would like one in this PR.
