### PR TITLE
fix(desktop): throttle hidden renderers

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/delta-flush.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/delta-flush.test.tsx
@@ -90,6 +90,42 @@ describe('useMessageStream delta flush scheduling', () => {
     expect(assistantText()).toBe('still streaming')
   })
 
+  it('flushes queued text immediately when a hidden window becomes visible', () => {
+    vi.mocked(performance.now).mockReturnValue(0)
+    mountStream()
+
+    act(() => appendAssistantDelta!(SID, 'caught up on focus'))
+    expect(assistantText()).toBe('')
+    expect(vi.getTimerCount()).toBe(1)
+
+    Object.defineProperty(globalThis.document, 'visibilityState', {
+      configurable: true,
+      value: 'visible'
+    })
+
+    act(() => globalThis.document.dispatchEvent(new Event('visibilitychange')))
+
+    expect(assistantText()).toBe('caught up on focus')
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('flushes queued text on focus when visibility remains visible', () => {
+    vi.mocked(performance.now).mockReturnValue(0)
+    Object.defineProperty(globalThis.document, 'visibilityState', {
+      configurable: true,
+      value: 'visible'
+    })
+    mountStream()
+
+    act(() => appendAssistantDelta!(SID, 'focused without visibility change'))
+    expect(assistantText()).toBe('')
+    expect(vi.getTimerCount()).toBe(1)
+
+    act(() => globalThis.window.dispatchEvent(new Event('focus')))
+
+    expect(assistantText()).toBe('focused without visibility change')
+  })
+
   it('cancels the pending timer on unmount and flushes exactly once', async () => {
     vi.mocked(performance.now).mockReturnValue(0)
     mountStream()

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -316,6 +316,34 @@ export function useMessageStream({
     [flushQueuedDeltas]
   )
 
+  // Page Visibility does not report every Windows/Linux focus transition.
+  // Flush queued deltas on both signals so returning to a chat cannot leave a
+  // completed chunk waiting for the next throttled timer.
+  useEffect(() => {
+    const flushPendingDeltas = () => {
+      if (flushHandleRef.current !== null) {
+        window.clearTimeout(flushHandleRef.current)
+        flushHandleRef.current = null
+      }
+
+      flushQueuedDeltas()
+    }
+
+    const flushWhenVisible = () => {
+      if (document.visibilityState === 'visible') {
+        flushPendingDeltas()
+      }
+    }
+
+    document.addEventListener('visibilitychange', flushWhenVisible)
+    window.addEventListener('focus', flushPendingDeltas)
+
+    return () => {
+      document.removeEventListener('visibilitychange', flushWhenVisible)
+      window.removeEventListener('focus', flushPendingDeltas)
+    }
+  }, [flushQueuedDeltas])
+
   const appendAssistantDelta = useCallback(
     (sessionId: string, delta: string) => {
       if (!delta) {


### PR DESCRIPTION
## Summary

- allow Chromium to throttle hidden and occluded Hermes chat windows
- remove process-wide switches that force renderer and GPU work at foreground cadence
- flush queued streaming deltas when visibility returns or the window regains focus

Related to #73082. This patch addresses hidden and occluded renderer work; it does not claim to resolve every visible-session performance path discussed in that issue.

## Root cause

Hermes disabled Electron renderer backgrounding, occlusion throttling, and background timer throttling process-wide, while every chat `BrowserWindow` also set `backgroundThrottling: false`. As a result, hidden or fully occluded Desktop windows continued timer and compositor work at foreground cadence.

The stream hook already uses a timer rather than `requestAnimationFrame`, so gateway events and stream state continue to progress when Chromium throttles an invisible renderer. This change flushes queued text on both `visibilitychange` and window focus. The focus path covers Windows and Linux cases where an occluded or unfocused window can remain `visibilityState === "visible"`.

## Measured impact

On the affected Apple Silicon system, matched 10-second Activity Monitor spindumps before and after the patch showed:

| Process | Before CPU time | After CPU time | Reduction |
|---|---:|---:|---:|
| GPU helper | 2.324 s | 0.192 s | 91.7% |
| Renderer helper | 4.803 s | 0.910 s | 81.1% |

The operator also observed materially lower GPU utilization and improved local model throughput after installing the patched Desktop build.

## Validation

- 20 focused Electron and stream-hook tests passed
- Electron TypeScript check passed
- Prettier check passed
- ESLint reported no errors (one pre-existing `document` warning in the test file)

The focused regression tests verify that chat windows retain background throttling, queued assistant text flushes when visibility returns, and a Windows/Linux-style focus transition flushes while visibility remains visible.