### PR TITLE
fix(google-workspace): correct gmail reply recipient and non-ASCII address headers

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -187,10 +187,15 @@ $GAPI gmail get MESSAGE_ID
 $GAPI gmail send --to user@example.com --subject "Hello" --body "Message text"
 $GAPI gmail send --to user@example.com --subject "Report" --body "<h1>Q4</h1><p>Details...</p>" --html
 $GAPI gmail send --to user@example.com --subject "Hello" --from '"Research Agent" <user@example.com>' --body "Message text"
+$GAPI gmail send --to user@example.com --subject "Hello" --body "..." --dry-run  # build + print headers, sends nothing
 
 # Reply (automatically threads and sets In-Reply-To)
+# Targets Reply-To, then From; replying to your OWN sent message targets its
+# original recipients instead of yourself. Non-ASCII display names are encoded
+# correctly (name only, never across the address).
 $GAPI gmail reply MESSAGE_ID --body "Thanks, that works for me."
 $GAPI gmail reply MESSAGE_ID --from '"Support Bot" <user@example.com>' --body "Thanks"
+$GAPI gmail reply MESSAGE_ID --body "..." --dry-run  # resolve recipient + print headers, sends nothing
 
 # Labels
 $GAPI gmail labels

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -8,8 +8,8 @@ libraries if `gws` is not installed.
 Usage:
   python google_api.py gmail search "is:unread" [--max 10]
   python google_api.py gmail get MESSAGE_ID
-  python google_api.py gmail send --to user@example.com --subject "Hi" --body "Hello"
-  python google_api.py gmail reply MESSAGE_ID --body "Thanks"
+  python google_api.py gmail send --to user@example.com --subject "Hi" --body "Hello" [--dry-run]
+  python google_api.py gmail reply MESSAGE_ID --body "Thanks" [--dry-run]
   python google_api.py calendar list [--from DATE] [--to DATE] [--calendar primary]
   python google_api.py calendar create --summary "Meeting" --start DATETIME --end DATETIME
   python google_api.py drive search "budget report" [--max 10]
@@ -28,7 +28,10 @@ import shutil
 import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
-from email.mime.text import MIMEText
+from email import policy
+from email.headerregistry import Address
+from email.message import EmailMessage
+from email.utils import getaddresses
 from pathlib import Path
 
 # Ensure sibling modules (_hermes_home) are importable when run standalone.
@@ -152,6 +155,75 @@ def _extract_message_body(msg: dict) -> str:
                     body = base64.urlsafe_b64decode(part["body"]["data"]).decode("utf-8", errors="replace")
                     break
     return body
+
+
+REPLY_METADATA_HEADERS = ["From", "To", "Reply-To", "Subject", "Message-ID"]
+
+
+def _own_email_address(service=None) -> str:
+    if service is None:
+        profile = _run_gws(["gmail", "users", "getProfile"], params={"userId": "me"})
+    else:
+        profile = service.users().getProfile(userId="me").execute()
+    address = (profile or {}).get("emailAddress", "")
+    if not address:
+        raise RuntimeError("Could not determine own address from users.getProfile")
+    return address.lower()
+
+
+def _address_list(raw: str) -> list[Address]:
+    """Parse a raw address-list string into Address objects.
+
+    Going through headerregistry.Address (not a raw str header on
+    MIMEText/compat32) is load-bearing: non-ASCII display names get RFC
+    2047-encoded on the name only, never across the addr-spec — Gmail rejects
+    whole-value-encoded address headers with "Invalid To header".
+    """
+    return [Address(display_name=name, addr_spec=addr) for name, addr in getaddresses([raw]) if addr and "@" in addr]
+
+
+def _build_reply_mime(headers: dict[str, str], body: str, own_address: str, from_header: str = "") -> EmailMessage:
+    """Build a reply targeting Reply-To, then From; when the original is our
+    own sent message, target its To recipients instead of ourselves.
+    """
+    recipients = _address_list(headers.get("reply-to") or headers.get("from", ""))
+    if recipients and all(a.addr_spec.lower() == own_address for a in recipients):
+        recipients = _address_list(headers.get("to", ""))
+    if not recipients:
+        raise RuntimeError("Cannot determine reply recipient from the original message headers")
+
+    subject = headers.get("subject", "")
+    if not subject.startswith("Re:"):
+        subject = f"Re: {subject}"
+
+    message = EmailMessage(policy=policy.SMTP)
+    message.set_content(body)
+    message["To"] = recipients
+    message["Subject"] = subject
+    if from_header:
+        message["From"] = from_header
+    if headers.get("message-id"):
+        message["In-Reply-To"] = headers["message-id"]
+        message["References"] = headers["message-id"]
+    return message
+
+
+def _build_send_mime(args) -> EmailMessage:
+    message = EmailMessage(policy=policy.SMTP)
+    message.set_content(args.body, subtype="html" if args.html else "plain")
+    recipients = _address_list(args.to)
+    if not recipients:
+        raise RuntimeError(f"No valid recipient address in --to: {args.to!r}")
+    message["To"] = recipients
+    message["Subject"] = args.subject
+    if args.cc:
+        cc = _address_list(args.cc)
+        if not cc:
+            raise RuntimeError(f"No valid recipient address in --cc: {args.cc!r}")
+        message["Cc"] = cc
+    if args.from_header:
+        message["From"] = args.from_header
+    return message
 
 
 def _extract_doc_text(doc: dict) -> str:
@@ -316,46 +388,34 @@ def gmail_get(args):
 
 
 def gmail_send(args):
+    message = _build_send_mime(args)
+    if args.dry_run:
+        _print_dry_run(message, args.thread_id)
+        return
+
+    raw = base64.urlsafe_b64encode(message.as_bytes()).decode()
+    body = {"raw": raw}
+    if args.thread_id:
+        body["threadId"] = args.thread_id
+
     if _gws_binary():
-        message = MIMEText(args.body, "html" if args.html else "plain")
-        message["To"] = args.to
-        message["Subject"] = args.subject
-        if args.cc:
-            message["Cc"] = args.cc
-        if args.from_header:
-            message["From"] = args.from_header
-
-        raw = base64.urlsafe_b64encode(message.as_bytes()).decode()
-        body = {"raw": raw}
-        if args.thread_id:
-            body["threadId"] = args.thread_id
-
         result = _run_gws(
             ["gmail", "users", "messages", "send"],
             params={"userId": "me"},
             body=body,
         )
-        print(json.dumps({"status": "sent", "id": result["id"], "threadId": result.get("threadId", "")}, indent=2))
-        return
-
-    service = build_service("gmail", "v1")
-    message = MIMEText(args.body, "html" if args.html else "plain")
-    message["To"] = args.to
-    message["Subject"] = args.subject
-    if args.cc:
-        message["Cc"] = args.cc
-    if args.from_header:
-        message["From"] = args.from_header
-
-    raw = base64.urlsafe_b64encode(message.as_bytes()).decode()
-    body = {"raw": raw}
-
-    if args.thread_id:
-        body["threadId"] = args.thread_id
-
-    result = service.users().messages().send(userId="me", body=body).execute()
+    else:
+        service = build_service("gmail", "v1")
+        result = service.users().messages().send(userId="me", body=body).execute()
     print(json.dumps({"status": "sent", "id": result["id"], "threadId": result.get("threadId", "")}, indent=2))
 
+
+def _print_dry_run(message: EmailMessage, thread_id: str) -> None:
+    print(json.dumps({
+        "status": "dry-run",
+        "threadId": thread_id,
+        "headers": {name: str(value) for name, value in message.items()},
+    }, indent=2))
 
 
 def gmail_reply(args):
@@ -366,23 +426,13 @@ def gmail_reply(args):
                 "userId": "me",
                 "id": args.message_id,
                 "format": "metadata",
-                "metadataHeaders": ["From", "Subject", "Message-ID"],
+                "metadataHeaders": REPLY_METADATA_HEADERS,
             },
         )
-        headers = _headers_dict(original)
-
-        subject = headers.get("subject", "")
-        if not subject.startswith("Re:"):
-            subject = f"Re: {subject}"
-
-        message = MIMEText(args.body)
-        message["To"] = headers.get("from", "")
-        message["Subject"] = subject
-        if args.from_header:
-            message["From"] = args.from_header
-        if headers.get("message-id"):
-            message["In-Reply-To"] = headers["message-id"]
-            message["References"] = headers["message-id"]
+        message = _build_reply_mime(_headers_dict(original), args.body, _own_email_address(), args.from_header)
+        if args.dry_run:
+            _print_dry_run(message, original["threadId"])
+            return
 
         raw = base64.urlsafe_b64encode(message.as_bytes()).decode()
         result = _run_gws(
@@ -396,22 +446,12 @@ def gmail_reply(args):
     service = build_service("gmail", "v1")
     original = service.users().messages().get(
         userId="me", id=args.message_id, format="metadata",
-        metadataHeaders=["From", "Subject", "Message-ID"],
+        metadataHeaders=REPLY_METADATA_HEADERS,
     ).execute()
-    headers = _headers_dict(original)
-
-    subject = headers.get("subject", "")
-    if not subject.startswith("Re:"):
-        subject = f"Re: {subject}"
-
-    message = MIMEText(args.body)
-    message["To"] = headers.get("from", "")
-    message["Subject"] = subject
-    if args.from_header:
-        message["From"] = args.from_header
-    if headers.get("message-id"):
-        message["In-Reply-To"] = headers["message-id"]
-        message["References"] = headers["message-id"]
+    message = _build_reply_mime(_headers_dict(original), args.body, _own_email_address(service), args.from_header)
+    if args.dry_run:
+        _print_dry_run(message, original["threadId"])
+        return
 
     raw = base64.urlsafe_b64encode(message.as_bytes()).decode()
     body = {"raw": raw, "threadId": original["threadId"]}
@@ -1076,12 +1116,14 @@ def main():
     p.add_argument("--from", dest="from_header", default="", help="Custom From header (e.g. '\"Agent Name\" <user@example.com>')")
     p.add_argument("--html", action="store_true", help="Send body as HTML")
     p.add_argument("--thread-id", default="", help="Thread ID for threading")
+    p.add_argument("--dry-run", action="store_true", help="Build the message and print headers without sending")
     p.set_defaults(func=gmail_send)
 
     p = gmail_sub.add_parser("reply")
     p.add_argument("message_id", help="Message ID to reply to")
     p.add_argument("--body", required=True)
     p.add_argument("--from", dest="from_header", default="", help="Custom From header (e.g. '\"Agent Name\" <user@example.com>')")
+    p.add_argument("--dry-run", action="store_true", help="Resolve recipient and print headers without sending")
     p.set_defaults(func=gmail_reply)
 
     p = gmail_sub.add_parser("labels")

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -195,3 +195,146 @@ def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, m
     assert isinstance(creds, FakeCredentials)
     assert saved["token"] == "ya29.refreshed"
     assert saved["type"] == "authorized_user"
+
+
+# ---------------------------------------------------------------------------
+# gmail reply/send MIME building (_build_reply_mime / _build_send_mime)
+# ---------------------------------------------------------------------------
+
+OWN_ADDRESS = "me@example.com"
+
+
+def _reply_headers(**overrides):
+    base = {
+        "from": "Support Desk <support@example.com>",
+        "to": f"Me <{OWN_ADDRESS}>",
+        "subject": "Order 1234",
+        "message-id": "<abc@mail.example.com>",
+    }
+    base.update(overrides)
+    return base
+
+
+def _send_args(api_module, **overrides):
+    base = dict(to="user@example.com", subject="Hi", body="Hello", html=False, cc="", from_header="")
+    base.update(overrides)
+    return api_module.argparse.Namespace(**base)
+
+
+def _unfolded_to_line(message):
+    wire = message.as_bytes().replace(b"\r\n ", b" ").replace(b"\r\n\t", b" ")
+    lines = [line for line in wire.split(b"\r\n") if line.lower().startswith(b"to:")]
+    assert lines, wire
+    return lines[0]
+
+
+def test_api_reply_targets_from_of_external_sender(api_module):
+    msg = api_module._build_reply_mime(_reply_headers(), "body", OWN_ADDRESS)
+    assert [a.addr_spec for a in msg["To"].addresses] == ["support@example.com"]
+
+
+def test_api_reply_to_own_sent_message_targets_original_recipients(api_module):
+    """Replying to your own sent message must address the counterparty, not yourself."""
+    msg = api_module._build_reply_mime(
+        _reply_headers(**{
+            "from": f"Me <{OWN_ADDRESS}>",
+            "to": "Support Desk <support@example.com>",
+        }),
+        "body",
+        OWN_ADDRESS,
+    )
+    assert [a.addr_spec for a in msg["To"].addresses] == ["support@example.com"]
+
+
+def test_api_reply_prefers_reply_to_header(api_module):
+    msg = api_module._build_reply_mime(
+        _reply_headers(**{"reply-to": "Case Desk <cases@example.com>"}), "body", OWN_ADDRESS
+    )
+    assert [a.addr_spec for a in msg["To"].addresses] == ["cases@example.com"]
+
+
+def test_api_reply_non_ascii_display_name_keeps_addr_spec_plain(api_module):
+    """Gmail rejects address headers where an RFC 2047 encoded-word spans the
+    whole value ("Invalid To header") — only the display name may be encoded."""
+    msg = api_module._build_reply_mime(
+        _reply_headers(**{"from": '"Jörg Müller" <jorg@example.de>'}), "body", OWN_ADDRESS
+    )
+    to_line = _unfolded_to_line(msg)
+    assert b"<jorg@example.de>" in to_line
+    assert msg["To"].addresses[0].display_name == "Jörg Müller"
+
+
+def test_api_reply_without_recipient_raises(api_module):
+    with pytest.raises(RuntimeError):
+        api_module._build_reply_mime(
+            _reply_headers(**{"from": "", "to": "", "reply-to": ""}), "body", OWN_ADDRESS
+        )
+
+
+def test_api_reply_subject_and_threading_headers(api_module):
+    msg = api_module._build_reply_mime(_reply_headers(), "body", OWN_ADDRESS)
+    assert str(msg["Subject"]) == "Re: Order 1234"
+    assert str(msg["In-Reply-To"]) == "<abc@mail.example.com>"
+    assert str(msg["References"]) == "<abc@mail.example.com>"
+
+    already = api_module._build_reply_mime(_reply_headers(subject="Re: x"), "body", OWN_ADDRESS)
+    assert str(already["Subject"]) == "Re: x"
+
+
+def test_api_send_non_ascii_display_name_keeps_addr_spec_plain(api_module):
+    msg = api_module._build_send_mime(_send_args(api_module, to='"Jörg Müller" <jorg@example.de>'))
+    to_line = _unfolded_to_line(msg)
+    assert b"<jorg@example.de>" in to_line
+    assert msg["To"].addresses[0].display_name == "Jörg Müller"
+
+
+def test_api_send_multiple_recipients_and_cc(api_module):
+    msg = api_module._build_send_mime(_send_args(
+        api_module,
+        to='a@example.com, "Bo Ärger" <b@example.de>',
+        cc="c@example.com",
+    ))
+    assert [a.addr_spec for a in msg["To"].addresses] == ["a@example.com", "b@example.de"]
+    assert [a.addr_spec for a in msg["Cc"].addresses] == ["c@example.com"]
+
+
+def test_api_send_html_subtype(api_module):
+    msg = api_module._build_send_mime(_send_args(api_module, body="<h1>x</h1>", html=True))
+    assert msg.get_content_type() == "text/html"
+
+
+def test_api_send_invalid_to_raises(api_module):
+    with pytest.raises(RuntimeError):
+        api_module._build_send_mime(_send_args(api_module, to="not-an-address"))
+
+
+def test_api_gmail_reply_dry_run_resolves_own_message(api_module, capsys):
+    """--dry-run resolves the recipient (via getProfile) and prints headers
+    without ever invoking messages.send."""
+
+    def fake_run_gws(parts, params=None, body=None):
+        if parts == ["gmail", "users", "messages", "get"]:
+            assert "To" in params["metadataHeaders"]
+            assert "Reply-To" in params["metadataHeaders"]
+            return {
+                "threadId": "t1",
+                "payload": {"headers": [
+                    {"name": "From", "value": f"Me <{OWN_ADDRESS}>"},
+                    {"name": "To", "value": "Shop <shop@example.com>"},
+                    {"name": "Subject", "value": "Order 1234"},
+                    {"name": "Message-ID", "value": "<x@example.com>"},
+                ]},
+            }
+        if parts == ["gmail", "users", "getProfile"]:
+            assert params == {"userId": "me"}
+            return {"emailAddress": OWN_ADDRESS}
+        raise AssertionError(f"unexpected gws call in dry-run: {parts}")
+
+    api_module._run_gws = fake_run_gws
+    args = api_module.argparse.Namespace(message_id="m1", body="ping", from_header="", dry_run=True)
+    api_module.gmail_reply(args)
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "dry-run"
+    assert out["threadId"] == "t1"
+    assert out["headers"]["To"] == "Shop <shop@example.com>"


### PR DESCRIPTION
## What does this PR do?

Fixes two bugs in the google-workspace skill's outgoing-mail building (`gmail reply` / `gmail send`):

1. **`gmail reply` addressed the reply to the original message's `From`** — so replying to a message the agent itself sent (e.g. a follow-up nudge on a thread the user started) targeted the authenticated account instead of the counterparty, and a successful send would pass label/threadId readback checks silently. Recipient resolution now prefers `Reply-To`, then `From`, and falls back to the original `To` recipients when `From` is the authenticated account (resolved via `users.getProfile`).
2. **Non-ASCII display names broke address headers.** `MIMEText`/compat32 RFC 2047-encodes the whole header value (including the addr-spec) when a display name contains e.g. `ö` or `Ø`, and the Gmail API rejects the message with `Invalid To header`. Messages are now built with `EmailMessage` + `policy.SMTP` + `headerregistry.Address`, which encode the display name only.

Also adds a `--dry-run` flag to `gmail send`/`gmail reply` that resolves the recipient and prints the headers without sending — previously there was no safe way to test reply addressing. The duplicated MIME-building in the `gws` and googleapiclient branches is consolidated into shared helpers (`_address_list`, `_build_reply_mime`, `_build_send_mime`).

## Related Issue

Fixes #74675

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `skills/productivity/google-workspace/scripts/google_api.py` — shared `_address_list()` / `_build_reply_mime()` / `_build_send_mime()` helpers built on `EmailMessage`; reply recipient resolution (Reply-To → From → own-message fallback to original To); `REPLY_METADATA_HEADERS` now fetches `To`/`Reply-To`; `--dry-run` on send/reply; `_own_email_address()` via `users.getProfile` (both gws and SDK paths).
- `skills/productivity/google-workspace/SKILL.md` — documents the reply-targeting behavior and the `--dry-run` flag.
- `tests/skills/test_google_workspace_api.py` — 11 new tests: reply targeting (external sender / own sent message / Reply-To precedence), non-ASCII display-name wire-format assertions for reply and send, multi-recipient + Cc, HTML subtype, invalid-recipient errors, and a `gmail reply --dry-run` flow test that asserts `messages.send` is never invoked.

## How to Test

1. `pytest tests/skills/test_google_workspace_api.py -q` — 15 passed (4 pre-existing + 11 new).
2. `python google_api.py gmail reply <id-of-a-message-you-sent> --body "ping" --dry-run` — headers show the original recipients as `To`, not your own address.
3. `python google_api.py gmail send --to '"Jörg Müller" <jorg@example.de>' --subject t --body t --dry-run` — the built `To` keeps the addr-spec plain ASCII with only the display name encoded.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran `pytest tests/skills -q` (189 passed) on this branch; the full suite was not run
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (including live Gmail API dry-run verification of both code paths)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — SKILL.md + module docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — stdlib `email` only, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — SKILL.md documents the new `--dry-run` flag and reply targeting

## Screenshots / Logs

Before (compat32 — rejected by Gmail with `Invalid To header`):

```
To: =?utf-8?b?IkrDtnJnIE3DvGxsZXIiIDxqb3JnQGV4YW1wbGUuZGU+?=
```

After (`EmailMessage` + `policy.SMTP` — display name only):

```
To: =?utf-8?q?J=C3=B6rg_M=C3=BCller?= <jorg@example.de>
```

`gmail reply --dry-run` on a message sent by the authenticated account now resolves the counterparty:

```json
{
  "status": "dry-run",
  "threadId": "…",
  "headers": {
    "To": "Support Desk <support@example.com>",
    "Subject": "Re: Order 1234",
    "In-Reply-To": "<…>",
    "References": "<…>"
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtVM9JeM2bGR8VrXuU4z7P
