### PR TITLE
Clamp session.list limit to avoid unbounded fetches

### DIFF
--- a/tests/gateway/test_session_list_allowed_sources.py
+++ b/tests/gateway/test_session_list_allowed_sources.py
@@ -69,3 +69,48 @@ def test_session_list_surfaces_all_user_facing_sources(monkeypatch):
     assert "tool-1" not in ids
 
 
+def test_session_list_clamps_excessive_limit(monkeypatch):
+    """Huge limits must not become unbounded SQL fetch sizes."""
+    rows = [{"id": f"s-{i}", "source": "cli", "started_at": i} for i in range(20)]
+    db = _StubDB(rows)
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+
+    resp = _call(limit=10_000_000)
+
+    assert resp["result"]["sessions"]
+    assert len(resp["result"]["sessions"]) <= 500
+    assert db.calls[0]["limit"] == 1000  # max(500 * 2, 200)
+
+
+def test_session_list_clamps_negative_limit(monkeypatch):
+    """Negative limits must not flip ``rows[:limit]`` into nearly-all rows."""
+    rows = [{"id": f"s-{i}", "source": "cli", "started_at": i} for i in range(20)]
+    db = _StubDB(rows)
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+
+    resp = _call(limit=-5)
+
+    assert len(resp["result"]["sessions"]) == 1
+    assert db.calls[0]["limit"] == 200  # max(1 * 2, 200)
+
+
+def test_session_list_clamps_zero_limit(monkeypatch):
+    rows = [{"id": f"s-{i}", "source": "cli", "started_at": i} for i in range(5)]
+    db = _StubDB(rows)
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+
+    resp = _call(limit=0)
+
+    assert len(resp["result"]["sessions"]) == 1
+    assert db.calls[0]["limit"] == 200
+
+
+def test_session_list_default_fetch_limit(monkeypatch):
+    rows = [{"id": "s-1", "source": "cli", "started_at": 1}]
+    db = _StubDB(rows)
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+
+    _call()
+
+    assert db.calls[0]["limit"] == 400  # max(200 * 2, 200)
+

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -175,7 +175,20 @@ def _(rid, params: dict) -> dict:
             # platform is added or a user names their own source.
             deny = frozenset({"tool"})
 
-            limit = int(params.get("limit", 200) or 200)
+            try:
+                raw_limit = params.get("limit", 200)
+                # Don't use ``or 200`` — falsy ``0`` must clamp to 1, not
+                # silently jump back to the default page size.
+                if raw_limit is None or raw_limit == "":
+                    limit = 200
+                else:
+                    limit = int(raw_limit)
+            except (TypeError, ValueError):
+                limit = 200
+            # Cap so a hostile/buggy client can't force unbounded SQL work,
+            # and so negative limits can't flip Python ``rows[:limit]`` into
+            # "return almost everything" slice semantics.
+            limit = max(1, min(limit, 500))
             # Over-fetch modestly so per-source filtering doesn't leave us
             # short; the compression-tip projection in ``list_sessions_rich``
             # can also merge rows.


### PR DESCRIPTION
The TUI gateway session.list RPC accepted unbounded and negative limit values, which could force oversized SQL fetches and cause Python negative-slice semantics to return nearly the full session list. This change clamps limit to a safe range of 1–500 while preserving the existing default of 200 for the resume picker.