### PR TITLE
docs(observability): document the audit and receipt-chain integration seam

### DIFF
--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -322,3 +322,8 @@ The bundled NeMo Relay plugin maps the same generic observer contract to NeMo
 Relay scopes, LLM spans, tool spans, marks, ATOF streams, and ATIF exports.
 NeMo Relay-specific configuration and examples live in
 [`plugins/observability/nemo_relay/README.md`](../../plugins/observability/nemo_relay/README.md).
+
+Audit and receipt-chain plugins use the same hooks with a different goal: producing
+signed, tamper-evident records rather than telemetry. The integration seam, the rules
+that differ from tracing, and the external implementations are documented in
+[Audit and receipt-chain plugins](audit-receipt-chains.md).

--- a/docs/observability/audit-receipt-chains.md
+++ b/docs/observability/audit-receipt-chains.md
@@ -1,0 +1,133 @@
+# Audit and Receipt-Chain Plugins
+
+This page documents the integration seam for plugins that build **tamper-evident audit
+trails** of agent activity: signed, hash-chained receipts of what a tool did, intended to
+survive scrutiny by someone who was not there when it ran.
+
+This is a different goal from tracing. Tracing answers *what did we observe and log?*.
+A receipt chain answers *what can we still prove happened, to a party who does not trust
+the operator?*. The two use the same hooks; only the guarantees differ.
+
+Signing and anchoring live outside core. The observer hook contract already carries
+everything a receipt chain needs, so these plugins integrate with **zero core changes**.
+See [#487](https://github.com/NousResearch/hermes-agent/issues/487) for the discussion that
+settled this, and [#49371](https://github.com/NousResearch/hermes-agent/pull/49371) for the
+proposed opt-in, local-only execution-receipt substrate, which is explicitly not a signing
+or proving feature and composes with the plugins below rather than replacing them.
+
+## The three-hook pattern
+
+Register from your plugin's `register(ctx)`:
+
+```python
+def register(ctx):
+    ctx.register_hook("pre_tool_call", on_pre_tool_call)
+    ctx.register_hook("post_tool_call", on_post_tool_call)
+    ctx.register_hook("transform_tool_result", on_transform_tool_result)  # optional
+```
+
+| Hook | Role in a receipt chain |
+| --- | --- |
+| `pre_tool_call` | Sign the *authorization*: what the agent intended to do, and under which policy, before it ran. |
+| `post_tool_call` | Sign the *outcome*: arguments, result, status, duration. This is the minimum viable receipt. |
+| `transform_tool_result` | Optional. Attach a receipt id or proof reference to the result the model sees. |
+
+The `post_tool_call` payload carries the fields a receipt needs:
+
+```python
+def on_post_tool_call(**kwargs):
+    tool_name = kwargs.get("tool_name")        # what ran
+    args = kwargs.get("args")                  # with which inputs
+    result = kwargs.get("result")              # producing what
+    status = kwargs.get("status")              # success or failure
+    duration_ms = kwargs.get("duration_ms")    # for how long
+    session_id = kwargs.get("session_id")      # correlation
+    task_id = kwargs.get("task_id")
+    tool_call_id = kwargs.get("tool_call_id")
+```
+
+These hooks fire on every tool dispatch across the CLI, gateway, cron, and subagents, so a
+plugin registered once covers every surface.
+
+Note that two payload surfaces are documented. The observer contract above
+(`hermes.observer.v1`) includes `status`, `error_type`, `error_message`, `session_id`, and
+`tool_call_id`; the older callback signature in
+[Event hooks](../../website/docs/user-guide/features/hooks.md) lists only `tool_name`,
+`args`, `result`, `task_id`, and `duration_ms`. Read every field with `kwargs.get(...)` and
+degrade gracefully when one is absent, rather than depending on either list being complete.
+
+## Rules that matter more for receipts than for tracing
+
+**Accept `**kwargs`.** Payload fields are additive. A receipt plugin that unpacks named
+positional parameters will break on the next field Hermes adds.
+
+**Never return a value from `pre_tool_call` unless you mean to block.** Returning
+`{"action": "block", "message": "..."}` blocks the tool. A recorder must return `None`.
+If your plugin is both a policy engine and a recorder, keep the two decisions explicit.
+
+**Stay fail-open.** Hermes catches callback exceptions, logs a warning, and keeps the agent
+loop running. Rely on that as a backstop, not as your error handling: swallow inside the
+callback so a signing or network failure cannot stall an agent or flood the log.
+
+**Do not silently paper over gaps.** If a receipt could not be written, that absence should
+be detectable later rather than hidden. An audit trail that quietly drops entries under load
+is worse than no audit trail, because it looks complete.
+
+## The property a hash chain does not give you
+
+Worth stating plainly, because it is the reason receipt chains are documented here as an
+integration pattern rather than shipped in core.
+
+A hash chain, verified only against itself, proves internal consistency: no entry was
+deleted or reordered *within the copy you are holding*. It does not prove that copy is the
+original. An operator with write access to the log can fork the chain at any point, rewrite
+every entry after the fork, and internal verification still passes, because the rewritten
+chain is self-consistent by construction.
+
+Closing that gap requires something outside the log:
+
+- **Signatures** prove *who* wrote each entry, so an attacker without the key cannot
+  fabricate entries even with full write access. Keeping the signing key out of the agent's
+  address space raises the bar further.
+- **An external anchor** binds the log to something the operator does not control: a trusted
+  timestamp, a transparency log with inclusion and consistency proofs, independent
+  cosigners, or a public chain.
+- **Deterministic canonicalization** (RFC 8785 JCS is the common choice) so that two
+  independent implementations hash identical bytes. Without it, a record is only verifiable
+  by the implementation that wrote it, which defeats the purpose.
+
+Evaluate any receipt plugin against those three questions.
+
+One limit applies to every implementation on this page, and is worth stating so nobody
+buys more than is on offer. A hook proves that what *was* recorded has not been altered. It
+cannot prove completeness, because an agent that never dispatches through the hook is never
+seen by it. Completeness needs a control outside the agent process, such as forced egress.
+
+## Implementations
+
+External projects implementing this pattern, alphabetically. Hermes does not endorse any of
+them; each has its own threat model, and the list is a starting point for evaluation rather
+than a recommendation.
+
+- [AgentLedger](https://github.com/dembovvski/agentledger): Ed25519-signed, hash-chained
+  receipts with cryptographic identity for multi-agent systems, plus an offline
+  verification CLI. MIT.
+- [asqav](https://www.asqav.com/): agent governance with server-side signing, so the
+  signing key never enters the agent process.
+- [nobulex](https://github.com/arian-gogani/nobulex): bilateral receipts, signed before and
+  after execution, implementing the OWASP Agentic Skills Top 10 AST09 pattern. MIT.
+- [Provenrail](https://provenrail.com): off-box append-only sink with an independent
+  server-side receipt chain, RFC 3161 trusted timestamps, and an RFC 6962 transparency log
+  with independent witness cosignatures, so a record can be checked against the operator
+  rather than only against itself. MIT client and verifier, AGPL server.
+- [Signet](https://github.com/Prismer-AI/signet): a proof layer for cryptographically
+  verifying agent actions. Apache-2.0.
+
+Cross-implementation spec work, including `policy_attestation` and shared canonicalization
+test vectors, was discussed in
+[LangChain RFC #35691](https://github.com/langchain-ai/langchain/issues/35691).
+
+## Related
+
+- [Observer hooks](README.md) for the full `hermes.observer.v1` contract.
+- [Monitoring](monitoring.md)


### PR DESCRIPTION
## What does this PR do?

Adds `docs/observability/audit-receipt-chains.md`, documenting the integration seam for
plugins that build signed, tamper-evident records of tool activity, and cross-links it from
the observer hooks reference.

This is the documentation @teknium1 scoped when closing #487: a page describing the
three-hook pattern, pointing at the external projects and the cross-implementation spec
work, so the receipt-chain use case is discoverable without any core changes.

The page covers:

- The three-hook pattern (`pre_tool_call` for authorization, `post_tool_call` for outcome,
  `transform_tool_result` for attaching a proof reference), with the payload fields a
  receipt actually needs.
- Four rules that matter more for receipts than for tracing: accept `**kwargs`; never return
  a value from `pre_tool_call` unless you mean to block; stay fail-open rather than leaning
  on Hermes catching your exception; do not silently drop entries, because an audit trail
  with invisible gaps is worse than none.
- The property a self-verified hash chain does not give you, which is the substance of
  @fernandosmither's objection in #487: an operator with write access can fork and rewrite
  the chain and internal verification still passes. The page states the three things that
  close that gap (signatures, an external anchor, deterministic canonicalization) as
  evaluation criteria rather than as a pitch for any one project.
- The external implementations, alphabetically, with an explicit note that Hermes endorses
  none of them.
- The limit that applies to all of them: a hook cannot prove completeness, because an agent
  that never dispatches through it is never seen.

## Related Issue

Refs #20034

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `docs/observability/audit-receipt-chains.md` (new)
- `docs/observability/README.md`: one paragraph in "Existing Consumers" pointing at it

## Notes on duplicates and accuracy

**Not a duplicate of #26808.** That PR edited `website/docs/user-guide/features/hooks.md` to
expand the `post_tool_call` use-case list, and its author closed it as stale for lack of
maintainer follow-up rather than on merit. This PR targets the observability docs instead,
and covers the parts #20034 asked for that #26808 did not: the external projects, the
canonicalization requirement, and the anchoring gap. I deliberately did not re-do the
user-guide edit, so the two do not conflict if #26808 is ever revived.

**Consistent with #49371.** The draft opt-in execution receipts PR describes itself as
local-only and explicitly not a signing or proving feature, so the page frames it as the
substrate these plugins compose with rather than something they replace. Happy to reword if
that PR's scope shifts.

**One inconsistency surfaced while writing this.** The observer contract in
`docs/observability/README.md` documents `status`, `error_type`, `error_message`,
`session_id`, and `tool_call_id` on `post_tool_call`, while the callback signature in
`website/docs/user-guide/features/hooks.md` lists only `tool_name`, `args`, `result`,
`task_id`, and `duration_ms`. Rather than pick a winner in a docs PR, the page notes both
and tells plugin authors to read every field with `kwargs.get(...)`. If you tell me which is
authoritative I will send a follow-up reconciling them.

**Verification.** Every claim is taken from this repo rather than assumed: the hook names
and return-value behavior from `docs/observability/README.md`, the payload shapes from
`_DEFAULT_PAYLOADS` in `hermes_cli/hooks.py`, the `status` vocabulary (`ok`, `error`,
`blocked`, `cancelled`) from the observer contract, and the registration pattern from
`plugins/disk-cleanup/__init__.py`. All relative links were checked to resolve.

**Disclosure.** I maintain Provenrail, one of the five listed implementations. I wrote the
page to be useful with that entry removed, listed everything alphabetically, described the
others from their own stated descriptions, and put the evaluation criteria in the reader's
hands rather than ranking anyone. Drop or reword the Provenrail line if you would prefer the
list came from someone with no stake in it. This PR was drafted with Claude Code and
reviewed by me before submission.
