### PR TITLE
fix(update): match gateways using full command lines

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -325,6 +325,14 @@ def get_process_start_time(pid: int) -> Optional[int]:
     return _get_process_start_time(pid)
 
 
+def _format_process_argv(parts: list[str]) -> str:
+    """Rebuild an argv list without losing argument boundaries."""
+    normalized = [str(part) for part in parts]
+    if _IS_WINDOWS:
+        return subprocess.list2cmdline(normalized)
+    return shlex.join(normalized)
+
+
 def _read_process_cmdline(pid: int) -> Optional[str]:
     """Return the process command line as a space-separated string.
 
@@ -332,6 +340,7 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
     platforms without /proc, falls back to ``ps -p <pid> -o command=``.
     On Windows (no /proc, no ps), uses psutil.
     """
+
     cmdline_path = Path(f"/proc/{pid}/cmdline")
     try:
         raw = cmdline_path.read_bytes()
@@ -339,7 +348,13 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
         pass
     else:
         if raw:
-            return raw.replace(b"\x00", b" ").decode("utf-8", errors="ignore").strip()
+            parts = [
+                part.decode("utf-8", errors="ignore")
+                for part in raw.split(b"\x00")
+                if part
+            ]
+            if parts:
+                return _format_process_argv(parts)
 
     if not _IS_WINDOWS:
         try:
@@ -360,7 +375,7 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
         proc = psutil.Process(pid)
         cmdline_parts = proc.cmdline()
         if cmdline_parts:
-            return " ".join(cmdline_parts)
+            return _format_process_argv(list(cmdline_parts))
     except Exception:
         pass
 
@@ -399,21 +414,82 @@ def _gateway_command_subcommand(command: str | None) -> str | None:
     if not tokens:
         return None
 
-    # Gateway-dedicated entrypoints carry no subcommand to inspect.
-    for token in tokens:
-        if token == "gateway/run.py" or token.endswith("/gateway/run.py"):
+    # ``ps -o command=`` may include leading shell-style environment
+    # assignments even though they are not part of the executable argv.
+    # Skip only syntactically valid NAME=value prefixes; assignments that
+    # occur later remain ordinary arguments and cannot confer gateway identity.
+    while tokens:
+        name, separator, _value = tokens[0].partition("=")
+        valid_name = bool(name) and (name[0].isalpha() or name[0] == "_") and all(
+            char.isalnum() or char == "_" for char in name
+        )
+        if not separator or not valid_name:
+            break
+        tokens.pop(0)
+    if not tokens:
+        return None
+
+    def _basename(token: str) -> str:
+        return token.rsplit("/", 1)[-1]
+
+    def _is_python_launcher(token: str) -> bool:
+        stem = _basename(token)
+        if stem.endswith(".exe"):
+            stem = stem[:-4]
+        for prefix in ("python", "pythonw"):
+            if not stem.startswith(prefix):
+                continue
+            version = stem[len(prefix) :]
+            if not version or all(
+                part.isdigit() and part for part in version.split(".")
+            ):
+                return True
+        return False
+
+    first = tokens[0]
+    first_basename = _basename(first)
+    is_python = _is_python_launcher(first)
+
+    # Gateway-dedicated entrypoints carry no subcommand to inspect. Treat an
+    # entrypoint as process identity only when it occupies argv[0], or argv[1]
+    # directly after a Python interpreter. Argument text that merely mentions
+    # one of these paths must not exempt an unrelated venv holder.
+    if first == "gateway/run.py" or first.endswith("/gateway/run.py"):
+        return "run"
+    if first_basename in ("hermes-gateway", "hermes-gateway.exe"):
+        return "run"
+    if is_python and len(tokens) > 1:
+        script = tokens[1]
+        script_basename = _basename(script)
+        if script == "gateway/run.py" or script.endswith("/gateway/run.py"):
             return "run"
-        basename = token.rsplit("/", 1)[-1]
-        if basename in ("hermes-gateway", "hermes-gateway.exe"):
+        if script_basename in ("hermes-gateway", "hermes-gateway.exe"):
             return "run"
 
-    joined = " ".join(tokens)
-    has_gateway_entry = (
-        "hermes_cli.main" in joined
-        or "hermes_cli/main.py" in joined
-        or any(t.rsplit("/", 1)[-1] in ("hermes", "hermes.exe") for t in tokens)
-    )
-    if not has_gateway_entry:
+    # Accept only actual Hermes entrypoint positions: the native launcher at
+    # argv[0], ``python -m hermes_cli.main``, or a direct main.py script. Keep
+    # only arguments after that entrypoint so a later ordinary argument named
+    # ``gateway`` cannot shadow the real subcommand.
+    gateway_args: list[str] | None = None
+    if first_basename in ("hermes", "hermes.exe"):
+        gateway_args = tokens[1:]
+    elif is_python and len(tokens) > 2 and tokens[1] == "-m":
+        module = tokens[2]
+        if module == "hermes_cli.main" or (
+            module == "hermes_cli/main.py" or module.endswith("/hermes_cli/main.py")
+        ):
+            gateway_args = tokens[3:]
+    elif is_python and len(tokens) > 1:
+        script = tokens[1]
+        script_basename = _basename(script)
+        if script == "hermes_cli/main.py" or script.endswith("/hermes_cli/main.py"):
+            gateway_args = tokens[2:]
+        elif script_basename in ("hermes", "hermes.exe"):
+            # POSIX console scripts are shebang files, so /proc may expose the
+            # interpreter as argv[0] and the installed ``hermes`` script as
+            # argv[1]. Do not search later arguments for the launcher name.
+            gateway_args = tokens[2:]
+    if gateway_args is None:
         return None
 
     # Drop profile selectors anywhere: --profile X / -p X / --profile=X / -p=X.
@@ -421,7 +497,7 @@ def _gateway_command_subcommand(command: str | None) -> str | None:
     # token is the one we land on below.
     filtered: list[str] = []
     skip_next = False
-    for token in tokens:
+    for token in gateway_args:
         if skip_next:
             skip_next = False
             continue
@@ -432,13 +508,11 @@ def _gateway_command_subcommand(command: str | None) -> str | None:
             continue
         filtered.append(token)
 
-    for i, token in enumerate(filtered):
-        if token != "gateway":
-            continue
-        if i + 1 >= len(filtered):
-            return "run"  # bare `hermes gateway` defaults to `run`
-        return filtered[i + 1]
-    return None
+    if not filtered or filtered[0] != "gateway":
+        return None
+    if len(filtered) == 1:
+        return "run"  # bare `hermes gateway` defaults to `run`
+    return filtered[1]
 
 
 def looks_like_gateway_command_line(command: str | None) -> bool:
@@ -477,7 +551,8 @@ def _record_looks_like_gateway(record: dict[str, Any]) -> bool:
     if not isinstance(argv, list) or not argv:
         return False
 
-    cmdline = " ".join(str(part) for part in argv)
+    parts = [str(part) for part in argv]
+    cmdline = _format_process_argv(parts)
     return looks_like_gateway_runtime_command_line(cmdline)
 
 

--- a/hermes_cli/_scan_venv_blockers.py
+++ b/hermes_cli/_scan_venv_blockers.py
@@ -136,7 +136,10 @@ def main() -> None:
     try:
         from hermes_cli.main import _detect_venv_python_processes  # noqa: PLC0415
 
-        matches = _detect_venv_python_processes()
+        # Gateway identity may occur after a long install path and profile
+        # selector. Match against the full command, then redact/truncate only
+        # the human-facing JSON below.
+        matches = _detect_venv_python_processes(truncate_cmdline=False)
     except Exception as exc:
         _emit_probe_fail(f"scan aborted: {exc}")
 
@@ -144,7 +147,7 @@ def main() -> None:
         {
             "pid": pid,
             "name": name,
-            "cmdline": _redact_sensitive_cmdline(cmdline),
+            "cmdline": _redact_sensitive_cmdline(cmdline)[:120],
         }
         for pid, name, cmdline in matches
         if not _is_pausable_gateway(cmdline)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -711,9 +711,9 @@ def _capture_gateway_argv(pid: int) -> list[str] | None:
     # reported by the scan: only respawn things that actually look like a
     # gateway run command line.
     try:
-        from gateway.status import looks_like_gateway_command_line
+        from gateway.status import _format_process_argv, looks_like_gateway_command_line
 
-        if not looks_like_gateway_command_line(" ".join(argv)):
+        if not looks_like_gateway_command_line(_format_process_argv(argv)):
             return None
     except Exception:
         pass

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2840,7 +2840,9 @@ def _venv_core_imports_healthy() -> tuple[bool, str]:
     return True, ""
 
 def _detect_venv_python_processes(
-    *, exclude_pids: set[int] | None = None
+    *,
+    exclude_pids: set[int] | None = None,
+    truncate_cmdline: bool = True,
 ) -> list[tuple[int, str, str]]:
     """Find live processes running from the project venv's interpreter.
 
@@ -2854,7 +2856,10 @@ def _detect_venv_python_processes(
     Killing them from here is pointless — the Desktop app supervises its
     backend and respawns it within seconds — so the caller should refuse and
     tell the user to close the app instead. Returns ``(pid, name, cmdline)``
-    tuples; empty off-Windows / without psutil / when nothing matches. The
+    tuples. Command lines are shortened for human-facing diagnostics by
+    default; process-identity callers must request the full text with
+    ``truncate_cmdline=False``. Empty off-Windows / without psutil / when
+    nothing matches. The
     calling process and its ancestors are always excluded (a CLI ``hermes
     update`` itself runs from the venv python). Never raises.
     """
@@ -2901,7 +2906,9 @@ def _detect_venv_python_processes(
             exe_norm = str(Path(exe).resolve()).lower()
         except (OSError, ValueError):
             exe_norm = str(exe).lower()
-        cmdline_raw = " ".join(info.get("cmdline") or [])
+        cmdline_raw = subprocess.list2cmdline(
+            [str(part) for part in (info.get("cmdline") or [])]
+        )
         cmdline_low = cmdline_raw.lower()
         cwd_low = str(info.get("cwd") or "").lower().rstrip(os.sep) + os.sep
 
@@ -2921,7 +2928,8 @@ def _detect_venv_python_processes(
         if not is_holder:
             continue
         name = info.get("name") or Path(exe).name
-        matches.append((int(pid), str(name), cmdline_raw[:120]))
+        command = cmdline_raw[:120] if truncate_cmdline else cmdline_raw
+        matches.append((int(pid), str(name), command))
     return matches
 
 def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> str:
@@ -3044,6 +3052,7 @@ def _leftover_pausable_gateway_pids(
     REPL, a stray script, or the Desktop backend has no pause machinery
     downstream, and the guard must keep refusing exactly as before.
     """
+    from gateway.status import _format_process_argv
     from hermes_cli._scan_venv_blockers import _is_pausable_gateway
 
     try:
@@ -3056,7 +3065,8 @@ def _leftover_pausable_gateway_pids(
         argv = cmdline
         if psutil is not None:
             try:
-                argv = " ".join(psutil.Process(int(pid)).cmdline()) or cmdline
+                live_argv = list(psutil.Process(int(pid)).cmdline() or [])
+                argv = _format_process_argv(live_argv) or cmdline
             except Exception:
                 pass
         if not _is_pausable_gateway(argv):

--- a/tests/gateway/test_gateway_command_line_matcher.py
+++ b/tests/gateway/test_gateway_command_line_matcher.py
@@ -22,11 +22,16 @@ ACCEPT = [
     r"C:\Users\me\hermes\venv\Scripts\pythonw.exe -m hermes_cli.main gateway run",
     "python -m hermes_cli.main --profile work gateway run",
     "python -m hermes_cli.main gateway run --replace",
+    "python3.11 -m hermes_cli.main gateway run",
+    "pythonw3.11.exe -m hermes_cli.main gateway run",
     "python -m hermes_cli/main.py gateway run",
+    "python hermes_cli/main.py gateway run",
+    "/opt/hermes/venv/bin/python /opt/hermes/venv/bin/hermes gateway run",
     "python gateway/run.py",
     "hermes-gateway.exe",
     "hermes gateway",          # bare `hermes gateway` defaults to run
     "hermes gateway run",
+    "HERMES_HOME=/opt/data/profiles/work hermes gateway run",
     # profile selector AFTER the `gateway` token (argv is profile-position
     # agnostic — _apply_profile_override strips --profile/-p anywhere)
     "hermes gateway --profile work run",
@@ -48,6 +53,17 @@ REJECT = [
     "python -m hermes_cli.main gateway stop",
     "python -m hermes_cli.main --profile x dashboard",    # non-gateway subcommand
     "some random python -m mygateway thing",
+    # Entry-point-like text in ordinary script arguments is not process
+    # identity. These holders must not be exempted from the update guard.
+    "python.exe myscript.py hermes_cli.main gateway run",
+    "python.exe -c print hermes_cli.main gateway run",
+    "python.exe worker.py --note hermes_cli.main gateway run",
+    r"python.exe worker.py C:\\tools\\hermes.exe gateway run",
+    "python.exe worker.py gateway/run.py",
+    "hermes chat gateway run",
+    "python -m hermes_cli.main chat gateway run",
+    "python hermes_cli/main.py dashboard gateway run",
+    "python /opt/hermes/venv/bin/not-hermes gateway run",
     "",
     None,
 ]
@@ -56,5 +72,35 @@ REJECT = [
 @pytest.mark.parametrize("cmd", ACCEPT)
 def test_accepts_real_gateway_run(cmd):
     assert matches(cmd) is True
+
+
+@pytest.mark.parametrize("cmd", REJECT)
+def test_rejects_non_gateway_commands(cmd):
+    assert matches(cmd) is False
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "hermes gateway restart",
+        "python -m hermes_cli.main gateway restart",
+        "/opt/hermes/venv/bin/python /opt/hermes/venv/bin/hermes gateway restart",
+    ],
+)
+def test_runtime_matcher_accepts_restart_without_calling_it_run(cmd):
+    assert matches_runtime(cmd) is True
+    assert matches(cmd) is False
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "hermes gateway status",
+        "hermes gateway stop",
+        "hermes dashboard gateway restart",
+    ],
+)
+def test_runtime_matcher_rejects_non_runtime_commands(cmd):
+    assert matches_runtime(cmd) is False
 
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -799,6 +799,33 @@ class TestReadProcessCmdlinePsFallback:
         assert "hermes_cli/main.py" in result
         assert calls == ["proc"]
 
+    def test_windows_psutil_preserves_argv_boundaries_for_space_path(
+        self, monkeypatch
+    ):
+        parts = [
+            r"C:\Program Files\Hermes\venv\Scripts\python.exe",
+            "-m",
+            "hermes_cli.main",
+            "gateway",
+            "run",
+        ]
+        fake_psutil = SimpleNamespace(
+            Process=lambda _pid: SimpleNamespace(cmdline=lambda: parts)
+        )
+        monkeypatch.setattr(
+            status.Path,
+            "read_bytes",
+            lambda self: (_ for _ in ()).throw(FileNotFoundError),
+        )
+        monkeypatch.setattr(status, "_IS_WINDOWS", True)
+        monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+        result = status._read_process_cmdline(873)
+
+        assert result is not None
+        assert result.startswith('"C:\\Program Files\\Hermes')
+        assert status.looks_like_gateway_command_line(result) is True
+
 
 class TestCorruptStatusFiles:
     """A status / pid file holding non-UTF-8 (binary) bytes must read as

--- a/tests/hermes_cli/test_gateway_external_supervisor.py
+++ b/tests/hermes_cli/test_gateway_external_supervisor.py
@@ -1,10 +1,27 @@
 """Tests for explicit ownership by a wrapped external gateway supervisor."""
 
+import sys
 from types import SimpleNamespace
 
 import pytest
 
 import hermes_cli.gateway as gateway
+
+
+def test_capture_gateway_argv_preserves_windows_space_path(monkeypatch):
+    argv = [
+        r"C:\Program Files\Hermes\venv\Scripts\pythonw.exe",
+        "-m",
+        "hermes_cli.main",
+        "gateway",
+        "run",
+    ]
+    fake_psutil = SimpleNamespace(
+        Process=lambda _pid: SimpleNamespace(cmdline=lambda: argv)
+    )
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+    assert gateway._capture_gateway_argv(1234) == argv
 
 
 def _clear_native_supervisor_markers(monkeypatch):

--- a/tests/hermes_cli/test_scan_venv_blockers.py
+++ b/tests/hermes_cli/test_scan_venv_blockers.py
@@ -157,11 +157,61 @@ def _run_main_with_detector(monkeypatch, capsys, matches):
         monkeypatch.setitem(sys.modules, name, mod)
     import hermes_cli.main as cli_main
 
-    monkeypatch.setattr(cli_main, "_detect_venv_python_processes", lambda: matches)
+    monkeypatch.setattr(
+        cli_main,
+        "_detect_venv_python_processes",
+        lambda **_kwargs: matches,
+    )
     with pytest.raises(SystemExit) as excinfo:
         main()
     out = capsys.readouterr().out
     return excinfo.value.code, json.loads(out)
+
+
+def test_main_uses_full_command_line_for_gateway_identity(monkeypatch, capsys):
+    """Long profile commands must be classified before display truncation."""
+    for name, mod in _psutil_fake().items():
+        monkeypatch.setitem(sys.modules, name, mod)
+    import hermes_cli.main as cli_main
+
+    full_command = (
+        r"C:\Users\Administrator\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe"
+        " -m hermes_cli.main --profile quality-manager gateway run"
+    )
+    assert len(full_command) > 120
+    calls: list[bool] = []
+
+    def fake_detector(*, truncate_cmdline: bool = True):
+        calls.append(truncate_cmdline)
+        command = full_command[:120] if truncate_cmdline else full_command
+        return [(12, "python.exe", command)]
+
+    monkeypatch.setattr(cli_main, "_detect_venv_python_processes", fake_detector)
+
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+
+    data = json.loads(capsys.readouterr().out)
+    assert excinfo.value.code == 0
+    assert calls == [False]
+    assert data["blocked"] is False
+    assert data["processes"] == []
+    assert data["pausable_gateways"] == 1
+
+
+def test_main_truncates_reported_command_after_identity_check(monkeypatch, capsys):
+    """Full commands are for matching only; diagnostics stay display-sized."""
+    long_serve = "python.exe -m hermes_cli.main serve " + "x" * 180
+
+    code, data = _run_main_with_detector(
+        monkeypatch,
+        capsys,
+        [(78, "python.exe", long_serve)],
+    )
+
+    assert code == 0
+    assert data["blocked"] is True
+    assert data["processes"][0]["cmdline"] == long_serve[:120]
 
 
 def test_main_exempts_gateway_chain_but_keeps_other_holders(monkeypatch, capsys):

--- a/tests/hermes_cli/test_update_concurrent_quarantine.py
+++ b/tests/hermes_cli/test_update_concurrent_quarantine.py
@@ -435,7 +435,7 @@ def test_pause_kill_set_covers_venv_guard_abort_set(
 
 
 GATEWAY_ARGV = [
-    r"C:\x\venv\Scripts\python.exe",
+    r"C:\Program Files\Hermes\venv\Scripts\python.exe",
     "-m",
     "hermes_cli.main",
     "gateway",

--- a/tests/hermes_cli/test_update_venv_health.py
+++ b/tests/hermes_cli/test_update_venv_health.py
@@ -86,6 +86,40 @@ def test_detect_venv_python_excludes_self_and_ancestors(_winp, tmp_path):
         assert cli_main._detect_venv_python_processes() == []
 
 
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_detect_venv_python_preserves_argv_boundaries_for_space_path(
+    _winp, tmp_path
+):
+    project_root = tmp_path / "Program Files" / "Hermes"
+    venv_py = str(project_root / "venv" / "Scripts" / "python.exe")
+    parts = [
+        venv_py,
+        "-m",
+        "hermes_cli.main",
+        "--profile",
+        "quality-manager",
+        "gateway",
+        "run",
+    ]
+    me = MagicMock()
+    me.parents.return_value = []
+    fake_psutil = types.SimpleNamespace(
+        process_iter=lambda attrs: iter([_proc(987654, venv_py, "python.exe", parts)]),
+        Process=lambda *a, **k: me,
+    )
+    with patch.object(cli_main, "PROJECT_ROOT", project_root), patch.dict(
+        sys.modules, {"psutil": fake_psutil}
+    ):
+        matches = cli_main._detect_venv_python_processes(truncate_cmdline=False)
+
+    assert len(matches) == 1
+    command = matches[0][2]
+    assert command.startswith(f'"{venv_py}"')
+    from gateway.status import looks_like_gateway_command_line
+
+    assert looks_like_gateway_command_line(command) is True
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- use full Windows venv-holder command lines for internal gateway identity matching
- preserve argv boundaries for Windows paths containing spaces
- redact and cap command lines at 120 characters only when emitting human-facing blocker diagnostics
- require a real Hermes gateway entrypoint and first subcommand position, so unrelated venv processes remain blockers
- preserve the existing default truncated detector behavior and fail-closed update guard

## Why
The Windows blocker detector shortened every process command line to 120 characters before gateway classification. With the managed install path and `--profile quality-manager`, the real command is 137 characters and was truncated before `gateway run`:

```text
... -m hermes_cli.main --profile quality-ma
```

The Desktop preflight therefore reported the managed gateway as an unknown venv holder (`pausable_gateways: 0`) and aborted the update.

Using full command lines for identity checks also required tightening the shared matcher: gateway entrypoint text in ordinary script arguments must not exempt an unrelated process, and argv arrays must retain quoting around paths with spaces.

## Safety
- full command lines stay internal to process classification
- diagnostics are redacted before being capped at 120 characters
- unknown/non-gateway venv holders still block the update
- matcher requires a real Hermes entrypoint and `gateway` as the first subcommand after profile selectors
- valid `hermes`, `python -m hermes_cli.main`, direct script, environment-prefix, versioned Python, and space-path launch forms remain supported

## Validation
- `uv run --with pytest --with pytest-xdist pytest -q -n auto tests/hermes_cli/test_scan_venv_blockers.py tests/hermes_cli/test_update_venv_health.py tests/hermes_cli/test_update_concurrent_quarantine.py tests/hermes_cli/test_gateway_external_supervisor.py tests/gateway/test_gateway_command_line_matcher.py tests/gateway/test_status.py tests/hermes_cli/test_gateway_proc_fallback.py tests/hermes_cli/test_gateway_service.py` — 145 passed, 1 skipped
- `uv run --with ruff ruff check ...` on all ten changed Python files — passed
- `python -m py_compile` on all ten changed Python files — passed
- Windows process-table integration check against a real `--profile quality-manager gateway run` process:
  - full command length: 137
  - full command classified as pausable: true
  - legacy 120-character command classified as pausable: false
  - unrelated-holder false positives: 0/4
  - quoted `C:\Program Files\...` gateway path classified correctly: true
  - POSIX Python shebang/console-script gateway classified correctly: true
  - `gateway restart` remains runtime-only and is not classified as `run`: true

Follow-up to #74326.
