### PR TITLE
fix(codex_app_server): send system prompt to the model on thread/start (#74712)

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -20,7 +20,7 @@ import json
 import logging
 import time
 from types import SimpleNamespace
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
 
@@ -623,6 +623,7 @@ def run_codex_app_server_turn(
     messages: List[Dict[str, Any]],
     effective_task_id: str,
     should_review_memory: bool = False,
+    active_system_prompt: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Codex app-server runtime path. Hands the entire turn to a `codex
     app-server` subprocess and projects its events back into Hermes'
@@ -680,6 +681,19 @@ def run_codex_app_server_turn(
         # users see no live tool-progress or interim commentary while
         # codex_app_server is running — only the final answer (#33200).
         # Supersedes the narrower item/started-only bridge from #38835.
+        # Build the effective system prompt for the codex thread. This
+        # mirrors how the standard conversation loop composes it from the
+        # base system prompt + ephemeral_system_prompt (channel overrides,
+        # memory, SOUL.md).  Without this, codex_app_server receives no
+        # persona, memory, or per-channel instructions (#74712).
+        _instructions: Optional[str] = None
+        if active_system_prompt:
+            _instructions = active_system_prompt
+            _ephemeral = getattr(agent, "ephemeral_system_prompt", None)
+            if _ephemeral:
+                _instructions = (_instructions + "\n\n" + _ephemeral).strip()
+        elif getattr(agent, "ephemeral_system_prompt", None):
+            _instructions = agent.ephemeral_system_prompt
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
             approval_callback=approval_callback,
@@ -688,6 +702,7 @@ def run_codex_app_server_turn(
                 auto_approve_apply_patch=auto_approve_requests,
             ),
             on_event=make_codex_app_server_event_bridge(agent),
+            instructions=_instructions,
         )
 
     # NOTE: the user message is ALREADY appended to messages by the

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1253,6 +1253,7 @@ def run_conversation(
             messages=messages,
             effective_task_id=effective_task_id,
             should_review_memory=_should_review_memory,
+            active_system_prompt=active_system_prompt,
         )
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -282,8 +282,10 @@ class CodexAppServerSession:
         on_event: Optional[Callable[[dict], None]] = None,
         request_routing: Optional[_ServerRequestRouting] = None,
         client_factory: Optional[Callable[..., CodexAppServerClient]] = None,
+        instructions: Optional[str] = None,
     ) -> None:
         self._cwd = cwd or os.getcwd()
+        self._instructions = instructions
         self._codex_bin = codex_bin
         self._codex_home = codex_home
         self._permission_profile = (
@@ -343,6 +345,8 @@ class CodexAppServerSession:
         # Users who want a write-capable profile configure it in their
         # ~/.codex/config.toml the same way they would for any codex usage.
         params: dict[str, Any] = {"cwd": self._cwd}
+        if self._instructions:
+            params["instructions"] = self._instructions
         result = self._client.request("thread/start", params, timeout=15)
         # Cross-fill thread.id/sessionId — different codex versions have
         # serialized this under either key. Mirrors openclaw beta.8's

--- a/run_agent.py
+++ b/run_agent.py
@@ -7186,10 +7186,11 @@ class AIAgent:
         messages: List[Dict[str, Any]],
         effective_task_id: str,
         should_review_memory: bool = False,
+        active_system_prompt: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.codex_runtime.run_codex_app_server_turn``."""
         from agent.codex_runtime import run_codex_app_server_turn
-        return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
+        return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory, active_system_prompt=active_system_prompt)
 
 def main(
     query: str = None,


### PR DESCRIPTION
## Summary

The `codex_app_server` runtime builds a full system prompt (SOUL.md, `MEMORY.md`, `USER.md`, per-channel `system_prompt` overrides) and persists it to `sessions.system_prompt`, but **never sends any of it to the model**. The `thread/start` call only included `cwd`, so every prompt-level configuration was silently inert.

## Root Cause

The early return at `conversation_loop.py:1249` hands the turn to `run_codex_app_server_turn()` without passing `active_system_prompt`. The codex session constructor (`CodexAppServerSession.__init__`) had no `instructions` parameter, and `ensure_started()` only sent `{"cwd": ...}` on `thread/start`.

## Fix

4 files, 23 insertions, 2 deletions:

1. **`agent/conversation_loop.py`** — pass `active_system_prompt` to the codex turn forwarder
2. **`run_agent.py`** — forward the new parameter through `_run_codex_app_server_turn()`
3. **`agent/codex_runtime.py`** — accept `active_system_prompt`, compose effective instructions from base + ephemeral (mirrors standard loop pattern), pass to `CodexAppServerSession`
4. **`agent/transports/codex_app_server_session.py`** — accept `instructions` in `__init__`, send on `thread/start`

## Notes

- The composed prompt follows the same merge pattern as the standard conversation loop: `active_system_prompt + "\n\n" + agent.ephemeral_system_prompt`
- The `instructions` field on `thread/start` was identified via `strings` on the codex 0.145.0 binary. If the field name changes in a future codex release, the session gracefully degrades (codex ignores unknown params)
- All 73 existing codex-related tests pass (29 integration + 23 transport + 21 event bridge + compaction)

## Related

- Fixes #74712
- Related to #73503 (compression no-op on same runtime, same early-return path)

@NousResearch — please review when you can.