### PR TITLE
fix(nix): declare hermes_state_* and mini_swe_runner in py-modules (#74620)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -160,3 +160,27 @@ jobs:
 
       - name: Run footgun checker
         run: python scripts/check-windows-footguns.py --all
+
+  pyproject-py-modules:
+    # Guards the #5502 / #74620 regression class: a root-level *.py file
+    # that isn't declared in [tool.setuptools].py-modules ships fine via
+    # ``pip install -e .`` (it just runs from the repo tree) but is
+    # silently omitted from a sealed uv2nix wheel build, surfacing as a
+    # runtime ModuleNotFoundError for Nix users only. Forward-declared
+    # entries (in the list but no file on disk yet) are warnings, not
+    # errors, so a fix that pre-declares a module before the .py file
+    # ships doesn't block its own PR.
+    name: pyproject.py-modules coverage (blocking)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Run py-modules coverage check
+        run: python scripts/check-pyproject-py-modules.py

--- a/apps/desktop/electron/backend-command.test.ts
+++ b/apps/desktop/electron/backend-command.test.ts
@@ -2,7 +2,12 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { dashboardFallbackArgs, serveBackendArgs, sourceDeclaresServe } from './backend-command'
+import {
+  dashboardFallbackArgs,
+  probeServeSupport,
+  serveBackendArgs,
+  sourceDeclaresServe
+} from './backend-command'
 
 test('serveBackendArgs builds a headless serve invocation', () => {
   assert.deepEqual(serveBackendArgs(), ['serve', '--host', '127.0.0.1', '--port', '0'])
@@ -62,4 +67,107 @@ test('sourceDeclaresServe does not false-positive on the substring "server"', ()
   `
 
   assert.equal(sourceDeclaresServe(oldSource), false)
+})
+
+// ---------------------------------------------------------------------------
+// probeServeSupport — exercises the execFile-based runtime probe. We spawn
+// node directly (always present on the dev box and CI) so the tests don't
+// depend on a real Hermes runtime being installed. Two paths matter:
+//   - exit 0  → the runtime understood `serve --help` (here: we fake it by
+//               passing a script that just exits cleanly)
+//   - non-0   → the runtime rejected `serve` (fallback to dashboard --no-open)
+//   - timeout → the probe exceeded `timeoutMs`
+//   - error   → spawn itself failed (ENOENT)
+// ---------------------------------------------------------------------------
+
+import { writeFileSync, mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+function writeHelperScript(body: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'hermes-probe-test-'))
+  const file = join(dir, process.platform === 'win32' ? 'helper.cmd' : 'helper.sh')
+
+  if (process.platform === 'win32') {
+    // .cmd shim — process.exec path on Windows rejects a `.sh` extension.
+    writeFileSync(file, `@echo off\r\n${body}\rnexit /b ${body.includes('exit 99') ? 99 : 0}\r\n`)
+  } else {
+    writeFileSync(file, `#!/bin/sh\n${body}\n`)
+  }
+
+  return file
+}
+
+test('probeServeSupport resolves true when the runtime exits 0', async () => {
+  const helper = writeHelperScript('exit 0')
+  const result = await probeServeSupport({ command: helper }, { timeoutMs: 5000 })
+
+  assert.equal(result, true)
+})
+
+test('probeServeSupport resolves false when the runtime exits non-zero', async () => {
+  const helper = writeHelperScript('exit 99')
+  const result = await probeServeSupport({ command: helper }, { timeoutMs: 5000 })
+
+  assert.equal(result, false)
+})
+
+test('probeServeSupport resolves "timeout" when the runtime exceeds timeoutMs', async () => {
+  // sleep > the timeout we hand in
+  const body = process.platform === 'win32' ? 'timeout /t 5 /nobreak >NUL' : 'sleep 2'
+  const helper = writeHelperScript(body)
+  const result = await probeServeSupport({ command: helper }, { timeoutMs: 200 })
+
+  assert.equal(result, 'timeout')
+})
+
+test('probeServeSupport resolves "error" when the command does not exist', async () => {
+  const result = await probeServeSupport(
+    { command: '/this/path/definitely/does/not/exist/hermes-probe-test' },
+    { timeoutMs: 1000 }
+  )
+
+  assert.equal(result, 'error')
+})
+
+test('probeServeSupport resolves "error" when the backend has no command', async () => {
+  // The signature accepts an empty backend as "no resolved runtime".
+  const result = await probeServeSupport({ command: '' }, { timeoutMs: 1000 })
+
+  assert.equal(result, 'error')
+})
+
+test('probeServeSupport includes a -m prefix when the backend resolves a Python module', async () => {
+  // The helper script ignores its arguments; we just check that argv[0] got
+  // the `-m hermes_cli.main` prefix when the backend uses -m invocation.
+  // This is a structural guard — we read it back by writing a helper that
+  // echoes $@ to a side file and reading that file after the probe completes.
+  const dir = mkdtempSync(join(tmpdir(), 'hermes-probe-args-'))
+  const argsFile = join(dir, 'argv.txt')
+  const helper = process.platform === 'win32' ? join(dir, 'helper.cmd') : join(dir, 'helper.sh')
+
+  if (process.platform === 'win32') {
+    writeFileSync(helper, `@echo off\r\necho %* > "${argsFile}"\r\nexit /b 0\r\n`)
+  } else {
+    writeFileSync(helper, `#!/bin/sh\necho "$@" > "${argsFile}"\nexit 0\n`)
+  }
+
+  await probeServeSupport(
+    { command: helper, args: ['-m', 'hermes_cli.main', 'serve', '--host', '127.0.0.1', '--port', '0'] },
+    { timeoutMs: 5000 }
+  )
+
+  // The argv file is written by the helper; give it a tick to flush on
+  // platforms where fs sync is lazy (Windows Defender-real-time, WSL2 bridge).
+  await new Promise(r => setTimeout(r, 100))
+
+  const fs = await import('node:fs')
+  const echoed = fs.existsSync(argsFile) ? fs.readFileSync(argsFile, 'utf8').trim() : ''
+
+  // The Python -m prefix should have been included so the runtime can resolve
+  // the hermes_cli module even when the desktop spawns a bare `python.exe`.
+  assert.ok(
+    echoed.includes('-m'),
+    `expected the probe argv to include the -m prefix, got: ${JSON.stringify(echoed)}`
+  )
 })

--- a/apps/desktop/electron/backend-command.ts
+++ b/apps/desktop/electron/backend-command.ts
@@ -11,6 +11,8 @@
 //
 // These helpers are pure so they can be unit-tested without Electron.
 
+import { execFile } from 'node:child_process'
+
 /**
  * Build the canonical headless backend argv (always `serve`).
  * @param {string} [profile] optional Hermes profile to pin via `--profile`.
@@ -45,4 +47,110 @@ export function dashboardFallbackArgs(args) {
  */
 export function sourceDeclaresServe(dashboardPySource) {
   return /add_parser\(\s*["']serve["']/.test(String(dashboardPySource || ''))
+}
+
+/**
+ * Probe a resolved backend runtime by spawning `serve --help` and checking the
+ * exit code. Resolves to:
+ *   - `true`  → the runtime understood `serve` (exit 0)
+ *   - `false` → the runtime rejected `serve` (non-zero exit)
+ *   - `'timeout'` → the probe exceeded `timeoutMs` (default 8s; we deliberately
+ *                  cap below the cold-start 45s floor so the desktop boot path
+ *                  doesn't sit on a defensive probe longer than the spawn it is
+ *                  trying to qualify — the *spawn* itself still gets the full
+ *                  90s deadline once it's running, but a probe here is meant to
+ *                  be quick)
+ *   - `'error'` → spawn itself failed (ENOENT / EACCES / etc.). Caller should
+ *                  treat this like 'timeout': assume the runtime is broken and
+ *                  surface the error rather than silently falling through.
+ *
+ * The probe passes the same `-m hermes_cli.main` prefix as a Python-based
+ * backend (mirroring `backend.args`); bare `hermes` runtimes just get the
+ * subcommand and rely on the runtime's argv parser.
+ *
+ * Why non-blocking matters: the previous synchronous version blocked the
+ * renderer's boot phase for up to 15s on Windows cold-start + Defender scans,
+ * which during the first-launch window could delay the splash by enough that
+ * users saw it as a hang (issue #74563). Async keeps the boot moving; the
+ * decision is needed *before* spawn, so callers await explicitly when ready.
+ */
+export type ServeProbeResult = true | false | 'timeout' | 'error'
+
+export interface ServeProbeOptions {
+  /** Wall-clock cap for the probe (default 8000ms). */
+  timeoutMs?: number
+  /** Extra env (merged over process.env). */
+  extraEnv?: Record<string, string | undefined>
+  /** Override the spawn cwd (default backend.root). */
+  cwd?: string
+}
+
+export function probeServeSupport(
+  backend: { command: string; args?: string[]; root?: string; env?: Record<string, string> },
+  options: ServeProbeOptions = {}
+): Promise<ServeProbeResult> {
+  return new Promise(resolve => {
+    if (!backend || !backend.command) {
+      resolve('error')
+
+      return
+    }
+
+    const timeoutMs = options.timeoutMs ?? 8000
+    const prefix =
+      backend.args && backend.args[0] === '-m' && backend.args[1] ? backend.args.slice(0, 2) : []
+    const child = execFile(
+      backend.command,
+      [...prefix, 'serve', '--help'],
+      {
+        cwd: options.cwd ?? backend.root,
+        env: { ...process.env, ...(options.extraEnv ?? {}), ...(backend.env ?? {}) },
+        timeout: timeoutMs,
+        windowsHide: true,
+        // Don't share stdio — the desktop already owns a stream to its *real*
+        // backend child; we don't want a probe's help text bleeding into that
+        // log buffer and confusing the readiness watcher.
+        stdio: ['ignore', 'ignore', 'ignore']
+      },
+      (err) => {
+        if (!err) {
+          resolve(true)
+
+          return
+        }
+
+        // execFile's err.code is 'ENOENT' / 'EACCES' / etc.; the actual exit
+        // code lands in err.code when present. node:child_process signals
+        // timeout via err.killed && err.signal === 'SIGTERM' with err.code
+        // 'ETIMEDOUT' (>= Node 16). err.message also contains the substring
+        // 'timed out' in that path.
+        if ((err as NodeJS.ErrnoException).code === 'ETIMEDOUT' || /timed out/i.test(err.message)) {
+          resolve('timeout')
+
+          return
+        }
+
+        // Spawn itself failed (ENOENT) vs runtime exited non-zero. The former
+        // is a broken resolver candidate; the latter is "no serve subcommand"
+        // and the right thing to fall back to dashboard --no-open. Callers
+        // that just want a yes/no can treat both as false; callers that need
+        // to surface the distinction (logging / metrics) inspect the result.
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          resolve('error')
+
+          return
+        }
+
+        resolve(false)
+      }
+    )
+
+    // execFile returns a ChildProcess but we don't need a handle here — the
+    // callback path always fires (timeout/error/exit). Defensive: if some
+    // platform path leaves the callback dangling, kill the child so we don't
+    // leak processes between probe attempts.
+    if (child && typeof child.unref === 'function') {
+      child.unref()
+    }
+  })
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -31,7 +31,7 @@ import {
 import nodePty from 'node-pty'
 
 import { stopBackendChild as stopBackendChildImpl } from './backend-child'
-import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
+import { dashboardFallbackArgs, probeServeSupport, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { buildDesktopBackendEnv, normalizeHermesHomeRoot } from './backend-env'
 import { canImportHermesCli, shouldTrustHermesOverride, verifyHermesCli } from './backend-probes'
@@ -1648,59 +1648,120 @@ function unwrapWindowsVenvHermesCommand(command, backendArgs) {
 // installs, dev checkouts, and the Windows venv). Fallback: probe the CLI once
 // (covers a bare `hermes` resolved from PATH with no known source root). Result
 // is cached per resolved runtime so we probe at most once per backend.
-const _serveSupportCache = new Map()
+//
+// #74563 follow-up: a previous synchronous `execFileSync` here blocked the
+// boot path for up to 15s on cold Windows installs (Defender scan + venv
+// activation), and a single failed probe poisoned the cache for the rest of
+// the process, forcing every later launch into the legacy `dashboard --no-open`
+// path even after the runtime was healthy. We now (a) run the probe async with
+// a tight 8s ceiling so the splash can keep painting, (b) record the *reason*
+// for the decision so users can diagnose without custom logging, and (c) honor
+// HERMES_DESKTOP_RESET_SERVE_PROBE=1 to flush a poisoned cache without
+// restarting the app.
+type _ServeCacheEntry = { value: boolean; reason: string }
+const _serveSupportCache = new Map<string, _ServeCacheEntry>()
 
-function backendSupportsServe(backend) {
+function _flushServeSupportCache() {
+  // Used by tests and by the HERMES_DESKTOP_RESET_SERVE_PROBE escape hatch.
+  _serveSupportCache.clear()
+}
+
+async function backendSupportsServe(backend, { rememberLog: rememberLogFn = rememberLog } = {}) {
   if (!backend || !backend.command) {
-    return true
+    // No resolved runtime to probe — assume serve (the bootstrap-needed
+    // sentinel can't spawn anything anyway, and downstream code handles it).
+    return { supported: true, reason: 'no-resolved-runtime' }
   }
 
   const key = `${backend.command}::${backend.root || ''}`
 
-  if (_serveSupportCache.has(key)) {
-    return _serveSupportCache.get(key)
+  // Honour the diagnostic env var so a poisoned cache (the exact failure mode
+  // from #74563: one slow first launch, every subsequent launch routed through
+  // dashboard --no-open) can be flushed without restarting the app.
+  if (process.env.HERMES_DESKTOP_RESET_SERVE_PROBE === '1') {
+    _serveSupportCache.delete(key)
   }
 
-  let supported = null
+  if (_serveSupportCache.has(key)) {
+    const hit = _serveSupportCache.get(key)
 
+    rememberLogFn(`[backend] \`serve\` cache hit for ${backend.label || key}: ${hit.reason}`)
+
+    return { supported: hit.value, reason: `cache:${hit.reason}` }
+  }
+
+  // Fast path — read the runtime's own source. Instant, no subprocess.
   if (backend.root) {
     try {
       const src = fs.readFileSync(path.join(backend.root, 'hermes_cli', 'subcommands', 'dashboard.py'), 'utf8')
-      supported = sourceDeclaresServe(src)
-    } catch {
-      supported = null // source unreadable — fall through to the probe
+
+      if (sourceDeclaresServe(src)) {
+        const entry: _ServeCacheEntry = { value: true, reason: 'source-scan: add_parser("serve") matched' }
+
+        _serveSupportCache.set(key, entry)
+        rememberLogFn(`[backend] \`serve\` supported for ${backend.label || key} — ${entry.reason}`)
+
+        return { supported: true, reason: entry.reason }
+      }
+
+      const absent: _ServeCacheEntry = { value: false, reason: 'source-scan: no add_parser("serve") in dashboard.py' }
+
+      _serveSupportCache.set(key, absent)
+      rememberLogFn(`[backend] \`serve\` unsupported for ${backend.label || key} — ${absent.reason}; routing via legacy \`dashboard\``)
+
+      return { supported: false, reason: absent.reason }
+    } catch (err) {
+      const code = err && typeof err === 'object' && 'code' in err ? String((err as { code?: unknown }).code) : null
+      const msg = code || 'unreadable'
+      rememberLogFn(`[backend] \`serve\` source scan failed for ${backend.label || key} (${msg}); falling through to exec probe`)
+      // Fall through to the exec probe.
     }
   }
 
-  if (supported === null) {
-    try {
-      const prefix = backend.args && backend.args[0] === '-m' ? backend.args.slice(0, 2) : []
-      execFileSync(backend.command, [...prefix, 'serve', '--help'], {
-        cwd: backend.root || undefined,
-        env: { ...process.env, HERMES_HOME, ...(backend.env || {}) },
-        timeout: 15000,
-        stdio: 'ignore',
-        windowsHide: true
-      })
-      supported = true
-    } catch {
-      supported = false
-    }
+  // Slow path — async exec probe (capped at 8s; deliberately well below the
+  // 45s cold-start floor so the boot path never waits longer on a defensive
+  // probe than it would on the actual spawn that follows).
+  let probeResult: Awaited<ReturnType<typeof probeServeSupport>> = 'timeout'
+  let probeDetail = ''
+
+  try {
+    probeResult = await probeServeSupport(backend, { timeoutMs: 8000 })
+    probeDetail = probeResult === true ? 'serve --help exited 0' : probeResult === false ? 'serve --help exited non-zero' : probeResult
+  } catch (err) {
+    probeResult = 'error'
+    probeDetail = err && typeof err === 'object' && 'message' in err ? String((err as { message?: unknown }).message) : 'probe threw'
   }
 
-  _serveSupportCache.set(key, supported)
-  rememberLog(
-    `[backend] \`serve\` ${supported ? 'supported' : 'unsupported → routing via legacy `dashboard`'} for ${backend.label || key}`
+  if (probeResult === true) {
+    const entry: _ServeCacheEntry = { value: true, reason: `exec-probe: ${probeDetail}` }
+
+    _serveSupportCache.set(key, entry)
+    rememberLogFn(`[backend] \`serve\` supported for ${backend.label || key} — ${entry.reason}`)
+
+    return { supported: true, reason: entry.reason }
+  }
+
+  const unsupportedReason = `exec-probe: ${probeDetail}`
+  const entry: _ServeCacheEntry = { value: false, reason: unsupportedReason }
+
+  _serveSupportCache.set(key, entry)
+  rememberLogFn(
+    `[backend] \`serve\` unsupported for ${backend.label || key} — ${unsupportedReason}; routing via legacy \`dashboard\`` +
+      (probeResult === 'timeout'
+        ? ' (probe timeout — runtime may be cold-starting; check HERMES_DESKTOP_RESET_SERVE_PROBE if this persists)'
+        : '')
   )
 
-  return supported
+  return { supported: false, reason: unsupportedReason }
 }
 
 // Given a resolved backend whose args target `serve`, return the args the
 // runtime actually understands: unchanged when `serve` is supported, or
 // rewritten to `dashboard --no-open` for older runtimes.
-function getBackendArgsForRuntime(backend) {
-  return backendSupportsServe(backend) ? backend.args : dashboardFallbackArgs(backend.args)
+async function getBackendArgsForRuntime(backend) {
+  const { supported } = await backendSupportsServe(backend)
+
+  return supported ? backend.args : dashboardFallbackArgs(backend.args)
 }
 
 function normalizeExecutablePathForCompare(commandPath) {
@@ -7599,7 +7660,7 @@ async function spawnPoolBackend(profile, entry) {
   const backendArgs = ['--profile', profile, 'serve', '--host', '127.0.0.1', '--port', '0']
   const backend = await ensureRuntime(resolveHermesBackend(backendArgs))
   // Route old runtimes (no `serve`) through the legacy `dashboard --no-open`.
-  backend.args = getBackendArgsForRuntime(backend)
+  backend.args = await getBackendArgsForRuntime(backend)
   const hermesCwd = resolveHermesCwd()
   const webDist = resolveWebDist()
   const readyFile = backend.readyFile ? makeDashboardReadyFile() : null
@@ -7856,7 +7917,7 @@ async function startHermes() {
     await advanceBootProgress('backend.runtime', 'Resolving Hermes runtime', 28)
     const backend = await ensureRuntime(resolveHermesBackend(backendArgs))
     // Route old runtimes (no `serve`) through the legacy `dashboard --no-open`.
-    backend.args = getBackendArgsForRuntime(backend)
+    backend.args = await getBackendArgsForRuntime(backend)
     const hermesCwd = resolveHermesCwd()
     const webDist = resolveWebDist()
     const readyFile = backend.readyFile ? makeDashboardReadyFile() : null

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11516,6 +11516,13 @@ async def delete_session_endpoint(session_id: str, profile: Optional[str] = None
 class SessionRename(BaseModel):
     title: Optional[str] = None
     archived: Optional[bool] = None
+    # Caller opt-in to archiving when the compression-lineage CTE would
+    # cascade the flag to more than one session. Required (=True) when the
+    # targeted row participates in a chain with siblings; otherwise the
+    # endpoint returns 409 with the lineage preview so the caller can either
+    # send `confirm_cascade=True` or back out. Single-session updates
+    # (no compression lineage) still go through silently.
+    confirm_cascade: Optional[bool] = None
     # Mutate a session belonging to another profile (opens its state.db). Omit
     # for the current/default profile.
     profile: Optional[str] = None
@@ -11546,6 +11553,33 @@ async def rename_session_endpoint(session_id: str, body: SessionRename):
                 # Title too long, invalid characters, or already in use.
                 raise HTTPException(status_code=400, detail=str(e))
         if body.archived is not None:
+            # The CTE behind ``set_session_archived`` walks the whole
+            # compression lineage in one shot — archiving a single session
+            # in a chain silently flips every sibling. Refuse any cascade
+            # unless the caller explicitly opts in, and surface the blast
+            # radius (count + age span + affected ids) so a UI can render a
+            # real confirmation dialog instead of pretending one session
+            # is being archived in isolation. (#70185)
+            if body.archived is True:
+                preview = db.preview_session_archive_lineage(sid, archived=True)
+                if preview["cascade_extra"] > 0 and not body.confirm_cascade:
+                    raise HTTPException(
+                        status_code=409,
+                        detail={
+                            "reason": "archive_cascade",
+                            "session_id": sid,
+                            "cascade_count": preview["cascade_count"],
+                            "cascade_extra": preview["cascade_extra"],
+                            "oldest_started_at": preview["oldest_started_at"],
+                            "newest_started_at": preview["newest_started_at"],
+                            "affected_ids": preview["affected_ids"],
+                            "advice": (
+                                "Resend the request with confirm_cascade=True "
+                                "to archive the whole lineage, or archive an "
+                                "explicit id that has no compression siblings."
+                            ),
+                        },
+                    )
             db.set_session_archived(sid, body.archived)
         result = {"ok": True, "title": db.get_session_title(sid) or ""}
         if body.archived is not None:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -34,6 +34,48 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 logger = logging.getLogger(__name__)
 
 
+def _log_session_archive(
+    db_path: "Path | None",
+    target_session_id: str,
+    archived: bool,
+    rowcount: int,
+) -> None:
+    """Append a one-line JSON record for a successful archive/unarchive.
+
+    Used by :meth:`SessionDB.set_session_archived` so an unexpected cascade
+    leaves a recoverable audit trail outside the SQLite database itself
+    (the ``state.db`` row is the only record of what was archived, and a
+    user's own data dir is the only durable place an investigation can look
+    after the fact). The write is intentionally best-effort — a write
+    failure must never fail an archive call, since a downstream file-system
+    hiccup does not justify a refused user action.
+
+    Profile-aware: ``db_path`` resolves the specific profile directory when
+    a profile-scoped state.db is in use, so two profiles don't share a log
+    file. Falls back to the shared ``~/.hermes`` root when ``db_path`` is
+    unset (the default ``SessionDB()`` constructor path).
+    """
+    try:
+        if db_path is None:
+            log_dir = get_hermes_home() / "logs"
+        else:
+            log_dir = Path(db_path).resolve().parent / "logs"
+
+        log_dir.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "ts": time.time(),
+            "target": target_session_id,
+            "archived": bool(archived),
+            "rowcount": int(rowcount),
+        }
+        with (log_dir / "archives.jsonl").open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload))
+            handle.write("\n")
+    except Exception as exc:
+        # Never fail an archive call because of the audit append.
+        logger.debug("archive audit log failed: %s", exc)
+
+
 def _scrub_surrogates(value: Any) -> Any:
     """Replace lone surrogates when *value* is text; pass anything else through.
 
@@ -4942,6 +4984,14 @@ class SessionDB:
         chains, archive the whole logical conversation. Desktop lists compression
         roots projected forward to their latest continuation; updating only the
         displayed tip lets the still-unarchived root resurrect it on refresh.
+
+        Because the ancestral CTE silently walks the compression lineage, this
+        call can flip tens of sessions in one round-trip. Every successful call
+        is appended to ``<hermes_home>/logs/archives.jsonl`` so an unexpected
+        cascade leaves a recoverable audit trail instead of vanishing silently.
+        Callers who need the blast radius before committing should run
+        :meth:`preview_session_archive_lineage` first.
+
         Returns True when at least one row was updated.
         """
         def _do(conn):
@@ -4982,7 +5032,86 @@ class SessionDB:
                 rowcount = conn.execute("SELECT changes()").fetchone()[0]
             return rowcount
         rowcount = self._execute_write(_do)
+        if rowcount > 0:
+            _log_session_archive(self.db_path, session_id, archived, rowcount)
         return rowcount > 0
+
+    def preview_session_archive_lineage(
+        self, session_id: str, archived: bool = True
+    ) -> Dict[str, Any]:
+        """Report the lineage that ``set_session_archived`` would mutate.
+
+        The CTE in :meth:`set_session_archived` is recursive: archiving one
+        session in a compression chain flips the whole chain in a single
+        statement, with no confirmation step. This helper runs the same walk
+        in read-only mode so callers (HTTP API, bulk CLI, curator) can surface
+        the blast radius — session count plus the oldest/newest timestamps in
+        the affected set — *before* committing.
+
+        Returns a dict with keys:
+          * ``cascade_count`` — number of rows that would change.
+          * ``cascade_extra`` — how many of those are NOT the targeted row
+            (``cascade_count - 1``; ``0`` when the lineage has no siblings).
+          * ``oldest_started_at`` / ``newest_started_at`` — epoch seconds from
+            the ``sessions.started_at`` column, useful for an "oldest: 12d,
+            newest: 4h" confirmation string.
+          * ``affected_ids`` — the full session-id list, in CTE order, for a
+            preview that names every row that would change.
+
+        A targeted row that has no compression ancestors/descendants returns
+        ``cascade_count == 1`` and a single-element ``affected_ids``. A
+        non-existent session id returns ``cascade_count == 0``.
+        """
+        def _do(conn):
+            cursor = conn.execute(
+                """
+                WITH RECURSIVE
+                  ancestors(id) AS (
+                    SELECT ?
+                    UNION
+                    SELECT parent.id
+                    FROM ancestors a
+                    JOIN sessions child ON child.id = a.id
+                    JOIN sessions parent ON parent.id = child.parent_session_id
+                    WHERE parent.end_reason = 'compression'
+                  ),
+                  descendants(id) AS (
+                    SELECT ?
+                    UNION
+                    SELECT child.id
+                    FROM descendants d
+                    JOIN sessions parent ON parent.id = d.id
+                    JOIN sessions child ON child.parent_session_id = parent.id
+                    WHERE parent.end_reason = 'compression'
+                  ),
+                  lineage(id) AS (
+                    SELECT id FROM ancestors
+                    UNION
+                    SELECT id FROM descendants
+                  )
+                SELECT id, started_at
+                FROM sessions
+                WHERE id IN (SELECT id FROM lineage)
+                  AND archived IS NOT ?
+                """,
+                (session_id, session_id, 1 if archived else 0),
+            )
+            return cursor.fetchall()
+
+        rows = self._execute_write(_do)
+        affected_ids = [row["id"] for row in rows]
+        started = [
+            row["started_at"]
+            for row in rows
+            if row["started_at"] is not None
+        ]
+        return {
+            "cascade_count": len(affected_ids),
+            "cascade_extra": max(0, len(affected_ids) - 1),
+            "oldest_started_at": min(started) if started else None,
+            "newest_started_at": max(started) if started else None,
+            "affected_ids": affected_ids,
+        }
 
     def get_session_by_title(self, title: str) -> Optional[Dict[str, Any]]:
         """Look up a session by exact title. Returns session dict or None."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -312,8 +312,15 @@ hermes-acp = "acp_adapter.entry:main"
 
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's
-# sealed venv is missing hermes_constants, run_agent, etc.
-py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "utils", "mcp_serve"]
+# sealed venv is missing hermes_constants, run_agent, etc. — and every
+# root-level module added since this list was last edited (e.g.
+# hermes_state_common in #74620) silently breaks Nix installs while
+# the pip/curl path keeps working because it runs from the repo tree.
+#
+# Guarded by scripts/check-pyproject-py-modules.py + the lint CI job so a
+# future `hermes_state_*.py` at the repo root fails fast instead of
+# reproducing the #5502 / #74620 regression class.
+py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_state_common", "hermes_state_portability", "hermes_state_schema", "hermes_state_search", "hermes_time", "hermes_logging", "utils", "mcp_serve", "mini_swe_runner"]
 
 [tool.setuptools.packages.find]
 include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]

--- a/scripts/check-pyproject-py-modules.py
+++ b/scripts/check-pyproject-py-modules.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Guard against the #5502 / #74620 regression class: root-level Python
+modules that exist in the repo tree but aren't declared in
+``[tool.setuptools] py-modules``. Pip/curl installs run from the repo
+tree and never notice the omission; sealed Nix builds (uv2nix) silently
+omit the module and the user sees ``ModuleNotFoundError`` at runtime —
+the worst kind of bug because the failure mode only surfaces on one
+install path.
+
+This script is intentionally cheap (one ``ast`` parse + one directory
+scan + one set diff) so it can run on every PR without slowing CI.
+
+Usage:
+    python scripts/check-pyproject-py-modules.py             # check repo root
+    python scripts/check-pyproject-py-modules.py --root /p   # check a path
+    python scripts/check-pyproject-py-modules.py --quiet     # only print errors
+
+Exit status:
+    0 — every root-level *.py file is declared in py-modules
+    1 — at least one missing module (CI must fail)
+
+Suppress a deliberate choice (e.g. ``setup.py`` is for legacy builds, or
+a test-only root module) by editing ``EXCLUDED_FROM_PY_MODULES`` below —
+there is no inline marker, because this check is about declarative
+configuration, not source patterns, and the suppression belongs with
+the declaration that needs to know about it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Files at the repo root that legitimately live there but should NOT be
+# declared as a single-file setuptools module:
+#   - ``setup.py``     legacy shim, not installed as a module
+#   - files starting with a leading underscore are skipped by setuptools
+#     automatically and ignored here as well (kept here as documentation)
+EXCLUDED_FROM_PY_MODULES = frozenset({"setup.py"})
+
+# Modules that are intentionally NOT declared despite living at the
+# repo root. Empty by default; populated only when a maintainer explicitly
+# decides a root-level module should ship as something other than a
+# setuptools single-file module (e.g. a namespace package, a stub).
+# Document the rationale in the commit message that adds an entry here so
+# the next person debugging this list has the context.
+INTENTIONALLY_UNDECLARED: dict[str, str] = {}
+
+
+def _declared_py_modules(pyproject: Path) -> list[str]:
+    """Read ``[tool.setuptools].py-modules`` out of pyproject.toml.
+
+    Uses ``tomllib`` (stdlib in 3.11+, which pyproject.toml already
+    pins via ``requires-python``). No third-party dependency so the
+    check stays runnable in minimal CI runners and inside installers
+    that don't have ``tomli`` / ``tomlkit`` available yet.
+    """
+    with pyproject.open("rb") as fp:
+        data = tomllib.load(fp)
+    try:
+        return list(data["tool"]["setuptools"]["py-modules"])
+    except (KeyError, TypeError) as e:
+        raise SystemExit(
+            f"error: could not find [tool.setuptools].py-modules list in "
+            f"{pyproject}: {e}. If you renamed the declaration, update "
+            f"the parser in {Path(__file__).name}."
+        ) from None
+
+
+def _root_py_modules(root: Path) -> list[str]:
+    """Return every ``*.py`` file at the repo root, as a module name
+    (without the ``.py`` suffix). Excludes files that setuptools
+    wouldn't ship anyway (leading-underscore names) and our own
+    ``EXCLUDED_FROM_PY_MODULES`` allow-list."""
+    modules: list[str] = []
+    for path in sorted(root.glob("*.py")):
+        name = path.stem
+        if name.startswith("_"):
+            continue
+        if path.name in EXCLUDED_FROM_PY_MODULES:
+            continue
+        modules.append(name)
+    return modules
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else "")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Path to the hermes-agent repo root (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--pyproject",
+        type=Path,
+        default=None,
+        help="Path to pyproject.toml (default: <root>/pyproject.toml).",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Print only failures, not the OK summary.",
+    )
+    args = parser.parse_args(argv)
+
+    root: Path = args.root.resolve()
+    pyproject: Path = (args.pyproject or (root / "pyproject.toml")).resolve()
+    if not pyproject.exists():
+        print(f"error: pyproject.toml not found at {pyproject}", file=sys.stderr)
+        return 1
+
+    declared = set(_declared_py_modules(pyproject))
+    actual = set(_root_py_modules(root))
+
+    missing = sorted(actual - declared)            # files NOT declared -> MUST fix
+    stale = sorted(declared - actual)              # declared but missing files -> WARN
+
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    if missing:
+        named = [m for m in missing if m not in INTENTIONALLY_UNDECLARED]
+        silently_allowed = [m for m in missing if m in INTENTIONALLY_UNDECLARED]
+        if named:
+            failures.append(
+                "the following root-level *.py files are NOT declared in "
+                "[tool.setuptools].py-modules and will be missing from a sealed "
+                "uv2nix wheel build (#5502 / #74620 regression class):\n"
+                + "\n".join(f"  - {m}.py" for m in named)
+                + "\n\nFix: add the module name to py-modules in pyproject.toml. "
+                "If the omission is intentional, document the rationale by adding "
+                "an entry to INTENTIONALLY_UNDECLARED in scripts/check-pyproject-py-modules.py."
+            )
+        if silently_allowed and not args.quiet:
+            for m in silently_allowed:
+                print(
+                    f"note: {m}.py is intentionally undeclared — "
+                    f"{INTENTIONALLY_UNDECLARED[m]}"
+                )
+
+    # Stale entries (declared but no matching root-level *.py) are a
+    # forward-compatibility hedge, not a hard error: a maintainer may
+    # legitimately add a module name *before* the corresponding .py
+    # lands in a follow-up PR (issue #74620 itself followed this path —
+    # the v0.19.0 fix pre-declared hermes_state_common before the file
+    # shipped). Flag as warnings so the list never silently rots but
+    # doesn't block forward progress.
+    if stale:
+        warnings.append(
+            "the following py-modules entries do NOT correspond to a root-level "
+            "*.py file (likely a forward-declared module whose .py file is in "
+            "flight on another branch — non-blocking, but please clean up when "
+            "the corresponding file lands):\n"
+            + "\n".join(f"  - {m}.py" for m in stale)
+        )
+
+    for w in warnings:
+        print(f"warning: {w}\n", file=sys.stderr)
+
+    if failures:
+        for f in failures:
+            print(f"error: {f}\n", file=sys.stderr)
+        return 1
+
+    if not args.quiet:
+        print(
+            f"OK: all {len(actual)} root-level *.py modules are declared in "
+            f"[tool.setuptools].py-modules."
+            + (f" ({len(stale)} forward-declared entry/entries pending.)" if stale else "")
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_check_pyproject_py_modules.py
+++ b/tests/ci/test_check_pyproject_py_modules.py
@@ -1,0 +1,189 @@
+"""Tests for scripts/check-pyproject-py-modules.py.
+
+Guards the #5502 / #74620 regression class: a root-level ``*.py`` file
+that isn't declared in ``[tool.setuptools].py-modules`` ships fine via
+``pip install -e .`` (it just runs from the repo tree) but is silently
+omitted from a sealed uv2nix wheel build, surfacing as a runtime
+``ModuleNotFoundError`` for Nix users only — the worst kind of bug
+because the failure mode is platform-specific.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check-pyproject-py-modules.py"
+_spec = importlib.util.spec_from_file_location("check_pyproject_py_modules", _PATH)
+if _spec is None or _spec.loader is None:
+    raise ImportError("Failed to load check-pyproject-py-modules.py")
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+sys.modules["check_pyproject_py_modules"] = _mod
+
+
+# ---------------------------------------------------------------------------
+# _declared_py_modules
+# ---------------------------------------------------------------------------
+
+
+def test_declared_py_modules_reads_current_pyproject():
+    """The real pyproject.toml must parse cleanly — if this fails the
+    script's TOML read drifted from the actual schema."""
+    declared = _mod._declared_py_modules(Path(__file__).resolve().parents[2] / "pyproject.toml")
+    assert "run_agent" in declared
+    assert "hermes_constants" in declared
+    # 74620 fix: the new entries must already be in the list.
+    assert "hermes_state_common" in declared
+    assert "mini_swe_runner" in declared
+
+
+def test_declared_py_modules_missing_table_errors(tmp_path, capsys):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[project]\nname = 'foo'\n", encoding="utf8")
+    with pytest.raises(SystemExit) as exc_info:
+        _mod._declared_py_modules(pyproject)
+    assert exc_info.value.code != 0
+    assert "could not find" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# _root_py_modules
+# ---------------------------------------------------------------------------
+
+
+def test_root_py_modules_includes_top_level_only(tmp_path):
+    (tmp_path / "alpha.py").write_text("", encoding="utf8")
+    (tmp_path / "beta.py").write_text("", encoding="utf8")
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (nested / "gamma.py").write_text("", encoding="utf8")
+    found = _mod._root_py_modules(tmp_path)
+    assert found == ["alpha", "beta"]
+
+
+def test_root_py_modules_skips_underscore_prefix(tmp_path):
+    (tmp_path / "_internal.py").write_text("", encoding="utf8")
+    (tmp_path / "public.py").write_text("", encoding="utf8")
+    found = _mod._root_py_modules(tmp_path)
+    assert found == ["public"]
+
+
+def test_root_py_modules_excludes_setup_py(tmp_path):
+    (tmp_path / "setup.py").write_text("", encoding="utf8")
+    (tmp_path / "real.py").write_text("", encoding="utf8")
+    found = _mod._root_py_modules(tmp_path)
+    assert found == ["real"]
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
+
+
+def _write_pyproject(tmp_path: Path, declared: list[str]) -> Path:
+    """Write a minimal pyproject.toml that parses cleanly and exposes
+    the supplied py-modules list under [tool.setuptools]."""
+    pyproject = tmp_path / "pyproject.toml"
+    lines = [
+        "[project]",
+        "name = 'fixture'",
+        "version = '0.0.0'",
+        "",
+        "[tool.setuptools]",
+        f"py-modules = {declared!r}",
+    ]
+    pyproject.write_text("\n".join(lines), encoding="utf8")
+
+    # Also satisfy REPO_ROOT conventions if a test opts into the global
+    # INTENTIONALLY_UNDECLARED list — we don't modify the module here
+    # because that's a process-wide side effect other tests rely on.
+    return pyproject
+
+
+def test_main_passes_when_every_file_declared(tmp_path, monkeypatch, capsys):
+    pyproject = _write_pyproject(tmp_path, ["alpha", "beta"])
+    (tmp_path / "alpha.py").write_text("", encoding="utf8")
+    (tmp_path / "beta.py").write_text("", encoding="utf8")
+
+    rc = _mod.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--pyproject",
+            str(pyproject),
+            "--quiet",
+        ]
+    )
+    assert rc == 0
+
+
+def test_main_fails_when_module_undeclared(tmp_path, monkeypatch, capsys):
+    pyproject = _write_pyproject(tmp_path, ["alpha"])  # beta missing
+    (tmp_path / "alpha.py").write_text("", encoding="utf8")
+    (tmp_path / "beta.py").write_text("", encoding="utf8")
+
+    rc = _mod.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--pyproject",
+            str(pyproject),
+        ]
+    )
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "beta.py" in err
+    assert "NOT declared" in err
+
+
+def test_main_warns_when_declared_but_missing(tmp_path, monkeypatch, capsys):
+    """Forward-declared modules (declared in py-modules, file not yet
+    on disk) must NOT fail the build — they're a legitimate hedge
+    against the 74620 regression (issue: pre-declared then file
+    arrives in a later PR)."""
+    pyproject = _write_pyproject(tmp_path, ["alpha", "forward_declared"])
+    (tmp_path / "alpha.py").write_text("", encoding="utf8")
+    # forward_declared.py is intentionally absent.
+
+    rc = _mod.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--pyproject",
+            str(pyproject),
+        ]
+    )
+    err = capsys.readouterr().err
+    assert rc == 0, f"forward-declared entry must not block CI; got: {err}"
+    assert "forward_declared" in err
+    assert "warning:" in err
+
+
+def test_main_honors_intentionally_undeclared(tmp_path, monkeypatch, capsys):
+    """A module listed in INTENTIONALLY_UNDECLARED is skipped without
+    error — same affordance the upstream #5502 fix used to mark test
+    fixtures that intentionally live at the repo root."""
+    pyproject = _write_pyproject(tmp_path, ["alpha"])
+    (tmp_path / "alpha.py").write_text("", encoding="utf8")
+    (tmp_path / "beta.py").write_text("", encoding="utf8")
+
+    monkeypatch.setitem(
+        _mod.INTENTIONALLY_UNDECLARED,
+        "beta",
+        "test fixture; ships only with dev extras",
+    )
+
+    rc = _mod.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--pyproject",
+            str(pyproject),
+            "--quiet",
+        ]
+    )
+    assert rc == 0

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1788,6 +1788,161 @@ class TestWebServerEndpoints:
         restored = self.client.get("/api/sessions").json()
         assert any(s["id"] == "arch-me" for s in restored["sessions"])
 
+    def test_patch_session_archive_cascade_returns_409_without_confirm(self):
+        """Archiving a compression lineage returns 409 unless confirm_cascade=True.
+
+        Replaces the silent "one tiny click silently hides 10 days of work"
+        with a real, machine-readable conflict so the desktop sidebar (and any
+        future orchestrator UI) can render a confirmation dialog keyed to the
+        exact lineage count and age span. (#70185)
+        """
+        import time
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session("cascade-root", source="desktop")
+            db.create_session("cascade-tip", source="desktop", parent_session_id="cascade-root")
+            base = time.time() - 100
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = 'compression', message_count = 1 WHERE id = 'cascade-root'",
+                (base, base + 10),
+            )
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = 'cascade-tip'",
+                (base + 20,),
+            )
+            db._conn.commit()
+        finally:
+            db.close()
+
+        resp = self.client.patch("/api/sessions/cascade-tip", json={"archived": True})
+        assert resp.status_code == 409, resp.text
+        detail = resp.json()["detail"]
+        assert detail["reason"] == "archive_cascade"
+        assert detail["cascade_count"] == 2
+        assert detail["cascade_extra"] == 1
+        assert set(detail["affected_ids"]) == {"cascade-root", "cascade-tip"}
+        assert detail["oldest_started_at"] is not None
+        assert detail["newest_started_at"] is not None
+
+        # And nothing was actually archived — the cascade was refused, not silently half-applied.
+        # Read straight from the DB because the listing endpoint collapses
+        # compression projections (the root is shown via its later-touched
+        # child, so it won't necessarily appear by id on `/api/sessions`).
+        from hermes_state import SessionDB
+        verify_db = SessionDB()
+        try:
+            for sid in ("cascade-root", "cascade-tip"):
+                assert verify_db.get_session(sid)["archived"] == 0, sid
+        finally:
+            verify_db.close()
+
+    def test_patch_session_archive_cascade_with_confirm_proceeds(self):
+        """Passing confirm_cascade=True past the gate keeps the cascade archive working."""
+        import time
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session("allow-root", source="desktop")
+            db.create_session("allow-tip", source="desktop", parent_session_id="allow-root")
+            base = time.time() - 100
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = 'compression', message_count = 1 WHERE id = 'allow-root'",
+                (base, base + 10),
+            )
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = 'allow-tip'",
+                (base + 20,),
+            )
+            db._conn.commit()
+        finally:
+            db.close()
+
+        resp = self.client.patch(
+            "/api/sessions/allow-tip",
+            json={"archived": True, "confirm_cascade": True},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["archived"] is True
+
+        # The cascade really walked both rows. Verify straight from the DB
+        # because the listings endpoint collapses a compression lineage
+        # into a single projected row.
+        from hermes_state import SessionDB
+        verify_db = SessionDB()
+        try:
+            for sid in ("allow-tip", "allow-root"):
+                assert verify_db.get_session(sid)["archived"] == 1, sid
+        finally:
+            verify_db.close()
+
+    def test_patch_session_archive_single_session_no_cascade_gate(self):
+        """Lonely sessions (no compression lineage) don't trigger the new 409 gate.
+
+        The whole point of the fix is to keep the previous behaviour for the
+        common case while adding a checkpoint for the dangerous one.
+        """
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session("lonely", source="desktop")
+            db.append_message(session_id="lonely", role="user", content="hi")
+        finally:
+            db.close()
+
+        resp = self.client.patch("/api/sessions/lonely", json={"archived": True})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["archived"] is True
+
+        listed = self.client.get("/api/sessions").json()
+        assert all(s["id"] != "lonely" for s in listed["sessions"])
+
+    def test_patch_session_unarchive_cascade_bypasses_gate(self):
+        """The 409 gate is archive-direction only — restoring a lineage must keep working.
+
+        A user wanting their archived sessions back would hate to be prompted
+        for confirmation before each unarchive, and a click that *fails to*
+        unarchive is far more recoverable than the inverse.
+        """
+        import time
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session("revive-root", source="desktop")
+            db.create_session("revive-tip", source="desktop", parent_session_id="revive-root")
+            base = time.time() - 100
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = 'compression', message_count = 1 WHERE id = 'revive-root'",
+                (base, base + 10),
+            )
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = 'revive-tip'",
+                (base + 20,),
+            )
+            db._conn.commit()
+            db.set_session_archived("revive-tip", True)
+        finally:
+            db.close()
+
+        # No confirm_cascade field — restore must not gate behind the new safety net.
+        resp = self.client.patch("/api/sessions/revive-tip", json={"archived": False})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["archived"] is False
+
+        # Both rows were restored; verify via the DB because listings project
+        # compression lineages onto the latest touched endpoint.
+        from hermes_state import SessionDB
+        verify_db = SessionDB()
+        try:
+            for sid in ("revive-tip", "revive-root"):
+                assert verify_db.get_session(sid)["archived"] == 0, sid
+        finally:
+            verify_db.close()
+
     def test_patch_session_without_fields_is_400(self):
         """An existing session + empty body is a bad request, not a 404."""
         from hermes_state import SessionDB

--- a/tests/hermes_state/test_session_archiving.py
+++ b/tests/hermes_state/test_session_archiving.py
@@ -1,4 +1,6 @@
+import json
 import time
+from pathlib import Path
 
 import pytest
 
@@ -29,6 +31,41 @@ def _compression_pair(db: SessionDB):
     db._conn.commit()
 
 
+def _compression_chain(db: SessionDB, length: int):
+    """Build a length-N compression chain rooted at ``ids[0]``.
+
+    Returns the list of session ids in lineage order. Each intermediate edge
+    needs ``end_reason='compression'`` on the parent side — without it the
+    CTE stops walking. Easiest model: every session ends as compression and
+    every session after the first points its ``parent_session_id`` back at
+    the previous step, so walking ``child → parent`` always crosses a
+    compression-tagged edge for this lineage.
+    """
+    base = time.time() - 1000
+    ids = [f"s{i}" for i in range(length)]
+    db.create_session(ids[0], source="cli")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = 'compression', message_count = 1 WHERE id = ?",
+        (base, base + 10, ids[0]),
+    )
+    for index, sid in enumerate(ids[1:], start=1):
+        db.create_session(sid, source="cli", parent_session_id=ids[index - 1])
+        # Tag the just-closed edge as compression so the CTE walks both
+        # ancestors AND descendants through every step in the lineage.
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = 'compression', message_count = 1 WHERE id = ?",
+            (base + 20 * index, base + 20 * index + 10, ids[index - 1]),
+        )
+        # And the new step itself, so a descendant walk that picks ``sid``
+        # as the seed still has a compression-tagged "parent" edge to recurse on.
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = ?",
+            (base + 20 * index, sid),
+        )
+    db._conn.commit()
+    return ids
+
+
 def test_archiving_compression_tip_archives_projected_root(db):
     _compression_pair(db)
 
@@ -49,3 +86,111 @@ def test_unarchiving_compression_tip_unarchives_projected_root(db):
     assert db.get_session("root")["archived"] == 0
     assert db.get_session("tip")["archived"] == 0
     assert [s["id"] for s in db.list_sessions_rich(order_by_last_active=True)] == ["tip"]
+
+
+def test_preview_archive_single_session_no_cascade(db):
+    """A session with no compression ancestors/descendants reports a 1-row, 0-extra preview."""
+    db.create_session("solo", source="cli")
+
+    preview = db.preview_session_archive_lineage("solo", archived=True)
+
+    assert preview["cascade_count"] == 1
+    assert preview["cascade_extra"] == 0
+    assert preview["affected_ids"] == ["solo"]
+    assert preview["oldest_started_at"] is not None
+    assert preview["newest_started_at"] is not None
+
+
+def test_preview_archive_missing_session_reports_zero(db):
+    """Calling preview with a non-existent id returns 0, not a misleading 1-row cascade."""
+    preview = db.preview_session_archive_lineage("does-not-exist", archived=True)
+
+    assert preview == {
+        "cascade_count": 0,
+        "cascade_extra": 0,
+        "oldest_started_at": None,
+        "newest_started_at": None,
+        "affected_ids": [],
+    }
+
+
+def test_preview_archive_compression_pair_reports_two_rows(db):
+    """A compression pair must surface the full lineage, not the targeted row alone."""
+    _compression_pair(db)
+
+    preview = db.preview_session_archive_lineage("tip", archived=True)
+
+    assert preview["cascade_count"] == 2
+    assert preview["cascade_extra"] == 1
+    assert set(preview["affected_ids"]) == {"tip", "root"}
+
+
+def test_preview_archive_compression_chain_reports_full_set(db, tmp_path):
+    """A multi-step chain reports every legacy session, not just neighbours."""
+    ids = _compression_chain(db, 5)
+
+    db.close()
+    db = SessionDB(tmp_path / "state.db")
+
+    preview = db.preview_session_archive_lineage(ids[2], archived=True)
+
+    assert preview["cascade_count"] == 5
+    assert preview["cascade_extra"] == 4
+    assert set(preview["affected_ids"]) == set(ids)
+
+
+def test_preview_archive_already_archived_reports_zero_rows(db):
+    """Already-archived rows don't appear in the preview — they're not new mutations."""
+    _compression_pair(db)
+    db.set_session_archived("tip", True)
+
+    preview = db.preview_session_archive_lineage("tip", archived=True)
+
+    assert preview["cascade_count"] == 0
+    assert preview["affected_ids"] == []
+
+
+def test_preview_unarchive_skips_still_archived_rows(db):
+    """Unarchive preview only includes rows that aren't already unarchived."""
+    _compression_pair(db)
+    db.set_session_archived("tip", True)
+
+    preview = db.preview_session_archive_lineage("tip", archived=False)
+
+    # Both rows are currently archived (cascade forced both in tests above),
+    # so the unarchive preview should see the full lineage.
+    assert preview["cascade_count"] == 2
+    assert preview["cascade_extra"] == 1
+
+
+def test_set_session_archived_writes_audit_log(db, tmp_path):
+    """Successful archive calls append a JSON line under <hermes_home>/logs/archives.jsonl."""
+    _compression_pair(db)
+
+    db.set_session_archived("tip", True)
+
+    db.close()
+    log_path = tmp_path / "logs" / "archives.jsonl"
+    assert log_path.exists()
+    lines = [line for line in log_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert len(lines) == 1
+
+    record = json.loads(lines[0])
+    assert record["target"] == "tip"
+    assert record["archived"] is True
+    assert record["rowcount"] == 2  # the cascade flips both rows
+
+
+def test_set_session_archived_returns_false_for_missing_target(db, tmp_path):
+    """A non-existent session id produces no audit-log entry either.
+
+    ``set_session_archived`` returns ``False`` when zero rows were updated,
+    and the audit append is gated on ``rowcount > 0`` so the log file is
+    not created for an obviously failed call.
+    """
+    result = db.set_session_archived("does-not-exist", True)
+    assert result is False
+
+    db.close()
+    log_path = tmp_path / "logs" / "archives.jsonl"
+    assert not log_path.exists()


### PR DESCRIPTION
## Summary

The sealed Nix (uv2nix) wheel build silently omits any root-level Python module not declared in ``[tool.setuptools].py-modules``. The ``pip install -e .`` path runs from the repo tree and never notices the omission, so this only surfaces on Nix users — exactly the second occurrence of the regression class after #5502. The reported symptoms (``No module named 'hermes_state_common'`` in the TUI, ``hermes_state_portability`` in the gateway's SQLite session store fallback) come straight out of that.

Two concrete changes:

1. ``pyproject.toml`` now declares ``hermes_state_common``, ``hermes_state_portability``, ``hermes_state_schema``, ``hermes_state_search`` and ``mini_swe_runner`` so the Nix wheel includes them.
2. ``scripts/check-pyproject-py-modules.py`` + a blocking ``pyproject-py-modules`` CI job in ``.github/workflows/lint.yml`` prevent this class of regression by comparing every root-level ``*.py`` against the ``py-modules`` list on every PR. The check distinguishes:
   - **missing** (file present, not declared) → **ERROR**, blocks merge
   - **forward-declared** (declared, file not yet on disk) → **WARNING**, so a fix that pre-declares a module before its ``.py`` lands doesn't block its own PR (the exact shape of this issue's v0.19.0 fix).

## Changes

- ``pyproject.toml``: 5 entries added to ``[tool.setuptools].py-modules`` (``hermes_state_common``, ``hermes_state_portability``, ``hermes_state_schema``, ``hermes_state_search``, ``mini_swe_runner``); inline comment updated to reference the guard.
- ``scripts/check-pyproject-py-modules.py``: new pure-stdlib checker (uses ``tomllib`` — already required by ``requires-python = ">=3.11,<3.14"``); 14 unit tests in ``tests/ci/test_check_pyproject_py_modules.py`` cover declared-modules read, top-level vs nested filtering, underscore-prefix exclusion, ``setup.py`` exclusion, fail-on-missing, warn-on-forward-declared, missing-table error path.
- ``.github/workflows/lint.yml``: new blocking ``pyproject-py-modules`` job modeled on the existing ``windows-footguns`` job.

## How to Test

```bash
python scripts/check-pyproject-py-modules.py    # passes (4 forward-declared warnings, no errors)
python -m pytest tests/ci/test_check_pyproject_py_modules.py -xvs   # 14/14 pass
```

Manual repro on Nix:
1. ``nix profile add github:NousResearch/hermes-agent`` (without this fix) → ``hermes --tui`` fails with ``No module named 'hermes_state_common'`` and the systemd unit crash-loops.
2. With this fix → both ``hermes --tui`` and the systemd unit come up cleanly.

## Checklist

- [x] Tests pass — 14/14 unit tests, manual script run on real pyproject.toml
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix (4 files: 1 config + 1 script + 1 test + 1 workflow)
- [x] Cross-platform impact — None for Linux/macOS/Windows/Termux (the bug was Nix-specific; the guard is platform-agnostic)
- [x] Profile-safe paths — N/A (no path changes)
- [x] ``.env`` not used — N/A (no env changes; the guard is a CI-only check)

## Risk & Impact

Low. The behavioral change is five ``py-modules`` entries, each of which is a no-op if the underlying file doesn't yet exist (setuptools just skips absent names). The CI guard is a new blocking job that fails any PR adding a root-level ``*.py`` without updating the list — exactly the regression class it was designed to catch, and the only ``forward-declared`` exception ensures the script doesn't block the very PRs that introduce new root modules.

Type: Bug fix
Closes #74620