### PR TITLE
fix(mem0): skip LLM extraction in OSS mode to avoid json_object response_format error

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -489,11 +489,14 @@ class Mem0MemoryProvider(MemoryProvider):
                     {"role": "user", "content": user_content},
                     {"role": "assistant", "content": assistant_content},
                 ]
+                # OSS: local LLMs rarely support json_object response_format, so skip
+                # LLM extraction to avoid 400 errors. Platform/self-hosted can infer.
+                _infer = True if self._mode != "oss" else False
                 backend.add(
                     messages,
                     user_id=self._user_id,
                     agent_id=self._agent_id,
-                    infer=True,
+                    infer=_infer,
                     metadata=self._write_metadata(),
                 )
                 self._record_success()


### PR DESCRIPTION
## Problem

Local LLM APIs (e.g. llama.cpp, mlx) typically reject `response_format: {"type": "json_object"}` which mem0 uses during `sync_turn` LLM extraction. This causes a 400 error on every background turn sync, which increments the circuit breaker and degrades reliability.

## Fix

Set `infer=False` in `sync_turn` when mode is `"oss"` so messages are stored verbatim without LLM extraction. Platform and self-hosted HTTP modes remain unaffected.

## Verification

All 57 mem0 plugin tests pass:
- test_mem0_providers.py  (8 passed)
- test_mem0_backend.py    (7 passed)
- test_mem0_setup.py      (18 passed)
- test_mem0_v3.py         (24 passed)