### PR TITLE
Fix/dashboard resume loading notice

### DIFF
--- a/web/src/lib/pty-resume-loading.test.ts
+++ b/web/src/lib/pty-resume-loading.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PTY_RESUME_LOADING_MAX_MS,
+  shouldFinishResumeHydrationOnChunk,
+  shouldShowResumeLoadingOverlay,
+} from "./pty-resume-loading";
+
+describe("shouldFinishResumeHydrationOnChunk", () => {
+  it("finishes on the first non-empty chunk", () => {
+    expect(shouldFinishResumeHydrationOnChunk("")).toBe(false);
+    expect(shouldFinishResumeHydrationOnChunk("hello")).toBe(true);
+  });
+
+  it("keeps a positive hard-cap timeout for wedged resumes", () => {
+    expect(PTY_RESUME_LOADING_MAX_MS).toBeGreaterThan(0);
+  });
+});
+
+describe("shouldShowResumeLoadingOverlay", () => {
+  it("shows while a resume target is connecting or open and still hydrating", () => {
+    expect(
+      shouldShowResumeLoadingOverlay({
+        hasResumeTarget: true,
+        ptyState: "connecting",
+        hydrating: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowResumeLoadingOverlay({
+        hasResumeTarget: true,
+        ptyState: "open",
+        hydrating: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("hides when there is no resume target", () => {
+    expect(
+      shouldShowResumeLoadingOverlay({
+        hasResumeTarget: false,
+        ptyState: "connecting",
+        hydrating: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("hides once hydration finishes", () => {
+    expect(
+      shouldShowResumeLoadingOverlay({
+        hasResumeTarget: true,
+        ptyState: "open",
+        hydrating: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("defers to reconnect / closed / ended overlays", () => {
+    for (const ptyState of ["reconnecting", "closed", "ended"] as const) {
+      expect(
+        shouldShowResumeLoadingOverlay({
+          hasResumeTarget: true,
+          ptyState,
+          hydrating: true,
+        }),
+      ).toBe(false);
+    }
+  });
+});

--- a/web/src/lib/pty-resume-loading.ts
+++ b/web/src/lib/pty-resume-loading.ts
@@ -1,0 +1,47 @@
+import type { PtyConnectionState } from "@/lib/pty-reconnect";
+
+/**
+ * Hard cap so a wedged resume (never gets PTY payload) cannot leave the
+ * wait notice up forever.
+ */
+export const PTY_RESUME_LOADING_MAX_MS = 30000;
+
+export const PTY_RESUME_LOADING_MESSAGE =
+  "Please wait while the conversation loads…";
+
+export interface ResumeLoadingOverlayInput {
+  hasResumeTarget: boolean;
+  ptyState: PtyConnectionState;
+  hydrating: boolean;
+}
+
+/**
+ * Show a wait notice only while a resumed chat is still blank. Once the
+ * first real PTY payload arrives the terminal has something to show, so
+ * the notice hides and history can stream in underneath.
+ *
+ * Reconnect / ended / closed states keep their own overlays and must not
+ * stack this one on top.
+ */
+export function shouldShowResumeLoadingOverlay({
+  hasResumeTarget,
+  ptyState,
+  hydrating,
+}: ResumeLoadingOverlayInput): boolean {
+  if (!hasResumeTarget || !hydrating) {
+    return false;
+  }
+  if (
+    ptyState === "reconnecting" ||
+    ptyState === "closed" ||
+    ptyState === "ended"
+  ) {
+    return false;
+  }
+  return ptyState === "connecting" || ptyState === "open";
+}
+
+/** First non-empty PTY chunk means the blank window is over. */
+export function shouldFinishResumeHydrationOnChunk(chunkText: string): boolean {
+  return chunkText.length > 0;
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -48,6 +48,12 @@ import {
   shouldReconnectPtyOnPageResume,
 } from "@/lib/pty-reconnect";
 import {
+  PTY_RESUME_LOADING_MAX_MS,
+  PTY_RESUME_LOADING_MESSAGE,
+  shouldFinishResumeHydrationOnChunk,
+  shouldShowResumeLoadingOverlay,
+} from "@/lib/pty-resume-loading";
+import {
   MOBILE_REPLACEMENT_WINDOW_MS,
   normalizePtyMobileInput,
   shouldTreatInputAsMobileReplacement,
@@ -204,6 +210,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const [ptyState, setPtyState] =
     useState<PtyConnectionState>("connecting");
   const ptyStateRef = useRef<PtyConnectionState>("connecting");
+  // True until the first real PTY payload arrives for a resumed session.
+  // Covers the blank terminal + blinking-cursor window so users don't think
+  // chat is broken; clears as soon as there is something to show.
+  const [resumeHydrating, setResumeHydrating] = useState(false);
   const [lastCloseCode, setLastCloseCode] = useState<number | null>(null);
   // NS-504: when the agent process exits cleanly (the user typed `/exit`, or
   // started a new session that ended the current PTY child), the PTY socket
@@ -892,12 +902,42 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     let onDataDisposable: { dispose(): void } | null = null;
     let onResizeDisposable: { dispose(): void } | null = null;
     let eraseSuppressionTimer: ReturnType<typeof setTimeout> | null = null;
+    let resumeMaxTimer: ReturnType<typeof setTimeout> | null = null;
     const clearEraseSuppressionTimer = () => {
       if (eraseSuppressionTimer) {
         clearTimeout(eraseSuppressionTimer);
         eraseSuppressionTimer = null;
       }
     };
+    const clearResumeLoadingTimers = () => {
+      if (resumeMaxTimer) {
+        clearTimeout(resumeMaxTimer);
+        resumeMaxTimer = null;
+      }
+    };
+    const finishResumeHydration = () => {
+      clearResumeLoadingTimers();
+      if (!unmounting) {
+        setResumeHydrating(false);
+      }
+    };
+    const noteResumePtyChunk = (chunkText: string) => {
+      if (!resumeParam || unmounting) {
+        return;
+      }
+      if (shouldFinishResumeHydrationOnChunk(chunkText)) {
+        finishResumeHydration();
+      }
+    };
+    if (resumeParam) {
+      setResumeHydrating(true);
+      resumeMaxTimer = setTimeout(
+        finishResumeHydration,
+        PTY_RESUME_LOADING_MAX_MS,
+      );
+    } else {
+      setResumeHydrating(false);
+    }
     const forceFresh = forceFreshPtyRef.current;
     forceFreshPtyRef.current = false;
     // A connect attempt is now in flight — set synchronously (before the async
@@ -1019,6 +1059,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
               stream: true,
             });
       term.write(resumeParam ? sanitizer.next(text) : text);
+      noteResumePtyChunk(text);
     };
 
     ws.onclose = (ev) => {
@@ -1180,6 +1221,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       imageUploadDisposed = true;
       syncMetricsRef.current = null;
       clearEraseSuppressionTimer();
+      clearResumeLoadingTimers();
+      setResumeHydrating(false);
       onDataDisposable?.dispose();
       onResizeDisposable?.dispose();
       mobileInputCleanup?.();
@@ -1354,6 +1397,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const visibleBanner = banner ?? reconnectBanner;
   const showReconnectOverlay =
     ptyState === "reconnecting" || (ptyState === "closed" && !banner);
+  const showResumeLoadingOverlay = shouldShowResumeLoadingOverlay({
+    hasResumeTarget: Boolean(resumeParam),
+    ptyState,
+    hydrating: resumeHydrating,
+  });
   const mobileModelToolsPortal =
     isActive &&
     narrow &&
@@ -1484,6 +1532,19 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
                 >
                   Reconnect now
                 </Button>
+              </div>
+            </div>
+          )}
+
+          {showResumeLoadingOverlay && (
+            <div
+              className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center"
+              role="status"
+              aria-live="polite"
+              aria-label={PTY_RESUME_LOADING_MESSAGE}
+            >
+              <div className="max-w-[min(28rem,calc(100vw-3rem))] border border-current/30 bg-black/80 px-4 py-3 text-center text-xs tracking-wide text-white/85 shadow-lg">
+                {PTY_RESUME_LOADING_MESSAGE}
               </div>
             </div>
           )}


### PR DESCRIPTION
## What does this PR do?

When resuming a long chat in the web dashboard, the embedded TUI can stay blank with only a blinking cursor for a few seconds before history appears. Users think chat is broken and click away.

This PR shows a short “Please wait while the conversation loads…” notice while a resumed session is still blank, then hides it as soon as the first real PTY payload arrives so history can stream in visibly. A hard-cap timeout still clears a wedged resume. Reconnect / ended / closed overlays keep owning those states so notices don’t stack.

## Related Issue

No tracked issue number — requested on Discord after the blank-resume UX: users wanted a wait message while long history loads.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `web/src/lib/pty-resume-loading.ts` — overlay visibility helpers + wait message + hard-cap constant
- `web/src/lib/pty-resume-loading.test.ts` — unit tests for show/hide rules
- `web/src/pages/ChatPage.tsx` — show notice on resume; clear on first non-empty PTY chunk

## How to Test

1. `cd web && npx vitest run src/lib/pty-resume-loading.test.ts`
2. Open the dashboard → resume a short session → notice appears while blank, then clears when the first output arrives
3. Resume a long history session → notice covers the blank/blinking-cursor window, then clears as soon as content starts streaming in
4. Trigger reconnect on a resumed session → reconnect overlay still owns the UI (no stacked wait notice)
5. Start a new chat (no `?resume=`) → no wait notice

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform:

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — frontend wait notice over the dashboard chat terminal while a resumed session is still blank.