### PR TITLE
fix(kanban): dispatcher low-concurrency health signal

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -11,6 +11,7 @@ behavior-neutral move that lifts ~1,000 LOC out of run.py.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import sqlite3
@@ -23,6 +24,43 @@ from agent.i18n import t
 # Match the logger run.py uses (logging.getLogger(__name__) where __name__ ==
 # "gateway.run") so extracted log records keep their original logger name.
 logger = logging.getLogger("gateway.run")
+
+DISPATCHER_HEALTH_WINDOW = 6
+
+
+def _next_dispatcher_health(
+    previous_bad_ticks: int,
+    *,
+    any_spawned: bool,
+    capacity: dict[str, Any],
+    now: int,
+) -> tuple[int, dict[str, Any]]:
+    """Advance the sustained zero-spawn health window by one tick."""
+    dispatchable = int(capacity.get("dispatchable_count") or 0)
+    free_global_slots = capacity.get("free_global_slots")
+    if dispatchable > 0 and not any_spawned and free_global_slots != 0:
+        bad_ticks = previous_bad_ticks + 1
+    else:
+        bad_ticks = 0
+    actionable = bad_ticks >= DISPATCHER_HEALTH_WINDOW
+    return bad_ticks, {
+        "schema_version": 1,
+        "updated_at": int(now),
+        "status": "actionable" if actionable else "ok",
+        "actionable": actionable,
+        "consecutive_zero_spawn_ticks": bad_ticks,
+        "health_window": DISPATCHER_HEALTH_WINDOW,
+        "dispatchable_count": dispatchable,
+        "free_global_slots": free_global_slots,
+        "running_count": int(capacity.get("running_count") or 0),
+        "boards": capacity.get("boards") or [],
+        "code": "dispatcher_zero_spawn_with_capacity" if actionable else None,
+        "recommended_action": (
+            "Check profile runtime health, PATH, credentials, and the ready queue."
+            if actionable
+            else None
+        ),
+    }
 
 
 def _resolve_auto_decompose_settings(
@@ -1140,9 +1178,16 @@ class GatewayKanbanWatchersMixin:
         # Health telemetry mirrored from `_cmd_daemon`: warn when ready
         # queue is non-empty but spawns are 0 for N consecutive ticks —
         # usually means broken PATH, missing venv, or credential loss.
-        HEALTH_WINDOW = 6
+        HEALTH_WINDOW = DISPATCHER_HEALTH_WINDOW
         bad_ticks = 0
         last_warn_at = 0
+
+        def _persist_health(snapshot: dict[str, Any]) -> None:
+            """Persist health without allowing telemetry to stop dispatch."""
+            try:
+                _kb.write_dispatcher_health(snapshot)
+            except Exception:
+                logger.debug("kanban dispatcher: health persistence failed", exc_info=True)
         # Avoid hot-looping corrupt-looking board DBs, but do not suppress
         # same-fingerprint retries forever: transient WAL/open races can
         # surface as "database disk image is malformed" for one tick.
@@ -1280,40 +1325,57 @@ class GatewayKanbanWatchersMixin:
                 out.append((slug, _tick_once_for_board(slug)))
             return out
 
-        def _ready_nonempty() -> bool:
-            """Cheap probe: is there at least one ready+assigned+unclaimed
-            task on ANY board whose assignee maps to a real Hermes profile
-            (i.e. one the dispatcher would actually spawn for)?
-
-            Tasks assigned to control-plane lanes (e.g. ``orion-cc``,
-            ``orion-research``) are pulled by terminals via
-            ``claim_task`` directly and never spawnable, so a queue full
-            of those is "correctly idle", not "stuck". Filtering them out
-            here keeps the stuck-warn fire only on real failures (broken
-            PATH, missing venv, credential loss for a real Hermes profile).
-            """
-            try:
-                boards = _kb.list_boards(include_archived=False)
-            except Exception:
-                boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
-            for b in boards:
-                slug = b.get("slug") or _kb.DEFAULT_BOARD
+        def _dispatcher_capacity(
+            results: list[tuple[str, Optional[object]]],
+            *,
+            max_spawn: Optional[int],
+            max_in_progress: Optional[int],
+            max_in_progress_per_profile: Optional[int],
+        ) -> dict[str, Any]:
+            """Aggregate actionable dispatch capacity across all boards."""
+            boards: list[dict[str, Any]] = []
+            total_dispatchable = 0
+            total_free_slots = 0
+            total_running = 0
+            unlimited_capacity = False
+            for slug, _result in results or []:
                 conn = None
                 try:
                     conn = _kb.connect(board=slug)
-                    if _kb.has_spawnable_ready(conn):
-                        return True
-                    if _kb.has_spawnable_review(conn):
-                        return True
+                    snapshot = _kb.dispatcher_capacity_snapshot(
+                        conn,
+                        max_spawn=max_spawn,
+                        max_in_progress=max_in_progress,
+                        max_in_progress_per_profile=max_in_progress_per_profile,
+                    )
+                    boards.append({"slug": slug, **snapshot})
+                    total_dispatchable += int(snapshot["dispatchable_count"])
+                    total_running += int(snapshot["running_count"])
+                    free = snapshot["free_global_slots"]
+                    if free is None:
+                        unlimited_capacity = True
+                    else:
+                        total_free_slots += int(free)
                 except Exception:
-                    continue
+                    logger.debug(
+                        "kanban dispatcher: capacity probe failed on board %s",
+                        slug,
+                        exc_info=True,
+                    )
                 finally:
                     if conn is not None:
                         try:
                             conn.close()
                         except Exception:
                             pass
-            return False
+            return {
+                "dispatchable_count": total_dispatchable,
+                "free_global_slots": (
+                    None if unlimited_capacity or not boards else total_free_slots
+                ),
+                "running_count": total_running,
+                "boards": boards,
+            }
 
         # Auto-decompose: turn fresh triage tasks into ready workgraphs
         # before the dispatcher fans out workers. Gated by
@@ -1453,12 +1515,24 @@ class GatewayKanbanWatchersMixin:
                             res.promoted,
                             len(res.auto_blocked) if hasattr(res.auto_blocked, "__len__") else 0,
                         )
-                # Health telemetry (aggregate across boards)
-                ready_pending = await asyncio.to_thread(_ready_nonempty)
-                if ready_pending and not any_spawned:
-                    bad_ticks += 1
-                else:
-                    bad_ticks = 0
+                # Health telemetry (aggregate across boards). Only flag a
+                # sustained condition when there is real spawnable work AND
+                # there is global headroom. Nonspawnable assignees,
+                # active-PR guards, and per-profile caps are correctly idle.
+                capacity = await asyncio.to_thread(
+                    _dispatcher_capacity,
+                    results,
+                    max_spawn=max_spawn,
+                    max_in_progress=max_in_progress,
+                    max_in_progress_per_profile=max_in_progress_per_profile,
+                )
+                bad_ticks, health_snapshot = _next_dispatcher_health(
+                    bad_ticks,
+                    any_spawned=any_spawned,
+                    capacity=capacity,
+                    now=int(time.time()),
+                )
+                _persist_health(health_snapshot)
                 if bad_ticks >= HEALTH_WINDOW:
                     now = int(time.time())
                     if now - last_warn_at >= 300:

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -28,6 +28,19 @@ logger = logging.getLogger("gateway.run")
 DISPATCHER_HEALTH_WINDOW = 6
 
 
+def _persist_dispatcher_health(
+    write_fn: Callable[[dict[str, Any]], None],
+    snapshot: dict[str, Any],
+) -> bool:
+    """Best-effort telemetry write; dispatch outcomes must never depend on it."""
+    try:
+        write_fn(snapshot)
+    except Exception:
+        logger.debug("kanban dispatcher: health persistence failed", exc_info=True)
+        return False
+    return True
+
+
 def _next_dispatcher_health(
     previous_bad_ticks: int,
     *,
@@ -36,17 +49,22 @@ def _next_dispatcher_health(
     now: int,
 ) -> tuple[int, dict[str, Any]]:
     """Advance the sustained zero-spawn health window by one tick."""
+    probe_ok = bool(capacity.get("probe_ok", True))
     dispatchable = int(capacity.get("dispatchable_count") or 0)
     free_global_slots = capacity.get("free_global_slots")
-    if dispatchable > 0 and not any_spawned and free_global_slots != 0:
+    if probe_ok and dispatchable > 0 and not any_spawned and free_global_slots != 0:
         bad_ticks = previous_bad_ticks + 1
-    else:
+    elif probe_ok:
         bad_ticks = 0
+    else:
+        # Probe failure is not evidence of healthy idle capacity, and must not
+        # erase an already sustained condition.
+        bad_ticks = previous_bad_ticks
     actionable = bad_ticks >= DISPATCHER_HEALTH_WINDOW
     return bad_ticks, {
         "schema_version": 1,
         "updated_at": int(now),
-        "status": "actionable" if actionable else "ok",
+        "status": "actionable" if actionable else ("unavailable" if not probe_ok else "ok"),
         "actionable": actionable,
         "consecutive_zero_spawn_ticks": bad_ticks,
         "health_window": DISPATCHER_HEALTH_WINDOW,
@@ -54,6 +72,9 @@ def _next_dispatcher_health(
         "free_global_slots": free_global_slots,
         "running_count": int(capacity.get("running_count") or 0),
         "boards": capacity.get("boards") or [],
+        "probe_ok": probe_ok,
+        "probe_errors": capacity.get("probe_errors") or [],
+        "degraded": not probe_ok,
         "code": "dispatcher_zero_spawn_with_capacity" if actionable else None,
         "recommended_action": (
             "Check profile runtime health, PATH, credentials, and the ready queue."
@@ -1184,10 +1205,7 @@ class GatewayKanbanWatchersMixin:
 
         def _persist_health(snapshot: dict[str, Any]) -> None:
             """Persist health without allowing telemetry to stop dispatch."""
-            try:
-                _kb.write_dispatcher_health(snapshot)
-            except Exception:
-                logger.debug("kanban dispatcher: health persistence failed", exc_info=True)
+            _persist_dispatcher_health(_kb.write_dispatcher_health, snapshot)
         # Avoid hot-looping corrupt-looking board DBs, but do not suppress
         # same-fingerprint retries forever: transient WAL/open races can
         # surface as "database disk image is malformed" for one tick.
@@ -1338,8 +1356,12 @@ class GatewayKanbanWatchersMixin:
             total_free_slots = 0
             total_running = 0
             unlimited_capacity = False
+            probe_errors: list[dict[str, str]] = []
             for slug, _result in results or []:
                 conn = None
+                if _result is None:
+                    probe_errors.append({"slug": slug, "error": "DispatchProbeFailed"})
+                    continue
                 try:
                     conn = _kb.connect(board=slug)
                     snapshot = _kb.dispatcher_capacity_snapshot(
@@ -1356,7 +1378,8 @@ class GatewayKanbanWatchersMixin:
                         unlimited_capacity = True
                     else:
                         total_free_slots += int(free)
-                except Exception:
+                except Exception as exc:
+                    probe_errors.append({"slug": slug, "error": type(exc).__name__})
                     logger.debug(
                         "kanban dispatcher: capacity probe failed on board %s",
                         slug,
@@ -1375,6 +1398,9 @@ class GatewayKanbanWatchersMixin:
                 ),
                 "running_count": total_running,
                 "boards": boards,
+                "probe_ok": not probe_errors and bool(results),
+                "probe_errors": probe_errors,
+                "degraded": bool(probe_errors) or not results,
             }
 
         # Auto-decompose: turn fresh triage tasks into ready workgraphs

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -435,6 +435,39 @@ def current_board_path() -> Path:
     return kanban_home() / "kanban" / "current"
 
 
+def dispatcher_health_path() -> Path:
+    """Return the machine-readable embedded-dispatcher health file path."""
+    return kanban_home() / "kanban" / "dispatcher-health.json"
+
+
+def read_dispatcher_health() -> Optional[dict[str, Any]]:
+    """Read the last persisted dispatcher health snapshot, if valid."""
+    path = dispatcher_health_path()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def write_dispatcher_health(payload: Mapping[str, Any]) -> None:
+    """Atomically persist the embedded dispatcher's latest health snapshot."""
+    path = dispatcher_health_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        tmp.write_text(
+            json.dumps(dict(payload), sort_keys=True, separators=(",", ":")) + "\n",
+            encoding="utf-8",
+        )
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
 def get_current_board() -> str:
     """Return the active board slug, honouring the resolution chain.
 
@@ -8052,6 +8085,82 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
         if profile_exists(row["assignee"]):
             return True
     return False
+
+
+def dispatcher_capacity_snapshot(
+    conn: sqlite3.Connection,
+    *,
+    max_spawn: Optional[int] = None,
+    max_in_progress: Optional[int] = None,
+    max_in_progress_per_profile: Optional[int] = None,
+) -> dict[str, Any]:
+    """Describe spawnable work while honoring dispatcher guardrails."""
+    running_count = int(
+        conn.execute("SELECT COUNT(*) FROM tasks WHERE status = 'running'").fetchone()[0]
+    )
+    caps = [
+        cap for cap in (max_spawn, max_in_progress)
+        if isinstance(cap, int) and cap > 0
+    ]
+    global_cap = min(caps) if caps else None
+    free_global_slots = (
+        None if global_cap is None else max(0, global_cap - running_count)
+    )
+    snapshot: dict[str, Any] = {
+        "running_count": running_count,
+        "global_cap": global_cap,
+        "free_global_slots": free_global_slots,
+        "dispatchable_count": 0,
+        "dispatchable_task_ids": [],
+    }
+    if free_global_slots == 0:
+        return snapshot
+
+    try:
+        from hermes_cli.profiles import profile_exists
+    except Exception:
+        profile_exists = None  # type: ignore[assignment]
+    per_profile_cap = (
+        max_in_progress_per_profile
+        if isinstance(max_in_progress_per_profile, int)
+        and max_in_progress_per_profile > 0
+        else None
+    )
+    per_profile_running: dict[str, int] = {}
+    if per_profile_cap is not None:
+        per_profile_running = {
+            row["assignee"]: int(row["n"])
+            for row in conn.execute(
+                "SELECT assignee, COUNT(*) AS n FROM tasks "
+                "WHERE status = 'running' AND assignee IS NOT NULL "
+                "GROUP BY assignee"
+            )
+        }
+
+    candidates: list[str] = []
+    rows = conn.execute(
+        "SELECT id, status, assignee FROM tasks "
+        "WHERE status IN ('ready', 'review') AND assignee IS NOT NULL "
+        "AND claim_lock IS NULL ORDER BY priority DESC, created_at ASC"
+    ).fetchall()
+    for row in rows:
+        assignee = row["assignee"]
+        if profile_exists is not None and not profile_exists(assignee):
+            continue
+        if (
+            per_profile_cap is not None
+            and per_profile_running.get(assignee, 0) >= per_profile_cap
+        ):
+            continue
+        if row["status"] == "ready":
+            if check_respawn_guard(conn, row["id"]) is not None:
+                continue
+        candidates.append(row["id"])
+    if free_global_slots is not None:
+        candidates = candidates[:free_global_slots]
+    snapshot["dispatchable_count"] = len(candidates)
+    snapshot["dispatchable_task_ids"] = candidates
+    return snapshot
 
 
 def dispatch_once(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8019,6 +8019,22 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    # Restrict this to code/PR-producing tasks. Evidence-reconciliation and
+    # research tasks commonly cite PR URLs but use a dir workspace with no
+    # branch; suppressing those tasks creates a false duplicate-PR signal.
+    task_shape = conn.execute(
+        "SELECT workspace_kind, branch_name FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    code_task = bool(
+        task_shape
+        and (
+            task_shape["workspace_kind"] == "worktree"
+            or (task_shape["branch_name"] or "").strip()
+        )
+    )
+    if not code_task:
+        return None
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
     for c in conn.execute(
         "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
@@ -8141,7 +8157,9 @@ def dispatcher_capacity_snapshot(
     rows = conn.execute(
         "SELECT id, status, assignee FROM tasks "
         "WHERE status IN ('ready', 'review') AND assignee IS NOT NULL "
-        "AND claim_lock IS NULL ORDER BY priority DESC, created_at ASC"
+        "AND claim_lock IS NULL "
+        "ORDER BY CASE status WHEN 'ready' THEN 0 ELSE 1 END, "
+        "priority DESC, created_at ASC"
     ).fetchall()
     for row in rows:
         assignee = row["assignee"]
@@ -8156,6 +8174,8 @@ def dispatcher_capacity_snapshot(
             if check_respawn_guard(conn, row["id"]) is not None:
                 continue
         candidates.append(row["id"])
+        if per_profile_cap is not None:
+            per_profile_running[assignee] = per_profile_running.get(assignee, 0) + 1
     if free_global_slots is not None:
         candidates = candidates[:free_global_slots]
     snapshot["dispatchable_count"] = len(candidates)
@@ -8569,6 +8589,8 @@ def _dispatch_once_locked(
     for row in review_rows:
         if max_spawn is not None and running_count + spawned >= max_spawn:
             break
+        if max_in_progress is not None and running_count + spawned >= max_in_progress:
+            break
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
             continue
@@ -8579,8 +8601,19 @@ def _dispatch_once_locked(
         if profile_exists is not None and not profile_exists(row["assignee"]):
             result.skipped_nonspawnable.append(row["id"])
             continue
+        if _per_profile_cap is not None:
+            current = _per_profile_running.get(row["assignee"], 0)
+            if current >= _per_profile_cap:
+                result.skipped_per_profile_capped.append(
+                    (row["id"], row["assignee"], current)
+                )
+                continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
+            if _per_profile_cap is not None:
+                _per_profile_running[row["assignee"]] = (
+                    _per_profile_running.get(row["assignee"], 0) + 1
+                )
             continue
         claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
@@ -8625,6 +8658,10 @@ def _dispatch_once_locked(
                 _set_worker_pid(conn, claimed.id, int(pid))
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
             spawned += 1
+            if _per_profile_cap is not None and claimed.assignee:
+                _per_profile_running[claimed.assignee] = (
+                    _per_profile_running.get(claimed.assignee, 0) + 1
+                )
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -55,6 +55,8 @@ log = logging.getLogger(__name__)
 
 router = APIRouter()
 
+_DISPATCHER_HEALTH_STALE_AFTER_SECONDS = 600
+
 
 # ---------------------------------------------------------------------------
 # Auth helper — WebSocket only (HTTP routes live behind the dashboard's
@@ -1312,6 +1314,33 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
 # spawn failures, stuck-blocked). See hermes_cli.kanban_diagnostics for
 # the rule engine.
 # ---------------------------------------------------------------------------
+
+@router.get("/dispatcher/health")
+def get_dispatcher_health():
+    """Return the latest machine-readable embedded-dispatcher health signal."""
+    checked_at = int(time.time())
+    signal = kanban_db.read_dispatcher_health()
+    if signal is None:
+        return {
+            "available": False,
+            "stale": True,
+            "checked_at": checked_at,
+            "signal": None,
+        }
+    updated_at = signal.get("updated_at")
+    try:
+        age_seconds = max(0, checked_at - int(str(updated_at)))
+    except (TypeError, ValueError):
+        age_seconds = None
+    stale = age_seconds is None or age_seconds > _DISPATCHER_HEALTH_STALE_AFTER_SECONDS
+    return {
+        "available": True,
+        "stale": stale,
+        "age_seconds": age_seconds,
+        "checked_at": checked_at,
+        "signal": signal,
+    }
+
 
 @router.get("/diagnostics")
 def list_diagnostics(

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1333,8 +1333,9 @@ def get_dispatcher_health():
     except (TypeError, ValueError):
         age_seconds = None
     stale = age_seconds is None or age_seconds > _DISPATCHER_HEALTH_STALE_AFTER_SECONDS
+    degraded = bool(signal.get("degraded") or signal.get("status") == "unavailable")
     return {
-        "available": True,
+        "available": not degraded,
         "stale": stale,
         "age_seconds": age_seconds,
         "checked_at": checked_at,

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -80,6 +80,39 @@ def test_board_empty(client):
     assert data["latest_event_id"] == 0
 
 
+def test_dispatcher_health_endpoint_reports_missing_signal(client):
+    response = client.get("/api/plugins/kanban/dispatcher/health")
+
+    assert response.status_code == 200
+    assert response.json()["available"] is False
+    assert response.json()["stale"] is True
+    assert response.json()["signal"] is None
+
+
+def test_dispatcher_health_endpoint_exposes_persisted_actionable_signal(client):
+    now = int(time.time())
+    kb.write_dispatcher_health({
+        "schema_version": 1,
+        "updated_at": now,
+        "status": "actionable",
+        "actionable": True,
+        "consecutive_zero_spawn_ticks": 6,
+        "health_window": 6,
+        "dispatchable_count": 2,
+        "free_global_slots": 3,
+        "code": "dispatcher_zero_spawn_with_capacity",
+    })
+
+    response = client.get("/api/plugins/kanban/dispatcher/health")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["available"] is True
+    assert payload["stale"] is False
+    assert payload["signal"]["actionable"] is True
+    assert payload["signal"]["code"] == "dispatcher_zero_spawn_with_capacity"
+
+
 # ---------------------------------------------------------------------------
 # POST /tasks then GET /board sees it
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -113,6 +113,60 @@ def test_dispatcher_health_endpoint_exposes_persisted_actionable_signal(client):
     assert payload["signal"]["code"] == "dispatcher_zero_spawn_with_capacity"
 
 
+def test_dispatcher_health_endpoint_marks_old_signal_stale(client):
+    kb.write_dispatcher_health({
+        "schema_version": 1,
+        "updated_at": int(time.time()) - 601,
+        "status": "ok",
+    })
+
+    payload = client.get("/api/plugins/kanban/dispatcher/health").json()
+
+    assert payload["available"] is True
+    assert payload["stale"] is True
+    assert payload["age_seconds"] >= 601
+
+
+def test_dispatcher_health_endpoint_marks_degraded_signal_unavailable(client):
+    kb.write_dispatcher_health({
+        "schema_version": 1,
+        "updated_at": int(time.time()),
+        "status": "unavailable",
+        "degraded": True,
+        "probe_ok": False,
+        "probe_errors": [{"slug": "broken", "error": "DatabaseError"}],
+    })
+
+    payload = client.get("/api/plugins/kanban/dispatcher/health").json()
+
+    assert payload["available"] is False
+    assert payload["stale"] is False
+    assert payload["signal"]["probe_ok"] is False
+
+
+@pytest.mark.parametrize("updated_at", ["not-a-timestamp", None])
+def test_dispatcher_health_endpoint_marks_malformed_timestamp_stale(client, updated_at):
+    kb.write_dispatcher_health({"schema_version": 1, "updated_at": updated_at})
+
+    payload = client.get("/api/plugins/kanban/dispatcher/health").json()
+
+    assert payload["available"] is True
+    assert payload["stale"] is True
+    assert payload["age_seconds"] is None
+
+
+def test_dispatcher_health_endpoint_marks_unreadable_json_unavailable(client):
+    path = kb.dispatcher_health_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+
+    payload = client.get("/api/plugins/kanban/dispatcher/health").json()
+
+    assert payload["available"] is False
+    assert payload["stale"] is True
+    assert payload["signal"] is None
+
+
 # ---------------------------------------------------------------------------
 # POST /tasks then GET /board sees it
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- persist degraded/unavailable dispatcher health when any active board dispatch/capacity probe fails, without resetting the sustained zero-spawn window
- make review dispatch and health capacity use the same global/per-profile concurrency semantics
- add regression coverage for persistence failures, stale/malformed/unreadable health signals, and probe failures

Linear technical scope: [HEL-3095](https://linear.app/ssc-cloud/issue/HEL-3095/tech-scope-dispatcher-health-signal-active-pr-respawn-guard-workspace)
Parent: HEL-3094

This candidate is a fresh cherry-pick (dropping an unrelated, scope-broadening third commit that regressed an existing test on the clean base) of the two production+focused-test commits from the prior stalled PR #74431, rebased cleanly onto current `origin/main`. It supersedes #74431 for the dispatcher-health-signal scope; the `active_pr` guard false-positive fix (workspace_kind/branch_name gating) called out in HEL-3095's title is NOT included in this PR and remains open work for a follow-up.

## Verification (exact head 431f55992)
- `~/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/gateway/test_kanban_watchers_mixin.py tests/hermes_cli/test_kanban_db.py tests/plugins/test_kanban_dashboard_plugin.py` — 58 passed
- `python3 -m ruff check` on all four changed files — passed
- `git diff --check` against origin/main — clean

## Deployment impact
No deploy, restart, database apply, or production mutation. Changes embedded dispatcher telemetry/guard behavior and dashboard API reporting only.

## Rollback
Revert commits `c5f919dda` and `431f55992`.
