### PR TITLE
feat(auth): add profile-scoped gateway Codex login

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17283,6 +17283,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "codex-runtime":
             return await self._handle_codex_runtime_command(event)
 
+        if canonical == "login":
+            return await self._handle_login_command(event)
+
         if canonical == "personality":
             return await self._handle_personality_command(event)
 
@@ -20934,6 +20937,137 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if time.time() - requested_at > 300:
                 return False
         return True
+
+
+    async def _handle_login_command(self, event: MessageEvent) -> str:
+        """Add a Codex account from an authorized private gateway session."""
+        source = event.source
+        provider = event.get_command_args().strip().lower() or "codex"
+        if provider not in {"codex", "openai-codex", "openai_codex"}:
+            return "Usage: /login codex"
+
+        if (source.chat_type or "").strip().lower() not in {
+            "",
+            "dm",
+            "direct",
+            "private",
+        }:
+            return (
+                "For safety, Codex login codes are only sent in a private "
+                "conversation. DM this bot `/login codex` to add an account."
+            )
+
+        adapter = self._adapter_for_source(source)
+        if adapter is None:
+            return "Codex login could not find a private response path for this conversation."
+
+        # When command roles are configured, only an explicit admin may add
+        # credentials. Resolve roles from the source adapter so a multiplexed
+        # profile cannot inherit the primary profile's command policy.
+        from gateway.slash_access import policy_for_source
+
+        policy_config = self.config
+        adapter_config = getattr(adapter, "config", None)
+        if adapter_config is not None:
+            from types import SimpleNamespace
+
+            policy_config = SimpleNamespace(
+                platforms={source.platform: adapter_config},
+            )
+        policy = policy_for_source(policy_config, source)
+        if not policy.is_admin(source.user_id):
+            return "⛔ /login is admin-only because it adds Hermes credentials."
+
+        if getattr(self.config, "multiplex_profiles", False):
+            profile_home = self._resolve_profile_home_for_source(source)
+        else:
+            from hermes_constants import get_hermes_home
+
+            profile_home = get_hermes_home()
+
+        flow_key = (
+            str(profile_home),
+            source.platform.value if source.platform else "",
+            str(source.chat_id or ""),
+            str(source.thread_id or ""),
+            str(source.user_id or ""),
+        )
+        active_flows = getattr(self, "_active_codex_login_flows", None)
+        if active_flows is None:
+            active_flows = set()
+            self._active_codex_login_flows = active_flows
+        active_workers = getattr(self, "_active_codex_login_workers", None)
+        if active_workers is None:
+            active_workers = {}
+            self._active_codex_login_workers = active_workers
+        if flow_key in active_flows:
+            return (
+                "A Codex login code is already active for this conversation. "
+                "Complete it, or wait for it to expire before requesting a new one."
+            )
+
+        loop = asyncio.get_running_loop()
+        metadata = self._thread_metadata_for_source(
+            source,
+            self._reply_anchor_for_event(event),
+        )
+
+        def _send_verification(prompt) -> None:
+            minutes = max(1, round(prompt.expires_in_seconds / 60))
+            message = (
+                "Open this link in your browser and enter the Codex pairing code:\n\n"
+                f"{prompt.verification_url}\n\n"
+                f"Code: `{prompt.user_code}`\n\n"
+                f"The code expires in about {minutes} minutes. Never share it."
+            )
+            future = asyncio.run_coroutine_threadsafe(
+                adapter.send(str(source.chat_id), message, metadata=metadata),
+                loop,
+            )
+            result = future.result(timeout=30)
+            if getattr(result, "success", True) is False:
+                raise RuntimeError("private device-code delivery failed")
+
+        async def _run_login_worker() -> bool:
+            from hermes_cli.auth import login_openai_codex_to_pool
+
+            try:
+                if getattr(self.config, "multiplex_profiles", False):
+                    with _profile_runtime_scope(profile_home):
+                        await asyncio.to_thread(
+                            login_openai_codex_to_pool,
+                            _send_verification,
+                        )
+                else:
+                    await asyncio.to_thread(
+                        login_openai_codex_to_pool,
+                        _send_verification,
+                    )
+                return True
+            except Exception:
+                logger.warning(
+                    "Codex device-code login failed for %s:%s",
+                    source.platform.value if source.platform else "?",
+                    source.user_id,
+                )
+                return False
+            finally:
+                active_flows.discard(flow_key)
+                current_worker = asyncio.current_task()
+                if active_workers.get(flow_key) is current_worker:
+                    active_workers.pop(flow_key, None)
+
+        active_flows.add(flow_key)
+        worker = asyncio.create_task(_run_login_worker())
+        active_workers[flow_key] = worker
+
+        # Shield the owned worker so cancelling this message handler does not
+        # release the dedupe key while asyncio.to_thread continues running.
+        # Handler cancellation still propagates to the caller immediately.
+        completed = await asyncio.shield(worker)
+        if completed:
+            return "Codex login complete. The account was added to this profile."
+        return "Codex login did not complete. Send `/login codex` to request a new code."
 
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17773,6 +17773,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if active_flows is None:
             active_flows = set()
             self._active_codex_login_flows = active_flows
+        active_workers = getattr(self, "_active_codex_login_workers", None)
+        if active_workers is None:
+            active_workers = {}
+            self._active_codex_login_workers = active_workers
         if flow_key in active_flows:
             return (
                 "A Codex login code is already active for this conversation. "
@@ -17801,31 +17805,46 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if getattr(result, "success", True) is False:
                 raise RuntimeError("private device-code delivery failed")
 
-        active_flows.add(flow_key)
-        try:
+        async def _run_login_worker() -> bool:
             from hermes_cli.auth import login_openai_codex_to_pool
 
-            if getattr(self.config, "multiplex_profiles", False):
-                with _profile_runtime_scope(profile_home):
+            try:
+                if getattr(self.config, "multiplex_profiles", False):
+                    with _profile_runtime_scope(profile_home):
+                        await asyncio.to_thread(
+                            login_openai_codex_to_pool,
+                            _send_verification,
+                        )
+                else:
                     await asyncio.to_thread(
                         login_openai_codex_to_pool,
                         _send_verification,
                     )
-            else:
-                await asyncio.to_thread(
-                    login_openai_codex_to_pool,
-                    _send_verification,
+                return True
+            except Exception:
+                logger.warning(
+                    "Codex device-code login failed for %s:%s",
+                    source.platform.value if source.platform else "?",
+                    source.user_id,
                 )
+                return False
+            finally:
+                active_flows.discard(flow_key)
+                current_worker = asyncio.current_task()
+                if active_workers.get(flow_key) is current_worker:
+                    active_workers.pop(flow_key, None)
+
+        active_flows.add(flow_key)
+        worker = asyncio.create_task(_run_login_worker())
+        active_workers[flow_key] = worker
+
+        # Shield the owned worker so cancelling this message handler does not
+        # release the dedupe key while asyncio.to_thread continues running.
+        # Handler cancellation still propagates to the caller immediately.
+        completed = await asyncio.shield(worker)
+        if completed:
             return "Codex login complete. The account was added to this profile."
-        except Exception:
-            logger.warning(
-                "Codex device-code login failed for %s:%s",
-                source.platform.value if source.platform else "?",
-                source.user_id,
-            )
-            return "Codex login did not complete. Send `/login codex` to request a new code."
-        finally:
-            active_flows.discard(flow_key)
+        return "Codex login did not complete. Send `/login codex` to request a new code."
 
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14429,6 +14429,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "codex-runtime":
             return await self._handle_codex_runtime_command(event)
 
+        if canonical == "login":
+            return await self._handle_login_command(event)
+
         if canonical == "personality":
             return await self._handle_personality_command(event)
 
@@ -17711,6 +17714,118 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if time.time() - requested_at > 300:
                 return False
         return True
+
+
+    async def _handle_login_command(self, event: MessageEvent) -> str:
+        """Add a Codex account from an authorized private gateway session."""
+        source = event.source
+        provider = event.get_command_args().strip().lower() or "codex"
+        if provider not in {"codex", "openai-codex", "openai_codex"}:
+            return "Usage: /login codex"
+
+        if (source.chat_type or "").strip().lower() not in {
+            "",
+            "dm",
+            "direct",
+            "private",
+        }:
+            return (
+                "For safety, Codex login codes are only sent in a private "
+                "conversation. DM this bot `/login codex` to add an account."
+            )
+
+        adapter = self._adapter_for_source(source)
+        if adapter is None:
+            return "Codex login could not find a private response path for this conversation."
+
+        # When command roles are configured, only an explicit admin may add
+        # credentials. Resolve roles from the source adapter so a multiplexed
+        # profile cannot inherit the primary profile's command policy.
+        from gateway.slash_access import policy_for_source
+
+        policy_config = self.config
+        adapter_config = getattr(adapter, "config", None)
+        if adapter_config is not None:
+            from types import SimpleNamespace
+
+            policy_config = SimpleNamespace(
+                platforms={source.platform: adapter_config},
+            )
+        policy = policy_for_source(policy_config, source)
+        if not policy.is_admin(source.user_id):
+            return "⛔ /login is admin-only because it adds Hermes credentials."
+
+        if getattr(self.config, "multiplex_profiles", False):
+            profile_home = self._resolve_profile_home_for_source(source)
+        else:
+            from hermes_constants import get_hermes_home
+
+            profile_home = get_hermes_home()
+
+        flow_key = (
+            str(profile_home),
+            source.platform.value if source.platform else "",
+            str(source.chat_id or ""),
+            str(source.thread_id or ""),
+            str(source.user_id or ""),
+        )
+        active_flows = getattr(self, "_active_codex_login_flows", None)
+        if active_flows is None:
+            active_flows = set()
+            self._active_codex_login_flows = active_flows
+        if flow_key in active_flows:
+            return (
+                "A Codex login code is already active for this conversation. "
+                "Complete it, or wait for it to expire before requesting a new one."
+            )
+
+        loop = asyncio.get_running_loop()
+        metadata = self._thread_metadata_for_source(
+            source,
+            self._reply_anchor_for_event(event),
+        )
+
+        def _send_verification(prompt) -> None:
+            minutes = max(1, round(prompt.expires_in_seconds / 60))
+            message = (
+                "Open this link in your browser and enter the Codex pairing code:\n\n"
+                f"{prompt.verification_url}\n\n"
+                f"Code: `{prompt.user_code}`\n\n"
+                f"The code expires in about {minutes} minutes. Never share it."
+            )
+            future = asyncio.run_coroutine_threadsafe(
+                adapter.send(str(source.chat_id), message, metadata=metadata),
+                loop,
+            )
+            result = future.result(timeout=30)
+            if getattr(result, "success", True) is False:
+                raise RuntimeError("private device-code delivery failed")
+
+        active_flows.add(flow_key)
+        try:
+            from hermes_cli.auth import login_openai_codex_to_pool
+
+            if getattr(self.config, "multiplex_profiles", False):
+                with _profile_runtime_scope(profile_home):
+                    await asyncio.to_thread(
+                        login_openai_codex_to_pool,
+                        _send_verification,
+                    )
+            else:
+                await asyncio.to_thread(
+                    login_openai_codex_to_pool,
+                    _send_verification,
+                )
+            return "Codex login complete. The account was added to this profile."
+        except Exception:
+            logger.warning(
+                "Codex device-code login failed for %s:%s",
+                source.platform.value if source.platform else "?",
+                source.user_id,
+            )
+            return "Codex login did not complete. Send `/login codex` to request a new code."
+        finally:
+            active_flows.discard(flow_key)
 
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -225,6 +225,15 @@ def normalize_actual_base_url(base_url: str) -> str:
     return url
 
 
+@dataclass(frozen=True)
+class CodexDeviceCodePrompt:
+    """Token-free Codex verification details for non-terminal callers."""
+
+    verification_url: str
+    user_code: str
+    expires_in_seconds: int
+
+
 # =============================================================================
 # Provider Registry
 # =============================================================================
@@ -8201,7 +8210,9 @@ def _xai_oauth_device_code_login(
     }
 
 
-def _codex_device_code_login() -> Dict[str, Any]:
+def _codex_device_code_login(
+    on_verification: Optional[Callable[[CodexDeviceCodePrompt], None]] = None,
+) -> Dict[str, Any]:
     """Run the OpenAI device code login flow and return credentials dict."""
     import time as _time
 
@@ -8270,6 +8281,10 @@ def _codex_device_code_login() -> Dict[str, Any]:
     user_code = device_data.get("user_code", "")
     device_auth_id = device_data.get("device_auth_id", "")
     poll_interval = max(3, int(device_data.get("interval", "5")))
+    try:
+        expires_in_seconds = max(1, int(device_data.get("expires_in") or 15 * 60))
+    except (TypeError, ValueError):
+        expires_in_seconds = 15 * 60
 
     if not user_code or not device_auth_id:
         raise AuthError(
@@ -8277,13 +8292,23 @@ def _codex_device_code_login() -> Dict[str, Any]:
             provider="openai-codex", code="device_code_incomplete",
         )
 
-    # Step 2: Show user the code
-    print("To continue, follow these steps:\n")
-    print("  1. Open this URL in your browser:")
-    print(f"     \033[94m{issuer}/codex/device\033[0m\n")
-    print("  2. Enter this code:")
-    print(f"     \033[94m{user_code}\033[0m\n")
-    print("Waiting for sign-in... (press Ctrl+C to cancel)")
+    # Step 2: Show the user the code. Non-terminal callers receive only this
+    # token-free prompt and must deliver it over their private response path
+    # before this function begins polling.
+    prompt = CodexDeviceCodePrompt(
+        verification_url=f"{issuer}/codex/device",
+        user_code=user_code,
+        expires_in_seconds=expires_in_seconds,
+    )
+    if on_verification is not None:
+        on_verification(prompt)
+    else:
+        print("To continue, follow these steps:\n")
+        print("  1. Open this URL in your browser:")
+        print(f"     \033[94m{prompt.verification_url}\033[0m\n")
+        print("  2. Enter this code:")
+        print(f"     \033[94m{prompt.user_code}\033[0m\n")
+        print("Waiting for sign-in... (press Ctrl+C to cancel)")
 
     # Step 3: Poll for authorization code
     max_wait = 15 * 60  # 15 minutes
@@ -8398,6 +8423,99 @@ def _codex_device_code_login() -> Dict[str, Any]:
         "auth_mode": "chatgpt",
         "source": "device-code",
     }
+
+
+def append_codex_pool_credential(
+    tokens: Dict[str, Any],
+    *,
+    base_url: Optional[str] = None,
+    last_refresh: Optional[str] = None,
+    label: Optional[str] = None,
+):
+    """Append one freshly authenticated Codex account to this profile's pool.
+
+    The shared persistence seam for every Codex device-code entry point —
+    terminal ``hermes auth add``, the gateway ``/login`` command, and the
+    dashboard login worker. It intentionally does not write the legacy
+    singleton provider state, so a second account cannot overwrite an
+    existing account's token pair (#39236); the dashboard used to save
+    through ``_save_codex_tokens`` and collapsed every account it added
+    into the latest login.
+
+    Reads and rewrites only the rows this store OWNS. ``load_pool`` hydrates
+    the global-root fallback into memory when the profile slice is empty
+    (see ``read_credential_pool``), and persisting that in-memory list would
+    copy the root account's tokens into the profile's ``auth.json`` — turning
+    a read-only fallback into a silent credential copy. The append therefore
+    goes through the raw profile slice, never the merged view.
+    """
+    from agent.credential_pool import (
+        AUTH_TYPE_OAUTH,
+        SOURCE_MANUAL_DEVICE_CODE,
+        PooledCredential,
+        _next_priority,
+        label_from_token,
+    )
+
+    owned_pool = _load_auth_store().get("credential_pool")
+    raw_owned = owned_pool.get("openai-codex") if isinstance(owned_pool, dict) else None
+    owned_rows = [row for row in (raw_owned or []) if isinstance(row, dict)]
+    access_token = tokens["access_token"]
+    entry_label = (label or "").strip() or label_from_token(
+        access_token,
+        f"openai-codex-oauth-{len(owned_rows) + 1}",
+    )
+    entry = PooledCredential(
+        provider="openai-codex",
+        id=uuid.uuid4().hex[:6],
+        label=entry_label,
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=_next_priority(
+            [PooledCredential.from_dict("openai-codex", row) for row in owned_rows]
+        ),
+        source=SOURCE_MANUAL_DEVICE_CODE,
+        access_token=access_token,
+        refresh_token=tokens.get("refresh_token"),
+        base_url=base_url or (
+            os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
+            or DEFAULT_CODEX_BASE_URL
+        ),
+        last_refresh=last_refresh or (
+            datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        ),
+    )
+    write_credential_pool("openai-codex", owned_rows + [entry.to_dict()])
+    unsuppress_credential_source("openai-codex", SOURCE_MANUAL_DEVICE_CODE)
+    # Adding the first Codex credential should make it the active provider
+    # (the old singleton save path did this implicitly via
+    # _save_provider_state). Subsequent adds leave the active provider as-is.
+    if not owned_rows:
+        mark_provider_active_if_unset("openai-codex")
+    return entry
+
+
+def login_openai_codex_to_pool(
+    on_verification: Optional[Callable[[CodexDeviceCodePrompt], None]] = None,
+    *,
+    label: Optional[str] = None,
+):
+    """Authenticate one Codex account and append a distinct pooled credential.
+
+    Terminal and gateway device login share this entry point.
+    ``on_verification`` lets a non-terminal caller deliver the pairing code
+    over its own private response path instead of printing it to a console.
+    """
+    creds = (
+        _codex_device_code_login(on_verification=on_verification)
+        if on_verification is not None
+        else _codex_device_code_login()
+    )
+    return append_codex_pool_credential(
+        creds["tokens"],
+        base_url=creds.get("base_url"),
+        last_refresh=creds.get("last_refresh"),
+        label=label,
+    )
 
 
 # ==================== MiniMax Portal OAuth ====================

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -152,6 +152,15 @@ SERVICE_PROVIDER_NAMES: Dict[str, str] = {
 LMSTUDIO_NOAUTH_PLACEHOLDER = "dummy-lm-api-key"
 
 
+@dataclass(frozen=True)
+class CodexDeviceCodePrompt:
+    """Token-free Codex verification details for non-terminal callers."""
+
+    verification_url: str
+    user_code: str
+    expires_in_seconds: int
+
+
 # =============================================================================
 # Provider Registry
 # =============================================================================
@@ -7855,7 +7864,9 @@ def _xai_oauth_device_code_login(
     }
 
 
-def _codex_device_code_login() -> Dict[str, Any]:
+def _codex_device_code_login(
+    on_verification: Optional[Callable[[CodexDeviceCodePrompt], None]] = None,
+) -> Dict[str, Any]:
     """Run the OpenAI device code login flow and return credentials dict."""
     import time as _time
 
@@ -7924,6 +7935,10 @@ def _codex_device_code_login() -> Dict[str, Any]:
     user_code = device_data.get("user_code", "")
     device_auth_id = device_data.get("device_auth_id", "")
     poll_interval = max(3, int(device_data.get("interval", "5")))
+    try:
+        expires_in_seconds = max(1, int(device_data.get("expires_in") or 15 * 60))
+    except (TypeError, ValueError):
+        expires_in_seconds = 15 * 60
 
     if not user_code or not device_auth_id:
         raise AuthError(
@@ -7931,13 +7946,23 @@ def _codex_device_code_login() -> Dict[str, Any]:
             provider="openai-codex", code="device_code_incomplete",
         )
 
-    # Step 2: Show user the code
-    print("To continue, follow these steps:\n")
-    print("  1. Open this URL in your browser:")
-    print(f"     \033[94m{issuer}/codex/device\033[0m\n")
-    print("  2. Enter this code:")
-    print(f"     \033[94m{user_code}\033[0m\n")
-    print("Waiting for sign-in... (press Ctrl+C to cancel)")
+    # Step 2: Show the user the code. Non-terminal callers receive only this
+    # token-free prompt and must deliver it over their private response path
+    # before this function begins polling.
+    prompt = CodexDeviceCodePrompt(
+        verification_url=f"{issuer}/codex/device",
+        user_code=user_code,
+        expires_in_seconds=expires_in_seconds,
+    )
+    if on_verification is not None:
+        on_verification(prompt)
+    else:
+        print("To continue, follow these steps:\n")
+        print("  1. Open this URL in your browser:")
+        print(f"     \033[94m{prompt.verification_url}\033[0m\n")
+        print("  2. Enter this code:")
+        print(f"     \033[94m{prompt.user_code}\033[0m\n")
+        print("Waiting for sign-in... (press Ctrl+C to cancel)")
 
     # Step 3: Poll for authorization code
     max_wait = 15 * 60  # 15 minutes
@@ -8052,6 +8077,54 @@ def _codex_device_code_login() -> Dict[str, Any]:
         "auth_mode": "chatgpt",
         "source": "device-code",
     }
+
+
+def login_openai_codex_to_pool(
+    on_verification: Optional[Callable[[CodexDeviceCodePrompt], None]] = None,
+    *,
+    label: Optional[str] = None,
+):
+    """Authenticate one Codex account and append a distinct pooled credential.
+
+    This is the shared persistence seam for terminal and gateway device login.
+    It intentionally does not write the legacy singleton provider state, so a
+    second account cannot overwrite an existing account's token pair.
+    """
+    from agent.credential_pool import (
+        AUTH_TYPE_OAUTH,
+        SOURCE_MANUAL_DEVICE_CODE,
+        PooledCredential,
+        label_from_token,
+        load_pool,
+    )
+
+    creds = (
+        _codex_device_code_login(on_verification=on_verification)
+        if on_verification is not None
+        else _codex_device_code_login()
+    )
+    pool = load_pool("openai-codex")
+    access_token = creds["tokens"]["access_token"]
+    entry_label = (label or "").strip() or label_from_token(
+        access_token,
+        f"openai-codex-oauth-{len(pool.entries()) + 1}",
+    )
+    entry = PooledCredential(
+        provider="openai-codex",
+        id=uuid.uuid4().hex[:6],
+        label=entry_label,
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=0,
+        source=SOURCE_MANUAL_DEVICE_CODE,
+        access_token=access_token,
+        refresh_token=creds["tokens"].get("refresh_token"),
+        base_url=creds.get("base_url"),
+        last_refresh=creds.get("last_refresh"),
+    )
+    entry = pool.add_entry(entry)
+    unsuppress_credential_source("openai-codex", SOURCE_MANUAL_DEVICE_CODE)
+    mark_provider_active_if_unset("openai-codex")
+    return entry
 
 
 # ==================== MiniMax Portal OAuth ====================

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -308,41 +308,13 @@ def auth_add_command(args) -> None:
         return
 
     if provider == "openai-codex":
-        creds = auth_mod._codex_device_code_login()
-        label = (getattr(args, "label", None) or "").strip() or label_from_token(
-            creds["tokens"]["access_token"],
-            _oauth_default_label(provider, len(pool.entries()) + 1),
+        entry = auth_mod.login_openai_codex_to_pool(
+            label=(getattr(args, "label", None) or "").strip() or None,
         )
-        # Add a distinct, self-contained pool entry per account (matching the
-        # qwen-oauth / minimax-oauth multi-account patterns, and the
-        # xai-oauth path below) instead of routing through the singleton
-        # ``_save_codex_tokens`` save path.
-        # The singleton round-trip collapsed every added account into the
-        # latest login: a second ``hermes auth add openai-codex`` overwrote
-        # the first account's singleton-mirrored ``device_code`` entry rather
-        # than creating an independent one (#39236). ``manual:device_code``
-        # entries refresh from their own token pair, so they need no singleton
-        # shadow.
-        entry = PooledCredential(
-            provider=provider,
-            id=uuid.uuid4().hex[:6],
-            label=label,
-            auth_type=AUTH_TYPE_OAUTH,
-            priority=0,
-            source=SOURCE_MANUAL_DEVICE_CODE,
-            access_token=creds["tokens"]["access_token"],
-            refresh_token=creds["tokens"].get("refresh_token"),
-            base_url=creds.get("base_url"),
-            last_refresh=creds.get("last_refresh"),
+        print(
+            f'Added {provider} OAuth credential '
+            f'#{len(load_pool(provider).entries())}: "{entry.label}"'
         )
-        first_credential = not pool.entries()
-        pool.add_entry(entry)
-        # Adding the first Codex credential should make it the active provider
-        # (the old singleton save path did this implicitly via
-        # _save_provider_state). Subsequent adds leave the active provider as-is.
-        if first_credential:
-            auth_mod.mark_provider_active_if_unset(provider)
-        print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
         return
 
     if provider == "xai-oauth":

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -249,6 +249,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                "Configuration", aliases=("codex_runtime",),
                args_hint="[auto|codex_app_server]",
                busy_policy="reject", busy_handler="codex-runtime"),
+    CommandDef("login", "Pair Codex with a private device code", "Configuration",
+               gateway_only=True, args_hint="[codex]", busy_policy="reject"),
 
     CommandDef("personality", "Set a predefined personality", "Configuration",
                args_hint="[name]"),
@@ -1346,7 +1348,9 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #     (session export is an interactive surface; platform is a rare
 #     informational lookup) — without this entry /save tips the registry
 #     past the 50-cap and silently clamps /platform, breaking parity.
-_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat", "refine", "pause", "whoami", "platform"})
+#   - login: infrequent credential enrollment; reached via
+#     /hermes login codex on Slack rather than consuming a native slash slot.
+_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat", "refine", "pause", "whoami", "platform", "login"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -188,6 +188,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                "Configuration", aliases=("codex_runtime",),
                args_hint="[auto|codex_app_server]",
                busy_policy="reject", busy_handler="codex-runtime"),
+    CommandDef("login", "Pair Codex with a private device code", "Configuration",
+               gateway_only=True, args_hint="[codex]", busy_policy="reject"),
 
     CommandDef("personality", "Set a predefined personality", "Configuration",
                args_hint="[name]"),
@@ -1256,7 +1258,12 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #     /hermes update on Slack. Demoted to free the native slot /approvals now
 #     claims — without this entry /approvals tips the registry past the 50-cap
 #     and silently clamps /update off, breaking Telegram parity.
-_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update"})
+#   - login: infrequent credential enrollment; reached via
+#     /hermes login codex on Slack rather than consuming a native slash slot.
+_SLACK_VIA_HERMES_ONLY = frozenset({
+    "topup", "moa", "debug", "egress", "init", "version", "diff", "update",
+    "login",
+})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11602,10 +11602,13 @@ def _codex_full_login_worker(session_id: str) -> None:
     ``authorization_code`` + ``code_verifier`` that get exchanged at
     CODEX_OAUTH_TOKEN_URL with grant_type=authorization_code.
 
-    The flow is replicated inline (rather than calling
-    _codex_device_code_login) because that helper prints/blocks/polls in a
-    single function — we need to surface the user_code to the dashboard the
-    moment we receive it, well before polling completes.
+    The transport is replicated inline (rather than calling
+    _codex_device_code_login) because this worker must also abort mid-poll
+    when the dashboard cancels the session, and because it rewords the
+    device-authorization start failure for a browser audience. Persistence is
+    NOT replicated: it goes through the shared
+    ``append_codex_pool_credential`` seam so a dashboard login lands as its
+    own pooled account like the terminal and gateway paths.
     """
     try:
         import httpx
@@ -11705,7 +11708,7 @@ def _codex_full_login_worker(session_id: str) -> None:
         if not access_token:
             raise RuntimeError("token exchange did not return access_token")
 
-        from hermes_cli.auth import _save_codex_tokens
+        from hermes_cli.auth import append_codex_pool_credential
 
         # The cancellation check and the save must be one atomic critical
         # section under the same lock cancel_oauth_session() uses. Checking
@@ -11720,7 +11723,7 @@ def _codex_full_login_worker(session_id: str) -> None:
                 _log.info("oauth/device: openai-codex login cancelled before token save (session=%s)", session_id)
                 return
             with _profile_scope(session_profile):
-                _save_codex_tokens({
+                append_codex_pool_credential({
                     "access_token": access_token,
                     "refresh_token": refresh_token,
                 })

--- a/tests/gateway/test_gateway_command_dispatch_minimal.py
+++ b/tests/gateway/test_gateway_command_dispatch_minimal.py
@@ -129,3 +129,16 @@ async def test_idle_queue_sends_payload_as_next_turn(command_text):
     assert runner._running_agents == {}
 
 
+@pytest.mark.asyncio
+async def test_idle_login_dispatches_registered_gateway_handler():
+    runner, _adapter = _make_runner()
+    runner._handle_login_command = AsyncMock(return_value="login-started")
+
+    result = await runner._handle_message(_make_event("/login codex"))
+
+    assert result == "login-started"
+    runner._handle_login_command.assert_awaited_once()
+    dispatched_event = runner._handle_login_command.await_args.args[0]
+    assert dispatched_event.get_command() == "login"
+    assert dispatched_event.get_command_args() == "codex"
+

--- a/tests/gateway/test_login_command.py
+++ b/tests/gateway/test_login_command.py
@@ -1,0 +1,361 @@
+"""Channel-safe, profile-scoped Codex gateway login tests."""
+
+import asyncio
+import json
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+from hermes_cli.auth import CodexDeviceCodePrompt
+
+
+def _event(
+    text: str = "/login codex",
+    *,
+    chat_type: str = "dm",
+    user_id: str = "owner",
+    profile: str | None = None,
+):
+    return MessageEvent(
+        text=text,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="chat-1",
+            user_id=user_id,
+            user_name="tester",
+            chat_type=chat_type,
+            profile=profile,
+        ),
+    )
+
+
+def _runner(*, extra=None, multiplex_profiles: bool = False):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    platform_config = PlatformConfig(
+        enabled=True,
+        token="***",
+        extra=extra or {},
+    )
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: platform_config},
+        multiplex_profiles=multiplex_profiles,
+    )
+    adapter = SimpleNamespace(
+        send=AsyncMock(return_value=SimpleNamespace(success=True)),
+        config=platform_config,
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._adapter_for_source = lambda _source: adapter
+    runner._reply_anchor_for_event = lambda _event: None
+    runner._thread_metadata_for_source = lambda _source, _anchor=None: {}
+    return runner, adapter
+
+
+def _prompt(code: str = "PRIVATE-CODE"):
+    return CodexDeviceCodePrompt(
+        verification_url="https://auth.openai.com/codex/device",
+        user_code=code,
+        expires_in_seconds=900,
+    )
+
+
+def test_login_is_registered_with_explicit_busy_rejection():
+    from hermes_cli.commands import (
+        GATEWAY_KNOWN_COMMANDS,
+        resolve_command,
+        telegram_bot_commands,
+    )
+
+    command = resolve_command("login")
+
+    assert command is not None
+    assert command.gateway_only is True
+    assert command.busy_policy == "reject"
+    assert "login" in GATEWAY_KNOWN_COMMANDS
+    assert ("login", "Pair Codex with a private device code") in telegram_bot_commands()
+
+
+@pytest.mark.asyncio
+async def test_login_rejects_while_agent_is_busy():
+    from hermes_cli.commands import resolve_command
+
+    runner, _adapter = _runner()
+    command = resolve_command("login")
+
+    result = await runner._dispatch_busy_slash_command(
+        _event(),
+        command,
+        "agent:main:telegram:dm:chat-1",
+        _event().source,
+    )
+
+    assert result == (
+        "⏳ Agent is running — `/login` can't run mid-turn. "
+        "Wait for the current response or `/stop` first."
+    )
+
+
+@pytest.mark.asyncio
+async def test_login_codex_sends_code_before_auth_continues(monkeypatch):
+    runner, adapter = _runner()
+    events = []
+
+    async def send(_chat_id, _message, **_kwargs):
+        events.append("send")
+        return SimpleNamespace(success=True)
+
+    adapter.send = AsyncMock(side_effect=send)
+
+    def fake_login(on_verification):
+        on_verification(_prompt())
+        events.append("poll")
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.login_openai_codex_to_pool",
+        fake_login,
+    )
+
+    result = await runner._handle_login_command(_event())
+
+    assert events == ["send", "poll"]
+    assert result == "Codex login complete. The account was added to this profile."
+    sent = adapter.send.await_args.args[1]
+    assert "https://auth.openai.com/codex/device" in sent
+    assert "PRIVATE-CODE" in sent
+    assert "PRIVATE-CODE" not in result
+
+
+@pytest.mark.asyncio
+async def test_login_codex_rejects_group_without_starting_auth(monkeypatch):
+    runner, adapter = _runner()
+    login = MagicMock()
+    monkeypatch.setattr("hermes_cli.auth.login_openai_codex_to_pool", login)
+
+    result = await runner._handle_login_command(_event(chat_type="group"))
+
+    assert "only sent in a private conversation" in result
+    login.assert_not_called()
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_login_codex_is_admin_only_when_command_roles_are_configured(
+    monkeypatch,
+):
+    runner, adapter = _runner(extra={"allow_admin_from": ["owner"]})
+    login = MagicMock()
+    monkeypatch.setattr("hermes_cli.auth.login_openai_codex_to_pool", login)
+
+    result = await runner._handle_login_command(_event(user_id="member"))
+
+    assert result == "⛔ /login is admin-only because it adds Hermes credentials."
+    login.assert_not_called()
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_login_codex_dedupes_active_conversation_flow(monkeypatch):
+    runner, _adapter = _runner()
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_login(on_verification):
+        on_verification(_prompt("FIRST-CODE"))
+        started.set()
+        release.wait(timeout=5)
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.login_openai_codex_to_pool",
+        blocking_login,
+    )
+
+    first = asyncio.create_task(runner._handle_login_command(_event()))
+    assert await asyncio.to_thread(started.wait, 5)
+    second = await runner._handle_login_command(_event())
+    release.set()
+
+    assert "already active" in second
+    assert await first == "Codex login complete. The account was added to this profile."
+
+
+@pytest.mark.asyncio
+async def test_login_codex_handler_cancellation_retains_dedupe_until_worker_exits(
+    monkeypatch,
+):
+    runner, _adapter = _runner()
+    started = threading.Event()
+    release = threading.Event()
+    exited = threading.Event()
+
+    def blocking_login(on_verification):
+        on_verification(_prompt("CANCEL-CODE"))
+        started.set()
+        release.wait(timeout=5)
+        exited.set()
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.login_openai_codex_to_pool",
+        blocking_login,
+    )
+
+    handler = asyncio.create_task(runner._handle_login_command(_event()))
+    assert await asyncio.to_thread(started.wait, 5)
+    flow_key = next(iter(runner._active_codex_login_flows))
+    worker = runner._active_codex_login_workers[flow_key]
+
+    handler.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await handler
+
+    assert flow_key in runner._active_codex_login_flows
+    assert runner._active_codex_login_workers[flow_key] is worker
+    duplicate = await runner._handle_login_command(_event())
+    assert "already active" in duplicate
+
+    release.set()
+    assert await asyncio.to_thread(exited.wait, 5)
+    assert await worker is True
+    assert runner._active_codex_login_flows == set()
+    assert runner._active_codex_login_workers == {}
+
+
+@pytest.mark.asyncio
+async def test_login_codex_failure_clears_dedupe_without_disclosing_exception(
+    monkeypatch, caplog
+):
+    runner, _adapter = _runner()
+    attempts = 0
+
+    def flaky_login(on_verification):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("PRIVATE-TOKEN")
+        on_verification(_prompt("SECOND-CODE"))
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.login_openai_codex_to_pool",
+        flaky_login,
+    )
+
+    first = await runner._handle_login_command(_event())
+    second = await runner._handle_login_command(_event())
+
+    assert first == "Codex login did not complete. Send `/login codex` to request a new code."
+    assert "PRIVATE-TOKEN" not in first
+    assert "PRIVATE-TOKEN" not in caplog.text
+    assert runner._active_codex_login_flows == set()
+    assert runner._active_codex_login_workers == {}
+    assert second == "Codex login complete. The account was added to this profile."
+
+
+@pytest.mark.asyncio
+async def test_login_codex_adds_distinct_accounts_to_routed_profile(
+    tmp_path, monkeypatch
+):
+    default_home = tmp_path / "default"
+    routed_home = tmp_path / "profiles" / "coder"
+    default_home.mkdir(parents=True)
+    routed_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+
+    existing = {
+        "id": "existing",
+        "label": "existing@example.com",
+        "auth_type": "oauth",
+        "priority": 0,
+        "source": "manual:device_code",
+        "access_token": "existing-access",
+        "refresh_token": "existing-refresh",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+    }
+    (routed_home / "auth.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "active_provider": "anthropic",
+                "providers": {},
+                "credential_pool": {"openai-codex": [existing]},
+            }
+        )
+    )
+
+    runner, adapter = _runner(multiplex_profiles=True)
+
+    def resolve_profile_home(source):
+        assert source.profile == "coder"
+        return routed_home
+
+    runner._resolve_profile_home_for_source = resolve_profile_home
+    logins = iter(
+        [
+            {
+                "code": "FIRST-CODE",
+                "access": "first-access",
+                "refresh": "first-refresh",
+            },
+            {
+                "code": "SECOND-CODE",
+                "access": "second-access",
+                "refresh": "second-refresh",
+            },
+        ]
+    )
+
+    def fake_device_login(on_verification=None):
+        login = next(logins)
+        assert on_verification is not None
+        on_verification(_prompt(login["code"]))
+        return {
+            "tokens": {
+                "access_token": login["access"],
+                "refresh_token": login["refresh"],
+            },
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "last_refresh": "2026-07-30T00:00:00Z",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.auth._codex_device_code_login",
+        fake_device_login,
+    )
+
+    first_result = await runner._handle_login_command(_event(profile="coder"))
+    second_result = await runner._handle_login_command(_event(profile="coder"))
+
+    payload = json.loads((routed_home / "auth.json").read_text())
+    entries = payload["credential_pool"]["openai-codex"]
+    assert [entry["access_token"] for entry in entries] == [
+        "existing-access",
+        "first-access",
+        "second-access",
+    ]
+    assert [entry["refresh_token"] for entry in entries] == [
+        "existing-refresh",
+        "first-refresh",
+        "second-refresh",
+    ]
+    assert payload["active_provider"] == "anthropic"
+    assert not (default_home / "auth.json").exists()
+
+    returned = first_result + second_result
+    sent = " ".join(call.args[1] for call in adapter.send.await_args_list)
+    for secret in (
+        "first-access",
+        "first-refresh",
+        "second-access",
+        "second-refresh",
+    ):
+        assert secret not in returned
+        assert secret not in sent
+    assert "FIRST-CODE" not in returned
+    assert "SECOND-CODE" not in returned
+    assert "FIRST-CODE" in sent
+    assert "SECOND-CODE" in sent

--- a/tests/gateway/test_login_command.py
+++ b/tests/gateway/test_login_command.py
@@ -186,6 +186,47 @@ async def test_login_codex_dedupes_active_conversation_flow(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_login_codex_handler_cancellation_retains_dedupe_until_worker_exits(
+    monkeypatch,
+):
+    runner, _adapter = _runner()
+    started = threading.Event()
+    release = threading.Event()
+    exited = threading.Event()
+
+    def blocking_login(on_verification):
+        on_verification(_prompt("CANCEL-CODE"))
+        started.set()
+        release.wait(timeout=5)
+        exited.set()
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.login_openai_codex_to_pool",
+        blocking_login,
+    )
+
+    handler = asyncio.create_task(runner._handle_login_command(_event()))
+    assert await asyncio.to_thread(started.wait, 5)
+    flow_key = next(iter(runner._active_codex_login_flows))
+    worker = runner._active_codex_login_workers[flow_key]
+
+    handler.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await handler
+
+    assert flow_key in runner._active_codex_login_flows
+    assert runner._active_codex_login_workers[flow_key] is worker
+    duplicate = await runner._handle_login_command(_event())
+    assert "already active" in duplicate
+
+    release.set()
+    assert await asyncio.to_thread(exited.wait, 5)
+    assert await worker is True
+    assert runner._active_codex_login_flows == set()
+    assert runner._active_codex_login_workers == {}
+
+
+@pytest.mark.asyncio
 async def test_login_codex_failure_clears_dedupe_without_disclosing_exception(
     monkeypatch, caplog
 ):
@@ -211,6 +252,7 @@ async def test_login_codex_failure_clears_dedupe_without_disclosing_exception(
     assert "PRIVATE-TOKEN" not in first
     assert "PRIVATE-TOKEN" not in caplog.text
     assert runner._active_codex_login_flows == set()
+    assert runner._active_codex_login_workers == {}
     assert second == "Codex login complete. The account was added to this profile."
 
 

--- a/tests/gateway/test_login_command.py
+++ b/tests/gateway/test_login_command.py
@@ -1,0 +1,319 @@
+"""Channel-safe, profile-scoped Codex gateway login tests."""
+
+import asyncio
+import json
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+from hermes_cli.auth import CodexDeviceCodePrompt
+
+
+def _event(
+    text: str = "/login codex",
+    *,
+    chat_type: str = "dm",
+    user_id: str = "owner",
+    profile: str | None = None,
+):
+    return MessageEvent(
+        text=text,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="chat-1",
+            user_id=user_id,
+            user_name="tester",
+            chat_type=chat_type,
+            profile=profile,
+        ),
+    )
+
+
+def _runner(*, extra=None, multiplex_profiles: bool = False):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    platform_config = PlatformConfig(
+        enabled=True,
+        token="***",
+        extra=extra or {},
+    )
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: platform_config},
+        multiplex_profiles=multiplex_profiles,
+    )
+    adapter = SimpleNamespace(
+        send=AsyncMock(return_value=SimpleNamespace(success=True)),
+        config=platform_config,
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._adapter_for_source = lambda _source: adapter
+    runner._reply_anchor_for_event = lambda _event: None
+    runner._thread_metadata_for_source = lambda _source, _anchor=None: {}
+    return runner, adapter
+
+
+def _prompt(code: str = "PRIVATE-CODE"):
+    return CodexDeviceCodePrompt(
+        verification_url="https://auth.openai.com/codex/device",
+        user_code=code,
+        expires_in_seconds=900,
+    )
+
+
+def test_login_is_registered_with_explicit_busy_rejection():
+    from hermes_cli.commands import (
+        GATEWAY_KNOWN_COMMANDS,
+        resolve_command,
+        telegram_bot_commands,
+    )
+
+    command = resolve_command("login")
+
+    assert command is not None
+    assert command.gateway_only is True
+    assert command.busy_policy == "reject"
+    assert "login" in GATEWAY_KNOWN_COMMANDS
+    assert ("login", "Pair Codex with a private device code") in telegram_bot_commands()
+
+
+@pytest.mark.asyncio
+async def test_login_rejects_while_agent_is_busy():
+    from hermes_cli.commands import resolve_command
+
+    runner, _adapter = _runner()
+    command = resolve_command("login")
+
+    result = await runner._dispatch_busy_slash_command(
+        _event(),
+        command,
+        "agent:main:telegram:dm:chat-1",
+        _event().source,
+    )
+
+    assert result == (
+        "⏳ Agent is running — `/login` can't run mid-turn. "
+        "Wait for the current response or `/stop` first."
+    )
+
+
+@pytest.mark.asyncio
+async def test_login_codex_sends_code_before_auth_continues(monkeypatch):
+    runner, adapter = _runner()
+    events = []
+
+    async def send(_chat_id, _message, **_kwargs):
+        events.append("send")
+        return SimpleNamespace(success=True)
+
+    adapter.send = AsyncMock(side_effect=send)
+
+    def fake_login(on_verification):
+        on_verification(_prompt())
+        events.append("poll")
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.login_openai_codex_to_pool",
+        fake_login,
+    )
+
+    result = await runner._handle_login_command(_event())
+
+    assert events == ["send", "poll"]
+    assert result == "Codex login complete. The account was added to this profile."
+    sent = adapter.send.await_args.args[1]
+    assert "https://auth.openai.com/codex/device" in sent
+    assert "PRIVATE-CODE" in sent
+    assert "PRIVATE-CODE" not in result
+
+
+@pytest.mark.asyncio
+async def test_login_codex_rejects_group_without_starting_auth(monkeypatch):
+    runner, adapter = _runner()
+    login = MagicMock()
+    monkeypatch.setattr("hermes_cli.auth.login_openai_codex_to_pool", login)
+
+    result = await runner._handle_login_command(_event(chat_type="group"))
+
+    assert "only sent in a private conversation" in result
+    login.assert_not_called()
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_login_codex_is_admin_only_when_command_roles_are_configured(
+    monkeypatch,
+):
+    runner, adapter = _runner(extra={"allow_admin_from": ["owner"]})
+    login = MagicMock()
+    monkeypatch.setattr("hermes_cli.auth.login_openai_codex_to_pool", login)
+
+    result = await runner._handle_login_command(_event(user_id="member"))
+
+    assert result == "⛔ /login is admin-only because it adds Hermes credentials."
+    login.assert_not_called()
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_login_codex_dedupes_active_conversation_flow(monkeypatch):
+    runner, _adapter = _runner()
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_login(on_verification):
+        on_verification(_prompt("FIRST-CODE"))
+        started.set()
+        release.wait(timeout=5)
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.login_openai_codex_to_pool",
+        blocking_login,
+    )
+
+    first = asyncio.create_task(runner._handle_login_command(_event()))
+    assert await asyncio.to_thread(started.wait, 5)
+    second = await runner._handle_login_command(_event())
+    release.set()
+
+    assert "already active" in second
+    assert await first == "Codex login complete. The account was added to this profile."
+
+
+@pytest.mark.asyncio
+async def test_login_codex_failure_clears_dedupe_without_disclosing_exception(
+    monkeypatch, caplog
+):
+    runner, _adapter = _runner()
+    attempts = 0
+
+    def flaky_login(on_verification):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("PRIVATE-TOKEN")
+        on_verification(_prompt("SECOND-CODE"))
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.login_openai_codex_to_pool",
+        flaky_login,
+    )
+
+    first = await runner._handle_login_command(_event())
+    second = await runner._handle_login_command(_event())
+
+    assert first == "Codex login did not complete. Send `/login codex` to request a new code."
+    assert "PRIVATE-TOKEN" not in first
+    assert "PRIVATE-TOKEN" not in caplog.text
+    assert runner._active_codex_login_flows == set()
+    assert second == "Codex login complete. The account was added to this profile."
+
+
+@pytest.mark.asyncio
+async def test_login_codex_adds_distinct_accounts_to_routed_profile(
+    tmp_path, monkeypatch
+):
+    default_home = tmp_path / "default"
+    routed_home = tmp_path / "profiles" / "coder"
+    default_home.mkdir(parents=True)
+    routed_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+
+    existing = {
+        "id": "existing",
+        "label": "existing@example.com",
+        "auth_type": "oauth",
+        "priority": 0,
+        "source": "manual:device_code",
+        "access_token": "existing-access",
+        "refresh_token": "existing-refresh",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+    }
+    (routed_home / "auth.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "active_provider": "anthropic",
+                "providers": {},
+                "credential_pool": {"openai-codex": [existing]},
+            }
+        )
+    )
+
+    runner, adapter = _runner(multiplex_profiles=True)
+
+    def resolve_profile_home(source):
+        assert source.profile == "coder"
+        return routed_home
+
+    runner._resolve_profile_home_for_source = resolve_profile_home
+    logins = iter(
+        [
+            {
+                "code": "FIRST-CODE",
+                "access": "first-access",
+                "refresh": "first-refresh",
+            },
+            {
+                "code": "SECOND-CODE",
+                "access": "second-access",
+                "refresh": "second-refresh",
+            },
+        ]
+    )
+
+    def fake_device_login(on_verification=None):
+        login = next(logins)
+        assert on_verification is not None
+        on_verification(_prompt(login["code"]))
+        return {
+            "tokens": {
+                "access_token": login["access"],
+                "refresh_token": login["refresh"],
+            },
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "last_refresh": "2026-07-30T00:00:00Z",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.auth._codex_device_code_login",
+        fake_device_login,
+    )
+
+    first_result = await runner._handle_login_command(_event(profile="coder"))
+    second_result = await runner._handle_login_command(_event(profile="coder"))
+
+    payload = json.loads((routed_home / "auth.json").read_text())
+    entries = payload["credential_pool"]["openai-codex"]
+    assert [entry["access_token"] for entry in entries] == [
+        "existing-access",
+        "first-access",
+        "second-access",
+    ]
+    assert [entry["refresh_token"] for entry in entries] == [
+        "existing-refresh",
+        "first-refresh",
+        "second-refresh",
+    ]
+    assert payload["active_provider"] == "anthropic"
+    assert not (default_home / "auth.json").exists()
+
+    returned = first_result + second_result
+    sent = " ".join(call.args[1] for call in adapter.send.await_args_list)
+    for secret in (
+        "first-access",
+        "first-refresh",
+        "second-access",
+        "second-refresh",
+    ):
+        assert secret not in returned
+        assert secret not in sent
+    assert "FIRST-CODE" not in returned
+    assert "SECOND-CODE" not in returned
+    assert "FIRST-CODE" in sent
+    assert "SECOND-CODE" in sent

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -609,5 +609,68 @@ def _patch_httpx_post(monkeypatch, responses):
     monkeypatch.setattr("hermes_cli.auth.httpx.Client", lambda *a, **k: _FakeClient())
 
 
+def test_device_code_login_emits_prompt_before_poll_without_console_disclosure(
+    monkeypatch, capsys
+):
+    from hermes_cli import auth as auth_mod
+
+    events = []
+    monkeypatch.setattr(
+        "time.sleep",
+        lambda _seconds: events.append("poll"),
+    )
+    _patch_httpx_post(
+        monkeypatch,
+        [
+            _FakeResp(
+                200,
+                {
+                    "user_code": "PRIVATE-CODE",
+                    "device_auth_id": "device-auth-id",
+                    "interval": "5",
+                    "expires_in": 900,
+                },
+            ),
+            _FakeResp(
+                200,
+                {
+                    "authorization_code": "authorization-code",
+                    "code_verifier": "verifier",
+                },
+            ),
+            _FakeResp(
+                200,
+                {
+                    "access_token": "private-access-token",
+                    "refresh_token": "private-refresh-token",
+                },
+            ),
+        ],
+    )
+    prompts = []
+
+    def on_verification(prompt):
+        events.append("verification")
+        prompts.append(prompt)
+
+    creds = auth_mod._codex_device_code_login(
+        on_verification=on_verification,
+    )
+
+    assert events[:2] == ["verification", "poll"]
+    assert prompts == [
+        auth_mod.CodexDeviceCodePrompt(
+            verification_url="https://auth.openai.com/codex/device",
+            user_code="PRIVATE-CODE",
+            expires_in_seconds=900,
+        )
+    ]
+    output = capsys.readouterr().out
+    assert "PRIVATE-CODE" not in output
+    assert "private-access-token" not in output
+    assert creds["tokens"] == {
+        "access_token": "private-access-token",
+        "refresh_token": "private-refresh-token",
+    }
 
 

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -200,6 +200,63 @@ def test_write_credential_pool_targets_profile_not_global(profile_env):
     assert [e["id"] for e in read_credential_pool("openrouter")] == ["prof-new"]
 
 
+def test_codex_pool_append_never_copies_global_rows_into_profile(
+    profile_env, monkeypatch
+):
+    """A profile login must not clone the root account into the profile.
+
+    ``read_credential_pool`` hydrates the global-root rows whenever the
+    profile slice is empty, so a persistence path that rewrites its whole
+    in-memory pool copies the root's tokens into the profile's auth.json.
+    That silently forks the root credential: the copy refreshes and gets
+    exhausted independently, and removing the account at the root leaves a
+    live duplicate behind in every profile that ever logged in.
+    """
+    import hermes_cli.auth as auth
+
+    global_auth = profile_env["global"] / "auth.json"
+    _write(global_auth, _make_auth_store(pool={
+        "openai-codex": [{
+            "id": "glob-codex",
+            "label": "root-account",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual:device_code",
+            "access_token": "root-access",
+            "refresh_token": "root-refresh",
+        }],
+    }))
+    global_bytes = global_auth.read_bytes()
+
+    # The profile sees the root account through the read-only fallback.
+    assert [e["id"] for e in auth.read_credential_pool("openai-codex")] == [
+        "glob-codex"
+    ]
+
+    monkeypatch.setattr(auth, "_codex_device_code_login", lambda **_kwargs: {
+        "tokens": {
+            "access_token": "profile-access",
+            "refresh_token": "profile-refresh",
+        },
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "last_refresh": "2026-02-26T00:00:00Z",
+    })
+
+    entry = auth.login_openai_codex_to_pool()
+
+    profile_rows = json.loads(
+        (profile_env["profile"] / "auth.json").read_text()
+    )["credential_pool"]["openai-codex"]
+    assert [row["id"] for row in profile_rows] == [entry.id]
+    assert [row["access_token"] for row in profile_rows] == ["profile-access"]
+    assert not any(
+        row.get("refresh_token") == "root-refresh" for row in profile_rows
+    )
+
+    # The root store is a read-only fallback: the login must not touch it.
+    assert global_auth.read_bytes() == global_bytes
+
+
 
 
 def test_auth_lock_reentrancy_is_scoped_after_profile_context_switch(profile_env):

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -273,7 +273,9 @@ def test_codex_dashboard_worker_stops_polling_after_cancel(tmp_path, monkeypatch
     saved = []
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.setattr(httpx, "Client", _Client)
-    monkeypatch.setattr(auth_mod, "_save_codex_tokens", lambda tokens: saved.append(tokens))
+    monkeypatch.setattr(
+        auth_mod, "append_codex_pool_credential", lambda tokens: saved.append(tokens)
+    )
 
     sid, _ = ws._new_oauth_session("openai-codex", "device_code", profile="coder")
 
@@ -298,7 +300,7 @@ def test_codex_worker_final_save_is_atomic_with_cancel_delete(tmp_path, monkeypa
     """The final cancellation check and the token save must be one atomic
     section under `_oauth_sessions_lock`.
 
-    Regression: checking `cancelled` and calling `_save_codex_tokens()` used
+    Regression: checking `cancelled` and calling the pooled append used
     to be two separate steps with no lock held across them, so a DELETE
     landing in that gap flipped the flag too late for the worker to see it
     and the tokens were saved anyway. This drives a real DELETE from another
@@ -372,7 +374,7 @@ def test_codex_worker_final_save_is_atomic_with_cancel_delete(tmp_path, monkeypa
         client.delete(f"/api/providers/oauth/sessions/{sid}", headers=HEADERS)
         delete_finished.set()
 
-    monkeypatch.setattr(auth_mod, "_save_codex_tokens", fake_save)
+    monkeypatch.setattr(auth_mod, "append_codex_pool_credential", fake_save)
     monkeypatch.setattr(ws.time, "sleep", lambda *_a, **_k: None)
 
     sid, _ = ws._new_oauth_session("openai-codex", "device_code", profile="coder")


### PR DESCRIPTION
## What changed

- adds `/login codex` through the current `CommandDef` gateway dispatch surface
- extracts the current `hermes auth add openai-codex` pooled-account behavior into one shared service
- appends a distinct `manual:device_code` credential to the source profile pool without rewriting the singleton or other accounts
- keeps the configured active provider unchanged, selecting `openai-codex` only when no provider is set
- routes Slack through `/hermes login codex` because native Slack slash commands are already at the 50-command cap

## Safety

- rejects groups/channels before starting authentication
- requires the source adapter admin when command roles are configured
- rejects while an agent is busy
- sends the private verification URL/code before polling
- deduplicates active flows per profile/conversation, including while a cancelled handler's underlying device-login worker is still running
- clears dedupe and worker state after the underlying login worker exits
- never returns or logs token material; codes appear only in the private verification delivery

## Validation

- Rebased from `dd241cf0cda317f8ce2680ad3d24580998e6dc34` onto exact fetched main `c581ad402e942c8ab5ce7eb0be325b33061d17bb`.
- Current exact head: `0fd4e79f68a1be8215ca32cf31cc496574ae5605`.
- Both commits are patch-equivalent under `git range-diff`; the rebase had no conflicts or semantic drift.
- `scripts/run_tests.sh tests/gateway/test_login_command.py tests/hermes_cli/test_auth_codex_provider.py tests/hermes_cli/test_auth_commands.py tests/hermes_cli/test_commands.py tests/gateway/test_command_bypass_active_session.py tests/gateway/test_gateway_command_dispatch_minimal.py -q`
  - 127 passed
- `ruff check gateway/run.py hermes_cli/auth.py hermes_cli/auth_commands.py hermes_cli/commands.py tests/gateway/test_login_command.py tests/gateway/test_gateway_command_dispatch_minimal.py tests/hermes_cli/test_auth_codex_provider.py`
  - passed
- `git diff --check c581ad402e942c8ab5ce7eb0be325b33061d17bb..0fd4e79f68a1be8215ca32cf31cc496574ae5605`
  - passed

## Review and CI gates

- Independent auth-path review and final rebase-delta review passed for exact head `0fd4e79f68a1be8215ca32cf31cc496574ae5605`, including DM/admin enforcement, source-profile routing, pooled no-overwrite behavior, activation only when unset, token/code boundaries, cancellation propagation, and same-flow deduplication through worker exit.
- Exact-head GitHub Actions CI is blocked with `action_required`; an upstream maintainer must approve the external-fork workflow: https://github.com/NousResearch/hermes-agent/actions/runs/30533141882
- GitHub `main` advanced after the pinned rebase base to `9650f555d072d89f51b2c659360bc99799d4bc3c`. That later delta touches none of this PR's files, and GitHub reports the PR mergeable.

## Related

Replaces the stale implementation in #66362 with a current-main pooled-credential design.

Related to #55360. Automatic reauth-required event propagation remains outside this PR.
