### PR TITLE
fix(desktop): match zone loading bg to chrome

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -345,7 +345,7 @@ export function TreeGroup({
 
   return (
     <div
-      className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-(--ui-bg-editor)"
+      className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-(--ui-editor-surface-background)"
       data-tree-group={node.id}
       // Advertises the visible tab strip so panes can drop their own
       // self-naming labels (see [data-pane-self-label] in styles.css).


### PR DESCRIPTION
## Summary

The layout zone floor was painted with `--ui-bg-editor` (the card/white token). While a session is still loading, that floor shows through — a white flash against the chrome titlebar and tab strip.

Point the zone at `--ui-editor-surface-background` instead (same chrome token as body / titlebar / other pane surfaces). Loaded chat still paints its own `--ui-chat-surface-background`; this only fixes the empty floor underneath.

## Test plan

- [ ] Cold open / session tab switch: spinner area matches titlebar and tab strip (no white flash)
- [ ] Loaded chat transcript bg unchanged for the active theme
- [ ] Other panes (terminal, preview, settings) still look right