### PR TITLE
fix(tui): session.history withholds the row_id message.react needs

### DIFF
--- a/tests/tui_gateway/test_session_history_row_ids.py
+++ b/tests/tui_gateway/test_session_history_row_ids.py
@@ -1,0 +1,103 @@
+"""``session.history`` must hand out the durable ``row_id`` for each message.
+
+``session.history`` is a renderer-facing projection: it returns
+``_history_to_messages(history)``, and that helper forwards ``row_id`` only
+when the history dicts carry ``_row_id`` (``tui_gateway/server.py``).
+
+``_row_id`` is opt-in (``include_row_ids=True``) so model-facing consumers —
+ACP restore, export, inspection, the post-undo live-replay reload — keep the
+historical transcript shape. Every *display* projection opts in; this pins
+``session.history`` to that side of the split, because ``message.react``
+addresses messages by exactly this id and its only fallback (``newest_role``)
+can reach the newest row of a role and nothing older.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_state import SessionDB
+from tui_gateway import server
+
+SESSION_KEY = "20260730_120000_abc123"
+
+
+@pytest.fixture
+def profile_home(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(SESSION_KEY, source="tui")
+    db.append_message(SESSION_KEY, "user", "first question")
+    db.append_message(SESSION_KEY, "assistant", "first answer")
+    db.append_message(SESSION_KEY, "user", "second question")
+    db.append_message(SESSION_KEY, "assistant", "second answer")
+    return tmp_path
+
+
+@pytest.fixture
+def live_session(profile_home):
+    sid = "tui-sid-1"
+    server._sessions[sid] = {
+        "session_key": SESSION_KEY,
+        "profile_home": str(profile_home),
+        "history": [],
+    }
+    try:
+        yield sid
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def _history(sid):
+    return server._methods["session.history"](1, {"session_id": sid})
+
+
+def test_session_history_carries_row_ids(live_session):
+    """Every rendered message is addressable by message.react."""
+    resp = _history(live_session)
+    messages = resp["result"]["messages"]
+
+    assert messages, "expected the persisted transcript"
+    missing = [m for m in messages if m.get("row_id") is None]
+    assert not missing, f"{len(missing)}/{len(messages)} messages have no row_id"
+
+
+def test_row_ids_match_the_durable_message_rows(live_session, profile_home):
+    """The ids handed out are the real ``messages.id`` values, in order."""
+    db = SessionDB(db_path=profile_home / "state.db")
+    expected = [
+        m["_row_id"]
+        for m in db.get_messages_as_conversation(
+            SESSION_KEY, include_ancestors=True, include_row_ids=True
+        )
+    ]
+
+    messages = _history(live_session)["result"]["messages"]
+    assert [m["row_id"] for m in messages] == expected
+
+
+def test_older_messages_are_addressable_not_just_the_newest(live_session, profile_home):
+    """The regression's user-visible shape: reacting to an older message.
+
+    Without row_ids the only way to name a message is ``newest_role``, which
+    resolves to the newest row of that role — so every earlier message becomes
+    unreactable.
+    """
+    db = SessionDB(db_path=profile_home / "state.db")
+    newest_user = db.latest_message_row_id(SESSION_KEY, role="user")
+
+    messages = _history(live_session)["result"]["messages"]
+    user_rows = [m["row_id"] for m in messages if m["role"] == "user"]
+
+    assert len(user_rows) > 1, "fixture should have more than one user turn"
+    older = [r for r in user_rows if r != newest_user]
+    assert older, "expected at least one message the newest_role fallback cannot reach"
+
+    # The write path accepts them — only the projection was withholding the id.
+    assert db.set_message_reaction(SESSION_KEY, older[0], "\N{THUMBS UP SIGN}") is not None
+
+
+def test_model_facing_projection_keeps_historical_shape(profile_home):
+    """Guard the other half of the split: no row ids leak into replay history."""
+    db = SessionDB(db_path=profile_home / "state.db")
+    replay = db.get_messages_as_conversation(SESSION_KEY, repair_alternation=True)
+    assert all("_row_id" not in m for m in replay)

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2265,8 +2265,16 @@ def _(rid, params: dict) -> dict:
         with _session_db(session) as db:
             if db is not None:
                 try:
+                    # Renderer-facing projection: the payload below goes
+                    # through _history_to_messages, which forwards the durable
+                    # ``row_id`` that message.react addresses. Ask for the row
+                    # ids like every other display projection does. Model-facing
+                    # reloads deliberately stay opt-out so ACP restore/export
+                    # keep the historical transcript shape.
                     history = db.get_messages_as_conversation(
-                        session["session_key"], include_ancestors=True
+                        session["session_key"],
+                        include_ancestors=True,
+                        include_row_ids=True,
                     )
                 except Exception:
                     pass


### PR DESCRIPTION
## What

`session.history` hands the renderer a transcript with **no durable message ids**, so the new reactions feature can only ever react to the newest message.

`session.history` is a renderer-facing projection — it returns `_history_to_messages(history)`, and that helper forwards `row_id` only when the history dicts carry `_row_id`:

```python
# tui_gateway/server.py
if m.get("_row_id") is not None:
    msg["row_id"] = m["_row_id"]
```

`1af883913` made `_row_id` opt-in (`include_row_ids=True`) so model-facing consumers — ACP restore, export, inspection — keep the historical transcript shape. That was the right call, and every other **display** projection was updated to opt in (`server.py` resume/display paths, `session.resume` in `methods_session.py`). `session.history` was missed.

`message.react` addresses messages by exactly that id, and its docstring says so: *"`row_id` is the durable `messages.id` forwarded by `_history_to_messages` — the renderer's own message ids are ephemeral."* Its only fallback, `newest_role`, resolves to the newest row of a role — so with the ids gone, every message except the latest becomes unreactable.

Measured on a 4-message transcript:

```
session.history  : 0/4 messages addressable   (row_id missing)
sibling projections : 4/4
newest_role fallback reaches user row 3; user row 1 is unreachable
```

The write path is fine — `set_message_reaction` accepts the older row once you can name it. Only the projection was withholding the id.

## Fix

Pass `include_row_ids=True` in `session.history`, matching the other display projections. The post-undo live-replay reload (`methods_tools.py`) deliberately stays opt-out so replay history keeps its historical shape.

## Tests

`tests/tui_gateway/test_session_history_row_ids.py` — 4 tests; the 3 behavioral ones fail without the fix (`KeyError: 'row_id'`), the 4th guards the other half of the split:

- every rendered message carries `row_id`
- the ids are the real `messages.id` values, in order
- older messages are addressable, not just the one `newest_role` can reach
- model-facing replay history still has no `_row_id`

```
tests/tui_gateway/test_session_history_row_ids.py ....  4 passed
```

Suite unaffected: `794 passed` across `tests/tui_gateway/` + `tests/test_tui_gateway_server.py` (the 2 failures there — `test_entry_import_off_main_thread`, `test_append_log_record_single_write_lines` — reproduce identically on `main` without this change).

