### PR TITLE
fix(slack): read real SDK responses instead of gating on isinstance dict

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -107,6 +107,22 @@ async def _read_error_text_limited(
     return str(text)[:limit]
 
 
+def _slack_response_payload(response: Any) -> Dict[str, Any]:
+    """Return a Slack Web API response as a plain dict.
+
+    ``slack_sdk`` returns ``SlackResponse``/``AsyncSlackResponse``, which is
+    mapping-like but is **not** a ``dict``, while tests inject plain dicts.
+    Callers must normalize here instead of gating on ``isinstance(resp, dict)``
+    — such a gate is always False at runtime and silently degrades results
+    (user/channel names collapsing to raw IDs, sends reported as failures).
+    An unrecognized shape yields ``{}`` so callers keep their fallbacks.
+    """
+    if isinstance(response, dict):
+        return response
+    data = getattr(response, "data", None)
+    return data if isinstance(data, dict) else {}
+
+
 _SLACK_SPECIAL_MENTION_RE = re.compile(
     r"<!(?:everyone|channel|here)(?:\|[^>\n]*)?>", re.IGNORECASE
 )
@@ -1627,10 +1643,11 @@ class SlackAdapter(BasePlatformAdapter):
                     user=user_id,
                     text=chunk,
                 )
-                if not (isinstance(result, dict) and result.get("ok")):
+                payload = _slack_response_payload(result)
+                if not payload.get("ok"):
                     err = (
-                        result.get("error", "unknown_error")
-                        if isinstance(result, dict)
+                        payload.get("error", "unknown_error")
+                        if payload
                         else "unexpected_response"
                     )
                     return SendResult(
@@ -2245,11 +2262,7 @@ class SlackAdapter(BasePlatformAdapter):
                 channel=parent_chat_id,
                 text=seed_text,
             )
-            ts = (
-                result.get("ts")
-                if isinstance(result, dict)
-                else getattr(result, "get", lambda _k, _d=None: None)("ts")
-            )
+            ts = _slack_response_payload(result).get("ts")
             if ts:
                 return str(ts)
         except Exception as exc:
@@ -3801,11 +3814,12 @@ class SlackAdapter(BasePlatformAdapter):
                 else self._app.client
             )
             result = await client.users_info(user=user_id)
-            if not isinstance(result, dict):
+            payload = _slack_response_payload(result)
+            if not payload:
                 self._user_is_bot_cache[cache_key] = False
                 self._user_name_cache[cache_key] = user_id
                 return user_id
-            user = result.get("user", {})
+            user = payload.get("user", {})
             profile = user.get("profile", {}) if isinstance(user, dict) else {}
             self._user_is_bot_cache[cache_key] = bool(
                 user.get("is_bot")
@@ -3854,10 +3868,11 @@ class SlackAdapter(BasePlatformAdapter):
             resp = await self._get_client(
                 channel_id, team_id=team_id or None
             ).conversations_info(channel=channel_id)
-            if not isinstance(resp, dict) or not resp.get("ok"):
+            payload = _slack_response_payload(resp)
+            if not payload.get("ok"):
                 name = channel_id
             else:
-                ch = resp.get("channel") or {}
+                ch = payload.get("channel") or {}
                 if ch.get("is_im"):
                     peer_user = ch.get("user", "")
                     name = (
@@ -3971,11 +3986,12 @@ class SlackAdapter(BasePlatformAdapter):
                 else self._app.client
             )
             result = await client.users_info(user=user_id)
-            if not isinstance(result, dict):
+            payload = _slack_response_payload(result)
+            if not payload:
                 self._user_is_bot_cache[cache_key] = False
                 self._user_name_cache.setdefault(cache_key, user_id)
                 return False
-            user = result.get("user", {})
+            user = payload.get("user", {})
             profile = user.get("profile", {}) if isinstance(user, dict) else {}
             is_bot = bool(
                 user.get("is_bot")
@@ -8560,12 +8576,13 @@ async def _standalone_upload_file(
     if thread_id:
         kwargs["thread_ts"] = thread_id
     result = await client.files_upload_v2(**kwargs)
-    if isinstance(result, dict) and result.get("ok") is False:
-        return {"error": f"Slack API error: {result.get('error', 'unknown')}"}
+    payload = _slack_response_payload(result)
+    if payload.get("ok") is False:
+        return {"error": f"Slack API error: {payload.get('error', 'unknown')}"}
     # files_upload_v2 responses vary by sdk version; prefer file timestamp when present.
     message_id = None
-    if isinstance(result, dict):
-        file_obj = result.get("file") or {}
+    if payload:
+        file_obj = payload.get("file") or {}
         shares = file_obj.get("shares") or {}
         for share_bucket in shares.values():
             if isinstance(share_bucket, dict):
@@ -8575,7 +8592,7 @@ async def _standalone_upload_file(
                         break
             if message_id:
                 break
-        message_id = message_id or file_obj.get("timestamp") or result.get("ts")
+        message_id = message_id or file_obj.get("timestamp") or payload.get("ts")
     return {"success": True, "message_id": message_id, "raw": result}
 
 
@@ -8707,14 +8724,14 @@ async def _standalone_send(
             if thread_id:
                 post_kwargs["thread_ts"] = thread_id
             try:
-                post_resp = await client.chat_postMessage(**post_kwargs)
-                if isinstance(post_resp, dict) and not post_resp.get("ok", True):
-                    return {
-                        "error": f"Slack API error: {post_resp.get('error', 'unknown')}"
-                    }
-                last_message_id = (
-                    post_resp.get("ts") if isinstance(post_resp, dict) else None
+                post_payload = _slack_response_payload(
+                    await client.chat_postMessage(**post_kwargs)
                 )
+                if not post_payload.get("ok", True):
+                    return {
+                        "error": f"Slack API error: {post_payload.get('error', 'unknown')}"
+                    }
+                last_message_id = post_payload.get("ts")
             except Exception as e:
                 return {"error": f"Slack send failed: {e}"}
 
@@ -8735,8 +8752,10 @@ async def _standalone_send(
                         }
                         if thread_id:
                             fallback_kwargs["thread_ts"] = thread_id
-                        fb = await client.chat_postMessage(**fallback_kwargs)
-                        if isinstance(fb, dict) and fb.get("ok", True):
+                        fb = _slack_response_payload(
+                            await client.chat_postMessage(**fallback_kwargs)
+                        )
+                        if fb.get("ok", True):
                             last_message_id = fb.get("ts") or last_message_id
                             caption_pending = False
                     except Exception:

--- a/tests/gateway/test_slack_sdk_response.py
+++ b/tests/gateway/test_slack_sdk_response.py
@@ -10,7 +10,9 @@ exercises the SDK-shaped response as well.
 """
 
 import asyncio
+import contextlib
 import sys
+from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -64,6 +66,7 @@ _slack_mod.SLACK_AVAILABLE = True
 from plugins.platforms.slack.adapter import (  # noqa: E402
     SlackAdapter,
     _slack_response_payload,
+    _standalone_send,
     _standalone_upload_file,
 )
 
@@ -248,3 +251,134 @@ class TestSendPaths:
             _standalone_upload_file(client, "C_GEN", str(media))
         )
         assert "not_in_channel" in result["error"]
+
+
+class TestHandoffThread:
+    """``create_handoff_thread`` anchors a session on the seed message's ts."""
+
+    @response_shape
+    def test_seed_ts_becomes_the_thread_id(self, make_response):
+        """Without the ts every handoff send lands in the channel, not a thread."""
+        adapter = _make_adapter()
+        client = MagicMock()
+        client.chat_postMessage = AsyncMock(
+            return_value=make_response({"ok": True, "ts": "1700000000.000100"})
+        )
+        adapter._get_client = lambda *_a, **_kw: client
+        thread_id = asyncio.run(adapter.create_handoff_thread("C_GEN", "review"))
+        assert thread_id == "1700000000.000100"
+
+    def test_unreadable_response_yields_no_thread(self):
+        """Callers must still see a clean ``None`` for genuinely opaque replies."""
+        adapter = _make_adapter()
+        client = MagicMock()
+        client.chat_postMessage = AsyncMock(return_value=object())
+        adapter._get_client = lambda *_a, **_kw: client
+        assert asyncio.run(adapter.create_handoff_thread("C_GEN", "review")) is None
+
+
+# ── standalone (out-of-process cron/send_message) delivery ─────────────────
+
+
+@contextlib.contextmanager
+def _fake_slack_sdk(client):
+    """Make ``from slack_sdk.web.async_client import AsyncWebClient`` yield ``client``."""
+    sdk = ModuleType("slack_sdk")
+    web = ModuleType("slack_sdk.web")
+    async_client = ModuleType("slack_sdk.web.async_client")
+    async_client.AsyncWebClient = MagicMock(return_value=client)
+    sdk.web = web
+    web.async_client = async_client
+
+    modules = {
+        "slack_sdk": sdk,
+        "slack_sdk.web": web,
+        "slack_sdk.web.async_client": async_client,
+    }
+    old = {name: sys.modules.get(name) for name in modules}
+    sys.modules.update(modules)
+    try:
+        yield
+    finally:
+        for name, prev in old.items():
+            if prev is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = prev
+
+
+class TestStandaloneSendMediaPath:
+    """``_standalone_send``'s media branch reads two chat.postMessage replies."""
+
+    @response_shape
+    def test_text_alongside_media_reports_its_ts(self, make_response, tmp_path):
+        """The text post's ts is the message_id cron threads follow-ups onto."""
+        media = tmp_path / "report.pdf"
+        media.write_bytes(b"%PDF-1.4 x")
+        client = MagicMock()
+        client.chat_postMessage = AsyncMock(
+            return_value=make_response({"ok": True, "ts": "111.222"})
+        )
+        client.files_upload_v2 = AsyncMock(
+            return_value=make_response({"ok": True, "file": {}})
+        )
+        with _fake_slack_sdk(client):
+            result = asyncio.run(
+                _standalone_send(
+                    SimpleNamespace(token="xoxb-test", extra={}),
+                    "C_GEN",
+                    "Here is the report",
+                    media_files=[(str(media), False)],
+                )
+            )
+        assert result["success"] is True
+        assert result["message_id"] == "111.222"
+
+    @response_shape
+    def test_text_post_error_is_surfaced(self, make_response, tmp_path):
+        """A rejected text post must fail loudly instead of silently uploading."""
+        media = tmp_path / "report.pdf"
+        media.write_bytes(b"%PDF-1.4 x")
+        client = MagicMock()
+        client.chat_postMessage = AsyncMock(
+            return_value=make_response({"ok": False, "error": "channel_not_found"})
+        )
+        client.files_upload_v2 = AsyncMock()
+        with _fake_slack_sdk(client):
+            result = asyncio.run(
+                _standalone_send(
+                    SimpleNamespace(token="xoxb-test", extra={}),
+                    "C_GEN",
+                    "Here is the report",
+                    media_files=[(str(media), False)],
+                )
+            )
+        assert "channel_not_found" in result["error"]
+        client.files_upload_v2.assert_not_awaited()
+
+    @response_shape
+    def test_caption_fallback_delivers_when_media_is_missing(
+        self, make_response, tmp_path
+    ):
+        """Caption-only delivery was reported as 'nothing deliverable' instead."""
+        client = MagicMock()
+        client.chat_postMessage = AsyncMock(
+            return_value=make_response({"ok": True, "ts": "555.666"})
+        )
+        client.files_upload_v2 = AsyncMock()
+        with _fake_slack_sdk(client):
+            result = asyncio.run(
+                _standalone_send(
+                    SimpleNamespace(token="xoxb-test", extra={}),
+                    "C_GEN",
+                    "",
+                    media_files=[(str(tmp_path / "gone.pdf"), False)],
+                    caption="Here is the report",
+                )
+            )
+        assert result["success"] is True
+        assert result["message_id"] == "555.666"
+        client.chat_postMessage.assert_awaited_once()
+        assert (
+            client.chat_postMessage.await_args.kwargs["text"] == "Here is the report"
+        )

--- a/tests/gateway/test_slack_sdk_response.py
+++ b/tests/gateway/test_slack_sdk_response.py
@@ -1,0 +1,250 @@
+"""Slack Web API responses must be read as real SDK responses, not dicts.
+
+``slack_sdk`` returns ``SlackResponse``/``AsyncSlackResponse`` — mapping-like
+objects that are **not** ``dict`` subclasses. Code that gated on
+``isinstance(resp, dict)`` therefore took its "unexpected shape" branch on
+every real call, collapsing user/channel names to raw IDs, treating every user
+as a non-bot, and reporting successful sends as failures. Existing Slack tests
+injected plain dicts, so the defect was invisible to them; every case here
+exercises the SDK-shaped response as well.
+"""
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+# Import the real response class first: the mock installer below fills
+# sys.modules with MagicMocks, which would mask an installed slack_sdk.
+try:
+    from slack_sdk.web.async_slack_response import (  # noqa: E402
+        AsyncSlackResponse as _AsyncSlackResponse,
+    )
+except Exception:  # pragma: no cover - slack extra not installed
+    _AsyncSlackResponse = None
+
+
+# ---------------------------------------------------------------------------
+# Mock slack-bolt if not installed (same pattern as test_slack_mention.py)
+# ---------------------------------------------------------------------------
+
+def _ensure_slack_mock():
+    if "slack_bolt" in sys.modules and hasattr(sys.modules["slack_bolt"], "__file__"):
+        return
+
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    slack_bolt.adapter.socket_mode.async_handler.AsyncSocketModeHandler = MagicMock
+
+    slack_sdk = MagicMock()
+    slack_sdk.web.async_client.AsyncWebClient = MagicMock
+
+    for name, mod in [
+        ("slack_bolt", slack_bolt),
+        ("slack_bolt.async_app", slack_bolt.async_app),
+        ("slack_bolt.adapter", slack_bolt.adapter),
+        ("slack_bolt.adapter.socket_mode", slack_bolt.adapter.socket_mode),
+        ("slack_bolt.adapter.socket_mode.async_handler",
+         slack_bolt.adapter.socket_mode.async_handler),
+        ("slack_sdk", slack_sdk),
+        ("slack_sdk.web", slack_sdk.web),
+        ("slack_sdk.web.async_client", slack_sdk.web.async_client),
+    ]:
+        sys.modules.setdefault(name, mod)
+
+
+_ensure_slack_mock()
+
+import plugins.platforms.slack.adapter as _slack_mod  # noqa: E402
+
+_slack_mod.SLACK_AVAILABLE = True
+
+from plugins.platforms.slack.adapter import (  # noqa: E402
+    SlackAdapter,
+    _slack_response_payload,
+    _standalone_upload_file,
+)
+
+
+class _SdkLikeResponse:
+    """Stand-in for ``AsyncSlackResponse``: mapping-like, but not a ``dict``."""
+
+    def __init__(self, data):
+        self.data = data
+
+    def get(self, key, default=None):
+        return self.data.get(key, default)
+
+    def __getitem__(self, key):
+        return self.data.get(key)
+
+
+def _real_sdk_response(data):
+    """Build an actual ``AsyncSlackResponse`` — the shape production sees."""
+    return _AsyncSlackResponse(
+        client=None,
+        http_verb="POST",
+        api_url="https://slack.com/api/users.info",
+        req_args={},
+        data=data,
+        headers={},
+        status_code=200,
+    )
+
+
+# Every behavioral case runs against both the hand-rolled stand-in and, when
+# installed, the real SDK class — mocks alone are what hid this bug.
+_FACTORIES = [pytest.param(_SdkLikeResponse, id="sdk-like")]
+if isinstance(_AsyncSlackResponse, type):
+    _FACTORIES.append(pytest.param(_real_sdk_response, id="slack_sdk"))
+
+response_shape = pytest.mark.parametrize("make_response", _FACTORIES)
+
+
+def _make_adapter():
+    # object.__new__ skips __init__ (heavy setup) — established slack-test pattern.
+    adapter = object.__new__(SlackAdapter)
+    adapter._app = MagicMock()
+    adapter._user_name_cache = {}
+    adapter._user_is_bot_cache = {}
+    adapter._channel_name_cache = {}
+    adapter._channel_team = {}
+    adapter._USER_NAME_CACHE_MAX = 5000
+    adapter._CHANNEL_NAME_CACHE_MAX = 5000
+    return adapter
+
+
+# ── the normalizer's contract ───────────────────────────────────────────────
+
+
+class TestSlackResponsePayload:
+    def test_plain_dict_passes_through(self):
+        payload = {"ok": True}
+        assert _slack_response_payload(payload) is payload
+
+    @response_shape
+    def test_sdk_response_yields_its_data(self, make_response):
+        assert _slack_response_payload(make_response({"ok": True})) == {"ok": True}
+
+    @response_shape
+    def test_sdk_response_is_not_a_dict(self, make_response):
+        """The premise of the bug: the runtime object fails an isinstance dict gate."""
+        assert not isinstance(make_response({"ok": True}), dict)
+
+    @response_shape
+    def test_binary_response_is_not_mistaken_for_data(self, make_response):
+        """``SlackResponse.data`` may be bytes; callers need their fallback then."""
+        assert _slack_response_payload(make_response(b"\x89PNG")) == {}
+
+    def test_unknown_shape_yields_empty(self):
+        assert _slack_response_payload(object()) == {}
+        assert _slack_response_payload(None) == {}
+
+
+# ── the call sites that silently degraded ──────────────────────────────────
+
+
+class TestIdentityResolution:
+    @response_shape
+    def test_user_name_resolves(self, make_response):
+        """The reported symptom: names collapsed to the raw user id."""
+        adapter = _make_adapter()
+        adapter._app.client.users_info = AsyncMock(
+            return_value=make_response(
+                {"ok": True, "user": {"profile": {"display_name": "Nikita"}}}
+            )
+        )
+        name = asyncio.run(adapter._resolve_user_name("U_HUMAN"))
+        assert name == "Nikita"
+
+    @response_shape
+    def test_user_is_bot_resolves(self, make_response):
+        """allow_bots policy depends on this; a wrong False re-opens routing loops."""
+        adapter = _make_adapter()
+        adapter._app.client.users_info = AsyncMock(
+            return_value=make_response(
+                {"ok": True, "user": {"is_bot": True, "profile": {}}}
+            )
+        )
+        assert asyncio.run(adapter._resolve_user_is_bot("U_PEER_BOT")) is True
+
+    @response_shape
+    def test_channel_name_resolves(self, make_response):
+        adapter = _make_adapter()
+        client = MagicMock()
+        client.conversations_info = AsyncMock(
+            return_value=make_response({"ok": True, "channel": {"name": "general"}})
+        )
+        adapter._get_client = lambda *_a, **_kw: client
+        assert asyncio.run(adapter._resolve_channel_name("C_GEN")) == "general"
+
+    def test_unknown_shape_still_falls_back_to_the_id(self):
+        """Degradation for genuinely unreadable responses must be preserved."""
+        adapter = _make_adapter()
+        adapter._app.client.users_info = AsyncMock(return_value=object())
+        assert asyncio.run(adapter._resolve_user_name("U_HUMAN")) == "U_HUMAN"
+
+
+class TestSendPaths:
+    @response_shape
+    def test_ephemeral_reply_is_reported_as_delivered(self, make_response):
+        """Slash-command replies were reported as 'unexpected_response' failures."""
+        adapter = _make_adapter()
+        client = MagicMock()
+        client.chat_postEphemeral = AsyncMock(
+            return_value=make_response({"ok": True})
+        )
+        adapter._get_client = lambda *_a, **_kw: client
+        result = asyncio.run(
+            adapter._post_ephemeral_fallback("C_GEN", {"user_id": "U_HUMAN"}, "hi")
+        )
+        assert result.success is True
+
+    @response_shape
+    def test_ephemeral_error_is_surfaced(self, make_response):
+        adapter = _make_adapter()
+        client = MagicMock()
+        client.chat_postEphemeral = AsyncMock(
+            return_value=make_response({"ok": False, "error": "channel_not_found"})
+        )
+        adapter._get_client = lambda *_a, **_kw: client
+        result = asyncio.run(
+            adapter._post_ephemeral_fallback("C_GEN", {"user_id": "U_HUMAN"}, "hi")
+        )
+        assert result.success is False
+        assert "channel_not_found" in result.error
+
+    @response_shape
+    def test_upload_returns_the_message_id(self, make_response, tmp_path):
+        """A lost message_id breaks threading of follow-up sends."""
+        media = tmp_path / "note.txt"
+        media.write_text("x")
+        client = MagicMock()
+        client.files_upload_v2 = AsyncMock(
+            return_value=make_response(
+                {"ok": True, "file": {"timestamp": "123.456"}}
+            )
+        )
+        result = asyncio.run(
+            _standalone_upload_file(client, "C_GEN", str(media))
+        )
+        assert result == {
+            "success": True,
+            "message_id": "123.456",
+            "raw": client.files_upload_v2.return_value,
+        }
+
+    @response_shape
+    def test_upload_error_is_surfaced(self, make_response, tmp_path):
+        media = tmp_path / "note.txt"
+        media.write_text("x")
+        client = MagicMock()
+        client.files_upload_v2 = AsyncMock(
+            return_value=make_response({"ok": False, "error": "not_in_channel"})
+        )
+        result = asyncio.run(
+            _standalone_upload_file(client, "C_GEN", str(media))
+        )
+        assert "not_in_channel" in result["error"]


### PR DESCRIPTION
## What does this PR do?

Slack user names, channel names and bot detection are silently broken on `main`: the agent receives `[U0BCE4NRVKN | Slack user <@U0BCE4NRVKN>]` instead of `[Nikita | Slack user <@U0BCE4NRVKN>]`, every user resolves as a non-bot, and some send paths report success as failure.

**Root cause.** `slack_sdk` Web API calls return `SlackResponse` / `AsyncSlackResponse`. Those objects are mapping-like (they expose `.get()` and `.data`) but they are **not** `dict` subclasses. Commit `3f08201ba` ("Fix Slack peer bot status routing loops", #51627) added `isinstance(result, dict)` guards around those responses, so at runtime the guard is **always** False and every guarded call site takes its "unexpected shape" degradation branch:

- `_resolve_user_name` → the name becomes the raw user id, and that wrong value is cached for the lifetime of the gateway process. This is the user-visible symptom.
- `_resolve_user_is_bot` → every user resolves as a non-bot, which defeats the `allow_bots` peer-bot loop guard that `3f08201ba` was written to add.
- `_resolve_channel_name` → the channel name degrades to `C0…`.
- `_post_ephemeral_fallback` → a successful ephemeral reply is reported as an `unexpected_response` failure.
- `_standalone_upload_file` and the standalone `chat.postMessage` path → `message_id` is lost (breaking threading of follow-up sends) and the caption fallback is never marked delivered.

**Fix.** Normalize every Slack response through one helper, `_slack_response_payload()`: a plain `dict` passes through, an SDK response yields `.data`, and anything else (including a binary `.data`, which `files_*` can return) yields `{}` so callers keep their existing fallbacks. This fixes the whole bug class rather than the one reported site — all eight guarded call sites are converted.

**Why the test suite did not catch it.** The existing Slack tests inject plain `dict`s into the mocked client, so the guard is True in tests and False in production. The new suite parametrizes every behavioral case to run against a real `AsyncSlackResponse` as well, which is what makes the defect (and any future recurrence) visible.

The premise was verified against the runtime, not assumed:

- `SlackResponse`/`AsyncSlackResponse` MRO ends at `object` in both `slack_sdk` 3.40.1 and 3.43.0 (the version pinned in `pyproject.toml`); the return type is fixed in the SDK signatures (`users_info(...) -> AsyncSlackResponse`), and Bolt hands out that same `AsyncWebClient`. No bot setting, OAuth scope, or Slack-side API change can flip this.
- The symptom was captured on a live gateway (the request dump sent to the model contained the id-for-name prefix), and a direct `users.info` with the same bot token returned the correct `display_name`, ruling out scopes/transport.
- Pre-fix behavior was reproduced against a real `AsyncSlackResponse`: `_resolve_user_name` returned `U_HUMAN` instead of `Nikita`; after the fix it returns the name.

## Related Issue

No open issue — the symptom ("Slack display names became user IDs") does not appear to be reported. The only PR with the same diagnosis, #72062, was closed by its own author without maintainer review; it also bundled two unrelated changes (`_apply_yaml_config` and `success_reaction` / `other_agent_patterns`). This PR is the isolated fix, extended to the remaining call sites of the same bug class and to a test that exercises the real SDK response shape.

Fixes the regression introduced by #51627 (`3f08201ba`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/slack/adapter.py`: new module-level `_slack_response_payload()` normalizer; all Slack Web API call sites read through it — `_resolve_user_name`, `_resolve_user_is_bot`, `_resolve_channel_name`, `_post_ephemeral_fallback`, the thread seed-post `ts` read, `_standalone_upload_file`, and the standalone `chat.postMessage` path including the caption fallback. Every `isinstance(resp, dict)` gate on an SDK response is removed.
- `tests/gateway/test_slack_sdk_response.py` (new, 23 tests): the normalizer's contract (dict passthrough, `.data`, binary `.data` → `{}`, unknown shape → `{}`), the identity/channel resolution paths, and the send paths — each parametrized over a hand-rolled stand-in **and** a real `AsyncSlackResponse` (skipped automatically when the `slack` extra is not installed). Includes an explicit assertion of the bug's premise (the runtime object fails an `isinstance` dict gate) and keeps coverage for the intended degradation on a genuinely unreadable response.

## How to Test

1. With a real Slack workspace, run the gateway in a shared channel on `main` and send a message: the text handed to the model is prefixed with `[U… | Slack user <@U…>]` — the display name has been replaced by the id.
2. Apply this PR, restart the gateway (the wrong name is cached per process) and start a new session: the prefix becomes `[Alice | Slack user <@U…>]`.
3. Automated: `scripts/run_tests.sh tests/gateway/test_slack_sdk_response.py tests/gateway/test_slack.py tests/gateway/test_slack_mention.py tests/tools/test_send_message_slack.py -q` → **212 passed, 0 failed** (branch cut from current `main`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(slack): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — closest is the author-closed #72062, see "Related Issue"
- [x] My PR contains **only** changes related to this fix (no unrelated commits) — 1 commit, 2 files
- [x] I've run the affected suites via `scripts/run_tests.sh` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (restores documented behavior; the new helper is documented in its docstring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure Python response handling)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool schema changed)

## Screenshots / Logs

**Before** (prefix the model receives, from a live gateway's request dump):

```
[U0BCE4NRVKN | Slack user <@U0BCE4NRVKN>] ...
```

**After:**

```
[Nikita | Slack user <@U0BCE4NRVKN>] ...
```

Behavioral side effect worth calling out for review: with the guard removed, `_resolve_user_is_bot` actually recognizes bots again, so the `allow_bots` policy starts enforcing as #51627 intended.
