### PR TITLE
fix(gateway): send home-channel notification on unexpected restarts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10309,6 +10309,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.info("Active profile: %s", _profile)
         except Exception:
             pass
+        # Snapshot the *previous* gateway's runtime state BEFORE we overwrite it
+        # with "starting" below.  This lets us detect an unexpected restart
+        # (previous gateway died while "running" / "draining") at the end of
+        # start(), without being fooled by our own status writes.
+        prev_gateway_state: Optional[str] = None
+        try:
+            from gateway.status import read_runtime_status
+            _prev_state = read_runtime_status()
+            prev_gateway_state = (_prev_state or {}).get("gateway_state")
+        except Exception:
+            prev_gateway_state = None
+
         try:
             from gateway.status import write_runtime_status
             write_runtime_status(gateway_state="starting", exit_reason=None)
@@ -10954,20 +10966,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         elif not chat_restart_notification_pending:
             # Also notify on unexpected restarts (SIGTERM from systemd, OOM kill,
             # etc.) so the operator always knows when the gateway has come back
-            # online — not just on planned restarts.  We detect an "unexpected
+            # online - not just on planned restarts.  We detect an "unexpected
             # restart" by checking whether the previous gateway left a
             # "running" / "draining" state behind (meaning it died while active)
             # rather than a clean "stopped" state.  A first-ever boot has no
             # state file at all, so we don't spam on initial install.
-            try:
-                from gateway.status import read_runtime_status
-                prev_state = read_runtime_status()
-                prev_gateway_state = (prev_state or {}).get("gateway_state")
-            except Exception:
-                prev_gateway_state = None
+            #
+            # prev_gateway_state was snapshotted at the top of start(), before
+            # we overwrote the status file with "starting" / "running".
             if prev_gateway_state in ("running", "draining"):
                 logger.info(
-                    "Previous gateway state was '%s' — treating as unexpected restart, "
+                    "Previous gateway state was '%s' - treating as unexpected restart, "
                     "sending home-channel startup notification",
                     prev_gateway_state,
                 )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10951,6 +10951,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             finally:
                 _clear_planned_restart_notification()
+        elif not chat_restart_notification_pending:
+            # Also notify on unexpected restarts (SIGTERM from systemd, OOM kill,
+            # etc.) so the operator always knows when the gateway has come back
+            # online — not just on planned restarts.  We detect an "unexpected
+            # restart" by checking whether the previous gateway left a
+            # "running" / "draining" state behind (meaning it died while active)
+            # rather than a clean "stopped" state.  A first-ever boot has no
+            # state file at all, so we don't spam on initial install.
+            try:
+                from gateway.status import read_runtime_status
+                prev_state = read_runtime_status()
+                prev_gateway_state = (prev_state or {}).get("gateway_state")
+            except Exception:
+                prev_gateway_state = None
+            if prev_gateway_state in ("running", "draining"):
+                logger.info(
+                    "Previous gateway state was '%s' — treating as unexpected restart, "
+                    "sending home-channel startup notification",
+                    prev_gateway_state,
+                )
+                await self._send_home_channel_startup_notifications(
+                    skip_targets=None,
+                )
 
         # Automatically continue fresh sessions that were interrupted by the
         # previous gateway restart/shutdown.  The resume_pending flag is cleared

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -413,3 +413,77 @@ async def test_shutdown_notifications_are_fully_muted_when_flag_disabled():
     adapter.send.assert_not_awaited()
 
 
+# ── unexpected-restart startup notification ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unexpected_restart_sends_home_channel_notification(tmp_path, monkeypatch):
+    """When the previous gateway died while running (state='running'),
+    the next boot treats it as an unexpected restart and notifies home channels
+    even without a .restart_pending.json marker."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-99",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="home"))
+
+    # Simulate: previous gateway left state="running" (signal-killed, OOM, etc.)
+    from gateway.status import write_runtime_status
+    write_runtime_status(gateway_state="running")
+
+    # No planned-restart marker, no chat-restart marker - it's an unexpected restart.
+    assert gateway_run._planned_restart_notification_pending() is False
+    assert gateway_run._restart_notification_pending() is False
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == {("telegram", "home-99", None)}
+    adapter.send.assert_called_once()
+    assert "Gateway online" in adapter.send.call_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_clean_stop_does_not_trigger_startup_notification(tmp_path, monkeypatch):
+    """When the previous gateway stopped cleanly (state='stopped'), the next
+    boot does NOT send a startup notification - the operator intentionally
+    stopped it and doesn't need a "back online" ping on manual restart."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-99",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock()
+
+    from gateway.status import write_runtime_status
+    write_runtime_status(gateway_state="stopped")
+
+    assert gateway_run._planned_restart_notification_pending() is False
+    assert gateway_run._restart_notification_pending() is False
+
+    # We can't easily run the full _start_impl, so verify the decision logic
+    # directly by reading state - this is what the new branch checks.
+    from gateway.status import read_runtime_status
+    prev_state = read_runtime_status()
+    assert prev_state.get("gateway_state") == "stopped"
+    # "stopped" is NOT in the trigger set -> no notification should fire.
+    assert prev_state.get("gateway_state") not in ("running", "draining")
+
+
+def test_first_boot_has_no_runtime_state(tmp_path, monkeypatch):
+    """On a first-ever boot, gateway_state.json doesn't exist at all.
+    The new branch correctly treats None as "not an unexpected restart"."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    from gateway.status import read_runtime_status
+    state = read_runtime_status()
+    # No file -> None or empty dict -> gateway_state is None -> not in trigger set.
+    gateway_state = (state or {}).get("gateway_state")
+    assert gateway_state is None
+    assert gateway_state not in ("running", "draining")

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -416,74 +416,115 @@ async def test_shutdown_notifications_are_fully_muted_when_flag_disabled():
 # ── unexpected-restart startup notification ────────────────────────────────
 
 
+def _simulate_startup_state_snapshot(monkeypatch, tmp_path):
+    """Reproduce the state-snapshot timing from ``GatewayRunner.start()``.
+
+    ``start()`` snapshots ``prev_gateway_state`` *before* overwriting the
+    status file with ``"starting"`` / ``"running"``.  This helper mirrors
+    that sequence so tests can verify the decision is based on the
+    *previous* gateway's state, not the current startup's writes.
+    """
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    from gateway.status import read_runtime_status, write_runtime_status
+
+    # 1. Snapshot previous state (what start() does at the very top).
+    prev_state = read_runtime_status()
+    prev_gateway_state = (prev_state or {}).get("gateway_state")
+
+    # 2. Simulate startup overwriting the status file (start() writes
+    #    "starting" at line ~8117, then "running" at line ~8665).
+    write_runtime_status(gateway_state="starting", exit_reason=None)
+    write_runtime_status(gateway_state="running", exit_reason=None)
+
+    return prev_gateway_state
+
+
 @pytest.mark.asyncio
 async def test_unexpected_restart_sends_home_channel_notification(tmp_path, monkeypatch):
     """When the previous gateway died while running (state='running'),
     the next boot treats it as an unexpected restart and notifies home channels
-    even without a .restart_pending.json marker."""
-    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    even without a .restart_pending.json marker.
 
-    runner, adapter = make_restart_runner()
-    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
-        platform=Platform.TELEGRAM,
-        chat_id="home-99",
-        name="Ops Home",
-    )
-    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="home"))
-
-    # Simulate: previous gateway left state="running" (signal-killed, OOM, etc.)
+    This test reproduces the start() lifecycle: the previous state is
+    snapshotted *before* the startup writes "starting"/"running", so the
+    decision uses the stale "running" from the dead gateway, not the
+    current boot's "running".
+    """
     from gateway.status import write_runtime_status
+
+    # Pre-seed: previous gateway died while "running" (SIGTERM, OOM, etc.)
     write_runtime_status(gateway_state="running")
 
-    # No planned-restart marker, no chat-restart marker - it's an unexpected restart.
+    # Run the snapshot sequence - mimics what start() does.
+    prev_gateway_state = _simulate_startup_state_snapshot(monkeypatch, tmp_path)
+
+    # The snapshot captured "running" from the *previous* gateway, even
+    # though the status file now says "running" from *this* boot.
+    assert prev_gateway_state == "running"
+
+    # No planned-restart marker, no chat-restart marker -> unexpected restart.
     assert gateway_run._planned_restart_notification_pending() is False
     assert gateway_run._restart_notification_pending() is False
 
-    delivered = await runner._send_home_channel_startup_notifications()
-
-    assert delivered == {("telegram", "home-99", None)}
-    adapter.send.assert_called_once()
-    assert "Gateway online" in adapter.send.call_args.args[1]
+    # The decision branch in start() would fire the notifier:
+    if prev_gateway_state in ("running", "draining"):
+        runner, adapter = make_restart_runner()
+        runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+            platform=Platform.TELEGRAM,
+            chat_id="home-99",
+            name="Ops Home",
+        )
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="home"))
+        delivered = await runner._send_home_channel_startup_notifications()
+        assert delivered == {("telegram", "home-99", None)}
+        adapter.send.assert_called_once()
+        assert "Gateway online" in adapter.send.call_args.args[1]
 
 
 @pytest.mark.asyncio
 async def test_clean_stop_does_not_trigger_startup_notification(tmp_path, monkeypatch):
     """When the previous gateway stopped cleanly (state='stopped'), the next
     boot does NOT send a startup notification - the operator intentionally
-    stopped it and doesn't need a "back online" ping on manual restart."""
-    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    stopped it and doesn't need a "back online" ping on manual restart.
 
-    runner, adapter = make_restart_runner()
-    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
-        platform=Platform.TELEGRAM,
-        chat_id="home-99",
-        name="Ops Home",
-    )
-    adapter.send = AsyncMock()
-
+    Crucially, even though start() overwrites the status file with
+    "starting"/"running" during boot, the snapshot was taken *before* those
+    writes, so it correctly captures "stopped".
+    """
     from gateway.status import write_runtime_status
+
+    # Pre-seed: previous gateway stopped cleanly.
     write_runtime_status(gateway_state="stopped")
 
+    # Run the snapshot sequence - mimics what start() does.
+    prev_gateway_state = _simulate_startup_state_snapshot(monkeypatch, tmp_path)
+
+    # The snapshot captured "stopped" from the *previous* gateway.
+    assert prev_gateway_state == "stopped"
+
+    # No planned-restart marker, no chat-restart marker.
     assert gateway_run._planned_restart_notification_pending() is False
     assert gateway_run._restart_notification_pending() is False
 
-    # We can't easily run the full _start_impl, so verify the decision logic
-    # directly by reading state - this is what the new branch checks.
-    from gateway.status import read_runtime_status
-    prev_state = read_runtime_status()
-    assert prev_state.get("gateway_state") == "stopped"
     # "stopped" is NOT in the trigger set -> no notification should fire.
-    assert prev_state.get("gateway_state") not in ("running", "draining")
+    assert prev_gateway_state not in ("running", "draining")
 
 
 def test_first_boot_has_no_runtime_state(tmp_path, monkeypatch):
     """On a first-ever boot, gateway_state.json doesn't exist at all.
-    The new branch correctly treats None as "not an unexpected restart"."""
-    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    The snapshot correctly captures None, which is not in the trigger set,
+    so no notification fires on fresh install.
 
-    from gateway.status import read_runtime_status
-    state = read_runtime_status()
-    # No file -> None or empty dict -> gateway_state is None -> not in trigger set.
-    gateway_state = (state or {}).get("gateway_state")
-    assert gateway_state is None
-    assert gateway_state not in ("running", "draining")
+    This also verifies the timing fix: even after start() writes
+    "starting"/"running", the snapshot was taken before those writes and
+    correctly reflects the absence of a prior state file.
+    """
+    # No pre-seed: first-ever boot, no state file exists.
+
+    # Run the snapshot sequence - mimics what start() does.
+    prev_gateway_state = _simulate_startup_state_snapshot(monkeypatch, tmp_path)
+
+    # No prior state file -> snapshot is None.
+    assert prev_gateway_state is None
+    # None is NOT in the trigger set -> no notification on first boot.
+    assert prev_gateway_state not in ("running", "draining")

--- a/tests/gateway/test_unexpected_restart_e2e.py
+++ b/tests/gateway/test_unexpected_restart_e2e.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""
+E2E verification script for the unexpected-restart notification feature (PR #74662).
+
+Exercises the REAL GatewayRunner.start() lifecycle (not a mock of it) to verify
+that the prev_gateway_state snapshot timing fix works correctly across all
+start/stop lifecycle scenarios.
+
+Usage:
+    source venv/bin/activate
+    python tests/gateway/test_unexpected_restart_e2e.py
+
+The script creates an isolated temp HERMES_HOME per scenario, so it is safe to
+run while a real gateway is live.  It constructs a real GatewayRunner with no
+platforms (skipping adapter I/O) and only mocks the notification sender to
+capture whether it was called -- the state-snapshot / decision logic in start()
+runs unmodified.
+
+SCENARIOS (full lifecycle coverage):
+
+  No markers (unexpected restart detection -- our new code):
+    1.  prev=running       -> notify (gateway died while active)
+    2.  prev=draining      -> notify (gateway died while draining)
+    3.  prev=stopped       -> NO    (clean stop, manual restart)
+    4.  prev=None          -> NO    (first boot)
+    5.  prev=startup_failed-> NO    (previous boot failed, never reached running)
+    6.  prev=degraded      -> NO    (NOT in trigger set -- edge case)
+    7.  prev=starting      -> NO    (crashed during startup, never reached running)
+
+  Planned restart marker (.restart_pending.json):
+    8.  prev=running  + .restart_pending -> notify (planned restart, branch 1)
+    9.  prev=stopped  + .restart_pending -> notify (planned restart overrides)
+    10. prev=None     + .restart_pending -> notify (planned restart on first boot)
+
+  Chat restart marker (.restart_notify.json):
+    11. prev=running  + .restart_notify  -> NO home-channel (chat restart, branch 3)
+    12. prev=stopped  + .restart_notify  -> NO home-channel (chat restart, branch 3)
+
+  Both markers (edge case):
+    13. prev=running + both markers      -> notify (branch 1 takes priority)
+
+  Timing regression:
+    14. prev=stopped, no markers          -> NO notify (proves snapshot is
+                                              taken BEFORE starting/running writes)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+# ── Ensure we can import from the repo root ──────────────────────────────────
+_repo_root = Path(__file__).resolve().parent.parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+
+class E2ETestResult:
+    def __init__(self, name: str):
+        self.name = name
+        self.passed = False
+        self.details: list[str] = []
+        self.error: str | None = None
+
+
+def _make_state_json(gateway_state: str | None) -> dict | None:
+    """Build a realistic gateway_state.json payload."""
+    if gateway_state is None:
+        return None
+    return {
+        "gateway_state": gateway_state,
+        "pid": 99999,
+        "kind": "gateway",
+        "start_time": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z",
+        "exit_reason": None,
+    }
+
+
+async def _run_scenario(
+    name: str,
+    prev_state: str | None,
+    *,
+    restart_pending: bool = False,
+    restart_notify: bool = False,
+    expect_home_notify: bool,
+) -> E2ETestResult:
+    """Run a single E2E scenario through the real GatewayRunner.start().
+
+    Args:
+        name:             Human-readable scenario name.
+        prev_state:       Gateway state to pre-seed in gateway_state.json.
+                          None means no file (first boot).
+        restart_pending:  If True, create .restart_pending.json marker.
+        restart_notify:   If True, create .restart_notify.json marker.
+        expect_home_notify: Whether _send_home_channel_startup_notifications
+                            is expected to be called.
+    """
+    result = E2ETestResult(name)
+    tmp_home = Path(tempfile.mkdtemp(prefix="hermes_e2e_"))
+
+    try:
+        os.environ["HERMES_HOME"] = str(tmp_home)
+        (tmp_home / "sessions").mkdir(exist_ok=True)
+        (tmp_home / "logs").mkdir(exist_ok=True)
+
+        # ── Pre-seed gateway_state.json ───────────────────────────────────
+        state_file = tmp_home / "gateway_state.json"
+        prev_content = _make_state_json(prev_state)
+        if prev_content is not None:
+            state_file.write_text(
+                json.dumps(prev_content, default=str), encoding="utf-8"
+            )
+            result.details.append(f"  prev_state = {prev_state!r}")
+        else:
+            result.details.append("  prev_state = None (no file)")
+
+        # ── Pre-seed marker files ─────────────────────────────────────────
+        if restart_pending:
+            (tmp_home / ".restart_pending.json").write_text(
+                json.dumps({"requested_at": 1, "via_service": False}), encoding="utf-8"
+            )
+            result.details.append("  .restart_pending.json = created")
+        if restart_notify:
+            (tmp_home / ".restart_notify.json").write_text(
+                json.dumps({"platform": "telegram", "chat_id": "123"}), encoding="utf-8"
+            )
+            result.details.append("  .restart_notify.json  = created")
+
+        if not restart_pending and not restart_notify:
+            result.details.append("  (no markers)")
+
+        # ── Construct real GatewayRunner ──────────────────────────────────
+        import importlib
+        import gateway.run as gateway_run_mod
+        import gateway.config as gateway_config_mod
+        importlib.reload(gateway_config_mod)
+        importlib.reload(gateway_run_mod)
+        from gateway.run import GatewayRunner
+        from gateway.config import GatewayConfig
+
+        config = GatewayConfig()
+        runner = GatewayRunner(config)
+
+        # ── Mock only what's needed to let start() run without external I/O ─
+        notification_sent = False
+
+        async def _capture_home_notify(*, skip_targets=None):
+            nonlocal notification_sent
+            notification_sent = True
+            result.details.append("  _send_home_channel_startup_notifications() CALLED")
+            return set()
+
+        runner._send_home_channel_startup_notifications = _capture_home_notify
+        runner._send_restart_notification = AsyncMock(return_value=None)
+        runner._send_update_notification = AsyncMock(return_value=True)
+        runner._redeliver_pending_obligations = AsyncMock(return_value=0)
+        runner._finish_startup_restore = AsyncMock(return_value=None)
+        runner._schedule_resume_pending_sessions = MagicMock(return_value=0)
+        runner.hooks.discover_and_load = MagicMock()
+        runner.hooks.emit = AsyncMock()
+
+        # ── Run start() ───────────────────────────────────────────────────
+        result.details.append("  Calling runner.start()...")
+        success = await runner.start()
+        result.details.append(f"  start() returned: {success}")
+
+        # ── Verify ────────────────────────────────────────────────────────
+        if expect_home_notify:
+            if notification_sent:
+                result.passed = True
+                result.details.append("  PASS: home-channel notification sent (expected)")
+            else:
+                result.passed = False
+                result.details.append("  FAIL: expected notification but none was sent")
+        else:
+            if not notification_sent:
+                result.passed = True
+                result.details.append("  PASS: no home-channel notification (expected)")
+            else:
+                result.passed = False
+                result.details.append("  FAIL: notification sent but should NOT have been")
+
+        # Verify final state file
+        if state_file.exists():
+            final = json.loads(state_file.read_text(encoding="utf-8"))
+            result.details.append(f"  final gateway_state = {final.get('gateway_state')!r}")
+
+        # Verify .restart_pending.json was cleared (branch 1 clears it after notify)
+        if restart_pending:
+            rp = tmp_home / ".restart_pending.json"
+            if not rp.exists():
+                result.details.append("  .restart_pending.json cleared (expected)")
+            else:
+                # It should have been cleared by _clear_planned_restart_notification()
+                result.details.append("  WARNING: .restart_pending.json still exists")
+
+    except Exception as exc:
+        result.passed = False
+        result.error = f"{type(exc).__name__}: {exc}"
+        result.details.append(f"  EXCEPTION: {traceback.format_exc()}")
+    finally:
+        try:
+            if 'runner' in dir() and hasattr(runner, '_running') and runner._running:
+                try:
+                    await runner.stop()
+                except Exception:
+                    pass
+        except Exception:
+            pass
+        shutil.rmtree(tmp_home, ignore_errors=True)
+
+    return result
+
+
+async def main():
+    print("=" * 76)
+    print("E2E Verification: Unexpected-Restart Notification (PR #74662)")
+    print("Full lifecycle scenario coverage")
+    print("=" * 76)
+
+    scenarios = [
+        # ── No markers: unexpected-restart detection (our new code) ──────
+        ("S1  prev=running        no markers  -> notify",
+         "running", False, False, True),
+        ("S2  prev=draining       no markers  -> notify",
+         "draining", False, False, True),
+        ("S3  prev=stopped        no markers  -> NO notify",
+         "stopped", False, False, False),
+        ("S4  prev=None (1st boot) no markers -> NO notify",
+         None, False, False, False),
+        ("S5  prev=startup_failed  no markers -> NO notify",
+         "startup_failed", False, False, False),
+        ("S6  prev=degraded        no markers -> NO notify (edge)",
+         "degraded", False, False, False),
+        ("S7  prev=starting        no markers -> NO notify",
+         "starting", False, False, False),
+
+        # ── Planned restart marker (.restart_pending.json) ───────────────
+        ("S8  prev=running  + .restart_pending -> notify (planned)",
+         "running", True, False, True),
+        ("S9  prev=stopped  + .restart_pending -> notify (planned)",
+         "stopped", True, False, True),
+        ("S10 prev=None     + .restart_pending -> notify (planned)",
+         None, True, False, True),
+
+        # ── Chat restart marker (.restart_notify.json) ───────────────────
+        ("S11 prev=running  + .restart_notify  -> NO home-notify (chat)",
+         "running", False, True, False),
+        ("S12 prev=stopped  + .restart_notify  -> NO home-notify (chat)",
+         "stopped", False, True, False),
+
+        # ── Both markers (edge case) ─────────────────────────────────────
+        ("S13 prev=running  + both markers     -> notify (planned wins)",
+         "running", True, True, True),
+
+        # ── Timing regression ────────────────────────────────────────────
+        ("S14 prev=stopped   no markers        -> NO notify (timing fix)",
+         "stopped", False, False, False),
+    ]
+
+    results: list[E2ETestResult] = []
+
+    for name, prev_state, rp, rn, expect in scenarios:
+        print(f"\n{'─' * 76}")
+        print(f"{name}")
+        print(f"{'─' * 76}")
+        r = await _run_scenario(name, prev_state,
+                                restart_pending=rp, restart_notify=rn,
+                                expect_home_notify=expect)
+        results.append(r)
+        for d in r.details:
+            print(d)
+        status = "PASS" if r.passed else "FAIL"
+        print(f"\n  >> {status}")
+        if r.error:
+            print(f"     {r.error}")
+
+    # ── Summary ──────────────────────────────────────────────────────────
+    print(f"\n{'=' * 76}")
+    print("SUMMARY")
+    print(f"{'=' * 76}")
+    passed = sum(1 for r in results if r.passed)
+    failed = sum(1 for r in results if not r.passed)
+    for r in results:
+        status = "PASS" if r.passed else "FAIL"
+        print(f"  [{status}] {r.name}")
+    print(f"\n  Total: {len(results)}  |  Passed: {passed}  |  Failed: {failed}")
+    print()
+
+    if failed > 0:
+        print("FAILURES:")
+        for r in results:
+            if not r.passed:
+                print(f"\n  {r.name}")
+                if r.error:
+                    print(f"    Error: {r.error}")
+                for d in r.details:
+                    if "FAIL" in d or "EXCEPTION" in d:
+                        print(f"    {d}")
+        sys.exit(1)
+    else:
+        print("All scenarios passed!")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

Previously, the gateway only sent a "Gateway online" notification to home channels during a *planned* restart (when `.restart_pending.json` existed). If the gateway died unexpectedly — e.g. SIGTERM from systemd, OOM kill, crash — the next boot would silently come online with no alert, making it hard for operators to notice that a restart had even happened.

This change adds a second detection path: if there is no planned-restart marker but the previous runtime state was `"running"` or `"draining"` (meaning the gateway died while active), we treat it as an unexpected restart and send the home-channel startup notification anyway.

Clean stops (`state="stopped"`) and first-ever boots (no state file) do **not** trigger the notification, so manual restarts and fresh installs stay quiet.

## Changes

- `gateway/run.py`: Add an `elif` branch in `_start_impl` that checks the previous runtime state and sends home-channel notifications when the previous gateway died while active
- `tests/gateway/test_restart_notification.py`: Add 3 tests covering unexpected restart, clean stop, and first-boot scenarios

## Test Plan

- [x] `test_unexpected_restart_sends_home_channel_notification` — state="running" triggers notification
- [x] `test_clean_stop_does_not_trigger_startup_notification` — state="stopped" does not trigger
- [x] `test_first_boot_has_no_runtime_state` — no state file does not trigger
