### PR TITLE
fix(routing): use hostname match for azure.com endpoint detection (#74312)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1679,7 +1679,7 @@ def resolve_runtime_provider(
     # return provider="custom" with chat_completions api_mode and no valid key).
     # Instead, use the Azure key directly with anthropic_messages api_mode.
     _eff_base = (explicit_base_url or "").strip()
-    if requested_provider == "anthropic" and "azure.com" in _eff_base:
+    if requested_provider == "anthropic" and base_url_host_matches(_eff_base, "openai.azure.com"):
         _azure_key = (
             (explicit_api_key or "").strip()
             or _getenv("AZURE_ANTHROPIC_KEY", "").strip()
@@ -2019,8 +2019,8 @@ def resolve_runtime_provider(
         # would find the Claude Code OAuth token first (priority 3) and return
         # that instead, causing 401s. Detect Azure endpoints and use the env
         # key directly to bypass the OAuth priority chain.
-        _is_azure_endpoint = "azure.com" in base_url.lower() or (
-            cfg_base_url and "azure.com" in cfg_base_url.lower()
+        _is_azure_endpoint = base_url_host_matches(base_url, "openai.azure.com") or (
+            cfg_base_url and base_url_host_matches(cfg_base_url, "openai.azure.com")
         )
         if _is_azure_endpoint:
             # Honor user-specified env var hints on the model config before


### PR DESCRIPTION
## Summary

Replace raw substring checks (`"azure.com" in full_url`) with the existing `base_url_host_matches()` helper at two sites in `hermes_cli/runtime_provider.py`.

## Security Impact

A URL whose **path** (not hostname) contains "azure.com" — e.g. `https://example.invalid/proxy/azure.com/v1` — was classified as an Azure endpoint. This caused:

1. **Wrong credential selection**: Azure key selected instead of explicit Anthropic token
2. **Trust boundary crossing**: A more-privileged Azure key could be sent to a non-Azure host
3. **Authentication failure**: Legitimate Anthropic route breaks when Azure key is tried

## Fix

- Line ~1682: `"azure.com" in _eff_base` → `base_url_host_matches(_eff_base, "openai.azure.com")`
- Lines ~2022-2023: Same pattern for `base_url` and `cfg_base_url`

`base_url_host_matches()` parses the URL and validates only the hostname against allowed Azure suffixes with proper boundary rules (`host == domain` or `host.endswith("." + domain)`). Already used correctly at ~10 other sites in the same file.

Fixes #74312