### PR TITLE
fix(nix) : handle missing nativeBuildInputs safely

### DIFF
--- a/nix/python.nix
+++ b/nix/python.nix
@@ -17,7 +17,7 @@ let
   hacks = callPackage pyproject-nix.build.hacks { };
 
   overlay = workspace.mkPyprojectOverlay {
-    sourcePreference = "wheel";
+    sourcePreference = "sdist";
   };
 
   isAarch64Darwin = stdenv.hostPlatform.system == "aarch64-darwin";
@@ -140,8 +140,12 @@ let
       (final: prev: {
         hermes-agent = prev.hermes-agent.overrideAttrs (old: {
           # point straight at the real source instead of the filtered nix store copy
-          src = workspaceRoot;
-          nativeBuildInputs = old.nativeBuildInputs ++ final.resolveBuildSystem { editables = [ ]; };
+          src = lib.cleanSource workspaceRoot;
+          nativeBuildInputs =
+            (old.nativeBuildInputs or [ ])
+            ++ final.resolveBuildSystem {
+              editables = [ ];
+            };
         });
       })
     ]

--- a/nix/python.nix
+++ b/nix/python.nix
@@ -17,7 +17,7 @@ let
   hacks = callPackage pyproject-nix.build.hacks { };
 
   overlay = workspace.mkPyprojectOverlay {
-    sourcePreference = "sdist";
+    sourcePreference = "wheel";
   };
 
   isAarch64Darwin = stdenv.hostPlatform.system == "aarch64-darwin";
@@ -140,7 +140,7 @@ let
       (final: prev: {
         hermes-agent = prev.hermes-agent.overrideAttrs (old: {
           # point straight at the real source instead of the filtered nix store copy
-          src = lib.cleanSource workspaceRoot;
+          src = workspaceRoot;
           nativeBuildInputs =
             (old.nativeBuildInputs or [ ])
             ++ final.resolveBuildSystem {


### PR DESCRIPTION
This PR improves the robustness of the editable Python environment by safely handling packages that do not define nativeBuildInputs.

Previously, the editable override assumed nativeBuildInputs always existed, which could cause Nix evaluation failures when overriding packages without that attribute. This change uses a default empty list before appending additional build inputs, preserving existing behavior while preventing missing attribute errors.


[x] 🐛 Bug fix (non-breaking change that fixes an issue)
[ ] ✨ New feature (non-breaking change that adds functionality)
[ ] 🔒 Security fix
[ ] 📝 Documentation update
[ ] ✅ Tests (adding or improving test coverage)
[ ] ♻️ Refactor (no behavior change)
[ ] 🎯 New skill (bundled or hub)