### PR TITLE
fix(signal): remove ?account= query param from SSE events URL

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -535,6 +535,25 @@ class SignalAdapter(BasePlatformAdapter):
 
     async def _handle_envelope(self, envelope: dict) -> None:
         """Process an incoming signal-cli envelope."""
+        # Outer-account gate: with the parameterless SSE endpoint
+        # (/api/v1/events without ?account=), signal-cli streams events from
+        # ALL registered accounts in multi-account mode. The outer event
+        # object carries the owning account (signal-cli sets "account" to the
+        # manager's self number — see JsonReceiveMessageHandler). Discard
+        # events belonging to a different account before unwrapping so a
+        # message received on another account cannot be dispatched here.
+        outer_account = envelope.get("account")
+        if (
+            outer_account
+            and self._account_normalized
+            and outer_account != self._account_normalized
+        ):
+            logger.debug(
+                "Signal: ignoring envelope for other account %s (adapter account %s)",
+                redact_phone(outer_account), redact_phone(self._account_normalized),
+            )
+            return
+
         # Unwrap nested envelope if present
         envelope_data = envelope.get("envelope", envelope)
 

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -26,7 +26,7 @@ from collections import OrderedDict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-from urllib.parse import quote, unquote
+from urllib.parse import unquote
 
 import httpx
 
@@ -425,7 +425,7 @@ class SignalAdapter(BasePlatformAdapter):
 
     async def _sse_listener(self) -> None:
         """Listen for SSE events from signal-cli daemon."""
-        url = f"{self.http_url}/api/v1/events?account={quote(self.account, safe='')}"
+        url = f"{self.http_url}/api/v1/events"
         backoff = SSE_RETRY_DELAY_INITIAL
 
         while self._running:

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -1225,6 +1225,86 @@ class TestSignalContentlessEnvelope:
         assert captured["event"].media_urls == ["/tmp/img.png"]
 
 
+class TestSignalOuterAccountGate:
+    """Multi-account SSE stream: parameterless URL + outer-account filtering.
+    Without ?account= signal-cli emits events for ALL accounts, each carrying
+    the owning account in the outer event object — anything for another
+    account must be discarded before unwrapping."""
+
+    @pytest.mark.asyncio
+    async def test_sse_url_is_parameterless(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        captured = {}
+
+        class FakeStream:
+            def __init__(self, method, url, **kwargs):
+                captured["url"] = url
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def aiter_text(self):
+                adapter._running = False  # stop loop after first iteration
+                yield ""
+
+        adapter.client = MagicMock()
+        adapter.client.stream = FakeStream
+        adapter._running = True
+
+        await adapter._sse_listener()
+
+        assert captured["url"] == f"{adapter.http_url}/api/v1/events"
+        assert "?" not in captured["url"]
+        assert "account=" not in captured["url"]
+
+    @pytest.mark.asyncio
+    async def test_discards_envelope_for_other_account(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch, account="+155****4567")
+        dispatched = []
+
+        async def fake_handle(event):
+            dispatched.append(event)
+
+        adapter.handle_message = fake_handle
+
+        await adapter._handle_envelope({
+            "account": "+499999999999",  # other account in the stream
+            "envelope": {
+                "sourceNumber": "+155****9999",
+                "sourceUuid": "05668cf3-8ffa-467e-9b24-f5eefa5cf475",
+                "timestamp": 1777600696077,
+                "dataMessage": {"message": "Hello from another account"},
+            },
+        })
+
+        assert not dispatched, "Envelope from another account must be discarded"
+
+    @pytest.mark.asyncio
+    async def test_accepts_envelope_for_own_account(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch, account="+155****4567")
+        dispatched = []
+
+        async def fake_handle(event):
+            dispatched.append(event)
+
+        adapter.handle_message = fake_handle
+
+        await adapter._handle_envelope({
+            "account": "+155****4567",  # own account
+            "envelope": {
+                "sourceNumber": "+155****9999",
+                "sourceUuid": "05668cf3-8ffa-467e-9b24-f5eefa5cf475",
+                "timestamp": 1777600696077,
+                "dataMessage": {"message": "Hello from my own account"},
+            },
+        })
+
+        assert dispatched, "Envelope from own account must be processed"
+
+
 class TestSignalSyncMessageHandling:
     """signal-cli running as a linked secondary device receives the user's
     own messages as ``syncMessage.sentMessage`` envelopes. Two cases must


### PR DESCRIPTION
### Description

Removes the `?account=` query parameter from the SSE events URL in `gateway/platforms/signal.py`.

### Problem

The `?account=` parameter causes **HTTP 400 Bad Request** when `signal-cli` runs in **multi-account mode** (without `-u` flag). In Docker environments, single-account mode often fails with `User is not registered` because Signal uses self-signed certificates that Java cannot verify. Multi-account mode works perfectly but rejects the `?account=` query param on the SSE endpoint.

The gateway then enters a reconnect loop and never processes events.

### Fix

- Removed `?account={quote(self.account, safe="")}` from the SSE URL (line 428)
- Cleaned up unused `quote` import from the `urllib.parse` import
- The account filtering already happens downstream in `_handle_envelope()` (line 572) — no information is lost

### Why this PR instead of #57881

PR #57881 had two commits — the first correctly removed `?account=`, but the second (17a0b389) reverted that approach and instead substituted the phone number with a cached UUID, keeping `?account=` in the URL. That partial approach does **not** fix the HTTP 400 in multi-account mode.

This PR applies the correct fix: remove `?account=` entirely. In multi-account mode, `/api/v1/events` without parameters streams events for all accounts, and the gateway already filters by account downstream.

### Related Issues

Fixes #57862

### Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project style
- [x] I have tested that the fix works with signal-cli in multi-account mode