### PR TITLE
fix(vercel): omit runtime when restoring snapshots

### DIFF
--- a/tests/tools/test_vercel_sandbox_environment.py
+++ b/tests/tools/test_vercel_sandbox_environment.py
@@ -163,6 +163,13 @@ class _FakeSDK:
 
     def create(self, **kwargs):
         self.create_kwargs.append(kwargs)
+        source = kwargs.get("source")
+        if (
+            isinstance(source, dict)
+            and source.get("type") == "snapshot"
+            and kwargs.get("runtime") is not None
+        ):
+            raise ValueError("source: snapshot source cannot be combined with runtime")
         if self.create_side_effects:
             effect = self.create_side_effects.pop(0)
             if isinstance(effect, Exception):
@@ -534,6 +541,7 @@ class TestSnapshotPersistence:
             "type": "snapshot",
             "snapshot_id": "snap_saved",
         }
+        assert "runtime" not in vercel_sdk.create_kwargs[0]
         assert vercel_module._load_snapshots() == {"task-123": "snap_saved"}
 
     def test_restore_failure_prunes_snapshot_and_falls_back_to_fresh_sandbox(
@@ -555,6 +563,7 @@ class TestSnapshotPersistence:
             "snapshot_id": "snap_stale",
         }
         assert "source" not in vercel_sdk.create_kwargs[1]
+        assert vercel_sdk.create_kwargs[1]["runtime"] == "node22"
         assert vercel_module._load_snapshots() == {}
 
     def test_cleanup_stops_when_snapshot_fails_without_storing_metadata(

--- a/tests/tools/test_vercel_sandbox_environment.py
+++ b/tests/tools/test_vercel_sandbox_environment.py
@@ -16,6 +16,13 @@ from types import SimpleNamespace
 
 import pytest
 
+try:
+    CreateSandboxRequest = importlib.import_module(
+        "vercel._internal.sandbox.models"
+    ).CreateSandboxRequest
+except ImportError:
+    CreateSandboxRequest = None
+
 
 class _FakeRunResult:
     def __init__(self, output: str | bytes = "", exit_code: int = 0):
@@ -163,6 +170,13 @@ class _FakeSDK:
 
     def create(self, **kwargs):
         self.create_kwargs.append(kwargs)
+        source = kwargs.get("source")
+        if (
+            isinstance(source, dict)
+            and source.get("type") == "snapshot"
+            and kwargs.get("runtime") is not None
+        ):
+            raise ValueError("source: snapshot source cannot be combined with runtime")
         if self.create_side_effects:
             effect = self.create_side_effects.pop(0)
             if isinstance(effect, Exception):
@@ -536,7 +550,31 @@ class TestSnapshotPersistence:
             "type": "snapshot",
             "snapshot_id": "snap_saved",
         }
+        assert "runtime" not in vercel_sdk.create_kwargs[0]
         assert vercel_module._load_snapshots() == {"task-123": "snap_saved"}
+
+    @pytest.mark.skipif(
+        CreateSandboxRequest is None,
+        reason="pinned vercel optional dependency is not installed",
+    )
+    def test_snapshot_restore_kwargs_satisfy_pinned_vercel_request_contract(
+        self, make_env, vercel_module, vercel_sdk, monkeypatch, tmp_path
+    ):
+        hermes_home = tmp_path / ".hermes"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        vercel_module._store_snapshot("task-123", "snap_saved")
+
+        make_env()
+
+        restore_kwargs = vercel_sdk.create_kwargs[0]
+        assert CreateSandboxRequest is not None
+        request = CreateSandboxRequest(
+            project_id="project-test",
+            source=restore_kwargs["source"],
+            runtime=restore_kwargs.get("runtime"),
+        )
+        assert request.source.type == "snapshot"
+        assert request.runtime is None
 
     def test_restore_failure_prunes_snapshot_and_falls_back_to_fresh_sandbox(
         self, make_env, vercel_module, vercel_sdk, monkeypatch, tmp_path
@@ -557,6 +595,7 @@ class TestSnapshotPersistence:
             "snapshot_id": "snap_stale",
         }
         assert "source" not in vercel_sdk.create_kwargs[1]
+        assert vercel_sdk.create_kwargs[1]["runtime"] == "node22"
         assert vercel_module._load_snapshots() == {}
 
     def test_cleanup_stops_when_snapshot_fails_without_storing_metadata(

--- a/tools/environments/vercel_sandbox.py
+++ b/tools/environments/vercel_sandbox.py
@@ -314,7 +314,6 @@ class VercelSandboxEnvironment(BaseEnvironment):
                     "sandbox restore",
                     lambda: Sandbox.create(
                         timeout=self._create_params.timeout,
-                        runtime=self._create_params.runtime,
                         resources=self._create_params.resources,
                         source={"type": "snapshot", "snapshot_id": snapshot_id},
                     ),

--- a/tools/environments/vercel_sandbox.py
+++ b/tools/environments/vercel_sandbox.py
@@ -167,19 +167,38 @@ class VercelSandboxEnvironment(BaseEnvironment):
     def _create_sandbox(self) -> Sandbox:
         _ensure_vercel_sdk()
         from vercel.sandbox import Sandbox
-        snapshot_id = _load_snapshots().get(self._task_id) if self._persistent and self._task_id else None
+
+        snapshot_id = (
+            _load_snapshots().get(self._task_id)
+            if self._persistent and self._task_id
+            else None
+        )
         if isinstance(snapshot_id, str) and snapshot_id:
             try:
                 source = {"type": "snapshot", "snapshot_id": snapshot_id}
+                restore_kwargs = {
+                    key: value
+                    for key, value in self._create_kwargs.items()
+                    if key != "runtime"
+                }
                 return _retry_vercel_call(
-                    "sandbox restore", lambda: Sandbox.create(**self._create_kwargs, source=source),
-                    attempts=_CREATE_RETRY_ATTEMPTS)
+                    "sandbox restore",
+                    lambda: Sandbox.create(**restore_kwargs, source=source),
+                    attempts=_CREATE_RETRY_ATTEMPTS,
+                )
             except Exception as exc:
-                logger.warning("Vercel: failed to restore snapshot %s for task %s; falling back to a fresh sandbox: %s",
-                               snapshot_id, self._task_id, exc)
+                logger.warning(
+                    "Vercel: failed to restore snapshot %s for task %s; falling back to a fresh sandbox: %s",
+                    snapshot_id,
+                    self._task_id,
+                    exc,
+                )
                 _delete_snapshot(self._task_id, snapshot_id)
-        return _retry_vercel_call("sandbox create", lambda: Sandbox.create(**self._create_kwargs),
-                                  attempts=_CREATE_RETRY_ATTEMPTS)
+        return _retry_vercel_call(
+            "sandbox create",
+            lambda: Sandbox.create(**self._create_kwargs),
+            attempts=_CREATE_RETRY_ATTEMPTS,
+        )
 
     def _attach_fresh_sandbox(self, requested_cwd: str) -> None:
         """Create a sandbox, wait until it runs, then wire cwd/home and the file sync manager."""


### PR DESCRIPTION
Fixes #74753

## Summary

- Omit `runtime` only when restoring a Vercel sandbox snapshot.
- Preserve configured runtime for fresh and fallback creation.
- Check generated restore source/runtime against the real pinned Vercel SDK 0.7.2 request model, without network I/O.

## Root cause and refresh

Refreshed onto `245e48008fa814b3251f50755eb656bd9fb86cb1` after #102117. The native `_create_sandbox()` owner now expands shared `self._create_kwargs`, including runtime, alongside snapshot source. The pinned SDK rejects this combination before network I/O. Hermes then treats a valid snapshot as failed and falls back to a fresh sandbox.

The restore branch now copies those kwargs omitting only runtime; the original mapping remains intact for fresh/fallback creation. No new abstraction or resolver, retry, or resource-policy changes. Formatting is confined to the edited method, as required by the changed-line formatter gate.

## Verification

- RED on unpatched current main: 2 targeted snapshot regressions fail, including the real validator's `source: snapshot source cannot be combined with runtime` error.
- GREEN after fix: both pass.
- `scripts/run_tests.sh tests/tools/test_vercel_sandbox_environment.py`: **17 passed, 0 failed**, including the real SDK contract test (not skipped in this run).
- Ruff, changed-line format gate, `git diff --check`: passed.
- Explicit Windows-footgun scan: 7 existing encoding warnings in unchanged test lines, reproduced on the exact baseline; no added warning. No unrelated cleanup bundled.

Tested on macOS with the canonical runner and explicit development `HERMES_PYTHON`. No live Vercel calls. Full-repository suite and hosted CI are not claimed as passed.

## Scope

Two files: native Vercel environment plus its existing tests. This preserves the original PR intent and author attribution while adapting to the current code layout.
