### PR TITLE
fix(wake): include pypinyin for sherpa phrases

### DIFF
--- a/contributors/emails/xuezhao@gmail.com
+++ b/contributors/emails/xuezhao@gmail.com
@@ -1,0 +1,2 @@
+xuezhaolan
+# PR #74768

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,7 @@ wake = [
   "onnxruntime==1.27.0",
   "sherpa-onnx==1.13.4",
   "sentencepiece==0.2.2",
+  "pypinyin==0.55.0",
   "pvporcupine==4.0.3",
   "sounddevice==0.5.5",
   "numpy==2.4.3",

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -168,6 +168,22 @@ def test_dingtalk_extra_includes_qrcode_for_qr_auth():
 
 
 
+def test_sherpa_wake_dependencies_include_text2token_imports():
+    """sherpa_onnx.text2token imports these at runtime for custom phrases."""
+    from tools.lazy_deps import LAZY_DEPS
+
+    optional_dependencies = _load_optional_dependencies()
+
+    wake_extra = optional_dependencies["wake"]
+    lazy_sherpa = LAZY_DEPS["wake.sherpa"]
+
+    for package in ("sentencepiece", "pypinyin"):
+        assert any(dep.startswith(f"{package}==") for dep in wake_extra)
+        assert any(dep.startswith(f"{package}==") for dep in lazy_sherpa)
+
+
+
+
 
 
 def _uv_lock_version(package: str) -> str:

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -169,11 +169,14 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "numpy==2.4.3",
     ),
     # Open-vocabulary keyword spotting: any typed phrase, zero training.
-    # sentencepiece is required by sherpa_onnx.text2token (runtime phrase
-    # tokenization) even though sherpa-onnx doesn't declare it.
+    # sentencepiece and pypinyin are required by sherpa_onnx.text2token
+    # (runtime phrase tokenization) even though sherpa-onnx doesn't declare
+    # them. pypinyin is imported unconditionally, including for English
+    # phrases.
     "wake.sherpa": (
         "sherpa-onnx==1.13.4",
         "sentencepiece==0.2.2",
+        "pypinyin==0.55.0",
         "sounddevice==0.5.5",
         "numpy==2.4.3",
     ),

--- a/uv.lock
+++ b/uv.lock
@@ -1760,6 +1760,7 @@ wake = [
     { name = "onnxruntime" },
     { name = "openwakeword" },
     { name = "pvporcupine" },
+    { name = "pypinyin" },
     { name = "sentencepiece" },
     { name = "sherpa-onnx" },
     { name = "sounddevice" },
@@ -1870,6 +1871,7 @@ requires-dist = [
     { name = "pvporcupine", marker = "extra == 'wake'", specifier = "==4.0.3" },
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.13.0" },
+    { name = "pypinyin", marker = "extra == 'wake'", specifier = "==0.55.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.2" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
@@ -3487,6 +3489,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pypinyin"
+version = "0.55.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/a4/784cf98c09e0dc22776b0d7d8a4a5b761218bcae4608c2416ce1e167c8af/pypinyin-0.55.0.tar.gz", hash = "sha256:b5711b3a0c6f76e67408ec6b2e3c4987a3a806b7c528076e7c7b86fcf0eaa66b", size = 839836, upload-time = "2025-07-20T12:01:50.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/7b/4cabc76fcc21c3c7d5c671d8783984d30ac9d3bb387c4ba784fca3cdfa3a/pypinyin-0.55.0-py2.py3-none-any.whl", hash = "sha256:d53b1e8ad2cdb815fb2cb604ed3123372f5a28c6f447571244aca36fc62a286f", size = 840203, upload-time = "2025-07-20T12:01:48.535Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds `pypinyin` to the `[wake]` extra and the lazy `wake.sherpa` dependency set.
- Documents that `sherpa_onnx.text2token` imports it unconditionally for custom phrase tokenization.
- Adds a metadata regression test so the eager extra and lazy install mirror stay in sync.

## Rationale
Sherpa custom wake phrases currently fail before the listener arms with `No module named 'pypinyin'`. Installing `pypinyin` manually fixes the reported configuration, so this makes the packaged wake dependencies match the runtime import path.

Fixes #74719

## Test Plan
- `git diff --check`
- `.venv/bin/python -m pytest tests/test_project_metadata.py -q -o 'addopts='`
- `.venv/bin/python -m ruff check tests/test_project_metadata.py tools/lazy_deps.py`
- `uv lock --check`