### PR TITLE
fix(agent): use template-visible roles for summary alternation (#74086)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -5417,11 +5417,46 @@ This compaction should PRIORITISE preserving all information related to the focu
                 tail_messages.append(stripped)
 
         _merge_summary_into_tail = False
+
+        # --- template-visible role helpers (Mistral fix #74086) ---
+        # Mistral's chat template exempts tool-flow messages (role="tool" and
+        # role="assistant" carrying tool_calls) from its alternation check.
+        # Using the *literal* last/first role (which may be "tool") causes the
+        # summary to collide with the nearest template-counted role, producing
+        # "user→user" or "assistant→assistant" and a permanent HTTP 500.
+        # Compute the nearest *visible* role by skipping tool-flow messages.
+
+        def _nearest_visible_role_in_head(msgs: list[dict]) -> str:
+            """Last role in *msgs* that Mistral's template counts."""
+            for msg in reversed(msgs):
+                role = msg.get("role", "user")
+                if role == "tool":
+                    continue
+                if role == "assistant" and msg.get("tool_calls"):
+                    continue
+                return role
+            return "system"
+
+        def _nearest_visible_role_in_tail(msgs: list[dict]) -> Optional[str]:
+            """First role in *msgs* that Mistral's template counts."""
+            for msg in msgs:
+                role = msg.get("role", "user")
+                if role == "tool":
+                    continue
+                if role == "assistant" and msg.get("tool_calls"):
+                    continue
+                return role
+            return None
+
         # last_head_role reads the assembled (post-strip) head; first_tail_role
         # reads the assembled (post-strip) tail_messages — a stripped stale
         # handoff must not influence alternation-safe role selection.
-        last_head_role = compressed[-1].get("role", "user") if compressed else "user"
-        first_tail_role = tail_messages[0].get("role", "user") if tail_messages else None
+        last_head_role = (
+            _nearest_visible_role_in_head(compressed) if compressed else "user"
+        )
+        first_tail_role = (
+            _nearest_visible_role_in_tail(tail_messages) if tail_messages else None
+        )
         # When the only protected head message is the system prompt, the
         # summary becomes the first *visible* message in the API request
         # (most adapters — Anthropic, Bedrock — send the system prompt as


### PR DESCRIPTION
## Summary

Mistral chat templates exempt tool-flow messages (role="tool" and assistant messages with `tool_calls`) from their role-alternation check. The previous code used the **literal** last/first role when picking the summary role, which could be "tool" — invisible to the template. This caused consecutive "user→user" or "assistant→assistant" visible roles, triggering a permanent HTTP 500 Jinja Exception on every compaction.

## Root Cause

In `agent/context_compressor.py`, `last_head_role` was read from `compressed[-1].get("role")` and `first_tail_role` from `tail_messages[0].get("role")`. When the head ended with a tool-flow sequence (`user → assistant(tool_calls) → tool`), `last_head_role` was "tool". The role-pinning logic then set `summary_role = "user"`, but Mistral counted the visible predecessor as "user" (the actual user message before the tool flow), producing `user → user` → HTTP 500.

## Fix

Add `_nearest_visible_role_in_head()` and `_nearest_visible_role_in_tail()` helpers that scan past tool-flow messages (role="tool" and assistant with `tool_calls`) to find the nearest role the template actually counts. Use these for `last_head_role` and `first_tail_role`.

The `_force_user_leading` guard for Anthropic and the zero-user-turn guard (#58753) are **unaffected** — they operate on different conditions.

## Testing

- Verified the captured request shape from the issue: head `[system, user, assistant(tool_calls), tool]` now correctly identifies `last_head_role = "user"`, producing `summary_role = "assistant"` which Mistral accepts.
- Existing alternation logic (flip, merge-into-tail) works unchanged with the new helpers.

Fixes #74086