### PR TITLE
fix: preserve base64 data URLs during redaction

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -7,6 +7,7 @@ Short tokens (< 18 chars) are fully masked. Longer tokens preserve
 the first 6 and last 4 characters for debuggability.
 """
 
+import base64
 import logging
 import os
 import re
@@ -617,6 +618,71 @@ def _mask_token_nonreusable(token: str) -> str:
             label = sub
             break
     return f"«redacted:{label}…»" if label else "«redacted-secret»"
+
+
+_BASE64_IMAGE_DATA_URL_RE = re.compile(
+    r"^data:image/[a-z0-9][a-z0-9!#$&^_.+\-]*;base64,[A-Za-z0-9+/]*={0,2}$",
+)
+
+
+def _is_base64_image_data_url(value: str) -> bool:
+    """Return True for a complete, strictly decodable base64 image data URL."""
+    match = _BASE64_IMAGE_DATA_URL_RE.fullmatch(value)
+    if not match:
+        return False
+    try:
+        base64.b64decode(value.split(",", 1)[1], validate=True)
+    except (ValueError, TypeError):
+        return False
+    return True
+
+
+def sanitize_provider_image_parts(value: object) -> object:
+    """Redact provider content while preserving typed base64 image bytes.
+
+    Only OpenAI-style image parts receive the exception. Standalone, untyped,
+    logging, persistence, and non-image values retain normal forced redaction.
+    """
+    if isinstance(value, str):
+        return redact_sensitive_text(
+            value,
+            force=True,
+            redact_url_credentials=True,
+        )
+    if isinstance(value, dict):
+        sanitized = {}
+        for key, item in value.items():
+            if (
+                value.get("type") == "image_url"
+                and key == "image_url"
+                and isinstance(item, dict)
+                and set(item) <= {"url", "detail"}
+                and isinstance(item.get("url"), str)
+                and _is_base64_image_data_url(item["url"])
+            ):
+                sanitized[key] = {
+                    nested_key: (
+                        nested_item
+                        if nested_key == "url"
+                        else sanitize_provider_image_parts(nested_item)
+                    )
+                    for nested_key, nested_item in item.items()
+                }
+            elif (
+                value.get("type") == "input_image"
+                and key == "image_url"
+                and isinstance(item, str)
+                and _is_base64_image_data_url(item)
+            ):
+                sanitized[key] = item
+            else:
+                sanitized[key] = sanitize_provider_image_parts(item)
+        return sanitized
+    if isinstance(value, list):
+        return [sanitize_provider_image_parts(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(sanitize_provider_image_parts(item) for item in value)
+    return value
 
 
 def redact_sensitive_text(

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -1,10 +1,16 @@
 """Tests for agent.redact -- secret masking in logs and output."""
 
+import base64
 import logging
 
 import pytest
 
-from agent.redact import redact_cdp_url, redact_sensitive_text, RedactingFormatter
+from agent.redact import (
+    redact_cdp_url,
+    redact_sensitive_text,
+    RedactingFormatter,
+    sanitize_provider_image_parts,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -13,6 +19,93 @@ def _ensure_redaction_enabled(monkeypatch):
     monkeypatch.delenv("HERMES_REDACT_SECRETS", raising=False)
     # Also patch the module-level snapshot so it reflects the cleared env var
     monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+
+
+class TestDataUrls:
+    def test_binary_image_data_url_is_preserved_byte_for_byte(self):
+        payload = (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8A"
+            "AusB9Y9ZQmcAAAAASUVORK5CYII="
+        )
+        value = "data:image/png;base64," + payload
+
+        sanitized = sanitize_provider_image_parts(
+            {"type": "input_image", "image_url": value}
+        )
+        assert isinstance(sanitized, dict)
+        redacted = sanitized["image_url"]
+
+        assert redacted == value
+        assert base64.b64decode(redacted.split(",", 1)[1], validate=True)
+
+    def test_canonical_nested_image_url_is_preserved(self):
+        value = (
+            "data:image/png;base64,"
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8A"
+            "AusB9Y9ZQmcAAAAASUVORK5CYII="
+        )
+        sanitized = sanitize_provider_image_parts(
+            {
+                "type": "image_url",
+                "image_url": {"url": value, "detail": "high"},
+            }
+        )
+
+        assert isinstance(sanitized, dict)
+        assert sanitized["image_url"] == {"url": value, "detail": "high"}
+
+    @pytest.mark.parametrize("media_type", ["text/plain", "audio/wav", "application/octet-stream"])
+    def test_non_image_media_does_not_bypass_typed_image_redaction(self, media_type):
+        value = f"data:{media_type};base64," + "AIza" + "A" * 32
+        sanitized = sanitize_provider_image_parts(
+            {"type": "input_image", "image_url": value}
+        )
+
+        assert isinstance(sanitized, dict)
+        assert sanitized["image_url"] != value
+
+    def test_noncanonical_data_url_casing_still_redacts(self):
+        value = "data:image/png;BASE64," + "AIza" + "A" * 32
+        sanitized = sanitize_provider_image_parts(
+            {"type": "input_image", "image_url": value}
+        )
+
+        assert isinstance(sanitized, dict)
+        assert sanitized["image_url"] != value
+
+    def test_malformed_image_data_url_still_redacts(self):
+        payload = "AIza" + "A" * 33
+        value = "data:image/png;base64," + payload
+        sanitized = sanitize_provider_image_parts(
+            {"type": "input_image", "image_url": value}
+        )
+
+        with pytest.raises(ValueError):
+            base64.b64decode(payload, validate=True)
+        assert isinstance(sanitized, dict)
+        assert sanitized["image_url"] != value
+
+    def test_standalone_data_url_credentials_still_redact(self):
+        value = "data:image/png;base64," + "AIza" + "A" * 32
+
+        redacted = redact_sensitive_text(
+            value,
+            force=True,
+            redact_url_credentials=True,
+        )
+
+        assert redacted != value
+
+    def test_non_data_url_credentials_still_redact(self):
+        value = "https://user:***@example.test/private.png"
+
+        redacted = redact_sensitive_text(
+            value,
+            force=True,
+            redact_url_credentials=True,
+        )
+
+        assert "password" not in redacted
 
 
 class TestKnownPrefixes:


### PR DESCRIPTION
## Summary
- add a typed provider-image sanitizer that preserves complete base64 `image/*` bytes only for multimodal image parts
- support flat Responses API and canonical nested Chat Completions image shapes
- keep ordinary forced redaction unchanged for standalone, untyped, logging, persistence, non-image media, and non-image values

## Provenance
The exact mutation point observed downstream is Nemobot's forced provider-egress sanitizer, which is not currently on Hermes `main`. This is therefore a preventive upstream hardening helper + regression suite, not a claim that current Hermes production dispatch already invokes the sanitizer.

## Root cause downstream
A Nemobot OpenAI Codex request dump contained literal redaction replacements inside `input[N].output[1].image_url`. Random image base64 bytes had matched a credential pattern, producing invalid base64 before provider dispatch.

## Tests
- `uv run --with pytest python -m pytest tests/agent/test_redact.py::TestDataUrls -q`
- 7 passed
- flat and nested typed-image forms remain byte-exact
- text/audio/application data URLs still redact
- standalone credential-shaped image data URL still redacts
- normal URL credentials still redact
- Ruff and `git diff --check` pass

## Downstream
Nemobot MR: https://netops.ooma.com/gitlab/nemobot/nemobot-agent/-/merge_requests/15