### PR TITLE
fix(telegram): retain long bursts across delivery jitter

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -690,6 +690,11 @@ class TelegramAdapter(BasePlatformAdapter):
     _TEXT_BATCH_FAST_DELAY_S = 0.18
     _TEXT_BATCH_SHORT_LEN = 1024
     _TEXT_BATCH_SHORT_DELAY_S = 0.24
+    # Long prompts tolerate a modest ingress pause better than a partial model
+    # call.  The 1.5s default covers an observed 1.177s server-side delivery
+    # gap while the short-message tiers above retain their existing latency.
+    _TEXT_BATCH_DEFAULT_DELAY_S = 1.5
+    _TEXT_BATCH_SPLIT_DEFAULT_DELAY_S = 2.0
 
     @staticmethod
     def _env_float_clamped(
@@ -773,22 +778,20 @@ class TelegramAdapter(BasePlatformAdapter):
         self._pending_photo_batch_tasks: Dict[str, asyncio.Task] = {}
         self._media_group_events: Dict[str, MessageEvent] = {}
         self._media_group_tasks: Dict[str, asyncio.Task] = {}
-        # Buffer rapid text messages so Telegram client-side splits of long
-        # messages are aggregated into a single MessageEvent.  Lower defaults
-        # (0.3s / 1.0s instead of 0.6s / 2.0s) let short replies stream
-        # without a noticeable wait — combined with the adaptive fast-path
-        # in ``_calc_text_batch_delay`` below, ≤320-codepoint replies settle
-        # in ~180ms.  All bounds are conservative for Telegram's
-        # ~1 edit/s flood envelope.
+        # Buffer rapid text messages so Telegram client-side splits and long
+        # user bursts are aggregated into a single MessageEvent.  Long prompts
+        # use a wider quiet period to tolerate delivery jitter; the adaptive
+        # fast-path in ``_calc_text_batch_delay`` still lets ≤320-codepoint
+        # replies settle in ~180ms and ≤1024-codepoint replies in ~240ms.
         self._text_batch_delay_seconds = self._env_float_clamped(
             "HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS",
-            0.3,
+            self._TEXT_BATCH_DEFAULT_DELAY_S,
             min_value=0.08,
             max_value=2.0,
         )
         self._text_batch_split_delay_seconds = self._env_float_clamped(
             "HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS",
-            1.0,
+            self._TEXT_BATCH_SPLIT_DEFAULT_DELAY_S,
             min_value=self._text_batch_delay_seconds,
             max_value=4.0,
         )
@@ -9632,10 +9635,10 @@ class TelegramAdapter(BasePlatformAdapter):
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text event and reset the flush timer.
 
-        When Telegram splits a long user message into multiple updates,
-        they arrive within a few hundred milliseconds.  This method
-        concatenates them and waits for a short quiet period before
-        dispatching the combined message.
+        Telegram client splits and rapid user bursts can arrive as multiple
+        updates with network jitter between them.  This method concatenates
+        them and waits for a quiet period before dispatching the combined
+        message.
         """
         if self._should_drop_delayed_delivery():
             self._hold_inbound_event(event, where="text-enqueue")
@@ -9665,39 +9668,45 @@ class TelegramAdapter(BasePlatformAdapter):
             self._flush_text_batch(key)
         )
 
+    def _calc_text_batch_delay(self, pending: Optional[MessageEvent]) -> float:
+        """Return the quiet period for the current Telegram text batch.
+
+        Adaptive delay tiers:
+         - last chunk ≥ _SPLIT_THRESHOLD: a continuation is almost
+           certain → wait the longer split delay.
+         - total accumulated text ≤ _TEXT_BATCH_FAST_LEN (~320 cp):
+           short message → cap delay at _TEXT_BATCH_FAST_DELAY_S
+           so the agent sees the text near-instantly.
+         - total ≤ _TEXT_BATCH_SHORT_LEN (~1024 cp):
+           medium → cap at _TEXT_BATCH_SHORT_DELAY_S.
+         - otherwise: use the configured cap.
+        Tiers compose with operator overrides via the env-var-driven
+        ``_text_batch_delay_seconds`` (e.g. an operator who sets the
+        cap below 0.18s gets that lower number on every tier).
+        """
+        last_len = getattr(pending, "_last_chunk_len", 0) if pending else 0
+        total_len = len(getattr(pending, "text", "") or "") if pending else 0
+        if last_len >= self._SPLIT_THRESHOLD:
+            return self._text_batch_split_delay_seconds
+        if total_len <= self._TEXT_BATCH_FAST_LEN:
+            return min(self._text_batch_delay_seconds, self._TEXT_BATCH_FAST_DELAY_S)
+        if total_len <= self._TEXT_BATCH_SHORT_LEN:
+            return min(self._text_batch_delay_seconds, self._TEXT_BATCH_SHORT_DELAY_S)
+        return self._text_batch_delay_seconds
+
     async def _flush_text_batch(self, key: str) -> None:
         """Wait for the quiet period then dispatch the aggregated text.
 
-        Uses a longer delay when the latest chunk is near Telegram's 4096-char
-        split point, since a continuation chunk is almost certain.
+        Uses fast tiers for short text, the configured long-text delay for
+        larger bursts, and a longer delay near Telegram's 4096-char split
+        point where a continuation chunk is likely.
         """
         current_task = asyncio.current_task()
         event = None
         try:
-            # Adaptive delay tiers:
-            #  - last chunk ≥ _SPLIT_THRESHOLD: a continuation is almost
-            #    certain → wait the longer split delay.
-            #  - total accumulated text ≤ _TEXT_BATCH_FAST_LEN (~320 cp):
-            #    short message → cap delay at _TEXT_BATCH_FAST_DELAY_S
-            #    so the agent sees the text near-instantly.
-            #  - total ≤ _TEXT_BATCH_SHORT_LEN (~1024 cp):
-            #    medium → cap at _TEXT_BATCH_SHORT_DELAY_S.
-            #  - otherwise: use the configured cap.
-            # Tiers compose with operator overrides via the env-var-driven
-            # ``_text_batch_delay_seconds`` (e.g. an operator who sets the
-            # cap below 0.18s gets that lower number on every tier).
+            # Adaptive delay tiers live in ``_calc_text_batch_delay``.
             pending = self._pending_text_batches.get(key)
-            last_len = getattr(pending, "_last_chunk_len", 0) if pending else 0
-            total_len = len(getattr(pending, "text", "") or "") if pending else 0
-            if last_len >= self._SPLIT_THRESHOLD:
-                delay = self._text_batch_split_delay_seconds
-            elif total_len <= self._TEXT_BATCH_FAST_LEN:
-                delay = min(self._text_batch_delay_seconds, self._TEXT_BATCH_FAST_DELAY_S)
-            elif total_len <= self._TEXT_BATCH_SHORT_LEN:
-                delay = min(self._text_batch_delay_seconds, self._TEXT_BATCH_SHORT_DELAY_S)
-            else:
-                delay = self._text_batch_delay_seconds
-            await asyncio.sleep(delay)
+            await asyncio.sleep(self._calc_text_batch_delay(pending))
             event = self._pending_text_batches.pop(key, None)
             if not event:
                 return

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -642,6 +642,11 @@ class TelegramAdapter(BasePlatformAdapter):
     _TEXT_BATCH_FAST_DELAY_S = 0.18
     _TEXT_BATCH_SHORT_LEN = 1024
     _TEXT_BATCH_SHORT_DELAY_S = 0.24
+    # Long prompts tolerate a modest ingress pause better than a partial model
+    # call.  The 1.5s default covers an observed 1.177s server-side delivery
+    # gap while the short-message tiers above retain their existing latency.
+    _TEXT_BATCH_DEFAULT_DELAY_S = 1.5
+    _TEXT_BATCH_SPLIT_DEFAULT_DELAY_S = 2.0
 
     @staticmethod
     def _env_float_clamped(
@@ -722,22 +727,20 @@ class TelegramAdapter(BasePlatformAdapter):
         self._pending_photo_batch_tasks: Dict[str, asyncio.Task] = {}
         self._media_group_events: Dict[str, MessageEvent] = {}
         self._media_group_tasks: Dict[str, asyncio.Task] = {}
-        # Buffer rapid text messages so Telegram client-side splits of long
-        # messages are aggregated into a single MessageEvent.  Lower defaults
-        # (0.3s / 1.0s instead of 0.6s / 2.0s) let short replies stream
-        # without a noticeable wait — combined with the adaptive fast-path
-        # in ``_calc_text_batch_delay`` below, ≤320-codepoint replies settle
-        # in ~180ms.  All bounds are conservative for Telegram's
-        # ~1 edit/s flood envelope.
+        # Buffer rapid text messages so Telegram client-side splits and long
+        # user bursts are aggregated into a single MessageEvent.  Long prompts
+        # use a wider quiet period to tolerate delivery jitter; the adaptive
+        # fast-path in ``_calc_text_batch_delay`` still lets ≤320-codepoint
+        # replies settle in ~180ms and ≤1024-codepoint replies in ~240ms.
         self._text_batch_delay_seconds = self._env_float_clamped(
             "HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS",
-            0.3,
+            self._TEXT_BATCH_DEFAULT_DELAY_S,
             min_value=0.08,
             max_value=2.0,
         )
         self._text_batch_split_delay_seconds = self._env_float_clamped(
             "HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS",
-            1.0,
+            self._TEXT_BATCH_SPLIT_DEFAULT_DELAY_S,
             min_value=self._text_batch_delay_seconds,
             max_value=4.0,
         )
@@ -8797,10 +8800,10 @@ class TelegramAdapter(BasePlatformAdapter):
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text event and reset the flush timer.
 
-        When Telegram splits a long user message into multiple updates,
-        they arrive within a few hundred milliseconds.  This method
-        concatenates them and waits for a short quiet period before
-        dispatching the combined message.
+        Telegram client splits and rapid user bursts can arrive as multiple
+        updates with network jitter between them.  This method concatenates
+        them and waits for a quiet period before dispatching the combined
+        message.
         """
         if self._should_drop_delayed_delivery():
             logger.debug("[Telegram] Dropping text batch enqueue after disconnect started")
@@ -8830,11 +8833,24 @@ class TelegramAdapter(BasePlatformAdapter):
             self._flush_text_batch(key)
         )
 
+    def _calc_text_batch_delay(self, pending: Optional[MessageEvent]) -> float:
+        """Return the quiet period for the current Telegram text batch."""
+        last_len = getattr(pending, "_last_chunk_len", 0) if pending else 0
+        total_len = len(getattr(pending, "text", "") or "") if pending else 0
+        if last_len >= self._SPLIT_THRESHOLD:
+            return self._text_batch_split_delay_seconds
+        if total_len <= self._TEXT_BATCH_FAST_LEN:
+            return min(self._text_batch_delay_seconds, self._TEXT_BATCH_FAST_DELAY_S)
+        if total_len <= self._TEXT_BATCH_SHORT_LEN:
+            return min(self._text_batch_delay_seconds, self._TEXT_BATCH_SHORT_DELAY_S)
+        return self._text_batch_delay_seconds
+
     async def _flush_text_batch(self, key: str) -> None:
         """Wait for the quiet period then dispatch the aggregated text.
 
-        Uses a longer delay when the latest chunk is near Telegram's 4096-char
-        split point, since a continuation chunk is almost certain.
+        Uses fast tiers for short text, the configured long-text delay for
+        larger bursts, and a longer delay near Telegram's 4096-char split
+        point where a continuation chunk is likely.
         """
         current_task = asyncio.current_task()
         try:
@@ -8851,17 +8867,7 @@ class TelegramAdapter(BasePlatformAdapter):
             # ``_text_batch_delay_seconds`` (e.g. an operator who sets the
             # cap below 0.18s gets that lower number on every tier).
             pending = self._pending_text_batches.get(key)
-            last_len = getattr(pending, "_last_chunk_len", 0) if pending else 0
-            total_len = len(getattr(pending, "text", "") or "") if pending else 0
-            if last_len >= self._SPLIT_THRESHOLD:
-                delay = self._text_batch_split_delay_seconds
-            elif total_len <= self._TEXT_BATCH_FAST_LEN:
-                delay = min(self._text_batch_delay_seconds, self._TEXT_BATCH_FAST_DELAY_S)
-            elif total_len <= self._TEXT_BATCH_SHORT_LEN:
-                delay = min(self._text_batch_delay_seconds, self._TEXT_BATCH_SHORT_DELAY_S)
-            else:
-                delay = self._text_batch_delay_seconds
-            await asyncio.sleep(delay)
+            await asyncio.sleep(self._calc_text_batch_delay(pending))
             event = self._pending_text_batches.pop(key, None)
             if not event:
                 return

--- a/tests/gateway/test_telegram_text_batch_perf.py
+++ b/tests/gateway/test_telegram_text_batch_perf.py
@@ -13,6 +13,7 @@ or out-of-bounds values that could break asyncio.sleep().
 from __future__ import annotations
 
 import math
+from types import SimpleNamespace
 
 import pytest
 
@@ -58,6 +59,11 @@ class TestAdaptiveTextBatchTiers:
         assert TelegramAdapter._TEXT_BATCH_FAST_DELAY_S < TelegramAdapter._TEXT_BATCH_SHORT_DELAY_S
         assert TelegramAdapter._TEXT_BATCH_FAST_DELAY_S > 0
         assert TelegramAdapter._TEXT_BATCH_SHORT_DELAY_S > 0
+        assert TelegramAdapter._TEXT_BATCH_DEFAULT_DELAY_S >= 1.177
+        assert (
+            TelegramAdapter._TEXT_BATCH_SPLIT_DEFAULT_DELAY_S
+            >= TelegramAdapter._TEXT_BATCH_DEFAULT_DELAY_S
+        )
 
     def test_fast_tier_uses_min_with_configured_cap(self, adapter):
         """A short message picks the lower of the fast-tier delay and
@@ -78,4 +84,32 @@ class TestAdaptiveTextBatchTiers:
         )
         assert delay == 0.10
 
+    def test_observed_sub_4000_shape_uses_long_grace(self, adapter):
+        """The observed 2566 -> 3955 burst must not use the short tiers."""
+        adapter._text_batch_delay_seconds = TelegramAdapter._TEXT_BATCH_DEFAULT_DELAY_S
+        adapter._text_batch_split_delay_seconds = (
+            TelegramAdapter._TEXT_BATCH_SPLIT_DEFAULT_DELAY_S
+        )
+
+        first = SimpleNamespace(text="a" * 2566, _last_chunk_len=2566)
+        combined = SimpleNamespace(
+            text=("a" * 2566) + "\n" + ("b" * 3955),
+            _last_chunk_len=3955,
+        )
+
+        assert adapter._calc_text_batch_delay(first) >= 1.177
+        assert adapter._calc_text_batch_delay(combined) >= 1.177
+
+    def test_fast_tiers_remain_unchanged(self, adapter):
+        """Long-burst protection must not slow common short messages."""
+        adapter._text_batch_delay_seconds = TelegramAdapter._TEXT_BATCH_DEFAULT_DELAY_S
+        adapter._text_batch_split_delay_seconds = (
+            TelegramAdapter._TEXT_BATCH_SPLIT_DEFAULT_DELAY_S
+        )
+
+        fast = SimpleNamespace(text="a" * 320, _last_chunk_len=320)
+        short = SimpleNamespace(text="a" * 1024, _last_chunk_len=1024)
+
+        assert adapter._calc_text_batch_delay(fast) == 0.18
+        assert adapter._calc_text_batch_delay(short) == 0.24
 

--- a/tests/gateway/test_telegram_text_batching.py
+++ b/tests/gateway/test_telegram_text_batching.py
@@ -119,6 +119,32 @@ class TestTextBatching:
         assert "chunk 2" in text
         assert "chunk 3" in text
 
+    @pytest.mark.asyncio
+    async def test_long_burst_survives_gap_beyond_old_window(self):
+        """Long messages remain buffered across the former 300ms window."""
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        adapter = _make_adapter()
+        adapter._text_batch_delay_seconds = TelegramAdapter._TEXT_BATCH_DEFAULT_DELAY_S
+        adapter._text_batch_split_delay_seconds = (
+            TelegramAdapter._TEXT_BATCH_SPLIT_DEFAULT_DELAY_S
+        )
+
+        first = "a" * 2566
+        second = "b" * 3955
+        adapter._enqueue_text_event(_make_event(first))
+
+        # The production reproduction crossed the old 300ms quiet period.
+        await asyncio.sleep(0.35)
+        adapter.handle_message.assert_not_called()
+
+        adapter._enqueue_text_event(_make_event(second))
+        await asyncio.sleep(TelegramAdapter._TEXT_BATCH_DEFAULT_DELAY_S + 0.1)
+
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        assert dispatched.text == f"{first}\n{second}"
+
 
     @pytest.mark.asyncio
     async def test_disconnected_adapter_drops_pending_media_group_flush_before_dispatch(self):

--- a/tests/gateway/test_telegram_text_batching.py
+++ b/tests/gateway/test_telegram_text_batching.py
@@ -115,6 +115,32 @@ class TestTextBatching:
         assert "chunk 2" in text
         assert "chunk 3" in text
 
+    @pytest.mark.asyncio
+    async def test_long_burst_survives_gap_beyond_old_window(self):
+        """Long messages remain buffered across the former 300ms window."""
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        adapter = _make_adapter()
+        adapter._text_batch_delay_seconds = TelegramAdapter._TEXT_BATCH_DEFAULT_DELAY_S
+        adapter._text_batch_split_delay_seconds = (
+            TelegramAdapter._TEXT_BATCH_SPLIT_DEFAULT_DELAY_S
+        )
+
+        first = "a" * 2566
+        second = "b" * 3955
+        adapter._enqueue_text_event(_make_event(first))
+
+        # The production reproduction crossed the old 300ms quiet period.
+        await asyncio.sleep(0.35)
+        adapter.handle_message.assert_not_called()
+
+        adapter._enqueue_text_event(_make_event(second))
+        await asyncio.sleep(TelegramAdapter._TEXT_BATCH_DEFAULT_DELAY_S + 0.1)
+
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        assert dispatched.text == f"{first}\n{second}"
+
 
     @pytest.mark.asyncio
     async def test_disconnected_adapter_drops_pending_media_group_flush_before_dispatch(self):

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -737,7 +737,7 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 
 | Variable | Description |
 |----------|-------------|
-| `HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS` | Grace window before flushing a queued Telegram text chunk (default: `0.6`). |
+| `HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS` | Grace window before flushing Telegram text over 1,024 characters (default: `1.5`). Shorter text keeps the adaptive 0.18/0.24-second fast paths. |
 | `HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS` | Delay between split chunks when a single Telegram message exceeds the length limit (default: `2.0`). |
 | `HERMES_SIMPLEX_TEXT_BATCH_DELAY` | Quiet-period seconds (default: `0.8`) used to concatenate rapid-fire inbound text messages into a single MessageEvent — same pattern as Telegram's text batching. |
 | `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS` | Grace window before flushing queued Telegram media (default: `0.6`). |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -735,7 +735,7 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 
 | Variable | Description |
 |----------|-------------|
-| `HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS` | Grace window before flushing a queued Telegram text chunk (default: `0.6`). |
+| `HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS` | Grace window before flushing Telegram text over 1,024 characters (default: `1.5`). Shorter text keeps the adaptive 0.18/0.24-second fast paths. |
 | `HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS` | Delay between split chunks when a single Telegram message exceeds the length limit (default: `2.0`). |
 | `HERMES_SIMPLEX_TEXT_BATCH_DELAY` | Quiet-period seconds (default: `0.8`) used to concatenate rapid-fire inbound text messages into a single MessageEvent — same pattern as Telegram's text batching. |
 | `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS` | Grace window before flushing queued Telegram media (default: `0.6`). |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
@@ -503,7 +503,7 @@ Graph 事件（Teams 会议、日历、聊天等）的入站变更通知监听�
 
 | 变量 | 描述 |
 |----------|-------------|
-| `HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS` | 刷新排队 Telegram 文本块前的宽限窗口（默认：`0.6`）。 |
+| `HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS` | 刷新超过 1,024 个字符的 Telegram 文本前的宽限窗口（默认：`1.5`）。较短的文本仍使用 0.18/0.24 秒的自适应快速路径。 |
 | `HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS` | 单条 Telegram 消息超过长度限制时分块之间的延迟（默认：`2.0`）。 |
 | `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS` | 刷新排队 Telegram 媒体前的宽限窗口（默认：`0.6`）。 |
 | `HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS` | agent 完成后发送后续消息前的延迟，以避免与最后一个流块竞争。 |


### PR DESCRIPTION
## Summary

- give Telegram text over 1,024 characters a 1.5-second quiet period
- retain the existing ~180 ms / ~240 ms fast paths for shorter text
- restore the near-4096-character split grace to 2 seconds
- add regression coverage for the observed 2,566 -> 3,955 character burst

Fixes #74752.

## Root cause

The normal Telegram text-batch default was 300 ms. In the production reproduction, two sub-4000-character adapter flushes were 1.177 seconds apart, so the first prompt entered the model before the second update arrived. With `busy_input_mode: steer`, the second update was then correctly handled as a steer, but the user-visible result was a partial initial turn and a self-steer acknowledgement.

The runtime was hosted remotely on a VPS-connected M4. An observed ~200 ms SSH round-trip confirms network distance but is not a Telegram Bot API latency measurement. Remote hosting may contribute delivery jitter; this change is sized from the server-side 1.177-second gap, with bounded headroom, rather than treating the SSH RTT as causal proof.

## Behavior

| Accumulated text | Default quiet period |
| --- | --- |
| <= 320 characters | 0.18 seconds |
| <= 1,024 characters | 0.24 seconds |
| > 1,024 characters | 1.5 seconds |
| latest chunk >= 4,000 characters | 2.0 seconds |

Operators can still lower the long-text cap with the existing `HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS` setting.

## Tests

```text
scripts/run_tests.sh \
  tests/gateway/test_telegram_text_batch_perf.py \
  tests/gateway/test_telegram_text_batching.py \
  tests/gateway/test_telegram_long_command_batching.py \
  tests/gateway/test_text_batching.py -q

23 passed
```

The new integration regression waits beyond the former 300 ms boundary, confirms no early dispatch, sends the second long chunk, and asserts one combined `MessageEvent`.

## Tradeoff

A standalone prompt over 1,024 characters waits up to 1.5 seconds before dispatch. This is intentional: for long prompts, avoiding a partial model call and mid-run self-steer is more valuable than the previous 1.2-second first-token advantage. Short Telegram messages keep their existing latency.
