### PR TITLE
fix(web): clamp dashboard log viewer lines parameter

### DIFF
--- a/hermes_cli/logs.py
+++ b/hermes_cli/logs.py
@@ -59,6 +59,28 @@ _LOGGER_NAME_RE = re.compile(
 # Level ordering for >= filtering
 _LEVEL_ORDER = {"DEBUG": 0, "INFO": 1, "WARNING": 2, "ERROR": 3, "CRITICAL": 4}
 
+# Shared bounds for ``hermes logs -n`` and dashboard ``GET /api/logs``.
+# The console-engine path already rejects values outside this range;
+# other surfaces must clamp or they hit Python negative-slice footguns.
+LOG_LINES_MIN = 1
+LOG_LINES_MAX = 500
+LOG_LINES_DEFAULT_CLI = 50
+LOG_LINES_DEFAULT_DASHBOARD = 100
+
+
+def clamp_log_lines(value, default: int = LOG_LINES_DEFAULT_CLI) -> int:
+    """Clamp a log line-count request to ``[1, 500]``.
+
+    A bare ``min(lines, 500)`` is not enough: negative values keep the
+    negative number (``min(-1, 500) == -1``), and Python negative slices
+    then return nearly the entire log buffer instead of a short tail.
+    """
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(LOG_LINES_MIN, min(LOG_LINES_MAX, parsed))
+
 
 def _parse_since(since_str: str) -> Optional[datetime]:
     """Parse a relative time string like '1h', '30m', '2d' into a datetime cutoff.
@@ -171,6 +193,8 @@ def tail_log(
     component
         Component name to filter by (e.g. ``"gateway"``, ``"tools"``).
     """
+    num_lines = clamp_log_lines(num_lines, default=LOG_LINES_DEFAULT_CLI)
+
     filename = LOG_FILES.get(log_name)
     if filename is None:
         print(f"Unknown log: {log_name!r}. Available: {', '.join(sorted(LOG_FILES))}")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11416,7 +11416,12 @@ async def get_logs(
     component: Optional[str] = None,
     search: Optional[str] = None,
 ):
-    from hermes_cli.logs import _read_tail, LOG_FILES
+    from hermes_cli.logs import (
+        LOG_FILES,
+        LOG_LINES_DEFAULT_DASHBOARD,
+        _read_tail,
+        clamp_log_lines,
+    )
 
     log_name = LOG_FILES.get(file)
     if not log_name:
@@ -11445,9 +11450,10 @@ async def get_logs(
     else:
         comp_prefixes = None
 
+    safe_lines = clamp_log_lines(lines, default=LOG_LINES_DEFAULT_DASHBOARD)
     has_filters = bool(min_level or comp_prefixes or search)
     result = _read_tail(
-        log_path, min(lines, 500) if not search else 2000,
+        log_path, safe_lines if not search else 2000,
         has_filters=has_filters,
         min_level=min_level,
         component_prefixes=comp_prefixes,
@@ -11457,7 +11463,7 @@ async def get_logs(
     # trim to the requested line count afterward.
     if search:
         needle = search.lower()
-        result = [l for l in result if needle in l.lower()][-min(lines, 500):]
+        result = [l for l in result if needle in l.lower()][-safe_lines:]
     return {"file": file, "lines": result}
 
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2161,7 +2161,9 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         self._polling_progress_event.set()
         self._polling_network_error_count = 0
-        if generation == self._polling_conflict_recovery_generation:
+        # Bare/test adapters may not have run ``__init__``; treat missing as
+        # "no conflict recovery in flight" (same defensive shape as teardown).
+        if generation == getattr(self, "_polling_conflict_recovery_generation", None):
             self._polling_conflict_recovery_generation = None
         else:
             self._polling_conflict_count = 0

--- a/tests/gateway/test_telegram_start_polling_timeout.py
+++ b/tests/gateway/test_telegram_start_polling_timeout.py
@@ -59,6 +59,7 @@ def _bare_adapter():
     a._fatal_error_retryable = True
     a._polling_network_error_count = 0
     a._polling_conflict_count = 0
+    a._polling_conflict_recovery_generation = None
     a._polling_error_callback_ref = None
     a._background_tasks = set()
     a._send_path_degraded = False

--- a/tests/hermes_cli/test_web_server_logs_clamp.py
+++ b/tests/hermes_cli/test_web_server_logs_clamp.py
@@ -1,0 +1,96 @@
+"""Regression tests for dashboard + CLI log line-count clamping."""
+
+import pytest
+
+from hermes_cli.logs import (
+    LOG_LINES_DEFAULT_CLI,
+    LOG_LINES_DEFAULT_DASHBOARD,
+    clamp_log_lines,
+    tail_log,
+)
+
+
+class TestClampLogLines:
+    def test_invalid_value_uses_default(self):
+        assert clamp_log_lines("bad") == LOG_LINES_DEFAULT_CLI
+        assert clamp_log_lines("bad", default=LOG_LINES_DEFAULT_DASHBOARD) == 100
+
+    def test_zero_clamped_to_one(self):
+        assert clamp_log_lines(0) == 1
+
+    def test_negative_clamped_to_one(self):
+        assert clamp_log_lines(-1) == 1
+
+    def test_excessive_lines_capped(self):
+        assert clamp_log_lines(9999) == 500
+
+    def test_valid_value_unchanged(self):
+        assert clamp_log_lines(50) == 50
+
+
+class TestApiLogsLinesClamp:
+    """Endpoint-level tests so both the normal and search paths stay clamped."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_client(self, monkeypatch, _isolate_hermes_home):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+
+        import hermes_state
+        from hermes_constants import get_hermes_home
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
+
+        logs_dir = get_hermes_home() / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        # 20 multi-line entries so lines=-1 would otherwise return ~19 lines
+        # via Python negative-slice semantics instead of a 1-line tail.
+        (logs_dir / "agent.log").write_text(
+            "".join(f"2026-01-01 00:00:00 INFO agent.run: line-{i} unique-{i}\n" for i in range(20)),
+            encoding="utf-8",
+        )
+
+        self.client = TestClient(app)
+        self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+        self.home = get_hermes_home()
+
+    def test_get_logs_negative_lines_returns_single_tail_line(self):
+        resp = self.client.get("/api/logs?lines=-1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["lines"]) == 1
+        assert "line-19" in data["lines"][0]
+
+    def test_get_logs_search_negative_lines_clamps_post_filter(self):
+        resp = self.client.get("/api/logs?lines=-1&search=unique")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["lines"]) == 1
+        assert "unique-19" in data["lines"][0]
+
+    def test_get_logs_huge_lines_capped(self):
+        resp = self.client.get("/api/logs?lines=9999")
+        assert resp.status_code == 200
+        assert len(resp.json()["lines"]) == 20  # file only has 20 lines
+
+
+class TestCliTailLogLinesClamp:
+    def test_tail_log_negative_lines_prints_single_line(self, monkeypatch, _isolate_hermes_home, capsys):
+        from hermes_constants import get_hermes_home
+
+        logs_dir = get_hermes_home() / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        (logs_dir / "agent.log").write_text(
+            "".join(f"line-{i}\n" for i in range(20)),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+        tail_log("agent", num_lines=-1)
+        out = capsys.readouterr().out
+        assert "line-19" in out
+        # Must not dump nearly the whole file (negative-slice footgun).
+        assert out.count("line-") == 1


### PR DESCRIPTION
The dashboard log viewer applied only an upper bound with min(lines, 500), so negative or invalid lines values could bypass that check and return nearly the entire log buffer via Python negative-slice semantics. This change clamps the lines query parameter to a safe range of 1–500 (default 100) before reading or post-filtering log content, matching the defensive pagination pattern used by nearby dashboard endpoints.