### PR TITLE
fix(auth): use secret_scope-aware resolution in fallback config (#74311)

### DIFF
--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 from typing import Any
 
+from agent.secret_scope import get_secret as _get_secret
+
 
 def _normalized_base_url(value: Any) -> str:
     if not isinstance(value, str):
@@ -27,7 +29,11 @@ def resolve_entry_api_key(entry: dict[str, Any] | None) -> str | None:
         return inline
     key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
     if key_env:
-        return os.getenv(key_env, "").strip() or None
+        # Use secret_scope-aware resolution so that multiplexed gateways
+        # (multiple profiles sharing one process) read the active profile's
+        # credential instead of the raw process environment (#74311).
+        val = _get_secret(key_env, "")
+        return val.strip() or None
     return None
 
 


### PR DESCRIPTION
## Summary

`resolve_entry_api_key()` in `hermes_cli/fallback_config.py` used raw `os.getenv()` to read `key_env`, bypassing the per-profile secret scope used by multiplexed gateways. In a multi-profile setup, this could select another profile's credential for a fallback request.

## Security Impact

- Breaks credential isolation between profiles in multiplexed gateways
- CLI, gateway, cron, and auxiliary-task fallback requests can use the wrong account's key
- Can leak one profile's credential to the endpoint configured under a different active profile
- Cost/usage/rate-limit accounting attributed to the wrong account

## Fix

Replace `os.getenv(key_env, "")` with `agent.secret_scope.get_secret(key_env, "")`, which:

1. Reads from the active profile scope under multiplexing (authoritative)
2. Falls back to `os.environ` only when no scope is installed
3. Handles genuinely-global vars correctly via `_is_global_env()`

This matches the resolution pattern already used in `runtime_provider.py` (line ~21: `from agent.secret_scope import get_secret as _get_secret`).

Fixes #74311