### PR TITLE
feat(tools): add ha_history to the Home Assistant toolset

### DIFF
--- a/tests/tools/test_homeassistant_tool.py
+++ b/tests/tools/test_homeassistant_tool.py
@@ -16,9 +16,11 @@ from tools.homeassistant_tool import (
     _parse_service_response,
     _get_headers,
     _handle_get_state,
+    _handle_get_history,
     _handle_call_service,
     _BLOCKED_DOMAINS,
     _ENTITY_ID_RE,
+    _ISO_TIMESTAMP_RE,
     _SERVICE_NAME_RE,
 )
 
@@ -327,6 +329,148 @@ class TestGetHeaders:
 # ---------------------------------------------------------------------------
 
 
+class TestHistory:
+    """ha_history: validation, ISO-timestamp guard, and response parsing."""
+
+    def test_missing_entity_id(self):
+        result = json.loads(_handle_get_history({}))
+        assert "error" in result
+        assert "entity_id" in result["error"]
+
+    def test_invalid_entity_id_rejected(self):
+        result = json.loads(_handle_get_history({"entity_id": "../../config"}))
+        assert "error" in result
+        assert "Invalid entity_id" in result["error"]
+
+    def test_iso_timestamp_regex_accepts_valid(self):
+        assert _ISO_TIMESTAMP_RE.match("2026-06-29T00:00:00Z")
+        assert _ISO_TIMESTAMP_RE.match("2026-06-29T12:34:56")
+        assert _ISO_TIMESTAMP_RE.match("2026-06-29T12:34:56.789Z")
+        assert _ISO_TIMESTAMP_RE.match("2026-06-29T12:34:56+02:00")
+
+    def test_iso_timestamp_regex_rejects_traversal_and_junk(self):
+        assert _ISO_TIMESTAMP_RE.match("../../api/config") is None
+        assert _ISO_TIMESTAMP_RE.match("2026-06-29/../../etc") is None
+        assert _ISO_TIMESTAMP_RE.match("not-a-date") is None
+        assert _ISO_TIMESTAMP_RE.match("") is None
+
+    def test_invalid_start_timestamp_rejected(self):
+        result = json.loads(_handle_get_history({
+            "entity_id": "sensor.temperature",
+            "start": "../../api/config",
+        }))
+        assert "error" in result
+        assert "start timestamp" in result["error"]
+
+    def test_invalid_end_timestamp_rejected(self):
+        result = json.loads(_handle_get_history({
+            "entity_id": "sensor.temperature",
+            "end": "yesterday",
+        }))
+        assert "error" in result
+        assert "end timestamp" in result["error"]
+
+    @patch("tools.homeassistant_tool._run_async")
+    def test_valid_request_reaches_fetch_and_parses(self, mock_run):
+        # HA returns a list-of-lists: one inner list per entity_id.
+        mock_run.return_value = {
+            "entity_id": "sensor.temperature",
+            "count": 2,
+            "history": [
+                {"state": "21.0", "last_changed": "2026-06-29T00:00:00Z"},
+                {"state": "22.5", "last_changed": "2026-06-29T01:00:00Z"},
+            ],
+        }
+        # Close the coroutine that _run_async would have awaited, so the
+        # patched-out call doesn't emit an "unawaited coroutine" warning.
+        def _close_coro(coro):
+            coro.close()
+            return mock_run.return_value
+        mock_run.side_effect = _close_coro
+
+        result = json.loads(_handle_get_history({
+            "entity_id": "sensor.temperature",
+            "start": "2026-06-29T00:00:00Z",
+        }))
+        assert result["result"]["count"] == 2
+        assert result["result"]["history"][0]["state"] == "21.0"
+        mock_run.assert_called_once()
+
+
+class TestHistoryParsing:
+    """The list-of-lists unwrap + compaction in _async_get_history.
+
+    We patch the network fetch at the aiohttp boundary via a small helper so
+    the test exercises the real unwrap/compaction logic without a live HA.
+    """
+
+    def _run_with_payload(self, payload, entity_id="sensor.x"):
+        """Run _async_get_history with the HA JSON response stubbed to `payload`."""
+        import asyncio
+        from tools import homeassistant_tool as ha
+
+        class _FakeResp:
+            def raise_for_status(self):
+                pass
+
+            async def json(self):
+                return payload
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+        class _FakeSession:
+            def get(self, *a, **k):
+                return _FakeResp()
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+        import aiohttp
+        orig = aiohttp.ClientSession
+        aiohttp.ClientSession = lambda *a, **k: _FakeSession()
+        try:
+            return asyncio.run(ha._async_get_history(entity_id))
+        finally:
+            aiohttp.ClientSession = orig
+
+    def test_parse_empty_history(self):
+        out = self._run_with_payload([])
+        assert out["entity_id"] == "sensor.x"
+        assert out["count"] == 0
+        assert out["history"] == []
+
+    def test_parse_unwraps_list_of_lists_and_compacts(self):
+        payload = [[
+            {"state": "21.0", "last_changed": "2026-06-29T00:00:00Z", "attributes": {"unit": "C"}},
+            {"state": "22.5", "last_changed": "2026-06-29T01:00:00Z"},
+        ]]
+        out = self._run_with_payload(payload, entity_id="sensor.temperature")
+        assert out["entity_id"] == "sensor.temperature"
+        assert out["count"] == 2
+        # Only state + last_changed are kept (attributes dropped for compactness)
+        assert out["history"][0] == {"state": "21.0", "last_changed": "2026-06-29T00:00:00Z"}
+        assert out["history"][1]["state"] == "22.5"
+
+    def test_parse_falls_back_to_lu_timestamp_key(self):
+        # minimal_response uses "lu" (last_updated) instead of "last_changed"
+        payload = [[{"state": "on", "lu": 1720000000.0}]]
+        out = self._run_with_payload(payload, entity_id="switch.pump")
+        assert out["count"] == 1
+        assert out["history"][0]["last_changed"] == 1720000000.0
+
+
+# ---------------------------------------------------------------------------
+# Registry integration
+# ---------------------------------------------------------------------------
+
+
 class TestRegistration:
     def test_tools_registered_in_registry(self):
         from tools.registry import registry
@@ -334,6 +478,7 @@ class TestRegistration:
         names = registry.get_all_tool_names()
         assert "ha_list_entities" in names
         assert "ha_get_state" in names
+        assert "ha_history" in names
         assert "ha_call_service" in names
 
 

--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -1,8 +1,9 @@
 """Home Assistant tool for controlling smart home devices via REST API.
 
-Registers four LLM-callable tools:
+Registers five LLM-callable tools:
 - ``ha_list_entities`` -- list/filter entities by domain or area
 - ``ha_get_state`` -- get detailed state of a single entity
+- ``ha_history`` -- fetch recorded state history for a single entity
 - ``ha_list_services`` -- list available services (actions) per domain
 - ``ha_call_service`` -- call a HA service (turn_on, turn_off, set_temperature, etc.)
 
@@ -136,6 +137,69 @@ async def _async_get_state(entity_id: str) -> Dict[str, Any]:
         "attributes": data.get("attributes", {}),
         "last_changed": data.get("last_changed"),
         "last_updated": data.get("last_updated"),
+    }
+
+
+# Regex for an ISO 8601 timestamp accepted by HA's /api/history/period path.
+# Deliberately strict: the timestamp is interpolated into the URL path
+# (/api/history/period/{start}), so we only allow the characters that make up
+# a legitimate ISO 8601 instant and reject anything that could enable path
+# traversal (e.g. "../") or other URL injection.
+_ISO_TIMESTAMP_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?$"
+)
+
+
+async def _async_get_history(
+    entity_id: str,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+    minimal: bool = True,
+    significant_only: bool = False,
+) -> Dict[str, Any]:
+    """Fetch state history for a single entity via /api/history/period.
+
+    Returns a compact list of {state, last_changed} points. ``start`` defaults
+    to HA's own default window (the last day) when omitted.
+    """
+    import aiohttp
+    from urllib.parse import quote
+
+    hass_url, hass_token = _get_config()
+    path = "history/period"
+    if start:
+        path += "/" + quote(start, safe="")
+
+    params = [("filter_entity_id", entity_id)]
+    if end:
+        params.append(("end_time", end))
+    if minimal:
+        params.append(("minimal_response", ""))
+    if significant_only:
+        params.append(("significant_changes_only", ""))
+
+    url = f"{hass_url}/api/{path}"
+    async with aiohttp.ClientSession() as session:
+        async with session.get(
+            url,
+            headers=_get_headers(hass_token),
+            params=params,
+            timeout=aiohttp.ClientTimeout(total=20),
+        ) as resp:
+            resp.raise_for_status()
+            data = await resp.json()
+
+    # HA returns a list of lists: one inner list per requested entity_id.
+    series = data[0] if isinstance(data, list) and data else []
+    points = [
+        {"state": p.get("state"), "last_changed": p.get("last_changed") or p.get("lu")}
+        for p in series
+        if isinstance(p, dict)
+    ]
+    return {
+        "entity_id": entity_id,
+        "count": len(points),
+        "history": points,
     }
 
 
@@ -337,6 +401,35 @@ def _handle_list_services(args: dict, **kw) -> str:
         return tool_error(f"Failed to list services: {e}")
 
 
+def _handle_get_history(args: dict, **kw) -> str:
+    """Handler for ha_history tool."""
+    entity_id = args.get("entity_id", "")
+    if not entity_id:
+        return tool_error("Missing required parameter: entity_id")
+    if not _ENTITY_ID_RE.match(entity_id):
+        return tool_error(f"Invalid entity_id format: {entity_id}")
+
+    start = args.get("start")
+    end = args.get("end")
+    if start and not _ISO_TIMESTAMP_RE.match(start):
+        return tool_error(f"Invalid start timestamp (expected ISO 8601): {start}")
+    if end and not _ISO_TIMESTAMP_RE.match(end):
+        return tool_error(f"Invalid end timestamp (expected ISO 8601): {end}")
+
+    try:
+        result = _run_async(_async_get_history(
+            entity_id=entity_id,
+            start=start,
+            end=end,
+            minimal=bool(args.get("minimal", True)),
+            significant_only=bool(args.get("significant_only", False)),
+        ))
+        return json.dumps({"result": result})
+    except Exception as e:
+        logger.error("ha_history error: %s", e)
+        return tool_error(f"Failed to get history for {entity_id}: {e}")
+
+
 # ---------------------------------------------------------------------------
 # Availability check
 # ---------------------------------------------------------------------------
@@ -469,6 +562,56 @@ HA_CALL_SERVICE_SCHEMA = {
     },
 }
 
+HA_HISTORY_SCHEMA = {
+    "name": "ha_history",
+    "description": (
+        "Fetch the recorded state history of a single Home Assistant entity "
+        "over a time window (e.g. how a sensor, switch, or thermostat changed "
+        "over the last hours or days). Returns a compact list of "
+        "{state, last_changed} points. Use this for trends, verifying that an "
+        "actuator actually toggled, or checking a reading's range over time. "
+        "For the current value only, use ha_get_state instead."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "entity_id": {
+                "type": "string",
+                "description": (
+                    "The entity ID to fetch history for (e.g. "
+                    "'sensor.temperature', 'switch.pump', 'climate.thermostat')."
+                ),
+            },
+            "start": {
+                "type": "string",
+                "description": (
+                    "ISO 8601 start time (e.g. '2026-06-29T00:00:00Z'). "
+                    "Omit to use Home Assistant's default window (the last day)."
+                ),
+            },
+            "end": {
+                "type": "string",
+                "description": "Optional ISO 8601 end time (e.g. '2026-06-30T00:00:00Z').",
+            },
+            "minimal": {
+                "type": "boolean",
+                "description": (
+                    "Return only state + last_changed per point (minimal_response). "
+                    "Default true; keeps the payload small."
+                ),
+            },
+            "significant_only": {
+                "type": "boolean",
+                "description": (
+                    "Return only significant state changes (significant_changes_only). "
+                    "Default false."
+                ),
+            },
+        },
+        "required": ["entity_id"],
+    },
+}
+
 
 # ---------------------------------------------------------------------------
 # Registration
@@ -490,6 +633,15 @@ registry.register(
     toolset="homeassistant",
     schema=HA_GET_STATE_SCHEMA,
     handler=_handle_get_state,
+    check_fn=_check_ha_available,
+    emoji="🏠",
+)
+
+registry.register(
+    name="ha_history",
+    toolset="homeassistant",
+    schema=HA_HISTORY_SCHEMA,
+    handler=_handle_get_history,
     check_fn=_check_ha_available,
     emoji="🏠",
 )


### PR DESCRIPTION
# feat(tools): add ha_history to the Home Assistant toolset

## Summary

The built-in `homeassistant` toolset can read current state
(`ha_get_state`) and control devices (`ha_call_service`), but has no way to
read an entity's recorded history. Answering "how did this sensor trend over
the last day" or "did this switch actually toggle" requires leaving the
toolset entirely.

This adds `ha_history`: fetch the recorded state history of a single entity
over a time window via `GET /api/history/period`. It returns a compact list of
`{state, last_changed}` points (`minimal_response` by default to keep the
payload small), with optional `start`/`end` (ISO 8601) and
`significant_changes_only`.

Example:

```text
ha_history(entity_id="sensor.temperature", start="2026-06-29T00:00:00Z")
```

## Why this shape (footprint ladder)

- **Pure addition to an existing toolset.** No new toolset, no new `HERMES_*`
  env var, gated by the same `_check_ha_available` check_fn, and consistent
  with the four existing `ha_*` tools.
- It fills a genuine capability gap: history is not expressible by composing
  the existing tools (there is no history service call), so this is not
  duplicable by a skill.

## Security

- `entity_id` is validated with the existing `_ENTITY_ID_RE` guard.
- `start`/`end` are validated against a strict ISO 8601 regex
  (`_ISO_TIMESTAMP_RE`) before being interpolated into the URL path, matching
  the path-traversal protection already applied to `ha_get_state` and
  `ha_call_service`. Traversal strings like `../../api/config` are rejected.

## Changes

**`tools/homeassistant_tool.py`**

- `_async_get_history(entity_id, start, end, minimal, significant_only)`: async
  fetch against `/api/history/period`, mirroring `_async_get_state`. Unwraps
  HA's list-of-lists response and compacts each point to `{state,
  last_changed}` (falls back to the `lu` key that `minimal_response` uses).
- `_ISO_TIMESTAMP_RE`: strict ISO 8601 validator for the URL-path timestamp.
- `_handle_get_history(args, **kw)`: validates `entity_id` and `start`/`end`,
  then dispatches via `_run_async`.
- `HA_HISTORY_SCHEMA` + `registry.register(name="ha_history", ...)`.
- Module docstring updated (four -> five tools).

**`tests/tools/test_homeassistant_tool.py`**: 10 new tests across `TestHistory`
and `TestHistoryParsing`:

- missing `entity_id`, invalid `entity_id`
- ISO-timestamp regex accept (Z, no-tz, fractional, offset) and reject
  (path-traversal, junk, empty)
- invalid `start` / invalid `end` rejection
- handler happy path (mocked fetch)
- list-of-lists unwrap + compaction: empty, two points, and the `lu`
  minimal_response timestamp-key fallback

## How to Test

```bash
python -m pytest tests/tools/test_homeassistant_tool.py -o 'addopts=' -q
```

Expected: `45 passed` (35 pre-existing + 10 new). History-only:

```bash
python -m pytest tests/tools/test_homeassistant_tool.py -o 'addopts=' -q -k history
```

Expected: `10 passed`. The new history tests also pass under
`-W error::RuntimeWarning` (no unawaited-coroutine noise introduced).

## Testing / platforms

Tested on Linux. The change is pure Python plus an aiohttp GET (same client
pattern as the existing `ha_*` tools), with no OS, path, process, or signal
code, so there is no cross-platform surface to guard; it is expected to behave
identically on macOS and Windows/WSL2.

## Related

Note for maintainers on dedup: PR #9397, which also added a history tool (ha_get_history), was closed by its author on 2026-07-30 ("moved on entirely"). This PR (#74666) is now the only open PR for Home Assistant history. It is single-purpose (history only), off current main, and adds 10 tests. The camera half of #9397 is carried forward separately in a focused camera-only PR.