### PR TITLE
Clamp dashboard analytics days parameter

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13853,9 +13853,28 @@ def _aux_task_summary(aux_rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return result
 
 
+_ANALYTICS_DEFAULT_DAYS = 30
+_ANALYTICS_MAX_DAYS = 365
+
+
+def _clamp_analytics_days(value: int) -> int:
+    """Clamp dashboard analytics lookback window to a safe positive range.
+
+    The UI only offers 7/30/90, but the query param is unbounded. Huge or
+    non-positive ``days`` values force expensive full-history SQL scans and
+    InsightsEngine work, or produce empty/inverted time windows.
+    """
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return _ANALYTICS_DEFAULT_DAYS
+    return max(1, min(_ANALYTICS_MAX_DAYS, parsed))
+
+
 def _get_usage_analytics(days: int = 30, profile: Optional[str] = None):
     from agent.insights import InsightsEngine
 
+    days = _clamp_analytics_days(days)
     db = _open_session_db_for_profile(profile)
     try:
         cutoff = time.time() - (days * 86400)
@@ -13945,6 +13964,7 @@ def _get_models_analytics(days: int = 30, profile: Optional[str] = None):
     Returns token/cost/session breakdown per model plus capability metadata
     from models.dev (context window, vision, tools, reasoning, etc.).
     """
+    days = _clamp_analytics_days(days)
     db = _open_session_db_for_profile(profile)
     try:
         cutoff = time.time() - (days * 86400)

--- a/tests/hermes_cli/test_web_server_analytics_days_clamp.py
+++ b/tests/hermes_cli/test_web_server_analytics_days_clamp.py
@@ -1,0 +1,22 @@
+"""Tests for dashboard analytics days clamping."""
+
+from hermes_cli.web_server import _clamp_analytics_days
+
+
+class TestClampAnalyticsDays:
+    def test_invalid_value_uses_default(self):
+        assert _clamp_analytics_days("bad") == 30
+
+    def test_zero_clamped_to_one(self):
+        assert _clamp_analytics_days(0) == 1
+
+    def test_negative_clamped_to_one(self):
+        assert _clamp_analytics_days(-7) == 1
+
+    def test_excessive_days_capped(self):
+        assert _clamp_analytics_days(9999) == 365
+
+    def test_ui_presets_unchanged(self):
+        assert _clamp_analytics_days(7) == 7
+        assert _clamp_analytics_days(30) == 30
+        assert _clamp_analytics_days(90) == 90


### PR DESCRIPTION
The dashboard analytics endpoints accepted an unbounded days query parameter, so huge or non-positive values could force expensive full-history SQL scans and InsightsEngine work or produce empty time windows. This change clamps days to a safe range of 1–365 (default 30) for both usage and models analytics while preserving the existing UI presets of 7, 30, and 90.