### PR TITLE
feat(qqbot): preserve stable group sender identity

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1391,7 +1391,14 @@ class QQAdapter(BasePlatformAdapter):
         group_openid = str(d.get("group_openid", ""))
         if not group_openid:
             return
-        member_openid = str(author.get("member_openid", ""))
+        member_openid = str(author.get("member_openid", "")).strip()
+        if not member_openid:
+            logger.warning(
+                "[%s] Dropping QQ group message %s without member_openid",
+                self._log_tag,
+                msg_id,
+            )
+            return
         if not self._is_group_allowed(group_openid, member_openid):
             return
 
@@ -1427,7 +1434,11 @@ class QQAdapter(BasePlatformAdapter):
             return
 
         self._chat_type_map[group_openid] = "group"
-        identity = self._identity_store.resolve(group_openid, author)
+        identity = await asyncio.to_thread(
+            self._identity_store.resolve,
+            group_openid,
+            author,
+        )
         self._log_group_identity_probe(identity.stable_id, author)
         event = MessageEvent(
             source=self.build_source(

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1391,7 +1391,7 @@ class QQAdapter(BasePlatformAdapter):
         group_openid = str(d.get("group_openid", ""))
         if not group_openid:
             return
-        member_openid = str(author.get("member_openid", "")).strip()
+        member_openid = str(author.get("member_openid") or "").strip()
         if not member_openid:
             logger.warning(
                 "[%s] Dropping QQ group message %s without member_openid",

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1474,7 +1474,15 @@ class QQAdapter(BasePlatformAdapter):
         # Without this check any member of any guild the bot is in could
         # bypass the configured allowlist.
         guild_id = str(d.get("guild_id", ""))
-        author_id = str(author.get("id", ""))
+        raw_author_id = author.get("id")
+        author_id = str(raw_author_id).strip() if raw_author_id is not None else ""
+        if not author_id:
+            logger.warning(
+                "[%s] Guild message missing author id: channel=%s",
+                self._log_tag,
+                channel_id,
+            )
+            return
         if not self._is_group_allowed(guild_id or channel_id, author_id):
             logger.debug(
                 "[%s] Guild message blocked by ACL: channel=%s user=%s",
@@ -1518,7 +1526,7 @@ class QQAdapter(BasePlatformAdapter):
         event = MessageEvent(
             source=self.build_source(
                 chat_id=channel_id,
-                user_id=str(author.get("id", "")),
+                user_id=author_id,
                 user_name=nick or None,
                 chat_type="group",
             ),

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -61,6 +61,7 @@ except ImportError:
     httpx = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
+from hermes_constants import get_hermes_home
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -72,6 +73,7 @@ from gateway.platforms.base import (
 )
 from gateway.platforms.helpers import strip_markdown
 from gateway.platforms.media_cache import ext_for_mime
+from gateway.platforms.qqbot.identity import QQIdentityStore
 
 logger = logging.getLogger(__name__)
 
@@ -244,6 +246,14 @@ class QQAdapter(BasePlatformAdapter):
         self._group_allow_from = _coerce_list(
             extra.get("group_allow_from") or extra.get("groupAllowFrom")
         )
+        identity_store_path = extra.get("identity_store_path")
+        self._identity_store = QQIdentityStore(
+            Path(identity_store_path).expanduser()
+            if identity_store_path
+            else get_hermes_home() / "platform_data" / "qqbot" / "identities.json"
+        )
+        self._identity_probe = bool(extra.get("identity_probe", False))
+        self._identity_probe_shapes: set[Tuple[str, ...]] = set()
 
         # Connection state
         self._session: Optional[aiohttp.ClientSession] = None
@@ -1336,6 +1346,39 @@ class QQAdapter(BasePlatformAdapter):
         )
         await self.handle_message(event)
 
+    def _log_group_identity_probe(
+            self,
+            sender_id: str,
+            author: Dict[str, Any],
+    ) -> None:
+        """Log one safe sample per QQ author shape for field discovery."""
+        if not self._identity_probe:
+            return
+        shape = tuple(sorted(str(key) for key in author))
+        if shape in self._identity_probe_shapes:
+            return
+        self._identity_probe_shapes.add(shape)
+        candidate_keys = (
+            "username",
+            "nickname",
+            "qq_nickname",
+            "nick",
+            "card",
+            "member_name",
+        )
+        name_fields = {
+            key: " ".join(str(author[key]).split())[:80]
+            for key in candidate_keys
+            if author.get(key) not in (None, "")
+        }
+        logger.info(
+            "[%s] Group sender identity probe: sender_id=%s author_keys=%s name_fields=%s",
+            self._log_tag,
+            sender_id,
+            list(shape),
+            name_fields,
+        )
+
     async def _handle_group_message(
             self,
             d: Dict[str, Any],
@@ -1348,9 +1391,8 @@ class QQAdapter(BasePlatformAdapter):
         group_openid = str(d.get("group_openid", ""))
         if not group_openid:
             return
-        if not self._is_group_allowed(
-                group_openid, str(author.get("member_openid", ""))
-        ):
+        member_openid = str(author.get("member_openid", ""))
+        if not self._is_group_allowed(group_openid, member_openid):
             return
 
         # Strip the @bot mention prefix from content
@@ -1385,10 +1427,13 @@ class QQAdapter(BasePlatformAdapter):
             return
 
         self._chat_type_map[group_openid] = "group"
+        identity = self._identity_store.resolve(group_openid, author)
+        self._log_group_identity_probe(identity.stable_id, author)
         event = MessageEvent(
             source=self.build_source(
                 chat_id=group_openid,
-                user_id=str(author.get("member_openid", "")),
+                user_id=member_openid,
+                user_name=identity.label,
                 chat_type="group",
             ),
             text=text,

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -61,6 +61,7 @@ except ImportError:
     httpx = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
+from hermes_constants import get_hermes_home
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -72,6 +73,7 @@ from gateway.platforms.base import (
 )
 from gateway.platforms.helpers import strip_markdown
 from gateway.platforms.media_cache import ext_for_mime
+from gateway.platforms.qqbot.identity import QQIdentityStore
 
 logger = logging.getLogger(__name__)
 
@@ -217,6 +219,14 @@ class QQAdapter(BasePlatformAdapter):
         self._group_allow_from = _coerce_list(
             extra.get("group_allow_from") or extra.get("groupAllowFrom")
         )
+        identity_store_path = extra.get("identity_store_path")
+        self._identity_store = QQIdentityStore(
+            Path(identity_store_path).expanduser()
+            if identity_store_path
+            else get_hermes_home() / "platform_data" / "qqbot" / "identities.json"
+        )
+        self._identity_probe = bool(extra.get("identity_probe", False))
+        self._identity_probe_shapes: set[Tuple[str, ...]] = set()
 
         # Connection state
         self._session: Optional[aiohttp.ClientSession] = None
@@ -1307,6 +1317,39 @@ class QQAdapter(BasePlatformAdapter):
         )
         await self.handle_message(event)
 
+    def _log_group_identity_probe(
+            self,
+            sender_id: str,
+            author: Dict[str, Any],
+    ) -> None:
+        """Log one safe sample per QQ author shape for field discovery."""
+        if not self._identity_probe:
+            return
+        shape = tuple(sorted(str(key) for key in author))
+        if shape in self._identity_probe_shapes:
+            return
+        self._identity_probe_shapes.add(shape)
+        candidate_keys = (
+            "username",
+            "nickname",
+            "qq_nickname",
+            "nick",
+            "card",
+            "member_name",
+        )
+        name_fields = {
+            key: " ".join(str(author[key]).split())[:80]
+            for key in candidate_keys
+            if author.get(key) not in (None, "")
+        }
+        logger.info(
+            "[%s] Group sender identity probe: sender_id=%s author_keys=%s name_fields=%s",
+            self._log_tag,
+            sender_id,
+            list(shape),
+            name_fields,
+        )
+
     async def _handle_group_message(
             self,
             d: Dict[str, Any],
@@ -1319,9 +1362,8 @@ class QQAdapter(BasePlatformAdapter):
         group_openid = str(d.get("group_openid", ""))
         if not group_openid:
             return
-        if not self._is_group_allowed(
-                group_openid, str(author.get("member_openid", ""))
-        ):
+        member_openid = str(author.get("member_openid", ""))
+        if not self._is_group_allowed(group_openid, member_openid):
             return
 
         # Strip the @bot mention prefix from content
@@ -1356,10 +1398,13 @@ class QQAdapter(BasePlatformAdapter):
             return
 
         self._chat_type_map[group_openid] = "group"
+        identity = self._identity_store.resolve(group_openid, author)
+        self._log_group_identity_probe(identity.stable_id, author)
         event = MessageEvent(
             source=self.build_source(
                 chat_id=group_openid,
-                user_id=str(author.get("member_openid", "")),
+                user_id=member_openid,
+                user_name=identity.label,
                 chat_type="group",
             ),
             text=text,

--- a/gateway/platforms/qqbot/identity.py
+++ b/gateway/platforms/qqbot/identity.py
@@ -35,22 +35,12 @@ class QQSenderIdentity:
     member_openid: str
     stable_id: str
     group_display_name: str = ""
-    qq_nickname: str = ""
-    qq_nickname_source: str = ""
 
     @property
     def label(self) -> str:
         parts = [f"QQ sender id={self.stable_id}"]
-        if self.group_display_name and self.qq_nickname:
-            if self.group_display_name == self.qq_nickname:
-                parts.append(f"昵称={self.group_display_name}")
-            else:
-                parts.append(f"群昵称={self.group_display_name}")
-                parts.append(f"QQ昵称={self.qq_nickname}")
-        elif self.group_display_name:
+        if self.group_display_name:
             parts.append(f"群昵称={self.group_display_name}")
-        elif self.qq_nickname:
-            parts.append(f"QQ昵称={self.qq_nickname}")
         return " | ".join(parts)
 
 
@@ -90,31 +80,6 @@ class QQIdentityStore:
         os.replace(temp_path, self.path)
         os.chmod(self.path, 0o600)
 
-    def set_verified_qq_nickname(
-        self,
-        group_openid: str,
-        member_openid: str,
-        nickname: str,
-        *,
-        source: str = "owner_verified",
-    ) -> None:
-        """Attach an explicitly verified QQ nickname to a stable member identity."""
-        clean_nickname = _clean_name(nickname)
-        if not clean_nickname:
-            raise ValueError("QQ nickname must not be empty")
-        clean_source = _clean_name(source) or "owner_verified"
-        key = self.member_key(group_openid, member_openid)
-        with self._lock:
-            members = self._data.setdefault("members", {})
-            profile = members.setdefault(key, {})
-            profile["stable_id"] = _stable_sender_id(group_openid, member_openid)
-            profile["qq_nickname"] = {
-                "value": clean_nickname,
-                "source": clean_source,
-                "verified_at": datetime.now(timezone.utc).isoformat(),
-            }
-            self._write()
-
     def resolve(self, group_openid: str, author: dict[str, Any]) -> QQSenderIdentity:
         """Resolve the current sender and record its latest group display name."""
         member_openid = str(author.get("member_openid") or author.get("id") or "").strip()
@@ -138,14 +103,6 @@ class QQIdentityStore:
                 }
                 changed = True
 
-            qq_nickname_record = profile.get("qq_nickname")
-            if isinstance(qq_nickname_record, dict):
-                qq_nickname = _clean_name(qq_nickname_record.get("value"))
-                qq_nickname_source = _clean_name(qq_nickname_record.get("source"))
-            else:
-                qq_nickname = ""
-                qq_nickname_source = ""
-
             if changed:
                 self._write()
 
@@ -154,6 +111,4 @@ class QQIdentityStore:
             member_openid=member_openid,
             stable_id=stable_id,
             group_display_name=group_display_name,
-            qq_nickname=qq_nickname,
-            qq_nickname_source=qq_nickname_source,
         )

--- a/gateway/platforms/qqbot/identity.py
+++ b/gateway/platforms/qqbot/identity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import threading
 from dataclasses import dataclass
@@ -12,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 
+logger = logging.getLogger(__name__)
 _MAX_NAME_LENGTH = 80
 
 
@@ -81,15 +83,23 @@ class QQIdentityStore:
         os.chmod(self.path, 0o600)
 
     def resolve(self, group_openid: str, author: dict[str, Any]) -> QQSenderIdentity:
-        """Resolve the current sender and record its latest group display name."""
-        member_openid = str(author.get("member_openid") or author.get("id") or "").strip()
+        """Resolve the current sender and best-effort persist its display name."""
+        member_openid = str(author.get("member_openid") or "").strip()
+        if not member_openid:
+            raise ValueError("QQ group sender is missing member_openid")
         stable_id = _stable_sender_id(group_openid, member_openid)
         group_display_name = _clean_name(author.get("username"))
         key = self.member_key(group_openid, member_openid)
 
         with self._lock:
             members = self._data.setdefault("members", {})
-            profile = members.setdefault(key, {})
+            if not isinstance(members, dict):
+                members = {}
+                self._data["members"] = members
+            profile = members.get(key)
+            if not isinstance(profile, dict):
+                profile = {}
+                members[key] = profile
             changed = profile.get("stable_id") != stable_id
             profile["stable_id"] = stable_id
 
@@ -104,7 +114,13 @@ class QQIdentityStore:
                 changed = True
 
             if changed:
-                self._write()
+                try:
+                    self._write()
+                except (OSError, TypeError, ValueError):
+                    logger.warning(
+                        "Could not persist QQ sender identity observation",
+                        exc_info=True,
+                    )
 
         return QQSenderIdentity(
             group_openid=group_openid,

--- a/gateway/platforms/qqbot/identity.py
+++ b/gateway/platforms/qqbot/identity.py
@@ -1,0 +1,159 @@
+"""Stable sender identity and nickname observations for QQ group messages."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+_MAX_NAME_LENGTH = 80
+
+
+def _clean_name(value: Any) -> str:
+    """Return a bounded, single-line value safe inside a sender prefix."""
+    text = " ".join(str(value or "").split()).strip()
+    text = text.replace("|", "／").replace("[", "【").replace("]", "】")
+    return text[:_MAX_NAME_LENGTH]
+
+
+def _stable_sender_id(group_openid: str, member_openid: str) -> str:
+    raw = f"qqbot\0{group_openid}\0{member_openid}".encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()[:8]
+
+
+@dataclass(frozen=True)
+class QQSenderIdentity:
+    """Resolved QQ sender identity for one inbound group message."""
+
+    group_openid: str
+    member_openid: str
+    stable_id: str
+    group_display_name: str = ""
+    qq_nickname: str = ""
+    qq_nickname_source: str = ""
+
+    @property
+    def label(self) -> str:
+        parts = [f"QQ sender id={self.stable_id}"]
+        if self.group_display_name and self.qq_nickname:
+            if self.group_display_name == self.qq_nickname:
+                parts.append(f"昵称={self.group_display_name}")
+            else:
+                parts.append(f"群昵称={self.group_display_name}")
+                parts.append(f"QQ昵称={self.qq_nickname}")
+        elif self.group_display_name:
+            parts.append(f"群昵称={self.group_display_name}")
+        elif self.qq_nickname:
+            parts.append(f"QQ昵称={self.qq_nickname}")
+        return " | ".join(parts)
+
+
+class QQIdentityStore:
+    """Persist QQ nickname observations keyed by group + member OpenID."""
+
+    def __init__(self, path: Path):
+        self.path = Path(path)
+        self._lock = threading.RLock()
+        self._data: dict[str, Any] = {"version": 1, "members": {}}
+        self._load()
+
+    @staticmethod
+    def member_key(group_openid: str, member_openid: str) -> str:
+        return f"{group_openid}:{member_openid}"
+
+    def _load(self) -> None:
+        if not self.path.exists():
+            return
+        try:
+            loaded = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError):
+            return
+        if not isinstance(loaded, dict) or not isinstance(loaded.get("members"), dict):
+            return
+        self._data = loaded
+        self._data.setdefault("version", 1)
+
+    def _write(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        temp_path = self.path.with_name(f".{self.path.name}.{os.getpid()}.tmp")
+        temp_path.write_text(
+            json.dumps(self._data, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        os.chmod(temp_path, 0o600)
+        os.replace(temp_path, self.path)
+        os.chmod(self.path, 0o600)
+
+    def set_verified_qq_nickname(
+        self,
+        group_openid: str,
+        member_openid: str,
+        nickname: str,
+        *,
+        source: str = "owner_verified",
+    ) -> None:
+        """Attach an explicitly verified QQ nickname to a stable member identity."""
+        clean_nickname = _clean_name(nickname)
+        if not clean_nickname:
+            raise ValueError("QQ nickname must not be empty")
+        clean_source = _clean_name(source) or "owner_verified"
+        key = self.member_key(group_openid, member_openid)
+        with self._lock:
+            members = self._data.setdefault("members", {})
+            profile = members.setdefault(key, {})
+            profile["stable_id"] = _stable_sender_id(group_openid, member_openid)
+            profile["qq_nickname"] = {
+                "value": clean_nickname,
+                "source": clean_source,
+                "verified_at": datetime.now(timezone.utc).isoformat(),
+            }
+            self._write()
+
+    def resolve(self, group_openid: str, author: dict[str, Any]) -> QQSenderIdentity:
+        """Resolve the current sender and record its latest group display name."""
+        member_openid = str(author.get("member_openid") or author.get("id") or "").strip()
+        stable_id = _stable_sender_id(group_openid, member_openid)
+        group_display_name = _clean_name(author.get("username"))
+        key = self.member_key(group_openid, member_openid)
+
+        with self._lock:
+            members = self._data.setdefault("members", {})
+            profile = members.setdefault(key, {})
+            changed = profile.get("stable_id") != stable_id
+            profile["stable_id"] = stable_id
+
+            observed = profile.get("group_display_name")
+            observed_value = observed.get("value") if isinstance(observed, dict) else ""
+            if group_display_name and observed_value != group_display_name:
+                profile["group_display_name"] = {
+                    "value": group_display_name,
+                    "source": "event.author.username",
+                    "observed_at": datetime.now(timezone.utc).isoformat(),
+                }
+                changed = True
+
+            qq_nickname_record = profile.get("qq_nickname")
+            if isinstance(qq_nickname_record, dict):
+                qq_nickname = _clean_name(qq_nickname_record.get("value"))
+                qq_nickname_source = _clean_name(qq_nickname_record.get("source"))
+            else:
+                qq_nickname = ""
+                qq_nickname_source = ""
+
+            if changed:
+                self._write()
+
+        return QQSenderIdentity(
+            group_openid=group_openid,
+            member_openid=member_openid,
+            stable_id=stable_id,
+            group_display_name=group_display_name,
+            qq_nickname=qq_nickname,
+            qq_nickname_source=qq_nickname_source,
+        )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7442,6 +7442,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # sites are untouched when multiplexing is off (this dict is empty).
         # Populated by _start_secondary_profile_adapters().
         self._profile_adapters: Dict[str, Dict[Platform, BasePlatformAdapter]] = {}
+        self._profile_configs: Dict[str, GatewayConfig] = {"default": self.config}
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+
+            self._profile_configs[get_active_profile_name() or "default"] = self.config
+        except Exception:
+            logger.debug("could not register active profile config", exc_info=True)
         self._warn_if_docker_media_delivery_is_risky()
         _gateway_runner_ref = _weakref.ref(self)
 
@@ -7481,10 +7488,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _bg_max_age_hours * 3600 if _bg_max_age_hours and _bg_max_age_hours > 0 else None
         )
         self.session_store = SessionStore(
-            self.config.sessions_dir, self.config,
+            self.config.sessions_dir,
+            self.config,
             has_active_processes_fn=lambda key: process_registry.has_active_for_session(
                 key, max_active_age=_bg_max_age_seconds,
             ),
+            config_for_source_fn=self._session_config_for_source,
         )
         # One enforced loop-side boundary for the synchronous SessionStore.
         # Sync helpers keep using ``session_store`` directly; async gateway
@@ -8403,6 +8412,36 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def exit_code(self) -> Optional[int]:
         return self._exit_code
 
+    def _session_config_for_source(
+        self, source: SessionSource
+    ) -> Optional[GatewayConfig]:
+        """Return the registered gateway config for ``source``'s profile.
+
+        Returning ``None`` for an unknown explicit profile is deliberate: key
+        derivation and ownership checks must fail closed rather than silently
+        applying the primary profile's isolation policy.
+        """
+        profile = str(getattr(source, "profile", "") or "").strip()
+        if not profile:
+            return self.config
+        configs = getattr(self, "_profile_configs", None)
+        if isinstance(configs, dict):
+            return configs.get(profile)
+        return self.config if profile == "default" else None
+
+    def _build_session_context_for_source(
+        self,
+        source: SessionSource,
+        session_entry: Optional[SessionEntry] = None,
+    ) -> SessionContext:
+        """Build prompt context with the same profile config used for routing."""
+        config = self._session_config_for_source(source)
+        if config is None:
+            raise RuntimeError(
+                f"no gateway config registered for session source profile {source.profile!r}"
+            )
+        return build_session_context(source, config, session_entry)
+
     def _session_key_for_source(self, source: SessionSource) -> str:
         """Resolve the current session key for a source, honoring gateway config when available."""
         if hasattr(self, "session_store") and self.session_store is not None:
@@ -8412,7 +8451,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     return session_key
             except Exception:
                 pass
-        config = getattr(self, "config", None)
+        config = self._session_config_for_source(source)
+        if config is None:
+            raise RuntimeError(
+                f"no gateway config registered for session source profile {source.profile!r}"
+            )
         # Mirror SessionStore._resolve_profile_for_key so this fallback path
         # produces the same namespace as the primary path: None (legacy
         # agent:main) unless multiplexing is on, then the active profile.
@@ -14970,10 +15013,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             profile=handoff_profile,
         )
 
-        # Make sure there's an entry in the session_store for this key. If
-        # the home channel has never been used, get_or_create_session
-        # creates one; switch_session then re-points it.
-        await self.async_session_store.get_or_create_session(dest_source)
+        # Make sure there's an entry in the session_store for this source and
+        # switch the exact key the store created. The store is the single source
+        # of truth for profile-specific isolation; independently rebuilding the
+        # key here can diverge when a secondary profile overrides group/thread
+        # policy.
+        created_entry = await self.async_session_store.get_or_create_session(dest_source)
+        created_key = getattr(created_entry, "session_key", None)
+        if not isinstance(created_key, str) or not created_key:
+            raise RuntimeError("session store returned an entry without a session key")
+        if created_key != session_key:
+            logger.debug(
+                "Handoff: store-resolved key %s supersedes precomputed key %s",
+                created_key,
+                session_key,
+            )
+        session_key = created_key
 
         # Re-bind the destination key to the CLI session_id. switch_session
         # ends the prior session in SQLite and reopens the CLI session under
@@ -16700,6 +16755,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "for that profile, or change dm_policy/group_policy away from "
                 "'open'."
             )
+        profile_configs = getattr(self, "_profile_configs", None)
+        if not isinstance(profile_configs, dict):
+            profile_configs = {"default": self.config}
+            self._profile_configs = profile_configs
+        profile_configs[profile_name] = profile_cfg
 
         port_binding_platforms = sorted(
             platform.value
@@ -19758,8 +19818,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _pending_stt_prepared
             else event.text
         ) or ""
+        isolation_config = self._session_config_for_source(source)
+        if isolation_config is None:
+            raise RuntimeError(
+                f"no gateway config registered for session source profile {source.profile!r}"
+            )
         _group_sessions_per_user, _thread_sessions_per_user = resolve_session_isolation(
-            self.config,
+            isolation_config,
             source,
         )
         # Prefer the already resolved session key from the caller so this write
@@ -20463,11 +20528,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _reply_id = getattr(event, "reply_to_message_id", None)
         _reply_txt = (getattr(event, "reply_to_text", None) or "")[:80].replace("\n", " ")
         logger.info(
-            "inbound message: platform=%s user_id=%s user_name=%s chat=%s "
-            "msg=%r reply_to_id=%s reply_to_text=%r",
+            "inbound message: platform=%s user=%s chat=%s msg=%r reply_to_id=%s reply_to_text=%r",
             _platform_name,
-            source.user_id or "unknown",
-            source.user_name or "unknown",
+            source.user_name or source.user_id or "unknown",
             source.chat_id or "unknown",
             _msg_preview,
             _reply_id,
@@ -20638,8 +20701,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "session_key": session_key,
             })
         
-        # Build session context
-        context = build_session_context(source, self.config, session_entry)
+        # Build session context with the same profile-specific isolation policy
+        # used by SessionStore and /resume ownership checks.
+        context = self._build_session_context_for_source(source, session_entry)
         
         # Set session context variables for tools (task-local, concurrency-safe)
         _session_env_tokens = self._set_session_env(context)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8422,12 +8422,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         applying the primary profile's isolation policy.
         """
         profile = str(getattr(source, "profile", "") or "").strip()
+        primary_config = getattr(self, "config", None)
         if not profile:
-            return self.config
+            return primary_config
         configs = getattr(self, "_profile_configs", None)
         if isinstance(configs, dict):
             return configs.get(profile)
-        return self.config if profile == "default" else None
+        return primary_config if profile == "default" else None
 
     def _build_session_context_for_source(
         self,
@@ -8453,8 +8454,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
         config = self._session_config_for_source(source)
         if config is None:
-            raise RuntimeError(
-                f"no gateway config registered for session source profile {source.profile!r}"
+            # Preserve the pre-profile fallback for intentionally partial
+            # ``GatewayRunner.__new__`` fixtures. An explicit profile still
+            # fails closed; only an unprofiled source on a runner that has
+            # never been initialized may use the legacy defaults.
+            if source.profile or hasattr(self, "config"):
+                raise RuntimeError(
+                    "no gateway config registered for session source profile "
+                    f"{source.profile!r}"
+                )
+            return build_session_key(
+                source,
+                group_sessions_per_user=True,
+                thread_sessions_per_user=False,
+                profile=None,
             )
         # Mirror SessionStore._resolve_profile_for_key so this fallback path
         # produces the same namespace as the primary path: None (legacy

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8469,7 +8469,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # ``GatewayRunner.__new__`` fixtures. An explicit profile still
             # fails closed; only an unprofiled source on a runner that has
             # never been initialized may use the legacy defaults.
-            if source.profile or hasattr(self, "config"):
+            if source.profile:
                 raise RuntimeError(
                     "no gateway config registered for session source profile "
                     f"{source.profile!r}"
@@ -23142,7 +23142,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not canonical_cmd:
             return None
         config = self._session_config_for_source(source)
-        if config is None:
+        if config is None and source.profile:
             logger.warning(
                 "Slash command /%s denied: no config registered for profile %r",
                 canonical_cmd,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2988,6 +2988,7 @@ from gateway.session import (
     build_session_key,
     is_shared_multi_user_session,
     neutralize_untrusted_inline_text,
+    resolve_session_isolation,
 )
 from gateway.delivery import (
     DeliveryRouter,
@@ -8425,10 +8426,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _profile = get_active_profile_name() or "default"
                 except Exception:
                     _profile = None
+        group_per_user, thread_per_user = resolve_session_isolation(config, source)
         return build_session_key(
             source,
-            group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
+            group_sessions_per_user=group_per_user,
+            thread_sessions_per_user=thread_per_user,
             profile=_profile,
         )
 
@@ -14930,8 +14932,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # entry. For thread destinations build_session_key keys without
         # user_id (thread_sessions_per_user defaults to False) — so the
         # next real user message in the thread shares this same session.
-        platform_cfg = handoff_config.platforms.get(platform)
-        extra = platform_cfg.extra if platform_cfg else {}
+        group_per_user, thread_per_user = resolve_session_isolation(
+            handoff_config,
+            dest_source,
+        )
         # Namespace the key to the profile that queued this handoff. Without
         # it, a multiplexed gateway builds ``agent:main:...`` here while the
         # profile's own adapter routes real inbound messages on
@@ -14961,8 +14965,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.debug("Handoff: could not resolve profile namespace", exc_info=True)
         session_key = build_session_key(
             dest_source,
-            group_sessions_per_user=extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=extra.get("thread_sessions_per_user", False),
+            group_sessions_per_user=group_per_user,
+            thread_sessions_per_user=thread_per_user,
             profile=handoff_profile,
         )
 
@@ -19754,8 +19758,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _pending_stt_prepared
             else event.text
         ) or ""
-        _group_sessions_per_user = getattr(self.config, "group_sessions_per_user", True)
-        _thread_sessions_per_user = getattr(self.config, "thread_sessions_per_user", False)
+        _group_sessions_per_user, _thread_sessions_per_user = resolve_session_isolation(
+            self.config,
+            source,
+        )
         # Prefer the already resolved session key from the caller so this write
         # key matches the consume key at the run_conversation site. Fall back
         # to deriving it here for tests and legacy standalone callers.
@@ -20457,9 +20463,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _reply_id = getattr(event, "reply_to_message_id", None)
         _reply_txt = (getattr(event, "reply_to_text", None) or "")[:80].replace("\n", " ")
         logger.info(
-            "inbound message: platform=%s user=%s chat=%s msg=%r reply_to_id=%s reply_to_text=%r",
-            _platform_name, source.user_name or source.user_id or "unknown",
-            source.chat_id or "unknown", _msg_preview, _reply_id, _reply_txt,
+            "inbound message: platform=%s user_id=%s user_name=%s chat=%s "
+            "msg=%r reply_to_id=%s reply_to_text=%r",
+            _platform_name,
+            source.user_id or "unknown",
+            source.user_name or "unknown",
+            source.chat_id or "unknown",
+            _msg_preview,
+            _reply_id,
+            _reply_txt,
         )
 
         # Get or create session

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8430,6 +8430,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return configs.get(profile)
         return primary_config if profile == "default" else None
 
+    def _quick_commands_for_source(self, source: SessionSource) -> Dict[str, Any]:
+        """Return only the quick commands registered for ``source``'s profile."""
+        config = self._session_config_for_source(source)
+        if config is None:
+            return {}
+        if isinstance(config, dict):
+            quick_commands = config.get("quick_commands", {}) or {}
+        else:
+            quick_commands = getattr(config, "quick_commands", {}) or {}
+        return quick_commands if isinstance(quick_commands, dict) else {}
+
     def _build_session_context_for_source(
         self,
         source: SessionSource,
@@ -18982,11 +18993,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Preserve built-in precedence; aliases only need early handling when
         # the typed command is not already known.
         if command and _cmd_def is None:
-            if isinstance(self.config, dict):
-                quick_commands = self.config.get("quick_commands", {}) or {}
-            else:
-                quick_commands = getattr(self.config, "quick_commands", {}) or {}
-            if isinstance(quick_commands, dict) and command in quick_commands:
+            quick_commands = self._quick_commands_for_source(source)
+            if command in quick_commands:
                 qcmd = quick_commands[command]
                 if qcmd.get("type") == "alias":
                     target = (qcmd.get("target") or "").strip()
@@ -19427,12 +19435,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # User-defined quick commands (bypass agent loop, no LLM call)
         if command:
-            if isinstance(self.config, dict):
-                quick_commands = self.config.get("quick_commands", {}) or {}
-            else:
-                quick_commands = getattr(self.config, "quick_commands", {}) or {}
-            if not isinstance(quick_commands, dict):
-                quick_commands = {}
+            quick_commands = self._quick_commands_for_source(source)
             if command in quick_commands:
                 # Quick commands are slash capabilities too — and type:exec
                 # ones run a shell command in the gateway process. The early

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16816,7 +16816,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 continue
             try:
                 with _profile_runtime_scope(profile_home):
-                    adapter = self._create_adapter(platform, platform_config)
+                    adapter = self._create_adapter(
+                        platform,
+                        platform_config,
+                        owner_config=profile_cfg,
+                    )
             except Exception as e:
                 logger.error(
                     "[MULTIPLEX] Profile '%s': _create_adapter('%s') raised %s",
@@ -16985,10 +16989,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                     profile_home = get_profile_dir(profile_name)
                     with _profile_runtime_scope(profile_home):
-                        profile_config = load_gateway_config().platforms.get(platform)
+                        profile_gateway_config = load_gateway_config()
+                        profile_config = profile_gateway_config.platforms.get(platform)
                         if profile_config is None or not profile_config.enabled:
                             return
-                        adapter = self._create_adapter(platform, profile_config)
+                        adapter = self._create_adapter(
+                            platform,
+                            profile_config,
+                            owner_config=profile_gateway_config,
+                        )
                         if adapter is None:
                             logger.warning(
                                 "Secondary %s reconnect skipped: adapter unavailable (profile: %s)",
@@ -17468,23 +17477,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return hashlib.sha256(("hermes-mux:" + token).encode("utf-8")).hexdigest()[:16]
 
     def _create_adapter(
-        self, 
-        platform: Platform, 
-        config: Any
+        self,
+        platform: Platform,
+        config: Any,
+        *,
+        owner_config: Optional[GatewayConfig] = None,
     ) -> Optional[BasePlatformAdapter]:
         """Create the appropriate adapter for a platform.
 
         Checks the platform_registry first (plugin adapters), then falls
         through to the built-in if/elif chain for core platforms.
         """
+        owning_config = owner_config or self.config
         if hasattr(config, "extra") and isinstance(config.extra, dict):
             config.extra.setdefault(
                 "group_sessions_per_user",
-                self.config.group_sessions_per_user,
+                owning_config.group_sessions_per_user,
             )
             config.extra.setdefault(
                 "thread_sessions_per_user",
-                getattr(self.config, "thread_sessions_per_user", False),
+                getattr(owning_config, "thread_sessions_per_user", False),
             )
 
         # ── Plugin-registered platforms (checked first) ───────────────────

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14870,16 +14870,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"profile '{profile_name}' has no live adapters in this gateway"
                 )
             handoff_adapters = secondary
-            # The watcher already entered _profile_runtime_scope for this
-            # profile, so a fresh load resolves that profile's config.yaml
-            # and .env (home channel, tokens) rather than the primary's.
-            try:
-                handoff_config = load_gateway_config()
-            except Exception:
-                logger.warning(
-                    "Handoff: could not load config for profile %s; "
-                    "falling back to the primary's config",
-                    profile_name, exc_info=True,
+            profile_configs = getattr(self, "_profile_configs", None)
+            handoff_config = (
+                profile_configs.get(profile_name)
+                if isinstance(profile_configs, dict)
+                else None
+            )
+            if handoff_config is None:
+                raise RuntimeError(
+                    f"profile '{profile_name}' has no registered gateway config"
                 )
 
         # Adapter must be live. A relay-fronted gateway registers ONE adapter
@@ -23127,7 +23126,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if not canonical_cmd:
             return None
-        policy = _policy_for_source(self.config, source)
+        config = self._session_config_for_source(source)
+        if config is None:
+            logger.warning(
+                "Slash command /%s denied: no config registered for profile %r",
+                canonical_cmd,
+                source.profile,
+            )
+            return (
+                f"⛔ /{canonical_cmd} denied because this profile's "
+                "configuration is unavailable."
+            )
+        policy = _policy_for_source(config, source)
         if not policy.enabled or policy.can_run(source.user_id, canonical_cmd):
             return None
         logger.info(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2192,6 +2192,7 @@ from gateway.session import (
     build_session_key,
     is_shared_multi_user_session,
     neutralize_untrusted_inline_text,
+    resolve_session_isolation,
 )
 from gateway.delivery import (
     DeliveryRouter,
@@ -6330,10 +6331,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _profile = get_active_profile_name() or "default"
                 except Exception:
                     _profile = None
+        group_per_user, thread_per_user = resolve_session_isolation(config, source)
         return build_session_key(
             source,
-            group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
+            group_sessions_per_user=group_per_user,
+            thread_sessions_per_user=thread_per_user,
             profile=_profile,
         )
 
@@ -11336,12 +11338,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # entry. For thread destinations build_session_key keys without
         # user_id (thread_sessions_per_user defaults to False) — so the
         # next real user message in the thread shares this same session.
-        platform_cfg = self.config.platforms.get(platform)
-        extra = platform_cfg.extra if platform_cfg else {}
+        group_per_user, thread_per_user = resolve_session_isolation(
+            self.config,
+            dest_source,
+        )
         session_key = build_session_key(
             dest_source,
-            group_sessions_per_user=extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=extra.get("thread_sessions_per_user", False),
+            group_sessions_per_user=group_per_user,
+            thread_sessions_per_user=thread_per_user,
         )
 
         # Make sure there's an entry in the session_store for this key. If
@@ -15025,8 +15029,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _pending_stt_prepared
             else event.text
         ) or ""
-        _group_sessions_per_user = getattr(self.config, "group_sessions_per_user", True)
-        _thread_sessions_per_user = getattr(self.config, "thread_sessions_per_user", False)
+        _group_sessions_per_user, _thread_sessions_per_user = resolve_session_isolation(
+            self.config,
+            source,
+        )
         # Prefer the already resolved session key from the caller so this write
         # key matches the consume key at the run_conversation site. Fall back
         # to deriving it here for tests and legacy standalone callers.
@@ -15503,9 +15509,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _reply_id = getattr(event, "reply_to_message_id", None)
         _reply_txt = (getattr(event, "reply_to_text", None) or "")[:80].replace("\n", " ")
         logger.info(
-            "inbound message: platform=%s user=%s chat=%s msg=%r reply_to_id=%s reply_to_text=%r",
-            _platform_name, source.user_name or source.user_id or "unknown",
-            source.chat_id or "unknown", _msg_preview, _reply_id, _reply_txt,
+            "inbound message: platform=%s user_id=%s user_name=%s chat=%s "
+            "msg=%r reply_to_id=%s reply_to_text=%r",
+            _platform_name,
+            source.user_id or "unknown",
+            source.user_name or "unknown",
+            source.chat_id or "unknown",
+            _msg_preview,
+            _reply_id,
+            _reply_txt,
         )
 
         # Get or create session

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -18,7 +18,7 @@ import uuid
 from pathlib import Path
 from datetime import datetime, timedelta
 from dataclasses import dataclass, field, replace
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Callable
 
 logger = logging.getLogger(__name__)
 
@@ -1271,10 +1271,18 @@ class SessionStore:
     Falls back to legacy JSONL files if SQLite is unavailable.
     """
     
-    def __init__(self, sessions_dir: Path, config: GatewayConfig,
-                 has_active_processes_fn=None):
+    def __init__(
+        self,
+        sessions_dir: Path,
+        config: GatewayConfig,
+        has_active_processes_fn=None,
+        config_for_source_fn: Optional[
+            Callable[[SessionSource], Optional[GatewayConfig]]
+        ] = None,
+    ):
         self.sessions_dir = sessions_dir
         self.config = config
+        self._config_for_source_fn = config_for_source_fn
         self._entries: Dict[str, SessionEntry] = {}
         self._loaded = False
         # A fallback-only initial load must be reconciled with state.db after
@@ -2229,10 +2237,22 @@ class SessionStore:
 
         return recovered_profile == self._active_profile_name()
 
+    def _config_for_source(self, source: SessionSource) -> GatewayConfig:
+        """Return the profile-specific config used to derive ``source`` keys."""
+        if self._config_for_source_fn is None:
+            return self.config
+        resolved = self._config_for_source_fn(source)
+        if resolved is None:
+            raise RuntimeError(
+                f"no gateway config registered for session source profile {source.profile!r}"
+            )
+        return resolved
+
     def _generate_session_key(self, source: SessionSource) -> str:
         """Generate a session key from a source."""
+        config = self._config_for_source(source)
         group_per_user, thread_per_user = resolve_session_isolation(
-            self.config,
+            config,
             source,
         )
         return build_session_key(
@@ -2253,8 +2273,9 @@ class SessionStore:
         if source.platform != Platform.SLACK or not source.scope_id:
             return None
         legacy_source = replace(source, scope_id=None, guild_id=None)
+        config = self._config_for_source(source)
         group_per_user, thread_per_user = resolve_session_isolation(
-            self.config,
+            config,
             source,
         )
         return build_session_key(

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1067,6 +1067,27 @@ def is_shared_multi_user_session(
     return not group_sessions_per_user
 
 
+def resolve_session_isolation(
+    config: GatewayConfig,
+    source: SessionSource,
+) -> tuple[bool, bool]:
+    """Resolve group/thread isolation with optional per-platform overrides."""
+    group_per_user = getattr(config, "group_sessions_per_user", True)
+    thread_per_user = getattr(config, "thread_sessions_per_user", False)
+
+    platform_cfg = getattr(config, "platforms", {}).get(source.platform)
+    extra = getattr(platform_cfg, "extra", None)
+    if isinstance(extra, dict):
+        group_override = extra.get("group_sessions_per_user")
+        thread_override = extra.get("thread_sessions_per_user")
+        if isinstance(group_override, bool):
+            group_per_user = group_override
+        if isinstance(thread_override, bool):
+            thread_per_user = thread_override
+
+    return group_per_user, thread_per_user
+
+
 def _session_key_namespace(profile: Optional[str]) -> str:
     """Return the ``agent:<ns>`` namespace prefix for a session key.
 
@@ -2210,10 +2231,14 @@ class SessionStore:
 
     def _generate_session_key(self, source: SessionSource) -> str:
         """Generate a session key from a source."""
+        group_per_user, thread_per_user = resolve_session_isolation(
+            self.config,
+            source,
+        )
         return build_session_key(
             source,
-            group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
+            group_sessions_per_user=group_per_user,
+            thread_sessions_per_user=thread_per_user,
             profile=self._resolve_profile_for_key(source),
         )
 
@@ -2228,14 +2253,14 @@ class SessionStore:
         if source.platform != Platform.SLACK or not source.scope_id:
             return None
         legacy_source = replace(source, scope_id=None, guild_id=None)
+        group_per_user, thread_per_user = resolve_session_isolation(
+            self.config,
+            source,
+        )
         return build_session_key(
             legacy_source,
-            group_sessions_per_user=getattr(
-                self.config, "group_sessions_per_user", True
-            ),
-            thread_sessions_per_user=getattr(
-                self.config, "thread_sessions_per_user", False
-            ),
+            group_sessions_per_user=group_per_user,
+            thread_sessions_per_user=thread_per_user,
             profile=self._resolve_profile_for_key(source),
         )
 
@@ -4521,14 +4546,15 @@ def build_session_context(
         if home:
             home_channels[platform] = home
     
+    group_per_user, thread_per_user = resolve_session_isolation(config, source)
     context = SessionContext(
         source=source,
         connected_platforms=connected,
         home_channels=home_channels,
         shared_multi_user_session=is_shared_multi_user_session(
             source,
-            group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
+            group_sessions_per_user=group_per_user,
+            thread_sessions_per_user=thread_per_user,
         ),
     )
     

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1006,6 +1006,27 @@ def is_shared_multi_user_session(
     return not group_sessions_per_user
 
 
+def resolve_session_isolation(
+    config: GatewayConfig,
+    source: SessionSource,
+) -> tuple[bool, bool]:
+    """Resolve group/thread isolation with optional per-platform overrides."""
+    group_per_user = getattr(config, "group_sessions_per_user", True)
+    thread_per_user = getattr(config, "thread_sessions_per_user", False)
+
+    platform_cfg = getattr(config, "platforms", {}).get(source.platform)
+    extra = getattr(platform_cfg, "extra", None)
+    if isinstance(extra, dict):
+        group_override = extra.get("group_sessions_per_user")
+        thread_override = extra.get("thread_sessions_per_user")
+        if isinstance(group_override, bool):
+            group_per_user = group_override
+        if isinstance(thread_override, bool):
+            thread_per_user = thread_override
+
+    return group_per_user, thread_per_user
+
+
 def _session_key_namespace(profile: Optional[str]) -> str:
     """Return the ``agent:<ns>`` namespace prefix for a session key.
 
@@ -1566,10 +1587,14 @@ class SessionStore:
 
     def _generate_session_key(self, source: SessionSource) -> str:
         """Generate a session key from a source."""
+        group_per_user, thread_per_user = resolve_session_isolation(
+            self.config,
+            source,
+        )
         return build_session_key(
             source,
-            group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
+            group_sessions_per_user=group_per_user,
+            thread_sessions_per_user=thread_per_user,
             profile=self._resolve_profile_for_key(source),
         )
 
@@ -1584,14 +1609,14 @@ class SessionStore:
         if source.platform != Platform.SLACK or not source.scope_id:
             return None
         legacy_source = replace(source, scope_id=None, guild_id=None)
+        group_per_user, thread_per_user = resolve_session_isolation(
+            self.config,
+            source,
+        )
         return build_session_key(
             legacy_source,
-            group_sessions_per_user=getattr(
-                self.config, "group_sessions_per_user", True
-            ),
-            thread_sessions_per_user=getattr(
-                self.config, "thread_sessions_per_user", False
-            ),
+            group_sessions_per_user=group_per_user,
+            thread_sessions_per_user=thread_per_user,
             profile=self._resolve_profile_for_key(source),
         )
 
@@ -3287,14 +3312,15 @@ def build_session_context(
         if home:
             home_channels[platform] = home
     
+    group_per_user, thread_per_user = resolve_session_isolation(config, source)
     context = SessionContext(
         source=source,
         connected_platforms=connected,
         home_channels=home_channels,
         shared_multi_user_session=is_shared_multi_user_session(
             source,
-            group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
+            group_sessions_per_user=group_per_user,
+            thread_sessions_per_user=thread_per_user,
         ),
     )
     

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -39,6 +39,7 @@ from gateway.session import (
     SessionSource,
     build_session_key,
     is_shared_multi_user_session,
+    resolve_session_isolation,
 )
 from hermes_cli.config import atomic_config_write, cfg_get, clear_model_endpoint_credentials
 from utils import (
@@ -991,10 +992,13 @@ class GatewaySlashCommandsMixin:
         # Non-DM: scope by participant whenever the session key for this source
         # is per-user. is_shared_multi_user_session mirrors build_session_key's
         # isolation rules exactly, so the guard stays in lock-step with the key.
+        group_per_user, thread_per_user = resolve_session_isolation(
+            self.config, current
+        )
         shared = is_shared_multi_user_session(
             current,
-            group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
+            group_sessions_per_user=group_per_user,
+            thread_sessions_per_user=thread_per_user,
         )
         if shared:
             return True
@@ -1146,10 +1150,13 @@ class GatewaySlashCommandsMixin:
             # do NOT also require user-id equality (otherwise a co-member is
             # wrongly blocked from their own shared session). A per-user session
             # still requires the same owner.
+            group_per_user, thread_per_user = resolve_session_isolation(
+                self.config, source
+            )
             shared = is_shared_multi_user_session(
                 source,
-                group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
-                thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
+                group_sessions_per_user=group_per_user,
+                thread_sessions_per_user=thread_per_user,
             )
             if shared:
                 return True

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3310,6 +3310,12 @@ class GatewaySlashCommandsMixin:
         chat_name = source.chat_name or chat_id
         if source.platform is None:
             return t("gateway.set_home.save_failed", error="Missing logical platform")
+        runtime_config = self._session_config_for_source(source)
+        if runtime_config is None:
+            return t(
+                "gateway.set_home.save_failed",
+                error=f"No gateway config registered for profile {source.profile!r}",
+            )
 
         via_relay = getattr(source, "delivered_via_upstream_relay", False) is True
         if via_relay:
@@ -3362,9 +3368,10 @@ class GatewaySlashCommandsMixin:
         except Exception as e:
             logger.warning("Home config saved but legacy env persistence failed: %s", e)
 
-        # Keep the running gateway config in sync too. The pre-restart
-        # notification path reads self.config before the process reloads config.
-        platform_config = getattr(self, "config").platforms.setdefault(
+        # Keep the running profile config in sync too. The pre-restart
+        # notification and handoff paths read this registered config before the
+        # process reloads config.
+        platform_config = runtime_config.platforms.setdefault(
             source.platform,
             PlatformConfig(enabled=not via_relay),
         )

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -39,6 +39,7 @@ from gateway.session import (
     SessionSource,
     build_session_key,
     is_shared_multi_user_session,
+    resolve_session_isolation,
 )
 from hermes_cli.config import atomic_config_write, cfg_get, clear_model_endpoint_credentials
 from utils import (
@@ -1069,10 +1070,13 @@ class GatewaySlashCommandsMixin:
         # Non-DM: scope by participant whenever the session key for this source
         # is per-user. is_shared_multi_user_session mirrors build_session_key's
         # isolation rules exactly, so the guard stays in lock-step with the key.
+        group_per_user, thread_per_user = resolve_session_isolation(
+            self.config, current
+        )
         shared = is_shared_multi_user_session(
             current,
-            group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
+            group_sessions_per_user=group_per_user,
+            thread_sessions_per_user=thread_per_user,
         )
         if shared:
             return True
@@ -1224,10 +1228,13 @@ class GatewaySlashCommandsMixin:
             # do NOT also require user-id equality (otherwise a co-member is
             # wrongly blocked from their own shared session). A per-user session
             # still requires the same owner.
+            group_per_user, thread_per_user = resolve_session_isolation(
+                self.config, source
+            )
             shared = is_shared_multi_user_session(
                 source,
-                group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
-                thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
+                group_sessions_per_user=group_per_user,
+                thread_sessions_per_user=thread_per_user,
             )
             if shared:
                 return True

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -417,7 +417,13 @@ class GatewaySlashCommandsMixin:
         from gateway.slash_access import policy_for_source as _policy_for_source
 
         source = event.source
-        policy = _policy_for_source(self.config, source)
+        config = self._session_config_for_source(source)
+        if config is None:
+            return (
+                "**You** — profile configuration unavailable\n"
+                "Slash command access cannot be resolved safely."
+            )
+        policy = _policy_for_source(config, source)
         platform = source.platform.value if source and source.platform else "?"
         chat_type = (source.chat_type if source else "") or "dm"
         scope = "DM" if chat_type.lower() in {"dm", "direct", "private", ""} else "group/channel"
@@ -1109,7 +1115,10 @@ class GatewaySlashCommandsMixin:
         """
         try:
             from gateway.slash_access import policy_for_source
-            policy = policy_for_source(self.config, source)
+            config = self._session_config_for_source(source)
+            if config is None:
+                return False
+            policy = policy_for_source(config, source)
             uid = getattr(source, "user_id", None)
             return bool(policy.enabled and uid and policy.is_admin(uid))
         except Exception:
@@ -4204,7 +4213,10 @@ class GatewaySlashCommandsMixin:
         # This mutates profile-wide security policy. The central slash gate can
         # allow selected commands to non-admin users, so enforce admin again at
         # this side-effect boundary. Unconfigured policies remain unrestricted.
-        policy = policy_for_source(self.config, event.source)
+        config = self._session_config_for_source(event.source)
+        if config is None:
+            return "Profile configuration is unavailable; approval mode was not changed."
+        policy = policy_for_source(config, event.source)
         if requested and not policy.is_admin(event.source.user_id):
             return "Only gateway admins can change the persistent approval mode."
         result = run_approval_mode_command(requested)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1070,8 +1070,14 @@ class GatewaySlashCommandsMixin:
         # Non-DM: scope by participant whenever the session key for this source
         # is per-user. is_shared_multi_user_session mirrors build_session_key's
         # isolation rules exactly, so the guard stays in lock-step with the key.
+        config_for_source = getattr(self, "_session_config_for_source", None)
+        isolation_config = (
+            config_for_source(current) if callable(config_for_source) else self.config
+        )
+        if isolation_config is None:
+            return False
         group_per_user, thread_per_user = resolve_session_isolation(
-            self.config, current
+            isolation_config, current
         )
         shared = is_shared_multi_user_session(
             current,
@@ -1228,8 +1234,16 @@ class GatewaySlashCommandsMixin:
             # do NOT also require user-id equality (otherwise a co-member is
             # wrongly blocked from their own shared session). A per-user session
             # still requires the same owner.
+            config_for_source = getattr(self, "_session_config_for_source", None)
+            isolation_config = (
+                config_for_source(source)
+                if callable(config_for_source)
+                else self.config
+            )
+            if isolation_config is None:
+                return False
             group_per_user, thread_per_user = resolve_session_isolation(
-                self.config, source
+                isolation_config, source
             )
             shared = is_shared_multi_user_session(
                 source,

--- a/tests/gateway/test_handoff_secondary_profile_adapter.py
+++ b/tests/gateway/test_handoff_secondary_profile_adapter.py
@@ -21,8 +21,9 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
 from gateway.run import GatewayRunner
-from gateway.session import SessionEntry
+from gateway.session import SessionEntry, SessionSource
 
 
 def _adapter(tag):
@@ -150,6 +151,53 @@ async def test_secondary_profile_handoff_uses_its_own_adapter(monkeypatch):
         f"session key must carry the profile namespace, got {captured['session_key']}"
     )
     assert captured["source"].profile == "medicina"
+
+
+@pytest.mark.asyncio
+async def test_secondary_sethome_refreshes_registered_handoff_config(monkeypatch):
+    runner, _ = _make_multiplex_runner()
+    monkeypatch.setattr(
+        "gateway.slash_commands.persist_home_channel",
+        lambda _home, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.save_env_value",
+        lambda _key, _value: None,
+    )
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="9999",
+        chat_name="new-secondary-home",
+        chat_type="dm",
+        user_id="secondary-user",
+        profile="medicina",
+    )
+
+    result = await runner._handle_set_home_command(
+        MessageEvent(text="/sethome", source=source, message_id="sethome-1")
+    )
+
+    assert "Home channel set" in result
+    assert runner.config.get_home_channel(Platform.TELEGRAM).chat_id == "1111"
+    assert (
+        runner._profile_configs["medicina"]
+        .get_home_channel(Platform.TELEGRAM)
+        .chat_id
+        == "9999"
+    )
+
+    used = {}
+    monkeypatch.setattr(
+        "gateway.run.resolve_delivery_transport",
+        _spy_transport_factory(used),
+    )
+    await runner._process_handoff(
+        {"id": "cli-session", "title": "work", "handoff_platform": "telegram"},
+        profile_name="medicina",
+    )
+
+    assert used["home_chat_id"] == "9999"
+    assert used["adapter_tag"] == "medicina"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_handoff_secondary_profile_adapter.py
+++ b/tests/gateway/test_handoff_secondary_profile_adapter.py
@@ -62,7 +62,7 @@ def _make_multiplex_runner():
 
     store = MagicMock()
     store.get_or_create_session = AsyncMock(return_value=SessionEntry(
-        session_key="k", session_id="s",
+        session_key="agent:medicina:telegram:dm:2222", session_id="s",
         created_at=datetime.now(), updated_at=datetime.now(),
         platform=Platform.TELEGRAM, chat_type="dm",
     ))
@@ -146,6 +146,39 @@ async def test_secondary_profile_handoff_uses_its_own_adapter(monkeypatch):
         f"session key must carry the profile namespace, got {captured['session_key']}"
     )
     assert captured["source"].profile == "medicina"
+
+
+@pytest.mark.asyncio
+async def test_handoff_switches_the_exact_key_created_by_session_store(monkeypatch):
+    runner, captured = _make_multiplex_runner()
+    created_key = "agent:medicina:telegram:thread:2222:topic:system:handoff"
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key=created_key,
+        session_id="created-session",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="thread",
+    )
+    used = {}
+    monkeypatch.setattr(
+        "gateway.run.resolve_delivery_transport", _spy_transport_factory(used),
+    )
+    secondary = _config("2222")
+    secondary.platforms[Platform.TELEGRAM].extra["thread_sessions_per_user"] = True
+    monkeypatch.setattr("gateway.run.load_gateway_config", lambda: secondary)
+
+    await runner._process_handoff(
+        {
+            "id": "cli-session",
+            "title": "work",
+            "handoff_platform": "telegram",
+            "handoff_thread_id": "topic",
+        },
+        profile_name="medicina",
+    )
+
+    assert captured["session_key"] == created_key
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_handoff_secondary_profile_adapter.py
+++ b/tests/gateway/test_handoff_secondary_profile_adapter.py
@@ -53,6 +53,10 @@ def _make_multiplex_runner():
     runner._profile_adapters = {
         "medicina": {Platform.TELEGRAM: _adapter("medicina")},
     }
+    runner._profile_configs = {
+        "default": runner.config,
+        "medicina": _config("2222"),
+    }
     runner._voice_mode = {}
     runner.hooks = SimpleNamespace(
         emit=AsyncMock(), emit_collect=AsyncMock(return_value=[]), loaded_hooks=False,
@@ -219,3 +223,25 @@ async def test_secondary_profile_without_live_adapters_fails_loudly(monkeypatch)
             {"id": "cli-session", "title": "work", "handoff_platform": "telegram"},
             profile_name="medicina",
         )
+
+
+@pytest.mark.asyncio
+async def test_secondary_profile_without_registered_config_fails_closed(monkeypatch):
+    runner, _ = _make_multiplex_runner()
+    runner._profile_configs.pop("medicina")
+    used = {}
+    monkeypatch.setattr(
+        "gateway.run.resolve_delivery_transport", _spy_transport_factory(used),
+    )
+    monkeypatch.setattr(
+        "gateway.run.load_gateway_config",
+        MagicMock(side_effect=RuntimeError("broken config")),
+    )
+
+    with pytest.raises(RuntimeError, match="no registered gateway config"):
+        await runner._process_handoff(
+            {"id": "cli-session", "title": "work", "handoff_platform": "telegram"},
+            profile_name="medicina",
+        )
+
+    assert used == {}

--- a/tests/gateway/test_model_picker_persist.py
+++ b/tests/gateway/test_model_picker_persist.py
@@ -24,7 +24,7 @@ import types
 import yaml
 import pytest
 
-from gateway.config import Platform
+from gateway.config import GatewayConfig, Platform
 from gateway.platforms.base import MessageEvent, MessageType
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource
@@ -126,6 +126,15 @@ def _make_named_runner(monkeypatch, default_adapter, named_adapter, named_home):
         runner,
         "_profile_adapters",
         {"named": {Platform.TELEGRAM: named_adapter}},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        runner,
+        "_profile_configs",
+        {
+            "default": runner.config,
+            "named": GatewayConfig(multiplex_profiles=True),
+        },
         raising=False,
     )
     monkeypatch.setattr(

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -18,6 +18,69 @@ class _FakeAdapter:
         self.config = config
 
 
+class TestProfileIsolationDefaults:
+    def test_create_adapter_uses_owning_profile_defaults(self):
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            group_sessions_per_user=False,
+            thread_sessions_per_user=False,
+        )
+        owner = GatewayConfig(
+            group_sessions_per_user=True,
+            thread_sessions_per_user=True,
+        )
+        platform_config = PlatformConfig(
+            enabled=True,
+            extra={"app_id": "app", "client_secret": "secret"},
+        )
+
+        adapter = runner._create_adapter(
+            Platform.QQBOT,
+            platform_config,
+            owner_config=owner,
+        )
+
+        assert adapter is not None
+        assert adapter.config.extra["group_sessions_per_user"] is True
+        assert adapter.config.extra["thread_sessions_per_user"] is True
+
+    @pytest.mark.asyncio
+    async def test_secondary_startup_passes_owning_profile_config(self, monkeypatch):
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            multiplex_profiles=True,
+            group_sessions_per_user=False,
+        )
+        runner._profile_adapters = {}
+        runner._snapshot_profile_busy_modes = lambda *_args: None
+        owner = GatewayConfig(
+            multiplex_profiles=True,
+            group_sessions_per_user=True,
+            platforms={
+                Platform.QQBOT: PlatformConfig(
+                    enabled=True,
+                    extra={"app_id": "app", "client_secret": "secret"},
+                )
+            },
+        )
+        captured = {}
+
+        def fake_create(platform, platform_config, owner_config=None):
+            captured["platform"] = platform
+            captured["platform_config"] = platform_config
+            captured["owner_config"] = owner_config
+            return None
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: owner)
+        monkeypatch.setattr(runner, "_create_adapter", fake_create)
+
+        await runner._start_one_profile_adapters("secondary", Path("/tmp/x"), {})
+
+        assert captured["platform"] is Platform.QQBOT
+        assert captured["platform_config"] is owner.platforms[Platform.QQBOT]
+        assert captured["owner_config"] is owner
+
+
 class TestCredentialFingerprint:
     def test_none_without_token(self):
         assert GatewayRunner._adapter_credential_fingerprint(_FakeAdapter()) is None
@@ -204,7 +267,7 @@ def _install_secondary_reconnect_context(monkeypatch, runner, adapter, scoped_ho
             },
         ),
     )
-    monkeypatch.setattr(runner, "_create_adapter", lambda platform, config: adapter)
+    monkeypatch.setattr(runner, "_create_adapter", lambda platform, config, **_kwargs: adapter)
 
 
 class TestSecondaryProfileFatalRecovery:
@@ -309,7 +372,7 @@ class TestSecondaryStartupFailureRecovery:
         # Startup creates `failed`; the reconnect runner creates `replacement`.
         created = [failed, replacement]
         monkeypatch.setattr(
-            runner, "_create_adapter", lambda platform, config: created.pop(0)
+            runner, "_create_adapter", lambda platform, config, **_kwargs: created.pop(0)
         )
 
         async def fail_initial_connect(adapter, platform):
@@ -372,7 +435,7 @@ class TestSecondaryStartupFailureRecovery:
 
         created = [failed, replacement]
         monkeypatch.setattr(
-            runner, "_create_adapter", lambda platform, config: created.pop(0)
+            runner, "_create_adapter", lambda platform, config, **_kwargs: created.pop(0)
         )
 
         async def explode(adapter, platform):
@@ -417,7 +480,7 @@ class TestSecondaryStartupFailureRecovery:
         _install_secondary_reconnect_context(
             monkeypatch, runner, _SecondaryRecoveryAdapter()
         )
-        monkeypatch.setattr(runner, "_create_adapter", lambda platform, config: failed)
+        monkeypatch.setattr(runner, "_create_adapter", lambda platform, config, **_kwargs: failed)
 
         async def fail_initial_connect(adapter, platform):
             return False
@@ -444,7 +507,7 @@ class TestSecondaryStartupFailureRecovery:
         _install_secondary_reconnect_context(
             monkeypatch, runner, _SecondaryRecoveryAdapter()
         )
-        monkeypatch.setattr(runner, "_create_adapter", lambda platform, config: failed)
+        monkeypatch.setattr(runner, "_create_adapter", lambda platform, config, **_kwargs: failed)
 
         async def fail_initial_connect(adapter, platform):
             return False
@@ -545,7 +608,7 @@ class TestSecondaryProfileConfigHandling:
         writes = []
 
         monkeypatch.setattr("gateway.config.load_gateway_config", lambda: config)
-        monkeypatch.setattr(runner, "_create_adapter", lambda _p, _c: adapter)
+        monkeypatch.setattr(runner, "_create_adapter", lambda _p, _c, **_kwargs: adapter)
         monkeypatch.setattr(
             runner,
             "_update_platform_runtime_status",
@@ -593,7 +656,7 @@ class TestSecondaryProfileConfigHandling:
         writes = []
 
         monkeypatch.setattr("gateway.config.load_gateway_config", lambda: config)
-        monkeypatch.setattr(runner, "_create_adapter", lambda _p, _c: adapter)
+        monkeypatch.setattr(runner, "_create_adapter", lambda _p, _c, **_kwargs: adapter)
         monkeypatch.setattr(
             runner,
             "_update_platform_runtime_status",
@@ -748,7 +811,7 @@ class TestSecondaryProfileConfigHandling:
             return True
 
         monkeypatch.setattr("gateway.config.load_gateway_config", lambda: reviewer_cfg)
-        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: secondary)
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c, **_kwargs: secondary)
         monkeypatch.setattr(runner, "_connect_adapter_with_timeout", _connect)
         monkeypatch.setattr(
             runner, "_make_adapter_auth_check", lambda p, **kwargs: None
@@ -806,7 +869,7 @@ class TestSecondaryProfileConfigHandling:
             return adapter.should_connect
 
         monkeypatch.setattr("gateway.config.load_gateway_config", lambda: profile_cfg)
-        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: next(adapters))
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c, **_kwargs: next(adapters))
         monkeypatch.setattr(runner, "_connect_adapter_with_timeout", _connect)
         monkeypatch.setattr(
             runner, "_make_adapter_auth_check", lambda p, **kwargs: None
@@ -842,7 +905,7 @@ class TestFeishuPortBindingConditional:
             ),
         }
         monkeypatch.setattr("gateway.config.load_gateway_config", lambda: reviewer_cfg)
-        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: None)
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c, **_kwargs: None)
 
         connected = await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
         assert connected == 0  # no error, just nothing connected

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -204,6 +204,29 @@ class TestQQGroupSenderAttribution:
         event = adapter.handle_message.await_args.args[0]
         assert "群昵称=Alice Group" in event.source.user_name
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "event_type",
+        ["GUILD_MESSAGE_CREATE", "GUILD_AT_MESSAGE_CREATE"],
+    )
+    @pytest.mark.parametrize("author", [None, {}, {"id": None}, {"id": " "}])
+    async def test_guild_message_without_author_id_is_rejected(
+        self, tmp_path, event_type, author
+    ):
+        adapter = self._make(tmp_path / "identities.json")
+        payload = {
+            "id": "msg-1",
+            "guild_id": "group-1",
+            "channel_id": "channel-1",
+            "content": "hello",
+        }
+        if author is not None:
+            payload["author"] = author
+
+        await adapter._on_message(event_type, payload)
+
+        adapter.handle_message.assert_not_awaited()
+
 
 # ---------------------------------------------------------------------------
 # _coerce_list

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -171,6 +171,26 @@ class TestQQGroupSenderAttribution:
         adapter.handle_message.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_group_message_with_null_member_openid_is_cleanly_rejected(
+        self, tmp_path
+    ):
+        adapter = self._make(tmp_path / "identities.json")
+
+        await adapter._handle_group_message(
+            {"group_openid": "group-1"},
+            "msg-1",
+            "hello",
+            {
+                "member_openid": None,
+                "id": "non-member-author-id",
+                "username": "Unknown",
+            },
+            "",
+        )
+
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_group_message_includes_event_group_nickname(self, tmp_path):
         adapter = self._make(tmp_path / "identities.json")
         await adapter._handle_group_message(

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -116,6 +116,31 @@ class TestQQGroupSenderAttribution:
         assert "群昵称=Alice" in event.source.user_name
 
     @pytest.mark.asyncio
+    async def test_identity_resolution_is_offloaded_from_event_loop(self, tmp_path):
+        adapter = self._make(tmp_path / "identities.json")
+
+        async def run_off_loop(func, *args):
+            return func(*args)
+
+        with mock.patch(
+            "gateway.platforms.qqbot.adapter.asyncio.to_thread",
+            new=mock.AsyncMock(side_effect=run_off_loop),
+        ) as to_thread:
+            await adapter._handle_group_message(
+                {"group_openid": "group-1"},
+                "msg-1",
+                "hello",
+                {"member_openid": "member-1", "username": "Alice"},
+                "",
+            )
+
+        to_thread.assert_awaited_once_with(
+            adapter._identity_store.resolve,
+            "group-1",
+            {"member_openid": "member-1", "username": "Alice"},
+        )
+
+    @pytest.mark.asyncio
     async def test_group_message_falls_back_to_stable_member_label(self, tmp_path):
         adapter = self._make(tmp_path / "identities.json")
 
@@ -130,6 +155,20 @@ class TestQQGroupSenderAttribution:
         event = adapter.handle_message.await_args.args[0]
         assert event.source.user_name.startswith("QQ sender id=")
         assert "群昵称=" not in event.source.user_name
+
+    @pytest.mark.asyncio
+    async def test_group_message_without_member_openid_is_rejected(self, tmp_path):
+        adapter = self._make(tmp_path / "identities.json")
+
+        await adapter._handle_group_message(
+            {"group_openid": "group-1"},
+            "msg-1",
+            "hello",
+            {"id": "non-member-author-id", "username": "Unknown"},
+            "",
+        )
+
+        adapter.handle_message.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_group_message_includes_event_group_nickname(self, tmp_path):

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -67,6 +67,92 @@ class TestQQAdapterInit:
         assert adapter._markdown_support is True
 
 
+class TestQQGroupSenderAttribution:
+    @staticmethod
+    def _attachment_result():
+        return {
+            "image_urls": [],
+            "image_media_types": [],
+            "voice_transcripts": [],
+            "attachment_info": "",
+        }
+
+    def _make(self, identity_path, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        from gateway.platforms.qqbot.identity import QQIdentityStore
+
+        adapter = QQAdapter(
+            _make_config(
+                app_id="a",
+                client_secret="b",
+                group_policy="allowlist",
+                group_allow_from=["group-1"],
+                **extra,
+            )
+        )
+        adapter._identity_store = QQIdentityStore(identity_path)
+        adapter._process_attachments = mock.AsyncMock(return_value=self._attachment_result())
+        adapter._process_quoted_context = mock.AsyncMock(
+            return_value={"quote_block": "", "image_urls": [], "image_media_types": []}
+        )
+        adapter.handle_message = mock.AsyncMock()
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_group_message_uses_event_native_username(self, tmp_path):
+        adapter = self._make(tmp_path / "identities.json")
+
+        await adapter._handle_group_message(
+            {"group_openid": "group-1"},
+            "msg-1",
+            "hello",
+            {"member_openid": "member-1", "username": "Alice"},
+            "",
+        )
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.source.user_id == "member-1"
+        assert event.source.user_name.startswith("QQ sender id=")
+        assert "群昵称=Alice" in event.source.user_name
+
+    @pytest.mark.asyncio
+    async def test_group_message_falls_back_to_stable_member_label(self, tmp_path):
+        adapter = self._make(tmp_path / "identities.json")
+
+        await adapter._handle_group_message(
+            {"group_openid": "group-1"},
+            "msg-1",
+            "hello",
+            {"member_openid": "member-2"},
+            "",
+        )
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.source.user_name.startswith("QQ sender id=")
+        assert "群昵称=" not in event.source.user_name
+
+    @pytest.mark.asyncio
+    async def test_group_message_includes_verified_qq_nickname(self, tmp_path):
+        adapter = self._make(tmp_path / "identities.json")
+        adapter._identity_store.set_verified_qq_nickname(
+            "group-1",
+            "member-1",
+            "alice_qq",
+        )
+
+        await adapter._handle_group_message(
+            {"group_openid": "group-1"},
+            "msg-1",
+            "hello",
+            {"member_openid": "member-1", "username": "Alice Group"},
+            "",
+        )
+
+        event = adapter.handle_message.await_args.args[0]
+        assert "群昵称=Alice Group" in event.source.user_name
+        assert "QQ昵称=alice_qq" in event.source.user_name
+
+
 # ---------------------------------------------------------------------------
 # _coerce_list
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -132,14 +132,8 @@ class TestQQGroupSenderAttribution:
         assert "群昵称=" not in event.source.user_name
 
     @pytest.mark.asyncio
-    async def test_group_message_includes_verified_qq_nickname(self, tmp_path):
+    async def test_group_message_includes_event_group_nickname(self, tmp_path):
         adapter = self._make(tmp_path / "identities.json")
-        adapter._identity_store.set_verified_qq_nickname(
-            "group-1",
-            "member-1",
-            "alice_qq",
-        )
-
         await adapter._handle_group_message(
             {"group_openid": "group-1"},
             "msg-1",
@@ -150,7 +144,6 @@ class TestQQGroupSenderAttribution:
 
         event = adapter.handle_message.await_args.args[0]
         assert "群昵称=Alice Group" in event.source.user_name
-        assert "QQ昵称=alice_qq" in event.source.user_name
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_qqbot_identity.py
+++ b/tests/gateway/test_qqbot_identity.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from gateway.platforms.qqbot.identity import QQIdentityStore
 
 
@@ -59,6 +61,46 @@ def test_missing_name_falls_back_to_stable_sender_id(tmp_path):
     identity = store.resolve("group-1", {"member_openid": "member-1"})
 
     assert identity.label == f"QQ sender id={identity.stable_id}"
+
+
+def test_missing_member_openid_is_rejected(tmp_path):
+    store = QQIdentityStore(tmp_path / "identities.json")
+
+    with pytest.raises(ValueError, match="member_openid"):
+        store.resolve("group-1", {"id": "different-principal-type"})
+
+
+def test_malformed_persisted_member_does_not_break_resolution(tmp_path):
+    path = tmp_path / "identities.json"
+    path.write_text(
+        json.dumps({"version": 1, "members": {"group-1:member-1": 42}}),
+        encoding="utf-8",
+    )
+    store = QQIdentityStore(path)
+
+    identity = store.resolve(
+        "group-1", {"member_openid": "member-1", "username": "Alice"}
+    )
+
+    assert identity.member_openid == "member-1"
+    assert identity.group_display_name == "Alice"
+    assert isinstance(store._data["members"]["group-1:member-1"], dict)
+
+
+def test_identity_write_failure_is_best_effort(tmp_path, monkeypatch):
+    store = QQIdentityStore(tmp_path / "identities.json")
+
+    def fail_write():
+        raise PermissionError("read-only identity store")
+
+    monkeypatch.setattr(store, "_write", fail_write)
+
+    identity = store.resolve(
+        "group-1", {"member_openid": "member-1", "username": "Alice"}
+    )
+
+    assert identity.member_openid == "member-1"
+    assert identity.group_display_name == "Alice"
 
 
 def test_names_are_single_line_and_length_limited(tmp_path):

--- a/tests/gateway/test_qqbot_identity.py
+++ b/tests/gateway/test_qqbot_identity.py
@@ -1,0 +1,102 @@
+from gateway.platforms.qqbot.identity import QQIdentityStore
+
+
+def test_sender_identity_uses_group_and_member_openids(tmp_path):
+    store = QQIdentityStore(tmp_path / "identities.json")
+
+    before = store.resolve(
+        "group-1",
+        {"member_openid": "member-1", "username": "Old name"},
+    )
+    after = store.resolve(
+        "group-1",
+        {"member_openid": "member-1", "username": "New name"},
+    )
+
+    assert before.stable_id == after.stable_id
+    assert before.member_openid == after.member_openid == "member-1"
+    assert after.group_display_name == "New name"
+
+
+def test_same_name_does_not_merge_different_members(tmp_path):
+    store = QQIdentityStore(tmp_path / "identities.json")
+
+    alice = store.resolve(
+        "group-1",
+        {"member_openid": "member-1", "username": "Same name"},
+    )
+    bob = store.resolve(
+        "group-1",
+        {"member_openid": "member-2", "username": "Same name"},
+    )
+
+    assert alice.stable_id != bob.stable_id
+
+
+def test_verified_qq_nickname_is_shown_with_group_name(tmp_path):
+    store = QQIdentityStore(tmp_path / "identities.json")
+    store.set_verified_qq_nickname(
+        "group-1",
+        "member-1",
+        "alice_qq",
+        source="owner_verified",
+    )
+
+    identity = store.resolve(
+        "group-1",
+        {"member_openid": "member-1", "username": "Alice Group"},
+    )
+
+    assert identity.qq_nickname == "alice_qq"
+    assert identity.qq_nickname_source == "owner_verified"
+    assert identity.label == (
+        f"QQ sender id={identity.stable_id} | 群昵称=Alice Group | QQ昵称=alice_qq"
+    )
+
+
+def test_duplicate_names_are_deduplicated(tmp_path):
+    store = QQIdentityStore(tmp_path / "identities.json")
+    store.set_verified_qq_nickname(
+        "group-1",
+        "member-1",
+        "Alice",
+        source="owner_verified",
+    )
+
+    identity = store.resolve(
+        "group-1",
+        {"member_openid": "member-1", "username": "Alice"},
+    )
+
+    assert identity.label == f"QQ sender id={identity.stable_id} | 昵称=Alice"
+
+
+def test_names_are_single_line_and_length_limited(tmp_path):
+    store = QQIdentityStore(tmp_path / "identities.json")
+    identity = store.resolve(
+        "group-1",
+        {"member_openid": "member-1", "username": "Alice\n[admin] " + "x" * 200},
+    )
+
+    assert "\n" not in identity.group_display_name
+    assert len(identity.group_display_name) <= 80
+
+
+def test_verified_profile_survives_reload(tmp_path):
+    path = tmp_path / "identities.json"
+    store = QQIdentityStore(path)
+    store.set_verified_qq_nickname(
+        "group-1",
+        "member-1",
+        "alice_qq",
+        source="owner_verified",
+    )
+
+    reloaded = QQIdentityStore(path)
+    identity = reloaded.resolve(
+        "group-1",
+        {"member_openid": "member-1", "username": "Alice Group"},
+    )
+
+    assert identity.qq_nickname == "alice_qq"
+    assert identity.qq_nickname_source == "owner_verified"

--- a/tests/gateway/test_qqbot_identity.py
+++ b/tests/gateway/test_qqbot_identity.py
@@ -1,3 +1,5 @@
+import json
+
 from gateway.platforms.qqbot.identity import QQIdentityStore
 
 
@@ -16,6 +18,7 @@ def test_sender_identity_uses_group_and_member_openids(tmp_path):
     assert before.stable_id == after.stable_id
     assert before.member_openid == after.member_openid == "member-1"
     assert after.group_display_name == "New name"
+    assert after.label == f"QQ sender id={after.stable_id} | 群昵称=New name"
 
 
 def test_same_name_does_not_merge_different_members(tmp_path):
@@ -33,42 +36,29 @@ def test_same_name_does_not_merge_different_members(tmp_path):
     assert alice.stable_id != bob.stable_id
 
 
-def test_verified_qq_nickname_is_shown_with_group_name(tmp_path):
-    store = QQIdentityStore(tmp_path / "identities.json")
-    store.set_verified_qq_nickname(
-        "group-1",
-        "member-1",
-        "alice_qq",
-        source="owner_verified",
-    )
+def test_group_display_observation_is_persisted_with_provenance(tmp_path):
+    path = tmp_path / "identities.json"
+    store = QQIdentityStore(path)
 
     identity = store.resolve(
         "group-1",
         {"member_openid": "member-1", "username": "Alice Group"},
     )
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    profile = persisted["members"]["group-1:member-1"]
 
-    assert identity.qq_nickname == "alice_qq"
-    assert identity.qq_nickname_source == "owner_verified"
-    assert identity.label == (
-        f"QQ sender id={identity.stable_id} | 群昵称=Alice Group | QQ昵称=alice_qq"
-    )
+    assert profile["stable_id"] == identity.stable_id
+    assert profile["group_display_name"]["value"] == "Alice Group"
+    assert profile["group_display_name"]["source"] == "event.author.username"
+    assert profile["group_display_name"]["observed_at"]
 
 
-def test_duplicate_names_are_deduplicated(tmp_path):
+def test_missing_name_falls_back_to_stable_sender_id(tmp_path):
     store = QQIdentityStore(tmp_path / "identities.json")
-    store.set_verified_qq_nickname(
-        "group-1",
-        "member-1",
-        "Alice",
-        source="owner_verified",
-    )
 
-    identity = store.resolve(
-        "group-1",
-        {"member_openid": "member-1", "username": "Alice"},
-    )
+    identity = store.resolve("group-1", {"member_openid": "member-1"})
 
-    assert identity.label == f"QQ sender id={identity.stable_id} | 昵称=Alice"
+    assert identity.label == f"QQ sender id={identity.stable_id}"
 
 
 def test_names_are_single_line_and_length_limited(tmp_path):
@@ -80,23 +70,3 @@ def test_names_are_single_line_and_length_limited(tmp_path):
 
     assert "\n" not in identity.group_display_name
     assert len(identity.group_display_name) <= 80
-
-
-def test_verified_profile_survives_reload(tmp_path):
-    path = tmp_path / "identities.json"
-    store = QQIdentityStore(path)
-    store.set_verified_qq_nickname(
-        "group-1",
-        "member-1",
-        "alice_qq",
-        source="owner_verified",
-    )
-
-    reloaded = QQIdentityStore(path)
-    identity = reloaded.resolve(
-        "group-1",
-        {"member_openid": "member-1", "username": "Alice Group"},
-    )
-
-    assert identity.qq_nickname == "alice_qq"
-    assert identity.qq_nickname_source == "owner_verified"

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -898,6 +898,88 @@ class TestSameOriginChatGroupScoping:
             self._src("alice"), "bobs_live_sid", allow_override=False
         ) is False
 
+    @staticmethod
+    def _configure_qq_group_override(runner, *, global_value, platform_value):
+        runner.config.group_sessions_per_user = global_value
+        runner.config.thread_sessions_per_user = False
+        runner.config.platforms = {
+            Platform.QQBOT: SimpleNamespace(
+                extra={"group_sessions_per_user": platform_value}
+            )
+        }
+
+    def test_qq_override_isolates_live_group_when_global_is_shared(self):
+        runner = _make_runner()
+        self._configure_qq_group_override(
+            runner, global_value=False, platform_value=True
+        )
+        alice = self._src("alice", platform=Platform.QQBOT, chat_id="qq-group")
+        bob = self._src("bob", platform=Platform.QQBOT, chat_id="qq-group")
+
+        assert runner._same_origin_chat(alice, bob) is False
+
+    def test_qq_override_shares_live_group_when_global_is_per_user(self):
+        runner = _make_runner()
+        self._configure_qq_group_override(
+            runner, global_value=True, platform_value=False
+        )
+        alice = self._src("alice", platform=Platform.QQBOT, chat_id="qq-group")
+        bob = self._src("bob", platform=Platform.QQBOT, chat_id="qq-group")
+
+        assert runner._same_origin_chat(alice, bob) is True
+
+    @pytest.mark.asyncio
+    async def test_qq_override_isolates_persisted_group_when_global_is_shared(
+        self, tmp_path
+    ):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(
+            "bobs_group",
+            "qqbot",
+            user_id="bob",
+            chat_id="qq-group",
+            chat_type="group",
+        )
+        runner = _make_runner(session_db=db)
+        runner._gateway_session_origin_for_id = lambda _sid: None
+        self._configure_qq_group_override(
+            runner, global_value=False, platform_value=True
+        )
+        alice = self._src("alice", platform=Platform.QQBOT, chat_id="qq-group")
+
+        assert await runner._resume_target_allowed(
+            alice, "bobs_group", allow_override=False
+        ) is False
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_qq_override_shares_persisted_group_when_global_is_per_user(
+        self, tmp_path
+    ):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(
+            "bobs_group",
+            "qqbot",
+            user_id="bob",
+            chat_id="qq-group",
+            chat_type="group",
+        )
+        runner = _make_runner(session_db=db)
+        runner._gateway_session_origin_for_id = lambda _sid: None
+        self._configure_qq_group_override(
+            runner, global_value=True, platform_value=False
+        )
+        alice = self._src("alice", platform=Platform.QQBOT, chat_id="qq-group")
+
+        assert await runner._resume_target_allowed(
+            alice, "bobs_group", allow_override=False
+        ) is True
+        db.close()
+
     # --- thread scoping: thread_id is part of the session key, so a session in
     # one thread must never match a caller in another thread of the same chat,
     # even when threads are shared among participants by default. ---

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -410,6 +410,88 @@ class TestSameOriginChatGroupScoping:
             self._src("alice"), "bobs_live_sid", allow_override=False
         ) is False
 
+    @staticmethod
+    def _configure_qq_group_override(runner, *, global_value, platform_value):
+        runner.config.group_sessions_per_user = global_value
+        runner.config.thread_sessions_per_user = False
+        runner.config.platforms = {
+            Platform.QQBOT: SimpleNamespace(
+                extra={"group_sessions_per_user": platform_value}
+            )
+        }
+
+    def test_qq_override_isolates_live_group_when_global_is_shared(self):
+        runner = _make_runner()
+        self._configure_qq_group_override(
+            runner, global_value=False, platform_value=True
+        )
+        alice = self._src("alice", platform=Platform.QQBOT, chat_id="qq-group")
+        bob = self._src("bob", platform=Platform.QQBOT, chat_id="qq-group")
+
+        assert runner._same_origin_chat(alice, bob) is False
+
+    def test_qq_override_shares_live_group_when_global_is_per_user(self):
+        runner = _make_runner()
+        self._configure_qq_group_override(
+            runner, global_value=True, platform_value=False
+        )
+        alice = self._src("alice", platform=Platform.QQBOT, chat_id="qq-group")
+        bob = self._src("bob", platform=Platform.QQBOT, chat_id="qq-group")
+
+        assert runner._same_origin_chat(alice, bob) is True
+
+    @pytest.mark.asyncio
+    async def test_qq_override_isolates_persisted_group_when_global_is_shared(
+        self, tmp_path
+    ):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(
+            "bobs_group",
+            "qqbot",
+            user_id="bob",
+            chat_id="qq-group",
+            chat_type="group",
+        )
+        runner = _make_runner(session_db=db)
+        runner._gateway_session_origin_for_id = lambda _sid: None
+        self._configure_qq_group_override(
+            runner, global_value=False, platform_value=True
+        )
+        alice = self._src("alice", platform=Platform.QQBOT, chat_id="qq-group")
+
+        assert await runner._resume_target_allowed(
+            alice, "bobs_group", allow_override=False
+        ) is False
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_qq_override_shares_persisted_group_when_global_is_per_user(
+        self, tmp_path
+    ):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(
+            "bobs_group",
+            "qqbot",
+            user_id="bob",
+            chat_id="qq-group",
+            chat_type="group",
+        )
+        runner = _make_runner(session_db=db)
+        runner._gateway_session_origin_for_id = lambda _sid: None
+        self._configure_qq_group_override(
+            runner, global_value=True, platform_value=False
+        )
+        alice = self._src("alice", platform=Platform.QQBOT, chat_id="qq-group")
+
+        assert await runner._resume_target_allowed(
+            alice, "bobs_group", allow_override=False
+        ) is True
+        db.close()
+
     # --- thread scoping: thread_id is part of the session key, so a session in
     # one thread must never match a caller in another thread of the same chat,
     # even when threads are shared among participants by default. ---

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import GatewayConfig, Platform
+from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent
 from gateway.session import SessionSource, build_session_key
 
@@ -941,6 +941,44 @@ class TestSameOriginChatGroupScoping:
         bob = replace(alice, user_id="bob")
 
         assert runner._same_origin_chat(alice, bob) is False
+
+    def test_secondary_profile_admin_override_uses_secondary_policy(self):
+        runner = _make_runner()
+        runner.config = GatewayConfig(
+            platforms={
+                Platform.QQBOT: PlatformConfig(
+                    enabled=True,
+                    extra={"group_allow_admin_from": ["primary-admin"]},
+                )
+            },
+            multiplex_profiles=True,
+        )
+        secondary = GatewayConfig(
+            platforms={
+                Platform.QQBOT: PlatformConfig(
+                    enabled=True,
+                    extra={"group_allow_admin_from": ["secondary-admin"]},
+                )
+            },
+            multiplex_profiles=True,
+        )
+        runner._profile_configs = {
+            "default": runner.config,
+            "secondary": secondary,
+        }
+        source = replace(
+            self._src(
+                "primary-admin",
+                platform=Platform.QQBOT,
+                chat_id="qq-group",
+            ),
+            profile="secondary",
+        )
+
+        assert runner._resume_caller_is_admin(source) is False
+        assert runner._resume_caller_is_admin(
+            replace(source, user_id="secondary-admin")
+        ) is True
 
     @pytest.mark.asyncio
     async def test_qq_override_isolates_persisted_group_when_global_is_shared(

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -4,12 +4,13 @@ Tests the _handle_resume_command handler (switch to a previously-named session)
 across gateway messenger platforms.
 """
 
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import Platform
+from gateway.config import GatewayConfig, Platform
 from gateway.platforms.base import MessageEvent
 from gateway.session import SessionSource, build_session_key
 
@@ -927,6 +928,19 @@ class TestSameOriginChatGroupScoping:
         bob = self._src("bob", platform=Platform.QQBOT, chat_id="qq-group")
 
         assert runner._same_origin_chat(alice, bob) is True
+
+    def test_secondary_profile_uses_its_own_isolation_policy(self):
+        runner = _make_runner()
+        runner.config.group_sessions_per_user = False
+        secondary = GatewayConfig(group_sessions_per_user=True)
+        runner._profile_configs = {"secondary": secondary}
+        alice = replace(
+            self._src("alice", platform=Platform.QQBOT, chat_id="qq-group"),
+            profile="secondary",
+        )
+        bob = replace(alice, user_id="bob")
+
+        assert runner._same_origin_chat(alice, bob) is False
 
     @pytest.mark.asyncio
     async def test_qq_override_isolates_persisted_group_when_global_is_shared(

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -17,12 +17,88 @@ from gateway.session import (
     build_session_key,
     canonical_whatsapp_identifier,
     neutralize_untrusted_inline_text,
+    resolve_session_isolation,
 )
 
 # Legacy name preserved for these tests; product renamed the function to
 # canonical_whatsapp_identifier.  Keep the tests referencing the old name
 # working without duplicating the suite.
 normalize_whatsapp_identifier = canonical_whatsapp_identifier
+
+
+def test_resolve_session_isolation_prefers_platform_override():
+    config = GatewayConfig(
+        platforms={
+            Platform.QQBOT: PlatformConfig(
+                enabled=True,
+                extra={
+                    "group_sessions_per_user": False,
+                    "thread_sessions_per_user": True,
+                },
+            ),
+            Platform.FEISHU: PlatformConfig(enabled=True),
+        },
+        group_sessions_per_user=True,
+        thread_sessions_per_user=False,
+    )
+
+    qq_source = SessionSource(
+        platform=Platform.QQBOT,
+        chat_id="qq-group",
+        chat_type="group",
+        user_id="member-1",
+    )
+    feishu_source = replace(qq_source, platform=Platform.FEISHU)
+
+    assert resolve_session_isolation(config, qq_source) == (False, True)
+    assert resolve_session_isolation(config, feishu_source) == (True, False)
+
+
+def test_session_context_uses_platform_group_override():
+    config = GatewayConfig(
+        platforms={
+            Platform.QQBOT: PlatformConfig(
+                enabled=True,
+                extra={"group_sessions_per_user": False},
+            ),
+        },
+        group_sessions_per_user=True,
+    )
+    source = SessionSource(
+        platform=Platform.QQBOT,
+        chat_id="qq-group",
+        chat_type="group",
+        user_id="member-1",
+        user_name="Alice",
+    )
+
+    context = build_session_context(source, config)
+
+    assert context.shared_multi_user_session is True
+
+
+def test_session_store_uses_platform_group_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(
+        platforms={
+            Platform.QQBOT: PlatformConfig(
+                enabled=True,
+                extra={"group_sessions_per_user": False},
+            ),
+        },
+        group_sessions_per_user=True,
+    )
+    store = SessionStore(tmp_path / "sessions", config)
+    alice = SessionSource(
+        platform=Platform.QQBOT,
+        chat_id="qq-group",
+        chat_type="group",
+        user_id="member-1",
+    )
+    bob = replace(alice, user_id="member-2")
+
+    assert store._generate_session_key(alice) == store._generate_session_key(bob)
+    assert store._generate_session_key(alice) == "agent:main:qqbot:group:qq-group"
 
 
 class TestSessionSourceRoundtrip:

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -54,6 +54,34 @@ def test_resolve_session_isolation_prefers_platform_override():
     assert resolve_session_isolation(config, feishu_source) == (True, False)
 
 
+def test_session_store_uses_secondary_profile_config_for_session_key(tmp_path):
+    primary = GatewayConfig(
+        multiplex_profiles=True,
+        group_sessions_per_user=False,
+    )
+    secondary = GatewayConfig(
+        multiplex_profiles=True,
+        group_sessions_per_user=True,
+    )
+    store = SessionStore(
+        tmp_path,
+        primary,
+        config_for_source_fn=lambda source: (
+            secondary if source.profile == "secondary" else primary
+        ),
+    )
+    alice = SessionSource(
+        platform=Platform.QQBOT,
+        chat_id="qq-group",
+        chat_type="group",
+        user_id="alice",
+        profile="secondary",
+    )
+    bob = replace(alice, user_id="bob")
+
+    assert store._generate_session_key(alice) != store._generate_session_key(bob)
+
+
 def test_session_context_uses_platform_group_override():
     config = GatewayConfig(
         platforms={

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -82,6 +82,28 @@ def test_session_store_uses_secondary_profile_config_for_session_key(tmp_path):
     assert store._generate_session_key(alice) != store._generate_session_key(bob)
 
 
+def test_partial_runner_session_key_fallback_keeps_explicit_profiles_closed():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="dm-1",
+        chat_type="dm",
+        user_id="alice",
+    )
+
+    assert runner._session_key_for_source(source) == build_session_key(
+        source,
+        group_sessions_per_user=True,
+        thread_sessions_per_user=False,
+        profile=None,
+    )
+
+    with pytest.raises(RuntimeError, match="no gateway config registered"):
+        runner._session_key_for_source(replace(source, profile="missing"))
+
+
 def test_session_context_uses_platform_group_override():
     config = GatewayConfig(
         platforms={

--- a/tests/gateway/test_shared_group_sender_prefix.py
+++ b/tests/gateway/test_shared_group_sender_prefix.py
@@ -15,6 +15,24 @@ def _make_runner(config: GatewayConfig) -> GatewayRunner:
     return runner
 
 
+def test_session_context_uses_secondary_profile_isolation_policy():
+    primary = GatewayConfig(multiplex_profiles=True, group_sessions_per_user=False)
+    secondary = GatewayConfig(multiplex_profiles=True, group_sessions_per_user=True)
+    runner = _make_runner(primary)
+    runner._profile_configs = {"default": primary, "secondary": secondary}
+    source = SessionSource(
+        platform=Platform.QQBOT,
+        chat_id="qq-group",
+        chat_type="group",
+        user_id="alice",
+        profile="secondary",
+    )
+
+    context = runner._build_session_context_for_source(source)
+
+    assert context.shared_multi_user_session is False
+
+
 @pytest.mark.asyncio
 async def test_preprocess_uses_qq_platform_group_override():
     runner = _make_runner(
@@ -46,6 +64,37 @@ async def test_preprocess_uses_qq_platform_group_override():
     assert result == (
         "[QQ sender id=abc12345 | 群昵称=Alice Group] hello"
     )
+
+
+@pytest.mark.asyncio
+async def test_preprocess_uses_secondary_profile_isolation_policy():
+    primary = GatewayConfig(
+        multiplex_profiles=True,
+        group_sessions_per_user=True,
+    )
+    secondary = GatewayConfig(
+        multiplex_profiles=True,
+        group_sessions_per_user=False,
+    )
+    runner = _make_runner(primary)
+    runner._profile_configs = {"default": primary, "secondary": secondary}
+    source = SessionSource(
+        platform=Platform.QQBOT,
+        chat_id="qq-group",
+        chat_type="group",
+        user_id="member-1",
+        user_name="Alice",
+        profile="secondary",
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="hello", source=source),
+        source=source,
+        history=[],
+        session_key="agent:secondary:qqbot:group:qq-group",
+    )
+
+    assert result == "[Alice] hello"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_shared_group_sender_prefix.py
+++ b/tests/gateway/test_shared_group_sender_prefix.py
@@ -16,6 +16,39 @@ def _make_runner(config: GatewayConfig) -> GatewayRunner:
 
 
 @pytest.mark.asyncio
+async def test_preprocess_uses_qq_platform_group_override():
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={
+                Platform.QQBOT: PlatformConfig(
+                    enabled=True,
+                    extra={"group_sessions_per_user": False},
+                ),
+            },
+            group_sessions_per_user=True,
+        )
+    )
+    source = SessionSource(
+        platform=Platform.QQBOT,
+        chat_id="qq-group",
+        chat_type="group",
+        user_id="member-1",
+        user_name="QQ sender id=abc12345 | 群昵称=Alice Group | QQ昵称=alice_qq",
+    )
+    event = MessageEvent(text="hello", source=source)
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result == (
+        "[QQ sender id=abc12345 | 群昵称=Alice Group | QQ昵称=alice_qq] hello"
+    )
+
+
+@pytest.mark.asyncio
 async def test_preprocess_includes_slack_author_mention_for_shared_thread():
     """Shared Slack threads expose the current author's verifiable user ID
     next to the display name so 'mention me again' requests can bind the

--- a/tests/gateway/test_shared_group_sender_prefix.py
+++ b/tests/gateway/test_shared_group_sender_prefix.py
@@ -33,7 +33,7 @@ async def test_preprocess_uses_qq_platform_group_override():
         chat_id="qq-group",
         chat_type="group",
         user_id="member-1",
-        user_name="QQ sender id=abc12345 | 群昵称=Alice Group | QQ昵称=alice_qq",
+        user_name="QQ sender id=abc12345 | 群昵称=Alice Group",
     )
     event = MessageEvent(text="hello", source=source)
 
@@ -44,7 +44,7 @@ async def test_preprocess_uses_qq_platform_group_override():
     )
 
     assert result == (
-        "[QQ sender id=abc12345 | 群昵称=Alice Group | QQ昵称=alice_qq] hello"
+        "[QQ sender id=abc12345 | 群昵称=Alice Group] hello"
     )
 
 

--- a/tests/gateway/test_slash_access_dispatch.py
+++ b/tests/gateway/test_slash_access_dispatch.py
@@ -19,6 +19,7 @@ Coverage targets:
 from __future__ import annotations
 
 from datetime import datetime
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -131,6 +132,51 @@ async def test_whoami_non_admin_lists_runnable_commands():
     assert "/whoami" in result    # always-allowed floor
     assert "/status" in result
     assert "/model" in result
+
+
+def test_secondary_profile_slash_gate_uses_secondary_policy():
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["primary-admin"],
+            "user_allowed_commands": [],
+        }
+    )
+    secondary = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                enabled=True,
+                token="***",
+                extra={
+                    "allow_admin_from": ["secondary-admin"],
+                    "user_allowed_commands": [],
+                },
+            )
+        },
+        multiplex_profiles=True,
+    )
+    runner._profile_configs = {
+        "default": runner.config,
+        "secondary": secondary,
+    }
+    source = replace(
+        _make_source(user_id="primary-admin"),
+        profile="secondary",
+    )
+
+    assert "admin-only" in runner._check_slash_access(source, "stop")
+    assert runner._check_slash_access(
+        replace(source, user_id="secondary-admin"), "stop"
+    ) is None
+
+
+def test_unknown_profile_slash_gate_fails_closed():
+    runner = _make_runner(platform_extra={})
+    runner._profile_configs = {"default": runner.config}
+    source = replace(_make_source(user_id="anyone"), profile="missing")
+
+    assert "configuration is unavailable" in runner._check_slash_access(
+        source, "stop"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slash_access_dispatch.py
+++ b/tests/gateway/test_slash_access_dispatch.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from datetime import datetime
 from dataclasses import replace
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -278,6 +278,76 @@ async def test_admin_runs_quick_command_when_gating_enabled():
     )
 
     assert result == "quick-command-admin"
+
+
+@pytest.mark.asyncio
+async def test_secondary_profile_executes_its_own_quick_command():
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["primary-admin"],
+            "user_allowed_commands": ["danger"],
+        }
+    )
+    runner.config.quick_commands = {
+        "danger": {"type": "exec", "command": "printf PRIMARY"}
+    }
+    secondary = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                enabled=True,
+                token="***",
+                extra={
+                    "allow_admin_from": ["secondary-admin"],
+                    "user_allowed_commands": ["danger"],
+                },
+            )
+        },
+        multiplex_profiles=True,
+        quick_commands={
+            "danger": {"type": "exec", "command": "printf SECONDARY"}
+        },
+    )
+    runner._profile_configs = {
+        "default": runner.config,
+        "secondary": secondary,
+    }
+    source = replace(_make_source(user_id="user1"), profile="secondary")
+    proc = AsyncMock()
+    proc.communicate.return_value = (b"ok", b"")
+
+    with patch(
+        "gateway.run.asyncio.create_subprocess_shell",
+        new=AsyncMock(return_value=proc),
+    ) as create_process:
+        result = await runner._handle_message(_make_event("/danger", source))
+
+    assert result == "ok"
+    assert create_process.await_args.args[0] == "printf SECONDARY"
+
+
+@pytest.mark.asyncio
+async def test_secondary_profile_expands_its_own_quick_alias():
+    runner = _make_runner(platform_extra={})
+    runner.config.quick_commands = {
+        "go": {"type": "alias", "target": "/help"}
+    }
+    secondary = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(enabled=True, token="***", extra={})
+        },
+        multiplex_profiles=True,
+        quick_commands={"go": {"type": "alias", "target": "/whoami"}},
+    )
+    runner._profile_configs = {
+        "default": runner.config,
+        "secondary": secondary,
+    }
+    source = replace(_make_source(user_id="user1"), profile="secondary")
+
+    result = await runner._handle_message(_make_event("/go", source))
+
+    assert "Tier:" in result
+    assert "Slash commands:" in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Preserve stable QQ group-member identity using `group_openid + member_openid` instead of mutable display names.
- Record the event-provided group nickname as provenance-aware display metadata.
- Allow QQ group sessions to opt into shared history without changing session isolation for other platforms.

## Motivation

QQ group nicknames are mutable and non-unique, while `member_openid` is the stable anonymous identifier supplied by the platform. Shared group sessions therefore need a stable sender key and explicit sender attribution so the agent can distinguish participants without treating a nickname as authorization identity.

## Changes

- Add `QQIdentityStore` for stable sender IDs and `event.author.username` observations.
- Build sender labels from the stable sender ID plus the current event-provided group nickname when available.
- Resolve group/thread session isolation per platform, so QQ can use shared group history while other platforms retain their existing defaults.
- Route the same resolver through both live and persisted `/resume` ownership guards.
- Prefix messages in shared group sessions with sender metadata.
- Separate `user_id` and `user_name` in inbound gateway logs.
- Add tests for identity persistence/provenance, platform session overrides, inverse-override `/resume` security, and shared-session sender prefixes.

## Test Plan

- [x] `pytest tests/gateway/test_resume_command.py tests/gateway/test_qqbot.py tests/gateway/test_qqbot_identity.py tests/gateway/test_session.py tests/gateway/test_shared_group_sender_prefix.py -q` — 150 passed
- [x] Ruff on all changed Python files
- [x] `py_compile` on changed gateway modules
- [x] `git diff --check`

## Notes for Reviewers

- Nicknames are display-only metadata. Authorization and stable identity continue to use OpenIDs.
- The identity store contains no hard-coded user mapping and only records fields observed in production QQ events with source metadata.
- The previously proposed owner-verified QQ-nickname persistence branch was removed because it had no authorized production caller.
- Test fixtures use synthetic identities only.
