### PR TITLE
fix(agent): retry leaked invoke markup as native calls

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -111,7 +111,7 @@ from utils import base_url_host_matches, env_var_enabled
 logger = logging.getLogger(__name__)
 
 _TEXTUAL_INVOKE_RE = re.compile(
-    r"(?:^|\r?\n)[ \t]*(?:card[ \t]*\r?\n[ \t]*)?"
+    r"(?:^|\r?\n)[ \t]*card[ \t]*\r?\n[ \t]*"
     r"<invoke\b[^>]*\bname\s*=\s*(?P<quote>[\"'])(?P<name>[^\"']+)"
     r"(?P=quote)[^>]*>.*</invoke>[ \t]*\Z",
     re.IGNORECASE | re.DOTALL,
@@ -1496,8 +1496,8 @@ def _textual_invoke_tool_name(content: str, valid_tool_names) -> Optional[str]:
 
     Some models copy transcript/UI tool markup into a normal text block and
     finish with ``stop`` instead of using the provider's structured tool-call
-    channel. Only recognize a complete trailing block for a currently exposed
-    tool; explanatory prose and unknown names remain ordinary text.
+    channel. Only recognize a complete trailing ``card`` block for a currently
+    exposed tool; explanatory prose and unknown names remain ordinary text.
     """
     if not isinstance(content, str) or not content:
         return None

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -110,6 +110,13 @@ from utils import base_url_host_matches, env_var_enabled
 
 logger = logging.getLogger(__name__)
 
+_TEXTUAL_INVOKE_RE = re.compile(
+    r"(?:^|\r?\n)[ \t]*(?:card[ \t]*\r?\n[ \t]*)?"
+    r"<invoke\b[^>]*\bname\s*=\s*(?P<quote>[\"'])(?P<name>[^\"']+)"
+    r"(?P=quote)[^>]*>.*</invoke>[ \t]*\Z",
+    re.IGNORECASE | re.DOTALL,
+)
+
 
 # Scaffold marker used by _apply_active_turn_redirect and the ghost-row filter
 # in the api_messages loop. Module-level so both sites can never drift.
@@ -296,7 +303,6 @@ _HANDOFF_SKIP_FINAL_RESPONSE = (
     "Context was compacted. The previous response is complete — "
     "awaiting your next message."
 )
-
 
 # Stable prefix of the local interrupt status string emitted when a turn is
 # cancelled while waiting on the provider. Surfaces (ACP, TUI) match on this
@@ -1483,6 +1489,23 @@ def _invalid_tool_name_error_content(name: str, valid_tool_names) -> str:
         )
     available = ", ".join(sorted(valid_tool_names))
     return f"Tool '{name}' does not exist. Available tools: {available}"
+
+
+def _textual_invoke_tool_name(content: str, valid_tool_names) -> Optional[str]:
+    """Return a known tool emitted as trailing ``<invoke>`` text.
+
+    Some models copy transcript/UI tool markup into a normal text block and
+    finish with ``stop`` instead of using the provider's structured tool-call
+    channel. Only recognize a complete trailing block for a currently exposed
+    tool; explanatory prose and unknown names remain ordinary text.
+    """
+    if not isinstance(content, str) or not content:
+        return None
+    match = _TEXTUAL_INVOKE_RE.search(content)
+    if not match:
+        return None
+    name = match.group("name").strip()
+    return name if name in (valid_tool_names or ()) else None
 
 
 def _content_policy_blocked_result(
@@ -8361,7 +8384,10 @@ def run_conversation(
                         if isinstance(_frag, dict):
                             _frag.pop("_length_continuation_fragment", None)
                             _frag.pop("_length_continuation_nudge", None)
-                
+
+                _textual_invoke_tool = _textual_invoke_tool_name(
+                    final_response, agent.valid_tool_names,
+                )
                 final_response = agent._strip_think_blocks(final_response).strip()
                 
                 final_msg = agent._build_assistant_message(assistant_message, finish_reason)
@@ -8369,27 +8395,46 @@ def run_conversation(
                 # ── Dropped tool-call recovery (copilot/Claude) ────────
                 # Some providers (observed: claude-opus-4.8 / claude-sonnet-4.5
                 # on GitHub Copilot, ~2026-07) return finish_reason="tool_calls"
-                # while the parsed tool_calls array is empty — the model
-                # signalled it wanted to act but the payload shipped no call.
+                # while the parsed tool_calls array is empty. Models can also
+                # copy transcript/UI ``card`` + ``<invoke>`` markup into a text
+                # block and return finish_reason="stop" instead of using the
+                # provider's structured tool channel.
                 # Reaching finalization with that mismatch means the turn is
                 # about to end with the task unstarted (the narration, which may
                 # be in content or only in the reasoning field, gets treated as
                 # the final answer). Re-prompt (bounded to 3 CONSECUTIVE stalls;
                 # the budget resets after any successful tool round) to make the
-                # model emit the call instead of exiting. finish_reason="stop"
-                # text finishes never enter this guard.
-                if (
+                # model emit the native call instead of exiting. Textual markup
+                # is never parsed or executed here.
+                _empty_structured_call = (
                     finish_reason == "tool_calls"
                     and not assistant_message.tool_calls
+                )
+                _textual_invoke_call = (
+                    finish_reason == "stop"
+                    and not assistant_message.tool_calls
+                    and _textual_invoke_tool is not None
+                )
+                if (
+                    (_empty_structured_call or _textual_invoke_call)
                     and getattr(agent, "_dropped_toolcall_retries", 0) < 3
                 ):
                     agent._dropped_toolcall_retries = getattr(agent, "_dropped_toolcall_retries", 0) + 1
-                    logger.warning(
-                        "finish_reason=tool_calls with empty tool_calls array "
-                        "(narration only) — re-prompting to emit the call "
-                        "(retry %d/3, model=%s provider=%s)",
-                        agent._dropped_toolcall_retries, agent.model, agent.provider,
-                    )
+                    if _textual_invoke_call:
+                        logger.warning(
+                            "finish_reason=stop with textual invoke for known tool %r "
+                            "— re-prompting to emit a structured call "
+                            "(retry %d/3, model=%s provider=%s)",
+                            _textual_invoke_tool, agent._dropped_toolcall_retries,
+                            agent.model, agent.provider,
+                        )
+                    else:
+                        logger.warning(
+                            "finish_reason=tool_calls with empty tool_calls array "
+                            "(narration only) — re-prompting to emit the call "
+                            "(retry %d/3, model=%s provider=%s)",
+                            agent._dropped_toolcall_retries, agent.model, agent.provider,
+                        )
                     agent._emit_status(
                         "↻ Model signaled a tool call but sent none — "
                         f"re-prompting ({agent._dropped_toolcall_retries}/3)"
@@ -8406,9 +8451,19 @@ def run_conversation(
                     # flush regardless of position.
                     final_msg["_dropped_toolcall_nudge"] = True
                     append_message(messages, final_msg)
+                    if _textual_invoke_call:
+                        _toolcall_nudge = (
+                            "Your previous turn wrote tool-call markup as plain text "
+                            f"for the {_textual_invoke_tool!r} tool, so no call ran. "
+                            "Do not emit XML, a card label, narration, or restate "
+                            "intent — issue the provider-native structured tool call "
+                            "now to continue the task."
+                        )
+                    else:
+                        _toolcall_nudge = _DROPPED_TOOLCALL_NUDGE_CONTENT
                     append_message(messages, {
                         "role": "user",
-                        "content": _DROPPED_TOOLCALL_NUDGE_CONTENT,
+                        "content": _toolcall_nudge,
                         "_dropped_toolcall_nudge": True,
                     })
                     agent._session_messages = messages

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -89,7 +89,7 @@ from utils import base_url_host_matches, env_var_enabled
 logger = logging.getLogger(__name__)
 
 _TEXTUAL_INVOKE_RE = re.compile(
-    r"(?:^|\r?\n)[ \t]*(?:card[ \t]*\r?\n[ \t]*)?"
+    r"(?:^|\r?\n)[ \t]*card[ \t]*\r?\n[ \t]*"
     r"<invoke\b[^>]*\bname\s*=\s*(?P<quote>[\"'])(?P<name>[^\"']+)"
     r"(?P=quote)[^>]*>.*</invoke>[ \t]*\Z",
     re.IGNORECASE | re.DOTALL,
@@ -729,8 +729,8 @@ def _textual_invoke_tool_name(content: str, valid_tool_names) -> Optional[str]:
 
     Some models copy transcript/UI tool markup into a normal text block and
     finish with ``stop`` instead of using the provider's structured tool-call
-    channel. Only recognize a complete trailing block for a currently exposed
-    tool; explanatory prose and unknown names remain ordinary text.
+    channel. Only recognize a complete trailing ``card`` block for a currently
+    exposed tool; explanatory prose and unknown names remain ordinary text.
     """
     if not isinstance(content, str) or not content:
         return None

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -88,6 +88,13 @@ from utils import base_url_host_matches, env_var_enabled
 
 logger = logging.getLogger(__name__)
 
+_TEXTUAL_INVOKE_RE = re.compile(
+    r"(?:^|\r?\n)[ \t]*(?:card[ \t]*\r?\n[ \t]*)?"
+    r"<invoke\b[^>]*\bname\s*=\s*(?P<quote>[\"'])(?P<name>[^\"']+)"
+    r"(?P=quote)[^>]*>.*</invoke>[ \t]*\Z",
+    re.IGNORECASE | re.DOTALL,
+)
+
 # Stable prefix of the local interrupt status string emitted when a turn is
 # cancelled while waiting on the provider. Surfaces (ACP, TUI) match on this
 # to treat it as cancellation metadata rather than assistant prose.
@@ -715,6 +722,23 @@ def _invalid_tool_name_error_content(name: str, valid_tool_names) -> str:
         )
     available = ", ".join(sorted(valid_tool_names))
     return f"Tool '{name}' does not exist. Available tools: {available}"
+
+
+def _textual_invoke_tool_name(content: str, valid_tool_names) -> Optional[str]:
+    """Return a known tool emitted as trailing ``<invoke>`` text.
+
+    Some models copy transcript/UI tool markup into a normal text block and
+    finish with ``stop`` instead of using the provider's structured tool-call
+    channel. Only recognize a complete trailing block for a currently exposed
+    tool; explanatory prose and unknown names remain ordinary text.
+    """
+    if not isinstance(content, str) or not content:
+        return None
+    match = _TEXTUAL_INVOKE_RE.search(content)
+    if not match:
+        return None
+    name = match.group("name").strip()
+    return name if name in (valid_tool_names or ()) else None
 
 
 def _content_policy_blocked_result(
@@ -6660,7 +6684,10 @@ def run_conversation(
                     final_response = "".join(truncated_response_parts) + final_response
                     truncated_response_parts = []
                     length_continue_retries = 0
-                
+
+                _textual_invoke_tool = _textual_invoke_tool_name(
+                    final_response, agent.valid_tool_names,
+                )
                 final_response = agent._strip_think_blocks(final_response).strip()
                 
                 final_msg = agent._build_assistant_message(assistant_message, finish_reason)
@@ -6668,27 +6695,46 @@ def run_conversation(
                 # ── Dropped tool-call recovery (copilot/Claude) ────────
                 # Some providers (observed: claude-opus-4.8 / claude-sonnet-4.5
                 # on GitHub Copilot, ~2026-07) return finish_reason="tool_calls"
-                # while the parsed tool_calls array is empty — the model
-                # signalled it wanted to act but the payload shipped no call.
+                # while the parsed tool_calls array is empty. Models can also
+                # copy transcript/UI ``card`` + ``<invoke>`` markup into a text
+                # block and return finish_reason="stop" instead of using the
+                # provider's structured tool channel.
                 # Reaching finalization with that mismatch means the turn is
                 # about to end with the task unstarted (the narration, which may
                 # be in content or only in the reasoning field, gets treated as
                 # the final answer). Re-prompt (bounded to 3 CONSECUTIVE stalls;
                 # the budget resets after any successful tool round) to make the
-                # model emit the call instead of exiting. finish_reason="stop"
-                # text finishes never enter this guard.
-                if (
+                # model emit the native call instead of exiting. Textual markup
+                # is never parsed or executed here.
+                _empty_structured_call = (
                     finish_reason == "tool_calls"
                     and not assistant_message.tool_calls
+                )
+                _textual_invoke_call = (
+                    finish_reason == "stop"
+                    and not assistant_message.tool_calls
+                    and _textual_invoke_tool is not None
+                )
+                if (
+                    (_empty_structured_call or _textual_invoke_call)
                     and getattr(agent, "_dropped_toolcall_retries", 0) < 3
                 ):
                     agent._dropped_toolcall_retries = getattr(agent, "_dropped_toolcall_retries", 0) + 1
-                    logger.warning(
-                        "finish_reason=tool_calls with empty tool_calls array "
-                        "(narration only) — re-prompting to emit the call "
-                        "(retry %d/3, model=%s provider=%s)",
-                        agent._dropped_toolcall_retries, agent.model, agent.provider,
-                    )
+                    if _textual_invoke_call:
+                        logger.warning(
+                            "finish_reason=stop with textual invoke for known tool %r "
+                            "— re-prompting to emit a structured call "
+                            "(retry %d/3, model=%s provider=%s)",
+                            _textual_invoke_tool, agent._dropped_toolcall_retries,
+                            agent.model, agent.provider,
+                        )
+                    else:
+                        logger.warning(
+                            "finish_reason=tool_calls with empty tool_calls array "
+                            "(narration only) — re-prompting to emit the call "
+                            "(retry %d/3, model=%s provider=%s)",
+                            agent._dropped_toolcall_retries, agent.model, agent.provider,
+                        )
                     agent._emit_status(
                         "↻ Model signaled a tool call but sent none — "
                         f"re-prompting ({agent._dropped_toolcall_retries}/3)"
@@ -6705,13 +6751,23 @@ def run_conversation(
                     # flush regardless of position.
                     final_msg["_dropped_toolcall_nudge"] = True
                     messages.append(final_msg)
-                    messages.append({
-                        "role": "user",
-                        "content": (
+                    if _textual_invoke_call:
+                        _toolcall_nudge = (
+                            "Your previous turn wrote tool-call markup as plain text "
+                            f"for the {_textual_invoke_tool!r} tool, so no call ran. "
+                            "Do not emit XML, a card label, narration, or restate "
+                            "intent — issue the provider-native structured tool call "
+                            "now to continue the task."
+                        )
+                    else:
+                        _toolcall_nudge = (
                             "Your previous turn indicated a tool call but none was "
                             "included. Do not narrate a plan or restate intent — issue "
                             "the actual tool call now to continue the task."
-                        ),
+                        )
+                    messages.append({
+                        "role": "user",
+                        "content": _toolcall_nudge,
                         "_dropped_toolcall_nudge": True,
                     })
                     agent._session_messages = messages

--- a/tests/run_agent/test_dropped_tool_call_recovery.py
+++ b/tests/run_agent/test_dropped_tool_call_recovery.py
@@ -11,8 +11,10 @@ answer, and exited with the task unstarted. On an unattended multi-step job
 The fix keys on the provider contract violation itself
 (``finish_reason == "tool_calls"`` with zero ``tool_calls``) and re-prompts,
 bounded to 3 consecutive stalls, with the budget resetting after any
-successful tool round so it guards each stall rather than the whole run. A
-genuine ``finish_reason="stop"`` text turn is unaffected.
+successful tool round so it guards each stall rather than the whole run. It
+also recovers when a model emits a trailing ``<invoke>`` block as plain text
+with ``finish_reason="stop"`` instead of using the provider's structured tool
+channel. Genuine text turns are unaffected.
 """
 
 from __future__ import annotations
@@ -67,6 +69,36 @@ def _dropped_tool_call_response(content: str):
 
 
 class TestDroppedToolCallRecovery:
+    def test_textual_invoke_stop_reprompts_instead_of_exiting(self, loop_agent):
+        """A known tool emitted as trailing XML text is an attempted call,
+        not a final answer, even when the provider reports a clean stop."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        loop_agent.valid_tool_names = {"memory"}
+        loop_agent.client.chat.completions.create.side_effect = [
+            _mock_response(
+                content=(
+                    "I will save that rule now.\n\n"
+                    "card\n"
+                    '<invoke name="memory">\n'
+                    '<parameter name="target">memory</parameter>\n'
+                    "</invoke>"
+                ),
+                finish_reason="stop",
+            ),
+            _mock_response(content="Saved the rule.", finish_reason="stop"),
+        ]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("remember this rule")
+
+        assert loop_agent.client.chat.completions.create.call_count == 2
+        assert "Saved the rule." in result["final_response"]
+
     def test_dropped_tool_call_reprompts_instead_of_exiting(self, loop_agent):
         """finish_reason=tool_calls with an empty tool_calls array must
         re-prompt the model to emit the call rather than exiting the loop
@@ -124,6 +156,36 @@ class TestDroppedToolCallRecovery:
             "A clean finish_reason=stop turn must not trigger a re-prompt."
         )
         assert "Here is your answer." in result["final_response"]
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            (
+                'For example: <invoke name="memory"></invoke> is transcript '
+                "data, not a tool call."
+            ),
+            'card\n<invoke name="not_a_real_tool"></invoke>',
+        ],
+    )
+    def test_non_call_invoke_text_is_unaffected(self, loop_agent, content):
+        """Explanatory text and unknown tool names must not be mistaken for
+        executable tool intent."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        loop_agent.valid_tool_names = {"memory"}
+        loop_agent.client.chat.completions.create.side_effect = [
+            _mock_response(content=content, finish_reason="stop"),
+        ]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("explain tool-call markup")
+
+        assert loop_agent.client.chat.completions.create.call_count == 1
+        assert content in result["final_response"]
 
     def test_persistent_dropped_tool_calls_are_bounded(self, loop_agent):
         """If the model never emits a call, the recovery must give up after a

--- a/tests/run_agent/test_dropped_tool_call_recovery.py
+++ b/tests/run_agent/test_dropped_tool_call_recovery.py
@@ -12,9 +12,9 @@ The fix keys on the provider contract violation itself
 (``finish_reason == "tool_calls"`` with zero ``tool_calls``) and re-prompts,
 bounded to 3 consecutive stalls, with the budget resetting after any
 successful tool round so it guards each stall rather than the whole run. It
-also recovers when a model emits a trailing ``<invoke>`` block as plain text
-with ``finish_reason="stop"`` instead of using the provider's structured tool
-channel. Genuine text turns are unaffected.
+also recovers when a model emits a trailing ``card`` + ``<invoke>`` block as
+plain text with ``finish_reason="stop"`` instead of using the provider's
+structured tool channel. Genuine text turns are unaffected.
 """
 
 from __future__ import annotations
@@ -164,12 +164,18 @@ class TestDroppedToolCallRecovery:
                 'For example: <invoke name="memory"></invoke> is transcript '
                 "data, not a tool call."
             ),
+            (
+                "A provider may represent a memory call like this:\n"
+                '<invoke name="memory">\n'
+                '<parameter name="target">memory</parameter>\n'
+                "</invoke>"
+            ),
             'card\n<invoke name="not_a_real_tool"></invoke>',
         ],
     )
     def test_non_call_invoke_text_is_unaffected(self, loop_agent, content):
-        """Explanatory text and unknown tool names must not be mistaken for
-        executable tool intent."""
+        """Explanatory text, including trailing known-tool examples, and
+        unknown tool names must not be mistaken for executable tool intent."""
         from tests.run_agent.test_run_agent import _mock_response
 
         loop_agent.valid_tool_names = {"memory"}


### PR DESCRIPTION
## What does this PR do?

Recovers a model turn that ends with a complete, trailing `card` / `<invoke name="...">` block in plain assistant text instead of a provider-native structured tool call.

The recovery is deliberately conservative:

- it only matches a complete trailing `<invoke>` block;
- the referenced name must be a tool currently exposed to the agent;
- the XML is never parsed into arguments or executed;
- the loop reuses the existing bounded dropped-tool-call retry and ephemeral-scaffolding cleanup.

This prevents the leaked markup from being accepted as a successful final response and persisted as a bad few-shot example for later turns.

Related work: #50279 and #73472. This is a focused alternative built on the dropped-tool-call recovery now present on `main`. Unlike direct XML recovery, it does not execute model-emitted markup; unlike a separate leaked-call retry subsystem, it reuses the existing retry counter, nudge lifecycle, and persistence filtering.

## Related Issue

Related: #50279, #73472

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add conservative recognition of complete trailing textual `card` + `<invoke>` blocks for currently exposed tools in `agent/conversation_loop.py`.
- Route recognized leaks through the existing bounded native-tool-call re-prompt instead of executing XML.
- Add loop-level regressions for the observed `card` + `<invoke>` shape, trailing known-tool XML examples, explanatory prose, and unknown tool names.

## How to Test

1. `scripts/run_tests.sh tests/run_agent/test_dropped_tool_call_recovery.py -q`
2. `scripts/run_tests.sh tests/run_agent/test_run_agent.py -q -k tool_call`
3. `ruff check agent/conversation_loop.py tests/run_agent/test_dropped_tool_call_recovery.py`
4. `python scripts/check-windows-footguns.py --diff origin/main`

Before the fix, the new loop regression exits after one API response and fails with `assert 1 == 2`. After the fix, the re-prompt occurs and the file passes 8/8 tests, including a trailing known-tool XML example that must remain ordinary text.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.11.15

Targeted results:

- dropped-tool-call recovery: 8 passed
- `test_run_agent.py -k tool_call`: 18 passed
- Ruff: passed
- Windows footgun scan: passed

I also ran `tests/run_agent/` with controlled concurrency. The remaining failures were Windows-specific failures outside this diff: open SQLite temp files prevent `TemporaryDirectory` cleanup, and one test expects a POSIX path after Windows normalization. They do not touch the modified files or the finalization path covered here.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is covered by the existing recovery comments and test module documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema changes

## Screenshots / Logs

```text
Before: test_textual_invoke_stop_reprompts_instead_of_exiting -> assert 1 == 2
After:  tests/run_agent/test_dropped_tool_call_recovery.py -> 8 passed
        tests/run_agent/test_run_agent.py -k tool_call -> 18 passed
```
