### PR TITLE
feat(provider): add openai-responses provider with retained reasoning and compaction

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1216,6 +1216,24 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
                     getattr(agent, "log_prefix", ""), exc,
                 )
 
+        # Resolve provider profile so ResponsesApiTransport can merge
+        # build_api_kwargs_extras / build_extra_body (e.g. openai-responses
+        # retained_reasoning + compaction). Without this, codex_responses
+        # never consulted the profile hooks.
+        _codex_profile = None
+        try:
+            from providers import get_provider_profile
+
+            _codex_profile = get_provider_profile(agent.provider)
+        except Exception:
+            _codex_profile = None
+
+        _supports_reasoning = False
+        try:
+            _supports_reasoning = bool(agent._supports_reasoning_extra_body())
+        except Exception:
+            _supports_reasoning = agent.reasoning_config is not None
+
         return _ct.build_kwargs(
             model=agent.model,
             messages=_msgs_for_codex,
@@ -1233,6 +1251,8 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             replay_encrypted_reasoning=bool(
                 getattr(agent, "_codex_reasoning_replay_enabled", True)
             ),
+            provider_profile=_codex_profile,
+            supports_reasoning=_supports_reasoning,
         )
 
     # ── chat_completions (default) ─────────────────────────────────────

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -179,6 +179,11 @@ class ResponsesApiTransport(ProviderTransport):
             is_codex_backend: bool — chatgpt.com/backend-api/codex
             is_xai_responses: bool — xAI/Grok backend
             github_reasoning_extra: dict | None — Copilot reasoning params
+            provider_profile: ProviderProfile | None — when set, merges
+                ``build_extra_body`` / ``build_api_kwargs_extras`` into the
+                request (parity with ChatCompletionsTransport). Required for
+                profiles such as openai-responses (retained_reasoning /
+                compaction) to reach the wire body.
         """
         from agent.codex_responses_adapter import (
             _chat_messages_to_responses_input,
@@ -365,6 +370,63 @@ class ResponsesApiTransport(ProviderTransport):
         elif not is_github_responses and not is_xai_responses:
             kwargs["include"] = []
 
+        # Provider-profile hooks (parity with ChatCompletionsTransport).
+        # chat_completion_helpers previously called build_kwargs without a
+        # profile, so profile extras such as openai-responses
+        # retained_reasoning / compaction never reached the request body.
+        profile = params.get("provider_profile")
+        if profile is not None:
+            try:
+                profile_body = (
+                    profile.build_extra_body(
+                        session_id=session_id,
+                        model=model,
+                        base_url=params.get("base_url"),
+                        reasoning_config=reasoning_config,
+                    )
+                    or {}
+                )
+            except Exception:
+                profile_body = {}
+            try:
+                supports_reasoning = params.get("supports_reasoning")
+                if supports_reasoning is None:
+                    supports_reasoning = bool(
+                        reasoning_enabled and reasoning_config is not None
+                    )
+                extra_from_profile, top_level_from_profile = (
+                    profile.build_api_kwargs_extras(
+                        reasoning_config=reasoning_config,
+                        supports_reasoning=bool(supports_reasoning),
+                        model=model,
+                        base_url=params.get("base_url"),
+                        session_id=session_id,
+                    )
+                )
+                extra_from_profile = extra_from_profile or {}
+                top_level_from_profile = top_level_from_profile or {}
+            except Exception:
+                extra_from_profile, top_level_from_profile = {}, {}
+
+            if top_level_from_profile:
+                kwargs.update(top_level_from_profile)
+
+            merged_profile_extra: Dict[str, Any] = {}
+            if isinstance(profile_body, dict) and profile_body:
+                merged_profile_extra.update(profile_body)
+            if isinstance(extra_from_profile, dict) and extra_from_profile:
+                merged_profile_extra.update(extra_from_profile)
+            if merged_profile_extra:
+                existing_extra_body = kwargs.get("extra_body")
+                if isinstance(existing_extra_body, dict):
+                    merged_extra = dict(existing_extra_body)
+                    merged_extra.update(merged_profile_extra)
+                    kwargs["extra_body"] = merged_extra
+                else:
+                    kwargs["extra_body"] = dict(merged_profile_extra)
+
+        # request_overrides win over profile extras (same order as chat
+        # completions transport).
         request_overrides = params.get("request_overrides")
         if request_overrides:
             kwargs.update(request_overrides)

--- a/plugins/model-providers/openai-responses/__init__.py
+++ b/plugins/model-providers/openai-responses/__init__.py
@@ -1,0 +1,42 @@
+"""OpenAI Responses API provider profile."""
+
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+class OpenAIResponsesProfile(ProviderProfile):
+    """OpenAI provider using the new Responses API."""
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        supports_reasoning: bool = False,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
+        
+        # Enable Responses API settings that maximize benchmark and production
+        # capabilities (ARC-AGI-3 scores tripled with these on GPT-5.6 Sol)
+        extra_body["retained_reasoning"] = True
+        extra_body["compaction"] = True
+
+        if supports_reasoning and reasoning_config is not None:
+            extra_body["reasoning"] = dict(reasoning_config)
+
+        return extra_body, top_level
+
+
+openai_responses = OpenAIResponsesProfile(
+    name="openai-responses",
+    aliases=("openai_responses",),
+    display_name="OpenAI (Responses API)",
+    description="OpenAI provider using the Responses API with retained reasoning and compaction.",
+    api_mode="codex_responses",
+    env_vars=("OPENAI_API_KEY", "OPENAI_BASE_URL"),
+    base_url="https://api.openai.com/v1",
+)
+
+register_provider(openai_responses)

--- a/plugins/model-providers/openai-responses/__init__.py
+++ b/plugins/model-providers/openai-responses/__init__.py
@@ -1,12 +1,18 @@
-"""OpenAI Responses API provider profile."""
+"""OpenAI Responses API provider profile.
+
+Uses ``api_mode="codex_responses"`` against ``api.openai.com`` and enables
+Responses API features that keep reasoning traces across tool calls and
+context boundaries (``retained_reasoning``, ``compaction``).
+"""
 
 from typing import Any
 
 from providers import register_provider
 from providers.base import ProviderProfile
 
+
 class OpenAIResponsesProfile(ProviderProfile):
-    """OpenAI provider using the new Responses API."""
+    """OpenAI provider using the Responses API with retained reasoning."""
 
     def build_api_kwargs_extras(
         self,
@@ -15,25 +21,25 @@ class OpenAIResponsesProfile(ProviderProfile):
         supports_reasoning: bool = False,
         **context: Any,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
-        extra_body: dict[str, Any] = {}
-        top_level: dict[str, Any] = {}
-        
-        # Enable Responses API settings that maximize benchmark and production
-        # capabilities (ARC-AGI-3 scores tripled with these on GPT-5.6 Sol)
-        extra_body["retained_reasoning"] = True
-        extra_body["compaction"] = True
-
-        if supports_reasoning and reasoning_config is not None:
-            extra_body["reasoning"] = dict(reasoning_config)
-
-        return extra_body, top_level
+        # These fields are not typed on every openai SDK build; send them via
+        # extra_body so ResponsesApiTransport / preflight forward them into the
+        # request JSON body unchanged.
+        del reasoning_config, supports_reasoning, context  # unused; transport owns effort
+        extra_body: dict[str, Any] = {
+            "retained_reasoning": True,
+            "compaction": True,
+        }
+        return extra_body, {}
 
 
 openai_responses = OpenAIResponsesProfile(
     name="openai-responses",
     aliases=("openai_responses",),
     display_name="OpenAI (Responses API)",
-    description="OpenAI provider using the Responses API with retained reasoning and compaction.",
+    description=(
+        "OpenAI provider using the Responses API with retained reasoning "
+        "and compaction."
+    ),
     api_mode="codex_responses",
     env_vars=("OPENAI_API_KEY", "OPENAI_BASE_URL"),
     base_url="https://api.openai.com/v1",

--- a/plugins/model-providers/openai-responses/plugin.yaml
+++ b/plugins/model-providers/openai-responses/plugin.yaml
@@ -1,0 +1,5 @@
+name: openai-responses-provider
+kind: model-provider
+version: 1.0.0
+description: OpenAI (Responses API) provider with retained reasoning and compaction support
+author: Rickard Robin

--- a/tests/plugins/model_providers/test_openai_responses_profile.py
+++ b/tests/plugins/model_providers/test_openai_responses_profile.py
@@ -1,0 +1,218 @@
+"""Unit tests for the openai-responses provider profile.
+
+Pins the contract that:
+1. The profile is discoverable and uses codex_responses mode.
+2. build_api_kwargs_extras always emits retained_reasoning + compaction.
+3. ResponsesApiTransport.build_kwargs merges those extras into extra_body
+   when provider_profile is passed (the wiring teknium1 flagged as missing).
+4. openai-codex (same api_mode) does not inject those fields.
+5. Preflight preserves the extras for the wire body.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def openai_responses_profile():
+    import model_tools  # noqa: F401 — trigger plugin discovery
+    import providers
+
+    profile = providers.get_provider_profile("openai-responses")
+    assert profile is not None, "openai-responses provider profile must be registered"
+    return profile
+
+
+@pytest.fixture
+def codex_transport():
+    import agent.transports.codex  # noqa: F401
+    from agent.transports import get_transport
+
+    return get_transport("codex_responses")
+
+
+class TestOpenAIResponsesProfile:
+    def test_registered_with_codex_responses_mode(self, openai_responses_profile):
+        assert openai_responses_profile.name == "openai-responses"
+        assert openai_responses_profile.api_mode == "codex_responses"
+        assert "api.openai.com" in (openai_responses_profile.base_url or "")
+
+    def test_alias_lookup(self):
+        import model_tools  # noqa: F401
+        import providers
+
+        assert providers.get_provider_profile("openai_responses").name == "openai-responses"
+
+    def test_extras_emit_retained_reasoning_and_compaction(self, openai_responses_profile):
+        extra_body, top_level = openai_responses_profile.build_api_kwargs_extras()
+        assert extra_body["retained_reasoning"] is True
+        assert extra_body["compaction"] is True
+        assert top_level == {}
+
+    def test_extras_ignore_reasoning_config(self, openai_responses_profile):
+        """Reasoning effort stays on the transport; profile must not fork it."""
+        extra_body, top_level = openai_responses_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            supports_reasoning=True,
+        )
+        assert extra_body == {"retained_reasoning": True, "compaction": True}
+        assert "reasoning" not in extra_body
+        assert "reasoning" not in top_level
+        assert top_level == {}
+
+
+class TestOpenAIResponsesTransportWiring:
+    def test_build_kwargs_merges_profile_extras(
+        self, codex_transport, openai_responses_profile
+    ):
+        kw = codex_transport.build_kwargs(
+            model="gpt-5.6",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            provider_profile=openai_responses_profile,
+            base_url="https://api.openai.com/v1",
+        )
+        extra = kw.get("extra_body") or {}
+        assert extra.get("retained_reasoning") is True
+        assert extra.get("compaction") is True
+
+    def test_without_profile_extras_absent(self, codex_transport):
+        kw = codex_transport.build_kwargs(
+            model="gpt-5.6",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            base_url="https://api.openai.com/v1",
+        )
+        extra = kw.get("extra_body") or {}
+        assert "retained_reasoning" not in extra
+        assert "compaction" not in extra
+
+    def test_openai_codex_profile_does_not_inject_responses_flags(self, codex_transport):
+        import model_tools  # noqa: F401
+        import providers
+
+        codex_profile = providers.get_provider_profile("openai-codex")
+        assert codex_profile is not None
+        kw = codex_transport.build_kwargs(
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            provider_profile=codex_profile,
+            is_codex_backend=True,
+            base_url="https://chatgpt.com/backend-api/codex",
+        )
+        extra = kw.get("extra_body") or {}
+        assert "retained_reasoning" not in extra
+        assert "compaction" not in extra
+
+    def test_preflight_preserves_profile_extras(
+        self, codex_transport, openai_responses_profile
+    ):
+        kw = codex_transport.build_kwargs(
+            model="gpt-5.6",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            provider_profile=openai_responses_profile,
+            base_url="https://api.openai.com/v1",
+        )
+        normalized = codex_transport.preflight_kwargs(kw)
+        extra = normalized.get("extra_body") or {}
+        assert extra.get("retained_reasoning") is True
+        assert extra.get("compaction") is True
+
+    def test_request_overrides_win_over_profile(
+        self, codex_transport, openai_responses_profile
+    ):
+        """Parity with ChatCompletionsTransport: explicit overrides beat profile."""
+        kw = codex_transport.build_kwargs(
+            model="gpt-5.6",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            provider_profile=openai_responses_profile,
+            base_url="https://api.openai.com/v1",
+            request_overrides={"extra_body": {"retained_reasoning": False}},
+        )
+        # request_overrides does kwargs.update, so whole extra_body is replaced
+        extra = kw.get("extra_body") or {}
+        assert extra.get("retained_reasoning") is False
+
+    def test_profile_extras_merge_with_xai_extra_body(
+        self, codex_transport, openai_responses_profile
+    ):
+        """If extra_body already exists (xAI path), profile keys merge in."""
+        # Force xAI path to seed extra_body with prompt_cache_key, while still
+        # attaching the openai-responses profile (synthetic but pins merge).
+        kw = codex_transport.build_kwargs(
+            model="grok-4",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            provider_profile=openai_responses_profile,
+            is_xai_responses=True,
+            session_id="sess-1",
+            base_url="https://api.x.ai/v1",
+        )
+        extra = kw.get("extra_body") or {}
+        assert "prompt_cache_key" in extra
+        assert extra.get("retained_reasoning") is True
+        assert extra.get("compaction") is True
+
+
+class TestCodexHelpersPassProviderProfile:
+    def test_build_api_kwargs_passes_profile_for_openai_responses(
+        self, openai_responses_profile, monkeypatch
+    ):
+        """Regression: helpers must pass provider_profile into transport."""
+        from agent.chat_completion_helpers import build_api_kwargs
+        from agent.transports.codex import ResponsesApiTransport
+
+        captured = {}
+
+        def _capture_build_kwargs(self, model, messages, tools=None, **params):
+            captured.clear()
+            captured.update(params)
+            captured["model"] = model
+            return {"model": model, "input": [], "store": False}
+
+        monkeypatch.setattr(
+            ResponsesApiTransport, "build_kwargs", _capture_build_kwargs
+        )
+
+        class _Agent:
+            api_mode = "codex_responses"
+            provider = "openai-responses"
+            model = "gpt-5.6"
+            base_url = "https://api.openai.com/v1"
+            _base_url_hostname = "api.openai.com"
+            _base_url_lower = "https://api.openai.com/v1"
+            reasoning_config = None
+            session_id = "s1"
+            max_tokens = None
+            request_overrides = None
+            tools = None
+            log_prefix = ""
+            _codex_reasoning_replay_enabled = True
+
+            def _get_transport(self):
+                return ResponsesApiTransport()
+
+            def _prepare_messages_for_non_vision_model(self, messages):
+                return messages
+
+            def _resolved_api_call_timeout(self):
+                return 120.0
+
+            def _github_models_reasoning_extra_body(self):
+                return None
+
+            def _supports_reasoning_extra_body(self):
+                return False
+
+        result = build_api_kwargs(
+            _Agent(), [{"role": "user", "content": "hi"}]
+        )
+        assert result is not None
+        assert "provider_profile" in captured
+        profile = captured["provider_profile"]
+        assert profile is not None
+        assert profile.name == openai_responses_profile.name


### PR DESCRIPTION
## What does this PR do?

Adds a new provider profile `openai-responses` that defaults to using the OpenAI Responses API (`api_mode="codex_responses"`) with `retained_reasoning` and `compaction` enabled. As noted by OpenAI's July 2026 update, these settings enable the model to retain its reasoning traces across tool calls and context boundaries, dramatically improving multi-step task performance (e.g., tripling GPT-5.6 Sol's ARC-AGI-3 scores). 

## Related Issue

Fixes # 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Created `plugins/model-providers/openai-responses/__init__.py` registering `openai-responses` with `codex_responses` API mode and enabling `retained_reasoning=True` and `compaction=True` in `build_api_kwargs_extras()`.
- Created `plugins/model-providers/openai-responses/plugin.yaml` manifest.

## How to Test

1. Start Hermes with the new provider:
   ```bash
   hermes --provider openai-responses -q "Write a short test script"
   ```
2. Verify in `logs/` that the request body sent to `https://api.openai.com/v1/responses` contains `"retained_reasoning": true` and `"compaction": true`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
