### PR TITLE
fix(cli): oneshot exits non-zero on HTTP 402 and provider refusal (#74659)

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -157,6 +157,13 @@ def _write_usage_file(path: Optional[str], result: dict, failure: Optional[str] 
             # paying for actually went out on the wire (July 2026 incident:
             # a config-matching bug silently dropped flex -> 2.3x billing).
             "service_tier": result.get("service_tier"),
+            # Why the turn ended the way it did, when the agent flagged it.
+            # Populated by agent/conversation_loop.py for the failure paths
+            # that previously exited 0 here (HTTP 402 / content-filter /
+            # context-overflow / interrupted). Pipelines that already parse
+            # this file can branch on ``failure_reason`` without inspecting
+            # the exit code — see #74659.
+            "failure_reason": result.get("failure_reason"),
         }
         if failure is not None:
             report["failure"] = failure
@@ -174,7 +181,32 @@ def run_oneshot(
     toolsets: object = None,
     usage_file: Optional[str] = None,
 ) -> int:
-    """Execute a single prompt and print only the final content block.
+    r"""Execute a single prompt and print only the final content block.
+
+    Exit codes (the contract this function owns — documented for the cron /
+    systemd / subprocess callers that branch on ``$?``):
+
+      0  → the turn produced usable output and the agent did not flag it as
+           failed/partial. (The natural reading of "the work succeeded".)
+      1  → the agent run itself crashed, raised, or produced no response at
+           all. Generic failure — investigate the stderr line.
+      2  → the call was made but the turn ended without doing the requested
+           work AND the agent flagged it as ``failed``. The two dominant
+           sub-cases (both historically exited 0 — #74659):
+
+             - ``failure_reason == "billing"``  (HTTP 402, credit exhaustion)
+             - ``failure_reason == "content_filter"`` (provider safety refusal)
+
+           Callers that only care about "did it run" can still treat 2 as a
+           soft failure; callers that need to distinguish "retry the provider"
+           from "escalate" can branch on ``--usage-file``'s ``failure_reason``.
+
+    The agent's own "I decline to proceed" text (e.g. a ``pre_tool_call`` hook
+    fenced the tool the task needed, and the model wrote a clarifying question
+    instead of doing the work) currently surfaces as a non-failed turn with a
+    non-empty ``final_response``. That is NOT detected here — it would require
+    semantic inspection of the response. The fix for that sub-case is tracked
+    separately; this change covers the unambiguous provider failures.
 
     Args:
         prompt: The user message to send.
@@ -186,7 +218,10 @@ def run_oneshot(
         usage_file: Optional path; when set, a JSON usage report (estimated
             cost, token counts, model, api_calls) is written there after the
             run — even when the run fails — so pipelines can account for
-            spend per invocation.
+            spend per invocation. The report gains a ``failure_reason`` field
+            when the turn ended in a flagged failure, so callers that already
+            parse the usage file can branch on it without inspecting the exit
+            code.
 
     Returns the exit code.  The caller owns process termination.
     """
@@ -283,10 +318,45 @@ def run_oneshot(
             real_stdout.write("\n")
         real_stdout.flush()
 
-    if (result.get("failed") or result.get("partial")) and not (response or "").strip():
+    # Exit-code contract — see the docstring above. The previous logic only
+    # surfaced a failure when the response was *empty*, so a 402 billing wall
+    # (which sets ``final_response`` to a guidance message AND ``failed=True``)
+    # exited 0 and was routinely misread as "the work succeeded" by unattended
+    # callers. #74659.
+    response_text = (response or "").strip()
+    run_failed = bool(result.get("failed"))
+    run_partial = bool(result.get("partial"))
+    failure_reason = result.get("failure_reason")
+
+    # Agent-flagged failure → non-zero regardless of whether the agent wrote
+    # a guidance/error string to ``final_response``. Use exit 2 (distinct from
+    # the generic 1 below) so callers can branch "retry the provider" (2)
+    # vs "investigate" (1) without parsing text. The common sub-cases are
+    # ``failure_reason`` values produced by agent/conversation_loop.py:
+    # ``billing`` (HTTP 402), ``content_filter`` (safety refusal),
+    # ``context_overflow`` / generic non-retryable exhaustion.
+    if run_failed:
+        if response_text:
+            # The agent produced an explanation (billing guidance, safety
+            # refusal text, etc.) — we already wrote it to stdout. Add a
+            # one-line stderr marker so cron/systemd logs aren't silent about
+            # the non-zero exit code, then return 2.
+            real_stderr.write(
+                f"hermes -z: turn ended without completing the request"
+                + (f" (failure_reason={failure_reason})" if failure_reason else "")
+                + ".\n"
+            )
+            real_stderr.flush()
+            return 2
+        # Failed AND no response at all — the generic crash path.
+        real_stderr.write("hermes -z: agent run failed and produced no final response.\n")
+        real_stderr.flush()
         return 2
 
-    if not (response or "").strip():
+    if run_partial and not response_text:
+        return 2
+
+    if not response_text:
         real_stderr.write("hermes -z: no final response was produced; treating the run as failed.\n")
         real_stderr.flush()
         return 1

--- a/tests/hermes_cli/test_oneshot_exit_code.py
+++ b/tests/hermes_cli/test_oneshot_exit_code.py
@@ -1,0 +1,194 @@
+"""Tests for ``hermes -z`` exit-code contract — #74659.
+
+The oneshot exit code is the contract unattended callers (cron, systemd,
+subprocess) branch on. Before #74659 it routinely lied: an HTTP 402
+billing wall (and a provider safety refusal) set ``failed=True`` on the
+run result but ALSO populated ``final_response`` with a guidance string,
+so the old ``if failed and not response: return 2`` branch never fired
+and the process exited 0. Pipelines read that as success.
+
+These tests pin the new contract:
+
+  0 → success (response present, agent did not flag failure)
+  1 → generic crash / no response at all
+  2 → agent-flagged failure (billing, content_filter, …) — distinguishes
+      "retry the provider" (2) from "investigate" (1)
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.oneshot import run_oneshot
+
+
+@pytest.fixture
+def capture_streams(monkeypatch, capsys):
+    """Collect stdout/stderr written by run_oneshot.
+
+    The function redirects stdio internally (to devnull) for the agent
+    call, then writes the final response / diagnostics to the *real*
+    stdout/stderr. ``capsys`` captures what lands on the real streams
+    because the redirect is via contextmanager, not a swap of ``sys.__*__``.
+    """
+    # Force the early-validation branches off so the test reaches the
+    # exit-code logic. The agent itself is mocked below, so none of these
+    # touch a real provider.
+    monkeypatch.setenv("HERMES_INFERENCE_MODEL", "test-model")
+    capsys.readouterr()  # drain any setup noise
+    yield capsys
+
+
+def _mock_agent_result(response: str | None, **result_fields) -> tuple[str, dict]:
+    """Build the (response, result) tuple ``_run_agent`` returns."""
+    base = {"failed": False, "partial": False, "completed": True, "final_response": response or ""}
+    base.update(result_fields)
+    return (response or ""), base
+
+
+class TestSuccessPath:
+    def test_clean_response_exits_zero(self, capture_streams):
+        with patch(
+            "hermes_cli.oneshot._run_agent",
+            return_value=_mock_agent_result("done"),
+        ):
+            rc = run_oneshot("do something")
+        assert rc == 0
+        assert capture_streams.readouterr().out.strip() == "done"
+
+    def test_response_without_trailing_newline_gets_one(self, capture_streams):
+        with patch(
+            "hermes_cli.oneshot._run_agent",
+            return_value=_mock_agent_result("no newline"),
+        ):
+            rc = run_oneshot("p")
+        assert rc == 0
+        assert capture_streams.readouterr().out.endswith("\n")
+
+
+class TestBillingFailure:
+    def test_http_402_billing_exits_two_not_zero(self, capture_streams):
+        # Mirrors agent/conversation_loop.py's billing-wall return shape:
+        # final_response is a guidance string AND failed is True.
+        with patch(
+            "hermes_cli.oneshot._run_agent",
+            return_value=_mock_agent_result(
+                "Billing or credits exhausted: add credits and retry.",
+                failed=True,
+                completed=False,
+                failure_reason="billing",
+            ),
+        ):
+            rc = run_oneshot("p")
+        assert rc == 2, "billing wall must not exit 0 — #74659"
+        # The guidance text still goes to stdout so users see the message.
+        assert "Billing or credits exhausted" in capture_streams.readouterr().out
+
+    def test_billing_failure_writes_stderr_marker(self, capture_streams):
+        with patch(
+            "hermes_cli.oneshot._run_agent",
+            return_value=_mock_agent_result(
+                "Billing exhausted",
+                failed=True,
+                failure_reason="billing",
+            ),
+        ):
+            rc = run_oneshot("p")
+        assert rc == 2
+        err = capture_streams.readouterr().err
+        assert "turn ended without completing the request" in err
+        assert "failure_reason=billing" in err
+
+
+class TestContentFilterRefusal:
+    def test_safety_refusal_exits_two(self, capture_streams):
+        # Mirrors the content-policy-blocked return shape from
+        # agent/conversation_loop.py (final_response is the refusal
+        # explanation, failed is True, failure_reason content_filter).
+        with patch(
+            "hermes_cli.oneshot._run_agent",
+            return_value=_mock_agent_result(
+                "⚠️  The model declined to respond to this request (safety refusal).",
+                failed=True,
+                completed=False,
+                failure_reason="content_filter",
+            ),
+        ):
+            rc = run_oneshot("p")
+        assert rc == 2
+
+
+class TestNoResponsePath:
+    def test_empty_response_and_not_failed_exits_one(self, capture_streams):
+        with patch(
+            "hermes_cli.oneshot._run_agent",
+            return_value=_mock_agent_result(""),
+        ):
+            rc = run_oneshot("p")
+        assert rc == 1
+        err = capture_streams.readouterr().err
+        assert "no final response" in err
+
+    def test_failed_and_empty_exits_two(self, capture_streams):
+        with patch(
+            "hermes_cli.oneshot._run_agent",
+            return_value=_mock_agent_result("", failed=True),
+        ):
+            rc = run_oneshot("p")
+        assert rc == 2
+
+
+class TestPartialPath:
+    def test_partial_with_response_still_exits_zero(self, capture_streams):
+        # A partial run that still produced output is "the turn did
+        # something" — keeping this at 0 preserves callers that interpret
+        # nonzero as "abort the pipeline" and would rather keep partial
+        # work than discard it.
+        with patch(
+            "hermes_cli.oneshot._run_agent",
+            return_value=_mock_agent_result("partial output", partial=True),
+        ):
+            rc = run_oneshot("p")
+        assert rc == 0
+
+    def test_partial_with_no_response_exits_two(self, capture_streams):
+        with patch(
+            "hermes_cli.oneshot._run_agent",
+            return_value=_mock_agent_result("", partial=True),
+        ):
+            rc = run_oneshot("p")
+        assert rc == 2
+
+
+class TestUsageFileFailureReason:
+    def test_usage_file_records_failure_reason_for_billing(self, tmp_path, capture_streams):
+        path = tmp_path / "usage.json"
+        with patch(
+            "hermes_cli.oneshot._run_agent",
+            return_value=_mock_agent_result(
+                "Billing exhausted",
+                failed=True,
+                failure_reason="billing",
+            ),
+        ):
+            rc = run_oneshot("p", usage_file=str(path))
+        assert rc == 2
+        report = json.loads(path.read_text())
+        assert report["failed"] is True
+        assert report["failure_reason"] == "billing"
+
+    def test_usage_file_failure_reason_null_on_success(self, tmp_path, capture_streams):
+        path = tmp_path / "usage.json"
+        with patch(
+            "hermes_cli.oneshot._run_agent",
+            return_value=_mock_agent_result("done"),
+        ):
+            rc = run_oneshot("p", usage_file=str(path))
+        assert rc == 0
+        report = json.loads(path.read_text())
+        assert report["failed"] is False
+        assert "failure_reason" in report
+        assert report["failure_reason"] is None


### PR DESCRIPTION
## Summary

`hermes -z` routinely exited 0 in two cases where the requested work did not happen: HTTP 402 (billing/credit exhaustion) and provider safety refusals. Both paths set `failed=True` on the run result AND populated `final_response` with a guidance string, so the old `if (result.get("failed") or result.get("partial")) and not (response or "").strip(): return 2` branch never fired — `response` was non-empty. Unattended callers (cron, systemd, subprocess) branch on the exit code and read the 0 as success; the failure was silent until someone inspected the artefacts by hand. In the reporter's case this shipped a "filed" message to a chat thread for work that had not been done.

**Root cause:** `agent/conversation_loop.py` populates `final_response` with a guidance message on billing walls (line ~4389) and safety refusals (line ~2140), and sets `failed=True` + `failure_reason=<reason>` on the same return. `hermes_cli/oneshot.py`'s exit-code logic only checked the failed flag when the response was empty, so any "failed but with explanation text" case exited 0.

**Fix:** the exit-code contract is now documented and tested:
- **0** → success (response present, agent did not flag failure)
- **1** → generic crash / no response at all
- **2** → agent-flagged failure (billing / content_filter / non-retryable exhaustion) — distinct from the generic 1 so callers can branch "retry the provider" (2) vs "investigate" (1) without parsing text.

`--usage-file` now also records `failure_reason` (the field `agent/conversation_loop.py` already populates for these paths: `billing`, `content_filter`, `context_overflow`, …) so pipelines that already parse the usage file can branch on it without inspecting the exit code.

**Out of scope (tracked separately):** the agent's own "I decline to proceed" text — e.g. a `pre_tool_call` hook fenced the tool the task needed, and the model wrote a clarifying question instead of doing the work — is NOT detected here. It surfaces as a non-failed turn with non-empty response and would require semantic inspection of the response. That sub-case is documented in the docstring and left for a follow-up.

## Changes

- `hermes_cli/oneshot.py`:
  - Exit-code logic rewritten (lines ~318-360): `failed` → exit 2 regardless of response content; `partial` + empty response → exit 2; empty response + not failed → exit 1; response + not failed → exit 0.
  - New stderr one-line marker on failed runs so cron/systemd logs aren't silent about the non-zero exit code (`hermes -z: turn ended without completing the request (failure_reason=billing).`).
  - `--usage-file` report now includes `failure_reason` (null on success).
  - Docstring rewritten to document the exit-code contract unambiguously — the old "Returns the exit code" was the implicit contract that was being misread.
- `tests/hermes_cli/test_oneshot_exit_code.py`: new test file, 11 tests pinning the new contract.
  - success → 0; billing 402 → 2 (was 0); content_filter → 2 (was 0); empty + not failed → 1; empty + failed → 2; partial + response → 0; partial + no response → 2; usage-file `failure_reason` round-trip for billing + null on success.

## How to Test

```bash
pytest tests/hermes_cli/test_oneshot_exit_code.py -xvs
# ✅ 11/11 passed

pytest tests/hermes_cli/test_oneshot_usage_file.py -xvs
# ✅ 6/6 passed — no regression in the existing usage-file tests
```

## Manual repro (from the issue)

```bash
# 402 path — with a provider whose credit is exhausted:
hermes -z 'Reply with exactly OK and nothing else.'; echo "EXIT=$?"
# Before: EXIT=0. After: EXIT=2 + stderr marker.

# Refusal path — register a pre_tool_call hook that denies the tool the prompt requires:
hermes -z '...'; echo "EXIT=$?"
# Before: EXIT=0. After (when the agent sets failed=True): EXIT=2.
```

## Checklist

- [x] Tests pass — 11/11 new, 6/6 existing unaffected
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only (2 files: `hermes_cli/oneshot.py` + new test)
- [x] Cross-platform impact assessed — None (pure exit-code logic, no platform-specific code)
- [x] Profile-safe paths — N/A (no path changes)
- [x] `.env` not used — N/A (no env changes; the `failure_reason` field is a result-dict addition, not an env var)

## Risk & Impact

Low. The exit-code change is backwards-compatible for the success path (still 0) and the no-response path (still 1). The only behavior change is for the "failed but with explanation text" paths (402, content-filter) which now exit 2 instead of 0 — which is exactly the bug fix. A caller that was treating 0 as success on a 402 will now correctly see a non-zero exit; no caller should have been relying on 0 in that case because the work manifestly did not happen.

Type: Bug fix
Closes #74659