### PR TITLE
Stop right-click showing a lone Select All on bare surfaces

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5642,8 +5642,12 @@ function installContextMenu(window) {
       }
     }
 
+    // Bare right-click on non-editable, non-selected, non-media content (a pane
+    // body, the sidebar, chrome): the renderer's own context menus own those
+    // surfaces, and anywhere without one shows nothing — not a lone, useless
+    // "Select All" from the native fallback.
     if (!template.length) {
-      template.push({ role: 'selectAll' })
+      return
     }
 
     Menu.buildFromTemplate(template).popup({ window })


### PR DESCRIPTION
Right-clicking anywhere the renderer doesn't own its own context menu — a pane body, the sidebar, empty chrome — popped a native Electron menu whose only item was **Select All**. It's the default nobody wants.

The native handler (`installContextMenu`) already builds a real menu for the cases that need one: image/link actions, spellcheck suggestions, and cut/copy/paste/select-all when the target is editable or has a text selection. Only the *empty-template* fallback was pushing a bare `selectAll`. This drops that fallback, so a bare right-click on a non-editable, non-selected, non-media surface shows nothing.

Editable fields and text selections are untouched — they still get the full copy/paste menu.