### PR TITLE
fix(desktop): hydrate pinned sessions outside recents

### DIFF
--- a/apps/desktop/src/app/session/hooks/pinned-session-hydration.test.ts
+++ b/apps/desktop/src/app/session/hooks/pinned-session-hydration.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo } from '@/hermes'
 
-import { hydratePinnedSessions, missingPinnedSessionIds, pinHydrationProfiles } from './pinned-session-hydration'
+import {
+  hydratePinnedSessions,
+  MAX_PIN_HYDRATION_IDS,
+  missingPinnedSessionIds,
+  PIN_HYDRATION_CONCURRENCY,
+  pinHydrationProfiles
+} from './pinned-session-hydration'
 
 const row = (id: string, extra: Partial<SessionInfo> = {}): SessionInfo =>
   ({ id, message_count: 1, source: 'desktop', started_at: 1, title: id, ...extra }) as SessionInfo
@@ -36,6 +42,39 @@ describe('hydratePinnedSessions', () => {
 
     expect(hydrated.map(session => session.id)).toEqual(['work-pin'])
     expect(getSession).toHaveBeenCalledWith('work-pin', 'work')
+  })
+
+  it('stamps the explicitly probed Desktop profile and preserves a historical local pin for migration', async () => {
+    const hydrated = await hydratePinnedSessions(['remote-pin'], ['work'], async id =>
+      row(id, { pinned: false, profile: 'default' })
+    )
+
+    expect(hydrated).toEqual([expect.objectContaining({ id: 'remote-pin', profile: 'work', pinned: undefined })])
+  })
+
+  it('bounds both the pin budget and concurrent profile probes', async () => {
+    let active = 0
+    let peak = 0
+    let calls = 0
+    const ids = Array.from({ length: MAX_PIN_HYDRATION_IDS + 25 }, (_, index) => `pin-${index}`)
+
+    const hydrated = await hydratePinnedSessions(ids, ['default', 'work'], async (id, profile) => {
+      calls += 1
+      active += 1
+      peak = Math.max(peak, active)
+      await Promise.resolve()
+      active -= 1
+
+      if (profile === 'default') {
+        throw new Error('not found')
+      }
+
+      return row(id, { profile: 'default' })
+    })
+
+    expect(hydrated).toHaveLength(MAX_PIN_HYDRATION_IDS)
+    expect(calls).toBe(MAX_PIN_HYDRATION_IDS * 2)
+    expect(peak).toBeLessThanOrEqual(PIN_HYDRATION_CONCURRENCY)
   })
 
   it('only hydrates pins missing from every already-loaded sidebar slice', () => {

--- a/apps/desktop/src/app/session/hooks/pinned-session-hydration.test.ts
+++ b/apps/desktop/src/app/session/hooks/pinned-session-hydration.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+
+import { hydratePinnedSessions, missingPinnedSessionIds, pinHydrationProfiles } from './pinned-session-hydration'
+
+const row = (id: string, extra: Partial<SessionInfo> = {}): SessionInfo =>
+  ({ id, message_count: 1, source: 'desktop', started_at: 1, title: id, ...extra }) as SessionInfo
+
+describe('hydratePinnedSessions', () => {
+  it('hydrates pins outside the recent page in persisted pin order', async () => {
+    const getSession = vi.fn(async (id: string, profile: null | string) => {
+      if (profile !== 'default') {
+        throw new Error('not found')
+      }
+
+      return row(id, { profile })
+    })
+
+    const hydrated = await hydratePinnedSessions(['old-pin', 'recent-pin'], ['default'], getSession)
+
+    expect(hydrated.map(session => session.id)).toEqual(['old-pin', 'recent-pin'])
+    expect(getSession).toHaveBeenCalledWith('old-pin', 'default')
+  })
+
+  it('falls through profiles and ignores missing or archived pins without failing the refresh', async () => {
+    const getSession = vi.fn(async (id: string, profile: null | string) => {
+      if (id === 'missing' || profile === 'default') {
+        throw new Error('not found')
+      }
+
+      return row(id, { archived: id === 'archived', profile: profile ?? undefined })
+    })
+
+    const hydrated = await hydratePinnedSessions(['work-pin', 'missing', 'archived'], ['default', 'work'], getSession)
+
+    expect(hydrated.map(session => session.id)).toEqual(['work-pin'])
+    expect(getSession).toHaveBeenCalledWith('work-pin', 'work')
+  })
+
+  it('only hydrates pins missing from every already-loaded sidebar slice', () => {
+    const loaded = [row('tip', { _lineage_root_id: 'root-pin' }), row('cron-pin')]
+
+    expect(missingPinnedSessionIds(['root-pin', 'cron-pin', 'old-pin'], loaded)).toEqual(['old-pin'])
+  })
+
+  it('scopes hydration to one profile or all known profiles with default fallback', () => {
+    expect(pinHydrationProfiles('work', ['default', 'work'])).toEqual(['work'])
+    expect(pinHydrationProfiles('__all__', ['work', 'default', 'work'])).toEqual(['default', 'work'])
+    expect(pinHydrationProfiles('__all__', [])).toEqual(['default'])
+  })
+})

--- a/apps/desktop/src/app/session/hooks/pinned-session-hydration.ts
+++ b/apps/desktop/src/app/session/hooks/pinned-session-hydration.ts
@@ -1,0 +1,53 @@
+import type { SessionInfo } from '@/hermes'
+
+const DEFAULT_PROFILE = 'default'
+const ALL_PROFILES_SCOPE = '__all__'
+
+export type GetSessionByProfile = (id: string, profile: null | string) => Promise<SessionInfo>
+
+export function missingPinnedSessionIds(pinIds: string[], loaded: SessionInfo[]): string[] {
+  const loadedKeys = new Set(loaded.flatMap(session => [session.id, session._lineage_root_id].filter(Boolean)))
+
+  return pinIds.filter(id => !loadedKeys.has(id))
+}
+
+export function pinHydrationProfiles(
+  profileScope: string,
+  knownProfiles: string[],
+  allProfilesScope = ALL_PROFILES_SCOPE
+): string[] {
+  if (profileScope !== allProfilesScope) {
+    return [profileScope.trim() || DEFAULT_PROFILE]
+  }
+
+  return [...new Set([DEFAULT_PROFILE, ...knownProfiles.map(name => name.trim()).filter(Boolean)])]
+}
+
+/** Resolve persisted pin ids into real rows without depending on the recent-page window. */
+export async function hydratePinnedSessions(
+  pinIds: string[],
+  profiles: string[],
+  getSession: GetSessionByProfile
+): Promise<SessionInfo[]> {
+  const resolved = await Promise.all(
+    pinIds.map(async id => {
+      for (const profile of profiles) {
+        try {
+          const session = await getSession(id, profile)
+
+          if (session.archived) {
+            return null
+          }
+
+          return session.profile ? session : { ...session, profile }
+        } catch {
+          // A pin can belong to another profile or point at a removed row.
+        }
+      }
+
+      return null
+    })
+  )
+
+  return resolved.filter((session): session is SessionInfo => session !== null)
+}

--- a/apps/desktop/src/app/session/hooks/pinned-session-hydration.ts
+++ b/apps/desktop/src/app/session/hooks/pinned-session-hydration.ts
@@ -1,7 +1,10 @@
 import type { SessionInfo } from '@/hermes'
+import { mapPool } from '@/lib/pool'
 
 const DEFAULT_PROFILE = 'default'
 const ALL_PROFILES_SCOPE = '__all__'
+export const MAX_PIN_HYDRATION_IDS = 100
+export const PIN_HYDRATION_CONCURRENCY = 4
 
 export type GetSessionByProfile = (id: string, profile: null | string) => Promise<SessionInfo>
 
@@ -29,25 +32,34 @@ export async function hydratePinnedSessions(
   profiles: string[],
   getSession: GetSessionByProfile
 ): Promise<SessionInfo[]> {
-  const resolved = await Promise.all(
-    pinIds.map(async id => {
-      for (const profile of profiles) {
-        try {
-          const session = await getSession(id, profile)
+  const boundedPinIds = [...new Set(pinIds)].slice(0, MAX_PIN_HYDRATION_IDS)
 
-          if (session.archived) {
-            return null
-          }
+  const resolved = await mapPool(boundedPinIds, PIN_HYDRATION_CONCURRENCY, async id => {
+    for (const profile of profiles) {
+      try {
+        const session = await getSession(id, profile)
 
-          return session.profile ? session : { ...session, profile }
-        } catch {
-          // A pin can belong to another profile or point at a removed row.
+        if (session.archived) {
+          return null
         }
-      }
 
-      return null
-    })
-  )
+        // The explicitly probed Desktop profile owns the row. A per-profile
+        // remote override answers as its own "default", which must not leak
+        // into Desktop routing. Also treat a historical local pin as the
+        // pending boot migration it is: `pinned:false` must not pull-delete
+        // the local pin before watchSessionPins can PATCH it true.
+        return {
+          ...session,
+          pinned: session.pinned === true ? true : undefined,
+          profile
+        } as SessionInfo
+      } catch {
+        // A pin can belong to another profile or point at a removed row.
+      }
+    }
+
+    return null
+  })
 
   return resolved.filter((session): session is SessionInfo => session !== null)
 }

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from 'react'
 
-import { getCronJobs, listAllProfileSessions, listSidebarSessions, type SessionInfo } from '@/hermes'
+import { getCronJobs, getSession, listAllProfileSessions, listSidebarSessions, type SessionInfo } from '@/hermes'
 import { sameCronSignature } from '@/lib/session-signatures'
 import {
   isMessagingSource,
@@ -10,7 +10,7 @@ import {
 } from '@/lib/session-source'
 import { setCronJobs } from '@/store/cron'
 import { $pinnedSessionIds, $sessionsLimit, bumpSessionsLimit, SIDEBAR_SESSIONS_PAGE_SIZE } from '@/store/layout'
-import { ALL_PROFILES, normalizeProfileKey } from '@/store/profile'
+import { $profiles, ALL_PROFILES, normalizeProfileKey } from '@/store/profile'
 import { $removedSessionIds } from '@/store/projects'
 import {
   $messagingSessions,
@@ -28,6 +28,8 @@ import {
   setSessionsLoading
 } from '@/store/session'
 import { $workingSessionIds, getRecentlySettledSessionIds } from '@/store/session-states'
+
+import { hydratePinnedSessions, missingPinnedSessionIds, pinHydrationProfiles } from './pinned-session-hydration'
 
 // The recents list is local-only: cron rows have their own section, and each
 // messaging platform (telegram, discord, …) is fetched separately into its own
@@ -177,6 +179,30 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         messagingExclude: MESSAGING_EXCLUDED_SOURCES
       })
 
+      // Pins are durable navigation state, not members of the current recents
+      // page. Resolve only the pins absent from the bounded recents/cron slices
+      // so old pins paint on cold start without forcing the user to "Load more".
+      // The by-id lookup also keeps this bounded: no full-history scan and no
+      // increase to the normal recents page size.
+      const pinIds = $pinnedSessionIds.get()
+
+      const missingPinIds = missingPinnedSessionIds(pinIds, [
+        ...result.recents.sessions,
+        ...result.cron.sessions
+      ])
+
+      const hydratedPins = missingPinIds.length
+        ? await hydratePinnedSessions(
+            missingPinIds,
+            pinHydrationProfiles(
+              profileScope,
+              $profiles.get().map(profile => profile.name),
+              ALL_PROFILES
+            ),
+            getSession
+          )
+        : []
+
       if (refreshSessionsRequestRef.current === requestId) {
         const recents = result.recents
 
@@ -186,11 +212,13 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         // (the tombstone self-clears once projects.tree confirms the delete).
         const tombstones = $removedSessionIds.get()
 
+        const hydratedRecents = [...recents.sessions, ...hydratedPins]
+
         const incoming = tombstones.size
-          ? recents.sessions.filter(
+          ? hydratedRecents.filter(
               s => !tombstones.has(s.id) && !(s._lineage_root_id && tombstones.has(s._lineage_root_id))
             )
-          : recents.sessions
+          : hydratedRecents
 
         // Signature-gate the swap (same pattern as cron/messaging): a refresh
         // that returns content-identical rows must keep the previous array


### PR DESCRIPTION
## Summary

- hydrate persisted pinned sessions by ID instead of relying on the bounded recent-session page
- preserve persisted pin order across profiles while ignoring missing or archived sessions
- keep recent-session pagination unchanged and avoid duplicate lineage rows

## Verification

- `npm run typecheck --workspace apps/desktop`
- targeted ESLint on the three changed files
- `npm run test:ui --workspace apps/desktop -- --run src/app/session/hooks/pinned-session-hydration.test.ts src/store/session.test.ts src/store/session-pin-sync.test.ts` — 48 passed
- `npm run build --workspace apps/desktop`
- isolated Electron canary with 11 old pinned sessions + 60 recent fillers: 11/11 visible on first launch and 11/11 after a second full restart, without Load more

Linear: HER-119

No merge or production installation performed.