### PR TITLE
fix(packaging): add missing hermes_state_* mixins + mini_swe_runner to py-modules (#74653)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -346,7 +346,7 @@ hermes-acp = "acp_adapter.entry:main"
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's
 # sealed venv is missing hermes_constants, run_agent, etc.
-py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "utils", "mcp_serve"]
+py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_state_common", "hermes_state_portability", "hermes_state_schema", "hermes_state_search", "hermes_time", "hermes_logging", "utils", "mcp_serve", "mini_swe_runner"]
 
 [tool.setuptools.packages.find]
 include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]


### PR DESCRIPTION
## fix(packaging): add missing hermes_state_* mixins + mini_swe_runner to py-modules

### Root Cause
Commit `21c7ae856` ("refactor: split SessionDB into Search/Schema/Portability mixins") added four new top-level modules (`hermes_state_common`, `hermes_state_portability`, `hermes_state_schema`, `hermes_state_search`) that are imported by `hermes_state.py` but never registered in `[tool.setuptools] py-modules`. Additionally, `mini_swe_runner.py` exists at repo root and is imported by tests but was not listed.

### Impact
- Fresh wheel/sdist installs (pip, uv, nix) fail with `ModuleNotFoundError` for these modules
- TUI: `hermes --tui` → `No module named 'hermes_state_common'`
- Gateway: crash-loops with `No module named 'hermes_state_portability'`
- SQLite session store silently disabled
- Git installs unaffected (run from repo tree)

### Fix
Add all five missing modules to the `py-modules` list in `pyproject.toml`.

### Supersedes
#74492 (which added the four `hermes_state_*` modules but omitted `mini_swe_runner`)

### Changes
- `pyproject.toml`: Added `hermes_state_common`, `hermes_state_portability`, `hermes_state_schema`, `hermes_state_search`, `mini_swe_runner` to `py-modules`
