### PR TITLE
fix(kanban): validate stored task skills before worker spawn

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -904,9 +904,11 @@ class Task:
     workflow_template_id: Optional[str] = None
     current_step_key: Optional[str] = None
     # Force-loaded skills for the worker on this task (passed via
-    # --skills). Stored as a JSON array of skill names. None = use only
-    # the defaults; empty list = explicitly no extra skills.
-    skills: Optional[list] = None
+    # --skills). Canonical rows decode to a list, while malformed/legacy
+    # stored values remain raw until the final pre-Popen validator can reject
+    # or normalize them. None = use only the defaults; empty list = explicitly
+    # no extra skills.
+    skills: object = None
     model_override: Optional[str] = None
     # Provider that ``model_override`` belongs to. When set, the dispatcher
     # passes ``--provider <name>`` alongside ``-m <model>`` so the worker
@@ -953,15 +955,23 @@ class Task:
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
         keys = set(row.keys())
-        # Parse skills JSON blob if present
-        skills_value: Optional[list] = None
-        if "skills" in keys and row["skills"]:
-            try:
-                parsed = json.loads(row["skills"])
-                if isinstance(parsed, list):
-                    skills_value = [str(s) for s in parsed if s]
-            except Exception:
-                skills_value = None
+        # Preserve the stored value until the final pre-Popen validation
+        # boundary. Canonical JSON arrays still decode to lists for the public
+        # Task API, but malformed JSON, non-array JSON, and unsupported SQLite
+        # values must not be swallowed, stringified, or filtered here: doing so
+        # would let a corrupt legacy row spawn with altered or missing skills.
+        skills_value: object = None
+        if "skills" in keys:
+            stored_skills = row["skills"]
+            skills_value = stored_skills
+            if isinstance(stored_skills, str):
+                try:
+                    parsed = json.loads(stored_skills)
+                except (json.JSONDecodeError, RecursionError):
+                    pass
+                else:
+                    if isinstance(parsed, list):
+                        skills_value = parsed
         return cls(
             id=row["id"],
             title=row["title"],
@@ -8788,6 +8798,77 @@ def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[st
         return None
 
 
+_SPAWN_SKILL_IDENTIFIER_RE = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9._-]*(?:[/:][A-Za-z0-9][A-Za-z0-9._-]*)*$"
+)
+_SPAWN_SKILL_IDENTIFIER_MAX_LENGTH = 256
+
+
+def _invalid_spawn_skills(task_id: object, reason: str) -> ValueError:
+    """Build a bounded, single-line worker-skill validation error."""
+    task_label = re.sub(r"\s+", " ", str(task_id)).strip() or "<unknown>"
+    if len(task_label) > 64:
+        task_label = f"{task_label[:61]}..."
+    return ValueError(
+        f"task {task_label} has invalid skills ({reason}); expected None, "
+        "list[str]/tuple[str, ...], a JSON-array string, or a "
+        "single/comma-delimited identifier string; identifiers may use only "
+        "letters, digits, '.', '_', '/', ':', and '-'"
+    )
+
+
+def _normalize_spawn_skills(value: object, *, task_id: object) -> list[str]:
+    """Normalize task skills at the final boundary before worker ``Popen``.
+
+    Keeping this independent of database decoding protects direct ``Task``
+    callers and broker serializers that hydrate the dataclass without calling
+    :meth:`Task.from_row`.
+    """
+    if value is None:
+        return []
+
+    raw_items: Iterable[object]
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return []
+        try:
+            decoded = json.loads(stripped)
+        except (json.JSONDecodeError, RecursionError):
+            if stripped[0] in '[{"':
+                raise _invalid_spawn_skills(
+                    task_id, "malformed JSON-looking value"
+                ) from None
+            raw_items = stripped.split(",")
+        else:
+            if not isinstance(decoded, list):
+                raise _invalid_spawn_skills(task_id, "JSON value must be an array")
+            raw_items = decoded
+    elif isinstance(value, (list, tuple)):
+        raw_items = list(value)
+    else:
+        raise _invalid_spawn_skills(task_id, "unsupported value type")
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for item in raw_items:
+        if not isinstance(item, str):
+            raise _invalid_spawn_skills(task_id, "members must be strings")
+        name = item.strip()
+        if not name:
+            raise _invalid_spawn_skills(task_id, "members must be non-empty")
+        if (
+            len(name) > _SPAWN_SKILL_IDENTIFIER_MAX_LENGTH
+            or _SPAWN_SKILL_IDENTIFIER_RE.fullmatch(name) is None
+        ):
+            raise _invalid_spawn_skills(task_id, "member is not a valid identifier")
+        if name in seen:
+            continue
+        seen.add(name)
+        normalized.append(name)
+    return normalized
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -8807,8 +8888,10 @@ def _default_spawn(
     from. Workers cannot accidentally see other boards.
     """
     import subprocess
+
     if not task.assignee:
         raise ValueError(f"task {task.id} has no assignee")
+    spawn_skills = _normalize_spawn_skills(task.skills, task_id=task.id)
 
     from hermes_cli.profiles import normalize_profile_name
 
@@ -8926,10 +9009,8 @@ def _default_spawn(
     # accepts both forms (action='append' + comma-split), but
     # per-name pairs are easier to read in `ps` output and avoid any
     # quoting ambiguity if a skill name ever contains unusual chars.
-    if task.skills:
-        for sk in task.skills:
-            if sk:
-                cmd.extend(["--skills", sk])
+    for skill in spawn_skills:
+        cmd.extend(["--skills", skill])
     if task.model_override:
         cmd.extend(["-m", task.model_override])
         # Pin the provider too when the override names one, so the worker

--- a/tests/hermes_cli/test_kanban_worker_spawn_skills.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_skills.py
@@ -1,0 +1,546 @@
+"""Regressions for fail-closed task-skill validation at worker spawn.
+
+The optional broker cases load the deployed ``boardd_shim.py`` named by
+``HERMES_BOARDD_SHIM_PATH``. Upstream does not ship that fleet overlay, so those
+cases skip when the path is absent; the live-lineage verification command sets
+it explicitly and exercises the overlay's real ``claim_task``/``_row_to_task``
+implementation.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any, cast
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+_NO_DB_OVERRIDE = object()
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (home / "config.yaml").write_text(
+        "platform_toolsets:\n  cli: []\n", encoding="utf-8"
+    )
+    for name in (
+        "HERMES_KANBAN_BROKER",
+        "BOARDD_SOCK",
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_HOME",
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+        "HERMES_KANBAN_BOARD",
+        "HERMES_KANBAN_TASK",
+        "HERMES_KANBAN_RUN_ID",
+        "HERMES_KANBAN_CLAIM_LOCK",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    kb.init_db()
+    return home
+
+
+def _task(skills: object) -> kb.Task:
+    return kb.Task(
+        id="t_spawn_skills",
+        title="spawn skills",
+        body=None,
+        assignee="worker",
+        status="running",
+        priority=0,
+        created_by=None,
+        created_at=0,
+        started_at=None,
+        completed_at=None,
+        workspace_kind="dir",
+        workspace_path=None,
+        claim_lock=None,
+        claim_expires=None,
+        tenant=None,
+        skills=skills,
+    )
+
+
+def _skill_names(cmd: list[str]) -> list[str]:
+    return [
+        cmd[index + 1]
+        for index, token in enumerate(cmd)
+        if token == "--skills" and index + 1 < len(cmd)
+    ]
+
+
+def _expected_spawn_cmd(
+    task_id: str, env: dict[str, str], skills: list[str]
+) -> list[str]:
+    cmd = [
+        *kb._resolve_hermes_argv(),
+        "-p",
+        "default",
+        "--cli",
+        "--accept-hooks",
+    ]
+    for skill in skills:
+        cmd.extend(["--skills", skill])
+    worker_toolsets = kb._resolve_worker_cli_toolsets(env.get("HERMES_HOME"))
+    if worker_toolsets:
+        cmd.extend(["--toolsets", ",".join(worker_toolsets)])
+    cmd.extend(["chat", "-q", f"work kanban task {task_id}"])
+    return cmd
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (["alpha", "beta"], ["alpha", "beta"]),
+        (("alpha", "beta"), ["alpha", "beta"]),
+        ('["alpha", "beta"]', ["alpha", "beta"]),
+        ("alpha", ["alpha"]),
+        ("alpha, beta", ["alpha", "beta"]),
+        (None, []),
+        ([], []),
+        ("   ", []),
+        (
+            [" category/alpha ", "plugin:beta", "category/alpha"],
+            ["category/alpha", "plugin:beta"],
+        ),
+    ],
+)
+def test_direct_task_spawn_emits_normalized_ordered_skill_pairs(
+    kanban_home: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    raw: object,
+    expected: list[str],
+) -> None:
+    captured: dict[str, list[str]] = {}
+
+    class FakeProc:
+        pid = 4242
+
+    def fake_popen(cmd: list[str], **_kwargs: object) -> FakeProc:
+        captured["cmd"] = list(cmd)
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    pid = kb._default_spawn(_task(raw), str(tmp_path))
+
+    assert pid == 4242
+    assert _skill_names(captured["cmd"]) == expected
+    if expected:
+        assert max(
+            index for index, token in enumerate(captured["cmd"]) if token == "--skills"
+        ) < captured["cmd"].index("chat")
+
+
+@pytest.mark.parametrize(
+    ("raw", "reason"),
+    [
+        ('["alpha"', "malformed JSON-looking value"),
+        ('{"skill": "alpha"}', "JSON value must be an array"),
+        ('"alpha"', "JSON value must be an array"),
+        (["alpha", 2], "members must be strings"),
+        (["alpha", ""], "members must be non-empty"),
+        ("alpha,,beta", "members must be non-empty"),
+        (["bad skill"], "member is not a valid identifier"),
+        (b'["alpha"]', "unsupported value type"),
+    ],
+)
+def test_normalizer_rejects_invalid_values(raw: object, reason: str) -> None:
+    with pytest.raises(ValueError, match=reason):
+        kb._normalize_spawn_skills(raw, task_id="t_bad")
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "bad$skill",
+        "/absolute",
+        "relative/../escape",
+        "plugin:",
+        "alpha\\beta",
+        "x" * 257,
+    ],
+)
+def test_normalizer_rejects_invalid_identifiers(name: str) -> None:
+    with pytest.raises(ValueError, match="valid identifier"):
+        kb._normalize_spawn_skills([name], task_id="t_bad")
+
+
+def test_validation_error_is_bounded_single_line_and_task_identifying() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        kb._normalize_spawn_skills(
+            ["bad skill" + ("x" * 10_000)],
+            task_id="t_" + ("z" * 10_000) + "\nforged",
+        )
+
+    message = str(exc_info.value)
+    assert message.startswith("task t_zzz")
+    assert "expected None, list[str]/tuple[str, ...]" in message
+    assert len(message) < 400
+    assert "\n" not in message
+    assert "x" * 100 not in message
+
+
+def test_direct_task_rejects_invalid_skills_before_provider_or_popen(
+    kanban_home: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider_calls: list[object] = []
+    popen_calls: list[object] = []
+
+    def fail_provider(*args: object, **_kwargs: object) -> None:
+        provider_calls.append(args)
+        raise AssertionError("profile/provider resolution must not run")
+
+    def fail_popen(*args: object, **_kwargs: object) -> None:
+        popen_calls.append(args)
+        raise AssertionError("Popen must not run")
+
+    monkeypatch.setattr(kb, "_resolve_worker_cli_toolsets", fail_provider)
+    monkeypatch.setattr(subprocess, "Popen", fail_popen)
+
+    with pytest.raises(ValueError, match=r"task t_spawn_skills has invalid skills"):
+        kb._default_spawn(_task(["alpha", 2]), str(tmp_path))
+
+    assert provider_calls == []
+    assert popen_calls == []
+
+
+@pytest.mark.parametrize(
+    ("stored", "expected"),
+    [
+        ('[" alpha ", "beta", "alpha"]', [" alpha ", "beta", "alpha"]),
+        ('["alpha", 2]', ["alpha", 2]),
+        ('{"skill": "alpha"}', '{"skill": "alpha"}'),
+        ('["unterminated"', '["unterminated"'),
+        (b'["alpha"]', b'["alpha"]'),
+    ],
+)
+def test_normal_row_hydration_preserves_values_for_final_validation(
+    kanban_home: Path,
+    stored: object,
+    expected: object,
+) -> None:
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="row hydration",
+            assignee="default",
+            skills=["seed"],
+        )
+        conn.execute("UPDATE tasks SET skills = ? WHERE id = ?", (stored, task_id))
+        conn.commit()
+        row = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
+
+    assert row is not None
+    assert kb.Task.from_row(row).skills == expected
+
+
+@pytest.mark.parametrize(
+    ("created_skills", "stored_skills", "expected"),
+    [
+        (["alpha", "beta"], _NO_DB_OVERRIDE, ["alpha", "beta"]),
+        (("alpha", "beta"), _NO_DB_OVERRIDE, ["alpha", "beta"]),
+        (["seed"], "alpha", ["alpha"]),
+        (["seed"], " alpha, beta ", ["alpha", "beta"]),
+        (
+            ["seed"],
+            '[" alpha ", "beta", "alpha", "beta "]',
+            ["alpha", "beta"],
+        ),
+    ],
+)
+def test_normal_db_dispatch_emits_exact_normalized_argv(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    created_skills: object,
+    stored_skills: object,
+    expected: list[str],
+) -> None:
+    popen_calls: list[tuple[list[str], dict[str, object]]] = []
+
+    class FakeProc:
+        pid = 2_000_000_000
+
+    def fake_popen(cmd: list[str], **kwargs: object) -> FakeProc:
+        popen_calls.append((list(cmd), dict(kwargs)))
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="normal DB skills dispatch",
+            assignee="default",
+            skills=cast(Any, created_skills),
+        )
+        if stored_skills is not _NO_DB_OVERRIDE:
+            conn.execute(
+                "UPDATE tasks SET skills = ? WHERE id = ?",
+                (stored_skills, task_id),
+            )
+            conn.commit()
+
+        result = kb.dispatch_once(conn, failure_limit=2)
+        task = kb.get_task(conn, task_id)
+
+    assert len(popen_calls) == 1
+    cmd, kwargs = popen_calls[0]
+    spawn_env = cast(dict[str, str], kwargs["env"])
+    assert cmd == _expected_spawn_cmd(task_id, spawn_env, expected)
+    assert result.spawned == [(task_id, "default", result.spawned[0][2])]
+    assert task is not None
+    assert task.status == "running"
+    assert task.worker_pid == FakeProc.pid
+    assert task.last_failure_error is None
+
+
+@pytest.mark.parametrize(
+    ("stored", "reason"),
+    [
+        ('["alpha"', "malformed JSON-looking value"),
+        ('{"skill": "alpha"}', "JSON value must be an array"),
+        ('["alpha", 2]', "members must be strings"),
+        ('["alpha", ""]', "members must be non-empty"),
+        ('["bad skill"]', "member is not a valid identifier"),
+        (b'["alpha"]', "unsupported value type"),
+    ],
+)
+def test_normal_db_dispatch_records_bounded_spawn_failure_without_popen(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stored: object,
+    reason: str,
+) -> None:
+    popen_calls: list[object] = []
+
+    def fail_popen(*args: object, **_kwargs: object) -> None:
+        popen_calls.append(args)
+        raise AssertionError("Popen must not run")
+
+    monkeypatch.setattr(subprocess, "Popen", fail_popen)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="invalid DB skills dispatch",
+            assignee="default",
+            skills=["seed"],
+        )
+        conn.execute("UPDATE tasks SET skills = ? WHERE id = ?", (stored, task_id))
+        conn.commit()
+
+        result = kb.dispatch_once(conn, failure_limit=2)
+        task = kb.get_task(conn, task_id)
+        run = conn.execute(
+            "SELECT status, outcome, worker_pid, error FROM task_runs "
+            "WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+
+    assert result.spawned == []
+    assert popen_calls == []
+    assert task is not None
+    assert task.status == "ready"
+    assert task.worker_pid is None
+    assert task.consecutive_failures == 1
+    assert task.last_failure_error is not None
+    assert task.last_failure_error.startswith(
+        f"task {task_id} has invalid skills ({reason})"
+    )
+    assert len(task.last_failure_error) < 400
+    assert "\n" not in task.last_failure_error
+    assert run is not None
+    assert run["status"] == "spawn_failed"
+    assert run["outcome"] == "spawn_failed"
+    assert run["worker_pid"] is None
+    assert run["error"] == task.last_failure_error
+
+
+def _load_live_boardd_shim(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    raw_path = os.environ.get("HERMES_BOARDD_SHIM_PATH")
+    if not raw_path:
+        pytest.skip("set HERMES_BOARDD_SHIM_PATH to run the live broker overlay tests")
+    assert raw_path is not None
+    shim_path = Path(raw_path).resolve()
+    if not shim_path.is_file():
+        pytest.skip(f"live broker overlay not found at {shim_path}")
+
+    import hermes_cli
+
+    package_path = [str(path) for path in hermes_cli.__path__]
+    live_package = str(shim_path.parent)
+    if live_package not in package_path:
+        package_path.append(live_package)
+    monkeypatch.setattr(hermes_cli, "__path__", package_path)
+
+    module_name = "hermes_cli.boardd_shim_live_skills_test"
+    spec = importlib.util.spec_from_file_location(module_name, shim_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"could not load broker overlay from {shim_path}")
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _install_local_broker_claim(
+    monkeypatch: pytest.MonkeyPatch,
+    shim: ModuleType,
+    conn: Any,
+) -> list[kb.Task]:
+    original_claim = kb.claim_task
+    original_row_to_task = shim._row_to_task
+    hydrated: list[kb.Task] = []
+
+    def observed_row_to_task(kdb: ModuleType, row: object) -> kb.Task:
+        task = original_row_to_task(kdb, row)
+        hydrated.append(task)
+        return task
+
+    class LocalBrokerClient:
+        def claim(
+            self,
+            task_id: str,
+            *,
+            claimer: str | None = None,
+            ttl_seconds: int = 7200,
+        ) -> dict[str, object]:
+            claimed = original_claim(
+                conn,
+                task_id,
+                claimer=claimer,
+                ttl_seconds=ttl_seconds,
+            )
+            return {
+                "won": claimed is not None,
+                "run_id": claimed.current_run_id if claimed is not None else None,
+            }
+
+        def get_task(self, task_id: str) -> dict[str, object] | None:
+            row = conn.execute(
+                "SELECT * FROM tasks WHERE id = ?", (task_id,)
+            ).fetchone()
+            return dict(row) if row is not None else None
+
+    client = LocalBrokerClient()
+    monkeypatch.setenv("HERMES_KANBAN_BROKER", "1")
+    assert shim.enabled() is True
+    monkeypatch.setattr(shim, "_c", lambda: client)
+    monkeypatch.setattr(shim, "_row_to_task", observed_row_to_task)
+    monkeypatch.setattr(kb, "claim_task", shim.claim_task)
+    return hydrated
+
+
+def test_live_broker_row_hydration_rejects_mixed_array_before_popen(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shim = _load_live_boardd_shim(monkeypatch)
+    popen_calls: list[object] = []
+
+    def fail_popen(*args: object, **_kwargs: object) -> None:
+        popen_calls.append(args)
+        raise AssertionError("Popen must not run")
+
+    monkeypatch.setattr(subprocess, "Popen", fail_popen)
+
+    with kb.connect() as conn:
+        hydrated = _install_local_broker_claim(monkeypatch, shim, conn)
+        task_id = kb.create_task(
+            conn,
+            title="broker invalid skills dispatch",
+            assignee="default",
+            skills=["seed"],
+        )
+        conn.execute(
+            "UPDATE tasks SET skills = ? WHERE id = ?",
+            (json.dumps(["a", 2]), task_id),
+        )
+        conn.commit()
+
+        result = kb.dispatch_once(conn, failure_limit=2)
+        task = kb.get_task(conn, task_id)
+        run = conn.execute(
+            "SELECT status, outcome, worker_pid FROM task_runs "
+            "WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+
+    assert result.spawned == []
+    assert popen_calls == []
+    assert len(hydrated) == 1
+    assert hydrated[0].skills == json.dumps(["a", 2])
+    assert task is not None
+    assert task.status == "ready"
+    assert task.worker_pid is None
+    assert task.last_failure_error is not None
+    assert "members must be strings" in task.last_failure_error
+    assert run is not None
+    assert run["status"] == "spawn_failed"
+    assert run["outcome"] == "spawn_failed"
+    assert run["worker_pid"] is None
+
+
+def test_live_broker_row_hydration_emits_exact_ordered_argv(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shim = _load_live_boardd_shim(monkeypatch)
+    popen_calls: list[tuple[list[str], dict[str, object]]] = []
+
+    class FakeProc:
+        pid = 2_000_000_001
+
+    def fake_popen(cmd: list[str], **kwargs: object) -> FakeProc:
+        popen_calls.append((list(cmd), dict(kwargs)))
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    with kb.connect() as conn:
+        hydrated = _install_local_broker_claim(monkeypatch, shim, conn)
+        task_id = kb.create_task(
+            conn,
+            title="broker valid skills dispatch",
+            assignee="default",
+            skills=["seed"],
+        )
+        conn.execute(
+            "UPDATE tasks SET skills = ? WHERE id = ?",
+            (
+                json.dumps([" skill/one ", "plugin:two", "skill/one", "third.skill"]),
+                task_id,
+            ),
+        )
+        conn.commit()
+
+        result = kb.dispatch_once(conn, failure_limit=2)
+        task = kb.get_task(conn, task_id)
+
+    assert len(popen_calls) == 1
+    assert len(hydrated) == 1
+    assert isinstance(hydrated[0].skills, str)
+    cmd, kwargs = popen_calls[0]
+    expected_skills = ["skill/one", "plugin:two", "third.skill"]
+    spawn_env = cast(dict[str, str], kwargs["env"])
+    assert cmd == _expected_spawn_cmd(task_id, spawn_env, expected_skills)
+    assert result.spawned == [(task_id, "default", result.spawned[0][2])]
+    assert task is not None
+    assert task.status == "running"
+    assert task.worker_pid == FakeProc.pid
+    assert task.last_failure_error is None


### PR DESCRIPTION
## Summary

- preserve malformed, non-array, and non-string stored `skills` values through `Task.from_row` instead of silently filtering/stringifying them
- validate and normalize task skills at the final pre-`Popen` worker-spawn boundary, independently of the row-hydration path
- trim and order-preserve/deduplicate valid identifiers while rejecting malformed JSON, non-array JSON, non-string/empty members, invalid identifiers, and unsupported values before provider resolution or subprocess creation
- add direct-construction, SQLite-row, dispatch-failure, exact-argv, and deployed broker-overlay regression coverage

## Context

This is the current-main semantic port of the two-file behavior from merged `o269/hermes-agent#9` (frozen base/head/merge tuple: `8968384e...` / `c028fe7718...` / `322f79f011...`). The old behavior relied too much on `Task.from_row`; the deployed board broker's `_row_to_task` hydrates `Task.skills` directly from the raw row, so the invariant belongs at `_default_spawn` immediately before any worker/provider side effect.

Upstream does not ship the deployed `boardd_shim.py`. The two broker-overlay tests therefore load the real deployed module only when `HERMES_BOARDD_SHIM_PATH` is supplied and otherwise skip; all non-overlay validation remains fully self-contained upstream.

## Verification

- baseline probe on current-main ancestor: malformed direct `Task.skills=["a", 2]` reached mocked `Popen` with `skills_argv=['a', 2]`
- `HERMES_BOARDD_SHIM_PATH=/home/odai/.hermes/hermes-agent/hermes_cli/boardd_shim.py pytest -q tests/hermes_cli/test_kanban_worker_spawn_skills.py` -> **43 passed**
- existing worker-spawn toolset/CWD tests -> **4 passed**
- relevant Kanban suite on this branch (broker path omitted) -> **183 passed, 2 skipped, 7 failed**
- the exact same relevant suite on base `fa8b959b9` -> **142 passed, 7 failed**; the seven failures are identical pre-existing failures, so this change adds no failures (the new file contributes 41 pass + 2 optional broker skips)
- `ruff check .` -> passed
- `ruff format --check` on the new test -> passed; formatter-overlap audit on the touched source hunks -> 0 overlapping lines
- `ty check tests/hermes_cli/test_kanban_worker_spawn_skills.py` -> passed; the touched source retains the same six pre-existing diagnostics as base
- `python -m compileall` on both changed files -> passed
- `python scripts/check-windows-footguns.py --all` -> passed (892 files)

No live/runtime files or databases were modified.
