### PR TITLE
docs(user-stories): add a user story about a hermes published magazine

### DIFF
--- a/website/src/data/userStories.json
+++ b/website/src/data/userStories.json
@@ -2880,5 +2880,16 @@
     "headline": "Recursively built a Supabase-backed CRM dashboard where each build reuses prior components",
     "quote": "Used the Hermes Desktop App to recursively generate a CRM dashboard where each build reuses components from prior generations; it can also build full videos using official HyperFrame skills — HTML-native, full control over scenes, animations, and rendering.",
     "size": "sm"
+  },
+  {
+    "id": "ronihelppi-hermes-kindle-magazine",
+    "source": "blog",
+    "author": "Roni Helppi",
+    "url": "https://ronihelppi.com/writing/every-monday-my-agent-ships-me-a-magazine/",
+    "date": "2026-07-30",
+    "category": "personal-assistant",
+    "headline": "Every Monday, my agent ships me a magazine",
+    "quote": "Every Monday at 9AM, a cron job fires on my private server, and a new issue of The Home Desk lands on my Kindle: a weekly magazine of interesting blog posts, articles, and essays, compiled and published by my AI agent. Hermes has chosen the pieces, found a theme, written a short editorial foreword, built an epub, and shipped it to my Kindle.",
+    "size": "md"
   }
 ]


### PR DESCRIPTION
## What does this PR do?

Adds a user story about a Hermes published magazine to the docs user stories section.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Adds a user story about a Hermes published magazine to the docs user stories section.

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A
- I've updated tool descriptions/schemas if I changed tool behavior — N/A