### PR TITLE
fix(bluebubbles): harden messaging delivery

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -9,13 +9,13 @@ downloading from PR #4588 (YuhangLin).
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
 import re
 import uuid
 from collections import OrderedDict
-from datetime import datetime
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
@@ -98,6 +98,13 @@ _PHONE_RE = re.compile(r"\+?\d{7,15}")
 _EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.]+")
 
 _GUID_CACHE_SIZE = 500  # LRU cap for resolved chat-GUID lookups
+_MESSAGE_DEDUP_SIZE = 2048  # LRU cap for completed message identity caches
+
+
+def _is_phone_handle(target: str) -> bool:
+    """Return true only for a complete international-style phone handle."""
+    value = target.strip()
+    return "@" not in value and bool(re.fullmatch(r"\+[1-9]\d{6,14}", value))
 
 
 def _redact(text: str) -> str:
@@ -178,6 +185,11 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        self._seen_message_guids: OrderedDict[str, None] = OrderedDict()
+        self._pending_message_identities: set[str] = set()
+        self._sent_message_keys: OrderedDict[str, str] = OrderedDict()
+        self._inbound_dedup_lock = asyncio.Lock()
+        self._outbound_dedup_lock = asyncio.Lock()
 
     # ------------------------------------------------------------------
     # API helpers
@@ -480,13 +492,16 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         return None
 
     async def _create_chat_for_handle(
-        self, address: str, message: str
+        self,
+        address: str,
+        message: str,
+        temp_guid: Optional[str] = None,
     ) -> SendResult:
         """Create a new chat by sending the first message to *address*."""
         payload = {
             "addresses": [address],
             "message": message,
-            "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+            "tempGuid": temp_guid or f"temp-{uuid.uuid4().hex}",
         }
         try:
             res = await self._api_post("/api/v1/chat/new", payload)
@@ -517,32 +532,101 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         text = self.format_message(content)
         if not text:
             return SendResult(success=False, error="BlueBubbles send requires text")
-        # Split on paragraph breaks first (double newlines) so each thought
-        # becomes its own iMessage bubble, then truncate any that are still
-        # too long.
-        paragraphs = [p.strip() for p in re.split(r'\n\s*\n', text) if p.strip()]
-        chunks: List[str] = []
-        for para in (paragraphs or [text]):
-            if len(para) <= self.MAX_MESSAGE_LENGTH:
-                chunks.append(para)
-            else:
-                chunks.extend(self.truncate_message(para, max_length=self.MAX_MESSAGE_LENGTH))
+        origin_id = reply_to or (
+            metadata.get("reply_to_message_id") if metadata else None
+        )
+        internal_notice = bool(metadata and metadata.get("internal_notice") is True)
+        if not origin_id:
+            return await self._send_formatted_text(
+                chat_id, text, reply_to, internal_notice=internal_notice
+            )
+
+        content_hash = hashlib.sha256(text.encode("utf-8")).hexdigest()
+        dedup_key = f"{chat_id}\0{origin_id}\0{content_hash}"
+        async with self._outbound_dedup_lock:
+            prior_message_id = self._sent_message_keys.get(dedup_key)
+            if prior_message_id is not None:
+                self._sent_message_keys.move_to_end(dedup_key)
+                logger.debug("[bluebubbles] suppressing duplicate outbound reply")
+                return SendResult(
+                    success=True,
+                    message_id=prior_message_id,
+                    raw_response={"deduplicated": True},
+                )
+            result = await self._send_formatted_text(
+                chat_id,
+                text,
+                reply_to,
+                internal_notice=internal_notice,
+                dedup_key=dedup_key,
+            )
+            if result.success and result.message_id:
+                self._sent_message_keys[dedup_key] = result.message_id
+                self._sent_message_keys.move_to_end(dedup_key)
+                while len(self._sent_message_keys) > _MESSAGE_DEDUP_SIZE:
+                    self._sent_message_keys.popitem(last=False)
+            return result
+
+    async def _send_formatted_text(
+        self,
+        chat_id: str,
+        text: str,
+        reply_to: Optional[str],
+        *,
+        internal_notice: bool,
+        dedup_key: Optional[str] = None,
+    ) -> SendResult:
+        # Keep a complete reply in one iMessage bubble whenever it fits. Only
+        # split when the platform's message-length limit requires it.
+        chunks = (
+            [text]
+            if len(text) <= self.MAX_MESSAGE_LENGTH
+            else self.truncate_message(text, max_length=self.MAX_MESSAGE_LENGTH)
+        )
         last = SendResult(success=True)
-        for chunk in chunks:
+        for chunk_index, chunk in enumerate(chunks):
+            if dedup_key:
+                temp_guid = "temp-" + hashlib.sha256(
+                    f"{dedup_key}\0{chunk_index}".encode("utf-8")
+                ).hexdigest()
+            else:
+                temp_guid = f"temp-{uuid.uuid4().hex}"
             guid = await self._resolve_chat_guid(chat_id)
             if not guid:
+                if internal_notice and _is_phone_handle(chat_id):
+                    logger.info(
+                        "[bluebubbles] suppressed internal notice to unresolved phone target"
+                    )
+                    return SendResult(
+                        success=True,
+                        raw_response={"suppressed": "internal_sms_notice"},
+                    )
                 # If the target looks like an address, try creating a new chat
                 if self._private_api_enabled and (
-                    "@" in chat_id or re.match(r"^\+\d+", chat_id)
+                    "@" in chat_id or _is_phone_handle(chat_id)
                 ):
-                    return await self._create_chat_for_handle(chat_id, chunk)
+                    created = await self._create_chat_for_handle(
+                        chat_id, chunk, temp_guid=temp_guid
+                    )
+                    if not created.success:
+                        return created
+                    last = created
+                    if chunk_index == len(chunks) - 1:
+                        return created
+                    continue
                 return SendResult(
                     success=False,
                     error=f"BlueBubbles chat not found for target: {chat_id}",
                 )
+            if guid.lower().startswith("sms;") and internal_notice:
+                logger.info("[bluebubbles] suppressed internal notice over SMS")
+                return SendResult(
+                    success=True,
+                    raw_response={"suppressed": "internal_sms_notice"},
+                )
             payload: Dict[str, Any] = {
                 "chatGuid": guid,
-                "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+                "tempGuid": temp_guid,
                 "message": chunk,
             }
             if reply_to and self._private_api_enabled and self._helper_connected:
@@ -869,6 +953,33 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 return candidate.strip()
         return None
 
+    async def _handle_reserved_message(
+        self,
+        event: MessageEvent,
+        message_identity: Optional[str],
+    ) -> None:
+        """Dispatch a claimed inbound revision and release it on failure."""
+        try:
+            await self.handle_message(event)
+        except asyncio.CancelledError:
+            if message_identity:
+                async with self._inbound_dedup_lock:
+                    self._pending_message_identities.discard(message_identity)
+            raise
+        except Exception:
+            if message_identity:
+                async with self._inbound_dedup_lock:
+                    self._pending_message_identities.discard(message_identity)
+            logger.exception("[bluebubbles] inbound dispatch failed; revision released")
+        else:
+            if message_identity:
+                async with self._inbound_dedup_lock:
+                    self._pending_message_identities.discard(message_identity)
+                    self._seen_message_guids[message_identity] = None
+                    self._seen_message_guids.move_to_end(message_identity)
+                    while len(self._seen_message_guids) > _MESSAGE_DEDUP_SIZE:
+                        self._seen_message_guids.popitem(last=False)
+
     async def _handle_webhook(self, request):
         from aiohttp import web
 
@@ -915,6 +1026,12 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if is_from_me:
             return web.Response(text="ok")
 
+        message_guid = self._value(
+            record.get("guid"),
+            record.get("messageGuid"),
+            record.get("id"),
+        )
+
         # Skip tapback reactions delivered as messages
         assoc_type = record.get("associatedMessageType")
         if isinstance(assoc_type, int) and assoc_type in {
@@ -934,6 +1051,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         attachments = record.get("attachments") or []
         media_urls: List[str] = []
         media_types: List[str] = []
+        downloaded_attachment_guids: set[str] = set()
         msg_type = MessageType.TEXT
 
         for att in attachments:
@@ -942,6 +1060,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 continue
             cached = await self._download_attachment(att_guid, att)
             if cached:
+                downloaded_attachment_guids.add(att_guid)
                 mime = (att.get("mimeType") or "").lower()
                 media_urls.append(cached)
                 media_types.append(mime)
@@ -1011,6 +1130,35 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 )
                 return web.Response(text="ok")
             text = self._clean_mention_text(text)
+
+        # Atomically claim the message only after validation and mention gating,
+        # so malformed payloads cannot poison the bounded identity cache and
+        # concurrent new/updated events cannot both dispatch.
+        message_identity: Optional[str] = None
+        if message_guid:
+            attachment_identity = [
+                {
+                    **att,
+                    "__hermes_downloaded": att.get("guid")
+                    in downloaded_attachment_guids,
+                }
+                for att in attachments
+                if isinstance(att, dict)
+            ]
+            revision_payload = json.dumps(
+                {"text": text, "attachments": attachment_identity},
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            revision_hash = hashlib.sha256(revision_payload.encode("utf-8")).hexdigest()
+            message_identity = f"{message_guid}\0{revision_hash}"
+            async with self._inbound_dedup_lock:
+                if message_identity in self._pending_message_identities:
+                    return web.Response(text="ok")
+                if message_identity in self._seen_message_guids:
+                    self._seen_message_guids.move_to_end(message_identity)
+                    return web.Response(text="ok")
+                self._pending_message_identities.add(message_identity)
         source = self.build_source(
             chat_id=session_chat_id,
             chat_name=chat_identifier or sender,
@@ -1024,11 +1172,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             message_type=msg_type,
             source=source,
             raw_message=payload,
-            message_id=self._value(
-                record.get("guid"),
-                record.get("messageGuid"),
-                record.get("id"),
-            ),
+            message_id=message_guid,
             reply_to_message_id=self._value(
                 record.get("threadOriginatorGuid"),
                 record.get("associatedMessageGuid"),
@@ -1036,7 +1180,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             media_urls=media_urls,
             media_types=media_types,
         )
-        task = asyncio.create_task(self.handle_message(event))
+        task = asyncio.create_task(
+            self._handle_reserved_message(event, message_identity)
+        )
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -316,6 +316,17 @@ def _non_conversational_metadata(
     return merged
 
 
+def _internal_notice_metadata(
+    metadata: Optional[Dict[str, Any]] = None,
+    *,
+    platform: Any = None,
+) -> Dict[str, Any]:
+    """Mark suppressible operational notices without hiding user prompts."""
+    merged = dict(_non_conversational_metadata(metadata, platform=platform) or {})
+    merged["internal_notice"] = True
+    return merged
+
+
 def _seed_hygiene_system_prompt(
     agent: Any,
     session_row: Optional[Dict[str, Any]],
@@ -628,6 +639,8 @@ async def _send_or_update_status_coro(adapter, chat_id, status_key, content, met
     Telegram) edit the previous bubble for the same status_key instead of
     appending a new one. Adapters without the method fall back to plain send.
     """
+    metadata = dict(metadata or {})
+    metadata["internal_notice"] = True
     sender = getattr(adapter, "send_or_update_status", None)
     if callable(sender):
         return await sender(chat_id, status_key, content, metadata=metadata)
@@ -4579,7 +4592,7 @@ class TurnRunner:
                 ctx._status_adapter.send(
                     ctx._status_chat_id,
                     message,
-                    metadata=_non_conversational_metadata(ctx._status_thread_metadata, platform=ctx.source.platform),
+                    metadata=_internal_notice_metadata(ctx._status_thread_metadata, platform=ctx.source.platform),
                 ),
                 ctx._loop_for_step,
                 logger=logger,
@@ -19807,7 +19820,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     await adapter.send(
                         chat_id,
                         f"```\n{chunk}\n```",
-                        metadata=_non_conversational_metadata(metadata, platform=platform),
+                        metadata=_internal_notice_metadata(metadata, platform=platform),
                     )
                 except Exception as e:
                     logger.debug("Update stream send failed: %s", e)
@@ -19834,13 +19847,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         await adapter.send(
                             chat_id,
                             "✅ Hermes update finished.",
-                            metadata=_non_conversational_metadata(metadata, platform=platform),
+                            metadata=_internal_notice_metadata(metadata, platform=platform),
                         )
                     else:
                         await adapter.send(
                             chat_id,
                             "❌ Hermes update failed (exit code {}).".format(exit_code),
-                            metadata=_non_conversational_metadata(metadata, platform=platform),
+                            metadata=_internal_notice_metadata(metadata, platform=platform),
                         )
                     logger.info("Update finished (exit=%s), notified %s", exit_code, session_key)
                 except Exception as e:
@@ -19939,7 +19952,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 await adapter.send(
                     chat_id,
                     "❌ Hermes update timed out after 30 minutes.",
-                    metadata=_non_conversational_metadata(metadata, platform=platform),
+                    metadata=_internal_notice_metadata(metadata, platform=platform),
                 )
             except Exception:
                 pass
@@ -20051,7 +20064,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 await adapter.send(
                     chat_id,
                     msg,
-                    metadata=_non_conversational_metadata(metadata, platform=platform),
+                    metadata=_internal_notice_metadata(metadata, platform=platform),
                 )
                 logger.info(
                     "Sent post-update notification to %s:%s (exit=%s)",
@@ -20122,7 +20135,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 platform,
                 str(chat_id),
                 "♻ Gateway restarted successfully. Your session continues.",
-                metadata=_non_conversational_metadata(metadata, platform=platform),
+                metadata=_internal_notice_metadata(metadata, platform=platform),
             )
             # adapter.send() catches provider errors (e.g. "Chat not found")
             # and returns SendResult(success=False) rather than raising, so
@@ -20197,7 +20210,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         metadata["user_id"] = home.user_id
                     if home.scope_id:
                         metadata["scope_id"] = home.scope_id
-                send_metadata = _non_conversational_metadata(metadata, platform=platform)
+                send_metadata = _internal_notice_metadata(metadata, platform=platform)
                 if send_metadata is not None or transport.is_relay:
                     result = await transport.send(
                         platform,
@@ -23474,7 +23487,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 reply_to_message_id=event_message_id,
             )
         ) if _progress_thread_id else None
-        _progress_metadata = _non_conversational_metadata(_progress_metadata, platform=source.platform)
+        _progress_metadata = _internal_notice_metadata(_progress_metadata, platform=source.platform)
         _progress_reply_to = (
             event_message_id
             if source.platform in (Platform.FEISHU, Platform.MATTERMOST) and source.thread_id and event_message_id
@@ -23873,7 +23886,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _notify_res = await _notify_adapter.send(
                             source.chat_id,
                             _heartbeat_text,
-                            metadata=_non_conversational_metadata(_status_thread_metadata, platform=source.platform),
+                            metadata=_internal_notice_metadata(_status_thread_metadata, platform=source.platform),
                         )
                         if getattr(_notify_res, "success", False) and getattr(
                             _notify_res, "message_id", None

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -52,6 +52,237 @@ class TestBlueBubblesHelpers:
 
         assert check_bluebubbles_requirements() is True
 
+    @pytest.mark.asyncio
+    async def test_send_keeps_paragraphs_in_one_bubble_when_under_limit(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        sent = []
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;user@example.com"
+
+        async def fake_api_post(path, payload):
+            sent.append(payload["message"])
+            return {"data": {"guid": f"msg-{len(sent)}"}}
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        content = "first thought\n\nsecond thought"
+        result = await adapter.send("user@example.com", content)
+
+        assert result.success is True
+        assert sent == [content]
+
+    @pytest.mark.asyncio
+    async def test_send_deduplicates_concurrent_content_for_same_origin(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        sent = []
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;user@example.com"
+
+        async def fake_api_post(path, payload):
+            sent.append(payload)
+            await asyncio.sleep(0.01)
+            return {"data": {"guid": "assistant-message-guid"}}
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        metadata = {"reply_to_message_id": "origin-message-guid"}
+
+        first, second = await asyncio.gather(
+            adapter.send("user@example.com", "same answer", metadata=metadata),
+            adapter.send("user@example.com", "same answer", metadata=metadata),
+        )
+
+        assert first.success is True
+        assert second.success is True
+        assert [payload["message"] for payload in sent] == ["same answer"]
+        assert {first.raw_response.get("deduplicated"), second.raw_response.get("deduplicated")} == {None, True}
+
+    @pytest.mark.asyncio
+    async def test_send_without_origin_does_not_deduplicate_legitimate_repeats(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        sent = []
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;user@example.com"
+
+        async def fake_api_post(path, payload):
+            sent.append(payload["message"])
+            return {"data": {"guid": f"message-{len(sent)}"}}
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        await adapter.send("user@example.com", "legitimate repeat")
+        await adapter.send("user@example.com", "legitimate repeat")
+
+        assert sent == ["legitimate repeat", "legitimate repeat"]
+
+    @pytest.mark.asyncio
+    async def test_send_reuses_idempotency_key_after_ambiguous_failure(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        payloads = []
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;user@example.com"
+
+        async def fake_api_post(path, payload):
+            payloads.append(payload)
+            if len(payloads) == 1:
+                raise TimeoutError("response lost")
+            return {"data": {"guid": "assistant-message-guid"}}
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        metadata = {"reply_to_message_id": "origin-message-guid"}
+
+        first = await adapter.send("user@example.com", "same answer", metadata=metadata)
+        second = await adapter.send("user@example.com", "same answer", metadata=metadata)
+
+        assert first.success is False
+        assert second.success is True
+        assert payloads[0]["tempGuid"] == payloads[1]["tempGuid"]
+
+    @pytest.mark.asyncio
+    async def test_send_suppresses_only_structured_internal_notice_over_sms(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        api_calls = []
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "SMS;-;+155****0100"
+
+        async def fake_api_post(path, payload):
+            api_calls.append((path, payload))
+            return {"data": {"guid": "sent-message"}}
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        text = "Gateway shutting down for maintenance"
+
+        legitimate = await adapter.send("+155****0100", text)
+        suppressed = await adapter.send(
+            "+155****0100",
+            text,
+            metadata={"internal_notice": True},
+        )
+
+        assert legitimate.success is True
+        assert suppressed.success is True
+        assert suppressed.raw_response == {"suppressed": "internal_sms_notice"}
+        assert [payload["message"] for _, payload in api_calls] == [text]
+
+    @pytest.mark.asyncio
+    async def test_internal_notice_does_not_create_unresolved_phone_chat(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        create_calls = []
+
+        async def fake_resolve_chat_guid(chat_id):
+            return None
+
+        async def fake_create_chat(address, message, temp_guid=None):
+            create_calls.append((address, message, temp_guid))
+            raise AssertionError("internal notice must not create an unresolved phone chat")
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_create_chat_for_handle", fake_create_chat)
+
+        result = await adapter.send(
+            "+15555550100",
+            "Gateway restarting",
+            metadata={"internal_notice": True},
+        )
+
+        assert result.success is True
+        assert result.raw_response == {"suppressed": "internal_sms_notice"}
+        assert create_calls == []
+
+    @pytest.mark.asyncio
+    async def test_internal_notice_allows_plus_prefixed_email_handle(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        payloads = []
+
+        async def fake_resolve_chat_guid(chat_id):
+            return None
+
+        async def fake_api_post(path, payload):
+            payloads.append((path, payload))
+            return {"data": {"guid": "new-chat-message"}}
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        result = await adapter.send(
+            "+15555550100@example.com",
+            "Internal iMessage notice",
+            metadata={"internal_notice": True},
+        )
+
+        assert result.success is True
+        assert [path for path, _ in payloads] == ["/api/v1/chat/new"]
+
+    @pytest.mark.asyncio
+    async def test_new_chat_retry_reuses_idempotency_key(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        payloads = []
+
+        async def fake_resolve_chat_guid(chat_id):
+            return None
+
+        async def fake_api_post(path, payload):
+            assert path == "/api/v1/chat/new"
+            payloads.append(payload)
+            if len(payloads) == 1:
+                raise TimeoutError("response lost")
+            return {"data": {"guid": "new-chat-message"}}
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        metadata = {"reply_to_message_id": "origin-message-guid"}
+
+        first = await adapter.send("user@example.com", "hello", metadata=metadata)
+        second = await adapter.send("user@example.com", "hello", metadata=metadata)
+
+        assert first.success is False
+        assert second.success is True
+        assert payloads[0]["tempGuid"] == payloads[1]["tempGuid"]
+
+    @pytest.mark.asyncio
+    async def test_new_chat_sends_remaining_chunks_after_creation(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        resolve_calls = 0
+        payloads = []
+
+        async def fake_resolve_chat_guid(chat_id):
+            nonlocal resolve_calls
+            resolve_calls += 1
+            return None if resolve_calls == 1 else "iMessage;-;user@example.com"
+
+        async def fake_api_post(path, payload):
+            payloads.append((path, payload))
+            return {"data": {"guid": f"message-{len(payloads)}"}}
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        text = "x" * (adapter.MAX_MESSAGE_LENGTH + 1)
+
+        result = await adapter.send(
+            "user@example.com",
+            text,
+            metadata={"reply_to_message_id": "origin-message-guid"},
+        )
+
+        assert result.success is True
+        assert [path for path, _ in payloads] == [
+            "/api/v1/chat/new",
+            "/api/v1/message/text",
+        ]
+        assert "".join(payload["message"] for _, payload in payloads) == text
 
     def test_format_message_preserves_underscores_in_identifiers(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
@@ -112,6 +343,277 @@ class TestBlueBubblesMentionGating:
 
         assert response.status == 200
         assert handled == []
+
+    @pytest.mark.asyncio
+    async def test_duplicate_new_and_updated_events_are_handled_once(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        message = {
+            "guid": "same-message-guid",
+            "text": "hello once",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatIdentifier": "user@example.com",
+        }
+
+        first, second = await asyncio.gather(
+            adapter._handle_webhook(_FakeBlueBubblesRequest({
+                "type": "new-message",
+                "data": {**message, "chatGuid": "iMessage;-;user@example.com"},
+            })),
+            adapter._handle_webhook(_FakeBlueBubblesRequest({
+                "type": "updated-message",
+                "data": message,
+            })),
+        )
+        await asyncio.sleep(0)
+
+        assert first.status == 200
+        assert second.status == 200
+        assert [event.text for event in handled] == ["hello once"]
+
+    @pytest.mark.asyncio
+    async def test_meaningful_text_revision_with_same_guid_is_processed(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        base = {
+            "guid": "edited-message-guid",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatIdentifier": "user@example.com",
+        }
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {**base, "text": "original text"},
+        }))
+        await asyncio.sleep(0)
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {**base, "text": "edited text"},
+        }))
+        await asyncio.sleep(0)
+
+        assert [event.text for event in handled] == ["original text", "edited text"]
+
+    @pytest.mark.asyncio
+    async def test_attachment_revision_with_same_guid_is_processed(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_download_attachment(att_guid, att_meta):
+            return f"/tmp/{att_guid}"
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+        base = {
+            "guid": "attachment-revision-guid",
+            "text": "",
+            "handle": {"address": "user@example.com"},
+            "isFromMe": False,
+            "chatIdentifier": "user@example.com",
+        }
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                **base,
+                "attachments": [
+                    {
+                        "guid": "same-attachment",
+                        "mimeType": "application/octet-stream",
+                        "uti": "public.data",
+                    }
+                ],
+            },
+        }))
+        await asyncio.sleep(0)
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                **base,
+                "attachments": [
+                    {
+                        "guid": "same-attachment",
+                        "mimeType": "application/octet-stream",
+                        "uti": "public.caf",
+                    }
+                ],
+            },
+        }))
+        await asyncio.sleep(0)
+
+        assert [event.media_urls for event in handled] == [
+            ["/tmp/same-attachment"],
+            ["/tmp/same-attachment"],
+        ]
+
+    @pytest.mark.asyncio
+    async def test_attachment_readiness_transition_is_processed(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+        downloads = 0
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_download_attachment(att_guid, att_meta):
+            nonlocal downloads
+            downloads += 1
+            return None if downloads == 1 else f"/tmp/{att_guid}"
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+        payload = {
+            "type": "updated-message",
+            "data": {
+                "guid": "attachment-ready-guid",
+                "text": "caption",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chatIdentifier": "user@example.com",
+                "attachments": [{"guid": "same-attachment", "mimeType": "image/png"}],
+            },
+        }
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        await asyncio.sleep(0)
+        await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        await asyncio.sleep(0)
+
+        assert [event.media_urls for event in handled] == [
+            [],
+            ["/tmp/same-attachment"],
+        ]
+
+    @pytest.mark.asyncio
+    async def test_failed_dispatch_releases_guid_for_retry(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        attempts = 0
+        handled = []
+
+        async def fake_handle_message(event):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("transient dispatch failure")
+            handled.append(event.text)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        payload = {
+            "type": "new-message",
+            "data": {
+                "guid": "retryable-message-guid",
+                "text": "retry me",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chatIdentifier": "user@example.com",
+            },
+        }
+
+        first = await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        await asyncio.sleep(0)
+        second = await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        await asyncio.sleep(0)
+
+        assert first.status == 200
+        assert second.status == 200
+        assert attempts == 2
+        assert handled == ["retry me"]
+
+    @pytest.mark.asyncio
+    async def test_cancelled_dispatch_releases_identity_for_retry(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        attempts = 0
+        handled = []
+
+        async def fake_handle_message(event):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise asyncio.CancelledError()
+            handled.append(event.text)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        payload = {
+            "type": "new-message",
+            "data": {
+                "guid": "cancelled-message-guid",
+                "text": "retry cancellation",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chatIdentifier": "user@example.com",
+            },
+        }
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        await asyncio.sleep(0)
+        await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        await asyncio.sleep(0)
+
+        assert attempts == 2
+        assert handled == ["retry cancellation"]
+
+    @pytest.mark.asyncio
+    async def test_pending_identity_is_not_evicted_by_completed_lru(self, monkeypatch):
+        import gateway.platforms.bluebubbles as bluebubbles_module
+
+        monkeypatch.setattr(bluebubbles_module, "_MESSAGE_DEDUP_SIZE", 1)
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        started = asyncio.Event()
+        release = asyncio.Event()
+        attempts = {"pending-guid": 0, "completed-guid": 0}
+
+        async def fake_handle_message(event):
+            attempts[event.message_id] += 1
+            if event.message_id == "pending-guid":
+                started.set()
+                await release.wait()
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+        def payload(guid, text):
+            return {
+                "type": "new-message",
+                "data": {
+                    "guid": guid,
+                    "text": text,
+                    "handle": {"address": "user@example.com"},
+                    "isFromMe": False,
+                    "chatIdentifier": "user@example.com",
+                },
+            }
+
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(payload("pending-guid", "still running"))
+        )
+        await started.wait()
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(payload("completed-guid", "done"))
+        )
+        await asyncio.sleep(0)
+        await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(payload("pending-guid", "still running"))
+        )
+        await asyncio.sleep(0)
+        pending_attempts = attempts["pending-guid"]
+        release.set()
+        await asyncio.sleep(0)
+
+        assert pending_attempts == 1
 
 
 class TestBlueBubblesWebhookParsing:
@@ -283,6 +785,7 @@ class TestBlueBubblesWebhookUrl:
     """_webhook_url property normalises local hosts to 'localhost'."""
 
     def test_default_host(self, monkeypatch):
+        monkeypatch.delenv("BLUEBUBBLES_WEBHOOK_HOST", raising=False)
         adapter = _make_adapter(monkeypatch)
         # Default webhook_host is 0.0.0.0 → normalized to localhost
         assert "localhost" in adapter._webhook_url

--- a/tests/gateway/test_internal_notice_metadata.py
+++ b/tests/gateway/test_internal_notice_metadata.py
@@ -1,0 +1,72 @@
+"""Regression tests for structured internal gateway notice metadata."""
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import (
+    _internal_notice_metadata,
+    _non_conversational_metadata,
+    _send_or_update_status_coro,
+)
+
+
+def test_non_conversational_metadata_leaves_bluebubbles_actionable():
+    metadata = _non_conversational_metadata(
+        {"thread_id": "thread-1"},
+        platform=Platform.BLUEBUBBLES,
+    )
+
+    assert metadata == {"thread_id": "thread-1"}
+
+
+def test_internal_notice_metadata_marks_bluebubbles_suppressible():
+    metadata = _internal_notice_metadata(
+        {"thread_id": "thread-1"},
+        platform=Platform.BLUEBUBBLES,
+    )
+
+    assert metadata == {
+        "thread_id": "thread-1",
+        "internal_notice": True,
+    }
+
+
+def test_non_conversational_metadata_preserves_discord_marker():
+    metadata = _non_conversational_metadata({}, platform=Platform.DISCORD)
+
+    assert metadata == {"non_conversational": True}
+
+
+def test_internal_notice_metadata_marks_discord_both_ways():
+    metadata = _internal_notice_metadata({}, platform=Platform.DISCORD)
+
+    assert metadata == {
+        "internal_notice": True,
+        "non_conversational": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_status_delivery_marks_notice_internal():
+    class Adapter:
+        def __init__(self):
+            self.metadata = None
+
+        async def send(self, chat_id, content, metadata=None):
+            self.metadata = metadata
+            return "ok"
+
+    adapter = Adapter()
+    result = await _send_or_update_status_coro(
+        adapter,
+        "chat-1",
+        "compaction",
+        "Compacting context",
+        {"thread_id": "thread-1"},
+    )
+
+    assert result == "ok"
+    assert adapter.metadata == {
+        "thread_id": "thread-1",
+        "internal_notice": True,
+    }


### PR DESCRIPTION
## Summary

- keep BlueBubbles replies in one bubble unless the 4,000-character limit requires splitting
- make inbound webhook deduplication concurrent-safe, revision-aware, bounded, and retry-safe
- make originated outbound replies idempotent across concurrency and ambiguous retries without collapsing independent sends
- suppress explicitly classified internal notices on SMS routes while preserving actionable prompts and normal messages
- propagate structured internal-notice metadata only from operational lifecycle/status paths

## Verification

- BlueBubbles and internal-notice regression suites
- gateway shutdown and Discord free-response regression suites
- Ruff
- `git diff --check`
- independent security/correctness review
