### PR TITLE
feat(tools): add ha_get_camera_image to the Home Assistant toolset

### DIFF
--- a/tests/tools/test_homeassistant_tool.py
+++ b/tests/tools/test_homeassistant_tool.py
@@ -16,9 +16,11 @@ from tools.homeassistant_tool import (
     _parse_service_response,
     _get_headers,
     _handle_get_state,
+    _handle_get_camera_image,
     _handle_call_service,
     _BLOCKED_DOMAINS,
     _ENTITY_ID_RE,
+    _CAMERA_ENTITY_RE,
     _SERVICE_NAME_RE,
 )
 
@@ -327,6 +329,135 @@ class TestGetHeaders:
 # ---------------------------------------------------------------------------
 
 
+class TestCameraEntityValidation:
+    """_CAMERA_ENTITY_RE guards the entity_id interpolated into camera_proxy URL."""
+
+    def test_valid_camera_ids_accepted(self):
+        assert _CAMERA_ENTITY_RE.match("camera.front_door")
+        assert _CAMERA_ENTITY_RE.match("camera.backyard")
+        assert _CAMERA_ENTITY_RE.match("camera.cam1")
+
+    def test_non_camera_domain_rejected(self):
+        assert _CAMERA_ENTITY_RE.match("light.bedroom") is None
+        assert _CAMERA_ENTITY_RE.match("sensor.temperature") is None
+        assert _CAMERA_ENTITY_RE.match("switch.fan") is None
+
+    def test_path_traversal_rejected(self):
+        assert _CAMERA_ENTITY_RE.match("camera.../../etc/passwd") is None
+        assert _CAMERA_ENTITY_RE.match("../../api/config") is None
+        assert _CAMERA_ENTITY_RE.match("camera./../secrets") is None
+
+    def test_case_and_whitespace_rejected(self):
+        assert _CAMERA_ENTITY_RE.match("camera.FrontDoor") is None
+        assert _CAMERA_ENTITY_RE.match("CAMERA.front_door") is None
+        assert _CAMERA_ENTITY_RE.match("camera.front door") is None
+        assert _CAMERA_ENTITY_RE.match("camera.front;rm") is None
+
+
+class TestHandleGetCameraImage:
+    """ha_get_camera_image handler: validation + save path."""
+
+    def test_missing_entity_id(self):
+        result = json.loads(_handle_get_camera_image({}))
+        assert "error" in result
+        assert "entity_id" in result["error"]
+
+    def test_non_camera_entity_rejected(self):
+        result = json.loads(_handle_get_camera_image({"entity_id": "light.bedroom"}))
+        assert "error" in result
+        assert "Invalid camera entity_id" in result["error"]
+
+    def test_traversal_entity_rejected(self):
+        result = json.loads(_handle_get_camera_image({"entity_id": "camera.../../etc"}))
+        assert "error" in result
+        assert "Invalid camera entity_id" in result["error"]
+
+    def test_valid_request_saves_and_returns_path(self, tmp_path, monkeypatch):
+        # Stub the network read and the save directory.
+        from tools import homeassistant_tool as ha
+
+        class _FakeResp:
+            headers = {"Content-Type": "image/jpeg"}
+
+            def raise_for_status(self):
+                pass
+
+            async def read(self):
+                return b"\xff\xd8\xff\xe0FAKEJPEGDATA"
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+        class _FakeSession:
+            def get(self, *a, **k):
+                return _FakeResp()
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+        import aiohttp
+        monkeypatch.setattr(aiohttp, "ClientSession", lambda *a, **k: _FakeSession())
+        monkeypatch.setattr(ha, "_camera_image_dir", lambda: tmp_path)
+
+        result = json.loads(_handle_get_camera_image({"entity_id": "camera.front_door"}))
+        r = result["result"]
+        assert r["entity_id"] == "camera.front_door"
+        assert r["mime_type"] == "image/jpeg"
+        assert r["size_bytes"] == len(b"\xff\xd8\xff\xe0FAKEJPEGDATA")
+        # File written with the camera name (minus prefix) + extension
+        assert r["image_path"].endswith("front_door.jpg")
+        from pathlib import Path
+        assert Path(r["image_path"]).read_bytes() == b"\xff\xd8\xff\xe0FAKEJPEGDATA"
+
+    def test_unknown_content_type_defaults_to_jpeg(self, tmp_path, monkeypatch):
+        from tools import homeassistant_tool as ha
+
+        class _FakeResp:
+            headers = {"Content-Type": "application/octet-stream"}
+
+            def raise_for_status(self):
+                pass
+
+            async def read(self):
+                return b"DATA"
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+        class _FakeSession:
+            def get(self, *a, **k):
+                return _FakeResp()
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+        import aiohttp
+        monkeypatch.setattr(aiohttp, "ClientSession", lambda *a, **k: _FakeSession())
+        monkeypatch.setattr(ha, "_camera_image_dir", lambda: tmp_path)
+
+        result = json.loads(_handle_get_camera_image({"entity_id": "camera.cam1"}))
+        r = result["result"]
+        assert r["mime_type"] == "image/jpeg"
+        assert r["image_path"].endswith("cam1.jpg")
+
+
+# ---------------------------------------------------------------------------
+# Registry integration
+# ---------------------------------------------------------------------------
+
+
 class TestRegistration:
     def test_tools_registered_in_registry(self):
         from tools.registry import registry
@@ -334,6 +465,7 @@ class TestRegistration:
         names = registry.get_all_tool_names()
         assert "ha_list_entities" in names
         assert "ha_get_state" in names
+        assert "ha_get_camera_image" in names
         assert "ha_call_service" in names
 
 

--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -1,10 +1,11 @@
 """Home Assistant tool for controlling smart home devices via REST API.
 
-Registers four LLM-callable tools:
+Registers five LLM-callable tools:
 - ``ha_list_entities`` -- list/filter entities by domain or area
 - ``ha_get_state`` -- get detailed state of a single entity
 - ``ha_list_services`` -- list available services (actions) per domain
 - ``ha_call_service`` -- call a HA service (turn_on, turn_off, set_temperature, etc.)
+- ``ha_get_camera_image`` -- snapshot a camera entity to a file for viewing
 
 Authentication uses a Long-Lived Access Token via ``HASS_TOKEN`` env var.
 The HA instance URL is read from ``HASS_URL`` (default: http://homeassistant.local:8123).
@@ -15,6 +16,7 @@ import json
 import logging
 import os
 import re
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
@@ -136,6 +138,68 @@ async def _async_get_state(entity_id: str) -> Dict[str, Any]:
         "attributes": data.get("attributes", {}),
         "last_changed": data.get("last_changed"),
         "last_updated": data.get("last_updated"),
+    }
+
+
+# Camera entity_id must be a well-formed camera.* id. This value is
+# interpolated into /api/camera_proxy/{entity_id}, so the strict pattern also
+# blocks path traversal (e.g. "camera.../../etc/passwd") and URL injection.
+_CAMERA_ENTITY_RE = re.compile(r"^camera\.[a-z0-9_]+$")
+
+_MIME_TO_EXT = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+}
+
+
+def _camera_image_dir() -> Path:
+    """Return (and create) the directory for camera snapshots."""
+    from hermes_constants import get_hermes_home
+
+    d = get_hermes_home() / "tmp" / "camera"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+async def _async_get_camera_image(entity_id: str) -> Dict[str, Any]:
+    """Fetch a camera snapshot via /api/camera_proxy and save it to disk.
+
+    Returns the saved file path plus mime type and size. Callers can hand the
+    path to a vision tool to see what the camera is showing.
+    """
+    import aiohttp
+
+    hass_url, hass_token = _get_config()
+    url = f"{hass_url}/api/camera_proxy/{entity_id}"
+
+    async with aiohttp.ClientSession() as session:
+        async with session.get(
+            url,
+            headers=_get_headers(hass_token),
+            timeout=aiohttp.ClientTimeout(total=30),
+        ) as resp:
+            resp.raise_for_status()
+            image_bytes = await resp.read()
+            content_type = resp.headers.get("Content-Type", "image/jpeg")
+
+    # Normalize the MIME type (strip charset etc.); default to jpeg.
+    mime_type = content_type.split(";")[0].strip()
+    if mime_type not in _MIME_TO_EXT:
+        mime_type = "image/jpeg"
+
+    ext = _MIME_TO_EXT[mime_type]
+    # File name: the entity id without the "camera." prefix, e.g. "front_door.jpg".
+    name = entity_id.split(".", 1)[1]
+    dest = _camera_image_dir() / f"{name}{ext}"
+    dest.write_bytes(image_bytes)
+
+    return {
+        "entity_id": entity_id,
+        "mime_type": mime_type,
+        "size_bytes": len(image_bytes),
+        "image_path": str(dest),
     }
 
 
@@ -337,6 +401,24 @@ def _handle_list_services(args: dict, **kw) -> str:
         return tool_error(f"Failed to list services: {e}")
 
 
+def _handle_get_camera_image(args: dict, **kw) -> str:
+    """Handler for ha_get_camera_image tool."""
+    entity_id = args.get("entity_id", "")
+    if not entity_id:
+        return tool_error("Missing required parameter: entity_id")
+    if not _CAMERA_ENTITY_RE.match(entity_id):
+        return tool_error(
+            f"Invalid camera entity_id: {entity_id}. "
+            "Must be a camera entity (e.g. 'camera.front_door')."
+        )
+    try:
+        result = _run_async(_async_get_camera_image(entity_id))
+        return json.dumps({"result": result})
+    except Exception as e:
+        logger.error("ha_get_camera_image error: %s", e)
+        return tool_error(f"Failed to get camera image for {entity_id}: {e}")
+
+
 # ---------------------------------------------------------------------------
 # Availability check
 # ---------------------------------------------------------------------------
@@ -469,6 +551,29 @@ HA_CALL_SERVICE_SCHEMA = {
     },
 }
 
+HA_GET_CAMERA_IMAGE_SCHEMA = {
+    "name": "ha_get_camera_image",
+    "description": (
+        "Snapshot a Home Assistant camera entity. Saves the current frame to a "
+        "file and returns its path (plus mime type and size). Use this to see "
+        "what a camera is showing (front door, backyard, etc.); hand the "
+        "returned image_path to a vision tool to analyze it."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "entity_id": {
+                "type": "string",
+                "description": (
+                    "The camera entity ID (e.g. 'camera.front_door', "
+                    "'camera.backyard'). Must start with 'camera.'."
+                ),
+            },
+        },
+        "required": ["entity_id"],
+    },
+}
+
 
 # ---------------------------------------------------------------------------
 # Registration
@@ -499,6 +604,15 @@ registry.register(
     toolset="homeassistant",
     schema=HA_LIST_SERVICES_SCHEMA,
     handler=_handle_list_services,
+    check_fn=_check_ha_available,
+    emoji="🏠",
+)
+
+registry.register(
+    name="ha_get_camera_image",
+    toolset="homeassistant",
+    schema=HA_GET_CAMERA_IMAGE_SCHEMA,
+    handler=_handle_get_camera_image,
     check_fn=_check_ha_available,
     emoji="🏠",
 )


### PR DESCRIPTION
# feat(tools): add ha_get_camera_image to the Home Assistant toolset

## Summary

The built-in `homeassistant` toolset can read state (`ha_get_state`) and
control devices (`ha_call_service`), but has no way to see what a camera is
showing. This adds `ha_get_camera_image`: fetch a snapshot from a camera entity
via `GET /api/camera_proxy/{entity_id}`, save it to `$HERMES_HOME/tmp/camera/`,
and return the file path plus mime type and size so the frame can be handed to
a vision tool.

Example:

```text
ha_get_camera_image(entity_id="camera.front_door")
-> {"entity_id": "camera.front_door", "mime_type": "image/jpeg",
    "size_bytes": 51234, "image_path": ".../tmp/camera/front_door.jpg"}
```

## Why this shape (footprint ladder)

- **Pure addition to an existing toolset.** No new toolset, no new `HERMES_*`
  env var, gated by the same `_check_ha_available` check_fn, consistent with
  the existing `ha_*` tools.
- Uses `camera_proxy` (a plain authenticated REST GET) rather than a
  `camera/stream` + ffmpeg path, so it needs no extra binaries and works on
  every platform. A full-resolution stream grab is a nice-to-have that belongs
  in a plugin, not the core tool.
- Returns a file path (not inline base64), so the frame integrates cleanly with
  the vision tool and keeps the tool result small.

## Security

`entity_id` is validated against a strict `_CAMERA_ENTITY_RE`
(`^camera\.[a-z0-9_]+$`) before it is interpolated into the proxy URL. This
rejects path traversal (`camera.../../etc/passwd`), wrong domains
(`light.bedroom`), and whitespace/case injection, mirroring the guards already
applied to `ha_get_state` and `ha_call_service`.

## Credit / provenance

This builds on the camera approach from the now-closed PR #9397
(author @jkennedyvz), extracted as a focused, camera-only change off current
`main`. That PR bundled camera + history across 11 files and went `CONFLICTING`;
its author closed it ("moved on entirely"). This PR carries just the camera tool
forward. (The history half is covered separately by #74666.)

## Changes

**`tools/homeassistant_tool.py`**

- `_CAMERA_ENTITY_RE`, `_MIME_TO_EXT`, `_camera_image_dir()` helpers.
- `_async_get_camera_image(entity_id)`: async `camera_proxy` GET, normalizes
  the Content-Type (defaulting to jpeg), and writes the frame to
  `$HERMES_HOME/tmp/camera/<name><ext>`.
- `_handle_get_camera_image(args, **kw)`: validates `entity_id`, dispatches via
  `_run_async`.
- `HA_GET_CAMERA_IMAGE_SCHEMA` + `registry.register(name="ha_get_camera_image", ...)`.
- Module docstring updated (four -> five tools).

**`tests/tools/test_homeassistant_tool.py`**: 9 new tests across
`TestCameraEntityValidation` and `TestHandleGetCameraImage`:

- camera-entity regex accept and reject (wrong domain, path traversal, case,
  whitespace/semicolon)
- handler validation (missing entity_id, non-camera entity, traversal)
- fetch + save happy path (correct path, bytes round-trip, size), and the
  unknown-content-type -> jpeg fallback, using a stubbed aiohttp session and
  `tmp_path`

## How to Test

```bash
python -m pytest tests/tools/test_homeassistant_tool.py -o 'addopts=' -q
```

Expected: `44 passed` (35 pre-existing + 9 new). Camera-only:

```bash
python -m pytest tests/tools/test_homeassistant_tool.py -o 'addopts=' -q -k camera
```

Expected: `9 passed`. The camera tests also pass under
`-W error::RuntimeWarning` (no unawaited-coroutine noise introduced).

## Testing / platforms

Tested on Linux. The change is an aiohttp GET plus a file write via
`pathlib.Path` (same client pattern as the existing `ha_*` tools), with no
OS-specific process/signal code, so it is expected to behave identically on
macOS and Windows/WSL2.