### PR TITLE
fix(ui-tui): prevent stickyScroll re-activation after manual scroll-up

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/components/ScrollBox.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/ScrollBox.tsx
@@ -169,6 +169,12 @@ function ScrollBox({ children, ref, stickyScroll, ...style }: PropsWithChildren<
         el.stickyScroll = false
         manualScrollAtRef.current = Date.now()
         el.scrollAnchor = undefined
+
+        // Mark recent scroll-up to prevent sticky re-activation.
+        if (dy < 0) {
+          el.recentScrollUpTime = Date.now()
+        }
+
         el.pendingScrollDelta = (el.pendingScrollDelta ?? 0) + Math.floor(dy)
         scrollMutated(el)
       },
@@ -181,6 +187,8 @@ function ScrollBox({ children, ref, stickyScroll, ...style }: PropsWithChildren<
 
         el.pendingScrollDelta = undefined
         el.stickyScroll = true
+        // Clear recentScrollUpTime since we're explicitly going to bottom.
+        el.recentScrollUpTime = undefined
         markDirty(el)
         notify()
         forceRender(n => n + 1)

--- a/ui-tui/packages/hermes-ink/src/ink/dom.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/dom.ts
@@ -73,6 +73,10 @@ export type DOMElement = {
   scrollViewportTop?: number
   stickyScroll?: boolean
   notifyScrollChange?: () => void
+  // Timestamp of last manual scroll-up (negative scrollBy). Used to
+  // prevent stickyScroll from re-activating immediately after user
+  // scrolls up. Expires after 500ms or next scrollToBottom.
+  recentScrollUpTime?: number
   // Set by ScrollBox.scrollToElement; render-node-to-output reads
   // el.yogaNode.getComputedTop() (FRESH — same Yoga pass as scrollHeight)
   // and sets scrollTop = top + offset, then clears this. Unlike an

--- a/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
@@ -799,7 +799,12 @@ function renderNodeToOutput(
           // undefined (never set by user action) leave it alone — setting it
           // would make the sticky flag sticky-by-default and lock out
           // direct scrollTop writes (e.g. the alt-screen-perf test).
-          if (node.stickyScroll === false && scrollTopBeforeFollow >= prevMaxScroll) {
+          // DON'T restore if user recently scrolled up (within 500ms) to
+          // prevent aggressive re-activation that fights user intent.
+          const now = Date.now()
+          const recentScrollUp = node.recentScrollUpTime && now - node.recentScrollUpTime < 500
+
+          if (node.stickyScroll === false && scrollTopBeforeFollow >= prevMaxScroll && !recentScrollUp) {
             node.stickyScroll = true
           }
         }


### PR DESCRIPTION
## Context

Fixes #12884. Ports #12982 forward onto current main (MestreY0d4-Uninter's original PR, closed without merge as the branch had diverged too far to merge cleanly). Confirmed as the best-fix approach via the automated triage on #12884.

## Problem

The follow-on-scroll mechanism in `render-node-to-output.ts` restores `stickyScroll=true` when the user is positionally at the bottom and `stickyScroll` was explicitly broken by a prior `scrollTo`/`scrollBy` call. This was too aggressive: streaming content arriving right after a user scrolls up could re-activate sticky mode almost immediately, fighting the user's intent to read earlier content.

## Fix

Track `recentScrollUpTime` on the DOM element, set whenever `scrollBy()` is called with a negative delta, cleared by `scrollToBottom()`. The follow-on-scroll restoration now also requires the scroll-up to not have happened within the last 500ms.

## Verification

1427/1428 tests pass (1 pre-existing skip, unrelated) in the full `ui-tui` vitest suite; `npm run typecheck` clean (0 errors).